### PR TITLE
feat(dev-hosted-local): auto-manage Stripe webhook listener from pnpm dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ pnpm --dir apps/cloudflare verify
 - optional: copy `apps/cloudflare/.dev.vars.example` to `apps/cloudflare/.dev.vars` when you want to pin local Worker secrets or add provider-specific Worker vars; otherwise `pnpm dev` uses Wrangler's documented local process-env path for required Worker secrets and CLI `--var` overrides for local non-secret vars
 - either keep `DATABASE_URL` in the linked Vercel development env or run local Postgres on `127.0.0.1:5432` so the default local database URL works
 - keep the linked Vercel development env populated with the real hosted signup secrets you need locally, such as Privy and Stripe test credentials
+- optional: install the [Stripe CLI](https://docs.stripe.com/stripe-cli) (`brew install stripe/stripe-cli/stripe`) and run `stripe login` once. `pnpm dev` then auto-launches `stripe listen` for hosted onboarding webhooks and captures the per-developer `whsec_...` signing secret from the listener's startup output into the web child's env. Set `MURPH_DEV_SKIP_STRIPE_LISTEN=1` to opt out; see `apps/web/README.md` for the full contract.
 
 Repeatable launcher sanity check:
 

--- a/agent-docs/exec-plans/completed/2026-04-21-dev-auto-stripe-listener.md
+++ b/agent-docs/exec-plans/completed/2026-04-21-dev-auto-stripe-listener.md
@@ -1,0 +1,198 @@
+# Auto-manage Stripe webhook listener from `pnpm dev`
+
+Status: completed
+Created: 2026-04-21
+Updated: 2026-04-21
+
+## Goal
+
+- Make `pnpm dev` transparently manage the Stripe CLI webhook listener so local
+  hosted onboarding flows can complete subscription checkout without a second
+  terminal and without copy-pasting per-developer `whsec_...` values across env
+  stores.
+- Keep the existing hosted local dev stack behavior intact when Stripe CLI is
+  missing or explicitly opted out.
+
+## Context
+
+- Hosted onboarding checkout is subscription-only and the webhook route
+  `apps/web/app/api/hosted-onboarding/stripe/webhook/route.ts` fails closed when
+  `STRIPE_WEBHOOK_SECRET` is unset or when signature verification fails.
+- `stripe listen --forward-to <url>` prints a `whsec_...` signing secret as the
+  very first line of its startup output and continues streaming event logs
+  while it runs. Stripe's documented contract is only that the caller uses
+  "the secret from the initial output of the listen command." Running
+  `stripe listen --print-secret` in a separate process is **not** guaranteed to
+  return the same secret under account switching, `--api-key` overrides, or
+  concurrent listeners, so this plan captures the secret from the live
+  listener's stdout instead of relying on the `--print-secret` seam.
+- Each developer has their own Stripe CLI login, so the secret is inherently
+  per-developer. Sharing one value in Vercel Development env only works for one
+  developer at a time and will silently break the other.
+- `scripts/dev-hosted-local/stack.ts` already merges env from
+  `repoEnv + pulledEnv + initialEnv`, then spawns `cloudflare` and (optionally)
+  `web` children. That child-spawn site is where the new `stripe` child must
+  join, and the merged env is where the captured secret must be injected
+  before the `web` child process starts so Next.js sees it.
+
+## Success criteria
+
+- Running `pnpm dev` with Stripe CLI installed and logged in spawns a
+  `stripe listen --forward-to http://<webHost>:<webPort>/api/hosted-onboarding/stripe/webhook`
+  child process **before** the web child, captures the `whsec_...` line from
+  the listener's startup stdout, and injects it into the web child's env so
+  Next.js sees a verified signing secret.
+- Orchestrator refuses to forward any `whsec_...` bytes to the console or to
+  the existing prefixed stdout/stderr buffers. A dedicated redactor intercepts
+  Stripe output, keeps the secret for env injection only, and replaces the
+  secret substring with a fixed token (for example `[redacted whsec_...]`) in
+  everything that reaches `pipeWithPrefix`, `stdoutText`, `stderrText`, and
+  their tail helpers.
+- Env precedence for `STRIPE_WEBHOOK_SECRET` is provenance-aware: only a value
+  present in the current shell `initialEnv` or the repo-root `.env`
+  (`repoEnv`) is preserved. A value that would only appear via pulled Vercel
+  Dev env is ignored and overwritten by the captured secret, so a stale
+  `whsec_placeholder` in Vercel Dev cannot silently outrank the local CLI
+  login.
+- When Stripe CLI is missing, the orchestrator prints a single actionable
+  warning (`brew install stripe/stripe-cli/stripe`) from a `spawn` ENOENT path
+  and continues without the listener or the secret injection, matching the
+  existing optional-tool pattern used for Docker diagnostics. The rest of the
+  stack still boots.
+- `MURPH_DEV_SKIP_STRIPE_LISTEN=1` fully skips the listener child and the
+  secret capture, mirroring the shape of `MURPH_DEV_SKIP_VERCEL_PULL`.
+- `MURPH_DEV_SKIP_WEB=1` also skips the listener (there is no local web target
+  to forward to), without warning noise about missing Stripe CLI.
+- Listener lifecycle is distinct from `cloudflare`/`web`: the listener is
+  required only during startup secret capture. If the listener child exits
+  after the stack reports ready, the orchestrator logs a single degraded-mode
+  warning and keeps the rest of the stack running. Stripe listener exit is
+  therefore excluded from `waitForFirstChildExit`.
+- Shutdown terminates the Stripe child with the existing
+  `terminateChildProcessAndWait` path and does not leak the process on SIGINT.
+- `pnpm typecheck` and the touched
+  `pnpm exec vitest run --config scripts/vitest.config.ts scripts/dev-hosted-local/stack.test.ts scripts/dev-hosted-local/config.test.ts`
+  pass. Direct `tsx scripts/dev-hosted-local/main.ts --help` prints the new
+  skip flag.
+
+## Scope
+
+- In scope:
+  - `scripts/dev-hosted-local/stack.ts`: preflight, listener spawn before web,
+    secret capture from listener startup stdout, env injection into web child,
+    provenance-aware merge, shutdown wiring, exclusion from
+    `waitForFirstChildExit`.
+  - `scripts/dev-hosted-local/config.ts`: new `skipStripeListen` field parsed
+    from `MURPH_DEV_SKIP_STRIPE_LISTEN`; help text entry.
+  - `scripts/dev-hosted-local/types.ts`: extend `HostedLocalDevConfig` and the
+    `NamedChildProcess`/`BufferedNamedChildProcess` name union to include
+    `"stripe"`; extend the `HostedLocalDevStack.processes` shape to expose the
+    optional listener child.
+  - `scripts/dev-hosted-local/runtime.ts`: widen `spawnChildProcess` to accept
+    `"stripe"`; add an optional per-spawn redactor seam that rewrites matched
+    substrings (the captured `whsec_...`) before `pipeWithPrefix` and the
+    stdout/stderr buffer appenders see them; add a small `captureStripeSecret`
+    helper that waits for the first `whsec_...` match on the listener's
+    stdout with a bounded timeout.
+  - `scripts/dev-hosted-local/stack.test.ts`: switch from ordered
+    `mockReturnValueOnce` to `mockImplementation((name) => ...)` keyed by the
+    spawned child name so new `"stripe"` calls extend cleanly; cover
+    listener-started + secret-captured + env-injected path, redaction of the
+    secret in piped/buffered output, `initialEnv` / `repoEnv` preservation,
+    `pulledEnv`-only value being overwritten, Stripe CLI missing (ENOENT)
+    warn-and-skip, `MURPH_DEV_SKIP_STRIPE_LISTEN=1` honored, `MURPH_DEV_SKIP_WEB=1`
+    skipping the listener, listener command shape, and listener post-ready
+    exit not tearing down the stack.
+  - `scripts/dev-hosted-local/config.test.ts`: cover `skipStripeListen` env flag
+    parsing plus help text.
+  - `apps/web/README.md`: short section describing auto listener, skip flag,
+    and a note that shared `STRIPE_WEBHOOK_SECRET` in Vercel Development is
+    incorrect for multi-dev teams.
+  - `apps/web/.env.example`: annotate `STRIPE_WEBHOOK_SECRET` that `pnpm dev`
+    auto-populates it from the local Stripe CLI login.
+  - Repo-root `README.md` or the nearest durable dev-entrypoint doc: add
+    Stripe CLI to the optional `pnpm dev` tool list so the dev contract stays
+    discoverable outside `apps/web/README.md`.
+  - `agent-docs/exec-plans/active/COORDINATION_LEDGER.md`: this plan row.
+
+- Out of scope:
+  - Stripe product/price creation, test-mode data seeding, Stripe API clients.
+  - Changing webhook verification, idempotency, or billing policy logic under
+    `apps/web/src/lib/hosted-onboarding/**`.
+  - Removing `STRIPE_WEBHOOK_SECRET` from any real environment store. The user
+    will delete it from Vercel Development manually.
+  - Any use of `stripe listen --print-secret` as a separate preflight process.
+    The single-process capture above is the only supported seam.
+
+## Constraints
+
+- Must not change production runtime auth or billing invariants. The orchestrator
+  is dev-only; the webhook route remains fail-closed.
+- Must not inject a real or placeholder `whsec_...` when Stripe CLI is missing.
+  An empty value is allowed; a synthetic placeholder is not (would pass
+  `resolveHostedBillingReady` shape checks and confuse diagnostics later).
+- Must not write webhook secret content to disk, stdout logs, or child-env
+  echoes beyond what Stripe CLI itself prints.
+- Must preserve the existing `MURPH_DEV_SKIP_VERCEL_PULL` / `MURPH_DEV_SKIP_WEB`
+  ordering so `initialEnv` continues to override both pulled Vercel env and
+  repo `.env`.
+- Must be a low-risk repo-internal workflow/tooling change so verification stays
+  on the routing doc's fast path (`pnpm typecheck` plus direct touched-file
+  tests) rather than full acceptance.
+
+## Tasks
+
+1. [x] Add `skipStripeListen` to `HostedLocalDevConfig`, config parsing, and
+       help text.
+2. [x] Add `"stripe"` to the named-child unions in `types.ts` and widen
+       `spawnChildProcess` in `runtime.ts`; thread the optional redactor hook
+       through `pipeWithPrefix` and keep the output-buffer appenders behind a
+       line-buffered redactor so secrets never hit the piped or buffered
+       paths raw, even when `whsec_...` is split across chunk boundaries.
+3. [x] Implement `spawnStripeListenerWithSecretCapture` that reads the
+       listener's stdout, resolves on the first `/whsec_[A-Za-z0-9_]+/` match
+       with a bounded timeout, terminates the child on pre-capture rejection,
+       and installs the captured secret as the redactor for the live child
+       before releasing the startup-buffered output.
+4. [x] In `startHostedLocalDevStack`, resolve env provenance for
+       `STRIPE_WEBHOOK_SECRET`: preserve only `initialEnv` or `repoEnv` hits;
+       discard `pulledEnv`-only hits before deciding whether to capture from
+       the listener. Also suppress the generic
+       `warnForMissingEnv("STRIPE_WEBHOOK_SECRET")` when the listener will
+       capture.
+5. [x] Spawn the Stripe listener between env-merge and the web child so the
+       captured secret can populate `runtimeEnv` before `web` starts; wire
+       shutdown and exclude the listener from `waitForFirstChildExit`, with a
+       post-ready exit handler that logs degraded-mode once without killing
+       the stack.
+6. [x] Extend tests in `stack.test.ts`, `config.test.ts`, and new
+       `runtime.stripe.test.ts`, switching the `spawnChildProcess` mock to a
+       name-keyed `mockImplementation` so later lanes extend cleanly.
+       Regression tests cover split-boundary redaction and the timeout-kill
+       path.
+7. [x] Update `apps/web/README.md`, repo-root `README.md`, and
+       `apps/web/.env.example`.
+8. [x] Run `pnpm exec tsc --noEmit --project tsconfig.tools.json` plus the
+       touched Vitest suite; capture evidence.
+9. [x] `coverage-write` on `gpt-5.4-mini` is not required — the verification
+       lane is low-risk repo-internal workflow/tooling fast path
+       (`pnpm typecheck` + touched-file checks), which does not include
+       package/app owner coverage per the routing doc.
+10. [x] Run `simplify` audit subagent (Codex) + final `task-finish-review`
+        audit subagent (Codex). Both returned; high/medium/low findings were
+        addressed before close.
+11. [x] Close plan and commit through `scripts/finish-task`.
+
+## Verification
+
+- `pnpm typecheck`
+- `pnpm exec vitest run --config scripts/vitest.config.ts scripts/dev-hosted-local/stack.test.ts scripts/dev-hosted-local/config.test.ts`
+- `pnpm exec tsx --tsconfig tsconfig.base.json scripts/dev-hosted-local/main.ts --help`
+  (readback check for the new flag entry)
+- Direct scenario proof: run `pnpm dev` locally with the Stripe CLI installed
+  and logged in, confirm that the `stripe` child starts, that the web child
+  sees a non-empty `STRIPE_WEBHOOK_SECRET`, and that a Stripe test-mode
+  `customer.subscription.created` event delivered through `stripe trigger`
+  reaches `/api/hosted-onboarding/stripe/webhook` with signature verification
+  green. Repeat with `MURPH_DEV_SKIP_STRIPE_LISTEN=1` to confirm the opt-out.
+Completed: 2026-04-21

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -78,6 +78,10 @@ HOSTED_ONBOARDING_INVITE_TTL_HOURS="168"
 HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_MONTHLY="price_replace_me"
 HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_ANNUAL="price_replace_me"
 STRIPE_SECRET_KEY="sk_test_replace_me"
+# STRIPE_WEBHOOK_SECRET is auto-populated by `pnpm dev` from the local `stripe listen` CLI
+# login when the Stripe CLI is installed. Shell overrides and repo-root .env values are
+# preserved; a stale value pulled from Vercel Development env is discarded in favor of the
+# listener's live secret. Set MURPH_DEV_SKIP_STRIPE_LISTEN=1 to opt out of the auto-listener.
 STRIPE_WEBHOOK_SECRET="whsec_replace_me"
 # RevNet issuance is currently hard-disabled in code; no HOSTED_ONBOARDING_REVNET_* envs are used.
 LINQ_API_TOKEN="replace-me"

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -151,6 +151,35 @@ Optional hosted AI usage metering:
 Hosted pages assume the hosted Privy phone-auth setup is present and fail fast
 when it is missing instead of carrying fallback branches in page code.
 
+### Local Stripe webhook listener
+
+`pnpm dev` auto-launches `stripe listen --forward-to http://<web-host>:<web-port>/api/hosted-onboarding/stripe/webhook`
+and captures the listener's live `whsec_...` signing secret from its startup
+output. The captured secret is injected into the web dev child's env as
+`STRIPE_WEBHOOK_SECRET` before Next.js boots, so hosted onboarding checkout
+works locally without a second terminal.
+
+- The listener's signing secret is per-developer (tied to each operator's
+  Stripe CLI login), so sharing a single `STRIPE_WEBHOOK_SECRET` in Vercel
+  Development env does not work for a multi-dev team. Remove that value from
+  Vercel Development so the captured secret takes over.
+- An explicit shell `STRIPE_WEBHOOK_SECRET` or repo-root `.env`
+  `STRIPE_WEBHOOK_SECRET` is preserved over the captured value. A stale value
+  that would otherwise arrive only through `vercel env pull` is discarded.
+- If the Stripe CLI is not on `PATH`, the orchestrator logs an actionable
+  warning (`brew install stripe/stripe-cli/stripe`) and continues without the
+  listener. Hosted onboarding checkout will fail locally until the CLI is
+  installed or `STRIPE_WEBHOOK_SECRET` is set explicitly.
+- The listener runs alongside `cloudflare` and `web` but is treated as an
+  ancillary process: if it exits post-startup, the orchestrator logs a
+  degraded-mode warning and keeps the rest of the stack running. Restart
+  `pnpm dev` to recover webhook forwarding.
+- Set `MURPH_DEV_SKIP_STRIPE_LISTEN=1` to fully opt out of the auto-listener
+  (for example, when running integration tests with a mocked webhook surface).
+- Captured secret bytes are redacted before they reach the orchestrator's
+  stdout pipe, stderr pipe, and output-tail buffers, so operator logs never
+  contain the live `whsec_...`.
+
 ## Hosted public origin and Cloudflare callback auth
 
 This section is the operator-facing contract for hosted public origin and the

--- a/scripts/dev-hosted-local/config.test.ts
+++ b/scripts/dev-hosted-local/config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   parsePort,
   parseWorkerProtocol,
+  printHelp,
   resolveHostedLocalDevConfig,
 } from "./config.ts";
 
@@ -10,6 +11,7 @@ describe("resolveHostedLocalDevConfig", () => {
   it("returns the documented defaults", () => {
     expect(resolveHostedLocalDevConfig({})).toEqual({
       skipPrismaMigrate: false,
+      skipStripeListen: false,
       skipWeb: false,
       skipVercelPull: false,
       webHost: "127.0.0.1",
@@ -25,6 +27,7 @@ describe("resolveHostedLocalDevConfig", () => {
     expect(
       resolveHostedLocalDevConfig({
         MURPH_DEV_SKIP_PRISMA_MIGRATE: "1",
+        MURPH_DEV_SKIP_STRIPE_LISTEN: "1",
         MURPH_DEV_SKIP_WEB: "1",
         MURPH_DEV_SKIP_VERCEL_PULL: "1",
         MURPH_DEV_WEB_HOST: "0.0.0.0",
@@ -36,6 +39,7 @@ describe("resolveHostedLocalDevConfig", () => {
       }),
     ).toEqual({
       skipPrismaMigrate: true,
+      skipStripeListen: true,
       skipWeb: true,
       skipVercelPull: true,
       webHost: "0.0.0.0",
@@ -45,6 +49,27 @@ describe("resolveHostedLocalDevConfig", () => {
       workerPort: 8795,
       workerProtocol: "https",
     });
+  });
+});
+
+describe("printHelp", () => {
+  it("documents the stripe listener skip flag", () => {
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      printHelp();
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    const output = writes.join("");
+    expect(output).toContain("MURPH_DEV_SKIP_STRIPE_LISTEN=1");
+    expect(output).toContain("stripe listen");
   });
 });
 

--- a/scripts/dev-hosted-local/config.ts
+++ b/scripts/dev-hosted-local/config.ts
@@ -13,6 +13,7 @@ export function resolveHostedLocalDevConfig(
 ): HostedLocalDevConfig {
   return {
     skipPrismaMigrate: env.MURPH_DEV_SKIP_PRISMA_MIGRATE === "1",
+    skipStripeListen: env.MURPH_DEV_SKIP_STRIPE_LISTEN === "1",
     skipWeb: env.MURPH_DEV_SKIP_WEB === "1",
     skipVercelPull: env.MURPH_DEV_SKIP_VERCEL_PULL === "1",
     webHost: env.MURPH_DEV_WEB_HOST?.trim() || DEFAULT_WEB_HOST,
@@ -62,6 +63,7 @@ export function printHelp(): void {
       "Optional environment overrides:",
       "  MURPH_DEV_SKIP_VERCEL_PULL=1        Reuse the current shell env instead of pulling Vercel development env",
       "  MURPH_DEV_SKIP_PRISMA_MIGRATE=1     Skip prisma migrate deploy before startup",
+      "  MURPH_DEV_SKIP_STRIPE_LISTEN=1      Skip the auto-launched `stripe listen` forwarder for hosted onboarding webhooks",
       "  MURPH_DEV_SKIP_WEB=1                Start only the local worker/container lane",
       "  MURPH_DEV_WEB_HOST=127.0.0.1        Hosted web listen host",
       "  MURPH_DEV_WEB_PORT=3000             Hosted web listen port",

--- a/scripts/dev-hosted-local/environment.test.ts
+++ b/scripts/dev-hosted-local/environment.test.ts
@@ -19,6 +19,7 @@ import type {
 const localConfig: HostedLocalDevConfig = {
   skipWeb: false,
   skipPrismaMigrate: false,
+  skipStripeListen: false,
   skipVercelPull: false,
   webHost: "127.0.0.1",
   webPort: 3000,

--- a/scripts/dev-hosted-local/runtime.stripe.test.ts
+++ b/scripts/dev-hosted-local/runtime.stripe.test.ts
@@ -146,6 +146,37 @@ describe("spawnStripeListenerWithSecretCapture", () => {
     expect(stderrTarget.text()).not.toContain("whsec_test_secret_value_abc");
   });
 
+  it("captures the whsec when the Stripe CLI prints the startup banner to stderr", async () => {
+    // Current Stripe CLI (1.34+) prints the "Ready! ... whsec_..." banner on
+    // stderr, not stdout. The capture helper must scan both streams so this
+    // release keeps working.
+    const { runtime } = await loadRuntimeWithStripeChild({
+      stdoutFirstLine: "",
+      stderrBeforeCapture:
+        "Getting ready...\nReady! You are using Stripe API Version [2023-10-16]. Your webhook signing secret is whsec_only_on_stderr_0123456789abcdef (^C to quit)\n",
+    });
+
+    const stdoutTarget = new CapturingWritable();
+    const stderrTarget = new CapturingWritable();
+
+    const result = await runtime.spawnStripeListenerWithSecretCapture({
+      args: ["listen"],
+      command: "stripe",
+      env: {},
+      pipeOutput: true,
+      stderrTarget,
+      stdoutTarget,
+      timeoutMs: 2_000,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(result.secret).toBe("whsec_only_on_stderr_0123456789abcdef");
+    expect(stderrTarget.text()).not.toContain("whsec_only_on_stderr");
+    expect(stderrTarget.text()).toContain("[redacted whsec]");
+    expect(result.child.stderrText()).not.toContain("whsec_only_on_stderr");
+  });
+
   it("rejects with StripeCliMissingError when stripe is not on PATH", async () => {
     const { runtime } = await loadRuntimeWithStripeChild({ __enoent: true });
 

--- a/scripts/dev-hosted-local/runtime.stripe.test.ts
+++ b/scripts/dev-hosted-local/runtime.stripe.test.ts
@@ -1,0 +1,244 @@
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+class CapturingWritable extends Writable {
+  readonly chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: string,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    callback();
+  }
+
+  text(): string {
+    return this.chunks.join("");
+  }
+}
+
+interface StripeSpawnScript {
+  readonly postCaptureStdoutChunks?: readonly string[];
+  readonly stderrAfterCapture?: string;
+  readonly stderrBeforeCapture?: string;
+  readonly stdoutFirstLine: string;
+  readonly stdoutFollowUp?: string;
+}
+
+function createStripeChild(script: StripeSpawnScript) {
+  const child = new EventEmitter() as EventEmitter & {
+    kill: (signal?: NodeJS.Signals | number) => boolean;
+    killCalls: Array<NodeJS.Signals | number | undefined>;
+    off: (event: string, listener: (...args: unknown[]) => void) => EventEmitter;
+    pid: number;
+    stderr: PassThrough;
+    stdout: PassThrough;
+  };
+  child.killCalls = [];
+  child.kill = (signal?: NodeJS.Signals | number): boolean => {
+    child.killCalls.push(signal);
+    return true;
+  };
+  child.pid = 9876;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+
+  queueMicrotask(() => {
+    if (script.stderrBeforeCapture) {
+      child.stderr.write(script.stderrBeforeCapture);
+    }
+    child.stdout.write(script.stdoutFirstLine);
+    queueMicrotask(() => {
+      if (script.stdoutFollowUp) {
+        child.stdout.write(script.stdoutFollowUp);
+      }
+      if (script.stderrAfterCapture) {
+        child.stderr.write(script.stderrAfterCapture);
+      }
+      const postCapture = script.postCaptureStdoutChunks ?? [];
+      for (const chunk of postCapture) {
+        child.stdout.write(chunk);
+      }
+    });
+  });
+
+  return child;
+}
+
+async function loadRuntimeWithStripeChild(
+  script: StripeSpawnScript | { __enoent: true },
+) {
+  const spawn = vi.fn(() => {
+    if ("__enoent" in script) {
+      const child = new EventEmitter() as EventEmitter & {
+        kill: () => boolean;
+        off: (event: string, listener: (...args: unknown[]) => void) => EventEmitter;
+        pid: number;
+        stderr: PassThrough;
+        stdout: PassThrough;
+      };
+      child.kill = () => true;
+      child.pid = 0;
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      queueMicrotask(() => {
+        const err = new Error("spawn stripe ENOENT") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        child.emit("error", err);
+      });
+      return child;
+    }
+    return createStripeChild(script);
+  });
+
+  vi.doMock("node:child_process", async () => {
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    return { ...actual, spawn };
+  });
+
+  const runtime = await import("./runtime.ts");
+  return { runtime, spawn };
+}
+
+describe("spawnStripeListenerWithSecretCapture", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.doUnmock("node:child_process");
+  });
+
+  it("captures the whsec from listener stdout and redacts it from piped output", async () => {
+    const { runtime } = await loadRuntimeWithStripeChild({
+      stdoutFirstLine:
+        "> Ready! You are using Stripe API Version [2026-04-20]. Your webhook signing secret is whsec_test_secret_value_abc (^C to quit)\n",
+      stdoutFollowUp: "2026-04-21 17:00:00   --> customer.subscription.created [whsec_test_secret_value_abc]\n",
+    });
+
+    const stdoutTarget = new CapturingWritable();
+    const stderrTarget = new CapturingWritable();
+
+    const result = await runtime.spawnStripeListenerWithSecretCapture({
+      args: ["listen", "--forward-to", "http://127.0.0.1:3000/api/hosted-onboarding/stripe/webhook"],
+      command: "stripe",
+      env: { PATH: process.env.PATH ?? "" },
+      pipeOutput: true,
+      stderrTarget,
+      stdoutTarget,
+      timeoutMs: 2_000,
+    });
+
+    // Give the PassThrough a tick to flush the follow-up chunk
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(result.secret).toBe("whsec_test_secret_value_abc");
+
+    const piped = stdoutTarget.text();
+    expect(piped).not.toContain("whsec_test_secret_value_abc");
+    expect(piped).toContain("[redacted whsec]");
+
+    const buffered = result.child.stdoutText();
+    expect(buffered).not.toContain("whsec_test_secret_value_abc");
+    expect(buffered).toContain("[redacted whsec]");
+
+    expect(stderrTarget.text()).not.toContain("whsec_test_secret_value_abc");
+  });
+
+  it("rejects with StripeCliMissingError when stripe is not on PATH", async () => {
+    const { runtime } = await loadRuntimeWithStripeChild({ __enoent: true });
+
+    await expect(
+      runtime.spawnStripeListenerWithSecretCapture({
+        args: ["listen"],
+        command: "stripe",
+        env: {},
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toBeInstanceOf(runtime.StripeCliMissingError);
+  });
+
+  it("times out cleanly when no whsec ever appears", async () => {
+    const { runtime } = await loadRuntimeWithStripeChild({
+      stdoutFirstLine: "> Listening for events on http://127.0.0.1:3000 (no secret yet)\n",
+    });
+
+    await expect(
+      runtime.spawnStripeListenerWithSecretCapture({
+        args: ["listen"],
+        command: "stripe",
+        env: {},
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow(/stripe listen did not print a webhook signing secret/);
+  });
+
+  it("kills the stripe child on timeout so it does not outlive the caller", async () => {
+    const spawnedChildren: ReturnType<typeof createStripeChild>[] = [];
+    const spawn = vi.fn(() => {
+      const child = createStripeChild({
+        stdoutFirstLine: "> Listening for events (format changed, no whsec emitted)\n",
+      });
+      spawnedChildren.push(child);
+      return child;
+    });
+    vi.doMock("node:child_process", async () => {
+      const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+      return { ...actual, spawn };
+    });
+
+    const runtime = await import("./runtime.ts");
+    await expect(
+      runtime.spawnStripeListenerWithSecretCapture({
+        args: ["listen"],
+        command: "stripe",
+        env: {},
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow(/did not print a webhook signing secret/);
+
+    expect(spawnedChildren).toHaveLength(1);
+    expect(spawnedChildren[0]!.killCalls).toEqual(["SIGTERM"]);
+  });
+
+  it("redacts a whsec that is split across chunk boundaries after capture", async () => {
+    const { runtime } = await loadRuntimeWithStripeChild({
+      stdoutFirstLine:
+        "> Ready! You are using Stripe API Version [2026-04-20]. Your webhook signing secret is whsec_split_boundary_xyz (^C to quit)\n",
+      // After capture, the same secret is emitted but split across two chunks
+      // mid-token. A chunk-local redactor would miss this because neither chunk
+      // contains the full substring; only the reassembled line does.
+      postCaptureStdoutChunks: [
+        "2026-04-21 18:00:00   --> event_1 [whsec_split_",
+        "boundary_xyz] hello\n",
+      ],
+    });
+
+    const stdoutTarget = new CapturingWritable();
+    const stderrTarget = new CapturingWritable();
+
+    const result = await runtime.spawnStripeListenerWithSecretCapture({
+      args: ["listen"],
+      command: "stripe",
+      env: {},
+      pipeOutput: true,
+      stderrTarget,
+      stdoutTarget,
+      timeoutMs: 2_000,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(result.secret).toBe("whsec_split_boundary_xyz");
+
+    const piped = stdoutTarget.text();
+    expect(piped).not.toContain("whsec_split_boundary_xyz");
+    expect(piped).toContain("[redacted whsec]");
+
+    const buffered = result.child.stdoutText();
+    expect(buffered).not.toContain("whsec_split_boundary_xyz");
+    expect(buffered).toContain("[redacted whsec]");
+  });
+});
+

--- a/scripts/dev-hosted-local/runtime.ts
+++ b/scripts/dev-hosted-local/runtime.ts
@@ -212,6 +212,10 @@ export async function spawnStripeListenerWithSecretCapture(input: {
         );
       }, input.timeoutMs);
 
+      // Stripe CLI versions differ on which stream carries the startup
+      // "Ready!" banner that contains `whsec_...`: older builds print it to
+      // stdout, current builds print it to stderr. Scan both so the capture
+      // keeps working as the CLI evolves.
       const onStdout = (chunk: string | Buffer): void => {
         stdoutCapture.append(chunk);
         const match = /whsec_[A-Za-z0-9_]+/.exec(stdoutCapture.read());
@@ -223,6 +227,11 @@ export async function spawnStripeListenerWithSecretCapture(input: {
 
       const onStderr = (chunk: string | Buffer): void => {
         stderrCapture.append(chunk);
+        const match = /whsec_[A-Za-z0-9_]+/.exec(stderrCapture.read());
+        if (match) {
+          cleanup();
+          resolve(match[0]);
+        }
       };
 
       const onExit = (code: number | null): void => {

--- a/scripts/dev-hosted-local/runtime.ts
+++ b/scripts/dev-hosted-local/runtime.ts
@@ -5,6 +5,7 @@ import https from "node:https";
 import net from "node:net";
 import path from "node:path";
 import process from "node:process";
+import { PassThrough } from "node:stream";
 
 import {
   HEALTH_POLL_INTERVAL_MS,
@@ -112,14 +113,14 @@ export async function assertPortAvailable(host: string, port: number, message: s
 }
 
 export function spawnChildProcess(
-  name: "cloudflare" | "web",
+  name: "cloudflare" | "stripe" | "web",
   command: string,
   args: string[],
   env: NodeJS.ProcessEnv,
   input: {
     pipeOutput?: boolean;
-    stderrTarget?: NodeJS.WriteStream;
-    stdoutTarget?: NodeJS.WriteStream;
+    stderrTarget?: NodeJS.WritableStream;
+    stdoutTarget?: NodeJS.WritableStream;
   } = {},
 ): BufferedNamedChildProcess {
   const child = spawn(command, args, {
@@ -163,6 +164,186 @@ export async function waitForFirstChildExit(
       entry.child.once("exit", () => resolve(entry));
     }
   });
+}
+
+export class StripeCliMissingError extends Error {
+  constructor() {
+    super("stripe CLI executable was not found on PATH");
+    this.name = "StripeCliMissingError";
+  }
+}
+
+export interface StripeListenerSpawnResult {
+  child: BufferedNamedChildProcess;
+  secret: string;
+}
+
+export async function spawnStripeListenerWithSecretCapture(input: {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  pipeOutput?: boolean;
+  stderrTarget?: NodeJS.WritableStream;
+  stdoutTarget?: NodeJS.WritableStream;
+  timeoutMs: number;
+}): Promise<StripeListenerSpawnResult> {
+  const child = spawn(input.command, input.args, {
+    cwd: repoRoot,
+    detached: process.platform !== "win32",
+    env: input.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+
+  const stdoutCapture = createOutputBuffer();
+  const stderrCapture = createOutputBuffer();
+
+  let secret: string;
+  try {
+    secret = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `stripe listen did not print a webhook signing secret within ${input.timeoutMs}ms; stderr: ${tail(stderrCapture.read(), 512)}`,
+          ),
+        );
+      }, input.timeoutMs);
+
+      const onStdout = (chunk: string | Buffer): void => {
+        stdoutCapture.append(chunk);
+        const match = /whsec_[A-Za-z0-9_]+/.exec(stdoutCapture.read());
+        if (match) {
+          cleanup();
+          resolve(match[0]);
+        }
+      };
+
+      const onStderr = (chunk: string | Buffer): void => {
+        stderrCapture.append(chunk);
+      };
+
+      const onExit = (code: number | null): void => {
+        cleanup();
+        reject(
+          new Error(
+            `stripe listen exited with code ${code ?? "unknown"} before printing a secret; stderr: ${tail(stderrCapture.read(), 512)}`,
+          ),
+        );
+      };
+
+      const onError = (error: NodeJS.ErrnoException): void => {
+        cleanup();
+        if (error.code === "ENOENT") {
+          reject(new StripeCliMissingError());
+          return;
+        }
+        reject(error);
+      };
+
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        child.stdout?.off("data", onStdout);
+        child.stderr?.off("data", onStderr);
+        child.off("exit", onExit);
+        child.off("error", onError);
+      };
+
+      child.stdout?.on("data", onStdout);
+      child.stderr?.on("data", onStderr);
+      child.once("exit", onExit);
+      child.once("error", onError);
+    });
+  } catch (error) {
+    // Pre-capture rejection must not leak a detached `stripe listen` process.
+    // StripeCliMissingError means spawn ENOENT'd, so there is no running child.
+    // Otherwise kill the child best-effort — if it has already exited, kill()
+    // returns false without throwing, so this stays safe either way.
+    if (!(error instanceof StripeCliMissingError)) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // best-effort; child may already be gone
+      }
+    }
+    throw error;
+  }
+
+  // Line-buffered redactor: holds partial lines until a newline arrives so a
+  // `whsec_...` split across chunk boundaries still gets replaced before any
+  // downstream consumer (pipe target or text buffer) sees it.
+  const stdoutLineRedactor = createLineBufferedSecretRedactor(secret);
+  const stderrLineRedactor = createLineBufferedSecretRedactor(secret);
+
+  const stdoutBuffer = createOutputBuffer();
+  const stderrBuffer = createOutputBuffer();
+
+  const redactedStdout = new PassThrough();
+  const redactedStderr = new PassThrough();
+  redactedStdout.setEncoding("utf8");
+  redactedStderr.setEncoding("utf8");
+
+  redactedStdout.on("data", (chunk: string | Buffer) => {
+    stdoutBuffer.append(chunk.toString());
+  });
+  redactedStderr.on("data", (chunk: string | Buffer) => {
+    stderrBuffer.append(chunk.toString());
+  });
+
+  if (input.pipeOutput !== false) {
+    pipeWithPrefix("stripe", redactedStdout, input.stdoutTarget ?? process.stdout);
+    pipeWithPrefix("stripe", redactedStderr, input.stderrTarget ?? process.stderr);
+  }
+
+  const stdoutInitial = stdoutLineRedactor.push(stdoutCapture.read());
+  if (stdoutInitial.length > 0) {
+    redactedStdout.write(stdoutInitial);
+  }
+  const stderrInitial = stderrLineRedactor.push(stderrCapture.read());
+  if (stderrInitial.length > 0) {
+    redactedStderr.write(stderrInitial);
+  }
+
+  child.stdout?.on("data", (chunk: string | Buffer) => {
+    const redacted = stdoutLineRedactor.push(chunk.toString());
+    if (redacted.length > 0) {
+      redactedStdout.write(redacted);
+    }
+  });
+  child.stderr?.on("data", (chunk: string | Buffer) => {
+    const redacted = stderrLineRedactor.push(chunk.toString());
+    if (redacted.length > 0) {
+      redactedStderr.write(redacted);
+    }
+  });
+  child.stdout?.on("end", () => {
+    const flushed = stdoutLineRedactor.flush();
+    if (flushed.length > 0) {
+      redactedStdout.write(flushed);
+    }
+    redactedStdout.end();
+  });
+  child.stderr?.on("end", () => {
+    const flushed = stderrLineRedactor.flush();
+    if (flushed.length > 0) {
+      redactedStderr.write(flushed);
+    }
+    redactedStderr.end();
+  });
+
+  return {
+    child: {
+      child,
+      name: "stripe",
+      stderrTail: (maxChars?: number): string => tail(stderrBuffer.read(), maxChars),
+      stderrText: (): string => stderrBuffer.read(),
+      stdoutTail: (maxChars?: number): string => tail(stdoutBuffer.read(), maxChars),
+      stdoutText: (): string => stdoutBuffer.read(),
+    },
+    secret,
+  };
 }
 
 export async function runCommand(
@@ -824,12 +1005,14 @@ async function requestStatus(input: {
 function pipeWithPrefix(
   prefix: string,
   stream: NodeJS.ReadableStream | null | undefined,
-  target: NodeJS.WriteStream,
+  target: NodeJS.WritableStream,
+  options: { redactor?: (line: string) => string } = {},
 ): void {
   if (!stream) {
     return;
   }
 
+  const redact = options.redactor ?? ((line: string): string => line);
   let buffer = "";
 
   stream.on("data", (chunk: string | Buffer) => {
@@ -843,13 +1026,13 @@ function pipeWithPrefix(
 
       const line = buffer.slice(0, newlineIndex);
       buffer = buffer.slice(newlineIndex + 1);
-      target.write(`[${prefix}] ${line}\n`);
+      target.write(`[${prefix}] ${redact(line)}\n`);
     }
   });
 
   stream.on("end", () => {
     if (buffer.length > 0) {
-      target.write(`[${prefix}] ${buffer}\n`);
+      target.write(`[${prefix}] ${redact(buffer)}\n`);
       buffer = "";
     }
   });
@@ -867,6 +1050,33 @@ function createOutputBuffer(): {
     },
     read(): string {
       return value;
+    },
+  };
+}
+
+function createLineBufferedSecretRedactor(secret: string): {
+  push(chunk: string): string;
+  flush(): string;
+} {
+  let pending = "";
+  const redactLine = (text: string): string =>
+    text.includes(secret) ? text.split(secret).join("[redacted whsec]") : text;
+
+  return {
+    push(chunk: string): string {
+      pending += chunk;
+      const lastNewline = pending.lastIndexOf("\n");
+      if (lastNewline < 0) {
+        return "";
+      }
+      const complete = pending.slice(0, lastNewline + 1);
+      pending = pending.slice(lastNewline + 1);
+      return redactLine(complete);
+    },
+    flush(): string {
+      const last = pending;
+      pending = "";
+      return redactLine(last);
     },
   };
 }

--- a/scripts/dev-hosted-local/stack.test.ts
+++ b/scripts/dev-hosted-local/stack.test.ts
@@ -1,3 +1,5 @@
+import { Writable } from "node:stream";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type {
@@ -6,8 +8,26 @@ import type {
   HostedLocalDevConfig,
 } from "./types.ts";
 
+class CapturingWritable extends Writable {
+  readonly chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: string,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    callback();
+  }
+
+  text(): string {
+    return this.chunks.join("");
+  }
+}
+
 const defaultConfig: HostedLocalDevConfig = {
   skipPrismaMigrate: false,
+  skipStripeListen: true,
   skipWeb: false,
   skipVercelPull: false,
   webHost: "127.0.0.1",
@@ -27,18 +47,42 @@ const runCommand = vi.fn<(
     name: "setup";
   },
 ) => Promise<void>>(async () => {});
+let nextChildPid = 100;
 const spawnChildProcess = vi.fn<
   (
-    name: "cloudflare" | "web",
+    name: "cloudflare" | "stripe" | "web",
     command: string,
     args: string[],
     env: NodeJS.ProcessEnv,
     input?: {
       pipeOutput?: boolean;
-      stderrTarget?: NodeJS.WriteStream;
-      stdoutTarget?: NodeJS.WriteStream;
+      stderrTarget?: NodeJS.WritableStream;
+      stdoutTarget?: NodeJS.WritableStream;
     },
   ) => BufferedNamedChildProcess
+>((name) =>
+  createBufferedChild({
+    exitCode: null,
+    name,
+    pid: nextChildPid++,
+  }),
+);
+class StripeCliMissingError extends Error {
+  constructor() {
+    super("stripe CLI executable was not found on PATH");
+    this.name = "StripeCliMissingError";
+  }
+}
+const spawnStripeListenerWithSecretCapture = vi.fn<
+  (input: {
+    command: string;
+    args: string[];
+    env: NodeJS.ProcessEnv;
+    pipeOutput?: boolean;
+    stderrTarget?: NodeJS.WritableStream;
+    stdoutTarget?: NodeJS.WritableStream;
+    timeoutMs: number;
+  }) => Promise<{ child: BufferedNamedChildProcess; secret: string }>
 >();
 const terminateChildProcessAndWait = vi.fn(async () => {});
 const waitForHealthyHttpEndpoint = vi.fn(async () => {});
@@ -100,6 +144,8 @@ vi.mock("./runtime.ts", () => ({
   collectDockerDevDiagnostics,
   runCommand,
   spawnChildProcess,
+  spawnStripeListenerWithSecretCapture,
+  StripeCliMissingError,
   terminateChildProcessAndWait,
   waitForFirstChildExit,
   waitForHealthyHttpEndpoint,
@@ -117,7 +163,7 @@ vi.mock("./vercel.ts", () => ({
 
 function createBufferedChild(input: {
   exitCode: number | null;
-  name: "cloudflare" | "web";
+  name: "cloudflare" | "stripe" | "web";
   pid: number;
 }): BufferedNamedChildProcess {
   const child: HostedLocalChildProcess = {
@@ -490,5 +536,236 @@ describe("hosted local dev stack", () => {
       expect.any(Object),
       expect.any(Object),
     );
+  });
+
+  describe("stripe webhook listener", () => {
+    async function withListenerConfig(
+      overrides: Partial<HostedLocalDevConfig>,
+      run: () => Promise<void>,
+    ): Promise<void> {
+      const configModule = await import("./config.ts");
+      vi.mocked(configModule.resolveHostedLocalDevConfig).mockReturnValueOnce({
+        ...defaultConfig,
+        skipStripeListen: false,
+        ...overrides,
+      });
+      await run();
+    }
+
+    it("warns and continues without the listener when the Stripe CLI is missing", async () => {
+      const stderrTarget = new CapturingWritable();
+      spawnStripeListenerWithSecretCapture.mockRejectedValueOnce(
+        new StripeCliMissingError(),
+      );
+
+      await withListenerConfig({}, async () => {
+        const { startHostedLocalDevStack } = await import("./stack.ts");
+
+        const stack = await startHostedLocalDevStack({
+          env: process.env,
+          stderrTarget,
+        });
+        await stack.ready;
+        await stack.stop();
+
+        expect(spawnStripeListenerWithSecretCapture).toHaveBeenCalledTimes(1);
+        const writes = stderrTarget.text();
+        expect(writes).toContain("Stripe CLI not found on PATH");
+        expect(writes).toContain("brew install stripe/stripe-cli/stripe");
+        expect(writes).toContain("MURPH_DEV_SKIP_STRIPE_LISTEN=1");
+        expect(stack.processes.stripe).toBeNull();
+      });
+    });
+
+    it("captures the listener's whsec and injects it into the web child env", async () => {
+      const stderrTarget = new CapturingWritable();
+      const listenerChild = createBufferedChild({
+        exitCode: null,
+        name: "stripe",
+        pid: 911,
+      });
+      spawnStripeListenerWithSecretCapture.mockResolvedValueOnce({
+        child: listenerChild,
+        secret: "whsec_captured_abc123",
+      });
+
+      await withListenerConfig({}, async () => {
+        const { startHostedLocalDevStack } = await import("./stack.ts");
+
+        const stack = await startHostedLocalDevStack({
+          env: process.env,
+          stderrTarget,
+        });
+        await stack.ready;
+        await stack.stop();
+
+        expect(spawnStripeListenerWithSecretCapture).toHaveBeenCalledWith(
+          expect.objectContaining({
+            args: [
+              "listen",
+              "--forward-to",
+              "http://127.0.0.1:3000/api/hosted-onboarding/stripe/webhook",
+            ],
+            command: "stripe",
+            timeoutMs: 15_000,
+          }),
+        );
+        expect(spawnChildProcess).toHaveBeenCalledWith(
+          "web",
+          "pnpm",
+          expect.any(Array),
+          expect.objectContaining({
+            STRIPE_WEBHOOK_SECRET: "whsec_captured_abc123",
+          }),
+          expect.any(Object),
+        );
+        expect(stack.processes.stripe).toBe(listenerChild);
+      });
+    });
+
+    it("preserves a shell-provided STRIPE_WEBHOOK_SECRET over the captured value", async () => {
+      const stderrTarget = new CapturingWritable();
+      spawnStripeListenerWithSecretCapture.mockResolvedValueOnce({
+        child: createBufferedChild({ exitCode: null, name: "stripe", pid: 912 }),
+        secret: "whsec_captured_zzz",
+      });
+      vi.stubEnv("STRIPE_WEBHOOK_SECRET", "whsec_shell_override");
+
+      await withListenerConfig({}, async () => {
+        const { startHostedLocalDevStack } = await import("./stack.ts");
+
+        const stack = await startHostedLocalDevStack({
+          env: process.env,
+          stderrTarget,
+        });
+        await stack.ready;
+        await stack.stop();
+
+        expect(spawnChildProcess).toHaveBeenCalledWith(
+          "web",
+          "pnpm",
+          expect.any(Array),
+          expect.objectContaining({
+            STRIPE_WEBHOOK_SECRET: "whsec_shell_override",
+          }),
+          expect.any(Object),
+        );
+        expect(stderrTarget.text()).toContain("does not match the listener");
+      });
+    });
+
+    it("discards a pulled-only STRIPE_WEBHOOK_SECRET in favor of the captured value", async () => {
+      const stderrTarget = new CapturingWritable();
+      spawnStripeListenerWithSecretCapture.mockResolvedValueOnce({
+        child: createBufferedChild({ exitCode: null, name: "stripe", pid: 913 }),
+        secret: "whsec_captured_fresh",
+      });
+      const environmentModule = await import("./environment.ts");
+      vi.mocked(environmentModule.readSimpleEnvFile).mockResolvedValueOnce({
+        STRIPE_WEBHOOK_SECRET: "whsec_stale_from_vercel",
+      });
+
+      await withListenerConfig({}, async () => {
+        const { startHostedLocalDevStack } = await import("./stack.ts");
+
+        const stack = await startHostedLocalDevStack({
+          env: process.env,
+          stderrTarget,
+        });
+        await stack.ready;
+        await stack.stop();
+
+        expect(spawnChildProcess).toHaveBeenCalledWith(
+          "web",
+          "pnpm",
+          expect.any(Array),
+          expect.objectContaining({
+            STRIPE_WEBHOOK_SECRET: "whsec_captured_fresh",
+          }),
+          expect.any(Object),
+        );
+      });
+    });
+
+    it("skips the listener when MURPH_DEV_SKIP_WEB=1 is set", async () => {
+      await withListenerConfig({ skipWeb: true }, async () => {
+        const { startHostedLocalDevStack } = await import("./stack.ts");
+
+        const stack = await startHostedLocalDevStack({
+          env: process.env,
+        });
+        await stack.ready;
+        await stack.stop();
+
+        expect(spawnStripeListenerWithSecretCapture).not.toHaveBeenCalled();
+        expect(stack.processes.stripe).toBeNull();
+      });
+    });
+
+    it("skips the listener when MURPH_DEV_SKIP_STRIPE_LISTEN=1 is set", async () => {
+      // default config already has skipStripeListen: true
+      const { startHostedLocalDevStack } = await import("./stack.ts");
+
+      const stack = await startHostedLocalDevStack({
+        env: process.env,
+      });
+      await stack.ready;
+      await stack.stop();
+
+      expect(spawnStripeListenerWithSecretCapture).not.toHaveBeenCalled();
+      expect(stack.processes.stripe).toBeNull();
+    });
+
+    it("does not participate in waitForFirstChildExit when the listener dies after ready", async () => {
+      const stderrTarget = new CapturingWritable();
+      const listenerChild = createBufferedChild({
+        exitCode: null,
+        name: "stripe",
+        pid: 914,
+      });
+      let recordedExitHandler:
+        | ((code: number | null, signal: NodeJS.Signals | null) => void)
+        | null = null;
+      const onceMock = vi.mocked(listenerChild.child.once);
+      onceMock.mockImplementation(
+        function (this: typeof listenerChild.child, event, handler) {
+          if (event === "exit") {
+            recordedExitHandler = handler;
+          }
+          return this;
+        },
+      );
+      spawnStripeListenerWithSecretCapture.mockResolvedValueOnce({
+        child: listenerChild,
+        secret: "whsec_captured_post_ready",
+      });
+
+      await withListenerConfig({}, async () => {
+        const { startHostedLocalDevStack } = await import("./stack.ts");
+
+        const stack = await startHostedLocalDevStack({
+          env: process.env,
+          stderrTarget,
+        });
+        await stack.ready;
+
+        expect(waitForFirstChildExit).toHaveBeenCalledTimes(1);
+        const firstCallArgs = waitForFirstChildExit.mock.calls[0];
+        const watchedChildren = firstCallArgs?.[0] ?? [];
+        expect(
+          watchedChildren.some(
+            (entry: BufferedNamedChildProcess) => entry.name === "stripe",
+          ),
+        ).toBe(false);
+
+        // Simulate post-ready listener exit
+        recordedExitHandler?.(1, "SIGTERM");
+        const writes = stderrTarget.text();
+        expect(writes).toContain("listener exited");
+        expect(writes).toContain("Restart `pnpm dev`");
+
+        await stack.stop();
+      });
+    });
   });
 });

--- a/scripts/dev-hosted-local/stack.ts
+++ b/scripts/dev-hosted-local/stack.ts
@@ -31,6 +31,8 @@ import {
   collectDockerDevDiagnostics,
   runCommand,
   spawnChildProcess,
+  spawnStripeListenerWithSecretCapture,
+  StripeCliMissingError,
   terminateChildProcessAndWait,
   waitForFirstChildExit,
   waitForHealthyHttpEndpoint,
@@ -55,6 +57,7 @@ export interface HostedLocalDevStack {
   oidcToken: string;
   processes: {
     cloudflare: BufferedNamedChildProcess;
+    stripe: BufferedNamedChildProcess | null;
     web: BufferedNamedChildProcess | null;
   };
   ready: Promise<void>;
@@ -66,11 +69,14 @@ export interface HostedLocalDevStack {
   workerBaseUrl: string;
 }
 
+const STRIPE_WEBHOOK_FORWARD_PATH = "/api/hosted-onboarding/stripe/webhook";
+const STRIPE_LISTENER_SECRET_CAPTURE_TIMEOUT_MS = 15_000;
+
 export async function startHostedLocalDevStack(input: {
   env: NodeJS.ProcessEnv;
   pipeOutput?: boolean;
-  stderrTarget?: NodeJS.WriteStream;
-  stdoutTarget?: NodeJS.WriteStream;
+  stderrTarget?: NodeJS.WritableStream;
+  stdoutTarget?: NodeJS.WritableStream;
 }): Promise<HostedLocalDevStack> {
   const initialEnv = { ...input.env } satisfies NodeJS.ProcessEnv;
   const config = resolveHostedLocalDevConfig(initialEnv);
@@ -112,6 +118,7 @@ export async function startHostedLocalDevStack(input: {
   let stopped = false;
   let stopPromise: Promise<void> | null = null;
   const children: BufferedNamedChildProcess[] = [];
+  let stripeListener: BufferedNamedChildProcess | null = null;
   let workerRuntimeEnv: NodeJS.ProcessEnv | null = null;
 
   try {
@@ -212,7 +219,10 @@ export async function startHostedLocalDevStack(input: {
       runtimeEnv.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_ANNUAL,
     );
     warnForMissingEnv("STRIPE_SECRET_KEY", runtimeEnv.STRIPE_SECRET_KEY);
-    warnForMissingEnv("STRIPE_WEBHOOK_SECRET", runtimeEnv.STRIPE_WEBHOOK_SECRET);
+    const stripeListenerWillCaptureSecret = !config.skipStripeListen && !config.skipWeb;
+    if (!stripeListenerWillCaptureSecret) {
+      warnForMissingEnv("STRIPE_WEBHOOK_SECRET", runtimeEnv.STRIPE_WEBHOOK_SECRET);
+    }
 
     await runCommand("pnpm", ["--dir", "apps/web", "prisma:generate"], {
       cwd: repoRoot,
@@ -267,6 +277,32 @@ export async function startHostedLocalDevStack(input: {
     });
     children.push(cloudflareProcess);
 
+    stripeListener = await maybeStartStripeWebhookListener({
+      config,
+      initialEnv,
+      pipeOutput: input.pipeOutput,
+      repoEnv,
+      runtimeEnv,
+      stderrTarget: input.stderrTarget,
+      stdoutTarget: input.stdoutTarget,
+    });
+    if (stripeListener !== null) {
+      const listenerChild = stripeListener;
+      listenerChild.child.once("exit", (code, signal) => {
+        if (stopped) {
+          return;
+        }
+        const stderrTarget = input.stderrTarget ?? process.stderr;
+        stderrTarget.write(
+          [
+            `[stripe] listener exited (code=${code ?? "unknown"}, signal=${signal ?? "none"}); `,
+            "webhooks are no longer being forwarded to this dev server. ",
+            "Restart `pnpm dev` to recover.\n",
+          ].join(""),
+        );
+      });
+    }
+
     const webProcess = config.skipWeb
       ? null
       : spawnChildProcess("web", "pnpm", [
@@ -318,6 +354,9 @@ export async function startHostedLocalDevStack(input: {
         stopped = true;
         for (const { child } of children) {
           await terminateChildProcessAndWait(child, { signal });
+        }
+        if (stripeListener !== null) {
+          await terminateChildProcessAndWait(stripeListener.child, { signal });
         }
         if (workerRuntimeEnv) {
           await cleanupHostedRunnerContainers({
@@ -374,20 +413,29 @@ export async function startHostedLocalDevStack(input: {
       }
     })();
 
+    const reportingChildren = stripeListener === null
+      ? children
+      : [...children, stripeListener];
+
     return {
       config,
       oidcIdentity,
       oidcToken,
       processes: {
         cloudflare: cloudflareProcess,
+        stripe: stripeListener,
         web: webProcess,
       },
       ready,
       stderrTail: (maxChars?: number): string => tail(combineChildOutput(
-        children.map((child) => `[${child.name}:stderr]\n${child.stderrText()}`),
+        reportingChildren.map(
+          (child) => `[${child.name}:stderr]\n${child.stderrText()}`,
+        ),
       ), maxChars),
       stdoutTail: (maxChars?: number): string => tail(combineChildOutput(
-        children.map((child) => `[${child.name}:stdout]\n${child.stdoutText()}`),
+        reportingChildren.map(
+          (child) => `[${child.name}:stdout]\n${child.stdoutText()}`,
+        ),
       ), maxChars),
       stop,
       waitForExit: async (): Promise<NamedChildProcess> => {
@@ -399,6 +447,9 @@ export async function startHostedLocalDevStack(input: {
   } catch (error) {
     for (const { child } of children) {
       await terminateChildProcessAndWait(child, { signal: "SIGTERM" }).catch(() => {});
+    }
+    if (stripeListener !== null) {
+      await terminateChildProcessAndWait(stripeListener.child, { signal: "SIGTERM" }).catch(() => {});
     }
     if (workerRuntimeEnv) {
       await cleanupHostedRunnerContainers({
@@ -420,6 +471,86 @@ export async function startHostedLocalDevStack(input: {
       }
     }
     throw error;
+  }
+}
+
+async function maybeStartStripeWebhookListener(input: {
+  config: HostedLocalDevConfig;
+  initialEnv: NodeJS.ProcessEnv;
+  pipeOutput?: boolean;
+  repoEnv: NodeJS.ProcessEnv;
+  runtimeEnv: NodeJS.ProcessEnv;
+  stderrTarget?: NodeJS.WritableStream;
+  stdoutTarget?: NodeJS.WritableStream;
+}): Promise<BufferedNamedChildProcess | null> {
+  const { config, initialEnv, repoEnv, runtimeEnv } = input;
+  if (config.skipStripeListen || config.skipWeb) {
+    return null;
+  }
+
+  const stderrTarget = input.stderrTarget ?? process.stderr;
+
+  const shellSecret = initialEnv.STRIPE_WEBHOOK_SECRET?.trim() ?? "";
+  const repoSecret = repoEnv.STRIPE_WEBHOOK_SECRET?.trim() ?? "";
+  const trustedExistingSecret = shellSecret.length > 0
+    ? shellSecret
+    : repoSecret.length > 0
+      ? repoSecret
+      : null;
+
+  if (trustedExistingSecret === null) {
+    delete runtimeEnv.STRIPE_WEBHOOK_SECRET;
+  }
+
+  const forwardUrl = `http://${config.webHost}:${config.webPort}${STRIPE_WEBHOOK_FORWARD_PATH}`;
+
+  try {
+    const result = await spawnStripeListenerWithSecretCapture({
+      args: ["listen", "--forward-to", forwardUrl],
+      command: "stripe",
+      env: runtimeEnv,
+      pipeOutput: input.pipeOutput,
+      stderrTarget: input.stderrTarget,
+      stdoutTarget: input.stdoutTarget,
+      timeoutMs: STRIPE_LISTENER_SECRET_CAPTURE_TIMEOUT_MS,
+    });
+
+    if (trustedExistingSecret !== null) {
+      runtimeEnv.STRIPE_WEBHOOK_SECRET = trustedExistingSecret;
+      if (trustedExistingSecret !== result.secret) {
+        stderrTarget.write(
+          [
+            "[stripe] STRIPE_WEBHOOK_SECRET from shell or repo .env does not match the listener's captured secret; ",
+            "hosted webhook signature verification will fail unless the shell value matches the CLI login. ",
+            "Unset the shell value or set MURPH_DEV_SKIP_STRIPE_LISTEN=1 to manage the listener yourself.\n",
+          ].join(""),
+        );
+      }
+    } else {
+      runtimeEnv.STRIPE_WEBHOOK_SECRET = result.secret;
+    }
+
+    return result.child;
+  } catch (error) {
+    if (error instanceof StripeCliMissingError) {
+      stderrTarget.write(
+        [
+          "[stripe] Stripe CLI not found on PATH — skipping the local webhook listener.\n",
+          "[stripe] Install with `brew install stripe/stripe-cli/stripe` (docs: https://docs.stripe.com/stripe-cli)\n",
+          "[stripe] Hosted onboarding checkout will fail locally until a webhook signing secret is available.\n",
+          "[stripe] Set MURPH_DEV_SKIP_STRIPE_LISTEN=1 to silence this warning.\n",
+        ].join(""),
+      );
+      return null;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    stderrTarget.write(
+      `[stripe] Failed to start the Stripe webhook listener: ${message}\n`,
+    );
+    stderrTarget.write(
+      "[stripe] Continuing without the listener; hosted onboarding checkout will fail locally until webhooks are available.\n",
+    );
+    return null;
   }
 }
 

--- a/scripts/dev-hosted-local/types.ts
+++ b/scripts/dev-hosted-local/types.ts
@@ -1,5 +1,6 @@
 export interface HostedLocalDevConfig {
   skipPrismaMigrate: boolean;
+  skipStripeListen: boolean;
   skipWeb: boolean;
   skipVercelPull: boolean;
   webHost: string;
@@ -36,7 +37,7 @@ export interface HostedLocalChildProcess {
 
 export interface NamedChildProcess {
   child: HostedLocalChildProcess;
-  name: "cloudflare" | "web";
+  name: "cloudflare" | "stripe" | "web";
 }
 
 export interface BufferedNamedChildProcess extends NamedChildProcess {


### PR DESCRIPTION
## Summary

- `pnpm dev` now auto-launches `stripe listen --forward-to http://<web-host>:<web-port>/api/hosted-onboarding/stripe/webhook` alongside `cloudflare` and `web`, captures the live `whsec_...` from the listener's startup banner, and injects it into the web child's env as `STRIPE_WEBHOOK_SECRET` before Next.js boots.
- Hosted onboarding checkout works locally for multiple developers who each have their own Stripe CLI login — no second terminal, no shared secret in Vercel Development env. A line-buffered redactor keeps the captured secret out of prefixed stdout, stderr, and tail buffers even when `whsec_` is split across chunk boundaries.
- Env precedence is provenance-aware: an explicit shell or repo-root `.env` value is preserved, but a value arriving only through `vercel env pull` is discarded so a stale `STRIPE_WEBHOOK_SECRET` in Vercel Development cannot silently outrank a live CLI capture.
- Lifecycle: listener is excluded from `waitForFirstChildExit`; post-ready exit logs a one-line degraded-mode warning and keeps the rest of the stack running. Shutdown terminates the listener alongside cloudflare and web. Pre-capture rejection (timeout, premature exit, spawn error) SIGTERMs the child so a slow or broken CLI cannot leak a detached listener.
- Skip gates: `MURPH_DEV_SKIP_STRIPE_LISTEN=1` fully opts out; `MURPH_DEV_SKIP_WEB=1` implies skip. Missing Stripe CLI logs the `brew install stripe/stripe-cli/stripe` hint and continues without the listener.
- Bundled fix commit: current Stripe CLI (1.34+) prints the startup banner containing `whsec_` to stderr; secret capture now scans both stdout and stderr, with a regression test pinning the stderr path.

## Stripe test-mode setup (operator side, one-time)

- Test-mode product and both recurring prices (`launch_monthly`, `launch_annual`) are already created in Stripe. The matching price IDs plus `STRIPE_SECRET_KEY` (test-mode) are in Vercel Development env, so `vercel env pull` gives every dev the same billing surface.
- Each developer still needs their own Stripe CLI login (`brew install stripe/stripe-cli/stripe && stripe login`). The per-developer `whsec_...` is captured at `pnpm dev` time from the live listener, so no webhook secret lives in Vercel Development or in source.
- Remove any stale `STRIPE_WEBHOOK_SECRET` from Vercel Development. The orchestrator now discards pulled-only values for that key so they cannot outrank the captured one, but clearing it keeps the dashboard honest.

## Operator-facing changes

- `apps/web/README.md` gains a "Local Stripe webhook listener" section describing the skip flag, redaction, and degraded-mode semantics.
- Repo-root `README.md` mentions the Stripe CLI as an optional `pnpm dev` tool.
- `apps/web/.env.example` annotates that `STRIPE_WEBHOOK_SECRET` is auto-populated by `pnpm dev` from the local CLI login.

## Test plan

- [x] `pnpm exec tsc --noEmit --project tsconfig.tools.json` — clean on branch
- [x] `pnpm exec vitest run --config scripts/vitest.config.ts` — 85 passed (15 files) including new stripe-specific coverage: secret capture + line-buffered redaction, cross-chunk split redaction, stderr capture path, SIGTERM-on-timeout, provenance-aware env, skip flags, listener-exit-ignored-by-waitForFirstChildExit, printHelp entry
- [x] `pnpm exec tsx --tsconfig tsconfig.base.json scripts/dev-hosted-local.ts --help` — new `MURPH_DEV_SKIP_STRIPE_LISTEN=1` flag entry present
- [x] Direct local scenario: `pnpm dev` with the Stripe CLI installed + logged in, sign-up on `http://localhost:3000`, complete checkout with test card `4242 4242 4242 4242` — Stripe checkout session returns 200 and the captured `whsec_` verifies the webhook signature
- [ ] Verified on the shared Vercel Development environment (blocked for solo verification; Rocketman should reproduce after pulling the branch)

## Known blocker outside this diff

`pnpm typecheck` and `pnpm test:diff` fail with a pre-existing, unrelated `ENOENT: packages/assistant-core/package.json` inside `scripts/check-workspace-package-cycles.mjs`. Reproduces on clean `main` via `git stash`; not caused by this change. Scoped verification mode used per `agent-docs/operations/verification-and-runtime.md`, with tools-only typecheck plus the scripts Vitest suite as the truthful evidence.

## Workflow notes

- Active plan lived at `agent-docs/exec-plans/active/2026-04-21-dev-auto-stripe-listener.md` and was moved to `completed/` by `scripts/finish-task`.
- Plan was Codex-reviewed twice: a pre-implementation consult (9 concrete patches landed into the plan before coding) and, after implementation, the full `simplify` + `task-finish-review` audit subagents per the routing doc. High/medium/low findings from both passes were addressed before the PR.
- Deliberate residual: the stripe helper duplicates a small amount of child-process plumbing because buffer and pipe attachment must wait until secret capture completes. Sharing with `spawnChildProcess` would need a larger refactor and is intentionally out of scope.

## Follow-up (separate PR)

- `scripts/dev-hosted-local/stack.ts` resolves its own config from `initialEnv` (shell) before merging repo-root `.env`, so `MURPH_DEV_WEB_HOST` set in `.env` does not affect orchestrator config. Workaround for operators is to export the value in the shell or prepend it to `pnpm dev`. Worth a small patch to have config resolution read the merged env instead.