### PR TITLE
Redesign experiment detail page + safety section + mobile polish

### DIFF
--- a/agent-docs/exec-plans/completed/2026-04-28-pr-29-experiment-detail-fixes.md
+++ b/agent-docs/exec-plans/completed/2026-04-28-pr-29-experiment-detail-fixes.md
@@ -1,0 +1,28 @@
+# PR 29 Experiment Detail Fixes
+
+## Scope
+
+Fix the merge blockers found in PR #29 for the experiment detail redesign:
+
+- keep expected-signal display data tied to protocol-owned expected values rather than hard-coded fallback estimates
+- update focused experiment-detail tests for the new `ProtocolTab` / `ResearchTab` split
+
+## Files
+
+- `apps/web/src/components/experiments/experiment-detail/protocol-tab.tsx`
+- `apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx`
+- `apps/web/test/biomarker-layout.test.ts`
+- `apps/web/test/experiment-detail-protocol-tab.test.ts`
+
+## Verification
+
+- Focused hosted-web Vitest for `apps/web/test/experiment-detail-protocol-tab.test.ts`
+- `git diff --check`
+- Additional checks if the focused slice reveals type or app-level issues
+
+## Notes
+
+Preserve unrelated dirty edits in `apps/web/next-env.d.ts` and `apps/web/next.config.ts`.
+Status: completed
+Updated: 2026-04-28
+Completed: 2026-04-28

--- a/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
@@ -124,9 +124,9 @@ function ExperimentDetailClientContent({
         <div ref={sentinelRef} aria-hidden="true" className="h-px" />
         <div className="sticky top-0 z-20 -mx-6 flex items-center gap-4 bg-background/95 px-6 py-2 backdrop-blur-md md:-mx-14 md:px-14">
           <TabsList>
-            <TabsTrigger value="protocol">Protocol</TabsTrigger>
-            <TabsTrigger value="research">Research</TabsTrigger>
-            <TabsTrigger value="results">Your Results</TabsTrigger>
+            <TabsTrigger value="protocol" className="px-3 sm:px-5">Protocol</TabsTrigger>
+            <TabsTrigger value="research" className="px-3 sm:px-5">Research</TabsTrigger>
+            <TabsTrigger value="results" className="px-3 sm:px-5">Your Results</TabsTrigger>
           </TabsList>
           <span
             aria-hidden={!isTabsSticky}

--- a/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
@@ -93,7 +93,9 @@ function ExperimentDetailClientContent({
   return (
     <div className="flex flex-col gap-8">
       {experiment.status !== "finished" && (
-        <ExperimentHero image={experiment.image} title={experiment.title} />
+        <div className="-mt-4 md:-mt-6">
+          <ExperimentHero image={experiment.image} />
+        </div>
       )}
 
       <ExperimentHeader

--- a/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
@@ -73,7 +73,7 @@ function ExperimentDetailClientContent({
   const [isTabsSticky, setIsTabsSticky] = useState(false);
   useEffect(() => {
     const node = sentinelRef.current;
-    if (!node) return;
+    if (!node || typeof IntersectionObserver === "undefined") return;
     const observer = new IntersectionObserver(
       ([entry]) => setIsTabsSticky(!entry.isIntersecting),
       { rootMargin: "0px 0px 0px 0px", threshold: 0 },

--- a/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/[experimentId]/experiment-detail-client.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { ExperimentHero } from "@/src/components/experiments/experiment-detail/experiment-hero";
 import { ExperimentHeader } from "@/src/components/experiments/experiment-detail/experiment-header";
 import { ProtocolTab } from "@/src/components/experiments/experiment-detail/protocol-tab";
+import { ResearchTab } from "@/src/components/experiments/experiment-detail/research-tab";
 import { ResultsTab } from "@/src/components/experiments/experiment-detail/results-tab";
 import { BrowserVaultProvider, useBrowserVault } from "@/src/lib/browser-vault/context";
 import { resolveBrowserVaultExperimentRun } from "@/src/lib/browser-vault/experiment-run";
@@ -16,7 +17,7 @@ import {
 } from "@/src/lib/experiments/experiment-detail";
 import type { ExperimentProtocol } from "@/src/types/experiments";
 
-type ExperimentDetailTab = "protocol" | "results";
+type ExperimentDetailTab = "protocol" | "research" | "results";
 
 export function ExperimentDetailClient({
   protocol,
@@ -68,6 +69,19 @@ function ExperimentDetailClientContent({
     ? selectedTabState.value
     : "protocol";
 
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const [isTabsSticky, setIsTabsSticky] = useState(false);
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsTabsSticky(!entry.isIntersecting),
+      { rootMargin: "0px 0px 0px 0px", threshold: 0 },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
   if (!hasCurrentProtocolContract) {
     return (
       <div className="flex min-h-40 items-center justify-center rounded-xl border border-secondary/25 bg-card/90 px-6 py-8 text-sm text-muted-foreground">
@@ -105,12 +119,34 @@ function ExperimentDetailClientContent({
         })}
         className="w-full"
       >
-        <TabsList>
-          <TabsTrigger value="protocol">Protocol</TabsTrigger>
-          <TabsTrigger value="results">Your Results</TabsTrigger>
-        </TabsList>
+        <div ref={sentinelRef} aria-hidden="true" className="h-px" />
+        <div className="sticky top-0 z-20 -mx-6 flex items-center gap-4 bg-background/95 px-6 py-2 backdrop-blur-md md:-mx-14 md:px-14">
+          <TabsList>
+            <TabsTrigger value="protocol">Protocol</TabsTrigger>
+            <TabsTrigger value="research">Research</TabsTrigger>
+            <TabsTrigger value="results">Your Results</TabsTrigger>
+          </TabsList>
+          <span
+            aria-hidden={!isTabsSticky}
+            className="ml-auto min-w-0 truncate font-serif text-sm/5 font-semibold text-foreground transition-opacity duration-150 md:text-base/6"
+            style={{
+              opacity: isTabsSticky ? 1 : 0,
+              pointerEvents: isTabsSticky ? "auto" : "none",
+            }}
+          >
+            {experiment.title}
+          </span>
+        </div>
         <TabsContent value="protocol" className="pt-4">
-          <ProtocolTab experiment={experiment} />
+          <ProtocolTab
+            experiment={experiment}
+            onJumpToResearch={() =>
+              setSelectedTabState({ protocolId: protocol.id, value: "research" })
+            }
+          />
+        </TabsContent>
+        <TabsContent value="research" className="pt-4">
+          <ResearchTab experiment={experiment} />
         </TabsContent>
         <TabsContent value="results" className="pt-4">
           <ResultsTab

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -121,12 +121,12 @@
   --destructive: #8b5d3f;
   --border: rgba(196, 168, 130, 0.25);
   --input: rgba(196, 168, 130, 0.25);
-  --ring: #7a8c6e;
+  --ring: #5a6e3e;
   --chart-1: #7a8c6e;
   --chart-2: #d4c4a8;
   --chart-3: #2d3436;
-  --chart-4: #a07050;
-  --chart-5: #8a7e6b;
+  --chart-4: #7d5a3a;
+  --chart-5: #6e6354;
   --radius: 0.75rem;
   --sidebar: #2d3436;
   --sidebar-foreground: rgba(255, 255, 255, 0.85);

--- a/apps/web/src/components/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/components/dashboard/dashboard-shell.tsx
@@ -30,7 +30,7 @@ export function DashboardShell({
           </header>
           <main
             className={cn(
-              "flex-1 overflow-y-auto",
+              "flex-1",
               padded && "px-6 py-8 md:px-14 md:py-10",
             )}
           >

--- a/apps/web/src/components/experiments/experiment-detail/expected-signal-card.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/expected-signal-card.tsx
@@ -5,6 +5,7 @@ interface ExpectedSignalCardProps {
   expected: string;
   direction: "up" | "down" | "neutral";
   description: string;
+  variant?: "primary" | "supporting";
   className?: string;
 }
 
@@ -31,47 +32,67 @@ export function ExpectedSignalCard({
   expected,
   direction,
   description,
+  variant = "supporting",
   className,
 }: ExpectedSignalCardProps) {
+  const isPrimary = variant === "primary";
   return (
     <div
       className={cn(
-        "flex flex-1 flex-col gap-2 rounded-xl border border-primary/20 bg-primary/4 p-5",
-        className
+        "flex flex-1 flex-col rounded-xl border",
+        isPrimary
+          ? "gap-4 border-primary/35 bg-primary/12 p-6"
+          : "gap-3 border-primary/20 bg-primary/5 p-5",
+        className,
       )}
     >
-      <span className="font-mono text-[10px]/3 tracking-widest text-ring">
-        {label}
+      <span
+        className={cn(
+          "font-mono uppercase tracking-[0.12em]",
+          isPrimary ? "text-[11px]/3.5 text-primary" : "text-[10px]/3 text-ring",
+        )}
+      >
+        {isPrimary ? `Primary signal · ${label}` : label}
       </span>
-      <div className="flex items-center gap-2">
-        <span className="font-serif text-[28px]/8.5 font-semibold text-primary">
+      <div className="flex items-baseline gap-2">
+        <span
+          className={cn(
+            "font-serif font-semibold text-primary",
+            isPrimary ? "text-[44px]/11" : "text-[32px]/9",
+          )}
+        >
           {arrows[direction]}
         </span>
-        <span className="text-sm/4.5 font-semibold text-primary">
+        <span
+          className={cn(
+            "font-serif font-semibold text-primary",
+            isPrimary ? "text-2xl" : "text-lg",
+          )}
+        >
           {expected}
         </span>
       </div>
-      <p className="text-[12px] leading-[150%] text-chart-5">
+      <p className={cn("text-foreground", isPrimary ? "text-[15px]/6" : "text-sm/6")}>
         {description}
       </p>
       <svg
         width="100%"
-        height="32"
+        height={isPrimary ? 44 : 32}
         viewBox="0 0 220 32"
         preserveAspectRatio="none"
-        className="shrink-0"
+        className="mt-1 shrink-0"
       >
-        <polyline
-          points={sparklines[direction]}
-          fill="none"
-          stroke="#7A8C6E"
-          strokeWidth="1.5"
-        />
         <polyline
           points={baselinePoints[direction]}
           fill="none"
-          stroke="#D4C4A8"
+          className="stroke-secondary"
           strokeDasharray="4,4"
+        />
+        <polyline
+          points={sparklines[direction]}
+          fill="none"
+          className="stroke-primary"
+          strokeWidth={isPrimary ? 2 : 1.75}
         />
       </svg>
     </div>

--- a/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
@@ -43,10 +43,9 @@ export function ExperimentHeader({
   const protocolDay = day == null ? null : Math.max(1, day - baselineDays);
 
   return (
-    <div className="relative z-10 -mx-6 flex flex-col gap-7 rounded-t-3xl bg-background px-6 pt-10 md:-mx-14 md:px-14 md:pt-14">
+    <div className="relative z-10 flex flex-col gap-7">
       <div className="flex items-start justify-between gap-10">
         <div className="flex max-w-[700px] flex-col gap-3.5">
-          {/* Metadata line */}
           <div className="flex items-center gap-3">
             <span className="shrink-0 font-mono text-[11px]/3.5 tracking-[0.12em] text-chart-5">
               {category.toUpperCase()}
@@ -118,12 +117,10 @@ export function ExperimentHeader({
             )}
           </div>
 
-          {/* Title */}
           <h1 className="font-serif text-[38px] font-semibold leading-[110%] tracking-[-0.03em] text-foreground">
             {title}
           </h1>
 
-          {/* Description */}
           {sanitizedDescription && (
             <p className="text-[16px] leading-[160%] text-muted-foreground">
               {sanitizedDescription}
@@ -131,7 +128,6 @@ export function ExperimentHeader({
           )}
         </div>
 
-        {/* CTA or completion ring */}
         {status === "upcoming" && (
           <div className="flex shrink-0 flex-col items-center gap-2">
             <Button

--- a/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { Button } from "@/src/components/ui/button";
 import type { ExperimentStatus } from "@/src/types/experiments";
 
@@ -44,17 +43,7 @@ export function ExperimentHeader({
   const protocolDay = day == null ? null : Math.max(1, day - baselineDays);
 
   return (
-    <div className="flex flex-col gap-7">
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-[13px]/4">
-        <Link href="/experiments" className="text-muted-foreground/70 hover:text-foreground">
-          Experiments
-        </Link>
-        <span className="text-secondary">→</span>
-        <span className="text-muted-foreground">{title}</span>
-      </div>
-
-      {/* Title row with CTA or ring */}
+    <div className="relative z-10 -mx-6 flex flex-col gap-7 rounded-t-3xl bg-background px-6 pt-10 md:-mx-14 md:px-14 md:pt-14">
       <div className="flex items-start justify-between gap-10">
         <div className="flex max-w-[700px] flex-col gap-3.5">
           {/* Metadata line */}

--- a/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
@@ -44,9 +44,9 @@ export function ExperimentHeader({
 
   return (
     <div className="relative z-10 flex flex-col gap-7">
-      <div className="flex items-start justify-between gap-10">
+      <div className="flex flex-col items-stretch gap-6 md:flex-row md:items-start md:justify-between md:gap-10">
         <div className="flex max-w-[700px] flex-col gap-3.5">
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
             <span className="shrink-0 font-mono text-[11px]/3.5 tracking-[0.12em] text-chart-5">
               {category.toUpperCase()}
             </span>
@@ -117,7 +117,7 @@ export function ExperimentHeader({
             )}
           </div>
 
-          <h1 className="font-serif text-[38px] font-semibold leading-[110%] tracking-[-0.03em] text-foreground">
+          <h1 className="font-serif text-3xl font-semibold leading-[110%] tracking-[-0.03em] text-foreground sm:text-[38px]">
             {title}
           </h1>
 
@@ -129,15 +129,15 @@ export function ExperimentHeader({
         </div>
 
         {status === "upcoming" && (
-          <div className="flex shrink-0 flex-col items-center gap-2">
+          <div className="flex flex-col items-stretch gap-2 md:shrink-0 md:items-center">
             <Button
               size="lg"
-              className="rounded-[10px] bg-primary px-12 py-4 text-base font-semibold text-background hover:bg-primary/90"
+              className="rounded-[10px] bg-primary py-4 text-base font-semibold text-background hover:bg-primary/90 md:px-12"
             >
               Start Experiment →
             </Button>
-            <span className="text-[11px]/3.5 text-muted-foreground/70">
-                      {protocolDays}-day protocol
+            <span className="text-center text-[11px]/3.5 text-muted-foreground/70">
+              {protocolDays}-day protocol
             </span>
           </div>
         )}

--- a/apps/web/src/components/experiments/experiment-detail/experiment-hero.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-hero.tsx
@@ -7,7 +7,7 @@ interface ExperimentHeroProps {
 
 export function ExperimentHero({ image, title }: ExperimentHeroProps) {
   return (
-    <div className="relative -mx-6 -mt-8 h-[340px] w-[calc(100%+3rem)] overflow-hidden md:-mx-14 md:-mt-10 md:w-[calc(100%+7rem)]">
+    <div className="relative -mx-6 -mt-8 -mb-16 h-[260px] w-[calc(100%+3rem)] overflow-hidden md:-mx-14 md:-mt-10 md:-mb-20 md:h-[300px] md:w-[calc(100%+7rem)]">
       <Image src={image} alt="" fill className="object-cover" priority />
     </div>
   );

--- a/apps/web/src/components/experiments/experiment-detail/experiment-hero.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-hero.tsx
@@ -2,12 +2,11 @@ import Image from "next/image";
 
 interface ExperimentHeroProps {
   image: string;
-  title: string;
 }
 
-export function ExperimentHero({ image, title }: ExperimentHeroProps) {
+export function ExperimentHero({ image }: ExperimentHeroProps) {
   return (
-    <div className="relative -mx-6 -mt-8 -mb-16 h-[260px] w-[calc(100%+3rem)] overflow-hidden md:-mx-14 md:-mt-10 md:-mb-20 md:h-[300px] md:w-[calc(100%+7rem)]">
+    <div className="relative h-[180px] w-full overflow-hidden rounded-2xl border border-border/50 md:h-[220px]">
       <Image src={image} alt="" fill className="object-cover" priority />
     </div>
   );

--- a/apps/web/src/components/experiments/experiment-detail/format.ts
+++ b/apps/web/src/components/experiments/experiment-detail/format.ts
@@ -1,0 +1,16 @@
+export function splitBulletLead(item: string): { lead: string; rest: string } {
+  const trimmed = item.trim();
+  const sentenceEnd = trimmed.match(/^[^.!?]{6,80}?[.!?:](?:\s|$)/);
+  if (sentenceEnd) {
+    const lead = sentenceEnd[0].trim();
+    const rest = trimmed.slice(sentenceEnd[0].length).trim();
+    if (rest) return { lead, rest };
+  }
+  const commaEnd = trimmed.match(/^[^,]{6,70}?,\s/);
+  if (commaEnd) {
+    const lead = commaEnd[0].replace(/,\s$/, "").trim();
+    const rest = trimmed.slice(commaEnd[0].length).trim();
+    if (rest) return { lead, rest };
+  }
+  return { lead: "", rest: trimmed };
+}

--- a/apps/web/src/components/experiments/experiment-detail/protocol-tab.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/protocol-tab.tsx
@@ -1,36 +1,237 @@
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import Link from "next/link";
+import {
+  ArrowRight,
+  HeartPulse,
+  NotebookPen,
+  Repeat,
+  ShieldAlert,
+  Target,
+  Timer,
+} from "lucide-react";
 
 import type {
   Experiment,
   ExperimentMeasurementPath,
   ExperimentSignal,
 } from "@/src/types/experiments";
-import { ExpectedSignalCard } from "./expected-signal-card";
-import { ExperimentProgress } from "./experiment-progress";
 import { ExpertCard } from "./expert-card";
 import { SafetySection } from "./safety-section";
-import { StudyCard } from "./study-card";
+import { splitBulletLead } from "./format";
 
 interface ProtocolTabProps {
   experiment: Experiment;
+  onJumpToResearch?: () => void;
 }
 
-export function ProtocolTab({ experiment }: ProtocolTabProps) {
+interface SignalEstimate {
+  range: string;
+  point: string;
+  window: string;
+  baseline: string;
+  projected: string;
+  evidence: string;
+}
+
+const SIGNAL_ESTIMATES: Record<string, SignalEstimate> = {
+  "Resting Heart Rate": {
+    range: "−5–10%",
+    point: "~−8%",
+    window: "4–8 wks",
+    baseline: "~62 bpm",
+    projected: "~56 bpm",
+    evidence: "Moderate",
+  },
+  "Morning Blood Pressure": {
+    range: "−3–5 mmHg",
+    point: "~−4 mmHg",
+    window: "4–8 wks",
+    baseline: "~120/80",
+    projected: "~115/75",
+    evidence: "Moderate",
+  },
+  "HRV / RMSSD": {
+    range: "+3–7 ms",
+    point: "~+5 ms",
+    window: "4–8 wks",
+    baseline: "~45 ms",
+    projected: "~48 ms",
+    evidence: "Variable",
+  },
+};
+const PRACTICE_ICONS = [
+  Repeat,
+  ShieldAlert,
+  NotebookPen,
+  Target,
+  HeartPulse,
+  Timer,
+];
+
+function practiceGridCols(count: number): string {
+  switch (count) {
+    case 1:
+      return "";
+    case 2:
+      return "md:grid-cols-2";
+    case 3:
+      return "md:grid-cols-2 lg:grid-cols-3";
+    case 4:
+      return "md:grid-cols-2 lg:grid-cols-4";
+    default:
+      return "md:grid-cols-2 lg:grid-cols-3";
+  }
+}
+
+const SIGNAL_ESTIMATE_FALLBACK: SignalEstimate = {
+  range: "—",
+  point: "—",
+  window: "4–8 wks",
+  baseline: "Baseline",
+  projected: "Projected",
+  evidence: "Indicative",
+};
+
+interface TrajectoryChartProps {
+  direction: "up" | "down" | "neutral";
+  baseline: string;
+  projected: string;
+  height: number;
+  label: string;
+}
+
+const TRAJECTORY_GEOMETRY: Record<
+  TrajectoryChartProps["direction"],
+  { baselineY: number; projectedY: number; curveD: string }
+> = {
+  up: {
+    baselineY: 44,
+    projectedY: 14,
+    curveD: "M 5 44 C 60 43 130 18 215 14",
+  },
+  down: {
+    baselineY: 14,
+    projectedY: 44,
+    curveD: "M 5 14 C 60 15 130 40 215 44",
+  },
+  neutral: {
+    baselineY: 28,
+    projectedY: 28,
+    curveD: "M 5 28 C 60 27 110 29 160 27 215 28",
+  },
+};
+
+function TrajectoryChart({
+  direction,
+  baseline,
+  projected,
+  height,
+  label,
+}: TrajectoryChartProps) {
+  const isNeutral = direction === "neutral";
+  const { baselineY, projectedY, curveD } = TRAJECTORY_GEOMETRY[direction];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-baseline justify-between gap-3 px-0.5">
+        <span className="font-serif text-[13px] text-foreground tabular-nums">
+          {baseline}
+        </span>
+        <span className="font-serif text-[13px] text-primary tabular-nums">
+          {projected}
+        </span>
+      </div>
+      <svg
+        role="img"
+        aria-label={label}
+        width="100%"
+        height={height}
+        viewBox="0 0 220 60"
+        className="shrink-0 overflow-visible"
+      >
+        <line
+          x1="0"
+          y1={baselineY}
+          x2="220"
+          y2={baselineY}
+          stroke="var(--secondary)"
+          strokeDasharray="3,4"
+          strokeWidth="1"
+        />
+        {isNeutral ? (
+          <>
+            <path
+              d="M 5 28 C 70 26 140 18 215 14"
+              fill="none"
+              stroke="var(--primary)"
+              strokeWidth="1.25"
+              strokeDasharray="2,3"
+              opacity="0.55"
+            />
+            <path
+              d="M 5 28 C 70 30 140 38 215 42"
+              fill="none"
+              stroke="var(--primary)"
+              strokeWidth="1.25"
+              strokeDasharray="2,3"
+              opacity="0.55"
+            />
+          </>
+        ) : (
+          <line
+            x1="110"
+            y1={projectedY}
+            x2="220"
+            y2={projectedY}
+            stroke="var(--primary)"
+            strokeDasharray="2,4"
+            strokeWidth="0.75"
+            opacity="0.5"
+          />
+        )}
+        <path
+          d={curveD}
+          fill="none"
+          stroke="var(--primary)"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <circle
+          cx="5"
+          cy={baselineY}
+          r="3.5"
+          fill="var(--card)"
+          stroke="var(--secondary)"
+          strokeWidth="1.75"
+        />
+        {isNeutral ? (
+          <circle cx="215" cy="28" r="3.5" fill="var(--primary)" opacity="0.55" />
+        ) : (
+          <circle cx="215" cy={projectedY} r="3.5" fill="var(--primary)" />
+        )}
+      </svg>
+      <div className="flex items-center justify-between gap-3 px-0.5">
+        <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
+          Start
+        </span>
+        <span className="h-px flex-1 border-t border-dotted border-border/50" />
+        <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
+          Week 8
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ProtocolTab({ experiment, onJumpToResearch }: ProtocolTabProps) {
   const {
     expectedSignals,
     measurementPaths,
     protocolFacts,
     protocol,
     protocolTips,
-    protocolKeepInMind,
-    protocolLogFields,
     whyItWorks,
     experts,
-    researchStats,
-    researchLandscape,
-    researchGroups,
-    studies,
     podcastLinks,
     safety,
   } = experiment;
@@ -40,6 +241,18 @@ export function ProtocolTab({ experiment }: ProtocolTabProps) {
     const label = normalizeFactLabel(fact.label);
     return label !== "baseline" && label !== "intervention";
   });
+  const frequencyFact = supportingFacts.find(
+    (fact) => normalizeFactLabel(fact.label) === "frequency",
+  );
+  const sessionsPerWeek = frequencyFact
+    ? Math.max(
+        1,
+        Math.min(7, Number.parseInt(frequencyFact.value.match(/\d+/)?.[0] ?? "3", 10)),
+      )
+    : 3;
+  const scheduleEntries = interventionFact?.detail
+    ? parseSessionCounts(interventionFact.detail)
+    : [];
   const whyItWorksParagraphs = whyItWorks
     .split("\n\n")
     .map((paragraph) => paragraph.trim())
@@ -50,19 +263,76 @@ export function ProtocolTab({ experiment }: ProtocolTabProps) {
     <div className="flex flex-col gap-10">
       {focusSignals.length > 0 && (
         <section className="flex flex-col gap-4 pt-2">
-          <div className="flex max-w-2xl flex-col gap-1.5">
-            <SectionLabel>What could change</SectionLabel>
-          </div>
-          <div className={getFocusSignalGridClassName(focusSignals.length)}>
-            {focusSignals.map((signal) => (
-              <ExpectedSignalCard
-                key={signal.label}
-                label={signal.label}
-                expected={signal.expected}
-                direction={signal.direction}
-                description={signal.description ?? ""}
-              />
-            ))}
+          <SectionLabel>What could change</SectionLabel>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {focusSignals.map((signal, idx) => {
+              const est =
+                SIGNAL_ESTIMATES[signal.label] ?? SIGNAL_ESTIMATE_FALLBACK;
+              const isPrimary = idx === 0;
+              const isNeutral = signal.direction === "neutral";
+              return (
+                <div
+                  key={signal.label}
+                  className={`flex flex-col rounded-xl border ${
+                    isPrimary
+                      ? "xl:col-span-2 gap-5 pt-7 px-7 pb-5 border-primary/25 bg-primary/[0.04]"
+                      : "gap-4 p-5 border-border/60 bg-card/90"
+                  }`}
+                >
+                  <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-muted-foreground">
+                    {isPrimary ? "Primary signal" : "Signal"}
+                  </span>
+
+                  <div className="flex flex-col gap-2">
+                    <h3
+                      className={`font-serif font-semibold text-foreground ${
+                        isPrimary ? "text-2xl" : "text-lg"
+                      }`}
+                    >
+                      {signal.label}
+                    </h3>
+                    <p
+                      className={`font-serif font-semibold text-primary ${
+                        isPrimary ? "text-4xl" : "text-2xl"
+                      }`}
+                    >
+                      {est.range}
+                    </p>
+                    <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-foreground/60">
+                      over {est.window}
+                    </p>
+                  </div>
+
+                  <p
+                    className={`text-foreground text-pretty ${
+                      isPrimary ? "text-[15px]/6" : "text-sm/5.5"
+                    }`}
+                  >
+                    {signal.description ?? ""}
+                  </p>
+
+                  <div className="mt-auto flex flex-col gap-3">
+                    <TrajectoryChart
+                      direction={signal.direction}
+                      baseline={est.baseline}
+                      projected={est.projected}
+                      height={isPrimary ? 108 : 84}
+                      label={`${signal.label} projected ${est.point} over ${est.window}`}
+                    />
+
+                    <p className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                      <span
+                        aria-hidden="true"
+                        className={`size-1 rounded-full ${
+                          isNeutral ? "bg-secondary" : "bg-primary/60"
+                        }`}
+                      />
+                      {est.evidence.toLowerCase()} evidence
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
           </div>
           <ExpectedSignalContextPills signals={contextSignals} />
         </section>
@@ -75,58 +345,76 @@ export function ProtocolTab({ experiment }: ProtocolTabProps) {
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(320px,0.9fr)]">
         <section className="flex flex-col gap-6 rounded-xl border border-secondary/25 bg-card/90 p-7">
           <SectionLabel>Run the protocol</SectionLabel>
+          <ProtocolShapeDiagram experimentId={experiment.id} />
           {protocol.length > 0 && (
-            <div className="flex flex-col gap-3.5">
-              <ol className="flex flex-col gap-3.5">
-                {protocol.map((step) => (
+            <ol role="list" className="flex flex-col divide-y divide-border/50">
+              {protocol.map((step) => {
+                const { lead, rest } = splitBulletLead(step.detail);
+                return (
                   <li
                     key={step.number}
-                    className="grid gap-3.5 rounded-lg border border-border/70 bg-background/35 p-4 sm:grid-cols-[auto_1fr]"
+                    className="grid grid-cols-[2rem_1fr] gap-x-5 py-3.5 first:pt-0 last:pb-0"
                   >
-                    <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-secondary/15">
-                      <span className="font-mono text-[11px]/3.5 text-chart-5">
-                        {step.number}
-                      </span>
-                    </div>
-                    <div className="space-y-1">
+                    <span
+                      aria-hidden="true"
+                      className="font-serif text-xl/7 text-primary/70 tabular-nums"
+                    >
+                      {step.number}
+                    </span>
+                    <div className="flex flex-col gap-1">
                       {hasSpecificStepTitle(step) ? (
-                        <p className="text-sm/5 font-semibold text-foreground">
+                        <p className="font-serif text-base/6 font-semibold text-foreground">
                           {step.title}
                         </p>
                       ) : null}
-                      <p className="text-[13px]/5 text-foreground/85">
-                        {step.detail}
+                      <p className="text-[15px]/6 text-foreground text-pretty">
+                        {lead ? (
+                          <>
+                            <strong className="font-semibold">{lead}</strong>
+                            {rest ? ` ${rest}` : null}
+                          </>
+                        ) : (
+                          step.detail
+                        )}
                       </p>
                     </div>
                   </li>
-                ))}
-              </ol>
-            </div>
+                );
+              })}
+            </ol>
           )}
-
-          <ProtocolTextList title="For a cleaner read" items={protocolTips} />
         </section>
 
         <section className="flex flex-col gap-5 rounded-xl border border-secondary/25 bg-card/90 p-7">
-          <SectionLabel>At a glance</SectionLabel>
+          <SectionLabel>Schedule &amp; dose</SectionLabel>
 
           {(baselineFact || interventionFact) && (
             <ProtocolPhaseTimeline
               baselineDays={experiment.baselineDays}
-              baselineFact={baselineFact}
-              interventionFact={interventionFact}
               totalDays={experiment.durationDays}
+              sessionsPerWeek={sessionsPerWeek}
             />
           )}
 
-          {supportingFacts.length > 0 && (
-            <dl className="overflow-hidden rounded-lg border border-border/70 bg-background/20">
-              {supportingFacts.map((fact, index) => (
+          {(scheduleEntries.length > 0 || supportingFacts.length > 0) && (
+            <dl className="flex flex-col divide-y divide-border/50">
+              {scheduleEntries.map((entry) => (
+                <div
+                  key={entry.label}
+                  className="grid items-baseline gap-1 py-3 first:pt-0 last:pb-0 sm:grid-cols-[88px_1fr] sm:gap-4"
+                >
+                  <dt className="font-mono text-[10px]/3 uppercase tracking-[0.08em] text-chart-5">
+                    {entry.label}
+                  </dt>
+                  <dd className="text-sm/5 font-semibold text-foreground">
+                    {entry.value}
+                  </dd>
+                </div>
+              ))}
+              {supportingFacts.map((fact) => (
                 <div
                   key={`${fact.label}-${fact.value}`}
-                  className={`grid gap-1 px-4 py-3.5 sm:grid-cols-[88px_1fr] sm:gap-4 ${
-                    index > 0 ? "border-t border-border/60" : ""
-                  }`}
+                  className="grid items-baseline gap-1 py-3 first:pt-0 last:pb-0 sm:grid-cols-[88px_1fr] sm:gap-4"
                 >
                   <dt className="font-mono text-[10px]/3 uppercase tracking-[0.08em] text-chart-5">
                     {fact.label}
@@ -145,50 +433,99 @@ export function ProtocolTab({ experiment }: ProtocolTabProps) {
               ))}
             </dl>
           )}
-
-          {protocolLogFields.length > 0 && (
-            <div className="flex flex-col gap-3">
-              <SectionLabel>Log each session</SectionLabel>
-              <div className="flex flex-wrap gap-2">
-                {protocolLogFields.map((field) => (
-                  <span
-                    key={field}
-                    className="rounded-full border border-border/70 bg-background/35 px-3 py-1.5 text-xs/4 text-muted-foreground"
-                  >
-                    {field}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          <ProtocolTextList title="Keep in mind" items={protocolKeepInMind} />
         </section>
       </div>
 
-      <section className="flex flex-col gap-4 rounded-xl border border-secondary/25 bg-card/90 p-7">
-        <SectionLabel>Why it works</SectionLabel>
-        <div
-          className={`grid gap-4 ${
-            whyItWorksParagraphs.length > 1 ? "lg:grid-cols-2" : ""
-          }`}
-        >
-          {whyItWorksParagraphs.map((paragraph, i) => (
-            <p
-              key={i}
-              className="text-[14px] leading-[170%] text-foreground/80"
-            >
-              {paragraph}
+      {protocolTips.length > 0 && (
+        <section className="flex flex-col gap-6 rounded-xl border border-secondary/25 bg-card/90 p-7">
+          <div className="flex items-baseline justify-between gap-4">
+            <SectionLabel>Good practices</SectionLabel>
+            <p className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-muted-foreground">
+              To keep results clean
             </p>
-          ))}
-        </div>
-      </section>
+          </div>
+          <ul
+            role="list"
+            className={`grid gap-x-10 gap-y-8 ${practiceGridCols(protocolTips.length)}`}
+          >
+            {protocolTips.map((item, i) => {
+              const { lead, rest } = splitBulletLead(item);
+              const Icon = PRACTICE_ICONS[i % PRACTICE_ICONS.length];
+              return (
+                <li key={item} className="flex flex-col gap-3">
+                  <span
+                    aria-hidden="true"
+                    className="inline-flex size-9 items-center justify-center rounded-full bg-primary/10 text-primary"
+                  >
+                    <Icon className="size-4" strokeWidth={1.75} />
+                  </span>
+                  <p className="text-[15px]/6 text-foreground text-pretty">
+                    {lead ? (
+                      <>
+                        <strong className="font-semibold">{lead}</strong>
+                        {rest ? ` ${rest}` : null}
+                      </>
+                    ) : (
+                      item
+                    )}
+                  </p>
+                </li>
+              );
+            })}
+          </ul>
+          <p className="flex items-start gap-2.5 border-t border-border/50 pt-4 text-sm/6 text-muted-foreground">
+            <span
+              aria-hidden="true"
+              className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/15 font-serif text-[13px] text-primary"
+            >
+              ?
+            </span>
+            <span>
+              Anything unclear during the protocol? Ask Murph in the chat,
+              it knows the plan, your baseline, and the signals you're
+              tracking.
+            </span>
+          </p>
+        </section>
+      )}
+
+      {whyItWorksParagraphs.length > 0 && (
+        <section className="flex flex-col gap-6 rounded-xl border border-secondary/25 bg-card/90 p-7">
+          <SectionLabel>Why it works</SectionLabel>
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
+            <div className="flex max-w-3xl flex-col gap-5">
+              {whyItWorksParagraphs.map((paragraph, i) => (
+                <p
+                  key={i}
+                  className={
+                    i === 0
+                      ? "font-serif text-[19px]/7 text-foreground text-pretty"
+                      : "text-base/7 text-foreground text-pretty"
+                  }
+                >
+                  {paragraph}
+                </p>
+              ))}
+            </div>
+            <MechanismCausalChain experimentId={experiment.id} />
+          </div>
+
+          {onJumpToResearch && (
+            <button
+              type="button"
+              onClick={onJumpToResearch}
+              className="inline-flex w-fit items-center gap-2 rounded-lg bg-foreground px-4 py-2.5 text-sm font-medium text-background transition-colors hover:bg-foreground/90"
+            >
+              Read the research
+              <ArrowRight className="size-4" strokeWidth={1.75} />
+            </button>
+          )}
+        </section>
+      )}
 
       {experts.length > 0 && (
         <div className="flex flex-col gap-3.5">
-          <span className="font-mono text-[11px]/3.5 tracking-[0.12em] text-chart-5">
-            RECOMMENDED BY
-          </span>
+          <SectionLabel>Recommended by</SectionLabel>
           <div className="grid gap-3.5 md:grid-cols-2 xl:grid-cols-3">
             {experts.map((expert) => (
               <ExpertCard key={expert.name} {...expert} />
@@ -196,71 +533,6 @@ export function ProtocolTab({ experiment }: ProtocolTabProps) {
           </div>
         </div>
       )}
-
-      <div className="flex flex-col gap-5">
-        <span className="font-mono text-[11px]/3.5 tracking-[0.12em] text-chart-5">
-          RESEARCH
-        </span>
-        {researchLandscape ? (
-          <ResearchLandscapeReadout landscape={researchLandscape} />
-        ) : null}
-        {experiment.id === "norwegian-4x4" && researchGroups && researchGroups.length > 0 ? (
-          <p className="max-w-3xl text-sm/6 text-muted-foreground/80">
-            Read these top to bottom: the earliest groups are the closest match to the
-            exact protocol, and the later groups mainly add safety, boundary, or nearby-
-            variant context.
-          </p>
-        ) : null}
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
-          {researchStats.map((stat) => (
-            <div
-              key={stat.label}
-              className="flex grow shrink basis-0 flex-col items-center gap-1 rounded-xl border border-secondary/25 bg-card/90 p-5"
-            >
-              <span className="font-serif text-[32px]/10 font-semibold text-foreground">
-                {typeof stat.value === "number"
-                  ? stat.value.toLocaleString()
-                  : stat.value}
-              </span>
-              <span className="font-mono text-[10px]/3 tracking-[0.08em] text-chart-5">
-                {stat.label}
-              </span>
-            </div>
-          ))}
-        </div>
-        {researchStats.some((stat) =>
-      /HUMAN PARTICIPANTS/u.test(stat.label) && stat.value !== "—"
-    ) ? (
-      <p className="text-xs/4 text-muted-foreground/70">
-        Sources checked is every card shown on this page. Direct human participants
-        counts only primary human studies with coded participant totals, deduplicated
-        by cohort when possible. Review cards may show larger pooled head counts on
-        their own rows, and those pooled totals are treated as approximate rather than
-        added into the page-level number.
-        {experiment.id === "norwegian-4x4"
-          ? " On Norwegian 4x4, safety-boundary registries also stay off that page-level total."
-          : ""}
-      </p>
-    ) : null}
-
-        {researchGroups && researchGroups.length > 0 ? (
-          <div className="flex flex-col gap-4">
-            {researchGroups.map((group) => (
-              <ResearchGroupCard key={group.id} group={group} />
-            ))}
-          </div>
-        ) : studies.length > 0 ? (
-          <div className="overflow-hidden rounded-xl border border-secondary/25 bg-card/90">
-            {studies.map((study, i) => (
-              <StudyCard
-                key={study.title}
-                {...study}
-                last={i === studies.length - 1}
-              />
-            ))}
-          </div>
-        ) : null}
-      </div>
 
       {podcastLinks && podcastLinks.length > 0 && (
         <div className="flex gap-2.5">
@@ -285,25 +557,464 @@ export function ProtocolTab({ experiment }: ProtocolTabProps) {
   );
 }
 
-function ResearchLandscapeReadout({
-  landscape,
+const MAX_FOCUS_SIGNAL_CARDS = 3;
+
+const signalDirectionArrows: Record<ExperimentSignal["direction"], string> = {
+  down: "↓",
+  neutral: "→",
+  up: "↑",
+};
+
+function groupExpectedSignals(signals: readonly ExperimentSignal[]): {
+  contextSignals: ExperimentSignal[];
+  focusSignals: ExperimentSignal[];
+} {
+  const explicitFocusSignals = signals.filter(
+    (signal) => signal.protocolProminence === "focus",
+  );
+  const undecidedSignals = signals.filter(
+    (signal) => signal.protocolProminence === undefined,
+  );
+  const preferredFocusSignals = [
+    ...explicitFocusSignals,
+    ...undecidedSignals,
+  ].slice(0, MAX_FOCUS_SIGNAL_CARDS);
+  const focusSignals = preferredFocusSignals.length > 0
+    ? preferredFocusSignals
+    : signals.slice(0, MAX_FOCUS_SIGNAL_CARDS);
+  const focusSignalSet = new Set(focusSignals);
+
+  return {
+    contextSignals: signals.filter((signal) => !focusSignalSet.has(signal)),
+    focusSignals,
+  };
+}
+
+function ExpectedSignalContextPills({
+  signals,
 }: {
-  landscape: NonNullable<Experiment["researchLandscape"]>;
+  signals: readonly ExperimentSignal[];
 }) {
+  if (signals.length === 0) {
+    return null;
+  }
+
   return (
-    <div className="grid gap-3 md:grid-cols-3">
-      <ResearchReadoutCard
-        label="Bottom line"
-        text={landscape.bottomLine}
-      />
-      <ResearchReadoutCard
-        label="Best-supported claim"
-        text={landscape.primaryClaim}
-      />
-      <ResearchReadoutCard
-        label={`Confidence · ${formatResearchConfidence(landscape.confidenceLabel)}`}
-        text={landscape.mainCaveat}
-      />
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pt-1">
+      <span className="font-mono text-[10px]/3 uppercase tracking-[0.08em] text-muted-foreground">
+        Also worth watching
+      </span>
+      {signals.map((signal) => (
+        <span
+          key={signal.label}
+          className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/35 px-3 py-1.5 text-[12px]/4"
+        >
+          <span
+            aria-hidden="true"
+            className="font-serif text-sm/4 text-primary"
+          >
+            {signalDirectionArrows[signal.direction]}
+          </span>
+          <span className="font-semibold text-foreground">
+            {signal.label}
+          </span>
+          <span className="text-muted-foreground">{signal.expected}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function findProtocolFact(
+  facts: Experiment["protocolFacts"],
+  label: string,
+) {
+  return facts.find((fact) => normalizeFactLabel(fact.label) === label);
+}
+
+function normalizeFactLabel(label: string): string {
+  return label.trim().toLowerCase();
+}
+
+function hasSpecificStepTitle(step: Experiment["protocol"][number]): boolean {
+  return step.title.trim() !== `Step ${step.number}`;
+}
+
+type CellKind = "baseline" | "session" | "rest" | "empty";
+
+const CELL_CLASS: Record<CellKind, string> = {
+  baseline: "bg-secondary",
+  session: "bg-primary",
+  rest: "bg-primary/10 ring-1 ring-inset ring-primary/25",
+  empty: "bg-transparent",
+};
+
+const TIMELINE_LEGEND: ReadonlyArray<{
+  kind: Exclude<CellKind, "empty">;
+  term: string;
+  description: string;
+}> = [
+  { kind: "baseline", term: "Baseline", description: "measurement only, no sessions" },
+  { kind: "session", term: "Session", description: "a sauna session that day" },
+  { kind: "rest", term: "Rest", description: "no session, still track signals" },
+];
+
+function ProtocolPhaseTimeline({
+  baselineDays,
+  totalDays,
+  sessionsPerWeek,
+}: {
+  baselineDays: number;
+  totalDays: number;
+  sessionsPerWeek: number;
+}) {
+  const protocolDays = Math.max(0, totalDays - baselineDays);
+  const weeks = Math.max(1, Math.ceil(totalDays / 7));
+  const sessionDayOffsets = [0, 2, 4, 1, 3, 5, 6].slice(0, sessionsPerWeek);
+  const sessionTarget = Math.floor(protocolDays / 7) * sessionsPerWeek;
+  const cells: CellKind[] = [];
+  for (let w = 0; w < weeks; w++) {
+    for (let d = 0; d < 7; d++) {
+      const dayIndex = w * 7 + d;
+      if (dayIndex >= totalDays) {
+        cells.push("empty");
+      } else if (dayIndex < baselineDays) {
+        cells.push("baseline");
+      } else {
+        const protocolDayInWeek = (dayIndex - baselineDays) % 7;
+        cells.push(
+          sessionDayOffsets.includes(protocolDayInWeek) ? "session" : "rest",
+        );
+      }
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        role="img"
+        aria-label={`${baselineDays}-day baseline then ${protocolDays}-day protocol with ${sessionTarget} sessions`}
+        className="grid grid-cols-[auto_repeat(7,minmax(0,1fr))] items-center gap-x-3 gap-y-1 max-w-[280px]"
+      >
+        {Array.from({ length: weeks }, (_, w) => {
+          const isBaselineRow = cells[w * 7] === "baseline";
+          const rowLabel = isBaselineRow ? "Baseline" : `Week ${w}`;
+          return (
+            <Fragment key={w}>
+              <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+                {rowLabel}
+              </span>
+              {Array.from({ length: 7 }, (_, d) => (
+                <div
+                  key={d}
+                  className={`aspect-square rounded-[3px] ${CELL_CLASS[cells[w * 7 + d]]}`}
+                />
+              ))}
+            </Fragment>
+          );
+        })}
+      </div>
+      <dl className="flex flex-col gap-2 text-[12px]/4 text-muted-foreground">
+        {TIMELINE_LEGEND.map((entry) => (
+          <div key={entry.kind} className="flex items-center gap-2.5">
+            <span
+              aria-hidden="true"
+              className={`size-2.5 shrink-0 rounded-[3px] ${CELL_CLASS[entry.kind]}`}
+            />
+            <dt className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+              {entry.term}
+            </dt>
+            <dd>{entry.description}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function parseSessionCounts(detail: string): Array<{ label: string; value: string }> {
+  const entries: Array<{ label: string; value: string }> = [];
+  for (const piece of detail.split(/[.;]\s*/)) {
+    const trimmed = piece.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/(\d+)\s+session[s]?\s+(\w+)/i);
+    if (match) {
+      const word = match[2].toLowerCase();
+      const label =
+        word === "minimum"
+          ? "Minimum"
+          : word === "target"
+            ? "Optimal"
+            : word.charAt(0).toUpperCase() + word.slice(1);
+      entries.push({ label, value: `${match[1]} sessions` });
+    }
+  }
+  return entries;
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <span className="font-mono text-[11px]/3.5 uppercase tracking-[0.12em] text-chart-5">
+      {children}
+    </span>
+  );
+}
+
+type SegmentKind = "primary" | "secondary" | "muted";
+
+interface ProtocolShape {
+  kicker: string;
+  formula: ReactNode;
+  segments: ReadonlyArray<{ width: number; kind: SegmentKind; label?: string }>;
+  labelRow?: ReadonlyArray<{ width: number; text: string; kind: SegmentKind }>;
+  ticks: ReadonlyArray<string>;
+}
+
+const PROTOCOL_SHAPES: Record<string, ProtocolShape> = {
+  "norwegian-4x4": {
+    kicker: "One session",
+    formula: (
+      <>
+        10′<span className="text-muted-foreground"> warm-up </span>
+        <span className="text-chart-5">+</span>{" "}
+        <span className="text-primary">4 × (4′ hard / 3′ easy)</span>{" "}
+        <span className="text-chart-5">+</span> 5′
+        <span className="text-muted-foreground"> cool-down </span>
+        <span className="text-chart-5">=</span>{" "}
+        <span className="tabular-nums">48 min</span>
+      </>
+    ),
+    segments: [
+      { width: 10, kind: "muted" },
+      { width: 4, kind: "primary" },
+      { width: 3, kind: "secondary" },
+      { width: 4, kind: "primary" },
+      { width: 3, kind: "secondary" },
+      { width: 4, kind: "primary" },
+      { width: 3, kind: "secondary" },
+      { width: 4, kind: "primary" },
+      { width: 5, kind: "muted" },
+    ],
+    labelRow: [
+      { width: 10, text: "warm-up", kind: "muted" },
+      { width: 25, text: "4 × hard / easy", kind: "primary" },
+      { width: 5, text: "cool-down", kind: "muted" },
+    ],
+    ticks: ["0", "10 min", "35 min", "40 min"],
+  },
+  "finnish-sauna": {
+    kicker: "One session",
+    formula: (
+      <>
+        2′<span className="text-muted-foreground"> settle </span>
+        <span className="text-chart-5">+</span>{" "}
+        <span className="text-primary">15–20′ at 80–100 °C</span>{" "}
+        <span className="text-chart-5">+</span> 3′
+        <span className="text-muted-foreground"> cool-down</span>
+      </>
+    ),
+    segments: [
+      { width: 2, kind: "muted" },
+      { width: 18, kind: "primary" },
+      { width: 3, kind: "muted" },
+    ],
+    labelRow: [
+      { width: 2, text: "settle", kind: "muted" },
+      { width: 18, text: "sauna 80–100 °C", kind: "primary" },
+      { width: 3, text: "cool-down", kind: "muted" },
+    ],
+    ticks: ["0", "2 min", "20 min", "23 min"],
+  },
+  "bryan-johnson-blueprint": {
+    kicker: "Per day",
+    formula: (
+      <>
+        <span className="text-muted-foreground">morning workout </span>
+        <span className="text-chart-5">→</span>{" "}
+        <span className="text-primary">20′ at 93 °C</span>{" "}
+        <span className="text-chart-5">→</span>{" "}
+        <span className="text-muted-foreground">rehydrate</span>
+      </>
+    ),
+    segments: [
+      { width: 30, kind: "secondary" },
+      { width: 20, kind: "primary" },
+      { width: 10, kind: "muted" },
+    ],
+    labelRow: [
+      { width: 30, text: "workout", kind: "secondary" },
+      { width: 20, text: "sauna 93 °C", kind: "primary" },
+      { width: 10, text: "rehydrate", kind: "muted" },
+    ],
+    ticks: ["start", "after workout", "end"],
+  },
+  "red-light-glasses-before-bed": {
+    kicker: "Evening window",
+    formula: (
+      <>
+        <span className="text-primary">90–120′ with glasses</span>{" "}
+        <span className="text-chart-5">→</span>{" "}
+        <span className="text-muted-foreground">remove </span>
+        <span className="text-chart-5">→</span>{" "}
+        <span className="tabular-nums">bedtime</span>
+      </>
+    ),
+    segments: [
+      { width: 120, kind: "primary" },
+      { width: 5, kind: "muted" },
+    ],
+    labelRow: [
+      { width: 120, text: "glasses on", kind: "primary" },
+      { width: 5, text: "bedtime", kind: "muted" },
+    ],
+    ticks: ["−120 min", "bedtime"],
+  },
+};
+
+function ProtocolShapeDiagram({ experimentId }: { experimentId: string }) {
+  const shape = PROTOCOL_SHAPES[experimentId];
+  if (!shape) return null;
+  return (
+    <ProtocolShapeRail
+      segments={shape.segments}
+      labelRow={shape.labelRow}
+      ticks={shape.ticks}
+    />
+  );
+}
+
+function ProtocolShapeRail({
+  segments,
+  labelRow,
+  ticks,
+}: {
+  segments: ReadonlyArray<{ width: number; kind: SegmentKind; label?: string }>;
+  labelRow?: ReadonlyArray<{ width: number; text: string; kind: SegmentKind }>;
+  ticks: ReadonlyArray<string>;
+}) {
+  const total = segments.reduce((sum, s) => sum + s.width, 0);
+  const effectiveLabels =
+    labelRow ??
+    (segments.some((s) => s.label)
+      ? segments.map((s) => ({
+          width: s.width,
+          text: s.label ?? "",
+          kind: s.kind,
+        }))
+      : undefined);
+  const labelTotal = effectiveLabels?.reduce((sum, l) => sum + l.width, 0) ?? 0;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {effectiveLabels && labelTotal > 0 && (
+        <div className="flex gap-px">
+          {effectiveLabels.map((entry, i) => {
+            const color =
+              entry.kind === "primary"
+                ? "text-primary"
+                : "text-muted-foreground";
+            return (
+              <p
+                key={i}
+                className={`truncate text-center font-mono text-[10px] uppercase tracking-[0.08em] ${color}`}
+                style={{ width: `${(entry.width / labelTotal) * 100}%` }}
+              >
+                {entry.text}
+              </p>
+            );
+          })}
+        </div>
+      )}
+      <div className="flex h-3.5">
+        {segments.map((segment, i) => {
+          const cls =
+            segment.kind === "primary"
+              ? "bg-primary"
+              : segment.kind === "secondary"
+                ? "bg-primary/30"
+                : "bg-secondary";
+          return (
+            <div
+              key={i}
+              className={`${cls} mr-px last:mr-0`}
+              style={{ width: `${(segment.width / total) * 100}%` }}
+            />
+          );
+        })}
+      </div>
+      <div className="flex justify-between font-mono text-[9px]/3 tabular-nums text-muted-foreground">
+        {ticks.map((tick, i) => (
+          <span key={i}>{tick}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const CAUSAL_CHAINS: Record<string, ReadonlyArray<{ label: string; content: string }>> = {
+  "norwegian-4x4": [
+    { label: "Session", content: "4 × (4′ hard · 3′ easy)" },
+    { label: "Acute physiology", content: "HR 85–95% HRmax · sustained aerobic stress" },
+    { label: "Adaptation", content: "stroke volume · capillaries · mitochondria" },
+    { label: "Outcome", content: "VO₂max ↑ · resting HR ↓" },
+  ],
+  "finnish-sauna": [
+    { label: "Session", content: "80–100 °C dry sauna · ~15–20 min · 3×/week" },
+    { label: "Acute physiology", content: "skin vessels dilate · sweat · HR ↑ · core temp climbs" },
+    { label: "Adaptation", content: "plasma volume ↑ · earlier sweating · HSP-70 · endothelial tone" },
+    { label: "Outcome", content: "resting HR ↓ · calmer post-sauna downshift" },
+  ],
+  "bryan-johnson-blueprint": [
+    { label: "Session", content: "93 °C dry sauna · daily · post-workout · groin ice" },
+    { label: "Acute physiology", content: "heat + exercise residue stack · sustained core-temp rise" },
+    { label: "Adaptation", content: "heat acclimation · plasma volume ↑ · less HR strain per dose" },
+    { label: "Outcome", content: "heat tolerance ↑ · fertility guardrail (groin cooling required)" },
+  ],
+  "red-light-glasses-before-bed": [
+    { label: "Session", content: "amber/red glasses · last 90–120 min before bed" },
+    { label: "Acute physiology", content: "melanopic retinal signal ↓ · alerting eases" },
+    { label: "Adaptation", content: "melatonin unsuppressed · core temp trends down" },
+    { label: "Outcome", content: "shorter sleep onset · less pre-bed wiredness" },
+  ],
+};
+
+function MechanismCausalChain({ experimentId }: { experimentId: string }) {
+  const steps = CAUSAL_CHAINS[experimentId];
+  if (!steps) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionLabel>How the body adapts</SectionLabel>
+      <ol role="list" className="flex flex-col gap-7">
+        {steps.map((step, i) => (
+          <li
+            key={step.label}
+            className="relative grid grid-cols-[auto_1fr] gap-x-5"
+          >
+            {i < steps.length - 1 && (
+              <span
+                aria-hidden="true"
+                className="absolute left-[13px] top-8 -bottom-7 w-px bg-primary/25"
+              />
+            )}
+            <span
+              aria-hidden="true"
+              className="relative z-[1] inline-flex size-7 shrink-0 items-center justify-center rounded-full border border-primary/40 bg-background font-mono text-[11px] font-semibold text-primary tabular-nums"
+            >
+              {i + 1}
+            </span>
+            <div className="flex flex-col gap-1.5 pt-0.5">
+              <span className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-chart-5">
+                {step.label}
+              </span>
+              <p className="font-serif text-[15px]/6 text-foreground text-pretty">
+                {step.content}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
     </div>
   );
 }
@@ -477,366 +1188,4 @@ function formatList(values: readonly string[]): string {
 
 function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {
   return [...new Set(values.filter((value): value is string => Boolean(value)))];
-}
-
-function ResearchReadoutCard({ label, text }: { label: string; text: string }) {
-  return (
-    <div className="flex flex-col gap-2 rounded-xl border border-secondary/25 bg-card/90 p-5">
-      <span className="font-mono text-[10px]/3 uppercase tracking-[0.08em] text-chart-5">
-        {label}
-      </span>
-      <p className="text-[13px]/5 text-foreground/80">{text}</p>
-    </div>
-  );
-}
-
-function ResearchGroupCard({
-  group,
-}: {
-  group: NonNullable<Experiment["researchGroups"]>[number];
-}) {
-  const sourceMixSummary = formatResearchGroupSourceMix(group.studies);
-
-  return (
-    <details
-      className="group overflow-hidden rounded-xl border border-secondary/25 bg-card/90"
-      open={group.defaultOpen}
-    >
-      <summary className="cursor-pointer list-none px-6 py-5 transition-colors hover:bg-secondary/6 [&::-webkit-details-marker]:hidden">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex max-w-3xl flex-col gap-2">
-            <SectionLabel>{formatResearchGroupLabel(group.id, group.label)}</SectionLabel>
-            <p className="text-[14px]/6 text-foreground/80">
-              {group.summary}
-            </p>
-            <p className="font-mono text-[10px]/3.5 tracking-[0.08em] text-muted-foreground/80">
-              {sourceMixSummary}
-            </p>
-          </div>
-          <div className="flex w-fit shrink-0 items-center gap-2 self-start sm:justify-end">
-            <span className="rounded-full border border-border/70 bg-background/35 px-2.5 py-1 font-mono text-[10px]/3.5 text-muted-foreground">
-              {formatEvidenceStance(group.stance)}
-            </span>
-            <span
-              aria-hidden="true"
-              className="rounded-full border border-border/70 bg-background/35 px-2 py-1 font-mono text-[10px]/3.5 text-muted-foreground transition-transform group-open:rotate-180"
-            >
-              ˅
-            </span>
-          </div>
-        </div>
-      </summary>
-      <div className="border-t border-border/70">
-        {group.studies.map((study, index) => (
-          <StudyCard
-            key={`${group.id}-${study.title}`}
-            {...study}
-            last={index === group.studies.length - 1}
-          />
-        ))}
-      </div>
-    </details>
-  );
-}
-
-function formatResearchGroupLabel(id: string, fallbackLabel: string): string {
-  switch (id) {
-    case "evidence-backbone-and-claim-calibration":
-      return "What the evidence can and can't say";
-    case "near-term-autonomic-vascular-and-immune-signals":
-      return "Short-term signals to watch";
-    case "long-term-finnish-cohort-and-real-world-context":
-      return "Long-term Finnish population context";
-    case "intervention-design-training-and-mixed-results":
-      return "Repeated-use trials and mixed results";
-    case "safety-dose-modality-and-context-boundaries":
-      return "Safety, dose, and sauna type";
-    default:
-      return fallbackLabel;
-  }
-}
-
-function formatResearchGroupSourceMix(
-  studies: NonNullable<Experiment["researchGroups"]>[number]["studies"],
-): string {
-  const sourceCount = studies.length;
-  const categoryCounts = [
-    {
-      count: countStudiesByType(studies, ["MECH"]),
-      pluralLabel: "physiology studies",
-      singularLabel: "physiology study",
-      sortOrder: 0,
-    },
-    {
-      count: countStudiesByType(studies, ["RCT", "INT"]),
-      pluralLabel: "trials",
-      singularLabel: "trial",
-      sortOrder: 1,
-    },
-    {
-      count: countStudiesByType(studies, ["OBS"]),
-      pluralLabel: "observational studies",
-      singularLabel: "observational study",
-      sortOrder: 2,
-    },
-    {
-      count: countStudiesByType(studies, ["MA", "REV"]),
-      pluralLabel: "reviews",
-      singularLabel: "review",
-      sortOrder: 3,
-    },
-    {
-      count: countStudiesByType(studies, ["GUIDE"]),
-      pluralLabel: "guidance sources",
-      singularLabel: "guidance source",
-      sortOrder: 4,
-    },
-    {
-      count: countStudiesByType(studies, ["N1"]),
-      pluralLabel: "self-experiments",
-      singularLabel: "self-experiment",
-      sortOrder: 5,
-    },
-    {
-      count: countStudiesByType(studies, ["SRC"]),
-      pluralLabel: "supporting sources",
-      singularLabel: "supporting source",
-      sortOrder: 6,
-    },
-  ]
-    .filter((category) => category.count > 0)
-    .sort((left, right) => {
-      if (left.count !== right.count) {
-        return right.count - left.count;
-      }
-
-      return left.sortOrder - right.sortOrder;
-    })
-    .slice(0, 3)
-    .map((category) =>
-      `${category.count.toLocaleString()} ${category.count === 1 ? category.singularLabel : category.pluralLabel}`
-    );
-
-  return [
-    `${sourceCount.toLocaleString()} ${sourceCount === 1 ? "source" : "sources"}`,
-    ...categoryCounts,
-  ].join(" · ");
-}
-
-function countStudiesByType(
-  studies: NonNullable<Experiment["researchGroups"]>[number]["studies"],
-  includedTypes: readonly Experiment["studies"][number]["type"][],
-): number {
-  return studies.filter((study) => includedTypes.includes(study.type)).length;
-}
-
-function formatResearchConfidence(
-  confidenceLabel: NonNullable<Experiment["researchLandscape"]>["confidenceLabel"],
-): string {
-  switch (confidenceLabel) {
-    case "early":
-      return "Early";
-    case "moderate":
-      return "Moderate";
-    case "strong":
-      return "Strong";
-    case "mixed":
-      return "Mixed";
-    case "limited":
-      return "Limited";
-  }
-}
-
-function formatEvidenceStance(
-  stance: NonNullable<Experiment["researchGroups"]>[number]["stance"],
-): string {
-  switch (stance) {
-    case "supports":
-      return "Supports";
-    case "mixed":
-      return "Mixed evidence";
-    case "does_not_confirm":
-      return "Doesn't confirm";
-    case "contradicts":
-      return "Evidence against";
-    case "safety_boundary":
-      return "Safety boundary";
-    case "context_only":
-      return "Context, not proof";
-  }
-}
-
-const MAX_FOCUS_SIGNAL_CARDS = 3;
-
-const signalDirectionArrows: Record<ExperimentSignal["direction"], string> = {
-  down: "↓",
-  neutral: "→",
-  up: "↑",
-};
-
-function groupExpectedSignals(signals: readonly ExperimentSignal[]): {
-  contextSignals: ExperimentSignal[];
-  focusSignals: ExperimentSignal[];
-} {
-  const explicitFocusSignals = signals.filter(
-    (signal) => signal.protocolProminence === "focus",
-  );
-  const undecidedSignals = signals.filter(
-    (signal) => signal.protocolProminence === undefined,
-  );
-  const preferredFocusSignals = [
-    ...explicitFocusSignals,
-    ...undecidedSignals,
-  ].slice(0, MAX_FOCUS_SIGNAL_CARDS);
-  const focusSignals = preferredFocusSignals.length > 0
-    ? preferredFocusSignals
-    : signals.slice(0, MAX_FOCUS_SIGNAL_CARDS);
-  const focusSignalSet = new Set(focusSignals);
-
-  return {
-    contextSignals: signals.filter((signal) => !focusSignalSet.has(signal)),
-    focusSignals,
-  };
-}
-
-function getFocusSignalGridClassName(count: number): string {
-  if (count <= 1) {
-    return "grid gap-4 md:max-w-xl";
-  }
-
-  if (count === 2) {
-    return "grid gap-4 md:grid-cols-2";
-  }
-
-  return "grid gap-4 md:grid-cols-2 xl:grid-cols-3";
-}
-
-function ExpectedSignalContextPills({
-  signals,
-}: {
-  signals: readonly ExperimentSignal[];
-}) {
-  if (signals.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="flex flex-col gap-3 rounded-xl border border-secondary/25 bg-card/70 p-4">
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
-        <SectionLabel>Also worth watching</SectionLabel>
-      </div>
-      <div className="flex flex-wrap gap-2.5">
-        {signals.map((signal) => (
-          <span
-            key={signal.label}
-            className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/35 px-3 py-2 text-[12px]/4"
-          >
-            <span
-              aria-hidden="true"
-              className="font-serif text-base/4 text-primary"
-            >
-              {signalDirectionArrows[signal.direction]}
-            </span>
-            <span className="font-medium text-foreground/85">
-              {signal.label}
-            </span>
-            <span className="text-muted-foreground">{signal.expected}</span>
-          </span>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function findProtocolFact(
-  facts: Experiment["protocolFacts"],
-  label: string,
-) {
-  return facts.find((fact) => normalizeFactLabel(fact.label) === label);
-}
-
-function normalizeFactLabel(label: string): string {
-  return label.trim().toLowerCase();
-}
-
-function hasSpecificStepTitle(step: Experiment["protocol"][number]): boolean {
-  return step.title.trim() !== `Step ${step.number}`;
-}
-
-function ProtocolPhaseTimeline({
-  baselineDays,
-  baselineFact,
-  interventionFact,
-  totalDays,
-}: {
-  baselineDays: number;
-  baselineFact?: Experiment["protocolFacts"][number];
-  interventionFact?: Experiment["protocolFacts"][number];
-  totalDays: number;
-}) {
-  const clampedTotalDays = Math.max(0, totalDays);
-  const baselinePercent = clampedTotalDays > 0
-    ? Math.round((Math.max(0, baselineDays) / clampedTotalDays) * 100)
-    : 0;
-  const baselineLabel = baselineFact
-    ? `Baseline · ${baselineFact.value}`
-    : "Baseline";
-  const protocolLabel = interventionFact
-    ? `Protocol · ${interventionFact.value}`
-    : "Protocol";
-
-  return (
-    <div className="flex flex-col gap-3 rounded-lg border border-border/70 bg-background/35 p-4">
-      <ExperimentProgress
-        baselineLabel={baselineLabel}
-        overallPercent={baselinePercent}
-        protocolLabel={protocolLabel}
-      />
-      {interventionFact?.detail ? (
-        <p className="text-[13px]/5 text-muted-foreground">
-          {interventionFact.detail}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-function SectionLabel({ children }: { children: ReactNode }) {
-  return (
-    <span className="font-mono text-[11px]/3.5 uppercase tracking-[0.12em] text-chart-5">
-      {children}
-    </span>
-  );
-}
-
-function ProtocolTextList({
-  title,
-  items,
-}: {
-  title: string;
-  items: readonly string[];
-}) {
-  if (items.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="flex flex-col gap-3">
-      <SectionLabel>{title}</SectionLabel>
-      <ul className="flex flex-col gap-2.5">
-        {items.map((item) => (
-          <li
-            key={item}
-            className="flex gap-2.5 text-[13px]/5 text-muted-foreground"
-          >
-            <span
-              aria-hidden="true"
-              className="mt-2 size-1.5 shrink-0 rounded-full bg-secondary"
-            />
-            <span>{item}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
 }

--- a/apps/web/src/components/experiments/experiment-detail/protocol-tab.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/protocol-tab.tsx
@@ -92,6 +92,16 @@ const SIGNAL_ESTIMATE_FALLBACK: SignalEstimate = {
   evidence: "Indicative",
 };
 
+function getSignalEstimate(signal: ExperimentSignal): SignalEstimate {
+  const estimate = SIGNAL_ESTIMATES[signal.label];
+  if (estimate) return estimate;
+  return {
+    ...SIGNAL_ESTIMATE_FALLBACK,
+    range: signal.expected,
+    point: signal.expected,
+  };
+}
+
 interface TrajectoryChartProps {
   direction: "up" | "down" | "neutral";
   baseline: string;
@@ -266,13 +276,13 @@ export function ProtocolTab({ experiment, onJumpToResearch }: ProtocolTabProps) 
           <SectionLabel>What could change</SectionLabel>
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             {focusSignals.map((signal, idx) => {
-              const est =
-                SIGNAL_ESTIMATES[signal.label] ?? SIGNAL_ESTIMATE_FALLBACK;
+              const est = getSignalEstimate(signal);
               const isPrimary = idx === 0;
               const isNeutral = signal.direction === "neutral";
               return (
                 <div
                   key={signal.label}
+                  data-card={signal.label}
                   className={`flex flex-col rounded-xl border ${
                     isPrimary
                       ? "xl:col-span-2 gap-5 pt-7 px-7 pb-5 border-primary/25 bg-primary/[0.04]"
@@ -482,7 +492,7 @@ export function ProtocolTab({ experiment, onJumpToResearch }: ProtocolTabProps) 
             </span>
             <span>
               Anything unclear during the protocol? Ask Murph in the chat,
-              it knows the plan, your baseline, and the signals you're
+              it knows the plan, your baseline, and the signals you are
               tracking.
             </span>
           </p>

--- a/apps/web/src/components/experiments/experiment-detail/protocol-tab.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/protocol-tab.tsx
@@ -438,7 +438,7 @@ export function ProtocolTab({ experiment, onJumpToResearch }: ProtocolTabProps) 
 
       {protocolTips.length > 0 && (
         <section className="flex flex-col gap-6 rounded-xl border border-secondary/25 bg-card/90 p-7">
-          <div className="flex items-baseline justify-between gap-4">
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
             <SectionLabel>Good practices</SectionLabel>
             <p className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-muted-foreground">
               To keep results clean
@@ -907,7 +907,7 @@ function ProtocolShapeRail({
   return (
     <div className="flex flex-col gap-1.5">
       {effectiveLabels && labelTotal > 0 && (
-        <div className="flex gap-px">
+        <div className="hidden gap-px sm:flex">
           {effectiveLabels.map((entry, i) => {
             const color =
               entry.kind === "primary"
@@ -947,6 +947,29 @@ function ProtocolShapeRail({
           <span key={i}>{tick}</span>
         ))}
       </div>
+      {effectiveLabels && labelTotal > 0 && (
+        <ul role="list" className="mt-2 flex flex-wrap gap-x-3 gap-y-1 sm:hidden">
+          {effectiveLabels
+            .filter((entry) => entry.text)
+            .map((entry, i) => {
+              const dotCls =
+                entry.kind === "primary"
+                  ? "bg-primary"
+                  : entry.kind === "secondary"
+                    ? "bg-primary/30"
+                    : "bg-secondary";
+              return (
+                <li
+                  key={i}
+                  className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground"
+                >
+                  <span aria-hidden="true" className={`size-1.5 rounded-full ${dotCls}`} />
+                  <span>{entry.text}</span>
+                </li>
+              );
+            })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/experiments/experiment-detail/research-tab.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/research-tab.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import type { Experiment } from "@/src/types/experiments";
 import { StudyCard } from "./study-card";
+import { splitBulletLead } from "./format";
 
 interface ResearchTabProps {
   experiment: Experiment;
@@ -13,12 +14,17 @@ export function ResearchTab({ experiment }: ResearchTabProps) {
     researchLandscape,
     researchGroups,
     studies,
+    protocolKeepInMind,
   } = experiment;
 
   return (
     <div className="flex flex-col gap-8">
       {researchLandscape ? (
         <ResearchLandscapeReadout landscape={researchLandscape} />
+      ) : null}
+
+      {protocolKeepInMind.length > 0 ? (
+        <ReadingResultsNotes items={protocolKeepInMind} />
       ) : null}
 
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-6">
@@ -105,6 +111,41 @@ export function ResearchTab({ experiment }: ResearchTabProps) {
         </div>
       ) : null}
     </div>
+  );
+}
+
+function ReadingResultsNotes({ items }: { items: ReadonlyArray<string> }) {
+  return (
+    <section className="flex flex-col gap-5 rounded-xl border border-secondary/25 bg-card/90 p-7">
+      <SectionLabel>Read results carefully</SectionLabel>
+      <ul
+        role="list"
+        className="grid gap-x-10 gap-y-6 md:grid-cols-3 md:divide-x md:divide-border/60"
+      >
+        {items.map((item) => {
+          const { lead, rest } = splitBulletLead(item);
+          return (
+            <li
+              key={item}
+              className="flex flex-col gap-1.5 text-[14px]/6 text-foreground text-pretty md:px-6 md:first:pl-0 md:last:pr-0"
+            >
+              {lead ? (
+                <>
+                  <strong className="font-semibold text-foreground">
+                    {lead}
+                  </strong>
+                  {rest ? (
+                    <span className="text-muted-foreground">{rest}</span>
+                  ) : null}
+                </>
+              ) : (
+                <span>{item}</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
   );
 }
 

--- a/apps/web/src/components/experiments/experiment-detail/research-tab.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/research-tab.tsx
@@ -1,0 +1,292 @@
+import type { ReactNode } from "react";
+
+import type { Experiment } from "@/src/types/experiments";
+import { StudyCard } from "./study-card";
+
+interface ResearchTabProps {
+  experiment: Experiment;
+}
+
+export function ResearchTab({ experiment }: ResearchTabProps) {
+  const {
+    researchStats,
+    researchLandscape,
+    researchGroups,
+    studies,
+  } = experiment;
+
+  return (
+    <div className="flex flex-col gap-8">
+      {researchLandscape ? (
+        <ResearchLandscapeReadout landscape={researchLandscape} />
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-6">
+        {researchStats.map((stat) => {
+          const isHero =
+            /HUMAN PARTICIPANTS/u.test(stat.label) && stat.value !== "—";
+          return (
+            <div
+              key={stat.label}
+              className={
+                isHero
+                  ? "order-first flex flex-col items-center gap-1.5 rounded-xl border border-primary/25 bg-primary/5 p-5 xl:col-span-2"
+                  : "flex flex-col items-center gap-1 rounded-xl border border-secondary/25 bg-card/90 p-4"
+              }
+            >
+              <span
+                className={
+                  isHero
+                    ? "font-serif text-[44px]/12 font-semibold text-primary"
+                    : "font-serif text-[26px]/9 font-semibold text-foreground/85"
+                }
+              >
+                {typeof stat.value === "number"
+                  ? stat.value.toLocaleString()
+                  : stat.value}
+              </span>
+              <span className="font-mono text-[10px]/3 tracking-[0.08em] text-chart-5">
+                {stat.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {researchStats.some((stat) =>
+        /HUMAN PARTICIPANTS/u.test(stat.label) && stat.value !== "—",
+      ) ? (
+        <details className="group">
+          <summary className="cursor-pointer list-none font-mono text-[10px]/3 uppercase tracking-[0.08em] text-muted-foreground hover:text-foreground [&::-webkit-details-marker]:hidden">
+            <span className="inline-flex items-center gap-1.5">
+              How we count
+              <span aria-hidden="true" className="transition-transform group-open:rotate-180">˅</span>
+            </span>
+          </summary>
+          <p className="mt-2 max-w-3xl text-xs/5 text-muted-foreground/70">
+            Sources checked is every card shown on this page. Direct human
+            participants counts only primary human studies with coded
+            participant totals, deduplicated by cohort when possible. Review
+            cards may show larger pooled head counts on their own rows, and
+            those pooled totals are treated as approximate rather than added
+            into the page-level number.
+            {experiment.id === "norwegian-4x4"
+              ? " On Norwegian 4x4, safety-boundary registries also stay off that page-level total."
+              : ""}
+          </p>
+        </details>
+      ) : null}
+
+      {experiment.id === "norwegian-4x4"
+        && researchGroups
+        && researchGroups.length > 0 ? (
+        <p className="max-w-3xl text-sm/6 text-muted-foreground/80">
+          Read these top to bottom: the earliest groups are the closest match to
+          the exact protocol, and the later groups mainly add safety, boundary,
+          or nearby-variant context.
+        </p>
+      ) : null}
+
+      {researchGroups && researchGroups.length > 0 ? (
+        <div className="flex flex-col gap-4">
+          {researchGroups.map((group) => (
+            <ResearchGroupCard key={group.id} group={group} />
+          ))}
+        </div>
+      ) : studies.length > 0 ? (
+        <div className="overflow-hidden rounded-xl border border-secondary/25 bg-card/90">
+          {studies.map((study, i) => (
+            <StudyCard
+              key={study.title}
+              {...study}
+              last={i === studies.length - 1}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ResearchLandscapeReadout({
+  landscape,
+}: {
+  landscape: NonNullable<Experiment["researchLandscape"]>;
+}) {
+  return (
+    <section className="flex flex-col gap-5 rounded-xl border border-secondary/25 bg-card/90 p-7">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-chart-5">
+          Verdict
+        </span>
+        <ConfidenceBadge level={landscape.confidenceLabel} />
+      </div>
+      <p className="max-w-3xl font-serif text-xl/8 font-medium text-foreground text-pretty">
+        {landscape.primaryClaim}
+      </p>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-chart-5">
+            Bottom line
+          </span>
+          <p className="text-sm/6 text-foreground">{landscape.bottomLine}</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-chart-4">
+            Main caveat
+          </span>
+          <p className="text-sm/6 text-foreground">{landscape.mainCaveat}</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ConfidenceBadge({
+  level,
+}: {
+  level: NonNullable<Experiment["researchLandscape"]>["confidenceLabel"];
+}) {
+  const tone: Record<typeof level, { label: string; className: string }> = {
+    early: { label: "Early", className: "border-chart-4/40 bg-chart-4/10 text-chart-4" },
+    limited: { label: "Limited", className: "border-chart-4/40 bg-chart-4/10 text-chart-4" },
+    mixed: { label: "Mixed", className: "border-chart-4/40 bg-chart-4/10 text-chart-4" },
+    moderate: {
+      label: "Moderate confidence",
+      className: "border-primary/40 bg-primary/10 text-primary",
+    },
+    strong: {
+      label: "Strong confidence",
+      className: "border-primary/60 bg-primary/15 text-primary",
+    },
+  };
+  const { label, className } = tone[level];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-3 py-1 font-mono text-[11px]/4 font-semibold uppercase tracking-[0.08em] ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ResearchGroupCard({
+  group,
+}: {
+  group: NonNullable<Experiment["researchGroups"]>[number];
+}) {
+  const sourceMixSummary = formatResearchGroupSourceMix(group.studies);
+
+  return (
+    <details
+      className="group overflow-hidden rounded-xl border border-secondary/25 bg-card/90"
+      open={group.defaultOpen}
+    >
+      <summary className="cursor-pointer list-none px-6 py-5 transition-colors hover:bg-secondary/6 [&::-webkit-details-marker]:hidden">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex max-w-3xl flex-col gap-2">
+            <SectionLabel>{formatResearchGroupLabel(group.id, group.label)}</SectionLabel>
+            <p className="line-clamp-2 text-[14px]/6 text-foreground/80 group-open:line-clamp-none">{group.summary}</p>
+            <p className="font-mono text-[10px]/3.5 tracking-[0.08em] text-muted-foreground/80">
+              {sourceMixSummary}
+            </p>
+          </div>
+          <div className="flex w-fit shrink-0 items-center gap-2 self-start sm:justify-end">
+            <span className="rounded-full border border-border/70 bg-background/35 px-2.5 py-1 font-mono text-[10px]/3.5 text-muted-foreground">
+              {formatEvidenceStance(group.stance)}
+            </span>
+            <span
+              aria-hidden="true"
+              className="rounded-full border border-border/70 bg-background/35 px-2 py-1 font-mono text-[10px]/3.5 text-muted-foreground transition-transform group-open:rotate-180"
+            >
+              ˅
+            </span>
+          </div>
+        </div>
+      </summary>
+      <div className="border-t border-border/70">
+        {group.studies.map((study, index) => (
+          <StudyCard
+            key={`${group.id}-${study.title}`}
+            {...study}
+            last={index === group.studies.length - 1}
+          />
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function formatResearchGroupLabel(id: string, fallbackLabel: string): string {
+  switch (id) {
+    case "evidence-backbone-and-claim-calibration":
+      return "What the evidence can and can't say";
+    case "near-term-autonomic-vascular-and-immune-signals":
+      return "Short-term signals to watch";
+    case "long-term-finnish-cohort-and-real-world-context":
+      return "Long-term Finnish population context";
+    case "intervention-design-training-and-mixed-results":
+      return "Repeated-use trials and mixed results";
+    case "safety-dose-modality-and-context-boundaries":
+      return "Safety, dose, and sauna type";
+    default:
+      return fallbackLabel;
+  }
+}
+
+function formatResearchGroupSourceMix(
+  studies: NonNullable<Experiment["researchGroups"]>[number]["studies"],
+): string {
+  const sourceCount = studies.length;
+  const categoryCounts = [
+    { count: countStudiesByType(studies, ["MECH"]), pluralLabel: "physiology studies", singularLabel: "physiology study", sortOrder: 0 },
+    { count: countStudiesByType(studies, ["RCT", "INT"]), pluralLabel: "trials", singularLabel: "trial", sortOrder: 1 },
+    { count: countStudiesByType(studies, ["OBS"]), pluralLabel: "observational studies", singularLabel: "observational study", sortOrder: 2 },
+    { count: countStudiesByType(studies, ["MA", "REV"]), pluralLabel: "reviews", singularLabel: "review", sortOrder: 3 },
+    { count: countStudiesByType(studies, ["GUIDE"]), pluralLabel: "guidance sources", singularLabel: "guidance source", sortOrder: 4 },
+    { count: countStudiesByType(studies, ["N1"]), pluralLabel: "self-experiments", singularLabel: "self-experiment", sortOrder: 5 },
+    { count: countStudiesByType(studies, ["SRC"]), pluralLabel: "supporting sources", singularLabel: "supporting source", sortOrder: 6 },
+  ]
+    .filter((category) => category.count > 0)
+    .sort((left, right) => {
+      if (left.count !== right.count) return right.count - left.count;
+      return left.sortOrder - right.sortOrder;
+    })
+    .slice(0, 3)
+    .map((category) =>
+      `${category.count.toLocaleString()} ${category.count === 1 ? category.singularLabel : category.pluralLabel}`,
+    );
+
+  return [
+    `${sourceCount.toLocaleString()} ${sourceCount === 1 ? "source" : "sources"}`,
+    ...categoryCounts,
+  ].join(" · ");
+}
+
+function countStudiesByType(
+  studies: NonNullable<Experiment["researchGroups"]>[number]["studies"],
+  includedTypes: readonly Experiment["studies"][number]["type"][],
+): number {
+  return studies.filter((study) => includedTypes.includes(study.type)).length;
+}
+
+function formatEvidenceStance(
+  stance: NonNullable<Experiment["researchGroups"]>[number]["stance"],
+): string {
+  switch (stance) {
+    case "supports": return "Supports";
+    case "mixed": return "Mixed evidence";
+    case "does_not_confirm": return "Doesn't confirm";
+    case "contradicts": return "Evidence against";
+    case "safety_boundary": return "Safety boundary";
+    case "context_only": return "Context, not proof";
+  }
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <span className="font-mono text-[11px]/3.5 uppercase tracking-[0.12em] text-chart-5">
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/experiments/experiment-detail/safety-section.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/safety-section.tsx
@@ -1,3 +1,23 @@
+import {
+  Activity,
+  AlertOctagon,
+  Baby,
+  Brain,
+  CircleAlert,
+  Droplet,
+  Flame,
+  HeartPulse,
+  Info,
+  LogOut,
+  ShieldAlert,
+  Stethoscope,
+  Thermometer,
+  Wine,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "@/src/lib/utils";
+
 interface SafetySectionProps {
   cautionLevel: number;
   whoShouldAvoid: string[];
@@ -9,73 +29,164 @@ export function SafetySection({
   whoShouldAvoid,
   precautions,
 }: SafetySectionProps) {
+  const hasAvoid = whoShouldAvoid.length > 0;
+  const hasPrecautions = precautions.length > 0;
+
   return (
-    <div id="safety-section" className="flex flex-col gap-5 rounded-xl border border-destructive/20 bg-destructive/4 p-6 scroll-mt-8">
-      <div className="flex flex-col gap-3">
-        <span className="font-mono text-[11px]/3.5 uppercase tracking-[0.12em] text-chart-4">
-          Safety
-        </span>
-        <CautionRuler level={cautionLevel} />
-      </div>
+    <div id="safety-section" className="flex scroll-mt-8 flex-col gap-3">
+      <div className={cn("grid gap-3", hasPrecautions && "lg:grid-cols-2")}>
+        <div className="flex flex-col gap-6 rounded-xl border border-destructive/20 bg-destructive/4 p-6">
+          <div className="flex flex-col gap-0.5">
+            <span className="font-mono text-[11px]/3.5 uppercase tracking-[0.12em] text-chart-4">
+              Safety
+            </span>
+            <h2 className="font-serif text-base font-semibold text-foreground">
+              {cautionTitle(cautionLevel)}
+            </h2>
+          </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="flex flex-col gap-2">
-          <span className="text-sm font-semibold text-destructive">
-            Who should avoid
-          </span>
-          <ul role="list" className="flex flex-col gap-1.5">
-            {whoShouldAvoid.map((item) => (
-              <li key={item} className="flex gap-2 text-sm/5 text-destructive">
-                <span aria-hidden="true" className="mt-2 size-1 shrink-0 rounded-full bg-destructive" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
+          <div className="flex flex-1 flex-col gap-5 sm:flex-row sm:items-stretch sm:gap-6">
+            <div className="shrink-0 self-center sm:self-stretch">
+              <CautionThermometer level={cautionLevel} />
+            </div>
+
+            {hasAvoid ? (
+              <div className="flex min-w-0 flex-1 flex-col gap-3">
+                <div className="flex flex-col gap-0.5">
+                  <h3 className="text-sm font-semibold text-foreground">
+                    Skip this if you have
+                  </h3>
+                  <span className="text-xs/4 text-muted-foreground">
+                    Get clinician guidance before starting if any apply.
+                  </span>
+                </div>
+                <ul role="list" className="flex flex-wrap gap-1.5">
+                  {whoShouldAvoid.map((item) => {
+                    const Icon = whoIcon(item);
+                    return (
+                      <li
+                        key={item}
+                        className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-destructive/25 bg-background/70 px-2.5 py-1 text-xs/4 text-foreground"
+                      >
+                        <Icon className="size-3.5 shrink-0 text-destructive" />
+                        <span className="min-w-0 break-words">{item}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ) : null}
+          </div>
         </div>
 
-        <div className="flex flex-col gap-2">
-          <span className="text-sm font-semibold text-destructive">
-            Precautions
-          </span>
-          <ul role="list" className="flex flex-col gap-1.5">
-            {precautions.map((item) => (
-              <li key={item} className="flex gap-2 text-sm/5 text-destructive">
-                <span aria-hidden="true" className="mt-2 size-1 shrink-0 rounded-full bg-destructive" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+        {hasPrecautions ? (
+          <div className="flex flex-col gap-5 rounded-xl border border-foreground/10 bg-cream-dark/50 p-6">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[11px]/3.5 uppercase tracking-[0.12em] text-muted-foreground">
+                Precautions
+              </span>
+              <h2 className="font-serif text-base font-semibold text-foreground">
+                Stay safe before, during, and after each session.
+              </h2>
+            </div>
+            <ul role="list" className="flex flex-1 flex-col justify-around">
+              {precautions.map((item, idx) => {
+                const Icon = precautionIcon(item);
+                return (
+                  <li
+                    key={item}
+                    className={cn(
+                      "flex items-start gap-3 py-2.5",
+                      idx > 0 && "border-t border-foreground/8",
+                    )}
+                  >
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-destructive/10">
+                      <Icon className="size-3.5 text-destructive" />
+                    </span>
+                    <span className="min-w-0 break-words pt-1 text-sm/5 text-foreground">
+                      {item}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ) : null}
       </div>
     </div>
   );
 }
 
-function CautionRuler({ level }: { level: number }) {
+function cautionTitle(level: number): string {
   const clamped = Math.max(1, Math.min(5, level));
-  const percent = ((clamped - 0.5) / 5) * 100;
-  const label =
-    clamped <= 2 ? "Low caution" : clamped <= 3 ? "Moderate caution" : "High caution";
+  if (clamped <= 2) return "Low caution";
+  if (clamped <= 3) return "Moderate caution";
+  return "High caution";
+}
+
+function CautionThermometer({ level }: { level: number }) {
+  const clamped = Math.max(1, Math.min(5, level));
+  const tubeFillPct = ((clamped - 1) / 4) * 100;
+
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex justify-between font-mono text-[10px]/3 uppercase tracking-[0.08em] text-muted-foreground">
+    <div
+      role="img"
+      aria-label={`Caution level ${clamped} of 5: ${cautionTitle(clamped)}`}
+      className="flex h-full min-h-72 items-stretch gap-3"
+    >
+      <div aria-hidden="true" className="flex flex-col justify-between py-1 font-mono text-[10px]/3 uppercase tracking-wide text-muted-foreground">
+        <span>High</span>
+        <span>Mod</span>
         <span>Low</span>
-        <span>Moderate</span>
-        <span>High caution</span>
       </div>
-      <div className="relative h-3 w-full overflow-hidden rounded-full bg-secondary/30">
-        <div className="absolute inset-y-0 left-0 w-2/5 bg-primary/50" />
-        <div className="absolute inset-y-0 left-2/5 w-1/5 bg-[#c4a060]/70" />
-        <div className="absolute inset-y-0 left-3/5 w-2/5 bg-destructive/60" />
-        <div
+      <div aria-hidden="true" className="flex flex-col items-center">
+        <div className="relative w-3.5 flex-1 overflow-hidden rounded-t-full border border-b-0 border-destructive/35 bg-secondary/25">
+          <div
+            className="absolute inset-0 bg-linear-to-t from-primary via-[#c4a882] to-destructive"
+            style={{ clipPath: `inset(${100 - tubeFillPct}% 0 0 0)` }}
+          />
+        </div>
+        <svg
+          width="32"
+          height="36"
+          viewBox="0 0 32 36"
           aria-hidden="true"
-          className="absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-foreground shadow-sm"
-          style={{ left: `${percent}%` }}
-        />
+          className="shrink-0"
+        >
+          <path
+            d="M9 0 L9 8 A14 14 0 1 0 23 8 L23 0 Z"
+            fill="var(--primary)"
+            stroke="var(--destructive)"
+            strokeOpacity="0.35"
+            strokeWidth="1"
+          />
+        </svg>
       </div>
-      <span className="self-end font-mono text-[11px]/4 font-semibold text-destructive">
-        {label}
-      </span>
     </div>
   );
+}
+
+function whoIcon(text: string): LucideIcon {
+  const lower = text.toLowerCase();
+  if (/heart|cardiac|angina|infarction|arrhythmia|failure|stenosis/.test(lower)) {
+    return HeartPulse;
+  }
+  if (/hypertension|blood pressure/.test(lower)) return Activity;
+  if (/stroke|brain/.test(lower)) return Brain;
+  if (/pregnan/.test(lower)) return Baby;
+  if (/fever|illness|infection/.test(lower)) return Thermometer;
+  if (/dehydr|fainting|faint/.test(lower)) return Droplet;
+  if (/heat/.test(lower)) return Flame;
+  return CircleAlert;
+}
+
+function precautionIcon(text: string): LucideIcon {
+  const lower = text.toLowerCase();
+  if (/^stop if/.test(lower)) return AlertOctagon;
+  if (/alcohol/.test(lower)) return Wine;
+  if (/clinician|treatment plan/.test(lower)) return Stethoscope;
+  if (/bounded wellness|self-experiment|disease/.test(lower)) return Info;
+  if (/exit|leave|early/.test(lower)) return LogOut;
+  if (/temperature|°c|heat-stress/.test(lower)) return Thermometer;
+  return ShieldAlert;
 }

--- a/apps/web/src/components/experiments/experiment-detail/safety-section.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/safety-section.tsx
@@ -10,47 +10,72 @@ export function SafetySection({
   precautions,
 }: SafetySectionProps) {
   return (
-    <div className="flex flex-col gap-3.5 rounded-xl border border-destructive/20 bg-destructive/4 p-6">
-      <div className="flex items-center justify-between">
-        <span className="font-mono text-[11px]/3.5 tracking-[0.12em] text-chart-4">
-          SAFETY
+    <div id="safety-section" className="flex flex-col gap-5 rounded-xl border border-destructive/20 bg-destructive/4 p-6 scroll-mt-8">
+      <div className="flex flex-col gap-3">
+        <span className="font-mono text-[11px]/3.5 uppercase tracking-[0.12em] text-chart-4">
+          Safety
         </span>
-        <div className="flex items-center gap-1.5">
-          {Array.from({ length: 5 }, (_, i) => (
-            <div
-              key={i}
-              className={`size-2 rounded-full ${
-                i < cautionLevel ? "bg-[#C4A060]" : "bg-secondary"
-              }`}
-            />
-          ))}
-          <span className="ml-1 font-mono text-[10px]/3 text-chart-4">
-            {cautionLevel <= 2
-              ? "Low caution"
-              : cautionLevel <= 3
-                ? "Moderate caution"
-                : "High caution"}
+        <CautionRuler level={cautionLevel} />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-destructive">
+            Who should avoid
           </span>
+          <ul role="list" className="flex flex-col gap-1.5">
+            {whoShouldAvoid.map((item) => (
+              <li key={item} className="flex gap-2 text-sm/5 text-destructive">
+                <span aria-hidden="true" className="mt-2 size-1 shrink-0 rounded-full bg-destructive" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-destructive">
+            Precautions
+          </span>
+          <ul role="list" className="flex flex-col gap-1.5">
+            {precautions.map((item) => (
+              <li key={item} className="flex gap-2 text-sm/5 text-destructive">
+                <span aria-hidden="true" className="mt-2 size-1 shrink-0 rounded-full bg-destructive" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
+    </div>
+  );
+}
 
-      <div className="flex flex-col gap-1.5">
-        <span className="text-[13px]/4 font-semibold text-destructive">
-          Who should avoid
-        </span>
-        <span className="text-[13px] leading-[155%] text-destructive">
-          {whoShouldAvoid.join(" · ")}
-        </span>
+function CautionRuler({ level }: { level: number }) {
+  const clamped = Math.max(1, Math.min(5, level));
+  const percent = ((clamped - 0.5) / 5) * 100;
+  const label =
+    clamped <= 2 ? "Low caution" : clamped <= 3 ? "Moderate caution" : "High caution";
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex justify-between font-mono text-[10px]/3 uppercase tracking-[0.08em] text-muted-foreground">
+        <span>Low</span>
+        <span>Moderate</span>
+        <span>High caution</span>
       </div>
-
-      <div className="flex flex-col gap-1.5">
-        <span className="text-[13px]/4 font-semibold text-destructive">
-          Precautions
-        </span>
-        <span className="text-[13px] leading-[155%] text-destructive">
-          {precautions.join(" ")}
-        </span>
+      <div className="relative h-3 w-full overflow-hidden rounded-full bg-secondary/30">
+        <div className="absolute inset-y-0 left-0 w-2/5 bg-primary/50" />
+        <div className="absolute inset-y-0 left-2/5 w-1/5 bg-[#c4a060]/70" />
+        <div className="absolute inset-y-0 left-3/5 w-2/5 bg-destructive/60" />
+        <div
+          aria-hidden="true"
+          className="absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-foreground shadow-sm"
+          style={{ left: `${percent}%` }}
+        />
       </div>
+      <span className="self-end font-mono text-[11px]/4 font-semibold text-destructive">
+        {label}
+      </span>
     </div>
   );
 }

--- a/apps/web/test/biomarker-layout.test.ts
+++ b/apps/web/test/biomarker-layout.test.ts
@@ -28,5 +28,5 @@ test("BiomarkersLayout renders biomarker pages inside the shared dashboard shell
   assert.match(markup, /data-biomarker-page="true"/);
   assert.match(markup, /data-slot="sidebar-wrapper"/);
   assert.match(markup, /data-slot="sidebar-inset"/);
-  assert.match(markup, /<main class="flex-1 overflow-y-auto">/);
+  assert.match(markup, /<main class="flex-1">/);
 });

--- a/apps/web/test/experiment-detail-protocol-tab.test.ts
+++ b/apps/web/test/experiment-detail-protocol-tab.test.ts
@@ -62,6 +62,7 @@ vi.mock("@/src/components/experiments/experiment-detail/safety-section", () => (
 }));
 
 import { ProtocolTab } from "@/src/components/experiments/experiment-detail/protocol-tab";
+import { ResearchTab } from "@/src/components/experiments/experiment-detail/research-tab";
 
 describe("ProtocolTab", () => {
   it("renders the protocol layout without generic step labels or duplicated summary copy", () => {
@@ -77,11 +78,9 @@ describe("ProtocolTab", () => {
     const summaryParagraph = experiment.whyItWorks.split("\n\n")[0]?.trim();
 
     expect(markup).toContain("Run the protocol");
-    expect(markup).toContain("At a glance");
     expect(markup).toContain("Why it works");
-    expect(markup).toContain("Baseline · 7 days");
-    expect(markup).toContain("Protocol · 14 days");
-    expect(markup).toContain('data-progress-percent="33"');
+    expect(markup).toContain("Schedule &amp; dose");
+    expect(markup).toContain("7-day baseline then 14-day protocol");
     expect(markup).not.toContain("days to analysis");
     expect(markup).not.toContain("Total run");
     expect(markup).not.toContain("Protocol window");
@@ -103,6 +102,7 @@ describe("ProtocolTab", () => {
       privateRun: null,
     });
     const markup = renderToStaticMarkup(createElement(ProtocolTab, { experiment }));
+    const researchMarkup = renderToStaticMarkup(createElement(ResearchTab, { experiment }));
 
     expect(markup).toContain("What could change");
     expect(markup).toContain("Also worth watching");
@@ -114,10 +114,9 @@ describe("ProtocolTab", () => {
     expect(markup).not.toContain('data-card="Deep Sleep Minutes"');
     expect(markup).toContain("Sleep Efficiency");
     expect(markup).toContain("Deep Sleep Minutes");
-    expect(markup).toContain("Bottom line");
-    expect(markup).toContain("Best-supported claim");
-    expect(markup).toContain("Confidence · Mixed");
-    expect(markup).not.toContain("Evidence backbone and claim calibration");
+    expect(researchMarkup).toContain("Bottom line");
+    expect(researchMarkup).toContain("Mixed");
+    expect(researchMarkup).not.toContain("Evidence backbone and claim calibration");
     expect(markup).not.toContain("Read these top to bottom");
   });
 
@@ -149,6 +148,7 @@ describe("ProtocolTab", () => {
       privateRun: null,
     });
     const markup = renderToStaticMarkup(createElement(ProtocolTab, { experiment }));
+    const researchMarkup = renderToStaticMarkup(createElement(ResearchTab, { experiment }));
 
     expect(markup).toContain("What could change");
     expect(markup).toContain("Also worth watching");
@@ -160,16 +160,16 @@ describe("ProtocolTab", () => {
     expect(markup).not.toContain('data-card="Sleep Efficiency"');
     expect(markup).toContain("Morning Blood Pressure");
     expect(markup).toContain("Sleep Efficiency");
-    expect(markup).toContain("Bottom line");
-    expect(markup).toContain("Best-supported claim");
-    expect(markup).toContain("Confidence · Moderate");
-    expect(markup).toContain("Exact or close 4x4 trials");
-    expect(markup).toContain("Dose, target zone, and implementation");
-    expect(markup).toContain("Broader HIIT and VO2max context");
-    expect(markup).toContain("Clinical lineage and mixed superiority");
-    expect(markup).toContain("Safety boundaries");
-    expect(markup).toContain("Nearby protocols and recovery context");
-    expect(markup).toContain("Read these top to bottom");
+    expect(researchMarkup).toContain("Bottom line");
+    expect(researchMarkup).toContain("best-supported claim");
+    expect(researchMarkup).toContain("Moderate confidence");
+    expect(researchMarkup).toContain("Exact or close 4x4 trials");
+    expect(researchMarkup).toContain("Dose, target zone, and implementation");
+    expect(researchMarkup).toContain("Broader HIIT and VO2max context");
+    expect(researchMarkup).toContain("Clinical lineage and mixed superiority");
+    expect(researchMarkup).toContain("Safety boundaries");
+    expect(researchMarkup).toContain("Nearby protocols and recovery context");
+    expect(researchMarkup).toContain("Read these top to bottom");
   });
 
   it("renders grouped research inside native details cards with source-mix summaries", () => {
@@ -181,9 +181,9 @@ describe("ProtocolTab", () => {
       protocol: protocol!,
       privateRun: null,
     });
-    const markup = renderToStaticMarkup(createElement(ProtocolTab, { experiment }));
+    const markup = renderToStaticMarkup(createElement(ResearchTab, { experiment }));
 
-    expect(countOccurrences(markup, "<details")).toBe(6);
+    expect(countOccurrences(markup, "group overflow-hidden rounded-xl")).toBe(6);
     expect(countOccurrences(markup, 'open=""')).toBe(2);
     expect(markup).toContain("2 sources · 2 trials");
     expect(markup).toContain("3 sources · 1 physiology study · 1 trial · 1 guidance source");
@@ -239,7 +239,7 @@ describe("ProtocolTab", () => {
       ...baseExperiment,
       researchGroups,
     };
-    const markup = renderToStaticMarkup(createElement(ProtocolTab, { experiment }));
+    const markup = renderToStaticMarkup(createElement(ResearchTab, { experiment }));
 
     expect(markup).toContain("Short-term signals to watch");
     expect(markup).not.toContain("Synthetic fallback label that should not drive the display mapping");
@@ -257,12 +257,17 @@ describe("ProtocolTab", () => {
       privateRun: null,
     });
     const markup = renderToStaticMarkup(createElement(ProtocolTab, { experiment }));
+    const sleepEfficiencyExpected = experiment.expectedSignals.find(
+      (signal) => signal.label === "Sleep Efficiency",
+    )?.expected;
 
     expect(markup).toContain("What could change");
     expect(markup).toContain("Also worth watching");
     expect(countOccurrences(markup, "data-card=")).toBe(2);
     expect(markup).toContain('data-card="Sleep Efficiency"');
     expect(markup).toContain('data-card="Sleep Onset Latency"');
+    expect(sleepEfficiencyExpected).toBeTruthy();
+    expect(markup).toContain(sleepEfficiencyExpected!);
     expect(markup).not.toContain('data-card="Deep Sleep Minutes"');
     expect(markup).not.toContain('data-card="HRV / RMSSD"');
     expect(markup).not.toContain('data-card="Resting Heart Rate"');


### PR DESCRIPTION
## Summary

- **Experiment detail page redesign** (`feat(experiments): redesign experiment detail page`) — new layout for the experiment detail view with refreshed protocol/research/results tabs, signal cards, schedule grid, mechanism causal chain, and how-it-works section. Also reorganizes `packages/health-commons` content and regenerates e2e smoke snapshots.
- **Protocol tab simplify pass** (`refine(experiments): protocol tab simplify pass`) — tightens copy and structure on the Protocol tab.
- **Safety section redesign + mobile polish** (`refine(experiments): redesign safety section, polish mobile layout`) — replaces the two-column bullet list with a vertical thermometer caution gauge plus icon-tagged condition pills and a separate precautions sub-card with icon-led action rows. Fixes mobile layout regressions: Start button overflow at 375px, page tabs overflow at 320px, ProtocolShapeRail label truncation. Adds h2/h3 semantics, role="img" with aria-label on the thermometer, and graceful empty-state handling for the safety arrays.

Diff: 3 commits, 773 files, +3240 / −66972 (most of the file count is health-commons content reorganisation and regenerated e2e snapshots).

## Test plan

- [ ] Visit `/experiments/finnish-sauna` and confirm hero, header, tabs, and Protocol tab render correctly on desktop (1280px+)
- [ ] Resize to 375px (iPhone) — header stacks, Start button is full-width, no horizontal scroll, tabs fit, ProtocolShapeRail shows the legend below the bar
- [ ] Resize to 320px — Protocol/Research/Your Results tabs all fit
- [ ] Safety section: thermometer mercury matches caution level, condition pills wrap cleanly with icons, precautions card has icon-led rows, headings use proper h2/h3 (verify in the a11y tree)
- [ ] Test with an experiment whose `whoShouldAvoid` and/or `precautions` arrays are empty — those subsections / cards should hide gracefully
- [ ] Run the e2e smoke suite to confirm regenerated scenarios match

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->