### PR TITLE
[codex] Route browser-vault refresh through mailbox

### DIFF
--- a/agent-docs/exec-plans/completed/browser-vault-demand-followup.md
+++ b/agent-docs/exec-plans/completed/browser-vault-demand-followup.md
@@ -1,0 +1,18 @@
+Goal:
+- Add focused demand-path coverage for browser-vault runtime-control mailbox items and simplify the runtime-control signal helper.
+
+Scope:
+- Add an explicit demand test proving `runtime.browser-vault-refresh-requested` system mailbox lag becomes browser-vault refresh runtime demand.
+- Remove the optional workspace-ensure skip from the shared runtime-control mailbox helper.
+
+Constraints:
+- Keep this on the existing browser-vault mailbox PR.
+- Do not start PR 2 or move browser-vault semantics into the local runtime in this change.
+- Do not change Temporal workflow logic, Cloudflare, `readRuntimeDemand` production logic, or runtime execution semantics.
+
+Verification:
+- Run the focused demand and signal tests.
+- Run diff-aware app verification for the touched files.
+Status: completed
+Updated: 2026-06-07
+Completed: 2026-06-07

--- a/agent-docs/exec-plans/completed/browser-vault-refresh-mailbox.md
+++ b/agent-docs/exec-plans/completed/browser-vault-refresh-mailbox.md
@@ -1,0 +1,20 @@
+Goal:
+- Make hosted browser-vault refresh use the durable runtime-control mailbox path before Temporal signaling, matching manual run behavior.
+
+Scope:
+- Update the web producer in `apps/web/src/lib/hosted-orchestration/signal-runtime.ts`.
+- Update focused hosted orchestration signal tests in `apps/web/test/hosted-orchestration-signal-runtime.test.ts`.
+
+Constraints:
+- Do not change Temporal workflow logic, Cloudflare behavior, `readRuntimeDemand`, or runtime execution semantics.
+- Keep Temporal signal payloads pointer-only and free of prompts, headers, payloads, messages, secrets, or direct identifiers.
+- Preserve legacy Temporal `browser_vault_refresh_requested` parser/handler compatibility; stop producing it from web.
+- Dedupe repeated browser-vault refresh requests only while they target the same hosted workspace version.
+
+Verification:
+- Run focused app/web hosted orchestration signal tests.
+- Run truthful diff/app verification required by repo policy.
+- Run required completion audits for hosted runtime control behavior.
+Status: completed
+Updated: 2026-06-07
+Completed: 2026-06-07

--- a/apps/web/src/lib/hosted-orchestration/signal-runtime.ts
+++ b/apps/web/src/lib/hosted-orchestration/signal-runtime.ts
@@ -156,7 +156,6 @@ export async function signalHostedBrowserVaultRefreshRuntime(
   return signalHostedRuntimeControlMailboxRequest({
     client: input.client,
     environment: input.environment,
-    ensureWorkspace: false,
     eventId: control.eventId,
     kind: "runtime.browser-vault-refresh-requested",
     occurredAt: control.occurredAt,
@@ -244,7 +243,6 @@ export async function signalHostedDeviceSyncMailboxRuntime(
 async function signalHostedRuntimeControlMailboxRequest(input: {
   client?: HostedRuntimeTemporalSignalClient | null;
   environment?: NodeJS.ProcessEnv;
-  ensureWorkspace?: boolean;
   eventId?: string | null;
   kind: HostedExecutionRuntimeControlWakeKind;
   occurredAt?: string | null;
@@ -253,9 +251,7 @@ async function signalHostedRuntimeControlMailboxRequest(input: {
   userId: string;
 }): Promise<HostedRuntimeSignalResult> {
   const prisma = input.prisma ?? getPrisma();
-  if (input.ensureWorkspace !== false) {
-    await ensureHostedRuntimeWorkspaceForActiveUser(input.userId, prisma);
-  }
+  await ensureHostedRuntimeWorkspaceForActiveUser(input.userId, prisma);
   const deterministicEventId = normalizeHostedRuntimeControlEventId(input.eventId);
   const occurredAt = normalizeHostedRuntimeControlOccurredAt(input.occurredAt)
     ?? (deterministicEventId ? HOSTED_RUNTIME_CONTROL_DETERMINISTIC_OCCURRED_AT : new Date().toISOString());

--- a/apps/web/src/lib/hosted-orchestration/signal-runtime.ts
+++ b/apps/web/src/lib/hosted-orchestration/signal-runtime.ts
@@ -146,32 +146,24 @@ export async function signalHostedMailboxAppendRuntime(
 export async function signalHostedBrowserVaultRefreshRuntime(
   input: SignalHostedBrowserVaultRefreshInput,
 ): Promise<HostedRuntimeSignalResult> {
-  await ensureHostedRuntimeWorkspaceForActiveUser(input.userId, input.prisma ?? getPrisma());
-  try {
-    return await signalHostedUserRuntimeWorkflow({
-      client: input.client,
-      environment: input.environment,
-      ensureWorkspace: false,
-      prisma: input.prisma,
-      signal: parseHostedRuntimeSignal({
-        kind: "browser_vault_refresh_requested",
-      }),
-      userId: input.userId,
-    });
-  } catch {
-    const fallbackControl =
-      buildHostedBrowserVaultRefreshRuntimeControlFallback(input.userId);
-    return signalHostedRuntimeControlMailboxRequest({
-      client: input.client,
-      environment: input.environment,
-      eventId: fallbackControl.eventId,
-      kind: "runtime.browser-vault-refresh-requested",
-      occurredAt: fallbackControl.occurredAt,
-      prisma: input.prisma,
-      source: "browser-vault-refresh",
-      userId: input.userId,
-    });
-  }
+  const prisma = input.prisma ?? getPrisma();
+  const workspace = await ensureHostedRuntimeWorkspaceForActiveUser(input.userId, prisma);
+  const control = buildHostedBrowserVaultRefreshRuntimeControlEvent({
+    userId: input.userId,
+    workspaceVersion: workspace.version,
+  });
+
+  return signalHostedRuntimeControlMailboxRequest({
+    client: input.client,
+    environment: input.environment,
+    ensureWorkspace: false,
+    eventId: control.eventId,
+    kind: "runtime.browser-vault-refresh-requested",
+    occurredAt: control.occurredAt,
+    prisma,
+    source: "browser-vault-refresh",
+    userId: input.userId,
+  });
 }
 
 export async function signalHostedManualRunRuntime(
@@ -252,6 +244,7 @@ export async function signalHostedDeviceSyncMailboxRuntime(
 async function signalHostedRuntimeControlMailboxRequest(input: {
   client?: HostedRuntimeTemporalSignalClient | null;
   environment?: NodeJS.ProcessEnv;
+  ensureWorkspace?: boolean;
   eventId?: string | null;
   kind: HostedExecutionRuntimeControlWakeKind;
   occurredAt?: string | null;
@@ -260,7 +253,9 @@ async function signalHostedRuntimeControlMailboxRequest(input: {
   userId: string;
 }): Promise<HostedRuntimeSignalResult> {
   const prisma = input.prisma ?? getPrisma();
-  await ensureHostedRuntimeWorkspaceForActiveUser(input.userId, prisma);
+  if (input.ensureWorkspace !== false) {
+    await ensureHostedRuntimeWorkspaceForActiveUser(input.userId, prisma);
+  }
   const deterministicEventId = normalizeHostedRuntimeControlEventId(input.eventId);
   const occurredAt = normalizeHostedRuntimeControlOccurredAt(input.occurredAt)
     ?? (deterministicEventId ? HOSTED_RUNTIME_CONTROL_DETERMINISTIC_OCCURRED_AT : new Date().toISOString());
@@ -297,7 +292,10 @@ const HOSTED_RUNTIME_CONTROL_DETERMINISTIC_OCCURRED_AT = "1970-01-01T00:00:00.00
 
 const BROWSER_VAULT_REFRESH_CONTROL_DEDUPE_WINDOW_MS = 60_000;
 
-function buildHostedBrowserVaultRefreshRuntimeControlFallback(userId: string): {
+function buildHostedBrowserVaultRefreshRuntimeControlEvent(input: {
+  userId: string;
+  workspaceVersion: string;
+}): {
   eventId: string;
   occurredAt: string;
 } {
@@ -306,8 +304,9 @@ function buildHostedBrowserVaultRefreshRuntimeControlFallback(userId: string): {
   const fingerprint = createHash("sha256")
     .update(JSON.stringify({
       bucketMs,
-      userId,
+      userId: input.userId,
       version: 1,
+      workspaceVersion: input.workspaceVersion,
     }))
     .digest("hex")
     .slice(0, 32);

--- a/apps/web/test/hosted-orchestration-demand.test.ts
+++ b/apps/web/test/hosted-orchestration-demand.test.ts
@@ -181,12 +181,6 @@ describe("hosted orchestration demand", () => {
 
   it.each([
     ["runtime.manual-requested", "manual", "manual", true],
-    [
-      "runtime.browser-vault-refresh-requested",
-      "browser_vault_refresh",
-      "browser_vault_refresh",
-      false,
-    ],
     ["runtime.device-sync-recovery-requested", "mailbox_backlog", "nudge", false],
     ["runtime.mailbox-lag-observed", "lag_recovery", "nudge", false],
   ] as const)(
@@ -234,6 +228,44 @@ describe("hosted orchestration demand", () => {
       }
     },
   );
+
+  it("runs browser-vault refresh demand for pending browser-vault system mailbox control", async () => {
+    mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
+      redactedStatusJson: {
+        conversationImportedSeq: "0",
+        systemImportedSeq: "0",
+      },
+    }));
+    mocks.readHostedMailboxMaxSeqByLane.mockResolvedValue([
+      {
+        lane: "conversation",
+        maxSeq: "0",
+      },
+      {
+        lane: "system",
+        maxSeq: "3",
+      },
+    ]);
+    mocks.readHostedMailboxFirstPendingSystemKind.mockResolvedValue(
+      "runtime.browser-vault-refresh-requested",
+    );
+
+    const response = await demandRoute.GET(requestForDemand(), routeContext());
+    const demand = parseHostedRuntimeDemand(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(demand).toMatchObject({
+      kind: "run",
+      reason: "browser_vault_refresh",
+      source: "browser_vault_refresh",
+    });
+    expect(mocks.readHostedMailboxFirstPendingSystemKind).toHaveBeenCalledWith({
+      afterSeq: "0",
+      prisma: { kind: "prisma" },
+      userId: MEMBER_ID,
+    });
+    expect(mocks.resolveHostedAiUsageGate).not.toHaveBeenCalled();
+  });
 
   it("keeps conversation mailbox backlog ahead of pending device-sync system wakes", async () => {
     mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({

--- a/apps/web/test/hosted-orchestration-signal-runtime.test.ts
+++ b/apps/web/test/hosted-orchestration-signal-runtime.test.ts
@@ -239,21 +239,35 @@ describe("hosted runtime Temporal signaling", () => {
     );
   });
 
-  it("signals browser-vault refresh directly as coalesced runtime demand", async () => {
+  it("persists browser-vault refresh as durable control demand before signaling", async () => {
     await signalHostedBrowserVaultRefreshRuntime({
       client: buildClient(),
       userId: "member_123",
     });
 
-    expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: expect.objectContaining({
+        eventId: expect.stringMatching(/^runtime-control:browser-vault-refresh:[0-9a-f]{32}$/u),
+        kind: "runtime.browser-vault-refresh-requested",
+        userId: "member_123",
+      }),
+      tx: { kind: "tx" },
+    });
     expect(mocks.signalWithStart).toHaveBeenCalledWith(
       HOSTED_USER_RUNTIME_WORKFLOW_TYPE,
       expect.objectContaining({
         signalArgs: [{
-          kind: "browser_vault_refresh_requested",
+          kind: "mailbox_appended",
+          lane: "system",
+          laneSeq: "77",
+          mailboxItemId: "mailbox_runtime.browser-vault-refresh-requested",
+          source: "browser-vault-refresh",
         }],
         workflowId: "hosted-user-runtime:member_123",
       }),
+    );
+    expect(mocks.appendHostedMailboxEnvelopeTx.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.signalWithStart.mock.invocationCallOrder[0] ?? 0,
     );
     expect(mocks.ensureHostedWorkspace).toHaveBeenCalledWith({
       prisma: mocks.prisma,
@@ -268,28 +282,24 @@ describe("hosted runtime Temporal signaling", () => {
     );
   });
 
-  it("persists browser-vault refresh as durable control demand when direct signaling fails", async () => {
-    mocks.signalWithStart
-      .mockRejectedValueOnce(new Error("temporal unavailable"))
-      .mockResolvedValueOnce(undefined);
+  it("keeps browser-vault refresh durable when Temporal signaling fails", async () => {
+    mocks.signalWithStart.mockRejectedValueOnce(new Error("temporal unavailable"));
 
     await expect(signalHostedBrowserVaultRefreshRuntime({
       client: buildClient(),
       userId: "member_123",
-    })).resolves.toEqual({
-      signalAccepted: true,
-      workflowId: "hosted-user-runtime:member_123",
-    });
+    })).rejects.toThrow("temporal unavailable");
 
     expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
       envelope: expect.objectContaining({
+        eventId: expect.stringMatching(/^runtime-control:browser-vault-refresh:[0-9a-f]{32}$/u),
         kind: "runtime.browser-vault-refresh-requested",
         userId: "member_123",
       }),
       tx: { kind: "tx" },
     });
-    expect(mocks.signalWithStart).toHaveBeenNthCalledWith(
-      2,
+    expect(mocks.signalWithStart).toHaveBeenCalledTimes(1);
+    expect(mocks.signalWithStart).toHaveBeenCalledWith(
       HOSTED_USER_RUNTIME_WORKFLOW_TYPE,
       expect.objectContaining({
         signalArgs: [{
@@ -302,18 +312,15 @@ describe("hosted runtime Temporal signaling", () => {
         workflowId: "hosted-user-runtime:member_123",
       }),
     );
+    expect(mocks.appendHostedMailboxEnvelopeTx.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.signalWithStart.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
-  it("dedupes browser-vault fallback control demands within a short outage window", async () => {
+  it("dedupes browser-vault control demands for the same workspace version within a short window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-28T08:15:31.000Z"));
     try {
-      mocks.signalWithStart
-        .mockRejectedValueOnce(new Error("temporal unavailable"))
-        .mockResolvedValueOnce(undefined)
-        .mockRejectedValueOnce(new Error("temporal unavailable"))
-        .mockResolvedValueOnce(undefined);
-
       await signalHostedBrowserVaultRefreshRuntime({
         client: buildClient(),
         userId: "member_123",
@@ -331,6 +338,59 @@ describe("hosted runtime Temporal signaling", () => {
         /^runtime-control:browser-vault-refresh:[0-9a-f]{32}$/u,
       );
       expect(envelopes[1]?.eventId).toBe(envelopes[0]?.eventId);
+      expect(envelopes.map((envelope) => envelope.occurredAt)).toEqual([
+        "2026-05-28T08:15:00.000Z",
+        "2026-05-28T08:15:00.000Z",
+      ]);
+      expect(mocks.signalWithStart).toHaveBeenCalledTimes(2);
+      expect(mocks.signalWithStart.mock.calls.map((call) => call[1].signalArgs[0])).toEqual([
+        {
+          kind: "mailbox_appended",
+          lane: "system",
+          laneSeq: "77",
+          mailboxItemId: "mailbox_runtime.browser-vault-refresh-requested",
+          source: "browser-vault-refresh",
+        },
+        {
+          kind: "mailbox_appended",
+          lane: "system",
+          laneSeq: "77",
+          mailboxItemId: "mailbox_runtime.browser-vault-refresh-requested",
+          source: "browser-vault-refresh",
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("creates a new browser-vault control demand after the workspace version advances", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-28T08:15:31.000Z"));
+    mocks.ensureHostedWorkspace
+      .mockResolvedValueOnce(buildHostedWorkspaceRecord({ version: "10" }))
+      .mockResolvedValueOnce(buildHostedWorkspaceRecord({ version: "11" }));
+    try {
+      await signalHostedBrowserVaultRefreshRuntime({
+        client: buildClient(),
+        userId: "member_123",
+      });
+      await signalHostedBrowserVaultRefreshRuntime({
+        client: buildClient(),
+        userId: "member_123",
+      });
+
+      const envelopes = mocks.appendHostedMailboxEnvelopeTx.mock.calls.map(
+        ([input]) => input.envelope,
+      );
+      expect(envelopes).toHaveLength(2);
+      expect(envelopes[0]?.eventId).toMatch(
+        /^runtime-control:browser-vault-refresh:[0-9a-f]{32}$/u,
+      );
+      expect(envelopes[1]?.eventId).toMatch(
+        /^runtime-control:browser-vault-refresh:[0-9a-f]{32}$/u,
+      );
+      expect(envelopes[1]?.eventId).not.toBe(envelopes[0]?.eventId);
       expect(envelopes.map((envelope) => envelope.occurredAt)).toEqual([
         "2026-05-28T08:15:00.000Z",
         "2026-05-28T08:15:00.000Z",
@@ -562,6 +622,7 @@ function buildActiveMemberRecord(overrides: Partial<{
 
 function buildHostedWorkspaceRecord(overrides: Partial<{
   redactedStatusJson: unknown;
+  version: string;
 }> = {}) {
   return {
     browserVaultReplicaRef: null,

--- a/apps/web/test/hosted-orchestration-signal-runtime.test.ts
+++ b/apps/web/test/hosted-orchestration-signal-runtime.test.ts
@@ -369,6 +369,8 @@ describe("hosted runtime Temporal signaling", () => {
     vi.setSystemTime(new Date("2026-05-28T08:15:31.000Z"));
     mocks.ensureHostedWorkspace
       .mockResolvedValueOnce(buildHostedWorkspaceRecord({ version: "10" }))
+      .mockResolvedValueOnce(buildHostedWorkspaceRecord({ version: "10" }))
+      .mockResolvedValueOnce(buildHostedWorkspaceRecord({ version: "11" }))
       .mockResolvedValueOnce(buildHostedWorkspaceRecord({ version: "11" }));
     try {
       await signalHostedBrowserVaultRefreshRuntime({


### PR DESCRIPTION
## Summary

- Routes `signalHostedBrowserVaultRefreshRuntime` through the existing durable runtime-control mailbox helper instead of direct `browser_vault_refresh_requested` signaling.
- Appends `runtime.browser-vault-refresh-requested` before signaling Temporal with a pointer-only `mailbox_appended` wake.
- Keeps same-version short-window dedupe, but includes hosted workspace version in the browser-vault control fingerprint so a later refresh after runtime checkpoint/import advancement gets a new mailbox row.
- Adds an explicit demand-path test proving a pending `runtime.browser-vault-refresh-requested` system mailbox item yields `browser_vault_refresh` runtime demand.
- Simplifies the shared runtime-control mailbox helper so it always checks active workspace before append/signal; browser-vault pays the extra check instead of adding a hidden helper mode.

## Compatibility

This intentionally keeps Temporal's legacy `browser_vault_refresh_requested` signal handler for compatibility/replay, but stops producing that signal from web. The PR only collapses the producer path.

## Validation

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-orchestration-signal-runtime.test.ts`
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-orchestration-demand.test.ts apps/web/test/hosted-orchestration-signal-runtime.test.ts`
- `bash scripts/workspace-verify.sh test:diff apps/web/src/lib/hosted-orchestration/signal-runtime.ts apps/web/test/hosted-orchestration-demand.test.ts apps/web/test/hosted-orchestration-signal-runtime.test.ts agent-docs/exec-plans/completed/browser-vault-refresh-mailbox.md agent-docs/exec-plans/active/browser-vault-demand-followup.md`

The final diff-aware lane passed app tests, lint, dev smoke, and Next build. Next build emitted the existing NFT trace warning in `apps/web/next.config.ts`.

## Audits

- Security/privacy review: no findings.
- Coverage-write: added append-before-signal assertions; no remaining coverage gaps reported.
- Deep review: found and fixed the same-minute dedupe-after-import edge case by adding workspace version to the event fingerprint; rerun had no findings.
- Follow-up final review for demand test + helper simplification: no findings.
- Final review: no findings.