### PR TITLE
Remove runtime source request contracts

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-08-runtime-contract-source-deletion.md
+++ b/agent-docs/exec-plans/completed/2026-06-08-runtime-contract-source-deletion.md
@@ -1,0 +1,36 @@
+# Runtime Contract Source Deletion
+
+## Goal
+
+Land the contract deletion on top of PR61 by keeping demand `source` in web/Temporal demand while removing it from shared runtime-wake and workspace-invocation request models.
+
+## Scope
+
+- Remove `source` from `HostedRuntimeEnsureProcessingRequest`.
+- Remove `source` from `HostedWorkspaceInvocationRequest`.
+- Keep legacy wire tolerance by validating old `source` values and dropping them from parsed runtime request objects.
+- Update focused contract/runtime tests, assistant-runtime parser tests, and Cloudflare expectations.
+
+## Constraints
+
+- Preserve `HostedRuntimeDemand.source`; web and Temporal demand still use it.
+- Do not add a new compatibility abstraction or runtime behavior keyed by `source`.
+- Keep parser compatibility fail-closed for unsupported legacy source values.
+- Preserve unrelated working-tree edits.
+
+## Verification Plan
+
+- Passed: `pnpm --filter @murphai/hosted-execution test -- hosted-orchestration-control.test.ts hosted-runtime-control.test.ts`
+- Passed: `pnpm --filter @murphai/assistant-runtime test -- hosted-runtime-workspace-entrypoint.test.ts`
+- Passed: `pnpm --dir . exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
+- Passed: `pnpm typecheck`
+- Passed: `pnpm test:diff <scoped runtime-contract files>`
+- Passed after coverage-write test addition: `pnpm --filter @murphai/hosted-execution test -- hosted-orchestration-control.test.ts hosted-runtime-control.test.ts`
+
+## Completion
+
+- Required audits completed: security/privacy review, coverage-write, deep-review, task-finish-review.
+- Final commit should use `scripts/finish-task` for this plan.
+Status: completed
+Updated: 2026-06-07
+Completed: 2026-06-07

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -1738,7 +1738,6 @@ describe("cloudflare worker routes", () => {
         orchestrationAttemptId: "orchestration-attempt-test",
         commandTimeoutMs: 10_000,
         reason: "nudge",
-        source: "workspace_wake",
         userId: "test-user",
       });
     });
@@ -1879,7 +1878,6 @@ describe("cloudflare worker routes", () => {
       expect(stub.ensureRuntimeProcessingForUser).toHaveBeenCalledWith({
         orchestrationAttemptId: "orchestration-attempt-test",
         reason: "nudge",
-        source: "workspace_wake",
         userId: "test-user",
       });
     });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -349,7 +349,6 @@ describe("HostedUserRunner execution coordination", () => {
     await expect(runner.ensureRuntimeProcessingForUser({
       orchestrationAttemptId: "test-orchestration-attempt",
       reason: "nudge",
-      source: "workspace_wake",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
       action: "started",
@@ -414,7 +413,6 @@ describe("HostedUserRunner execution coordination", () => {
     await expect(runner.ensureRuntimeProcessingForUser({
       orchestrationAttemptId: "test-orchestration-attempt",
       reason: "nudge",
-      source: "workspace_wake",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
       action: "started",
@@ -1193,7 +1191,6 @@ describe("HostedUserRunner execution coordination", () => {
     await expect(runner.ensureRuntimeProcessingForUser({
       orchestrationAttemptId: "test-orchestration-attempt",
       reason: "nudge",
-      source: "workspace_wake",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
       action: "woken",

--- a/packages/assistant-runtime/src/hosted-runtime/parsers.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/parsers.ts
@@ -2,7 +2,6 @@ import {
   parseConfiguredDeviceSyncRuntimeConfig,
 } from "@murphai/device-syncd/runtime-config";
 import {
-  parseHostedRuntimeDemandRunSource,
   parseHostedWorkspaceState,
 } from "@murphai/hosted-execution/parsers";
 
@@ -84,6 +83,14 @@ export function parseHostedAssistantWorkspaceRuntimeJobRequest(
     record.reason,
     "Hosted assistant workspace runtime job request.reason",
   );
+  if (record.source !== undefined && record.source !== null) {
+    // Legacy job tolerance only. Runtime behavior should come from reason,
+    // workspace state, and canonical mailbox facts.
+    parseHostedWorkspaceInvocationSource(
+      record.source,
+      "Hosted assistant workspace runtime job request.source",
+    );
+  }
 
   return {
     attemptId: requireString(
@@ -121,14 +128,6 @@ export function parseHostedAssistantWorkspaceRuntimeJobRequest(
           ),
         }),
     reason,
-    ...(record.source === undefined || record.source === null
-      ? {}
-      : {
-          source: parseHostedRuntimeDemandRunSource(
-            record.source,
-            "Hosted assistant workspace runtime job request.source",
-          ),
-        }),
     userId: requireString(
       record.userId,
       "Hosted assistant workspace runtime job request.userId",
@@ -468,6 +467,21 @@ function parseHostedWorkspaceInvocationReason(
       return reason;
     default:
       throw new TypeError(`${label} is not supported.`);
+  }
+}
+
+function parseHostedWorkspaceInvocationSource(
+  value: unknown,
+  label: string,
+): void {
+  if (
+    value !== "mailbox_backlog"
+    && value !== "manual"
+    && value !== "browser_vault_refresh"
+    && value !== "workspace_wake"
+    && value !== "lag_recovery"
+  ) {
+    throw new TypeError(`${label} is not supported.`);
   }
 }
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -4190,7 +4190,6 @@ function createPhaseInput(input: {
   now?: () => string;
   reason?: HostedWorkspaceRuntimeAssistantPhaseInput["request"]["reason"];
   resolvedDeviceSync?: HostedWorkspaceRuntimeAssistantPhaseInput["runtime"]["resolvedConfig"]["deviceSync"];
-  source?: HostedWorkspaceRuntimeAssistantPhaseInput["request"]["source"];
   runtimeDeviceSyncPort?: RuntimeDeviceSyncPort;
   runtimeForwardedEnv?: Record<string, string>;
   runtimeEnv?: Record<string, string>;
@@ -4267,7 +4266,6 @@ function createPhaseInput(input: {
       attemptId: "attempt_synthetic_phase",
       leaseGeneration: "3",
       reason: input.reason ?? "nudge",
-      ...(input.source ? { source: input.source } : {}),
       userId: "member_synthetic_phase",
       workspaceVersion: "8",
     },

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -7323,7 +7323,8 @@ describe("hosted workspace runtime entrypoint", () => {
         source: "workspace_wake",
       },
     });
-    assert.equal(workspaceWakeParsed.request.source, "workspace_wake");
+    assert.equal(workspaceWakeParsed.request.reason, "nudge");
+    assert.equal("source" in workspaceWakeParsed.request, false);
 
     expect(() =>
       parseHostedAssistantWorkspaceRuntimeJobInput({

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -151,7 +151,6 @@ export type HostedRuntimeDemand =
 export interface HostedRuntimeEnsureProcessingRequest {
   orchestrationAttemptId: string;
   reason: HostedWorkspaceInvocationReason;
-  source?: HostedRuntimeDemandRunSource | null;
 }
 
 export const HOSTED_RUNTIME_ENSURE_PROCESSING_RESPONSE_KINDS = [

--- a/packages/hosted-execution/src/parsers/orchestration-control.ts
+++ b/packages/hosted-execution/src/parsers/orchestration-control.ts
@@ -283,6 +283,14 @@ export function parseHostedRuntimeEnsureProcessingRequest(
     "reason",
     "source",
   ]);
+  if (record.source !== undefined && record.source !== null) {
+    // Legacy wire tolerance only. Runtime ensure-processing is source-less;
+    // validate old source-bearing callers, then drop the field.
+    parseHostedRuntimeDemandRunSource(
+      record.source,
+      "Hosted runtime ensure-processing request source",
+    );
+  }
 
   return {
     orchestrationAttemptId: requireOpaqueIdentifier(
@@ -293,14 +301,6 @@ export function parseHostedRuntimeEnsureProcessingRequest(
       record.reason,
       "Hosted runtime ensure-processing request reason",
     ),
-    ...(record.source === undefined || record.source === null
-      ? {}
-      : {
-          source: parseHostedRuntimeDemandRunSource(
-            record.source,
-            "Hosted runtime ensure-processing request source",
-          ),
-        }),
   };
 }
 

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -93,9 +93,6 @@ import {
   parseHostedBrowserVaultReplicaRef,
   parseHostedExecutionSnapshotRef,
 } from "./cursor.ts";
-import {
-  parseHostedRuntimeDemandRunSource,
-} from "./demand-source.ts";
 
 const FORBIDDEN_RAW_REDACTED_KEY_NAMES = [
   "address",
@@ -1214,6 +1211,15 @@ export function parseHostedWorkspaceInvocationRequest(value: unknown): HostedWor
     );
   }
   const reason = parseHostedWorkspaceInvocationReason(record.reason);
+  if (record.source !== undefined && record.source !== null) {
+    // Legacy wire tolerance only. Workspace invocation is source-less; validate
+    // old source-bearing requests, then drop the field.
+    parseAllowedString(
+      record.source,
+      "Hosted workspace invocation request source",
+      ["mailbox_backlog", "manual", "browser_vault_refresh", "workspace_wake", "lag_recovery"] as const,
+    );
+  }
 
   return {
     attemptId: requireString(record.attemptId, "Hosted workspace invocation request attemptId"),
@@ -1248,14 +1254,6 @@ export function parseHostedWorkspaceInvocationRequest(value: unknown): HostedWor
           ),
         }),
     reason,
-    ...(record.source === undefined || record.source === null
-      ? {}
-      : {
-          source: parseHostedRuntimeDemandRunSource(
-            record.source,
-            "Hosted workspace invocation request source",
-          ),
-        }),
     userId: requireString(record.userId, "Hosted workspace invocation request userId"),
     ...(record.workspace === undefined
       ? {}

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -889,9 +889,6 @@ export const HOSTED_WORKSPACE_INVOCATION_REASONS = [
 
 export type HostedWorkspaceInvocationReason = (typeof HOSTED_WORKSPACE_INVOCATION_REASONS)[number];
 
-export type HostedWorkspaceInvocationSource =
-  import("./orchestration-control.ts").HostedRuntimeDemandRunSource;
-
 export const HOSTED_WORKSPACE_INVOCATION_STATUSES = [
   "idle",
   "budget_exhausted",
@@ -913,7 +910,6 @@ export interface HostedWorkspaceInvocationRequest {
   leaseGeneration: string;
   providerEgressToken?: string | null;
   reason: HostedWorkspaceInvocationReason;
-  source?: HostedWorkspaceInvocationSource | null;
   userId: string;
   workspace?: HostedWorkspaceState | null;
   workspaceVersion: string;

--- a/packages/hosted-execution/test/hosted-orchestration-control.test.ts
+++ b/packages/hosted-execution/test/hosted-orchestration-control.test.ts
@@ -85,6 +85,7 @@ describe("hosted orchestration control contracts", () => {
   });
 
   it("keeps retired runtime wake sources out of durable demand sources", () => {
+    expect(HOSTED_RUNTIME_DEMAND_RUN_SOURCES).toContain("workspace_wake");
     expect(HOSTED_RUNTIME_DEMAND_RUN_SOURCES).not.toContain(
       "linq.imessage.typing",
     );
@@ -289,15 +290,16 @@ describe("hosted orchestration control contracts", () => {
   });
 
   it("parses ensure-processing request and response variants", () => {
-    expect(parseHostedRuntimeEnsureProcessingRequest({
-      orchestrationAttemptId: "orchestration_attempt_test",
-      reason: "manual",
-      source: "workspace_wake",
-    })).toEqual({
+    const ensureProcessingRequest = parseHostedRuntimeEnsureProcessingRequest({
       orchestrationAttemptId: "orchestration_attempt_test",
       reason: "manual",
       source: "workspace_wake",
     });
+    expect(ensureProcessingRequest).toEqual({
+      orchestrationAttemptId: "orchestration_attempt_test",
+      reason: "manual",
+    });
+    expect(ensureProcessingRequest).not.toHaveProperty("source");
 
     for (const action of [
       "started",
@@ -335,6 +337,14 @@ describe("hosted orchestration control contracts", () => {
       reason: "nudge",
     })).toThrow(
       "Hosted runtime ensure-processing request must not include aiUsageAllowDecision.",
+    );
+
+    expect(() => parseHostedRuntimeEnsureProcessingRequest({
+      orchestrationAttemptId: "orchestration_attempt_test",
+      reason: "nudge",
+      source: "device_sync_recovery",
+    })).toThrow(
+      "Hosted runtime ensure-processing request source is not supported.",
     );
 
     expect(() => parseHostedRuntimeEnsureProcessingResponse({

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -229,15 +229,16 @@ describe("hosted runtime control contracts", () => {
     expect(parseHostedWorkspaceInvocationRequest(workspaceInvocationRequest)).toEqual(
       workspaceInvocationRequest,
     );
-    expect(parseHostedWorkspaceInvocationRequest({
-      ...workspaceInvocationRequest,
-      source: "workspace_wake",
-      workspace: null,
-    })).toEqual({
+    const legacySourceInvocationRequest = parseHostedWorkspaceInvocationRequest({
       ...workspaceInvocationRequest,
       source: "workspace_wake",
       workspace: null,
     });
+    expect(legacySourceInvocationRequest).toEqual({
+      ...workspaceInvocationRequest,
+      workspace: null,
+    });
+    expect(legacySourceInvocationRequest).not.toHaveProperty("source");
     expect(parseHostedWorkspaceInvocationRequest({
       ...workspaceInvocationRequest,
       workspace: workspaceState,
@@ -245,6 +246,12 @@ describe("hosted runtime control contracts", () => {
       ...workspaceInvocationRequest,
       workspace: workspaceState,
     });
+    expect(() => parseHostedWorkspaceInvocationRequest({
+      ...workspaceInvocationRequest,
+      source: "device_sync_recovery",
+    })).toThrow(
+      "Hosted workspace invocation request source is not supported.",
+    );
     expect(() => parseHostedWorkspaceInvocationRequest({
       attemptId: "attempt_3",
       checkpointNextWakeAt: null,


### PR DESCRIPTION
## Summary
- remove `source` from runtime ensure-processing and workspace invocation request types
- keep legacy source-bearing wire/job inputs tolerated by validating known old values, then dropping `source`
- keep durable demand `source` intact and update runtime/Cloudflare tests for source-less request flow

## Verification
- `pnpm --filter @murphai/hosted-execution test -- hosted-orchestration-control.test.ts hosted-runtime-control.test.ts`
- `pnpm --filter @murphai/assistant-runtime test -- hosted-runtime-workspace-entrypoint.test.ts`
- `pnpm --dir . exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
- `pnpm typecheck`
- `pnpm test:diff <scoped runtime-contract files>`
- post-coverage addition: `pnpm --filter @murphai/hosted-execution test -- hosted-orchestration-control.test.ts hosted-runtime-control.test.ts`

## Audits
- security/privacy review: no issues found
- coverage-write: added demand-source preservation assertion
- deep review: no production-breaking bugs found; residual deploy-order risk noted
- task-finish-review: no issues found

DEPLOYMENT CONCERNS:
This PR should deploy after or with PR61. PR61 already drops `source` before Temporal posts ensure-processing to Cloudflare; deploying this PR without that producer change could reject older `device_sync_recovery` ensure-processing bodies. No web/Cloudflare tandem deploy is otherwise required beyond the stacked order.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783477103&installation_id=127572939&pr_number=62&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F62&signature=8da74536eedb687349d61770c46829fc842366a4719d9fa0197c95ed1a525ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->