### PR TITLE
settings: replace nested email verification dialog with inline auto-submitting OTP step

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-09-email-settings-inline-otp.md
+++ b/agent-docs/exec-plans/completed/2026-06-09-email-settings-inline-otp.md
@@ -1,0 +1,46 @@
+Goal (incl. success criteria):
+- Remove the stacked dialog-in-dialog email verification flow on /settings: the "Change email" dialog currently opens a second "Enter your verification code" dialog on top of itself while the underlying dialog still shows a redundant pending alert with duplicate Enter code/Resend code buttons.
+- Replace it with one dialog and two steps: email entry -> inline code entry, reusing the existing `HostedVerificationCodeStep` OTP component the phone/email auth flows already use.
+- Verification code auto-submits when all 6 digits are entered (built into `HostedVerificationCodeStep` via InputOTP `onComplete`).
+- Success means: no nested dialog, no duplicate "we sent a code"/"Resend code" affordances, OTP auto-submits, existing send/verify/sync behavior (Privy `useUpdateEmail` + `/api/settings/email/sync`) unchanged.
+
+Constraints/Assumptions:
+- `HostedEmailSettings` is only mounted inside `HostedSettingsIdentityLinkDialog`, so the inline two-step swap is safe everywhere it renders.
+- No auth/session behavior change: same Privy sendCode/verifyCode calls, same sync route; this is UI restructuring plus auto-submit.
+- Default to deletion: remove `HostedEmailVerificationDialog`, the pending alert, and the `dialogOpen`/`effectiveDialogOpen` controller state instead of layering new state.
+
+Key decisions:
+- Mirror `HostedEmailAuthButton`'s proven pattern: `pendingEmailAddress` gates the step swap; code input read through a ref on submit so auto-submit never reads stale state.
+- Resend while in the code step targets `pendingEmailAddress` directly (the email input is no longer rendered in that step), matching the auth-button flow.
+- Add a "Use another email" secondary action that clears the pending state and returns to step 1.
+
+State:
+- Complete; ready for finish-task commit and PR.
+
+Done:
+- Root-cause analysis of the stacked dialogs (page-section component reused inside a dialog, bringing its own modal).
+- Implemented the inline two-step swap and controller cleanup (dialog state, email-coupled resend, dead code normalization removed).
+- Established harness fact: linkedom cannot drive React synthetic onChange, so InputOTP auto-submit is exercised in production by the shared phone-flow component, and tests drive the same onSubmit callback through the verify button.
+- frontend-review fixes: drained input-otp's uncleared 0-50ms timers in afterEach (unhandled-error noise gone), dropped size="compact" for OTP size parity with the phone flow in the same dialog, focus restore after "Use another email", silent unreachable resend guard, clear code on verify failure. Rejected as pre-existing parity/old-behavior polish: stale outer dialog description during step 2; brief form flash during post-verify sync.
+- coverage-write additions: empty-code guard + whitespace-trim test, submitting-state disabled/label test, strengthened resend test; focused file 15/15 with no unhandled errors.
+- task-finish-review: no material findings; residual is the manual browser pass below.
+- Verification: pnpm test:diff green on final state (full apps/web verify: next build, 255 test files / 2216 tests, eslint, dev smoke).
+
+Now:
+- finish-task commit, push, PR.
+
+Next:
+- Manual browser pass of the /settings change-email dialog (auto-submit on 6th digit, cleared code after failure, resend, focus restore on "Use another email").
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/src/components/settings/hosted-email-settings-sections.tsx
+- apps/web/src/components/settings/hosted-email-settings.tsx
+- apps/web/src/components/settings/hosted-email-settings-controller.ts
+- apps/web/test/settings-email-settings.test.ts
+- pnpm test:diff apps/web/src/components/settings apps/web/test/settings-email-settings.test.ts
+Status: completed
+Updated: 2026-06-09
+Completed: 2026-06-09

--- a/apps/web/src/components/settings/hosted-email-settings-controller.ts
+++ b/apps/web/src/components/settings/hosted-email-settings-controller.ts
@@ -36,7 +36,6 @@ export function useHostedEmailSettingsController(input: {
     linkedAccounts,
   });
   const [code, setCode] = useState("");
-  const [dialogOpen, setDialogOpen] = useState(false);
   const [emailAddress, setEmailAddress] = useState(() => baseDisplayState.currentEmail?.address ?? "");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isSyncingEmailRoute, setIsSyncingEmailRoute] = useState(false);
@@ -72,11 +71,9 @@ export function useHostedEmailSettingsController(input: {
   const normalizedCurrentEmail = overrideDisplayState.normalizedCurrentEmail;
   const canManageEmail = input.authenticated;
   const canSendEmailUpdateCode = Boolean(effectiveCurrentEmail?.address);
-  const isAwaitingCode = state.status === "awaiting-code-input";
   const isSendingCode = state.status === "sending-code";
   const isSubmittingCode = state.status === "submitting-code";
   const isBusy = isSendingCode || isSubmittingCode || isSyncingEmailRoute;
-  const effectiveDialogOpen = dialogOpen || isAwaitingCode || isSubmittingCode;
 
   async function requestCodeForEmail(nextEmailAddress: string) {
     setErrorMessage(null);
@@ -109,7 +106,6 @@ export function useHostedEmailSettingsController(input: {
       }
 
       setPendingEmailAddress(nextEmailAddress);
-      setDialogOpen(true);
       setCode("");
     } catch (error) {
       setErrorMessage(toErrorMessage(error, "We could not send a verification code to that email address."));
@@ -136,41 +132,32 @@ export function useHostedEmailSettingsController(input: {
     await requestCodeForEmail(nextEmailAddress);
   }
 
-  async function handleResendCode(rawEmailAddress?: string) {
-    if (!canSendEmailUpdateCode) {
-      handleLinkEmail();
+  async function handleResendCode() {
+    // Resend only renders in the code-entry step, where a pending email
+    // address is always set; bail quietly if that invariant ever breaks.
+    if (!pendingEmailAddress) {
       return;
     }
 
-    const nextEmailAddress = rawEmailAddress === undefined
-      ? normalizeEmailAddress(emailAddress)
-      : normalizeEmailAddress(rawEmailAddress);
+    await requestCodeForEmail(pendingEmailAddress);
+  }
 
-    if (!nextEmailAddress) {
-      setErrorMessage("Enter a valid email address before we send a code.");
-      return;
-    }
-
-    if (nextEmailAddress !== emailAddress) {
-      setEmailAddress(nextEmailAddress);
-    }
-
-    await requestCodeForEmail(nextEmailAddress);
+  function handleUseAnotherEmail() {
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setCode("");
+    setPendingEmailAddress(null);
   }
 
   async function handleVerifyCode(rawCode?: string) {
     setErrorMessage(null);
     setSuccessMessage(null);
 
-    const normalizedCode = typeof rawCode === "string" ? rawCode.trim() : code.trim();
+    const normalizedCode = (rawCode ?? code).trim();
 
     if (!normalizedCode) {
       setErrorMessage("Enter the verification code we emailed you.");
       return;
-    }
-
-    if (normalizedCode !== code) {
-      setCode(normalizedCode);
     }
 
     let verifiedEmailAddress: string | null = null;
@@ -195,7 +182,6 @@ export function useHostedEmailSettingsController(input: {
       verifiedEmailAddress = nextEmail?.address ?? pendingEmailAddress ?? normalizeEmailAddress(emailAddress);
 
       setCode("");
-      setDialogOpen(false);
       setPendingEmailAddress(null);
       setEmailAddress(verifiedEmailAddress ?? emailAddress);
 
@@ -206,6 +192,7 @@ export function useHostedEmailSettingsController(input: {
         });
       }
     } catch (error) {
+      setCode("");
       setErrorMessage(toErrorMessage(error, "We could not verify that code."));
       return;
     }
@@ -223,7 +210,6 @@ export function useHostedEmailSettingsController(input: {
     setSuccessMessage(null);
     setCode("");
     setPendingEmailAddress(null);
-    setDialogOpen(false);
 
     if (!input.authenticated) {
       setErrorMessage("Sign in with your existing hosted account before you try to link an email address.");
@@ -302,7 +288,6 @@ export function useHostedEmailSettingsController(input: {
     authenticated: input.authenticated,
     canManageEmail,
     code,
-    dialogOpen: effectiveDialogOpen,
     effectiveCurrentEmail,
     effectiveVerifiedEmail,
     emailAddress,
@@ -315,11 +300,11 @@ export function useHostedEmailSettingsController(input: {
     pendingEmailAddress,
     successMessage,
     setCode,
-    setDialogOpen,
     setEmailAddress,
     handleResendCode,
     handleSendCode,
     handleSyncVerifiedEmail,
+    handleUseAnotherEmail,
     handleVerifyCode,
   };
 }

--- a/apps/web/src/components/settings/hosted-email-settings-sections.tsx
+++ b/apps/web/src/components/settings/hosted-email-settings-sections.tsx
@@ -3,24 +3,17 @@
 import { useRef, type RefObject } from "react";
 
 import { Button } from "@/src/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/src/components/ui/dialog";
+import { HostedVerificationCodeStep } from "@/src/components/hosted-onboarding/hosted-verification-code-step";
 import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
 import type { HostedPrivyEmailAccount } from "@/src/lib/hosted-onboarding/privy-shared";
 import { isHostedPrivyEmailAccountVerified } from "@/src/lib/hosted-onboarding/privy-shared";
 
-import { Alert, AlertDescription } from "@/src/components/ui/alert";
-
 import { ConnectedAccountCard, SettingsContactLink } from "./connected-account-card";
 
 export function HostedEmailSettingsContent(props: {
   changeFlow?: boolean;
+  code: string;
   currentEmail: HostedPrivyEmailAccount | null;
   currentVerifiedEmail: (HostedPrivyEmailAccount & { verifiedAt: number }) | null;
   emailAddress: string;
@@ -29,13 +22,16 @@ export function HostedEmailSettingsContent(props: {
   canSendEmailUpdateCode: boolean;
   isBusy: boolean;
   isSendingCode: boolean;
+  isSubmittingCode: boolean;
   isSyncingEmailRoute: boolean;
   pendingEmailAddress: string | null;
+  onChangeCode: (value: string) => void;
   onChangeEmailAddress: (value: string) => void;
-  onOpenDialog: () => void;
-  onResendCode: (emailAddress?: string) => Promise<void>;
+  onResendCode: () => Promise<void>;
   onSendCode: (emailAddress?: string) => Promise<void>;
   onSyncVerifiedEmail: () => Promise<void>;
+  onUseAnotherEmail: () => void;
+  onVerifyCode: (code?: string) => Promise<void>;
 }) {
   const {
     currentEmail,
@@ -46,16 +42,56 @@ export function HostedEmailSettingsContent(props: {
     canSendEmailUpdateCode,
     isBusy,
     isSendingCode,
+    isSubmittingCode,
     isSyncingEmailRoute,
     pendingEmailAddress,
+    onChangeCode,
     onChangeEmailAddress,
-    onOpenDialog,
     onResendCode,
     onSendCode,
     onSyncVerifiedEmail,
+    onUseAnotherEmail,
+    onVerifyCode,
   } = props;
 
+  const codeInputRef = useRef<HTMLInputElement | null>(null);
   const isVerified = currentEmail ? isHostedPrivyEmailAccountVerified(currentEmail) : false;
+
+  if (pendingEmailAddress) {
+    return (
+      <div className="space-y-5">
+        <HostedVerificationCodeStep
+          code={props.code}
+          description={`We sent a code to ${pendingEmailAddress}. Codes expire quickly — use the most recent one.`}
+          disabled={isBusy}
+          inputRef={codeInputRef}
+          pendingAction={
+            isSendingCode ? "send-code" : isSubmittingCode ? "verify-code" : null
+          }
+          primaryActionLabel="Verify email"
+          primaryActionPendingLabel="Verifying..."
+          secondaryAction={
+            <Button
+              type="button"
+              variant="ghost"
+              size="lg"
+              disabled={isBusy}
+              onClick={() => {
+                onUseAnotherEmail();
+                requestAnimationFrame(() => emailInputRef.current?.focus());
+              }}
+              className="w-full text-muted-foreground hover:text-foreground"
+            >
+              Use another email
+            </Button>
+          }
+          onCodeChange={onChangeCode}
+          onResendCode={() => void onResendCode()}
+          onSubmit={() => void onVerifyCode(codeInputRef.current?.value ?? props.code)}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-5">
@@ -139,97 +175,6 @@ export function HostedEmailSettingsContent(props: {
           </Button>
         </div>
       ) : null}
-
-      {pendingEmailAddress ? (
-        <Alert className="border-border bg-card">
-          <AlertDescription className="flex flex-wrap items-center gap-3">
-            <span className="text-sm text-muted-foreground">
-              We sent a verification code to{" "}
-              <strong className="text-foreground">{pendingEmailAddress}</strong>.
-            </span>
-            <Button type="button" onClick={onOpenDialog} disabled={isBusy} variant="outline">
-              Enter code
-            </Button>
-            <Button
-              type="button"
-              onClick={() => void onResendCode(emailInputRef.current?.value ?? emailAddress)}
-              disabled={isBusy}
-              variant="outline"
-            >
-              {isSendingCode ? "Sending code..." : "Resend code"}
-            </Button>
-          </AlertDescription>
-        </Alert>
-      ) : null}
     </div>
-  );
-}
-
-export function HostedEmailVerificationDialog(props: {
-  code: string;
-  dialogOpen: boolean;
-  emailAddress: string;
-  emailInputRef: RefObject<HTMLInputElement | null>;
-  isBusy: boolean;
-  isSendingCode: boolean;
-  isSubmittingCode: boolean;
-  pendingEmailAddress: string | null;
-  onChangeCode: (value: string) => void;
-  onOpenChange: (nextOpen: boolean) => void;
-  onResendCode: (emailAddress?: string) => Promise<void>;
-  onVerifyCode: (code?: string) => Promise<void>;
-}) {
-  const codeInputRef = useRef<HTMLInputElement | null>(null);
-
-  return (
-    <Dialog open={props.dialogOpen} onOpenChange={props.onOpenChange}>
-      <DialogContent className="max-w-md p-6 md:p-7" showCloseButton={!props.isSubmittingCode}>
-        <DialogHeader className="pr-10">
-          <DialogTitle className="text-xl font-bold tracking-tight text-stone-900">
-            Enter your verification code
-          </DialogTitle>
-          <DialogDescription>
-            {props.pendingEmailAddress
-              ? `We sent a code to ${props.pendingEmailAddress}. Enter it below.`
-              : "Enter the code we sent to your email."}
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="flex flex-col gap-3">
-          <Label htmlFor="settings-email-code">Verification code</Label>
-          <Input
-            id="settings-email-code"
-            autoComplete="one-time-code"
-            inputMode="numeric"
-            placeholder="123456"
-            ref={codeInputRef}
-            value={props.code}
-            onChange={(event) => props.onChangeCode(event.currentTarget.value)}
-            className="h-10 px-3.5 text-sm"
-          />
-          <p className="text-sm text-stone-500">
-            Codes expire quickly — use the most recent one.
-          </p>
-        </div>
-
-        <div className="flex flex-wrap gap-3">
-          <Button
-            type="button"
-            onClick={() => void props.onVerifyCode(codeInputRef.current?.value ?? props.code)}
-            disabled={props.isBusy}
-          >
-            {props.isSubmittingCode ? "Verifying..." : "Verify email"}
-          </Button>
-          <Button
-            type="button"
-            onClick={() => void props.onResendCode(props.emailInputRef.current?.value ?? props.emailAddress)}
-            disabled={props.isBusy}
-            variant="outline"
-          >
-            {props.isSendingCode ? "Sending code..." : "Resend code"}
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/apps/web/src/components/settings/hosted-email-settings.tsx
+++ b/apps/web/src/components/settings/hosted-email-settings.tsx
@@ -9,10 +9,7 @@ import {
   useHostedEmailSettingsController,
   type HostedEmailSettingsInitialEmail,
 } from "./hosted-email-settings-controller";
-import {
-  HostedEmailSettingsContent,
-  HostedEmailVerificationDialog,
-} from "./hosted-email-settings-sections";
+import { HostedEmailSettingsContent } from "./hosted-email-settings-sections";
 import { HostedSettingsSessionState } from "./hosted-settings-session-state";
 
 export function HostedEmailSettings(props: {
@@ -54,6 +51,7 @@ export function HostedEmailSettings(props: {
     <div className="space-y-5">
       <HostedEmailSettingsContent
         changeFlow={props.changeFlow}
+        code={controller.code}
         currentEmail={controller.effectiveCurrentEmail}
         currentVerifiedEmail={controller.effectiveVerifiedEmail}
         emailAddress={controller.emailAddress}
@@ -62,13 +60,16 @@ export function HostedEmailSettings(props: {
         canSendEmailUpdateCode={controller.canSendEmailUpdateCode}
         isBusy={controller.isBusy}
         isSendingCode={controller.isSendingCode}
+        isSubmittingCode={controller.isSubmittingCode}
         isSyncingEmailRoute={controller.isSyncingEmailRoute}
         pendingEmailAddress={controller.pendingEmailAddress}
+        onChangeCode={controller.setCode}
         onChangeEmailAddress={controller.setEmailAddress}
-        onOpenDialog={() => controller.setDialogOpen(true)}
         onResendCode={controller.handleResendCode}
         onSendCode={controller.handleSendCode}
         onSyncVerifiedEmail={controller.handleSyncVerifiedEmail}
+        onUseAnotherEmail={controller.handleUseAnotherEmail}
+        onVerifyCode={controller.handleVerifyCode}
       />
 
       {statusMessage ? (
@@ -77,25 +78,6 @@ export function HostedEmailSettings(props: {
           tone={statusTone === "neutral" && controller.isSyncingEmailRoute ? "neutral" : statusTone}
         />
       ) : null}
-
-      <HostedEmailVerificationDialog
-        code={controller.code}
-        dialogOpen={controller.dialogOpen}
-        emailAddress={controller.emailAddress}
-        emailInputRef={emailInputRef}
-        isBusy={controller.isBusy}
-        isSendingCode={controller.isSendingCode}
-        isSubmittingCode={controller.isSubmittingCode}
-        pendingEmailAddress={controller.pendingEmailAddress}
-        onChangeCode={controller.setCode}
-        onOpenChange={(nextOpen) => {
-          if (!controller.isSubmittingCode) {
-            controller.setDialogOpen(nextOpen);
-          }
-        }}
-        onResendCode={controller.handleResendCode}
-        onVerifyCode={controller.handleVerifyCode}
-      />
     </div>
   );
 }

--- a/apps/web/test/dashboard-sidebar.test.ts
+++ b/apps/web/test/dashboard-sidebar.test.ts
@@ -5,6 +5,7 @@ import {
   cloneElement,
   createElement,
   isValidElement,
+  useEffect,
   type ReactNode,
 } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -40,6 +41,16 @@ vi.mock("@/src/components/hosted-onboarding/hosted-auth-panel", () => ({
 
 vi.mock("@/src/components/hosted-onboarding/hosted-app-session-client", () => ({
   logoutHostedAppSession: mocks.logoutHostedAppSession,
+}));
+
+vi.mock("@/src/components/hosted-onboarding/hosted-privy-logout", () => ({
+  HostedPrivyLogout: ({ onDone }: { onDone: () => void }) => {
+    useEffect(() => {
+      onDone();
+    }, [onDone]);
+
+    return null;
+  },
 }));
 
 vi.mock("@/src/components/hosted-onboarding/client-api", () => ({

--- a/apps/web/test/settings-email-settings.test.ts
+++ b/apps/web/test/settings-email-settings.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { act, createElement, type ReactNode } from "react";
+import { act, createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -35,29 +35,6 @@ vi.mock("@privy-io/react-auth", () => ({
   useLinkAccount: mocks.useLinkAccount,
   useUpdateEmail: mocks.useUpdateEmail,
   useUser: mocks.useUser,
-}));
-
-vi.mock("@/src/components/ui/dialog", () => ({
-  Dialog(input: { children: ReactNode; open?: boolean; onOpenChange?: (open: boolean) => void }) {
-    return createElement("div", {
-      "data-dialog-open": String(input.open ?? false),
-    }, input.children);
-  },
-  DialogContent(input: Record<string, unknown> & { children?: ReactNode }) {
-    return createElement("div", {
-      ...input,
-      "data-show-close-button": String(input.showCloseButton ?? true),
-    }, input.children);
-  },
-  DialogDescription(input: Record<string, unknown> & { children?: ReactNode }) {
-    return createElement("p", input, input.children);
-  },
-  DialogHeader(input: Record<string, unknown> & { children?: ReactNode }) {
-    return createElement("div", input, input.children);
-  },
-  DialogTitle(input: Record<string, unknown> & { children?: ReactNode }) {
-    return createElement("h2", input, input.children);
-  },
 }));
 
 let cleanupRender: (() => Promise<void>) | null = null;
@@ -109,6 +86,10 @@ describe("HostedEmailSettings", () => {
     if (cleanupRender) {
       await cleanupRender();
       cleanupRender = null;
+      // input-otp schedules uncleared 0-50ms selection-sync timers that call
+      // setState; drain them while the linkedom globals are still stubbed so
+      // they cannot fire into a torn-down environment.
+      await new Promise((resolve) => setTimeout(resolve, 60));
     }
   });
 
@@ -204,8 +185,8 @@ describe("HostedEmailSettings", () => {
 
     expect(mocks.linkEmail).toHaveBeenCalledTimes(1);
     expect(mocks.sendCode).not.toHaveBeenCalled();
-    expect(container.querySelector('[data-dialog-open="true"]')).toBeNull();
-    expect(container.textContent).not.toContain("We sent a verification code to");
+    expect(container.querySelector("input[data-input-otp]")).toBeNull();
+    expect(container.textContent).not.toContain("We sent a code to");
   });
 
   it("prefills an unverified server-provided email and lets the member send a verification code", async () => {
@@ -378,7 +359,7 @@ describe("HostedEmailSettings", () => {
     });
   });
 
-  it("sends and verifies update-email codes from the live settings inputs", async () => {
+  it("sends an update-email code and verifies it from the inline code step", async () => {
     const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
     const syncFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
       emailAddress: "member@example.com",
@@ -424,10 +405,14 @@ describe("HostedEmailSettings", () => {
     expect(mocks.sendCode).toHaveBeenCalledWith({
       newEmailAddress: "member@example.com",
     });
-    expect(container.textContent).toContain("We sent a verification code to");
+    expect(container.textContent).toContain("We sent a code to");
+    expect(container.querySelector('input[id="settings-email-address"]')).toBeNull();
 
+    // The linkedom harness cannot drive React's synthetic onChange, so the
+    // InputOTP auto-submit (onComplete) path cannot fire here; the verify
+    // button exercises the same onSubmit callback, reading the code ref.
     const codeInput = container.querySelector(
-      'input[id="settings-email-code"]',
+      "input[data-input-otp]",
     ) as HTMLInputElement | null;
     const verifyButton = Array.from(container.querySelectorAll("button")).find(
       (candidate) => candidate.textContent?.includes("Verify email"),
@@ -442,6 +427,7 @@ describe("HostedEmailSettings", () => {
       verifyButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
+    expect(mocks.verifyCode).toHaveBeenCalledTimes(1);
     expect(mocks.verifyCode).toHaveBeenCalledWith({
       code: "123456",
     });
@@ -485,7 +471,8 @@ describe("HostedEmailSettings", () => {
     });
 
     expect(container.textContent).toContain("We could not send a verification code to that email address.");
-    expect(container.textContent).not.toContain("We sent a verification code to");
+    expect(container.textContent).not.toContain("We sent a code to");
+    expect(container.querySelector("input[data-input-otp]")).toBeNull();
   });
 
   it("does not sync the hosted email route when Privy reports an update-email verify error", async () => {
@@ -533,11 +520,12 @@ describe("HostedEmailSettings", () => {
     });
 
     const codeInput = container.querySelector(
-      'input[id="settings-email-code"]',
+      "input[data-input-otp]",
     ) as HTMLInputElement | null;
     const verifyButton = Array.from(container.querySelectorAll("button")).find(
       (candidate) => candidate.textContent?.includes("Verify email"),
     );
+    expect(codeInput).toBeTruthy();
 
     await act(async () => {
       if (codeInput) {
@@ -546,11 +534,156 @@ describe("HostedEmailSettings", () => {
       verifyButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
+    expect(mocks.verifyCode).toHaveBeenCalledTimes(1);
     expect(syncFetch).not.toHaveBeenCalled();
     expect(container.textContent).toContain("We could not verify that code.");
   });
 
-  it("does not resend to a stale pending email after the visible email input is cleared", async () => {
+  it("rejects an empty code without calling Privy and trims whitespace from the inline code input", async () => {
+    const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
+    const syncFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      emailAddress: "member@example.com",
+      ok: true,
+      runTriggered: true,
+      verifiedAt: "2026-04-25T00:00:00.000Z",
+    }), {
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+      },
+      status: 200,
+    }));
+    vi.stubGlobal("fetch", syncFetch);
+
+    const { cleanup, container, window } = await renderClientComponent(
+      createElement(HostedEmailSettings, {
+        authenticated: true,
+        initialEmail: {
+          address: "old@example.com",
+          verifiedAt: 1771891200,
+        },
+      }),
+    );
+    cleanupRender = cleanup;
+
+    const emailInput = container.querySelector(
+      'input[id="settings-email-address"]',
+    ) as HTMLInputElement | null;
+    const sendButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Send verification code"),
+    );
+
+    await act(async () => {
+      if (emailInput) {
+        setInputValue(window, emailInput, "member@example.com");
+      }
+      sendButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    const codeInput = container.querySelector(
+      "input[data-input-otp]",
+    ) as HTMLInputElement | null;
+    const verifyButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Verify email"),
+    );
+    expect(codeInput).toBeTruthy();
+    expect(verifyButton).toBeTruthy();
+
+    await act(async () => {
+      verifyButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(mocks.verifyCode).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Enter the verification code we emailed you.");
+    expect(container.querySelector("input[data-input-otp]")).toBeTruthy();
+
+    await act(async () => {
+      if (codeInput) {
+        setInputValue(window, codeInput, "  123456  ");
+      }
+      verifyButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(mocks.verifyCode).toHaveBeenCalledTimes(1);
+    expect(mocks.verifyCode).toHaveBeenCalledWith({
+      code: "123456",
+    });
+  });
+
+  it("disables the inline code step actions and shows the verifying label while the code is submitting", async () => {
+    let updateEmailStatus: "idle" | "submitting-code" = "idle";
+    mocks.useUpdateEmail.mockImplementation((callbacks: UpdateEmailCallbacks) => {
+      mocks.updateEmailCallbacks = callbacks;
+
+      return {
+        sendCode: mocks.sendCode,
+        state: {
+          status: updateEmailStatus,
+        },
+        verifyCode: mocks.verifyCode,
+      };
+    });
+    const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
+    const { cleanup, container, window } = await renderClientComponent(
+      createElement(HostedEmailSettings, {
+        authenticated: true,
+        initialEmail: {
+          address: "old@example.com",
+          verifiedAt: 1771891200,
+        },
+      }),
+    );
+    cleanupRender = cleanup;
+
+    const emailInput = container.querySelector(
+      'input[id="settings-email-address"]',
+    ) as HTMLInputElement | null;
+    const sendButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Send verification code"),
+    );
+
+    await act(async () => {
+      if (emailInput) {
+        setInputValue(window, emailInput, "member@example.com");
+      }
+      sendButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    const verifyButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Verify email"),
+    );
+    expect(verifyButton).toBeTruthy();
+    expect(verifyButton?.hasAttribute("disabled")).toBe(false);
+
+    // Flip the mocked Privy hook into the submitting state, then trigger a
+    // re-render through the empty-code validation path (the harness cannot
+    // drive React onChange, so a state-setting click is the re-render seam).
+    updateEmailStatus = "submitting-code";
+
+    await act(async () => {
+      verifyButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Verifying...");
+    expect(container.textContent).not.toContain("Verify email");
+    const pendingVerifyButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Verifying..."),
+    );
+    const resendButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Resend code"),
+    );
+    const useAnotherEmailButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Use another email"),
+    );
+    expect(pendingVerifyButton?.hasAttribute("disabled")).toBe(true);
+    expect(resendButton?.hasAttribute("disabled")).toBe(true);
+    expect(useAnotherEmailButton?.hasAttribute("disabled")).toBe(true);
+    expect(
+      (container.querySelector("input[data-input-otp]") as HTMLInputElement | null)
+        ?.hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("resends the code to the pending email from the code step", async () => {
     const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
     const { cleanup, container, window } = await renderClientComponent(
       createElement(HostedEmailSettings, {
@@ -585,17 +718,18 @@ describe("HostedEmailSettings", () => {
     expect(resendButton).toBeTruthy();
 
     await act(async () => {
-      if (emailInput) {
-        setInputValue(window, emailInput, " ");
-      }
       resendButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
-    expect(mocks.sendCode).toHaveBeenCalledTimes(1);
-    expect(container.textContent).toContain("Enter a valid email address before we send a code.");
+    expect(mocks.sendCode).toHaveBeenCalledTimes(2);
+    expect(mocks.sendCode).toHaveBeenLastCalledWith({
+      newEmailAddress: "member@example.com",
+    });
+    expect(container.querySelector("input[data-input-otp]")).toBeTruthy();
+    expect(container.textContent).toContain("We sent a code to member@example.com");
   });
 
-  it("does not resend from the verification dialog after the visible email input is cleared", async () => {
+  it("returns to email entry when the member chooses to use another email", async () => {
     const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
     const { cleanup, container, window } = await renderClientComponent(
       createElement(HostedEmailSettings, {
@@ -622,24 +756,20 @@ describe("HostedEmailSettings", () => {
       sendButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
-    await act(async () => {
-      if (emailInput) {
-        setInputValue(window, emailInput, " ");
-      }
-    });
+    expect(container.querySelector("input[data-input-otp]")).toBeTruthy();
 
-    const dialog = container.querySelector('[data-dialog-open="true"]');
-    expect(dialog).toBeTruthy();
-    const dialogResendButton = Array.from(dialog?.querySelectorAll("button") ?? []).find(
-      (candidate) => candidate.textContent?.includes("Resend code"),
+    const useAnotherEmailButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Use another email"),
     );
+    expect(useAnotherEmailButton).toBeTruthy();
 
     await act(async () => {
-      dialogResendButton?.dispatchEvent(new Event("click", { bubbles: true }));
+      useAnotherEmailButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
+    expect(container.querySelector("input[data-input-otp]")).toBeNull();
+    expect(container.querySelector('input[id="settings-email-address"]')).toBeTruthy();
     expect(mocks.sendCode).toHaveBeenCalledTimes(1);
-    expect(container.textContent).toContain("Enter a valid email address before we send a code.");
   });
 });
 


### PR DESCRIPTION
## Why

Changing your email on /settings opened a second "Enter your verification code" dialog **on top of** the "Change email" dialog, while the dialog underneath still showed a redundant pending alert with duplicate "Enter code"/"Resend code" buttons. The inner dialog's close button was also force-disabled while a code was in flight (`effectiveDialogOpen = dialogOpen || isAwaitingCode || isSubmittingCode`).

Root cause: `HostedEmailSettings` was built as a flat settings-page section that opens its own modal for code entry, then got embedded wholesale inside the `HostedSettingsIdentityLinkDialog` modal.

## What

One dialog, two steps:
- Step 1: email entry (unchanged form).
- Step 2: inline `HostedVerificationCodeStep` — the same shared OTP component the phone signup uses — which **auto-submits when the 6th digit is entered** (InputOTP `onComplete`), with Resend and a "Use another email" reset that restores focus to the email input.

Deleted: `HostedEmailVerificationDialog`, the pending alert, all `dialogOpen` controller state, the email-input-coupled resend (resend now targets the pending address), and dead code normalization in `handleVerifyCode`. On verify failure the code is cleared so a resent code re-arms auto-submit. Net −100 lines.

`HostedEmailSettings` is mounted only inside the identity-link dialog, so the swap is safe at every mount. Privy `sendCode`/`verifyCode` call shapes and the `/api/settings/email/sync` flow are unchanged.

## Verification

- `pnpm test:diff` (full `apps/web verify`: next build, 255 test files / 2216 tests, eslint, dev smoke) — green
- Focused `test/settings-email-settings.test.ts` — 15/15 (2 new tests: empty-code guard + trim, submitting-state wiring), no unhandled errors
- Completion audits run: frontend-review (6 findings — 4 fixed, 2 rejected as pre-existing parity), coverage-write, task-finish-review (no material findings)
- Known gap: the linkedom harness cannot drive React synthetic onChange, so the auto-submit path itself rides on the shared component's production use in the phone flow; worth one manual browser pass (auto-submit on 6th digit, cleared code after a failed attempt, focus restore on "Use another email")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783630050&installation_id=127572939&pr_number=78&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F78&signature=3fce56db93f9812c5295646b05d797f97e4f66cf2a929233468521abd11c4953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->