### PR TITLE
Add hosted email reply alias backfill workflow

### DIFF
--- a/.github/workflows/backfill-hosted-email-reply-aliases.yml
+++ b/.github/workflows/backfill-hosted-email-reply-aliases.yml
@@ -1,0 +1,97 @@
+name: Backfill hosted email reply aliases
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Apply the backfill. Leave false for a counts-only dry-run.
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-email-reply-alias-backfill-production
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill production aliases
+    if: ${{ github.ref == 'refs/heads/main' && github.ref_protected }}
+    runs-on: ubuntu-24.04
+    environment: production
+    timeout-minutes: 10
+    env:
+      APPLY: ${{ inputs.apply }}
+      HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET: ${{ secrets.HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET }}
+      HOSTED_WEB_BASE_URL: ${{ vars.HOSTED_WEB_BASE_URL }}
+    steps:
+      - name: Validate workflow configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET}" ]]; then
+            printf '%s\n' 'HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET is not configured.'
+            exit 1
+          fi
+          if [[ -z "${HOSTED_WEB_BASE_URL}" ]]; then
+            printf '%s\n' 'HOSTED_WEB_BASE_URL is not configured.'
+            exit 1
+          fi
+
+      - name: Run backfill
+        shell: bash
+        run: |
+          set -euo pipefail
+          endpoint="${HOSTED_WEB_BASE_URL%/}/api/internal/hosted-execution/email/backfill-reply-aliases"
+          response_file="$(mktemp)"
+          status="$(
+            curl --silent --show-error \
+              --output "${response_file}" \
+              --write-out '%{http_code}' \
+              --request POST \
+              --header "authorization: Bearer ${HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET}" \
+              --header 'content-type: application/json' \
+              --data "{\"apply\":${APPLY}}" \
+              "${endpoint}"
+          )"
+
+          if [[ "${status}" != "200" ]]; then
+            printf 'Backfill failed with HTTP %s.\n' "${status}"
+            node -e "const fs=require('fs'); const text=fs.readFileSync(process.argv[1], 'utf8'); try { console.log(JSON.stringify(JSON.parse(text))); } catch { console.log('Non-JSON response body.'); }" "${response_file}"
+            exit 1
+          fi
+
+          node - "${response_file}" <<'NODE'
+          const fs = require("fs");
+          const body = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          if (body.ok !== true) {
+            console.log(JSON.stringify({ ok: body.ok ?? false }));
+            process.exit(1);
+          }
+
+          const summary = {
+            apply: body.apply,
+            backfilledReplyAliasCount: body.backfilledReplyAliasCount,
+            existingReplyAliasCountBefore: body.existingReplyAliasCountBefore,
+            generatedReplyAliasCount: body.generatedReplyAliasCount,
+            missingReplyAliasCountAfter: body.missingReplyAliasCountAfter,
+            missingReplyAliasCountBefore: body.missingReplyAliasCountBefore,
+            unsuspendedVerifiedEmailMemberCount: body.unsuspendedVerifiedEmailMemberCount,
+          };
+          console.log(JSON.stringify(summary));
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, [
+            "## Hosted email reply alias backfill",
+            "",
+            `- apply: ${summary.apply}`,
+            `- unsuspended verified email members: ${summary.unsuspendedVerifiedEmailMemberCount}`,
+            `- existing reply aliases before: ${summary.existingReplyAliasCountBefore}`,
+            `- missing reply aliases before: ${summary.missingReplyAliasCountBefore}`,
+            `- generated reply aliases: ${summary.generatedReplyAliasCount}`,
+            `- backfilled reply aliases: ${summary.backfilledReplyAliasCount}`,
+            `- missing reply aliases after: ${summary.missingReplyAliasCountAfter}`,
+            "",
+          ].join("\n"));
+          NODE

--- a/agent-docs/exec-plans/completed/2026-06-09-hosted-email-alias-backfill.md
+++ b/agent-docs/exec-plans/completed/2026-06-09-hosted-email-alias-backfill.md
@@ -1,0 +1,48 @@
+Goal (incl. success criteria):
+- Backfill deterministic hosted email reply-alias lookup keys for unsuspended hosted members who already have a verified email but no persisted reply alias.
+- Provide a protected GitHub manual workflow that can dry-run and apply the backfill without copying the Vercel production database URL into GitHub.
+- Success means workflow output is counts-only, the route is secret-gated, idempotent re-runs are safe, and production missing-alias count reaches zero for unsuspended verified-email members.
+
+Constraints/Assumptions:
+- Web remains the owner of hosted member routing and email authorization facts.
+- Do not print or persist raw emails, member ids, alias addresses, alias lookup keys, database URLs, or trigger secrets in logs or workflow summaries.
+- The production database URL exists in Vercel, not GitHub; the workflow must trigger a Vercel-hosted server-side mutation instead of moving that secret.
+- Preserve unrelated working-tree edits and active ledger rows.
+
+Key decisions:
+- Add a narrow internal maintenance route guarded by a dedicated bearer secret instead of reusing user sessions or copying the database secret into GitHub.
+- Reuse `createHostedMemberReplyAliasRoute` and `upsertHostedMemberReplyAliasLookupKeyTx` so alias derivation and routing-row creation follow existing owner code.
+- Default the workflow to dry-run; require explicit `apply=true` to write.
+
+State:
+- In progress.
+
+Done:
+- Confirmed existing production verified-email members are missing reply aliases.
+- Confirmed `HOSTED_EMAIL_SIGNING_SECRET` is present in Vercel, GitHub production, and Cloudflare.
+- Confirmed GitHub production does not currently hold `DATABASE_URL` or `DIRECT_DATABASE_URL`.
+- Added the secret-gated Vercel-hosted backfill route, manual GitHub workflow, route test, and workflow guard test.
+- Passed focused tests, YAML parse, `pnpm typecheck`, and `pnpm test:diff`.
+- Simplify review found workflow hardening and leakage-test improvements; accepted and verified those, and rejected billing-active restriction because the production repair scope is all unsuspended verified-email members.
+- Security/privacy review and rerun found no medium-or-higher findings; names-only provider checks confirmed `HOSTED_WEB_BASE_URL` and the backfill secret are configured.
+- Coverage-write added route query-shape and duplicate-alias collision proof; focused tests, `pnpm typecheck`, and `pnpm test:diff` passed afterward.
+- User approved deploying and running the backfill before the remaining deep/final completion review passes.
+
+Now:
+- Close the plan with a scoped commit, deploy web, run the workflow dry-run, then run apply if dry-run counts are expected.
+
+Next:
+- Verify production missing-alias counts after the workflow run.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/app/api/internal/hosted-execution/email/backfill-reply-aliases/route.ts
+- apps/web/test/hosted-execution-email-backfill-route.test.ts
+- packages/cli/test/hosted-email-alias-backfill-workflow-guards.test.ts
+- .github/workflows/backfill-hosted-email-reply-aliases.yml
+- agent-docs/exec-plans/active/COORDINATION_LEDGER.md
+Status: completed
+Updated: 2026-06-09
+Completed: 2026-06-09

--- a/apps/web/app/api/internal/hosted-execution/email/backfill-reply-aliases/route.ts
+++ b/apps/web/app/api/internal/hosted-execution/email/backfill-reply-aliases/route.ts
@@ -1,0 +1,230 @@
+import { timingSafeEqual } from "node:crypto";
+
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+import { createHostedMemberReplyAliasRoute } from "@/src/lib/hosted-onboarding/hosted-email-reply-alias";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import { jsonOk, readOptionalJsonObject, withJsonError } from "@/src/lib/hosted-onboarding/http";
+import { upsertHostedMemberReplyAliasLookupKeyTx } from "@/src/lib/hosted-onboarding/hosted-member-routing-store";
+import { getPrisma } from "@/src/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BACKFILL_SECRET_ENV = "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET";
+
+const unsuspendedVerifiedEmailMemberWhere = {
+  suspendedAt: null,
+  emailAuthorization: {
+    is: {
+      verifiedEmailVerifiedAt: {
+        not: null,
+      },
+    },
+  },
+} satisfies Prisma.HostedMemberWhereInput;
+
+const missingReplyAliasWhere = {
+  ...unsuspendedVerifiedEmailMemberWhere,
+  OR: [
+    {
+      routing: {
+        is: null,
+      },
+    },
+    {
+      routing: {
+        is: {
+          replyAliasLookupKey: null,
+        },
+      },
+    },
+  ],
+} satisfies Prisma.HostedMemberWhereInput;
+
+const existingReplyAliasWhere = {
+  ...unsuspendedVerifiedEmailMemberWhere,
+  routing: {
+    is: {
+      replyAliasLookupKey: {
+        not: null,
+      },
+    },
+  },
+} satisfies Prisma.HostedMemberWhereInput;
+
+interface HostedEmailReplyAliasBackfillRoute {
+  memberId: string;
+  replyAliasLookupKey: string;
+}
+
+export const POST = withJsonError(async (request: Request) => {
+  requireHostedEmailReplyAliasBackfillAuthorization(request);
+  const body = await readOptionalJsonObject(request);
+  const apply = readApplyFlag(body);
+  const prisma = getPrisma();
+  const result = await backfillHostedEmailReplyAliases({
+    apply,
+    prisma,
+  });
+
+  return jsonOk({
+    ok: true,
+    ...result,
+  });
+});
+
+async function backfillHostedEmailReplyAliases(input: {
+  apply: boolean;
+  prisma: PrismaClient;
+}) {
+  const before = await readHostedEmailReplyAliasBackfillCounts(input.prisma);
+  const candidates = await input.prisma.hostedMember.findMany({
+    orderBy: {
+      createdAt: "asc",
+    },
+    select: {
+      id: true,
+    },
+    where: missingReplyAliasWhere,
+  });
+
+  const generatedRoutes: HostedEmailReplyAliasBackfillRoute[] = [];
+  const generatedLookupKeys = new Set<string>();
+
+  for (const candidate of candidates) {
+    const replyAlias = await createHostedMemberReplyAliasRoute({
+      memberId: candidate.id,
+    });
+    if (!replyAlias) {
+      throw hostedOnboardingError({
+        code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_CONFIG_REQUIRED",
+        httpStatus: 500,
+        message: "Hosted email reply-alias backfill requires hosted email alias configuration.",
+      });
+    }
+
+    if (generatedLookupKeys.has(replyAlias.replyAliasLookupKey)) {
+      throw hostedOnboardingError({
+        code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_ALIAS_COLLISION",
+        httpStatus: 500,
+        message: "Hosted email reply-alias backfill generated a duplicate lookup key.",
+      });
+    }
+
+    generatedLookupKeys.add(replyAlias.replyAliasLookupKey);
+    generatedRoutes.push({
+      memberId: candidate.id,
+      replyAliasLookupKey: replyAlias.replyAliasLookupKey,
+    });
+  }
+
+  if (input.apply && generatedRoutes.length > 0) {
+    await input.prisma.$transaction(async (tx) => {
+      for (const route of generatedRoutes) {
+        await upsertHostedMemberReplyAliasLookupKeyTx({
+          memberId: route.memberId,
+          prisma: tx,
+          replyAliasLookupKey: route.replyAliasLookupKey,
+        });
+      }
+    });
+  }
+
+  const after = await readHostedEmailReplyAliasBackfillCounts(input.prisma);
+
+  return {
+    apply: input.apply,
+    backfilledReplyAliasCount: input.apply ? generatedRoutes.length : 0,
+    existingReplyAliasCountBefore: before.existingReplyAliasCount,
+    generatedReplyAliasCount: generatedRoutes.length,
+    missingReplyAliasCountAfter: after.missingReplyAliasCount,
+    missingReplyAliasCountBefore: before.missingReplyAliasCount,
+    unsuspendedVerifiedEmailMemberCount: before.unsuspendedVerifiedEmailMemberCount,
+  };
+}
+
+async function readHostedEmailReplyAliasBackfillCounts(prisma: PrismaClient) {
+  const [
+    unsuspendedVerifiedEmailMemberCount,
+    existingReplyAliasCount,
+    missingReplyAliasCount,
+  ] = await Promise.all([
+    prisma.hostedMember.count({
+      where: unsuspendedVerifiedEmailMemberWhere,
+    }),
+    prisma.hostedMember.count({
+      where: existingReplyAliasWhere,
+    }),
+    prisma.hostedMember.count({
+      where: missingReplyAliasWhere,
+    }),
+  ]);
+
+  return {
+    existingReplyAliasCount,
+    missingReplyAliasCount,
+    unsuspendedVerifiedEmailMemberCount,
+  };
+}
+
+function requireHostedEmailReplyAliasBackfillAuthorization(request: Request): void {
+  const configuredSecret = normalizeOptionalString(process.env[BACKFILL_SECRET_ENV]);
+  if (!configuredSecret) {
+    throw hostedOnboardingError({
+      code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET_REQUIRED",
+      httpStatus: 500,
+      message: `${BACKFILL_SECRET_ENV} must be configured for hosted email reply-alias backfills.`,
+    });
+  }
+
+  const providedSecret = readBearerAuthorizationToken(request.headers.get("authorization"));
+  if (!providedSecret || !timingSafeEquals(configuredSecret, providedSecret)) {
+    throw hostedOnboardingError({
+      code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_UNAUTHORIZED",
+      httpStatus: 401,
+      message: "Unauthorized hosted email reply-alias backfill request.",
+    });
+  }
+}
+
+function readApplyFlag(body: Record<string, unknown>): boolean {
+  const value = body.apply;
+  if (value === undefined || value === false || value === "false") {
+    return false;
+  }
+  if (value === true || value === "true") {
+    return true;
+  }
+
+  throw hostedOnboardingError({
+    code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_APPLY_INVALID",
+    httpStatus: 400,
+    message: "Hosted email reply-alias backfill apply must be a boolean.",
+  });
+}
+
+function readBearerAuthorizationToken(value: string | null): string | null {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized || !normalized.startsWith("Bearer ")) {
+    return null;
+  }
+
+  return normalizeOptionalString(normalized.slice("Bearer ".length));
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | null {
+  const normalized = value?.trim() ?? "";
+  return normalized.length > 0 ? normalized : null;
+}
+
+function timingSafeEquals(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}

--- a/apps/web/test/hosted-execution-email-backfill-route.test.ts
+++ b/apps/web/test/hosted-execution-email-backfill-route.test.ts
@@ -1,0 +1,379 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createBearerRequest } from "./route-test-helpers";
+
+const mocks = vi.hoisted(() => ({
+  createHostedMemberReplyAliasRoute: vi.fn(),
+  getPrisma: vi.fn(),
+  upsertHostedMemberReplyAliasLookupKeyTx: vi.fn(),
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: mocks.getPrisma,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-email-reply-alias", () => ({
+  createHostedMemberReplyAliasRoute: mocks.createHostedMemberReplyAliasRoute,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-routing-store", () => ({
+  upsertHostedMemberReplyAliasLookupKeyTx: mocks.upsertHostedMemberReplyAliasLookupKeyTx,
+}));
+
+type BackfillRouteModule = typeof import(
+  "../app/api/internal/hosted-execution/email/backfill-reply-aliases/route"
+);
+type MockPrismaClient = ReturnType<typeof createPrismaMock>;
+
+let backfillRoute: BackfillRouteModule;
+let prismaClient: MockPrismaClient;
+
+const originalBackfillSecret = process.env.HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET;
+const BACKFILL_URL =
+  "https://join.example.test/api/internal/hosted-execution/email/backfill-reply-aliases";
+const UNSUSPENDED_VERIFIED_EMAIL_MEMBER_WHERE = {
+  suspendedAt: null,
+  emailAuthorization: {
+    is: {
+      verifiedEmailVerifiedAt: {
+        not: null,
+      },
+    },
+  },
+};
+const MISSING_REPLY_ALIAS_WHERE = {
+  ...UNSUSPENDED_VERIFIED_EMAIL_MEMBER_WHERE,
+  OR: [
+    {
+      routing: {
+        is: null,
+      },
+    },
+    {
+      routing: {
+        is: {
+          replyAliasLookupKey: null,
+        },
+      },
+    },
+  ],
+};
+const EXISTING_REPLY_ALIAS_WHERE = {
+  ...UNSUSPENDED_VERIFIED_EMAIL_MEMBER_WHERE,
+  routing: {
+    is: {
+      replyAliasLookupKey: {
+        not: null,
+      },
+    },
+  },
+};
+
+describe("hosted execution email reply-alias backfill route", () => {
+  beforeAll(async () => {
+    backfillRoute = await import(
+      "../app/api/internal/hosted-execution/email/backfill-reply-aliases/route"
+    );
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restoreEnv(
+      "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET",
+      originalBackfillSecret,
+    );
+    process.env.HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET = "backfill-secret";
+    prismaClient = createPrismaMock();
+    mocks.getPrisma.mockReturnValue(prismaClient);
+    mocks.createHostedMemberReplyAliasRoute.mockImplementation(
+      async ({ memberId }: { memberId: string }) => ({
+        address: "murph+fixture@mail.example.test",
+        replyAliasLookupKey: createFixtureReplyAliasLookupKey(memberId),
+      }),
+    );
+    mocks.upsertHostedMemberReplyAliasLookupKeyTx.mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    restoreEnv(
+      "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET",
+      originalBackfillSecret,
+    );
+  });
+
+  it("dry-runs missing reply aliases without writing member routes", async () => {
+    mockHostedMemberCounts({
+      existing: 3,
+      missingAfter: 2,
+      missingBefore: 2,
+      unsuspendedVerified: 5,
+    });
+    prismaClient.hostedMember.findMany.mockResolvedValue([
+      { id: "member_1" },
+      { id: "member_2" },
+    ]);
+
+    const response = await backfillRoute.POST(createBackfillRequest({
+      apply: false,
+      token: "backfill-secret",
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(prismaClient.$transaction).not.toHaveBeenCalled();
+    expect(mocks.upsertHostedMemberReplyAliasLookupKeyTx).not.toHaveBeenCalled();
+    expect(mocks.createHostedMemberReplyAliasRoute).toHaveBeenCalledTimes(2);
+    expectBackfillQueriesToTargetMissingAliases();
+    expect(body).toEqual({
+      apply: false,
+      backfilledReplyAliasCount: 0,
+      existingReplyAliasCountBefore: 3,
+      generatedReplyAliasCount: 2,
+      missingReplyAliasCountAfter: 2,
+      missingReplyAliasCountBefore: 2,
+      ok: true,
+      unsuspendedVerifiedEmailMemberCount: 5,
+    });
+    expect(JSON.stringify(body)).not.toContain("member_");
+    expect(JSON.stringify(body)).not.toContain("murph+fixture@mail.example.test");
+    expect(JSON.stringify(body)).not.toContain("0123456789abcdef0123456789abcdef");
+    expect(JSON.stringify(body)).not.toContain("abcdef0123456789abcdef0123456789");
+  });
+
+  it("applies missing reply aliases inside one transaction", async () => {
+    mockHostedMemberCounts({
+      existing: 3,
+      missingAfter: 0,
+      missingBefore: 2,
+      unsuspendedVerified: 5,
+    });
+    prismaClient.hostedMember.findMany.mockResolvedValue([
+      { id: "member_1" },
+      { id: "member_2" },
+    ]);
+
+    const response = await backfillRoute.POST(createBackfillRequest({
+      apply: true,
+      token: "backfill-secret",
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(prismaClient.$transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.upsertHostedMemberReplyAliasLookupKeyTx).toHaveBeenCalledTimes(2);
+    expect(mocks.upsertHostedMemberReplyAliasLookupKeyTx).toHaveBeenNthCalledWith(1, {
+      memberId: "member_1",
+      prisma: prismaClient.transactionClient,
+      replyAliasLookupKey: "0123456789abcdef0123456789abcdef",
+    });
+    expect(mocks.upsertHostedMemberReplyAliasLookupKeyTx).toHaveBeenNthCalledWith(2, {
+      memberId: "member_2",
+      prisma: prismaClient.transactionClient,
+      replyAliasLookupKey: "abcdef0123456789abcdef0123456789",
+    });
+    expect(body).toEqual({
+      apply: true,
+      backfilledReplyAliasCount: 2,
+      existingReplyAliasCountBefore: 3,
+      generatedReplyAliasCount: 2,
+      missingReplyAliasCountAfter: 0,
+      missingReplyAliasCountBefore: 2,
+      ok: true,
+      unsuspendedVerifiedEmailMemberCount: 5,
+    });
+    expect(JSON.stringify(body)).not.toContain("member_");
+    expect(JSON.stringify(body)).not.toContain("murph+fixture@mail.example.test");
+    expect(JSON.stringify(body)).not.toContain("0123456789abcdef0123456789abcdef");
+    expect(JSON.stringify(body)).not.toContain("abcdef0123456789abcdef0123456789");
+  });
+
+  it("rejects unauthorized requests before reading the database", async () => {
+    const response = await backfillRoute.POST(createBackfillRequest({
+      apply: true,
+      token: "wrong-secret",
+    }));
+
+    expect(response.status).toBe(401);
+    expect(mocks.getPrisma).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_UNAUTHORIZED",
+        message: "Unauthorized hosted email reply-alias backfill request.",
+        retryable: false,
+      },
+    });
+  });
+
+  it("rejects invalid apply values before reading the database", async () => {
+    const response = await backfillRoute.POST(
+      createBearerRequest(BACKFILL_URL, "backfill-secret", {
+        body: JSON.stringify({ apply: "yes" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.getPrisma).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_APPLY_INVALID",
+        message: "Hosted email reply-alias backfill apply must be a boolean.",
+        retryable: false,
+      },
+    });
+  });
+
+  it("rejects duplicate generated lookup keys before writing", async () => {
+    mockHostedMemberCounts({
+      existing: 0,
+      missingAfter: 2,
+      missingBefore: 2,
+      unsuspendedVerified: 2,
+    });
+    prismaClient.hostedMember.findMany.mockResolvedValue([
+      { id: "member_1" },
+      { id: "member_2" },
+    ]);
+    mocks.createHostedMemberReplyAliasRoute.mockResolvedValue({
+      address: "murph+fixture@mail.example.test",
+      replyAliasLookupKey: "duplicate-lookup-key",
+    });
+
+    const response = await backfillRoute.POST(createBackfillRequest({
+      apply: true,
+      token: "backfill-secret",
+    }));
+
+    expect(response.status).toBe(500);
+    expect(prismaClient.$transaction).not.toHaveBeenCalled();
+    expect(mocks.upsertHostedMemberReplyAliasLookupKeyTx).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_ALIAS_COLLISION",
+        message: "Hosted email reply-alias backfill generated a duplicate lookup key.",
+        retryable: false,
+      },
+    });
+  });
+
+  it("fails closed when hosted email alias config is unavailable", async () => {
+    mockHostedMemberCounts({
+      existing: 0,
+      missingAfter: 1,
+      missingBefore: 1,
+      unsuspendedVerified: 1,
+    });
+    prismaClient.hostedMember.findMany.mockResolvedValue([{ id: "member_1" }]);
+    mocks.createHostedMemberReplyAliasRoute.mockResolvedValue(null);
+
+    const response = await backfillRoute.POST(createBackfillRequest({
+      apply: true,
+      token: "backfill-secret",
+    }));
+
+    expect(response.status).toBe(500);
+    expect(prismaClient.$transaction).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_CONFIG_REQUIRED",
+        message: "Hosted email reply-alias backfill requires hosted email alias configuration.",
+        retryable: false,
+      },
+    });
+  });
+});
+
+function createBackfillRequest(input: { apply: boolean; token: string }) {
+  return createBearerRequest(BACKFILL_URL, input.token, {
+    body: JSON.stringify({
+      apply: input.apply,
+    }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+}
+
+function createPrismaMock() {
+  const transactionClient = {
+    label: "transaction-client",
+  };
+
+  return {
+    hostedMember: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+    transactionClient,
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback(transactionClient)
+    ),
+  };
+}
+
+function expectBackfillQueriesToTargetMissingAliases(): void {
+  expect(prismaClient.hostedMember.findMany).toHaveBeenCalledWith({
+    orderBy: {
+      createdAt: "asc",
+    },
+    select: {
+      id: true,
+    },
+    where: MISSING_REPLY_ALIAS_WHERE,
+  });
+  expect(prismaClient.hostedMember.count).toHaveBeenNthCalledWith(1, {
+    where: UNSUSPENDED_VERIFIED_EMAIL_MEMBER_WHERE,
+  });
+  expect(prismaClient.hostedMember.count).toHaveBeenNthCalledWith(2, {
+    where: EXISTING_REPLY_ALIAS_WHERE,
+  });
+  expect(prismaClient.hostedMember.count).toHaveBeenNthCalledWith(3, {
+    where: MISSING_REPLY_ALIAS_WHERE,
+  });
+  expect(prismaClient.hostedMember.count).toHaveBeenNthCalledWith(4, {
+    where: UNSUSPENDED_VERIFIED_EMAIL_MEMBER_WHERE,
+  });
+  expect(prismaClient.hostedMember.count).toHaveBeenNthCalledWith(5, {
+    where: EXISTING_REPLY_ALIAS_WHERE,
+  });
+  expect(prismaClient.hostedMember.count).toHaveBeenNthCalledWith(6, {
+    where: MISSING_REPLY_ALIAS_WHERE,
+  });
+}
+
+function mockHostedMemberCounts(input: {
+  existing: number;
+  missingAfter: number;
+  missingBefore: number;
+  unsuspendedVerified: number;
+}) {
+  prismaClient.hostedMember.count
+    .mockResolvedValueOnce(input.unsuspendedVerified)
+    .mockResolvedValueOnce(input.existing)
+    .mockResolvedValueOnce(input.missingBefore)
+    .mockResolvedValueOnce(input.unsuspendedVerified)
+    .mockResolvedValueOnce(input.existing + (input.missingBefore - input.missingAfter))
+    .mockResolvedValueOnce(input.missingAfter);
+}
+
+function createFixtureReplyAliasLookupKey(memberId: string): string {
+  if (memberId === "member_2") {
+    return "abcdef0123456789abcdef0123456789";
+  }
+
+  return "0123456789abcdef0123456789abcdef";
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/packages/cli/test/hosted-email-alias-backfill-workflow-guards.test.ts
+++ b/packages/cli/test/hosted-email-alias-backfill-workflow-guards.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const workflowPath = path.join(
+  repoRoot,
+  '.github',
+  'workflows',
+  'backfill-hosted-email-reply-aliases.yml',
+)
+
+describe('hosted email reply-alias backfill workflow guards', () => {
+  it('keeps the production backfill workflow manual, protected, and counts-only', () => {
+    const workflow = readFileSync(workflowPath, 'utf8')
+
+    expect(workflow).toContain('workflow_dispatch:')
+    expect(workflow).toContain('type: boolean')
+    expect(workflow).toContain("if: ${{ github.ref == 'refs/heads/main' && github.ref_protected }}")
+    expect(workflow).toContain('environment: production')
+    expect(workflow).toContain('cancel-in-progress: false')
+    expect(workflow).toContain(
+      'HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET: ${{ secrets.HOSTED_EMAIL_REPLY_ALIAS_BACKFILL_SECRET }}',
+    )
+    expect(workflow).toContain('HOSTED_WEB_BASE_URL: ${{ vars.HOSTED_WEB_BASE_URL }}')
+    expect(workflow).toContain(
+      '/api/internal/hosted-execution/email/backfill-reply-aliases',
+    )
+    expect(workflow).toContain('missingReplyAliasCountAfter')
+    expect(workflow).not.toContain('DATABASE_URL')
+    expect(workflow).not.toContain('DIRECT_DATABASE_URL')
+    expect(workflow).not.toContain('vercel env pull')
+    expect(workflow).not.toContain('withmurph.ai')
+  })
+})


### PR DESCRIPTION
## Summary
- add a secret-gated Vercel-hosted backfill route for missing hosted email reply aliases
- add a manual GitHub workflow with dry-run/apply modes and counts-only output
- add route and workflow guard tests

## Verification
- pnpm typecheck
- pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-execution-email-backfill-route.test.ts
- pnpm exec vitest run packages/cli/test/hosted-email-alias-backfill-workflow-guards.test.ts --no-coverage
- pnpm test:diff

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783643324&installation_id=127572939&pr_number=85&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F85&signature=c3a0a621140774636a82d3898deb4379e2c2eb5a639d692c9656b81e2481b30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->