### PR TITLE
feat(device-sync): surface Junction source error details into device_connection_source

### DIFF
--- a/packages/device-syncd/src/providers/junction-client.ts
+++ b/packages/device-syncd/src/providers/junction-client.ts
@@ -47,6 +47,12 @@ export interface JunctionProviderConnectionOrigin {
   sourceInstanceId?: string | null;
 }
 
+export interface JunctionProviderConnectionErrorDetails {
+  errorType: string | null;
+  errorMessage: string | null;
+  erroredAt: string | null;
+}
+
 export interface JunctionProviderConnection {
   id: string | null;
   slug: string;
@@ -55,6 +61,7 @@ export interface JunctionProviderConnection {
   source: JunctionProviderConnectionSource | null;
   origin: JunctionProviderConnectionOrigin;
   resourceAvailability: Record<string, unknown>;
+  errorDetails: JunctionProviderConnectionErrorDetails | null;
 }
 
 export type JunctionDateQueryFormat = "date" | "datetime";
@@ -775,7 +782,26 @@ function parseJunctionProviderConnection(value: unknown): JunctionProviderConnec
       sourceInstanceId: origin.sourceInstanceId,
     },
     resourceAvailability: readResourceAvailability(record),
+    errorDetails: readJunctionProviderConnectionErrorDetails(record),
   };
+}
+
+function readJunctionProviderConnectionErrorDetails(
+  record: Record<string, unknown>,
+): JunctionProviderConnectionErrorDetails | null {
+  const details = readPlainObject(record.error_details) ?? readPlainObject(record.errorDetails);
+  if (!details) {
+    return null;
+  }
+
+  const errorType = normalizeString(details.error_type) ?? normalizeString(details.errorType) ?? null;
+  const errorMessage = normalizeString(details.error_message) ?? normalizeString(details.errorMessage) ?? null;
+  const erroredAt = normalizeString(details.errored_at) ?? normalizeString(details.erroredAt) ?? null;
+  if (!errorType && !errorMessage && !erroredAt) {
+    return null;
+  }
+
+  return { errorType, errorMessage, erroredAt };
 }
 
 function readJunctionProviderConnectionId(record: Record<string, unknown>): string | null {

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -5180,26 +5180,31 @@ async function projectJunctionSources(
       displayName: null,
       status: source.status,
       resourceAvailabilitySummary: source.resourceAvailabilitySummary,
+      // Only assert error fields when this projection saw an errored entry;
+      // omitting the keys lets the store preserve existing detail while the
+      // status stays "error" and auto-clear it once the status recovers.
+      ...(source.lastErrorCode !== null || source.lastErrorMessage !== null
+        ? { lastErrorCode: source.lastErrorCode, lastErrorMessage: source.lastErrorMessage }
+        : {}),
       lastSeenAt: context.now,
     });
   }
 }
 
-function projectJunctionSourcesByProviderSlug(
-  connectionId: string,
-  providers: readonly JunctionProviderConnection[],
-): Array<{
+interface ProjectedJunctionSource {
   sourceInstanceKey: string;
   sourceProviderSlug: string;
   status: DeviceConnectionSourceStatus;
   resourceAvailabilitySummary: Record<string, string | number | boolean | null>;
-}> {
-  const projected = new Map<string, {
-    sourceInstanceKey: string;
-    sourceProviderSlug: string;
-    status: DeviceConnectionSourceStatus;
-    resourceAvailabilitySummary: Record<string, string | number | boolean | null>;
-  }>();
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+}
+
+function projectJunctionSourcesByProviderSlug(
+  connectionId: string,
+  providers: readonly JunctionProviderConnection[],
+): ProjectedJunctionSource[] {
+  const projected = new Map<string, ProjectedJunctionSource>();
 
   for (const provider of providers) {
     const origin = resolveJunctionOrigin(
@@ -5232,28 +5237,57 @@ function projectJunctionSourcesByProviderSlug(
     }
 
     const resourceAvailabilitySummary = sanitizeJunctionResourceAvailabilitySummary(provider.resourceAvailability);
+    const status = mapJunctionSourceStatus(provider.status);
+    const lastErrorCode = status === "error"
+      ? truncateJunctionSourceErrorText(provider.errorDetails?.errorType, JUNCTION_SOURCE_ERROR_CODE_MAX_LENGTH)
+      : null;
+    const lastErrorMessage = status === "error"
+      ? truncateJunctionSourceErrorText(provider.errorDetails?.errorMessage, JUNCTION_SOURCE_ERROR_MESSAGE_MAX_LENGTH)
+      : null;
     const existing = projected.get(sourceProviderSlug);
     if (existing) {
       mergeJunctionResourceAvailabilitySummary(
         existing.resourceAvailabilitySummary,
         resourceAvailabilitySummary,
       );
-      existing.status = mergeJunctionSourceStatus(
-        existing.status,
-        mapJunctionSourceStatus(provider.status),
-      );
+      existing.status = mergeJunctionSourceStatus(existing.status, status);
+      if (existing.status !== "error") {
+        existing.lastErrorCode = null;
+        existing.lastErrorMessage = null;
+      } else if (existing.lastErrorCode === null && existing.lastErrorMessage === null) {
+        existing.lastErrorCode = lastErrorCode;
+        existing.lastErrorMessage = lastErrorMessage;
+      }
       continue;
     }
 
     projected.set(sourceProviderSlug, {
       sourceInstanceKey,
       sourceProviderSlug,
-      status: mapJunctionSourceStatus(provider.status),
+      status,
       resourceAvailabilitySummary,
+      lastErrorCode,
+      lastErrorMessage,
     });
   }
 
   return [...projected.values()];
+}
+
+// device_connection_source bounds (the store rejects longer values).
+const JUNCTION_SOURCE_ERROR_CODE_MAX_LENGTH = 80;
+const JUNCTION_SOURCE_ERROR_MESSAGE_MAX_LENGTH = 240;
+
+function truncateJunctionSourceErrorText(
+  value: string | null | undefined,
+  maxLength: number,
+): string | null {
+  const normalized = value?.trim() ?? "";
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
 }
 
 function mergeJunctionResourceAvailabilitySummary(

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -4404,6 +4404,331 @@ test("Junction source projection uses provider-level keys for slug-only sources"
   assert.equal(sources[0]?.resourceAvailabilitySummary.sourceInstanceKeyFallback, undefined);
 });
 
+test("Junction source projection persists provider error details for errored sources", async () => {
+  const longErrorMessage = `WHOOP rejected the refresh token. ${"detail ".repeat(60)}`;
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            slug: "whoop_v2",
+            name: "WHOOP",
+            status: "error",
+            error_details: {
+              error_type: "token_refresh_failed",
+              error_message: longErrorMessage,
+              errored_at: "2026-04-02T21:28:00+00:00",
+            },
+            resource_availability: {
+              sleep: true,
+            },
+          },
+          {
+            slug: "oura",
+            name: "Oura",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+  const context = createJunctionJobContext({
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return {
+        id: `src-${upserts.length}`,
+        connectionId: "acct-junction-1",
+        ...input,
+        displayName: input.displayName ?? null,
+        resourceAvailabilitySummary: input.resourceAvailabilitySummary ?? {},
+        lastErrorCode: input.lastErrorCode ?? null,
+        lastErrorMessage: input.lastErrorMessage ?? null,
+        firstSeenAt: input.firstSeenAt ?? input.lastSeenAt,
+        createdAt: input.lastSeenAt,
+        updatedAt: input.lastSeenAt,
+      };
+    },
+  });
+
+  await executeJunctionJob(
+    provider,
+    context,
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  const erroredUpsert = upserts.find((input) => input.sourceProviderSlug === "whoop_v2");
+  assert.ok(erroredUpsert, "Errored WHOOP source should be projected.");
+  assert.equal(erroredUpsert.status, "error");
+  assert.equal(erroredUpsert.lastErrorCode, "token_refresh_failed");
+  assert.equal(erroredUpsert.lastErrorMessage?.length, 240);
+  assert.match(erroredUpsert.lastErrorMessage ?? "", /^WHOOP rejected the refresh token\./u);
+
+  const connectedUpsert = upserts.find((input) => input.sourceProviderSlug === "oura");
+  assert.ok(connectedUpsert, "Connected Oura source should be projected.");
+  assert.equal(connectedUpsert.status, "connected");
+  // Omitted keys let the store auto-clear stale error detail on recovery.
+  assert.equal(Object.hasOwn(connectedUpsert, "lastErrorCode"), false);
+  assert.equal(Object.hasOwn(connectedUpsert, "lastErrorMessage"), false);
+});
+
+test("Junction source projection drops error details when a sibling source entry is connected", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            slug: "whoop_v2",
+            name: "WHOOP",
+            status: "error",
+            error_details: {
+              error_type: "token_refresh_failed",
+              error_message: "WHOOP rejected the refresh token.",
+            },
+            resource_availability: {
+              sleep: true,
+            },
+          },
+          {
+            slug: "whoop_v2",
+            name: "WHOOP",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+  const context = createJunctionJobContext({
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return {
+        id: `src-${upserts.length}`,
+        connectionId: "acct-junction-1",
+        ...input,
+        displayName: input.displayName ?? null,
+        resourceAvailabilitySummary: input.resourceAvailabilitySummary ?? {},
+        lastErrorCode: input.lastErrorCode ?? null,
+        lastErrorMessage: input.lastErrorMessage ?? null,
+        firstSeenAt: input.firstSeenAt ?? input.lastSeenAt,
+        createdAt: input.lastSeenAt,
+        updatedAt: input.lastSeenAt,
+      };
+    },
+  });
+
+  await executeJunctionJob(
+    provider,
+    context,
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0]?.sourceProviderSlug, "whoop_v2");
+  assert.equal(upserts[0]?.status, "connected");
+  assert.equal(Object.hasOwn(upserts[0] ?? {}, "lastErrorCode"), false);
+  assert.equal(Object.hasOwn(upserts[0] ?? {}, "lastErrorMessage"), false);
+});
+
+test("Junction source projection tolerates malformed error details and reads camelCase fields", async () => {
+  const longErrorType = `token_refresh_failed_${"x".repeat(100)}`;
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            slug: "whoop_v2",
+            name: "WHOOP",
+            status: "error",
+            error_details: "token refresh failed",
+            resource_availability: {
+              sleep: true,
+            },
+          },
+          {
+            slug: "oura",
+            name: "Oura",
+            status: "error",
+            error_details: {
+              error_type: "   ",
+              error_message: "",
+            },
+            resource_availability: {
+              activity: true,
+            },
+          },
+          {
+            slug: "garmin",
+            name: "Garmin",
+            status: "error",
+            errorDetails: {
+              errorType: longErrorType,
+              errorMessage: "Garmin revoked access.",
+            },
+            resource_availability: {
+              activity: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+  const context = createJunctionJobContext({
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return {
+        id: `src-${upserts.length}`,
+        connectionId: "acct-junction-1",
+        ...input,
+        displayName: input.displayName ?? null,
+        resourceAvailabilitySummary: input.resourceAvailabilitySummary ?? {},
+        lastErrorCode: input.lastErrorCode ?? null,
+        lastErrorMessage: input.lastErrorMessage ?? null,
+        firstSeenAt: input.firstSeenAt ?? input.lastSeenAt,
+        createdAt: input.lastSeenAt,
+        updatedAt: input.lastSeenAt,
+      };
+    },
+  });
+
+  await executeJunctionJob(
+    provider,
+    context,
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  // Non-object error_details: errored projection keeps the status but omits
+  // the error keys so the store can preserve any previously stored detail.
+  const malformedUpsert = upserts.find((input) => input.sourceProviderSlug === "whoop_v2");
+  assert.ok(malformedUpsert, "Errored WHOOP source should be projected.");
+  assert.equal(malformedUpsert.status, "error");
+  assert.equal(Object.hasOwn(malformedUpsert, "lastErrorCode"), false);
+  assert.equal(Object.hasOwn(malformedUpsert, "lastErrorMessage"), false);
+
+  // All-blank error detail fields collapse to null details and omit the keys.
+  const blankUpsert = upserts.find((input) => input.sourceProviderSlug === "oura");
+  assert.ok(blankUpsert, "Errored Oura source should be projected.");
+  assert.equal(blankUpsert.status, "error");
+  assert.equal(Object.hasOwn(blankUpsert, "lastErrorCode"), false);
+  assert.equal(Object.hasOwn(blankUpsert, "lastErrorMessage"), false);
+
+  // camelCase errorDetails parse, and the code truncates to the 80-char bound.
+  const camelUpsert = upserts.find((input) => input.sourceProviderSlug === "garmin");
+  assert.ok(camelUpsert, "Errored Garmin source should be projected.");
+  assert.equal(camelUpsert.status, "error");
+  assert.equal(camelUpsert.lastErrorCode?.length, 80);
+  assert.match(camelUpsert.lastErrorCode ?? "", /^token_refresh_failed_x/u);
+  assert.equal(camelUpsert.lastErrorMessage, "Garmin revoked access.");
+});
+
+test("Junction source projection fills error details from a later errored sibling entry", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            slug: "whoop_v2",
+            name: "WHOOP",
+            status: "error",
+            resource_availability: {
+              sleep: true,
+            },
+          },
+          {
+            slug: "whoop_v2",
+            name: "WHOOP",
+            status: "error",
+            error_details: {
+              error_type: "token_refresh_failed",
+              error_message: "WHOOP rejected the refresh token.",
+            },
+            resource_availability: {
+              activity: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+  const context = createJunctionJobContext({
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return {
+        id: `src-${upserts.length}`,
+        connectionId: "acct-junction-1",
+        ...input,
+        displayName: input.displayName ?? null,
+        resourceAvailabilitySummary: input.resourceAvailabilitySummary ?? {},
+        lastErrorCode: input.lastErrorCode ?? null,
+        lastErrorMessage: input.lastErrorMessage ?? null,
+        firstSeenAt: input.firstSeenAt ?? input.lastSeenAt,
+        createdAt: input.lastSeenAt,
+        updatedAt: input.lastSeenAt,
+      };
+    },
+  });
+
+  await executeJunctionJob(
+    provider,
+    context,
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0]?.sourceProviderSlug, "whoop_v2");
+  assert.equal(upserts[0]?.status, "error");
+  assert.equal(upserts[0]?.lastErrorCode, "token_refresh_failed");
+  assert.equal(upserts[0]?.lastErrorMessage, "WHOOP rejected the refresh token.");
+});
+
 test("Junction polling skips optional unavailable resource collections", async () => {
   const warnings: Record<string, unknown>[] = [];
   const importedSnapshots: unknown[] = [];

--- a/packages/device-syncd/test/store.test.ts
+++ b/packages/device-syncd/test/store.test.ts
@@ -892,6 +892,95 @@ test("device sync store keeps source instances distinct and lists them determini
   }
 });
 
+test("device sync store preserves omitted source error detail while errored and clears it on recovery", async () => {
+  const tempDir = await makeTempDirectory("murph-device-syncd-store-source-error-detail");
+  const store = new SqliteDeviceSyncStore(path.join(tempDir, "state.sqlite"));
+
+  try {
+    const connection = store.upsertAccount({
+      provider: "aggregator",
+      externalAccountId: "aggregator-source-error-detail",
+      displayName: "Aggregator",
+      scopes: [],
+      credential: {
+        kind: "none",
+      },
+      metadata: {},
+      connectedAt: "2026-04-07T00:00:00.000Z",
+    });
+
+    const errored = store.upsertConnectionSource({
+      connectionId: connection.id,
+      sourceInstanceKey: "src_whoop_hash_a",
+      sourceProviderSlug: "whoop_v2",
+      status: "error",
+      lastErrorCode: "token_refresh_failed",
+      lastErrorMessage: "WHOOP rejected the refresh token.",
+      lastSeenAt: "2026-04-07T01:00:00.000Z",
+    });
+
+    assert.equal(errored.lastErrorCode, "token_refresh_failed");
+    assert.equal(errored.lastErrorMessage, "WHOOP rejected the refresh token.");
+
+    // Still errored with the error keys omitted: existing detail is preserved.
+    const stillErrored = store.upsertConnectionSource({
+      connectionId: connection.id,
+      sourceInstanceKey: "src_whoop_hash_a",
+      sourceProviderSlug: "whoop_v2",
+      status: "error",
+      lastSeenAt: "2026-04-07T02:00:00.000Z",
+    });
+
+    assert.equal(stillErrored.lastErrorCode, "token_refresh_failed");
+    assert.equal(stillErrored.lastErrorMessage, "WHOOP rejected the refresh token.");
+
+    // Recovery with the error keys omitted: stale detail auto-clears.
+    const recovered = store.upsertConnectionSource({
+      connectionId: connection.id,
+      sourceInstanceKey: "src_whoop_hash_a",
+      sourceProviderSlug: "whoop_v2",
+      status: "connected",
+      lastSeenAt: "2026-04-07T03:00:00.000Z",
+    });
+
+    assert.equal(recovered.lastErrorCode, null);
+    assert.equal(recovered.lastErrorMessage, null);
+
+    // The store rejects over-length error fields, which is why projections
+    // must truncate to 80/240 before persisting.
+    assert.throws(
+      () =>
+        store.upsertConnectionSource({
+          connectionId: connection.id,
+          sourceInstanceKey: "src_whoop_hash_a",
+          sourceProviderSlug: "whoop_v2",
+          status: "error",
+          lastErrorCode: "x".repeat(81),
+          lastSeenAt: "2026-04-07T04:00:00.000Z",
+        }),
+      /lastErrorCode must be 80 characters or fewer\./u,
+    );
+    assert.throws(
+      () =>
+        store.upsertConnectionSource({
+          connectionId: connection.id,
+          sourceInstanceKey: "src_whoop_hash_a",
+          sourceProviderSlug: "whoop_v2",
+          status: "error",
+          lastErrorMessage: "x".repeat(241),
+          lastSeenAt: "2026-04-07T04:00:00.000Z",
+        }),
+      /lastErrorMessage must be 240 characters or fewer\./u,
+    );
+  } finally {
+    store.close();
+    await rm(tempDir, {
+      force: true,
+      recursive: true,
+    });
+  }
+});
+
 test("device sync store cascades source projection rows when the parent connection is deleted", async () => {
   const tempDir = await makeTempDirectory("murph-device-syncd-store-source-cascade");
   const store = new SqliteDeviceSyncStore(path.join(tempDir, "state.sqlite"));


### PR DESCRIPTION
**Stacked on #84** (`device-sync-failure-observability`) — review/merge that first. Base is the #84 branch, so this PR's diff shows only the error-details delta. No file overlap with #84.

## Why

The June 8-9 WHOOP incident exposed a blind spot: two WHOOP sources sat in Junction-side `provider.connection.error` with `device_connection_source.last_error_code` / `last_error_message` **null** — we could see a source was broken but had no idea *why*, and one user's reconnect didn't clear it. Junction's provider-connection payload actually carries an `error_details` object (type / message / timestamp); we were parsing the connection but discarding it.

This is the third blind spot from the incident, closed:
- **#87** stops the data loss (resource-inference + reconcile starvation)
- **#84** logs *our* job failures durably
- **this** surfaces *Junction's* connection errors into queryable source state

## Change (`packages/device-syncd`)

- `junction-client.ts`: parse `error_details` (snake/camel tolerant) into a typed `errorDetails` on `JunctionProviderConnection`; null when absent or empty.
- `junction.ts`: `projectJunctionSourcesByProviderSlug` carries `lastErrorCode`/`lastErrorMessage` for errored sources, truncated to the `device_connection_source` column bounds (80 / 240), merged across grouped sources, cleared when status recovers. `projectJunctionSources` only asserts the error keys when an errored entry was seen, so the store preserves existing detail while status stays `error` and auto-clears on recovery.
- Tests: provider-projection + store coverage for the set / merge / clear paths.

## Verification

- Full `packages/device-syncd` suite **with #84's changes present**: 604 passed / 37 files.
- `@murphai/device-syncd` typecheck: clean.

## Deployment

Runner-bundle only (`packages/device-syncd`). Pure read-enrichment of an existing projection that already writes `device_connection_source`; no schema change, no contract surface, no deploy-order constraint. Safe in either order vs #84 (no shared files) — stacked only for clean review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783648414&installation_id=127572939&pr_number=90&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F90&signature=59887e16473e2279f44d13c627ac600eaeba01f51a9250c642c77301b27415de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->