### PR TITLE
feat(assistant): widen one-shot notification stale window to 60 minutes

### DIFF
--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -60,7 +60,7 @@ import {
 
 const ASSISTANT_CRON_RUN_SCHEMA = 'murph.assistant-cron-run.v1'
 const ASSISTANT_CRON_MAX_RESPONSE_LENGTH = 4_000
-const ASSISTANT_CRON_NOTIFICATION_EXPIRES_AFTER_MS = 30 * 60 * 1000
+const ASSISTANT_CRON_NOTIFICATION_EXPIRES_AFTER_MS = 60 * 60 * 1000
 const ASSISTANT_CRON_NOTIFICATION_EXPIRED_ERROR =
   'Assistant cron notification expired before delivery.'
 

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -55,7 +55,10 @@ export const MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID =
 // lazily on background wakes, so a dormant user may first see a one-shot
 // seed long after its scheduled moment. Past this window the seed is
 // skipped rather than installed, so a stale announcement is never sent late.
-const MURPH_MANAGED_ONE_SHOT_NOTIFICATION_EXPIRES_AFTER_MS = 30 * 60 * 1000
+// Keep aligned with ASSISTANT_CRON_NOTIFICATION_EXPIRES_AFTER_MS in
+// cron/execution.ts: both express the same product window for how late a
+// one-shot notification may still go out.
+const MURPH_MANAGED_ONE_SHOT_NOTIFICATION_EXPIRES_AFTER_MS = 60 * 60 * 1000
 
 const MURPH_MANAGED_AUTOMATION_BASE_TAGS = [
   'assistant',

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -1384,7 +1384,7 @@ describe('assistant cron runtime orchestration', () => {
 
   it('skips stale recurring canonical notification retries by original occurrence', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-08T10:45:00.000Z'))
+    vi.setSystemTime(new Date('2026-04-08T11:15:00.000Z'))
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-stale-recurring-canonical-retry-',
     )
@@ -1420,8 +1420,8 @@ describe('assistant cron runtime orchestration', () => {
     )
 
     const updated = await getAssistantCronJob(vaultRoot, canonicalJob.jobId)
-    expect(updated.state.lastRunAt).toBe('2026-04-08T10:45:00.000Z')
-    expect(updated.state.lastSucceededAt).toBe('2026-04-08T10:45:00.000Z')
+    expect(updated.state.lastRunAt).toBe('2026-04-08T11:15:00.000Z')
+    expect(updated.state.lastSucceededAt).toBe('2026-04-08T11:15:00.000Z')
     expect(updated.state.lastError).toBeNull()
     expect(updated.state.consecutiveFailures).toBe(0)
     expect(updated.state.nextRunAt).toBe('2026-04-09T10:00:00.000Z')
@@ -1435,7 +1435,7 @@ describe('assistant cron runtime orchestration', () => {
       runs: [
         expect.objectContaining({
           error: expect.stringContaining(
-            'Scheduled occurrence was 45 minute(s) late.',
+            'Scheduled occurrence was 75 minute(s) late.',
           ),
           response: null,
           status: 'skipped',
@@ -1446,7 +1446,7 @@ describe('assistant cron runtime orchestration', () => {
 
   it('skips stale recurring local cron jobs without removing them', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-08T10:10:00.000Z'))
+    vi.setSystemTime(new Date('2026-04-08T10:35:00.000Z'))
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-stale-recurring-local-',
     )
@@ -1464,8 +1464,8 @@ describe('assistant cron runtime orchestration', () => {
     })
     expect(cronMocks.sendAssistantMessageLocal).not.toHaveBeenCalled()
     const updated = await getAssistantCronJob(vaultRoot, job.jobId)
-    expect(updated.state.lastRunAt).toBe('2026-04-08T10:10:00.000Z')
-    expect(updated.state.lastSucceededAt).toBe('2026-04-08T10:10:00.000Z')
+    expect(updated.state.lastRunAt).toBe('2026-04-08T10:35:00.000Z')
+    expect(updated.state.lastSucceededAt).toBe('2026-04-08T10:35:00.000Z')
     expect(updated.state.lastError).toBeNull()
     expect(updated.state.consecutiveFailures).toBe(0)
     expect(updated.state.nextRunAt).toBe('2026-04-09T09:30:00.000Z')
@@ -1489,7 +1489,7 @@ describe('assistant cron runtime orchestration', () => {
 
   it('skips stale kept one-shot local cron jobs and disables them', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-08T10:10:00.000Z'))
+    vi.setSystemTime(new Date('2026-04-08T10:35:00.000Z'))
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-stale-kept-one-shot-',
     )
@@ -1533,7 +1533,7 @@ describe('assistant cron runtime orchestration', () => {
 
   it('expires canonical one-shot notification retries by original occurrence', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-08T09:45:00.000Z'))
+    vi.setSystemTime(new Date('2026-04-08T10:05:00.000Z'))
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-expired-one-shot-retry-',
     )
@@ -1581,7 +1581,7 @@ describe('assistant cron runtime orchestration', () => {
     ).resolves.toMatchObject({
       runs: [
         expect.objectContaining({
-          error: expect.stringContaining('Scheduled occurrence was 45 minute(s) late.'),
+          error: expect.stringContaining('Scheduled occurrence was 65 minute(s) late.'),
           status: 'skipped',
         }),
       ],
@@ -1590,7 +1590,9 @@ describe('assistant cron runtime orchestration', () => {
 
   it('runs canonical one-shot notification cron jobs within the expiry window', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-08T09:20:00.000Z'))
+    // 55 minutes late: stale under the previous 30-minute window, deliverable
+    // under the 60-minute window.
+    vi.setSystemTime(new Date('2026-04-08T09:55:00.000Z'))
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-fresh-one-shot-',
     )
@@ -1637,6 +1639,110 @@ describe('assistant cron runtime orchestration', () => {
         expect.objectContaining({
           error: null,
           status: 'succeeded',
+        }),
+      ],
+    })
+  })
+
+  it('delivers canonical one-shot notifications exactly at the 60-minute expiry boundary', async () => {
+    vi.useFakeTimers()
+    // Exactly 60 minutes late: the expiry window is inclusive, so this must
+    // still deliver.
+    vi.setSystemTime(new Date('2026-04-08T10:00:00.000Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-boundary-one-shot-',
+    )
+    const canonicalJob = await addAssistantCronJob({
+      channel: 'telegram',
+      deliveryTarget: 'room-1',
+      name: 'boundary one-shot reminder',
+      now: new Date('2026-04-08T08:00:00.000Z'),
+      prompt: 'First-session prep reminder.',
+      schedule: {
+        kind: 'at',
+        at: '2026-04-08T09:00:00.000Z',
+      },
+      vault: vaultRoot,
+    })
+
+    const summary = await processDueAssistantCronJobsLocal({
+      limit: 1,
+      vault: vaultRoot,
+    })
+
+    expect(summary).toEqual({
+      failed: 0,
+      processed: 1,
+      succeeded: 1,
+    })
+    expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliveryDedupeToken: expect.stringContaining(
+          `assistant-cron|${canonicalJob.jobId}|2026-04-08T09:00:00.000Z`,
+        ),
+        instructions: 'First-session prep reminder.',
+        turnTrigger: 'automation-cron',
+      }),
+    )
+    await expect(
+      listAssistantCronRuns({
+        job: canonicalJob.jobId,
+        vault: vaultRoot,
+      }),
+    ).resolves.toMatchObject({
+      jobId: canonicalJob.jobId,
+      runs: [
+        expect.objectContaining({
+          error: null,
+          status: 'succeeded',
+        }),
+      ],
+    })
+  })
+
+  it('skips canonical one-shot notifications just past the 60-minute expiry boundary', async () => {
+    vi.useFakeTimers()
+    // One millisecond past the inclusive 60-minute window: must skip and
+    // archive instead of delivering.
+    vi.setSystemTime(new Date('2026-04-08T10:00:00.001Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-past-boundary-one-shot-',
+    )
+    const canonicalJob = await addAssistantCronJob({
+      channel: 'telegram',
+      deliveryTarget: 'room-1',
+      name: 'past-boundary one-shot reminder',
+      now: new Date('2026-04-08T08:00:00.000Z'),
+      prompt: 'First-session prep reminder.',
+      schedule: {
+        kind: 'at',
+        at: '2026-04-08T09:00:00.000Z',
+      },
+      vault: vaultRoot,
+    })
+
+    const summary = await processDueAssistantCronJobsLocal({
+      limit: 1,
+      vault: vaultRoot,
+    })
+
+    expect(summary).toEqual({
+      failed: 0,
+      processed: 1,
+      succeeded: 0,
+    })
+    expect(cronMocks.sendAssistantMessageLocal).not.toHaveBeenCalled()
+    await expect(listAssistantCronJobs(vaultRoot)).resolves.toEqual([])
+    await expect(
+      listAssistantCronRuns({
+        job: canonicalJob.jobId,
+        vault: vaultRoot,
+      }),
+    ).resolves.toMatchObject({
+      runs: [
+        expect.objectContaining({
+          error: expect.stringContaining('Scheduled occurrence was 60 minute(s) late.'),
+          status: 'skipped',
         }),
       ],
     })

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -413,7 +413,7 @@ describe('applyMurphManagedAutomations', () => {
 
     await expect(applyMurphManagedAutomations({
       defaultRoute,
-      now: new Date('2026-06-09T14:31:00.000Z'),
+      now: new Date('2026-06-09T15:01:00.000Z'),
       seeds: [featureDropSeed],
       vaultRoot,
     })).resolves.toEqual({


### PR DESCRIPTION
## Why

The 30-minute stale expiry converts recoverable infra delays into silent permanent reminder drops. In the June 9–10 incident, a quota outage left the 11:45 PM meditation reminder retrying; it delivered 23 minutes late — 7 minutes from being silently archived. User-approved product decision: one-shot notifications tolerate up to an hour of lateness.

## What

- `ASSISTANT_CRON_NOTIFICATION_EXPIRES_AFTER_MS` (cron notification execution): 30 → 60 min
- `MURPH_MANAGED_ONE_SHOT_NOTIFICATION_EXPIRES_AFTER_MS` (managed one-shot seed install): 30 → 60 min, kept aligned — surfaced by the task-finish-review audit as the same product window one layer up; comments now cross-reference the two constants

## Verification

- Stale tests shifted past the new window (65/75 min late); within-window test now runs **55 min late and proves the newly-allowed 30–60 band delivers**
- Exact boundary proven: 60:00.000 delivers (inclusive `<=`), 60:00.001 skips + archives with `60 minute(s) late`
- `assistant-cron-runtime` + `managed-automations` suites 53/53; full assistant-engine suite 1211 passed / 3 skipped; package typecheck clean
- Audits: coverage-write (added the boundary tests) + task-finish-review (verdict: safe; its one medium finding — the managed-seed sibling window — is fixed in this PR)
- Reviewed interaction with retry backoff (attempt 5 lands ~21.5 min late, well inside) and claim-reclaim staleness (already 60 min) — no coupling

## Follow-ups (separate)

- Durable runtime log + alert for provider quota/billing failure classes (the June 10 outage was invisible in `hosted_runtime_log`)
- Optional: notify the user when a reminder is skipped as stale instead of silent archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698536&installation_id=127572939&pr_number=107&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F107&signature=f84c1c64455e33786ad5e965d1047abada55e4dd70f2a6f2fcb597e82d72d010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->