### PR TITLE
fix(assistant): make preserve reminders continue the user's conversation

### DIFF
--- a/packages/assistant-engine/src/assistant/cron/canonical-jobs.ts
+++ b/packages/assistant-engine/src/assistant/cron/canonical-jobs.ts
@@ -20,6 +20,7 @@ import {
   type AssistantCronCanonicalRuntimeState,
   type AssistantCronCanonicalRuntimeStore,
 } from './runtime-state.js'
+import { resolveAssistantConversationKey } from '../bindings.js'
 import { computeAssistantCronNextRunAt } from './schedule.js'
 import {
   normalizeCanonicalScheduledLogCronRecord,
@@ -139,20 +140,39 @@ export function resolveCanonicalRuntimeState(
   )
 }
 
+// A route whose fields form a conversation key continues that conversation's
+// live chat session at fire time, with the conversation-key path's fingerprint
+// and expiry checks. Pinning a previous run's session would bypass those
+// checks and go stale, so the pin is reserved for keyless routes (e.g. a bare
+// delivery target), where it is the only continuity available.
+export function automationContinuityUsesSessionPin(
+  source: CanonicalAssistantCronJobRecord,
+): boolean {
+  return (
+    source.kind === 'automation' &&
+    source.continuityPolicy === 'preserve' &&
+    resolveAssistantConversationKey({
+      channel: source.route.channel,
+      identityId: source.route.identityId,
+      actorId: source.route.participantId,
+      threadId: source.route.threadId,
+    }) === null
+  )
+}
+
 export function projectCanonicalAssistantCronJob(input: {
   source: CanonicalAssistantCronJobRecord
   runtimeState: AssistantCronCanonicalRuntimeRecord
 }): AssistantCronJob {
-  const continuitySessionId =
+  const preservesContinuity =
     input.source.kind === 'automation' &&
     input.source.continuityPolicy === 'preserve'
-      ? input.runtimeState.sessionId
-      : null
-  const continuityAlias =
-    input.source.kind === 'automation' &&
-    input.source.continuityPolicy === 'preserve'
-      ? input.runtimeState.alias
-      : null
+  const continuitySessionId = automationContinuityUsesSessionPin(input.source)
+    ? input.runtimeState.sessionId
+    : null
+  // Aliases only enter runtime state as explicit creation-time bindings, so
+  // they stay honored even when the automatic session pin is gated off.
+  const continuityAlias = preservesContinuity ? input.runtimeState.alias : null
   const targetRoute =
     input.source.kind === 'automation'
       ? input.source.route

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -37,6 +37,7 @@ import {
   buildCanonicalAutomationUpsertInput,
   buildVisibleLocalAssistantCronStore,
   isCanonicalAssistantCronSourceEnabled,
+  automationContinuityUsesSessionPin,
   listCanonicalAssistantCronRecords,
   projectCanonicalAssistantCronJob,
   type CanonicalAssistantCronJobRecord,
@@ -428,6 +429,7 @@ export async function executeClaimedAssistantCronJob(input: {
     }
     await appendAssistantCronRun(input.paths, run)
 
+    const usesSessionPin = automationContinuityUsesSessionPin(input.job.source)
     const updatedRuntimeState = finalizeCanonicalAssistantCronRuntimeAfterRun({
       finishedAt,
       run: {
@@ -435,26 +437,20 @@ export async function executeClaimedAssistantCronJob(input: {
         status,
       },
       runtimeState: currentRuntimeState,
-      responseSessionId:
-        input.job.source.kind === 'automation' &&
-        input.job.source.continuityPolicy === 'preserve'
-          ? sessionId
-          : null,
+      responseSessionId: usesSessionPin ? sessionId : null,
       pendingDeliveryIntentId,
       source: input.job.source,
     })
     const persistedRuntimeState: AssistantCronCanonicalRuntimeRecord = {
       ...currentRuntimeState,
+      // Aliases are explicit creation-time bindings and survive preserve runs;
+      // only the automatic session pin is gated by the conversation key.
       alias:
         input.job.source.kind === 'automation' &&
         input.job.source.continuityPolicy === 'preserve'
           ? updatedRuntimeState.alias
           : null,
-      sessionId:
-        input.job.source.kind === 'automation' &&
-        input.job.source.continuityPolicy === 'preserve'
-          ? updatedRuntimeState.sessionId
-          : null,
+      sessionId: usesSessionPin ? updatedRuntimeState.sessionId : null,
       updatedAt: finishedAt,
       state: updatedRuntimeState.state,
     }

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -770,7 +770,7 @@ When creating automations, choose continuity deliberately. Use ${code(
     "--continuity-policy preserve"
   )} for simple reminders, check-ins, and lightweight support where recent prior automation context can help. Use ${code(
     "--continuity-policy fresh"
-  )} for larger automations such as research, audits, roundups, content inspection, or any recurring task likely to need multiple tool calls, so each run starts from current vault/tool evidence instead of prior run transcript context.
+  )} for larger automations such as research, audits, roundups, content inspection, or any recurring task likely to need multiple tool calls, so each run starts from current vault/tool evidence instead of prior run transcript context. For an automation meant for the current conversation, route flags may name this conversation or be omitted entirely; the route then inherits this conversation, and a preserve automation continues it instead of starting a separate thread.
 
 Before asking the user to repeat phone, Telegram, or email routing details for an automation route, inspect saved local self-targets. If the needed route is not already saved, ask for the missing details explicitly instead of guessing.`;
 }

--- a/packages/assistant-engine/test/assistant-cron-channels-branches.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-channels-branches.test.ts
@@ -112,7 +112,12 @@ vi.mock('../src/assistant/channel-adapters.ts', () => ({
   getAssistantChannelAdapter: cronMocks.getAssistantChannelAdapter,
 }))
 
-vi.mock('../src/assistant/bindings.ts', () => ({
+vi.mock('../src/assistant/bindings.ts', async (importOriginal) => ({
+  // The conversation-key predicate is pure routing logic; keep the real one
+  // so continuity gating behaves as in production.
+  resolveAssistantConversationKey: (
+    await importOriginal<typeof import('../src/assistant/bindings.ts')>()
+  ).resolveAssistantConversationKey,
   resolveAssistantBindingDelivery: cronMocks.resolveAssistantBindingDelivery,
 }))
 

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -90,7 +90,12 @@ vi.mock('../src/assistant/channel-adapters.ts', () => ({
   getAssistantChannelAdapter: cronMocks.getAssistantChannelAdapter,
 }))
 
-vi.mock('../src/assistant/bindings.ts', () => ({
+vi.mock('../src/assistant/bindings.ts', async (importOriginal) => ({
+  // The conversation-key predicate is pure routing logic; keep the real one
+  // so continuity gating behaves as in production.
+  resolveAssistantConversationKey: (
+    await importOriginal<typeof import('../src/assistant/bindings.ts')>()
+  ).resolveAssistantConversationKey,
   resolveAssistantBindingDelivery: cronMocks.resolveAssistantBindingDelivery,
 }))
 
@@ -2101,6 +2106,132 @@ describe('assistant cron runtime orchestration', () => {
     })
     const runtimeRecord = finalizedRuntimeStore.jobs.find((record) => record.jobId === claimed.job.jobId)
     expect(runtimeRecord?.state.runningClaimId).toBeNull()
+  })
+
+  it('ignores and clears a stale session pin when a preserve route has conversation locators', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T10:20:00.000Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-keyed-preserve-',
+    )
+    getVaultAutomationStore(vaultRoot).push({
+      automationId: 'automation-keyed-preserve',
+      continuityPolicy: 'preserve',
+      createdAt: '2026-04-08T08:00:00.000Z',
+      instructions: 'Remind me to stretch.',
+      route: {
+        channel: 'linq',
+        deliverySource: null,
+        deliveryTarget: 'linq_chat_real',
+        identityId: 'identity-1',
+        participantId: 'participant-1',
+        threadId: 'thread-1',
+      },
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '10:00',
+      },
+      slug: 'keyed-preserve-reminder',
+      status: 'active',
+      summary: null,
+      tags: ['assistant', 'scheduled'],
+      title: 'Keyed preserve reminder',
+      updatedAt: '2026-04-08T08:00:00.000Z',
+    })
+    const paths = resolveAssistantStatePaths(vaultRoot)
+    const source = (await listCanonicalAssistantCronRecords(vaultRoot))[0]
+
+    if (!source) {
+      throw new Error('Expected canonical source to exist.')
+    }
+
+    const runtimeStore = await readAssistantCronCanonicalRuntimeStore(paths)
+    const runtimeState = {
+      ...resolveCanonicalRuntimeState(source, runtimeStore),
+      sessionId: 'session-stale-pin',
+    }
+    const projected = projectCanonicalAssistantCronJob({
+      source,
+      runtimeState,
+    })
+    expect(projected.target.sessionId).toBeNull()
+    expect(projected.target.threadId).toBe('thread-1')
+
+    const claimed = await claimResolvedAssistantCronJob({
+      job: {
+        kind: 'canonical',
+        source,
+        runtimeState,
+        job: projected,
+      },
+      paths,
+    })
+    const result = await executeClaimedAssistantCronJob({
+      job: claimed,
+      paths,
+      trigger: 'scheduled',
+      vault: vaultRoot,
+    })
+
+    expect(result.run.status).toBe('succeeded')
+    expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: null,
+        threadId: 'thread-1',
+      }),
+    )
+    const finalizedRuntimeStore = await readAssistantCronCanonicalRuntimeStore(paths, {
+      reclaimStaleRunningClaims: false,
+    })
+    const runtimeRecord = finalizedRuntimeStore.jobs.find(
+      (record) => record.jobId === claimed.job.jobId,
+    )
+    expect(runtimeRecord?.sessionId).toBeNull()
+  })
+
+  it('keeps pinning the response session for a preserve route without conversation locators', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T10:20:00.000Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-keyless-preserve-',
+    )
+    await createCanonicalJob(vaultRoot, 'keyless-preserve')
+    const paths = resolveAssistantStatePaths(vaultRoot)
+    const source = (await listCanonicalAssistantCronRecords(vaultRoot))[0]
+
+    if (!source) {
+      throw new Error('Expected canonical source to exist.')
+    }
+
+    const runtimeStore = await readAssistantCronCanonicalRuntimeStore(paths)
+    const runtimeState = resolveCanonicalRuntimeState(source, runtimeStore)
+    const claimed = await claimResolvedAssistantCronJob({
+      job: {
+        kind: 'canonical',
+        source,
+        runtimeState,
+        job: projectCanonicalAssistantCronJob({
+          source,
+          runtimeState,
+        }),
+      },
+      paths,
+    })
+    const result = await executeClaimedAssistantCronJob({
+      job: claimed,
+      paths,
+      trigger: 'scheduled',
+      vault: vaultRoot,
+    })
+
+    expect(result.run.status).toBe('succeeded')
+    const finalizedRuntimeStore = await readAssistantCronCanonicalRuntimeStore(paths, {
+      reclaimStaleRunningClaims: false,
+    })
+    const runtimeRecord = finalizedRuntimeStore.jobs.find(
+      (record) => record.jobId === claimed.job.jobId,
+    )
+    expect(runtimeRecord?.sessionId).toBe('session-default')
   })
 
   it('processes a canonical daily-local midnight job when runtime state is missing', async () => {

--- a/packages/assistant-engine/test/assistant-cron-thresholds.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-thresholds.test.ts
@@ -82,7 +82,12 @@ vi.mock('../src/assistant/channel-adapters.ts', () => ({
   getAssistantChannelAdapter: cronMocks.getAssistantChannelAdapter,
 }))
 
-vi.mock('../src/assistant/bindings.ts', () => ({
+vi.mock('../src/assistant/bindings.ts', async (importOriginal) => ({
+  // The conversation-key predicate is pure routing logic; keep the real one
+  // so continuity gating behaves as in production.
+  resolveAssistantConversationKey: (
+    await importOriginal<typeof import('../src/assistant/bindings.ts')>()
+  ).resolveAssistantConversationKey,
   resolveAssistantBindingDelivery: cronMocks.resolveAssistantBindingDelivery,
 }))
 

--- a/packages/cli/src/commands/automation.ts
+++ b/packages/cli/src/commands/automation.ts
@@ -215,16 +215,20 @@ function buildAutomationRouteFromOptions(
   input: AutomationRouteOptions,
   currentRoute: HostedCliAssistantCurrentRoute | null,
 ): AutomationRoute {
-  const route = stripPrivateAssistantRoutePlaceholders(
-    resolveAssistantDeliveryRouteWithCurrentRoute({
-      channel: input.channel,
-      deliveryTarget: input.deliveryTarget,
-      identityId: input.identityId,
-      participantId: input.participantId,
-      threadId: input.threadId,
-    }, currentRoute),
+  // Strip redacted placeholders from the model-typed flags before merging:
+  // the current route comes from the hosted bridge, not model text, and its
+  // locators are trusted as-is (hosted linq locators are hid_-blinded by
+  // design, the same values session bindings persist).
+  const explicit = stripPrivateAssistantRoutePlaceholders({
+    channel: normalizeAutomationRouteOption(input.channel),
+    deliveryTarget: normalizeAutomationRouteOption(input.deliveryTarget),
+    identityId: normalizeAutomationRouteOption(input.identityId),
+    participantId: normalizeAutomationRouteOption(input.participantId),
+    threadId: normalizeAutomationRouteOption(input.threadId),
+  });
+  const parsed = automationRouteSchema.parse(
+    resolveAssistantDeliveryRouteWithCurrentRoute(explicit, currentRoute),
   );
-  const parsed = normalizeAutomationRouteFieldsForSave(route);
 
   assertAutomationRouteCanDeliver(parsed);
   return parsed;
@@ -254,18 +258,14 @@ async function readAutomationSaveCurrentRoute(input: AutomationRouteOptions): Pr
   return null;
 }
 
+// The current route both fills a fully omitted route and enriches an explicit
+// same-conversation target with its missing conversation locators, so it is
+// needed whenever any of those fields is still unset.
 function automationSaveNeedsCurrentRoute(input: AutomationRouteOptions): boolean {
-  const channel = normalizeAutomationRouteOption(input.channel);
-  const deliveryTarget = normalizeAutomationRouteOption(input.deliveryTarget);
-  if (!channel) {
-    return true;
-  }
-  if (channel === "linq") {
-    return !deliveryTarget;
-  }
-  return !deliveryTarget
-    && !normalizeAutomationRouteOption(input.participantId)
-    && !normalizeAutomationRouteOption(input.threadId);
+  return !normalizeAutomationRouteOption(input.channel)
+    || !normalizeAutomationRouteOption(input.identityId)
+    || !normalizeAutomationRouteOption(input.participantId)
+    || !normalizeAutomationRouteOption(input.threadId);
 }
 
 function assertAutomationRouteCanDeliver(route: AutomationRoute): void {

--- a/packages/cli/test/automation-current-route-continuity.test.ts
+++ b/packages/cli/test/automation-current-route-continuity.test.ts
@@ -185,3 +185,197 @@ test("automation save preserves hosted iMessage current-route continuity locator
     await rm(parentRoot, { recursive: true, force: true });
   }
 });
+
+// Hosted linq conversation locators are hid_-blinded; an explicit delivery
+// target naming the current conversation must still inherit them so the saved
+// route can resolve that conversation's session at fire time.
+test("automation save enriches an explicit same-conversation target with blinded locators", async () => {
+  const { parentRoot, vaultRoot } = await createTempVaultContext(
+    "murph-automation-current-route-enrich-",
+  );
+  const bridge = await startAssistantCurrentRouteBridgeStub({
+    response: {
+      route: {
+        channel: "linq",
+        deliveryTarget: "linq_chat_real",
+        identityId: "hid_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        participantId: "hid_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        threadId: "hid_cccccccccccccccccccccccccccccccc",
+      },
+    },
+    token: "test-bridge-token",
+  });
+
+  try {
+    const cli = Cli.create("vault-cli", {
+      description: "automation current route enrichment test cli",
+      version: "0.0.0-test",
+    });
+    registerAutomationCommands(cli);
+    vi.stubEnv(HOSTED_RUNTIME_PROCESS_ENV, "1");
+    vi.stubEnv(HOSTED_CLI_BRIDGE_TOKEN_ENV, "test-bridge-token");
+    vi.stubEnv(HOSTED_CLI_BRIDGE_URL_ENV, bridge.url);
+
+    const saved = await runInProcessJsonCli(cli, [
+      "automation",
+      "save",
+      "Explicit current conversation reminder",
+      "--slug",
+      "explicit-current-conversation-reminder",
+      "--instructions",
+      "Send the reminder.",
+      "--schedule-kind",
+      "at",
+      "--schedule-at",
+      "2026-12-06T12:00:00.000Z",
+      "--channel",
+      "linq",
+      "--delivery-target",
+      "linq_chat_real",
+      // Model-echoed placeholder flags are stripped and replaced by the
+      // trusted bridge locators for the same conversation.
+      "--thread-id",
+      "hid_model_echoed_thread",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(
+      saved.envelope.ok,
+      true,
+      saved.envelope.ok
+        ? undefined
+        : `${saved.envelope.error.code ?? "unknown"}: ${
+            saved.envelope.error.message ?? "unknown error"
+          }`,
+    );
+    assert.equal(saved.exitCode, null);
+
+    const shown = await runInProcessJsonCli<{
+      automation: {
+        route: {
+          channel: string;
+          deliveryTarget: string | null;
+          identityId: string | null;
+          participantId: string | null;
+          threadId: string | null;
+        };
+      } | null;
+      vault: string;
+    }>(cli, [
+      "automation",
+      "show",
+      "explicit-current-conversation-reminder",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(shown.exitCode, null);
+    assert.equal(shown.envelope.ok, true);
+    assert.equal(shown.envelope.data?.automation?.route.channel, "linq");
+    assert.equal(
+      shown.envelope.data?.automation?.route.deliveryTarget,
+      "linq_chat_real",
+    );
+    assert.equal(
+      shown.envelope.data?.automation?.route.identityId,
+      "hid_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    assert.equal(
+      shown.envelope.data?.automation?.route.participantId,
+      "hid_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+    assert.equal(
+      shown.envelope.data?.automation?.route.threadId,
+      "hid_cccccccccccccccccccccccccccccccc",
+    );
+    assert.deepEqual(bridge.requests, [
+      HOSTED_CLI_BRIDGE_ASSISTANT_CURRENT_ROUTE_PATH,
+    ]);
+  } finally {
+    await bridge.stop();
+    await rm(parentRoot, { recursive: true, force: true });
+  }
+});
+
+// A different conversation's explicit target must not absorb the current
+// conversation's locators.
+test("automation save does not enrich an explicit different-conversation target", async () => {
+  const { parentRoot, vaultRoot } = await createTempVaultContext(
+    "murph-automation-current-route-no-enrich-",
+  );
+  const bridge = await startAssistantCurrentRouteBridgeStub({
+    response: {
+      route: {
+        channel: "linq",
+        deliveryTarget: "linq_chat_real",
+        identityId: "hid_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        participantId: "hid_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        threadId: "hid_cccccccccccccccccccccccccccccccc",
+      },
+    },
+    token: "test-bridge-token",
+  });
+
+  try {
+    const cli = Cli.create("vault-cli", {
+      description: "automation current route no-enrichment test cli",
+      version: "0.0.0-test",
+    });
+    registerAutomationCommands(cli);
+    vi.stubEnv(HOSTED_RUNTIME_PROCESS_ENV, "1");
+    vi.stubEnv(HOSTED_CLI_BRIDGE_TOKEN_ENV, "test-bridge-token");
+    vi.stubEnv(HOSTED_CLI_BRIDGE_URL_ENV, bridge.url);
+
+    const saved = await runInProcessJsonCli(cli, [
+      "automation",
+      "save",
+      "Other conversation reminder",
+      "--slug",
+      "other-conversation-reminder",
+      "--instructions",
+      "Send the reminder.",
+      "--schedule-kind",
+      "at",
+      "--schedule-at",
+      "2026-12-06T12:00:00.000Z",
+      "--channel",
+      "linq",
+      "--delivery-target",
+      "linq_chat_other",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(saved.envelope.ok, true);
+    assert.equal(saved.exitCode, null);
+
+    const shown = await runInProcessJsonCli<{
+      automation: {
+        route: {
+          channel: string;
+          deliveryTarget: string | null;
+          identityId: string | null;
+          participantId: string | null;
+          threadId: string | null;
+        };
+      } | null;
+      vault: string;
+    }>(cli, [
+      "automation",
+      "show",
+      "other-conversation-reminder",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(shown.exitCode, null);
+    assert.equal(shown.envelope.ok, true);
+    assert.equal(
+      shown.envelope.data?.automation?.route.deliveryTarget,
+      "linq_chat_other",
+    );
+    assert.equal(shown.envelope.data?.automation?.route.identityId, null);
+    assert.equal(shown.envelope.data?.automation?.route.participantId, null);
+    assert.equal(shown.envelope.data?.automation?.route.threadId, null);
+  } finally {
+    await bridge.stop();
+    await rm(parentRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/automation.test.ts
+++ b/packages/cli/test/automation.test.ts
@@ -580,7 +580,11 @@ test("automation edit patches sparse fields without implicit route rebinding", a
     assert.equal(saved.exitCode, null);
     assert.equal(saved.envelope.ok, true);
     assert.equal(saved.envelope.data?.created, true);
-    assert.deepEqual(bridge.requests, []);
+    // Save fetches the current route to enrich same-conversation targets; the
+    // linq current route must not leak into this explicit telegram route.
+    assert.deepEqual(bridge.requests, [
+      HOSTED_CLI_BRIDGE_ASSISTANT_CURRENT_ROUTE_PATH,
+    ]);
 
     const edited = await runInProcessJsonCli<{
       automationId: string;
@@ -599,7 +603,10 @@ test("automation edit patches sparse fields without implicit route rebinding", a
     assert.equal(edited.envelope.ok, true);
     assert.equal(edited.envelope.data?.automationId, saved.envelope.data?.automationId);
     assert.equal(edited.envelope.data?.created, false);
-    assert.deepEqual(bridge.requests, []);
+    // Edit never consults the current route.
+    assert.deepEqual(bridge.requests, [
+      HOSTED_CLI_BRIDGE_ASSISTANT_CURRENT_ROUTE_PATH,
+    ]);
 
     const shown = await runInProcessJsonCli<{
       automation: {

--- a/packages/operator-config/src/assistant/current-delivery-route.ts
+++ b/packages/operator-config/src/assistant/current-delivery-route.ts
@@ -36,18 +36,37 @@ export function resolveAssistantDeliveryRouteWithCurrentRoute(
     participantId: normalizeAssistantRouteString(input.participantId),
     threadId: normalizeAssistantRouteString(input.threadId),
   }
+  if (
+    normalizedCurrentRoute === null ||
+    explicit.channel === null ||
+    normalizedCurrentRoute.channel !== explicit.channel
+  ) {
+    return explicit
+  }
   // The target and locator fields together describe one conversation, so the
   // current route is inherited atomically: mixing explicit and inherited
   // fields would fabricate a route that never existed.
-  const useCurrentRoute =
+  if (
     explicit.deliveryTarget === null &&
     explicit.identityId === null &&
     explicit.participantId === null &&
-    explicit.threadId === null &&
-    explicit.channel !== null &&
-    normalizedCurrentRoute?.channel === explicit.channel
-
-  return useCurrentRoute ? normalizedCurrentRoute : explicit
+    explicit.threadId === null
+  ) {
+    return normalizedCurrentRoute
+  }
+  // An explicit delivery target naming the current conversation (channel +
+  // delivery target identify one conversation) inherits its missing locators,
+  // so the saved route can resolve that conversation's session later.
+  if (explicit.deliveryTarget !== normalizedCurrentRoute.deliveryTarget) {
+    return explicit
+  }
+  return {
+    channel: explicit.channel,
+    deliveryTarget: explicit.deliveryTarget,
+    identityId: explicit.identityId ?? normalizedCurrentRoute.identityId,
+    participantId: explicit.participantId ?? normalizedCurrentRoute.participantId,
+    threadId: explicit.threadId ?? normalizedCurrentRoute.threadId,
+  }
 }
 
 function normalizeAssistantCurrentDeliveryRoute(

--- a/packages/operator-config/test/assistant-current-delivery-route.test.ts
+++ b/packages/operator-config/test/assistant-current-delivery-route.test.ts
@@ -57,6 +57,79 @@ describe('assistant current delivery route', () => {
     })
   })
 
+  it('fills missing locators when the explicit target names the current conversation', () => {
+    expect(
+      resolveAssistantDeliveryRouteWithCurrentRoute(
+        {
+          channel: 'linq',
+          deliveryTarget: 'linq_chat_real',
+        },
+        {
+          channel: 'linq',
+          deliveryTarget: 'linq_chat_real',
+          identityId: LINQ_IDENTITY_ID,
+          participantId: LINQ_PARTICIPANT_ID,
+          threadId: LINQ_THREAD_ID,
+        },
+      ),
+    ).toEqual({
+      channel: 'linq',
+      deliveryTarget: 'linq_chat_real',
+      identityId: LINQ_IDENTITY_ID,
+      participantId: LINQ_PARTICIPANT_ID,
+      threadId: LINQ_THREAD_ID,
+    })
+  })
+
+  it('keeps explicit locators over current-route locators for the same conversation', () => {
+    expect(
+      resolveAssistantDeliveryRouteWithCurrentRoute(
+        {
+          channel: 'linq',
+          deliveryTarget: 'linq_chat_real',
+          threadId: 'explicit_thread',
+        },
+        {
+          channel: 'linq',
+          deliveryTarget: 'linq_chat_real',
+          identityId: LINQ_IDENTITY_ID,
+          participantId: LINQ_PARTICIPANT_ID,
+          threadId: LINQ_THREAD_ID,
+        },
+      ),
+    ).toEqual({
+      channel: 'linq',
+      deliveryTarget: 'linq_chat_real',
+      identityId: LINQ_IDENTITY_ID,
+      participantId: LINQ_PARTICIPANT_ID,
+      threadId: 'explicit_thread',
+    })
+  })
+
+  it('does not enrich an explicit target on a different channel', () => {
+    expect(
+      resolveAssistantDeliveryRouteWithCurrentRoute(
+        {
+          channel: 'telegram',
+          deliveryTarget: 'linq_chat_real',
+        },
+        {
+          channel: 'linq',
+          deliveryTarget: 'linq_chat_real',
+          identityId: LINQ_IDENTITY_ID,
+          participantId: LINQ_PARTICIPANT_ID,
+          threadId: LINQ_THREAD_ID,
+        },
+      ),
+    ).toEqual({
+      channel: 'telegram',
+      deliveryTarget: 'linq_chat_real',
+      identityId: null,
+      participantId: null,
+      threadId: null,
+    })
+  })
+
   it('keeps private lookup identifiers separate from redacted placeholders', () => {
     expect(looksLikePrivateAssistantRoutePlaceholder(LINQ_THREAD_ID)).toBe(true)
     expect(


### PR DESCRIPTION
## Problem

Preserve-continuity reminders (e.g. the daily PT reset, nightly meditation reminders) fired into a brand-new assistant session every run instead of continuing the iMessage conversation they were scheduled from.

Two root causes:

1. **Saved routes never carried conversation locators.** Hosted linq conversation locators are `hid_`-blinded, and `automation save` ran `stripPrivateAssistantRoutePlaceholders` *after* merging in the hosted current route — nulling exactly those locators. With `threadId`/`participantId` null, the route forms no conversation key, so session resolution fell through to create-new on every fire. (#'ebbff495e' added locator inheritance but tested with `h1_` values; production `hid_` values were still stripped.)
2. **The after-run session auto-pin fought rotation.** `preserve` pinned whatever session the previous run used; an explicit session ID bypasses the conversation-key path's continuity-fingerprint/expiry checks, so the pin went stale on every prompt deploy.

## Change

- **operator-config**: `resolveAssistantDeliveryRouteWithCurrentRoute` enriches an explicit delivery target that names the *same* conversation as the current route (channel + delivery target match) with its missing locators. Different conversation / different channel → untouched; atomic all-or-nothing inheritance unchanged.
- **cli `automation save`**: strip model-typed flags *before* the merge and trust hosted-bridge locators as-is — they're the same blinded values session bindings already persist. Save fetches the current route whenever any locator is missing (edit still never inherits).
- **assistant-engine**: new `automationContinuityUsesSessionPin` predicate gates the automatic session pin off when the route forms a conversation key — those automations now resolve exactly like an inbound message and follow the conversation's live session through fingerprint rotations. Keyless routes (bare delivery target, e.g. email) keep the pin as their only continuity. Explicit aliases remain honored.
- **system-prompt**: one sentence telling the assistant that routing an automation at the current conversation makes a preserve automation continue it.

## Backward compatibility

- Existing automations all have keyless routes today (locators were always stripped in prod) → pin behavior unchanged for them until re-saved.
- Stale pins already in runtime state on keyed routes are ignored at projection and cleared after the next run — no migration.
- Preset cron jobs with explicit aliases keep resolving by alias (covered by existing tests).

## Verification

- `pnpm test:diff` over the touched files: 82 files / 1298 tests green on this base.
- New tests: same-conversation enrichment (incl. production-shaped `hid_` locators surviving save, model-echoed placeholder flags replaced by trusted bridge values, no cross-conversation/cross-channel leakage), stale pin ignored + cleared for keyed preserve routes, pin retained for keyless preserve routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783701246&installation_id=127572939&pr_number=111&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F111&signature=393c5366e67756d612406f4c3d33cd15b9fd3b54068946407f51463d8bb77024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->