### PR TITLE
feat(assistant): classify Codex failures from structured codexErrorInfo

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-10-codex-structured-error-info.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-codex-structured-error-info.md
@@ -1,0 +1,45 @@
+Goal (incl. success criteria):
+- Classify Codex provider failures from the app-server's structured `codexErrorInfo` (pinned codex 0.135.0 protocol) instead of free-text pattern matching, and surface the typed failure code in persisted `cron.job.completed` runtime-log events.
+- Success: usage-limit/connection classification is immune to provider message rewording (proven by tests using non-matching text), text matchers are removed from the RPC turn-failure path (stderr sniffing retained only for process crashes with no RPC error), and a quota-coded cron failure is queryable via `failureContext.errorCode` in `hosted_runtime_log`.
+
+Constraints/Assumptions:
+- `ASSISTANT_CODEX_USAGE_LIMIT` / `ASSISTANT_CODEX_CONNECTION_LOST` / `ASSISTANT_CODEX_FAILED` code strings and retryable semantics unchanged (turn_failed stays non-retryable; process-exit connection loss stays retryable).
+- No contract changes: `AssistantCronRunRecord` schema untouched; the error code rides the execution result, not the persisted run record.
+- Verified against codex tag rust-v0.135.0: `TurnError { message, codexErrorInfo?, additionalDetails? }` in v2 `ErrorNotification`; variants include usageLimitExceeded, httpConnectionFailed{httpStatusCode}, responseStreamConnectionFailed, responseStreamDisconnected, responseTooManyFailedAttempts, serverOverloaded, unauthorized, etc.
+
+Key decisions:
+- Structured-first with explicit precedence: when `codexErrorInfo` is present it solely determines classification (a non-connection structured code is not overridden by connection-sounding text); stderr/text sniffing applies only when no structured error ever arrived (true process-crash path).
+- `isCodexUsageLimitFailureText` deleted outright (quota failures always arrive via RPC, never stderr-only); `isCodexConnectionLossText` retained for the crash path and display logic.
+- Context fields `codexErrorInfoPresent` / `codexErrorInfo` / `codexErrorHttpStatusCode` added to failure errors so prod can confirm structured info coverage before any further matcher deletion.
+
+State:
+- Done; ready for PR.
+
+Done:
+- Extractor (`extractCodexErrorInfo`) + threading (`lastEventErrorInfo`) + classification rework + cron `runErrorCode` -> `cron.job.completed` failureContext.errorCode.
+- Full assistant-engine suite 1214 passed / 3 skipped; both packages typecheck clean.
+- coverage-write pass added e2e turn-failure classification via simulated app-server stream, structured-over-text precedence at process exit, extractor edges, abort precedence (157 tests green).
+- task-finish-review: safe to land; accepted findings fixed (turn.completed added to extractor gate so the embedded `Turn.error.codexErrorInfo` on failed turns is read; `runErrorCode` added to `AssistantCronRunExecutionResult`; maintenance-level test proves `failureErrorCode` lands in the persisted redacted log, 51/51).
+- Advisory accepted as follow-up: `willRetry: true` stream-retry errors update `lastEventErrorInfo` (exact parity with pre-existing text behavior; connection kinds make the stale outcome correct today).
+
+Now:
+- Commit + PR.
+
+Next:
+- Post-deploy: confirm `failureContext.errorCode` rows appear for provider failures and `codexErrorInfoPresent: true` covers them.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/assistant-engine/src/assistant-codex-events.ts
+- packages/assistant-engine/src/assistant-codex/failures.ts
+- packages/assistant-engine/src/assistant-codex.ts
+- packages/assistant-engine/src/assistant/cron/execution.ts
+- packages/assistant-engine/src/assistant/cron.ts
+- packages/assistant-engine/test/assistant-codex-failures.test.ts
+- packages/assistant-engine/test/assistant-codex-runtime.test.ts
+- packages/assistant-engine/test/assistant-cron-runtime.test.ts
+Status: completed
+Updated: 2026-06-10
+Completed: 2026-06-10

--- a/packages/assistant-engine/src/assistant-codex-events.ts
+++ b/packages/assistant-engine/src/assistant-codex-events.ts
@@ -1314,6 +1314,129 @@ export function extractCodexErrorMessage(event: unknown): string | null {
   )
 }
 
+// Structured error classification from the Codex app-server protocol
+// (`TurnError.codexErrorInfo`). String variants arrive as e.g.
+// "usageLimitExceeded"; carrier variants arrive as single-key objects like
+// `{ "httpConnectionFailed": { "httpStatusCode": 502 } }`.
+export interface CodexStructuredErrorInfo {
+  httpStatusCode: number | null
+  kind: string
+}
+
+export function extractCodexErrorInfo(
+  event: unknown,
+): CodexStructuredErrorInfo | null {
+  const record = asRecord(event)
+  if (!record) {
+    return null
+  }
+
+  const eventType = normalizeIdentifier(
+    typeof record.type === 'string'
+      ? record.type
+      : typeof record.method === 'string'
+        ? record.method
+        : null,
+  )
+  // turn.completed is included because a failed turn embeds its TurnError
+  // (with codexErrorInfo) at params.turn.error; successful turns carry
+  // error: null, so the deep search finds nothing there.
+  if (
+    eventType !== 'error' &&
+    eventType !== 'turn.completed' &&
+    eventType !== 'turn.failed' &&
+    eventType !== 'turn.error'
+  ) {
+    return null
+  }
+
+  return normalizeCodexErrorInfoValue(
+    findDeepValueByKeys(record, ['codexErrorInfo', 'codex_error_info']),
+  )
+}
+
+function normalizeCodexErrorInfoValue(
+  value: unknown,
+): CodexStructuredErrorInfo | null {
+  if (typeof value === 'string') {
+    const kind = normalizeNullableString(value)
+    return kind
+      ? {
+          httpStatusCode: null,
+          kind,
+        }
+      : null
+  }
+
+  const record = asRecord(value)
+  if (!record) {
+    return null
+  }
+
+  const entries = Object.entries(record)
+  if (entries.length !== 1) {
+    return null
+  }
+
+  const [kind, payload] = entries[0] as [string, unknown]
+  const normalizedKind = normalizeNullableString(kind)
+  if (!normalizedKind) {
+    return null
+  }
+
+  const payloadRecord = asRecord(payload)
+  const httpStatusCode = payloadRecord?.httpStatusCode
+  return {
+    httpStatusCode:
+      typeof httpStatusCode === 'number' && Number.isFinite(httpStatusCode)
+        ? httpStatusCode
+        : null,
+    kind: normalizedKind,
+  }
+}
+
+function findDeepValueByKeys(
+  value: unknown,
+  keys: readonly string[],
+  visited = new Set<unknown>(),
+): unknown {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  if (visited.has(value)) {
+    return null
+  }
+  visited.add(value)
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findDeepValueByKeys(item, keys, visited)
+      if (found !== null) {
+        return found
+      }
+    }
+    return null
+  }
+
+  const record = value as Record<string, unknown>
+  for (const key of keys) {
+    const candidate = record[key]
+    if (candidate !== undefined && candidate !== null) {
+      return candidate
+    }
+  }
+
+  for (const nested of Object.values(record)) {
+    const found = findDeepValueByKeys(nested, keys, visited)
+    if (found !== null) {
+      return found
+    }
+  }
+
+  return null
+}
+
 function findDeepStringByKeys(
   value: unknown,
   keys: readonly string[],

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -20,8 +20,10 @@ import type {
 } from './assistant-codex-events.js'
 import {
   extractAssistantMessageFallback,
+  extractCodexErrorInfo,
   extractCodexErrorMessage,
   extractCodexProgressEventFromNormalized,
+  type CodexStructuredErrorInfo,
   extractCodexSessionId,
   extractCodexStatusEventFromStderrLine,
   extractCodexTraceUpdatesFromNormalized,
@@ -861,6 +863,7 @@ class CodexAppServerProcess {
         abortRequested: false,
         code: this.child.exitCode,
         diagnostics: this.buildStartupProcessDiagnostics(),
+        errorInfo: null,
         fallback: buildCodexStdinFailureFallback({
           error,
           lastEventError: null,
@@ -971,6 +974,7 @@ class CodexAppServerProcess {
       abortRequested: false,
       code,
       diagnostics: this.buildStartupProcessDiagnostics(),
+      errorInfo: null,
       fallback: null,
       providerActionCount: 0,
       codexThreadId: null,
@@ -1015,6 +1019,7 @@ class CodexAppServerProcess {
         abortRequested: false,
         code: this.child.exitCode,
         diagnostics: this.buildStartupProcessDiagnostics(),
+        errorInfo: null,
         fallback: null,
         providerActionCount: 0,
         codexThreadId: null,
@@ -1238,6 +1243,7 @@ async function runCodexAppServerTurnOnProcess(
   let expectedTurnId: string | null = null
   let lastAgentMessage: string | null = null
   let lastEventError: string | null = null
+  let lastEventErrorInfo: CodexStructuredErrorInfo | null = null
   let responseMedia: AssistantResponseMedia[] = []
   const additionalUsages: AssistantProviderUsageDraft[] = []
   let nextDynamicToolUsageOrdinal = (input.providerRequestOrdinal ?? 0) + 1
@@ -1439,6 +1445,7 @@ async function runCodexAppServerTurnOnProcess(
         abortRequested,
         code: codexProcess.child.exitCode,
         diagnostics: buildProcessExitDiagnostics(),
+        errorInfo: lastEventErrorInfo,
         fallback: buildCodexStdinFailureFallback({
           error,
           lastEventError,
@@ -1818,6 +1825,7 @@ async function runCodexAppServerTurnOnProcess(
     acceptJsonEvent(message)
     codexThreadId = codexThreadId ?? extractCodexSessionId(message)
     lastEventError = extractCodexErrorMessage(message) ?? lastEventError
+    lastEventErrorInfo = extractCodexErrorInfo(message) ?? lastEventErrorInfo
     if (isCodexTurnStartedMethod(method)) {
       turnId = extractCodexTurnIdFromMessage(message) ?? turnId
     }
@@ -1881,6 +1889,7 @@ async function runCodexAppServerTurnOnProcess(
       turnTerminal = true
       failTurn?.(
         buildCodexTurnFailedError({
+          errorInfo: extractCodexErrorInfo(message) ?? lastEventErrorInfo,
           fallback: lastEventError ?? extractCodexTurnErrorMessage(message),
           providerActionCount,
           codexThreadId,
@@ -2114,6 +2123,7 @@ async function runCodexAppServerTurnOnProcess(
           abortRequested,
           code,
           diagnostics: buildProcessExitDiagnostics(),
+          errorInfo: lastEventErrorInfo,
           fallback: lastEventError,
           providerActionCount,
           codexThreadId,

--- a/packages/assistant-engine/src/assistant-codex/failures.ts
+++ b/packages/assistant-engine/src/assistant-codex/failures.ts
@@ -4,12 +4,49 @@ import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import {
   isCodexConnectionLossText,
   normalizeStatusText,
+  type CodexStructuredErrorInfo,
 } from '../assistant-codex-events.js'
 
 type CodexTurnMessage = Record<string, unknown>
 
 export const ASSISTANT_CODEX_USAGE_LIMIT_ERROR_CODE =
   'ASSISTANT_CODEX_USAGE_LIMIT'
+
+// CodexErrorInfo variants (app-server protocol, pinned codex 0.135.0) that
+// describe a lost or unusable provider connection. These map to the
+// retryable ASSISTANT_CODEX_CONNECTION_LOST process-exit classification.
+const CODEX_CONNECTION_LOSS_ERROR_INFO_KINDS = new Set([
+  'httpConnectionFailed',
+  'responseStreamConnectionFailed',
+  'responseStreamDisconnected',
+  'responseTooManyFailedAttempts',
+  'serverOverloaded',
+])
+
+function isCodexUsageLimitErrorInfo(
+  errorInfo: CodexStructuredErrorInfo | null,
+): boolean {
+  return errorInfo?.kind === 'usageLimitExceeded'
+}
+
+function isCodexConnectionLossErrorInfo(
+  errorInfo: CodexStructuredErrorInfo | null,
+): boolean {
+  return errorInfo !== null &&
+    CODEX_CONNECTION_LOSS_ERROR_INFO_KINDS.has(errorInfo.kind)
+}
+
+function buildCodexErrorInfoContext(
+  errorInfo: CodexStructuredErrorInfo | null,
+): Record<string, boolean | number | string> {
+  return {
+    codexErrorInfoPresent: errorInfo !== null,
+    ...(errorInfo ? { codexErrorInfo: errorInfo.kind } : {}),
+    ...(errorInfo?.httpStatusCode !== null && errorInfo?.httpStatusCode !== undefined
+      ? { codexErrorHttpStatusCode: errorInfo.httpStatusCode }
+      : {}),
+  }
+}
 
 export function extractCodexThreadIdFromResult(result: unknown): string | null {
   const record = asRecord(result)
@@ -120,6 +157,7 @@ export function isFailedCodexTurnStatus(status: string | null): boolean {
 }
 
 export function buildCodexTurnFailedError(input: {
+  errorInfo: CodexStructuredErrorInfo | null
   fallback: string | null
   providerActionCount: number
   codexThreadId: string | null
@@ -141,7 +179,7 @@ export function buildCodexTurnFailedError(input: {
   if (detail) {
     parts.push(detail)
   }
-  const usageLimit = isCodexUsageLimitFailureText(detail)
+  const usageLimit = isCodexUsageLimitErrorInfo(input.errorInfo)
 
   return new VaultCliError(
     usageLimit ? ASSISTANT_CODEX_USAGE_LIMIT_ERROR_CODE : 'ASSISTANT_CODEX_FAILED',
@@ -151,6 +189,7 @@ export function buildCodexTurnFailedError(input: {
       codexDiagnosticsPresent: true,
       codexFailureStage: 'turn_failed',
       codexTurnStatus: input.status,
+      ...buildCodexErrorInfoContext(input.errorInfo),
       providerActionCount: input.providerActionCount,
       codexThreadIdPresent: input.codexThreadId !== null,
       ...(usageLimit ? { providerUsageLimit: true } : {}),
@@ -162,6 +201,7 @@ export function buildCodexTurnFailedError(input: {
 export function buildCodexFailure(input: {
   code: number | null
   diagnostics?: CodexProcessExitDiagnostics
+  errorInfo: CodexStructuredErrorInfo | null
   fallback: string | null
   providerActionCount: number
   codexThreadId: string | null
@@ -173,9 +213,15 @@ export function buildCodexFailure(input: {
     normalizeStatusText(input.fallback ?? stderrTail) ??
     input.fallback ??
     stderrTail
-  const usageLimit = isCodexUsageLimitFailureText(detail)
+  const usageLimit = isCodexUsageLimitErrorInfo(input.errorInfo)
+  // Prefer the structured protocol classification when an RPC error arrived
+  // before the process died; fall back to stderr text sniffing only for true
+  // process crashes where no structured error was ever observed.
   const connectionLost =
-    !usageLimit && detail !== null && isCodexConnectionLossText(detail)
+    !usageLimit &&
+    (input.errorInfo
+      ? isCodexConnectionLossErrorInfo(input.errorInfo)
+      : detail !== null && isCodexConnectionLossText(detail))
 
   return new VaultCliError(
     connectionLost
@@ -206,6 +252,7 @@ export function buildCodexFailure(input: {
           }
         : {}),
       ...buildCodexProcessExitDiagnosticsContext(input.diagnostics),
+      ...buildCodexErrorInfoContext(input.errorInfo),
       providerActionCount: input.providerActionCount,
       ...(usageLimit ? { providerUsageLimit: true } : {}),
       codexThreadIdPresent: input.codexThreadId !== null,
@@ -215,25 +262,11 @@ export function buildCodexFailure(input: {
   )
 }
 
-export function isCodexUsageLimitFailureText(value: string | null): boolean {
-  const normalized = value?.toLowerCase() ?? ''
-
-  return (
-    normalized.includes('usage limit') ||
-    normalized.includes('quota exceeded') ||
-    normalized.includes('current quota') ||
-    normalized.includes('insufficient quota') ||
-    normalized.includes('purchase more credits') ||
-    normalized.includes('out of credits') ||
-    normalized.includes('credit balance') ||
-    normalized.includes('plan and billing details')
-  )
-}
-
 export function buildCodexProcessExitError(input: {
   abortRequested: boolean
   code: number | null
   diagnostics?: CodexProcessExitDiagnostics
+  errorInfo: CodexStructuredErrorInfo | null
   fallback: string | null
   providerActionCount: number
   codexThreadId: string | null
@@ -395,40 +428,12 @@ function buildCodexFailureMessage(input: {
   signal: NodeJS.Signals | null
   stderr: string
 }): string {
+  // Connection-loss phrasing is chosen by buildCodexFailure (the only
+  // caller), which routes those failures to buildCodexConnectionFailureMessage.
   const detail =
     normalizeStatusText(input.fallback ?? tailText(input.stderr)) ??
     input.fallback ??
     tailText(input.stderr)
-  const recoverableConnectionLoss =
-    !isCodexUsageLimitFailureText(detail) &&
-    detail !== null &&
-    isCodexConnectionLossText(detail)
-
-  if (recoverableConnectionLoss) {
-    const parts = ['Codex app-server lost the provider stream before the turn finished.']
-
-    if (typeof input.code === 'number') {
-      parts.push(`exit code ${input.code}.`)
-    }
-
-    if (input.signal) {
-      parts.push(`signal ${input.signal}.`)
-    }
-
-    if (detail) {
-      parts.push(detail)
-    }
-
-    if (input.codexThreadId) {
-      parts.push(
-        'Codex thread id was captured for diagnostics only. Send another message to retry the turn.',
-      )
-    } else {
-      parts.push('Send another message to retry the turn.')
-    }
-
-    return parts.join(' ')
-  }
 
   const parts = ['Codex app-server failed.']
 

--- a/packages/assistant-engine/src/assistant/cron.ts
+++ b/packages/assistant-engine/src/assistant/cron.ts
@@ -102,6 +102,7 @@ export interface AssistantCronRunExecutionResult {
   job: AssistantCronJob
   removedAfterRun: boolean
   run: AssistantCronRunRecord
+  runErrorCode: string | null
 }
 
 export interface AssistantCronTargetMutationResult {
@@ -566,6 +567,7 @@ export async function processDueAssistantCronJobsLocal(
       summary.failed += 1
     }
     emitAssistantCronJobCompletedEvent({
+      errorCode: result.runErrorCode,
       errorPresent: result.run.error !== null,
       job: result.job,
       onEvent: input.onEvent,
@@ -661,6 +663,7 @@ async function emitAssistantCronScanEvents(input: {
 }
 
 function emitAssistantCronJobCompletedEvent(input: {
+  errorCode: string | null
   errorPresent: boolean
   job: AssistantCronJob
   onEvent?: (event: AssistantRunEvent) => void
@@ -677,6 +680,10 @@ function emitAssistantCronJobCompletedEvent(input: {
     details: 'scheduled job run completed',
     safeDetails,
     failureContext: {
+      // Typed VaultCliError code (e.g. ASSISTANT_CODEX_USAGE_LIMIT) so
+      // provider-level outages are queryable in the persisted hosted runtime
+      // log; the June 2026 quota incident was invisible there.
+      errorCode: input.errorCode,
       errorPresent: input.errorPresent,
       routeConfigured: assistantCronJobHasDeliveryRoute(input.job),
       runStatus: input.runStatus,

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -239,6 +239,7 @@ export async function executeClaimedAssistantCronJob(input: {
   job: AssistantCronJob
   removedAfterRun: boolean
   run: AssistantCronRunRecord
+  runErrorCode: string | null
 }> {
   const claimedJob = input.job.job
   const startedAt = new Date().toISOString()
@@ -246,6 +247,7 @@ export async function executeClaimedAssistantCronJob(input: {
   let sessionId: string | null = null
   let response: string | null = null
   let errorText: string | null = null
+  let errorCode: string | null = null
   let status: AssistantCronRunRecord['status'] = 'failed'
   let pendingDeliveryIntentId: string | null = null
   const occurrenceAt =
@@ -348,6 +350,7 @@ export async function executeClaimedAssistantCronJob(input: {
     }
   } catch (error) {
     errorText = errorMessage(error)
+    errorCode = error instanceof VaultCliError ? error.code : null
     status = 'failed'
   } finally {
     finishedAt = new Date().toISOString()
@@ -512,6 +515,9 @@ export async function executeClaimedAssistantCronJob(input: {
     job: finalized.job,
     removedAfterRun: finalized.removedAfterRun,
     run,
+    // Typed failure class (e.g. ASSISTANT_CODEX_USAGE_LIMIT) for runtime-log
+    // observability; the persisted run record keeps only the error text.
+    runErrorCode: errorCode,
   }
 }
 

--- a/packages/assistant-engine/test/assistant-codex-failures.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-failures.test.ts
@@ -106,6 +106,7 @@ describe('assistant Codex failure helpers', () => {
   it('builds typed turn-failure and interruption errors', () => {
     expect(
       buildCodexTurnFailedError({
+        errorInfo: null,
         fallback: '  model returned an invalid terminal event  ',
         providerActionCount: 2,
         codexThreadId: 'thread-1',
@@ -114,6 +115,7 @@ describe('assistant Codex failure helpers', () => {
     ).toMatchObject({
       code: 'ASSISTANT_CODEX_FAILED',
       context: {
+        codexErrorInfoPresent: false,
         codexFailureDetailPresent: true,
         codexFailureStage: 'turn_failed',
         providerActionCount: 2,
@@ -126,6 +128,7 @@ describe('assistant Codex failure helpers', () => {
 
     expect(
       buildCodexTurnFailedError({
+        errorInfo: null,
         fallback: null,
         providerActionCount: 0,
         codexThreadId: null,
@@ -143,10 +146,17 @@ describe('assistant Codex failure helpers', () => {
     })
   })
 
-  it('builds specific usage-limit errors for quota and credit exhaustion', () => {
+  it('classifies usage-limit failures from structured codexErrorInfo, not message text', () => {
+    // Message text deliberately matches none of the historical usage-limit
+    // phrases: classification must come from the protocol enum, so provider
+    // rewording can no longer break it (June 2026 quota incident).
     expect(
       buildCodexTurnFailedError({
-        fallback: 'Quota exceeded. Check your plan and billing details.',
+        errorInfo: {
+          httpStatusCode: null,
+          kind: 'usageLimitExceeded',
+        },
+        fallback: 'You have reached your monthly cap.',
         providerActionCount: 0,
         codexThreadId: 'thread-usage-limit',
         status: 'failed',
@@ -154,6 +164,8 @@ describe('assistant Codex failure helpers', () => {
     ).toMatchObject({
       code: ASSISTANT_CODEX_USAGE_LIMIT_ERROR_CODE,
       context: {
+        codexErrorInfo: 'usageLimitExceeded',
+        codexErrorInfoPresent: true,
         codexFailureDetailPresent: true,
         codexFailureStage: 'turn_failed',
         codexTurnStatus: 'failed',
@@ -163,13 +175,34 @@ describe('assistant Codex failure helpers', () => {
         retryable: false,
       },
       message:
-        'Codex app-server turn failed. status failed. Quota exceeded. Check your plan and billing details.',
+        'Codex app-server turn failed. status failed. You have reached your monthly cap.',
+    })
+
+    // Quota-sounding text WITHOUT structured info no longer classifies as a
+    // usage limit: text matching is gone from the turn-failed path.
+    expect(
+      buildCodexTurnFailedError({
+        errorInfo: null,
+        fallback: 'Quota exceeded. Check your plan and billing details.',
+        providerActionCount: 0,
+        codexThreadId: 'thread-usage-limit-text-only',
+        status: 'failed',
+      }),
+    ).toMatchObject({
+      code: 'ASSISTANT_CODEX_FAILED',
+      context: {
+        codexErrorInfoPresent: false,
+      },
     })
 
     expect(
       buildCodexFailure({
         code: 1,
-        fallback: 'Purchase more credits before retrying.',
+        errorInfo: {
+          httpStatusCode: null,
+          kind: 'usageLimitExceeded',
+        },
+        fallback: 'Top up to continue.',
         providerActionCount: 1,
         codexThreadId: 'thread-process-exit',
         signal: null,
@@ -178,6 +211,8 @@ describe('assistant Codex failure helpers', () => {
     ).toMatchObject({
       code: ASSISTANT_CODEX_USAGE_LIMIT_ERROR_CODE,
       context: {
+        codexErrorInfo: 'usageLimitExceeded',
+        codexErrorInfoPresent: true,
         codexExitCode: 1,
         codexFailureStage: 'process_exit',
         providerActionCount: 1,
@@ -185,7 +220,57 @@ describe('assistant Codex failure helpers', () => {
         providerUsageLimit: true,
         retryable: false,
       },
-      message: 'Codex app-server failed. exit code 1. Purchase more credits before retrying.',
+      message: 'Codex app-server failed. exit code 1. Top up to continue.',
+    })
+  })
+
+  it('classifies connection loss from structured codexErrorInfo when present', () => {
+    expect(
+      buildCodexFailure({
+        code: null,
+        errorInfo: {
+          httpStatusCode: 502,
+          kind: 'httpConnectionFailed',
+        },
+        fallback: 'an entirely novel provider transport message',
+        providerActionCount: 1,
+        codexThreadId: 'thread-structured-connection',
+        signal: null,
+        stderr: '',
+      }),
+    ).toMatchObject({
+      code: 'ASSISTANT_CODEX_CONNECTION_LOST',
+      context: {
+        codexErrorHttpStatusCode: 502,
+        codexErrorInfo: 'httpConnectionFailed',
+        codexErrorInfoPresent: true,
+        recoverableConnectionLoss: true,
+        retryable: true,
+      },
+    })
+
+    // When structured info names a non-connection failure, connection-loss
+    // sounding text must not override it.
+    expect(
+      buildCodexFailure({
+        code: null,
+        errorInfo: {
+          httpStatusCode: null,
+          kind: 'internalServerError',
+        },
+        fallback: 'stream disconnected before completion: connection reset',
+        providerActionCount: 1,
+        codexThreadId: 'thread-structured-non-connection',
+        signal: null,
+        stderr: '',
+      }),
+    ).toMatchObject({
+      code: 'ASSISTANT_CODEX_FAILED',
+      context: {
+        codexErrorInfo: 'internalServerError',
+        connectionLost: false,
+        retryable: false,
+      },
     })
   })
 
@@ -232,6 +317,7 @@ describe('assistant Codex failure helpers', () => {
       buildCodexProcessExitError({
         abortRequested: false,
         code: null,
+        errorInfo: null,
         fallback: null,
         providerActionCount: 1,
         codexThreadId: 'thread-sigint',
@@ -245,6 +331,30 @@ describe('assistant Codex failure helpers', () => {
         codexThreadIdPresent: true,
       },
       message: expect.stringContaining('signal SIGINT.'),
+    })
+
+    // Abort wins over structured error info: an interrupted turn stays
+    // INTERRUPTED even when a usage-limit error arrived before the abort.
+    expect(
+      buildCodexProcessExitError({
+        abortRequested: true,
+        code: null,
+        errorInfo: {
+          httpStatusCode: null,
+          kind: 'usageLimitExceeded',
+        },
+        fallback: 'You have reached your monthly cap.',
+        providerActionCount: 1,
+        codexThreadId: 'thread-abort-over-error-info',
+        signal: null,
+        stderr: '',
+      }),
+    ).toMatchObject({
+      code: 'ASSISTANT_CODEX_INTERRUPTED',
+      context: {
+        interrupted: true,
+        retryable: false,
+      },
     })
 
     expect(
@@ -290,6 +400,7 @@ describe('assistant Codex failure helpers', () => {
     expect(
       buildCodexFailure({
         code: null,
+        errorInfo: null,
         fallback: null,
         providerActionCount: 3,
         codexThreadId: 'thread-terminal',
@@ -316,6 +427,7 @@ describe('assistant Codex failure helpers', () => {
       buildCodexProcessExitError({
         abortRequested: false,
         code: null,
+        errorInfo: null,
         diagnostics: {
           abortRequested: false,
           jsonEventCount: 3,
@@ -361,6 +473,7 @@ describe('assistant Codex failure helpers', () => {
     const interruptedWithDiagnostics = buildCodexProcessExitError({
       abortRequested: true,
       code: null,
+      errorInfo: null,
       diagnostics: {
         abortRequested: false,
         jsonEventCount: Number.POSITIVE_INFINITY,
@@ -408,8 +521,11 @@ describe('assistant Codex failure helpers', () => {
       'codexProcessLifetimeMs',
     )
 
+    // No structured info ever arrived (true process-crash path): stderr/text
+    // sniffing still classifies the connection loss.
     const connectionLoss = buildCodexFailure({
       code: 1,
+      errorInfo: null,
       fallback: 'connection closed before response.completed',
       providerActionCount: 1,
       codexThreadId: 'thread-stream-diagnostics',

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -63,6 +63,7 @@ import {
 import {
   CODEX_CONTEXT_COMPACTION_PROGRESS_TEXTS,
   extractAssistantMessageFallback,
+  extractCodexErrorInfo,
   extractCodexErrorMessage,
   extractCodexProgressEventFromNormalized,
   extractCodexSessionId,
@@ -6190,6 +6191,189 @@ describe('assistant codex runtime', () => {
     })
   })
 
+  it('classifies usage-limit turn failures from structured error notifications end to end', async () => {
+    // Proves the lastEventErrorInfo threading: the structured codexErrorInfo
+    // arrives on an `error` notification, then the turn fails via a separate
+    // turn/completed event that carries no structured info of its own. The
+    // message text deliberately matches none of the historical usage-limit
+    // phrases (June 2026 quota incident regression guard).
+    const workingDirectory = await createTempDir('assistant-codex-structured-usage-limit-')
+
+    codexMocks.spawn.mockImplementation(() => {
+      const child = new MockChildProcess()
+
+      queueMicrotask(() => {
+        void (async () => {
+          await waitForRpcMethod(child, 'initialize')
+          child.stdout.write(jsonLine({ id: 1, result: {} }))
+          await waitForRpcMethod(child, 'thread/start')
+          child.stdout.write(
+            jsonLine({
+              id: 2,
+              result: {
+                thread: {
+                  id: 'thread-structured-usage',
+                },
+              },
+            }),
+          )
+          await waitForRpcMessages(child, 4)
+          child.stdout.write(
+            jsonLine({
+              id: 3,
+              result: {
+                turn: {
+                  id: 'turn-structured-usage',
+                },
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'turn/started',
+              params: {
+                turn: {
+                  id: 'turn-structured-usage',
+                },
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'error',
+              params: {
+                error: {
+                  codexErrorInfo: 'usageLimitExceeded',
+                  message: 'You have reached your monthly cap.',
+                },
+                threadId: 'thread-structured-usage',
+                turnId: 'turn-structured-usage',
+                willRetry: false,
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'turn/completed',
+              params: {
+                turn: {
+                  id: 'turn-structured-usage',
+                  status: 'failed',
+                },
+              },
+            }),
+          )
+        })()
+      })
+
+      return child
+    })
+
+    await expect(
+      executeCodexAppServerTurn({
+        prompt: 'structured usage limit',
+        workingDirectory,
+      }),
+    ).rejects.toMatchObject({
+      code: 'ASSISTANT_CODEX_USAGE_LIMIT',
+      context: {
+        codexErrorInfo: 'usageLimitExceeded',
+        codexErrorInfoPresent: true,
+        codexFailureStage: 'turn_failed',
+        codexThreadIdPresent: true,
+        codexTurnStatus: 'failed',
+        providerUsageLimit: true,
+        retryable: false,
+      },
+      message: expect.stringContaining('You have reached your monthly cap.'),
+    })
+  })
+
+  it('does not classify process exits as connection loss when structured info names another failure', async () => {
+    // Same connection-sounding stderr as the retryable connection-loss test
+    // above, but a structured non-connection error arrived first: the
+    // structured classification must win over text sniffing end to end.
+    const workingDirectory = await createTempDir('assistant-codex-structured-non-connection-')
+
+    codexMocks.spawn.mockImplementation(() => {
+      const child = new MockChildProcess()
+
+      queueMicrotask(() => {
+        void (async () => {
+          await waitForRpcMethod(child, 'initialize')
+          child.stdout.write(jsonLine({ id: 1, result: {} }))
+          await waitForRpcMethod(child, 'thread/start')
+          child.stdout.write(
+            jsonLine({
+              id: 2,
+              result: {
+                thread: {
+                  id: 'thread-structured-exit',
+                },
+              },
+            }),
+          )
+          await waitForRpcMessages(child, 4)
+          child.stdout.write(
+            jsonLine({
+              id: 3,
+              result: {
+                turn: {
+                  id: 'turn-structured-exit',
+                },
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'turn/started',
+              params: {
+                turn: {
+                  id: 'turn-structured-exit',
+                },
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'error',
+              params: {
+                error: {
+                  codexErrorInfo: 'internalServerError',
+                  message: 'provider rejected the request',
+                },
+                threadId: 'thread-structured-exit',
+                turnId: 'turn-structured-exit',
+                willRetry: false,
+              },
+            }),
+          )
+          child.stderr.write('connection closed before response.completed\n')
+          child.emit('exit', 1, null)
+          child.emit('close', 1, null)
+        })()
+      })
+
+      return child
+    })
+
+    await expect(
+      executeCodexAppServerTurn({
+        prompt: 'structured non-connection exit',
+        workingDirectory,
+      }),
+    ).rejects.toMatchObject({
+      code: 'ASSISTANT_CODEX_FAILED',
+      context: {
+        codexErrorInfo: 'internalServerError',
+        codexErrorInfoPresent: true,
+        codexFailureStage: 'process_exit',
+        connectionLost: false,
+        retryable: false,
+      },
+    })
+  })
+
   it('classifies stale resume failures from thread/resume RPC errors', async () => {
     const workingDirectory = await createTempDir('assistant-codex-stale-resume-')
 
@@ -9538,6 +9722,131 @@ describe('assistant codex event shaping', () => {
       extractCodexErrorMessage({
         message: 'ignored',
         type: 'item.completed',
+      }),
+    ).toBeNull()
+
+    // Wire shape from the app-server v2 ErrorNotification:
+    // { method: 'error', params: { error: TurnError, threadId, turnId, willRetry } }
+    expect(
+      extractCodexErrorInfo({
+        method: 'error',
+        params: {
+          error: {
+            codexErrorInfo: 'usageLimitExceeded',
+            message: 'You have reached your monthly cap.',
+          },
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          willRetry: false,
+        },
+      }),
+    ).toEqual({
+      httpStatusCode: null,
+      kind: 'usageLimitExceeded',
+    })
+    expect(
+      extractCodexErrorInfo({
+        method: 'error',
+        params: {
+          error: {
+            codexErrorInfo: {
+              httpConnectionFailed: {
+                httpStatusCode: 502,
+              },
+            },
+            message: 'connection failed',
+          },
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          willRetry: true,
+        },
+      }),
+    ).toEqual({
+      httpStatusCode: 502,
+      kind: 'httpConnectionFailed',
+    })
+    expect(
+      extractCodexErrorInfo({
+        method: 'error',
+        params: {
+          error: {
+            message: 'no structured info attached',
+          },
+        },
+      }),
+    ).toBeNull()
+    // Carrier variants are single-key enums: a multi-key object is not a
+    // valid CodexErrorInfo and must not be guessed at.
+    expect(
+      extractCodexErrorInfo({
+        method: 'error',
+        params: {
+          error: {
+            codexErrorInfo: {
+              httpConnectionFailed: {
+                httpStatusCode: 502,
+              },
+              serverOverloaded: {},
+            },
+            message: 'ambiguous payload',
+          },
+        },
+      }),
+    ).toBeNull()
+    expect(
+      extractCodexErrorInfo({
+        params: {
+          error: {
+            codex_error_info: 'usageLimitExceeded',
+            message: 'snake_case wire key',
+          },
+        },
+        type: 'turn.error',
+      }),
+    ).toEqual({
+      httpStatusCode: null,
+      kind: 'usageLimitExceeded',
+    })
+    expect(
+      extractCodexErrorInfo({
+        codexErrorInfo: 'usageLimitExceeded',
+        type: 'item.completed',
+      }),
+    ).toBeNull()
+    expect(extractCodexErrorInfo(null)).toBeNull()
+
+    // A failed turn embeds its TurnError directly on turn/completed
+    // (Turn.error is only populated for failed turns at codex 0.135.0), so
+    // classification works even if the standalone error notification never
+    // arrived.
+    expect(
+      extractCodexErrorInfo({
+        method: 'turn/completed',
+        params: {
+          turn: {
+            error: {
+              codexErrorInfo: 'usageLimitExceeded',
+              message: 'You have reached your monthly cap.',
+            },
+            id: 'turn-embedded-error',
+            status: 'failed',
+          },
+        },
+      }),
+    ).toEqual({
+      httpStatusCode: null,
+      kind: 'usageLimitExceeded',
+    })
+    expect(
+      extractCodexErrorInfo({
+        method: 'turn/completed',
+        params: {
+          turn: {
+            error: null,
+            id: 'turn-successful',
+            status: 'completed',
+          },
+        },
       }),
     ).toBeNull()
 

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -1334,6 +1334,68 @@ describe('assistant cron runtime orchestration', () => {
     )
   })
 
+  it('surfaces the typed failure code in cron.job.completed events', async () => {
+    // Provider quota exhaustion (June 2026 incident) must be queryable from
+    // the persisted runtime log via failureContext.errorCode instead of only
+    // living as free text in per-vault run records.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T09:05:00.000Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-error-code-',
+    )
+    await addAssistantCronJob({
+      channel: 'telegram',
+      deliveryTarget: 'room-1',
+      name: 'quota failing reminder',
+      now: new Date('2026-04-08T08:00:00.000Z'),
+      prompt: 'Evening reminder.',
+      schedule: {
+        kind: 'at',
+        at: '2026-04-08T09:00:00.000Z',
+      },
+      vault: vaultRoot,
+    })
+    cronMocks.sendAssistantMessageLocal.mockRejectedValueOnce(
+      new VaultCliError(
+        'ASSISTANT_CODEX_USAGE_LIMIT',
+        'Codex app-server turn failed. status failed. You have reached your monthly cap.',
+      ),
+    )
+    const events: Array<{
+      failureContext?: Record<string, boolean | number | string | null>
+      safeDetails?: string
+      type: string
+    }> = []
+
+    const summary = await processDueAssistantCronJobsLocal({
+      limit: 1,
+      onEvent: (event) => {
+        events.push(event)
+      },
+      vault: vaultRoot,
+    })
+
+    expect(summary).toEqual({
+      failed: 1,
+      processed: 1,
+      succeeded: 0,
+    })
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          failureContext: expect.objectContaining({
+            errorCode: 'ASSISTANT_CODEX_USAGE_LIMIT',
+            errorPresent: true,
+            runStatus: 'failed',
+            scheduleKind: 'at',
+            sourceKind: 'automation',
+          }),
+          type: 'cron.job.completed',
+        }),
+      ]),
+    )
+  })
+
   it('skips stale recurring canonical notification cron jobs and advances the schedule', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-08T13:00:00.000Z'))

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -340,6 +340,64 @@ describe("runHostedAssistantAutomation", () => {
     );
   });
 
+  it("persists the typed cron failure code from cron.job.completed events", async () => {
+    // June 2026 quota incident: provider quota failures on scheduled
+    // reminders must land queryable in hosted_runtime_log.
+    mocks.runAssistantAutomationPass.mockImplementationOnce(async (input) => {
+      input.onEvent?.({
+        failureContext: {
+          errorCode: "ASSISTANT_CODEX_USAGE_LIMIT",
+          errorPresent: true,
+          routeConfigured: true,
+          runStatus: "failed",
+          scheduleKind: "at",
+          sourceKind: "automation",
+        },
+        safeDetails: "cron_job_enqueue_failed",
+        type: "cron.job.completed",
+      });
+      return {
+        nextWakeAt: null,
+        progressed: true,
+      };
+    });
+
+    const result = await runHostedAssistantAutomation(
+      "/tmp/vault-root",
+      "req_cron_error_code",
+      {
+        hosted: {
+          issueDeviceConnectLink: vi.fn(),
+          memberId: "member_123",
+          userEnvKeys: [],
+        },
+      },
+      {
+        eventId: "evt_cron_error_code",
+        kind: "runtime.timer",
+        occurredAt: "2026-04-08T00:00:00.000Z",
+        triggerKind: "runtime_timer",
+        userId: "member_123",
+      },
+    );
+
+    expect(result.redactedLogEntries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "Hosted assistant automation event: cron.job.completed.",
+          redacted: expect.objectContaining({
+            failureErrorCode: "ASSISTANT_CODEX_USAGE_LIMIT",
+            failureErrorPresent: true,
+            failureRunStatus: "failed",
+            failureScheduleKind: "at",
+            safeDetails: "cron_job_enqueue_failed",
+            type: "cron.job.completed",
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("reports active-turn ingestion when automation reads staged conversation input", async () => {
     const listNewConversationInputs = vi.fn(async (query) => ({
       inputs: [


### PR DESCRIPTION
## Why

Provider failure classification was 8 phrases of English pattern matching (`isCodexUsageLimitFailureText`, connection-loss text sniffing). One reworded OpenAI error message silently breaks it — a missed usage-limit match gets retried, a missed disconnect surfaces as terminal. Meanwhile the app-server has been handing us the classification the whole time: `TurnError.codexErrorInfo` (verified at pinned codex `rust-v0.135.0`: `usageLimitExceeded`, `httpConnectionFailed{httpStatusCode}`, `responseStreamDisconnected`, `serverOverloaded`, `unauthorized`, …) — murph had zero references to it.

## What

- `extractCodexErrorInfo` reads the structured enum from `error` notifications **and** the failed turn's embedded `Turn.error` on `turn/completed` (only populated for failed turns); threaded as `lastEventErrorInfo` through the turn-failed path and all five process-exit call sites
- **Structured info, when present, solely determines classification** (a non-connection structured code is not overridden by connection-sounding text); stderr/text sniffing survives only for true process crashes where no RPC error ever arrived
- 8-phrase usage-limit matcher **deleted**; dead connection-loss re-derivation in `buildCodexFailureMessage` removed
- Error code strings (`ASSISTANT_CODEX_USAGE_LIMIT` / `_CONNECTION_LOST` / `_FAILED`) and retryable semantics **unchanged**; SIGINT/abort interruption precedence unchanged
- New failure-context fields `codexErrorInfoPresent` / `codexErrorInfo` / `codexErrorHttpStatusCode` so prod can confirm structured coverage
- **Quota observability** (follow-up from the June 9–10 reminder incident): `executeClaimedAssistantCronJob` returns the typed `runErrorCode`, and `cron.job.completed` events now persist `failureErrorCode` to `hosted_runtime_log` — the quota outage that ate the meditation reminder produced zero durable log signal; now it's one query: `redacted_json->>'failureErrorCode' = 'ASSISTANT_CODEX_USAGE_LIMIT'`

## Verification

- Usage-limit/connection classification proven **rewording-immune**: tests use message text matching none of the historical phrases, classified purely from the enum; complementary test proves quota-sounding text *without* structured info no longer classifies
- E2E through the simulated app-server stream: error notification + `turn/completed status=failed` → `ASSISTANT_CODEX_USAGE_LIMIT`; structured-over-text precedence at process exit; embedded-turn-error extraction; abort precedence; extractor edges (multi-key carrier → null, snake_case key)
- Persistence boundary proven: maintenance-level test asserts `failureErrorCode` lands in the redacted runtime log entry
- Full assistant-engine suite 1214 passed / 3 skipped; touched files 157/157 + 51/51; both packages typecheck clean
- Audits: coverage-write + task-finish-review; review verdict safe-to-land, accepted findings fixed in this PR (extractor gate widened to `turn.completed`, `AssistantCronRunExecutionResult.runErrorCode` typed, persistence test added); protocol claims independently re-verified against the pinned tag by the reviewer

## Accepted follow-up (advisory)

`willRetry: true` stream-retry error notifications update `lastEventErrorInfo` (exact parity with the pre-existing text behavior; at 0.135.0 those carry connection kinds so the stale outcome is correct). Optionally ignore them in a follow-up.

## Post-deploy check

Provider failures should show `codexErrorInfoPresent: true` and `failureErrorCode` rows in `hosted_runtime_log`; once confirmed across a few real failures, the remaining connection-loss text list is deletable too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783701720&installation_id=127572939&pr_number=112&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F112&signature=b0a13afb64a4f40bc6cc4ce3ac2dc54bf2527eaee6473b42fea01fa367eec122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->