### PR TITLE
fix(web): email linking flow + Chat with Murph dialog cleanup

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import { PageHeader } from "@/src/components/ui/page-header";
 import {
   readHostedAccountSettingsSnapshot,
-  withServerApprovedTelegramUsernameHint,
+  withServerApprovedPrivyAccountHints,
 } from "@/src/lib/hosted-onboarding/account-settings-snapshot";
 import {
   canStartHostedPulseTrialPaidPlan,
@@ -57,7 +57,7 @@ export default async function SettingsPage() {
     ? freshPrivySession.linkedAccounts
     : null;
   const accountWithPrivyDisplay = account
-    ? withServerApprovedTelegramUsernameHint({
+    ? withServerApprovedPrivyAccountHints({
         snapshot: account,
         serverApprovedPrivyLinkedAccounts,
       })

--- a/apps/web/src/components/dashboard/sidebar-chat-contact-dialog.tsx
+++ b/apps/web/src/components/dashboard/sidebar-chat-contact-dialog.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Check, Copy, ExternalLink, Mail, MessageCircle, Send } from "lucide-react";
+import {
+  Check,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Mail,
+  MessageCircle,
+  Send,
+} from "lucide-react";
 import { useState } from "react";
 
 import {
@@ -84,7 +92,7 @@ export function SidebarChatWithMurphContactDialog({
               return (
                 <div
                   key={option.kind}
-                  className="rounded-lg border border-border bg-card transition-colors hover:bg-accent"
+                  className="relative rounded-lg border border-border bg-card transition-colors hover:bg-accent"
                 >
                   <div className="flex items-center">
                     <a
@@ -94,14 +102,17 @@ export function SidebarChatWithMurphContactDialog({
                       aria-label={`Chat with Murph in ${option.label}${
                         opensInNewTab ? " (opens in a new tab)" : ""
                       }`}
-                      className="flex flex-1 items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium text-foreground outline-none after:absolute after:inset-0 after:rounded-lg after:content-[''] focus-visible:after:ring-2 focus-visible:after:ring-ring"
                       onClick={() => setOpen(false)}
                     >
-                      <Icon className="size-4 text-muted-foreground" aria-hidden="true" />
-                      <span className="flex flex-col">
+                      <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                      <span className="flex min-w-0 flex-col">
                         <span>{option.label}</span>
                         {option.copyValue ? (
-                          <span className="text-xs font-normal text-muted-foreground">
+                          <span
+                            className="truncate text-xs font-normal text-muted-foreground"
+                            title={option.copyValue}
+                          >
                             {option.copyValue}
                           </span>
                         ) : null}
@@ -110,26 +121,30 @@ export function SidebarChatWithMurphContactDialog({
                     {option.copyValue ? (
                       <button
                         type="button"
-                        className="mr-2 rounded-md p-2 text-muted-foreground transition-colors outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                        className="relative z-10 shrink-0 rounded-md p-2 text-muted-foreground/70 transition-colors outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
                         aria-label={
                           copied ? "Copied" : `Copy ${option.label} contact info`
                         }
                         onClick={() => void copyOptionValue(option)}
                       >
                         {copied ? (
-                          <Check className="size-4" aria-hidden="true" />
+                          <Check className="size-3.5" aria-hidden="true" />
                         ) : (
-                          <Copy className="size-4" aria-hidden="true" />
+                          <Copy className="size-3.5" aria-hidden="true" />
                         )}
                       </button>
                     ) : null}
+                    <ChevronRight
+                      className="mr-3 size-4 shrink-0 text-muted-foreground"
+                      aria-hidden="true"
+                    />
                   </div>
                   {option.webmail ? (
                     <a
                       href={option.webmail.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="flex items-center gap-1.5 px-4 pb-3 pl-11 text-xs font-medium text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                      className="relative z-10 flex items-center gap-1.5 px-4 pb-3 pl-11 text-xs font-medium text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
                       onClick={() => setOpen(false)}
                     >
                       Open in {option.webmail.label}

--- a/apps/web/src/components/settings/hosted-email-murph-contact-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-email-murph-contact-dialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { ExternalLink, Mail } from "lucide-react";
+import { useState } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import {
+  buildMurphEmailHref,
+  resolveMurphWebmailShortcut,
+} from "@/src/lib/murph-contact-routing";
+
+const MURPH_EMAIL_SUBJECT = "Hey Murph";
+
+/**
+ * "Email Murph" contact link. When the member's own address belongs to a
+ * known webmail provider we cannot tell whether they read mail there or in a
+ * native app, so the link opens a chooser; otherwise it is a plain mailto.
+ */
+export function HostedEmailMurphContactDialog(props: {
+  murphEmailAddress: string;
+  userEmailAddress: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const mailtoHref = buildMurphEmailHref({
+    address: props.murphEmailAddress,
+    subject: MURPH_EMAIL_SUBJECT,
+  });
+  const webmail = resolveMurphWebmailShortcut({
+    address: props.murphEmailAddress,
+    subject: MURPH_EMAIL_SUBJECT,
+    userEmailAddress: props.userEmailAddress,
+  });
+  const linkClassName =
+    "font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline";
+
+  if (!webmail) {
+    return (
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        <a
+          href={mailtoHref}
+          aria-label={`Email Murph at ${props.murphEmailAddress}`}
+          className={linkClassName}
+        >
+          Email Murph
+        </a>
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-xs leading-relaxed text-muted-foreground">
+      <button
+        type="button"
+        aria-label={`Email Murph at ${props.murphEmailAddress}`}
+        aria-haspopup="dialog"
+        className={linkClassName}
+        onClick={() => setOpen(true)}
+      >
+        Email Murph
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-[min(24rem,calc(100vw-2rem))] gap-6 rounded-2xl border border-border/80 bg-popover p-6 text-popover-foreground ring-border sm:max-w-[24rem] md:p-8">
+          <DialogHeader className="gap-2 pr-10">
+            <DialogTitle className="font-serif text-2xl/8 font-semibold tracking-normal text-popover-foreground">
+              Email Murph
+            </DialogTitle>
+            <DialogDescription className="text-base/7 text-muted-foreground">
+              Pick where you want to write it.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2">
+            <a
+              href={mailtoHref}
+              aria-label={`Email Murph from your mail app at ${props.murphEmailAddress}`}
+              className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm font-medium text-foreground transition-colors outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => setOpen(false)}
+            >
+              <Mail className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              Mail app
+            </a>
+            <a
+              href={webmail.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Email Murph in ${webmail.label} (opens in a new tab)`}
+              className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm font-medium text-foreground transition-colors outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => setOpen(false)}
+            >
+              <ExternalLink className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              {webmail.label}
+            </a>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </p>
+  );
+}

--- a/apps/web/src/components/settings/hosted-email-privy-link-hand-off.tsx
+++ b/apps/web/src/components/settings/hosted-email-privy-link-hand-off.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { LoaderCircle } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+
+import type { HostedEmailSyncResult } from "./hosted-email-settings-helpers";
+
+import { useHostedEmailSettingsController } from "./hosted-email-settings-controller";
+
+/**
+ * Links an email through Privy's own modal without showing a Murph dialog.
+ * Privy has no headless link-email API, so when the Privy user has no email
+ * yet this is the only flow — the member should see Privy's modal as THE
+ * dialog, not stacked on top of ours. We render only transient chrome: a
+ * spinner while the Privy client boots or while the linked email syncs, and
+ * a small dialog if linking fails.
+ */
+export function HostedEmailPrivyLinkHandOff(props: {
+  onAborted: () => void;
+  onSynced?: (payload: HostedEmailSyncResult) => Promise<void> | void;
+}) {
+  const { ready } = usePrivy();
+  const controller = useHostedEmailSettingsController({
+    authenticated: true,
+    initialEmail: null,
+    onPrivyLinkAborted: props.onAborted,
+    onSynced: props.onSynced,
+  });
+  const startedRef = useRef(false);
+  const { handleLinkEmail } = controller;
+
+  useEffect(() => {
+    if (!ready || startedRef.current) {
+      return;
+    }
+
+    startedRef.current = true;
+    handleLinkEmail();
+    // handleLinkEmail is recreated each render; startedRef keeps this one-shot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready]);
+
+  // Defensive: if linking finished without a route sync (no verified email in
+  // the linked payload), there is nothing further to show — close the flow.
+  const completedWithoutSync =
+    Boolean(controller.successMessage) && !controller.isSyncingEmailRoute;
+  const { onAborted } = props;
+
+  useEffect(() => {
+    if (completedWithoutSync) {
+      onAborted();
+    }
+  }, [completedWithoutSync, onAborted]);
+
+  if (controller.errorMessage) {
+    return (
+      <Dialog
+        open
+        onOpenChange={(open) => {
+          if (!open) {
+            props.onAborted();
+          }
+        }}
+      >
+        <DialogContent className="max-w-[min(24rem,calc(100vw-2rem))] gap-6 rounded-2xl border border-border/80 bg-popover p-6 text-popover-foreground ring-border sm:max-w-[24rem] md:p-8">
+          <DialogHeader className="gap-2 pr-10">
+            <DialogTitle className="font-serif text-2xl/8 font-semibold tracking-normal text-popover-foreground">
+              Link email
+            </DialogTitle>
+            <DialogDescription className="text-base/7 text-muted-foreground">
+              {controller.errorMessage}
+            </DialogDescription>
+          </DialogHeader>
+          <Button
+            type="button"
+            size="xl"
+            className="w-full"
+            disabled={controller.isBusy || controller.isPrivyLinkModalActive}
+            onClick={controller.handleLinkEmail}
+          >
+            Try again
+          </Button>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // While Privy's modal is up it is the only visible surface.
+  if (controller.isPrivyLinkModalActive) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/10 supports-backdrop-filter:backdrop-blur-xs">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <LoaderCircle aria-hidden="true" className="size-4 animate-spin" />
+        {controller.isSyncingEmailRoute || controller.successMessage
+          ? "Saving your email…"
+          : "Opening secure window…"}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/hosted-email-settings-controller.ts
+++ b/apps/web/src/components/settings/hosted-email-settings-controller.ts
@@ -1,4 +1,4 @@
-import { useLinkAccount, useUpdateEmail, useUser } from "@privy-io/react-auth";
+import { useLinkAccount, usePrivy, useUpdateEmail, useUser } from "@privy-io/react-auth";
 import { useRef, useState } from "react";
 
 import type {
@@ -28,9 +28,12 @@ export interface HostedEmailSettingsInitialEmail {
 export function useHostedEmailSettingsController(input: {
   authenticated: boolean;
   initialEmail: HostedEmailSettingsInitialEmail | null;
+  /** Called when the member dismisses Privy's link modal without linking. */
+  onPrivyLinkAborted?: () => void;
   onSynced?: (payload: HostedEmailSyncResult) => Promise<void> | void;
 }) {
-  const { refreshUser } = useUser();
+  const { refreshUser, user: privyUser } = useUser();
+  const { ready: privyReady } = usePrivy();
   const linkedAccounts = toInitialEmailLinkedAccounts(input.initialEmail);
   const baseDisplayState = resolveHostedEmailSettingsDisplayState({
     linkedAccounts,
@@ -43,16 +46,29 @@ export function useHostedEmailSettingsController(input: {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [verifiedEmailOverride, setVerifiedEmailOverride] = useState<HostedPrivyEmailAccount | null>(null);
   const updateEmailErrorRef = useRef(false);
+  const updateEmailErrorCodeRef = useRef<string | null>(null);
   const { sendCode, state, verifyCode } = useUpdateEmail({
-    onError: () => {
+    onError: (error) => {
       updateEmailErrorRef.current = true;
+      updateEmailErrorCodeRef.current = typeof error === "string" ? error : null;
+      console.error("[hosted-email-settings] Privy update email error:", error);
     },
   });
+  const [isPrivyLinkModalActive, setIsPrivyLinkModalActive] = useState(false);
   const { linkEmail } = useLinkAccount({
-    onError: () => {
+    onError: (error) => {
+      setIsPrivyLinkModalActive(false);
+
+      // Closing the Privy modal is a cancel, not a failure.
+      if (error === "exited_link_flow") {
+        input.onPrivyLinkAborted?.();
+        return;
+      }
+
       setErrorMessage("We could not link that email address.");
     },
     onSuccess: (params) => {
+      setIsPrivyLinkModalActive(false);
       if (params.linkMethod === "email") {
         void handleLinkedEmailAccount({
           linkedUser: params.user,
@@ -71,9 +87,13 @@ export function useHostedEmailSettingsController(input: {
   const normalizedCurrentEmail = overrideDisplayState.normalizedCurrentEmail;
   const canManageEmail = input.authenticated;
   const canSendEmailUpdateCode = Boolean(effectiveCurrentEmail?.address);
+  // Privy's headless update-email flow refuses to send a code unless the
+  // Privy user already has an email linked; otherwise we must link instead,
+  // which Privy only supports through its own modal.
+  const canUpdatePrivyEmail = Boolean(privyUser?.email?.address);
   const isSendingCode = state.status === "sending-code";
   const isSubmittingCode = state.status === "submitting-code";
-  const isBusy = isSendingCode || isSubmittingCode || isSyncingEmailRoute;
+  const isBusy = !privyReady || isSendingCode || isSubmittingCode || isSyncingEmailRoute;
 
   async function requestCodeForEmail(nextEmailAddress: string) {
     setErrorMessage(null);
@@ -99,10 +119,14 @@ export function useHostedEmailSettingsController(input: {
 
     try {
       updateEmailErrorRef.current = false;
+      updateEmailErrorCodeRef.current = null;
       await sendCode({ newEmailAddress: nextEmailAddress });
 
       if (updateEmailErrorRef.current) {
-        throw new Error("We could not send a verification code to that email address.");
+        throw new Error(formatUpdateEmailErrorMessage(
+          "We could not send a verification code to that email address.",
+          updateEmailErrorCodeRef.current,
+        ));
       }
 
       setPendingEmailAddress(nextEmailAddress);
@@ -113,7 +137,7 @@ export function useHostedEmailSettingsController(input: {
   }
 
   async function handleSendCode(rawEmailAddress?: string) {
-    if (!canSendEmailUpdateCode) {
+    if (!canSendEmailUpdateCode || !canUpdatePrivyEmail) {
       handleLinkEmail();
       return;
     }
@@ -216,6 +240,7 @@ export function useHostedEmailSettingsController(input: {
       return;
     }
 
+    setIsPrivyLinkModalActive(true);
     linkEmail();
   }
 
@@ -293,6 +318,7 @@ export function useHostedEmailSettingsController(input: {
     emailAddress,
     errorMessage,
     isBusy,
+    isPrivyLinkModalActive,
     isSendingCode,
     isSubmittingCode,
     isSyncingEmailRoute,
@@ -301,6 +327,7 @@ export function useHostedEmailSettingsController(input: {
     successMessage,
     setCode,
     setEmailAddress,
+    handleLinkEmail,
     handleResendCode,
     handleSendCode,
     handleSyncVerifiedEmail,
@@ -310,6 +337,10 @@ export function useHostedEmailSettingsController(input: {
 }
 
 type HostedEmailPrivyUser = { linkedAccounts?: unknown } | null | undefined;
+
+function formatUpdateEmailErrorMessage(baseMessage: string, errorCode: string | null): string {
+  return errorCode ? `${baseMessage} (${errorCode})` : baseMessage;
+}
 
 function resolveHostedEmailSettingsDisplayStateFromUsers(input: {
   fallbackUser: HostedEmailPrivyUser;

--- a/apps/web/src/components/settings/hosted-email-settings-sections.tsx
+++ b/apps/web/src/components/settings/hosted-email-settings-sections.tsx
@@ -9,7 +9,8 @@ import { Label } from "@/src/components/ui/label";
 import type { HostedPrivyEmailAccount } from "@/src/lib/hosted-onboarding/privy-shared";
 import { isHostedPrivyEmailAccountVerified } from "@/src/lib/hosted-onboarding/privy-shared";
 
-import { ConnectedAccountCard, SettingsContactLink } from "./connected-account-card";
+import { ConnectedAccountCard } from "./connected-account-card";
+import { HostedEmailMurphContactDialog } from "./hosted-email-murph-contact-dialog";
 
 export function HostedEmailSettingsContent(props: {
   changeFlow?: boolean;
@@ -138,12 +139,10 @@ export function HostedEmailSettingsContent(props: {
       )}
 
       {currentEmail && murphEmailAddress && !props.changeFlow ? (
-        <SettingsContactLink
-          href={`mailto:${murphEmailAddress}`}
-          label={`Email Murph at ${murphEmailAddress}`}
-        >
-          Email Murph
-        </SettingsContactLink>
+        <HostedEmailMurphContactDialog
+          murphEmailAddress={murphEmailAddress}
+          userEmailAddress={currentEmail.address}
+        />
       ) : null}
 
       {canSendEmailUpdateCode ? (

--- a/apps/web/src/components/settings/hosted-email-settings-sections.tsx
+++ b/apps/web/src/components/settings/hosted-email-settings-sections.tsx
@@ -142,7 +142,7 @@ export function HostedEmailSettingsContent(props: {
           href={`mailto:${murphEmailAddress}`}
           label={`Email Murph at ${murphEmailAddress}`}
         >
-          Email {murphEmailAddress}
+          Email Murph
         </SettingsContactLink>
       ) : null}
 

--- a/apps/web/src/components/settings/hosted-settings-identity-link-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-settings-identity-link-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/src/components/ui/dialog";
 import type { HostedAccountSettingsSnapshot } from "@/src/lib/hosted-onboarding/account-settings-snapshot";
 
+import { HostedEmailPrivyLinkHandOff } from "./hosted-email-privy-link-hand-off";
 import { HostedEmailSettings } from "./hosted-email-settings";
 import { HostedPhoneSettings } from "./hosted-phone-settings";
 import { formatMaskedPhoneNumber } from "./hosted-settings-utils";
@@ -43,6 +44,21 @@ export function HostedSettingsIdentityLinkDialog({
     onOpenChange(false);
     router.refresh();
   };
+
+  // The server told us the Privy user has no email linked, which means the
+  // inline update form cannot work — Privy only supports linking an email
+  // through its own modal. Skip our dialog entirely and hand off to Privy's,
+  // so the member sees a single dialog instead of two stacked ones.
+  if (initialMode === "email" && account.email.privyEmailLinked === false && appId) {
+    return (
+      <HostedPrivyProvider appId={appId} clientId={clientId}>
+        <HostedEmailPrivyLinkHandOff
+          onAborted={() => onOpenChange(false)}
+          onSynced={closeAndRefresh}
+        />
+      </HostedPrivyProvider>
+    );
+  }
 
   return (
     <Dialog open onOpenChange={onOpenChange}>

--- a/apps/web/src/lib/hosted-onboarding/account-settings-snapshot.ts
+++ b/apps/web/src/lib/hosted-onboarding/account-settings-snapshot.ts
@@ -4,6 +4,7 @@ import { getPrisma } from "../prisma";
 import { createHostedMemberReplyAliasRouteFromLookupKey } from "./hosted-email-reply-alias";
 import { readHostedMemberSnapshot } from "./hosted-member-store";
 import {
+  extractHostedPrivyEmailAccount,
   extractHostedPrivyTelegramAccount,
   type PrivyLinkedAccountLike,
 } from "./privy-shared";
@@ -12,6 +13,13 @@ export interface HostedAccountSettingsSnapshot {
   email: {
     address: string | null;
     murphEmailAddress?: string | null;
+    /**
+     * Whether the server-approved Privy session has an email linked. Privy's
+     * headless update-email flow only works when this is true; otherwise the
+     * email must be linked through Privy's own modal. Null when the Privy
+     * session could not be confirmed server-side.
+     */
+    privyEmailLinked?: boolean | null;
     verifiedAt: string | null;
   };
   phone: {
@@ -57,12 +65,18 @@ export async function readHostedAccountSettingsSnapshot(input: {
   };
 }
 
-export function withServerApprovedTelegramUsernameHint(input: {
+export function withServerApprovedPrivyAccountHints(input: {
   serverApprovedPrivyLinkedAccounts?: PrivyLinkedAccountLike[] | null;
   snapshot: HostedAccountSettingsSnapshot;
 }): HostedAccountSettingsSnapshot {
   return {
     ...input.snapshot,
+    email: {
+      ...input.snapshot.email,
+      privyEmailLinked: input.serverApprovedPrivyLinkedAccounts
+        ? extractHostedPrivyEmailAccount(input.serverApprovedPrivyLinkedAccounts) !== null
+        : null,
+    },
     telegram: {
       ...input.snapshot.telegram,
       username: resolveHostedAccountTelegramUsername({

--- a/apps/web/test/account-settings-snapshot.test.ts
+++ b/apps/web/test/account-settings-snapshot.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", async () => {
 
 import {
   readHostedAccountSettingsSnapshot,
-  withServerApprovedTelegramUsernameHint,
+  withServerApprovedPrivyAccountHints,
   type HostedAccountSettingsSnapshot,
 } from "@/src/lib/hosted-onboarding/account-settings-snapshot";
 
@@ -115,7 +115,7 @@ describe("hosted account settings snapshot", () => {
   });
 
   it("adds a server-approved Privy Telegram username only when it matches the stored Telegram id", () => {
-    expect(withServerApprovedTelegramUsernameHint({
+    expect(withServerApprovedPrivyAccountHints({
       snapshot: makeAccountSettingsSnapshot({ telegramUserId: "456" }),
       serverApprovedPrivyLinkedAccounts: [
         {
@@ -133,7 +133,7 @@ describe("hosted account settings snapshot", () => {
   });
 
   it("does not add a server-approved Privy Telegram username from a different Telegram id", () => {
-    expect(withServerApprovedTelegramUsernameHint({
+    expect(withServerApprovedPrivyAccountHints({
       snapshot: makeAccountSettingsSnapshot({ telegramUserId: "456" }),
       serverApprovedPrivyLinkedAccounts: [
         {
@@ -146,6 +146,40 @@ describe("hosted account settings snapshot", () => {
       telegram: {
         telegramUserId: "456",
         username: null,
+      },
+    });
+  });
+
+  it("marks whether the server-approved Privy session has an email linked", () => {
+    expect(withServerApprovedPrivyAccountHints({
+      snapshot: makeAccountSettingsSnapshot({ telegramUserId: null }),
+      serverApprovedPrivyLinkedAccounts: [
+        {
+          address: "member@example.com",
+          type: "email",
+        },
+      ],
+    })).toMatchObject({
+      email: {
+        privyEmailLinked: true,
+      },
+    });
+
+    expect(withServerApprovedPrivyAccountHints({
+      snapshot: makeAccountSettingsSnapshot({ telegramUserId: null }),
+      serverApprovedPrivyLinkedAccounts: [],
+    })).toMatchObject({
+      email: {
+        privyEmailLinked: false,
+      },
+    });
+
+    expect(withServerApprovedPrivyAccountHints({
+      snapshot: makeAccountSettingsSnapshot({ telegramUserId: null }),
+      serverApprovedPrivyLinkedAccounts: null,
+    })).toMatchObject({
+      email: {
+        privyEmailLinked: null,
       },
     });
   });

--- a/apps/web/test/settings-email-settings.test.ts
+++ b/apps/web/test/settings-email-settings.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderClientComponent } from "./render-client-component";
 
 type LinkAccountCallbacks = {
-  onError?: () => void;
+  onError?: (error?: string) => void;
   onSuccess?: (params: {
     linkedAccount: unknown;
     linkMethod: string;
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   sendCode: vi.fn(),
   updateEmailCallbacks: null as UpdateEmailCallbacks | null,
   useLinkAccount: vi.fn(),
+  usePrivy: vi.fn(),
   useUpdateEmail: vi.fn(),
   useUser: vi.fn(),
   verifyCode: vi.fn(),
@@ -33,6 +34,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@privy-io/react-auth", () => ({
   useLinkAccount: mocks.useLinkAccount,
+  usePrivy: mocks.usePrivy,
   useUpdateEmail: mocks.useUpdateEmail,
   useUser: mocks.useUser,
 }));
@@ -65,9 +67,17 @@ describe("HostedEmailSettings", () => {
         verifyCode: mocks.verifyCode,
       };
     });
+    mocks.usePrivy.mockReturnValue({
+      ready: true,
+    });
+    // Privy's headless update-email flow requires an email on the Privy user;
+    // the default mock mirrors that so the inline send-code path is exercised.
     mocks.useUser.mockReturnValue({
       refreshUser: mocks.refreshUser,
-      user: null,
+      user: {
+        email: { address: "old@example.com" },
+        linkedAccounts: [],
+      },
     });
     mocks.verifyCode.mockResolvedValue({
       user: {
@@ -187,6 +197,86 @@ describe("HostedEmailSettings", () => {
     expect(mocks.sendCode).not.toHaveBeenCalled();
     expect(container.querySelector("input[data-input-otp]")).toBeNull();
     expect(container.textContent).not.toContain("We sent a code to");
+  });
+
+  describe("HostedEmailPrivyLinkHandOff", () => {
+    it("opens Privy's link modal once the client is ready without rendering Murph chrome", async () => {
+      mocks.useUser.mockReturnValue({
+        refreshUser: mocks.refreshUser,
+        user: {
+          linkedAccounts: [],
+        },
+      });
+      const onAborted = vi.fn();
+      const { HostedEmailPrivyLinkHandOff } = await import(
+        "@/src/components/settings/hosted-email-privy-link-hand-off"
+      );
+
+      const { cleanup, container } = await renderClientComponent(
+        createElement(HostedEmailPrivyLinkHandOff, {
+          onAborted,
+        }),
+        { requireButton: false },
+      );
+      cleanupRender = cleanup;
+
+      expect(mocks.linkEmail).toHaveBeenCalledTimes(1);
+      expect(mocks.sendCode).not.toHaveBeenCalled();
+      // Privy's modal is the only visible surface while it is open.
+      expect(container.textContent).toBe("");
+      expect(onAborted).not.toHaveBeenCalled();
+    });
+
+    it("shows a spinner instead of opening the modal while the Privy client boots", async () => {
+      mocks.usePrivy.mockReturnValue({
+        ready: false,
+      });
+      mocks.useUser.mockReturnValue({
+        refreshUser: mocks.refreshUser,
+        user: null,
+      });
+      const { HostedEmailPrivyLinkHandOff } = await import(
+        "@/src/components/settings/hosted-email-privy-link-hand-off"
+      );
+
+      const { cleanup, container } = await renderClientComponent(
+        createElement(HostedEmailPrivyLinkHandOff, {
+          onAborted: vi.fn(),
+        }),
+        { requireButton: false },
+      );
+      cleanupRender = cleanup;
+
+      expect(mocks.linkEmail).not.toHaveBeenCalled();
+      expect(container.textContent).toContain("Opening secure window");
+    });
+
+    it("closes the flow when the member dismisses Privy's modal", async () => {
+      mocks.useUser.mockReturnValue({
+        refreshUser: mocks.refreshUser,
+        user: {
+          linkedAccounts: [],
+        },
+      });
+      const onAborted = vi.fn();
+      const { HostedEmailPrivyLinkHandOff } = await import(
+        "@/src/components/settings/hosted-email-privy-link-hand-off"
+      );
+
+      const { cleanup } = await renderClientComponent(
+        createElement(HostedEmailPrivyLinkHandOff, {
+          onAborted,
+        }),
+        { requireButton: false },
+      );
+      cleanupRender = cleanup;
+
+      await act(async () => {
+        mocks.linkAccountCallbacks?.onError?.("exited_link_flow");
+      });
+
+      expect(onAborted).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("prefills an unverified server-provided email and lets the member send a verification code", async () => {

--- a/apps/web/test/settings-email-settings.test.ts
+++ b/apps/web/test/settings-email-settings.test.ts
@@ -137,10 +137,29 @@ describe("HostedEmailSettings", () => {
       }),
     );
 
-    assert.match(markup, /href="mailto:murph\+u2-private-alias@mail\.example\.test"/);
+    assert.match(markup, /href="mailto:murph\+u2-private-alias@mail\.example\.test\?subject=Hey%20Murph"/);
     assert.match(markup, /Email Murph at murph\+u2-private-alias@mail\.example\.test/);
     assert.match(markup, /Email Murph</);
     assert.doesNotMatch(markup, /Email murph\+u2-private-alias/);
+  });
+
+  it("offers a webmail chooser for the Murph email alias when the member uses a known webmail provider", async () => {
+    const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
+
+    const markup = renderToStaticMarkup(
+      createElement(HostedEmailSettings, {
+        authenticated: true,
+        initialEmail: {
+          address: "member@gmail.com",
+          verifiedAt: 1741194420,
+        },
+        murphEmailAddress: "murph+u2-private-alias@mail.example.test",
+      }),
+    );
+
+    // A webmail member gets a chooser button instead of a direct mailto link.
+    assert.match(markup, /aria-haspopup="dialog"[^>]*>Email Murph</);
+    assert.doesNotMatch(markup, /<a[^>]*href="mailto:[^"]*"[^>]*>Email Murph</);
   });
 
   it("does not use Privy client user state as the displayed email authority", async () => {

--- a/apps/web/test/settings-email-settings.test.ts
+++ b/apps/web/test/settings-email-settings.test.ts
@@ -138,7 +138,9 @@ describe("HostedEmailSettings", () => {
     );
 
     assert.match(markup, /href="mailto:murph\+u2-private-alias@mail\.example\.test"/);
-    assert.match(markup, /Email murph\+u2-private-alias@mail\.example\.test/);
+    assert.match(markup, /Email Murph at murph\+u2-private-alias@mail\.example\.test/);
+    assert.match(markup, /Email Murph</);
+    assert.doesNotMatch(markup, /Email murph\+u2-private-alias/);
   });
 
   it("does not use Privy client user state as the displayed email authority", async () => {

--- a/apps/web/test/settings-identity-link-dialog.test.tsx
+++ b/apps/web/test/settings-identity-link-dialog.test.tsx
@@ -74,6 +74,22 @@ vi.mock("@/src/components/settings/hosted-email-settings", () => ({
   },
 }));
 
+vi.mock("@/src/components/settings/hosted-email-privy-link-hand-off", () => ({
+  HostedEmailPrivyLinkHandOff(props: {
+    onAborted: () => void;
+    onSynced?: (payload: { mode: string }) => void;
+  }) {
+    return createElement(
+      "button",
+      {
+        type: "button",
+        onClick: () => props.onSynced?.({ mode: "email" }),
+      },
+      "Privy hand-off child",
+    );
+  },
+}));
+
 vi.mock("@/src/components/settings/hosted-telegram-card-settings", () => ({
   HostedTelegramCardSettings(props: {
     autoLink?: boolean;
@@ -142,6 +158,75 @@ describe("HostedSettingsIdentityLinkDialog", () => {
 
       expect(mocks.onOpenChange).toHaveBeenCalledWith(false);
       expect(mocks.refresh).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips the Murph dialog and hands off to Privy when the Privy user has no email", async () => {
+    const { HostedSettingsIdentityLinkDialog } = await import(
+      "@/src/components/settings/hosted-settings-identity-link-dialog"
+    );
+
+    const { cleanup, container } = await renderClientComponent(
+      createElement(HostedSettingsIdentityLinkDialog, {
+        account: {
+          ...makeAccountSnapshot(),
+          email: {
+            address: "member@example.com",
+            privyEmailLinked: false,
+            verifiedAt: null,
+          },
+        },
+        initialMode: "email",
+        onOpenChange: mocks.onOpenChange,
+      }),
+    );
+
+    try {
+      expect(container.querySelector("[data-dialog-open]")).toBeNull();
+      expect(container.textContent).toContain("Privy hand-off child");
+      expect(container.textContent).not.toContain("Link email child");
+
+      const handOffButton = Array.from(container.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.includes("Privy hand-off child"),
+      );
+
+      await act(async () => {
+        handOffButton?.dispatchEvent(new Event("click", { bubbles: true }));
+      });
+
+      expect(mocks.onOpenChange).toHaveBeenCalledWith(false);
+      expect(mocks.refresh).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps the inline email dialog when the Privy user already has an email", async () => {
+    const { HostedSettingsIdentityLinkDialog } = await import(
+      "@/src/components/settings/hosted-settings-identity-link-dialog"
+    );
+
+    const { cleanup, container } = await renderClientComponent(
+      createElement(HostedSettingsIdentityLinkDialog, {
+        account: {
+          ...makeAccountSnapshot(),
+          email: {
+            address: "member@example.com",
+            privyEmailLinked: true,
+            verifiedAt: "2026-05-02T00:00:00.000Z",
+          },
+        },
+        initialMode: "email",
+        onOpenChange: mocks.onOpenChange,
+      }),
+    );
+
+    try {
+      expect(container.querySelector('[data-dialog-open="true"]')).toBeTruthy();
+      expect(container.textContent).toContain("Link email child");
+      expect(container.textContent).not.toContain("Privy hand-off child");
     } finally {
       await cleanup();
     }

--- a/apps/web/test/settings-page.test.ts
+++ b/apps/web/test/settings-page.test.ts
@@ -38,7 +38,7 @@ const mocks = vi.hoisted(() => ({
   readHostedAccountSettingsSnapshot: vi.fn(),
   readHostedMemberStripeBillingRef: vi.fn(),
   readHostedMemberRoutingState: vi.fn(),
-  withServerApprovedTelegramUsernameHint: vi.fn((input: {
+  withServerApprovedPrivyAccountHints: vi.fn((input: {
     serverApprovedPrivyLinkedAccounts?: unknown;
     snapshot: unknown;
   }) => input.snapshot),
@@ -72,7 +72,7 @@ vi.mock("@/src/lib/hosted-onboarding/hosted-member-billing-store", () => ({
 
 vi.mock("@/src/lib/hosted-onboarding/account-settings-snapshot", () => ({
   readHostedAccountSettingsSnapshot: mocks.readHostedAccountSettingsSnapshot,
-  withServerApprovedTelegramUsernameHint: mocks.withServerApprovedTelegramUsernameHint,
+  withServerApprovedPrivyAccountHints: mocks.withServerApprovedPrivyAccountHints,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-session", () => ({
@@ -242,7 +242,7 @@ test("SettingsPage reads the app session and persisted account settings into the
     memberId: "member_123",
   });
   expect(mocks.getHostedPrivySession).toHaveBeenCalledTimes(1);
-  expect(mocks.withServerApprovedTelegramUsernameHint).toHaveBeenCalledWith({
+  expect(mocks.withServerApprovedPrivyAccountHints).toHaveBeenCalledWith({
     snapshot: accountSnapshot,
     serverApprovedPrivyLinkedAccounts: [
       {
@@ -318,7 +318,7 @@ test("SettingsPage ignores Privy Telegram display hints from a stale Privy sessi
 
   renderToStaticMarkup(await SettingsPage());
 
-  expect(mocks.withServerApprovedTelegramUsernameHint).toHaveBeenCalledWith({
+  expect(mocks.withServerApprovedPrivyAccountHints).toHaveBeenCalledWith({
     snapshot: accountSnapshot,
     serverApprovedPrivyLinkedAccounts: null,
   });

--- a/apps/web/test/sidebar-chat-contact-dialog.test.tsx
+++ b/apps/web/test/sidebar-chat-contact-dialog.test.tsx
@@ -98,7 +98,7 @@ test("SidebarChatWithMurphContactDialog opens connected contact links", async ()
     );
     assert.equal(links[1]?.getAttribute("target"), "_blank");
     assert.equal(links[1]?.getAttribute("rel"), "noopener noreferrer");
-    assert.match(links[0]?.getAttribute("class") ?? "", /focus-visible:ring-2/);
+    assert.match(links[0]?.getAttribute("class") ?? "", /focus-visible:after:ring-2/);
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
## Summary
- **Chat with Murph dialog**: truncate the long email alias to one line, make the whole card tappable with a chevron affordance, demote the copy button to a secondary action
- **Email linking bug**: Privy's headless update-email flow throws `unknown_auth_error` when the Privy user has no email linked, so those members could never receive a verification code from the settings dialog
- **Email linking UX**: the settings page now computes `email.privyEmailLinked` server-side from the fresh Privy session (decorator renamed to `withServerApprovedPrivyAccountHints`); when the Privy user has no email, the identity-link dialog skips Murph chrome entirely and hands off to Privy's modal (the only way Privy supports linking a first email) via a new `HostedEmailPrivyLinkHandOff` component — one dialog on screen at a time, dismissing Privy's modal cancels the flow
- Controller surfaces Privy's error code in send failures instead of swallowing it

## Test plan
- [x] `settings-email-settings` (incl. new hand-off component tests: opens modal once ready, boot spinner, dismiss-as-cancel)
- [x] `settings-identity-link-dialog` (hand-off vs inline-form routing on `privyEmailLinked`)
- [x] `account-settings-snapshot` (email hint true/false/null)
- [x] `settings-page`, `sidebar-chat-contact-dialog`, `sidebar-chat-action`
- [x] Manually verified locally: link email from settings lands directly in Privy's modal; verified email then syncs and the page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783701980&installation_id=127572939&pr_number=113&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F113&signature=170d5ab1b009b2a262895caae092ea6503cf5209ee403521dbf97f4f7c725879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->