### PR TITLE
Make device imports idempotent on externalRef; stabilize Junction import accountId

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-10-device-import-externalref-idempotency.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-device-import-externalref-idempotency.md
@@ -1,0 +1,88 @@
+# Device Import ExternalRef Idempotency
+
+Created: 2026-06-10
+Status: completed
+
+## Problem
+
+Hosted Junction imports duplicate the same provider records massively (one WHOOP
+workout appeared 11×; one sleep session 143×; ~4,100 duplicate events across a
+hosted vault). Root cause chain, proven against hosted raw-ingest receipts and
+manifests:
+
+1. `importDeviceBatch` event identity is a deterministic content hash that
+   includes `accountId` (`packages/core/src/mutations.ts`,
+   `normalizeDeviceEventInputs`). Dedupe is "exact id already in target shard".
+2. Junction's import `accountId` (`jxn_acct_*`) is derived from the local
+   device-sync account row id (`buildJunctionImportAccountId(context.account.id)`),
+   which is a random `dsa_*` id minted on registration.
+3. The device-sync SQLite store is `machine_local` and hosted runners are
+   ephemeral, so every cold start re-registers the account with a fresh row id
+   → fresh `jxn_acct_*` → fresh event ids → every overlapping trailing-window
+   poll re-appends already-imported events.
+
+`agent-docs/operations/device-sync-ingestion-invariants.md` invariant 4 says
+"Merge is idempotent on `externalRef.resourceId`. Core upserts on the record's
+own resource id" — push/pull overlap safety (invariants 2–3) depends on it, but
+core never consulted `externalRef`. The duplicate events all share an identical
+stable `externalRef`. This change makes invariant 4 actually true.
+
+## Changes
+
+1. `packages/core`: in `importDeviceBatch`, reconcile prepared device events
+   against the latest live ledger records by `externalRef`
+   (system/resourceType/resourceId/facet) within the target shards before
+   building the append plan:
+   - identical content (ignoring `id`, `rawRefs`, `lifecycle`, `recordedAt`) →
+     skip append;
+   - changed content → append an event-spine revision reusing the existing
+     event id (append-only preserved, reads collapse via spine);
+   - no match / no `externalRef` → current behavior.
+2. `packages/device-syncd`: derive `buildJunctionImportAccountId` from the
+   stable provider `externalAccountId` instead of the per-registration local
+   row id, so import identity survives hosted cold starts.
+3. Tests for re-import idempotency across differing accountId/raw paths,
+   spine-revision update on changed content, and unchanged no-externalRef
+   behavior.
+
+## Decisions from deep review
+
+- `externalRef.version` is NOT part of the reconcile identity: WHOOP/Oura/
+  Strava stamp it from the record's mutable `updated_at`, so keying on it would
+  mint a new event per provider rescore. Version still participates in content
+  equality, so version bumps with changed data become spine revisions.
+- Supersede revision numbers come from the max revision across ALL stored rows
+  of the matched event id (not just ref-bearing rows), so a user edit that did
+  not echo the externalRef can never collide with an import revision.
+- Device events are provider-owned: a changed provider re-delivery supersedes
+  with pure provider content and may drop user-added fields on that event.
+  Accepted explicitly; durable user context belongs in notes/journal, not in
+  edits to imported device events.
+
+## Accepted residual risks
+
+- Cross-month occurredAt drift on a re-import misses the shard-scoped match
+  and duplicates once.
+- The Junction accountId migration changes deterministic ids once: junction
+  samples (no externalRef reconcile) can duplicate one generation in
+  overlapping windows post-deploy, and previously deleted junction events can
+  resurrect once under a new id. Both converge immediately and fold into the
+  deferred duplicate cleanup.
+- Stored rows that fail strict contract parse are skipped by the reconcile
+  index (lenient, unlike findEventByExternalRef); a legacy unparseable row can
+  yield one self-healing duplicate.
+- Supersede revision numbering is shard-local: a user edit that moves a device
+  event's occurredAt to a different month writes its revision to another shard,
+  and a later changed re-delivery can append a colliding revision number in the
+  original shard (read-side winner falls to the recordedAt tiebreak).
+- Each import reads target event shards twice (reconcile index + append-plan
+  id scan); acceptable at monthly-shard sizes.
+
+## Out of scope
+
+- One-time hosted vault cleanup of existing duplicates (runs as vault-only data
+  work via existing delete/spine primitives, not a repo change).
+- Sample-stream dedupe (Junction summary resources emit events; revisit if a
+  provider emits duplicated samples).
+Updated: 2026-06-10
+Completed: 2026-06-10

--- a/agent-docs/operations/device-sync-ingestion-invariants.md
+++ b/agent-docs/operations/device-sync-ingestion-invariants.md
@@ -47,10 +47,12 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
    harmless, since invariant 4 makes the extra fetch idempotent and Junction
    reads are unmetered.)
 
-4. **Merge is idempotent on `externalRef.resourceId`.** Core upserts on the
+4. **Merge is idempotent on `externalRef.resourceId`.** Core reconciles on the
    record's own resource id (the explicit Junction id for summaries;
-   resource/source/timestamp for timeseries). Push-then-pull writes overwrite
-   the same row, so importing a record more than once — or via a different path —
+   resource/source/timestamp for timeseries). Push-then-pull re-imports of
+   identical content are skipped, and changed content appends an event-spine
+   revision of the same event id (read-side revision collapse keeps one live
+   record), so importing a record more than once — or via a different path —
    is overlap-free. This is what makes invariants 2 and 3 safe, and it is why an
    import-vs-skip optimization is unnecessary: re-fetching is cheap and correct,
    not a correctness risk.

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -53,7 +53,13 @@ import { pathExists, readUtf8File, writeVaultTextFile } from "./fs.ts";
 import { parseFrontmatterDocument, stringifyFrontmatterDocument } from "./frontmatter.ts";
 import { deterministicContractId, generateRecordId } from "./ids.ts";
 import { readJsonlRecords, toMonthlyShardRelativePath } from "./jsonl.ts";
-import { buildEventSpineLifecycle, eventSpineRevision } from "./history/event-spine.ts";
+import {
+  buildEventSpineLifecycle,
+  collapseEventSpineEntries,
+  eventSpineRevision,
+  selectLatestEventSpineEntry,
+  type EventSpineEntry,
+} from "./history/event-spine.ts";
 import { loadEventLedgerShardsById, selectLatestMatchedEvent } from "./domains/events/ledger.ts";
 import {
   normalizeMealNutrition,
@@ -1069,6 +1075,7 @@ async function buildJsonlAppendPlan<RecordType extends { id: string }>(
   entries: readonly PreparedJsonlEntry<RecordType>[],
   options: {
     dedupeWithinPlan?: boolean;
+    forceAppendIds?: ReadonlySet<string>;
   } = {},
 ): Promise<JsonlAppendPlan> {
   assertCanonicalWriteLockScope(vaultRoot);
@@ -1084,7 +1091,7 @@ async function buildJsonlAppendPlan<RecordType extends { id: string }>(
 
     existingIdsByShard.set(entry.relativePath, existingIds);
 
-    if (existingIds.has(entry.record.id)) {
+    if (existingIds.has(entry.record.id) && !options.forceAppendIds?.has(entry.record.id)) {
       continue;
     }
 
@@ -1457,6 +1464,201 @@ function isImplicitDeviceRawRefFallbackRole(role: string): boolean {
   return !role.startsWith("wearable-raw-receipt:")
     && !role.startsWith("wearable-raw-envelope:")
     && !role.startsWith("wearable-canonical-records:");
+}
+
+interface DeviceEventExternalRefReconciliation {
+  appendEntries: PreparedJsonlEntry<EventRecord>[];
+  records: EventRecord[];
+  forceAppendIds: ReadonlySet<string>;
+  skippedDuplicateCount: number;
+  supersededCount: number;
+}
+
+// externalRef.version is intentionally NOT part of the reconcile identity:
+// direct providers (WHOOP, Oura, Strava) stamp it from the record's mutable
+// updated_at, so a provider-side rescore would change the key and mint a new
+// event instead of superseding the existing one. Version still participates in
+// content equality, so a version bump with changed data becomes a spine
+// revision of the same event.
+function deviceEventExternalRefKey(externalRef: ExternalRef): string {
+  return stableStringify({
+    system: externalRef.system,
+    resourceType: externalRef.resourceType,
+    resourceId: externalRef.resourceId,
+    facet: externalRef.facet ?? null,
+  });
+}
+
+function deviceEventContentKey(record: EventRecord): string {
+  const {
+    id: _id,
+    rawRefs: _rawRefs,
+    lifecycle: _lifecycle,
+    recordedAt: _recordedAt,
+    ...content
+  } = record;
+  return stableStringify(content);
+}
+
+interface DeviceEventShardIndex {
+  latestByRefKey: Map<string, EventRecord>;
+  maxRevisionById: Map<string, number>;
+}
+
+async function indexLatestDeviceEventsByExternalRef(
+  vaultRoot: string,
+  relativePath: string,
+): Promise<DeviceEventShardIndex> {
+  const latestByRefKey = new Map<string, EventRecord>();
+  const maxRevisionById = new Map<string, number>();
+  const resolved = resolveVaultPath(vaultRoot, relativePath);
+
+  if (!(await pathExists(resolved.absolutePath))) {
+    return { latestByRefKey, maxRevisionById };
+  }
+
+  const grouped = new Map<string, EventSpineEntry<EventRecord>[]>();
+
+  for (const raw of await readJsonlRecords({ vaultRoot, relativePath })) {
+    const parsed = safeParseContract(eventRecordSchema, raw);
+
+    if (!parsed.success) {
+      continue;
+    }
+
+    // Track the highest revision per event id across ALL rows, including
+    // revisions without an externalRef (e.g. a user edit through upsertEvent
+    // that did not echo the ref), so a supersede never reuses a taken
+    // revision number.
+    maxRevisionById.set(
+      parsed.data.id,
+      Math.max(maxRevisionById.get(parsed.data.id) ?? 0, eventSpineRevision(parsed.data)),
+    );
+
+    if (!parsed.data.externalRef) {
+      continue;
+    }
+
+    const refKey = deviceEventExternalRefKey(parsed.data.externalRef);
+    const group = grouped.get(refKey) ?? [];
+    group.push({ relativePath, record: parsed.data });
+    grouped.set(refKey, group);
+  }
+
+  for (const [refKey, group] of grouped) {
+    // Collapse spine revisions per event id first; raw revision counts are not
+    // comparable across different event ids (a deleted duplicate's tombstone
+    // must not outrank a surviving live copy of the same provider record).
+    // The collapse drops ids whose latest revision is deleted, so a fully
+    // tombstoned ref yields no match and re-imports append a fresh event,
+    // bounded by the deterministic-id skip for identical content.
+    const latest = selectLatestEventSpineEntry(collapseEventSpineEntries(group));
+
+    if (latest) {
+      latestByRefKey.set(refKey, latest.record);
+    }
+  }
+
+  return { latestByRefKey, maxRevisionById };
+}
+
+// Device-sync ingestion invariant 4: merge is idempotent on the record's own
+// externalRef, so overlapping push/pull re-imports of the same provider record
+// must not mint new events. Re-imports with identical content (ignoring
+// per-import identity such as id, rawRefs, lifecycle, and recordedAt) are
+// skipped; changed content appends an event-spine revision onto the existing
+// event id instead of a new event.
+async function reconcileDeviceEventEntriesByExternalRef(
+  vaultRoot: string,
+  entries: readonly PreparedJsonlEntry<EventRecord>[],
+): Promise<DeviceEventExternalRefReconciliation> {
+  assertCanonicalWriteLockScope(vaultRoot);
+
+  const indexByShard = new Map<string, DeviceEventShardIndex>();
+  const appendEntries: PreparedJsonlEntry<EventRecord>[] = [];
+  const records: EventRecord[] = [];
+  const forceAppendIds = new Set<string>();
+  let skippedDuplicateCount = 0;
+  let supersededCount = 0;
+
+  for (const entry of entries) {
+    const externalRef = entry.record.externalRef;
+
+    if (!externalRef) {
+      appendEntries.push(entry);
+      records.push(entry.record);
+      continue;
+    }
+
+    const shardIndex =
+      indexByShard.get(entry.relativePath) ??
+      (await indexLatestDeviceEventsByExternalRef(vaultRoot, entry.relativePath));
+
+    indexByShard.set(entry.relativePath, shardIndex);
+
+    const refKey = deviceEventExternalRefKey(externalRef);
+    const latest = shardIndex.latestByRefKey.get(refKey);
+
+    if (!latest) {
+      shardIndex.latestByRefKey.set(refKey, entry.record);
+      appendEntries.push(entry);
+      records.push(entry.record);
+      continue;
+    }
+
+    if (deviceEventContentKey(latest) === deviceEventContentKey(entry.record)) {
+      skippedDuplicateCount += 1;
+      records.push(latest);
+      continue;
+    }
+
+    const revision = Math.max(
+      eventSpineRevision(latest),
+      shardIndex.maxRevisionById.get(latest.id) ?? 0,
+    ) + 1;
+    const superseding: EventRecord = {
+      ...entry.record,
+      id: latest.id,
+      lifecycle: buildEventSpineLifecycle(revision),
+    };
+
+    forceAppendIds.add(latest.id);
+    shardIndex.latestByRefKey.set(refKey, superseding);
+    shardIndex.maxRevisionById.set(latest.id, revision);
+    appendEntries.push({ relativePath: entry.relativePath, record: superseding });
+    records.push(superseding);
+    supersededCount += 1;
+  }
+
+  return {
+    appendEntries,
+    records,
+    forceAppendIds,
+    skippedDuplicateCount,
+    supersededCount,
+  };
+}
+
+function buildDeviceBatchAuditSummary(input: {
+  provider: string;
+  eventCount: number;
+  sampleCount: number;
+  skippedDuplicateCount: number;
+  supersededCount: number;
+}): string {
+  const dedupeNotes: string[] = [];
+
+  if (input.skippedDuplicateCount > 0) {
+    dedupeNotes.push(`${input.skippedDuplicateCount} duplicate event(s) skipped by externalRef`);
+  }
+
+  if (input.supersededCount > 0) {
+    dedupeNotes.push(`${input.supersededCount} event(s) updated in place by externalRef`);
+  }
+
+  const dedupeSuffix = dedupeNotes.length > 0 ? ` (${dedupeNotes.join(", ")})` : "";
+
+  return `Imported ${input.provider} device batch with ${input.eventCount} event(s) and ${input.sampleCount} sample(s)${dedupeSuffix}.`;
 }
 
 function prepareDeviceSampleEntries(
@@ -2046,13 +2248,21 @@ export async function importDeviceBatch({
     rawArtifacts,
     provenance,
   });
-  const eventAppendPlan = await buildJsonlAppendPlan(vaultRoot, deviceBatchPlan.preparedEvents, {
+  const eventReconciliation = await reconcileDeviceEventEntriesByExternalRef(
+    vaultRoot,
+    deviceBatchPlan.preparedEvents,
+  );
+  const eventAppendPlan = await buildJsonlAppendPlan(vaultRoot, eventReconciliation.appendEntries, {
     dedupeWithinPlan: true,
+    forceAppendIds: eventReconciliation.forceAppendIds,
   });
   const sampleAppendPlan = await buildJsonlAppendPlan(vaultRoot, deviceBatchPlan.preparedSamples, {
     dedupeWithinPlan: true,
   });
-  const eventRecords = deviceBatchPlan.preparedEvents.map((entry) => entry.record);
+  const eventRecords = eventReconciliation.records;
+  const eventTargetShardPaths = [
+    ...new Set(deviceBatchPlan.preparedEvents.map((entry) => entry.relativePath)),
+  ].sort();
   const sampleRecords = deviceBatchPlan.preparedSamples.map((entry) => entry.record);
 
   return runCanonicalWrite({
@@ -2119,7 +2329,13 @@ export async function importDeviceBatch({
         batch,
         action: "device_import",
         commandName: "core.importDeviceBatch",
-        summary: `Imported ${deviceBatchPlan.provider} device batch with ${eventRecords.length} event(s) and ${sampleRecords.length} sample(s).`,
+        summary: buildDeviceBatchAuditSummary({
+          provider: deviceBatchPlan.provider,
+          eventCount: eventRecords.length,
+          sampleCount: sampleRecords.length,
+          skippedDuplicateCount: eventReconciliation.skippedDuplicateCount,
+          supersededCount: eventReconciliation.supersededCount,
+        }),
         occurredAt: deviceBatchPlan.importedAt,
         files: touchedPaths,
         targetIds: [deviceBatchPlan.importId],
@@ -2132,7 +2348,7 @@ export async function importDeviceBatch({
         importedAt: deviceBatchPlan.importedAt,
         events: eventRecords,
         samples: sampleRecords,
-        eventShardPaths: eventAppendPlan.targetShardPaths,
+        eventShardPaths: eventTargetShardPaths,
         sampleShardPaths: sampleAppendPlan.targetShardPaths,
         rawArtifacts: deviceBatchPlan.preparedRawArtifacts.map((artifact) => artifact.raw),
         auditPath: audit.relativePath,

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -7,6 +7,8 @@ import { test } from "vitest";
 import type { AuditRecord, EventRecord, SampleRecord } from "@murphai/contracts";
 
 import {
+  deleteEvent,
+  findEventByExternalRef,
   importDeviceBatch,
   initializeVault,
   readJsonlRecords,
@@ -1572,4 +1574,640 @@ test("raw artifact helpers normalize category paths and inferred media types", (
     "raw/integrations/whoop/2026/03/xfm_01JQ9R7WF97M1WAB2B4QF2Q1AB/payload.json",
   );
   assert.equal(explicitInline.mediaType, "application/json");
+});
+
+function buildJunctionStyleWorkoutEvent(overrides: {
+  recordedAt?: string;
+  durationMinutes?: number;
+  resourceId?: string;
+} = {}) {
+  return {
+    kind: "activity_session",
+    occurredAt: "2026-06-03T19:55:00.000Z",
+    recordedAt: overrides.recordedAt ?? "2026-06-03T20:30:00.000Z",
+    title: "Running",
+    externalRef: {
+      system: "junction",
+      resourceType: "junction-whoop-v2-workouts",
+      resourceId: overrides.resourceId ?? "workouts-393350f4b34bad8c",
+      facet: "session",
+    },
+    fields: {
+      durationMinutes: overrides.durationMinutes ?? 34,
+      activityType: "running",
+      workout: {
+        sourceApp: "whoop",
+        sourceWorkoutId: "whoop-workout-1",
+        startedAt: "2026-06-03T19:55:00.000Z",
+        endedAt: "2026-06-03T20:29:00.000Z",
+        exercises: [],
+      },
+    },
+  } as const;
+}
+
+test("importDeviceBatch dedupes overlapping re-imports by externalRef across unstable accountIds", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-externalref-dedupe");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const buildInput = (accountId: string, importedAt: string) => ({
+    vaultRoot,
+    provider: "junction",
+    accountId,
+    importedAt,
+    events: [buildJunctionStyleWorkoutEvent()],
+    rawArtifacts: [
+      {
+        role: "junction-summary-workouts",
+        fileName: "junction-summary-workouts.json",
+        content: { id: "whoop-workout-1", sport: "running" },
+      },
+    ],
+  });
+
+  const first = await importDeviceBatch(buildInput("jxn_acct_cold_start_a", "2026-06-03T21:00:00.000Z"));
+  const second = await importDeviceBatch(buildInput("jxn_acct_cold_start_b", "2026-06-04T21:00:00.000Z"));
+  const third = await importDeviceBatch(buildInput("jxn_acct_cold_start_c", "2026-06-05T21:00:00.000Z"));
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+  const auditRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: second.auditPath,
+  })) as AuditRecord[];
+
+  assert.equal(eventRecords.length, 1);
+  assert.equal(first.events.length, 1);
+  assert.equal(second.events.length, 1);
+  assert.equal(third.events.length, 1);
+  assert.equal(second.events[0]?.id, first.events[0]?.id);
+  assert.equal(third.events[0]?.id, first.events[0]?.id);
+  assert.ok(first.eventShardPaths.length > 0);
+  assert.deepEqual(second.eventShardPaths, first.eventShardPaths);
+  assert.deepEqual(third.eventShardPaths, first.eventShardPaths);
+  assert.ok(
+    auditRecords.some((record) =>
+      record.summary.includes("1 duplicate event(s) skipped by externalRef"),
+    ),
+    "expected the device import audit summary to surface externalRef dedupe",
+  );
+});
+
+test("importDeviceBatch updates changed provider records in place by externalRef", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-externalref-update");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const second = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [
+      buildJunctionStyleWorkoutEvent({
+        recordedAt: "2026-06-04T07:00:00.000Z",
+        durationMinutes: 36,
+      }),
+    ],
+  });
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  assert.equal(eventRecords.length, 2);
+  assert.equal(second.events.length, 1);
+  assert.equal(second.events[0]?.id, first.events[0]?.id);
+  assert.equal(second.events[0]?.lifecycle?.revision, 2);
+  const latest = eventRecords.find((record) => record.lifecycle?.revision === 2);
+  assert.equal(
+    (latest as { durationMinutes?: number } | undefined)?.durationMinutes,
+    36,
+  );
+});
+
+test("importDeviceBatch keeps deterministic content identity for events without externalRef", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-no-externalref");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const buildInput = (accountId: string) => ({
+    vaultRoot,
+    provider: "junction",
+    accountId,
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [
+      {
+        kind: "note",
+        occurredAt: "2026-06-03T19:55:00.000Z",
+        recordedAt: "2026-06-03T20:30:00.000Z",
+        note: "no external ref",
+      },
+    ],
+  });
+
+  const first = await importDeviceBatch(buildInput("jxn_acct_same"));
+  const second = await importDeviceBatch(buildInput("jxn_acct_same"));
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  assert.equal(eventRecords.length, 1);
+  assert.equal(second.events[0]?.id, first.events[0]?.id);
+});
+
+test("importDeviceBatch collapses in-batch duplicates sharing one externalRef", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-inbatch-dedupe");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const result = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent(), buildJunctionStyleWorkoutEvent()],
+  });
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: result.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  assert.equal(eventRecords.length, 1);
+  assert.equal(result.events.length, 2);
+  assert.equal(result.events[0]?.id, result.events[1]?.id);
+});
+
+test("importDeviceBatch chains repeated updates into successive spine revisions and reads collapse to latest", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-externalref-revision-chain");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const importAt = (importedAt: string, durationMinutes: number) =>
+    importDeviceBatch({
+      vaultRoot,
+      provider: "junction",
+      accountId: "jxn_acct_stable",
+      importedAt,
+      events: [
+        buildJunctionStyleWorkoutEvent({
+          recordedAt: importedAt,
+          durationMinutes,
+        }),
+      ],
+    });
+
+  const first = await importAt("2026-06-03T21:00:00.000Z", 34);
+  const second = await importAt("2026-06-04T21:00:00.000Z", 36);
+  const third = await importAt("2026-06-05T21:00:00.000Z", 38);
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  assert.equal(eventRecords.length, 3);
+  assert.equal(second.events[0]?.id, first.events[0]?.id);
+  assert.equal(third.events[0]?.id, first.events[0]?.id);
+  assert.equal(second.events[0]?.lifecycle?.revision, 2);
+  assert.equal(third.events[0]?.lifecycle?.revision, 3);
+  assert.deepEqual(
+    eventRecords.map((record) => record.lifecycle?.revision ?? 1),
+    [1, 2, 3],
+  );
+
+  const latest = await findEventByExternalRef({
+    vaultRoot,
+    system: "junction",
+    resourceType: "junction-whoop-v2-workouts",
+    resourceId: "workouts-393350f4b34bad8c",
+    facet: "session",
+  });
+
+  assert.equal(latest?.id, first.events[0]?.id);
+  assert.equal(latest?.lifecycle?.revision, 3);
+  assert.equal((latest as { durationMinutes?: number } | null)?.durationMinutes, 38);
+});
+
+test("importDeviceBatch does not dedupe distinct facets sharing one externalRef resourceId", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-externalref-facets");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const buildFacetObservation = (facet: string, value: number) => ({
+    kind: "observation" as const,
+    occurredAt: "2026-06-03T07:30:00.000Z",
+    recordedAt: "2026-06-03T07:30:00.000Z",
+    title: `Junction ${facet}`,
+    externalRef: {
+      system: "junction",
+      resourceType: "junction-whoop-v2-recovery",
+      resourceId: "recovery-1",
+      facet,
+    },
+    fields: {
+      metric: facet,
+      value,
+      unit: "%",
+    },
+  });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [
+      buildFacetObservation("recovery-score", 67),
+      buildFacetObservation("skin-temp-deviation", 3),
+    ],
+  });
+  const second = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [
+      buildFacetObservation("recovery-score", 67),
+      buildFacetObservation("skin-temp-deviation", 4),
+    ],
+  });
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  assert.equal(first.events.length, 2);
+  assert.notEqual(first.events[0]?.id, first.events[1]?.id);
+  // recovery-score is an unchanged duplicate, skin-temp-deviation is a revision.
+  assert.equal(eventRecords.length, 3);
+  assert.equal(second.events[0]?.id, first.events[0]?.id);
+  assert.equal(second.events[0]?.lifecycle?.revision ?? 1, 1);
+  assert.equal(second.events[1]?.id, first.events[1]?.id);
+  assert.equal(second.events[1]?.lifecycle?.revision, 2);
+  assert.equal(
+    eventRecords.filter((record) => record.externalRef?.facet === "recovery-score").length,
+    1,
+  );
+  assert.equal(
+    eventRecords.filter((record) => record.externalRef?.facet === "skin-temp-deviation").length,
+    2,
+  );
+});
+
+test("importDeviceBatch handles mixed duplicate, changed, and new events in one batch", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-externalref-mixed");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [
+      buildJunctionStyleWorkoutEvent({ resourceId: "workouts-aaa" }),
+      buildJunctionStyleWorkoutEvent({ resourceId: "workouts-bbb" }),
+    ],
+  });
+  const second = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [
+      // Unchanged duplicate of workouts-aaa.
+      buildJunctionStyleWorkoutEvent({ resourceId: "workouts-aaa" }),
+      // Changed content for workouts-bbb.
+      buildJunctionStyleWorkoutEvent({ resourceId: "workouts-bbb", durationMinutes: 41 }),
+      // Brand-new provider record.
+      buildJunctionStyleWorkoutEvent({ resourceId: "workouts-ccc" }),
+    ],
+  });
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+  const auditRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: second.auditPath,
+  })) as AuditRecord[];
+
+  // 2 originals + 1 revision of workouts-bbb + 1 new workouts-ccc.
+  assert.equal(eventRecords.length, 4);
+  assert.equal(second.events.length, 3);
+  assert.equal(second.events[0]?.id, first.events[0]?.id);
+  assert.equal(second.events[0]?.lifecycle?.revision ?? 1, 1);
+  assert.equal(second.events[1]?.id, first.events[1]?.id);
+  assert.equal(second.events[1]?.lifecycle?.revision, 2);
+  assert.notEqual(second.events[2]?.id, first.events[0]?.id);
+  assert.notEqual(second.events[2]?.id, first.events[1]?.id);
+  assert.equal(second.events[2]?.lifecycle, undefined);
+
+  const mixedSummary = auditRecords.find(
+    (record) =>
+      record.action === "device_import" &&
+      record.summary.includes("duplicate event(s) skipped by externalRef"),
+  );
+  assert.ok(mixedSummary, "expected mixed-batch audit summary to surface dedupe counts");
+  assert.ok(mixedSummary.summary.includes("1 duplicate event(s) skipped by externalRef"));
+  assert.ok(mixedSummary.summary.includes("1 event(s) updated in place by externalRef"));
+});
+
+test("importDeviceBatch does not resurrect a deleted event from an identical re-import", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-externalref-deleted-replay");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const buildInput = () => ({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+
+  const first = await importDeviceBatch(buildInput());
+  const eventId = first.events[0]?.id;
+  assert.ok(eventId);
+  await deleteEvent({ vaultRoot, eventId });
+
+  // Overlapping trailing-window polls re-send the identical provider payload.
+  await importDeviceBatch(buildInput());
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  // Append-only ledger holds the original plus its tombstone, and nothing else.
+  assert.equal(eventRecords.length, 2);
+  assert.equal(eventRecords[1]?.id, eventId);
+  assert.equal(eventRecords[1]?.lifecycle?.state, "deleted");
+
+  const latest = await findEventByExternalRef({
+    vaultRoot,
+    system: "junction",
+    resourceType: "junction-whoop-v2-workouts",
+    resourceId: "workouts-393350f4b34bad8c",
+    facet: "session",
+  });
+  assert.equal(latest, null);
+});
+
+test("importDeviceBatch appends a new event when changed content arrives after a deletion", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-externalref-deleted-changed");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const originalId = first.events[0]?.id;
+  assert.ok(originalId);
+  await deleteEvent({ vaultRoot, eventId: originalId });
+
+  const second = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [
+      buildJunctionStyleWorkoutEvent({
+        recordedAt: "2026-06-04T07:00:00.000Z",
+        durationMinutes: 41,
+      }),
+    ],
+  });
+
+  const eventRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  // The tombstoned spine is never reused: changed content mints a fresh event.
+  assert.equal(second.events.length, 1);
+  assert.notEqual(second.events[0]?.id, originalId);
+  assert.equal(second.events[0]?.lifecycle, undefined);
+  assert.equal(eventRecords.length, 3);
+  assert.equal(
+    eventRecords.filter((record) => record.id === originalId).length,
+    2,
+  );
+  assert.equal(
+    eventRecords.filter(
+      (record) => record.id === originalId && record.lifecycle?.state === "deleted",
+    ).length,
+    1,
+  );
+  assert.equal(
+    (eventRecords.find((record) => record.id === second.events[0]?.id) as
+      | { durationMinutes?: number }
+      | undefined)?.durationMinutes,
+    41,
+  );
+});
+
+
+test("importDeviceBatch keeps deduping against a surviving live copy after a duplicate is tombstoned", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-cleanup-survivor");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  // Survivor copy imported normally.
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_cold_start_a",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const survivorId = first.events[0]?.id as string;
+  const shardPath = first.eventShardPaths[0] as string;
+
+  // Simulate the legacy pre-fix on-disk state: the same provider record also
+  // exists as a second live event under a different id (accountId churn
+  // minted it before dedupe existed). Write it directly as legacy shard state.
+  const survivorLine = (await readJsonlRecords({ vaultRoot, relativePath: shardPath }))[0] as EventRecord;
+  const legacyDuplicate = { ...survivorLine, id: "evt_0000000000000000000000DP20" };
+  await fs.appendFile(
+    path.join(vaultRoot, shardPath),
+    `${JSON.stringify(legacyDuplicate)}\n`,
+  );
+
+  // Cleanup tombstones the legacy duplicate and keeps the survivor live.
+  await deleteEvent({ vaultRoot, eventId: "evt_0000000000000000000000DP20" });
+
+  // The next overlapping poll re-delivers the same record. It must dedupe
+  // against the live survivor; the higher-revision tombstone of the deleted
+  // duplicate must not shadow it and re-mint a fresh event.
+  const replay = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_cold_start_b",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+
+  assert.equal(replay.events[0]?.id, survivorId);
+
+  const records = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  const deletedIds = new Set(
+    records
+      .filter((record) => record.lifecycle?.state === "deleted")
+      .map((record) => record.id),
+  );
+  const liveIds = new Set(
+    records.map((record) => record.id).filter((id) => !deletedIds.has(id)),
+  );
+  assert.equal(records.length, 3, "expected survivor + legacy duplicate + tombstone only");
+  assert.deepEqual([...liveIds], [survivorId]);
+});
+
+test("importDeviceBatch supersedes in place when the provider bumps externalRef.version", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-version-bump");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const buildInput = (version: string, value: number, importedAt: string) => ({
+    vaultRoot,
+    provider: "whoop",
+    accountId: "whoop-user-1",
+    importedAt,
+    events: [
+      {
+        kind: "observation",
+        occurredAt: "2026-06-03T07:30:00.000Z",
+        recordedAt: "2026-06-03T07:30:00.000Z",
+        title: "WHOOP recovery score",
+        externalRef: {
+          system: "whoop",
+          resourceType: "recovery",
+          resourceId: "sleep-1",
+          version,
+          facet: "recovery-score",
+        },
+        fields: {
+          metric: "recovery-score",
+          value,
+          unit: "%",
+        },
+      },
+    ],
+  });
+
+  // WHOOP stamps externalRef.version from the record's mutable updated_at, so
+  // a provider-side rescore arrives with a new version. It must supersede the
+  // existing event, not mint a second live event.
+  const first = await importDeviceBatch(buildInput("2026-06-03T10:00:00.000Z", 67, "2026-06-03T11:00:00.000Z"));
+  const rescored = await importDeviceBatch(buildInput("2026-06-04T09:00:00.000Z", 70, "2026-06-04T11:00:00.000Z"));
+  const replay = await importDeviceBatch(buildInput("2026-06-04T09:00:00.000Z", 70, "2026-06-05T11:00:00.000Z"));
+
+  const records = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  assert.equal(rescored.events[0]?.id, first.events[0]?.id);
+  assert.equal(rescored.events[0]?.lifecycle?.revision, 2);
+  assert.equal(replay.events[0]?.id, first.events[0]?.id);
+  assert.equal(records.length, 2, "expected original + one supersede, no duplicate live events");
+  assert.equal(new Set(records.map((record) => record.id)).size, 1);
+});
+
+test("importDeviceBatch never reuses a revision number taken by a no-externalRef edit", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-revision-collision");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const eventId = first.events[0]?.id as string;
+  const shardPath = first.eventShardPaths[0] as string;
+
+  // Simulate a user edit through the generic event spine that did not echo
+  // the externalRef: same id, revision 2, no externalRef.
+  const stored = (await readJsonlRecords({ vaultRoot, relativePath: shardPath }))[0] as EventRecord;
+  const { externalRef: _externalRef, ...editedBase } = stored;
+  const edited = {
+    ...editedBase,
+    note: "user-added context",
+    lifecycle: { revision: 2 },
+  };
+  await fs.appendFile(path.join(vaultRoot, shardPath), `${JSON.stringify(edited)}\n`);
+
+  // A changed provider re-delivery must take revision 3, not collide with the
+  // edit's revision 2.
+  const updated = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [
+      buildJunctionStyleWorkoutEvent({
+        recordedAt: "2026-06-04T07:00:00.000Z",
+        durationMinutes: 36,
+      }),
+    ],
+  });
+
+  assert.equal(updated.events[0]?.id, eventId);
+  assert.equal(updated.events[0]?.lifecycle?.revision, 3);
+
+  const records = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  const revisions = records
+    .filter((record) => record.id === eventId)
+    .map((record) => record.lifecycle?.revision ?? 1)
+    .sort((left, right) => left - right);
+  assert.deepEqual(revisions, [1, 2, 3]);
+});
+
+test("importDeviceBatch supersedes an in-batch fresh record when a later entry changes it", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-inbatch-supersede");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  // One batch carries the same provider record twice with different content
+  // (e.g. merged overlapping bundles): the second entry must supersede the
+  // first as a spine revision inside the same append plan.
+  const result = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [
+      buildJunctionStyleWorkoutEvent(),
+      buildJunctionStyleWorkoutEvent({
+        recordedAt: "2026-06-03T22:00:00.000Z",
+        durationMinutes: 36,
+      }),
+    ],
+  });
+
+  const records = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: result.eventShardPaths[0] as string,
+  })) as EventRecord[];
+
+  assert.equal(records.length, 2);
+  assert.equal(new Set(records.map((record) => record.id)).size, 1);
+  assert.deepEqual(
+    records.map((record) => record.lifecycle?.revision ?? 1).sort((left, right) => left - right),
+    [1, 2],
+  );
+  assert.equal(result.events.length, 2);
+  assert.equal(result.events[0]?.id, result.events[1]?.id);
+  assert.equal(result.events[1]?.lifecycle?.revision, 2);
 });

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -612,7 +612,7 @@ export function createJunctionDeviceSyncProvider(
     if (job.kind !== "backfill" || summaryHasFetchedRecords) {
       await context.importSnapshot({
         provider: "junction",
-        accountId: buildJunctionImportAccountId(context.account.id),
+        accountId: buildJunctionImportAccountId(context.account.externalAccountId),
         connectionId: context.account.id,
         importedAt: summaryWindow.windowEnd,
         windowStart: summaryWindow.windowStart,
@@ -1141,7 +1141,7 @@ export function createJunctionDeviceSyncProvider(
     const sourceProviders = await loadAndProjectSourceProviders();
     await context.importSnapshot({
       provider: "junction",
-      accountId: buildJunctionImportAccountId(context.account.id),
+      accountId: buildJunctionImportAccountId(context.account.externalAccountId),
       connectionId: context.account.id,
       importedAt: context.now,
       windowStart: window.windowStart,
@@ -1445,7 +1445,7 @@ export function createJunctionDeviceSyncProvider(
     if (executionWindowStart && executionWindowEnd && hasJunctionSnapshotRecords(dedupedTimeseries)) {
       await context.importSnapshot({
         provider: "junction",
-        accountId: buildJunctionImportAccountId(context.account.id),
+        accountId: buildJunctionImportAccountId(context.account.externalAccountId),
         connectionId: context.account.id,
         importedAt: executionWindowEnd,
         windowStart: executionWindowStart,
@@ -1491,7 +1491,7 @@ export function createJunctionDeviceSyncProvider(
 
       await context.importSnapshot({
         provider: "junction",
-        accountId: buildJunctionImportAccountId(context.account.id),
+        accountId: buildJunctionImportAccountId(context.account.externalAccountId),
         connectionId: context.account.id,
         importedAt: window.windowEnd,
         windowStart: window.windowStart,
@@ -1525,7 +1525,7 @@ export function createJunctionDeviceSyncProvider(
 
     await context.importSnapshot({
       provider: "junction",
-      accountId: buildJunctionImportAccountId(context.account.id),
+      accountId: buildJunctionImportAccountId(context.account.externalAccountId),
       connectionId: context.account.id,
       importedAt: context.now,
       windowStart,
@@ -5147,10 +5147,15 @@ function mergeJunctionSourceStatus(
   return "disconnected";
 }
 
-function buildJunctionImportAccountId(connectionId: string): string {
+// Derive import identity from the stable Junction user id, never from the
+// local device-sync account row id: row ids are re-minted whenever the
+// machine-local device-sync store is recreated (every hosted cold start), and
+// an unstable accountId changes the deterministic event identity of every
+// re-imported record.
+function buildJunctionImportAccountId(externalAccountId: string): string {
   return `jxn_acct_${
     createHash("sha256")
-      .update(JSON.stringify(["junction-import-account", connectionId]))
+      .update(JSON.stringify(["junction-import-account", externalAccountId]))
       .digest("hex")
       .slice(0, 32)
   }`;

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -6702,3 +6702,38 @@ test("Junction resource job with an unresolvable resource records an observable 
   assert.equal(metadataPatch.junctionSkippedResourceLast, "summary.mystery_records.0.unsupported");
   assert.equal(metadataPatch.junctionSkippedResourceJobCount, 1);
 });
+
+test("Junction import accountId is stable across local account row re-registration", async () => {
+  const importedAccountIds: string[] = [];
+  const provider = createEmptyJunctionBackfillProvider();
+
+  const runReconcileWithAccountRowId = async (rowId: string) => {
+    await executeJunctionJob(
+      provider,
+      createJunctionJobContext({
+        account: createAccount({ id: rowId }),
+        importSnapshot: async (snapshot) => {
+          const accountId = (snapshot as { accountId?: string }).accountId;
+          if (accountId) {
+            importedAccountIds.push(accountId);
+          }
+          return { imported: true };
+        },
+      }),
+      createJob("reconcile", {
+        windowStart: "2026-04-02T00:00:00.000Z",
+        windowEnd: "2026-04-03T00:00:00.000Z",
+      }),
+    );
+  };
+
+  // Hosted cold starts recreate the machine-local device-sync store, so the
+  // same Junction user is re-registered under a fresh local row id. Import
+  // identity must follow the stable Junction user, not the local row.
+  await runReconcileWithAccountRowId("dsa_cold_start_row_a");
+  await runReconcileWithAccountRowId("dsa_cold_start_row_b");
+
+  assert.ok(importedAccountIds.length >= 2, "expected reconcile runs to import snapshots");
+  assert.match(importedAccountIds[0] ?? "", /^jxn_acct_[a-f0-9]{32}$/u);
+  assert.equal(new Set(importedAccountIds).size, 1);
+});


### PR DESCRIPTION
## Problem

Hosted Junction imports duplicated the same provider records massively — one WHOOP workout imported 11×, sleep sessions up to 143×, ~4,100 duplicate events in one hosted vault (Dec 27 → Jun 10). Root cause chain, proven against hosted raw-ingest receipts/manifests:

1. `importDeviceBatch` event identity is a deterministic content hash that includes `accountId` (`packages/core/src/mutations.ts`), and dedupe is only "exact id already in target shard".
2. Junction derived its import accountId (`jxn_acct_*`) from the **machine-local device-sync account row id** (random `dsa_*` minted on registration).
3. The device-sync SQLite store is `machine_local` and hosted runners are ephemeral, so every cold start re-registered the account with a fresh row id → fresh `jxn_acct_*` → fresh event ids → every overlapping trailing-window poll re-appended already-imported events.

This violated device-sync ingestion **invariant 4** ("Merge is idempotent on `externalRef.resourceId`"), which the push/pull overlap architecture (invariants 2–3) depends on but core never implemented.

## Fix

- **core**: `importDeviceBatch` reconciles prepared device events by `externalRef` (system/resourceType/resourceId/facet — `version` intentionally excluded: WHOOP/Oura/Strava stamp it from mutable `updated_at`) against the latest live records in the target monthly shard. Identical content (ignoring id/rawRefs/lifecycle/recordedAt) → skipped, existing record returned. Changed content → appends an event-spine revision reusing the existing event id (ledger stays append-only; revision number = max across all stored rows of that id so no-ref edits can't collide). Tombstoned duplicates can't shadow a live survivor (per-id spine collapse before ref matching). Audit summary surfaces skip/update counts.
- **device-syncd**: `buildJunctionImportAccountId` now derives from the stable provider `externalAccountId` instead of the local row id (other providers already did this; Junction was the outlier).

## Verification

- `packages/core`: 431/431 (incl. 13 new regression tests: accountId-churn dedupe, in-place supersede, version-bump supersede, revision-collision, facet isolation, deletion semantics, post-cleanup survivor, in-batch dedupe/supersede), typecheck + coverage green
- `packages/device-syncd`: 621/621 (incl. accountId stability across row re-registration), coverage green
- `packages/importers`: 197/197; root typecheck green; `pnpm test:smoke` green
- `pnpm test:diff` red only at `packages/query`: 4 failures reproduced identically on main (provider display-name / sleep-window ranking; untouched by this diff)
- Direct scenario proof: 11 overlapping junction snapshot imports with 11 different accountIds through the real importer+core pipeline → exactly **1** workout event

Completion audits run: simplify, coverage-write, deep-review, task-finish-review — all findings fixed or explicitly documented as accepted residual risks in the archived plan (`agent-docs/exec-plans/completed/2026-06-10-device-import-externalref-idempotency.md`).

## Notes

- One-time cleanup of the ~4,100 existing hosted duplicates is deliberately deferred (vault-only data work; dedupe now holds even against the existing duplicates).
- Expected one-time post-deploy effects (documented in plan): junction samples may duplicate one generation in overlapping windows after the accountId migration, then converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783713841&installation_id=127572939&pr_number=116&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F116&signature=b6760b3aa42ee299a3bbdd7ae493fd7bb311ffad1cd58ad6a8090c5dfd2d0178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->