### PR TITLE
perf(hosted): instrument dispatch gap, defer smoke imports

### DIFF
--- a/Dockerfile.cloudflare-hosted-runner
+++ b/Dockerfile.cloudflare-hosted-runner
@@ -8,14 +8,6 @@ ARG HOSTED_RUNNER_BUNDLE_DIR=.deploy/runner-bundle
 
 COPY --chown=root:root ${HOSTED_RUNNER_BUNDLE_DIR}/ /app/
 
-# Warm Node's on-disk compile cache at image build so cold container boots read
-# precompiled V8 bytecode instead of re-parsing the unbundled dist/node_modules
-# tree. The guarded import evaluates the entrypoint module graph without
-# starting the server (isHostedContainerCliEntrypoint() is false for -e runs).
-# The cache becomes read-only below; runtime cache writes are best-effort no-ops.
-ENV NODE_COMPILE_CACHE=/app/.node-compile-cache
-RUN cd /app && node --input-type=module -e "await import('/app/dist/container-entrypoint.js');"
-
 RUN chmod -R a-w /app \
   && chmod -R a+rX /app
 

--- a/Dockerfile.cloudflare-hosted-runner
+++ b/Dockerfile.cloudflare-hosted-runner
@@ -8,6 +8,14 @@ ARG HOSTED_RUNNER_BUNDLE_DIR=.deploy/runner-bundle
 
 COPY --chown=root:root ${HOSTED_RUNNER_BUNDLE_DIR}/ /app/
 
+# Warm Node's on-disk compile cache at image build so cold container boots read
+# precompiled V8 bytecode instead of re-parsing the unbundled dist/node_modules
+# tree. The guarded import evaluates the entrypoint module graph without
+# starting the server (isHostedContainerCliEntrypoint() is false for -e runs).
+# The cache becomes read-only below; runtime cache writes are best-effort no-ops.
+ENV NODE_COMPILE_CACHE=/app/.node-compile-cache
+RUN cd /app && node --input-type=module -e "await import('/app/dist/container-entrypoint.js');"
+
 RUN chmod -R a-w /app \
   && chmod -R a+rX /app
 

--- a/agent-docs/exec-plans/completed/2026-06-10-cold-start-boot-trims.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-cold-start-boot-trims.md
@@ -1,0 +1,62 @@
+# Cold-start boot trims and dispatch-gap instrumentation
+
+## Goal
+
+Cut measured hosted cold-start latency (message accept → provider start, ~13s
+p50) on its two cheapest axes and make the remaining uninstrumented dispatch
+gap measurable, without adding new state, data paths, or orchestration
+authority.
+
+Success criteria:
+
+- Container image bakes a warmed `NODE_COMPILE_CACHE` so cold-boot V8
+  parse/compile of the unbundled `node_modules` + `dist` tree is cached at
+  image build instead of paid per cold start (`nodeStartupMs` ~3.7s avg today).
+- The deploy-smoke-only modules (`hosted-runner-smoke-contract.ts`,
+  `hosted-assistant-bootstrap`) stop loading on the job path; they load lazily
+  inside the smoke handler only.
+- `phaseBreakdown.dispatch` carries two DO-side epoch-ms stamps
+  (`invokeReceivedAtEpochMs`, `containerStartRequestedAtEpochMs`) so the
+  `temporal_signal_accepted_at` → `runner_job_accepted_at` gap decomposes into
+  DO dispatch vs Cloudflare container scheduling in
+  `hosted_ingress_latency_trace`, using only the existing strict
+  phase-breakdown parser and idempotent web merge.
+
+## Constraints
+
+- Temporal stays the only wake authority; no new wake/nudge paths.
+- No new persisted state classes: dispatch stamps ride the existing
+  `phaseBreakdownJson` (schemaVersion 1) through the existing strict parser
+  (numbers only; secret-safety leaf guard unchanged).
+- Minimal textual touch on `apps/cloudflare/src/runner-container.ts` (active
+  ledger lane on destroy/lifecycle symbols): stamps + two request headers on
+  the existing containerFetch POST only.
+- The restore/boot overlap optimization (presign-before-start) is explicitly
+  out of scope; decide later with the new dispatch data.
+
+## Approach
+
+1. `Dockerfile.cloudflare-hosted-runner`: set `NODE_COMPILE_CACHE=/app/.node-compile-cache`,
+   warm it via a guarded `import()` of `dist/container-entrypoint.js` before
+   the read-only chmod (the `isHostedContainerCliEntrypoint()` guard keeps the
+   warm import from starting the server).
+2. `container-entrypoint.ts`: move the two smoke-only imports to dynamic
+   imports inside `runHostedContainerCliSurfaceContractSmoke`.
+3. Dispatch stamps: `runner-container.ts` stamps `Date.now()` at
+   `invokeHostedExecution` entry and immediately before `ensureContainerReady`,
+   sends both as `x-dispatch-*` headers on the runner POST;
+   `container-entrypoint.ts` reads the headers and threads them through the
+   existing invocation options; `hosted-workspace-invocation.ts` includes them
+   in the staged `phaseBreakdown`; `@murphai/hosted-execution` type + strict
+   parser gain the `dispatch` subkey; web store merge list adds `"dispatch"`.
+4. Focused tests: parser accepts/rejects dispatch shapes, entrypoint passes
+   headers through, web merge persists dispatch idempotently, Dockerfile
+   contract test updated for the new warm step.
+5. Scoped verification + required completion audits, then PR.
+
+## State
+
+Active.
+Status: completed
+Updated: 2026-06-10
+Completed: 2026-06-10

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -38,15 +38,8 @@ import {
   stopWarmCodexAppServer,
 } from "@murphai/assistant-engine/codex-lifecycle";
 import {
-  readHostedAssistantCliSurfaceBootstrapContext,
-} from "@murphai/assistant-runtime/hosted-assistant-bootstrap";
-import {
   HOSTED_RUNTIME_ARCHITECTURE_VERSION,
 } from "./hosted-runtime-architecture.ts";
-import {
-  HOSTED_RUNNER_SMOKE_CLI_SURFACE_HOT_PATH_PROOF_COUNT,
-  countAssistantCliSurfaceHotPathProofs,
-} from "./hosted-runner-smoke-contract.ts";
 import {
   runHostedWorkspaceInvocation as runHostedWorkspaceInvocationDirect,
 } from "./hosted-workspace-invocation.ts";
@@ -530,6 +523,7 @@ export async function startHostedContainerEntrypoint(input: {
       const runnerJobAcceptedAt = new Date().toISOString();
       const coldNodeStartupMs = pendingColdNodeStartupMs;
       pendingColdNodeStartupMs = null;
+      const dispatchMilestones = readHostedContainerDispatchMilestones(request);
       emitHostedExecutionStructuredLog({
         component: "container",
         details: {
@@ -576,6 +570,7 @@ export async function startHostedContainerEntrypoint(input: {
           }
         },
         ...(coldNodeStartupMs === null ? {} : { nodeStartupMs: coldNodeStartupMs }),
+        ...(dispatchMilestones ? { dispatch: dispatchMilestones } : {}),
         runnerJobAcceptedAt,
         shutdownSignal: containerShutdownController.signal,
         signal: invocationAbort.signal,
@@ -873,6 +868,35 @@ function writeJsonResponse(
   response.statusCode = statusCode;
   response.setHeader("content-type", "application/json; charset=utf-8");
   response.end(JSON.stringify(payload));
+}
+
+// Best-effort dispatch telemetry stamped by the Durable Object onto the runner
+// POST headers. Invalid or absent values are dropped rather than failing the
+// job; these stamps are diagnostics, not authority.
+function readHostedContainerDispatchMilestones(
+  request: IncomingMessage,
+): { invokeReceivedAtEpochMs?: number; containerStartRequestedAtEpochMs?: number } | null {
+  const invokeReceivedAtEpochMs = readDispatchEpochMs(
+    request.headers["x-dispatch-invoke-received-at-ms"],
+  );
+  const containerStartRequestedAtEpochMs = readDispatchEpochMs(
+    request.headers["x-dispatch-container-start-requested-at-ms"],
+  );
+  if (invokeReceivedAtEpochMs === null && containerStartRequestedAtEpochMs === null) {
+    return null;
+  }
+  return {
+    ...(invokeReceivedAtEpochMs === null ? {} : { invokeReceivedAtEpochMs }),
+    ...(containerStartRequestedAtEpochMs === null ? {} : { containerStartRequestedAtEpochMs }),
+  };
+}
+
+function readDispatchEpochMs(raw: string | string[] | undefined): number | null {
+  if (typeof raw !== "string" || !/^\d+$/u.test(raw)) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : null;
 }
 
 function discardUnreadRequestBody(request: IncomingMessage): void {
@@ -1449,6 +1473,18 @@ async function runHostedContainerCliSurfaceContractSmoke(smokeVaultRoot: string)
   contractBytes: number;
   hotPathProofCount: number;
 }> {
+  // Deploy-smoke-only modules: loaded lazily so the cold-boot job path never
+  // pays their module-evaluation cost.
+  const [
+    { readHostedAssistantCliSurfaceBootstrapContext },
+    {
+      HOSTED_RUNNER_SMOKE_CLI_SURFACE_HOT_PATH_PROOF_COUNT,
+      countAssistantCliSurfaceHotPathProofs,
+    },
+  ] = await Promise.all([
+    import("@murphai/assistant-runtime/hosted-assistant-bootstrap"),
+    import("./hosted-runner-smoke-contract.ts"),
+  ]);
   const contract = await readHostedAssistantCliSurfaceBootstrapContext({
     sessionId: "hosted-container-deploy-smoke",
     vault: smokeVaultRoot,
@@ -2151,6 +2187,7 @@ async function runHostedWorkspaceInvocation(
   input: HostedExecutionRunnerJobInput,
   runtime: HostedContainerRuntimeDependencies,
   options?: {
+    dispatch?: { invokeReceivedAtEpochMs?: number; containerStartRequestedAtEpochMs?: number } | null;
     nodeStartupMs?: number | null;
     onRuntimeWakeReady?: (sendWake: () => boolean) => void;
     runnerJobAcceptedAt?: string | null;
@@ -2159,6 +2196,7 @@ async function runHostedWorkspaceInvocation(
   },
 ): Promise<Awaited<ReturnType<typeof runHostedWorkspaceInvocationDirect>>> {
   return await runtime.runWorkspaceInvocation(input, {
+    dispatch: options?.dispatch ?? null,
     nodeStartupMs: options?.nodeStartupMs ?? null,
     onRuntimeWakeReady: options?.onRuntimeWakeReady,
     runnerJobAcceptedAt: options?.runnerJobAcceptedAt ?? null,
@@ -2172,6 +2210,7 @@ async function runHostedWorkspaceInvocationWithProcessIsolation(
   input: HostedExecutionRunnerJobInput,
   runtime: HostedContainerRuntimeDependencies,
   options?: {
+    dispatch?: { invokeReceivedAtEpochMs?: number; containerStartRequestedAtEpochMs?: number } | null;
     nodeStartupMs?: number | null;
     onCleanupStatus?: (status: Exclude<HostedContainerCleanupStatus, "not_run">) => void;
     onRuntimeWakeReady?: (sendWake: () => boolean) => void;

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -875,19 +875,19 @@ function writeJsonResponse(
 // job; these stamps are diagnostics, not authority.
 function readHostedContainerDispatchMilestones(
   request: IncomingMessage,
-): { invokeReceivedAtEpochMs?: number; containerStartRequestedAtEpochMs?: number } | null {
+): { invokeReceivedAtEpochMs?: number; containerEnsureReadyStartedAtEpochMs?: number } | null {
   const invokeReceivedAtEpochMs = readDispatchEpochMs(
     request.headers["x-dispatch-invoke-received-at-ms"],
   );
-  const containerStartRequestedAtEpochMs = readDispatchEpochMs(
-    request.headers["x-dispatch-container-start-requested-at-ms"],
+  const containerEnsureReadyStartedAtEpochMs = readDispatchEpochMs(
+    request.headers["x-dispatch-container-ensure-ready-started-at-ms"],
   );
-  if (invokeReceivedAtEpochMs === null && containerStartRequestedAtEpochMs === null) {
+  if (invokeReceivedAtEpochMs === null && containerEnsureReadyStartedAtEpochMs === null) {
     return null;
   }
   return {
     ...(invokeReceivedAtEpochMs === null ? {} : { invokeReceivedAtEpochMs }),
-    ...(containerStartRequestedAtEpochMs === null ? {} : { containerStartRequestedAtEpochMs }),
+    ...(containerEnsureReadyStartedAtEpochMs === null ? {} : { containerEnsureReadyStartedAtEpochMs }),
   };
 }
 
@@ -2187,7 +2187,7 @@ async function runHostedWorkspaceInvocation(
   input: HostedExecutionRunnerJobInput,
   runtime: HostedContainerRuntimeDependencies,
   options?: {
-    dispatch?: { invokeReceivedAtEpochMs?: number; containerStartRequestedAtEpochMs?: number } | null;
+    dispatch?: { invokeReceivedAtEpochMs?: number; containerEnsureReadyStartedAtEpochMs?: number } | null;
     nodeStartupMs?: number | null;
     onRuntimeWakeReady?: (sendWake: () => boolean) => void;
     runnerJobAcceptedAt?: string | null;
@@ -2210,7 +2210,7 @@ async function runHostedWorkspaceInvocationWithProcessIsolation(
   input: HostedExecutionRunnerJobInput,
   runtime: HostedContainerRuntimeDependencies,
   options?: {
-    dispatch?: { invokeReceivedAtEpochMs?: number; containerStartRequestedAtEpochMs?: number } | null;
+    dispatch?: { invokeReceivedAtEpochMs?: number; containerEnsureReadyStartedAtEpochMs?: number } | null;
     nodeStartupMs?: number | null;
     onCleanupStatus?: (status: Exclude<HostedContainerCleanupStatus, "not_run">) => void;
     onRuntimeWakeReady?: (sendWake: () => boolean) => void;

--- a/apps/cloudflare/src/hosted-workspace-invocation.ts
+++ b/apps/cloudflare/src/hosted-workspace-invocation.ts
@@ -63,6 +63,10 @@ const HOSTED_RUNNER_WARM_LAUNCHER_DIRECTORY_NAMES = [
 ] as const;
 
 export interface HostedWorkspaceInvocationOptions {
+  dispatch?: {
+    invokeReceivedAtEpochMs?: number;
+    containerStartRequestedAtEpochMs?: number;
+  } | null;
   nodeStartupMs?: number | null;
   onRuntimeWakeReady?: (sendWake: () => boolean) => void;
   runnerJobAcceptedAt?: string | null;
@@ -185,18 +189,23 @@ export async function runHostedWorkspaceInvocation(
       timeoutMs: readHostedRunnerCommitTimeoutMs(job.runtime?.commitTimeoutMs ?? null),
     });
 
+    const hasNodeStartup = options.nodeStartupMs !== null && options.nodeStartupMs !== undefined;
+    const hasDispatch = options.dispatch !== null
+      && options.dispatch !== undefined
+      && Object.keys(options.dispatch).length > 0;
     const latencyMilestones: HostedRuntimeLatencyTraceStagedMilestones = {
       ...(options.runnerJobAcceptedAt
         ? { runnerJobAcceptedAt: options.runnerJobAcceptedAt }
         : {}),
-      ...(options.nodeStartupMs === null || options.nodeStartupMs === undefined
-        ? {}
-        : {
+      ...(hasNodeStartup || hasDispatch
+        ? {
             phaseBreakdown: {
               schemaVersion: 1,
-              boot: { nodeStartupMs: options.nodeStartupMs },
+              ...(hasDispatch ? { dispatch: { ...options.dispatch } } : {}),
+              ...(hasNodeStartup ? { boot: { nodeStartupMs: options.nodeStartupMs as number } } : {}),
             },
-          }),
+          }
+        : {}),
     };
     const result = await runPackageHostedWorkspaceInvocation({
       job,

--- a/apps/cloudflare/src/hosted-workspace-invocation.ts
+++ b/apps/cloudflare/src/hosted-workspace-invocation.ts
@@ -65,7 +65,7 @@ const HOSTED_RUNNER_WARM_LAUNCHER_DIRECTORY_NAMES = [
 export interface HostedWorkspaceInvocationOptions {
   dispatch?: {
     invokeReceivedAtEpochMs?: number;
-    containerStartRequestedAtEpochMs?: number;
+    containerEnsureReadyStartedAtEpochMs?: number;
   } | null;
   nodeStartupMs?: number | null;
   onRuntimeWakeReady?: (sendWake: () => boolean) => void;

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -850,7 +850,7 @@ export class RunnerContainer extends Container {
         phase: "container.starting",
         userId: routeUserId,
       });
-      const dispatchContainerStartRequestedAtEpochMs = Date.now();
+      const dispatchContainerEnsureReadyStartedAtEpochMs = Date.now();
       await this.ensureContainerReady(input, operationAbortController.signal);
       this.clearRecentReadinessProof();
       cleanupWarmContainerOnFailure = true;
@@ -877,8 +877,8 @@ export class RunnerContainer extends Container {
           headers: {
             "content-type": "application/json; charset=utf-8",
             "x-dispatch-invoke-received-at-ms": String(dispatchInvokeReceivedAtEpochMs),
-            "x-dispatch-container-start-requested-at-ms": String(
-              dispatchContainerStartRequestedAtEpochMs,
+            "x-dispatch-container-ensure-ready-started-at-ms": String(
+              dispatchContainerEnsureReadyStartedAtEpochMs,
             ),
           },
           method: "POST",

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -812,6 +812,10 @@ export class RunnerContainer extends Container {
   private async invokeHostedExecution(
     input: HostedExecutionContainerInvokeInput,
   ): Promise<HostedExecutionRunnerJobResult> {
+    // Dispatch latency stamps (epoch ms, this DO's clock). Sent as headers on
+    // the runner POST so the latency trace can split DO dispatch work from
+    // Cloudflare container scheduling inside the temporal->runner-accept gap.
+    const dispatchInvokeReceivedAtEpochMs = Date.now();
     const routeUserId = readHostedExecutionRunnerJobUserId(input.job);
     const logContext: RunnerContainerLogContext = {
       userId: routeUserId,
@@ -846,6 +850,7 @@ export class RunnerContainer extends Container {
         phase: "container.starting",
         userId: routeUserId,
       });
+      const dispatchContainerStartRequestedAtEpochMs = Date.now();
       await this.ensureContainerReady(input, operationAbortController.signal);
       this.clearRecentReadinessProof();
       cleanupWarmContainerOnFailure = true;
@@ -871,6 +876,10 @@ export class RunnerContainer extends Container {
           }),
           headers: {
             "content-type": "application/json; charset=utf-8",
+            "x-dispatch-invoke-received-at-ms": String(dispatchInvokeReceivedAtEpochMs),
+            "x-dispatch-container-start-requested-at-ms": String(
+              dispatchContainerStartRequestedAtEpochMs,
+            ),
           },
           method: "POST",
           signal: operationAbortController.signal,

--- a/apps/cloudflare/test/container-entrypoint.test.ts
+++ b/apps/cloudflare/test/container-entrypoint.test.ts
@@ -1422,6 +1422,80 @@ describe("startHostedContainerEntrypoint", () => {
     }
   });
 
+  it("parses x-dispatch-* headers into options.dispatch and drops invalid values", async () => {
+    const runnerSpy = vi.spyOn(hostedInvocation, "runHostedWorkspaceInvocation").mockResolvedValue(
+      buildWorkspaceRunnerResult(),
+    );
+
+    try {
+      const server = await startHostedContainerEntrypoint({
+        port: 0,
+      });
+      servers.push(server);
+      const address = server.address();
+
+      if (!address || typeof address === "string") {
+        throw new Error("Expected the hosted container entrypoint to expose a TCP port.");
+      }
+
+      const sendInvocation = async (eventId: string, dispatchHeaders: Record<string, string>) =>
+        await fetch(`http://127.0.0.1:${address.port}/internal/workspace-invocation`, {
+          body: JSON.stringify(buildJobBody({
+            wake: {
+              event: { kind: "runtime.timer", triggerKind: "runtime_timer", userId: "u1" },
+              eventId,
+              occurredAt: "2026-03-26T12:00:00.000Z",
+            },
+          })),
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+            ...dispatchHeaders,
+          },
+          method: "POST",
+        });
+
+      // Both stamps valid: parsed into options.dispatch as epoch-ms integers.
+      const both = await sendInvocation("evt_dispatch_headers_valid", {
+        "x-dispatch-container-start-requested-at-ms": "1777000000050",
+        "x-dispatch-invoke-received-at-ms": "1777000000000",
+      });
+      expect(both.status).toBe(200);
+
+      // Invalid stamps are diagnostics-only and must be dropped per value: the
+      // non-numeric stamp disappears while the valid one survives, and the job
+      // itself is never failed by a bad header.
+      const partial = await sendInvocation("evt_dispatch_headers_partial", {
+        "x-dispatch-container-start-requested-at-ms": "1777000000050",
+        "x-dispatch-invoke-received-at-ms": "not-a-number",
+      });
+      expect(partial.status).toBe(200);
+
+      // All invalid (non-numeric, negative): no dispatch object at all.
+      const invalid = await sendInvocation("evt_dispatch_headers_invalid", {
+        "x-dispatch-container-start-requested-at-ms": "-5",
+        "x-dispatch-invoke-received-at-ms": "soon",
+      });
+      expect(invalid.status).toBe(200);
+
+      // Absent headers: no dispatch object either.
+      const absent = await sendInvocation("evt_dispatch_headers_absent", {});
+      expect(absent.status).toBe(200);
+
+      expect(runnerSpy).toHaveBeenCalledTimes(4);
+      expect(runnerSpy.mock.calls[0]?.[1]?.dispatch).toEqual({
+        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+      });
+      expect(runnerSpy.mock.calls[1]?.[1]?.dispatch).toEqual({
+        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+      });
+      expect(runnerSpy.mock.calls[2]?.[1]?.dispatch ?? null).toBeNull();
+      expect(runnerSpy.mock.calls[3]?.[1]?.dispatch ?? null).toBeNull();
+    } finally {
+      runnerSpy.mockRestore();
+    }
+  });
+
   it("returns a stable invalid request error when the run body is not an object", async () => {
     const server = await startHostedContainerEntrypoint({
       port: 0,

--- a/apps/cloudflare/test/container-entrypoint.test.ts
+++ b/apps/cloudflare/test/container-entrypoint.test.ts
@@ -1456,7 +1456,7 @@ describe("startHostedContainerEntrypoint", () => {
 
       // Both stamps valid: parsed into options.dispatch as epoch-ms integers.
       const both = await sendInvocation("evt_dispatch_headers_valid", {
-        "x-dispatch-container-start-requested-at-ms": "1777000000050",
+        "x-dispatch-container-ensure-ready-started-at-ms": "1777000000050",
         "x-dispatch-invoke-received-at-ms": "1777000000000",
       });
       expect(both.status).toBe(200);
@@ -1465,14 +1465,14 @@ describe("startHostedContainerEntrypoint", () => {
       // non-numeric stamp disappears while the valid one survives, and the job
       // itself is never failed by a bad header.
       const partial = await sendInvocation("evt_dispatch_headers_partial", {
-        "x-dispatch-container-start-requested-at-ms": "1777000000050",
+        "x-dispatch-container-ensure-ready-started-at-ms": "1777000000050",
         "x-dispatch-invoke-received-at-ms": "not-a-number",
       });
       expect(partial.status).toBe(200);
 
       // All invalid (non-numeric, negative): no dispatch object at all.
       const invalid = await sendInvocation("evt_dispatch_headers_invalid", {
-        "x-dispatch-container-start-requested-at-ms": "-5",
+        "x-dispatch-container-ensure-ready-started-at-ms": "-5",
         "x-dispatch-invoke-received-at-ms": "soon",
       });
       expect(invalid.status).toBe(200);
@@ -1483,11 +1483,11 @@ describe("startHostedContainerEntrypoint", () => {
 
       expect(runnerSpy).toHaveBeenCalledTimes(4);
       expect(runnerSpy.mock.calls[0]?.[1]?.dispatch).toEqual({
-        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
         invokeReceivedAtEpochMs: 1_777_000_000_000,
       });
       expect(runnerSpy.mock.calls[1]?.[1]?.dispatch).toEqual({
-        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
       });
       expect(runnerSpy.mock.calls[2]?.[1]?.dispatch ?? null).toBeNull();
       expect(runnerSpy.mock.calls[3]?.[1]?.dispatch ?? null).toBeNull();

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -487,14 +487,10 @@ describe("hosted runner container image contract", () => {
     );
     expect(finalDockerfile).toContain("RUN chmod -R a-w /app");
     expect(finalDockerfile).toContain("  && chmod -R a+rX /app");
-    // Compile-cache warm: env is set and the cache is warmed after the bundle
-    // copy but before the read-only chmod, so cold boots read baked bytecode.
-    expect(finalDockerfile).toContain("ENV NODE_COMPILE_CACHE=/app/.node-compile-cache");
-    const finalCompileCacheWarmIndex = finalDockerfile.indexOf(
-      "RUN cd /app && node --input-type=module -e \"await import('/app/dist/container-entrypoint.js');\"",
-    );
-    expect(finalCompileCacheWarmIndex).toBeGreaterThan(finalRunnerBundleCopyIndex);
-    expect(finalCompileCacheWarmIndex).toBeLessThan(finalChmodIndex);
+    // Measured 2026-06-10: a baked NODE_COMPILE_CACHE was a no-op for this
+    // bundle (real-bundle module eval ~0.8s even under qemu; cache hits gave
+    // no speedup), so the image intentionally ships no compile-cache warm step.
+    expect(finalDockerfile).not.toContain("NODE_COMPILE_CACHE");
     expect(readLastDockerUser(baseDockerfile)).toBe("runner");
     expect(readDockerUsers(finalDockerfile)).toEqual(["root", "runner"]);
     expect(finalDockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-s", "--"]');

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -487,6 +487,14 @@ describe("hosted runner container image contract", () => {
     );
     expect(finalDockerfile).toContain("RUN chmod -R a-w /app");
     expect(finalDockerfile).toContain("  && chmod -R a+rX /app");
+    // Compile-cache warm: env is set and the cache is warmed after the bundle
+    // copy but before the read-only chmod, so cold boots read baked bytecode.
+    expect(finalDockerfile).toContain("ENV NODE_COMPILE_CACHE=/app/.node-compile-cache");
+    const finalCompileCacheWarmIndex = finalDockerfile.indexOf(
+      "RUN cd /app && node --input-type=module -e \"await import('/app/dist/container-entrypoint.js');\"",
+    );
+    expect(finalCompileCacheWarmIndex).toBeGreaterThan(finalRunnerBundleCopyIndex);
+    expect(finalCompileCacheWarmIndex).toBeLessThan(finalChmodIndex);
     expect(readLastDockerUser(baseDockerfile)).toBe("runner");
     expect(readDockerUsers(finalDockerfile)).toEqual(["root", "runner"]);
     expect(finalDockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-s", "--"]');

--- a/apps/cloudflare/test/hosted-workspace-invocation.test.ts
+++ b/apps/cloudflare/test/hosted-workspace-invocation.test.ts
@@ -339,6 +339,83 @@ describe("runHostedWorkspaceInvocation", () => {
     expect(mocks.runPackageHostedWorkspaceInvocation).not.toHaveBeenCalled();
   });
 
+  it("threads dispatch stamps into latencyMilestones.phaseBreakdown alongside or without boot", async () => {
+    const capturedInvocationInputs: Record<string, unknown>[] = [];
+    mocks.runPackageHostedWorkspaceInvocation.mockImplementation(async (input: Record<string, unknown>) => {
+      capturedInvocationInputs.push(input);
+      return {
+        nextWakeAt: null,
+        redactedStatus: {
+          importedCount: 0,
+        },
+        status: "idle" as const,
+      };
+    });
+    const supervisorEnv = {
+      HOSTED_ASSISTANT_MODEL: "gpt-supervisor",
+      HOSTED_ASSISTANT_PROVIDER: "openai",
+      NODE_ENV: "production",
+    };
+    const createJob = (attemptId: string) => createWorkspaceJob({
+      forwardedEnv: {
+        HOSTED_ASSISTANT_MODEL: "gpt-job",
+        HOSTED_ASSISTANT_PROVIDER: "openai",
+        NODE_ENV: "production",
+      },
+    }, { attemptId });
+
+    // Dispatch + cold node startup: both land in the same schemaVersion 1 breakdown.
+    await runHostedWorkspaceInvocation(createJob("attempt_dispatch_with_boot"), {
+      dispatch: {
+        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+      },
+      nodeStartupMs: 4200,
+      runnerJobAcceptedAt: "2026-04-26T00:00:01.000Z",
+      supervisorEnv,
+    });
+    expect(capturedInvocationInputs[0]?.latencyMilestones).toEqual({
+      phaseBreakdown: {
+        schemaVersion: 1,
+        dispatch: {
+          containerStartRequestedAtEpochMs: 1_777_000_000_050,
+          invokeReceivedAtEpochMs: 1_777_000_000_000,
+        },
+        boot: { nodeStartupMs: 4200 },
+      },
+      runnerJobAcceptedAt: "2026-04-26T00:00:01.000Z",
+    });
+
+    // Dispatch without nodeStartupMs (warm container): the breakdown is still
+    // attached, carrying dispatch only, with no boot sub-object.
+    await runHostedWorkspaceInvocation(createJob("attempt_dispatch_without_boot"), {
+      dispatch: {
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+      },
+      nodeStartupMs: null,
+      supervisorEnv,
+    });
+    expect(capturedInvocationInputs[1]?.latencyMilestones).toEqual({
+      phaseBreakdown: {
+        schemaVersion: 1,
+        dispatch: { invokeReceivedAtEpochMs: 1_777_000_000_000 },
+      },
+    });
+
+    // Neither dispatch nor nodeStartupMs (and an empty dispatch object counts as
+    // absent): no phaseBreakdown — the empty milestones object is omitted entirely.
+    await runHostedWorkspaceInvocation(createJob("attempt_no_breakdown"), {
+      dispatch: {},
+      nodeStartupMs: null,
+      supervisorEnv,
+    });
+    const bareInput = capturedInvocationInputs[2];
+    if (!bareInput) {
+      throw new Error("Expected the third direct invocation to call the package invocation.");
+    }
+    expect("latencyMilestones" in bareInput).toBe(false);
+  });
+
   it("preserves former launcher compatibility roots for direct in-process invocations", async () => {
     const capturedInvocationInputs: Record<string, unknown>[] = [];
     mocks.runPackageHostedWorkspaceInvocation.mockImplementation(async (input: Record<string, unknown>) => {

--- a/apps/cloudflare/test/hosted-workspace-invocation.test.ts
+++ b/apps/cloudflare/test/hosted-workspace-invocation.test.ts
@@ -367,7 +367,7 @@ describe("runHostedWorkspaceInvocation", () => {
     // Dispatch + cold node startup: both land in the same schemaVersion 1 breakdown.
     await runHostedWorkspaceInvocation(createJob("attempt_dispatch_with_boot"), {
       dispatch: {
-        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
         invokeReceivedAtEpochMs: 1_777_000_000_000,
       },
       nodeStartupMs: 4200,
@@ -378,7 +378,7 @@ describe("runHostedWorkspaceInvocation", () => {
       phaseBreakdown: {
         schemaVersion: 1,
         dispatch: {
-          containerStartRequestedAtEpochMs: 1_777_000_000_050,
+          containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
           invokeReceivedAtEpochMs: 1_777_000_000_000,
         },
         boot: { nodeStartupMs: 4200 },

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -1564,9 +1564,13 @@ describe("RunnerContainer", () => {
       );
       expect(executeCalls[0]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
+        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
       expect(executeCalls[1]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
+        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
     } finally {
       vi.useRealTimers();
@@ -1677,9 +1681,13 @@ describe("RunnerContainer", () => {
       );
       expect(executeCalls[0]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
+        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
       expect(executeCalls[1]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
+        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
     } finally {
       vi.useRealTimers();

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -1564,12 +1564,12 @@ describe("RunnerContainer", () => {
       );
       expect(executeCalls[0]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
-        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-container-ensure-ready-started-at-ms": expect.stringMatching(/^\d+$/),
         "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
       expect(executeCalls[1]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
-        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-container-ensure-ready-started-at-ms": expect.stringMatching(/^\d+$/),
         "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
     } finally {
@@ -1681,12 +1681,12 @@ describe("RunnerContainer", () => {
       );
       expect(executeCalls[0]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
-        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-container-ensure-ready-started-at-ms": expect.stringMatching(/^\d+$/),
         "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
       expect(executeCalls[1]?.[1]?.headers).toEqual({
         "content-type": "application/json; charset=utf-8",
-        "x-dispatch-container-start-requested-at-ms": expect.stringMatching(/^\d+$/),
+        "x-dispatch-container-ensure-ready-started-at-ms": expect.stringMatching(/^\d+$/),
         "x-dispatch-invoke-received-at-ms": expect.stringMatching(/^\d+$/),
       });
     } finally {

--- a/apps/web/src/lib/hosted-runtime-latency/store.ts
+++ b/apps/web/src/lib/hosted-runtime-latency/store.ts
@@ -223,6 +223,7 @@ export async function recordHostedIngressAssistantInputStaged(input: {
         workspaceRestoreDoneAt,
       ),
       ...readPhaseBreakdownMergeUpdate(trace.phaseBreakdownJson, input.phaseBreakdown, [
+        "dispatch",
         "restore",
         "boot",
       ]),
@@ -723,7 +724,7 @@ function readEarlierDateUpdate<Field extends string>(
   return { [field]: next } as Partial<Record<Field, Date>>;
 }
 
-type HostedRuntimeLatencyPhaseBreakdownSubKey = "restore" | "boot" | "provider";
+type HostedRuntimeLatencyPhaseBreakdownSubKey = "dispatch" | "restore" | "boot" | "provider";
 
 // Shallow-merges incoming phase-breakdown sub-objects into the existing trace
 // JSON within the SAME update() (no extra request). Idempotent: an already-populated

--- a/apps/web/test/hosted-runtime-latency-store.test.ts
+++ b/apps/web/test/hosted-runtime-latency-store.test.ts
@@ -260,6 +260,10 @@ describe("hosted runtime latency dashboard store", () => {
       mailboxItemId: "mailbox_latency_1",
       phaseBreakdown: {
         schemaVersion: 1,
+        dispatch: {
+          invokeReceivedAtEpochMs: 1_777_000_000_000,
+          containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        },
         restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
         boot: { nodeStartupMs: 4200, restoreWasCold: true },
       },
@@ -271,11 +275,15 @@ describe("hosted runtime latency dashboard store", () => {
     let trace = prisma.readTrace();
     expect(trace?.phaseBreakdownJson).toEqual({
       schemaVersion: 1,
+      dispatch: {
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+      },
       restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
       boot: { nodeStartupMs: 4200, restoreWasCold: true },
     });
 
-    // Idempotent re-send must not clobber the already-populated restore/boot.
+    // Idempotent re-send must not clobber the already-populated dispatch/restore/boot.
     await recordHostedIngressAssistantInputStaged({
       assistantInputId: "input_phase_1",
       at: instant("2026-06-09T10:00:01.000Z"),
@@ -283,6 +291,7 @@ describe("hosted runtime latency dashboard store", () => {
       mailboxItemId: "mailbox_latency_1",
       phaseBreakdown: {
         schemaVersion: 1,
+        dispatch: { invokeReceivedAtEpochMs: 999 },
         restore: { sizeGuardMs: 999 },
         boot: { nodeStartupMs: 999 },
       },
@@ -293,6 +302,10 @@ describe("hosted runtime latency dashboard store", () => {
     trace = prisma.readTrace();
     expect(trace?.phaseBreakdownJson).toEqual({
       schemaVersion: 1,
+      dispatch: {
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+      },
       restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
       boot: { nodeStartupMs: 4200, restoreWasCold: true },
     });
@@ -314,6 +327,10 @@ describe("hosted runtime latency dashboard store", () => {
     trace = prisma.readTrace();
     expect(trace?.phaseBreakdownJson).toEqual({
       schemaVersion: 1,
+      dispatch: {
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+      },
       restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
       boot: { nodeStartupMs: 4200, restoreWasCold: true },
       provider: { sessionResolveMs: 11, promptBuildMs: 22, admissionMs: 33 },

--- a/apps/web/test/hosted-runtime-latency-store.test.ts
+++ b/apps/web/test/hosted-runtime-latency-store.test.ts
@@ -262,7 +262,7 @@ describe("hosted runtime latency dashboard store", () => {
         schemaVersion: 1,
         dispatch: {
           invokeReceivedAtEpochMs: 1_777_000_000_000,
-          containerStartRequestedAtEpochMs: 1_777_000_000_050,
+          containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
         },
         restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
         boot: { nodeStartupMs: 4200, restoreWasCold: true },
@@ -277,7 +277,7 @@ describe("hosted runtime latency dashboard store", () => {
       schemaVersion: 1,
       dispatch: {
         invokeReceivedAtEpochMs: 1_777_000_000_000,
-        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
       },
       restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
       boot: { nodeStartupMs: 4200, restoreWasCold: true },
@@ -304,7 +304,7 @@ describe("hosted runtime latency dashboard store", () => {
       schemaVersion: 1,
       dispatch: {
         invokeReceivedAtEpochMs: 1_777_000_000_000,
-        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
       },
       restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
       boot: { nodeStartupMs: 4200, restoreWasCold: true },
@@ -329,7 +329,7 @@ describe("hosted runtime latency dashboard store", () => {
       schemaVersion: 1,
       dispatch: {
         invokeReceivedAtEpochMs: 1_777_000_000_000,
-        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
       },
       restore: { sizeGuardMs: 1, decryptMs: 5, extractMs: 7 },
       boot: { nodeStartupMs: 4200, restoreWasCold: true },

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -590,8 +590,10 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
     // await, or I/O: restore timings were returned in-memory by the restore call,
     // and the boot.nodeStartupMs (if any) rode in via options.latencyMilestones.
     const incomingBoot = initialAssistantInputLatencyMilestones.phaseBreakdown?.boot;
+    const incomingDispatch = initialAssistantInputLatencyMilestones.phaseBreakdown?.dispatch;
     initialAssistantInputLatencyMilestones.phaseBreakdown = {
       schemaVersion: 1,
+      ...(incomingDispatch ? { dispatch: incomingDispatch } : {}),
       ...(restored.restoreTiming ? { restore: restored.restoreTiming } : {}),
       boot: {
         ...(incomingBoot ?? {}),

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -1426,6 +1426,7 @@ describe("hosted workspace runtime entrypoint", () => {
     });
     const mailboxPort = createMailboxPort({ events, items });
     const imported: Array<{ id: string; route: string }> = [];
+    const importContextMilestones: unknown[] = [];
 
     try {
       const ensureHostedInboxSidecarReadyImpl =
@@ -1466,13 +1467,31 @@ describe("hosted workspace runtime entrypoint", () => {
               }),
             };
           },
-          async importItem(item) {
+          async importItem(item, context) {
             imported.push({
               id: item.item.id,
               route: item.route.action,
             });
             events.push(`import:${item.item.id}`);
+            // Snapshot at call time: the milestone object is shared and mutated
+            // by the runtime across the post-restore phase-breakdown rebuild.
+            importContextMilestones.push(structuredClone(context?.latencyMilestones ?? null));
             return { status: "imported" };
+          },
+          // Incoming container-side milestones: the post-restore rebuild must
+          // PRESERVE the dispatch sub-object alongside the rebuilt restore/boot
+          // (a dropped dispatch here previously killed the instrumentation
+          // end-to-end despite valid headers and a valid parser).
+          latencyMilestones: {
+            phaseBreakdown: {
+              schemaVersion: 1,
+              dispatch: {
+                invokeReceivedAtEpochMs: 1_777_000_000_000,
+                containerStartRequestedAtEpochMs: 1_777_000_000_050,
+              },
+              boot: { nodeStartupMs: 4321 },
+            },
+            runnerJobAcceptedAt: "2026-04-27T00:00:00.100Z",
           },
           platform: createPlatform({
             mailboxPort,
@@ -1493,6 +1512,24 @@ describe("hosted workspace runtime entrypoint", () => {
           id: "mailbox_item_entrypoint_001",
           route: "import-conversation-message",
         },
+      ]);
+      expect(importContextMilestones).toEqual([
+        expect.objectContaining({
+          phaseBreakdown: expect.objectContaining({
+            schemaVersion: 1,
+            dispatch: {
+              invokeReceivedAtEpochMs: 1_777_000_000_000,
+              containerStartRequestedAtEpochMs: 1_777_000_000_050,
+            },
+            boot: expect.objectContaining({
+              nodeStartupMs: 4321,
+              restoreWasCold: expect.any(Boolean),
+            }),
+          }),
+          runnerJobAcceptedAt: "2026-04-27T00:00:00.100Z",
+          runtimePhaseStartedAt: expect.any(String),
+          workspaceRestoreDoneAt: expect.any(String),
+        }),
       ]);
       assert.deepEqual(checkpointRequests.map((request) => request.reason), [
         "idle_shutdown",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -1487,7 +1487,7 @@ describe("hosted workspace runtime entrypoint", () => {
               schemaVersion: 1,
               dispatch: {
                 invokeReceivedAtEpochMs: 1_777_000_000_000,
-                containerStartRequestedAtEpochMs: 1_777_000_000_050,
+                containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
               },
               boot: { nodeStartupMs: 4321 },
             },
@@ -1519,7 +1519,7 @@ describe("hosted workspace runtime entrypoint", () => {
             schemaVersion: 1,
             dispatch: {
               invokeReceivedAtEpochMs: 1_777_000_000_000,
-              containerStartRequestedAtEpochMs: 1_777_000_000_050,
+              containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
             },
             boot: expect.objectContaining({
               nodeStartupMs: 4321,

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -260,7 +260,7 @@ const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_KEYS = new Set([
 ]);
 const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_DISPATCH_KEYS = new Set([
   "invokeReceivedAtEpochMs",
-  "containerStartRequestedAtEpochMs",
+  "containerEnsureReadyStartedAtEpochMs",
 ]);
 const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_RESTORE_KEYS = new Set([
   "sizeGuardMs",
@@ -813,7 +813,7 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
     );
     breakdown.dispatch = {
       ...requireOptionalNonNegativeInteger(dispatch, "invokeReceivedAtEpochMs", dispatchLabel),
-      ...requireOptionalNonNegativeInteger(dispatch, "containerStartRequestedAtEpochMs", dispatchLabel),
+      ...requireOptionalNonNegativeInteger(dispatch, "containerEnsureReadyStartedAtEpochMs", dispatchLabel),
     };
   }
 

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -253,9 +253,14 @@ const HOSTED_RUNTIME_LATENCY_TRACE_PROVIDER_STARTED_KEYS = new Set([
 ]);
 const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_KEYS = new Set([
   "schemaVersion",
+  "dispatch",
   "restore",
   "boot",
   "provider",
+]);
+const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_DISPATCH_KEYS = new Set([
+  "invokeReceivedAtEpochMs",
+  "containerStartRequestedAtEpochMs",
 ]);
 const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_RESTORE_KEYS = new Set([
   "sizeGuardMs",
@@ -797,6 +802,20 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
       `${label}.schemaVersion`,
     ),
   };
+
+  if (record.dispatch !== undefined) {
+    const dispatchLabel = `${label}.dispatch`;
+    const dispatch = requireObject(record.dispatch, dispatchLabel);
+    assertAllowedObjectKeys(
+      dispatch,
+      HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_DISPATCH_KEYS,
+      dispatchLabel,
+    );
+    breakdown.dispatch = {
+      ...requireOptionalNonNegativeInteger(dispatch, "invokeReceivedAtEpochMs", dispatchLabel),
+      ...requireOptionalNonNegativeInteger(dispatch, "containerStartRequestedAtEpochMs", dispatchLabel),
+    };
+  }
 
   if (record.restore !== undefined) {
     const restoreLabel = `${label}.restore`;

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -626,6 +626,14 @@ export type HostedRuntimeLatencyTraceMilestone =
 
 export interface HostedRuntimeLatencyPhaseBreakdown {
   schemaVersion: number;
+  // Durable Object dispatch stamps (DO-side Date.now() epoch ms). Together with
+  // temporal_signal_accepted_at and runner_job_accepted_at they decompose the
+  // dispatch gap into Temporal->DO, DO work, and Cloudflare container
+  // scheduling segments.
+  dispatch?: {
+    invokeReceivedAtEpochMs?: number;
+    containerStartRequestedAtEpochMs?: number;
+  };
   restore?: {
     sizeGuardMs?: number;
     dataKeyUnwrapMs?: number;

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -626,13 +626,16 @@ export type HostedRuntimeLatencyTraceMilestone =
 
 export interface HostedRuntimeLatencyPhaseBreakdown {
   schemaVersion: number;
-  // Durable Object dispatch stamps (DO-side Date.now() epoch ms). Together with
-  // temporal_signal_accepted_at and runner_job_accepted_at they decompose the
-  // dispatch gap into Temporal->DO, DO work, and Cloudflare container
-  // scheduling segments.
+  // Durable Object dispatch stamps (DO-side Date.now() epoch ms), diagnostics
+  // only. invokeReceivedAtEpochMs is stamped when the DO invoke handler starts;
+  // containerEnsureReadyStartedAtEpochMs immediately before ensureContainerReady,
+  // which may be a warm no-op rather than a container start. The segment from
+  // there to runner_job_accepted_at therefore bundles container scheduling/boot
+  // (cold only, nodeStartupMs measures the boot slice), the runner POST, request
+  // body decode, and the lazy runtime-contract load — not pure CF scheduling.
   dispatch?: {
     invokeReceivedAtEpochMs?: number;
-    containerStartRequestedAtEpochMs?: number;
+    containerEnsureReadyStartedAtEpochMs?: number;
   };
   restore?: {
     sizeGuardMs?: number;

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -720,7 +720,7 @@ describe("hosted runtime control contracts", () => {
       schemaVersion: 1,
       dispatch: {
         invokeReceivedAtEpochMs: 1_777_000_000_000,
-        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+        containerEnsureReadyStartedAtEpochMs: 1_777_000_000_050,
       },
       restore: {
         sizeGuardMs: 1,
@@ -819,7 +819,7 @@ describe("hosted runtime control contracts", () => {
     for (const unsafeDispatch of [
       { invokeReceivedAtEpochMs: 1, routedThroughColo: 1 }, // unknown sub key
       { invokeReceivedAtEpochMs: 1.5 }, // non-integer leaf
-      { containerStartRequestedAtEpochMs: -1 }, // negative leaf
+      { containerEnsureReadyStartedAtEpochMs: -1 }, // negative leaf
       { invokeReceivedAtEpochMs: "1777000000000" }, // string leaf
     ]) {
       const parsed = parseHostedRuntimeLatencyTraceRequest({

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -718,6 +718,10 @@ describe("hosted runtime control contracts", () => {
   it("round-trips phaseBreakdown on both latency events and rejects unsafe leaves", () => {
     const stagedBreakdown = {
       schemaVersion: 1,
+      dispatch: {
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+        containerStartRequestedAtEpochMs: 1_777_000_000_050,
+      },
       restore: {
         sizeGuardMs: 1,
         dataKeyUnwrapMs: 2,
@@ -753,6 +757,9 @@ describe("hosted runtime control contracts", () => {
 
     const providerBreakdown = {
       schemaVersion: 1,
+      dispatch: {
+        invokeReceivedAtEpochMs: 1_777_000_000_000,
+      },
       provider: {
         turnLockWaitMs: 1,
         sessionResolveMs: 2,
@@ -803,6 +810,29 @@ describe("hosted runtime control contracts", () => {
         },
       });
       expect(parsed.event.type).toBe("provider_started");
+      expect("phaseBreakdown" in parsed.event).toBe(false);
+    }
+
+    // Dispatch is the same trust boundary: unknown sub keys and non-integer or
+    // negative epoch leaves must drop the whole breakdown (never partially
+    // salvage it) while the staged event itself still parses.
+    for (const unsafeDispatch of [
+      { invokeReceivedAtEpochMs: 1, routedThroughColo: 1 }, // unknown sub key
+      { invokeReceivedAtEpochMs: 1.5 }, // non-integer leaf
+      { containerStartRequestedAtEpochMs: -1 }, // negative leaf
+      { invokeReceivedAtEpochMs: "1777000000000" }, // string leaf
+    ]) {
+      const parsed = parseHostedRuntimeLatencyTraceRequest({
+        event: {
+          assistantInputId: "input_1",
+          at: "2026-04-26T00:00:00.000Z",
+          mailboxItemId: "mailbox_item_1",
+          phaseBreakdown: { schemaVersion: 1, dispatch: unsafeDispatch },
+          source: "linq",
+          type: "assistant_input_staged",
+        },
+      });
+      expect(parsed.event.type).toBe("assistant_input_staged");
       expect("phaseBreakdown" in parsed.event).toBe(false);
     }
 


### PR DESCRIPTION
## What

Two reduced-scope cold-start changes (hosted cold start measures ~13.2s p50 / ~20.6s p90 message-accept → provider-start; the temporal→runner dispatch gap ~3.3s was uninstrumented):

1. **Defer deploy-smoke-only imports** in `container-entrypoint.ts` (`hosted-runner-smoke-contract`, `hosted-assistant-bootstrap`) to dynamic imports inside the smoke handler — dead weight on the cold-boot job path, following the file's existing `loadRuntimeContracts` lazy pattern.
2. **Instrument the dispatch gap**: the per-user DO stamps `Date.now()` at `invokeHostedExecution` entry and immediately before `ensureContainerReady`, sends both as `x-dispatch-*` headers on the existing internal runner POST; they ride the existing `latencyMilestones` seam into `phaseBreakdown.dispatch` (`invokeReceivedAtEpochMs`, `containerEnsureReadyStartedAtEpochMs`). This decomposes the opaque `temporal_signal_accepted_at → runner_job_accepted_at` gap, queryable in `hosted_ingress_latency_trace`. No migration (rides `phase_breakdown_json` schemaVersion 1), no new wake path (Temporal stays sole wake authority), stamps are diagnostics only and never gate a job. Note the final segment bundles container scheduling/boot + runner POST + body decode + lazy contract load (documented on the type); `nodeStartupMs` measures the boot slice and on warm paths `ensureContainerReady` can be a no-op — hence the `EnsureReadyStarted` naming.

### Dropped after measurement: baked `NODE_COMPILE_CACHE`

An earlier revision of this PR baked a warmed Node compile cache into the runner image. Review caught that the original placement (read-only `/app`) silently disabled the cache at runtime (`getCompileCacheDir() === undefined` as the `runner` user). After fixing placement to a runner-writable dir and verifying enablement + 944 cache hits in the real image, benchmarks on the **real production bundle** showed **zero speedup** (module eval ~0.77s cached vs ~0.77s disabled — even under qemu, which amplifies CPU cost). Conclusion: prod's ~3.7s `nodeStartupMs` is not V8 parse-bound; it is most likely I/O on lazy-pulled image layers. Per repo doctrine (optimize only measured bottlenecks), the Dockerfile change was removed; the image-contract test records the measured posture (`not.toContain("NODE_COMPILE_CACHE")` with the rationale). The likely real lever for `nodeStartupMs` is reducing cold file reads (bundling) — a separate decision once the dispatch data from this PR confirms where the time goes.

Also explicitly out of scope: overlapping snapshot fetch with boot — to be decided with the dispatch data.

## Safety

- `phaseBreakdown` remains the secret-safety trust boundary: the new `dispatch` subkey is strictly parsed (two-key allowlist, non-negative safe integers only, unknown keys rejected); the web leaf guard is unchanged. Deploy skew drops only the breakdown, never the latency event.
- Headers carry no authority and are parsed best-effort (`/^\d+$/` + safe-integer; invalid/absent → dropped).
- `/app` immutability posture is untouched (the Dockerfile is unchanged from main).

## Audits

Completion workflow passes (fable subagents, high reasoning): `security-privacy-review` (no security findings; caught a dispatch-drop bug in the post-restore `phaseBreakdown` rebuild in `assistant-runtime/hosted-runtime.ts`, fixed here), `coverage-write` (end-to-end dispatch proofs: parser round-trip/rejection, invocation seam, restore-rebuild preservation with red/green verification, web merge idempotency, header parsing), `task-finish-review` (ready-to-land). A subsequent external review drove: the compile-cache investigation above, the `containerEnsureReadyStartedAtEpochMs` rename, the honest segment comment, and rebasing onto `origin/main` so unpublished base commits no longer leak into this diff.

## Verification

- `packages/hosted-execution` test:coverage: 160/160, 87.7% lines
- `apps/cloudflare` targeted node lanes: runner-container 106/106, entrypoint 46/46, hosted-workspace-invocation + container-image-contract + entrypoint-abort green (170 tests across the four files post-rename)
- `packages/assistant-runtime`: 826 passed; `apps/web` latency-store: 7/7; app/package typechecks green
- Image proofs: `runner:docker:smoke` green; runtime cache-enablement and benchmark probes documented above
- Known pre-existing red: `packages/cli` commons/CI-workflow tests fail identically on pristine HEAD in a fresh worktree (environmental; unrelated files)

## Post-deploy check

Watch `hosted_ingress_latency_trace`: `phaseBreakdown.dispatch.*` should appear on cold/lukewarm traces. Segments: accept→temporal, temporal→`invokeReceivedAtEpochMs` (Temporal+routing), →`containerEnsureReadyStartedAtEpochMs` (DO work), →`runner_job_accepted_at` (container scheduling/boot + request decode; subtract `nodeStartupMs` for the non-boot slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
