### PR TITLE
fix(linq): require direct-chat attestation before rebinding a member's home chat

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/linq-routing-policy.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-routing-policy.ts
@@ -5,6 +5,9 @@ export type HostedLinqActiveRouteDecision =
       kind: "bind_home";
     }
   | {
+      kind: "ignore_unattested_direct";
+    }
+  | {
       kind: "ignore_unknown_home";
     }
   | {
@@ -86,6 +89,7 @@ export function resolveHostedLinqActiveRouteDecision(input: {
   homeChatId: string | null;
   homeRecipientPhone: string | null;
   incomingChatId: string;
+  incomingDirectAttested: boolean;
   incomingRecipientPhone: string | null;
 }): HostedLinqActiveRouteDecision {
   const incomingRecipientPhone = normalizePhoneNumber(input.incomingRecipientPhone);
@@ -117,6 +121,20 @@ export function resolveHostedLinqActiveRouteDecision(input: {
   if (input.homeChatId && !homeRecipientPhone && input.homeChatId !== input.incomingChatId) {
     return {
       kind: "ignore_unknown_home",
+    };
+  }
+
+  // REBINDING a home chat to a different chat id requires the webhook payload to
+  // explicitly attest the chat is direct (is_group === false). Without that attestation a
+  // group message whose is_group flag went missing could silently rebind a member's home
+  // 1:1 thread to the group — and route their private replies into it. Known chat ids are
+  // unaffected (first branch above), and FIRST binds stay permissive: Linq 1:1 payloads
+  // are not confirmed to always carry the flag, and failing closed there would break
+  // signup. Rebind is the only transition where the failure is an irreversible privacy
+  // leak instead of a visible, recoverable onboarding hiccup.
+  if (input.homeChatId && !input.incomingDirectAttested) {
+    return {
+      kind: "ignore_unattested_direct",
     };
   }
 

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -237,6 +237,7 @@ export async function planHostedOnboardingLinqWebhook(input: {
       homeChatId: homeRoute?.linqChatId ?? null,
       homeRecipientPhone: homeRoute?.linqRecipientPhone ?? null,
       incomingChatId: summary.chatId,
+      incomingDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
       incomingRecipientPhone: recipientPhoneNumber,
     });
 
@@ -256,6 +257,19 @@ export async function planHostedOnboardingLinqWebhook(input: {
           reason: "redirect-to-home",
           routeDecision: routeDecision.kind,
           routeStage: "active-member-redirect",
+        }),
+      );
+    }
+
+    if (routeDecision.kind === "ignore_unattested_direct") {
+      return logHostedLinqWebhookPlannerDecisionAndReturn(
+        buildIgnoredLinqWebhookPlan("unattested-direct-chat"),
+        buildHostedLinqWebhookPlannerDetails(input.event, context, {
+          existingMemberActive: true,
+          existingMemberMatch,
+          homeRoutePresent: Boolean(homeRoute?.linqChatId),
+          reason: "unattested-direct-chat",
+          routeStage: "active-member-ignored-unattested-direct",
         }),
       );
     }
@@ -556,6 +570,7 @@ export async function planHostedOnboardingLinqWebhook(input: {
       sourceEventId: input.event.event_id,
     }),
     buildHostedLinqWebhookPlannerDetails(input.event, context, {
+      chatDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
       dailyInboundCount: dailyState.inboundCount,
       existingMemberActive: existingMember ? hasHostedMemberActiveAccess(existingMember) : false,
       existingMemberMatch,
@@ -930,6 +945,12 @@ function isLocalHostedDomainRootAuthorityMismatch(error: unknown): boolean {
 
 function isHostedLinqGroupChat(messageEvent: HostedLinqMessageReceivedEvent): boolean {
   return messageEvent.data.chat?.is_group === true;
+}
+
+function isHostedLinqDirectChatAttested(
+  messageEvent: HostedLinqMessageReceivedEvent,
+): boolean {
+  return messageEvent.data.chat?.is_group === false;
 }
 
 function normalizeHostedLinqPartText(value: unknown): string | null {

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -3315,6 +3315,98 @@ https://join.example.test/join/code_first_text`);
     expect(readHostedMemberRoutingUpsertMock(prisma)).not.toHaveBeenCalled();
   });
 
+  it("refuses to rebind a member's home chat to a new chat id when the payload does not attest the chat is direct", async () => {
+    const prisma = asPrismaTransactionClient({
+      hostedWebhookReceipt: {
+        create: vi.fn().mockResolvedValue({}),
+        findUnique: vi.fn().mockResolvedValue({
+          payloadJson: {
+            eventType: "message.received",
+            receiptAttemptCount: 1,
+            receiptStatus: "processing",
+          },
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      hostedMember: {
+        findUnique: vi.fn().mockResolvedValue({
+          billingStatus: HostedBillingStatus.active,
+          id: "member_123",
+          invites: [],
+          phoneLookupKey: "+15551234567",
+          routing: {
+            linqChatIdEncrypted: await encryptHostedWebNullableString({
+              field: "hosted-member-routing.home-linq-chat-id",
+              memberId: "member_123",
+              value: "chat_home",
+            }),
+            linqRecipientPhoneEncrypted: await encryptHostedWebNullableString({
+              field: "hosted-member-routing.home-linq-recipient-phone",
+              memberId: "member_123",
+              value: "+15550100001",
+            }),
+            memberId: "member_123",
+            pendingLinqChatIdEncrypted: null,
+            pendingLinqRecipientPhoneEncrypted: null,
+            telegramUserIdEncrypted: null,
+            telegramUserLookupKey: null,
+          },
+        }),
+      },
+      hostedMemberRouting: {
+        findUnique: vi.fn().mockResolvedValue({
+          linqChatIdEncrypted: await encryptHostedWebNullableString({
+            field: "hosted-member-routing.home-linq-chat-id",
+            memberId: "member_123",
+            value: "chat_home",
+          }),
+          linqRecipientPhoneEncrypted: await encryptHostedWebNullableString({
+            field: "hosted-member-routing.home-linq-recipient-phone",
+            memberId: "member_123",
+            value: "+15550100001",
+          }),
+          memberId: "member_123",
+        }),
+        upsert: vi.fn(),
+      },
+    });
+
+    // Same recipient line as the bound home, NEW chat id, and no is_group flag at all —
+    // exactly what a group message would look like if the provider's flag went missing.
+    const response = await handleHostedOnboardingLinqWebhook({
+      prisma,
+      rawBody: buildHostedLinqWebhookBody({
+        data: {
+          chat: {
+            id: "chat_possible_group",
+            owner_handle: {
+              handle: "+15550100001",
+              id: "handle_owner_123",
+              is_me: true,
+              service: "iMessage",
+            },
+          },
+        },
+        eventId: "evt_unattested_rebind",
+        service: "iMessage",
+      }),
+      signature: null,
+      timestamp: null,
+    });
+
+    expect(response).toMatchObject({
+      ignored: true,
+      ok: true,
+      reason: "unattested-direct-chat",
+    });
+    expect(readHostedMemberRoutingUpsertMock(prisma)).not.toHaveBeenCalled();
+    expect(mocks.incrementHostedLinqInboundDailyState).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+    expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
+    expect(mocks.enqueueHostedExecutionOutbox).not.toHaveBeenCalled();
+  });
+
   it("suppresses repeat signup links after the first send that day", async () => {
     mocks.readHostedLinqDailyState.mockResolvedValueOnce(makeHostedLinqDailyState({
       inboundCount: 1,

--- a/apps/web/test/hosted-onboarding-linq-routing.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-routing.test.ts
@@ -94,6 +94,8 @@ describe("resolveHostedLinqActiveRouteDecision", () => {
         homeChatId: "chat_home",
         homeRecipientPhone: "+15550100001",
         incomingChatId: "chat_home",
+        // Known chat ids bind without consulting the attestation flag.
+        incomingDirectAttested: false,
         incomingRecipientPhone: "+15550100002",
       }),
     ).toEqual({
@@ -107,6 +109,7 @@ describe("resolveHostedLinqActiveRouteDecision", () => {
         homeChatId: "chat_home",
         homeRecipientPhone: "+15550100001",
         incomingChatId: "chat_other",
+        incomingDirectAttested: false,
         incomingRecipientPhone: "+15550100002",
       }),
     ).toEqual({
@@ -121,6 +124,7 @@ describe("resolveHostedLinqActiveRouteDecision", () => {
         homeChatId: "chat_home",
         homeRecipientPhone: null,
         incomingChatId: "chat_other",
+        incomingDirectAttested: true,
         incomingRecipientPhone: "+15550100002",
       }),
     ).toEqual({
@@ -134,10 +138,69 @@ describe("resolveHostedLinqActiveRouteDecision", () => {
         homeChatId: "chat_home",
         homeRecipientPhone: "+15550100001",
         incomingChatId: "chat_other",
+        incomingDirectAttested: true,
         incomingRecipientPhone: null,
       }),
     ).toEqual({
       kind: "ignore_unknown_home",
+    });
+  });
+
+  it("still binds a FIRST home chat without attestation (signup compatibility)", () => {
+    // Linq 1:1 payloads are not confirmed to always carry is_group; failing closed on the
+    // first bind would break signup. Only rebinds demand the explicit attestation.
+    expect(
+      resolveHostedLinqActiveRouteDecision({
+        homeChatId: null,
+        homeRecipientPhone: null,
+        incomingChatId: "chat_new",
+        incomingDirectAttested: false,
+        incomingRecipientPhone: "+15550100001",
+      }),
+    ).toEqual({
+      kind: "bind_home",
+    });
+  });
+
+  it("binds a first home chat when the payload attests the chat is direct", () => {
+    expect(
+      resolveHostedLinqActiveRouteDecision({
+        homeChatId: null,
+        homeRecipientPhone: null,
+        incomingChatId: "chat_new",
+        incomingDirectAttested: true,
+        incomingRecipientPhone: "+15550100001",
+      }),
+    ).toEqual({
+      kind: "bind_home",
+    });
+  });
+
+  it("refuses to rebind the home chat to a new chat id without an explicit direct attestation", () => {
+    expect(
+      resolveHostedLinqActiveRouteDecision({
+        homeChatId: "chat_home",
+        homeRecipientPhone: "+15550100001",
+        incomingChatId: "chat_other",
+        incomingDirectAttested: false,
+        incomingRecipientPhone: "+15550100001",
+      }),
+    ).toEqual({
+      kind: "ignore_unattested_direct",
+    });
+  });
+
+  it("rebinds to a new chat id when the payload attests the chat is direct", () => {
+    expect(
+      resolveHostedLinqActiveRouteDecision({
+        homeChatId: "chat_home",
+        homeRecipientPhone: "+15550100001",
+        incomingChatId: "chat_other",
+        incomingDirectAttested: true,
+        incomingRecipientPhone: "+15550100001",
+      }),
+    ).toEqual({
+      kind: "bind_home",
     });
   });
 });

--- a/packages/messaging-ingress/src/linq-webhook.ts
+++ b/packages/messaging-ingress/src/linq-webhook.ts
@@ -467,6 +467,26 @@ function normalizeNullableString(value: unknown): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+function normalizeLinqIsGroupFlag(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  // Provider type drift defense: a stringly-typed flag must not silently demote a group
+  // chat to "unknown" (and thereby look more direct than it is).
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") {
+      return true;
+    }
+    if (normalized === "false") {
+      return false;
+    }
+  }
+
+  return undefined;
+}
+
 function normalizeRequiredString(value: unknown, label: string): string {
   const normalized = normalizeNullableString(value);
   if (!normalized) {
@@ -715,7 +735,7 @@ function parseOptionalChatInfo(value: unknown): LinqChatInfo | null {
   const record = toLinqObjectRecord(value, "Linq message.received chat");
   return {
     id: normalizeRequiredString(record.id, "Linq message.received chat.id"),
-    is_group: typeof record.is_group === "boolean" ? record.is_group : undefined,
+    is_group: normalizeLinqIsGroupFlag(record.is_group),
     owner_handle: parseOptionalChatHandle(record.owner_handle) ?? undefined,
   };
 }

--- a/packages/messaging-ingress/test/linq-webhook.test.ts
+++ b/packages/messaging-ingress/test/linq-webhook.test.ts
@@ -1559,3 +1559,56 @@ function buildV2026MessageReceivedWebhook(input: {
     trace_id: input.traceId ?? undefined,
   };
 }
+
+test("parseLinqMessageReceivedEvent coerces stringly-typed is_group flags", () => {
+  const buildPayload = (isGroup: unknown) => ({
+    api_version: "v3",
+    created_at: "2026-04-04T01:02:03.000Z",
+    data: {
+      chat: {
+        id: "chat_flag_drift",
+        is_group: isGroup,
+        owner_handle: {
+          handle: "+15557654321",
+          id: "handle_owner_flag_drift",
+          is_me: true,
+          service: "iMessage",
+        },
+      },
+      direction: "inbound",
+      id: "msg_flag_drift",
+      parts: [
+        {
+          type: "text",
+          value: "hello",
+        },
+      ],
+      sender_handle: {
+        handle: "+15551234567",
+        id: "handle_sender_flag_drift",
+        service: "iMessage",
+      },
+      sent_at: "2026-04-04T01:02:00.000Z",
+      service: "iMessage",
+    },
+    event_id: "evt_flag_drift",
+    event_type: "message.received",
+  });
+
+  assert.equal(
+    parseLinqMessageReceivedEvent(buildPayload("True")).data.chat?.is_group,
+    true,
+  );
+  assert.equal(
+    parseLinqMessageReceivedEvent(buildPayload("false")).data.chat?.is_group,
+    false,
+  );
+  assert.equal(
+    parseLinqMessageReceivedEvent(buildPayload(1)).data.chat?.is_group,
+    undefined,
+  );
+  assert.equal(
+    parseLinqMessageReceivedEvent(buildPayload("yes")).data.chat?.is_group,
+    undefined,
+  );
+});


### PR DESCRIPTION
## What

Trust-boundary hardening before Murph's number starts living in family group chats (Wizard-of-Oz referee experiments).

**The hole:** inbound group messages are dropped by the `is_group === true` gate — but if Linq ever *omits* the flag (or sends it as a string), a group message from a registered member fell through to the routing policy, whose final fall-through silently **rebound the member's home 1:1 chat to the group thread**. Their private Murph's next reply would land in the family chat. Irreversible privacy leak, one missing provider field away.

## The guard

Rebinding a home chat to a **new** chat id now requires the payload to explicitly attest `is_group === false` (new `ignore_unattested_direct` decision, logged with routeStage `active-member-ignored-unattested-direct`).

Deliberately narrow:
- **Known chat ids bind exactly as before** — flag-irrelevant (established 1:1 threads keep working even if Linq drops the field entirely)
- **First binds stay permissive** — Linq 1:1 payloads are not confirmed to always carry the flag (the dispatch-test fixtures, modeled on real payloads, omit it), and failing closed there would break signup. Rebind is the only transition where failure is an irreversible privacy leak instead of a visible, recoverable onboarding hiccup
- **Observability for tightening later:** the signup planner log now records `chatDirectAttested`, so real traffic will show whether the flag is always present on 1:1s — evidence to gate first-contact too, if it holds

Plus ingress parser hardening: stringly-typed `is_group` (`"true"`/`"false"`, any case) coerces to boolean; anything else stays unknown.

## Tests

- Routing policy: refuses unattested rebind; allows attested rebind; known-chat and first-bind unchanged (flag-irrelevance asserted)
- Dispatch-level: registered member + bound home + new chat id + **no flag at all** (exact missing-flag group shape) → ignored, zero routing upserts / mailbox appends / signals / sends
- Parser: string coercion cases

`pnpm --dir apps/web typecheck` clean; web suite 258 files / 2,274 tests green; messaging-ingress 68 green.

## DEPLOYMENT CONCERNS

None — apps/web only (plus messaging-ingress consumed by web). No schema, no Cloudflare coupling, independently deployable. After deploy, the family group-chat smoke test should show `routeStage: "ignored-group-chat"` for a test message, and `chatDirectAttested: true/false` in signup logs reveals Linq's real flag behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783718335&installation_id=127572939&pr_number=121&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F121&signature=690e5a9ed155ad36d40e329261a854ff7185a57bccbf94de1279428026b74053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->