### PR TITLE
Add dedupe-device-imports cleanup for pre-idempotency duplicate device events

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-10-device-event-dedupe-cleanup.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-device-event-dedupe-cleanup.md
@@ -1,0 +1,45 @@
+# Device Event Dedupe Cleanup Primitive
+
+Created: 2026-06-10
+Status: completed
+
+## Problem
+
+Vaults that imported wearable data before device imports became idempotent on
+externalRef (#116) carry duplicate device events (one hosted vault: ~4,100
+duplicates across ~341 provider records). The importer fix stops new
+duplicates but old ones are outside every trailing poll window, so they never
+self-heal. Affected hosted users need a safe, repeatable cleanup they can run
+by asking their Murph.
+
+## Change
+
+- `packages/core`: `dedupeDeviceEventsByExternalRef({ vaultRoot, apply })` —
+  groups live device events per monthly shard by the same externalRef identity
+  the importer reconciles on, keeps the spine-latest copy per group, and
+  appends tombstone spine revisions for the rest (same shape as `deleteEvent`,
+  append-only). Dry-run by default; `apply: true` writes one canonical batch
+  with one `event_delete` audit record. Idempotent.
+- `packages/vault-usecases`: `dedupeDeviceImportEventRecords` usecase wrapping
+  the core port with CLI error translation.
+- `packages/cli`: `vault-cli event dedupe-device-imports [--apply]`, dry-run
+  report by default; regenerated `incur.generated.ts` / `config.schema.json`.
+
+## Safety decisions
+
+- Revision-visibility guard: any duplicate id that has a higher spine revision
+  anywhere in the ledger than the device-filtered view can see (e.g. a user
+  edit that dropped the device source or externalRef) is skipped entirely and
+  surfaced as `skippedRevisedElsewhereCount`, never tombstoned.
+- Duplicates of one provider record split across different monthly shards
+  (pre-#116 occurredAt drift) are not collapsed; this mirrors the importer's
+  per-shard reconcile scope and stays visible in the dry-run report.
+
+## Verification
+
+- Core tests: dry-run/apply/idempotency/no-op coverage in
+  `packages/core/test/device-import.test.ts`.
+- Built-CLI scenario: seeded vault with 2 legacy duplicates → dry-run reports
+  2, `--apply` tombstones 2 + audit, rerun reports 0.
+Updated: 2026-06-10
+Completed: 2026-06-10

--- a/packages/cli/config.schema.json
+++ b/packages/cli/config.schema.json
@@ -7228,6 +7228,29 @@
                     }
                   }
                 },
+                "dedupe-device-imports": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "options": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "requestId": {
+                          "description": "Optional caller-supplied request id for audit correlation.",
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 128
+                        },
+                        "apply": {
+                          "default": false,
+                          "description": "Apply the cleanup. Without this flag the command only reports what it would tombstone.",
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                },
                 "encounter": {
                   "type": "object",
                   "additionalProperties": false,

--- a/packages/cli/src/commands/event.ts
+++ b/packages/cli/src/commands/event.ts
@@ -22,6 +22,7 @@ import {
   type JsonObject,
 } from '@murphai/vault-usecases'
 import {
+  dedupeDeviceImportEventRecords,
   deleteEventRecord,
   editEventRecord,
   upsertEventRecord,
@@ -58,6 +59,18 @@ const eventUpsertResultSchema = z.object({
   lookupId: z.string().min(1),
   ledgerFile: pathSchema,
   created: z.boolean(),
+})
+
+const eventDedupeDeviceImportsResultSchema = z.object({
+  vault: pathSchema,
+  applied: z.boolean(),
+  scannedLiveDeviceEventCount: z.number().int().nonnegative(),
+  duplicateGroupCount: z.number().int().nonnegative(),
+  tombstonedEventCount: z.number().int().nonnegative(),
+  tombstonedByKind: z.record(z.string(), z.number().int().nonnegative()),
+  skippedRevisedElsewhereCount: z.number().int().nonnegative(),
+  shardPaths: z.array(pathSchema),
+  auditPath: pathSchema.nullable(),
 })
 
 const eventListResultSchema = z.object({
@@ -913,6 +926,27 @@ export function registerEventCommands(cli: Cli.Cli, services: VaultServices) {
         vault: options.vault,
         kind: 'exposure',
         result,
+      })
+    },
+  })
+
+  event.command('dedupe-device-imports', {
+    description:
+      'Report duplicate device-imported events that share one provider record identity, and optionally tombstone all but the latest copy.',
+    hint:
+      'Runs as a dry-run report by default. Re-run with --apply to tombstone the duplicates; the latest copy of each record is kept.',
+    args: z.object({}),
+    options: withBaseOptions({
+      apply: z
+        .boolean()
+        .default(false)
+        .describe('Apply the cleanup. Without this flag the command only reports what it would tombstone.'),
+    }),
+    output: eventDedupeDeviceImportsResultSchema,
+    async run({ options }) {
+      return dedupeDeviceImportEventRecords({
+        vault: options.vault,
+        apply: options.apply,
       })
     },
   })

--- a/packages/cli/src/incur.generated.ts
+++ b/packages/cli/src/incur.generated.ts
@@ -77,6 +77,7 @@ declare module 'incur' {
       'document manifest': { args: { id: string }; options: { requestId?: string } }
       'document show': { args: { id: string }; options: { requestId?: string } }
       'event adverse-effect add': { args: {}; options: { requestId?: string; substance: string; effect: string; severity?: "mild" | "moderate" | "severe"; occurredAt: string | string; source?: "manual" | "import" | "device" | "derived"; title?: string; note?: string; tag?: string[] } }
+      'event dedupe-device-imports': { args: {}; options: { requestId?: string; apply: boolean } }
       'event delete': { args: { id: string }; options: { requestId?: string } }
       'event edit': { args: { id: string }; options: { requestId?: string; title?: string; note?: string; occurredAt?: string | string; timeZone?: string; dayKey?: string; source?: "manual" | "import" | "device" | "derived"; tag?: string[]; clearTitle?: boolean; clearNote?: boolean; clearTimeZone?: boolean; clearDayKey?: boolean; clearSource?: boolean; clearTags?: boolean; dayKeyPolicy?: "keep" | "recompute" } }
       'event encounter add': { args: {}; options: { requestId?: string; encounterType: string; location?: string; providerId?: string; occurredAt: string | string; source?: "manual" | "import" | "device" | "derived"; title?: string; note?: string; tag?: string[] } }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,7 @@ export {
   checkpointExperiment,
   copyRawArtifact,
   createExperiment,
+  dedupeDeviceEventsByExternalRef,
   deleteEvent,
   deleteFood,
   deleteProvider,

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -49,7 +49,7 @@ import {
   normalizeCanonicalEventLinks,
 } from "./event-links.ts";
 import { VaultError } from "./errors.ts";
-import { pathExists, readUtf8File, writeVaultTextFile } from "./fs.ts";
+import { pathExists, readUtf8File, walkVaultFiles, writeVaultTextFile } from "./fs.ts";
 import { parseFrontmatterDocument, stringifyFrontmatterDocument } from "./frontmatter.ts";
 import { deterministicContractId, generateRecordId } from "./ids.ts";
 import { readJsonlRecords, toMonthlyShardRelativePath } from "./jsonl.ts";
@@ -1637,6 +1637,186 @@ async function reconcileDeviceEventEntriesByExternalRef(
     skippedDuplicateCount,
     supersededCount,
   };
+}
+
+export interface DedupeDeviceEventsByExternalRefInput {
+  vaultRoot: string;
+  apply?: boolean;
+}
+
+export interface DedupeDeviceEventsByExternalRefResult {
+  applied: boolean;
+  scannedLiveDeviceEventCount: number;
+  duplicateGroupCount: number;
+  tombstonedEventCount: number;
+  tombstonedByKind: Record<string, number>;
+  skippedRevisedElsewhereCount: number;
+  shardPaths: string[];
+  auditPath: string | null;
+}
+
+const DEDUPE_AUDIT_TARGET_ID_LIMIT = 50;
+
+// One-time/maintenance cleanup for vaults that accumulated duplicate device
+// events before importDeviceBatch merged idempotently on externalRef: group
+// live device events by the same externalRef identity the importer uses, keep
+// the spine-latest copy per group, and tombstone the rest (append-only spine
+// deletes, same shape as deleteEvent). Dry-run by default.
+export async function dedupeDeviceEventsByExternalRef({
+  vaultRoot,
+  apply = false,
+}: DedupeDeviceEventsByExternalRefInput): Promise<DedupeDeviceEventsByExternalRefResult> {
+  const shardPaths = await walkVaultFiles(vaultRoot, VAULT_LAYOUT.eventLedgerDirectory, {
+    extension: ".jsonl",
+  });
+  const deletedAt = new Date().toISOString();
+  const groupedByShard = new Map<string, Map<string, EventSpineEntry<EventRecord>[]>>();
+  // Highest revision per event id across ALL parsed rows in ALL shards,
+  // including revisions without a device source or externalRef (e.g. a user
+  // edit through upsertEvent that did not echo them). The device-filtered
+  // grouping below cannot see those revisions, so any id with a higher
+  // revision elsewhere is left untouched instead of risking a tombstone that
+  // collides with or shadows the invisible revision.
+  const maxRevisionById = new Map<string, number>();
+
+  for (const relativePath of shardPaths) {
+    const grouped = new Map<string, EventSpineEntry<EventRecord>[]>();
+
+    for (const raw of await readJsonlRecords({ vaultRoot, relativePath })) {
+      const parsed = safeParseContract(eventRecordSchema, raw);
+
+      if (!parsed.success) {
+        continue;
+      }
+
+      maxRevisionById.set(
+        parsed.data.id,
+        Math.max(maxRevisionById.get(parsed.data.id) ?? 0, eventSpineRevision(parsed.data)),
+      );
+
+      if (parsed.data.source !== "device" || !parsed.data.externalRef) {
+        continue;
+      }
+
+      const refKey = deviceEventExternalRefKey(parsed.data.externalRef);
+      const group = grouped.get(refKey) ?? [];
+      group.push({ relativePath, record: parsed.data });
+      grouped.set(refKey, group);
+    }
+
+    if (grouped.size > 0) {
+      groupedByShard.set(relativePath, grouped);
+    }
+  }
+
+  const tombstonePayloadByShard = new Map<string, string>();
+  const tombstonedEventIds: string[] = [];
+  const tombstonedByKind: Record<string, number> = {};
+  let scannedLiveDeviceEventCount = 0;
+  let duplicateGroupCount = 0;
+  let skippedRevisedElsewhereCount = 0;
+
+  for (const grouped of groupedByShard.values()) {
+    for (const group of grouped.values()) {
+      const livePerId = collapseEventSpineEntries(group);
+      scannedLiveDeviceEventCount += livePerId.length;
+
+      if (livePerId.length <= 1) {
+        continue;
+      }
+
+      const winner = selectLatestEventSpineEntry(livePerId);
+      duplicateGroupCount += 1;
+
+      for (const entry of livePerId) {
+        if (entry.record.id === winner?.record.id) {
+          continue;
+        }
+
+        if ((maxRevisionById.get(entry.record.id) ?? 0) > eventSpineRevision(entry.record)) {
+          skippedRevisedElsewhereCount += 1;
+          continue;
+        }
+
+        const tombstone = {
+          ...entry.record,
+          recordedAt: deletedAt,
+          lifecycle: buildEventSpineLifecycle(eventSpineRevision(entry.record) + 1, "deleted"),
+        };
+        assertContractShape(
+          eventRecordSchema,
+          tombstone,
+          "EVENT_CONTRACT_INVALID",
+          "Deduped device event tombstone is invalid.",
+        );
+        tombstonePayloadByShard.set(
+          entry.relativePath,
+          `${tombstonePayloadByShard.get(entry.relativePath) ?? ""}${JSON.stringify(tombstone)}\n`,
+        );
+        tombstonedEventIds.push(entry.record.id);
+        tombstonedByKind[entry.record.kind] = (tombstonedByKind[entry.record.kind] ?? 0) + 1;
+      }
+    }
+  }
+
+  const touchedShardPaths = [...tombstonePayloadByShard.keys()].sort();
+  const truncationNote = tombstonedEventIds.length > DEDUPE_AUDIT_TARGET_ID_LIMIT
+    ? ` (first ${DEDUPE_AUDIT_TARGET_ID_LIMIT} target ids listed)`
+    : "";
+  const summary =
+    `Deduped device events by externalRef: tombstoned ${tombstonedEventIds.length} duplicate event(s) `
+    + `across ${duplicateGroupCount} group(s), keeping the latest copy per group${truncationNote}.`;
+
+  if (!apply || tombstonedEventIds.length === 0) {
+    return {
+      applied: false,
+      scannedLiveDeviceEventCount,
+      duplicateGroupCount,
+      tombstonedEventCount: tombstonedEventIds.length,
+      tombstonedByKind,
+      skippedRevisedElsewhereCount,
+      shardPaths: touchedShardPaths,
+      auditPath: null,
+    };
+  }
+
+  return runCanonicalWrite({
+    vaultRoot,
+    operationType: "device_event_dedupe",
+    summary,
+    occurredAt: deletedAt,
+    mutate: async ({ batch }) => {
+      for (const relativePath of touchedShardPaths) {
+        const payload = tombstonePayloadByShard.get(relativePath);
+
+        if (payload) {
+          await batch.stageJsonlAppend(relativePath, payload);
+        }
+      }
+
+      const audit = await emitAuditRecord({
+        vaultRoot,
+        batch,
+        action: "event_delete",
+        commandName: "core.dedupeDeviceEventsByExternalRef",
+        summary,
+        occurredAt: deletedAt,
+        files: touchedShardPaths,
+        targetIds: tombstonedEventIds.slice(0, DEDUPE_AUDIT_TARGET_ID_LIMIT),
+      });
+
+      return {
+        applied: true,
+        scannedLiveDeviceEventCount,
+        duplicateGroupCount,
+        tombstonedEventCount: tombstonedEventIds.length,
+        tombstonedByKind,
+        skippedRevisedElsewhereCount,
+        shardPaths: touchedShardPaths,
+        auditPath: audit.relativePath,
+      };
+    },
+  });
 }
 
 function buildDeviceBatchAuditSummary(input: {

--- a/packages/core/src/public-mutations.ts
+++ b/packages/core/src/public-mutations.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   addMeal as addMealInternal,
+  dedupeDeviceEventsByExternalRef as dedupeDeviceEventsByExternalRefInternal,
   importDeviceBatch as importDeviceBatchInternal,
   importDocument as importDocumentInternal,
   importSamples as importSamplesInternal,
@@ -589,6 +590,12 @@ export async function importDeviceBatch(
   input: Parameters<typeof importDeviceBatchInternal>[0],
 ): ReturnType<typeof importDeviceBatchInternal> {
   return withCanonicalInputWriteLock(input, importDeviceBatchInternal);
+}
+
+export async function dedupeDeviceEventsByExternalRef(
+  input: Parameters<typeof dedupeDeviceEventsByExternalRefInternal>[0],
+): ReturnType<typeof dedupeDeviceEventsByExternalRefInternal> {
+  return withCanonicalInputWriteLock(input, dedupeDeviceEventsByExternalRefInternal);
 }
 
 export async function importAssessmentResponse(

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -7,6 +7,7 @@ import { test } from "vitest";
 import type { AuditRecord, EventRecord, SampleRecord } from "@murphai/contracts";
 
 import {
+  dedupeDeviceEventsByExternalRef,
   deleteEvent,
   findEventByExternalRef,
   importDeviceBatch,
@@ -2210,4 +2211,377 @@ test("importDeviceBatch supersedes an in-batch fresh record when a later entry c
   assert.equal(result.events.length, 2);
   assert.equal(result.events[0]?.id, result.events[1]?.id);
   assert.equal(result.events[1]?.lifecycle?.revision, 2);
+});
+
+test("dedupeDeviceEventsByExternalRef tombstones legacy duplicates and keeps the latest copy", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-dedupe-cleanup");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_a",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const keptId = first.events[0]?.id as string;
+  const shardPath = first.eventShardPaths[0] as string;
+
+  // Simulate the pre-fix on-disk state: the same provider record exists as
+  // two more live events under different ids (accountId churn duplicates).
+  const stored = (await readJsonlRecords({ vaultRoot, relativePath: shardPath }))[0] as EventRecord;
+  for (const [duplicateId, recordedAt] of [
+    ["evt_0000000000000000000000DP21", "2026-06-02T07:00:00.000Z"],
+    ["evt_0000000000000000000000DP22", "2026-06-01T07:00:00.000Z"],
+  ] as const) {
+    await fs.appendFile(
+      path.join(vaultRoot, shardPath),
+      `${JSON.stringify({ ...stored, id: duplicateId, recordedAt })}\n`,
+    );
+  }
+
+  const dryRun = await dedupeDeviceEventsByExternalRef({ vaultRoot });
+
+  assert.equal(dryRun.applied, false);
+  assert.equal(dryRun.duplicateGroupCount, 1);
+  assert.equal(dryRun.tombstonedEventCount, 2);
+  assert.deepEqual(dryRun.tombstonedByKind, { activity_session: 2 });
+  assert.equal(
+    (await readJsonlRecords({ vaultRoot, relativePath: shardPath })).length,
+    3,
+    "dry run must not write",
+  );
+
+  const applied = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+
+  assert.equal(applied.applied, true);
+  assert.equal(applied.duplicateGroupCount, 1);
+  assert.equal(applied.tombstonedEventCount, 2);
+  assert.ok(applied.auditPath);
+
+  const records = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  const deletedIds = new Set(
+    records.filter((record) => record.lifecycle?.state === "deleted").map((record) => record.id),
+  );
+  const liveIds = new Set(records.map((record) => record.id).filter((id) => !deletedIds.has(id)));
+
+  assert.equal(records.length, 5, "expected 3 originals + 2 tombstones");
+  assert.deepEqual([...liveIds], [keptId]);
+
+  // Idempotent: a second pass finds nothing.
+  const second = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+  assert.equal(second.tombstonedEventCount, 0);
+  assert.equal(second.duplicateGroupCount, 0);
+  assert.equal(second.applied, false);
+
+  // And the importer keeps deduping against the surviving copy afterwards.
+  const replay = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_b",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  assert.equal(replay.events[0]?.id, keptId);
+  assert.equal(
+    (await readJsonlRecords({ vaultRoot, relativePath: shardPath })).length,
+    5,
+    "replay after cleanup must not append",
+  );
+});
+
+test("dedupeDeviceEventsByExternalRef leaves distinct records and non-device events alone", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-dedupe-noop");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_a",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [
+      buildJunctionStyleWorkoutEvent(),
+      buildJunctionStyleWorkoutEvent({ resourceId: "workouts-other" }),
+      {
+        kind: "note",
+        occurredAt: "2026-06-03T19:55:00.000Z",
+        recordedAt: "2026-06-03T20:30:00.000Z",
+        note: "no external ref",
+      },
+    ],
+  });
+
+  const result = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+
+  assert.equal(result.duplicateGroupCount, 0);
+  assert.equal(result.tombstonedEventCount, 0);
+  assert.equal(result.scannedLiveDeviceEventCount, 2);
+});
+
+test("dedupeDeviceEventsByExternalRef keeps the highest-revision duplicate and skips already-tombstoned copies", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-dedupe-revision-winner");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_a",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const loserId = first.events[0]?.id as string;
+  const shardPath = first.eventShardPaths[0] as string;
+  const stored = (await readJsonlRecords({ vaultRoot, relativePath: shardPath }))[0] as EventRecord;
+
+  // A churn duplicate that was later superseded in place (revision 2). Its
+  // recordedAt is older than the rev-1 copy's, so revision priority — not
+  // recordedAt — must decide the surviving copy.
+  const supersededId = "evt_0000000000000000000000DP31";
+  await fs.appendFile(
+    path.join(vaultRoot, shardPath),
+    `${JSON.stringify({ ...stored, id: supersededId, recordedAt: "2026-06-01T07:00:00.000Z" })}\n`
+      + `${JSON.stringify({ ...stored, id: supersededId, recordedAt: "2026-06-01T08:00:00.000Z", lifecycle: { revision: 2 } })}\n`,
+  );
+
+  // A third duplicate already tombstoned by a partial prior cleanup: it must
+  // stay deleted and stay out of the live grouping.
+  const priorTombstonedId = "evt_0000000000000000000000DP32";
+  await fs.appendFile(
+    path.join(vaultRoot, shardPath),
+    `${JSON.stringify({ ...stored, id: priorTombstonedId, recordedAt: "2026-06-01T09:00:00.000Z" })}\n`
+      + `${JSON.stringify({ ...stored, id: priorTombstonedId, recordedAt: "2026-06-02T09:00:00.000Z", lifecycle: { revision: 2, state: "deleted" } })}\n`,
+  );
+
+  const applied = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+
+  assert.equal(
+    applied.scannedLiveDeviceEventCount,
+    2,
+    "already-tombstoned duplicate must not count as live",
+  );
+  assert.equal(applied.duplicateGroupCount, 1);
+  assert.equal(applied.tombstonedEventCount, 1);
+
+  const records = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  const deletedIds = new Set(
+    records.filter((record) => record.lifecycle?.state === "deleted").map((record) => record.id),
+  );
+  const liveIds = new Set(records.map((record) => record.id).filter((id) => !deletedIds.has(id)));
+
+  assert.deepEqual([...liveIds], [supersededId], "the revision-2 copy must survive");
+  assert.ok(deletedIds.has(loserId), "the rev-1 copy with the latest recordedAt must be tombstoned");
+  const loserTombstone = records.find(
+    (record) => record.id === loserId && record.lifecycle?.state === "deleted",
+  );
+  assert.equal(loserTombstone?.lifecycle?.revision, 2);
+  assert.equal(
+    records.filter((record) => record.id === priorTombstonedId).length,
+    2,
+    "already-tombstoned duplicate must not be tombstoned again",
+  );
+});
+
+test("dedupeDeviceEventsByExternalRef does not cross-tombstone distinct facets sharing one resourceId", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-dedupe-facets");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const buildFacetObservation = (facet: string, value: number) => ({
+    kind: "observation" as const,
+    occurredAt: "2026-06-03T07:30:00.000Z",
+    recordedAt: "2026-06-03T07:30:00.000Z",
+    title: `Junction ${facet}`,
+    externalRef: {
+      system: "junction",
+      resourceType: "junction-whoop-v2-recovery",
+      resourceId: "recovery-1",
+      facet,
+    },
+    fields: {
+      metric: facet,
+      value,
+      unit: "%",
+    },
+  });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_a",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [
+      buildFacetObservation("recovery-score", 67),
+      buildFacetObservation("skin-temp-deviation", 3),
+    ],
+  });
+  const shardPath = first.eventShardPaths[0] as string;
+
+  // Only the recovery-score facet has a legacy churn duplicate; the
+  // skin-temp-deviation facet shares the resourceId and must stay untouched.
+  const stored = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  const recoveryScore = stored.find(
+    (record) => record.externalRef?.facet === "recovery-score",
+  ) as EventRecord;
+  const duplicateId = "evt_0000000000000000000000DP33";
+  await fs.appendFile(
+    path.join(vaultRoot, shardPath),
+    `${JSON.stringify({ ...recoveryScore, id: duplicateId, recordedAt: "2026-06-01T07:00:00.000Z" })}\n`,
+  );
+
+  const applied = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+
+  assert.equal(applied.scannedLiveDeviceEventCount, 3);
+  assert.equal(applied.duplicateGroupCount, 1);
+  assert.equal(applied.tombstonedEventCount, 1);
+
+  const records = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  const deletedIds = new Set(
+    records.filter((record) => record.lifecycle?.state === "deleted").map((record) => record.id),
+  );
+  const liveFacets = records
+    .filter((record) => !deletedIds.has(record.id))
+    .map((record) => record.externalRef?.facet)
+    .sort();
+
+  assert.deepEqual(deletedIds, new Set([duplicateId]));
+  assert.deepEqual(liveFacets, ["recovery-score", "skin-temp-deviation"]);
+});
+
+test("dedupeDeviceEventsByExternalRef cleans duplicates across monthly shards in one apply", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-dedupe-multishard");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const june = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_a",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const july = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_a",
+    importedAt: "2026-07-03T21:00:00.000Z",
+    events: [
+      {
+        ...buildJunctionStyleWorkoutEvent({
+          recordedAt: "2026-07-03T20:30:00.000Z",
+          resourceId: "workouts-july-7a51",
+        }),
+        occurredAt: "2026-07-03T19:55:00.000Z",
+      },
+    ],
+  });
+  const juneShard = june.eventShardPaths[0] as string;
+  const julyShard = july.eventShardPaths[0] as string;
+  assert.notEqual(juneShard, julyShard, "expected the July event to land in a second monthly shard");
+
+  const juneDuplicateId = "evt_0000000000000000000000DP41";
+  const julyDuplicateId = "evt_0000000000000000000000DP42";
+  for (const [shardPath, duplicateId] of [
+    [juneShard, juneDuplicateId],
+    [julyShard, julyDuplicateId],
+  ] as const) {
+    const stored = (await readJsonlRecords({ vaultRoot, relativePath: shardPath }))[0] as EventRecord;
+    await fs.appendFile(
+      path.join(vaultRoot, shardPath),
+      `${JSON.stringify({ ...stored, id: duplicateId, recordedAt: "2026-05-30T07:00:00.000Z" })}\n`,
+    );
+  }
+
+  const dryRun = await dedupeDeviceEventsByExternalRef({ vaultRoot });
+
+  assert.equal(dryRun.applied, false);
+  assert.equal(dryRun.duplicateGroupCount, 2);
+  assert.equal(dryRun.tombstonedEventCount, 2);
+  assert.deepEqual(dryRun.shardPaths, [juneShard, julyShard].sort());
+
+  const applied = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+
+  assert.equal(applied.applied, true);
+  assert.equal(applied.duplicateGroupCount, 2);
+  assert.equal(applied.tombstonedEventCount, 2);
+  assert.deepEqual(applied.shardPaths, [juneShard, julyShard].sort());
+  assert.ok(applied.auditPath);
+
+  // Both shards got their tombstone in the single canonical write.
+  for (const [shardPath, duplicateId, keptId] of [
+    [juneShard, juneDuplicateId, june.events[0]?.id as string],
+    [julyShard, julyDuplicateId, july.events[0]?.id as string],
+  ] as const) {
+    const records = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+    assert.equal(records.length, 3, `expected original + duplicate + tombstone in ${shardPath}`);
+    const deletedIds = new Set(
+      records.filter((record) => record.lifecycle?.state === "deleted").map((record) => record.id),
+    );
+    assert.deepEqual(deletedIds, new Set([duplicateId]));
+    assert.ok(records.some((record) => record.id === keptId));
+  }
+
+  // One audit record covers both shards.
+  const auditRecords = (await readJsonlRecords({
+    vaultRoot,
+    relativePath: applied.auditPath as string,
+  })) as AuditRecord[];
+  const dedupeAudits = auditRecords.filter(
+    (record) => record.commandName === "core.dedupeDeviceEventsByExternalRef",
+  );
+  assert.equal(dedupeAudits.length, 1, "expected one audit record for the whole apply");
+  assert.equal(dedupeAudits[0]?.action, "event_delete");
+  assert.deepEqual(
+    [...(dedupeAudits[0]?.targetIds ?? [])].sort(),
+    [juneDuplicateId, julyDuplicateId].sort(),
+  );
+  const auditChangePaths = dedupeAudits[0]?.changes.map((change) => change.path) ?? [];
+  assert.ok(auditChangePaths.includes(juneShard), "audit must reference the June shard");
+  assert.ok(auditChangePaths.includes(julyShard), "audit must reference the July shard");
+
+  const second = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+  assert.equal(second.tombstonedEventCount, 0);
+  assert.equal(second.applied, false);
+});
+
+test("dedupeDeviceEventsByExternalRef leaves duplicates with invisible later revisions untouched", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-dedupe-revised-elsewhere");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_a",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [buildJunctionStyleWorkoutEvent()],
+  });
+  const shardPath = first.eventShardPaths[0] as string;
+  const stored = (await readJsonlRecords({ vaultRoot, relativePath: shardPath }))[0] as EventRecord;
+
+  // Legacy churn duplicate, then a user edit of that duplicate through the
+  // generic event spine that dropped both source and externalRef: the edit
+  // revision is invisible to the device-filtered dedupe scan.
+  const duplicateId = "evt_0000000000000000000000DP41";
+  await fs.appendFile(
+    path.join(vaultRoot, shardPath),
+    `${JSON.stringify({ ...stored, id: duplicateId, recordedAt: "2026-06-02T07:00:00.000Z" })}\n`,
+  );
+  const { externalRef: _externalRef, ...editedBase } = stored;
+  await fs.appendFile(
+    path.join(vaultRoot, shardPath),
+    `${JSON.stringify({
+      ...editedBase,
+      id: duplicateId,
+      source: "manual",
+      note: "user-curated copy",
+      lifecycle: { revision: 2 },
+    })}\n`,
+  );
+
+  const result = await dedupeDeviceEventsByExternalRef({ vaultRoot, apply: true });
+
+  assert.equal(result.tombstonedEventCount, 0);
+  assert.equal(result.skippedRevisedElsewhereCount, 1);
+  assert.equal(
+    (await readJsonlRecords({ vaultRoot, relativePath: shardPath })).length,
+    3,
+    "the edited duplicate must be left for manual review, not tombstoned",
+  );
 });

--- a/packages/vault-usecases/src/usecases/event-record-mutations.ts
+++ b/packages/vault-usecases/src/usecases/event-record-mutations.ts
@@ -36,6 +36,19 @@ interface EventMutationCoreRuntime {
     retainedPaths: string[]
     deleted: true
   }>
+  dedupeDeviceEventsByExternalRef(input: {
+    vaultRoot: string
+    apply?: boolean
+  }): Promise<{
+    applied: boolean
+    scannedLiveDeviceEventCount: number
+    duplicateGroupCount: number
+    tombstonedEventCount: number
+    tombstonedByKind: Record<string, number>
+    skippedRevisedElsewhereCount: number
+    shardPaths: string[]
+    auditPath: string | null
+  }>
 }
 
 interface EventRecordMutationLookupInput {
@@ -437,6 +450,31 @@ export async function deleteEventRecord(
         code: 'not_found',
         message: `No ${input.entityLabel} found for "${input.lookup}".`,
       },
+      EVENT_CONTRACT_INVALID: {
+        code: 'contract_invalid',
+      },
+    })
+  }
+}
+
+export async function dedupeDeviceImportEventRecords(input: {
+  vault: string
+  apply?: boolean
+}) {
+  const core = await loadEventMutationCoreRuntime()
+
+  try {
+    const result = await core.dedupeDeviceEventsByExternalRef({
+      vaultRoot: input.vault,
+      apply: input.apply === true,
+    })
+
+    return {
+      vault: input.vault,
+      ...result,
+    }
+  } catch (error) {
+    throw toVaultCliError(error, {
       EVENT_CONTRACT_INVALID: {
         code: 'contract_invalid',
       },


### PR DESCRIPTION
## Problem

Vaults that imported wearable data before #116 (device imports idempotent on externalRef) carry duplicate device events — one hosted vault has ~4,100 duplicates across ~341 provider records (workouts 11×, sleep sessions up to 143×). The importer fix stops new duplicates, but the old ones sit outside every trailing poll window and never self-heal.

## Change

An operator-invoked cleanup that any user can run by asking their Murph:

```
vault-cli event dedupe-device-imports            # dry-run report (default)
vault-cli event dedupe-device-imports --apply    # tombstone duplicates, keep latest copy
```

- **core** `dedupeDeviceEventsByExternalRef({vaultRoot, apply})`: groups live device events per monthly shard by the exact externalRef identity the importer reconciles on (#116's `deviceEventExternalRefKey` — version excluded, facet included), keeps the spine-latest copy per group, appends `deleteEvent`-shaped tombstone spine revisions for the rest. One canonical write + one `event_delete` audit record. Idempotent; ledger stays append-only.
- **Safety guard**: any duplicate id with a spine revision invisible to the device-filtered view (e.g. a user edit that dropped the device source/externalRef) is skipped entirely and surfaced as `skippedRevisedElsewhereCount` — never tombstoned. (Found by the task-finish-review audit; mirrors the importer's `maxRevisionById` guard.)
- **vault-usecases** `dedupeDeviceImportEventRecords` usecase (lazy core runtime + CLI error translation, mirrors `deleteEventRecord`).
- **cli** command registered on the `event` group; `incur.generated.ts`/`config.schema.json` regenerated.

## Verification

- packages/core: 437/437 incl. 6 dedupe tests (dry-run no-write, apply + audit content, idempotent rerun, post-cleanup importer convergence, no-op cases, revision-priority winner + prior-tombstone exclusion, facet isolation, multi-shard single apply, revised-elsewhere guard); coverage lane green
- packages/vault-usecases 122/122, packages/cli 916/916 (source lane), root typecheck green
- Built-CLI direct scenario: seeded vault with 2 legacy duplicates → dry-run reports 2 → `--apply` tombstones 2 + audit → rerun reports 0
- Audits: coverage-write (+3 tests) and task-finish-review (1 medium finding — the revision-visibility guard — fixed with regression test; 2 low findings addressed: rebased onto main, audit truncation note)

## Rollout

1. Deploy (hosted runner image picks up the new CLI command)
2. Each affected user asks their Murph: dry-run → eyeball the report → `--apply`
3. Known residual: duplicates split across monthly shards by pre-#116 occurredAt drift are not collapsed (mirrors the importer's shard-scoped reconcile; visible in the dry-run report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783719191&installation_id=127572939&pr_number=122&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F122&signature=9a8b908707a62e67fc644ed4895185ce77b535a6ec311a5eb14630eeedf2b151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->