### PR TITLE
fix(vault-share): status-only deliver response, night-date occurredAt, per-share isolation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-10-vault-share-v0-followup.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-vault-share-v0-followup.md
@@ -1,0 +1,83 @@
+# VaultShare v0 follow-up — contract shrink, stale-probe fix, metadata exposure, runbook SQL
+
+Created: 2026-06-10
+Updated: 2026-06-10
+
+Goal (incl. success criteria):
+- Resolve the real findings from the post-merge review of PR #104 with a net-smaller surface:
+  1. Deliver response collapses to `{ status }`; `appendedCount`/`duplicateCount` are deleted
+     (the runtime never reads them, and they leak fan-out cardinality and duplicate history).
+  2. The deliver route's status depends only on share configuration, never on record
+     staleness: an all-stale offer with a granted-but-inactive destination must return
+     `no-active-share`, matching the documented invariant.
+  3. One failing destination share must not block delivery to later shares (per-share
+     isolation) and each share's records append in one transaction.
+  4. Mailbox envelope `occurredAt` for `sleep-times.v0` becomes the night-date midnight UTC
+     instead of the exact wake timestamp, so no plaintext sleep timing lands in Postgres;
+     the parser asserts this server-side. Doc claim narrowed to what is true.
+  5. Parser asserts `sleepStartAt < sleepEndAt` (fails closed on corrupted projections).
+  6. Operator runbook SQL fixed: raw INSERT/UPDATE must set `updated_at` (no DB default;
+     Prisma `@updatedAt` is client-side); re-grant documented as UPDATE (unique index).
+
+Constraints/Assumptions:
+- Web remains the sole share authority; the grantor runtime may learn only "an active share
+  exists" (inherent in the status), never cardinality or duplicate history.
+- Accepted residual side channels: response latency scales with granted-share count
+  (sequential destination reads/deliveries), and the standard mailbox envelope columns
+  (kind, lane, created_at) still record that and when a delivery happened — not when sleep
+  occurred. Both are weak, pre-existing, and acceptable for operator-seeded v0 scale.
+- Zero `hosted_vault_share` rows exist in the database (verified read-only), so the stricter
+  `occurredAt` parser is safe to deploy web-first; un-updated runtimes fail open
+  (`outcome: "error"`, logged, wake continues) until containers roll. Do not seed grants
+  until both web and runner images carry this change (same tandem rule as PR #104).
+- No schema/migration changes; doc + code + tests only.
+- Conscious exception to completed-plan immutability: this change edits
+  `agent-docs/exec-plans/completed/2026-06-10-vault-share-v0.md` because its operator
+  runbook SQL would fail outright (missing `updated_at`) and its privacy claim was
+  factually wrong. The runbook has never been run (zero share rows verified read-only),
+  so correcting the live operator instructions in place is safer than preserving a broken
+  snapshot; the snapshot's history remains in git.
+
+Key decisions:
+- Delete the counts rather than gate them: nothing consumes them, so removal is the fix.
+- Anchor recency on the night date (already exposed by the dedupe key) rather than hashing
+  the dedupe key; hashing would destroy operability for ~zero sensitivity gain.
+- Skip fan-out batching of destination reads (≤7 records, ~1 share in v0; no measured need).
+
+State:
+- Complete; awaiting finish-task commit and PR.
+
+Done:
+- Findings verified against merged code and live DB (zero share rows; runbook never run).
+- Contract/route/store/projector/parser changes plus test updates implemented.
+- `pnpm test:diff` green (11 affected owners, incl. apps/web and apps/cloudflare verify).
+- security-privacy-review: no blocking findings; applied ids-only delivery-failure log and
+  builder-derived envelope occurredAt; recorded accepted residual side channels.
+- coverage-write: added store unit tests (single-transaction, envelope determinism,
+  all-duplicate null), route signal-skip + ids-only log assertions, 24h boundary test,
+  projector→parser consistency test.
+- task-finish-review: no blocking findings; split signal-failure swallow from
+  delivery-failure logging; recorded the completed-plan-edit exception above.
+
+Now:
+- finish-task commit, push, PR.
+
+Next:
+- After merge: deploy web first; runner image rolls behind it (old runtimes fail open);
+  do not seed `hosted_vault_share` grants until both sides are live.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/hosted-execution/src/vault-share.ts
+- packages/hosted-execution/test/vault-share.test.ts
+- apps/web/app/api/internal/hosted-runtime/vault-share/deliver/route.ts
+- apps/web/src/lib/hosted-mailbox/vault-share-store.ts
+- apps/web/test/vault-share-deliver-route.test.ts
+- packages/assistant-runtime/src/hosted-runtime/vault-share-projection.ts
+- packages/assistant-runtime/test/vault-share-projection.test.ts
+- apps/cloudflare/test/runner-outbound.test.ts (if it asserts counts)
+- agent-docs/exec-plans/completed/2026-06-10-vault-share-v0.md (runbook SQL + claim)
+Status: completed
+Completed: 2026-06-10

--- a/agent-docs/exec-plans/completed/2026-06-10-vault-share-v0.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-vault-share-v0.md
@@ -16,8 +16,13 @@ assistant reads deliveries as ordinary mailbox context.
 Design rules:
 - Consent is a row (grantor, kind, destination, status), not an encoded string.
 - Shares are defined over canonical vault data (query projections), not a producer pipe.
-- No plaintext user data at rest in Postgres: deliveries ride the existing encrypted
-  mailbox payload path; grants hold no payload.
+- Delivery payloads ride the existing encrypted mailbox path; grants hold no payload. The
+  only delivery-specific plaintext-at-rest columns are mailbox envelope metadata: the
+  dedupe key (share id + night date) and `occurred_at`, parser-pinned to the night date at
+  UTC midnight so exact sleep timestamps never land in Postgres (follow-up to PR #104,
+  which originally stored the wake timestamp as `occurred_at`). Standard envelope columns
+  (kind, lane, destination user id, created_at) additionally reveal that and when a
+  delivery happened — not when sleep occurred.
 - Destination is a member; future group containers consume the same deliveries unchanged.
 - Projection and delivery are deterministic code; no assistant involvement on either side.
 
@@ -31,7 +36,8 @@ Design rules:
 - Re-delivery of an already-delivered night is a dedupe no-op (no duplicate items).
 - Projection/delivery failures never fail the runtime wake (fail-open, logged without payload).
 - Members with no sleep data make no delivery calls.
-- No plaintext user data added to Postgres; no new env vars; no new external surface.
+- No plaintext sleep timestamps added to Postgres (envelope metadata limited to ids plus
+  the night date); no new env vars; no new external surface.
 
 ## Scope
 
@@ -125,13 +131,18 @@ Out of scope (v1+ fights this list):
 2. Create referee member via normal invite flow (spare email; web/telegram channel).
 3. After explicit verbal consent in the group chat, per grantor:
    `INSERT INTO hosted_vault_share (id, grantor_member_id, projection_kind,
-    destination_member_id, status, source, granted_at) VALUES
+    destination_member_id, status, source, granted_at, updated_at) VALUES
     (<cuid>, '<grantor>', 'sleep-times.v0', '<referee>', 'granted',
-     'operator-recorded-verbal', now());`
+     'operator-recorded-verbal', now(), now());`
    plus a `hosted_consent_event` row (scope `vault-share:sleep-times.v0:<referee>`,
    action `granted`, source `operator-recorded-verbal`).
-4. Revoke: `UPDATE hosted_vault_share SET status='revoked', revoked_at=now() WHERE ...;`
-   plus matching consent event.
+   `updated_at` is required: the column is NOT NULL with no database default (Prisma's
+   `@updatedAt` only fills it on Prisma-client writes, not raw SQL).
+4. Revoke: `UPDATE hosted_vault_share SET status='revoked', revoked_at=now(),
+   updated_at=now() WHERE ...;` plus matching consent event.
+   Re-grant is an UPDATE back to `status='granted'` (with `revoked_at=NULL,
+   updated_at=now()`), never a second INSERT: the unique index on
+   (grantor, kind, destination) allows only one row per share.
 5. Verify after next overnight wake: referee assistant can state each grantor's bed/wake
    times; spot-check no plaintext payloads in `hosted_mailbox_item`.
 Completed: 2026-06-10

--- a/apps/cloudflare/test/runner-outbound.test.ts
+++ b/apps/cloudflare/test/runner-outbound.test.ts
@@ -646,7 +646,7 @@ describe("handleRunnerOutboundRequest", () => {
                 sleepEndAt: "2026-06-10T06:31:00.000Z",
                 sleepStartAt: "2026-06-09T22:04:00.000Z",
               },
-              occurredAt: "2026-06-10T06:31:00.000Z",
+              occurredAt: "2026-06-09T00:00:00.000Z",
               recordKey: "2026-06-09",
             },
           ],
@@ -680,8 +680,6 @@ describe("handleRunnerOutboundRequest", () => {
       ..._args: Parameters<typeof fetch>
     ): Promise<Response> =>
       new Response(JSON.stringify({
-        appendedCount: 1,
-        duplicateCount: 0,
         status: "delivered",
       }), {
         headers: {
@@ -703,7 +701,7 @@ describe("handleRunnerOutboundRequest", () => {
                 sleepEndAt: "2026-06-10T06:31:00.000Z",
                 sleepStartAt: "2026-06-09T22:04:00.000Z",
               },
-              occurredAt: "2026-06-10T06:31:00.000Z",
+              occurredAt: "2026-06-09T00:00:00.000Z",
               recordKey: "2026-06-09",
             },
           ],
@@ -759,7 +757,7 @@ describe("handleRunnerOutboundRequest", () => {
                 sleepEndAt: "2026-06-10T06:31:00.000Z",
                 sleepStartAt: "2026-06-09T22:04:00.000Z",
               },
-              occurredAt: "2026-06-10T06:31:00.000Z",
+              occurredAt: "2026-06-09T00:00:00.000Z",
               recordKey: "2026-06-09",
             },
           ],

--- a/apps/web/app/api/internal/hosted-runtime/vault-share/deliver/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/vault-share/deliver/route.ts
@@ -16,6 +16,7 @@ import {
 import {
   deliverHostedVaultShareRecords,
   findActiveHostedVaultShares,
+  type ActiveHostedVaultShare,
 } from "@/src/lib/hosted-mailbox/vault-share-store";
 import {
   signalHostedMailboxAppendRuntime,
@@ -30,9 +31,11 @@ const HOSTED_VAULT_SHARE_DELIVER_MAX_RECORD_FUTURE_DAYS = 2;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const NO_ACTIVE_SHARE_RESPONSE: HostedVaultShareDeliverResponse = {
-  appendedCount: 0,
-  duplicateCount: 0,
   status: "no-active-share",
+};
+
+const DELIVERED_RESPONSE: HostedVaultShareDeliverResponse = {
+  status: "delivered",
 };
 
 /**
@@ -40,51 +43,53 @@ const NO_ACTIVE_SHARE_RESPONSE: HostedVaultShareDeliverResponse = {
  * signed Cloudflare callback; the grantor's runtime offers projected records without
  * knowing whether shares exist. Web is the sole authority: it fans the offer out to every
  * active HostedVaultShare for (grantor, projectionKind), skipping inactive destinations.
- * No grants — or only inactive destinations — resolves to `no-active-share` with nothing
- * appended, so the grantor runtime learns nothing about share configuration.
+ * The response is a function of share configuration alone — no grants, or only inactive
+ * destinations, resolves to `no-active-share`; everything else resolves to a bare
+ * `delivered`, so the grantor runtime learns nothing beyond "an active share exists".
  */
 export const POST = withJsonError(async (request: Request) => {
   const grantorMemberId = await requireHostedCloudflareCallbackRequest(request, {
     maxBodyBytes: HOSTED_VAULT_SHARE_DELIVER_BODY_LIMIT_BYTES,
   });
   const body = parseHostedVaultShareDeliverRequest(await readOptionalJsonObject(request));
-  const records = filterDeliverableRecords(body.records);
+  const prisma = getPrisma();
 
   const shares = await findActiveHostedVaultShares({
     grantorMemberId,
     projectionKind: body.projectionKind,
   });
+  const activeShares: ActiveHostedVaultShare[] = [];
 
-  if (shares.length === 0) {
+  for (const share of shares) {
+    const destination = await readHostedMemberCoreState({
+      memberId: share.destinationMemberId,
+      prisma,
+    });
+
+    if (destination && hasHostedMemberActiveAccess(destination)) {
+      activeShares.push(share);
+    }
+  }
+
+  if (activeShares.length === 0) {
     return jsonOk(NO_ACTIVE_SHARE_RESPONSE);
   }
 
-  let appendedCount = 0;
-  let duplicateCount = 0;
+  // An all-stale offer appends nothing but still resolves `delivered`: the status reflects
+  // share configuration only, so record staleness can never probe finer-grained share
+  // state, and stale records never put the grantor runtime in a permanent error loop.
+  const records = filterDeliverableRecords(body.records);
 
-  // An all-stale offer skips delivery entirely but still resolves as delivered with zero
-  // counts: stale records must never produce a permanent error loop for the grantor runtime.
-  if (records.length > 0) {
-    let delivered = false;
+  if (records.length === 0) {
+    return jsonOk(DELIVERED_RESPONSE);
+  }
 
-    for (const share of shares) {
-      const destination = await readHostedMemberCoreState({
-        memberId: share.destinationMemberId,
-        prisma: getPrisma(),
-      });
-
-      if (!destination || !hasHostedMemberActiveAccess(destination)) {
-        continue;
-      }
-
+  for (const share of activeShares) {
+    try {
       const delivery = await deliverHostedVaultShareRecords({
         records,
         share,
       });
-
-      delivered = true;
-      appendedCount += delivery.appendedRecordKeys.length;
-      duplicateCount += delivery.duplicateRecordKeys.length;
 
       if (delivery.lastAppendedMailboxItemId !== null) {
         try {
@@ -93,22 +98,24 @@ export const POST = withJsonError(async (request: Request) => {
             mailboxItemId: delivery.lastAppendedMailboxItemId,
           });
         } catch {
-          // Durable append succeeded; the destination imports on its next wake. Matches the
-          // repo invariant that Temporal signal failures after durable append are not retried.
+          // The append is already durable; the destination imports on its next wake.
+          // Matches the repo invariant that signal failures after a durable append are
+          // not retried — and must not be logged as a delivery failure.
         }
       }
-    }
-
-    if (!delivered) {
-      return jsonOk(NO_ACTIVE_SHARE_RESPONSE);
+    } catch (error) {
+      // Best-effort per destination: one failing share must not block delivery to the
+      // others, and the next wake re-offers (already-appended records dedupe). Log ids
+      // only — never payload fields or timestamps — so a persistently failing destination
+      // stays visible to operators.
+      console.error("Hosted vault-share delivery to a destination share failed.", {
+        errorName: error instanceof Error ? error.name : "unknown",
+        shareId: share.id,
+      });
     }
   }
 
-  return jsonOk({
-    appendedCount,
-    duplicateCount,
-    status: "delivered",
-  } satisfies HostedVaultShareDeliverResponse);
+  return jsonOk(DELIVERED_RESPONSE);
 });
 
 /**

--- a/apps/web/src/lib/hosted-mailbox/vault-share-store.ts
+++ b/apps/web/src/lib/hosted-mailbox/vault-share-store.ts
@@ -7,7 +7,6 @@ import {
   buildHostedVaultShareDeliveryDedupeKey,
   HOSTED_VAULT_SHARE_DELIVERY_PAYLOAD_SCHEMA,
   isHostedVaultShareProjectionKind,
-  type HostedVaultShareDeliveryPayload,
   type HostedVaultShareDeliveryRecord,
   type HostedVaultShareProjectionKind,
 } from "@murphai/hosted-execution/vault-share";
@@ -61,18 +60,18 @@ export async function findActiveHostedVaultShares(input: {
 }
 
 export interface DeliverHostedVaultShareRecordsResult {
-  appendedRecordKeys: string[];
-  duplicateRecordKeys: string[];
   lastAppendedMailboxItemId: string | null;
 }
 
 /**
  * Appends one typed `vault-share.delivery` wake envelope per shared record into the
- * destination mailbox. The envelope eventId doubles as the mailbox dedupe key — derived
- * from (shareId, recordKey) — and occurredAt comes from the record itself, so the
- * envelope is fully deterministic for a given (share, record) and re-offering an
- * already-delivered record is a byte-identical no-op rather than a dedupe conflict.
- * Payloads ride the standard encrypted mailbox path; nothing lands in plaintext.
+ * destination mailbox, all in a single transaction per share. The envelope eventId doubles
+ * as the mailbox dedupe key — derived from (shareId, recordKey) — and occurredAt comes from
+ * the record itself (parser-pinned to the night date for sleep-times), so the envelope is
+ * fully deterministic for a given (share, record) and re-offering an already-delivered
+ * record is a byte-identical no-op rather than a dedupe conflict. Payload data rides the
+ * standard encrypted mailbox path; only the dedupe key and night-date occurredAt are
+ * plaintext mailbox metadata.
  */
 export async function deliverHostedVaultShareRecords(input: {
   prisma?: PrismaClient;
@@ -80,45 +79,35 @@ export async function deliverHostedVaultShareRecords(input: {
   share: ActiveHostedVaultShare;
 }): Promise<DeliverHostedVaultShareRecordsResult> {
   const prisma = input.prisma ?? getPrisma();
-  const appendedRecordKeys: string[] = [];
-  const duplicateRecordKeys: string[] = [];
-  let lastAppendedMailboxItemId: string | null = null;
 
-  for (const record of input.records) {
-    const delivery: HostedVaultShareDeliveryPayload = {
-      grantorMemberId: input.share.grantorMemberId,
-      projectionKind: input.share.projectionKind,
-      record,
-      schema: HOSTED_VAULT_SHARE_DELIVERY_PAYLOAD_SCHEMA,
-      shareId: input.share.id,
-    };
-    const envelope = buildHostedExecutionVaultShareDeliveryWake({
-      delivery,
-      eventId: buildHostedVaultShareDeliveryDedupeKey({
-        recordKey: record.recordKey,
-        shareId: input.share.id,
-      }),
-      memberId: input.share.destinationMemberId,
-      occurredAt: record.occurredAt,
-    });
-    const result = await prisma.$transaction((tx) =>
-      appendHostedMailboxEnvelopeTx({
+  return prisma.$transaction(async (tx) => {
+    let lastAppendedMailboxItemId: string | null = null;
+
+    for (const record of input.records) {
+      const envelope = buildHostedExecutionVaultShareDeliveryWake({
+        delivery: {
+          grantorMemberId: input.share.grantorMemberId,
+          projectionKind: input.share.projectionKind,
+          record,
+          schema: HOSTED_VAULT_SHARE_DELIVERY_PAYLOAD_SCHEMA,
+          shareId: input.share.id,
+        },
+        eventId: buildHostedVaultShareDeliveryDedupeKey({
+          recordKey: record.recordKey,
+          shareId: input.share.id,
+        }),
+        memberId: input.share.destinationMemberId,
+      });
+      const result = await appendHostedMailboxEnvelopeTx({
         envelope,
         tx,
-      }),
-    );
+      });
 
-    if (result.inserted) {
-      appendedRecordKeys.push(record.recordKey);
-      lastAppendedMailboxItemId = result.item.id;
-    } else {
-      duplicateRecordKeys.push(record.recordKey);
+      if (result.inserted) {
+        lastAppendedMailboxItemId = result.item.id;
+      }
     }
-  }
 
-  return {
-    appendedRecordKeys,
-    duplicateRecordKeys,
-    lastAppendedMailboxItemId,
-  };
+    return { lastAppendedMailboxItemId };
+  });
 }

--- a/apps/web/test/vault-share-deliver-route.test.ts
+++ b/apps/web/test/vault-share-deliver-route.test.ts
@@ -54,7 +54,9 @@ function recentRecord(daysAgo: number): {
       sleepEndAt: end.toISOString(),
       sleepStartAt: start.toISOString(),
     },
-    occurredAt: end.toISOString(),
+    // occurredAt is parser-pinned to the night-date midnight: it becomes plaintext mailbox
+    // metadata, so it must disclose nothing beyond the night date.
+    occurredAt: `${date}T00:00:00.000Z`,
     recordKey: date,
   };
 }
@@ -65,7 +67,7 @@ const STALE_RECORD = {
     sleepEndAt: "1999-01-01T06:31:00.000Z",
     sleepStartAt: "1998-12-31T22:04:00.000Z",
   },
-  occurredAt: "1999-01-01T06:31:00.000Z",
+  occurredAt: "1999-01-01T00:00:00.000Z",
   recordKey: "1999-01-01",
 };
 
@@ -78,6 +80,13 @@ const ACTIVE_SHARE = {
   destinationMemberId: "member_referee",
   grantorMemberId: "member_grantor",
   id: "share_1",
+  projectionKind: "sleep-times.v0",
+};
+
+const SECOND_SHARE = {
+  destinationMemberId: "member_other_referee",
+  grantorMemberId: "member_grantor",
+  id: "share_2",
   projectionKind: "sleep-times.v0",
 };
 
@@ -103,8 +112,6 @@ describe("vault-share deliver route", () => {
     mocks.readHostedMemberCoreState.mockResolvedValue({ id: "member_referee" });
     mocks.hasHostedMemberActiveAccess.mockReturnValue(true);
     mocks.deliverHostedVaultShareRecords.mockResolvedValue({
-      appendedRecordKeys: ["2026-06-09"],
-      duplicateRecordKeys: [],
       lastAppendedMailboxItemId: "mailbox_item_1",
     });
     mocks.signalHostedMailboxAppendRuntime.mockResolvedValue({ signaled: true });
@@ -114,11 +121,7 @@ describe("vault-share deliver route", () => {
     const response = await deliverRoute.POST(buildRequest(VALID_BODY));
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      appendedCount: 1,
-      duplicateCount: 0,
-      status: "delivered",
-    });
+    expect(await response.json()).toEqual({ status: "delivered" });
     expect(mocks.findActiveHostedVaultShares).toHaveBeenCalledWith({
       grantorMemberId: "member_grantor",
       projectionKind: "sleep-times.v0",
@@ -139,11 +142,7 @@ describe("vault-share deliver route", () => {
     const response = await deliverRoute.POST(buildRequest(VALID_BODY));
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      appendedCount: 0,
-      duplicateCount: 0,
-      status: "no-active-share",
-    });
+    expect(await response.json()).toEqual({ status: "no-active-share" });
     expect(mocks.deliverHostedVaultShareRecords).not.toHaveBeenCalled();
     expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
   });
@@ -154,11 +153,7 @@ describe("vault-share deliver route", () => {
     const response = await deliverRoute.POST(buildRequest(VALID_BODY));
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      appendedCount: 0,
-      duplicateCount: 0,
-      status: "no-active-share",
-    });
+    expect(await response.json()).toEqual({ status: "no-active-share" });
     expect(mocks.deliverHostedVaultShareRecords).not.toHaveBeenCalled();
   });
 
@@ -171,13 +166,26 @@ describe("vault-share deliver route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      appendedCount: 0,
-      duplicateCount: 0,
-      status: "delivered",
-    });
+    expect(await response.json()).toEqual({ status: "delivered" });
     expect(mocks.deliverHostedVaultShareRecords).not.toHaveBeenCalled();
     expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+  });
+
+  it("keeps an all-stale offer indistinguishable when the destination is inactive", async () => {
+    // The status must be a function of share configuration alone: a grantor probing with
+    // stale records learns nothing finer than the normal active/no-active-share split.
+    mocks.hasHostedMemberActiveAccess.mockReturnValue(false);
+
+    const response = await deliverRoute.POST(
+      buildRequest({
+        projectionKind: "sleep-times.v0",
+        records: [STALE_RECORD],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "no-active-share" });
+    expect(mocks.deliverHostedVaultShareRecords).not.toHaveBeenCalled();
   });
 
   it("delivers only the in-window records when an offer mixes stale and fresh records", async () => {
@@ -190,16 +198,61 @@ describe("vault-share deliver route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      appendedCount: 1,
-      duplicateCount: 0,
-      status: "delivered",
-    });
+    expect(await response.json()).toEqual({ status: "delivered" });
     expect(mocks.deliverHostedVaultShareRecords).toHaveBeenCalledTimes(1);
     expect(mocks.deliverHostedVaultShareRecords).toHaveBeenCalledWith({
       records: [freshRecord],
       share: ACTIVE_SHARE,
     });
+  });
+
+  it("keeps delivering to later shares when an earlier share's delivery fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      mocks.findActiveHostedVaultShares.mockResolvedValue([ACTIVE_SHARE, SECOND_SHARE]);
+      mocks.readHostedMemberCoreState
+        .mockResolvedValueOnce({ id: "member_referee" })
+        .mockResolvedValueOnce({ id: "member_other_referee" });
+      mocks.deliverHostedVaultShareRecords
+        .mockRejectedValueOnce(new Error("destination mailbox down"))
+        .mockResolvedValueOnce({ lastAppendedMailboxItemId: "mailbox_item_2" });
+
+      const response = await deliverRoute.POST(buildRequest(VALID_BODY));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ status: "delivered" });
+      expect(mocks.deliverHostedVaultShareRecords).toHaveBeenCalledTimes(2);
+      expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
+      expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+        expectedUserId: "member_other_referee",
+        mailboxItemId: "mailbox_item_2",
+      });
+      // The operator log carries ids only — never payload fields, timestamps, or the
+      // raw error message, which could echo destination state back into shared logs.
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        "Hosted vault-share delivery to a destination share failed.",
+        { errorName: "Error", shareId: "share_1" },
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("skips the wake signal when every offered record is a dedupe duplicate", async () => {
+    // Re-offering already-delivered nights appends nothing; waking the destination for a
+    // no-op import would be pure noise, and the response still reveals only "delivered".
+    mocks.deliverHostedVaultShareRecords.mockResolvedValue({
+      lastAppendedMailboxItemId: null,
+    });
+
+    const response = await deliverRoute.POST(buildRequest(VALID_BODY));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "delivered" });
+    expect(mocks.deliverHostedVaultShareRecords).toHaveBeenCalledTimes(1);
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
   });
 
   it("rejects payloads that do not match the closed schema", async () => {
@@ -229,23 +282,24 @@ describe("vault-share deliver route", () => {
       grantorMemberId: "member_other",
       projectionKind: "sleep-times.v0",
     });
-    expect(await response.json()).toEqual({
-      appendedCount: 0,
-      duplicateCount: 0,
-      status: "no-active-share",
-    });
+    expect(await response.json()).toEqual({ status: "no-active-share" });
   });
 
   it("still reports delivered when the wake signal fails after a durable append", async () => {
-    mocks.signalHostedMailboxAppendRuntime.mockRejectedValue(new Error("temporal down"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    const response = await deliverRoute.POST(buildRequest(VALID_BODY));
+    try {
+      mocks.signalHostedMailboxAppendRuntime.mockRejectedValue(new Error("temporal down"));
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      appendedCount: 1,
-      duplicateCount: 0,
-      status: "delivered",
-    });
+      const response = await deliverRoute.POST(buildRequest(VALID_BODY));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ status: "delivered" });
+      // The append is durable and the destination imports on its next wake: a signal
+      // failure is not a delivery failure and must not be logged as one.
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/apps/web/test/vault-share-store.test.ts
+++ b/apps/web/test/vault-share-store.test.ts
@@ -1,0 +1,129 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  appendHostedMailboxEnvelopeTx: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-mailbox/store", () => ({
+  appendHostedMailboxEnvelopeTx: mocks.appendHostedMailboxEnvelopeTx,
+}));
+
+import { deliverHostedVaultShareRecords } from "@/src/lib/hosted-mailbox/vault-share-store";
+
+const SHARE = {
+  destinationMemberId: "member_referee",
+  grantorMemberId: "member_grantor",
+  id: "share_1",
+  projectionKind: "sleep-times.v0" as const,
+};
+
+function nightRecord(date: string, nextDate: string): {
+  data: { date: string; sleepEndAt: string; sleepStartAt: string };
+  occurredAt: string;
+  recordKey: string;
+} {
+  return {
+    data: {
+      date,
+      sleepEndAt: `${nextDate}T06:31:00.000Z`,
+      sleepStartAt: `${date}T22:04:00.000Z`,
+    },
+    occurredAt: `${date}T00:00:00.000Z`,
+    recordKey: date,
+  };
+}
+
+const FIRST_RECORD = nightRecord("2026-06-07", "2026-06-08");
+const RECORDS = [
+  FIRST_RECORD,
+  nightRecord("2026-06-08", "2026-06-09"),
+  nightRecord("2026-06-09", "2026-06-10"),
+];
+
+const TX = { tag: "tx" };
+
+function fakePrisma(): PrismaClient {
+  return {
+    $transaction: vi.fn(async (fn: (tx: typeof TX) => Promise<unknown>) => fn(TX)),
+  } as unknown as PrismaClient;
+}
+
+describe("deliverHostedVaultShareRecords", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("appends every record in one transaction and reports the last inserted item id", async () => {
+    const prisma = fakePrisma();
+    mocks.appendHostedMailboxEnvelopeTx
+      .mockResolvedValueOnce({ inserted: true, item: { id: "mailbox_item_1" } })
+      // Re-offered records dedupe (inserted: false) and must not clobber or report an id.
+      .mockResolvedValueOnce({ duplicate: true, inserted: false })
+      .mockResolvedValueOnce({ inserted: true, item: { id: "mailbox_item_3" } });
+
+    const result = await deliverHostedVaultShareRecords({
+      prisma,
+      records: RECORDS,
+      share: SHARE,
+    });
+
+    expect(result).toEqual({ lastAppendedMailboxItemId: "mailbox_item_3" });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(3);
+    // Every append runs on the single transaction client, not the base prisma client.
+    for (const call of mocks.appendHostedMailboxEnvelopeTx.mock.calls) {
+      expect(call[0].tx).toBe(TX);
+    }
+  });
+
+  it("builds the envelope deterministically: dedupe-key eventId and record-derived occurredAt", async () => {
+    const prisma = fakePrisma();
+    mocks.appendHostedMailboxEnvelopeTx.mockResolvedValue({
+      inserted: true,
+      item: { id: "mailbox_item_1" },
+    });
+
+    await deliverHostedVaultShareRecords({
+      prisma,
+      records: [FIRST_RECORD],
+      share: SHARE,
+    });
+
+    // The store passes no occurredAt: the builder derives it from the parsed record, so
+    // the plaintext occurred_at mailbox column can only ever hold the night-date midnight.
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: {
+        delivery: {
+          grantorMemberId: "member_grantor",
+          projectionKind: "sleep-times.v0",
+          record: FIRST_RECORD,
+          schema: "murph.vault-share.delivery.v1",
+          shareId: "share_1",
+        },
+        eventId: "vault-share:share_1:2026-06-07",
+        kind: "vault-share.delivery",
+        occurredAt: "2026-06-07T00:00:00.000Z",
+        userId: "member_referee",
+      },
+      tx: TX,
+    });
+  });
+
+  it("reports a null item id when every record is a dedupe duplicate", async () => {
+    const prisma = fakePrisma();
+    mocks.appendHostedMailboxEnvelopeTx.mockResolvedValue({
+      duplicate: true,
+      inserted: false,
+    });
+
+    const result = await deliverHostedVaultShareRecords({
+      prisma,
+      records: RECORDS,
+      share: SHARE,
+    });
+
+    // Null is the route's signal-skip contract: a fully re-delivered offer wakes nobody.
+    expect(result).toEqual({ lastAppendedMailboxItemId: null });
+  });
+});

--- a/packages/assistant-runtime/src/hosted-runtime/vault-share-projection.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/vault-share-projection.ts
@@ -78,7 +78,10 @@ export async function readProjectableSleepNights(
  * Pure selection step: keep the most recent fully-timed nights, capped at the projection
  * window, and drop nights older than the recency cutoff so members with only stale sleep
  * data never offer undeliverable records. Each night maps to one delivery record whose
- * recordKey is the night date and whose occurredAt is the night's sleepEndAt.
+ * recordKey is the night date and whose occurredAt is the night date at UTC midnight —
+ * occurredAt becomes plaintext mailbox metadata on the destination side, so it must
+ * disclose nothing beyond the night date the dedupe key already carries; the exact
+ * sleep timestamps stay inside the encrypted payload.
  */
 export function selectProjectableSleepNights(
   summaries: readonly Pick<ProjectedWearableSleepSummary, "date" | "sleepEndAt" | "sleepStartAt">[],
@@ -104,7 +107,7 @@ export function selectProjectableSleepNights(
         sleepEndAt: summary.sleepEndAt,
         sleepStartAt: summary.sleepStartAt,
       },
-      occurredAt: summary.sleepEndAt,
+      occurredAt: `${summary.date}T00:00:00.000Z`,
       recordKey: summary.date,
     });
 

--- a/packages/assistant-runtime/test/vault-share-projection.test.ts
+++ b/packages/assistant-runtime/test/vault-share-projection.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { parseHostedVaultShareDeliverRequest } from "@murphai/hosted-execution/vault-share";
 import { describe, expect, it, vi } from "vitest";
 
 import { importHostedVaultShareDeliveryWake } from "../src/hosted-runtime/vault-share-import.ts";
@@ -19,7 +20,7 @@ const NIGHT = {
 
 const RECORD = {
   data: NIGHT,
-  occurredAt: NIGHT.sleepEndAt,
+  occurredAt: `${NIGHT.date}T00:00:00.000Z`,
   recordKey: NIGHT.date,
 };
 
@@ -34,11 +35,7 @@ describe("offerHostedVaultShareProjectionBestEffort", () => {
   });
 
   it("offers projectable records and reports delivery", async () => {
-    const deliver = vi.fn().mockResolvedValue({
-      appendedCount: 1,
-      duplicateCount: 0,
-      status: "delivered",
-    });
+    const deliver = vi.fn().mockResolvedValue({ status: "delivered" });
     const result = await offerHostedVaultShareProjectionBestEffort({
       readRecords: async () => [RECORD],
       vaultRoot: "/unused",
@@ -93,11 +90,27 @@ describe("selectProjectableSleepNights", () => {
 
     const selected = selectProjectableSleepNights(summaries, nowMs);
 
-    // recordKey is the night date and occurredAt is the night's sleepEndAt, so the dedupe
-    // key and the destination vault path stay byte-identical to the night itself.
+    // recordKey is the night date and occurredAt is the night date at UTC midnight, so the
+    // dedupe key, vault path, and plaintext mailbox metadata all reduce to the night itself
+    // — the exact sleep timestamps travel only inside the encrypted payload.
     expect(selected).toEqual([RECORD]);
     expect(selected[0]?.recordKey).toBe(NIGHT.date);
-    expect(selected[0]?.occurredAt).toBe(NIGHT.sleepEndAt);
+    expect(selected[0]?.occurredAt).toBe(`${NIGHT.date}T00:00:00.000Z`);
+  });
+
+  it("emits records the hosted-execution deliver-request parser accepts unchanged", () => {
+    // Cross-package drift guard: the deliver parser pins occurredAt to the night-date
+    // midnight and bounds the sleep window, so a projector that drifts from that contract
+    // would make web reject every offer. Pipe real projector output through the real parser.
+    const selected = selectProjectableSleepNights([NIGHT], nowMs);
+
+    expect(selected).toHaveLength(1);
+    expect(
+      parseHostedVaultShareDeliverRequest({
+        projectionKind: "sleep-times.v0",
+        records: selected,
+      }).records,
+    ).toEqual(selected);
   });
 
   it("drops nights older than the recency cutoff exactly", () => {

--- a/packages/hosted-execution/src/builders.ts
+++ b/packages/hosted-execution/src/builders.ts
@@ -328,16 +328,20 @@ export function buildHostedExecutionVaultShareDeliveryWake(input: {
   delivery: HostedVaultShareDeliveryPayload;
   eventId: string;
   memberId: string;
-  occurredAt: string;
 }): HostedExecutionVaultShareDeliveryWake {
+  const delivery = parseHostedVaultShareDeliveryPayload(input.delivery);
+
   return {
     ...buildHostedExecutionMemberOwnedWakeBase({
       eventId: input.eventId,
       kind: "vault-share.delivery",
       memberId: input.memberId,
-      occurredAt: input.occurredAt,
+      // The envelope occurredAt becomes the plaintext occurred_at mailbox column. Deriving
+      // it from the parsed record (parser-pinned to the night date for sleep-times) makes
+      // the pin authoritative for every caller instead of trusting a separate input.
+      occurredAt: delivery.record.occurredAt,
     }),
-    delivery: parseHostedVaultShareDeliveryPayload(input.delivery),
+    delivery,
   };
 }
 

--- a/packages/hosted-execution/src/parsers.ts
+++ b/packages/hosted-execution/src/parsers.ts
@@ -179,11 +179,12 @@ export function parseHostedExecutionWake(value: unknown): HostedExecutionWake {
         ),
       });
     case "vault-share.delivery":
+      // The builder derives the envelope occurredAt from the delivery record, so a wire
+      // envelope timestamp that drifted from the record normalizes back to the record.
       return buildHostedExecutionVaultShareDeliveryWake({
         delivery: parseHostedVaultShareDeliveryPayload(record.delivery),
         eventId,
         memberId: wireUserId,
-        occurredAt,
       });
     case "member.channels.updated":
       return buildHostedExecutionMemberChannelsUpdatedWake({

--- a/packages/hosted-execution/src/vault-share.ts
+++ b/packages/hosted-execution/src/vault-share.ts
@@ -55,9 +55,12 @@ export interface HostedVaultShareDeliverRequest {
   records: HostedVaultShareDeliveryRecord[];
 }
 
+/**
+ * The deliver response is intentionally a bare status that depends on share configuration
+ * alone: the grantor runtime may learn that an active share exists, never fan-out
+ * cardinality, duplicate history, or per-record outcomes.
+ */
 export interface HostedVaultShareDeliverResponse {
-  appendedCount: number;
-  duplicateCount: number;
   status: "delivered" | "no-active-share";
 }
 
@@ -105,15 +108,18 @@ export function parseHostedVaultShareDeliveryRecord(
     "Vault share delivery record recordKey",
   );
 
+  const occurredAt = requireIsoTimestamp(
+    record.occurredAt,
+    "Vault share delivery record occurredAt",
+  );
+
   return {
     data: parseHostedVaultShareDeliveryRecordData(record.data, {
+      occurredAt,
       projectionKind,
       recordKey,
     }),
-    occurredAt: requireIsoTimestamp(
-      record.occurredAt,
-      "Vault share delivery record occurredAt",
-    ),
+    occurredAt,
     recordKey,
   };
 }
@@ -121,19 +127,22 @@ export function parseHostedVaultShareDeliveryRecord(
 function parseHostedVaultShareDeliveryRecordData(
   value: unknown,
   context: {
+    occurredAt: string;
     projectionKind: HostedVaultShareProjectionKind;
     recordKey: string;
   },
 ): HostedVaultShareDeliveryRecordData {
   switch (context.projectionKind) {
     case "sleep-times.v0":
-      return parseHostedVaultShareSleepTimesData(value, context.recordKey);
+      return parseHostedVaultShareSleepTimesData(value, context);
   }
 }
 
+const HOSTED_VAULT_SHARE_SLEEP_MAX_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 function parseHostedVaultShareSleepTimesData(
   value: unknown,
-  recordKey: string,
+  context: { occurredAt: string; recordKey: string },
 ): HostedVaultShareSleepTimesData {
   const data = requireObject(value, "Vault share sleep-times data");
   const date = requireString(data.date, "Vault share sleep-times data date");
@@ -146,23 +155,40 @@ function parseHostedVaultShareSleepTimesData(
 
   // The record's identity is its night date; rejecting any drift keeps the dedupe key and
   // the destination vault path derived from recordKey byte-identical to the night itself.
-  if (recordKey !== date) {
+  if (context.recordKey !== date) {
     throw new TypeError(
       "Vault share sleep-times recordKey must equal the data date.",
     );
   }
 
-  return {
-    date,
-    sleepEndAt: requireIsoTimestamp(
-      data.sleepEndAt,
-      "Vault share sleep-times data sleepEndAt",
-    ),
-    sleepStartAt: requireIsoTimestamp(
-      data.sleepStartAt,
-      "Vault share sleep-times data sleepStartAt",
-    ),
-  };
+  // occurredAt is the envelope's only plaintext timestamp at rest (mailbox metadata).
+  // Pinning it to the night-date midnight keeps exact sleep times out of Postgres and
+  // anchors server-side recency filtering on the night itself, not a runtime-chosen time.
+  if (context.occurredAt !== `${date}T00:00:00.000Z`) {
+    throw new TypeError(
+      "Vault share sleep-times occurredAt must be the night date at UTC midnight.",
+    );
+  }
+
+  const sleepEndAt = requireIsoTimestamp(
+    data.sleepEndAt,
+    "Vault share sleep-times data sleepEndAt",
+  );
+  const sleepStartAt = requireIsoTimestamp(
+    data.sleepStartAt,
+    "Vault share sleep-times data sleepStartAt",
+  );
+  const windowMs = Date.parse(sleepEndAt) - Date.parse(sleepStartAt);
+
+  // Fails closed on corrupted projections: a sleep window must be a positive interval of
+  // plausible length, not reversed and not spanning multiple days.
+  if (!(windowMs > 0) || windowMs > HOSTED_VAULT_SHARE_SLEEP_MAX_WINDOW_MS) {
+    throw new TypeError(
+      "Vault share sleep-times window must end after it starts and span at most 24 hours.",
+    );
+  }
+
+  return { date, sleepEndAt, sleepStartAt };
 }
 
 export function parseHostedVaultShareDeliverRequest(
@@ -205,17 +231,7 @@ export function parseHostedVaultShareDeliverResponse(
     );
   }
 
-  return {
-    appendedCount: requireNonNegativeCount(
-      record.appendedCount,
-      "Vault share deliver response appendedCount",
-    ),
-    duplicateCount: requireNonNegativeCount(
-      record.duplicateCount,
-      "Vault share deliver response duplicateCount",
-    ),
-    status,
-  };
+  return { status };
 }
 
 export function parseHostedVaultShareDeliveryPayload(
@@ -271,12 +287,4 @@ function requireIsoTimestamp(value: unknown, label: string): string {
   }
 
   return text;
-}
-
-function requireNonNegativeCount(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
-    throw new TypeError(`${label} must be a non-negative integer.`);
-  }
-
-  return value;
 }

--- a/packages/hosted-execution/test/vault-share.test.ts
+++ b/packages/hosted-execution/test/vault-share.test.ts
@@ -16,7 +16,7 @@ const VALID_RECORD = {
     sleepEndAt: "2026-06-10T06:31:00.000Z",
     sleepStartAt: "2026-06-09T22:04:00.000Z",
   },
-  occurredAt: "2026-06-10T06:31:00.000Z",
+  occurredAt: "2026-06-09T00:00:00.000Z",
   recordKey: "2026-06-09",
 };
 
@@ -103,6 +103,80 @@ describe("vault-share contracts", () => {
     ).toThrow(/recordKey must equal the data date/u);
   });
 
+  it("rejects a sleep record whose occurredAt is not the night-date UTC midnight", () => {
+    // occurredAt is plaintext mailbox metadata on the destination side; anything beyond
+    // the night date (e.g. the exact wake timestamp) would leak sleep timing into Postgres.
+    for (const occurredAt of ["2026-06-10T06:31:00.000Z", "2026-06-09T00:00:00Z"]) {
+      expect(() =>
+        parseHostedVaultShareDeliverRequest({
+          projectionKind: "sleep-times.v0",
+          records: [{ ...VALID_RECORD, occurredAt }],
+        }),
+      ).toThrow(/night date at UTC midnight/u);
+    }
+  });
+
+  it("rejects reversed or implausibly long sleep windows", () => {
+    expect(() =>
+      parseHostedVaultShareDeliverRequest({
+        projectionKind: "sleep-times.v0",
+        records: [{
+          ...VALID_RECORD,
+          data: {
+            ...VALID_RECORD.data,
+            sleepEndAt: "2026-06-09T22:04:00.000Z",
+            sleepStartAt: "2026-06-10T06:31:00.000Z",
+          },
+        }],
+      }),
+    ).toThrow(/end after it starts/u);
+    expect(() =>
+      parseHostedVaultShareDeliverRequest({
+        projectionKind: "sleep-times.v0",
+        records: [{
+          ...VALID_RECORD,
+          data: {
+            ...VALID_RECORD.data,
+            sleepEndAt: "2026-06-11T22:05:00.000Z",
+            sleepStartAt: "2026-06-09T22:04:00.000Z",
+          },
+        }],
+      }),
+    ).toThrow(/at most 24 hours/u);
+  });
+
+  it("accepts a sleep window of exactly 24 hours and rejects a zero-length one", () => {
+    // The plausibility bound is inclusive: exactly 24 hours is the longest valid window,
+    // and a window must be strictly positive — start == end fails closed.
+    const exactDayRecord = {
+      ...VALID_RECORD,
+      data: {
+        ...VALID_RECORD.data,
+        sleepEndAt: "2026-06-10T22:04:00.000Z",
+        sleepStartAt: "2026-06-09T22:04:00.000Z",
+      },
+    };
+
+    expect(
+      parseHostedVaultShareDeliverRequest({
+        projectionKind: "sleep-times.v0",
+        records: [exactDayRecord],
+      }).records,
+    ).toEqual([exactDayRecord]);
+    expect(() =>
+      parseHostedVaultShareDeliverRequest({
+        projectionKind: "sleep-times.v0",
+        records: [{
+          ...VALID_RECORD,
+          data: {
+            ...VALID_RECORD.data,
+            sleepEndAt: VALID_RECORD.data.sleepStartAt,
+          },
+        }],
+      }),
+    ).toThrow(/end after it starts/u);
+  });
+
   it("rejects malformed dates and timestamps", () => {
     expect(() =>
       parseHostedVaultShareDeliverRequest({
@@ -150,24 +224,24 @@ describe("vault-share contracts", () => {
     ).toThrow(/ISO-8601/u);
   });
 
-  it("parses deliver responses and rejects unknown statuses", () => {
+  it("parses deliver responses to a bare status and rejects unknown statuses", () => {
+    // The response is deliberately status-only: counts would leak fan-out cardinality and
+    // duplicate history to the grantor runtime, and nothing consumes them.
     expect(
-      parseHostedVaultShareDeliverResponse({
-        appendedCount: 2,
-        duplicateCount: 1,
-        status: "delivered",
-      }),
-    ).toEqual({ appendedCount: 2, duplicateCount: 1, status: "delivered" });
+      parseHostedVaultShareDeliverResponse({ status: "delivered" }),
+    ).toEqual({ status: "delivered" });
+    expect(
+      parseHostedVaultShareDeliverResponse({ status: "no-active-share" }),
+    ).toEqual({ status: "no-active-share" });
     expect(() =>
-      parseHostedVaultShareDeliverResponse({
-        appendedCount: 0,
-        duplicateCount: 0,
-        status: "partial",
-      }),
+      parseHostedVaultShareDeliverResponse({ status: "partial" }),
     ).toThrow(/delivered or no-active-share/u);
   });
 
-  it("round-trips a vault-share delivery wake through the wake parser", () => {
+  it("round-trips a vault-share delivery wake and pins the envelope occurredAt to the record", () => {
+    // The envelope occurredAt becomes the plaintext occurred_at mailbox column, so the
+    // builder derives it from the parsed record: a wire envelope timestamp that drifted
+    // from the record normalizes back to the record's night-date midnight.
     const parsed = parseHostedExecutionWake({
       delivery: VALID_DELIVERY,
       eventId: "vault-share:share_1:2026-06-09",
@@ -180,7 +254,7 @@ describe("vault-share contracts", () => {
       delivery: VALID_DELIVERY,
       eventId: "vault-share:share_1:2026-06-09",
       kind: "vault-share.delivery",
-      occurredAt: "2026-06-10T07:00:00.000Z",
+      occurredAt: VALID_RECORD.occurredAt,
       userId: "member_referee",
     });
   });


### PR DESCRIPTION
Follow-up to #104, resolving the real findings from the post-merge review with a net-smaller surface.

## What changed

1. **Deliver response collapsed to `{ status }`** — `appendedCount`/`duplicateCount` deleted from the contract, parser, route, and tests. Nothing consumed them, and they leaked fan-out cardinality and duplicate history to the grantor runtime.
2. **Status is now a function of share configuration alone** — the route filters shares to active destinations *first*. Previously an all-stale offer returned `delivered` whenever a granted share row existed, even with an inactive destination — a probe that violated the documented "indistinguishable no-active-share" invariant. New regression test locks the fix in.
3. **Per-share failure isolation** — one failing destination no longer fails the route or starves later shares (try/catch per share, ids-only `console.error`; wake-signal failures after a durable append stay silent as before). Each share's records now append in **one transaction** instead of one per record.
4. **No plaintext sleep timestamps in Postgres** — the envelope `occurredAt` (a plaintext mailbox column) is now the night-date midnight UTC instead of the exact wake timestamp: the projector emits it, the parser enforces it server-side, and `buildHostedExecutionVaultShareDeliveryWake` derives it from the parsed record (parameter deleted) so the pin is authoritative for every caller. Parser also rejects reversed/>24h sleep windows.
5. **Operator runbook fixed** — the checked-in INSERT/UPDATE SQL omitted `updated_at` (NOT NULL, no DB default; Prisma `@updatedAt` is client-side only) and would have failed outright. Re-grant documented as UPDATE (unique index). Privacy claims narrowed to what is actually true.

## Verification

- `pnpm test:diff` green (owners: apps/cloudflare, apps/web, packages/assistant-runtime, packages/hosted-execution; expanded to 11 affected packages/apps incl. `apps/web verify` next build and `apps/cloudflare verify` lanes).
- Focused suites: hosted-execution 163, web route+store 14 (incl. new store unit tests for single-transaction/dedupe semantics), assistant-runtime projection 10, cloudflare runner-outbound 134.
- Completion audits run and resolved: security-privacy-review (no blocking; 2 advisory fixes applied), coverage-write (5 gaps closed), task-finish-review (no blocking).

## Deployment concerns

- **Deploy web first.** Un-rolled runner images still send the wake timestamp as `occurredAt`; the stricter web parser rejects those offers and the runtime fails open (`outcome: "error"`, logged, wake continues) until the runner image rolls.
- **Do not seed `hosted_vault_share` grants until both sides are live.** Zero rows exist today (verified read-only), so no live shares are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783719796&installation_id=127572939&pr_number=123&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F123&signature=23deb97940454ee37c401ad2385c3870538ee5a5fbc7b0da741f8370df10ff1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->