### PR TITLE
feat(hosted): per-turn token usage profile on hosted_ai_usage

### DIFF
--- a/.github/workflows/cloudflare-hosted-e2e.yml
+++ b/.github/workflows/cloudflare-hosted-e2e.yml
@@ -21,6 +21,13 @@ env:
   # jobs need a real loopback Postgres target rather than the unreachable
   # build-only placeholder URL used by release/build verification lanes.
   DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/murph_test
+  # Stream harness child-process logs (web/wrangler/runner/temporal) straight
+  # to the CI log. Without this the harness buffers them in memory, so a
+  # beforeAll spin-up hang times out with zero diagnostic output (observed
+  # 2026-06-10: codex-image-media e2e hung 300s silently). This lane runs an
+  # all-synthetic local stack (stub tokens, loopback Postgres), so streaming
+  # exposes no real credentials; deploy lanes keep this set to "0".
+  MURPH_E2E_STREAM_DEV_LOGS: "1"
   HOSTED_DEVICE_ROUTING_INDEX_KEY: 0101010101010101010101010101010101010101010101010101010101010101
   HOSTED_CONTACT_PRIVACY_KEYS: v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc
   HOSTED_MAILBOX_FINGERPRINT_KEY: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc

--- a/agent-docs/exec-plans/completed/2026-06-10-hosted-ai-usage-turn-profile.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-hosted-ai-usage-turn-profile.md
@@ -1,0 +1,61 @@
+# Hosted AI usage per-turn profile observability
+
+## Goal
+
+Make hosted token burn diagnosable per turn directly from `hosted_ai_usage`:
+which provider requests carried which token counts (cold-cache misses visible
+per request), how big the thread context was, and which tool calls produced
+the output that inflates the thread.
+
+Success criteria:
+
+- Each hosted turn's usage row carries a compact `turn_profile_json` with the
+  per-request `{input, cachedInput, output}` series, request count, model
+  context window, and a `{label, calls, outputChars, durationMs}` tool
+  breakdown.
+- The profile is derived entirely from notifications the Codex App Server
+  already emits (`thread/tokenUsage/updated` per provider request,
+  `item/completed` typed items) — no new provider surface, no extra calls,
+  no hot-path work.
+- Persisted tool labels are secret-safe by construction: command head only
+  (binary + subcommands), never arguments; labels validated against a strict
+  pattern at the contract boundary.
+- Payload stays well under the 16 KB usage-record callback cap (series capped
+  at 32 requests, tools at 16 entries).
+
+## Constraints / Assumptions
+
+- The extraction is a pure function over the existing `rawEvents` array in
+  `packages/assistant-engine/src/assistant/providers/helpers.ts`, attached to
+  the existing usage draft; recording stays fire-and-forget so reply latency
+  is untouched.
+- The contract owner is `@murphai/hosted-execution` (`assistant-usage.ts`);
+  the parser uses the same strict-allowlist style as `rawUsageJson`.
+- Storage is one additive nullable jsonb column on `hosted_ai_usage`
+  (`turn_profile_json`), migration `2026061001_hosted_ai_usage_turn_profile`.
+- No billing/allowance behavior changes; the field is telemetry only.
+
+## Steps
+
+1. `buildAssistantCodexTurnProfileJson` in assistant-engine helpers +
+   `turnProfileJson` on `AssistantProviderUsage`; unit test with synthetic
+   events. (done)
+2. `turnProfileJson` on `AssistantUsageRecord` with strict normalizer +
+   parser tests; pass-through in `service-usage.ts`. (done)
+3. Prisma column + migration; `usage.ts` create-data mapping; fixture
+   updates across affected tests. (done)
+4. Completion audits (simplify ∥ security-privacy-review, coverage-write,
+   task-finish-review), then `scripts/finish-task`.
+
+## Verification
+
+- `pnpm --filter @murphai/hosted-execution test` (161 pass)
+- assistant-engine `codex-runtime-helpers` + `assistant-codex-runtime`
+  (147 pass), typecheck clean
+- web usage suites (`hosted-execution-usage-route`, `hosted-execution-usage`,
+  `hosted-execution-usage-allowance`: 48 pass), `apps/web` typecheck clean
+- cloudflare `runner-platform` (95 pass) + egress intercept suite (137 pass),
+  typecheck clean
+Status: completed
+Updated: 2026-06-10
+Completed: 2026-06-10

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -179,6 +179,7 @@ function createAssistantUsageRecord(): AssistantUsageRecord {
     totalTokens: 3,
     triggerKind: null,
     turnId: "turn_usage",
+    turnProfileJson: null,
     usageExtractionSourcePath: null,
     usageExtractionVersion: "test",
     usageId: "turn_usage.attempt-1",

--- a/apps/web/prisma/migrations/2026061001_hosted_ai_usage_turn_profile/migration.sql
+++ b/apps/web/prisma/migrations/2026061001_hosted_ai_usage_turn_profile/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "hosted_ai_usage"
+  ADD COLUMN "turn_profile_json" JSONB;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -720,6 +720,7 @@ model HostedAiUsage {
   providerRequestId          String?      @map("provider_request_id")
   rawUsageJson               Json?        @map("raw_usage_json")
   rawUsageJsonHash           String?      @map("raw_usage_json_hash")
+  turnProfileJson            Json?        @map("turn_profile_json")
   usageExtractionVersion     String       @default("legacy") @map("usage_extraction_version")
   usageExtractionSourcePath  String?      @map("usage_extraction_source_path")
   baseUrl                    String?      @map("base_url")

--- a/apps/web/src/lib/hosted-execution/usage.ts
+++ b/apps/web/src/lib/hosted-execution/usage.ts
@@ -201,6 +201,9 @@ function buildHostedAiUsageCreateData(
       ? normalizeHostedAiUsageJsonObject(record.rawUsageJson, "rawUsageJson")
       : undefined,
     rawUsageJsonHash: record.rawUsageJsonHash,
+    turnProfileJson: record.turnProfileJson
+      ? normalizeHostedAiUsageJsonObject(record.turnProfileJson, "turnProfileJson")
+      : undefined,
     usageExtractionSourcePath: record.usageExtractionSourcePath,
     usageExtractionVersion: record.usageExtractionVersion,
     providerRequestOutcome: record.providerRequestOutcome ?? "succeeded",

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -45,6 +45,7 @@ const BASE_USAGE_RECORD = {
   totalTokens: 165,
   triggerKind: null,
   turnId: "turn_123",
+  turnProfileJson: null,
   usageId: "turn_123.attempt-1",
   usageExtractionSourcePath: null,
   usageExtractionVersion: "codex-usage-v1",

--- a/apps/web/test/hosted-execution-usage.test.ts
+++ b/apps/web/test/hosted-execution-usage.test.ts
@@ -175,6 +175,62 @@ describe("recordHostedAiUsageRecords", () => {
     }));
   });
 
+  it("persists the validated per-turn profile JSON and drops invalid profiles", async () => {
+    const hostedAiUsageUpsert = vi.fn(async (args: { create: Record<string, unknown> }) => args.create);
+    const prisma = makeUsagePrisma(hostedAiUsageUpsert);
+    const turnProfileJson = {
+      modelContextWindow: 258400,
+      requestCount: 1,
+      requests: [{ cachedInput: 12, input: 120, output: 45 }],
+      requestsTruncated: false,
+      schema: "murph.assistant-turn-profile.v1",
+      tools: [
+        { calls: 1, durationMs: 420, label: "vault-cli samples query", outputChars: 2048 },
+      ],
+      toolsTruncated: false,
+    };
+
+    const result = await recordHostedAiUsageRecords({
+      prisma: prisma as never,
+      trustedUserId: "member_123",
+      usage: [{ ...BASE_USAGE_RECORD, turnProfileJson }],
+    });
+
+    expect(result.recordedIds).toEqual(["turn_123.attempt-1"]);
+    expect(hostedAiUsageUpsert).toHaveBeenCalledWith(expect.objectContaining({
+      create: expect.objectContaining({
+        turnProfileJson,
+      }),
+    }));
+
+    // Out-of-contract profiles must not reject the row: the usage record is
+    // still persisted for billing, just without the telemetry payload.
+    const droppedUpsert = vi.fn(async (args: { create: Record<string, unknown> }) => args.create);
+    const droppedPrisma = makeUsagePrisma(droppedUpsert);
+
+    const droppedResult = await recordHostedAiUsageRecords({
+      prisma: droppedPrisma as never,
+      trustedUserId: "member_123",
+      usage: [{
+        ...BASE_USAGE_RECORD,
+        turnProfileJson: {
+          ...turnProfileJson,
+          tools: [
+            { calls: 1, durationMs: 0, label: "grep 'member glucose'", outputChars: 1 },
+          ],
+        },
+      }],
+    });
+
+    expect(droppedResult.recordedIds).toEqual(["turn_123.attempt-1"]);
+    const droppedCreate = droppedUpsert.mock.calls[0]?.[0]?.create as
+      | Record<string, unknown>
+      | undefined;
+    expect(droppedCreate).toBeDefined();
+    expect(droppedCreate?.turnProfileJson).toBeUndefined();
+    expect(droppedCreate?.inputTokens).toBe(120);
+  });
+
   it("dedupes identical usage rows by usageId before persisting them", async () => {
     const hostedAiUsageUpsert = vi.fn(async (args: { create: Record<string, unknown> }) => args.create);
     const prisma = makeUsagePrisma(hostedAiUsageUpsert);

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -308,6 +308,7 @@ describe("hosted Prisma baseline migration", () => {
       "2026060900_hosted_latency_phase_breakdown",
       "2026061000_hosted_mailbox_consumed_seq",
       "2026061000_hosted_vault_share",
+      "2026061001_hosted_ai_usage_turn_profile",
       "migration_lock.toml",
     ]);
     expect(baselineMigrationSql).toContain('CREATE TABLE "hosted_assistant_runtime_issue"');

--- a/packages/assistant-engine/src/assistant/providers/helpers.ts
+++ b/packages/assistant-engine/src/assistant/providers/helpers.ts
@@ -13,6 +13,12 @@ import {
   resolveAssistantCodexModelProviderConfig,
 } from '@murphai/operator-config/assistant/target-runtime'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
+import {
+  ASSISTANT_TURN_PROFILE_MAX_REQUESTS,
+  ASSISTANT_TURN_PROFILE_MAX_TOOL_LABEL_LENGTH,
+  ASSISTANT_TURN_PROFILE_MAX_TOOLS,
+  ASSISTANT_TURN_PROFILE_SCHEMA,
+} from '@murphai/hosted-execution/assistant-usage'
 import type {
   AssistantUserMessageContentPart,
 } from '../content-types.js'
@@ -301,17 +307,27 @@ export function extractCodexAssistantProviderUsage(input: {
   const completionMetrics =
     readAssistantProviderRecord(completionParams?.metrics) ??
     readAssistantProviderRecord(completionRecord?.metrics)
+  const turnId = readAssistantCodexTurnIdFromCompletion({
+    completionParams,
+    completionRecord,
+    completionTurn,
+  })
   const usageSource = resolveAssistantProviderUsageSource({
     completionMetrics,
     completionParams,
     completionRecord,
     completionTurn,
     rawEvents: input.rawEvents,
+    turnId,
   })
   const usageRecord = usageSource?.record ?? null
   const sanitizedRawUsageJson = sanitizeAssistantProviderRawUsageJson(
     usageRecord ?? completionRecord,
   )
+  const turnProfileJson = buildAssistantCodexTurnProfileJson({
+    rawEvents: input.rawEvents,
+    turnId,
+  })
   const inputTokens = readAssistantProviderInteger(
     usageRecord ?? completionRecord,
     'inputTokens',
@@ -388,6 +404,7 @@ export function extractCodexAssistantProviderUsage(input: {
         inputTokens,
         outputTokens,
       }),
+    turnProfileJson,
     usageExtractionSourcePath: usageSource?.sourcePath ?? (completionRecord ? 'completion' : null),
     usageExtractionVersion: CODEX_USAGE_EXTRACTION_VERSION,
   }
@@ -399,6 +416,7 @@ function resolveAssistantProviderUsageSource(input: {
   completionRecord: Record<string, unknown> | null
   completionTurn: Record<string, unknown> | null
   rawEvents: readonly unknown[]
+  turnId: string | null
 }): { record: Record<string, unknown>; sourcePath: string } | null {
   const candidates = [
     {
@@ -430,7 +448,7 @@ function resolveAssistantProviderUsageSource(input: {
 
   return findAssistantCodexThreadTokenUsageSource({
     rawEvents: input.rawEvents,
-    turnId: readAssistantCodexTurnIdFromCompletion(input),
+    turnId: input.turnId,
   })
 }
 
@@ -507,6 +525,7 @@ function readAssistantCodexThreadTokenUsageEvents(input: {
   turnId: string | null
 }): Array<{
   last: Record<string, unknown> | null
+  tokenUsage: Record<string, unknown> | null
   total: Record<string, unknown> | null
 }> {
   const turnStartedEventIndex = findAssistantCodexTurnStartedEventIndex(input)
@@ -542,14 +561,16 @@ function readAssistantCodexThreadTokenUsageEvents(input: {
       {
         index,
         last: readAssistantProviderRecord(tokenUsage?.last),
+        tokenUsage,
         total: readAssistantProviderRecord(tokenUsage?.total),
       },
     ]
   })
 
   if (currentTurnOutputEventIndex === null) {
-    return events.map(({ last, total }) => ({
+    return events.map(({ last, tokenUsage, total }) => ({
       last,
+      tokenUsage,
       total,
     }))
   }
@@ -559,10 +580,214 @@ function readAssistantCodexThreadTokenUsageEvents(input: {
   )
   const selectedEvents = postOutputEvents.length > 0 ? postOutputEvents : events
 
-  return selectedEvents.map(({ last, total }) => ({
+  return selectedEvents.map(({ last, tokenUsage, total }) => ({
     last,
+    tokenUsage,
     total,
   }))
+}
+
+const ASSISTANT_TURN_PROFILE_SAFE_TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/u
+const ASSISTANT_TURN_PROFILE_SUBCOMMAND_TOKEN_PATTERN = /^[a-z][a-z0-9-]{0,24}$/u
+const ASSISTANT_TURN_PROFILE_SHELL_TOKEN_PATTERN = /^(?:.*\/)?(?:ba|z|da)?sh$/u
+// Only these head binaries get subcommand tokens in persisted labels. For any
+// other command the first positional token can be member content (search
+// terms, vault paths), so the label stops at the binary name.
+const ASSISTANT_TURN_PROFILE_SUBCOMMAND_HEAD_BINARIES = new Set(['vault-cli', 'murph'])
+
+interface AssistantTurnProfileToolAggregate {
+  calls: number
+  durationMs: number
+  label: string
+  outputChars: number
+}
+
+// Compact per-turn profile derived entirely from notifications Codex already
+// emits (thread/tokenUsage/updated per provider request, item/completed per
+// tool call). This is what lets prod answer "which tool calls and which
+// requests made this turn expensive" without re-deriving anything client-side.
+// The request series reuses the same filtered event reader as the billed
+// totals so the profile always reconciles with the row's token deltas.
+export function buildAssistantCodexTurnProfileJson(input: {
+  rawEvents: readonly unknown[]
+  turnId: string | null
+}): Record<string, unknown> | null {
+  const tokenUsageEvents = readAssistantCodexThreadTokenUsageEvents(input)
+  const requests: Array<Record<string, number>> = []
+  let modelContextWindow: number | null = null
+  for (const event of tokenUsageEvents) {
+    modelContextWindow =
+      readAssistantProviderInteger(
+        event.tokenUsage,
+        'modelContextWindow',
+        'model_context_window',
+      ) ?? modelContextWindow
+    if (event.last) {
+      requests.push({
+        cachedInput:
+          readAssistantProviderInteger(event.last, 'cachedInputTokens', 'cached_input_tokens')
+          ?? 0,
+        input: readAssistantProviderInteger(event.last, 'inputTokens', 'input_tokens') ?? 0,
+        output: readAssistantProviderInteger(event.last, 'outputTokens', 'output_tokens') ?? 0,
+      })
+    }
+  }
+
+  const toolsByLabel = new Map<string, AssistantTurnProfileToolAggregate>()
+  const startIndex = findAssistantCodexTurnStartedEventIndex(input) ?? 0
+  for (let index = startIndex; index < input.rawEvents.length; index += 1) {
+    const record = readAssistantProviderRecord(input.rawEvents[index])
+    const eventType = readAssistantProviderString(
+      record?.method,
+      record?.type,
+      record?.event,
+    )
+    if (eventType !== 'item/completed' && eventType !== 'item.completed') {
+      continue
+    }
+
+    // Replayed foreign-turn items must not inflate this turn's aggregates;
+    // stay lenient when the event predates turn-id stamping.
+    const itemTurnId = readAssistantCodexTurnIdFromRecord(record)
+    if (input.turnId && itemTurnId && itemTurnId !== input.turnId) {
+      continue
+    }
+
+    const params = readAssistantProviderRecord(record?.params)
+    const item = readAssistantProviderRecord(params?.item)
+    const aggregate = readAssistantTurnProfileToolAggregate(item)
+    if (!aggregate) {
+      continue
+    }
+
+    const existing = toolsByLabel.get(aggregate.label)
+    if (existing) {
+      existing.calls += aggregate.calls
+      existing.durationMs += aggregate.durationMs
+      existing.outputChars += aggregate.outputChars
+    } else {
+      toolsByLabel.set(aggregate.label, aggregate)
+    }
+  }
+
+  if (requests.length === 0 && toolsByLabel.size === 0) {
+    return null
+  }
+
+  const tools = [...toolsByLabel.values()].sort(
+    (left, right) => right.outputChars - left.outputChars,
+  )
+
+  return {
+    modelContextWindow,
+    requestCount: requests.length,
+    requests: requests.slice(-ASSISTANT_TURN_PROFILE_MAX_REQUESTS),
+    requestsTruncated: requests.length > ASSISTANT_TURN_PROFILE_MAX_REQUESTS,
+    schema: ASSISTANT_TURN_PROFILE_SCHEMA,
+    tools: tools.slice(0, ASSISTANT_TURN_PROFILE_MAX_TOOLS),
+    toolsTruncated: tools.length > ASSISTANT_TURN_PROFILE_MAX_TOOLS,
+  }
+}
+
+function readAssistantTurnProfileToolAggregate(
+  item: Record<string, unknown> | null,
+): AssistantTurnProfileToolAggregate | null {
+  const itemType = readAssistantProviderString(item?.type)
+  if (!item || !itemType) {
+    return null
+  }
+
+  if (itemType === 'commandExecution') {
+    return {
+      calls: 1,
+      durationMs: readAssistantProviderInteger(item, 'durationMs', 'duration_ms') ?? 0,
+      label: buildAssistantTurnProfileCommandLabel(
+        readAssistantProviderString(item.command),
+      ),
+      outputChars: readAssistantTurnProfileTextLength(
+        item.aggregatedOutput ?? item.aggregated_output,
+      ),
+    }
+  }
+
+  if (itemType === 'mcpToolCall' || itemType === 'dynamicToolCall') {
+    const server = readAssistantProviderString(item.server)
+    const tool = readAssistantProviderString(item.tool, item.name)
+    const label = [server, tool]
+      .filter((part): part is string =>
+        part !== null && ASSISTANT_TURN_PROFILE_SAFE_TOKEN_PATTERN.test(part),
+      )
+      .join('.')
+
+    return {
+      calls: 1,
+      durationMs: readAssistantProviderInteger(item, 'durationMs', 'duration_ms') ?? 0,
+      label: truncateAssistantTurnProfileLabel(label.length > 0 ? label : itemType),
+      outputChars: readAssistantTurnProfileTextLength(item.result),
+    }
+  }
+
+  return null
+}
+
+// Tool labels must stay secret-safe: persist only the binary name unless the
+// head binary is a known subcommand-style CLI, because the first positional
+// argument of arbitrary commands (grep patterns, file paths) can carry member
+// health content even when it matches a benign-looking token charset.
+function buildAssistantTurnProfileCommandLabel(command: string | null): string {
+  const tokens = (command ?? '').split(/\s+/u).filter((token) => token.length > 0)
+  const labelTokens: string[] = []
+
+  for (const token of tokens) {
+    if (labelTokens.length === 0) {
+      if (ASSISTANT_TURN_PROFILE_SHELL_TOKEN_PATTERN.test(token) || token.startsWith('-')) {
+        continue
+      }
+      // Path-invoked binaries (`scripts/check-x.sh`) can carry member-named
+      // files; only bare binary names may persist.
+      if (!ASSISTANT_TURN_PROFILE_SAFE_TOKEN_PATTERN.test(token) || token.includes('/')) {
+        break
+      }
+      labelTokens.push(token)
+      if (!ASSISTANT_TURN_PROFILE_SUBCOMMAND_HEAD_BINARIES.has(token)) {
+        break
+      }
+      continue
+    }
+    if (!ASSISTANT_TURN_PROFILE_SUBCOMMAND_TOKEN_PATTERN.test(token)) {
+      break
+    }
+
+    labelTokens.push(token)
+    if (labelTokens.length >= 3) {
+      break
+    }
+  }
+
+  return truncateAssistantTurnProfileLabel(
+    labelTokens.length > 0 ? labelTokens.join(' ') : 'command',
+  )
+}
+
+function truncateAssistantTurnProfileLabel(label: string): string {
+  return label.length > ASSISTANT_TURN_PROFILE_MAX_TOOL_LABEL_LENGTH
+    ? label.slice(0, ASSISTANT_TURN_PROFILE_MAX_TOOL_LABEL_LENGTH)
+    : label
+}
+
+function readAssistantTurnProfileTextLength(value: unknown): number {
+  if (typeof value === 'string') {
+    return value.length
+  }
+  if (value === null || value === undefined) {
+    return 0
+  }
+
+  try {
+    return JSON.stringify(value)?.length ?? 0
+  } catch {
+    return 0
+  }
 }
 
 function findAssistantCodexTurnStartedEventIndex(input: {

--- a/packages/assistant-engine/src/assistant/providers/types.ts
+++ b/packages/assistant-engine/src/assistant/providers/types.ts
@@ -166,6 +166,7 @@ export interface AssistantProviderUsage {
   requestedModel: string | null
   servedModel: string | null
   totalTokens: number | null
+  turnProfileJson?: Record<string, unknown> | null
   usageExtractionSourcePath?: string | null
   usageExtractionVersion?: string | null
 }

--- a/packages/assistant-engine/src/assistant/service-usage.ts
+++ b/packages/assistant-engine/src/assistant/service-usage.ts
@@ -93,6 +93,7 @@ export async function recordAssistantUsageEvent(input: {
       usageExtractionSourcePath: normalizeNullableString(usage.usageExtractionSourcePath),
       usageExtractionVersion: normalizeNullableString(usage.usageExtractionVersion) ?? 'unknown',
       totalTokens: usage.totalTokens,
+      turnProfileJson: usage.turnProfileJson ?? null,
     }
 
     void usageRecorder.recordUsage(record).catch((error: unknown) => {

--- a/packages/assistant-engine/test/assistant-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-service-runtime.test.ts
@@ -584,6 +584,7 @@ describe("assistant usage recording seam", () => {
         totalTokens: 41,
         triggerKind: null,
         turnId: "turn-usage",
+        turnProfileJson: null,
         usageId: "turn-usage:0:3",
         usageExtractionSourcePath: "params.usage",
         usageExtractionVersion: "codex-usage-v1",

--- a/packages/assistant-engine/test/codex-runtime-helpers.test.ts
+++ b/packages/assistant-engine/test/codex-runtime-helpers.test.ts
@@ -25,6 +25,10 @@ vi.mock('../src/assistant/turns.ts', () => ({
   appendAssistantTurnReceiptEvent: turnsMocks.appendAssistantTurnReceiptEvent,
 }))
 
+import {
+  ASSISTANT_USAGE_SCHEMA,
+  parseAssistantUsageRecord,
+} from '@murphai/hosted-execution/assistant-usage'
 import { normalizeAssistantProviderConfig } from '@murphai/operator-config/assistant/provider-config'
 import { serializeAssistantProviderSessionOptions } from '@murphai/operator-config/assistant/provider-config'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
@@ -39,6 +43,7 @@ import {
   createCatalogModel,
 } from '../src/assistant/providers/catalog.ts'
 import {
+  buildAssistantCodexTurnProfileJson,
   extractCodexAssistantProviderUsage,
   resolveAssistantProviderPrompt,
 } from '../src/assistant/providers/helpers.ts'
@@ -171,6 +176,243 @@ describe('Codex assistant registry helpers', () => {
       servedModel: 'codex-mini',
       totalTokens: null,
     })
+  })
+
+  it('builds a per-turn profile from token usage and tool item events', () => {
+    const usage = extractCodexAssistantProviderUsage({
+      providerConfig: normalizeAssistantProviderConfig({
+        provider: 'codex-cli',
+        model: 'gpt-5.5',
+        oss: false,
+      }),
+      rawEvents: [
+        {
+          method: 'turn/started',
+          params: { turn: { id: 'turn_profile' } },
+        },
+        {
+          method: 'thread/tokenUsage/updated',
+          params: {
+            turnId: 'turn_profile',
+            tokenUsage: {
+              last: { inputTokens: 32000, cachedInputTokens: 0, outputTokens: 50 },
+              total: { inputTokens: 32000, cachedInputTokens: 0, outputTokens: 50 },
+              modelContextWindow: 258400,
+            },
+          },
+        },
+        {
+          method: 'item/completed',
+          params: {
+            item: {
+              type: 'commandExecution',
+              id: 'item_1',
+              command: "bash -lc vault-cli samples query --metric 'sleep score'",
+              aggregatedOutput: 'x'.repeat(2048),
+              durationMs: 420,
+            },
+          },
+        },
+        {
+          method: 'item/completed',
+          params: {
+            item: {
+              type: 'mcpToolCall',
+              id: 'item_2',
+              server: 'images',
+              tool: 'generate',
+              result: { url: 'https://example.test/generated' },
+              durationMs: 900,
+            },
+          },
+        },
+        {
+          method: 'item/completed',
+          params: {
+            item: {
+              type: 'commandExecution',
+              id: 'item_3',
+              // Positional arguments can be member health content; only the
+              // binary name may reach the persisted label.
+              command: 'grep glucose journal.md',
+              aggregatedOutput: 'x'.repeat(512),
+              durationMs: 35,
+            },
+          },
+        },
+        {
+          method: 'thread/tokenUsage/updated',
+          params: {
+            turnId: 'turn_profile',
+            tokenUsage: {
+              last: { inputTokens: 34100, cachedInputTokens: 33920, outputTokens: 80 },
+              total: { inputTokens: 66100, cachedInputTokens: 33920, outputTokens: 130 },
+              modelContextWindow: 258400,
+            },
+          },
+        },
+        {
+          method: 'turn/completed',
+          params: { turn: { id: 'turn_profile' } },
+        },
+      ],
+    })
+
+    expect(usage.turnProfileJson).toEqual({
+      modelContextWindow: 258400,
+      requestCount: 2,
+      requests: [
+        { cachedInput: 0, input: 32000, output: 50 },
+        { cachedInput: 33920, input: 34100, output: 80 },
+      ],
+      requestsTruncated: false,
+      schema: 'murph.assistant-turn-profile.v1',
+      tools: [
+        { calls: 1, durationMs: 420, label: 'vault-cli samples query', outputChars: 2048 },
+        { calls: 1, durationMs: 35, label: 'grep', outputChars: 512 },
+        { calls: 1, durationMs: 900, label: 'images.generate', outputChars: 40 },
+      ],
+      toolsTruncated: false,
+    })
+
+    // Producer→contract round-trip: label-charset drift between this builder
+    // and the hosted-execution allowlist would silently null every profile in
+    // prod (the parser drops invalid profiles by design), so pin it here.
+    const parsed = parseAssistantUsageRecord({
+      attemptCount: 1,
+      credentialSource: 'platform',
+      inputTokens: 66100,
+      occurredAt: '2026-06-10T12:00:00.000Z',
+      outputTokens: 130,
+      provider: 'codex-cli',
+      schema: ASSISTANT_USAGE_SCHEMA,
+      sessionId: 'asst_profile',
+      turnId: 'turn_profile',
+      turnProfileJson: usage.turnProfileJson,
+      usageId: 'turn_profile.attempt-1',
+    })
+    expect(parsed.turnProfileJson).toEqual(usage.turnProfileJson)
+  })
+
+  it('caps the per-turn profile request series and tool list under the callback payload limit', () => {
+    const rawEvents: unknown[] = [
+      // Replayed pre-turn tool output must never count toward this turn even
+      // when it would otherwise dominate the top-by-outputChars ranking.
+      {
+        method: 'item/completed',
+        params: {
+          item: {
+            type: 'commandExecution',
+            id: 'item_replay',
+            command: 'replayed-binary',
+            aggregatedOutput: 'x'.repeat(100000),
+            durationMs: 1,
+          },
+        },
+      },
+      { method: 'turn/started', params: { turn: { id: 'turn_caps' } } },
+    ]
+    for (let request = 1; request <= 34; request += 1) {
+      rawEvents.push({
+        method: 'thread/tokenUsage/updated',
+        params: {
+          turnId: 'turn_caps',
+          tokenUsage: {
+            last: { inputTokens: request, cachedInputTokens: 0, outputTokens: 1 },
+            total: { inputTokens: request, cachedInputTokens: 0, outputTokens: request },
+          },
+        },
+      })
+    }
+    for (let tool = 1; tool <= 18; tool += 1) {
+      rawEvents.push({
+        method: 'item/completed',
+        params: {
+          item: {
+            type: 'commandExecution',
+            id: `item_${tool}`,
+            command: `tool-${tool}`,
+            aggregatedOutput: 'x'.repeat(tool),
+            durationMs: tool,
+          },
+        },
+      })
+    }
+
+    const profile = buildAssistantCodexTurnProfileJson({
+      rawEvents,
+      turnId: 'turn_caps',
+    })
+
+    expect(profile).toMatchObject({
+      // No event carried a context window: stays null instead of 0/undefined.
+      modelContextWindow: null,
+      requestCount: 34,
+      requestsTruncated: true,
+      toolsTruncated: true,
+    })
+    const requests = profile?.requests as Array<Record<string, number>>
+    expect(requests).toHaveLength(32)
+    // The last 32 requests are kept so the expensive tail of a long turn
+    // stays visible after truncation.
+    expect(requests[0]).toEqual({ cachedInput: 0, input: 3, output: 1 })
+    expect(requests[31]).toEqual({ cachedInput: 0, input: 34, output: 1 })
+    const tools = profile?.tools as Array<{ label: string }>
+    expect(tools).toHaveLength(16)
+    expect(tools[0]).toMatchObject({ label: 'tool-18', outputChars: 18 })
+    expect(tools[15]).toMatchObject({ label: 'tool-3', outputChars: 3 })
+    const labels = tools.map((tool) => tool.label)
+    expect(labels).not.toContain('replayed-binary')
+    expect(labels).not.toContain('tool-1')
+    expect(labels).not.toContain('tool-2')
+  })
+
+  it('keeps per-turn profile command labels member-content safe at the edges', () => {
+    const commandEvent = (id: string, command: string, outputChars: number) => ({
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'commandExecution',
+          id,
+          command,
+          aggregatedOutput: 'x'.repeat(outputChars),
+          durationMs: 10,
+        },
+      },
+    })
+    const profile = buildAssistantCodexTurnProfileJson({
+      rawEvents: [
+        { method: 'turn/started', params: { turn: { id: 'turn_labels' } } },
+        // Uppercase positional token fails the subcommand shape even after an
+        // allowlisted head binary: 'Samples' could be a member-named vault dir.
+        commandEvent('item_1', 'vault-cli Samples', 40),
+        // 'murph' is the second allowlisted head binary; labels stop at three
+        // tokens so trailing args never persist.
+        commandEvent('item_2', 'murph reminders list --all glucose', 30),
+        // Quoted shell wrapping leaves no safe head token: fail closed to the
+        // generic 'command' label instead of persisting quoted content.
+        commandEvent('item_3', 'bash -lc "vault-cli samples query"', 20),
+        // Repeated labels aggregate into one entry instead of multiplying.
+        commandEvent('item_4', 'murph reminders list', 25),
+        // Overlong safe binary names truncate to the persisted label cap.
+        commandEvent('item_5', 'a'.repeat(70), 10),
+      ],
+      turnId: 'turn_labels',
+    })
+
+    expect(profile).toMatchObject({
+      modelContextWindow: null,
+      requestCount: 0,
+      requests: [],
+      requestsTruncated: false,
+      toolsTruncated: false,
+    })
+    expect(profile?.tools).toEqual([
+      { calls: 2, durationMs: 20, label: 'murph reminders list', outputChars: 55 },
+      { calls: 1, durationMs: 10, label: 'vault-cli', outputChars: 40 },
+      { calls: 1, durationMs: 10, label: 'command', outputChars: 20 },
+      { calls: 1, durationMs: 10, label: 'a'.repeat(64), outputChars: 10 },
+    ])
   })
 
   it('records privacy-safe provider-attempt-started diagnostics', async () => {
@@ -1432,6 +1674,7 @@ describe('Codex assistant registry helpers', () => {
         requestedModel: null,
         servedModel: null,
         totalTokens: null,
+        turnProfileJson: null,
         usageExtractionSourcePath: null,
         usageExtractionVersion: 'codex-usage-v1',
       },

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -4761,6 +4761,7 @@ function createAssistantUsageRecord(): AssistantUsageRecord {
     totalTokens: 15,
     triggerKind: null,
     turnId: "turn_direct_usage",
+    turnProfileJson: null,
     usageId: "turn_direct_usage.attempt-1",
     usageExtractionSourcePath: null,
     usageExtractionVersion: "codex-usage-v1",

--- a/packages/hosted-execution/src/assistant-usage.ts
+++ b/packages/hosted-execution/src/assistant-usage.ts
@@ -28,6 +28,11 @@ const ASSISTANT_USAGE_RAW_DETAIL_TOKEN_KEYS = new Map<string, ReadonlySet<string
   ["output_tokens_details", new Set(["image_tokens", "reasoning_tokens", "text_tokens"])],
   ["prompt_tokens_details", new Set(["cached_tokens"])],
 ]);
+export const ASSISTANT_TURN_PROFILE_SCHEMA = "murph.assistant-turn-profile.v1";
+export const ASSISTANT_TURN_PROFILE_MAX_REQUESTS = 32;
+export const ASSISTANT_TURN_PROFILE_MAX_TOOLS = 16;
+export const ASSISTANT_TURN_PROFILE_MAX_TOOL_LABEL_LENGTH = 64;
+const ASSISTANT_TURN_PROFILE_TOOL_LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/ -]*$/u;
 
 export type AssistantUsageCredentialSource = "member" | "platform" | "unknown";
 export type AssistantProviderRequestOutcome =
@@ -69,6 +74,7 @@ export interface AssistantUsageRecord {
   totalTokens: number | null;
   triggerKind: string | null;
   turnId: string;
+  turnProfileJson: Record<string, unknown> | null;
   usageId: string;
   usageExtractionSourcePath: string | null;
   usageExtractionVersion: string;
@@ -166,6 +172,7 @@ export function parseAssistantUsageRecord(value: unknown): AssistantUsageRecord 
     totalTokens: normalizeOptionalInteger(record.totalTokens, "totalTokens"),
     triggerKind: normalizeOptionalString(record.triggerKind, "triggerKind"),
     turnId,
+    turnProfileJson: normalizeOptionalTurnProfileJson(record.turnProfileJson, "turnProfileJson"),
     usageId,
     usageExtractionSourcePath: normalizeOptionalString(
       record.usageExtractionSourcePath,
@@ -402,6 +409,110 @@ function normalizeOptionalRawUsageJsonRecord(
   }
 
   return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+// Strict allowlist for the per-turn profile: numeric series plus sanitized
+// tool labels only, so nothing member-authored can ride along into the DB.
+// The profile is droppable telemetry: an invalid profile becomes null instead
+// of rejecting the whole usage record, so token accounting never fails open
+// because of a telemetry-only validation mismatch.
+function normalizeOptionalTurnProfileJson(
+  value: unknown,
+  label: string,
+): Record<string, unknown> | null {
+  try {
+    return requireValidTurnProfileJson(value, label);
+  } catch {
+    return null;
+  }
+}
+
+function requireValidTurnProfileJson(
+  value: unknown,
+  label: string,
+): Record<string, unknown> | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const record = requireRecord(value, label);
+  if (record.schema !== ASSISTANT_TURN_PROFILE_SCHEMA) {
+    throw new TypeError(`${label}.schema must be ${ASSISTANT_TURN_PROFILE_SCHEMA}.`);
+  }
+  if (!isNonNegativeInteger(record.requestCount)) {
+    throw new TypeError(`${label}.requestCount must be a non-negative integer.`);
+  }
+  if (record.modelContextWindow !== null && !isNonNegativeInteger(record.modelContextWindow)) {
+    throw new TypeError(`${label}.modelContextWindow must be null or a non-negative integer.`);
+  }
+  if (typeof record.requestsTruncated !== "boolean" || typeof record.toolsTruncated !== "boolean") {
+    throw new TypeError(`${label} truncation flags must be booleans.`);
+  }
+  if (!Array.isArray(record.requests) || record.requests.length > ASSISTANT_TURN_PROFILE_MAX_REQUESTS) {
+    throw new TypeError(
+      `${label}.requests must be an array of at most ${ASSISTANT_TURN_PROFILE_MAX_REQUESTS} entries.`,
+    );
+  }
+  if (!Array.isArray(record.tools) || record.tools.length > ASSISTANT_TURN_PROFILE_MAX_TOOLS) {
+    throw new TypeError(
+      `${label}.tools must be an array of at most ${ASSISTANT_TURN_PROFILE_MAX_TOOLS} entries.`,
+    );
+  }
+
+  return {
+    modelContextWindow: record.modelContextWindow,
+    requestCount: record.requestCount,
+    requests: record.requests.map((entry, index) =>
+      normalizeTurnProfileIntegerRecord(
+        entry,
+        `${label}.requests[${index}]`,
+        ["cachedInput", "input", "output"],
+      ),
+    ),
+    requestsTruncated: record.requestsTruncated,
+    schema: ASSISTANT_TURN_PROFILE_SCHEMA,
+    tools: record.tools.map((entry, index) => {
+      const toolLabel = `${label}.tools[${index}]`;
+      const tool = requireRecord(entry, toolLabel);
+      if (
+        typeof tool.label !== "string"
+        || tool.label.length === 0
+        || tool.label.length > ASSISTANT_TURN_PROFILE_MAX_TOOL_LABEL_LENGTH
+        || !ASSISTANT_TURN_PROFILE_TOOL_LABEL_PATTERN.test(tool.label)
+      ) {
+        throw new TypeError(`${toolLabel}.label must be a short sanitized tool label.`);
+      }
+
+      return {
+        ...normalizeTurnProfileIntegerRecord(tool, toolLabel, [
+          "calls",
+          "durationMs",
+          "outputChars",
+        ]),
+        label: tool.label,
+      };
+    }),
+    toolsTruncated: record.toolsTruncated,
+  };
+}
+
+function normalizeTurnProfileIntegerRecord(
+  value: unknown,
+  label: string,
+  keys: readonly string[],
+): Record<string, number> {
+  const record = requireRecord(value, label);
+  const normalized: Record<string, number> = {};
+
+  for (const key of keys) {
+    const entry = record[key];
+    if (!isNonNegativeInteger(entry)) {
+      throw new TypeError(`${label}.${key} must be a non-negative integer.`);
+    }
+    normalized[key] = entry;
+  }
+
+  return normalized;
 }
 
 function isNonNegativeInteger(value: unknown): value is number {

--- a/packages/hosted-execution/test/assistant-usage.test.ts
+++ b/packages/hosted-execution/test/assistant-usage.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 
 import {
+  ASSISTANT_TURN_PROFILE_MAX_REQUESTS,
+  ASSISTANT_TURN_PROFILE_MAX_TOOL_LABEL_LENGTH,
+  ASSISTANT_TURN_PROFILE_MAX_TOOLS,
   ASSISTANT_USAGE_SCHEMA,
   createAssistantUsageId,
   createAssistantUsageReportingUserId,
@@ -118,11 +121,142 @@ test("assistant usage parsing preserves a missing totalTokens value", () => {
       totalTokens: null,
       triggerKind: null,
       turnId: "turn_123",
+      turnProfileJson: null,
       usageId: "turn_123.attempt-1",
       usageExtractionSourcePath: null,
       usageExtractionVersion: "legacy",
     },
   );
+});
+
+test("assistant usage parsing validates the turn profile allowlist", () => {
+  const profile = {
+    modelContextWindow: 258400,
+    requestCount: 2,
+    requests: [
+      { cachedInput: 0, input: 32000, output: 120 },
+      { cachedInput: 31872, input: 33000, output: 80 },
+    ],
+    requestsTruncated: false,
+    schema: "murph.assistant-turn-profile.v1",
+    tools: [
+      { calls: 2, durationMs: 1200, label: "vault-cli samples query", outputChars: 20480 },
+    ],
+    toolsTruncated: false,
+  };
+  const baseRecord = {
+    attemptCount: 1,
+    credentialSource: "platform",
+    inputTokens: 10,
+    occurredAt: "2026-03-29T12:00:00.000Z",
+    outputTokens: 5,
+    provider: "codex-cli",
+    schema: ASSISTANT_USAGE_SCHEMA,
+    sessionId: "asst_123",
+    turnId: "turn_123",
+    usageId: "turn_123.attempt-1",
+  };
+
+  assert.deepEqual(
+    parseAssistantUsageRecord({
+      ...baseRecord,
+      turnProfileJson: profile,
+    }).turnProfileJson,
+    profile,
+  );
+
+  // Invalid profiles are droppable telemetry: the usage record (and its token
+  // accounting) must survive with turnProfileJson nulled, never be rejected.
+  const dropped = parseAssistantUsageRecord({
+    ...baseRecord,
+    turnProfileJson: {
+      ...profile,
+      tools: [{ calls: 1, durationMs: 0, label: "rm -rf 'member secret'", outputChars: 1 }],
+    },
+  });
+  assert.equal(dropped.turnProfileJson, null);
+  assert.equal(dropped.inputTokens, 10);
+});
+
+test("assistant usage parsing drops out-of-contract turn profiles without failing the record", () => {
+  const validProfile = {
+    // A null context window is part of the contract (older runtimes omit it).
+    modelContextWindow: null,
+    requestCount: 1,
+    requests: [{ cachedInput: 0, input: 10, output: 5 }],
+    requestsTruncated: false,
+    schema: "murph.assistant-turn-profile.v1",
+    tools: [],
+    toolsTruncated: false,
+  };
+  const baseRecord = {
+    attemptCount: 1,
+    credentialSource: "platform",
+    inputTokens: 10,
+    occurredAt: "2026-03-29T12:00:00.000Z",
+    outputTokens: 5,
+    provider: "codex-cli",
+    schema: ASSISTANT_USAGE_SCHEMA,
+    sessionId: "asst_123",
+    turnId: "turn_123",
+    usageId: "turn_123.attempt-1",
+  };
+
+  assert.deepEqual(
+    parseAssistantUsageRecord({
+      ...baseRecord,
+      turnProfileJson: validProfile,
+    }).turnProfileJson,
+    validProfile,
+  );
+
+  const invalidProfiles: Array<Record<string, unknown>> = [
+    // Unknown schema versions never persist under the v1 contract.
+    { ...validProfile, schema: "murph.assistant-turn-profile.v0" },
+    // Non-integer and non-safe-integer counters are out of contract.
+    { ...validProfile, requests: [{ cachedInput: 0, input: 10.5, output: 5 }] },
+    { ...validProfile, requests: [{ cachedInput: 0, input: 2 ** 53, output: 5 }] },
+    { ...validProfile, modelContextWindow: -1 },
+    // Series longer than the producer-side caps mean an untrusted producer.
+    {
+      ...validProfile,
+      requestCount: ASSISTANT_TURN_PROFILE_MAX_REQUESTS + 1,
+      requests: Array.from(
+        { length: ASSISTANT_TURN_PROFILE_MAX_REQUESTS + 1 },
+        () => ({ cachedInput: 0, input: 1, output: 1 }),
+      ),
+      requestsTruncated: true,
+    },
+    {
+      ...validProfile,
+      tools: Array.from(
+        { length: ASSISTANT_TURN_PROFILE_MAX_TOOLS + 1 },
+        (_, index) => ({ calls: 1, durationMs: 0, label: `tool-${index}`, outputChars: 1 }),
+      ),
+      toolsTruncated: true,
+    },
+    // Overlong labels exceed what the producer is allowed to emit.
+    {
+      ...validProfile,
+      tools: [{
+        calls: 1,
+        durationMs: 0,
+        label: "a".repeat(ASSISTANT_TURN_PROFILE_MAX_TOOL_LABEL_LENGTH + 1),
+        outputChars: 1,
+      }],
+    },
+  ];
+
+  for (const profile of invalidProfiles) {
+    const parsed = parseAssistantUsageRecord({
+      ...baseRecord,
+      turnProfileJson: profile,
+    });
+    // Telemetry drops; token accounting must survive untouched.
+    assert.equal(parsed.turnProfileJson, null);
+    assert.equal(parsed.inputTokens, 10);
+    assert.equal(parsed.outputTokens, 5);
+  }
 });
 
 test("assistant usage parsing allows only token-count raw usage metadata", () => {

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -1641,6 +1641,7 @@ function createAssistantUsageRecord(): AssistantUsageRecord {
     totalTokens: 15,
     triggerKind: "conversation.message",
     turnId: "turn_usage",
+    turnProfileJson: null,
     usageId: "turn_usage.attempt-1",
     usageExtractionSourcePath: null,
     usageExtractionVersion: "legacy",


### PR DESCRIPTION
## Why

Hosted token spend was only recorded as one summed delta per turn, which made the $128/wk burn undiagnosable from prod data: no visibility into per-request cache misses, thread context size, or which tool calls inflate the thread. (Investigation context: ~88% of spend is Linq auto-replies on gpt-5.5; single turns sum to 2.7M+ input tokens across tool round-trips; cold-cache turns pay ~$0.90 for 7-token replies.)

## What

Adds a compact `turn_profile_json` to each `hosted_ai_usage` row, derived **entirely from notifications Codex already emits** — no new provider surface, no extra calls, no hot-path work (built once per turn inside the existing fire-and-forget usage recording):

- `requests`: per-provider-request `{input, cachedInput, output}` series (capped 32), reusing the same replay-filtered event reader as the billed totals so the series always reconciles with the row's token deltas
- `requestCount`, `modelContextWindow`
- `tools`: `{label, calls, outputChars, durationMs}` per tool (capped 16, top by outputChars)

Pipeline: one pure function in assistant-engine → optional field on the existing `AssistantUsageRecord` contract (strict allowlist normalizer in hosted-execution) → existing signed usage callback → one additive nullable jsonb column (migration `2026061001`).

Privacy / fail-safety (from the security-privacy audit):
- Persisted command labels carry the binary name only, unless the head binary is `vault-cli`/`murph` (then up to 2 lowercase subcommand tokens). Positional args (`grep glucose journal.md` → `grep`), quoted content, and path-invoked scripts never persist. Tool output persists only as a character count.
- Invalid profiles drop to `null` at the contract parser instead of rejecting the usage record — token/allowance accounting can never be lost to a telemetry validation mismatch (pinned by tests at parser and storage boundaries).

## Verification

- Full `pnpm test:diff` lane over all touched owners: exit 0
- Owner suites after audit fixes: hosted-execution 162, engine helpers 36 (incl. producer→contract round-trip + label-leak regressions), web usage suites, cloudflare runner-platform 95
- Typechecks clean: assistant-engine, assistant-runtime, hosted-execution, apps/web, apps/cloudflare
- Completion audits run and resolved: simplify (6 findings applied), security-privacy-review (2 applied), coverage-write (4 tests added), task-finish-review (3 findings applied)
- Post-deploy spot-check: confirm the first prod turn's `turn_profile_json.requests` reconciles with the row's token deltas

DEPLOYMENT CONCERNS: deploy web (`apps/web`) before Cloudflare so the usage-record route and DB column exist before runners send the new field. If the order slips, the failure mode is benign: the old web parser ignores unknown keys, so records persist and billing is unaffected — only the telemetry field is silently dropped during the skew window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783722930&installation_id=127572939&pr_number=124&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F124&signature=5ca14dac5ff9a51f75e08248f7dd2e59f68d590686adafd480a8aa07c58ce916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->