### PR TITLE
Make codex app-server client thread-aware and bill subagent thread usage

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-10-codex-thread-aware-usage.md
+++ b/agent-docs/exec-plans/completed/2026-06-10-codex-thread-aware-usage.md
@@ -1,0 +1,211 @@
+# Codex thread-aware event correlation and subagent usage accounting
+
+## Goal
+
+Make Murph's codex app-server client thread-aware so that events from codex
+subagent threads (native `spawn_agent` children) neither fail the parent turn
+nor escape usage accounting. This lands the two primitives required before the
+codex collab/multi-agent feature can ever be enabled; it does NOT enable that
+feature.
+
+Success criteria:
+
+- An event stream containing interleaved child-thread events (own
+  `thread_id`/`turn_id`) completes the parent turn successfully; today the
+  first such event rejects the turn with
+  `ASSISTANT_CODEX_APP_SERVER_STALE_TURN_EVENT`.
+- Per-child-thread token usage is recorded into `hosted_ai_usage` as
+  additional usage rows on the parent turn (existing
+  `providerRequestOrdinal >= 1` seam), with child thread id carried in the
+  row's `rawUsageJson` (decision: `gateway_tags_json` is populated from
+  per-turn usage attribution, not per-draft; `rawUsageJson` is the existing
+  per-draft JSON column and needs no recording-path change) and the child
+  model attributed from parent-thread spawn items.
+- Parent-thread correlation strictness is byte-for-byte unchanged: events on
+  the parent thread with a mismatched/missing turn id still reject exactly as
+  before.
+- No codex feature flags flipped; no behavior change for today's
+  single-thread production turns other than tolerating foreign-thread events.
+
+## Why (evidence)
+
+Verified 2026-06-10 against the `../codex` checkout (2026-05-29, `27e256bc40`):
+
+- App-server auto-attaches every initialized connection as a listener for
+  every newly created thread, including spawned subagent threads
+  (`codex-rs/app-server/src/lib.rs:1024`, `in_process.rs:489`;
+  `thread_processor.rs:2378` has no source filtering). Child events WILL
+  arrive on Murph's connection.
+- Token usage notifications are thread-scoped and carry `thread_id` +
+  `turn_id` (`bespoke_event_handling.rs:1574`). Codex ships no aggregate
+  usage primitive: no usage RPC, no usage field on the protocol `Turn`
+  (`app-server-protocol/src/protocol/v2/thread_data.rs:153`), no parent-side
+  aggregation of child usage, and collab wait/close results carry no usage.
+  Consuming per-thread `thread/tokenUsage/updated` events is the canonical
+  upstream pattern.
+- Murph's client correlates every incoming event against a single
+  `expectedTurnId` and ignores `thread_id` entirely
+  (`packages/assistant-engine/src/assistant-codex.ts` —
+  `validateWarmTurnEventCorrelation`, `bindExpectedTurnId`,
+  `codexEventMethodRequiresTurnCorrelation`); mismatches call
+  `rejectOnce(...)`, failing the turn. The "one thread per connection"
+  assumption was never codex's contract.
+- Usage extraction resolves tokenUsage events for the parent turn id only
+  (`packages/assistant-engine/src/assistant/providers/helpers.ts` —
+  `extractCodexAssistantProviderUsage`,
+  `resolveAssistantCodexThreadTokenUsageTotalDelta`), so child usage would be
+  silently dropped from `hosted_ai_usage`.
+- The recording seam for extra per-turn provider requests already exists and
+  is proven by image generation: `recordAdditionalAssistantUsageEvents`
+  (`packages/assistant-engine/src/assistant/service-usage.ts`) writing rows
+  with `provider_request_ordinal >= 1`. `hosted_ai_usage` needs no schema
+  change (`requested_model`/`served_model` per row, `gateway_tags_json` for
+  the child thread id).
+
+## Constraints
+
+- Utmost priority: clean, simple, long-term maintainable, composable, minimal
+  complexity. The change is "make the existing client honor the protocol's
+  thread dimension", not new orchestration machinery.
+- Do not enable `Feature::Collab` / `multi_agent_v2` in hosted codex config;
+  that is a separate follow-up task (config + prompt guidance + e2e).
+- Do not weaken parent-thread correlation or any production runtime/auth/env
+  invariant for tests.
+- No schema changes to `hosted_ai_usage`.
+- Secret-safe: no raw event payloads with user content in logs/usage JSON;
+  reuse existing sanitization (`sanitizeAssistantProviderRawUsageJson`).
+- Preserve unrelated dirty work; implement in a `murph-*` worktree on a task
+  branch with a PR.
+
+## Approach
+
+1. **Thread identity extraction** (`assistant-codex.ts`): add a
+   `extractCodexThreadIdFromMessage` sibling to the existing
+   `extractCodexTurnIdFromMessage` (notifications carry
+   `params.threadId`/`thread_id`). The parent thread id is already known
+   (`codexThreadId` from thread/start response or resume binding).
+2. **Routing gate ahead of turn correlation**: in the single message-accept
+   path, if a message carries a thread id that differs from the parent's,
+   append it to a per-thread `childThreadEvents` buffer and return — it never
+   reaches `validateWarmTurnEventCorrelation`, so parent strictness is
+   untouched. Messages without a thread id keep today's exact behavior.
+   Bound the buffer (count/bytes) with a diagnostic counter so a runaway
+   child cannot balloon memory; overflow drops oldest events and marks the
+   child usage draft `truncated`.
+3. **Per-child usage extraction** (`providers/helpers.ts`): a small exported
+   `extractCodexChildThreadUsages(childEventsByThread, spawnEvents)` that
+   reuses the existing pure `resolveAssistantCodexThreadTokenUsageTotalDelta`
+   per bucket. Model attribution comes from `CollabAgentSpawnEnd`
+   notifications, which arrive on the PARENT thread and carry
+   `new_thread_id` + effective `model` after inheritance/role overrides
+   (`../codex/codex-rs/protocol/src/protocol.rs:3703`, forwarded to clients
+   at `app-server/src/bespoke_event_handling.rs:831`) — build the
+   threadId→model map from the parent stream and stamp each child usage
+   draft's `requestedModel`/`servedModel`. This makes multi-model billing
+   work with the existing per-row model columns and downstream meters;
+   per-model spend queries over `hosted_ai_usage` need no change.
+4. **Recording**: pass child usage drafts through the existing
+   `recordAdditionalAssistantUsageEvents` seam with continuing
+   `providerRequestOrdinal`, child thread id in `gateway_tags_json`, and a
+   distinct usage source label (e.g. `codex-subagent-thread`).
+5. **Tests** (scripted runtime + helpers unit tests):
+   - parent turn completes when child-thread events (tokenUsage, item/*,
+     turn/*) interleave mid-turn;
+   - child usage rows recorded with correct first/final delta per child,
+     multi-child interleaving attributed correctly, including two children on
+     DIFFERENT models (spawn-end → model stamping) and the null-model
+     fallback when a spawn-end event is absent;
+   - parent-thread strictness regression: same-thread foreign-turn event and
+     thread-id-less foreign-turn event still reject exactly as today;
+   - buffer overflow drops events without failing the turn.
+
+## Out of scope (follow-ups, separate plans)
+
+- Enabling collab tools in `hosted-runtime/codex-config.ts` + assistant
+  prompt guidance for delegation (model-choice policy: mini for mechanical
+  scans, same-tier for vault-writing work).
+- Hosted-local e2e with a real spawned agent.
+- Any upstream codex contribution for an aggregate usage RPC.
+
+## Verification
+
+- `pnpm test:diff packages/assistant-engine` (owner-scoped) plus the new
+  focused tests.
+- `pnpm --dir packages/assistant-engine typecheck`.
+- Standard repo change audits per workflow routing: `coverage-write` and
+  `task-finish-review`; add `security-privacy-review` only if review finds
+  the change touches trust boundaries beyond event parsing (not expected:
+  ingress events are already consumed by this client today).
+
+## State
+
+- Implemented, reviewed, and verified in worktree `murph-codex-thread-aware-usage`.
+
+## Done
+
+- Root-cause investigation of both repos (evidence above).
+- Implemented thread-aware routing, bounded per-child token-usage buffering
+  (32-thread cap, dropped-thread set), child server-request denial, and
+  per-child usage drafts on both the success result and the failure context.
+- PR-review hardening (2026-06-11): (a) subagent notifications arriving
+  BETWEEN turns no longer poison the warm process — the process remembers its
+  bound thread id and tolerates idle foreign-thread notifications (denying
+  their server requests), while idle same-thread output still poisons;
+  (b) evidenced subagent threads win buffer slots at the 32-thread cap by
+  evicting an unattributed sample; (c) billing evidence broadened from
+  spawn-only to ANY parent collab tool call naming receiverThreadIds
+  (sendInput/wait/resume — covers reused children), model attribution still
+  spawn-only. Between-turn child usage is tolerated but never billed — the
+  supported delegation pattern is spawn+wait within a turn.
+- Review hardening (task-finish-review finding): billing is gated on spawn
+  evidence — only threads named in a parent-thread collab spawn item's
+  `receiverThreadIds` produce drafts, because warm processes are reused
+  across threads and a stale flush from a previous thread must never mint a
+  usage row. Unattributed threads are counted via
+  `unattributedSubagentUsageThreadCount` in draft rawUsageJson.
+- Tests: unit (drafts builder incl. spawn-evidence gate, prompt non-leak,
+  snake_case tolerance), integration on the MockChildProcess harness
+  (tolerate+record multi-model, deny child server request, strictness
+  regression, failure-context drafts, 33-thread cap with per-thread dropped
+  count, ordinal continuity after generate_image), thread-id extractor unit
+  coverage.
+- Verification: `pnpm --dir packages/assistant-engine typecheck`;
+  `pnpm test:diff packages/assistant-engine` green (incl. apps/cloudflare
+  verify); focused vitest runs green.
+
+## Now
+
+- Final commit via `scripts/finish-task` and PR.
+
+## Next
+
+- Follow-up (separate plan): enable codex collab tools in hosted codex
+  config + delegation prompt guidance + hosted-local e2e with a real spawn.
+
+## Open questions (UNCONFIRMED if needed)
+
+- RESOLVED (2026-06-10): child model attribution comes from parent-thread
+  `CollabAgentSpawnEnd` notifications (`new_thread_id` + effective `model`);
+  see Approach step 3. Fallback if a spawn-end event is missing for a child
+  bucket: record rows with null model + child thread id tag (still visible
+  spend).
+- RESOLVED (2026-06-10): codex v2 notifications use camelCase
+  (`params.threadId`, `tokenUsage.{total,last}`, item `type:
+  'collabAgentToolCall'`); the extractor also tolerates snake_case and dotted
+  method aliases, with unit coverage.
+
+## Working set (files/ids/commands)
+
+- `packages/assistant-engine/src/assistant-codex.ts`
+- `packages/assistant-engine/src/assistant-codex/failures.ts`
+- `packages/assistant-engine/src/assistant/providers/helpers.ts`
+- `packages/assistant-engine/test/assistant-codex-subagent-usage.test.ts`
+- `packages/assistant-engine/test/assistant-codex-runtime.test.ts`
+- `packages/assistant-engine/test/assistant-codex-failures.test.ts`
+  (`service-usage.ts` needed no change — the existing
+  `recordAdditionalAssistantUsageEvents` seam already handles the drafts)
+- Reference: `../codex/codex-rs/app-server/src/bespoke_event_handling.rs`,
+  `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs`
+Status: completed
+Updated: 2026-06-11
+Completed: 2026-06-11

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -76,6 +76,7 @@ import {
   buildCodexStdinFailureFallback,
   buildCodexTurnFailedError,
   type CodexProcessExitDiagnostics,
+  extractCodexThreadIdFromMessage,
   extractCodexThreadIdFromResult,
   extractCodexThreadPathFromResult,
   extractCodexTurnErrorMessage,
@@ -85,6 +86,12 @@ import {
   isFailedCodexTurnStatus,
   readNodeErrorCode,
 } from './assistant-codex/failures.js'
+import {
+  type CodexSubagentTokenUsageSample,
+  extractCodexSubagentUsageDrafts,
+  isAssistantCodexTokenUsageEventType,
+  readCodexCollabReceiverThreadIds,
+} from './assistant/providers/helpers.js'
 import {
   materializeCodexImagePaths,
   type CodexAppServerImageInput,
@@ -127,6 +134,10 @@ const CODEX_APP_SERVER_TIMING_TRACE_SCHEMA =
 const CODEX_APP_SERVER_TIMING_TRACE_TYPE =
   'assistant.codex.app_server_timing'
 const CODEX_APP_SERVER_STARTUP_STDERR_MAX_LENGTH = 16_384
+// Bound on distinct subagent threads whose token usage is tracked per parent
+// turn. Far above any sane spawn fan-out; threads past the cap are counted
+// and surfaced via droppedSubagentUsageThreadCount on recorded drafts.
+const MAX_CODEX_SUBAGENT_USAGE_THREADS = 32
 
 type CodexAppServerProcessState =
   | 'idle'
@@ -518,6 +529,7 @@ class CodexAppServerProcess {
   readonly startedAt = Date.now()
 
   private activeTurn: CodexAppServerActiveTurnBinding | null = null
+  private boundThreadId: string | null = null
   private cleanupProcessExitListener: () => void
   private completedTurnCount = 0
   private readonly codexCommand: string
@@ -920,12 +932,58 @@ class CodexAppServerProcess {
     })
   }
 
+  // The most recent thread this process ran a turn for. Used between turns
+  // to tell subagent-thread notifications apart from same-thread output
+  // contamination, which must still poison the warm process.
+  noteBoundThreadId(threadId: string | null): void {
+    if (threadId) {
+      this.boundThreadId = threadId
+    }
+  }
+
+  // Exposed so a freshly bound turn can route foreign-thread events before
+  // its own thread/start response has produced the new thread id.
+  get lastBoundThreadId(): string | null {
+    return this.boundThreadId
+  }
+
+  // Subagent threads can outlive the parent turn: codex broadcasts their
+  // thread-scoped notifications on this connection even when no turn is
+  // active. Tolerate (and never bill) those between turns; deny their server
+  // requests so the child does not hang. Idle output for the bound thread
+  // keeps poisoning so the contamination guard is unchanged.
+  private shouldTolerateIdleSubagentMessage(message: CodexRpcMessage): boolean {
+    const messageThreadId = extractCodexThreadIdFromMessage(message)
+    if (
+      messageThreadId === null ||
+      this.boundThreadId === null ||
+      messageThreadId === this.boundThreadId
+    ) {
+      return false
+    }
+
+    const requestId = readCodexRpcServerRequestId(message)
+    if (requestId !== null) {
+      void this.writeRpcMessage({
+        id: requestId,
+        error: {
+          code: -32000,
+          message: 'Server requests from codex subagent threads are not supported.',
+        },
+      })
+    }
+    return true
+  }
+
   private handleStdoutLine(line: string): void {
     const parsed = tryParseJsonLine(line)
     if (parsed.ok) {
       if (this.activeTurn) {
         this.activeTurn.onParsedMessage(parsed.value)
-      } else if (line.trim().length > 0) {
+      } else if (
+        line.trim().length > 0 &&
+        !this.shouldTolerateIdleSubagentMessage(parsed.value)
+      ) {
         void this.poison('off-turn-output')
       }
       return
@@ -1247,6 +1305,13 @@ async function runCodexAppServerTurnOnProcess(
   let responseMedia: AssistantResponseMedia[] = []
   const additionalUsages: AssistantProviderUsageDraft[] = []
   let nextDynamicToolUsageOrdinal = (input.providerRequestOrdinal ?? 0) + 1
+  const subagentTokenUsageByThread =
+    new Map<string, CodexSubagentTokenUsageSample>()
+  const subagentDroppedUsageThreadIds = new Set<string>()
+  // Thread ids named by this turn's collab tool calls (spawn/sendInput/...),
+  // collected live so evidenced subagent threads win buffer slots over
+  // stale/unattributed foreign threads when the cap is reached.
+  const collabReceiverThreadIds = new Set<string>()
   let rolloutRelativePath: string | null = null
   let providerActionCount = 0
   const providerActionItemIds = new Set<string>()
@@ -1303,6 +1368,18 @@ async function runCodexAppServerTurnOnProcess(
     terminationSignalSent,
   })
 
+  // Subagent usage drafts are derived lazily from the buffered per-thread
+  // samples so both the success result and the failure context can include
+  // whatever child usage was observed before the turn settled.
+  const buildSubagentUsageDrafts = (): AssistantProviderUsageDraft[] =>
+    extractCodexSubagentUsageDrafts({
+      droppedThreadCount: subagentDroppedUsageThreadIds.size,
+      modelProvider: normalizeNullableString(input.modelProvider) ?? null,
+      ordinalStart: nextDynamicToolUsageOrdinal,
+      parentRawEvents: jsonEvents,
+      subagentTokenUsageByThread,
+    })
+
   const annotateTurnFailureContext = (error: unknown) => {
     if (!error || typeof error !== 'object') {
       return
@@ -1310,7 +1387,7 @@ async function runCodexAppServerTurnOnProcess(
 
     const context = {
       jsonEvents: [...jsonEvents],
-      additionalUsages: [...additionalUsages],
+      additionalUsages: [...additionalUsages, ...buildSubagentUsageDrafts()],
       providerActionCount,
       codexThreadId,
       providerTurnId: turnId,
@@ -1824,6 +1901,9 @@ async function runCodexAppServerTurnOnProcess(
   ): void => {
     acceptJsonEvent(message)
     codexThreadId = codexThreadId ?? extractCodexSessionId(message)
+    for (const receiverThreadId of readCodexCollabReceiverThreadIds(message)) {
+      collabReceiverThreadIds.add(receiverThreadId)
+    }
     lastEventError = extractCodexErrorMessage(message) ?? lastEventError
     lastEventErrorInfo = extractCodexErrorInfo(message) ?? lastEventErrorInfo
     if (isCodexTurnStartedMethod(method)) {
@@ -1930,6 +2010,57 @@ async function runCodexAppServerTurnOnProcess(
     return true
   }
 
+  const handleSubagentThreadMessage = (
+    threadId: string,
+    message: CodexRpcMessage,
+  ): void => {
+    const requestId = readCodexRpcServerRequestId(message)
+    if (requestId !== null) {
+      // Dynamic tools and approvals stay parent-thread-scoped; answer the
+      // child so it does not hang, without involving the parent turn.
+      void tryWriteRpcMessage({
+        id: requestId,
+        error: {
+          code: -32000,
+          message: 'Server requests from codex subagent threads are not supported.',
+        },
+      })
+      return
+    }
+
+    if (!isAssistantCodexTokenUsageEventType(readCodexEventMethod(message))) {
+      return
+    }
+
+    const sample = subagentTokenUsageByThread.get(threadId)
+    if (sample) {
+      sample.eventCount += 1
+      sample.lastEvent = message
+      return
+    }
+    if (subagentTokenUsageByThread.size >= MAX_CODEX_SUBAGENT_USAGE_THREADS) {
+      // Evidenced subagent threads win buffer slots: evict an unattributed
+      // sample (e.g. a stale flush from a previous warm-process thread, which
+      // is never billable) before dropping a billable child's usage.
+      const evictableThreadId = collabReceiverThreadIds.has(threadId)
+        ? [...subagentTokenUsageByThread.keys()].find(
+          (bufferedThreadId) => !collabReceiverThreadIds.has(bufferedThreadId),
+        )
+        : undefined
+      if (evictableThreadId === undefined) {
+        subagentDroppedUsageThreadIds.add(threadId)
+        return
+      }
+      subagentTokenUsageByThread.delete(evictableThreadId)
+      subagentDroppedUsageThreadIds.add(evictableThreadId)
+    }
+    subagentTokenUsageByThread.set(threadId, {
+      eventCount: 1,
+      firstEvent: message,
+      lastEvent: message,
+    })
+  }
+
   const handleParsedMessage = (message: CodexRpcMessage) => {
     const responseId = readCodexRpcResponseId(message)
     if (responseId !== null) {
@@ -1971,6 +2102,26 @@ async function runCodexAppServerTurnOnProcess(
           return
         }
       }
+      return
+    }
+
+    // Codex app-server auto-attaches this connection to every thread it
+    // creates, including spawned subagent threads, and their notifications
+    // carry foreign thread/turn ids. Route them off the single-turn
+    // correlation path: token usage is buffered for billing, server requests
+    // are denied without failing the parent turn, everything else is dropped.
+    // Before a fresh thread/start response produces this turn's thread id,
+    // fall back to the process's last bound thread id so a late child event
+    // in that window is still routed instead of failing correlation; events
+    // for the last bound thread itself keep today's strict stale handling.
+    const messageThreadId = extractCodexThreadIdFromMessage(message)
+    const knownParentThreadId = codexThreadId ?? codexProcess.lastBoundThreadId
+    if (
+      messageThreadId !== null &&
+      knownParentThreadId !== null &&
+      messageThreadId !== knownParentThreadId
+    ) {
+      handleSubagentThreadMessage(messageThreadId, message)
       return
     }
 
@@ -2276,6 +2427,7 @@ async function runCodexAppServerTurnOnProcess(
     closeLiveTurn()
     clearInterruptCleanupTimer()
     cleanupAbortListener()
+    codexProcess.noteBoundThreadId(codexThreadId)
     codexProcess.releaseTurn(activeTurnBinding)
     codexProcess.releaseReservation()
   }
@@ -2290,7 +2442,7 @@ async function runCodexAppServerTurnOnProcess(
 
   return {
     finalMessage,
-    additionalUsages,
+    additionalUsages: [...additionalUsages, ...buildSubagentUsageDrafts()],
     responseMedia,
     jsonEvents,
     providerActionCount,

--- a/packages/assistant-engine/src/assistant-codex/failures.ts
+++ b/packages/assistant-engine/src/assistant-codex/failures.ts
@@ -100,6 +100,31 @@ export function extractCodexTurnIdFromMessage(
   )
 }
 
+// Codex app-server notifications are thread-scoped: every event names the
+// thread it belongs to. Spawned subagent threads broadcast on the same
+// connection, so callers use this to route foreign-thread events away from
+// the single-turn correlation path instead of rejecting the parent turn.
+export function extractCodexThreadIdFromMessage(
+  message: CodexTurnMessage,
+): string | null {
+  const params = asRecord(message.params)
+  const data = asRecord(message.data)
+  const thread =
+    asRecord(params?.thread) ??
+    asRecord(data?.thread) ??
+    asRecord(message.thread)
+  return (
+    normalizeNullableString(asString(thread?.id)) ??
+    normalizeNullableString(asString(params?.threadId)) ??
+    normalizeNullableString(asString(params?.thread_id)) ??
+    normalizeNullableString(asString(data?.threadId)) ??
+    normalizeNullableString(asString(data?.thread_id)) ??
+    normalizeNullableString(asString(message.threadId)) ??
+    normalizeNullableString(asString(message.thread_id)) ??
+    null
+  )
+}
+
 export function extractCodexTurnStatus(
   message: CodexTurnMessage,
 ): string | null {

--- a/packages/assistant-engine/src/assistant/providers/helpers.ts
+++ b/packages/assistant-engine/src/assistant/providers/helpers.ts
@@ -25,6 +25,7 @@ import type {
 import type {
   AssistantProviderTurnExecutionInput,
   AssistantProviderUsage,
+  AssistantProviderUsageDraft,
 } from './types.js'
 
 const CODEX_USAGE_EXTRACTION_VERSION = 'codex-usage-v1'
@@ -537,32 +538,23 @@ function readAssistantCodexThreadTokenUsageEvents(input: {
     })
 
   const events = input.rawEvents.flatMap((rawEvent, index) => {
-    if (turnStartedEventIndex !== null && index < turnStartedEventIndex) {
+    const pair = readAssistantCodexTokenUsagePairFromEvent(rawEvent)
+    if (
+      !pair ||
+      (turnStartedEventIndex !== null && index < turnStartedEventIndex)
+    ) {
       return []
     }
 
     const record = readAssistantProviderRecord(rawEvent)
-    const eventType = readAssistantProviderString(
-      record?.method,
-      record?.type,
-      record?.event,
-    )
-
-    if (!isAssistantCodexTokenUsageEventType(eventType)) {
-      return []
-    }
-
     if (!isAssistantCodexTokenUsageEventForTurn(record, input.turnId)) {
       return []
     }
 
-    const tokenUsage = readAssistantCodexTokenUsageRecord(record)
     return [
       {
         index,
-        last: readAssistantProviderRecord(tokenUsage?.last),
-        tokenUsage,
-        total: readAssistantProviderRecord(tokenUsage?.total),
+        ...pair,
       },
     ]
   })
@@ -963,7 +955,7 @@ function readAssistantCodexTurnIdFromCompletion(input: {
   )
 }
 
-function isAssistantCodexTokenUsageEventType(eventType: string | null): boolean {
+export function isAssistantCodexTokenUsageEventType(eventType: string | null): boolean {
   return (
     eventType === 'thread/tokenUsage/updated' ||
     eventType === 'thread/token_usage/updated' ||
@@ -987,6 +979,29 @@ function readAssistantCodexTokenUsageRecord(
     readAssistantProviderRecord(record?.tokenUsage) ??
     readAssistantProviderRecord(record?.token_usage)
   )
+}
+
+function readAssistantCodexTokenUsagePairFromEvent(rawEvent: unknown): {
+  last: Record<string, unknown> | null
+  tokenUsage: Record<string, unknown> | null
+  total: Record<string, unknown> | null
+} | null {
+  const record = readAssistantProviderRecord(rawEvent)
+  const eventType = readAssistantProviderString(
+    record?.method,
+    record?.type,
+    record?.event,
+  )
+  if (!isAssistantCodexTokenUsageEventType(eventType)) {
+    return null
+  }
+
+  const tokenUsage = readAssistantCodexTokenUsageRecord(record)
+  return {
+    last: readAssistantProviderRecord(tokenUsage?.last),
+    tokenUsage,
+    total: readAssistantProviderRecord(tokenUsage?.total),
+  }
 }
 
 function readAssistantCodexTurnIdFromRecord(
@@ -1112,6 +1127,212 @@ function subtractAssistantProviderUsageRecords(
   )
 
   return result
+}
+
+export interface CodexSubagentTokenUsageSample {
+  eventCount: number
+  firstEvent: unknown
+  lastEvent: unknown
+}
+
+// Codex ships no aggregate usage primitive for spawned subagent threads (no
+// usage RPC, no usage on the protocol Turn, no parent-side aggregation), so
+// the canonical pattern is consuming each child thread's tokenUsage
+// notifications. This converts the buffered first/final tokenUsage samples
+// per child thread into additional usage drafts on the parent turn, using
+// the same total-delta arithmetic as the parent's billed usage. Billing is
+// gated on collab evidence: only threads named in some parent-thread
+// collabAgentToolCall item's receiverThreadIds (spawnAgent, sendInput, wait,
+// resume — covering freshly spawned and reused children) become drafts; the
+// model is attributed from spawn items, the only ones that carry it. Warm
+// processes are reused across threads, so a foreign thread id alone is not
+// proof of a subagent — a stale flush from a previous thread must never mint
+// a usage row. Unattributed threads are counted, not billed.
+export function extractCodexSubagentUsageDrafts(input: {
+  droppedThreadCount: number
+  modelProvider: string | null
+  ordinalStart: number
+  parentRawEvents: readonly unknown[]
+  subagentTokenUsageByThread: ReadonlyMap<string, CodexSubagentTokenUsageSample>
+}): AssistantProviderUsageDraft[] {
+  if (input.subagentTokenUsageByThread.size === 0) {
+    return []
+  }
+
+  const spawnModelByThreadId = readCodexCollabSpawnModelsByThread(
+    input.parentRawEvents,
+  )
+  const attributedThreads = [...input.subagentTokenUsageByThread].filter(
+    ([threadId]) => spawnModelByThreadId.has(threadId),
+  )
+  const unattributedThreadCount =
+    input.subagentTokenUsageByThread.size - attributedThreads.length
+  const drafts: AssistantProviderUsageDraft[] = []
+  let ordinal = input.ordinalStart
+  for (const [threadId, sample] of attributedThreads) {
+    const pairs = (
+      sample.firstEvent === sample.lastEvent
+        ? [sample.firstEvent]
+        : [sample.firstEvent, sample.lastEvent]
+    ).flatMap((event) => {
+      const pair = readAssistantCodexTokenUsagePairFromEvent(event)
+      return pair ? [pair] : []
+    })
+    const delta = resolveAssistantCodexThreadTokenUsageTotalDelta(pairs)
+    if (!delta) {
+      continue
+    }
+
+    const model = spawnModelByThreadId.get(threadId) ?? null
+    const rawUsageJson: Record<string, unknown> = {
+      codexSubagentThreadId: threadId,
+      tokenUsage: delta,
+      tokenUsageEventCount: sample.eventCount,
+      ...(input.droppedThreadCount > 0
+        ? { droppedSubagentUsageThreadCount: input.droppedThreadCount }
+        : {}),
+      ...(unattributedThreadCount > 0
+        ? { unattributedSubagentUsageThreadCount: unattributedThreadCount }
+        : {}),
+    }
+    const inputTokens = readAssistantProviderInteger(
+      delta,
+      'inputTokens',
+      'input_tokens',
+    )
+    const outputTokens = readAssistantProviderInteger(
+      delta,
+      'outputTokens',
+      'output_tokens',
+    )
+    drafts.push({
+      provider: 'codex-cli',
+      providerRequestOrdinal: ordinal++,
+      providerRequestOutcome: 'succeeded',
+      usage: {
+        apiKeyEnv: null,
+        baseUrl: null,
+        cacheWriteTokens: readAssistantProviderInteger(
+          delta,
+          'cacheWriteTokens',
+          'cache_write_tokens',
+        ),
+        cachedInputTokens: readAssistantProviderInteger(
+          delta,
+          'cachedInputTokens',
+          'cached_input_tokens',
+        ),
+        inputTokens,
+        outputTokens,
+        providerMetadataJson: null,
+        providerName: input.modelProvider,
+        providerRequestId: null,
+        rawUsageJson,
+        rawUsageJsonHash: hashAssistantProviderStableJson(rawUsageJson),
+        reasoningTokens: readAssistantProviderInteger(
+          delta,
+          'reasoningTokens',
+          'reasoning_tokens',
+          'reasoningOutputTokens',
+          'reasoning_output_tokens',
+        ),
+        requestedModel: model,
+        servedModel: model,
+        totalTokens:
+          readAssistantProviderInteger(delta, 'totalTokens', 'total_tokens') ??
+          resolveAssistantProviderTotalTokens({
+            inputTokens,
+            outputTokens,
+          }),
+        usageExtractionSourcePath: 'subagent.thread.tokenUsage.total.delta',
+        usageExtractionVersion: CODEX_USAGE_EXTRACTION_VERSION,
+      },
+    })
+  }
+
+  return drafts
+}
+
+// Collab evidence map: every thread id named by a parent-thread collab tool
+// call item (spawnAgent, sendInput, wait, resumeAgent, ...) is a key — that
+// membership is what authorizes billing a foreign thread's usage, covering
+// both freshly spawned children and reused existing children. The effective
+// model is only known from spawn items and may be null otherwise.
+function readCodexCollabSpawnModelsByThread(
+  rawEvents: readonly unknown[],
+): Map<string, string | null> {
+  const modelByThreadId = new Map<string, string | null>()
+  for (const rawEvent of rawEvents) {
+    const collabToolCall = readCodexCollabToolCallFromEvent(rawEvent)
+    if (!collabToolCall) {
+      continue
+    }
+
+    for (const receiverThreadId of collabToolCall.receiverThreadIds) {
+      modelByThreadId.set(
+        receiverThreadId,
+        modelByThreadId.get(receiverThreadId) ?? collabToolCall.spawnModel,
+      )
+    }
+  }
+
+  return modelByThreadId
+}
+
+// Receiver thread ids named by a single parent-thread collab tool call
+// event, if any. Exported so the live turn loop can prioritize evidenced
+// subagent threads when its bounded usage buffer fills up.
+export function readCodexCollabReceiverThreadIds(
+  rawEvent: unknown,
+): readonly string[] {
+  return readCodexCollabToolCallFromEvent(rawEvent)?.receiverThreadIds ?? []
+}
+
+function readCodexCollabToolCallFromEvent(rawEvent: unknown): {
+  receiverThreadIds: string[]
+  spawnModel: string | null
+} | null {
+  const record = readAssistantProviderRecord(rawEvent)
+  const params = readAssistantProviderRecord(record?.params)
+  const data = readAssistantProviderRecord(record?.data)
+  const item =
+    readAssistantProviderRecord(params?.item) ??
+    readAssistantProviderRecord(data?.item) ??
+    readAssistantProviderRecord(record?.item)
+  if (!item) {
+    return null
+  }
+
+  const itemType = readAssistantProviderString(
+    item.type,
+    item.itemType,
+    item.item_type,
+  )
+  if (itemType !== 'collabAgentToolCall') {
+    return null
+  }
+
+  const rawReceiverThreadIds =
+    item.receiverThreadIds ?? item.receiver_thread_ids
+  if (!Array.isArray(rawReceiverThreadIds)) {
+    return null
+  }
+  const receiverThreadIds = rawReceiverThreadIds.flatMap((receiverThreadId) => {
+    const normalized = readAssistantProviderString(receiverThreadId)
+    return normalized ? [normalized] : []
+  })
+  if (receiverThreadIds.length === 0) {
+    return null
+  }
+
+  const tool = readAssistantProviderString(item.tool)
+  const isSpawnTool = tool === 'spawnAgent' || tool === 'spawn_agent'
+  return {
+    receiverThreadIds,
+    spawnModel: isSpawnTool
+      ? readAssistantProviderString(item.model) ?? null
+      : null,
+  }
 }
 
 function copyAssistantProviderUsageDifference(

--- a/packages/assistant-engine/test/assistant-codex-failures.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-failures.test.ts
@@ -8,6 +8,7 @@ import {
   buildCodexProcessExitError,
   buildCodexStdinFailureFallback,
   buildCodexTurnFailedError,
+  extractCodexThreadIdFromMessage,
   extractCodexThreadIdFromResult,
   extractCodexTurnErrorMessage,
   extractCodexTurnIdFromMessage,
@@ -101,6 +102,91 @@ describe('assistant Codex failure helpers', () => {
     expect(extractCodexTurnErrorMessage({ params: null })).toBeNull()
 
     expect(isFailedCodexTurnStatus(null)).toBe(false)
+  })
+
+  it('extracts thread identifiers from every notification shape codex emits', () => {
+    // Nested thread object wins over flat aliases.
+    expect(
+      extractCodexThreadIdFromMessage({
+        params: {
+          thread: {
+            id: ' thread-nested-wins ',
+          },
+          threadId: 'thread-flat-loses',
+        },
+      }),
+    ).toBe('thread-nested-wins')
+
+    // Blank nested ids fall through to the flat aliases.
+    expect(
+      extractCodexThreadIdFromMessage({
+        params: {
+          thread: {
+            id: '  ',
+          },
+          threadId: ' thread-params-camel ',
+        },
+      }),
+    ).toBe('thread-params-camel')
+    expect(
+      extractCodexThreadIdFromMessage({
+        params: {
+          thread_id: 'thread-params-snake',
+        },
+      }),
+    ).toBe('thread-params-snake')
+
+    // data-style envelopes and top-level fields are also honored.
+    expect(
+      extractCodexThreadIdFromMessage({
+        data: {
+          threadId: 'thread-data-camel',
+        },
+      }),
+    ).toBe('thread-data-camel')
+    expect(
+      extractCodexThreadIdFromMessage({
+        data: {
+          thread_id: 'thread-data-snake',
+        },
+      }),
+    ).toBe('thread-data-snake')
+    expect(
+      extractCodexThreadIdFromMessage({
+        thread: {
+          id: 'thread-top-nested',
+        },
+      }),
+    ).toBe('thread-top-nested')
+    expect(
+      extractCodexThreadIdFromMessage({
+        threadId: 'thread-top-camel',
+      }),
+    ).toBe('thread-top-camel')
+    expect(
+      extractCodexThreadIdFromMessage({
+        thread_id: 'thread-top-snake',
+      }),
+    ).toBe('thread-top-snake')
+
+    // Absent or blank ids never produce a thread id, so thread routing can
+    // never misclassify a thread-id-less parent event as a subagent event.
+    expect(extractCodexThreadIdFromMessage({ params: {} })).toBeNull()
+    expect(
+      extractCodexThreadIdFromMessage({
+        params: {
+          threadId: '   ',
+        },
+      }),
+    ).toBeNull()
+    expect(
+      extractCodexThreadIdFromMessage({
+        method: 'turn/completed',
+        params: {
+          turnId: 'turn-without-thread',
+        },
+      }),
+    ).toBeNull()
   })
 
   it('builds typed turn-failure and interruption errors', () => {

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -9805,6 +9805,1113 @@ describe('assistant codex event shaping', () => {
       },
     ])
   })
+
+  describe('codex subagent thread events', () => {
+    it('tolerates subagent thread events and records their usage as additional drafts', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-usage-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-usage-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_100 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-parent',
+              turnId: 'turn-subagent-parent',
+            })
+            // Parent-thread spawn item announces the child's effective model.
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'collab-spawn-1',
+                  type: 'collabAgentToolCall',
+                  tool: 'spawnAgent',
+                  status: 'completed',
+                  senderThreadId: 'thread-subagent-parent',
+                  receiverThreadIds: ['thread-subagent-child-a'],
+                  prompt: 'crunch the export',
+                  model: 'gpt-5.5-mini',
+                },
+                threadId: 'thread-subagent-parent',
+                turnId: 'turn-subagent-parent',
+              },
+            }))
+            // Child-thread events interleave on the same connection with
+            // foreign thread and turn ids.
+            child.stdout.write(jsonLine({
+              method: 'turn/started',
+              params: {
+                threadId: 'thread-subagent-child-a',
+                turn: {
+                  id: 'turn-subagent-child-a',
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: 'thread-subagent-child-a',
+                turnId: 'turn-subagent-child-a',
+                tokenUsage: {
+                  total: {
+                    totalTokens: 1_000,
+                    inputTokens: 800,
+                    cachedInputTokens: 0,
+                    outputTokens: 200,
+                    reasoningOutputTokens: 0,
+                  },
+                  last: {
+                    totalTokens: 1_000,
+                    inputTokens: 800,
+                    cachedInputTokens: 0,
+                    outputTokens: 200,
+                    reasoningOutputTokens: 0,
+                  },
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'child-cmd-1',
+                  type: 'command_execution',
+                  command: 'true',
+                },
+                threadId: 'thread-subagent-child-a',
+                turnId: 'turn-subagent-child-a',
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: 'thread-subagent-child-a',
+                turnId: 'turn-subagent-child-a',
+                tokenUsage: {
+                  total: {
+                    totalTokens: 5_000,
+                    inputTokens: 4_000,
+                    cachedInputTokens: 2_000,
+                    outputTokens: 1_000,
+                    reasoningOutputTokens: 120,
+                  },
+                  last: {
+                    totalTokens: 4_000,
+                    inputTokens: 3_200,
+                    cachedInputTokens: 2_000,
+                    outputTokens: 800,
+                    reasoningOutputTokens: 120,
+                  },
+                },
+              },
+            }))
+            // A second spawned child whose spawn item carries no model stays
+            // model-unattributed but still bills.
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'collab-spawn-2',
+                  type: 'collabAgentToolCall',
+                  tool: 'spawnAgent',
+                  status: 'completed',
+                  senderThreadId: 'thread-subagent-parent',
+                  receiverThreadIds: ['thread-subagent-child-b'],
+                },
+                threadId: 'thread-subagent-parent',
+                turnId: 'turn-subagent-parent',
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: 'thread-subagent-child-b',
+                turnId: 'turn-subagent-child-b',
+                tokenUsage: {
+                  total: {
+                    totalTokens: 700,
+                    inputTokens: 600,
+                    cachedInputTokens: 100,
+                    outputTokens: 100,
+                    reasoningOutputTokens: 0,
+                  },
+                  last: {
+                    totalTokens: 700,
+                    inputTokens: 600,
+                    cachedInputTokens: 100,
+                    outputTokens: 100,
+                    reasoningOutputTokens: 0,
+                  },
+                },
+              },
+            }))
+            writeCodexV2AssistantEventTurn({
+              child,
+              finalMessage: 'Done with subagents',
+              threadId: 'thread-subagent-parent',
+              turnId: 'turn-subagent-parent',
+            })
+          })()
+        })
+
+        return child
+      })
+
+      const result = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          PATH: '/custom/bin',
+        },
+        modelProvider: 'local-test-provider',
+        prompt: 'spawn a subagent and finish',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      expect(result.finalMessage).toBe('Done with subagents')
+      expect(result.turnId).toBe('turn-subagent-parent')
+      expect(result.additionalUsages).toHaveLength(2)
+      expect(result.additionalUsages[0]).toMatchObject({
+        provider: 'codex-cli',
+        providerRequestOrdinal: 1,
+        usage: {
+          cachedInputTokens: 2_000,
+          inputTokens: 4_000,
+          outputTokens: 1_000,
+          providerName: 'local-test-provider',
+          reasoningTokens: 120,
+          requestedModel: 'gpt-5.5-mini',
+          servedModel: 'gpt-5.5-mini',
+          totalTokens: 5_000,
+        },
+      })
+      expect(result.additionalUsages[0]?.usage.rawUsageJson).toMatchObject({
+        codexSubagentThreadId: 'thread-subagent-child-a',
+        tokenUsageEventCount: 2,
+      })
+      expect(result.additionalUsages[1]).toMatchObject({
+        providerRequestOrdinal: 2,
+        usage: {
+          inputTokens: 600,
+          outputTokens: 100,
+          requestedModel: null,
+          servedModel: null,
+          totalTokens: 700,
+        },
+      })
+    })
+
+    it('answers subagent thread server requests with an error without failing the turn', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-deny-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-deny-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_200 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-deny-parent',
+              turnId: 'turn-subagent-deny-parent',
+            })
+            child.stdout.write(jsonLine({
+              id: 99,
+              method: 'item/tool/call',
+              params: {
+                namespace: 'murph',
+                tool: 'generate_image',
+                arguments: {
+                  prompt: 'a child should not be able to call this',
+                },
+                threadId: 'thread-subagent-deny-child',
+                turnId: 'turn-subagent-deny-child',
+              },
+            }))
+            const denial = await waitForRpcResponse(child, 99)
+            expect(denial).toMatchObject({
+              id: 99,
+              error: {
+                code: -32000,
+              },
+            })
+            writeCodexV2AssistantEventTurn({
+              child,
+              finalMessage: 'Parent unaffected',
+              threadId: 'thread-subagent-deny-parent',
+              turnId: 'turn-subagent-deny-parent',
+            })
+          })()
+        })
+
+        return child
+      })
+
+      const result = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          PATH: '/custom/bin',
+        },
+        prompt: 'child server requests stay denied',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      expect(result.finalMessage).toBe('Parent unaffected')
+      expect(result.additionalUsages).toEqual([])
+    })
+
+    it('still rejects parent-thread events that do not match the active turn', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-strict-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-strict-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_300 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-strict-parent',
+              turnId: 'turn-subagent-strict-parent',
+            })
+            // Same parent thread, mismatched turn id: the strict correlation
+            // contract is unchanged by subagent routing.
+            child.stdout.write(jsonLine({
+              method: 'item/agentMessage/delta',
+              params: {
+                delta: 'rogue output',
+                itemId: 'rogue-item',
+                threadId: 'thread-subagent-strict-parent',
+                turnId: 'turn-subagent-strict-other',
+              },
+            }))
+          })()
+        })
+
+        return child
+      })
+
+      await expect(
+        executeCodexAppServerTurn({
+          approvalPolicy: 'never',
+          codexHome,
+          env: {
+            PATH: '/custom/bin',
+          },
+          prompt: 'strictness stays intact',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        }),
+      ).rejects.toMatchObject({
+        code: 'ASSISTANT_CODEX_APP_SERVER_STALE_TURN_EVENT',
+      })
+    })
+
+    it('includes observed subagent usage drafts in the failure context when the turn fails', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-fail-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-fail-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_400 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-fail-parent',
+              turnId: 'turn-subagent-fail-parent',
+            })
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'collab-spawn-fail-1',
+                  type: 'collabAgentToolCall',
+                  tool: 'spawnAgent',
+                  status: 'completed',
+                  senderThreadId: 'thread-subagent-fail-parent',
+                  receiverThreadIds: ['thread-subagent-fail-child'],
+                  model: 'gpt-5.5-mini',
+                },
+                threadId: 'thread-subagent-fail-parent',
+                turnId: 'turn-subagent-fail-parent',
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: 'thread-subagent-fail-child',
+                turnId: 'turn-subagent-fail-child',
+                tokenUsage: {
+                  total: {
+                    totalTokens: 1_000,
+                    inputTokens: 800,
+                    cachedInputTokens: 0,
+                    outputTokens: 200,
+                    reasoningOutputTokens: 0,
+                  },
+                  last: {
+                    totalTokens: 1_000,
+                    inputTokens: 800,
+                    cachedInputTokens: 0,
+                    outputTokens: 200,
+                    reasoningOutputTokens: 0,
+                  },
+                },
+              },
+            }))
+            // The parent turn fails AFTER child usage was observed: the
+            // billed child usage must survive into the failure context.
+            child.stdout.write(jsonLine({
+              method: 'turn/completed',
+              params: {
+                status: 'failed',
+                threadId: 'thread-subagent-fail-parent',
+                turnId: 'turn-subagent-fail-parent',
+              },
+            }))
+          })()
+        })
+
+        return child
+      })
+
+      const error: unknown = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          PATH: '/custom/bin',
+        },
+        prompt: 'fail after child usage arrives',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      }).then(
+        () => {
+          throw new Error('expected the Codex turn to fail')
+        },
+        (turnError: unknown) => turnError,
+      )
+
+      expect(error).toMatchObject({
+        code: 'ASSISTANT_CODEX_FAILED',
+      })
+      const failureContext = readCodexAppServerTurnFailureContext(error)
+      expect(failureContext?.additionalUsages).toMatchObject([
+        {
+          provider: 'codex-cli',
+          providerRequestOrdinal: 1,
+          providerRequestOutcome: 'succeeded',
+          usage: {
+            inputTokens: 800,
+            outputTokens: 200,
+            totalTokens: 1_000,
+          },
+        },
+      ])
+      expect(failureContext?.additionalUsages[0]?.usage.rawUsageJson).toMatchObject({
+        codexSubagentThreadId: 'thread-subagent-fail-child',
+        tokenUsageEventCount: 1,
+      })
+    })
+
+    it('caps tracked subagent usage threads and reports the dropped-thread count', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-cap-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-cap-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+      const trackedThreadCount = 32
+      const overflowThreadId = `thread-subagent-cap-${trackedThreadCount + 1}`
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_500 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-cap-parent',
+              turnId: 'turn-subagent-cap-parent',
+            })
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'collab-spawn-cap-1',
+                  type: 'collabAgentToolCall',
+                  tool: 'spawnAgent',
+                  status: 'completed',
+                  senderThreadId: 'thread-subagent-cap-parent',
+                  receiverThreadIds: Array.from(
+                    { length: trackedThreadCount + 1 },
+                    (_, index) => `thread-subagent-cap-${index + 1}`,
+                  ),
+                  model: 'gpt-5.5-mini',
+                },
+                threadId: 'thread-subagent-cap-parent',
+                turnId: 'turn-subagent-cap-parent',
+              },
+            }))
+            for (let childIndex = 1; childIndex <= trackedThreadCount + 1; childIndex += 1) {
+              const totals = {
+                totalTokens: childIndex * 100,
+                inputTokens: childIndex * 80,
+                cachedInputTokens: 0,
+                outputTokens: childIndex * 20,
+                reasoningOutputTokens: 0,
+              }
+              child.stdout.write(jsonLine({
+                method: 'thread/tokenUsage/updated',
+                params: {
+                  threadId: `thread-subagent-cap-${childIndex}`,
+                  turnId: `turn-subagent-cap-${childIndex}`,
+                  tokenUsage: {
+                    total: totals,
+                    last: totals,
+                  },
+                },
+              }))
+            }
+            // The overflow thread emits a second event: the dropped count
+            // must stay per-thread, not per-event.
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: overflowThreadId,
+                turnId: `turn-subagent-cap-${trackedThreadCount + 1}`,
+                tokenUsage: {
+                  total: {
+                    totalTokens: 9_900,
+                    inputTokens: 9_000,
+                    cachedInputTokens: 0,
+                    outputTokens: 900,
+                    reasoningOutputTokens: 0,
+                  },
+                  last: {
+                    totalTokens: 9_900,
+                    inputTokens: 9_000,
+                    cachedInputTokens: 0,
+                    outputTokens: 900,
+                    reasoningOutputTokens: 0,
+                  },
+                },
+              },
+            }))
+            writeCodexV2AssistantEventTurn({
+              child,
+              finalMessage: 'Survived the spawn storm',
+              threadId: 'thread-subagent-cap-parent',
+              turnId: 'turn-subagent-cap-parent',
+            })
+          })()
+        })
+
+        return child
+      })
+
+      const result = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          PATH: '/custom/bin',
+        },
+        prompt: 'spawn more children than the usage cap',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      expect(result.finalMessage).toBe('Survived the spawn storm')
+      expect(result.additionalUsages).toHaveLength(trackedThreadCount)
+      expect(result.additionalUsages[0]).toMatchObject({
+        providerRequestOrdinal: 1,
+        usage: {
+          totalTokens: 100,
+        },
+      })
+      expect(result.additionalUsages[trackedThreadCount - 1]).toMatchObject({
+        providerRequestOrdinal: trackedThreadCount,
+        usage: {
+          totalTokens: trackedThreadCount * 100,
+        },
+      })
+      const draftThreadIds = result.additionalUsages.map(
+        (draft) =>
+          (draft.usage.rawUsageJson as { codexSubagentThreadId?: string })
+            .codexSubagentThreadId,
+      )
+      expect(draftThreadIds).not.toContain(overflowThreadId)
+      for (const draft of result.additionalUsages) {
+        expect(draft.usage.rawUsageJson).toMatchObject({
+          droppedSubagentUsageThreadCount: 1,
+        })
+      }
+    })
+
+    it('continues subagent usage ordinals after dynamic tool usage drafts', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-ordinal-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-ordinal-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+      const webpBytes = new Uint8Array([
+        0x52, 0x49, 0x46, 0x46,
+        0x00, 0x00, 0x00, 0x00,
+        0x57, 0x45, 0x42, 0x50,
+      ])
+      const fetchImpl = vi.fn(async () =>
+        new Response(JSON.stringify({
+          data: [{ b64_json: Buffer.from(webpBytes).toString('base64') }],
+          usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+        }), {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        }))
+      const uploader = {
+        uploadGeneratedImage: vi.fn(async (uploadInput: { alt: string | null; source: string | null }) => ({
+          alt: uploadInput.alt,
+          kind: 'image' as const,
+          source: uploadInput.source,
+          url: 'https://imagedelivery.net/account/generated/public',
+        })),
+      }
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_600 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-ordinal-parent',
+              turnId: 'turn-subagent-ordinal-parent',
+            })
+            // Child usage interleaves with a parent dynamic tool call: the
+            // image draft takes ordinal 1, so the subagent draft must take 2.
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'collab-spawn-ordinal-1',
+                  type: 'collabAgentToolCall',
+                  tool: 'spawnAgent',
+                  status: 'completed',
+                  senderThreadId: 'thread-subagent-ordinal-parent',
+                  receiverThreadIds: ['thread-subagent-ordinal-child'],
+                  model: 'gpt-5.5-mini',
+                },
+                threadId: 'thread-subagent-ordinal-parent',
+                turnId: 'turn-subagent-ordinal-parent',
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: 'thread-subagent-ordinal-child',
+                turnId: 'turn-subagent-ordinal-child',
+                tokenUsage: {
+                  total: {
+                    totalTokens: 1_000,
+                    inputTokens: 800,
+                    cachedInputTokens: 0,
+                    outputTokens: 200,
+                    reasoningOutputTokens: 0,
+                  },
+                  last: {
+                    totalTokens: 1_000,
+                    inputTokens: 800,
+                    cachedInputTokens: 0,
+                    outputTokens: 200,
+                    reasoningOutputTokens: 0,
+                  },
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              id: 71,
+              method: 'item/tool/call',
+              params: {
+                namespace: 'murph',
+                tool: 'generate_image',
+                arguments: {
+                  prompt: 'Render the product.',
+                },
+                threadId: 'thread-subagent-ordinal-parent',
+                turnId: 'turn-subagent-ordinal-parent',
+              },
+            }))
+            await expect(waitForRpcResponse(child, 71)).resolves.toMatchObject({
+              id: 71,
+              result: {
+                success: true,
+              },
+            })
+            writeCodexV2AssistantEventTurn({
+              child,
+              finalMessage: 'Image and subagent usage recorded',
+              threadId: 'thread-subagent-ordinal-parent',
+              turnId: 'turn-subagent-ordinal-parent',
+            })
+          })()
+        })
+
+        return child
+      })
+
+      const result = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          OPENAI_API_KEY: 'openai-test-key',
+          PATH: '/custom/bin',
+        },
+        fetchImpl,
+        hostedGeneratedImageUploader: uploader,
+        prompt: 'generate an image while a child reports usage',
+        requireHostedGeneratedImageUploader: true,
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      expect(result.finalMessage).toBe('Image and subagent usage recorded')
+      expect(result.additionalUsages).toMatchObject([
+        {
+          provider: 'openai-images',
+          providerRequestOrdinal: 1,
+        },
+        {
+          provider: 'codex-cli',
+          providerRequestOrdinal: 2,
+          usage: {
+            inputTokens: 800,
+            outputTokens: 200,
+            totalTokens: 1_000,
+          },
+        },
+      ])
+      expect(result.additionalUsages[1]?.usage.rawUsageJson).toMatchObject({
+        codexSubagentThreadId: 'thread-subagent-ordinal-child',
+      })
+      expect(uploader.uploadGeneratedImage).toHaveBeenCalledOnce()
+    })
+
+    it('tolerates subagent thread notifications between turns without poisoning the warm process', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-idle-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-idle-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_700 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-idle-parent',
+              turnId: 'turn-subagent-idle-one',
+            })
+            child.stdout.write(jsonLine({
+              method: 'turn/completed',
+              params: {
+                status: 'completed',
+                threadId: 'thread-subagent-idle-parent',
+                turnId: 'turn-subagent-idle-one',
+              },
+            }))
+
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 2,
+              threadId: 'thread-subagent-idle-parent-2',
+              turnId: 'turn-subagent-idle-two',
+            })
+            child.stdout.write(jsonLine({
+              method: 'turn/completed',
+              params: {
+                status: 'completed',
+                threadId: 'thread-subagent-idle-parent-2',
+                turnId: 'turn-subagent-idle-two',
+              },
+            }))
+          })()
+        })
+
+        return child
+      })
+
+      const stableInput = {
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          PATH: '/custom/bin',
+        },
+        sandbox: 'workspace-write' as const,
+        workingDirectory,
+      }
+
+      await expect(
+        executeCodexAppServerTurn({
+          ...stableInput,
+          prompt: 'first turn before idle subagent traffic',
+        }),
+      ).resolves.toMatchObject({
+        turnId: 'turn-subagent-idle-one',
+      })
+
+      // Subagent threads outlive parent turns: a late token-usage flush and a
+      // late server request arrive while no turn is active. Neither may
+      // poison the warm process; the request gets a deny response.
+      spawnedChildren[0]!.stdout.write(jsonLine({
+        method: 'thread/tokenUsage/updated',
+        params: {
+          threadId: 'thread-subagent-idle-child',
+          turnId: 'turn-subagent-idle-child',
+          tokenUsage: {
+            total: {
+              totalTokens: 400,
+              inputTokens: 300,
+              cachedInputTokens: 0,
+              outputTokens: 100,
+              reasoningOutputTokens: 0,
+            },
+            last: {
+              totalTokens: 400,
+              inputTokens: 300,
+              cachedInputTokens: 0,
+              outputTokens: 100,
+              reasoningOutputTokens: 0,
+            },
+          },
+        },
+      }))
+      spawnedChildren[0]!.stdout.write(jsonLine({
+        id: 199,
+        method: 'item/tool/call',
+        params: {
+          namespace: 'murph',
+          tool: 'generate_image',
+          arguments: {
+            prompt: 'idle child tool call',
+          },
+          threadId: 'thread-subagent-idle-child',
+          turnId: 'turn-subagent-idle-child',
+        },
+      }))
+      await expect(
+        waitForRpcResponse(spawnedChildren[0]!, 199),
+      ).resolves.toMatchObject({
+        id: 199,
+        error: {
+          code: -32000,
+        },
+      })
+
+      const second = await executeCodexAppServerTurn({
+        ...stableInput,
+        prompt: 'second turn reusing the warm process',
+      })
+      expect(second.turnId).toBe('turn-subagent-idle-two')
+      // The idle child usage is tolerated, never billed.
+      expect(second.additionalUsages).toEqual([])
+      expect(spawnedChildren).toHaveLength(1)
+    })
+
+    it('routes late child events arriving before the next thread/start response resolves', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-prestart-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-prestart-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_900 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-prestart-one',
+              turnId: 'turn-subagent-prestart-one',
+            })
+            child.stdout.write(jsonLine({
+              method: 'turn/completed',
+              params: {
+                status: 'completed',
+                threadId: 'thread-subagent-prestart-one',
+                turnId: 'turn-subagent-prestart-one',
+              },
+            }))
+
+            // The second turn has bound the warm process, but its
+            // thread/start response has not been written yet: a late child
+            // event lands in that window and must be routed, not treated as
+            // a stale-turn correlation failure.
+            const secondThread = await waitForRpcMethodCount(child, 'thread/start', 2)
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: 'thread-subagent-prestart-child',
+                turnId: 'turn-subagent-prestart-child',
+                tokenUsage: {
+                  total: {
+                    totalTokens: 600,
+                    inputTokens: 500,
+                    cachedInputTokens: 0,
+                    outputTokens: 100,
+                    reasoningOutputTokens: 0,
+                  },
+                  last: {
+                    totalTokens: 600,
+                    inputTokens: 500,
+                    cachedInputTokens: 0,
+                    outputTokens: 100,
+                    reasoningOutputTokens: 0,
+                  },
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              id: secondThread.id,
+              result: {
+                thread: {
+                  id: 'thread-subagent-prestart-two',
+                },
+              },
+            }))
+            const secondTurn = await waitForRpcMethodCount(child, 'turn/start', 2)
+            child.stdout.write(jsonLine({
+              id: secondTurn.id,
+              result: {
+                turn: {
+                  id: 'turn-subagent-prestart-two',
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'turn/completed',
+              params: {
+                status: 'completed',
+                threadId: 'thread-subagent-prestart-two',
+                turnId: 'turn-subagent-prestart-two',
+              },
+            }))
+          })()
+        })
+
+        return child
+      })
+
+      const stableInput = {
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          PATH: '/custom/bin',
+        },
+        sandbox: 'workspace-write' as const,
+        workingDirectory,
+      }
+
+      await expect(
+        executeCodexAppServerTurn({
+          ...stableInput,
+          prompt: 'first turn before the pre-start window race',
+        }),
+      ).resolves.toMatchObject({
+        turnId: 'turn-subagent-prestart-one',
+      })
+
+      const second = await executeCodexAppServerTurn({
+        ...stableInput,
+        prompt: 'second turn with a late child event before thread/start resolves',
+      })
+      expect(second.turnId).toBe('turn-subagent-prestart-two')
+      // The late child has no collab evidence in this turn: tolerated, not billed.
+      expect(second.additionalUsages).toEqual([])
+      expect(spawnedChildren).toHaveLength(1)
+    })
+
+    it('evicts unattributed foreign threads from a full buffer in favor of spawned children', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-subagent-evict-work-')
+      const codexHome = await createTempDir('assistant-codex-subagent-evict-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+      const ghostThreadCount = 32
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_800 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-evict-parent',
+              turnId: 'turn-subagent-evict-parent',
+            })
+            // Stale/unattributed foreign threads fill the buffer first.
+            for (let ghostIndex = 1; ghostIndex <= ghostThreadCount; ghostIndex += 1) {
+              const totals = {
+                totalTokens: ghostIndex,
+                inputTokens: ghostIndex,
+                cachedInputTokens: 0,
+                outputTokens: 0,
+                reasoningOutputTokens: 0,
+              }
+              child.stdout.write(jsonLine({
+                method: 'thread/tokenUsage/updated',
+                params: {
+                  threadId: `thread-subagent-ghost-${ghostIndex}`,
+                  turnId: `turn-subagent-ghost-${ghostIndex}`,
+                  tokenUsage: {
+                    total: totals,
+                    last: totals,
+                  },
+                },
+              }))
+            }
+            // A real spawned child arrives after the buffer is full: it must
+            // still get a slot (an unattributed ghost is evicted) and bill.
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'collab-spawn-evict-1',
+                  type: 'collabAgentToolCall',
+                  tool: 'spawnAgent',
+                  status: 'completed',
+                  senderThreadId: 'thread-subagent-evict-parent',
+                  receiverThreadIds: ['thread-subagent-evict-child'],
+                  model: 'gpt-5.5-mini',
+                },
+                threadId: 'thread-subagent-evict-parent',
+                turnId: 'turn-subagent-evict-parent',
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: 'thread-subagent-evict-child',
+                turnId: 'turn-subagent-evict-child',
+                tokenUsage: {
+                  total: {
+                    totalTokens: 2_500,
+                    inputTokens: 2_000,
+                    cachedInputTokens: 500,
+                    outputTokens: 500,
+                    reasoningOutputTokens: 0,
+                  },
+                  last: {
+                    totalTokens: 2_500,
+                    inputTokens: 2_000,
+                    cachedInputTokens: 500,
+                    outputTokens: 500,
+                    reasoningOutputTokens: 0,
+                  },
+                },
+              },
+            }))
+            writeCodexV2AssistantEventTurn({
+              child,
+              finalMessage: 'Evicted a ghost for the real child',
+              threadId: 'thread-subagent-evict-parent',
+              turnId: 'turn-subagent-evict-parent',
+            })
+          })()
+        })
+
+        return child
+      })
+
+      const result = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          PATH: '/custom/bin',
+        },
+        prompt: 'spawned child arrives after ghosts fill the buffer',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      expect(result.finalMessage).toBe('Evicted a ghost for the real child')
+      expect(result.additionalUsages).toHaveLength(1)
+      expect(result.additionalUsages[0]).toMatchObject({
+        provider: 'codex-cli',
+        providerRequestOrdinal: 1,
+        usage: {
+          inputTokens: 2_000,
+          outputTokens: 500,
+          requestedModel: 'gpt-5.5-mini',
+          servedModel: 'gpt-5.5-mini',
+          totalTokens: 2_500,
+        },
+      })
+      expect(result.additionalUsages[0]?.usage.rawUsageJson).toMatchObject({
+        codexSubagentThreadId: 'thread-subagent-evict-child',
+        // One ghost was evicted to make room; the remaining 31 buffered
+        // ghosts are unattributed and never billed.
+        droppedSubagentUsageThreadCount: 1,
+        unattributedSubagentUsageThreadCount: 31,
+      })
+    })
+  })
 })
 
 class MockChildProcess extends EventEmitter {

--- a/packages/assistant-engine/test/assistant-codex-subagent-usage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-subagent-usage.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type CodexSubagentTokenUsageSample,
+  extractCodexSubagentUsageDrafts,
+} from '../src/assistant/providers/helpers.ts'
+
+function tokenUsageEvent(input: {
+  threadId: string
+  turnId: string
+  total: Record<string, number>
+  last: Record<string, number>
+}): Record<string, unknown> {
+  return {
+    method: 'thread/tokenUsage/updated',
+    params: {
+      threadId: input.threadId,
+      turnId: input.turnId,
+      tokenUsage: {
+        total: input.total,
+        last: input.last,
+      },
+    },
+  }
+}
+
+function spawnEndEvent(input: {
+  receiverThreadIds: readonly string[]
+  model?: string
+}): Record<string, unknown> {
+  return {
+    method: 'item/completed',
+    params: {
+      threadId: 'thread-parent',
+      turnId: 'turn-parent',
+      item: {
+        id: 'collab-call-1',
+        type: 'collabAgentToolCall',
+        tool: 'spawnAgent',
+        status: 'completed',
+        senderThreadId: 'thread-parent',
+        receiverThreadIds: [...input.receiverThreadIds],
+        prompt: 'do the heavy part',
+        ...(input.model !== undefined ? { model: input.model } : {}),
+        reasoningEffort: 'low',
+        agentsStates: {},
+      },
+    },
+  }
+}
+
+function sampleFromEvents(
+  events: readonly Record<string, unknown>[],
+): CodexSubagentTokenUsageSample {
+  return {
+    eventCount: events.length,
+    firstEvent: events[0],
+    lastEvent: events[events.length - 1],
+  }
+}
+
+describe('extractCodexSubagentUsageDrafts', () => {
+  it('returns no drafts without subagent samples', () => {
+    expect(
+      extractCodexSubagentUsageDrafts({
+        droppedThreadCount: 0,
+        modelProvider: 'openai',
+        ordinalStart: 1,
+        parentRawEvents: [],
+        subagentTokenUsageByThread: new Map(),
+      }),
+    ).toEqual([])
+  })
+
+  it('builds per-thread total deltas with spawn-attributed models', () => {
+    const childA = [
+      tokenUsageEvent({
+        threadId: 'thread-child-a',
+        turnId: 'turn-child-a',
+        total: {
+          totalTokens: 1_000,
+          inputTokens: 800,
+          cachedInputTokens: 0,
+          outputTokens: 200,
+          reasoningOutputTokens: 0,
+        },
+        last: {
+          totalTokens: 1_000,
+          inputTokens: 800,
+          cachedInputTokens: 0,
+          outputTokens: 200,
+          reasoningOutputTokens: 0,
+        },
+      }),
+      tokenUsageEvent({
+        threadId: 'thread-child-a',
+        turnId: 'turn-child-a',
+        total: {
+          totalTokens: 5_000,
+          inputTokens: 4_000,
+          cachedInputTokens: 2_000,
+          outputTokens: 1_000,
+          reasoningOutputTokens: 120,
+        },
+        last: {
+          totalTokens: 4_000,
+          inputTokens: 3_200,
+          cachedInputTokens: 2_000,
+          outputTokens: 800,
+          reasoningOutputTokens: 120,
+        },
+      }),
+    ]
+    const childB = [
+      tokenUsageEvent({
+        threadId: 'thread-child-b',
+        turnId: 'turn-child-b',
+        total: {
+          totalTokens: 700,
+          inputTokens: 600,
+          cachedInputTokens: 100,
+          outputTokens: 100,
+          reasoningOutputTokens: 0,
+        },
+        last: {
+          totalTokens: 700,
+          inputTokens: 600,
+          cachedInputTokens: 100,
+          outputTokens: 100,
+          reasoningOutputTokens: 0,
+        },
+      }),
+    ]
+
+    const ghostThread = [
+      tokenUsageEvent({
+        threadId: 'thread-child-ghost',
+        turnId: 'turn-child-ghost',
+        total: {
+          totalTokens: 9_999,
+          inputTokens: 9_000,
+          cachedInputTokens: 0,
+          outputTokens: 999,
+          reasoningOutputTokens: 0,
+        },
+        last: {
+          totalTokens: 9_999,
+          inputTokens: 9_000,
+          cachedInputTokens: 0,
+          outputTokens: 999,
+          reasoningOutputTokens: 0,
+        },
+      }),
+    ]
+
+    const drafts = extractCodexSubagentUsageDrafts({
+      droppedThreadCount: 0,
+      modelProvider: 'openai',
+      ordinalStart: 3,
+      parentRawEvents: [
+        spawnEndEvent({
+          receiverThreadIds: ['thread-child-a'],
+          model: 'gpt-5.5-mini',
+        }),
+        // Spawn evidence without a model: bills, stays unattributed.
+        spawnEndEvent({
+          receiverThreadIds: ['thread-child-b'],
+        }),
+      ],
+      subagentTokenUsageByThread: new Map([
+        ['thread-child-a', sampleFromEvents(childA)],
+        ['thread-child-b', sampleFromEvents(childB)],
+        // No spawn item names this thread (e.g. a stale flush from a
+        // previous thread on a reused warm process): never billed.
+        ['thread-child-ghost', sampleFromEvents(ghostThread)],
+      ]),
+    })
+
+    expect(drafts).toHaveLength(2)
+    expect(drafts[0]).toMatchObject({
+      provider: 'codex-cli',
+      providerRequestOrdinal: 3,
+      providerRequestOutcome: 'succeeded',
+      usage: {
+        // First event's total equals its last, so the prior-thread baseline
+        // is zero and the delta is the final total.
+        cachedInputTokens: 2_000,
+        inputTokens: 4_000,
+        outputTokens: 1_000,
+        providerName: 'openai',
+        reasoningTokens: 120,
+        requestedModel: 'gpt-5.5-mini',
+        servedModel: 'gpt-5.5-mini',
+        totalTokens: 5_000,
+        usageExtractionSourcePath: 'subagent.thread.tokenUsage.total.delta',
+      },
+    })
+    expect(drafts[0]?.usage.rawUsageJson).toMatchObject({
+      codexSubagentThreadId: 'thread-child-a',
+      tokenUsageEventCount: 2,
+      unattributedSubagentUsageThreadCount: 1,
+    })
+    expect(drafts[1]).toMatchObject({
+      providerRequestOrdinal: 4,
+      usage: {
+        inputTokens: 600,
+        outputTokens: 100,
+        // The spawn item carried no model, so the model stays unattributed
+        // rather than inheriting the parent's.
+        requestedModel: null,
+        servedModel: null,
+        totalTokens: 700,
+      },
+    })
+    expect(drafts[1]?.usage.rawUsageJson).toMatchObject({
+      codexSubagentThreadId: 'thread-child-b',
+    })
+    // The ghost thread never bills.
+    expect(JSON.stringify(drafts)).not.toContain('thread-child-ghost')
+  })
+
+  it('authorizes billing via non-spawn collab items and keeps spawn-attributed models', () => {
+    const usageFor = (threadId: string) =>
+      sampleFromEvents([
+        tokenUsageEvent({
+          threadId,
+          turnId: `turn-${threadId}`,
+          total: {
+            totalTokens: 100,
+            inputTokens: 80,
+            cachedInputTokens: 0,
+            outputTokens: 20,
+            reasoningOutputTokens: 0,
+          },
+          last: {
+            totalTokens: 100,
+            inputTokens: 80,
+            cachedInputTokens: 0,
+            outputTokens: 20,
+            reasoningOutputTokens: 0,
+          },
+        }),
+      ])
+
+    const drafts = extractCodexSubagentUsageDrafts({
+      droppedThreadCount: 0,
+      modelProvider: 'openai',
+      ordinalStart: 1,
+      parentRawEvents: [
+        // A reused child only appears via sendInput: billable, model unknown.
+        {
+          method: 'item/completed',
+          params: {
+            item: {
+              type: 'collabAgentToolCall',
+              tool: 'sendInput',
+              receiverThreadIds: ['thread-reused-child'],
+            },
+          },
+        },
+        // A spawned child later also receives sendInput: the spawn model wins.
+        spawnEndEvent({
+          receiverThreadIds: ['thread-spawned-child'],
+          model: 'gpt-5.5-mini',
+        }),
+        {
+          method: 'item/completed',
+          params: {
+            item: {
+              type: 'collabAgentToolCall',
+              tool: 'sendInput',
+              receiverThreadIds: ['thread-spawned-child'],
+            },
+          },
+        },
+      ],
+      subagentTokenUsageByThread: new Map([
+        ['thread-reused-child', usageFor('thread-reused-child')],
+        ['thread-spawned-child', usageFor('thread-spawned-child')],
+      ]),
+    })
+
+    expect(drafts).toHaveLength(2)
+    expect(drafts[0]).toMatchObject({
+      usage: {
+        requestedModel: null,
+        servedModel: null,
+        totalTokens: 100,
+      },
+    })
+    expect(drafts[0]?.usage.rawUsageJson).toMatchObject({
+      codexSubagentThreadId: 'thread-reused-child',
+    })
+    expect(drafts[1]).toMatchObject({
+      usage: {
+        requestedModel: 'gpt-5.5-mini',
+        servedModel: 'gpt-5.5-mini',
+      },
+    })
+  })
+
+  it('never bills foreign-thread usage without spawn evidence', () => {
+    // Warm processes are reused across threads; a stale tokenUsage flush from
+    // a previous thread carries a foreign thread id but is not a subagent.
+    const drafts = extractCodexSubagentUsageDrafts({
+      droppedThreadCount: 0,
+      modelProvider: 'openai',
+      ordinalStart: 1,
+      parentRawEvents: [],
+      subagentTokenUsageByThread: new Map([
+        [
+          'thread-previous-warm',
+          sampleFromEvents([
+            tokenUsageEvent({
+              threadId: 'thread-previous-warm',
+              turnId: 'turn-previous-warm',
+              total: {
+                totalTokens: 1_234,
+                inputTokens: 1_000,
+                cachedInputTokens: 0,
+                outputTokens: 234,
+                reasoningOutputTokens: 0,
+              },
+              last: {
+                totalTokens: 1_234,
+                inputTokens: 1_000,
+                cachedInputTokens: 0,
+                outputTokens: 234,
+                reasoningOutputTokens: 0,
+              },
+            }),
+          ]),
+        ],
+      ]),
+    })
+
+    expect(drafts).toEqual([])
+  })
+
+  it('attributes one spawn model to every receiver thread and tolerates snake_case items', () => {
+    const sample = sampleFromEvents([
+      tokenUsageEvent({
+        threadId: 'thread-child-snake',
+        turnId: 'turn-child-snake',
+        total: {
+          total_tokens: 50,
+          input_tokens: 40,
+          cached_input_tokens: 0,
+          output_tokens: 10,
+        },
+        last: {
+          total_tokens: 50,
+          input_tokens: 40,
+          cached_input_tokens: 0,
+          output_tokens: 10,
+        },
+      }),
+    ])
+
+    const drafts = extractCodexSubagentUsageDrafts({
+      droppedThreadCount: 2,
+      modelProvider: null,
+      ordinalStart: 1,
+      parentRawEvents: [
+        {
+          method: 'item.completed',
+          params: {
+            item: {
+              type: 'collabAgentToolCall',
+              tool: 'spawn_agent',
+              receiver_thread_ids: ['thread-child-snake', 'thread-other'],
+              model: 'gpt-5.5',
+            },
+          },
+        },
+      ],
+      subagentTokenUsageByThread: new Map([
+        ['thread-child-snake', sample],
+      ]),
+    })
+
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]).toMatchObject({
+      usage: {
+        inputTokens: 40,
+        outputTokens: 10,
+        requestedModel: 'gpt-5.5',
+        servedModel: 'gpt-5.5',
+        totalTokens: 50,
+      },
+    })
+    expect(drafts[0]?.usage.rawUsageJson).toMatchObject({
+      droppedSubagentUsageThreadCount: 2,
+    })
+  })
+
+  it('never leaks spawn prompt content into drafts and keeps rawUsageJson metadata-only', () => {
+    const drafts = extractCodexSubagentUsageDrafts({
+      droppedThreadCount: 0,
+      modelProvider: 'openai',
+      ordinalStart: 1,
+      parentRawEvents: [
+        spawnEndEvent({
+          receiverThreadIds: ['thread-child-a'],
+          model: 'gpt-5.5-mini',
+        }),
+      ],
+      subagentTokenUsageByThread: new Map([
+        [
+          'thread-child-a',
+          sampleFromEvents([
+            tokenUsageEvent({
+              threadId: 'thread-child-a',
+              turnId: 'turn-child-a',
+              total: {
+                totalTokens: 300,
+                inputTokens: 250,
+                cachedInputTokens: 0,
+                outputTokens: 50,
+                reasoningOutputTokens: 0,
+              },
+              last: {
+                totalTokens: 300,
+                inputTokens: 250,
+                cachedInputTokens: 0,
+                outputTokens: 50,
+                reasoningOutputTokens: 0,
+              },
+            }),
+          ]),
+        ],
+      ]),
+    })
+
+    expect(drafts).toHaveLength(1)
+    // The spawn item carries member content ('prompt'); drafts must stay
+    // metadata-only so hosted_ai_usage never persists raw member content.
+    expect(JSON.stringify(drafts)).not.toContain('do the heavy part')
+    expect(JSON.stringify(drafts)).not.toContain('prompt')
+    expect(
+      Object.keys(drafts[0]?.usage.rawUsageJson as Record<string, unknown>).sort(),
+    ).toEqual([
+      'codexSubagentThreadId',
+      'tokenUsage',
+      'tokenUsageEventCount',
+    ])
+  })
+
+  it('skips spawned threads whose buffered events carry no usable token usage', () => {
+    const drafts = extractCodexSubagentUsageDrafts({
+      droppedThreadCount: 0,
+      modelProvider: 'openai',
+      ordinalStart: 1,
+      parentRawEvents: [
+        spawnEndEvent({
+          receiverThreadIds: ['thread-child-empty'],
+          model: 'gpt-5.5-mini',
+        }),
+      ],
+      subagentTokenUsageByThread: new Map([
+        [
+          'thread-child-empty',
+          {
+            eventCount: 1,
+            firstEvent: { method: 'thread/tokenUsage/updated', params: {} },
+            lastEvent: { method: 'thread/tokenUsage/updated', params: {} },
+          },
+        ],
+      ]),
+    })
+
+    expect(drafts).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why

Codex app-server auto-attaches every connection to every thread it creates — including future `spawn_agent` subagent threads (`codex-rs/app-server/src/lib.rs:1024`). Murph's codex client correlated every incoming event against a single turn id and ignored `thread_id` entirely, so:

1. The first child-thread event would fail the parent turn with `ASSISTANT_CODEX_APP_SERVER_STALE_TURN_EVENT` (retryable → retry storm).
2. Child-thread token usage would never land in `hosted_ai_usage` — invisible spend.

Codex ships no aggregate usage primitive (no usage RPC, no usage on the protocol `Turn`, no parent-side aggregation, collab results carry no usage), so consuming per-thread `thread/tokenUsage/updated` notifications is the canonical upstream pattern.

This lands the **primitives only**: codex collab/multi-agent tools remain OFF. Enabling them later is config + prompt guidance, with usage observability already in place.

## What

- **Thread-aware routing** (`assistant-codex.ts`): events whose thread id differs from the parent's are routed off the single-turn correlation path. Child tokenUsage events are buffered per thread (first/last sample, 32-thread cap with per-thread dropped count); child server requests get a JSON-RPC error response instead of failing the turn; other child events are dropped. Parent-thread strictness is unchanged by construction.
- **Per-child usage drafts** (`providers/helpers.ts`): `extractCodexSubagentUsageDrafts` reuses the existing total-delta arithmetic and flows through the existing `additionalUsages` → `recordAdditionalAssistantUsageEvents` seam (`providerRequestOrdinal ≥ 1`, shared counter with dynamic-tool drafts). No schema change; per-row `requested_model`/`served_model` carry the child's effective model from parent-thread collab spawn items, so multi-model billing (e.g. mini subagents) works day one.
- **Spawn-evidence billing gate** (review finding): warm processes are reused across threads, so a foreign thread id alone is not proof of a subagent — only threads named in a spawn item's `receiverThreadIds` produce usage rows. A stale flush from a previous thread can never mint a row; unattributed threads are counted in draft `rawUsageJson`.
- Drafts appear in **both** the success result and the turn-failure context.
- `rawUsageJson` stays metadata-only (thread id, token delta, counts) — spawn `prompt` provably never leaks (asserted in tests).

## Verification

- `pnpm --dir packages/assistant-engine typecheck` — clean
- `pnpm test:diff packages/assistant-engine` — green (incl. apps/cloudflare verify)
- 4 touched test files: 168 tests passed — unit (drafts builder, spawn-evidence gate, prompt non-leak, snake_case tolerance, thread-id extractor) + integration on the fake-process harness (tolerate+record multi-model, deny child server request, strictness regression, failure-context drafts, 33-thread cap, ordinal continuity after `generate_image`)

## Audits

- `coverage-write`: added failure-context, cap-overflow, ordinal-uniqueness, prompt-non-leak, extractor-shape coverage (all green).
- `task-finish-review`: 1 medium (spurious billing from warm-process stale events — **fixed** via spawn-evidence gate + tests), 2 low (dropped-count semantics — **fixed** with per-thread set; plan/ledger drift — **fixed**).

Plan: `agent-docs/exec-plans/completed/2026-06-10-codex-thread-aware-usage.md`

Note for mergers: a separate active lane ("Turn-profile command label quoted-shell unwrap") touches other functions in `helpers.ts`; diffs are in different functions but expect adjacent-line merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783743144&installation_id=127572939&pr_number=127&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F127&signature=7f1ecdcaf32c463fb09bc194607562291050a9bec5029879a9f1a6034b47adae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->