### PR TITLE
feat(cloudflare): add hosted runner container CPU watchdog diagnostics

### DIFF
--- a/apps/cloudflare/src/container-cpu-watchdog.ts
+++ b/apps/cloudflare/src/container-cpu-watchdog.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 
 import { emitHostedExecutionStructuredLog } from "@murphai/hosted-execution";
 
@@ -47,12 +47,21 @@ export interface HostedContainerCpuWatchdogProcessApi {
 interface HostedContainerCpuWatchdogProcessSample {
   comm: string;
   cpuTicks: number;
+  // stat field 22 kept as an opaque equality token: same pid + same start time
+  // is the same process; a changed start time is a reused pid.
+  startTimeTicks: string | null;
 }
 
 interface HostedContainerCpuWatchdogSample {
   cgroupUsageUsec: number | null;
   nrThrottled: number | null;
   perPid: Map<number, HostedContainerCpuWatchdogProcessSample>;
+  // False when /proc enumeration failed or a live process could not be read,
+  // meaning a process may be missing from perPid. Attribution for pids absent
+  // from an incomplete sample is unknowable and must be suppressed, or a
+  // long-running process missed once would have its whole lifetime counted as
+  // interval CPU on the next tick.
+  procScanComplete: boolean;
   sampledAtMs: number;
   throttledUsec: number | null;
 }
@@ -66,18 +75,25 @@ interface HostedContainerCpuWatchdogSample {
 export function startHostedContainerCpuWatchdog(input: {
   processApi: HostedContainerCpuWatchdogProcessApi;
 }): () => void {
+  const fingerprintSecret = resolveCpuWatchdogFingerprintSecret();
   let previous: HostedContainerCpuWatchdogSample | null = null;
   let sampling = false;
+  let stopped = false;
   const tick = async () => {
     // Skip overlapping ticks if /proc reads stall instead of queueing them.
-    if (sampling) {
+    if (stopped || sampling) {
       return;
     }
     sampling = true;
     try {
       const current = await readHostedContainerCpuWatchdogSample(input.processApi);
+      // A sample already in flight when the server closed must not emit into
+      // a shutting-down process or advance state.
+      if (stopped) {
+        return;
+      }
       if (previous) {
-        emitHostedContainerCpuWatchdogReport({ current, previous });
+        emitHostedContainerCpuWatchdogReport({ current, fingerprintSecret, previous });
       } else {
         // One-time liveness signal: steady-state watchdog silence is otherwise
         // ambiguous between "no burns" and "sampler broken on this platform",
@@ -112,8 +128,16 @@ export function startHostedContainerCpuWatchdog(input: {
   // The watchdog must never hold the process open during shutdown drain.
   interval.unref();
   return () => {
+    stopped = true;
     clearInterval(interval);
   };
+}
+
+function resolveCpuWatchdogFingerprintSecret(): string | null {
+  // Same resolution order as the hosted context diagnostics fingerprints.
+  const secret = process.env.HOSTED_LOG_FINGERPRINT_SECRET?.trim()
+    || process.env.HOSTED_AI_USAGE_REPORTING_SECRET?.trim();
+  return secret || null;
 }
 
 async function readHostedContainerCpuWatchdogSample(
@@ -123,29 +147,51 @@ async function readHostedContainerCpuWatchdogSample(
     await readOptionalCpuWatchdogText(processApi, "/sys/fs/cgroup/cpu.stat"),
   );
   const perPid = new Map<number, HostedContainerCpuWatchdogProcessSample>();
+  let procScanComplete = true;
   let processEntries: HostedContainerCpuWatchdogDirectoryEntryLike[] = [];
   try {
     processEntries = await processApi.readdir("/proc");
   } catch {
     // Tolerate an unreadable /proc; cgroup totals still report on their own.
+    procScanComplete = false;
   }
   for (const entry of processEntries) {
     if (!entry.isDirectory() || !/^\d+$/u.test(entry.name)) {
       continue;
     }
-    const stat = await readOptionalCpuWatchdogText(processApi, `/proc/${entry.name}/stat`);
-    const parsed = stat === null ? null : parseHostedContainerProcPidStat(stat);
+    let stat: string;
+    try {
+      stat = await processApi.readFile(`/proc/${entry.name}/stat`, "utf8");
+    } catch (error) {
+      // A process exiting between readdir and read is normal churn; any other
+      // failure means a live process may be missing from this sample.
+      if (!isCpuWatchdogGoneProcessError(error)) {
+        procScanComplete = false;
+      }
+      continue;
+    }
+    const parsed = parseHostedContainerProcPidStat(stat);
     if (parsed) {
       perPid.set(Number.parseInt(entry.name, 10), parsed);
+    } else {
+      procScanComplete = false;
     }
   }
   return {
     cgroupUsageUsec: cpuStat.usageUsec,
     nrThrottled: cpuStat.nrThrottled,
     perPid,
+    procScanComplete,
     sampledAtMs: Date.now(),
     throttledUsec: cpuStat.throttledUsec,
   };
+}
+
+function isCpuWatchdogGoneProcessError(error: unknown): boolean {
+  const code = error && typeof error === "object" && "code" in error
+    ? (error as { code?: unknown }).code
+    : null;
+  return code === "ENOENT" || code === "ESRCH";
 }
 
 async function readOptionalCpuWatchdogText(
@@ -195,17 +241,23 @@ function parseHostedContainerProcPidStat(
   }
   const comm = text.slice(commStart + 1, commEnd);
   const rest = text.slice(commEnd + 1).trim().split(/\s+/u);
-  // rest[0] is stat field 3 (state); utime/stime are stat fields 14 and 15.
+  // rest[0] is stat field 3 (state); utime/stime are stat fields 14 and 15,
+  // and starttime is stat field 22.
   const utime = Number.parseInt(rest[11] ?? "", 10);
   const stime = Number.parseInt(rest[12] ?? "", 10);
   if (!Number.isSafeInteger(utime) || !Number.isSafeInteger(stime)) {
     return null;
   }
-  return { comm, cpuTicks: utime + stime };
+  return {
+    comm,
+    cpuTicks: utime + stime,
+    startTimeTicks: rest[19] ?? null,
+  };
 }
 
 function emitHostedContainerCpuWatchdogReport(input: {
   current: HostedContainerCpuWatchdogSample;
+  fingerprintSecret: string | null;
   previous: HostedContainerCpuWatchdogSample;
 }): void {
   const intervalMs = input.current.sampledAtMs - input.previous.sampledAtMs;
@@ -216,18 +268,35 @@ function emitHostedContainerCpuWatchdogReport(input: {
   const topCpuProcesses: Array<{ comm: string; cpuCores: number; pid: number }> = [];
   let perPidTicksDelta = 0;
   for (const [pid, current] of input.current.perPid) {
-    // A reused pid can report fewer cumulative ticks than its predecessor;
-    // clamp to zero instead of letting it cancel real usage. A pid with no
-    // previous sample started inside the interval, so its full cumulative
-    // ticks are attributable to this interval.
-    const deltaTicks = Math.max(
-      0,
-      current.cpuTicks - (input.previous.perPid.get(pid)?.cpuTicks ?? 0),
-    );
+    const prior = input.previous.perPid.get(pid);
+    let deltaTicks: number | null = null;
+    if (prior) {
+      const pidReused = prior.startTimeTicks !== null
+        && current.startTimeTicks !== null
+        && prior.startTimeTicks !== current.startTimeTicks;
+      // Same pid + same start time is the same process: a monotonic counter
+      // delta (clamped defensively). A changed start time means the pid was
+      // reused by a process started after the previous sample, so its full
+      // cumulative ticks are interval CPU.
+      deltaTicks = pidReused
+        ? current.cpuTicks
+        : Math.max(0, current.cpuTicks - prior.cpuTicks);
+    } else if (input.previous.procScanComplete) {
+      // Absent from a complete previous scan proves the process started
+      // inside the interval, so its full cumulative ticks are interval CPU.
+      deltaTicks = current.cpuTicks;
+    }
+    // Absent from an incomplete previous scan stays unattributed: a
+    // long-running process missed by a failed /proc read would otherwise have
+    // its whole lifetime counted as interval CPU. Under-reporting is the
+    // right failure direction for a diagnostic.
+    if (deltaTicks === null) {
+      continue;
+    }
     perPidTicksDelta += deltaTicks;
     if (deltaTicks > 0) {
       topCpuProcesses.push({
-        comm: redactHostedContainerCpuWatchdogComm(current.comm),
+        comm: redactHostedContainerCpuWatchdogComm(current.comm, input.fingerprintSecret),
         cpuCores: roundHostedContainerCpuCores(
           deltaTicks / HOSTED_CONTAINER_CPU_WATCHDOG_TICKS_PER_SECOND / intervalSeconds,
         ),
@@ -279,11 +348,22 @@ function emitHostedContainerCpuWatchdogReport(input: {
   });
 }
 
-function redactHostedContainerCpuWatchdogComm(comm: string): string {
+// comm values are short, process-controlled text, so an unkeyed digest is
+// guessable by dictionary. With the hosted log fingerprint secret configured,
+// unknown names get a stable keyed label so a recurring unknown burner stays
+// distinguishable across intervals; without it they collapse into one
+// undifferentiated bucket rather than carrying any comm-derived identifier.
+function redactHostedContainerCpuWatchdogComm(
+  comm: string,
+  fingerprintSecret: string | null,
+): string {
   if (HOSTED_CONTAINER_CPU_WATCHDOG_KNOWN_COMMS.has(comm)) {
     return comm;
   }
-  return `other:${createHash("sha256").update(comm).digest("hex").slice(0, 8)}`;
+  if (fingerprintSecret === null) {
+    return "other";
+  }
+  return `other:${createHmac("sha256", fingerprintSecret).update(comm).digest("hex").slice(0, 16)}`;
 }
 
 function subtractOptionalCpuWatchdogCounters(

--- a/apps/cloudflare/src/container-cpu-watchdog.ts
+++ b/apps/cloudflare/src/container-cpu-watchdog.ts
@@ -1,0 +1,301 @@
+import { createHash } from "node:crypto";
+
+import { emitHostedExecutionStructuredLog } from "@murphai/hosted-execution";
+
+const HOSTED_CONTAINER_CPU_WATCHDOG_INTERVAL_MS = 20_000;
+const HOSTED_CONTAINER_CPU_WATCHDOG_EMIT_THRESHOLD_CORES = 0.5;
+const HOSTED_CONTAINER_CPU_WATCHDOG_TOP_PROCESS_COUNT = 3;
+// Linux exports per-process utime/stime in USER_HZ ticks; USER_HZ is 100 on the
+// linux/amd64 hosted runner image. Diagnostics-only conversion, not authority.
+const HOSTED_CONTAINER_CPU_WATCHDOG_TICKS_PER_SECOND = 100;
+// Expected infrastructure process names in the hosted runner image. comm is
+// process-controlled content (script basenames via shebang, PR_SET_NAME), so
+// anything outside this vocabulary is logged as a stable non-reversible digest
+// instead of raw text, mirroring the entrypoint's commandLineDigest precedent.
+const HOSTED_CONTAINER_CPU_WATCHDOG_KNOWN_COMMS = new Set([
+  "bash",
+  "codex",
+  "ffmpeg",
+  "ffprobe",
+  "file",
+  "git",
+  "node",
+  "npm",
+  "npx",
+  "pdfinfo",
+  "pdftoppm",
+  "pdftotext",
+  "pnpm",
+  "python",
+  "python3",
+  "sh",
+  "tini",
+]);
+
+interface HostedContainerCpuWatchdogDirectoryEntryLike {
+  isDirectory(): boolean;
+  name: string;
+}
+
+// Structural subset of the entrypoint's HostedContainerProcessApi so the
+// watchdog stays decoupled from the entrypoint module graph.
+export interface HostedContainerCpuWatchdogProcessApi {
+  readFile(path: string, encoding: BufferEncoding): Promise<string>;
+  readdir(path: string): Promise<HostedContainerCpuWatchdogDirectoryEntryLike[]>;
+}
+
+interface HostedContainerCpuWatchdogProcessSample {
+  comm: string;
+  cpuTicks: number;
+}
+
+interface HostedContainerCpuWatchdogSample {
+  cgroupUsageUsec: number | null;
+  nrThrottled: number | null;
+  perPid: Map<number, HostedContainerCpuWatchdogProcessSample>;
+  sampledAtMs: number;
+  throttledUsec: number | null;
+}
+
+// Always-on CPU attribution sampler for the hosted runner container. Samples
+// cgroup CPU totals plus per-process tick counters on a fixed interval and
+// emits one structured log per interval whose CPU usage crosses the threshold,
+// naming the top processes by kernel comm name only (never command lines), so
+// production CPU burns are attributable to a specific process. Diagnostics
+// only: sampling failures never affect the runner.
+export function startHostedContainerCpuWatchdog(input: {
+  processApi: HostedContainerCpuWatchdogProcessApi;
+}): () => void {
+  let previous: HostedContainerCpuWatchdogSample | null = null;
+  let sampling = false;
+  const tick = async () => {
+    // Skip overlapping ticks if /proc reads stall instead of queueing them.
+    if (sampling) {
+      return;
+    }
+    sampling = true;
+    try {
+      const current = await readHostedContainerCpuWatchdogSample(input.processApi);
+      if (previous) {
+        emitHostedContainerCpuWatchdogReport({ current, previous });
+      } else {
+        // One-time liveness signal: steady-state watchdog silence is otherwise
+        // ambiguous between "no burns" and "sampler broken on this platform",
+        // and cgroupCpuStatAvailable reports whether the per-pid fallback
+        // below is live or dead code in the real fleet.
+        emitHostedExecutionStructuredLog({
+          component: "container",
+          details: {
+            cgroupCpuStatAvailable: current.cgroupUsageUsec !== null,
+            lifecycleStage: "entrypoint-cpu-watchdog-started",
+            sampledProcessCount: current.perPid.size,
+          },
+          message: "Hosted container CPU watchdog started.",
+          phase: "wake.running",
+          userId: null,
+        });
+      }
+      previous = current;
+    } catch {
+      // Diagnostics-only: sampling failures must never affect the runner.
+    } finally {
+      sampling = false;
+    }
+  };
+  // Seed the baseline immediately: boot-time burns are a primary target, and
+  // waiting for the first setInterval firing would bake the whole boot window
+  // into a t≈20s baseline, making the first reportable interval start there.
+  void tick();
+  const interval = setInterval(() => {
+    void tick();
+  }, HOSTED_CONTAINER_CPU_WATCHDOG_INTERVAL_MS);
+  // The watchdog must never hold the process open during shutdown drain.
+  interval.unref();
+  return () => {
+    clearInterval(interval);
+  };
+}
+
+async function readHostedContainerCpuWatchdogSample(
+  processApi: HostedContainerCpuWatchdogProcessApi,
+): Promise<HostedContainerCpuWatchdogSample> {
+  const cpuStat = parseHostedContainerCgroupCpuStat(
+    await readOptionalCpuWatchdogText(processApi, "/sys/fs/cgroup/cpu.stat"),
+  );
+  const perPid = new Map<number, HostedContainerCpuWatchdogProcessSample>();
+  let processEntries: HostedContainerCpuWatchdogDirectoryEntryLike[] = [];
+  try {
+    processEntries = await processApi.readdir("/proc");
+  } catch {
+    // Tolerate an unreadable /proc; cgroup totals still report on their own.
+  }
+  for (const entry of processEntries) {
+    if (!entry.isDirectory() || !/^\d+$/u.test(entry.name)) {
+      continue;
+    }
+    const stat = await readOptionalCpuWatchdogText(processApi, `/proc/${entry.name}/stat`);
+    const parsed = stat === null ? null : parseHostedContainerProcPidStat(stat);
+    if (parsed) {
+      perPid.set(Number.parseInt(entry.name, 10), parsed);
+    }
+  }
+  return {
+    cgroupUsageUsec: cpuStat.usageUsec,
+    nrThrottled: cpuStat.nrThrottled,
+    perPid,
+    sampledAtMs: Date.now(),
+    throttledUsec: cpuStat.throttledUsec,
+  };
+}
+
+async function readOptionalCpuWatchdogText(
+  processApi: HostedContainerCpuWatchdogProcessApi,
+  filePath: string,
+): Promise<string | null> {
+  try {
+    return await processApi.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function parseHostedContainerCgroupCpuStat(text: string | null): {
+  nrThrottled: number | null;
+  throttledUsec: number | null;
+  usageUsec: number | null;
+} {
+  const values = new Map<string, number>();
+  for (const line of (text ?? "").split("\n")) {
+    const [key, raw] = line.trim().split(/\s+/u);
+    if (!key || raw === undefined) {
+      continue;
+    }
+    const value = Number.parseInt(raw, 10);
+    if (Number.isSafeInteger(value) && value >= 0) {
+      values.set(key, value);
+    }
+  }
+  return {
+    nrThrottled: values.get("nr_throttled") ?? null,
+    throttledUsec: values.get("throttled_usec") ?? null,
+    usageUsec: values.get("usage_usec") ?? null,
+  };
+}
+
+// Parses `pid (comm) state ppid ... utime stime ...`. Only the comm name (the
+// kernel-truncated executable name, never arguments or paths) is retained, so
+// watchdog logs stay free of command-line content.
+function parseHostedContainerProcPidStat(
+  text: string,
+): HostedContainerCpuWatchdogProcessSample | null {
+  const commStart = text.indexOf("(");
+  const commEnd = text.lastIndexOf(")");
+  if (commStart === -1 || commEnd <= commStart) {
+    return null;
+  }
+  const comm = text.slice(commStart + 1, commEnd);
+  const rest = text.slice(commEnd + 1).trim().split(/\s+/u);
+  // rest[0] is stat field 3 (state); utime/stime are stat fields 14 and 15.
+  const utime = Number.parseInt(rest[11] ?? "", 10);
+  const stime = Number.parseInt(rest[12] ?? "", 10);
+  if (!Number.isSafeInteger(utime) || !Number.isSafeInteger(stime)) {
+    return null;
+  }
+  return { comm, cpuTicks: utime + stime };
+}
+
+function emitHostedContainerCpuWatchdogReport(input: {
+  current: HostedContainerCpuWatchdogSample;
+  previous: HostedContainerCpuWatchdogSample;
+}): void {
+  const intervalMs = input.current.sampledAtMs - input.previous.sampledAtMs;
+  if (intervalMs <= 0) {
+    return;
+  }
+  const intervalSeconds = intervalMs / 1000;
+  const topCpuProcesses: Array<{ comm: string; cpuCores: number; pid: number }> = [];
+  let perPidTicksDelta = 0;
+  for (const [pid, current] of input.current.perPid) {
+    // A reused pid can report fewer cumulative ticks than its predecessor;
+    // clamp to zero instead of letting it cancel real usage. A pid with no
+    // previous sample started inside the interval, so its full cumulative
+    // ticks are attributable to this interval.
+    const deltaTicks = Math.max(
+      0,
+      current.cpuTicks - (input.previous.perPid.get(pid)?.cpuTicks ?? 0),
+    );
+    perPidTicksDelta += deltaTicks;
+    if (deltaTicks > 0) {
+      topCpuProcesses.push({
+        comm: redactHostedContainerCpuWatchdogComm(current.comm),
+        cpuCores: roundHostedContainerCpuCores(
+          deltaTicks / HOSTED_CONTAINER_CPU_WATCHDOG_TICKS_PER_SECOND / intervalSeconds,
+        ),
+        pid,
+      });
+    }
+  }
+  const cgroupUsageUsecDelta =
+    input.current.cgroupUsageUsec !== null && input.previous.cgroupUsageUsec !== null
+      ? Math.max(0, input.current.cgroupUsageUsec - input.previous.cgroupUsageUsec)
+      : null;
+  const cpuCoresUsed = cgroupUsageUsecDelta !== null
+    ? cgroupUsageUsecDelta / (intervalMs * 1000)
+    : perPidTicksDelta / HOSTED_CONTAINER_CPU_WATCHDOG_TICKS_PER_SECOND / intervalSeconds;
+  if (cpuCoresUsed < HOSTED_CONTAINER_CPU_WATCHDOG_EMIT_THRESHOLD_CORES) {
+    return;
+  }
+  topCpuProcesses.sort((left, right) => right.cpuCores - left.cpuCores);
+  emitHostedExecutionStructuredLog({
+    component: "container",
+    details: {
+      // Processes that start and exit within one interval burn cgroup CPU but
+      // appear in neither sample; the gap between cpuCoresUsed and this
+      // per-pid-attributed total exposes that churn instead of hiding it.
+      attributedCpuCores: roundHostedContainerCpuCores(
+        perPidTicksDelta / HOSTED_CONTAINER_CPU_WATCHDOG_TICKS_PER_SECOND / intervalSeconds,
+      ),
+      cgroupNrThrottledDelta: subtractOptionalCpuWatchdogCounters(
+        input.current.nrThrottled,
+        input.previous.nrThrottled,
+      ),
+      cgroupThrottledUsecDelta: subtractOptionalCpuWatchdogCounters(
+        input.current.throttledUsec,
+        input.previous.throttledUsec,
+      ),
+      cgroupUsageUsecDelta,
+      cpuCoresUsed: roundHostedContainerCpuCores(cpuCoresUsed),
+      intervalMs,
+      lifecycleStage: "entrypoint-cpu-watchdog",
+      sampledProcessCount: input.current.perPid.size,
+      topCpuProcesses: topCpuProcesses.slice(
+        0,
+        HOSTED_CONTAINER_CPU_WATCHDOG_TOP_PROCESS_COUNT,
+      ),
+    },
+    message: "Hosted container CPU watchdog observed elevated CPU usage.",
+    phase: "wake.running",
+    userId: null,
+  });
+}
+
+function redactHostedContainerCpuWatchdogComm(comm: string): string {
+  if (HOSTED_CONTAINER_CPU_WATCHDOG_KNOWN_COMMS.has(comm)) {
+    return comm;
+  }
+  return `other:${createHash("sha256").update(comm).digest("hex").slice(0, 8)}`;
+}
+
+function subtractOptionalCpuWatchdogCounters(
+  current: number | null,
+  previous: number | null,
+): number | null {
+  if (current === null || previous === null) {
+    return null;
+  }
+  return Math.max(0, current - previous);
+}
+
+function roundHostedContainerCpuCores(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -810,23 +810,30 @@ function isHostedContainerCliEntrypoint(): boolean {
 async function startHostedContainerEntrypointCli(): Promise<void> {
   const port = Number.parseInt(process.env.PORT ?? "8080", 10) || 8080;
 
-  const server = await startHostedContainerEntrypoint({
-    port,
-    runtime: {
-      processIsolation: true,
-    },
-  });
-
   // Always-on CPU attribution sampler: the per-job diagnostic heartbeat only
   // observes active invocations, but production CPU burns have been observed
-  // both at boot and on long-lived warm containers between jobs. CLI-only on
-  // the real process API: entrypoint unit tests inject sequenced processApi
-  // mocks that the watchdog must not consume. Job-activity correlation comes
-  // from the adjacent active-job heartbeat logs in the same stream.
+  // both at boot and on long-lived warm containers between jobs. Started
+  // before entrypoint startup so manifest read, dependency resolution, and
+  // listen are inside the first sampled interval. CLI-only on the real
+  // process API: entrypoint unit tests inject sequenced processApi mocks that
+  // the watchdog must not consume. Job-activity correlation comes from the
+  // adjacent active-job heartbeat logs in the same stream.
   const stopCpuWatchdog = startHostedContainerCpuWatchdog({
     processApi: defaultHostedContainerProcessApi,
   });
-  server.once("close", stopCpuWatchdog);
+
+  try {
+    const server = await startHostedContainerEntrypoint({
+      port,
+      runtime: {
+        processIsolation: true,
+      },
+    });
+    server.once("close", stopCpuWatchdog);
+  } catch (error) {
+    stopCpuWatchdog();
+    throw error;
+  }
 }
 
 async function readHostedContainerInvocationRequestBody(

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -37,6 +37,7 @@ import {
   snapshotExpectedCodexRootProcess,
   stopWarmCodexAppServer,
 } from "@murphai/assistant-engine/codex-lifecycle";
+import { startHostedContainerCpuWatchdog } from "./container-cpu-watchdog.ts";
 import {
   HOSTED_RUNTIME_ARCHITECTURE_VERSION,
 } from "./hosted-runtime-architecture.ts";
@@ -809,12 +810,23 @@ function isHostedContainerCliEntrypoint(): boolean {
 async function startHostedContainerEntrypointCli(): Promise<void> {
   const port = Number.parseInt(process.env.PORT ?? "8080", 10) || 8080;
 
-  await startHostedContainerEntrypoint({
+  const server = await startHostedContainerEntrypoint({
     port,
     runtime: {
       processIsolation: true,
     },
   });
+
+  // Always-on CPU attribution sampler: the per-job diagnostic heartbeat only
+  // observes active invocations, but production CPU burns have been observed
+  // both at boot and on long-lived warm containers between jobs. CLI-only on
+  // the real process API: entrypoint unit tests inject sequenced processApi
+  // mocks that the watchdog must not consume. Job-activity correlation comes
+  // from the adjacent active-job heartbeat logs in the same stream.
+  const stopCpuWatchdog = startHostedContainerCpuWatchdog({
+    processApi: defaultHostedContainerProcessApi,
+  });
+  server.once("close", stopCpuWatchdog);
 }
 
 async function readHostedContainerInvocationRequestBody(

--- a/apps/cloudflare/test/container-cpu-watchdog.test.ts
+++ b/apps/cloudflare/test/container-cpu-watchdog.test.ts
@@ -33,7 +33,9 @@ function createFakeProcessApi(state: FakeProcessState): HostedContainerCpuWatchd
       const match = /^\/proc\/(\d+)\/stat$/u.exec(path);
       const statText = match ? state.pidStats.get(match[1] ?? "") : undefined;
       if (statText === undefined || statText === null) {
-        throw new Error(`unreadable ${path}`);
+        // Mirrors a process exiting between readdir and read: normal churn
+        // that must not mark the scan incomplete.
+        throw Object.assign(new Error(`unreadable ${path}`), { code: "ENOENT" });
       }
       return statText;
     },
@@ -65,14 +67,21 @@ function cpuStatText(input: {
   ].join("\n");
 }
 
-function pidStatText(input: { comm: string; pid: number; totalTicks: number }): string {
+function pidStatText(input: {
+  comm: string;
+  pid: number;
+  startTime?: string;
+  totalTicks: number;
+}): string {
   const tail = Array.from({ length: 38 }, () => "0");
   // The explicit `S` below is stat field 3, so tail[10]/tail[11] land at stat
-  // fields 14 (utime) and 15 (stime); split the ticks across both.
+  // fields 14 (utime) and 15 (stime); split the ticks across both. tail[18]
+  // is stat field 22 (starttime), the pid-reuse discriminator.
   const utime = Math.floor(input.totalTicks / 2);
   const stime = input.totalTicks - utime;
   tail[10] = String(utime);
   tail[11] = String(stime);
+  tail[18] = input.startTime ?? "5000";
   return `${input.pid} (${input.comm}) S ${tail.join(" ")}`;
 }
 
@@ -114,10 +123,12 @@ describe("startHostedContainerCpuWatchdog", () => {
   afterEach(() => {
     stopWatchdog?.();
     stopWatchdog = null;
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
   it("attributes elevated CPU to the top processes by comm name", async () => {
+    vi.stubEnv("HOSTED_LOG_FINGERPRINT_SECRET", "test-secret");
     const state: FakeProcessState = {
       cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
       pidStats: new Map([
@@ -157,10 +168,37 @@ describe("startHostedContainerCpuWatchdog", () => {
     expect(details.topCpuProcesses).toEqual([
       // 1,300 ticks at 100 Hz over 20s = 0.65 cores. The comm parse keeps the
       // inner parens, and the non-allowlisted name is emitted as a stable
-      // sha256 digest label instead of raw process-controlled text.
-      { comm: "other:8b473696", cpuCores: 0.65, pid: 45 },
+      // keyed HMAC label instead of raw process-controlled text:
+      // hmac-sha256("test-secret", "codex (smoke)") truncated to 16 hex.
+      { comm: "other:30d556de684e009a", cpuCores: 0.65, pid: 45 },
       // 200 ticks = 0.1 cores; allowlisted infrastructure comm passes through.
       { comm: "node", cpuCores: 0.1, pid: 12 },
+    ]);
+  });
+
+  it("collapses unknown comms into one bucket without the fingerprint secret", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: null,
+      pidStats: new Map([
+        ["45", pidStatText({ comm: "check_health.sh", pid: 45, totalTicks: 100 })],
+      ]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    state.pidStats.set(
+      "45",
+      pidStatText({ comm: "check_health.sh", pid: 45, totalTicks: 1_400 }),
+    );
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(1);
+    // No keyed secret configured: no comm-derived identifier at all.
+    expect((emits[0]?.details as Record<string, unknown>).topCpuProcesses).toEqual([
+      { comm: "other", cpuCores: 0.65, pid: 45 },
     ]);
   });
 
@@ -287,6 +325,93 @@ describe("startHostedContainerCpuWatchdog", () => {
     ]);
   });
 
+  it("attributes full ticks to a pid reused by a fresh process", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: null,
+      pidStats: new Map([
+        ["12", pidStatText({ comm: "node", pid: 12, startTime: "100", totalTicks: 9_000 })],
+      ]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    // Same pid, new starttime: a fresh process whose 1,400 cumulative ticks
+    // (0.7 cores) all landed inside the interval, even though it reports
+    // fewer ticks than its predecessor did.
+    state.pidStats.set(
+      "12",
+      pidStatText({ comm: "node", pid: 12, startTime: "2200", totalTicks: 1_400 }),
+    );
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(1);
+    const details = emits[0]?.details as Record<string, unknown>;
+    expect(details.cpuCoresUsed).toBe(0.7);
+    expect(details.topCpuProcesses).toEqual([
+      { comm: "node", cpuCores: 0.7, pid: 12 },
+    ]);
+  });
+
+  it("never attributes lifetime ticks to pids missed by an incomplete scan", async () => {
+    // Pid 12 has 30,000 lifetime ticks (300s of CPU): if the failed first
+    // /proc scan were trusted as "complete and empty", the next interval
+    // would attribute all of it (a false 15 cores) to this interval.
+    let procReadable = false;
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map([
+        ["12", pidStatText({ comm: "node", pid: 12, totalTicks: 30_000 })],
+      ]),
+    };
+    const inner = createFakeProcessApi(state);
+    const processApi: HostedContainerCpuWatchdogProcessApi = {
+      readFile: (path, encoding) => inner.readFile(path, encoding),
+      readdir: (path) =>
+        procReadable ? inner.readdir(path) : Promise.reject(new Error("EACCES: /proc")),
+    };
+    stopWatchdog = await startWatchdog({ processApi });
+
+    procReadable = true;
+    state.cpuStatText = cpuStatText({ usageUsec: 16_000_000 });
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(1);
+    const details = emits[0]?.details as Record<string, unknown>;
+    // The cgroup truth still reports, with the unknown-history pid excluded
+    // from attribution rather than misreported.
+    expect(details.cpuCoresUsed).toBe(0.75);
+    expect(details.attributedCpuCores).toBe(0);
+    expect(details.topCpuProcesses).toEqual([]);
+  });
+
+  it("stays silent in fallback mode after an incomplete scan", async () => {
+    // The same missed-pid scenario without cgroup totals: with nothing
+    // trustworthy to report, the interval must not produce a false alarm.
+    let procReadable = false;
+    const state: FakeProcessState = {
+      cpuStatText: null,
+      pidStats: new Map([
+        ["12", pidStatText({ comm: "node", pid: 12, totalTicks: 30_000 })],
+      ]),
+    };
+    const inner = createFakeProcessApi(state);
+    const processApi: HostedContainerCpuWatchdogProcessApi = {
+      readFile: (path, encoding) => inner.readFile(path, encoding),
+      readdir: (path) =>
+        procReadable ? inner.readdir(path) : Promise.reject(new Error("EACCES: /proc")),
+    };
+    stopWatchdog = await startWatchdog({ processApi });
+
+    procReadable = true;
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    expect(watchdogEmits()).toHaveLength(0);
+  });
+
   it("reports from cgroup totals alone when /proc is unreadable", async () => {
     const state: FakeProcessState = {
       cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
@@ -396,6 +521,27 @@ describe("startHostedContainerCpuWatchdog", () => {
     const emits = watchdogEmits();
     expect(emits).toHaveLength(2);
     expect((emits[1]?.details as Record<string, unknown>).cpuCoresUsed).toBe(1);
+  });
+
+  it("does not emit from a sample still in flight when stopped", async () => {
+    let releaseRead: (text: string) => void = () => {};
+    const processApi: HostedContainerCpuWatchdogProcessApi = {
+      readFile: () =>
+        new Promise((resolve) => {
+          releaseRead = resolve;
+        }),
+      readdir: () => Promise.resolve([]),
+    };
+    stopWatchdog = await startWatchdog({ processApi });
+
+    // The seed sample is still stalled on its cgroup read when stop runs.
+    stopWatchdog();
+    stopWatchdog = null;
+    releaseRead(cpuStatText({ usageUsec: 1_000_000 }));
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    // Even the one-time started signal is suppressed after stop.
+    expect(mocks.emitHostedExecutionStructuredLog).not.toHaveBeenCalled();
   });
 
   it("unrefs the sampling interval so it never holds the process open", () => {

--- a/apps/cloudflare/test/container-cpu-watchdog.test.ts
+++ b/apps/cloudflare/test/container-cpu-watchdog.test.ts
@@ -1,0 +1,414 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  emitHostedExecutionStructuredLog: vi.fn(),
+}));
+
+// The watchdog imports exactly one symbol from hosted-execution.
+vi.mock("@murphai/hosted-execution", () => ({
+  emitHostedExecutionStructuredLog: mocks.emitHostedExecutionStructuredLog,
+}));
+
+import {
+  startHostedContainerCpuWatchdog,
+  type HostedContainerCpuWatchdogProcessApi,
+} from "../src/container-cpu-watchdog.ts";
+
+const WATCHDOG_INTERVAL_MS = 20_000;
+
+interface FakeProcessState {
+  cpuStatText: string | null;
+  pidStats: Map<string, string | null>;
+}
+
+function createFakeProcessApi(state: FakeProcessState): HostedContainerCpuWatchdogProcessApi {
+  return {
+    async readFile(path) {
+      if (path === "/sys/fs/cgroup/cpu.stat") {
+        if (state.cpuStatText === null) {
+          throw new Error("cpu.stat unavailable");
+        }
+        return state.cpuStatText;
+      }
+      const match = /^\/proc\/(\d+)\/stat$/u.exec(path);
+      const statText = match ? state.pidStats.get(match[1] ?? "") : undefined;
+      if (statText === undefined || statText === null) {
+        throw new Error(`unreadable ${path}`);
+      }
+      return statText;
+    },
+    async readdir(path) {
+      if (path !== "/proc") {
+        throw new Error(`unexpected readdir ${path}`);
+      }
+      return [...state.pidStats.keys(), "self", "sys"].map((name) => ({
+        isDirectory: () => true,
+        name,
+      }));
+    },
+  };
+}
+
+function cpuStatText(input: {
+  nrThrottled?: number;
+  throttledUsec?: number;
+  usageUsec: number;
+}): string {
+  return [
+    `usage_usec ${input.usageUsec}`,
+    "user_usec 0",
+    "system_usec 0",
+    "nr_periods 0",
+    `nr_throttled ${input.nrThrottled ?? 0}`,
+    `throttled_usec ${input.throttledUsec ?? 0}`,
+    "",
+  ].join("\n");
+}
+
+function pidStatText(input: { comm: string; pid: number; totalTicks: number }): string {
+  const tail = Array.from({ length: 38 }, () => "0");
+  // The explicit `S` below is stat field 3, so tail[10]/tail[11] land at stat
+  // fields 14 (utime) and 15 (stime); split the ticks across both.
+  const utime = Math.floor(input.totalTicks / 2);
+  const stime = input.totalTicks - utime;
+  tail[10] = String(utime);
+  tail[11] = String(stime);
+  return `${input.pid} (${input.comm}) S ${tail.join(" ")}`;
+}
+
+function emitsWithLifecycleStage(lifecycleStage: string): Array<Record<string, unknown>> {
+  return mocks.emitHostedExecutionStructuredLog.mock.calls
+    .map(([entry]) => entry as Record<string, unknown>)
+    .filter((entry) =>
+      (entry.details as Record<string, unknown> | undefined)?.lifecycleStage
+        === lifecycleStage,
+    );
+}
+
+function watchdogEmits(): Array<Record<string, unknown>> {
+  return emitsWithLifecycleStage("entrypoint-cpu-watchdog");
+}
+
+function startedEmits(): Array<Record<string, unknown>> {
+  return emitsWithLifecycleStage("entrypoint-cpu-watchdog-started");
+}
+
+// Starts the watchdog and settles its immediate baseline seed at the current
+// fake-timer timestamp so every test interval is a deterministic 20s.
+async function startWatchdog(
+  input: Parameters<typeof startHostedContainerCpuWatchdog>[0],
+): Promise<() => void> {
+  const stop = startHostedContainerCpuWatchdog(input);
+  await vi.advanceTimersByTimeAsync(0);
+  return stop;
+}
+
+describe("startHostedContainerCpuWatchdog", () => {
+  let stopWatchdog: (() => void) | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.emitHostedExecutionStructuredLog.mockReset();
+  });
+
+  afterEach(() => {
+    stopWatchdog?.();
+    stopWatchdog = null;
+    vi.useRealTimers();
+  });
+
+  it("attributes elevated CPU to the top processes by comm name", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map([
+        ["1", pidStatText({ comm: "tini", pid: 1, totalTicks: 10 })],
+        ["12", pidStatText({ comm: "node", pid: 12, totalTicks: 500 })],
+        ["45", pidStatText({ comm: "codex (smoke)", pid: 45, totalTicks: 100 })],
+      ]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    expect(watchdogEmits()).toHaveLength(0);
+
+    state.cpuStatText = cpuStatText({
+      nrThrottled: 3,
+      throttledUsec: 250_000,
+      usageUsec: 16_000_000,
+    });
+    state.pidStats.set("12", pidStatText({ comm: "node", pid: 12, totalTicks: 700 }));
+    state.pidStats.set("45", pidStatText({ comm: "codex (smoke)", pid: 45, totalTicks: 1_400 }));
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(1);
+    const details = emits[0]?.details as Record<string, unknown>;
+    // 15,000,000 usec over 20s = 0.75 cores.
+    expect(details.cpuCoresUsed).toBe(0.75);
+    expect(details.cgroupUsageUsecDelta).toBe(15_000_000);
+    expect(details.cgroupNrThrottledDelta).toBe(3);
+    expect(details.cgroupThrottledUsecDelta).toBe(250_000);
+    expect(details.intervalMs).toBe(WATCHDOG_INTERVAL_MS);
+    // 1,500 total per-pid ticks = 0.75 cores fully attributed (no short-lived
+    // process churn in this fixture, so it matches the cgroup figure).
+    expect(details.attributedCpuCores).toBe(0.75);
+    expect(details.topCpuProcesses).toEqual([
+      // 1,300 ticks at 100 Hz over 20s = 0.65 cores. The comm parse keeps the
+      // inner parens, and the non-allowlisted name is emitted as a stable
+      // sha256 digest label instead of raw process-controlled text.
+      { comm: "other:8b473696", cpuCores: 0.65, pid: 45 },
+      // 200 ticks = 0.1 cores; allowlisted infrastructure comm passes through.
+      { comm: "node", cpuCores: 0.1, pid: 12 },
+    ]);
+  });
+
+  it("emits a one-time started signal reporting cgroup availability", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map([
+        ["12", pidStatText({ comm: "node", pid: 12, totalTicks: 100 })],
+      ]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    const started = startedEmits();
+    expect(started).toHaveLength(1);
+    expect(started[0]?.details).toMatchObject({
+      cgroupCpuStatAvailable: true,
+      sampledProcessCount: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS * 3);
+    expect(startedEmits()).toHaveLength(1);
+  });
+
+  it("stays silent while CPU usage is below the threshold", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map([
+        ["12", pidStatText({ comm: "node", pid: 12, totalTicks: 500 })],
+      ]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    state.cpuStatText = cpuStatText({ usageUsec: 2_000_000 });
+    state.pidStats.set("12", pidStatText({ comm: "node", pid: 12, totalTicks: 520 }));
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    expect(watchdogEmits()).toHaveLength(0);
+  });
+
+  it("falls back to per-process ticks when cgroup cpu.stat is unreadable", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: null,
+      pidStats: new Map([
+        ["12", pidStatText({ comm: "node", pid: 12, totalTicks: 100 })],
+        ["77", "not a valid stat line"],
+      ]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    // The started signal reports the fallback as live on this "platform".
+    expect(startedEmits()[0]?.details).toMatchObject({ cgroupCpuStatAvailable: false });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    // 1,300 fresh ticks at 100 Hz over 20s = 0.65 cores from /proc alone.
+    state.pidStats.set("12", pidStatText({ comm: "node", pid: 12, totalTicks: 1_400 }));
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(1);
+    const details = emits[0]?.details as Record<string, unknown>;
+    expect(details.cgroupUsageUsecDelta).toBeNull();
+    expect(details.cpuCoresUsed).toBe(0.65);
+    expect(details.topCpuProcesses).toEqual([
+      { comm: "node", cpuCores: 0.65, pid: 12 },
+    ]);
+  });
+
+  it("stops sampling after the returned stop function runs", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map(),
+    };
+    const processApi = createFakeProcessApi(state);
+    const readdirSpy = vi.spyOn(processApi, "readdir");
+    stopWatchdog = await startWatchdog({
+      processApi,
+    });
+
+    // One readdir from the immediate baseline seed plus one interval tick.
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    expect(readdirSpy).toHaveBeenCalledTimes(2);
+
+    stopWatchdog();
+    stopWatchdog = null;
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS * 3);
+    expect(readdirSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("clamps reused-pid tick regressions to zero instead of negative usage", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: null,
+      pidStats: new Map([
+        ["12", pidStatText({ comm: "node", pid: 12, totalTicks: 2_000 })],
+      ]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    // Pid 12 was reused: the successor's cumulative ticks regressed from
+    // 2,000 to 50. Without the clamp, the -1,950 delta would cancel pid 13's
+    // real 1,400-tick (0.65-core) burn and suppress the report entirely.
+    state.pidStats.set("12", pidStatText({ comm: "node", pid: 12, totalTicks: 50 }));
+    state.pidStats.set("13", pidStatText({ comm: "node", pid: 13, totalTicks: 1_400 }));
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(1);
+    const details = emits[0]?.details as Record<string, unknown>;
+    // 1,400 fresh ticks at 100 Hz over 20s = 0.7 cores; the reused pid
+    // contributes exactly zero and is excluded from attribution.
+    expect(details.cpuCoresUsed).toBe(0.7);
+    expect(details.attributedCpuCores).toBe(0.7);
+    expect(details.topCpuProcesses).toEqual([
+      { comm: "node", cpuCores: 0.7, pid: 13 },
+    ]);
+  });
+
+  it("reports from cgroup totals alone when /proc is unreadable", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map(),
+    };
+    const processApi = createFakeProcessApi(state);
+    processApi.readdir = () => Promise.reject(new Error("EACCES: /proc"));
+    stopWatchdog = await startWatchdog({
+      processApi,
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    state.cpuStatText = cpuStatText({ usageUsec: 17_000_000 });
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(1);
+    const details = emits[0]?.details as Record<string, unknown>;
+    // 16,000,000 usec over 20s = 0.8 cores from the cgroup counters alone;
+    // none of it is per-pid attributable, and the gap is explicit.
+    expect(details.cpuCoresUsed).toBe(0.8);
+    expect(details.attributedCpuCores).toBe(0);
+    expect(details.sampledProcessCount).toBe(0);
+    expect(details.topCpuProcesses).toEqual([]);
+  });
+
+  it("skips overlapping ticks while a sample is still in flight", async () => {
+    let cpuStatReads = 0;
+    // Reassigned synchronously by the first read's promise executor.
+    let releaseFirstRead: (text: string) => void = () => {};
+    const processApi: HostedContainerCpuWatchdogProcessApi = {
+      readFile(path) {
+        if (path !== "/sys/fs/cgroup/cpu.stat") {
+          return Promise.reject(new Error(`unexpected read ${path}`));
+        }
+        cpuStatReads += 1;
+        if (cpuStatReads === 1) {
+          return new Promise((resolve) => {
+            releaseFirstRead = resolve;
+          });
+        }
+        return Promise.resolve(cpuStatText({ usageUsec: 1_000_000 }));
+      },
+      readdir: () => Promise.resolve([]),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi,
+    });
+
+    // The first tick starts and stalls on the cgroup read.
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    expect(cpuStatReads).toBe(1);
+
+    // The next interval fires while the sample is in flight and is skipped
+    // rather than queued behind it.
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    expect(cpuStatReads).toBe(1);
+
+    // Once the stalled read resolves, later ticks sample again.
+    releaseFirstRead(cpuStatText({ usageUsec: 0 }));
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    expect(cpuStatReads).toBe(2);
+  });
+
+  it("skips the report when the wall clock did not advance between samples", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map(),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    // Step the wall clock back so the next sample lands on the same
+    // timestamp; without the intervalMs guard the 29M-usec delta below would
+    // divide by zero and emit cpuCoresUsed: Infinity.
+    vi.setSystemTime(Date.now() - WATCHDOG_INTERVAL_MS);
+    state.cpuStatText = cpuStatText({ usageUsec: 30_000_000 });
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    expect(watchdogEmits()).toHaveLength(0);
+  });
+
+  it("swallows a throwing emit and keeps reporting on later intervals", async () => {
+    const state: FakeProcessState = {
+      cpuStatText: cpuStatText({ usageUsec: 1_000_000 }),
+      pidStats: new Map(),
+    };
+    stopWatchdog = await startWatchdog({
+      processApi: createFakeProcessApi(state),
+    });
+    mocks.emitHostedExecutionStructuredLog.mockImplementationOnce(() => {
+      throw new Error("log sink unavailable");
+    });
+
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    state.cpuStatText = cpuStatText({ usageUsec: 21_000_000 });
+    // This interval's emit throws inside the tick; an escaped rejection from
+    // the interval callback would fail the test as an unhandled error.
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+    state.cpuStatText = cpuStatText({ usageUsec: 41_000_000 });
+    await vi.advanceTimersByTimeAsync(WATCHDOG_INTERVAL_MS);
+
+    // The throwing call is still recorded by the mock; the follow-up interval
+    // proves the watchdog kept sampling and reporting after the failure.
+    const emits = watchdogEmits();
+    expect(emits).toHaveLength(2);
+    expect((emits[1]?.details as Record<string, unknown>).cpuCoresUsed).toBe(1);
+  });
+
+  it("unrefs the sampling interval so it never holds the process open", () => {
+    vi.useRealTimers();
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    try {
+      stopWatchdog = startHostedContainerCpuWatchdog({
+        processApi: createFakeProcessApi({ cpuStatText: null, pidStats: new Map() }),
+      });
+      const interval = setIntervalSpy.mock.results[0]?.value as NodeJS.Timeout;
+      expect(interval.hasRef()).toBe(false);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Production container metrics show recurring unattributed CPU pinning at ~100% of 1 vCPU on hosted runner containers — both seconds after boot and mid-lifetime on warm containers (one observed 12-minute sustained burn between jobs, instance `c224...`, Jun 11 01:54–02:06 UTC). Existing diagnostics (the per-job heartbeat) sample only memory and only during active jobs, so these burns are unattributable today.

## What

- **`apps/cloudflare/src/container-cpu-watchdog.ts`** (new, self-contained): every 20s samples `/sys/fs/cgroup/cpu.stat` + `/proc/<pid>/stat`; when interval usage ≥ 0.5 cores, emits one structured log (`lifecycleStage: "entrypoint-cpu-watchdog"`) with cgroup usage/throttle deltas, the per-pid attributed total (`attributedCpuCores` — exposes short-lived-process churn as an explicit gap), and the top-3 processes by CPU.
- **Comm redaction**: comm names pass an infrastructure allowlist; anything else (script basenames, PR_SET_NAME) logs as a stable `other:<sha256-prefix>` label, so process-controlled text never reaches persisted Workers Logs.
- **Boot visibility**: the baseline seeds immediately at start, so the first reportable interval covers the boot window — half the production mystery.
- **Liveness**: a one-time `entrypoint-cpu-watchdog-started` log reports `cgroupCpuStatAvailable` + `sampledProcessCount`, disambiguating "no burns" from "sampler broken" and answering whether the cgroup fallback is live fleet-wide.
- **Wiring** (`container-entrypoint.ts`, CLI path only): started in `startHostedContainerEntrypointCli` on the default process API — entrypoint unit tests inject sequenced `processApi` mocks the watchdog must not consume. Stopped on server close; interval is unref'd; every failure path is swallowed (diagnostics-only).

## Verification

- `pnpm test:diff` → full `apps/cloudflare verify` (typecheck + Node + Workers lanes): **84 files / 1,323 tests, green** (run after every revision)
- New focused suite: 11 tests (attribution + redaction both branches, threshold silence, cgroup fallback, started signal, pid-reuse clamp, unreadable `/proc`, tick re-entrancy, wall-clock guard, emit-throw resilience, unref)
- Known proof gap: not yet observed against real Linux `/proc`+cgroup (dev is macOS; fixtures encode the stat(5)/cgroup-v2 layouts). The started-signal log closes this within one interval of first deploy.

## Audits (repo completion workflow)

- `security-privacy-review`: 1 MEDIUM (raw process-controlled comm → persisted logs) — fixed via allowlist+digest; scoped re-review: **resolved, no new findings**
- `simplify`: removed unused config options; module boundary + structural ProcessApi subset (no `kill` capability) confirmed; cgroup fallback consciously kept (~8 lines vs silent blindness)
- `coverage-write`: +6 boundary tests, production code untouched
- `task-finish-review`: boot-window blind spot + liveness gap + attribution-gap findings accepted and fixed; sanitizer-seam test rejected (boundary proven by inspection; sanitizer preserves the payload shape, nesting depth 3 ≤ 4, valid keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783745979&installation_id=127572939&pr_number=128&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F128&signature=033454d374afe7be18849982e0d3d0f154d385c0b9069931e53eff62dfde5361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->