### PR TITLE
perf(cloudflare): bundle vault-cli with esbuild splitting in the hosted runner image

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-11-vault-cli-esbuild-runner-bundle.md
+++ b/agent-docs/exec-plans/completed/2026-06-11-vault-cli-esbuild-runner-bundle.md
@@ -1,0 +1,49 @@
+# vault-cli esbuild bundle in the hosted runner image
+
+## Problem
+
+Even after the import-hygiene fix (PR #131), every vault-cli invocation in the 1-vCPU runner container pays per-file module-loading overhead: ESM resolution, stat/open syscalls, and parse/compile across hundreds of small dist files. Container file I/O is far slower than a dev laptop (container node boot ~1.9s vs ~45ms locally), so this overhead dominates per-command latency there.
+
+## Approach
+
+Bundle the installed vault-cli at runner-bundle assembly time (CI, before docker build) with esbuild `--splitting`, which collapses ~700 module files into ~126 chunks while preserving the CLI's scoped lazy loading. Three correctness hazards discovered during prototyping, each handled structurally:
+
+1. **Top-level-await poisons lazy chunks** (esbuild's async lazy-init for TLA-infected dynamic-import targets never settles → silent exit-0). Two sources found and removed: ink/yoga-layout (kept `external`, resolved from installed node_modules only on the lazy chat path) and `packages/runtime-state/src/sqlite.ts`'s `await import("node:sqlite")` (replaced with `process.getBuiltinModule("node:sqlite")`, which preserves the warning-filter-before-load ordering without TLA).
+2. **tsconfig `paths` leak src**: esbuild auto-applies workspace tsconfig paths and bundles sibling packages' TypeScript sources instead of built dist. Neutralized with `tsconfigRaw: "{}"` (matches the runner bundle's real layout: installed tarballs, dist-only).
+3. **`createRequire(import.meta.url)` + `require('../package.json')`**: chunks must sit one level under the package root, so the bundle dir is `node_modules/@murphai/cli/.bundle/`.
+
+Silent-failure class is fenced by an assembly-time parity battery: bundled vs unbundled byte-identical output (stdout + exit status) for `--help`, `--llms`, `--llms-full --format json`, and two scoped probes (`wearables day`, `meal totals`) that exercise routing, loader-backed services, and lazy runtime imports. Divergence fails the assembly.
+
+`NODE_COMPILE_CACHE` was evaluated and intentionally NOT shipped: it showed ~15-20% locally, but the 2026-06-10 in-container measurement (recorded in `apps/cloudflare/test/container-image-contract.test.ts`) found a baked compile cache to be a no-op — module *eval* dominates in the container, and the cache only skips parse/compile. Re-verified 2026-06-11 on this branch's assembled bundle in docker (`--cpus=1`, qemu amd64, runner base image): unbundled scoped 888ms → 885ms with warm cache (noise); split-bundle deltas also within qemu jitter. The contract test guards against reintroducing it.
+
+## In-container measurements (docker --cpus=1, qemu amd64, runner base image, 3-run averages)
+
+| Variant | scoped `wearables day` | full `--help` |
+| --- | --- | --- |
+| unbundled dist | 888ms | 1610ms |
+| split bundle | 778ms (−12%) | 1190ms (−26%) |
+| compile cache (either variant) | within noise | within noise |
+
+## Changes
+
+1. `packages/runtime-state/src/sqlite.ts` — TLA removal via `process.getBuiltinModule`.
+2. `apps/cloudflare/scripts/runner-bundle/bundle-cli.ts` (new) — esbuild split bundle + parity battery + bin wrapper retarget; called from `assemble-runner-bundle.ts` after `rewriteRuntimeBinWrappers`.
+3. `apps/cloudflare/scripts/runner-bundle/runtime-shape.ts` — export `buildPortableNodeBinWrapper`.
+4. `apps/cloudflare/package.json` — `esbuild` devDependency (+ lockfile).
+
+## Measured (local, user CPU; container gain expected mainly from fewer file opens/resolutions)
+
+- scoped command: 0.28s unbundled → 0.28s split bundle (parity locally; container I/O is the target).
+- full `--help`: 0.46s → 0.38s split bundle.
+- single-file (non-split) bundling was measured SLOWER for scoped commands (0.43s — parses all 7MB every run) and rejected.
+- Parity battery: all probes byte-identical.
+
+## Verification
+
+- Full local `runner:bundle:assemble-only` run with the new step (includes the parity battery against the real installed layout).
+- Focused unit test for the bundle step.
+- `pnpm test:diff` over touched files.
+
+## Status
+
+Active.

--- a/agent-docs/exec-plans/completed/2026-06-11-vault-cli-esbuild-runner-bundle.md
+++ b/agent-docs/exec-plans/completed/2026-06-11-vault-cli-esbuild-runner-bundle.md
@@ -46,4 +46,4 @@ Silent-failure class is fenced by an assembly-time parity battery: bundled vs un
 
 ## Status
 
-Active.
+Completed 2026-06-11; shipped as PR #134 (stacked on PR #131).

--- a/apps/cloudflare/package.json
+++ b/apps/cloudflare/package.json
@@ -85,6 +85,7 @@
     "@cloudflare/workers-types": "^4.20260511.1",
     "@murphai/hosted-local-harness": "workspace:*",
     "@types/node": "^25.6.2",
+    "esbuild": "^0.27.4",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^4.1.6",

--- a/apps/cloudflare/scripts/assemble-runner-bundle.ts
+++ b/apps/cloudflare/scripts/assemble-runner-bundle.ts
@@ -13,6 +13,7 @@ import {
   resolveHostedRunnerBuildPackageNames,
   resolveHostedRunnerWorkspacePackageNames,
 } from "./runner-bundle-contract.js";
+import { bundleInstalledVaultCliBinary } from "./runner-bundle/bundle-cli.js";
 import {
   assertInstalledRunnerHealthCommonsRuntimeImport,
   installPackedRunnerDependencies,
@@ -140,6 +141,7 @@ async function assembleRunnerBundle(): Promise<void> {
     await pruneRunnerBundle(stagingBundleDir);
     await rewriteRuntimePackageManifest(stagingBundleDir);
     await rewriteRuntimeBinWrappers(stagingBundleDir);
+    await bundleInstalledVaultCliBinary(stagingBundleDir);
     await materializeFinalRunnerBundle(
       stagingBundleDir,
       runnerBundleDeployRoot,

--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -1,27 +1,51 @@
-import { execFileSync } from "node:child_process";
-import { access, chmod, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { access, chmod, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { build } from "esbuild";
 
 import { buildPortableNodeBinWrapper } from "./runtime-shape.js";
 
-// The interactive chat/setup UI stack stays external: ink drags react and
-// yoga-layout (top-level-await WASM) into the graph, which both bloats the
-// bundle and is exactly the surface the hosted runner never renders. The
-// externals resolve from the installed node_modules on the rare lazy path
-// (hosted chat fail-closed error) that still loads them.
-const VAULT_CLI_BUNDLE_EXTERNALS = ["ink", "react-devtools-core"];
+// Externals resolve from the installed node_modules at runtime instead of
+// being inlined into the bundle:
+// - ink/react/react-devtools-core: the interactive chat/setup UI stack. ink
+//   drags yoga-layout (top-level-await WASM) into the graph, and react must
+//   stay external alongside it so the lazy UI path never sees two React
+//   instances (external ink resolving installed react while murph UI code
+//   uses a bundled copy would break hooks dispatch).
+// - sharp/zxing-wasm: native binaries and WASM assets resolved relative to
+//   their own package directories; bundling their JS would detach it from
+//   those assets.
+const VAULT_CLI_BUNDLE_EXTERNALS = [
+  "ink",
+  "react",
+  "react/*",
+  "react-devtools-core",
+  "sharp",
+  "zxing-wasm",
+];
+
+// Source-path markers that must never appear in the bundle's inputs. Guards
+// the externals list against drift: a newly added import path that drags one
+// of these packages into the bundle fails the assembly instead of shipping a
+// duplicate runtime copy.
+const VAULT_CLI_BUNDLE_FORBIDDEN_INPUT_MARKERS = [
+  "/ink/",
+  "/react/",
+  "/react-devtools-core/",
+  "/sharp/",
+  "/yoga-layout/",
+  "/zxing-wasm/",
+];
 
 const VAULT_CLI_BUNDLE_DIRECTORY_NAME = ".bundle";
-const VAULT_CLI_BUNDLE_BIN_NAMES = ["vault-cli", "murph"] as const;
 
 // Bundled and unbundled binaries must produce byte-identical output on the
 // discovery surfaces and on a representative scoped command (which exercises
 // command routing, the loader-backed services, and the lazy runtime imports).
-// The scoped probe runs without a vault on purpose: the missing-vault error is
-// emitted after the full scoped module graph has loaded, so identical output
-// still proves the bundled graph wires up correctly.
+// The scoped probes run without a vault on purpose: the missing-vault error is
+// emitted (on stderr) after the full scoped module graph has loaded, so
+// identical output still proves the bundled graph wires up correctly.
 const VAULT_CLI_BUNDLE_PARITY_PROBES: ReadonlyArray<readonly string[]> = [
   ["--help"],
   ["--llms"],
@@ -40,7 +64,7 @@ export async function bundleInstalledVaultCliBinary(
   const bundleOutDir = path.join(cliPackageDir, VAULT_CLI_BUNDLE_DIRECTORY_NAME);
   await rm(bundleOutDir, { force: true, recursive: true });
 
-  await build({
+  const buildResult = await build({
     banner: {
       js: "import { createRequire as __vaultCliCreateRequire } from 'node:module'; const require = __vaultCliCreateRequire(import.meta.url);",
     },
@@ -49,6 +73,7 @@ export async function bundleInstalledVaultCliBinary(
     external: [...VAULT_CLI_BUNDLE_EXTERNALS],
     format: "esm",
     logLevel: "error",
+    metafile: true,
     outdir: bundleOutDir,
     platform: "node",
     splitting: true,
@@ -58,8 +83,25 @@ export async function bundleInstalledVaultCliBinary(
     tsconfigRaw: "{}",
   });
 
+  assertVaultCliBundleInputsStayExternal(Object.keys(buildResult.metafile.inputs));
   assertVaultCliBundleParity({ bundleOutDir, cliPackageDir, entryPath });
   await retargetVaultCliBinWrappers(bundleDir, cliPackageDir);
+}
+
+function assertVaultCliBundleInputsStayExternal(inputPaths: string[]): void {
+  for (const inputPath of inputPaths) {
+    if (!inputPath.includes("node_modules")) {
+      continue;
+    }
+
+    for (const marker of VAULT_CLI_BUNDLE_FORBIDDEN_INPUT_MARKERS) {
+      if (inputPath.includes(`node_modules${marker}`)) {
+        throw new Error(
+          `vault-cli bundle inlined ${inputPath}; keep ${marker.replaceAll("/", "")} external so the runtime resolves the installed copy.`,
+        );
+      }
+    }
+  }
 }
 
 function assertVaultCliBundleParity(input: {
@@ -76,23 +118,28 @@ function assertVaultCliBundleParity(input: {
     // Symmetric unknown-command output would otherwise "pass" parity while
     // proving nothing — a renamed command or broken CLI bootstrap must fail
     // the assembly, not slip through as matching error text.
-    if (expected.output.includes("is not a command for")) {
+    if (expected.stdout.includes("is not a command for")) {
       throw new Error(
         [
           `Unbundled vault-cli no longer recognizes parity probe \`${probe.join(" ")}\`.`,
           `Update VAULT_CLI_BUNDLE_PARITY_PROBES to match the current command surface.`,
-          `unbundled head: ${expected.output.slice(0, 400)}`,
+          `unbundled stdout head: ${expected.stdout.slice(0, 400)}`,
         ].join("\n"),
       );
     }
 
-    if (expected.output !== actual.output || expected.status !== actual.status) {
+    if (
+      expected.stdout !== actual.stdout ||
+      expected.stderr !== actual.stderr ||
+      expected.status !== actual.status
+    ) {
       throw new Error(
         [
           `Bundled vault-cli output diverged for \`${probe.join(" ")}\`.`,
-          `unbundled status=${expected.status} bytes=${expected.output.length}`,
-          `bundled status=${actual.status} bytes=${actual.output.length}`,
-          `bundled head: ${actual.output.slice(0, 400)}`,
+          `unbundled status=${expected.status} stdout=${expected.stdout.length}B stderr=${expected.stderr.length}B`,
+          `bundled status=${actual.status} stdout=${actual.stdout.length}B stderr=${actual.stderr.length}B`,
+          `bundled stdout head: ${actual.stdout.slice(0, 200)}`,
+          `bundled stderr head: ${actual.stderr.slice(0, 400)}`,
         ].join("\n"),
       );
     }
@@ -103,45 +150,38 @@ function runVaultCliParityProbe(
   entryPath: string,
   args: readonly string[],
   cwd: string,
-): { output: string; status: number } {
-  try {
-    const stdout = execFileSync(process.execPath, [entryPath, ...args], {
-      cwd,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        // Keep probes hermetic: no operator config or vault may leak in from
-        // the assembling machine.
-        HOME: path.join(cwd, ".parity-probe-home"),
-        VAULT: "",
-      },
-      // The full `--llms-full` manifest exceeds the 1MiB execFileSync default;
-      // a too-small buffer kills the child mid-stream and turns OS pipe
-      // chunking into phantom parity divergence.
-      maxBuffer: 64 * 1024 * 1024,
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 60_000,
-    });
-    return { output: stdout, status: 0 };
-  } catch (error) {
-    const failure = error as {
-      code?: string;
-      status?: number | null;
-      stdout?: string | Buffer;
-    };
+): { status: number; stderr: string; stdout: string } {
+  const result = spawnSync(process.execPath, [entryPath, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      // Keep probes hermetic: no operator config or vault may leak in from
+      // the assembling machine.
+      HOME: path.join(cwd, ".parity-probe-home"),
+      VAULT: "",
+    },
+    // The full `--llms-full` manifest exceeds the 1MiB default; a too-small
+    // buffer kills the child mid-stream and turns OS pipe chunking into
+    // phantom parity divergence.
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 60_000,
+  });
 
-    // A child that exited on its own has a numeric status; anything else
-    // (ENOBUFS, timeout kill, spawn failure) is probe infrastructure breaking
-    // and must fail the assembly loudly instead of posing as a parity result.
-    if (typeof failure.status !== "number") {
-      throw new Error(
-        `vault-cli parity probe \`${args.join(" ")}\` did not exit cleanly (${failure.code ?? "unknown"}).`,
-      );
-    }
-
-    const stdout = failure.stdout?.toString() ?? "";
-    return { output: stdout, status: failure.status };
+  // A child that exited on its own has a numeric status and no signal;
+  // anything else (spawn failure, timeout kill, buffer kill) is probe
+  // infrastructure breaking and must fail the assembly loudly instead of
+  // posing as a parity result.
+  if (result.error || result.signal !== null || typeof result.status !== "number") {
+    throw new Error(
+      `vault-cli parity probe \`${args.join(" ")}\` did not exit cleanly (${
+        result.error?.message ?? `signal ${result.signal ?? "unknown"}`
+      }).`,
+    );
   }
+
+  return { status: result.status, stderr: result.stderr, stdout: result.stdout };
 }
 
 async function retargetVaultCliBinWrappers(
@@ -155,17 +195,44 @@ async function retargetVaultCliBinWrappers(
     "bin.js",
   );
 
-  for (const binName of VAULT_CLI_BUNDLE_BIN_NAMES) {
-    const wrapperPath = path.join(binDir, binName);
-    const relativeTargetPath = path
-      .relative(binDir, bundledEntryPath)
-      .replaceAll(path.sep, "/");
+  // The package manifest is the single source of truth for bin names: every
+  // bin that pointed at the unbundled entry is retargeted to the bundle.
+  const manifest = JSON.parse(
+    await readFile(path.join(cliPackageDir, "package.json"), "utf8"),
+  ) as { bin?: Record<string, string> | string };
+  const binMap = typeof manifest.bin === "string" ? null : manifest.bin ?? null;
 
+  if (!binMap) {
+    throw new Error(
+      "Installed @murphai/murph package manifest has no bin map to retarget.",
+    );
+  }
+
+  const relativeTargetPath = path
+    .relative(binDir, bundledEntryPath)
+    .replaceAll(path.sep, "/");
+  let retargetedCount = 0;
+
+  const unbundledEntryPath = path.resolve(cliPackageDir, "dist", "bin.js");
+
+  for (const [binName, binTarget] of Object.entries(binMap)) {
+    if (path.resolve(cliPackageDir, binTarget) !== unbundledEntryPath) {
+      continue;
+    }
+
+    const wrapperPath = path.join(binDir, binName);
     await writeFile(
       wrapperPath,
       buildPortableNodeBinWrapper(relativeTargetPath),
       "utf8",
     );
     await chmod(wrapperPath, 0o755);
+    retargetedCount += 1;
+  }
+
+  if (retargetedCount === 0) {
+    throw new Error(
+      "No @murphai/murph bin entries pointed at dist/bin.js; the bundle retarget found nothing to rewrite.",
+    );
   }
 }

--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -40,6 +40,18 @@ const VAULT_CLI_BUNDLE_FORBIDDEN_INPUT_MARKERS = [
 
 const VAULT_CLI_BUNDLE_DIRECTORY_NAME = ".bundle";
 
+// Known divergence the parity battery cannot reach (it would need a live
+// codex session): assistant-engine resolves two assets relative to its own
+// module location, which differs inside chunks — `resolveAssistantSkillsRoot`
+// lands on `@murphai/murph/skills` (absent) instead of
+// `@murphai/assistant-engine/skills`, and the prebuilt CLI surface contract
+// path misses, silently falling back to runtime generation. Hosted production
+// is unaffected (the runtime runs the engine unbundled via
+// `dist/container-entrypoint.js`); only an in-container `vault-cli assistant
+// run` through the bundled wrapper would hit these, degrading softly. If that
+// path ever becomes load-bearing, make those resolvers honor env overrides
+// before relying on the bundle.
+
 // Bundled and unbundled binaries must produce byte-identical output on the
 // discovery surfaces and on a representative scoped command (which exercises
 // command routing, the loader-backed services, and the lazy runtime imports).

--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -73,6 +73,19 @@ function assertVaultCliBundleParity(input: {
     const expected = runVaultCliParityProbe(input.entryPath, probe, input.cliPackageDir);
     const actual = runVaultCliParityProbe(bundledEntryPath, probe, input.cliPackageDir);
 
+    // Symmetric unknown-command output would otherwise "pass" parity while
+    // proving nothing — a renamed command or broken CLI bootstrap must fail
+    // the assembly, not slip through as matching error text.
+    if (expected.output.includes("is not a command for")) {
+      throw new Error(
+        [
+          `Unbundled vault-cli no longer recognizes parity probe \`${probe.join(" ")}\`.`,
+          `Update VAULT_CLI_BUNDLE_PARITY_PROBES to match the current command surface.`,
+          `unbundled head: ${expected.output.slice(0, 400)}`,
+        ].join("\n"),
+      );
+    }
+
     if (expected.output !== actual.output || expected.status !== actual.status) {
       throw new Error(
         [

--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -115,17 +115,32 @@ function runVaultCliParityProbe(
         HOME: path.join(cwd, ".parity-probe-home"),
         VAULT: "",
       },
+      // The full `--llms-full` manifest exceeds the 1MiB execFileSync default;
+      // a too-small buffer kills the child mid-stream and turns OS pipe
+      // chunking into phantom parity divergence.
+      maxBuffer: 64 * 1024 * 1024,
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 60_000,
     });
     return { output: stdout, status: 0 };
   } catch (error) {
     const failure = error as {
+      code?: string;
       status?: number | null;
       stdout?: string | Buffer;
     };
+
+    // A child that exited on its own has a numeric status; anything else
+    // (ENOBUFS, timeout kill, spawn failure) is probe infrastructure breaking
+    // and must fail the assembly loudly instead of posing as a parity result.
+    if (typeof failure.status !== "number") {
+      throw new Error(
+        `vault-cli parity probe \`${args.join(" ")}\` did not exit cleanly (${failure.code ?? "unknown"}).`,
+      );
+    }
+
     const stdout = failure.stdout?.toString() ?? "";
-    return { output: stdout, status: failure.status ?? 1 };
+    return { output: stdout, status: failure.status };
   }
 }
 

--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -1,0 +1,143 @@
+import { execFileSync } from "node:child_process";
+import { access, chmod, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { build } from "esbuild";
+
+import { buildPortableNodeBinWrapper } from "./runtime-shape.js";
+
+// The interactive chat/setup UI stack stays external: ink drags react and
+// yoga-layout (top-level-await WASM) into the graph, which both bloats the
+// bundle and is exactly the surface the hosted runner never renders. The
+// externals resolve from the installed node_modules on the rare lazy path
+// (hosted chat fail-closed error) that still loads them.
+const VAULT_CLI_BUNDLE_EXTERNALS = ["ink", "react-devtools-core"];
+
+const VAULT_CLI_BUNDLE_DIRECTORY_NAME = ".bundle";
+const VAULT_CLI_BUNDLE_BIN_NAMES = ["vault-cli", "murph"] as const;
+
+// Bundled and unbundled binaries must produce byte-identical output on the
+// discovery surfaces and on a representative scoped command (which exercises
+// command routing, the loader-backed services, and the lazy runtime imports).
+// The scoped probe runs without a vault on purpose: the missing-vault error is
+// emitted after the full scoped module graph has loaded, so identical output
+// still proves the bundled graph wires up correctly.
+const VAULT_CLI_BUNDLE_PARITY_PROBES: ReadonlyArray<readonly string[]> = [
+  ["--help"],
+  ["--llms"],
+  ["--llms-full", "--format", "json"],
+  ["wearables", "day", "2026-01-01", "--format", "json"],
+  ["meal", "totals", "--from", "2026-01-01", "--to", "2026-01-01", "--format", "json"],
+];
+
+export async function bundleInstalledVaultCliBinary(
+  bundleDir: string,
+): Promise<void> {
+  const cliPackageDir = path.join(bundleDir, "node_modules", "@murphai", "murph");
+  const entryPath = path.join(cliPackageDir, "dist", "bin.js");
+  await access(entryPath);
+
+  const bundleOutDir = path.join(cliPackageDir, VAULT_CLI_BUNDLE_DIRECTORY_NAME);
+  await rm(bundleOutDir, { force: true, recursive: true });
+
+  await build({
+    banner: {
+      js: "import { createRequire as __vaultCliCreateRequire } from 'node:module'; const require = __vaultCliCreateRequire(import.meta.url);",
+    },
+    bundle: true,
+    entryPoints: [entryPath],
+    external: [...VAULT_CLI_BUNDLE_EXTERNALS],
+    format: "esm",
+    logLevel: "error",
+    outdir: bundleOutDir,
+    platform: "node",
+    splitting: true,
+    // The bundle directory sits at the package root so `../package.json`
+    // resolved through createRequire(import.meta.url) inside chunks still
+    // lands on the installed package manifest.
+    tsconfigRaw: "{}",
+  });
+
+  assertVaultCliBundleParity({ bundleOutDir, cliPackageDir, entryPath });
+  await retargetVaultCliBinWrappers(bundleDir, cliPackageDir);
+}
+
+function assertVaultCliBundleParity(input: {
+  bundleOutDir: string;
+  cliPackageDir: string;
+  entryPath: string;
+}): void {
+  const bundledEntryPath = path.join(input.bundleOutDir, "bin.js");
+
+  for (const probe of VAULT_CLI_BUNDLE_PARITY_PROBES) {
+    const expected = runVaultCliParityProbe(input.entryPath, probe, input.cliPackageDir);
+    const actual = runVaultCliParityProbe(bundledEntryPath, probe, input.cliPackageDir);
+
+    if (expected.output !== actual.output || expected.status !== actual.status) {
+      throw new Error(
+        [
+          `Bundled vault-cli output diverged for \`${probe.join(" ")}\`.`,
+          `unbundled status=${expected.status} bytes=${expected.output.length}`,
+          `bundled status=${actual.status} bytes=${actual.output.length}`,
+          `bundled head: ${actual.output.slice(0, 400)}`,
+        ].join("\n"),
+      );
+    }
+  }
+}
+
+function runVaultCliParityProbe(
+  entryPath: string,
+  args: readonly string[],
+  cwd: string,
+): { output: string; status: number } {
+  try {
+    const stdout = execFileSync(process.execPath, [entryPath, ...args], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        // Keep probes hermetic: no operator config or vault may leak in from
+        // the assembling machine.
+        HOME: path.join(cwd, ".parity-probe-home"),
+        VAULT: "",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 60_000,
+    });
+    return { output: stdout, status: 0 };
+  } catch (error) {
+    const failure = error as {
+      status?: number | null;
+      stdout?: string | Buffer;
+    };
+    const stdout = failure.stdout?.toString() ?? "";
+    return { output: stdout, status: failure.status ?? 1 };
+  }
+}
+
+async function retargetVaultCliBinWrappers(
+  bundleDir: string,
+  cliPackageDir: string,
+): Promise<void> {
+  const binDir = path.join(bundleDir, "node_modules", ".bin");
+  const bundledEntryPath = path.join(
+    cliPackageDir,
+    VAULT_CLI_BUNDLE_DIRECTORY_NAME,
+    "bin.js",
+  );
+
+  for (const binName of VAULT_CLI_BUNDLE_BIN_NAMES) {
+    const wrapperPath = path.join(binDir, binName);
+    const relativeTargetPath = path
+      .relative(binDir, bundledEntryPath)
+      .replaceAll(path.sep, "/");
+
+    await writeFile(
+      wrapperPath,
+      buildPortableNodeBinWrapper(relativeTargetPath),
+      "utf8",
+    );
+    await chmod(wrapperPath, 0o755);
+  }
+}

--- a/apps/cloudflare/scripts/runner-bundle/runtime-shape.ts
+++ b/apps/cloudflare/scripts/runner-bundle/runtime-shape.ts
@@ -303,7 +303,7 @@ function normalizeBinMap(packageJson: {
   );
 }
 
-function buildPortableNodeBinWrapper(relativeTargetPath: string): string {
+export function buildPortableNodeBinWrapper(relativeTargetPath: string): string {
   return [
     "#!/bin/sh",
     "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")",

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -176,6 +176,24 @@ describe("hosted runner container image contract", () => {
     expect(bundleAssemblyScript).toContain(
       "await rewriteRuntimeBinWrappers(stagingBundleDir);",
     );
+    expect(bundleAssemblyScript).toContain(
+      'import { bundleInstalledVaultCliBinary } from "./runner-bundle/bundle-cli.js";',
+    );
+    // The vault-cli esbuild step retargets the freshly rewritten bin wrappers
+    // at the bundle, so it must run after rewriteRuntimeBinWrappers and before
+    // the staging dir is materialized into the final bundle.
+    const rewriteBinWrappersCallIndex = bundleAssemblyScript.indexOf(
+      "await rewriteRuntimeBinWrappers(stagingBundleDir);",
+    );
+    const bundleVaultCliCallIndex = bundleAssemblyScript.indexOf(
+      "await bundleInstalledVaultCliBinary(stagingBundleDir);",
+    );
+    const materializeFinalBundleCallIndex = bundleAssemblyScript.indexOf(
+      "await materializeFinalRunnerBundle(",
+    );
+    expect(rewriteBinWrappersCallIndex).toBeGreaterThan(-1);
+    expect(bundleVaultCliCallIndex).toBeGreaterThan(rewriteBinWrappersCallIndex);
+    expect(materializeFinalBundleCallIndex).toBeGreaterThan(bundleVaultCliCallIndex);
     expect(runtimeShapeScript).toContain(
       'removeBundlePathIfPresent(path.join(bundleDir, "README.md"))',
     );

--- a/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bundleInstalledVaultCliBinary } from "../scripts/runner-bundle/bundle-cli.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { force: true, recursive: true }),
+    ),
+  );
+});
+
+// A miniature installed CLI that exercises the two bundle hazards the real
+// vault-cli has: createRequire(import.meta.url) + require('../package.json'),
+// and a deterministic response for every parity probe.
+const FAKE_CLI_SOURCE = [
+  "import { createRequire } from 'node:module';",
+  "const require = createRequire(import.meta.url);",
+  "const packageJson = require('../package.json');",
+  "console.log(JSON.stringify({ args: process.argv.slice(2), version: packageJson.version }));",
+  "",
+].join("\n");
+
+// Output that depends on the executing file's location diverges between the
+// bundled and unbundled binaries, which the parity battery must reject.
+const DIVERGENT_CLI_SOURCE = [
+  "import { createRequire } from 'node:module';",
+  "const require = createRequire(import.meta.url);",
+  "require('../package.json');",
+  "console.log(import.meta.url);",
+  "",
+].join("\n");
+
+async function stageFakeInstalledCli(cliSource: string): Promise<string> {
+  const bundleDir = await mkdtemp(path.join(tmpdir(), "murph-runner-cli-bundle-"));
+  temporaryDirectories.push(bundleDir);
+
+  const cliPackageDir = path.join(bundleDir, "node_modules", "@murphai", "murph");
+  await mkdir(path.join(cliPackageDir, "dist"), { recursive: true });
+  await mkdir(path.join(bundleDir, "node_modules", ".bin"), { recursive: true });
+  await writeFile(
+    path.join(cliPackageDir, "package.json"),
+    JSON.stringify({ name: "@murphai/murph", type: "module", version: "9.9.9" }),
+    "utf8",
+  );
+  await writeFile(path.join(cliPackageDir, "dist", "bin.js"), cliSource, "utf8");
+
+  return bundleDir;
+}
+
+describe("runner bundle vault-cli esbuild step", () => {
+  it("bundles the installed CLI, passes parity, and retargets both bin wrappers", async () => {
+    const bundleDir = await stageFakeInstalledCli(FAKE_CLI_SOURCE);
+
+    await bundleInstalledVaultCliBinary(bundleDir);
+
+    const bundledEntry = path.join(
+      bundleDir,
+      "node_modules",
+      "@murphai",
+      "murph",
+      ".bundle",
+      "bin.js",
+    );
+    await access(bundledEntry);
+
+    for (const binName of ["vault-cli", "murph"]) {
+      const wrapper = await readFile(
+        path.join(bundleDir, "node_modules", ".bin", binName),
+        "utf8",
+      );
+      expect(wrapper).toContain("../@murphai/murph/.bundle/bin.js");
+    }
+
+    // The bundled binary must resolve ../package.json from its on-disk
+    // location exactly like the unbundled one.
+    const output = execFileSync(process.execPath, [bundledEntry, "--help"], {
+      encoding: "utf8",
+    });
+    expect(JSON.parse(output)).toEqual({ args: ["--help"], version: "9.9.9" });
+  });
+
+  it("fails the assembly when bundled output diverges from the unbundled binary", async () => {
+    const bundleDir = await stageFakeInstalledCli(DIVERGENT_CLI_SOURCE);
+
+    await expect(bundleInstalledVaultCliBinary(bundleDir)).rejects.toThrow(
+      /Bundled vault-cli output diverged/,
+    );
+  });
+
+  it("fails fast when the installed CLI entry is missing", async () => {
+    const bundleDir = await mkdtemp(path.join(tmpdir(), "murph-runner-cli-bundle-"));
+    temporaryDirectories.push(bundleDir);
+
+    await expect(bundleInstalledVaultCliBinary(bundleDir)).rejects.toThrow();
+  });
+});

--- a/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
@@ -44,6 +44,17 @@ const DIVERGENT_CLI_SOURCE = [
   "",
 ].join("\n");
 
+// Same divergence, but on stderr with empty stdout and a nonzero exit — the
+// exact shape of the scoped no-vault probes.
+const STDERR_DIVERGENT_CLI_SOURCE = [
+  "import { createRequire } from 'node:module';",
+  "const require = createRequire(import.meta.url);",
+  "require('../package.json');",
+  "console.error(import.meta.url);",
+  "process.exitCode = 1;",
+  "",
+].join("\n");
+
 async function stageFakeInstalledCli(cliSource: string): Promise<string> {
   const bundleDir = await mkdtemp(path.join(tmpdir(), "murph-runner-cli-bundle-"));
   temporaryDirectories.push(bundleDir);
@@ -53,7 +64,12 @@ async function stageFakeInstalledCli(cliSource: string): Promise<string> {
   await mkdir(path.join(bundleDir, "node_modules", ".bin"), { recursive: true });
   await writeFile(
     path.join(cliPackageDir, "package.json"),
-    JSON.stringify({ name: "@murphai/murph", type: "module", version: "9.9.9" }),
+    JSON.stringify({
+      bin: { murph: "dist/bin.js", "vault-cli": "dist/bin.js" },
+      name: "@murphai/murph",
+      type: "module",
+      version: "9.9.9",
+    }),
     "utf8",
   );
   await writeFile(path.join(cliPackageDir, "dist", "bin.js"), cliSource, "utf8");
@@ -91,11 +107,25 @@ describe("runner bundle vault-cli esbuild step", () => {
     await access(bundledEntry);
 
     for (const binName of ["vault-cli", "murph"]) {
-      const wrapper = await readFile(
-        path.join(bundleDir, "node_modules", ".bin", binName),
-        "utf8",
-      );
+      const wrapperPath = path.join(bundleDir, "node_modules", ".bin", binName);
+      const wrapper = await readFile(wrapperPath, "utf8");
       expect(wrapper).toContain("../@murphai/murph/.bundle/bin.js");
+
+      // Execute the wrapper itself, exactly as the hosted runtime does via
+      // PATH — this catches shebang, chmod, and relative-path regressions
+      // that reading the wrapper text cannot.
+      const wrapperOutput = execFileSync(wrapperPath, ["--help"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: path.join(bundleDir, ".parity-probe-home"),
+          VAULT: "",
+        },
+      });
+      expect(JSON.parse(wrapperOutput)).toEqual({
+        args: ["--help"],
+        version: "9.9.9",
+      });
     }
 
     // The bundled binary must resolve ../package.json from its on-disk
@@ -113,6 +143,17 @@ describe("runner bundle vault-cli esbuild step", () => {
 
   it("fails the assembly when bundled output diverges from the unbundled binary", async () => {
     const bundleDir = await stageFakeInstalledCli(DIVERGENT_CLI_SOURCE);
+
+    await expect(bundleInstalledVaultCliBinary(bundleDir)).rejects.toThrow(
+      /Bundled vault-cli output diverged/,
+    );
+  });
+
+  // The scoped no-vault probes exit nonzero with their error on stderr and an
+  // empty stdout, so stderr must participate in parity — otherwise a broken
+  // bundled graph that fails differently still "matches".
+  it("fails the assembly when only stderr diverges between the binaries", async () => {
+    const bundleDir = await stageFakeInstalledCli(STDERR_DIVERGENT_CLI_SOURCE);
 
     await expect(bundleInstalledVaultCliBinary(bundleDir)).rejects.toThrow(
       /Bundled vault-cli output diverged/,

--- a/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
@@ -19,11 +19,17 @@ afterEach(async () => {
 
 // A miniature installed CLI that exercises the two bundle hazards the real
 // vault-cli has: createRequire(import.meta.url) + require('../package.json'),
-// and a deterministic response for every parity probe.
+// and a deterministic response for every parity probe. The hermeticity
+// tripwire emits a location-dependent line whenever a probe inherits operator
+// config (HOME or VAULT) from the assembling machine, so a regression in the
+// probes' env overrides surfaces as parity divergence.
 const FAKE_CLI_SOURCE = [
   "import { createRequire } from 'node:module';",
   "const require = createRequire(import.meta.url);",
   "const packageJson = require('../package.json');",
+  "if (!(process.env.HOME ?? '').endsWith('.parity-probe-home') || process.env.VAULT !== '') {",
+  "  console.log(import.meta.url);",
+  "}",
   "console.log(JSON.stringify({ args: process.argv.slice(2), version: packageJson.version }));",
   "",
 ].join("\n");
@@ -56,10 +62,23 @@ async function stageFakeInstalledCli(cliSource: string): Promise<string> {
 }
 
 describe("runner bundle vault-cli esbuild step", () => {
-  it("bundles the installed CLI, passes parity, and retargets both bin wrappers", async () => {
+  it("bundles the installed CLI, passes parity hermetically, and retargets both bin wrappers", async () => {
     const bundleDir = await stageFakeInstalledCli(FAKE_CLI_SOURCE);
 
-    await bundleInstalledVaultCliBinary(bundleDir);
+    // Simulate an operator vault configured on the assembling machine: the
+    // parity probes must not see it (the fake CLI's tripwire would otherwise
+    // diverge and fail the bundle step).
+    const previousVault = process.env.VAULT;
+    process.env.VAULT = path.join(bundleDir, "operator-vault-must-not-leak");
+    try {
+      await bundleInstalledVaultCliBinary(bundleDir);
+    } finally {
+      if (previousVault === undefined) {
+        delete process.env.VAULT;
+      } else {
+        process.env.VAULT = previousVault;
+      }
+    }
 
     const bundledEntry = path.join(
       bundleDir,
@@ -83,6 +102,11 @@ describe("runner bundle vault-cli esbuild step", () => {
     // location exactly like the unbundled one.
     const output = execFileSync(process.execPath, [bundledEntry, "--help"], {
       encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: path.join(bundleDir, ".parity-probe-home"),
+        VAULT: "",
+      },
     });
     expect(JSON.parse(output)).toEqual({ args: ["--help"], version: "9.9.9" });
   });
@@ -100,5 +124,53 @@ describe("runner bundle vault-cli esbuild step", () => {
     temporaryDirectories.push(bundleDir);
 
     await expect(bundleInstalledVaultCliBinary(bundleDir)).rejects.toThrow();
+  });
+
+  // The parity battery compares bundled vs unbundled output, so a probe whose
+  // command was renamed away makes BOTH sides emit the same command-not-found
+  // error and the battery silently stops exercising the scoped module graph.
+  // Pin every scoped probe to a literal command path in the vault-cli command
+  // manifest so a rename fails here instead.
+  it("aims every scoped parity probe at a real vault-cli command path", async () => {
+    const bundleCliSource = await readFile(
+      new URL("../scripts/runner-bundle/bundle-cli.ts", import.meta.url),
+      "utf8",
+    );
+    const probesSection = bundleCliSource
+      .split("VAULT_CLI_BUNDLE_PARITY_PROBES")[1]
+      ?.split("];")[0];
+    expect(probesSection).toBeDefined();
+    const parityProbes = [...(probesSection ?? "").matchAll(/\[([^\][]+)\]/g)]
+      .map((arrayMatch) => JSON.parse(`[${arrayMatch[1]}]`) as string[])
+      .filter((probe) => probe.length > 0);
+    expect(parityProbes).toContainEqual(["--help"]);
+    const scopedProbes = parityProbes.filter((probe) => !probe[0]?.startsWith("-"));
+    expect(scopedProbes.length).toBeGreaterThan(0);
+
+    const manifestSource = await readFile(
+      new URL(
+        "../../../packages/cli/src/vault-cli-command-manifest.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const manifestCommandPaths = [
+      ...manifestSource.matchAll(/path: \[([^\]]+)\]/g),
+    ].map((pathMatch) =>
+      [...pathMatch[1].matchAll(/'([^']+)'/g)].map((segment) => segment[1]),
+    );
+    expect(manifestCommandPaths.length).toBeGreaterThan(50);
+
+    for (const probe of scopedProbes) {
+      const startsWithManifestCommandPath = manifestCommandPaths.some(
+        (commandPath) =>
+          commandPath.length > 0 &&
+          commandPath.every((segment, index) => probe[index] === segment),
+      );
+      expect(
+        startsWithManifestCommandPath,
+        `parity probe \`${probe.join(" ")}\` does not start with any command path from the vault-cli command manifest`,
+      ).toBe(true);
+    }
   });
 });

--- a/packages/runtime-state/src/sqlite.ts
+++ b/packages/runtime-state/src/sqlite.ts
@@ -7,7 +7,11 @@ type DatabaseSync = import("node:sqlite").DatabaseSync;
 
 installSqliteExperimentalWarningFilter();
 
-const { DatabaseSync: NodeSqliteDatabaseSync } = await import("node:sqlite");
+// process.getBuiltinModule keeps statement order (the warning filter above must
+// install before node:sqlite first loads) without top-level await, which would
+// poison every downstream module graph for single-file bundlers.
+const { DatabaseSync: NodeSqliteDatabaseSync } =
+  process.getBuiltinModule("node:sqlite");
 
 export const DEFAULT_SQLITE_TIMEOUT_MS = 5_000;
 

--- a/packages/runtime-state/test/sqlite-warning-filter.test.ts
+++ b/packages/runtime-state/test/sqlite-warning-filter.test.ts
@@ -22,7 +22,6 @@ describe("runtime-state sqlite warning filter", () => {
     process.emitWarning = originalEmitWarning;
     delete (process as ProcessWithSqliteWarningFilterFlag)[SQLITE_WARNING_FILTER_FLAG];
     delete (process as ProcessWithSqliteWarningFilterFlag)[SQLITE_WARNING_FILTER_INCLUDES_FLAG];
-    vi.doUnmock("node:sqlite");
   });
 
   it("suppresses only the sqlite experimental warning", async () => {
@@ -117,26 +116,31 @@ describe("runtime-state sqlite warning filter", () => {
     expect(process.emitWarning).toBe(includesWrappedEmitWarning);
   });
 
-  it("installs the sqlite warning filter before importing node:sqlite", async () => {
+  it("installs the sqlite warning filter before node:sqlite first loads", async () => {
     const forwardedWarnings: unknown[][] = [];
 
     process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
       forwardedWarnings.push([warning, ...args]);
     }) as typeof process.emitWarning;
 
-    vi.doMock("node:sqlite", () => {
-      process.emitWarning(
-        "SQLite is an experimental feature and might change at any time",
-        "ExperimentalWarning",
-      );
-
-      return {
-        DatabaseSync: class FakeDatabaseSync {},
-      };
-    });
+    // src/sqlite.ts loads node:sqlite through process.getBuiltinModule (no
+    // top-level await), which bypasses vitest module mocks, so this test
+    // exercises the real builtin: its ExperimentalWarning fires synchronously
+    // through process.emitWarning on first load. Guard against vacuity first —
+    // the ordering invariant is only provable on the first node:sqlite load in
+    // this process. moduleLoadList is real but untyped in @types/node.
+    const processWithModuleLoadList = process as NodeJS.Process & {
+      moduleLoadList?: readonly string[];
+    };
+    expect(processWithModuleLoadList.moduleLoadList ?? []).not.toContain(
+      "NativeModule sqlite",
+    );
 
     await import("../src/sqlite.ts");
 
+    expect(processWithModuleLoadList.moduleLoadList ?? []).toContain(
+      "NativeModule sqlite",
+    );
     expect(forwardedWarnings).toEqual([]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@types/node':
         specifier: ^25.6.2
         version: 25.6.2
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.4
       tsx:
         specifier: ^4.20.6
         version: 4.21.0


### PR DESCRIPTION
> Stacked on #131 (import hygiene) — review/merge that first; this PR's base is its branch.

## Why

Even after #131, every vault-cli invocation in the 1-vCPU runner pays per-file module-loading overhead: ESM resolution, stat/open syscalls, parse across hundreds of small dist files — and container file I/O is far slower than a laptop. Bundling collapses that. Measured in the runner base image (docker `--cpus=1`, qemu amd64, 3-run averages):

| Variant | scoped `wearables day` | full `--help` |
|---|---|---|
| unbundled dist | 888ms | 1610ms |
| **split bundle** | **778ms (−12%)** | **1190ms (−26%)** |
| NODE_COMPILE_CACHE (either) | within noise | within noise |

`NODE_COMPILE_CACHE` was re-evaluated on this exact bundle and confirmed a no-op in-container (matching the 2026-06-10 finding recorded in `container-image-contract.test.ts` — module eval dominates; the cache only skips parse/compile). Intentionally not shipped.

## What

- **`apps/cloudflare/scripts/runner-bundle/bundle-cli.ts` (new)**: at runner-bundle assembly time (CI, before docker build), esbuild-bundle the installed `@murphai/murph` CLI with `--splitting` into `node_modules/@murphai/murph/.bundle/` (~126 chunks; scoped lazy loading preserved), then retarget the `vault-cli`/`murph` bin wrappers. `ink`/`react-devtools-core` stay external (yoga-layout's TLA WASM and react stay out of the bundle; they resolve from installed node_modules only on the lazy interactive-chat path).
- **Assembly-time byte-parity battery**: bundled vs unbundled stdout + exit status must match for `--help`, `--llms`, `--llms-full --format json`, and two scoped probes (`wearables day`, `meal totals`) that exercise routing, loader-backed services, and the lazy runtime imports. Divergence fails the assembly — this fences the silent-exit-0 failure class observed during prototyping.
- **`packages/runtime-state/src/sqlite.ts`**: replace top-level `await import("node:sqlite")` with `process.getBuiltinModule("node:sqlite")`. Statement ordering (warning filter installs before node:sqlite loads) is preserved without top-level await, which poisoned every downstream module graph for single-file bundlers (esbuild's lazy-init for TLA-infected dynamic-import targets never settles → silent exit 0).
- esbuild `^0.27.4` devDependency in apps/cloudflare (+ lockfile); `buildPortableNodeBinWrapper` exported from runtime-shape.

Bundle hazards found during prototyping and handled structurally: tsconfig `paths` leaking workspace TypeScript sources into the bundle (neutralized with `tsconfigRaw: "{}"`, matching the installed dist-only layout), and `createRequire(import.meta.url)` + `require('../package.json')` (bundle dir placed at package root so relative resolution holds).

## Verification

- Real `runner:bundle:assemble-only` run green with the new step: 126 chunks, parity battery passed, wrappers retargeted.
- New `apps/cloudflare/test/runner-bundle-cli-bundle.test.ts` (3 tests): happy path incl. `../package.json` resolution from the bundled location, parity-divergence rejection, missing-entry failure.
- `pnpm test:diff` over touched files: apps/cloudflare + packages/cli + assistant-cli green. One known-environmental failure: `assistant-engine/test/assistant-cli-surface-bootstrap.test.ts` asserts the repo root matches `/murph(-suffix)?$/` and fails in this worktree by name alone — reproduced identically at HEAD with zero changes; CI checkout is named `murph` and will be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783793072&installation_id=127572939&pr_number=134&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F134&signature=edabb676d9ce056b35a59e5bd67dc92fd71ef5c0cff93d5e5cc84192830d4443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->