### PR TITLE
fix(web): blur OTP input on completion to dismiss iOS autofill selection handles

### DIFF
--- a/apps/web/src/components/hosted-onboarding/hosted-verification-code-step.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-verification-code-step.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode, Ref } from "react";
-import { useId } from "react";
+import type { ReactNode, RefObject } from "react";
+import { useId, useRef } from "react";
 
 import { Button } from "@/src/components/ui/button";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/src/components/ui/input-otp";
@@ -33,12 +33,23 @@ export function HostedVerificationCodeStep({
   primaryActionPendingLabel: string;
   secondaryAction?: ReactNode;
   size?: "default" | "compact";
-  inputRef?: Ref<HTMLInputElement>;
+  inputRef?: RefObject<HTMLInputElement | null>;
   onCodeChange: (value: string) => void;
   onResendCode: () => void;
   onSubmit: () => void;
 }) {
   const codeInputId = useId();
+  const localInputRef = useRef<HTMLInputElement | null>(null);
+  const codeInputRef = inputRef ?? localInputRef;
+  // iOS draws native selection handles over the OTP boxes after one-time-code
+  // autofill (input-otp keeps a ranged selection on its hidden input, and CSS
+  // cannot hide the handles; see input-otp issues #75 and #110). Blurring on
+  // completion dismisses them, along with the keyboard, while the code
+  // auto-submits.
+  const handleComplete = () => {
+    codeInputRef.current?.blur();
+    onSubmit();
+  };
 
   return (
     <>
@@ -63,11 +74,11 @@ export function HostedVerificationCodeStep({
           data-1p-ignore
           data-lpignore="true"
           maxLength={CODE_LENGTH}
-          ref={inputRef}
+          ref={codeInputRef}
           value={code}
           disabled={disabled}
           onChange={onCodeChange}
-          onComplete={onSubmit}
+          onComplete={handleComplete}
         >
           <InputOTPGroup className="w-full justify-center gap-2">
             {Array.from({ length: CODE_LENGTH }, (_, index) => (


### PR DESCRIPTION
## Problem

On iOS, after autofilling the SMS verification code from Messages, native blue selection handles appear over the OTP boxes on the login/signup modal.

## Root cause

The `input-otp` library renders an invisible real `<input>` over the six boxes and continuously keeps a **ranged text selection** on it (via `setSelectionRange`) to track the active slot. The library hides the selection highlight with CSS, but the blue grabber handles are native iOS chrome that CSS cannot hide. They normally don't render for programmatic selections, but after one-time-code autofill WebKit treats the resulting selection as user-initiated and draws them. Known upstream, unfixed: [input-otp#75](https://github.com/guilhermerodz/input-otp/issues/75), [input-otp#110](https://github.com/guilhermerodz/input-otp/issues/110).

## Fix

Blur the hidden input in `onComplete`, before calling `onSubmit`. Selection handles only render on focused fields, and the form auto-submits at completion anyway, so the keyboard dismissing is desirable. The blur runs in a passive effect strictly **after** the autofilled value has propagated to state, so it cannot break autofill. Covers all three flows that share `HostedVerificationCodeStep`: phone auth, email auth, and email settings verification.

`inputRef` was narrowed from `Ref` to `RefObject` (both existing callers pass plain `useRef` objects) with a local fallback ref when absent.

## Verification

- `pnpm test:diff apps/web/...` (apps/web verify lane incl. next build) ✅
- eslint (incl. React Compiler rules) + tsc clean ✅
- frontend-review audit pass: no blockers/majors; confirmed both ref-reading callers read `.value` which survives blur, and that `disabled` was already force-blurring the input during submit pre-change, so error-path retry UX is unchanged
- Residual: needs a one-time check on a real iPhone after deploy (iOS autofill can't be reproduced locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783801272&installation_id=127572939&pr_number=136&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F136&signature=dd7a8a73e1ccd14b5214b2ef05cdd3ecdbfe39e3e4bda051d8dd3c5b39cdbec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->