### PR TITLE
fix(hosted-local): keep per-class runner images distinct and stream docker-events forensics

### DIFF
--- a/Dockerfile.cloudflare-hosted-runner
+++ b/Dockerfile.cloudflare-hosted-runner
@@ -17,5 +17,17 @@ ARG HOSTED_RUNNER_LOCAL_BUILD_ID=local
 
 LABEL murph.hosted.local-build-id="${HOSTED_RUNNER_LOCAL_BUILD_ID}"
 
+# Differentiates the per-class image config so sibling container classes built
+# from this shared Dockerfile (RunnerContainer, DeploySmokeRunnerContainer)
+# never share a Docker image ID in local dev. wrangler dev's duplicate-tag
+# cleanup (`cleanupDuplicateImageTags` in @cloudflare/containers-shared) runs
+# `docker rmi` on every other `cloudflare-dev/*` tag pointing at the same image
+# ID, which untagged the runner image right after the deploy-smoke image build
+# and made hosted-local cold starts fail with
+# "No such image available named cloudflare-dev/runnercontainer:<tag>".
+ARG HOSTED_RUNNER_CONTAINER_CLASS=RunnerContainer
+
+LABEL murph.hosted.container-class="${HOSTED_RUNNER_CONTAINER_CLASS}"
+
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]
 CMD ["node", "dist/container-entrypoint.js"]

--- a/agent-docs/exec-plans/completed/2026-06-11-hosted-e2e-exit137-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-06-11-hosted-e2e-exit137-diagnostics.md
@@ -131,4 +131,4 @@ settle poll" covers the right surface.
 
 ## State
 
-Active. Changes left uncommitted per task instruction.
+Completed in PR #137. Shape B is fixed here; Shape C is handed off to the hosted-runner destroy-timeout lane (see handoff section).

--- a/agent-docs/exec-plans/completed/2026-06-11-hosted-e2e-exit137-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-06-11-hosted-e2e-exit137-diagnostics.md
@@ -1,0 +1,134 @@
+# Hosted-local E2E exit-137 container flake: root cause + docker forensics
+
+## Problem
+
+Hosted-local E2E CI lanes flaked four times on 2026-06-11 with hosted runner
+containers dying at exit code 137 (SIGKILL). An old note blamed "OOM at cold
+start"; that was unverified. Evidence (CI jobs 80876196374, 80890585563,
+80879600241) shows three distinct shapes that all log a 137 signature.
+
+## Evidence and proven causes
+
+### Shape A — benign: every local `destroy()` is a docker force-remove SIGKILL
+
+`ctx.container.destroy()` in wrangler local dev is implemented by workerd's
+docker client (`workerd 1.20260507.1`, `src/workerd/server/container-client.c++`)
+as `DELETE /containers/<name>?force=true` (`removeContainer`, line 609-630;
+`destroy`, line 2345-2360). Docker force-remove sends SIGKILL immediately — no
+SIGTERM, no grace period. Local repro: `docker events` shows `kill 9` → `die
+137` ~135ms after the DELETE on a healthy container whose SIGTERM trap never
+fires. This matches every CI `requested-nonzero-stop`/`exitCode:137` warning
+(destroy→onStop latencies 69–132ms across all three jobs). These warnings are
+expected local-dev semantics, not OOM and not slow entrypoint shutdown. The
+"SIGTERM grace escalation" hypothesis is disproven for local dev: SIGTERM is
+never sent, so `container-entrypoint.ts` shutdown handling is never exercised
+by destroy.
+
+### Shape B — test-killing: runner image tag removed by wrangler dev (job 80890585563)
+
+Both container classes (`RunnerContainer`, `DeploySmokeRunnerContainer`) build
+from the same Dockerfile/context/build-args, so both builds produce one Docker
+image ID with two `cloudflare-dev/*` tags (CI logs show identical
+`writing image sha256:…` for both builds). wrangler 4.90.0's
+`cleanupDuplicateImageTags` (containers-shared `utils.ts`; runs after each
+image build in `prepareContainerImagesForDev`) executes `docker rmi` on every
+other `cloudflare-dev*` tag pointing at the same image ID — untagging
+`cloudflare-dev/runnercontainer:<tag>` right after the deploy-smoke build.
+The next runner cold start then fails in workerd `createContainer` with
+"No such image available named cloudflare-dev/runnercontainer:150ccde4"
+(`container-client.c++:1744`), the floating `container.start()` rejection logs
+as an uncaught error, the monitor guard rejects "Container failed to start"
+(`container-client.c++:2328`), and every wake retries with
+`container_rpc_error` for ~2 minutes until "Timed out waiting for hosted
+runtime processing to be accepted after retry_later".
+
+Deterministic local repro: two identical builds share an image ID with
+unprefixed `RepoTags`; `docker rmi <runner tag>` untags it; container create
+returns 404 "No such image". Why some runs survive (jobs 1/3 ran runner
+containers fine after the same dual build) is not fully explained — the new
+docker-events forensics records `tag`/`untag`/`delete` image events with
+timestamps so the next occurrence settles it. Upstream bug candidate worth
+reporting to wrangler: `cleanupDuplicateImageTags` assumes same-ID tags are
+stale duplicates, which is false when sibling container classes share a
+Dockerfile.
+
+### Shape C — test-killing: SIGKILL lands on a freshly recreated same-name container (jobs 80876196374, 80879600241)
+
+Identical fingerprint in both jobs: a warm invocation fails → DO requests a
+fail-closed destroy → `destroyIfRunning` races `this.destroy()` against the
+onStop settle poll and the settle wins in 88–132ms (`settleReason: "onStop"`),
+abandoning the native destroy RPC mid-flight
+(`apps/cloudflare/src/runner-container.ts:1255-1295`) → the DO immediately
+cold-starts a NEW docker container under the SAME deterministic per-DO name →
+748–857ms into readiness polling the new container dies with monitor rejection
+"Container exited with unexpected exit code: 137", with no destroy requested by
+the DO (no `destroy-requested` log between the cold start and the kill).
+
+The kill is a docker-level SIGKILL. The only SIGKILL issuers are force-removes
+keyed by the deterministic container NAME, and workerd has three unguarded
+stale-removal paths at the pinned version: (1) the abandoned/cancelled destroy
+RPC whose daemon-side DELETE proceeds after cancellation, (2)
+`KJ_DEFER … waitUntilTasks.add(destroyContainer())` fired when a start RPC
+fails or is cancelled (`container-client.c++:2259`), and (3) the
+`~ContainerClient` destructor cleanup (`container-client.c++:974`) whose
+pending promise a successor client may cancel without cancelling the
+daemon-side operation. Docker resolves the name at DELETE-handling time, so a
+delayed force-remove kills whichever container currently owns the name — the
+new one. Host-OOM is implausible on the evidence: kills land only on
+fresh containers ~800ms after a destroy of the same name while much larger
+processes survive, and workerd sets no container memory limit (no cgroup OOM
+possible; `HostConfig` carries only `RestartPolicy: on-failure`).
+
+Not yet proven: which of the three stale-removal paths fired. The docker-events
+forensics (container `kill` events carry the signal, `die` events carry the
+exit code, `oom` events flag cgroup OOM, all with container IDs) makes the next
+occurrence attributable from CI logs alone and definitively kills or confirms
+the OOM hypothesis.
+
+## Changes
+
+- `packages/hosted-local-harness/src/dev-hosted-local/runtime.ts`: new
+  `spawnHostedLocalDockerEventsForensics` — streams
+  `docker events --format {{json .}}` filtered to container/image lifecycle
+  actions (create/start/kill/die/stop/destroy/oom/tag/untag/delete) through the
+  existing redacted child-log piping under the `docker-events` prefix.
+- `packages/hosted-local-harness/src/dev-hosted-local/stack.ts`: spawns the
+  forensics child before wrangler dev (so image builds and tag cleanup are
+  captured), keeps it out of the fail-fast `children` set, terminates it in
+  `kill`/`stop`/startup-failure paths, and includes it in failure-report tails.
+- `packages/hosted-local-harness/src/dev-hosted-local/types.ts`: adds the
+  `docker-events` child process name.
+- `Dockerfile.cloudflare-hosted-runner` +
+  `packages/hosted-local-harness/src/dev-hosted-local/environment.ts`: per-class
+  `HOSTED_RUNNER_CONTAINER_CLASS` build arg feeding a label, so the two class
+  images can never share a Docker image ID in local dev — making wrangler's
+  duplicate-tag `docker rmi` a no-op (fixes shape B). Verified locally:
+  identical builds differing only in this build arg produce distinct image IDs
+  and disjoint `RepoTags`.
+
+## Handoff to the hosted-runner-destroy-timeout lane (owns `runner-container.ts`)
+
+Shape C's durable correction belongs to that lane's in-flight work on bounding
+destroys: `destroyIfRunning` must not let the cold-start path proceed on
+`settleReason: "onStop"` alone while the native `this.destroy()` RPC is still
+pending — onStop only proves the old process exited, not that the
+name-keyed docker force-remove has finished (or was safely cancelled). Either
+await the retained `destroyRequest` promise (bounded) before any
+`startAndWaitForPorts` on the same DO, or treat an unsettled destroy as
+`warmShellInvalidatedByUnsettledDestroy` and refuse the immediate same-name
+restart. Their existing plan step "destroy requests are bounded before the
+settle poll" covers the right surface.
+
+## Verification
+
+- Mechanism repros (local docker): force-remove SIGKILL semantics
+  (`kill 9`/`die 137`, ~135ms, SIGTERM trap untriggered); duplicate-tag
+  untag → create 404 "No such image"; per-class build arg → distinct image IDs.
+- `pnpm --dir packages/hosted-local-harness exec vitest run
+  test/dev-hosted-local/stack.test.ts test/dev-hosted-local/environment.test.ts`
+  — 123/123 pass (includes new per-class image_vars assertions).
+- `pnpm test:diff` over the changed files.
+
+## State
+
+Active. Changes left uncommitted per task instruction.

--- a/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
@@ -924,6 +924,13 @@ export function buildWranglerLocalDevConfig(
     image: runnerContainerImage,
     image_build_context: runnerContainerImageBuildContext,
     image_vars: {
+      // The per-class build arg keeps the two class images' Docker image IDs
+      // distinct. Without it, wrangler dev's duplicate-tag cleanup
+      // (`cleanupDuplicateImageTags`) untags the runner image right after the
+      // deploy-smoke image build (both tags point at one image ID), and hosted
+      // cold starts then fail with "No such image available named
+      // cloudflare-dev/runnercontainer:<tag>" until the harness times out.
+      HOSTED_RUNNER_CONTAINER_CLASS: input.className,
       HOSTED_RUNNER_LOCAL_BUILD_ID: hostedRunnerLocalBuildId,
     },
     instance_type: "standard-1",

--- a/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
@@ -423,6 +423,59 @@ export function spawnChildProcess(
   };
 }
 
+// Container/image lifecycle actions worth keeping in CI logs. `kill` carries
+// the delivered signal, `die` carries the exit code, `oom` marks cgroup OOM
+// kills, and `tag`/`untag`/`delete` expose image-tag churn (wrangler dev's
+// duplicate-tag cleanup untagging a runner image mid-session). High-churn
+// noise such as health-check `exec_*` events is intentionally excluded.
+const HOSTED_LOCAL_DOCKER_FORENSICS_EVENTS = [
+  "create",
+  "start",
+  "kill",
+  "die",
+  "stop",
+  "destroy",
+  "oom",
+  "tag",
+  "untag",
+  "delete",
+] as const;
+
+// Streams `docker events` for the lifetime of the hosted-local dev stack so a
+// container that exits 137 (SIGKILL) is attributable from CI logs alone:
+// the event stream shows which container/image got which action, the signal
+// behind a kill, the exit code behind a die, and whether an OOM kill occurred.
+// Locally and in CI the only SIGKILL paths are docker force-removes keyed by
+// the deterministic per-DO container name, which this stream timestamps.
+// Diagnostics-only: the child must never gate stack startup or teardown, so
+// callers keep it out of the fail-fast `children` set.
+export function spawnHostedLocalDockerEventsForensics(
+  env: NodeJS.ProcessEnv,
+  input: {
+    pipeOutput?: boolean;
+    stderrTarget?: NodeJS.WritableStream;
+    stdoutTarget?: NodeJS.WritableStream;
+  } = {},
+): BufferedNamedChildProcess {
+  const forensics = spawnChildProcess("docker-events", "docker", [
+    "events",
+    "--format",
+    "{{json .}}",
+    "--filter",
+    "type=container",
+    "--filter",
+    "type=image",
+    ...HOSTED_LOCAL_DOCKER_FORENSICS_EVENTS.flatMap((event) => [
+      "--filter",
+      `event=${event}`,
+    ]),
+  ], env, input);
+  // Diagnostics must stay best-effort: a missing/failing docker CLI here must
+  // not crash the harness with an unhandled "error" event.
+  forensics.child.once("error", () => {});
+  return forensics;
+}
+
 export async function waitForFirstChildExit(
   children: readonly NamedChildProcess[],
 ): Promise<NamedChildProcess> {

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -593,7 +593,11 @@ export async function startHostedLocalDevStack(input: {
     // Start docker lifecycle forensics before wrangler dev so the stream also
     // captures its container image builds and (buggy) duplicate-tag cleanup.
     // Kept out of `children`: a forensics hiccup must not fail the stack.
+    // Gated to E2E-isolated runs (plus an explicit opt-in) because the stream
+    // observes the whole Docker daemon: an ordinary local dev stack should not
+    // log unrelated local container/image lifecycle metadata by default.
     dockerEventsProcess = workerRuntimeEnv === null
+      || !shouldStreamHostedLocalDockerEventsForensics(initialEnv)
       ? null
       : spawnHostedLocalDockerEventsForensics(workerProcessEnv ?? workerRuntimeEnv, {
         pipeOutput: input.pipeOutput,
@@ -872,6 +876,12 @@ export async function startHostedLocalDevStack(input: {
       return await stopPromise;
     };
 
+    const buildReportingChildren = (): BufferedNamedChildProcess[] => [
+      ...children,
+      ...(stripeListener === null ? [] : [stripeListener]),
+      ...(dockerEventsProcess === null ? [] : [dockerEventsProcess]),
+    ];
+
     const ready = (async (): Promise<void> => {
       try {
         const healthChecks = [
@@ -925,18 +935,18 @@ export async function startHostedLocalDevStack(input: {
         if (!stopped) {
           await stop("SIGTERM");
         }
+        // Startup failures are exactly where the docker-events forensics
+        // matter (image untags, cold-start kills), so the rejection
+        // diagnostics must include that stream, not just the fail-fast
+        // children.
         throw appendStartupDiagnostics(error, await collectDockerDevDiagnostics({
           cwd: repoRoot,
           env: workerProcessEnv ?? workerRuntimeEnv ?? undefined,
-        }), children);
+        }), buildReportingChildren());
       }
     })();
 
-    const reportingChildren = [
-      ...children,
-      ...(stripeListener === null ? [] : [stripeListener]),
-      ...(dockerEventsProcess === null ? [] : [dockerEventsProcess]),
-    ];
+    const reportingChildren = buildReportingChildren();
 
     return {
       config: {
@@ -1260,6 +1270,13 @@ function assertHostedLocalE2eIsolation(
       ...failures.map((failure) => `- ${failure}`),
     ].join("\n"),
   );
+}
+
+function shouldStreamHostedLocalDockerEventsForensics(
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return requiresHostedLocalE2eIsolation(env)
+    || env.MURPH_HOSTED_LOCAL_DOCKER_EVENTS_FORENSICS === "1";
 }
 
 function requiresHostedLocalE2eIsolation(env: NodeJS.ProcessEnv): boolean {

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -61,6 +61,7 @@ import {
   resolveHostedLocalWorkerPortMode,
   runCommand,
   spawnChildProcess,
+  spawnHostedLocalDockerEventsForensics,
   spawnStripeListenerWithSecretCapture,
   StripeCliMissingError,
   terminateChildProcess,
@@ -257,6 +258,7 @@ export async function startHostedLocalDevStack(input: {
   let stopped = false;
   let stopPromise: Promise<void> | null = null;
   const children: BufferedNamedChildProcess[] = [];
+  let dockerEventsProcess: BufferedNamedChildProcess | null = null;
   let healthCommonsWatcher: BufferedNamedChildProcess | null = null;
   let linqTunnelProcess: BufferedNamedChildProcess | null = null;
   let linqWebhookSetup: HostedLocalLinqWebhookSetup | null = null;
@@ -588,6 +590,17 @@ export async function startHostedLocalDevStack(input: {
     }
     throwIfAbortSignalAborted(input.abortSignal);
 
+    // Start docker lifecycle forensics before wrangler dev so the stream also
+    // captures its container image builds and (buggy) duplicate-tag cleanup.
+    // Kept out of `children`: a forensics hiccup must not fail the stack.
+    dockerEventsProcess = workerRuntimeEnv === null
+      ? null
+      : spawnHostedLocalDockerEventsForensics(workerProcessEnv ?? workerRuntimeEnv, {
+        pipeOutput: input.pipeOutput,
+        stderrTarget: input.stderrTarget,
+        stdoutTarget: input.stdoutTarget,
+      });
+
     const cloudflareProcess = workerRuntimeEnv === null
       ? null
       : spawnChildProcess("cloudflare", "pnpm", [
@@ -745,6 +758,9 @@ export async function startHostedLocalDevStack(input: {
       if (stripeListener !== null) {
         terminateChildProcess(stripeListener.child, childSignal);
       }
+      if (dockerEventsProcess !== null) {
+        terminateChildProcess(dockerEventsProcess.child, childSignal);
+      }
       terminateKnownHostedLocalProcessResidue({
         config,
         owned: {
@@ -798,6 +814,12 @@ export async function startHostedLocalDevStack(input: {
           ),
           ...(stripeListener !== null
             ? [terminateChildProcessAndWait(stripeListener.child, { signal: childSignal })]
+            : []),
+          ...(dockerEventsProcess !== null
+            ? [
+              terminateChildProcessAndWait(dockerEventsProcess.child, { signal: childSignal })
+                .catch(() => {}),
+            ]
             : []),
         ]);
         const terminationFailure = terminationResults.find(
@@ -910,9 +932,11 @@ export async function startHostedLocalDevStack(input: {
       }
     })();
 
-    const reportingChildren = stripeListener === null
-      ? children
-      : [...children, stripeListener];
+    const reportingChildren = [
+      ...children,
+      ...(stripeListener === null ? [] : [stripeListener]),
+      ...(dockerEventsProcess === null ? [] : [dockerEventsProcess]),
+    ];
 
     return {
       config: {
@@ -959,6 +983,10 @@ export async function startHostedLocalDevStack(input: {
     }
     if (stripeListener !== null) {
       await terminateChildProcessAndWait(stripeListener.child, { signal: "SIGTERM" }).catch(() => {});
+    }
+    if (dockerEventsProcess !== null) {
+      await terminateChildProcessAndWait(dockerEventsProcess.child, { signal: "SIGTERM" })
+        .catch(() => {});
     }
     if (workerRuntimeEnv && workerPortMode === "start") {
       await cleanupHostedRunnerContainers({

--- a/packages/hosted-local-harness/src/dev-hosted-local/types.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/types.ts
@@ -35,6 +35,7 @@ export interface HostedLocalTemporalConfig {
 
 export type HostedLocalChildProcessName =
   | "cloudflare"
+  | "docker-events"
   | "health-commons"
   | "linq-tunnel"
   | "minio"
@@ -63,6 +64,7 @@ export interface HostedLocalChildProcess {
     event: "exit",
     listener: (code: number | null, signal: NodeJS.Signals | null) => void,
   ): this;
+  once(event: "error", listener: (error: Error) => void): this;
   pid?: number;
   signalCode?: NodeJS.Signals | null;
 }

--- a/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
@@ -1273,12 +1273,20 @@ describe("buildWranglerLocalDevConfig", () => {
     expect(container.image).toBe("../../../Dockerfile.cloudflare-hosted-runner");
     expect(container.image_build_context).toBe("..");
     expect(container.image_vars).toEqual({
+      HOSTED_RUNNER_CONTAINER_CLASS: "RunnerContainer",
       HOSTED_RUNNER_LOCAL_BUILD_ID: "local",
     });
     expect(smokeContainer).toMatchObject({
       image: container.image,
       image_build_context: container.image_build_context,
-      image_vars: container.image_vars,
+      // The per-class build arg must differ so the two classes never produce
+      // the same Docker image ID: wrangler dev untags duplicate
+      // cloudflare-dev tags that share one image ID, which removed the runner
+      // image tag right after the deploy-smoke image build.
+      image_vars: {
+        HOSTED_RUNNER_CONTAINER_CLASS: "DeploySmokeRunnerContainer",
+        HOSTED_RUNNER_LOCAL_BUILD_ID: "local",
+      },
       max_instances: 1,
     });
   });
@@ -1321,19 +1329,24 @@ describe("buildWranglerLocalDevConfig", () => {
     expect(productionLikeConfig.main).toBe("../src/index.ts");
   });
 
-  it("passes the local runner build id as a Docker build arg", () => {
+  it("passes the local runner build id and container class as Docker build args", () => {
     const config = buildWranglerLocalDevConfig({
       MURPH_HOSTED_RUNNER_LOCAL_BUILD_ID: "stack-test-build-id",
     });
     const containers = config.containers as {
+      class_name: string;
       image_vars: Record<string, string>;
     }[];
 
     for (const container of containers) {
       expect(container.image_vars).toEqual({
+        HOSTED_RUNNER_CONTAINER_CLASS: container.class_name,
         HOSTED_RUNNER_LOCAL_BUILD_ID: buildHostedRunnerLocalBuildId("stack-test-build-id"),
       });
     }
+    expect(
+      new Set(containers.map((entry) => entry.image_vars.HOSTED_RUNNER_CONTAINER_CLASS)).size,
+    ).toBe(containers.length);
   });
 
   it("uses an isolated worker name for E2E profiles", () => {

--- a/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
@@ -111,6 +111,22 @@ class StripeCliMissingError extends Error {
     this.name = "StripeCliMissingError";
   }
 }
+const spawnHostedLocalDockerEventsForensics = vi.fn<
+  (
+    env: NodeJS.ProcessEnv,
+    input?: {
+      pipeOutput?: boolean;
+      stderrTarget?: NodeJS.WritableStream;
+      stdoutTarget?: NodeJS.WritableStream;
+    },
+  ) => BufferedNamedChildProcess
+>(() =>
+  createBufferedChild({
+    exitCode: null,
+    name: "docker-events",
+    pid: nextChildPid++,
+  }),
+);
 const spawnStripeListenerWithSecretCapture = vi.fn<
   (input: {
     command: string;
@@ -358,6 +374,7 @@ vi.mock("../../src/dev-hosted-local/runtime.ts", () => ({
   resolveHostedLocalWorkerPortMode,
   runCommand,
   spawnChildProcess,
+  spawnHostedLocalDockerEventsForensics,
   spawnStripeListenerWithSecretCapture,
   StripeCliMissingError,
   terminateChildProcess,
@@ -614,7 +631,7 @@ describe("hosted local dev stack", () => {
       }),
     );
     expect(stack.config.workerPersistDir).toBe("/tmp/murph-dev-env-test/wrangler-state");
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
     expect(waitForHealthyHttpEndpoint).toHaveBeenCalledTimes(2);
     expect(waitForHealthyHttpEndpoint).toHaveBeenNthCalledWith(1, {
       host: "127.0.0.1",
@@ -774,7 +791,7 @@ describe("hosted local dev stack", () => {
     expect(webEnv.HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK).toBeUndefined();
     expect(stack.processes.temporalServer).toBe(temporalServer);
     expect(stack.processes.temporalWorker).toBe(temporalWorker);
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(4);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(5);
     const pkillArgs = spawnSync.mock.calls
       .filter(([command]) => command === "pkill")
       .map(([, args]) => args);
@@ -1076,7 +1093,7 @@ describe("hosted local dev stack", () => {
     const stopPromise = stack.stop();
     await Promise.resolve();
 
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
     releaseFirstTermination();
     await stopPromise;
   });
@@ -1105,10 +1122,10 @@ describe("hosted local dev stack", () => {
     const secondStop = stack.stop("SIGKILL");
     await Promise.resolve();
 
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
     releaseFirstTermination();
     await Promise.all([firstStop, secondStop]);
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
   });
 
   it("treats Ctrl-C as child termination and force-sweeps owned worker residue", async () => {
@@ -1673,7 +1690,7 @@ describe("hosted local dev stack", () => {
     });
 
     await expect(stack.ready).rejects.toThrow("fetch failed");
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(1);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
   });
 
   it("starts a managed Linq cloudflared tunnel and registers the local webhook target", async () => {
@@ -1764,7 +1781,7 @@ describe("hosted local dev stack", () => {
       spawnSync.mock.invocationCallOrder[runnerImageInspectCallIndex] ?? Number.POSITIVE_INFINITY,
     ).toBeLessThan(waitForHostedLocalLinqWebhookTarget.mock.invocationCallOrder[0]);
     expect(stack.processes.linqTunnel?.name).toBe("linq-tunnel");
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(4);
   });
 
   it("uses prisma migrate deploy for non-local databases instead of forcing db push", async () => {
@@ -2104,7 +2121,7 @@ describe("hosted local dev stack", () => {
 
     expect(spawnChildProcess).toHaveBeenCalledTimes(1);
     expect(waitForHealthyHttpEndpoint).toHaveBeenCalledTimes(1);
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(1);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
     expect(stack.webBaseUrl).toBeNull();
   });
 
@@ -2180,7 +2197,7 @@ describe("hosted local dev stack", () => {
     await expect(stack.ready).rejects.toThrow(
       "cloudflare dev process exited before the hosted local stack became healthy.",
     );
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
     expect(cleanupHostedRunnerContainers).toHaveBeenCalledWith(
       expect.objectContaining({
         ignoreErrors: true,

--- a/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
@@ -631,7 +631,7 @@ describe("hosted local dev stack", () => {
       }),
     );
     expect(stack.config.workerPersistDir).toBe("/tmp/murph-dev-env-test/wrangler-state");
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
     expect(waitForHealthyHttpEndpoint).toHaveBeenCalledTimes(2);
     expect(waitForHealthyHttpEndpoint).toHaveBeenNthCalledWith(1, {
       host: "127.0.0.1",
@@ -791,7 +791,7 @@ describe("hosted local dev stack", () => {
     expect(webEnv.HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK).toBeUndefined();
     expect(stack.processes.temporalServer).toBe(temporalServer);
     expect(stack.processes.temporalWorker).toBe(temporalWorker);
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(5);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(4);
     const pkillArgs = spawnSync.mock.calls
       .filter(([command]) => command === "pkill")
       .map(([, args]) => args);
@@ -1093,7 +1093,7 @@ describe("hosted local dev stack", () => {
     const stopPromise = stack.stop();
     await Promise.resolve();
 
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
     releaseFirstTermination();
     await stopPromise;
   });
@@ -1122,10 +1122,10 @@ describe("hosted local dev stack", () => {
     const secondStop = stack.stop("SIGKILL");
     await Promise.resolve();
 
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
     releaseFirstTermination();
     await Promise.all([firstStop, secondStop]);
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
   });
 
   it("treats Ctrl-C as child termination and force-sweeps owned worker residue", async () => {
@@ -1781,7 +1781,7 @@ describe("hosted local dev stack", () => {
       spawnSync.mock.invocationCallOrder[runnerImageInspectCallIndex] ?? Number.POSITIVE_INFINITY,
     ).toBeLessThan(waitForHostedLocalLinqWebhookTarget.mock.invocationCallOrder[0]);
     expect(stack.processes.linqTunnel?.name).toBe("linq-tunnel");
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(4);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
   });
 
   it("uses prisma migrate deploy for non-local databases instead of forcing db push", async () => {
@@ -2121,7 +2121,7 @@ describe("hosted local dev stack", () => {
 
     expect(spawnChildProcess).toHaveBeenCalledTimes(1);
     expect(waitForHealthyHttpEndpoint).toHaveBeenCalledTimes(1);
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(1);
     expect(stack.webBaseUrl).toBeNull();
   });
 
@@ -2176,6 +2176,60 @@ describe("hosted local dev stack", () => {
     expect(waitForHealthyHttpEndpoint).toHaveBeenCalledTimes(2);
   });
 
+  it("streams docker-events forensics only for isolated or opted-in stacks", async () => {
+    const { startHostedLocalDevStack } = await import("../../src/dev-hosted-local/stack.ts");
+
+    const stack = await startHostedLocalDevStack({
+      env: {
+        ...process.env,
+        MURPH_HOSTED_LOCAL_DOCKER_EVENTS_FORENSICS: "",
+        MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED: "",
+        MURPH_HOSTED_LOCAL_PROFILE: "",
+      },
+    });
+
+    // An ordinary dev stack must not observe the whole Docker daemon.
+    expect(spawnHostedLocalDockerEventsForensics).not.toHaveBeenCalled();
+    await stack.stop("SIGTERM");
+  });
+
+  it("includes docker-events output in startup-failure diagnostics", async () => {
+    const cloudflareChild = createBufferedChild({
+      exitCode: 1,
+      name: "cloudflare",
+      pid: 511,
+    });
+    spawnChildProcess
+      .mockReturnValueOnce(cloudflareChild)
+      .mockReturnValueOnce(createBufferedChild({ exitCode: null, name: "web", pid: 512 }));
+    spawnHostedLocalDockerEventsForensics.mockReturnValueOnce(
+      createBufferedChild({
+        exitCode: null,
+        name: "docker-events",
+        pid: 513,
+        stdoutText: '{"Action":"kill","Actor":{"Attributes":{"signal":"9"}}}',
+      }),
+    );
+    waitForHealthyHttpEndpoint.mockImplementationOnce(() => new Promise(() => {}));
+    waitForFirstChildExit.mockResolvedValueOnce(cloudflareChild);
+
+    const { startHostedLocalDevStack } = await import("../../src/dev-hosted-local/stack.ts");
+
+    const stack = await startHostedLocalDevStack({
+      env: {
+        ...process.env,
+        // The opt-in flag streams forensics without requiring full E2E
+        // isolation, which keeps this unit test independent of isolation
+        // preconditions.
+        MURPH_HOSTED_LOCAL_DOCKER_EVENTS_FORENSICS: "1",
+      },
+    });
+
+    // Startup failures (image untags, cold-start kills) are exactly what the
+    // forensics exist to explain, so the rejection itself must carry them.
+    await expect(stack.ready).rejects.toThrow(/\[docker-events:stdout\][\s\S]*"signal":"9"/u);
+  });
+
   it("fails fast and cleans up when a dev child exits before readiness", async () => {
     const cloudflareChild = createBufferedChild({
       exitCode: 1,
@@ -2197,7 +2251,7 @@ describe("hosted local dev stack", () => {
     await expect(stack.ready).rejects.toThrow(
       "cloudflare dev process exited before the hosted local stack became healthy.",
     );
-    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(3);
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
     expect(cleanupHostedRunnerContainers).toHaveBeenCalledWith(
       expect.objectContaining({
         ignoreErrors: true,


### PR DESCRIPTION
## Why

Hosted-local E2E lanes have been flaking with hosted containers dying at exit 137 (it hit 4 CI runs today alone, each passing on rerun; an old debugging note blamed "OOM at cold start"). A full evidence-path investigation found **three distinct shapes behind the one signature — and none of them are OOM** (no memory limit is even set on these containers; `docker events` shows no oom events).

**Shape A — benign local-dev noise.** In wrangler local dev, `ctx.container.destroy()` is implemented by workerd as Docker force-remove: SIGKILL immediately, no SIGTERM, no grace (proven locally: `kill 9 → die 137` in ~135ms, the entrypoint's SIGTERM trap never fires). Every `requested-nonzero-stop`/137 lifecycle warning in these lanes is expected local semantics, not a failure.

**Shape B — real, deterministically reproduced, fixed here.** Both container classes (`RunnerContainer`, `DeploySmokeRunnerContainer`) build from the same Dockerfile/context/args, producing ONE Docker image ID with two tags. wrangler dev's `cleanupDuplicateImageTags` then `docker rmi`s every other `cloudflare-dev/*` tag on that image ID — **untagging the runner image right after the deploy-smoke build**. The next cold start fails inside workerd with "No such image available named cloudflare-dev/runnercontainer:<tag>" and the wake retries `container_rpc_error` until the harness times out ("Timed out waiting for hosted runtime processing to be accepted after retry_later"). Reproduced end-to-end locally (same-ID builds → rmi untag → create 404).

**Shape C — mechanism proven, handed off.** Invoke-failure destroys settle via `onStop` in ~100ms while the native destroy RPC is abandoned mid-flight; the immediate same-name cold start then gets SIGKILLed ~800ms into readiness by a stale name-keyed force-remove. The fix belongs to `runner-container.ts`, which the active "Hosted runner destroy timeout triage" lane owns — full handoff written up in `agent-docs/exec-plans/completed/2026-06-11-hosted-e2e-exit137-diagnostics.md` (don't release the cold-start path on `settleReason:"onStop"` while the native destroy RPC is unsettled).

## What

- **Fix (Shape B):** per-class `HOSTED_RUNNER_CONTAINER_CLASS` build arg + label so the two class images never share an image ID, making wrangler's duplicate-tag rmi a no-op. Verified locally: distinct image IDs, disjoint RepoTags. Production builds are unaffected (defaulted arg, metadata-only label).
- **Forensics (all shapes):** the harness now streams `docker events` (create/start/kill+signal/die+exitCode/oom/tag/untag/delete) through the existing redacted child-log piping, wired before wrangler dev starts and included in failure tails — the next 137 occurrence is attributable from CI logs alone, including a definitive OOM verdict.

## Verification

`pnpm test:diff` over all touched files: harness typecheck + 123 tests (incl. updated image_vars/stack assertions), apps/cloudflare verify 87 files / 1361 tests, all repo guards green. Shape B repro chain and the distinct-image-ID fix both verified against local Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783802720&installation_id=127572939&pr_number=137&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F137&signature=28ac4c8c80e722899da409264fdddd13d0eff7fd2b47b1b98626a398d4acef09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->