### PR TITLE
fix(hosted): deep-review follow-ups for #147 — drain bounds, direct warn writes, presign abort, webhook trace cap

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { access, rm } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { build, type Metafile } from "esbuild";
 
@@ -176,7 +177,7 @@ function assertRunnerEntrypointBundleBoots(input: {
       encoding: "utf8",
       env: {
         ...process.env,
-        RUNNER_ENTRYPOINT_BUNDLE_PROBE_PATH: bundledEntryPath,
+        RUNNER_ENTRYPOINT_BUNDLE_PROBE_PATH: pathToFileURL(bundledEntryPath).href,
       },
       timeout: 60_000,
     },

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -301,6 +301,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
                 fetchImpl: input.fetchImpl,
                 objectKey: request.ref.objectKey,
                 ref: request.ref,
+                signal: encryptedObjectAbort.signal,
                 snapshotId: request.ref.snapshotId,
                 timeoutMs: input.timeoutMs,
                 workspaceCheckpointBridge: input.workspaceCheckpointBridge,
@@ -515,6 +516,7 @@ async function presignWorkspaceSnapshotGet(input: {
   fetchImpl: typeof fetch;
   objectKey: string;
   ref: HostedWorkspaceSnapshotV2Ref;
+  signal?: AbortSignal | null;
   snapshotId: string;
   timeoutMs: number;
   workspaceCheckpointBridge: HostedWorkspaceCheckpointBridgeAuthority;
@@ -534,6 +536,7 @@ async function presignWorkspaceSnapshotGet(input: {
     headers,
     redactedLogPath: "/workspace-snapshots/REDACTED/presign-get",
     method: "POST",
+    signal: input.signal ?? null,
     timeoutMs: input.timeoutMs,
     url: new URL(
       `/workspace-snapshots/${encodeURIComponent(input.snapshotId)}/presign-get`,

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -470,6 +470,49 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
   }, 15_000);
 
+  it("aborts the in-flight presign request when the data-key unwrap fails", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-presign-abort-"));
+    const ref = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 128,
+    });
+    let presignSignalAborted = false;
+    const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
+      const request = requireFetchRequest(args, "workspace snapshot presign abort fetch");
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
+        await delayWithAbort(50, request.signal);
+        return new Response("unwrap denied", { status: 403 });
+      }
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/presign-get`)) {
+        // Held open far beyond the test budget: only the unwrap-failure abort
+        // can settle this leg.
+        try {
+          await delayWithAbort(30_000, request.signal);
+        } catch (error) {
+          presignSignalAborted = true;
+          throw error;
+        }
+        return new Response("unreachable", { status: 500 });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    try {
+      await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
+        durableRoot: path.join(tempRoot, "durable"),
+        ref,
+        scratchRoot: path.join(tempRoot, "scratch"),
+      })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/);
+
+      expect(presignSignalAborted).toBe(true);
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  }, 15_000);
+
   it("sends direct R2 workspace snapshot PUTs with signed metadata headers", async () => {
     const encryptedBytes = new Uint8Array([1, 2, 3, 4, 5]);
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-put-"));

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
@@ -45,12 +45,23 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
 
   // The accepted-latency-trace write is observability only; run it
   // concurrently with the Temporal signal instead of serializing a DB round
-  // trip ahead of the wake. Both settle before this function returns, and the
-  // helper never rejects (it logs its own failures).
+  // trip ahead of the wake. The helper never rejects (it logs its own
+  // failures). Settling is capped: normally the write finished during the
+  // signal round trip, and a degraded latency-trace DB must not extend the
+  // webhook request lifetime (observability never gates user latency). On
+  // timeout the write keeps running for whatever remains of the request
+  // lifecycle; losing a trace row is acceptable, blocking ingress is not.
   const acceptedTraceWrite = recordHostedWebhookIngressLatencyAcceptedBestEffort({
     mailboxItemId,
     source: input.source,
   });
+  const settleAcceptedTraceWriteBounded = () =>
+    Promise.race([
+      acceptedTraceWrite,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 1_500);
+      }),
+    ]);
 
   let signal: Awaited<ReturnType<typeof signalHostedMailboxAppendRuntime>>;
   try {
@@ -59,14 +70,14 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
       mailboxItemId,
     });
   } catch (error) {
-    await acceptedTraceWrite;
+    await settleAcceptedTraceWriteBounded();
     const errorName = deriveHostedOnboardingTimingErrorName(error);
     finishHostedOnboardingTiming(handoffTiming, "failed", {
       errorName,
     });
     throw error;
   }
-  await acceptedTraceWrite;
+  await settleAcceptedTraceWriteBounded();
 
   await recordHostedWebhookIngressLatencyTemporalSignalBestEffort({
     mailboxItemId,

--- a/packages/assistant-runtime/src/hosted-invocation.ts
+++ b/packages/assistant-runtime/src/hosted-invocation.ts
@@ -94,8 +94,11 @@ export async function runHostedWorkspaceInvocation(
   } finally {
     // Info-level runtime log writes are queued off the reply hot path; flush
     // them before the invocation result commits so a normal container stop
-    // never drops queued diagnostics.
-    await drainHostedRuntimeLogWritesBestEffort();
+    // never drops queued diagnostics. Bounded so a degraded log endpoint
+    // cannot delay result commit / checkpoint / next-wake handoff; on timeout
+    // the remaining writes keep flushing in the background while the warm
+    // container lives on.
+    await drainHostedRuntimeLogWritesBestEffort({ timeoutMs: 2_000 });
   }
 }
 

--- a/packages/assistant-runtime/src/hosted-runtime/runtime-logs.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/runtime-logs.ts
@@ -29,15 +29,18 @@ export function buildHostedRuntimeLogContextFields(
 
 // Every awaited runtime log write costs a full runner->worker->web round trip
 // (~150ms in production), and several sit directly on the reply hot path
-// between mailbox import and provider start. Info-level entries are durable
-// diagnostics, not control flow: queue them so the caller returns immediately
-// while writes flush in the background in enqueue order. warn/error entries
-// still block — they are the crash-diagnostic tail and must be durable before
-// the runtime proceeds. `at` is stamped at enqueue, so persisted ordering
-// still reflects logical time. A single module-level tail is enough: hosted
-// runner processes hold one live log port per invocation, and chaining every
-// write preserves per-port enqueue order as a strict subset. The chain never
-// rejects (each write swallows its own failure).
+// between mailbox import and provider start (see the "observability writes
+// are never user latency" invariant in docs/contracts/00-invariants.md).
+// Info-level entries are durable diagnostics, not control flow: queue them so
+// the caller returns immediately while writes flush in the background in
+// enqueue order. warn/error entries write directly and block only on their
+// own write — the crash-diagnostic tail must be durable before the runtime
+// proceeds, and must not wait behind a queued info backlog. `at` is stamped
+// at enqueue, so persisted ordering still reflects logical time even when a
+// direct warn write lands before older queued info writes. A single
+// module-level tail is enough: hosted runner processes hold one live log
+// port per invocation. The chain never rejects (each write swallows its own
+// failure).
 let pendingHostedRuntimeLogWriteTail: Promise<void> = Promise.resolve();
 
 export async function writeHostedRuntimeLogBestEffort(input: {
@@ -68,23 +71,53 @@ export async function writeHostedRuntimeLogBestEffort(input: {
       });
     }
   };
-  pendingHostedRuntimeLogWriteTail = pendingHostedRuntimeLogWriteTail.then(write);
 
-  if (entry.level === "info") {
+  if (entry.level !== "info") {
+    await write();
     return;
   }
-  await pendingHostedRuntimeLogWriteTail;
+  pendingHostedRuntimeLogWriteTail = pendingHostedRuntimeLogWriteTail.then(write);
 }
 
 // Awaited at invocation end so a normal shutdown never drops queued entries.
 // Queued writes swallow their own failures, so this never rejects. Re-reads
 // the tail after each await in case settled writes enqueued more entries.
-export async function drainHostedRuntimeLogWritesBestEffort(): Promise<void> {
-  let observed: Promise<void>;
-  do {
-    observed = pendingHostedRuntimeLogWriteTail;
-    await observed;
-  } while (observed !== pendingHostedRuntimeLogWriteTail);
+// The optional bound keeps a degraded log endpoint from delaying invocation
+// completion (result commit / checkpoint / next-wake handoff): on timeout the
+// drain returns while remaining writes keep flushing in the background.
+export async function drainHostedRuntimeLogWritesBestEffort(
+  options?: { timeoutMs?: number },
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs;
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = timeoutMs === undefined
+    ? null
+    : new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          timedOut = true;
+          resolve();
+        }, timeoutMs);
+        timer.unref?.();
+      });
+
+  try {
+    let observed: Promise<void>;
+    do {
+      observed = pendingHostedRuntimeLogWriteTail;
+      await (timeout ? Promise.race([observed, timeout]) : observed);
+      if (timedOut) {
+        console.warn("Hosted runtime log drain timed out; queued writes continue in the background.", {
+          timeoutMs,
+        });
+        return;
+      }
+    } while (observed !== pendingHostedRuntimeLogWriteTail);
+  } finally {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export function compactHostedRuntimeLogCodes(codes: readonly string[]): string[] {

--- a/packages/assistant-runtime/test/hosted-runtime-log-queue.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-log-queue.test.ts
@@ -102,7 +102,7 @@ describe("hosted runtime log write queue", () => {
     expect(drainSettled()).toBe(true);
   });
 
-  it("blocks warn and error writes until queued-ahead entries and their own write are durable", async () => {
+  it("writes warn and error directly, never waiting behind a queued info backlog", async () => {
     const { port, writes } = createControlledLogPort();
 
     const infoSettled = trackSettled(writeHostedRuntimeLogBestEffort({
@@ -115,38 +115,53 @@ describe("hosted runtime log write queue", () => {
       now: () => "2026-06-12T00:00:02.000Z",
       platform: { logPort: port },
     }));
-    const errorSettled = trackSettled(writeHostedRuntimeLogBestEffort({
-      entry: buildQueueLogEntry("error"),
-      now: () => "2026-06-12T00:00:03.000Z",
-      platform: { logPort: port },
-    }));
 
     await flushMicrotasks();
     expect(infoSettled()).toBe(true);
     expect(warnSettled()).toBe(false);
-    expect(errorSettled()).toBe(false);
-    // Enqueue order is preserved: the second write may not start before the
-    // first one settles.
+    // The warn write starts immediately (synchronously, ahead of the
+    // microtask-scheduled info write): the crash-diagnostic tail must not
+    // wait behind backlog. `at` stamps preserve logical ordering for readers.
+    expect(writes).toHaveLength(2);
+    const warnWrite = writes.find((write) => write.entries[0]!.at === "2026-06-12T00:00:02.000Z");
+    const infoWrite = writes.find((write) => write.entries[0]!.at === "2026-06-12T00:00:01.000Z");
+    expect(warnWrite).toBeDefined();
+    expect(infoWrite).toBeDefined();
+
+    // The warn settles on its own write, independent of the info backlog.
+    warnWrite!.resolve();
+    await flushMicrotasks();
+    expect(warnSettled()).toBe(true);
+
+    infoWrite!.resolve();
+    await flushMicrotasks();
+    await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
+  });
+
+  it("bounded drain returns on timeout while queued writes keep flushing", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { port, writes } = createControlledLogPort();
+
+    const infoSettled = trackSettled(writeHostedRuntimeLogBestEffort({
+      entry: buildQueueLogEntry("info"),
+      now: () => "2026-06-12T00:00:06.000Z",
+      platform: { logPort: port },
+    }));
+    await flushMicrotasks();
+    expect(infoSettled()).toBe(true);
     expect(writes).toHaveLength(1);
-    expect(writes[0]!.entries[0]!.at).toBe("2026-06-12T00:00:01.000Z");
+
+    // The queued write never resolves within the bound: the drain must
+    // return (not hang) and warn that writes continue in the background.
+    await drainHostedRuntimeLogWritesBestEffort({ timeoutMs: 20 });
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "Hosted runtime log drain timed out; queued writes continue in the background.",
+      { timeoutMs: 20 },
+    );
 
     writes[0]!.resolve();
     await flushMicrotasks();
-    expect(warnSettled()).toBe(false);
-    expect(errorSettled()).toBe(false);
-    expect(writes).toHaveLength(2);
-    expect(writes[1]!.entries[0]!.at).toBe("2026-06-12T00:00:02.000Z");
-
-    writes[1]!.resolve();
-    await flushMicrotasks();
-    expect(warnSettled()).toBe(true);
-    expect(errorSettled()).toBe(false);
-    expect(writes).toHaveLength(3);
-    expect(writes[2]!.entries[0]!.at).toBe("2026-06-12T00:00:03.000Z");
-
-    writes[2]!.resolve();
-    await flushMicrotasks();
-    expect(errorSettled()).toBe(true);
+    await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
   });
 
   it("swallows queued port-write failures so the chain and later writes never reject", async () => {
@@ -158,8 +173,8 @@ describe("hosted runtime log write queue", () => {
       now: () => "2026-06-12T00:00:04.000Z",
       platform: { logPort: port },
     });
-    const warnSettled = trackSettled(writeHostedRuntimeLogBestEffort({
-      entry: buildQueueLogEntry("warn"),
+    const secondInfoSettled = trackSettled(writeHostedRuntimeLogBestEffort({
+      entry: buildQueueLogEntry("info"),
       now: () => "2026-06-12T00:00:05.000Z",
       platform: { logPort: port },
     }));
@@ -177,13 +192,12 @@ describe("hosted runtime log write queue", () => {
       },
     );
 
-    // The failed info write did not poison the chain: the queued warn write
-    // still runs and resolves.
-    expect(warnSettled()).toBe(false);
+    // The failed info write did not poison the chain: the next queued info
+    // write still runs, and the drain resolves cleanly.
+    expect(secondInfoSettled()).toBe(true);
     expect(writes).toHaveLength(2);
     writes[1]!.resolve();
     await flushMicrotasks();
-    expect(warnSettled()).toBe(true);
     await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
   });
 


### PR DESCRIPTION
Round-1 verified findings from the external PR deep-review loop on the #147/#149 perf work — all four confirmed against code before fixing:

1. **Bounded invocation-end log drain** (`runtime-logs.ts`, `hosted-invocation.ts`): the queued info-log drain in the invocation `finally` is now capped (2s) so a degraded log endpoint can never delay result commit / checkpoint / next-wake handoff; on timeout the remaining writes keep flushing in the background and a structured console warn records the bound.
2. **warn/error log writes go direct** (`runtime-logs.ts`): the crash-diagnostic tail no longer waits behind a queued info backlog — warn/error write immediately and block only on their own durability. `at` stamps keep logical order for readers.
3. **Unwrap failure now aborts the presign leg too** (`workspace-snapshot-port.ts`): previously only the R2 object fetch took the abort signal; a hung presign could still delay surfacing a fast unwrap failure. Signal threaded through `presignWorkspaceSnapshotGet` → `fetchHostedJson` (which already supported it). New deadlock-style test proves it.
4. **Webhook accepted-trace settle is capped at 1.5s** (`webhook-service-wake.ts`): the observability write normally settles inside the Temporal signal round trip; a degraded trace DB can no longer extend the webhook request lifetime (per the new `observability writes are never user latency` invariant, docs/contracts/00-invariants.md).
5. Minor: bundle boot probe passes the entry as a `file://` URL (`pathToFileURL`) for portability.

Rejected from the same round: per-invocation queue port (module-level tail is deliberate — one live log port per runner process; the bounded drain removes the lifecycle-coupling risk without new plumbing).

Verification: apps/cloudflare node suite 1374/1374 (incl. new presign-abort test), assistant-runtime 853 (queue tests updated to the new warn/drain contracts + new bounded-drain test), web handoff 8/8 + web tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783868422&installation_id=127572939&pr_number=151&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F151&signature=18b67c22f5dceffcd8c7db0dd09c21a607692175905c38de74b92e8c963cc790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->