### PR TITLE
fix(query): resolve whoop_v2 to the whoop provider across wearable query identity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-12-whoop-provider-alias.md
+++ b/agent-docs/exec-plans/completed/2026-06-12-whoop-provider-alias.md
@@ -1,0 +1,46 @@
+Goal (incl. success criteria):
+- Make the wearable query surface treat `whoop_v2` (Junction's WHOOP implementation slug) as the canonical public provider `whoop`, so `--provider whoop` resolves all WHOOP-family sources (manual ZIP export with `externalRef.system: "whoop"` plus Junction `whoop_v2` sync) instead of only the stale ZIP import.
+- Keep canonical vault provenance untouched: no event rewrites, `externalRef.system` and `dataOrigin.sourceProviderSlug` stay as ingested.
+- Success means: `wearables * --provider whoop` includes Junction `whoop_v2` data; public outputs/source-health/projection rows report provider `whoop` with display name `WHOOP`; `--provider whoop_v2`/`whoop-v2` are accepted and canonicalize to `whoop`; the Junction direct-duplicate selection penalty recognizes `whoop_v2` as a duplicate of direct `whoop` evidence.
+
+Constraints/Assumptions:
+- No bulk rewrite/migration of vault events; this is a query/normalizer-layer identity fix.
+- Provider identity vocabulary stays in the shared descriptor registry (`packages/importers/src/device-providers/provider-descriptors.ts`), per `docs/device-provider-contribution-kit.md`.
+- Device-sync connect/config surfaces keep using raw implementation slugs (`whoop_v2` for Junction routing); only the public query identity is aliased.
+- Preserve unrelated worktree edits and ledger rows.
+
+Key decisions:
+- Add optional `aliases` to `DeviceProviderDescriptor` and set `aliases: ["whoop_v2", "whoop-v2"]` on the WHOOP descriptor; make `resolveDeviceProviderDescriptor` alias-aware and expose `canonicalizeDeviceProviderSlug`.
+- Canonicalize at the existing public-provider seams only: `resolveWearablePublicSourceProvider` (query origin), `resolveProjectionPublicProvider` (projection grouping), CLI `--provider` input normalization, and the Junction direct-duplicate comparison in selection.
+- Do not change `automationDeviceActivitySourceValues` (`whoop` already matches `whoop-v2` there) or device-sync connect routes.
+
+State:
+- Implemented and verified; final commit pending.
+
+Done:
+- Root-cause evidence: candidates filter compared user `whoop` against public slug `whoop-v2`; projection rows keyed `providers:whoop-v2` unreadable via `providers:whoop`.
+- Descriptor aliases + canonicalization at the identity seams; fixture comparison helper; focused tests; coverage-write and task-finish-review audits.
+- Review fixes: rebased onto origin/main (post #142/#146 stored codec) and re-verified; bumped `QUERY_PROJECTION_SQLITE_VERSION` 8 -> 9 so pre-fix projections re-key `providers:whoop-v2` rows on deploy.
+
+Now:
+- Final `pnpm test:diff` on the rebased tree, then finish-task commit and PR.
+
+Next:
+- None.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/importers/src/device-providers/provider-descriptors.ts
+- packages/importers/test/provider-descriptors.test.ts
+- packages/query/src/wearables/origin.ts
+- packages/query/src/wearables/selection.ts
+- packages/query/src/projection/wearable-summary-projector.ts
+- packages/query/test/wearables-candidates-final.test.ts
+- packages/cli/src/commands/wearables.ts
+- packages/vault-usecases/src/testing/junction-wearable-fixture.ts
+- docs/device-provider-contribution-kit.md
+Status: completed
+Updated: 2026-06-12
+Completed: 2026-06-12

--- a/docs/device-provider-contribution-kit.md
+++ b/docs/device-provider-contribution-kit.md
@@ -24,6 +24,7 @@ Murph intentionally splits provider work across four seams.
 
 `packages/importers/src/device-providers/provider-descriptors.ts` is the single shared source for:
 - provider key and display name
+- implementation-slug aliases that resolve to the provider's public identity (for example Junction's `whoop_v2` resolves to `whoop` through `canonicalizeDeviceProviderSlug`); the wearable query layer and CLI provider filters canonicalize through this seam while vault records keep their raw ingested provenance
 - transport modes
 - OAuth callback path and default scopes
 - webhook path and delivery mode

--- a/packages/cli/src/commands/wearables.ts
+++ b/packages/cli/src/commands/wearables.ts
@@ -4,6 +4,9 @@ import {
   wearableCanonicalMetricKeys,
 } from '@murphai/importers/device-providers/metric-catalog'
 import {
+  canonicalizeDeviceProviderSlug,
+} from '@murphai/importers/device-providers/provider-descriptors'
+import {
   emptyArgsSchema,
   requestIdFromOptions,
   withBaseOptions,
@@ -441,7 +444,7 @@ function withWearableComparisonOptions() {
 
 function normalizeWearableProviders(value: readonly string[] | undefined): string[] {
   return normalizeRepeatableEnumFlagOption(
-    value?.map((entry) => entry.toLowerCase()),
+    value?.map((entry) => canonicalizeDeviceProviderSlug(entry)),
     'provider',
     wearablePreferenceProviderValues,
   ) ?? []

--- a/packages/cli/test/wearables-additive-commands.test.ts
+++ b/packages/cli/test/wearables-additive-commands.test.ts
@@ -344,6 +344,8 @@ test('wearables additive commands return the shared normalized result envelopes'
     '--vault',
     vault,
     '--provider',
+    'whoop_v2',
+    '--provider',
     'whoop',
   ])
   assert.equal(dayResult.exitCode, null)
@@ -473,4 +475,35 @@ test('wearables additive commands return the shared normalized result envelopes'
     vault,
     windowDays: 6,
   })
+})
+
+test('wearables commands still reject providers that do not canonicalize to a supported value', async () => {
+  const { cli, services } = createWearablesCliAndServices()
+  const showWearableDay = vi.fn()
+  Object.defineProperty(services.query, 'showWearableDay', {
+    configurable: true,
+    value: showWearableDay,
+    writable: true,
+  })
+
+  for (const provider of ['fitbit', 'junction']) {
+    const result = await runInProcessJsonCli(cli, [
+      'wearables',
+      'day',
+      '2026-04-05',
+      '--vault',
+      '/tmp/wearables-additive-vault',
+      '--provider',
+      provider,
+    ])
+
+    const envelope = result.envelope
+    if (envelope.ok) {
+      throw new Error(`expected an error envelope for --provider ${provider}`)
+    }
+    assert.equal(envelope.error.code, 'invalid_option')
+    assert.match(envelope.error.message ?? '', new RegExp(`"${provider}"`, 'u'))
+  }
+
+  assert.equal(showWearableDay.mock.calls.length, 0)
 })

--- a/packages/importers/src/device-providers/provider-descriptors.ts
+++ b/packages/importers/src/device-providers/provider-descriptors.ts
@@ -624,6 +624,39 @@ export const defaultDeviceProviderDescriptors = Object.freeze([
   JUNCTION_DEVICE_PROVIDER_DESCRIPTOR,
 ] as const);
 
+function buildDeviceProviderDescriptorLookup(
+  descriptors: readonly DeviceProviderDescriptor[],
+): Map<string, DeviceProviderDescriptor> {
+  const lookup = new Map<string, DeviceProviderDescriptor>();
+
+  for (const descriptor of descriptors) {
+    const providerKey = normalizeDeviceProviderKey(descriptor.provider);
+    if (!providerKey) {
+      throw new TypeError("provider descriptor must define a non-empty provider");
+    }
+
+    for (const rawKey of [descriptor.provider, ...(descriptor.aliases ?? [])]) {
+      const key = normalizeDeviceProviderKey(rawKey);
+      if (!key) {
+        throw new TypeError(`${descriptor.provider} defines a blank provider alias`);
+      }
+
+      const existing = lookup.get(key);
+      if (existing && existing.provider !== descriptor.provider) {
+        throw new TypeError(
+          `provider key "${key}" resolves to both "${existing.provider}" and "${descriptor.provider}"`,
+        );
+      }
+
+      lookup.set(key, descriptor);
+    }
+  }
+
+  return lookup;
+}
+
+const defaultDeviceProviderDescriptorLookup = buildDeviceProviderDescriptorLookup(defaultDeviceProviderDescriptors);
+
 export function resolveDeviceProviderDescriptor(
   provider: string,
   descriptors: readonly DeviceProviderDescriptor[] = defaultDeviceProviderDescriptors,
@@ -634,10 +667,10 @@ export function resolveDeviceProviderDescriptor(
     return undefined;
   }
 
-  return descriptors.find((descriptor) =>
-    normalizeDeviceProviderKey(descriptor.provider) === key
-    || descriptor.aliases?.some((alias) => normalizeDeviceProviderKey(alias) === key),
-  );
+  const lookup = descriptors === defaultDeviceProviderDescriptors
+    ? defaultDeviceProviderDescriptorLookup
+    : buildDeviceProviderDescriptorLookup(descriptors);
+  return lookup.get(key);
 }
 
 export function canonicalizeDeviceProviderSlug(
@@ -647,7 +680,7 @@ export function canonicalizeDeviceProviderSlug(
   const key = normalizeDeviceProviderKey(provider);
 
   if (!key) {
-    return provider;
+    return "";
   }
 
   return resolveDeviceProviderDescriptor(key, descriptors)?.provider ?? key;

--- a/packages/importers/src/device-providers/provider-descriptors.ts
+++ b/packages/importers/src/device-providers/provider-descriptors.ts
@@ -73,6 +73,11 @@ export interface DeviceProviderSourcePriorityHints {
 
 export interface DeviceProviderDescriptor {
   provider: string;
+  /**
+   * Implementation/source slugs (such as Junction source-provider slugs) that
+   * resolve to this provider's public identity, e.g. `whoop_v2` -> `whoop`.
+   */
+  aliases?: readonly string[];
   displayName: string;
   transportModes: readonly DeviceProviderTransportMode[];
   connection?: DeviceProviderConnectionDescriptor;
@@ -507,6 +512,7 @@ export const STRAVA_DEVICE_PROVIDER_DESCRIPTOR = {
 
 export const WHOOP_DEVICE_PROVIDER_DESCRIPTOR = {
   provider: "whoop",
+  aliases: ["whoop_v2", "whoop-v2"],
   displayName: "WHOOP",
   transportModes: ["oauth_callback", "scheduled_poll", "webhook_push"],
   connection: {
@@ -628,5 +634,21 @@ export function resolveDeviceProviderDescriptor(
     return undefined;
   }
 
-  return descriptors.find((descriptor) => normalizeDeviceProviderKey(descriptor.provider) === key);
+  return descriptors.find((descriptor) =>
+    normalizeDeviceProviderKey(descriptor.provider) === key
+    || descriptor.aliases?.some((alias) => normalizeDeviceProviderKey(alias) === key),
+  );
+}
+
+export function canonicalizeDeviceProviderSlug(
+  provider: string,
+  descriptors: readonly DeviceProviderDescriptor[] = defaultDeviceProviderDescriptors,
+): string {
+  const key = normalizeDeviceProviderKey(provider);
+
+  if (!key) {
+    return provider;
+  }
+
+  return resolveDeviceProviderDescriptor(key, descriptors)?.provider ?? key;
 }

--- a/packages/importers/test/provider-descriptors.test.ts
+++ b/packages/importers/test/provider-descriptors.test.ts
@@ -5,6 +5,7 @@ import {
   canonicalizeDeviceProviderSlug,
   DEFAULT_DEVICE_SYNC_BACKFILL_DAYS,
   defaultDeviceProviderDescriptors,
+  type DeviceProviderDescriptor,
   JUNCTION_DEVICE_PROVIDER_DESCRIPTOR,
   OURA_DEVICE_PROVIDER_DESCRIPTOR,
   resolveDeviceProviderConnectionDescriptor,
@@ -73,6 +74,34 @@ describe("device provider descriptors", () => {
     expect(canonicalizeDeviceProviderSlug("oura")).toBe("oura");
     expect(canonicalizeDeviceProviderSlug("fitbit")).toBe("fitbit");
     expect(canonicalizeDeviceProviderSlug("")).toBe("");
+    expect(canonicalizeDeviceProviderSlug("   ")).toBe("");
+  });
+
+  it("rejects provider alias collisions instead of resolving order-dependently", () => {
+    const duplicateAliasDescriptors = [
+      {
+        ...WHOOP_DEVICE_PROVIDER_DESCRIPTOR,
+        aliases: ["wearable-v2"],
+      },
+      {
+        ...OURA_DEVICE_PROVIDER_DESCRIPTOR,
+        aliases: ["wearable-v2"],
+      },
+    ] satisfies readonly DeviceProviderDescriptor[];
+    const providerAliasCollisionDescriptors = [
+      WHOOP_DEVICE_PROVIDER_DESCRIPTOR,
+      {
+        ...OURA_DEVICE_PROVIDER_DESCRIPTOR,
+        provider: "whoop-v2",
+      },
+    ] satisfies readonly DeviceProviderDescriptor[];
+
+    expect(() => resolveDeviceProviderDescriptor("wearable-v2", duplicateAliasDescriptors)).toThrow(
+      /provider key "wearable-v2" resolves to both "whoop" and "oura"/u,
+    );
+    expect(() => resolveDeviceProviderDescriptor("whoop-v2", providerAliasCollisionDescriptors)).toThrow(
+      /provider key "whoop-v2" resolves to both "whoop" and "whoop-v2"/u,
+    );
   });
 
   it("resolves metric priority from the shared descriptor policy", () => {

--- a/packages/importers/test/provider-descriptors.test.ts
+++ b/packages/importers/test/provider-descriptors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { defaultDeviceProviderAdapters } from "../src/device-providers/defaults.ts";
 import {
+  canonicalizeDeviceProviderSlug,
   DEFAULT_DEVICE_SYNC_BACKFILL_DAYS,
   defaultDeviceProviderDescriptors,
   JUNCTION_DEVICE_PROVIDER_DESCRIPTOR,
@@ -59,6 +60,19 @@ describe("device provider descriptors", () => {
       DEFAULT_DEVICE_SYNC_BACKFILL_DAYS,
     );
     expect(STRAVA_DEVICE_PROVIDER_DESCRIPTOR.sync.windows.backfillDays).toBe(30);
+  });
+
+  it("resolves implementation-slug aliases to the canonical provider identity", () => {
+    expect(resolveDeviceProviderDescriptor("whoop_v2")).toBe(WHOOP_DEVICE_PROVIDER_DESCRIPTOR);
+    expect(resolveDeviceProviderDescriptor("whoop-v2")).toBe(WHOOP_DEVICE_PROVIDER_DESCRIPTOR);
+    expect(resolveDeviceProviderDescriptor(" WHOOP_V2 ")).toBe(WHOOP_DEVICE_PROVIDER_DESCRIPTOR);
+
+    expect(canonicalizeDeviceProviderSlug("whoop_v2")).toBe("whoop");
+    expect(canonicalizeDeviceProviderSlug("whoop-v2")).toBe("whoop");
+    expect(canonicalizeDeviceProviderSlug(" WHOOP ")).toBe("whoop");
+    expect(canonicalizeDeviceProviderSlug("oura")).toBe("oura");
+    expect(canonicalizeDeviceProviderSlug("fitbit")).toBe("fitbit");
+    expect(canonicalizeDeviceProviderSlug("")).toBe("");
   });
 
   it("resolves metric priority from the shared descriptor policy", () => {

--- a/packages/query/src/projection/provider-scope.ts
+++ b/packages/query/src/projection/provider-scope.ts
@@ -1,8 +1,11 @@
+import { canonicalizeDeviceProviderSlug } from "@murphai/importers/device-providers/provider-descriptors";
+
 export function normalizeWearableProviders(providers: readonly string[] | undefined): string[] {
   return [...new Set(
     (providers ?? [])
       .map((provider) => provider.trim().toLowerCase())
-      .filter((provider) => provider.length > 0),
+      .filter((provider) => provider.length > 0)
+      .map((provider) => canonicalizeDeviceProviderSlug(provider)),
   )].sort();
 }
 

--- a/packages/query/src/projection/schema.ts
+++ b/packages/query/src/projection/schema.ts
@@ -13,7 +13,8 @@ export type DatabaseSync = import("node:sqlite").DatabaseSync;
 export type SqliteRow = Record<string, unknown>;
 
 export const QUERY_PROJECTION_SCHEMA_ID = "murph.query-projection";
-export const QUERY_PROJECTION_SQLITE_VERSION = 8;
+// 9: wearable provider aliasing re-keys whoop_v2 rows under providers:whoop.
+export const QUERY_PROJECTION_SQLITE_VERSION = 9;
 
 export interface QueryProjectionLocation {
   absolutePath: string;

--- a/packages/query/src/projection/wearable-summary-projector.ts
+++ b/packages/query/src/projection/wearable-summary-projector.ts
@@ -1,19 +1,13 @@
-import { canonicalizeDeviceProviderSlug } from "@murphai/importers/device-providers/provider-descriptors";
-
 import type { VaultReadModel } from "../read-model.ts";
 import {
   buildWearableSummaryBundleFromDataset,
   type WearableSummaryBundle,
 } from "../wearables.ts";
 import { collectWearableDataset } from "../wearables/candidates.ts";
-import {
-  inferJunctionWearableDataOriginFromExternalRef,
-  normalizeWearableOriginSourceSlug,
-} from "../wearables/origin.ts";
+import { resolveWearablePublicSourceProvider } from "../wearables/origin.ts";
 import type {
   WearableActivitySessionAggregate,
   WearableDataset,
-  WearableExternalRef,
   WearableMetricCandidate,
   WearableSleepWindowCandidate,
 } from "../wearables/types.ts";
@@ -105,53 +99,25 @@ function emptyWearableDataset(): MutableWearableDataset {
 }
 
 function resolveMetricCandidatePublicProvider(candidate: WearableMetricCandidate): string {
-  return resolveProjectionPublicProvider({
-    dataOrigin: candidate.dataOrigin ?? null,
-    externalRef: candidate.externalRef,
-    provider: candidate.provider,
-  });
+  return resolveProjectionPublicProvider(candidate);
 }
 
 function resolveWearableDatasetItemPublicProvider(
   item: WearableActivitySessionAggregate | WearableSleepWindowCandidate,
 ): string {
-  return resolveProjectionPublicProvider({
-    dataOrigin: item.dataOrigin ?? null,
-    provider: item.provider,
+  return resolveProjectionPublicProvider(item);
+}
+
+function resolveProjectionPublicProvider(
+  input: WearableActivitySessionAggregate | WearableMetricCandidate | WearableSleepWindowCandidate,
+): string {
+  return resolveWearablePublicSourceProvider({
+    dataOrigin: input.dataOrigin ?? null,
+    externalRef: "externalRef" in input ? input.externalRef : null,
+    provider: input.provider,
+  }, {
+    useSourceInstanceFallback: false,
   });
-}
-
-function resolveProjectionPublicProvider(input: {
-  dataOrigin?: WearableMetricCandidate["dataOrigin"];
-  externalRef?: WearableExternalRef | null;
-  provider?: string | null;
-}): string {
-  return canonicalizeDeviceProviderSlug(resolveRawProjectionProvider(input));
-}
-
-function resolveRawProjectionProvider(input: {
-  dataOrigin?: WearableMetricCandidate["dataOrigin"];
-  externalRef?: WearableExternalRef | null;
-  provider?: string | null;
-}): string {
-  const originSourceProvider = normalizeWearableOriginSourceSlug(input.dataOrigin?.sourceProviderSlug);
-  if (originSourceProvider && originSourceProvider !== "junction") {
-    return originSourceProvider;
-  }
-
-  const inferredSourceProvider = normalizeWearableOriginSourceSlug(
-    inferJunctionWearableDataOriginFromExternalRef(input.externalRef ?? null)?.sourceProviderSlug,
-  );
-  if (inferredSourceProvider && inferredSourceProvider !== "junction") {
-    return inferredSourceProvider;
-  }
-
-  const directProvider = normalizeWearableProviders([input.provider ?? input.externalRef?.system ?? ""])[0];
-  if (directProvider && directProvider !== "junction") {
-    return directProvider;
-  }
-
-  return "unknown";
 }
 
 function resolveProjectionDiagnosticProvider(

--- a/packages/query/src/projection/wearable-summary-projector.ts
+++ b/packages/query/src/projection/wearable-summary-projector.ts
@@ -1,3 +1,5 @@
+import { canonicalizeDeviceProviderSlug } from "@murphai/importers/device-providers/provider-descriptors";
+
 import type { VaultReadModel } from "../read-model.ts";
 import {
   buildWearableSummaryBundleFromDataset,
@@ -120,6 +122,14 @@ function resolveWearableDatasetItemPublicProvider(
 }
 
 function resolveProjectionPublicProvider(input: {
+  dataOrigin?: WearableMetricCandidate["dataOrigin"];
+  externalRef?: WearableExternalRef | null;
+  provider?: string | null;
+}): string {
+  return canonicalizeDeviceProviderSlug(resolveRawProjectionProvider(input));
+}
+
+function resolveRawProjectionProvider(input: {
   dataOrigin?: WearableMetricCandidate["dataOrigin"];
   externalRef?: WearableExternalRef | null;
   provider?: string | null;

--- a/packages/query/src/wearables/candidates.ts
+++ b/packages/query/src/wearables/candidates.ts
@@ -1,4 +1,5 @@
 import { normalizeWearableMetricValue } from "@murphai/importers/device-providers/metric-catalog";
+import { canonicalizeDeviceProviderSlug } from "@murphai/importers/device-providers/provider-descriptors";
 import { deviceDataOriginSchema, extractIsoDatePrefix, type DeviceDataOrigin } from "@murphai/contracts";
 
 import type { CanonicalEntity } from "../canonical-entities.ts";
@@ -45,7 +46,12 @@ export function collectWearableDataset(
   const sleepStageCandidates: WearableMetricCandidate[] = [];
   const sleepWindows: WearableSleepWindowCandidate[] = [];
   const providerSet = filters.providers
-    ? new Set(filters.providers.map((provider) => provider.trim().toLowerCase()).filter(Boolean))
+    ? new Set(
+        filters.providers
+          .map((provider) => provider.trim().toLowerCase())
+          .filter(Boolean)
+          .map((provider) => canonicalizeDeviceProviderSlug(provider)),
+      )
     : null;
 
   for (const entity of [...vault.events, ...vault.samples.filter((sample) => sample.kind !== "metric_sample")]) {

--- a/packages/query/src/wearables/origin.ts
+++ b/packages/query/src/wearables/origin.ts
@@ -1,4 +1,5 @@
 import type { DeviceDataOrigin } from "@murphai/contracts";
+import { canonicalizeDeviceProviderSlug } from "@murphai/importers/device-providers/provider-descriptors";
 
 import { normalizeLowercaseString } from "./shared.ts";
 import type { WearableExternalRef } from "./types.ts";
@@ -8,6 +9,14 @@ export function normalizeWearableOriginSourceSlug(value: string | null | undefin
 }
 
 export function resolveWearablePublicSourceProvider(input: {
+  dataOrigin?: DeviceDataOrigin | null;
+  externalRef?: WearableExternalRef | null;
+  provider?: string | null;
+}): string {
+  return canonicalizeDeviceProviderSlug(resolveRawWearableSourceProvider(input));
+}
+
+function resolveRawWearableSourceProvider(input: {
   dataOrigin?: DeviceDataOrigin | null;
   externalRef?: WearableExternalRef | null;
   provider?: string | null;

--- a/packages/query/src/wearables/origin.ts
+++ b/packages/query/src/wearables/origin.ts
@@ -12,14 +12,18 @@ export function resolveWearablePublicSourceProvider(input: {
   dataOrigin?: DeviceDataOrigin | null;
   externalRef?: WearableExternalRef | null;
   provider?: string | null;
-}): string {
-  return canonicalizeDeviceProviderSlug(resolveRawWearableSourceProvider(input));
+}, options: {
+  useSourceInstanceFallback?: boolean;
+} = {}): string {
+  return canonicalizeDeviceProviderSlug(resolveRawWearableSourceProvider(input, options));
 }
 
 function resolveRawWearableSourceProvider(input: {
   dataOrigin?: DeviceDataOrigin | null;
   externalRef?: WearableExternalRef | null;
   provider?: string | null;
+}, options: {
+  useSourceInstanceFallback?: boolean;
 }): string {
   const originSourceProvider = normalizeWearableOriginSourceSlug(input.dataOrigin?.sourceProviderSlug);
   if (originSourceProvider && originSourceProvider !== "junction") {
@@ -36,9 +40,11 @@ function resolveRawWearableSourceProvider(input: {
     return provider;
   }
 
-  const sourceInstanceId = normalizeWearableOriginSourceSlug(input.dataOrigin?.sourceInstanceId);
-  if (sourceInstanceId) {
-    return sourceInstanceId;
+  if (options.useSourceInstanceFallback ?? true) {
+    const sourceInstanceId = normalizeWearableOriginSourceSlug(input.dataOrigin?.sourceInstanceId);
+    if (sourceInstanceId) {
+      return sourceInstanceId;
+    }
   }
 
   return "unknown";

--- a/packages/query/src/wearables/public-output.ts
+++ b/packages/query/src/wearables/public-output.ts
@@ -386,6 +386,7 @@ function projectWearableResolvedMetricPublicSources(
       ...resolved.confidence,
       conflictingProviders: publicConflictingProviders,
       reasons: projectMetricConfidenceReasons({
+        candidates: resolved.candidates,
         publicAgreeingProviders,
         publicConflictingProviders,
         sameSourceDisagreement,
@@ -487,6 +488,7 @@ function collectPublicAgreeingProviders(resolved: WearableResolvedMetric): strin
 }
 
 function projectMetricConfidenceReasons(input: {
+  candidates: readonly WearableMetricCandidate[];
   publicAgreeingProviders: readonly string[];
   publicConflictingProviders: readonly string[];
   sameSourceDisagreement: boolean;
@@ -516,10 +518,33 @@ function projectMetricConfidenceReasons(input: {
         : [];
     }
 
-    return [reason];
+    return [projectMetricEvidenceReasonPublicProviders(reason, input.candidates)];
   });
 
   return uniqueStrings(reasons);
+}
+
+function projectMetricEvidenceReasonPublicProviders(
+  reason: string,
+  candidates: readonly WearableMetricCandidate[],
+): string {
+  let projected = reason;
+
+  for (const candidate of candidates) {
+    const sourceLabel = formatMetricEvidenceLabel(candidate, candidate.provider);
+    const publicLabel = formatMetricEvidenceLabel(candidate, resolvePublicSourceProvider(candidate));
+
+    if (sourceLabel !== publicLabel) {
+      projected = projected.replaceAll(sourceLabel, publicLabel);
+    }
+  }
+
+  return projected;
+}
+
+function formatMetricEvidenceLabel(candidate: WearableMetricCandidate, provider: string): string {
+  const timestamp = candidate.recordedAt ?? candidate.occurredAt ?? "unknown time";
+  return `${formatProviderName(provider)} ${candidate.sourceKind} recorded ${timestamp}`;
 }
 
 function selectMetricSelectionCandidate(resolved: WearableResolvedMetric): WearableMetricCandidate | null {
@@ -540,6 +565,8 @@ function resolvePublicSourceProvider(candidate: WearableMetricCandidate): string
     dataOrigin: candidate.dataOrigin ?? null,
     externalRef: candidate.externalRef,
     provider: candidate.provider,
+  }, {
+    useSourceInstanceFallback: false,
   });
 }
 

--- a/packages/query/src/wearables/public-output.ts
+++ b/packages/query/src/wearables/public-output.ts
@@ -6,7 +6,7 @@ import {
 import { summarizeMetricsConfidence } from "./confidence.ts";
 import { resolveWearablePublicSourceProvider } from "./origin.ts";
 import { formatProviderName, resolveMetricTolerance } from "./provider-policy.ts";
-import { uniqueStrings } from "./shared.ts";
+import { normalizeLowercaseString, uniqueStrings } from "./shared.ts";
 import type {
   WearableActivityDay,
   WearableBodyStateDay,
@@ -189,13 +189,12 @@ export function projectWearableSleepNightPublicSources(night: WearableSleepNight
     "No sleep metrics were available for this date.",
     sourceMetrics,
   );
-  const sleepWindowSourceProvider = night.sleepWindowProvider ?? night.provider;
-  const sleepWindowPublicProvider = sessionMinutes.selection.provider;
+  const sleepProviderTextEntries = buildMetricProviderTextProjectionEntries(sourceMetrics);
   const summaryConfidence = {
     ...rawSummaryConfidence,
-    notes: rawSummaryConfidence.notes.map((note) =>
-      projectSleepWindowProviderNote(note, sleepWindowSourceProvider, sleepWindowPublicProvider)
-    ),
+    notes: rawSummaryConfidence.notes
+      .filter((note) => !isSleepWindowProviderNote(note))
+      .map((note) => projectProviderTextPublicSources(note, sleepProviderTextEntries)),
   };
 
   return {
@@ -213,8 +212,9 @@ export function projectWearableSleepNightPublicSources(night: WearableSleepNight
       originalSummaryConfidence: night.summaryConfidence,
       sourceMetrics,
       summaryConfidence,
-      projectOriginalNote: (note) =>
-        projectSleepWindowProviderNote(note, sleepWindowSourceProvider, sleepWindowPublicProvider),
+      filterOriginalNote: (note) => !isSleepWindowProviderNote(note),
+      projectOriginalNote: (note) => projectProviderTextPublicSources(note, sleepProviderTextEntries),
+      fallbackNotes: buildPublicSleepWindowNotes(night, sessionMinutes.selection.provider),
     }),
     provider: sessionMinutes.selection.provider,
     remMinutes,
@@ -376,6 +376,7 @@ function projectWearableResolvedMetricPublicSources(
   resolved: WearableResolvedMetric,
 ): WearableResolvedMetric {
   const selectedCandidate = selectMetricSelectionCandidate(resolved);
+  const titleProjectionEntries = buildProviderTextProjectionEntries(resolved.candidates);
   const selectionProvider = resolved.selection.provider
     ? selectedCandidate
       ? resolvePublicSourceProvider(selectedCandidate)
@@ -390,7 +391,7 @@ function projectWearableResolvedMetricPublicSources(
     candidates: resolved.candidates.map((candidate) => ({
       ...candidate,
       provider: resolvePublicSourceProvider(candidate),
-      title: candidate.title,
+      title: projectProviderTextPublicSources(candidate.title, buildProviderTextProjectionEntries([candidate])),
     })),
     confidence: {
       ...resolved.confidence,
@@ -407,7 +408,7 @@ function projectWearableResolvedMetricPublicSources(
     selection: {
       ...resolved.selection,
       provider: selectionProvider,
-      title: resolved.selection.title,
+      title: projectProviderTextPublicSources(resolved.selection.title, titleProjectionEntries),
     },
   };
 }
@@ -429,6 +430,7 @@ function rebuildPublicSummaryConfidence(
 
 function projectSummaryNotes(input: {
   fallbackNotes?: readonly string[];
+  filterOriginalNote?: (note: string) => boolean;
   metrics: readonly WearableResolvedMetric[];
   originalNotes: readonly string[];
   originalSummaryConfidence: WearableSummaryConfidence;
@@ -440,6 +442,7 @@ function projectSummaryNotes(input: {
   const originalSummaryNotes = new Set(input.originalSummaryConfidence.notes);
   const projectedOriginalNotes = input.originalNotes
     .filter((note) => !originalSummaryNotes.has(note))
+    .filter((note) => input.filterOriginalNote?.(note) ?? true)
     .map((note) => input.projectOriginalNote?.(note) ?? note);
 
   return uniqueStrings([
@@ -449,20 +452,130 @@ function projectSummaryNotes(input: {
   ]);
 }
 
-function projectSleepWindowProviderNote(
-  note: string,
-  sourceProvider: string | null,
+function buildPublicSleepWindowNotes(
+  night: WearableSleepNight,
   publicProvider: string | null,
-): string {
-  if (!sourceProvider || !publicProvider || sourceProvider === publicProvider) {
-    return note;
+): string[] {
+  if (!publicProvider) {
+    return [];
   }
 
-  if (!/\b(?:sleep|nap) window\b/iu.test(note)) {
-    return note;
+  return [
+    `Selected sleep window from ${formatProviderName(publicProvider)} spanning ${night.sleepStartAt ?? "unknown start"} to ${night.sleepEndAt ?? "unknown end"}.`,
+  ];
+}
+
+function isSleepWindowProviderNote(note: string): boolean {
+  return /\b(?:sleep|nap) windows?\b/iu.test(note);
+}
+
+interface ProviderTextProjectionEntry {
+  publicLabel: string;
+  sourceLabels: readonly string[];
+}
+
+function buildMetricProviderTextProjectionEntries(
+  metrics: readonly WearableResolvedMetric[],
+): ProviderTextProjectionEntry[] {
+  return buildProviderTextProjectionEntries(metrics.flatMap((metric) => metric.candidates));
+}
+
+function buildProviderTextProjectionEntries(
+  candidates: readonly WearableMetricCandidate[],
+): ProviderTextProjectionEntry[] {
+  const entries: ProviderTextProjectionEntry[] = [];
+
+  for (const candidate of candidates) {
+    const publicProvider = resolvePublicSourceProvider(candidate);
+    const publicLabel = formatProviderName(publicProvider);
+    const sourceLabels = uniqueStrings([
+      ...providerTextLabels(candidate.provider),
+      ...providerTextLabels(candidate.dataOrigin?.aggregatorProvider),
+      ...providerTextLabels(candidate.dataOrigin?.sourceProviderSlug),
+    ]).filter((label) => label !== publicLabel);
+
+    if (sourceLabels.length > 0) {
+      entries.push({ publicLabel, sourceLabels });
+    }
   }
 
-  return note.replaceAll(formatProviderName(sourceProvider), formatProviderName(publicProvider));
+  return entries;
+}
+
+function projectProviderTextPublicSources(
+  text: string,
+  entries: readonly ProviderTextProjectionEntry[],
+): string;
+function projectProviderTextPublicSources(
+  text: null,
+  entries: readonly ProviderTextProjectionEntry[],
+): null;
+function projectProviderTextPublicSources(
+  text: string | null,
+  entries: readonly ProviderTextProjectionEntry[],
+): string | null;
+function projectProviderTextPublicSources(
+  text: string | null,
+  entries: readonly ProviderTextProjectionEntry[],
+): string | null {
+  if (!text || entries.length === 0) {
+    return text;
+  }
+
+  let projected = text;
+  const publicLabels = uniqueStrings(entries.map((entry) => entry.publicLabel));
+
+  for (const entry of entries) {
+    for (const sourceLabel of entry.sourceLabels) {
+      projected = replaceProviderToken(projected, sourceLabel, entry.publicLabel);
+    }
+  }
+
+  for (const publicLabel of publicLabels) {
+    projected = collapseRepeatedProviderLabel(projected, publicLabel);
+  }
+
+  return projected;
+}
+
+function providerTextLabels(provider: unknown): string[] {
+  const normalized = normalizeLowercaseString(provider);
+  if (!normalized) {
+    return [];
+  }
+
+  return uniqueStrings([
+    formatProviderName(normalized),
+    normalized,
+    normalized.replace(/_/gu, "-"),
+    normalized.replace(/-/gu, "_"),
+  ]);
+}
+
+function replaceProviderToken(text: string, sourceLabel: string, publicLabel: string): string {
+  if (sourceLabel.length === 0 || sourceLabel === publicLabel) {
+    return text;
+  }
+
+  const pattern = new RegExp(`(^|[^A-Za-z0-9_-])${escapeRegExp(sourceLabel)}(?=$|[^A-Za-z0-9_-])`, "giu");
+  return text.replace(pattern, (_match, prefix: string) => `${prefix}${publicLabel}`);
+}
+
+function collapseRepeatedProviderLabel(text: string, providerLabel: string): string {
+  if (providerLabel.length === 0) {
+    return text;
+  }
+
+  const escaped = escapeRegExp(providerLabel);
+  const pattern = new RegExp(
+    `(^|[^A-Za-z0-9_-])${escaped}(?:\\s+${escaped})+(?=$|[^A-Za-z0-9_-])`,
+    "giu",
+  );
+  return text.replace(pattern, (_match, prefix: string) => `${prefix}${providerLabel}`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function collectPublicConflictingProviders(

--- a/packages/query/src/wearables/public-output.ts
+++ b/packages/query/src/wearables/public-output.ts
@@ -183,12 +183,20 @@ export function projectWearableSleepNightPublicSources(night: WearableSleepNight
     ["spo2", spo2],
   ];
   const projectedMetrics = metrics.map(([, metric]) => metric);
-  const summaryConfidence = rebuildPublicSummaryConfidence(
+  const rawSummaryConfidence = rebuildPublicSummaryConfidence(
     metrics,
     night.summaryConfidence,
     "No sleep metrics were available for this date.",
     sourceMetrics,
   );
+  const sleepWindowSourceProvider = night.sleepWindowProvider ?? night.provider;
+  const sleepWindowPublicProvider = sessionMinutes.selection.provider;
+  const summaryConfidence = {
+    ...rawSummaryConfidence,
+    notes: rawSummaryConfidence.notes.map((note) =>
+      projectSleepWindowProviderNote(note, sleepWindowSourceProvider, sleepWindowPublicProvider)
+    ),
+  };
 
   return {
     ...night,
@@ -205,6 +213,8 @@ export function projectWearableSleepNightPublicSources(night: WearableSleepNight
       originalSummaryConfidence: night.summaryConfidence,
       sourceMetrics,
       summaryConfidence,
+      projectOriginalNote: (note) =>
+        projectSleepWindowProviderNote(note, sleepWindowSourceProvider, sleepWindowPublicProvider),
     }),
     provider: sessionMinutes.selection.provider,
     remMinutes,
@@ -422,19 +432,37 @@ function projectSummaryNotes(input: {
   metrics: readonly WearableResolvedMetric[];
   originalNotes: readonly string[];
   originalSummaryConfidence: WearableSummaryConfidence;
+  projectOriginalNote?: (note: string) => string;
   sourceMetrics: readonly WearableResolvedMetric[];
   summaryConfidence: WearableSummaryConfidence;
 }): string[] {
   void input.sourceMetrics;
   const originalSummaryNotes = new Set(input.originalSummaryConfidence.notes);
   const projectedOriginalNotes = input.originalNotes
-    .filter((note) => !originalSummaryNotes.has(note));
+    .filter((note) => !originalSummaryNotes.has(note))
+    .map((note) => input.projectOriginalNote?.(note) ?? note);
 
   return uniqueStrings([
     ...input.summaryConfidence.notes,
     ...(input.fallbackNotes ?? []),
     ...projectedOriginalNotes,
   ]);
+}
+
+function projectSleepWindowProviderNote(
+  note: string,
+  sourceProvider: string | null,
+  publicProvider: string | null,
+): string {
+  if (!sourceProvider || !publicProvider || sourceProvider === publicProvider) {
+    return note;
+  }
+
+  if (!/\b(?:sleep|nap) window\b/iu.test(note)) {
+    return note;
+  }
+
+  return note.replaceAll(formatProviderName(sourceProvider), formatProviderName(publicProvider));
 }
 
 function collectPublicConflictingProviders(

--- a/packages/query/src/wearables/selection.ts
+++ b/packages/query/src/wearables/selection.ts
@@ -1,3 +1,5 @@
+import { canonicalizeDeviceProviderSlug } from "@murphai/importers/device-providers/provider-descriptors";
+
 import { dedupeExactMetricCandidates } from "./dedupe.ts";
 import {
   compareWearableProviders,
@@ -418,8 +420,9 @@ function scoreJunctionSourcePolicy(
     return JUNCTION_UNSUPPORTED_SOURCE_PRIORITY_BOOST;
   }
 
+  const sourceProvider = canonicalizeDeviceProviderSlug(sourceProviderSlug);
   const directCandidateExists = candidates.some((other) =>
-    normalizeLowercaseString(other.provider) === sourceProviderSlug
+    normalizeLowercaseString(other.provider) === sourceProvider
   );
   return directCandidateExists ? JUNCTION_DIRECT_DUPLICATE_PENALTY : 0;
 }

--- a/packages/query/src/wearables/selection.ts
+++ b/packages/query/src/wearables/selection.ts
@@ -422,7 +422,7 @@ function scoreJunctionSourcePolicy(
 
   const sourceProvider = canonicalizeDeviceProviderSlug(sourceProviderSlug);
   const directCandidateExists = candidates.some((other) =>
-    normalizeLowercaseString(other.provider) === sourceProvider
+    canonicalizeDeviceProviderSlug(normalizeLowercaseString(other.provider) ?? "") === sourceProvider
   );
   return directCandidateExists ? JUNCTION_DIRECT_DUPLICATE_PENALTY : 0;
 }

--- a/packages/query/src/wearables/source-health.ts
+++ b/packages/query/src/wearables/source-health.ts
@@ -354,6 +354,8 @@ function resolvePublicSourceProvider(
     dataOrigin: candidate.dataOrigin ?? null,
     externalRef: "externalRef" in candidate ? candidate.externalRef : null,
     provider: candidate.provider,
+  }, {
+    useSourceInstanceFallback: false,
   });
 }
 

--- a/packages/query/test/query-projection-provider-scope.test.ts
+++ b/packages/query/test/query-projection-provider-scope.test.ts
@@ -15,6 +15,10 @@ import {
   summarizeWearableSleepRuntime,
   summarizeWearableSourceHealthRuntime,
 } from "../src/index.ts";
+import {
+  normalizeWearableProviders,
+  wearableProviderRowKey,
+} from "../src/projection/provider-scope.ts";
 
 test("runtime wearable provider filters do not fall back to all-provider summaries", async () => {
   const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-query-provider-scope-"));
@@ -479,6 +483,117 @@ test("provider-scoped wearable projection rows use resolved public providers", a
   } finally {
     await rm(vaultRoot, { recursive: true, force: true });
   }
+});
+
+test("whoop provider filter resolves Junction whoop_v2 evidence to the whoop scope", async () => {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-query-whoop-alias-"));
+  const eventLedgerPath = path.join(vaultRoot, "ledger/events/2026/2026-04.jsonl");
+
+  try {
+    await mkdir(path.dirname(eventLedgerPath), { recursive: true });
+    await writeFile(
+      eventLedgerPath,
+      [
+        {
+          schemaVersion: "murph.event.v1",
+          id: "evt_whoop_export_steps",
+          kind: "observation",
+          occurredAt: "2025-11-23T07:00:00Z",
+          recordedAt: "2026-04-03T09:00:00Z",
+          dayKey: "2025-11-23",
+          source: "device",
+          title: "WHOOP export steps",
+          metric: "steps",
+          value: 8400,
+          unit: "count",
+          externalRef: {
+            system: "whoop",
+            resourceType: "daily_activity",
+            resourceId: "whoop-export-daily-activity-2025-11-23",
+          },
+        },
+        {
+          schemaVersion: "murph.event.v1",
+          id: "evt_junction_whoop_v2_steps",
+          kind: "observation",
+          occurredAt: "2026-04-04T07:00:00Z",
+          recordedAt: "2026-04-04T07:01:00Z",
+          dayKey: "2026-04-04",
+          source: "device",
+          title: "Junction WHOOP steps",
+          metric: "steps",
+          value: 9100,
+          unit: "count",
+          dataOrigin: {
+            version: 1,
+            aggregatorProvider: "junction",
+            sourceProviderSlug: "whoop_v2",
+          },
+          externalRef: {
+            system: "junction",
+            resourceType: "junction-whoop-v2-activity",
+            resourceId: "junction-whoop-daily-activity-2026-04-04",
+          },
+        },
+      ].map((record) => JSON.stringify(record)).join("\n").concat("\n"),
+      "utf8",
+    );
+    await rebuildQueryProjection(vaultRoot);
+
+    const database = openSqliteRuntimeDatabase(path.join(vaultRoot, QUERY_DB_RELATIVE_PATH), {
+      readOnly: true,
+    });
+    try {
+      const scopeRows = database
+        .prepare(`
+          SELECT DISTINCT provider_scope_key AS providerScopeKey
+          FROM query_wearable_summaries
+          ORDER BY provider_scope_key ASC
+        `)
+        .all() as Array<{ providerScopeKey: string }>;
+
+      assert.deepEqual(scopeRows.map((row) => row.providerScopeKey), ["providers:whoop"]);
+    } finally {
+      database.close();
+    }
+
+    const whoopRecent = await summarizeWearableActivityRuntime(vaultRoot, {
+      date: "2026-04-04",
+      providers: ["whoop"],
+    });
+    const whoopHistorical = await summarizeWearableActivityRuntime(vaultRoot, {
+      date: "2025-11-23",
+      providers: ["whoop"],
+    });
+    const aliasFiltered = await summarizeWearableActivityRuntime(vaultRoot, {
+      date: "2026-04-04",
+      providers: ["whoop_v2"],
+    });
+    const sourceHealth = await summarizeWearableSourceHealthRuntime(vaultRoot);
+
+    assert.equal(whoopRecent.length, 1);
+    assert.equal(whoopRecent[0]?.steps.selection.provider, "whoop");
+    assert.equal(whoopRecent[0]?.steps.selection.value, 9100);
+    assert.equal(whoopHistorical.length, 1);
+    assert.equal(whoopHistorical[0]?.steps.selection.value, 8400);
+    assert.equal(aliasFiltered.length, 1);
+    assert.equal(aliasFiltered[0]?.steps.selection.value, 9100);
+    assert.deepEqual(sourceHealth.map((row) => row.provider), ["whoop"]);
+    assert.equal(sourceHealth[0]?.providerDisplayName, "WHOOP");
+    assert.equal(sourceHealth[0]?.lastDate, "2026-04-04");
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("projection provider scope canonicalizes whoop aliases for both write and read keys", () => {
+  assert.deepEqual(
+    normalizeWearableProviders(["whoop", " WHOOP_V2 ", "whoop-v2", "oura"]),
+    ["oura", "whoop"],
+  );
+  assert.equal(wearableProviderRowKey("whoop_v2"), "providers:whoop");
+  assert.equal(wearableProviderRowKey("whoop-v2"), "providers:whoop");
+  assert.equal(wearableProviderRowKey("whoop"), "providers:whoop");
 });
 
 test("multi-provider projected sleep reads do not invent sleep windows from total sleep metrics", async () => {

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -4422,12 +4422,12 @@ test("rebuildQueryProjection creates the compact metric point schema", async () 
     });
 
     try {
-      // Pin the literal version: a revert of the 7 -> 8 bump would keep every
-      // constant-relative assertion green while legacy v7 stores (full
-      // wearable summary JSON without the compact stored codec, on top of the
-      // v6 dropped metric point columns) were treated as current instead of
-      // being rebuilt.
-      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 8);
+      // Pin the literal version: a revert of the 8 -> 9 bump would keep every
+      // constant-relative assertion green while legacy v8 stores (wearable
+      // summary rows still scoped under raw whoop_v2 provider keys, on top of
+      // the v7 pre-codec JSON and v6 dropped metric point columns) were
+      // treated as current instead of being rebuilt.
+      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 9);
       assert.equal(readSqliteRuntimeUserVersion(database), QUERY_PROJECTION_SQLITE_VERSION);
 
       const columnRows = database

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -919,7 +919,7 @@ test("sleep-window ranking does not treat selected session duration as total sle
     assert.equal(sleep[0]?.timeInBedMinutes.selection.resolution, "fallback");
     assert.equal(sleep[0]?.timeInBedMinutes.selection.fallbackFromMetric, "sessionMinutes");
     assert.equal(
-      sleep[0]?.notes.some((note) => note.includes("Selected Garmin sleep window recorded")),
+      sleep[0]?.notes.some((note) => note.includes("Selected sleep window from Garmin spanning")),
       true,
     );
     assert.equal(

--- a/packages/query/test/wearables-candidates-final.test.ts
+++ b/packages/query/test/wearables-candidates-final.test.ts
@@ -646,6 +646,67 @@ test("collectWearableDataset infers Junction source provenance from legacy resou
   assert.equal(candidate?.externalRef?.resourceType, "junction-oura-sleep");
 });
 
+test("collectWearableDataset resolves Junction whoop_v2 sources under the whoop provider filter", () => {
+  const vault = makeVault([
+    makeWearableEntity({
+      attributes: {
+        dataOrigin: {
+          version: 1,
+          aggregatorProvider: "junction",
+          sourceProviderSlug: "whoop_v2",
+        },
+        externalRef: makeExternalRef({
+          resourceId: "junction-whoop-steps-1",
+          resourceType: "junction-whoop-v2-activity",
+          system: "junction",
+        }),
+        metric: "daily-steps",
+        recordedAt: "2026-06-12T07:00:00Z",
+        unit: "count",
+        value: 9100,
+      },
+      entityId: "evt_junction_whoop_v2_steps",
+      family: "event",
+      kind: "observation",
+      recordClass: "ledger",
+      title: "Junction WHOOP steps",
+    }),
+    makeWearableEntity({
+      attributes: {
+        externalRef: makeExternalRef({
+          resourceId: "whoop-export-steps-1",
+          resourceType: "daily_activity",
+          system: "whoop",
+        }),
+        metric: "daily-steps",
+        recordedAt: "2025-11-23T07:00:00Z",
+        unit: "count",
+        value: 8400,
+      },
+      entityId: "evt_whoop_export_steps",
+      family: "event",
+      kind: "observation",
+      recordClass: "ledger",
+      title: "WHOOP export steps",
+    }),
+  ]);
+
+  const whoopFiltered = collectWearableDataset(vault, { providers: ["whoop"] });
+  assert.deepEqual(
+    whoopFiltered.rawMetricCandidates.map((candidate) => candidate.value).sort(),
+    [8400, 9100],
+  );
+
+  const aliasFiltered = collectWearableDataset(vault, { providers: ["whoop_v2"] });
+  assert.deepEqual(
+    aliasFiltered.rawMetricCandidates.map((candidate) => candidate.value).sort(),
+    [8400, 9100],
+  );
+
+  const ouraFiltered = collectWearableDataset(vault, { providers: ["oura"] });
+  assert.equal(ouraFiltered.rawMetricCandidates.length, 0);
+});
+
 test("collectWearableDataset ignores malformed persisted origin before legacy fallback", () => {
   const vault = makeVault([
     makeWearableEntity({

--- a/packages/query/test/wearables-coverage-branches.test.ts
+++ b/packages/query/test/wearables-coverage-branches.test.ts
@@ -1219,7 +1219,7 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
           resourceType,
           system: "junction",
         }),
-        recordedAt: `${date}T07:00:00Z`,
+        recordedAt: `${date}T07:10:00Z`,
         stage,
       },
       entityId: `sample_sleep_stage_${resourcePrefix}_${date}_${stage}`,
@@ -1336,6 +1336,32 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
     makeJunctionSleepStage("deep", 90, { date: "2026-04-09", sourceSlug: "oura" }),
     makeJunctionSleepStage("light", 250, { date: "2026-04-09", sourceSlug: "oura" }),
     makeJunctionSleepStage("rem", 80, { date: "2026-04-09", sourceSlug: "oura" }),
+    makeEntity({
+      attributes: {
+        dataOrigin: {
+          aggregatorProvider: "junction",
+          sourceProviderSlug: "whoop_v2",
+          sourceType: "watch",
+          version: 1,
+        },
+        dayKey: "2026-04-10",
+        externalRef: makeExternalRef({
+          resourceId: "junction-whoop-v2-steps",
+          resourceType: "junction-whoop-v2-activity",
+          system: "junction",
+        }),
+        metric: "daily-steps",
+        recordedAt: "2026-04-10T08:00:00Z",
+        unit: "count",
+        value: 7200,
+      },
+      entityId: "event_steps_junction_whoop_v2",
+      family: "event",
+      kind: "observation",
+      occurredAt: "2026-04-10T08:00:00Z",
+      recordClass: "ledger",
+      title: "Junction WHOOP steps",
+    }),
   ]);
 
   const garminDataset = collectWearableDataset(vault, { providers: ["garmin"] });
@@ -1361,13 +1387,21 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
   assert.equal(sourceHealth[0]?.notes.some((note) => /\bjunction\b/iu.test(note)), false);
 
   const rawSourceDay = summarizeWearableDay(vault, "2026-04-06");
-  assert.deepEqual(rawSourceDay?.providers, ["source-junction-unmapped-steps"]);
-  assert.equal(rawSourceDay?.activity?.steps.selection.provider, "source-junction-unmapped-steps");
+  assert.deepEqual(rawSourceDay?.providers, ["unknown"]);
+  assert.equal(rawSourceDay?.activity?.steps.selection.provider, "unknown");
 
   const garminSleep = summarizeWearableSleep(vault, { providers: ["garmin"] })
     .find((night) => night.date === "2026-04-07");
   assert.equal(garminSleep?.totalSleepMinutes.selection.provider, "garmin");
   assert.equal(garminSleep?.totalSleepMinutes.selection.value, 390);
+  assert.equal(
+    garminSleep?.totalSleepMinutes.confidence.reasons.some((reason) => /\bJunction\b/u.test(reason)),
+    false,
+  );
+  assert.equal(
+    garminSleep?.totalSleepMinutes.confidence.reasons.some((reason) => reason.startsWith("Selected Garmin ")),
+    true,
+  );
 
   const mixedSourceSleep = summarizeWearableSleep(vault)
     .find((night) => night.date === "2026-04-08");
@@ -1386,6 +1420,18 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
       ...(conflictingSleep?.totalSleepMinutes.confidence.conflictingProviders ?? []),
     ]),
     new Set(["garmin", "oura"]),
+  );
+
+  const whoopDay = summarizeWearableDay(vault, "2026-04-10", { providers: ["whoop"] });
+  assert.deepEqual(whoopDay?.providers, ["whoop"]);
+  assert.equal(whoopDay?.activity?.steps.selection.provider, "whoop");
+  assert.equal(
+    whoopDay?.activity?.steps.confidence.reasons.some((reason) => /\bJunction\b/u.test(reason)),
+    false,
+  );
+  assert.equal(
+    whoopDay?.activity?.steps.confidence.reasons.some((reason) => reason.startsWith("Selected WHOOP ")),
+    true,
   );
 });
 

--- a/packages/query/test/wearables-coverage-branches.test.ts
+++ b/packages/query/test/wearables-coverage-branches.test.ts
@@ -1402,6 +1402,14 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
     garminSleep?.totalSleepMinutes.confidence.reasons.some((reason) => reason.startsWith("Selected Garmin ")),
     true,
   );
+  assert.equal(
+    garminSleep?.summaryConfidence.notes.some((note) => /\bJunction\b/u.test(note)),
+    false,
+  );
+  assert.equal(
+    garminSleep?.notes.some((note) => /\bJunction\b/u.test(note)),
+    false,
+  );
 
   const mixedSourceSleep = summarizeWearableSleep(vault)
     .find((night) => night.date === "2026-04-08");

--- a/packages/query/test/wearables-coverage-branches.test.ts
+++ b/packages/query/test/wearables-coverage-branches.test.ts
@@ -1338,6 +1338,52 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
     makeJunctionSleepStage("rem", 80, { date: "2026-04-09", sourceSlug: "oura" }),
     makeEntity({
       attributes: {
+        dayKey: "2026-04-11",
+        durationMinutes: 480,
+        endAt: "2026-04-11T06:30:00Z",
+        externalRef: makeExternalRef({
+          resourceId: "garmin-sleep-direct-window",
+          resourceType: "sleep_session",
+          system: "garmin",
+        }),
+        recordedAt: "2026-04-11T06:35:00Z",
+        startAt: "2026-04-10T22:30:00Z",
+      },
+      entityId: "event_sleep_session_garmin_direct",
+      family: "event",
+      kind: "sleep_session",
+      occurredAt: "2026-04-10T22:30:00Z",
+      recordClass: "ledger",
+      title: "Garmin sleep window",
+    }),
+    makeEntity({
+      attributes: {
+        dataOrigin: {
+          aggregatorProvider: "junction",
+          sourceProviderSlug: "garmin",
+          sourceType: "watch",
+          version: 1,
+        },
+        dayKey: "2026-04-11",
+        durationMinutes: 420,
+        endAt: "2026-04-11T06:00:00Z",
+        externalRef: makeExternalRef({
+          resourceId: "junction-garmin-sleep-conflict-window",
+          resourceType: "junction-garmin-sleep",
+          system: "junction",
+        }),
+        recordedAt: "2026-04-11T06:10:00Z",
+        startAt: "2026-04-10T23:00:00Z",
+      },
+      entityId: "event_sleep_session_junction_garmin_conflict",
+      family: "event",
+      kind: "sleep_session",
+      occurredAt: "2026-04-10T23:00:00Z",
+      recordClass: "ledger",
+      title: "Junction Garmin sleep window",
+    }),
+    makeEntity({
+      attributes: {
         dataOrigin: {
           aggregatorProvider: "junction",
           sourceProviderSlug: "whoop_v2",
@@ -1395,7 +1441,7 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
   assert.equal(garminSleep?.totalSleepMinutes.selection.provider, "garmin");
   assert.equal(garminSleep?.totalSleepMinutes.selection.value, 390);
   assert.equal(
-    garminSleep?.totalSleepMinutes.confidence.reasons.some((reason) => /\bJunction\b/u.test(reason)),
+    garminSleep?.totalSleepMinutes.confidence.reasons.some((reason) => /\bjunction\b/iu.test(reason)),
     false,
   );
   assert.equal(
@@ -1403,12 +1449,27 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
     true,
   );
   assert.equal(
-    garminSleep?.summaryConfidence.notes.some((note) => /\bJunction\b/u.test(note)),
+    garminSleep?.summaryConfidence.notes.some((note) => /\bjunction\b/iu.test(note)),
     false,
   );
   assert.equal(
-    garminSleep?.notes.some((note) => /\bJunction\b/u.test(note)),
+    garminSleep?.notes.some((note) => /\bjunction\b/iu.test(note)),
     false,
+  );
+  const directConflictSleep = summarizeWearableSleep(vault, { providers: ["garmin"] })
+    .find((night) => night.date === "2026-04-11");
+  assert.equal(directConflictSleep?.sessionMinutes.selection.provider, "garmin");
+  assert.equal(
+    directConflictSleep?.summaryConfidence.notes.some((note) => /\bjunction\b/iu.test(note)),
+    false,
+  );
+  assert.equal(
+    directConflictSleep?.notes.some((note) => /\bjunction\b/iu.test(note)),
+    false,
+  );
+  assert.equal(
+    directConflictSleep?.notes.some((note) => note.startsWith("Selected sleep window from Garmin ")),
+    true,
   );
 
   const mixedSourceSleep = summarizeWearableSleep(vault)
@@ -1434,7 +1495,17 @@ test("public wearable surfaces present Junction-backed Garmin as Garmin", () => 
   assert.deepEqual(whoopDay?.providers, ["whoop"]);
   assert.equal(whoopDay?.activity?.steps.selection.provider, "whoop");
   assert.equal(
-    whoopDay?.activity?.steps.confidence.reasons.some((reason) => /\bJunction\b/u.test(reason)),
+    whoopDay?.activity?.steps.confidence.reasons.some((reason) => /\bjunction\b/iu.test(reason)),
+    false,
+  );
+  assert.equal(
+    /(?:\bJunction\b|whoop[_-]v2)/iu.test(whoopDay?.activity?.steps.selection.title ?? ""),
+    false,
+  );
+  assert.equal(
+    whoopDay?.activity?.steps.candidates.some((candidate) =>
+      /(?:\bJunction\b|whoop[_-]v2)/iu.test(candidate.title ?? "")
+    ),
     false,
   );
   assert.equal(

--- a/packages/query/test/wearables-selection-shared-final.test.ts
+++ b/packages/query/test/wearables-selection-shared-final.test.ts
@@ -750,11 +750,11 @@ test("selection treats Junction whoop_v2 evidence as a direct WHOOP duplicate", 
     externalRef: makeExternalRef({
       resourceId: "whoop-recovery-1",
       resourceType: "recovery",
-      system: "whoop",
+      system: "whoop_v2",
     }),
     metric: "hrv",
     occurredAt: "2026-04-12T07:00:00Z",
-    provider: "whoop",
+    provider: "whoop_v2",
     recordedAt: "2026-04-12T07:01:00Z",
     sourceFamily: "event",
     sourceKind: "observation:hrv",
@@ -792,7 +792,7 @@ test("selection treats Junction whoop_v2 evidence as a direct WHOOP duplicate", 
     { metricFamily: "recovery" },
   );
 
-  assert.equal(resolved.selection.provider, "whoop");
+  assert.equal(resolved.selection.provider, "whoop_v2");
   assert.equal(resolved.selection.title, "Direct WHOOP HRV");
 });
 

--- a/packages/query/test/wearables-selection-shared-final.test.ts
+++ b/packages/query/test/wearables-selection-shared-final.test.ts
@@ -743,6 +743,59 @@ test("selection helpers cover direct, fallback, agreement, conflict, and tie-bre
   assert.equal(fallbackTimestampSleepSelection.selection?.title, "Alpha end-at sleep");
 });
 
+test("selection treats Junction whoop_v2 evidence as a direct WHOOP duplicate", () => {
+  const directWhoopHrv = makeMetricCandidate({
+    candidateId: "whoop:hrv:direct",
+    date: "2026-04-12",
+    externalRef: makeExternalRef({
+      resourceId: "whoop-recovery-1",
+      resourceType: "recovery",
+      system: "whoop",
+    }),
+    metric: "hrv",
+    occurredAt: "2026-04-12T07:00:00Z",
+    provider: "whoop",
+    recordedAt: "2026-04-12T07:01:00Z",
+    sourceFamily: "event",
+    sourceKind: "observation:hrv",
+    title: "Direct WHOOP HRV",
+    unit: "ms",
+    value: 52,
+  });
+  const junctionWhoopHrv = makeMetricCandidate({
+    candidateId: "junction:whoop-v2:hrv",
+    dataOrigin: {
+      version: 1,
+      aggregatorProvider: "junction",
+      sourceProviderSlug: "whoop_v2",
+    },
+    date: "2026-04-12",
+    externalRef: makeExternalRef({
+      resourceId: "junction-whoop-recovery-1",
+      resourceType: "junction-whoop-v2-recovery",
+      system: "junction",
+    }),
+    metric: "hrv",
+    occurredAt: "2026-04-12T07:05:00Z",
+    provider: "junction",
+    recordedAt: "2026-04-12T07:06:00Z",
+    sourceFamily: "event",
+    sourceKind: "observation:hrv",
+    title: "Junction WHOOP HRV",
+    unit: "ms",
+    value: 52,
+  });
+
+  const resolved = resolveMetric(
+    "hrv",
+    [junctionWhoopHrv, directWhoopHrv],
+    { metricFamily: "recovery" },
+  );
+
+  assert.equal(resolved.selection.provider, "whoop");
+  assert.equal(resolved.selection.title, "Direct WHOOP HRV");
+});
+
 test("selection keeps Junction source policy separate from provider identity", () => {
   const directOuraSteps = makeMetricCandidate({
     candidateId: "oura:steps:direct",

--- a/packages/vault-usecases/src/testing/junction-wearable-fixture.ts
+++ b/packages/vault-usecases/src/testing/junction-wearable-fixture.ts
@@ -14,6 +14,7 @@ import {
   JUNCTION_ALLOWED_TIMESERIES_RESOURCES,
   normalizeJunctionResourceName,
 } from "@murphai/importers/device-providers/junction-resources";
+import { canonicalizeDeviceProviderSlug } from "@murphai/importers/device-providers/provider-descriptors";
 import {
   buildMetricProjection,
   readVault,
@@ -572,11 +573,13 @@ export function promoteWearableCaptureToJunctionHostedSmokeFixture(
 }
 
 export function normalizeJunctionProviderSlugForComparison(provider: string): string {
-  return provider
+  const slug = provider
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/gu, "-")
     .replace(/^-+|-+$/gu, "");
+
+  return canonicalizeDeviceProviderSlug(slug);
 }
 
 export function collectJunctionWearableBrowserVaultSummaryFailures(

--- a/packages/vault-usecases/test/junction-wearable-fixture.test.ts
+++ b/packages/vault-usecases/test/junction-wearable-fixture.test.ts
@@ -7,11 +7,22 @@ import { describe, expect, it } from "vitest";
 import {
   buildJunctionWearableHostedReplayPlan,
   JUNCTION_WEARABLE_HOSTED_DIRECT_REPLAY_BROWSER_VAULT_METRIC_EXPECTATIONS,
+  normalizeJunctionProviderSlugForComparison,
   promoteWearableCaptureToJunctionHostedSmokeFixture,
   runJunctionWearableFixtureE2e,
 } from "../src/testing.ts";
 
 describe("Junction wearable fixture testing helpers", () => {
+  it("canonicalizes WHOOP implementation slugs when comparing provider identities", () => {
+    expect(normalizeJunctionProviderSlugForComparison("whoop_v2")).toBe("whoop");
+    expect(normalizeJunctionProviderSlugForComparison("Whoop V2")).toBe("whoop");
+    expect(normalizeJunctionProviderSlugForComparison("whoop_v2")).toBe(
+      normalizeJunctionProviderSlugForComparison(" WHOOP "),
+    );
+    expect(normalizeJunctionProviderSlugForComparison("OURA")).toBe("oura");
+    expect(normalizeJunctionProviderSlugForComparison(" Oura Ring ")).toBe("oura-ring");
+  });
+
   it("reject unsafe fixture data before building replay payloads or importing into a vault", async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), "murph-junction-fixture-"));
     const fixturePath = path.join(tempRoot, "junction-wearables-sanitized.json");


### PR DESCRIPTION
## Problem

WHOOP data reaches vaults from two sources with two provider identities:
- manual WHOOP ZIP export imports land as `externalRef.system: "whoop"`
- Junction live sync lands as `dataOrigin.sourceProviderSlug: "whoop_v2"`

The wearable query layer treated these as distinct public providers (`whoop` vs `whoop-v2`), so:
- `wearables * --provider whoop` returned only the stale ZIP export (Sept–Nov 2025) and missed the live Junction stream
- projection rows split across `providers:whoop` / `providers:whoop-v2` scope keys
- `whoop_v2` was rejected as CLI input, and source-health showed a raw `whoop-v2` row

## Fix

Canonical provider aliasing in the shared descriptor registry (the documented single source of provider identity), applied at the public-identity seams only:

- `provider-descriptors.ts`: optional `aliases` on `DeviceProviderDescriptor`; WHOOP gets `["whoop_v2", "whoop-v2"]`; alias-aware `resolveDeviceProviderDescriptor`; new `canonicalizeDeviceProviderSlug`
- query: `resolveWearablePublicSourceProvider`, projection grouping + row keys (`normalizeWearableProviders`), candidates provider filter, and the junction direct-duplicate selection comparison all canonicalize
- CLI: `--provider whoop_v2`/`whoop-v2` accepted and canonicalized to `whoop`
- `QUERY_PROJECTION_SQLITE_VERSION` 8 → 9 so pre-fix projections re-key stale `providers:whoop-v2` rows on next open instead of waiting for a vault write

Vault records keep raw provenance (`externalRef.system`, `dataOrigin.sourceProviderSlug` untouched) — no data migration. Device-sync connect routing and the automation contract (`whoop_v2` narrowing) intentionally unchanged; this mirrors the aliasing the automations layer already hand-rolls and the connect-routes' existing whoop_v2→whoop connect-target mapping.

## Verification

- `pnpm test:diff` green on the rebased tree (post #142/#146 stored codec)
- New regression tests: descriptor alias resolution, candidates filter, junction-whoop_v2 direct-duplicate selection, end-to-end projection scope keys + runtime reads + source health, CLI alias acceptance/dedupe + unknown-provider rejection, fixture comparison helper
- Direct scenario (synthetic vault, ZIP whoop 2025-11-23 + junction whoop_v2 2026-06-12): before — two split source rows, `--provider whoop` returns stale data; after — one `whoop`/WHOOP row spanning both eras, `--provider whoop` selects the fresh junction reading
- `gen:config-schema` drift check: no diff
- Completion audits run: coverage-write (3 proof gaps closed) and task-finish-review (rebase + projection-version-bump findings fixed; cross-provider rank pin consciously skipped as consistent with the existing junction-oura precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783873987&installation_id=127572939&pr_number=155&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F155&signature=86c0828bc7a478bc570a2c455b548a64d17455872e1805f0935e37da5eaab9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->