### PR TITLE
fix(hosted): restore the mailbox consumed-watermark ack dropped by the abort-guard wrapper

### DIFF
--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -2242,6 +2242,8 @@ function createAbortGuardedHostedRuntimePlatform(
             // they are replay-safe; consume is a durable write and takes the
             // abort guard like every other write port.
             ...platform.mailboxPort,
+            fetch: (request) => platform.mailboxPort!.fetch(request),
+            fetchPayload: (request) => platform.mailboxPort!.fetchPayload(request),
             ...(platform.mailboxPort.consume
               ? {
                   consume: (request) =>

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -2235,8 +2235,19 @@ function createAbortGuardedHostedRuntimePlatform(
     ...(platform.mailboxPort
       ? {
           mailboxPort: {
-            fetch: platform.mailboxPort.fetch,
-            fetchPayload: platform.mailboxPort.fetchPayload,
+            // Spread so optional port methods survive this wrapper; the
+            // consumed-watermark ack silently vanished here when consume was
+            // added to the port but not to this enumeration (2026-06 prod
+            // consume_port_missing incident). Reads stay unguarded because
+            // they are replay-safe; consume is a durable write and takes the
+            // abort guard like every other write port.
+            ...platform.mailboxPort,
+            ...(platform.mailboxPort.consume
+              ? {
+                  consume: (request) =>
+                    guard(() => platform.mailboxPort!.consume!(request)),
+                }
+              : {}),
           },
         }
       : {}),

--- a/packages/assistant-runtime/test/hosted-runtime-abort-guard.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-abort-guard.test.ts
@@ -4,9 +4,14 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { initializeVault } from "@murphai/core";
+import {
+  HOSTED_MAILBOX_ITEM_PAYLOAD_SCHEMA,
+  HOSTED_MAILBOX_PAYLOAD_SCHEMA,
+} from "@murphai/hosted-execution/runtime-control";
 import type {
   HostedMailboxFetchRequest,
   HostedMailboxFetchResponse,
+  HostedMailboxItem,
   HostedMailboxPayloadFetchRequest,
   HostedMailboxPayloadFetchResponse,
   HostedWorkspaceCheckpointResponse,
@@ -19,6 +24,7 @@ import {
   runHostedWorkspaceRuntimeJobInProcess,
 } from "../src/hosted-runtime.ts";
 import type {
+  HostedRuntimeMailboxPort,
   HostedRuntimePlatform,
 } from "../src/hosted-runtime-contracts.ts";
 
@@ -26,6 +32,122 @@ const TEST_NOW = "2026-04-27T00:00:00.000Z";
 const TEST_USER_ID = "member_synthetic_abort_guard";
 
 describe("hosted runtime abort guard", () => {
+  test("preserves prototype-backed required mailbox read methods", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-mailbox-guard-"));
+    const mailboxItem = createMailboxItem({
+      id: "mailbox_item_prototype_mailbox_guard",
+      kind: "member.activated",
+      lane: "system",
+      payloadInlineCiphertext: null,
+      payloadRef: "payload_ref_prototype_mailbox_guard",
+    });
+    const fetchRequests: HostedMailboxFetchRequest[] = [];
+    const payloadFetchRequests: HostedMailboxPayloadFetchRequest[] = [];
+    const importedPayloadSources: string[] = [];
+
+    class PrototypeMailboxPort implements HostedRuntimeMailboxPort {
+      readonly #mailboxItem = mailboxItem;
+      readonly #userId = TEST_USER_ID;
+
+      async fetch(request: HostedMailboxFetchRequest): Promise<HostedMailboxFetchResponse> {
+        fetchRequests.push(request);
+        return {
+          fetchedAt: TEST_NOW,
+          items: [this.#mailboxItem],
+          maxSeqByLane: request.lanes.map((lane) => ({
+            lane: lane.lane,
+            maxSeq: lane.lane === this.#mailboxItem.lane
+              ? this.#mailboxItem.laneSeq
+              : lane.importedSeq,
+          })),
+          userId: this.#userId,
+        };
+      }
+
+      async fetchPayload(
+        request: HostedMailboxPayloadFetchRequest,
+      ): Promise<HostedMailboxPayloadFetchResponse> {
+        payloadFetchRequests.push(request);
+        return {
+          fetchedAt: TEST_NOW,
+          payload: {
+            createdAt: TEST_NOW,
+            mailboxItemId: this.#mailboxItem.id,
+            payloadCiphertext: "ciphertext_synthetic_sidecar",
+            payloadSchema: HOSTED_MAILBOX_PAYLOAD_SCHEMA,
+            userId: this.#userId,
+          },
+        };
+      }
+    }
+
+    try {
+      await initializeVault({
+        createdAt: new Date(TEST_NOW),
+        timezone: "UTC",
+        title: "Hosted Runtime Prototype Mailbox Test Vault",
+        vaultRoot,
+      });
+
+      const result = await runHostedWorkspaceRuntimeJobInProcess({
+        request: {
+          attemptId: "attempt_synthetic_prototype_mailbox_guard",
+          idleCheckpointDelayMs: 1,
+          leaseGeneration: "1",
+          userId: TEST_USER_ID,
+          workspace: createWorkspaceState(),
+          workspaceVersion: "0",
+        },
+        runtime: {
+          forwardedEnv: {
+            HOSTED_ASSISTANT_MODEL: "gpt-synthetic",
+            HOSTED_ASSISTANT_PROVIDER: "openai",
+            OPENAI_API_KEY: "test-api-key",
+          },
+        },
+      }, {
+        async createCheckpointSnapshot() {
+          return {
+            snapshotRef: {
+              hash: "c".repeat(64),
+              key: "users/bundles/member-synthetic/prototype-mailbox-guard.bundle.json",
+              size: 512,
+              updatedAt: TEST_NOW,
+            },
+          };
+        },
+        async importItem(item) {
+          importedPayloadSources.push(item.payload.source);
+          assert.equal(item.payload.payloadCiphertext, "ciphertext_synthetic_sidecar");
+          return {
+            assistantInputId: "ain_prototype_mailbox_guard",
+            status: "imported",
+          };
+        },
+        platform: createPlatform(vi.fn<typeof fetch>(), new PrototypeMailboxPort()),
+        async runAssistantPhase() {
+          return {
+            progressed: false,
+          };
+        },
+        vaultRoot,
+      });
+
+      assert.equal(result.status, "idle");
+      assert.equal(fetchRequests.length > 0, true);
+      assert.deepEqual(
+        payloadFetchRequests.map((request) => request.payloadRef),
+        ["payload_ref_prototype_mailbox_guard"],
+      );
+      assert.deepEqual(importedPayloadSources, ["sidecar"]);
+    } finally {
+      await rm(vaultRoot, {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
   test("blocks providerFetch after the host signal aborts", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-abort-guard-"));
     const hostAbortController = new AbortController();
@@ -88,7 +210,10 @@ describe("hosted runtime abort guard", () => {
   });
 });
 
-function createPlatform(providerFetch: typeof fetch): HostedRuntimePlatform {
+function createPlatform(
+  providerFetch: typeof fetch,
+  mailboxPort: HostedRuntimeMailboxPort = createDefaultMailboxPort(),
+): HostedRuntimePlatform {
   return {
     artifactStore: {
       async get() {
@@ -104,24 +229,7 @@ function createPlatform(providerFetch: typeof fetch): HostedRuntimePlatform {
         return undefined;
       },
     },
-    mailboxPort: {
-      async fetch(request: HostedMailboxFetchRequest): Promise<HostedMailboxFetchResponse> {
-        return {
-          fetchedAt: TEST_NOW,
-          items: [],
-          maxSeqByLane: request.lanes.map((lane) => ({
-            lane: lane.lane,
-            maxSeq: lane.importedSeq,
-          })),
-          userId: TEST_USER_ID,
-        };
-      },
-      async fetchPayload(
-        _request: HostedMailboxPayloadFetchRequest,
-      ): Promise<HostedMailboxPayloadFetchResponse> {
-        throw new Error("Abort guard test should not fetch mailbox payloads.");
-      },
-    },
+    mailboxPort,
     providerFetch,
     workspacePort: {
       async read(): Promise<HostedWorkspaceReadResponse> {
@@ -130,14 +238,67 @@ function createPlatform(providerFetch: typeof fetch): HostedRuntimePlatform {
           workspace: createWorkspaceState(),
         };
       },
-      async checkpoint(): Promise<HostedWorkspaceCheckpointResponse> {
-        throw new Error("Abort guard test should not checkpoint workspace.");
+      async checkpoint(request): Promise<HostedWorkspaceCheckpointResponse> {
+        return {
+          checkpointed: true,
+          workspace: createWorkspaceState({
+            checkpointedAt: TEST_NOW,
+            nextWakeAt: request.nextWakeAt ?? null,
+            nextWakeReason: request.nextWakeReason ?? null,
+            redactedStatus: request.redactedStatus ?? null,
+            snapshotRef: request.snapshotRef,
+            version: String(BigInt(request.expectedWorkspaceVersion) + 1n),
+          }),
+        };
       },
     },
   };
 }
 
-function createWorkspaceState(): HostedWorkspaceState {
+function createDefaultMailboxPort(): HostedRuntimeMailboxPort {
+  return {
+    async fetch(request: HostedMailboxFetchRequest): Promise<HostedMailboxFetchResponse> {
+      return {
+        fetchedAt: TEST_NOW,
+        items: [],
+        maxSeqByLane: request.lanes.map((lane) => ({
+          lane: lane.lane,
+          maxSeq: lane.importedSeq,
+        })),
+        userId: TEST_USER_ID,
+      };
+    },
+    async fetchPayload(
+      _request: HostedMailboxPayloadFetchRequest,
+    ): Promise<HostedMailboxPayloadFetchResponse> {
+      throw new Error("Abort guard test should not fetch mailbox payloads.");
+    },
+  };
+}
+
+function createMailboxItem(overrides: Partial<HostedMailboxItem> = {}): HostedMailboxItem {
+  return {
+    createdAt: TEST_NOW,
+    dedupeKey: `dedupe_${overrides.id ?? "mailbox_item_abort_guard_001"}`,
+    expiresAt: null,
+    id: "mailbox_item_abort_guard_001",
+    kind: "conversation.message",
+    lane: "conversation",
+    laneSeq: "1",
+    occurredAt: TEST_NOW,
+    payloadBytes: 128,
+    payloadInlineCiphertext: "ciphertext_synthetic_inline",
+    payloadRef: null,
+    payloadSchema: HOSTED_MAILBOX_ITEM_PAYLOAD_SCHEMA,
+    updatedAt: TEST_NOW,
+    userId: TEST_USER_ID,
+    ...overrides,
+  };
+}
+
+function createWorkspaceState(
+  overrides: Partial<HostedWorkspaceState> = {},
+): HostedWorkspaceState {
   return {
     checkpointedAt: TEST_NOW,
     createdAt: TEST_NOW,
@@ -148,5 +309,6 @@ function createWorkspaceState(): HostedWorkspaceState {
     updatedAt: TEST_NOW,
     userId: TEST_USER_ID,
     version: "0",
+    ...overrides,
   };
 }

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -29,6 +29,8 @@ import {
 import {
   HOSTED_MAILBOX_ITEM_PAYLOAD_SCHEMA,
   HOSTED_MAILBOX_PAYLOAD_SCHEMA,
+  type HostedMailboxConsumeRequest,
+  type HostedMailboxConsumeResponse,
   type HostedMailboxFetchRequest,
   type HostedMailboxFetchResponse,
   type HostedMailboxItem,
@@ -1547,6 +1549,190 @@ describe("hosted workspace runtime entrypoint", () => {
         status: "idle",
       });
     } finally {
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
+  test("foreground consume ack reaches the mailbox port through the abort-guarded platform", async () => {
+    // Regression: the abort-guard platform wrapper rebuilt mailboxPort with
+    // only fetch/fetchPayload, silently dropping consume — every prod reply
+    // pass skipped the consumed-watermark ack with consume_port_missing. The
+    // runner-level consume-ack tests inject the platform directly and never
+    // see that wrapper, so this must hold at the in-process job entrypoint.
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const events: string[] = [];
+    const consumeRequests: HostedMailboxConsumeRequest[] = [];
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const mailboxPort = createMailboxPort({
+      consumeRequests,
+      events,
+      items: [
+        createMailboxItem({
+          id: "mailbox_item_entrypoint_consume_ack",
+          laneSeq: "1",
+        }),
+      ],
+    });
+
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      await runHostedWorkspaceRuntimeJobInProcess(createWorkspaceRuntimeJobInput(), {
+        async createCheckpointSnapshot() {
+          return {
+            snapshotRef: createBundleRef({
+              hash: "b".repeat(64),
+              key: "users/bundles/member-synthetic/workspace-entrypoint-consume-ack.bundle.json",
+              size: 512,
+            }),
+          };
+        },
+        async importItem() {
+          return { status: "imported" };
+        },
+        platform: createPlatform({
+          events,
+          logRequests,
+          mailboxPort,
+          workspacePort: createWorkspacePort({
+            checkpointRequests: [],
+            events,
+            workspace: createWorkspaceState({ version: "0" }),
+          }),
+        }),
+        async runAssistantPhase() {
+          return { foregroundReplyFailed: 0, progressed: false };
+        },
+        vaultRoot,
+      });
+
+      assert.deepEqual(
+        consumeRequests.map((request) => request.lanes),
+        [[{ consumedSeq: "1", lane: "conversation" }]],
+      );
+      const consumeAckEntries = logRequests
+        .flatMap((request) => request.entries)
+        .filter((entry) =>
+          entry.eventCode === "mailbox.consume_ack_advanced"
+          || entry.eventCode === "mailbox.consume_ack_skipped"
+        );
+      assert.deepEqual(
+        consumeAckEntries.map((entry) => ({
+          eventCode: entry.eventCode,
+          mailboxSeqEnd: entry.mailboxSeqEnd,
+        })),
+        [{
+          eventCode: "mailbox.consume_ack_advanced",
+          mailboxSeqEnd: "1",
+        }],
+      );
+    } finally {
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
+  test("runtime abort blocks the foreground consume ack at the abort-guarded platform", async () => {
+    // The guard half of the consume passthrough: the consumed-watermark ack is
+    // a durable write, so once the runtime abort signal fires it must never
+    // reach the mailbox port — an aborted attempt has no durably delivered
+    // reply, and advancing the watermark anyway would permanently drop those
+    // mailbox items instead of replaying them. The job promise rejects at the
+    // abort race before the runner's detached best-effort ack runs, and the
+    // abort-guarded log port swallows the runner.error/mailbox_consume_failed
+    // durable write, so the runner's consume-failure console warning is the
+    // only deterministic completion signal for the detached pass.
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const events: string[] = [];
+    const consumeRequests: HostedMailboxConsumeRequest[] = [];
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const hostAbortController = new AbortController();
+    const hostAbortReason = new Error("synthetic runtime abort during assistant phase");
+    const consumeAttemptSettled = createDeferred<
+      "consume_failure_warned" | "underlying_consume_invoked"
+    >();
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      if (
+        typeof args[0] === "string"
+        && args[0].includes("Hosted conversation mailbox consume ack failed")
+      ) {
+        consumeAttemptSettled.resolve("consume_failure_warned");
+      }
+    });
+    const basePort = createMailboxPort({
+      consumeRequests,
+      events,
+      items: [
+        createMailboxItem({
+          id: "mailbox_item_entrypoint_consume_abort",
+          laneSeq: "1",
+        }),
+      ],
+    });
+    const mailboxPort: HostedRuntimeMailboxPort = {
+      ...basePort,
+      async consume(request) {
+        consumeAttemptSettled.resolve("underlying_consume_invoked");
+        return await basePort.consume!(request);
+      },
+    };
+
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const outcome = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: { attemptId: "attempt_synthetic_consume_abort" },
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "c".repeat(64),
+                key: "users/bundles/member-synthetic/workspace-entrypoint-consume-abort.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem() {
+            return { status: "imported" };
+          },
+          platform: createPlatform({
+            events,
+            logRequests,
+            mailboxPort,
+            workspacePort: createWorkspacePort({
+              checkpointRequests: [],
+              events,
+              workspace: createWorkspaceState({ version: "0" }),
+            }),
+          }),
+          async runAssistantPhase() {
+            hostAbortController.abort(hostAbortReason);
+            return { foregroundReplyFailed: 0, progressed: false };
+          },
+          signal: hostAbortController.signal,
+          vaultRoot,
+        },
+      ).then(
+        () => "resolved" as const,
+        (error: unknown) => error,
+      );
+      assert.equal(outcome, hostAbortReason);
+
+      const consumeAttempt = await Promise.race([
+        consumeAttemptSettled.promise,
+        new Promise<"timed_out_waiting_for_consume_attempt">((resolve) =>
+          setTimeout(() => resolve("timed_out_waiting_for_consume_attempt"), 5_000)
+        ),
+      ]);
+      assert.equal(consumeAttempt, "consume_failure_warned");
+      assert.deepEqual(consumeRequests, []);
+      assert.deepEqual(
+        logRequests
+          .flatMap((request) => request.entries)
+          .filter((entry) => entry.eventCode === "mailbox.consume_ack_advanced"),
+        [],
+      );
+    } finally {
+      consoleWarn.mockRestore();
       await removeTempRoot(vaultRoot);
     }
   });
@@ -7812,12 +7998,28 @@ async function writeMailboxImportStateFile(
 }
 
 function createMailboxPort(input: {
+  consumeRequests?: HostedMailboxConsumeRequest[];
   events: string[];
   fetchRequests?: HostedMailboxFetchRequest[];
   items: HostedMailboxItem[];
   stageSamples?: StageTimingSample[];
 }): HostedRuntimeMailboxPort {
+  const consumeRequests = input.consumeRequests;
+
   return {
+    ...(consumeRequests
+      ? {
+          async consume(request): Promise<HostedMailboxConsumeResponse> {
+            input.events.push("mailbox.consume");
+            consumeRequests.push(request);
+            return {
+              acknowledgedAt: TEST_NOW,
+              consumedSeqByLane: request.lanes,
+              userId: TEST_USER_ID,
+            };
+          },
+        }
+      : {}),
     async fetch(request: HostedMailboxFetchRequest): Promise<HostedMailboxFetchResponse> {
       return await measureStage(input.stageSamples, "mailbox.fetch", async () => {
         input.events.push("mailbox.fetch");


### PR DESCRIPTION
## Problem

The hosted runner's conversation consumed-watermark ack (PR #110) never fired in production: `consumed_seq` stayed 0 for every member/lane, leaving an unbounded replay window — after an unclean container death, already-replied mailbox items could replay as fresh reply candidates (duplicate replies).

PR #133's gate instrumentation pinpointed it in prod logs: since the instrumented deploy, every clean foreground reply pass logged `mailbox.consume_ack_skipped` with `skipReason: consume_port_missing` (46×, warn), zero `mailbox.consume_ack_advanced`, and none of the other gates ever fired.

## Root cause

`createAbortGuardedHostedRuntimePlatform` (`packages/assistant-runtime/src/hosted-runtime.ts`) rebuilt `mailboxPort` by enumerating only `fetch` and `fetchPayload` — the block predates `consume`, and PR #110 added `consume` to the port type and web implementation but missed this wrapper. The runner only ever sees the guarded platform, so `mailboxPort.consume` was always `undefined` at the gate in `workspace-runner.ts`.

## Fix

Spread `...platform.mailboxPort` in the wrapper (optional port methods can no longer silently vanish — same shape `effectsPort` already uses) and override `consume` with the abort-guarded call, matching every other durable-write port in the wrapper. Reads stay unguarded (replay-safe) as before.

## Tests (both halves proven red→green at the wrapper layer)

The existing runner-level consume-ack tests inject the platform directly and bypass this wrapper — which is exactly why the bug was invisible. Two new tests drive `runHostedWorkspaceRuntimeJobInProcess`, the only layer that applies the wrapper:

- **Passthrough:** clean foreground pass → consume reaches the port (`consumedSeq: "1"`) and `mailbox.consume_ack_advanced` is logged. Fails on the old enumeration (consume never arrives).
- **Guard:** runtime abort during the assistant phase → the underlying `consume` is never invoked and no advanced log lands (an aborted attempt advancing the watermark would permanently drop items — the inverse failure of the incident). Fails if the guarded override is removed.

## Verification

- `pnpm typecheck` + `pnpm test:diff packages/assistant-runtime/...` green on rebased `origin/main` (includes reverse-dependent `apps/cloudflare verify`, 1374 tests)
- Entrypoint test file 83/83
- Completion audits: coverage-write (added the abort-path test) and task-finish-review (no high/medium findings) both run

## Deployment notes

Cloudflare-only deploy surface (`packages/assistant-runtime` ships in the runner bundle); the web consume route already exists in prod — no tandem deploy needed. Post-deploy readback: `mailbox.consume_ack_advanced` should appear on clean reply passes in `hosted_runtime_log`, and `consumed_seq` should start rising in `hosted_mailbox_lane_counter` (all 0 today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783874193&installation_id=127572939&pr_number=156&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F156&signature=f46dbc52a5222e6cfec8daf1f943b3a2fe4f0875284ed8f26efa9b709c3d116f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->