### PR TITLE
[codex] Add hosted timezone injection e2e

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-12-hosted-timezone-e2e.md
+++ b/agent-docs/exec-plans/completed/2026-06-12-hosted-timezone-e2e.md
@@ -1,0 +1,43 @@
+Goal (incl. success criteria):
+- Add a focused hosted-local e2e test proving an explicit hosted signup timezone reaches the hosted runtime assistant context through the activation/bootstrap path.
+- Success means the `timezone-injection` hosted-local scenario activates a member with an explicit timezone, drives a real Linq assistant turn, and verifies the assistant prompt uses the activation wake timezone rather than the default fallback.
+
+Constraints/Assumptions:
+- Keep the implementation narrow: test and scenario registry only.
+- Preserve hosted ownership boundaries; do not add production test-only routes or runtime behavior.
+- Use synthetic member ids and IANA timezone values only; no real identifiers or secrets.
+- Avoid overlapping active hosted-local e2e work beyond the minimal scenario registry entry.
+
+Key decisions:
+- Exercise the runtime boundary by sending a `member.activated` wake with an explicit `timeZone`.
+- Do not broaden to browser onboarding; browser/header capture and web activation transaction already have focused tests.
+- Assert through the next hosted assistant turn instead of adding a test-only v2 snapshot inspection path.
+
+State:
+- Implementation and focused verification complete.
+
+Done:
+- Read required workflow, verification, testing, and Cloudflare skill guidance.
+- Inspected existing timezone unit coverage and hosted-local e2e patterns.
+- Added the hosted-local timezone injection scenario and registry wiring.
+- Verified the focused scenario, registry unit test, and repo typecheck.
+
+Now:
+- Close the active plan through the repo finish workflow.
+
+Next:
+- Commit and hand off.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- `apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts`
+- `packages/hosted-local-harness/src/e2e.ts`
+- `packages/hosted-local-harness/test/hosted-local.test.ts`
+- `pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts test/hosted-local.test.ts --no-coverage`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts --no-coverage`
+- `pnpm typecheck`
+Status: completed
+Updated: 2026-06-12
+Completed: 2026-06-12

--- a/apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts
@@ -1,0 +1,209 @@
+import { createHmac } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  buildHostedExecutionMemberActivatedWake,
+} from "@murphai/hosted-execution";
+
+import {
+  startHostedLocalFullStackScenario,
+  type HostedLocalFullStackScenario,
+} from "./helpers/hosted-local-full-stack-scenario.js";
+import {
+  buildHostedLinqInboundEvent,
+  buildLinqHomePhoneNumber,
+  buildLinqRecipientPhoneNumber,
+  startHostedLocalLinqStub,
+  type HostedLocalLinqStub,
+} from "./helpers/hosted-local-linq-support.js";
+
+const runId = Date.now();
+const userId = `member_local_timezone_injection_${runId}`;
+const chatId = `chat_local_timezone_injection_${runId}`;
+const activationTimeZone = "Pacific/Auckland";
+const defaultHostedTimeZone = "America/New_York";
+const linqWebhookSecret = "linq-local-timezone-injection-secret";
+const userText = "timezone injection probe";
+const replyText = "Timezone injection probe reply.";
+
+const streamDevLogs = process.env.MURPH_E2E_STREAM_DEV_LOGS === "1";
+const workerPersistDirOverride = process.env.MURPH_E2E_CF_PERSIST_DIR?.trim() || null;
+const localDatabaseUrl = process.env.DATABASE_URL?.trim() || undefined;
+
+let scenario: HostedLocalFullStackScenario | null = null;
+let linqStub: HostedLocalLinqStub | null = null;
+
+describe("hosted local timezone injection e2e", () => {
+  beforeAll(async () => {
+    linqStub = await startHostedLocalLinqStub();
+    scenario = await startHostedLocalFullStackScenario({
+      additionalEnv: {
+        HOSTED_ONBOARDING_LINQ_LOCAL_ALLOWED_INBOUND_PHONE_NUMBERS:
+          buildLinqRecipientPhoneNumber(userId),
+        LINQ_API_BASE_URL: requireLinqStub().runnerBaseUrl,
+        LINQ_API_TOKEN: "linq-local-test-token",
+        LINQ_WEBHOOK_SECRET: linqWebhookSecret,
+        MURPH_DEV_SKIP_HEALTH_COMMONS_WATCH: "1",
+      },
+      localDatabaseUrl,
+      persistDirOverride: workerPersistDirOverride,
+      persistDirPrefix: "murph-hosted-local-timezone-injection-",
+      requiredRunnerEnvProfile: "linq",
+      scenarioLabel: "Local hosted timezone injection e2e",
+      streamLogs: streamDevLogs,
+    });
+  }, 600_000);
+
+  afterAll(async () => {
+    await scenario?.stop();
+    scenario = null;
+    await linqStub?.stop();
+    linqStub = null;
+  }, 120_000);
+
+  it("injects the activation wake timezone into the hosted assistant context", async () => {
+    const memberPhone = buildLinqRecipientPhoneNumber(userId);
+    const homePhone = buildLinqHomePhoneNumber(userId);
+    const replyPath = `/chats/${encodeURIComponent(chatId)}/messages`;
+
+    await requireScenario().seedActiveHostedLinqMember({
+      homePhone,
+      memberId: userId,
+      memberPhone,
+    });
+    await requireScenario().runWake(buildActivationWake(), userId);
+    await requireScenario().waitForHostedCompletion(userId);
+    await requireScenario().bindActiveHostedLinqHomeChat({
+      chatId,
+      memberId: userId,
+      recipientPhone: memberPhone,
+    });
+
+    const baselineSendCount = requireLinqStub().countObservedSends(replyPath);
+    const baselineProviderRequestCount = countAssistantProviderResponsesApiRequests();
+    requireScenario().queueAssistantResponses([replyText]);
+
+    const webhookResponse = await postSignedLinqWebhook(
+      buildHostedLinqInboundEvent(userId, chatId, {
+        eventId: `evt_timezone_injection_${runId}`,
+        messageId: `msg_timezone_injection_${runId}`,
+        text: userText,
+      }),
+    );
+    expect(webhookResponse.status).toBe(202);
+    await expect(webhookResponse.json()).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+
+    await requireScenario().waitForLatestPendingWake(userId);
+    const reply = await requireLinqStub().waitForAdditionalSend({
+      baselineCount: baselineSendCount,
+      expectedPath: replyPath,
+      scenario: requireScenario(),
+      userId,
+    });
+    expect(requireLinqStub().readObservedMessageText(reply)).toBe(replyText);
+
+    const finalStatus = await requireScenario().waitForHostedCompletion(userId);
+    expect(finalStatus.workspace).not.toBeNull();
+    expect(finalStatus.lastErrorCode ?? null).toBeNull();
+
+    const assistantProviderRequests = requireScenario().assistantProviderRequests
+      .filter((request) => request.url === "/v1/responses")
+      .slice(baselineProviderRequestCount);
+    expect(assistantProviderRequests).toHaveLength(1);
+
+    const promptText = readAssistantProviderRequestText(assistantProviderRequests[0]!);
+    expect(promptText).toContain(
+      `The user's canonical timezone for this vault is ${activationTimeZone}.`,
+    );
+    expect(promptText).not.toContain(
+      `The user's canonical timezone for this vault is ${defaultHostedTimeZone}.`,
+    );
+  }, 300_000);
+});
+
+function buildActivationWake() {
+  return buildHostedExecutionMemberActivatedWake({
+    eventId: `member.activated:local:${userId}:evt_timezone_injection`,
+    memberId: userId,
+    memberChannels: {
+      email: false,
+      linq: true,
+      telegram: false,
+    },
+    occurredAt: new Date().toISOString(),
+    timeZone: activationTimeZone,
+  });
+}
+
+function countAssistantProviderResponsesApiRequests(): number {
+  return requireScenario().assistantProviderRequests.filter((request) =>
+    request.url === "/v1/responses"
+  ).length;
+}
+
+function readAssistantProviderRequestText(request: { body: string }): string {
+  return collectJsonStrings(JSON.parse(request.body)).join("\n\n");
+}
+
+function collectJsonStrings(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectJsonStrings(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).flatMap((entry) => collectJsonStrings(entry));
+  }
+
+  return [];
+}
+
+async function postSignedLinqWebhook(event: Record<string, unknown>): Promise<Response> {
+  const rawBody = JSON.stringify(event);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature = signLinqWebhook(linqWebhookSecret, rawBody, timestamp);
+
+  return await fetch(
+    `${requireScenario().harness.webBaseUrl}/api/hosted-onboarding/linq/webhook`,
+    {
+      body: rawBody,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "x-webhook-signature": signature,
+        "x-webhook-timestamp": timestamp,
+      },
+      method: "POST",
+    },
+  );
+}
+
+function signLinqWebhook(secret: string, payload: string, timestamp: string): string {
+  const signature = createHmac("sha256", secret)
+    .update(`${timestamp}.${payload}`)
+    .digest("hex");
+
+  return `sha256=${signature}`;
+}
+
+function requireScenario(): HostedLocalFullStackScenario {
+  if (!scenario) {
+    throw new Error("Hosted local timezone injection scenario was not started.");
+  }
+
+  return scenario;
+}
+
+function requireLinqStub(): HostedLocalLinqStub {
+  if (!linqStub) {
+    throw new Error("Hosted local Linq stub was not initialized.");
+  }
+
+  return linqStub;
+}

--- a/apps/cloudflare/test/run-hosted-local-e2e-runner.test.ts
+++ b/apps/cloudflare/test/run-hosted-local-e2e-runner.test.ts
@@ -56,6 +56,7 @@ const expectedScenarioFiles = [
   "apps/cloudflare/test/hosted-local-idle-checkpoint-deferred-progress-e2e.test.ts",
   "apps/cloudflare/test/hosted-local-mailbox-platform-env-e2e.test.ts",
   "apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts",
+  "apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts",
   "apps/cloudflare/test/hosted-local-linq-first-contact-e2e.test.ts",
   "apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts",
   "apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts",

--- a/packages/hosted-local-harness/src/e2e.ts
+++ b/packages/hosted-local-harness/src/e2e.ts
@@ -48,6 +48,7 @@ export type HostedLocalE2eScenarioName =
   | "runner-warm-reuse"
   | "snapshot-stress"
   | "stuck-invocation-recovery"
+  | "timezone-injection"
   | "temporal-orchestration"
   | "telegram"
   | "telegram-first-contact"
@@ -131,6 +132,10 @@ export const hostedLocalE2eScenarios: readonly HostedLocalE2eScenario[] = [
   {
     file: "apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts",
     name: "temporal-orchestration",
+  },
+  {
+    file: "apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts",
+    name: "timezone-injection",
   },
   {
     aliases: ["linq-delivery"],

--- a/packages/hosted-local-harness/test/hosted-local.test.ts
+++ b/packages/hosted-local-harness/test/hosted-local.test.ts
@@ -98,8 +98,14 @@ describe("hosted-local harness", () => {
     expect(resolveHostedLocalE2eScenarios("temporal-orchestration")[0]?.file).toBe(
       "apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts",
     );
+    expect(resolveHostedLocalE2eScenarios("timezone-injection")[0]?.file).toBe(
+      "apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts",
+    );
     expect(resolveHostedLocalE2eScenarios("all").map((scenario) => scenario.name)).toContain(
       "temporal-orchestration",
+    );
+    expect(resolveHostedLocalE2eScenarios("all").map((scenario) => scenario.name)).toContain(
+      "timezone-injection",
     );
   });
 


### PR DESCRIPTION
## Summary

Adds a focused hosted-local E2E scenario for timezone injection. The test activates a hosted Linq member with an explicit `member.activated.timeZone`, drives a real Linq assistant turn through the hosted-local stack, and asserts the assistant provider prompt contains the injected canonical timezone instead of the default fallback.

Also registers the scenario as `timezone-injection` in the hosted-local harness and covers that registry entry in the harness unit test.

## Validation

- `pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts test/hosted-local.test.ts --no-coverage`
- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts apps/cloudflare/test/hosted-local-timezone-injection-e2e.test.ts --no-coverage`
- `pnpm typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783878567&installation_id=127572939&pr_number=160&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F160&signature=f3a5921310bf885b3386d8645682ca9f699c21d2e223fe22421c918720d37951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->