### PR TITLE
[codex] partition assistant thread context instructions

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-12-thread-context-developer-instructions.md
+++ b/agent-docs/exec-plans/completed/2026-06-12-thread-context-developer-instructions.md
@@ -1,0 +1,77 @@
+# Thread-level context developer instructions
+
+Status: completed
+Owner: Claude
+Worktree: `murph-thread-context-instructions`
+
+## Goal
+
+Stop re-sending thread-stable prompt context inside every per-turn user message.
+Today `dynamicTurnContextPrompt` (~2.3–5.5KB: evidence/reply style, link
+self-check, date-format prose, onboarding guidance, and sometimes the cached
+context snapshot) is
+injected into the composed user prompt on every turn. Codex remote compaction
+retains user messages (newest-first, 64k-token budget) and drops
+developer-role items, then re-injects the session's developer instructions
+once after each compaction — so per-turn user-message context is exactly the
+content compaction must preserve (the measured ~40k-token post-compaction
+floor), while developer-instruction content costs one resident copy total.
+
+Re-partition the system prompt into four volatility tiers:
+
+- `staticCacheableCorePrompt` (deploy-stable) — unchanged.
+- `stableRouteCapabilityPrompt` (route-stable) — unchanged.
+- `threadContextPrompt` (new, thread-birth-stable): timezone + date-format
+  prose + product base URL, evidence/reply style, onboarding guidance (while
+  open), link self-check.
+- `dynamicTurnContextPrompt` (genuinely per-turn): the "Today's date is X"
+  line, cached assistant context snapshot when present, and the
+  automation-cron execution-context note.
+
+`developerInstructions` (thread/start) becomes static + stable +
+threadContext. The existing contract fingerprint hashes developer
+instructions, so thread-context changes (onboarding completion, timezone
+change, product URL change) rotate to a fresh thread — the semantics the
+fingerprint design already implements and the onboarding skill guard
+(1833f04be) already handles. Cached assistant context snapshots stay per-turn
+because hosted runtime snapshots can change during retries and must not rotate
+the native Codex thread contract.
+
+## Success criteria
+
+- Per-turn composed user prompt carries only the date line, cron note (when
+  applicable), cached assistant context snapshot, conversation context lines
+  (fresh threads), and the member's message.
+- Thread-start developer instructions carry the moved sections verbatim (no
+  prose rewrites in this change).
+- Notification-decision profile output text is byte-identical (isolated
+  one-shot threads; no benefit to moving content there).
+- Contract fingerprint changes when thread-context content changes, but not
+  when only the cached assistant context snapshot changes; resume binding
+  behavior otherwise unchanged.
+- assistant-engine typecheck + owner coverage green.
+
+## Non-goals
+
+- No prompt prose rewrites; sections move verbatim.
+- No resume-time instruction refresh mechanism (deliberately removed before;
+  fingerprint rotation is the refresh path).
+- No changes to `compactWarmCodexThread` (separate active lane).
+
+## Steps
+
+1. `system-prompt.ts`: add `threadContextPrompt` layer; split
+   `buildAssistantCurrentDateContextText` into thread-stable prose vs
+   per-turn date line; move section builders between layer composers;
+   keep notification-decision composition byte-identical.
+2. `planning.ts`: include `threadContextPrompt` in
+   `buildDeveloperInstructions`; per-turn `turnContextPrompt` keeps using
+   `dynamicTurnContextPrompt`.
+3. Update affected tests (layer expectations, developer-instruction
+   contents, onboarding injection placement, prompt-composition snapshots).
+4. Verification: `pnpm typecheck` + `pnpm test:diff` over touched files
+   (assistant-engine owner coverage).
+5. Completion audits per workflow (coverage-write, task-finish-review;
+   prompt-review not required — prose unchanged), then `scripts/finish-task`.
+Updated: 2026-06-12
+Completed: 2026-06-12

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -470,6 +470,7 @@ export async function resolveAssistantRouteTurnPlan(input: {
     [
       promptResult.layers.staticCacheableCorePrompt,
       promptResult.layers.stableRouteCapabilityPrompt,
+      promptResult.layers.threadContextPrompt,
     ]
       .filter((section): section is string =>
         Boolean(normalizeNullableString(section)),

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -64,6 +64,14 @@ export interface AssistantSystemPromptLayers {
   prompt: string;
   stableRouteCapabilityPrompt: string;
   staticCacheableCorePrompt: string;
+  /**
+   * Thread-birth-stable context (timezone/date-style prose, evidence/reply
+   * style, onboarding guidance, link self-check). Joined into the thread-level
+   * developer instructions so it costs one resident copy per thread instead of
+   * one copy per turn; a change rotates the thread through the contract
+   * fingerprint.
+   */
+  threadContextPrompt: string;
 }
 
 export interface AssistantPromptCacheMetadata {
@@ -144,6 +152,10 @@ export function buildAssistantSystemPromptLayers(
     buildStableRouteCapabilityPrompt(input),
     input.assistantToolNameAliases
   );
+  const threadContextPrompt = renderAssistantToolNameAliases(
+    buildThreadContextPrompt(input),
+    input.assistantToolNameAliases
+  );
   const dynamicTurnContextPrompt = renderAssistantToolNameAliases(
     buildDynamicTurnContextPrompt(input),
     input.assistantToolNameAliases
@@ -152,7 +164,11 @@ export function buildAssistantSystemPromptLayers(
     staticCacheableCorePrompt,
     stableRouteCapabilityPrompt
   );
-  const prompt = joinPromptSections(stablePrefix, dynamicTurnContextPrompt);
+  const prompt = joinPromptSections(
+    stablePrefix,
+    threadContextPrompt,
+    dynamicTurnContextPrompt
+  );
 
   return {
     dynamicContextStartsAfterStaticCore: stablePrefix.length,
@@ -160,6 +176,7 @@ export function buildAssistantSystemPromptLayers(
     prompt,
     stableRouteCapabilityPrompt,
     staticCacheableCorePrompt,
+    threadContextPrompt,
   };
 }
 
@@ -203,22 +220,27 @@ function buildStableRouteCapabilityPrompt(
   );
 }
 
-function buildDynamicTurnContextPrompt(input: AssistantSystemPromptInput): string {
+function buildThreadContextPrompt(input: AssistantSystemPromptInput): string {
   return joinPromptSections(
-    buildAssistantCurrentDateContextText({
-      currentLocalDate: input.currentLocalDate,
+    buildAssistantTimeStyleContextText({
       currentMurphProductBaseUrl: input.murphProductBaseUrl ?? null,
       currentTimeZone: input.currentTimeZone,
     }),
-    input.assistantContextSnapshotPrompt ?? null,
     buildAssistantEvidenceAndReplyStyleText(input.channel),
-    buildAssistantExecutionContextText({
-      turnTrigger: input.turnTrigger ?? null,
-    }),
     buildAssistantOnboardingGuidanceText({
       enabled: input.onboardingGuidance,
     }),
     buildAssistantUserFacingLinkSelfCheckText()
+  );
+}
+
+function buildDynamicTurnContextPrompt(input: AssistantSystemPromptInput): string {
+  return joinPromptSections(
+    buildAssistantCurrentDateLineText(input.currentLocalDate),
+    input.assistantContextSnapshotPrompt ?? null,
+    buildAssistantExecutionContextText({
+      turnTrigger: input.turnTrigger ?? null,
+    })
   );
 }
 
@@ -282,6 +304,9 @@ export function buildAssistantNotificationDecisionSystemPromptLayers(
     prompt,
     stableRouteCapabilityPrompt,
     staticCacheableCorePrompt,
+    // Notification-decision turns run on isolated one-shot threads, so a
+    // separate thread-stable layer buys nothing; keep its context per-turn.
+    threadContextPrompt: "",
   };
 }
 
@@ -340,22 +365,52 @@ function stableStringifyAssistantPromptCacheValue(value: unknown): string {
   return `{${entries.join(",")}}`;
 }
 
+const ASSISTANT_DATE_STYLE_GUIDANCE_TEXT =
+  'In user-facing prose, refer to dates with a month name and day, such as "April 3" or "April 3, 2026" when the year matters, instead of raw ISO dates. Keep ISO dates for command arguments, filenames, frontmatter, ids, or other machine-readable fields.';
+
+function buildAssistantTimezoneLineText(currentTimeZone: string): string {
+  return `The user's canonical timezone for this vault is ${currentTimeZone}.`;
+}
+
+function buildAssistantCurrentDateLineText(currentLocalDate: string): string {
+  return `Today's date for the user is ${formatAssistantHumanReadableLocalDate(
+    currentLocalDate
+  )}.`;
+}
+
+function buildAssistantProductBaseUrlLineText(
+  currentMurphProductBaseUrl: string | null
+): string | null {
+  return currentMurphProductBaseUrl
+    ? `Current Murph product base URL for user-facing app links: ${currentMurphProductBaseUrl}`
+    : null;
+}
+
+function buildAssistantTimeStyleContextText(input: {
+  currentMurphProductBaseUrl: string | null;
+  currentTimeZone: string;
+}): string {
+  return joinPromptSections(
+    [
+      buildAssistantTimezoneLineText(input.currentTimeZone),
+      ASSISTANT_DATE_STYLE_GUIDANCE_TEXT,
+    ].join("\n"),
+    buildAssistantProductBaseUrlLineText(input.currentMurphProductBaseUrl)
+  );
+}
+
 function buildAssistantCurrentDateContextText(input: {
   currentLocalDate: string;
   currentMurphProductBaseUrl: string | null;
   currentTimeZone: string;
 }): string {
-  const humanReadableCurrentLocalDate = formatAssistantHumanReadableLocalDate(
-    input.currentLocalDate
-  );
-
   return joinPromptSections(
-    `The user's canonical timezone for this vault is ${input.currentTimeZone}.
-Today's date for the user is ${humanReadableCurrentLocalDate}.
-In user-facing prose, refer to dates with a month name and day, such as "April 3" or "April 3, 2026" when the year matters, instead of raw ISO dates. Keep ISO dates for command arguments, filenames, frontmatter, ids, or other machine-readable fields.`,
-    input.currentMurphProductBaseUrl
-      ? `Current Murph product base URL for user-facing app links: ${input.currentMurphProductBaseUrl}`
-      : null
+    [
+      buildAssistantTimezoneLineText(input.currentTimeZone),
+      buildAssistantCurrentDateLineText(input.currentLocalDate),
+      ASSISTANT_DATE_STYLE_GUIDANCE_TEXT,
+    ].join("\n"),
+    buildAssistantProductBaseUrlLineText(input.currentMurphProductBaseUrl)
   );
 }
 

--- a/packages/assistant-engine/test/assistant-protocol-index-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-protocol-index-planning.test.ts
@@ -154,14 +154,15 @@ describe('assistant protocol index planning', () => {
 
     expect(plan.onboardingGuidanceInjected).toBe(true)
     expect(plan.systemPrompt).toContain(skillRef)
-    expect(plan.turnContextPrompt).toContain('Murph onboarding:')
-    expect(plan.turnContextPrompt).toContain(
+    expect(plan.turnContextPrompt).not.toContain('Murph onboarding:')
+    expect(plan.developerInstructions).toContain('Murph onboarding:')
+    expect(plan.developerInstructions).toContain(
       `Read and follow \`${skillRef}\` when onboarding is open and you need the next unresolved onboarding step`,
     )
-    expect(plan.turnContextPrompt).toContain(
+    expect(plan.developerInstructions).toContain(
       'Before ending a normal reply while onboarding is open, keep onboarding moving unless a skip condition applies',
     )
-    expect(plan.turnContextPrompt).not.toContain(
+    expect(plan.developerInstructions).not.toContain(
       'roughly 5-6 short assistant messages',
     )
     expect(plan.turnContextPrompt).not.toContain('Natural first-run flow')
@@ -319,6 +320,63 @@ describe('assistant protocol index planning', () => {
     )
   })
 
+  it('resumes Codex threads when only the per-turn date changes', async () => {
+    planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(null)
+    planningMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
+      supportsNativeResume: true,
+    })
+    const route = createRoute()
+    const oldPlan = await resolveAssistantRouteTurnPlan({
+      executionContext: null,
+      input: createMessageInput(),
+      profile: {
+        promptProfile: 'conversation',
+        threadScope: 'session-thread',
+        toolProfile: 'provider-turn',
+      },
+      promptTimeContext: {
+        currentLocalDate: '2026-05-04',
+        currentTimeZone: 'Asia/Kuala_Lumpur',
+      },
+      route,
+      session: createSession(),
+      sharedPlan: createSharedPlan(),
+    })
+
+    const plan = await resolveAssistantRouteTurnPlan({
+      executionContext: null,
+      input: createMessageInput(),
+      profile: {
+        promptProfile: 'conversation',
+        threadScope: 'session-thread',
+        toolProfile: 'provider-turn',
+      },
+      promptTimeContext: {
+        currentLocalDate: '2026-05-05',
+        currentTimeZone: 'Asia/Kuala_Lumpur',
+      },
+      route,
+      session: createSession({
+        resumeState: {
+          assistantContractFingerprint: oldPlan.assistantContractFingerprint,
+          routeFingerprint: route.routeFingerprint ?? route.routeId,
+          threadId: 'thread-date-change',
+        },
+      }),
+      sharedPlan: createSharedPlan(),
+    })
+
+    expect(plan.resume?.codexThreadId).toBe('thread-date-change')
+    expect(plan.developerInstructions).toBeNull()
+    expect(plan.turnContextPrompt).toBe(
+      'Today\'s date for the user is May 5, 2026.',
+    )
+    expect(plan.assistantContractFingerprint).toBe(
+      oldPlan.assistantContractFingerprint,
+    )
+  })
+
   it('starts a fresh thread when stable developer instructions change', async () => {
     planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValueOnce('old bootstrap')
     planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(null)
@@ -370,6 +428,183 @@ describe('assistant protocol index planning', () => {
     expect(plan.resume).toBeNull()
     expect(plan.developerInstructions).toContain('new bootstrap')
     expect(plan.assistantContractFingerprint).not.toBe(oldPlan.assistantContractFingerprint)
+  })
+
+  it('starts a fresh thread when thread-stable context changes', async () => {
+    planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(null)
+    planningMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
+      supportsNativeResume: true,
+    })
+    const route = createRoute()
+    const executionProfile: AssistantCodexTurnResolvedExecutionProfile = {
+      promptProfile: 'conversation',
+      threadScope: 'session-thread',
+      toolProfile: 'provider-turn',
+    }
+    const basePromptTimeContext = {
+      currentLocalDate: '2026-05-04',
+      currentTimeZone: 'Asia/Kuala_Lumpur',
+    }
+
+    const scenarios = [
+      {
+        expectedDeveloperText:
+          "The user's canonical timezone for this vault is America/New_York.",
+        name: 'timezone',
+        newPromptTimeContext: {
+          ...basePromptTimeContext,
+          currentTimeZone: 'America/New_York',
+        },
+        newSharedPlan: createSharedPlan(),
+        oldPromptTimeContext: basePromptTimeContext,
+        oldSharedPlan: createSharedPlan(),
+        unexpectedTurnText: 'America/New_York',
+      },
+      {
+        expectedDeveloperText:
+          'Current Murph product base URL for user-facing app links: https://new.example.test',
+        name: 'product URL',
+        newPromptTimeContext: basePromptTimeContext,
+        newSharedPlan: createSharedPlan({
+          cliAccess: {
+            env: {
+              HOSTED_WEB_BASE_URL: 'https://new.example.test',
+            },
+            rawCommand: 'vault-cli',
+            setupCommand: 'murph',
+          },
+        }),
+        oldPromptTimeContext: basePromptTimeContext,
+        oldSharedPlan: createSharedPlan({
+          cliAccess: {
+            env: {
+              HOSTED_WEB_BASE_URL: 'https://old.example.test',
+            },
+            rawCommand: 'vault-cli',
+            setupCommand: 'murph',
+          },
+        }),
+        unexpectedTurnText: 'https://new.example.test',
+      },
+      {
+        expectedDeveloperText: 'Murph onboarding:',
+        name: 'onboarding',
+        newPromptTimeContext: basePromptTimeContext,
+        newSharedPlan: createSharedPlan({
+          onboardingGuidanceOpen: true,
+        }),
+        oldPromptTimeContext: basePromptTimeContext,
+        oldSharedPlan: createSharedPlan({
+          onboardingGuidanceOpen: false,
+        }),
+        unexpectedTurnText: 'Murph onboarding:',
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      const oldPlan = await resolveAssistantRouteTurnPlan({
+        executionContext: null,
+        input: createMessageInput(),
+        profile: executionProfile,
+        promptTimeContext: scenario.oldPromptTimeContext,
+        route,
+        session: createSession(),
+        sharedPlan: scenario.oldSharedPlan,
+      })
+
+      const plan = await resolveAssistantRouteTurnPlan({
+        executionContext: null,
+        input: createMessageInput(),
+        profile: executionProfile,
+        promptTimeContext: scenario.newPromptTimeContext,
+        route,
+        session: createSession({
+          resumeState: {
+            assistantContractFingerprint: oldPlan.assistantContractFingerprint,
+            routeFingerprint: route.routeFingerprint ?? route.routeId,
+            threadId: `thread-old-${scenario.name}`,
+          },
+        }),
+        sharedPlan: scenario.newSharedPlan,
+      })
+
+      expect(plan.resume, scenario.name).toBeNull()
+      expect(plan.developerInstructions, scenario.name).toContain(
+        scenario.expectedDeveloperText,
+      )
+      expect(plan.turnContextPrompt, scenario.name).not.toContain(
+        scenario.unexpectedTurnText,
+      )
+      expect(plan.assistantContractFingerprint, scenario.name).not.toBe(
+        oldPlan.assistantContractFingerprint,
+      )
+    }
+  })
+
+  it('keeps native resume when only the assistant context snapshot changes', async () => {
+    planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValueOnce(
+      'Old assistant context snapshot.',
+    )
+    planningMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
+      supportsNativeResume: true,
+    })
+    const route = createRoute()
+    const oldPlan = await resolveAssistantRouteTurnPlan({
+      executionContext: null,
+      input: createMessageInput(),
+      profile: {
+        promptProfile: 'conversation',
+        threadScope: 'session-thread',
+        toolProfile: 'provider-turn',
+      },
+      promptTimeContext: {
+        currentLocalDate: '2026-05-04',
+        currentTimeZone: 'Asia/Kuala_Lumpur',
+      },
+      route,
+      session: createSession(),
+      sharedPlan: createSharedPlan(),
+    })
+
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValueOnce(
+      'Updated assistant context snapshot.',
+    )
+    const plan = await resolveAssistantRouteTurnPlan({
+      executionContext: null,
+      input: createMessageInput(),
+      profile: {
+        promptProfile: 'conversation',
+        threadScope: 'session-thread',
+        toolProfile: 'provider-turn',
+      },
+      promptTimeContext: {
+        currentLocalDate: '2026-05-04',
+        currentTimeZone: 'Asia/Kuala_Lumpur',
+      },
+      route,
+      session: createSession({
+        resumeState: {
+          assistantContractFingerprint: oldPlan.assistantContractFingerprint,
+          routeFingerprint: route.routeFingerprint ?? route.routeId,
+          threadId: 'thread-old-snapshot',
+        },
+      }),
+      sharedPlan: createSharedPlan(),
+    })
+
+    expect(plan.resume?.codexThreadId).toBe('thread-old-snapshot')
+    expect(plan.developerInstructions).toBeNull()
+    expect(plan.turnContextPrompt).toContain(
+      'Updated assistant context snapshot.',
+    )
+    expect(plan.turnContextPrompt).not.toContain(
+      'Old assistant context snapshot.',
+    )
+    expect(plan.assistantContractFingerprint).toBe(
+      oldPlan.assistantContractFingerprint,
+    )
   })
 
   it('starts a fresh thread when the dynamic tool contract changes', async () => {
@@ -427,9 +662,9 @@ describe('assistant protocol index planning', () => {
     expect(plan.assistantContractFingerprint).not.toBe(oldToolContractFingerprint)
   })
 
-  it('reads only the cached assistant context snapshot on sensitive native resume', async () => {
+  it('reads current assistant context snapshot on sensitive native resume', async () => {
     planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
-    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValueOnce(
       'Cached assistant context snapshot.',
     )
     planningMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
@@ -455,6 +690,9 @@ describe('assistant protocol index planning', () => {
     })
     planningMocks.readAssistantCliSurfaceBootstrapContext.mockClear()
     planningMocks.readAssistantContextSnapshotPrompt.mockClear()
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValueOnce(
+      'Current assistant context snapshot.',
+    )
     const resumedSession = createSession({
       resumeState: {
         assistantContractFingerprint: initialPlan.assistantContractFingerprint,
@@ -479,8 +717,9 @@ describe('assistant protocol index planning', () => {
     expect(resumedPlan.resume?.codexThreadId).toBe('thread-sensitive-resume')
     expect(resumedPlan.developerInstructions).toBeNull()
     expect(resumedPlan.turnContextPrompt).toContain(
-      'Cached assistant context snapshot.',
+      'Current assistant context snapshot.',
     )
+    expect(resumedPlan.turnContextPrompt).not.toContain('Cached assistant context snapshot.')
     expect(
       planningMocks.readAssistantCliSurfaceBootstrapContext,
     ).toHaveBeenCalledTimes(1)
@@ -490,6 +729,12 @@ describe('assistant protocol index planning', () => {
     const fallback = await resumedPlan.resume?.prepareFreshThreadFallback()
 
     expect(fallback?.developerInstructions).toContain('bootstrap contract')
+    expect(fallback?.developerInstructions).not.toContain(
+      'Current assistant context snapshot.',
+    )
+    expect(fallback?.turnContextPrompt).toContain(
+      'Current assistant context snapshot.',
+    )
     expect(
       planningMocks.readAssistantCliSurfaceBootstrapContext,
     ).toHaveBeenCalledTimes(1)

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -6,8 +6,10 @@ import {
   resolveAssistantModelBehaviorProfile,
 } from '../src/assistant/model-behavior.js'
 import {
+  buildAssistantNotificationDecisionSystemPromptLayers,
   buildAssistantNotificationDecisionSystemPromptWithCacheMetadata,
   buildAssistantSystemPrompt,
+  buildAssistantSystemPromptLayers,
   buildAssistantSystemPromptWithCacheMetadata,
   resolveAssistantMurphProductBaseUrl,
   type AssistantNotificationDecisionSystemPromptInput,
@@ -554,6 +556,99 @@ describe('assistant user-facing wording guidance', () => {
 })
 
 describe('assistant system prompt cache stability', () => {
+  it('partitions thread-stable context away from per-turn Codex context', () => {
+    const layers = buildAssistantSystemPromptLayers(createCommonCodexPromptInput({
+      assistantContextSnapshotPrompt: 'Layer partition assistant context snapshot.',
+      currentLocalDate: '2026-04-15',
+      currentTimeZone: 'Asia/Kuala_Lumpur',
+      murphProductBaseUrl: 'http://localhost:3000',
+      onboardingGuidance: true,
+      turnTrigger: 'automation-cron',
+    }))
+
+    const stablePrefix = [
+      layers.staticCacheableCorePrompt,
+      layers.stableRouteCapabilityPrompt,
+    ].join('\n\n')
+
+    expect(layers.prompt.slice(0, layers.dynamicContextStartsAfterStaticCore)).toBe(
+      stablePrefix,
+    )
+    expect(stablePrefix).not.toContain('Layer partition assistant context snapshot.')
+    expect(stablePrefix).not.toContain('Asia/Kuala_Lumpur')
+    expect(stablePrefix).not.toContain('Murph onboarding:')
+
+    expect(layers.threadContextPrompt).toContain(
+      "The user's canonical timezone for this vault is Asia/Kuala_Lumpur.",
+    )
+    expect(layers.threadContextPrompt).toContain(
+      'In user-facing prose, refer to dates with a month name and day',
+    )
+    expect(layers.threadContextPrompt).toContain(
+      'Current Murph product base URL for user-facing app links: http://localhost:3000',
+    )
+    expect(layers.threadContextPrompt).not.toContain(
+      'Layer partition assistant context snapshot.',
+    )
+    expect(layers.threadContextPrompt).toContain('Answer the human request directly.')
+    expect(layers.threadContextPrompt).toContain(
+      'Before sending any user-facing reply, quickly scan the visible answer for forbidden link and source formatting',
+    )
+    expect(layers.threadContextPrompt).toContain('Murph onboarding:')
+    expect(layers.threadContextPrompt).not.toContain(
+      "Today's date for the user is April 15, 2026.",
+    )
+    expect(layers.threadContextPrompt).not.toContain('Execution context:')
+
+    expect(layers.dynamicTurnContextPrompt).toBe(`Today's date for the user is April 15, 2026.
+
+Layer partition assistant context snapshot.
+
+Execution context:
+- This turn was triggered by an existing scheduled automation run.
+- The automation already exists and is active.
+- Treat the user prompt as the execution instructions for this scheduled run.`)
+    expect(layers.dynamicTurnContextPrompt).not.toContain('Asia/Kuala_Lumpur')
+    expect(layers.dynamicTurnContextPrompt).toContain(
+      'Layer partition assistant context snapshot.',
+    )
+    expect(layers.dynamicTurnContextPrompt).not.toContain('Murph onboarding:')
+    expect(layers.dynamicTurnContextPrompt).not.toContain(
+      'Before sending any user-facing reply',
+    )
+    expect(layers.prompt.endsWith(layers.dynamicTurnContextPrompt)).toBe(true)
+  })
+
+  it('keeps notification decision context per-turn with no thread layer', () => {
+    const input = createCommonNotificationPromptInput({
+      assistantContextSnapshotPrompt: 'Notification layer partition snapshot.',
+      currentLocalDate: '2026-04-15',
+      currentTimeZone: 'Asia/Kuala_Lumpur',
+    })
+    const layers = buildAssistantNotificationDecisionSystemPromptLayers(input)
+
+    expect(layers.threadContextPrompt).toBe('')
+    expect(layers.dynamicTurnContextPrompt).toContain(
+      "The user's canonical timezone for this vault is Asia/Kuala_Lumpur.",
+    )
+    expect(layers.dynamicTurnContextPrompt).toContain(
+      "Today's date for the user is April 15, 2026.",
+    )
+    expect(layers.dynamicTurnContextPrompt).toContain(
+      'Notification layer partition snapshot.',
+    )
+    expect(layers.dynamicTurnContextPrompt).toContain('Notification execution rules:')
+    expect(layers.dynamicTurnContextPrompt).toContain(
+      'Before sending any user-facing reply, quickly scan the visible answer for forbidden link and source formatting',
+    )
+    expect(layers.prompt).toBe(
+      [
+        [layers.staticCacheableCorePrompt, layers.stableRouteCapabilityPrompt].join('\n\n'),
+        layers.dynamicTurnContextPrompt,
+      ].join('\n\n'),
+    )
+  })
+
   it('renders current date context with natural user-facing date guidance', () => {
     const prompt = buildAssistantSystemPrompt(createCommonCodexPromptInput({
       currentLocalDate: '2026-04-03',


### PR DESCRIPTION
## Summary

Moves thread-birth-stable Codex prompt context out of every per-turn user prompt and into thread-level developer instructions.

- adds a `threadContextPrompt` layer for timezone/date-style prose, product URL, evidence/reply style, onboarding guidance, and link self-check
- keeps `dynamicTurnContextPrompt` for truly per-turn facts: current date, cached assistant context snapshot, and automation-cron execution context
- includes the new thread context in developer instructions so the existing contract fingerprint rotates threads when stable context changes, without rotating on mutable snapshot refreshes
- keeps notification-decision prompts one-shot/per-turn with no separate thread layer
- archives the active execution plan

## Why

Codex remote compaction preserves user messages and drops developer-role items before re-injecting developer instructions once. Repeating stable context inside every per-turn user prompt forces compaction to preserve that context repeatedly. Moving stable context into developer instructions reduces the per-turn prompt payload while keeping mutable assistant context snapshots in the current turn so hosted retries can keep native Codex resume stable.

## Validation

- `pnpm typecheck` passed
- `pnpm --dir packages/assistant-engine test:coverage` passed: 106 files, 1256 tests, 3 skipped
- `pnpm test:diff packages/assistant-engine/src/assistant/codex-turn/planning.ts packages/assistant-engine/src/assistant/system-prompt.ts packages/assistant-engine/test/assistant-protocol-index-planning.test.ts packages/assistant-engine/test/model-behavior.test.ts` passed
- `git diff --check` passed
- PR CI passed: 18/18 checks green
- completion audits: coverage-write passed; task-finish-review found only the missing ledger row, resolved before `scripts/finish-task`
- `review:gpt pr-review` round 1: no findings worth changing
