### PR TITLE
Fix Telegram attachment download retries

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-15-telegram-attachment-retry.md
+++ b/agent-docs/exec-plans/completed/2026-06-15-telegram-attachment-retry.md
@@ -1,0 +1,78 @@
+Goal (incl. success criteria):
+- Make hosted Telegram PDF/document attachment hydration tolerate transient Telegram/effect egress failures.
+- Success means transient retryable `getFile` or file download failures are retried before the assistant sees only metadata, while terminal failures still degrade to metadata-only without blocking mailbox import.
+
+Constraints/Assumptions:
+- Web remains the owner of Telegram ingress, mailbox append, and Temporal wake handoff.
+- Cloudflare remains the owner of Worker-mediated Telegram credential injection/effects.
+- Assistant runtime may retry read-only Telegram file lookup/download calls, but must not change webhook acknowledgement semantics, mailbox watermarks, or provider-visible sends.
+- Retries must be bounded and abort-aware.
+- Preserve unrelated active ledger rows and unrelated working-tree edits.
+
+Key decisions:
+- Add the retry at the assistant-runtime Telegram attachment download-driver boundary so both direct hosted-local fetch and Cloudflare effects-port paths are covered.
+- Retry only transient transport/status failures; do not retry terminal Telegram/API/auth/not-found/oversize failures.
+- Keep final failure behavior unchanged: the inbox normalizer still returns a metadata-only attachment after retry exhaustion.
+- Thread the existing runner abort signal into conversation mailbox import instead of adding a new cancellation mechanism.
+- Abort is not a terminal Telegram attachment failure: cancellation must stop import work instead of producing a durable metadata-only capture.
+- The Telegram download limit must be enforced before or during byte reads, not only after buffering a completed response.
+
+State:
+- Implementation, audit follow-up, and scripted verification complete.
+
+Done:
+- Production logs and local repro identified transient `getFile` failure degrading PDF attachment hydration to metadata-only.
+- Official Telegram docs checked: `getFile` returns a file path for download, links are at least one hour, files up to 20 MB are downloadable by Bot API, and `file_unique_id` cannot be used for download.
+- Added a bounded retry wrapper around the selected Telegram attachment download driver before existing logging.
+- Added regression coverage for transient retry success, terminal failure no-retry, abort no-retry, and metadata-only PDF preservation after retry exhaustion.
+- Security/privacy and coverage-write audits passed; deep review found one accepted follow-up for oversized Telegram downloads returning retryable 502 from the Cloudflare effect boundary.
+- Fixed the Cloudflare provider-effect oversize path to return terminal 413 + `retryable: false` instead of generic 502, with contract coverage.
+- Fixed the deep-review abort-signal follow-up by passing the runner signal through the mailbox import context to Telegram normalization, with adapter coverage.
+- Ran ReviewGPT on PR 180; accepted and fixed its three cancellation findings:
+  - production runtime import wrappers now preserve the foreground import signal;
+  - Telegram attachment aborts rethrow through inboxd and mailbox projection instead of recording a failed imported outcome;
+  - Telegram provider-effect calls now pass caller signals into the Cloudflare internal fetch.
+- Ran a second ReviewGPT pass on PR 180; accepted and fixed its two findings:
+  - Telegram direct downloads now enforce a bounded byte reader and content-length gate, and known oversized Telegram files stay metadata-only without calling download;
+  - conversation mailbox import now checks cancellation before preparation/staging/projection side effects.
+- Verified:
+  - `pnpm --dir packages/assistant-runtime test -- hosted-runtime-telegram-event.test.ts hosted-runtime-conversation-event.test.ts hosted-runtime-mailbox-conversation-import.test.ts`
+  - `pnpm --dir packages/inboxd test -- telegram-connector.test.ts`
+  - `pnpm --dir apps/cloudflare test -- runner-platform.test.ts runner-provider-effects-contract.test.ts`
+  - `pnpm build:test-runtime:prepared`
+  - `pnpm typecheck`
+  - `pnpm test:diff packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/src/hosted-runtime/events/telegram.ts packages/assistant-runtime/src/hosted-runtime/events/conversation.ts packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts packages/assistant-runtime/src/hosted-runtime/platform.ts packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts packages/assistant-runtime/test/hosted-runtime-conversation-event.test.ts packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts packages/inboxd/src/connectors/telegram/normalize.ts packages/inboxd/test/telegram-connector.test.ts apps/cloudflare/src/runner-outbound/provider-effects.ts apps/cloudflare/src/runtime-platform/effects-port.ts apps/cloudflare/src/runtime-platform/hosted-http.ts apps/cloudflare/test/runner-provider-effects-contract.test.ts apps/cloudflare/test/runner-platform.test.ts`
+  - `pnpm test:smoke`
+
+Now:
+- Handoff after final diff review and PR update.
+
+Next:
+- Handoff with ReviewGPT round 2 result, fix summary, and verification.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/assistant-runtime/src/hosted-runtime/events/telegram.ts
+- packages/assistant-runtime/src/hosted-runtime/events/conversation.ts
+- packages/assistant-runtime/src/hosted-runtime.ts
+- packages/assistant-runtime/src/hosted-runtime/platform.ts
+- packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+- packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+- packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts
+- packages/assistant-runtime/test/hosted-runtime-conversation-event.test.ts
+- packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+- packages/inboxd/src/connectors/telegram/normalize.ts
+- packages/inboxd/test/telegram-connector.test.ts
+- apps/cloudflare/src/runtime-platform/effects-port.ts
+- apps/cloudflare/src/runtime-platform/hosted-http.ts
+- apps/cloudflare/src/runner-outbound/provider-effects.ts
+- apps/cloudflare/test/runner-provider-effects-contract.test.ts
+- apps/cloudflare/test/runner-platform.test.ts
+- pnpm typecheck
+- pnpm test:diff packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/src/hosted-runtime/events/telegram.ts packages/assistant-runtime/src/hosted-runtime/events/conversation.ts packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts packages/assistant-runtime/src/hosted-runtime/platform.ts packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts packages/assistant-runtime/test/hosted-runtime-conversation-event.test.ts packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts packages/inboxd/src/connectors/telegram/normalize.ts packages/inboxd/test/telegram-connector.test.ts apps/cloudflare/src/runner-outbound/provider-effects.ts apps/cloudflare/src/runtime-platform/effects-port.ts apps/cloudflare/src/runtime-platform/hosted-http.ts apps/cloudflare/test/runner-provider-effects-contract.test.ts apps/cloudflare/test/runner-platform.test.ts
+- pnpm test:smoke
+Status: completed
+Updated: 2026-06-16
+Completed: 2026-06-16

--- a/apps/cloudflare/src/runner-outbound/provider-effects.ts
+++ b/apps/cloudflare/src/runner-outbound/provider-effects.ts
@@ -186,12 +186,28 @@ async function handleTelegramDownloadFileEffect(
   request: ReturnType<typeof parseHostedRunnerTelegramDownloadFileRequest>,
   dependencies: HostedProviderEffectDependencies,
 ): Promise<Response> {
-  const bytes = await downloadHostedProviderTelegramFile(request, dependencies);
+  let bytes: Uint8Array | null;
+  try {
+    bytes = await downloadHostedProviderTelegramFile(request, dependencies);
+  } catch (error) {
+    const response = readHostedProviderEffectErrorResponse(error);
+    if (readProviderEffectStatus(response.context?.status) === 413) {
+      return json(response, 413);
+    }
+    throw error;
+  }
   if (!bytes) {
     return json({ file: null });
   }
   if (bytes.byteLength > TELEGRAM_FILE_DOWNLOAD_MAX_BYTES) {
-    throw new RangeError("Hosted Telegram file exceeds the download limit.");
+    return json({
+      context: {
+        failureStage: "download_limit",
+        retryable: false,
+        status: 413,
+      },
+      error: "Provider effect failed.",
+    }, 413);
   }
 
   return json({

--- a/apps/cloudflare/src/runtime-platform/effects-port.ts
+++ b/apps/cloudflare/src/runtime-platform/effects-port.ts
@@ -31,6 +31,7 @@ function createCloudflareRunnerProviderFileEffectsPort(input: {
     body: unknown;
     description: string;
     path: string;
+    signal?: AbortSignal | null;
   }) => await fetchHostedProviderEffectJson({
     body: requestInput.body,
     description: requestInput.description,
@@ -39,6 +40,7 @@ function createCloudflareRunnerProviderFileEffectsPort(input: {
       input.workspaceCheckpointBridge,
       requestInput.description,
     ),
+    signal: requestInput.signal ?? null,
     timeoutMs: input.timeoutMs,
     url: new URL(
       requestInput.path,
@@ -47,19 +49,21 @@ function createCloudflareRunnerProviderFileEffectsPort(input: {
   });
 
   return {
-    async downloadTelegramFile(request) {
+    async downloadTelegramFile(request, context) {
       const payload = await post({
         body: request,
         description: "Hosted Telegram file download",
         path: HOSTED_EXECUTION_RUNNER_TELEGRAM_DOWNLOAD_FILE_PATH,
+        signal: context?.signal ?? null,
       });
       return parseHostedRunnerTelegramDownloadFileResponse(payload).file;
     },
-    async getTelegramFile(request) {
+    async getTelegramFile(request, context) {
       const payload = await post({
         body: request,
         description: "Hosted Telegram file lookup",
         path: HOSTED_EXECUTION_RUNNER_TELEGRAM_GET_FILE_PATH,
+        signal: context?.signal ?? null,
       });
       return parseHostedRunnerTelegramGetFileResponse(payload).file;
     },

--- a/apps/cloudflare/src/runtime-platform/hosted-http.ts
+++ b/apps/cloudflare/src/runtime-platform/hosted-http.ts
@@ -156,6 +156,7 @@ export async function fetchHostedProviderEffectJson(input: {
   description: string;
   fetchImpl: typeof fetch;
   headers: Headers;
+  signal?: AbortSignal | null;
   timeoutMs: number;
   url: URL;
 }): Promise<unknown> {
@@ -167,6 +168,7 @@ export async function fetchHostedProviderEffectJson(input: {
       headers: mergeHostedRuntimeJsonHeaders(input.headers),
       method: "POST",
     },
+    signal: input.signal ?? null,
     timeoutMs: input.timeoutMs,
     url: input.url,
   });

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -5441,6 +5441,52 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect("sendWhatsApp" in platform.effectsPort).toBe(false);
   });
 
+  it("passes Telegram provider-effect caller signals to the internal fetch", async () => {
+    const controller = new AbortController();
+    let observedAbort = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      request.signal.addEventListener("abort", () => {
+        observedAbort = true;
+      }, { once: true });
+      controller.abort(new DOMException("Stopped", "AbortError"));
+      await Promise.resolve();
+      return new Response(JSON.stringify({
+        file: {
+          file_id: "telegram_file_123",
+          file_path: "photos/file.jpg",
+        },
+      }), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        status: 200,
+      });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "5",
+        }),
+      },
+    });
+
+    await expect(platform.effectsPort.getTelegramFile!(
+      { fileId: "telegram_file_123" },
+      { signal: controller.signal },
+    )).resolves.toEqual({
+      file_id: "telegram_file_123",
+      file_path: "photos/file.jpg",
+    });
+
+    expect(observedAbort).toBe(true);
+  });
+
   it("preserves structured details from remaining provider effect failures", async () => {
     const platform = buildTestHostedExecutionRuntimePlatform({
       boundUserId: "member_123",

--- a/apps/cloudflare/test/runner-provider-effects-contract.test.ts
+++ b/apps/cloudflare/test/runner-provider-effects-contract.test.ts
@@ -187,4 +187,33 @@ describe("telegram provider effect contract", () => {
       }),
     ]);
   });
+
+  it("maps oversized Telegram downloads to a terminal provider-effect response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(
+      new Uint8Array(20 * 1024 * 1024 + 1),
+      { status: 200 },
+    )));
+
+    const response = await handleRunnerProviderEffectsRequest({
+      env: createProviderEffectsEnv() as never,
+      pathname: "/telegram/files/download",
+      request: new Request("http://results.worker/telegram/files/download", {
+        body: JSON.stringify({ filePath: "documents/large.pdf" }),
+        headers: PROVIDER_EFFECT_HEADERS,
+        method: "POST",
+      }),
+      userId: "member_123",
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      context: {
+        failureStage: "download_limit",
+        retryable: false,
+        status: 413,
+      },
+      error: "Provider effect failed.",
+    });
+    expect(readProviderEffectFailureLogs()).toEqual([]);
+  });
 });

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -547,7 +547,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       mailboxBudget.exhausted || foregroundMailboxBudget.exhausted;
     let hostedCliBridgeMessagingReturnTarget: HostedRuntimeDeviceSyncMessagingReturnTarget | null =
       null;
-    const importMailboxItem: HostedWorkspaceRunnerInput["importItem"] = (item) =>
+    const importMailboxItem: HostedWorkspaceRunnerInput["importItem"] = (item, context) =>
       mailboxBudget.importItem(
         item,
         async (importItem, context) => {
@@ -562,10 +562,10 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           },
           latencyMilestones: initialAssistantInputLatencyMilestones,
           runtimeAttemptId: input.request.attemptId,
-          signal: runtimeAbortController.signal,
+          signal: context?.signal ?? runtimeAbortController.signal,
         },
       );
-    const importForegroundMailboxItem: HostedWorkspaceRunnerInput["importItem"] = (item) =>
+    const importForegroundMailboxItem: HostedWorkspaceRunnerInput["importItem"] = (item, context) =>
       foregroundMailboxBudget.importItem(
         item,
         async (importItem, context) => {
@@ -579,7 +579,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             hostedCliBridgeMessagingReturnTarget = target;
           },
           runtimeAttemptId: input.request.attemptId,
-          signal: runtimeAbortController.signal,
+          signal: context?.signal ?? runtimeAbortController.signal,
         },
       );
     emitPhaseLog({

--- a/packages/assistant-runtime/src/hosted-runtime/events/conversation.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/conversation.ts
@@ -44,6 +44,7 @@ import {
   createHostedTelegramEffectsAttachmentDownloadDriver,
   logHostedTelegramAttachmentDownloadUnavailable,
   withHostedTelegramAttachmentDownloadLogging,
+  withHostedTelegramAttachmentDownloadRetry,
 } from "./telegram.ts";
 import type {
   HostedConversationWakeMetrics,
@@ -66,6 +67,7 @@ export async function importHostedConversationMessageWakeIntoLocalInbox(input: {
   wake: HostedExecutionConversationMessageWake;
   runtime: Pick<NormalizedHostedAssistantRuntimeConfig, "forwardedEnv" | "platform" | "platformEnv" | "userEnv">
     & Partial<Pick<NormalizedHostedAssistantRuntimeConfig, "parserToolchain">>;
+  signal?: AbortSignal | null;
   vaultRoot: string;
 }): Promise<HostedConversationWakeLocalImportResult> {
   const capture = await normalizeHostedConversationMessageWake(input);
@@ -268,6 +270,7 @@ async function normalizeHostedConversationMessageWake(input: {
   wake: HostedExecutionConversationMessageWake;
   runtime: Pick<NormalizedHostedAssistantRuntimeConfig, "forwardedEnv" | "platform" | "platformEnv" | "userEnv">
     & Partial<Pick<NormalizedHostedAssistantRuntimeConfig, "parserToolchain">>;
+  signal?: AbortSignal | null;
 }) {
   if (isHostedLinqConversationMessageWake(input.wake)) {
     const contact = readHostedLinqConversationMessageContact(input.wake.message);
@@ -305,13 +308,14 @@ async function normalizeHostedConversationMessageWake(input: {
     return normalizeHostedTelegramConversationCapture({
       accountId: "bot",
       downloadDriver: withHostedTelegramAttachmentDownloadLogging(
-        downloadDriver,
+        withHostedTelegramAttachmentDownloadRetry(downloadDriver),
         input.runtime.platform,
       ),
       externalId: input.wake.eventId,
       message: input.wake.message.telegramMessage,
       occurredAt: input.wake.occurredAt,
       receivedAt: input.wake.occurredAt,
+      signal: input.signal ?? undefined,
     });
   }
 

--- a/packages/assistant-runtime/src/hosted-runtime/events/telegram.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/telegram.ts
@@ -13,8 +13,36 @@ import {
 
 const DEFAULT_TELEGRAM_API_BASE_URL = "https://api.telegram.org";
 const DEFAULT_TELEGRAM_FILE_BASE_URL = "https://api.telegram.org/file";
+const DEFAULT_TELEGRAM_ATTACHMENT_DOWNLOAD_RETRY_DELAYS_MS = [100, 500] as const;
+export const HOSTED_TELEGRAM_ATTACHMENT_DOWNLOAD_MAX_BYTES = 20 * 1024 * 1024;
 
 type HostedTelegramAttachmentDownloadPlatform = Pick<HostedRuntimePlatform, "logPort">;
+
+export function withHostedTelegramAttachmentDownloadRetry(
+  driver: TelegramAttachmentDownloadDriver | null,
+  options: {
+    retryDelaysMs?: readonly number[];
+  } = {},
+): TelegramAttachmentDownloadDriver | null {
+  if (!driver) {
+    return null;
+  }
+
+  const retryDelaysMs = options.retryDelaysMs ??
+    DEFAULT_TELEGRAM_ATTACHMENT_DOWNLOAD_RETRY_DELAYS_MS;
+  return {
+    downloadFile: (filePath, signal) => retryHostedTelegramAttachmentDownloadCall({
+      retryDelaysMs,
+      run: () => driver.downloadFile(filePath, signal),
+      signal,
+    }),
+    getFile: (fileId, signal) => retryHostedTelegramAttachmentDownloadCall({
+      retryDelaysMs,
+      run: () => driver.getFile(fileId, signal),
+      signal,
+    }),
+  };
+}
 
 // Mirrors mailbox.linq_attachment_download_finished: conversation-import
 // attachment downloads are otherwise swallowed by the normalizer's
@@ -88,6 +116,28 @@ async function logHostedTelegramAttachmentDownloadCall<T>(input: {
   }
 }
 
+async function retryHostedTelegramAttachmentDownloadCall<T>(input: {
+  retryDelaysMs: readonly number[];
+  run: () => Promise<T>;
+  signal?: AbortSignal;
+}): Promise<T> {
+  for (let attemptIndex = 0; ; attemptIndex += 1) {
+    try {
+      return await input.run();
+    } catch (error) {
+      const retryDelayMs = input.retryDelaysMs[attemptIndex];
+      if (
+        retryDelayMs === undefined
+        || !shouldRetryHostedTelegramAttachmentDownloadError(error, input.signal)
+      ) {
+        throw error;
+      }
+
+      await waitHostedTelegramAttachmentDownloadRetryDelay(retryDelayMs, input.signal);
+    }
+  }
+}
+
 async function writeHostedTelegramAttachmentDownloadLog(input: {
   attempt: HostedTelegramAttachmentDownloadAttemptLog;
   platform: HostedTelegramAttachmentDownloadPlatform | null;
@@ -116,22 +166,8 @@ async function writeHostedTelegramAttachmentDownloadLog(input: {
 function classifyHostedTelegramAttachmentDownloadError(
   error: unknown,
 ): Pick<HostedTelegramAttachmentDownloadAttemptLog, "failureCode" | "failureStatus"> {
-  const record = error && typeof error === "object" ? error as Record<string, unknown> : null;
-  const context = record?.context && typeof record.context === "object" && !Array.isArray(record.context)
-    ? record.context as Record<string, unknown>
-    : null;
-  const status =
-    readHostedTelegramStatus(context?.status)
-    ?? readHostedTelegramStatus(context?.upstreamStatus)
-    ?? readHostedTelegramStatus(record?.status)
-    ?? readHostedTelegramStatus(record?.statusCode);
-  const aborted = (
-    error instanceof DOMException
-    && error.name === "AbortError"
-  ) || (
-    error instanceof Error
-    && error.name === "AbortError"
-  );
+  const status = readHostedTelegramAttachmentDownloadErrorStatus(error);
+  const aborted = isHostedTelegramAttachmentDownloadAbortError(error);
 
   return {
     failureCode: aborted ? "download_aborted" : "download_fetch_failed",
@@ -139,10 +175,122 @@ function classifyHostedTelegramAttachmentDownloadError(
   };
 }
 
+function shouldRetryHostedTelegramAttachmentDownloadError(
+  error: unknown,
+  signal: AbortSignal | undefined,
+): boolean {
+  if (signal?.aborted || isHostedTelegramAttachmentDownloadAbortError(error)) {
+    return false;
+  }
+
+  const record = readHostedTelegramErrorRecord(error);
+  const context = readHostedTelegramErrorContext(record);
+  const retryable =
+    readHostedTelegramBoolean(context?.retryable)
+    ?? readHostedTelegramBoolean(record?.retryable);
+  if (retryable === false) {
+    return false;
+  }
+
+  const status = readHostedTelegramAttachmentDownloadErrorStatus(error);
+  if (status !== null) {
+    return status === 408 || status === 429 || status >= 500;
+  }
+
+  return retryable === true || isHostedTelegramTransientTransportError(error);
+}
+
+function readHostedTelegramAttachmentDownloadErrorStatus(error: unknown): number | null {
+  const record = readHostedTelegramErrorRecord(error);
+  const context = readHostedTelegramErrorContext(record);
+  return readHostedTelegramStatus(context?.status)
+    ?? readHostedTelegramStatus(context?.upstreamStatus)
+    ?? readHostedTelegramStatus(record?.status)
+    ?? readHostedTelegramStatus(record?.statusCode);
+}
+
+function readHostedTelegramErrorRecord(error: unknown): Record<string, unknown> | null {
+  return error && typeof error === "object" ? error as Record<string, unknown> : null;
+}
+
+function readHostedTelegramErrorContext(
+  record: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  return record?.context && typeof record.context === "object" && !Array.isArray(record.context)
+    ? record.context as Record<string, unknown>
+    : null;
+}
+
+function readHostedTelegramBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function isHostedTelegramAttachmentDownloadAbortError(error: unknown): boolean {
+  return (
+    error instanceof DOMException
+    && error.name === "AbortError"
+  ) || (
+    error instanceof Error
+    && error.name === "AbortError"
+  );
+}
+
+function isHostedTelegramTransientTransportError(error: unknown): boolean {
+  const record = readHostedTelegramErrorRecord(error);
+  const code = typeof record?.code === "string" ? record.code.toLowerCase() : "";
+  const causeKind = typeof record?.hostedRuntimeFetchCauseKind === "string"
+    ? record.hostedRuntimeFetchCauseKind.toLowerCase()
+    : "";
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return code.includes("network")
+    || code.includes("timeout")
+    || code.includes("fetch")
+    || causeKind === "network"
+    || causeKind === "timeout"
+    || causeKind === "fetch_failed"
+    || message.includes("fetch failed")
+    || message.includes("network")
+    || message.includes("timed out")
+    || message.includes("timeout");
+}
+
+async function waitHostedTelegramAttachmentDownloadRetryDelay(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (!Number.isFinite(delayMs) || delayMs <= 0) {
+    return;
+  }
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const onAbort = () => {
+      if (timeout !== null) {
+        clearTimeout(timeout);
+      }
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+  });
+}
+
 export function createHostedTelegramAttachmentDownloadDriver(
   options: {
     env?: Readonly<Record<string, string | undefined>>;
     fetchImplementation: typeof fetch | null;
+    maxDownloadBytes?: number | null;
   },
 ): TelegramAttachmentDownloadDriver | null {
   const env = options.env ?? process.env;
@@ -163,6 +311,9 @@ export function createHostedTelegramAttachmentDownloadDriver(
   if (!apiBaseUrl || !fileBaseUrl) {
     return null;
   }
+  const maxDownloadBytes = normalizeHostedTelegramMaxDownloadBytes(
+    options.maxDownloadBytes ?? HOSTED_TELEGRAM_ATTACHMENT_DOWNLOAD_MAX_BYTES,
+  );
 
   return {
     downloadFile: async (filePath, signal) => {
@@ -178,7 +329,7 @@ export function createHostedTelegramAttachmentDownloadDriver(
         );
       }
 
-      return new Uint8Array(await response.arrayBuffer());
+      return readHostedTelegramResponseBytes(response, maxDownloadBytes);
     },
     getFile: async (fileId, signal) => {
       const url = new URL(`${apiBaseUrl}/bot${token}/getFile`);
@@ -192,6 +343,67 @@ export function createHostedTelegramAttachmentDownloadDriver(
   };
 }
 
+function normalizeHostedTelegramMaxDownloadBytes(value: number | null): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+async function readHostedTelegramResponseBytes(
+  response: Response,
+  maxBytes: number | null,
+): Promise<Uint8Array> {
+  const contentLength = readHostedTelegramContentLength(response.headers);
+  if (maxBytes !== null && contentLength !== null && contentLength > maxBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    throw createHostedTelegramDownloadLimitError(maxBytes);
+  }
+
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (maxBytes !== null && bytes.byteLength > maxBytes) {
+      throw createHostedTelegramDownloadLimitError(maxBytes);
+    }
+    return bytes;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!value) {
+      continue;
+    }
+    totalBytes += value.byteLength;
+    if (maxBytes !== null && totalBytes > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw createHostedTelegramDownloadLimitError(maxBytes);
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function readHostedTelegramContentLength(headers: Headers): number | null {
+  const value = headers.get("content-length");
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
 export function createHostedTelegramEffectsAttachmentDownloadDriver(input: {
   effectsPort?: Pick<HostedRuntimeEffectsPort, "downloadTelegramFile" | "getTelegramFile"> | null;
 }): TelegramAttachmentDownloadDriver | null {
@@ -202,16 +414,16 @@ export function createHostedTelegramEffectsAttachmentDownloadDriver(input: {
   }
 
   return {
-    downloadFile: async (filePath) => {
-      const file = await downloadTelegramFile({ filePath });
+    downloadFile: async (filePath, signal) => {
+      const file = await downloadTelegramFile({ filePath }, { signal: signal ?? null });
       if (!file) {
         throw new Error("Hosted Telegram effects attachment download returned no file.");
       }
 
       return decodeBase64ToBytes(file.bytesBase64);
     },
-    getFile: async (fileId) => {
-      const file = await getTelegramFile({ fileId });
+    getFile: async (fileId, signal) => {
+      const file = await getTelegramFile({ fileId }, { signal: signal ?? null });
       if (!file) {
         throw new Error("Hosted Telegram effects attachment lookup returned no file.");
       }
@@ -292,6 +504,29 @@ function createHostedTelegramStatusError(message: string, status: number): Error
     status,
     statusCode: status,
   });
+}
+
+function createHostedTelegramDownloadLimitError(maxBytes: number): Error & {
+  context: {
+    failureStage: "download_limit";
+    retryable: false;
+    status: 413;
+  };
+  status: number;
+  statusCode: number;
+} {
+  return Object.assign(
+    new Error(`Hosted Telegram attachment exceeds the ${maxBytes} byte download limit.`),
+    {
+      context: {
+        failureStage: "download_limit" as const,
+        retryable: false as const,
+        status: 413 as const,
+      },
+      status: 413,
+      statusCode: 413,
+    },
+  );
 }
 
 function readHostedTelegramStatus(value: unknown): number | null {

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -125,6 +125,7 @@ type HostedConversationMailboxRuntime = Pick<
 
 export type HostedConversationMailboxLocalImporter = (input: {
   runtime: HostedConversationMailboxRuntime;
+  signal?: AbortSignal | null;
   vaultRoot: string;
   wake: HostedExecutionConversationMessageWake;
 }) => Promise<HostedConversationMailboxLocalImportResult>;
@@ -207,6 +208,7 @@ export function createHostedConversationMailboxImportItem(input: {
   context?: {
     latencyMilestones?: HostedRuntimeLatencyTraceStagedMilestones | null;
     runtimeAttemptId?: string | null;
+    signal?: AbortSignal | null;
   },
 ) => Promise<HostedMailboxItemImportOutcome> {
   return (item, context) =>
@@ -215,6 +217,7 @@ export function createHostedConversationMailboxImportItem(input: {
       item,
       latencyMilestones: context?.latencyMilestones ?? null,
       runtimeAttemptId: context?.runtimeAttemptId ?? null,
+      signal: context?.signal ?? null,
     });
 }
 
@@ -228,6 +231,7 @@ export async function importHostedConversationMailboxItem(input: {
   onDecodedConversationWake?(wake: HostedExecutionConversationMessageWake): void;
   runtime: HostedConversationMailboxRuntime;
   runtimeAttemptId?: string | null;
+  signal?: AbortSignal | null;
   stageAssistantInputEvent?: HostedConversationMailboxAssistantInputStager;
   vaultRoot: string;
 }): Promise<HostedConversationMailboxImportOutcome> {
@@ -288,6 +292,7 @@ export async function importHostedConversationMailboxItem(input: {
     ?? loadHostedConversationAttachmentEvidenceCapture;
   const prepareWakeContext =
     input.prepareWakeContext ?? prepareHostedConversationMailboxWakeContext;
+  assertHostedConversationMailboxImportLive(input.signal ?? null);
   if (!input.prepareWakeContext) {
     await requireHostedBootstrapForWake(input.vaultRoot, decoded.wake);
     await prepareHostedAssistantAutoReplyForWake(
@@ -301,6 +306,7 @@ export async function importHostedConversationMailboxItem(input: {
     );
   }
 
+  assertHostedConversationMailboxImportLive(input.signal ?? null);
   const stagedInput = await stageAssistantInputEvent({
     item: input.item,
     vaultRoot: input.vaultRoot,
@@ -316,11 +322,13 @@ export async function importHostedConversationMailboxItem(input: {
   });
 
   const linqDeliveryContext = buildHostedAssistantLinqDeliveryContextFromWake(decoded.wake);
+  assertHostedConversationMailboxImportLive(input.signal ?? null);
   const projectionEffect = await projectHostedConversationAssistantInputBestEffort({
     importConversationWake,
     loadAttachmentEvidenceCapture,
     prepareWakeContext,
     runtime: input.runtime,
+    signal: input.signal ?? null,
     stagedInput,
     vaultRoot: input.vaultRoot,
     wake: decoded.wake,
@@ -386,6 +394,7 @@ async function projectHostedConversationAssistantInputBestEffort(input: {
   loadAttachmentEvidenceCapture: HostedConversationMailboxAttachmentEvidenceCaptureLoader;
   prepareWakeContext: HostedConversationMailboxWakeContextPreparer;
   runtime: HostedConversationMailboxRuntime;
+  signal?: AbortSignal | null;
   stagedInput: HostedConversationMailboxAssistantInputStageResult;
   vaultRoot: string;
   wake: HostedExecutionConversationMessageWake;
@@ -399,10 +408,15 @@ async function projectHostedConversationAssistantInputBestEffort(input: {
     });
     imported = await input.importConversationWake({
       runtime: input.runtime,
+      signal: input.signal ?? null,
       vaultRoot: input.vaultRoot,
       wake: input.wake,
     });
   } catch (error) {
+    if (isHostedConversationMailboxAbortError(error, input.signal ?? null)) {
+      throw readHostedConversationMailboxAbortReason(error, input.signal ?? null);
+    }
+
     const reasonCode = readHostedConversationProjectionFailureReason(error);
     const projectionUpdated = await recordHostedConversationProjectionBestEffort(input.stagedInput, {
       captureId: null,
@@ -518,6 +532,37 @@ async function recordHostedConversationAttachmentEvidenceFromProjectionBestEffor
       updated,
     };
   }
+}
+
+function assertHostedConversationMailboxImportLive(signal: AbortSignal | null): void {
+  if (signal?.aborted) {
+    throw readHostedConversationMailboxAbortReason(
+      new DOMException("Aborted", "AbortError"),
+      signal,
+    );
+  }
+}
+
+function isHostedConversationMailboxAbortError(
+  error: unknown,
+  signal: AbortSignal | null,
+): boolean {
+  return signal?.aborted === true
+    || (
+      error instanceof DOMException
+      && error.name === "AbortError"
+    )
+    || (
+      error instanceof Error
+      && error.name === "AbortError"
+    );
+}
+
+function readHostedConversationMailboxAbortReason(
+  error: unknown,
+  signal: AbortSignal | null,
+): unknown {
+  return signal?.reason ?? error;
 }
 
 async function loadHostedConversationAttachmentEvidenceCapture(input: {

--- a/packages/assistant-runtime/src/hosted-runtime/platform.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/platform.ts
@@ -200,9 +200,11 @@ type HostedRuntimeEffectsPortBase = {
   ): Promise<void>;
   downloadTelegramFile?(
     request: HostedRuntimeTelegramDownloadFileRequest,
+    context?: { signal?: AbortSignal | null },
   ): Promise<HostedRuntimeProviderFileResponse | null>;
   getTelegramFile?(
     request: HostedRuntimeTelegramGetFileRequest,
+    context?: { signal?: AbortSignal | null },
   ): Promise<HostedRuntimeTelegramFile | null>;
   readRawEmailMessage(rawMessageKey: string): Promise<Uint8Array | null>;
   readAssistantDeliveryRecord?(

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -212,6 +212,9 @@ export type HostedWorkspaceDurableCheckpointEffects =
 
 export type HostedWorkspaceRunnerMailboxImportItem = (
   item: HostedMailboxResolvedImportItem,
+  context?: {
+    signal?: AbortSignal | null;
+  },
 ) => Promise<HostedMailboxItemImportOutcome>;
 
 export interface HostedWorkspaceRunnerInput {
@@ -375,6 +378,7 @@ export async function runHostedWorkspaceUntilIdleOrBudget(
       input,
       lanes: input.runAssistantPhase ? ["conversation"] : undefined,
       requestId: input.requestId,
+      signal: input.signal ?? null,
     });
   checkpointRequestSession.recordCheckpointResult(initialMailboxImport);
   markHostedMailboxImportDirtyIfNeeded(checkpointRequestSession, initialMailboxImport);
@@ -390,6 +394,7 @@ export async function runHostedWorkspaceUntilIdleOrBudget(
       input,
       lanes: ["system"],
       requestId: input.requestId,
+      signal: input.signal ?? null,
     });
     checkpointRequestSession.recordCheckpointResult(initialMailboxImport);
     markHostedMailboxImportDirtyIfNeeded(checkpointRequestSession, initialMailboxImport);
@@ -651,6 +656,7 @@ function startHostedForegroundConversationMailboxImportLoop(input: {
           lanes: ["conversation"],
           limitPerLane: input.input.foregroundLimitPerLane ?? input.input.limitPerLane,
           requestId,
+          signal: controller.signal,
         });
         if (shouldRecordHostedForegroundMailboxImportResult(result)) {
           input.checkpointRequestBuilder.recordCheckpointResult(result);
@@ -770,7 +776,10 @@ export async function importHostedMailboxForWorkspaceRunner(input: {
   limitPerLane?: number | null;
   prefetch?: HostedMailboxPrefixPrefetch | null;
   requestId: string;
+  signal?: AbortSignal | null;
 }): Promise<HostedMailboxImportCheckpointResult> {
+  const importItem = input.importItem ?? input.input.importItem;
+  const signal = input.signal ?? input.input.signal ?? null;
   const result = await importHostedMailboxPrefixAndCheckpoint({
     checkpointReason: input.checkpointReason,
     createCheckpointRequest: (requestInput) =>
@@ -787,7 +796,7 @@ export async function importHostedMailboxForWorkspaceRunner(input: {
     deferConversationUntil: input.deferConversationUntil ?? null,
     deferCheckpoint: input.deferCheckpoint === true,
     expectedUserId: input.input.expectedUserId,
-    importItem: input.importItem ?? input.input.importItem,
+    importItem: (item) => importItem(item, { signal }),
     lanes: input.lanes,
     limitPerLane: input.limitPerLane ?? input.input.limitPerLane,
     mailboxPort: input.input.platform.mailboxPort,

--- a/packages/assistant-runtime/test/hosted-runtime-conversation-event.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-conversation-event.test.ts
@@ -67,6 +67,9 @@ vi.mock("../src/hosted-runtime/events/telegram.ts", () => ({
   withHostedTelegramAttachmentDownloadLogging: (
     driver: unknown,
   ) => driver,
+  withHostedTelegramAttachmentDownloadRetry: (
+    driver: unknown,
+  ) => driver,
 }));
 
 vi.mock("@murphai/operator-config/linq-runtime", () => ({

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -2165,6 +2165,71 @@ describe("hosted mailbox conversation import adapter", () => {
     assert.equal(serialized.includes("source_cursor"), false);
   });
 
+  test("passes the mailbox import context signal to the local conversation importer", async () => {
+    const controller = new AbortController();
+    const observedSignals: Array<AbortSignal | null | undefined> = [];
+    const importItem = createHostedConversationMailboxImportItem({
+      decodePayload: createDecodedPayloadDecoder(createConversationWake()),
+      async importConversationWake(input) {
+        observedSignals.push(input.signal);
+        return {
+          captureId: null,
+          metrics: {
+            nextWakeAt: null,
+            parserProcessed: 0,
+          },
+        };
+      },
+      async prepareWakeContext() {},
+      runtime: createRuntime(),
+      stageAssistantInputEvent: createAssistantInputEventStager(),
+      vaultRoot: "synthetic-vault-root",
+    });
+
+    const outcome = await importItem(
+      createResolvedConversationMailboxItem(),
+      { signal: controller.signal },
+    );
+
+    assert.equal(outcome.status, "imported");
+    assert.equal(observedSignals[0], controller.signal);
+  });
+
+  test("rethrows local conversation import aborts instead of recording projection failure", async () => {
+    const abortReason = new DOMException("Stopped", "AbortError");
+    const controller = new AbortController();
+    controller.abort(abortReason);
+    const projectionUpdates: unknown[] = [];
+    let importCalled = false;
+    let stageCalled = false;
+
+    await assert.rejects(
+      () =>
+        importHostedConversationMailboxItem({
+          decodePayload: createDecodedPayloadDecoder(createConversationWake()),
+          async importConversationWake() {
+            importCalled = true;
+            throw abortReason;
+          },
+          async prepareWakeContext() {},
+          item: createResolvedConversationMailboxItem(),
+          runtime: createRuntime(),
+          signal: controller.signal,
+          async stageAssistantInputEvent(input) {
+            stageCalled = true;
+            return createAssistantInputEventStager({
+              projectionUpdates,
+            })(input);
+          },
+          vaultRoot: "synthetic-vault-root",
+        }),
+      (error) => error === abortReason,
+    );
+    assert.equal(stageCalled, false);
+    assert.equal(importCalled, false);
+    assert.equal(projectionUpdates.length, 0);
+  });
+
   test("keeps staged mailbox input imported when projection preparation fails", async () => {
     const item = createResolvedConversationMailboxItem();
     const projectionUpdates: unknown[] = [];

--- a/packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts
@@ -8,10 +8,15 @@ import type {
 } from "@murphai/hosted-execution/runtime-control";
 
 import {
+  normalizeHostedTelegramConversationCapture,
+} from "@murphai/inboxd/connectors/hosted-conversation";
+
+import {
   createHostedTelegramAttachmentDownloadDriver,
   createHostedTelegramEffectsAttachmentDownloadDriver,
   logHostedTelegramAttachmentDownloadUnavailable,
   withHostedTelegramAttachmentDownloadLogging,
+  withHostedTelegramAttachmentDownloadRetry,
 } from "../src/hosted-runtime/events/telegram.ts";
 
 const originalTelegramBotToken = process.env.TELEGRAM_BOT_TOKEN;
@@ -238,6 +243,30 @@ describe("createHostedTelegramAttachmentDownloadDriver", () => {
     assert.equal(String(fetchMock.mock.calls[0]?.[0]), "https://files.telegram.example/bottelegram-token/photos/cat.jpg");
   });
 
+  it("rejects Telegram attachment downloads that exceed the byte limit while streaming", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "telegram-token";
+    process.env.TELEGRAM_FILE_BASE_URL = "https://files.telegram.example/";
+
+    const fetchMock = vi.fn(async () => new Response(Uint8Array.from([1, 2, 3]), {
+      status: 200,
+    }));
+    const driver = createHostedTelegramAttachmentDownloadDriver({
+      fetchImplementation: fetchMock as typeof fetch,
+      maxDownloadBytes: 2,
+    });
+    assert.ok(driver);
+
+    await expect(driver.downloadFile("/documents/large.pdf", undefined)).rejects.toMatchObject({
+      context: {
+        failureStage: "download_limit",
+        retryable: false,
+        status: 413,
+      },
+      status: 413,
+      statusCode: 413,
+    });
+  });
+
   it("preserves HTTP status on Telegram API response failures", async () => {
     process.env.TELEGRAM_BOT_TOKEN = "telegram-token";
 
@@ -273,6 +302,7 @@ describe("createHostedTelegramEffectsAttachmentDownloadDriver", () => {
   });
 
   it("adapts Telegram file effects to the inbox driver shape", async () => {
+    const controller = new AbortController();
     const getTelegramFile = vi.fn(async () => ({
       file_id: "file_123",
       file_path: "photos/cat.jpg",
@@ -292,19 +322,172 @@ describe("createHostedTelegramEffectsAttachmentDownloadDriver", () => {
     });
     assert.ok(driver);
 
-    await expect(driver.getFile("file_123")).resolves.toEqual({
+    await expect(driver.getFile("file_123", controller.signal)).resolves.toEqual({
       file_id: "file_123",
       file_path: "photos/cat.jpg",
     });
-    await expect(driver.downloadFile("photos/cat.jpg")).resolves.toEqual(
+    await expect(driver.downloadFile("photos/cat.jpg", controller.signal)).resolves.toEqual(
       Uint8Array.from([1, 2, 3]),
     );
-    expect(getTelegramFile).toHaveBeenCalledWith({
-      fileId: "file_123",
+    expect(getTelegramFile).toHaveBeenCalledWith(
+      { fileId: "file_123" },
+      { signal: controller.signal },
+    );
+    expect(downloadTelegramFile).toHaveBeenCalledWith(
+      { filePath: "photos/cat.jpg" },
+      { signal: controller.signal },
+    );
+  });
+});
+
+describe("withHostedTelegramAttachmentDownloadRetry", () => {
+  it("retries transient Telegram getFile failures before returning metadata", async () => {
+    const firstFailure = Object.assign(new Error("Bad Gateway"), {
+      status: 502,
+      statusCode: 502,
     });
-    expect(downloadTelegramFile).toHaveBeenCalledWith({
-      filePath: "photos/cat.jpg",
+    const getFile = vi.fn()
+      .mockRejectedValueOnce(firstFailure)
+      .mockResolvedValueOnce({
+        file_id: "file_123",
+        file_path: "documents/lab.pdf",
+      });
+    const driver = withHostedTelegramAttachmentDownloadRetry({
+      downloadFile: async () => Uint8Array.from([]),
+      getFile,
+    }, {
+      retryDelaysMs: [0],
     });
+    assert.ok(driver);
+
+    await expect(driver.getFile("file_123")).resolves.toEqual({
+      file_id: "file_123",
+      file_path: "documents/lab.pdf",
+    });
+    expect(getFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry terminal Telegram API failures", async () => {
+    const failure = Object.assign(new Error("Bad Request"), {
+      status: 400,
+      statusCode: 400,
+    });
+    const getFile = vi.fn(async () => {
+      throw failure;
+    });
+    const driver = withHostedTelegramAttachmentDownloadRetry({
+      downloadFile: async () => Uint8Array.from([]),
+      getFile,
+    }, {
+      retryDelaysMs: [0, 0],
+    });
+    assert.ok(driver);
+
+    await expect(driver.getFile("file_123")).rejects.toBe(failure);
+    expect(getFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry aborted attachment downloads", async () => {
+    const failure = new DOMException("Aborted", "AbortError");
+    const downloadFile = vi.fn(async () => {
+      throw failure;
+    });
+    const driver = withHostedTelegramAttachmentDownloadRetry({
+      downloadFile,
+      getFile: async () => ({ file_id: "file_123" }),
+    }, {
+      retryDelaysMs: [0, 0],
+    });
+    assert.ok(driver);
+
+    await expect(driver.downloadFile("documents/lab.pdf")).rejects.toBe(failure);
+    expect(downloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops waiting for the next retry when the caller aborts", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const failure = new TypeError("fetch failed");
+      const getFile = vi.fn(async () => {
+        throw failure;
+      });
+      const driver = withHostedTelegramAttachmentDownloadRetry({
+        downloadFile: async () => Uint8Array.from([]),
+        getFile,
+      }, {
+        retryDelaysMs: [10_000],
+      });
+      assert.ok(driver);
+
+      const promise = driver.getFile("file_123", controller.signal);
+      await Promise.resolve();
+
+      expect(getFile).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(1);
+
+      controller.abort();
+
+      await expect(promise).rejects.toMatchObject({
+        name: "AbortError",
+      });
+      expect(getFile).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps Telegram PDF attachments metadata-only after retry exhaustion", async () => {
+    const failure = Object.assign(new Error("Bad Gateway"), {
+      status: 502,
+      statusCode: 502,
+    });
+    const getFile = vi.fn(async () => {
+      throw failure;
+    });
+    const downloadFile = vi.fn(async () => Uint8Array.from([1, 2, 3]));
+    const driver = withHostedTelegramAttachmentDownloadRetry({
+      downloadFile,
+      getFile,
+    }, {
+      retryDelaysMs: [0, 0],
+    });
+
+    const capture = await normalizeHostedTelegramConversationCapture({
+      accountId: "bot",
+      downloadDriver: driver,
+      externalId: "evt_pdf",
+      message: {
+        attachments: [
+          {
+            fileId: "file_pdf",
+            fileName: "lab-results.pdf",
+            fileSize: 123_456,
+            fileUniqueId: "file_pdf_unique",
+            kind: "document",
+            mimeType: "application/pdf",
+          },
+        ],
+        messageId: "123",
+        text: null,
+        threadId: "chat_123",
+      },
+      occurredAt: "2026-06-15T22:41:25.000Z",
+      receivedAt: "2026-06-15T22:41:25.000Z",
+    });
+
+    expect(getFile).toHaveBeenCalledTimes(3);
+    expect(downloadFile).not.toHaveBeenCalled();
+    expect(capture.attachments).toHaveLength(1);
+    expect(capture.attachments[0]).toMatchObject({
+      byteSize: 123_456,
+      externalId: "file_pdf_unique",
+      fileName: "lab-results.pdf",
+      kind: "document",
+      mime: "application/pdf",
+    });
+    expect(capture.attachments[0]?.data).toBeUndefined();
   });
 });
 

--- a/packages/inboxd/src/connectors/telegram/normalize.ts
+++ b/packages/inboxd/src/connectors/telegram/normalize.ts
@@ -19,6 +19,8 @@ import { createInboundCaptureFromChatMessage } from "../chat/message.ts";
 import type { InboundAttachment, InboundCapture } from "../../contracts/capture.ts";
 import { normalizeTextValue, toIsoTimestamp } from "../../shared-runtime.ts";
 
+const TELEGRAM_ATTACHMENT_DOWNLOAD_MAX_BYTES = 20 * 1024 * 1024;
+
 export interface TelegramAttachmentDownloadDriver {
   getFile(fileId: string, signal?: AbortSignal): Promise<TelegramFile>;
   downloadFile(filePath: string, signal?: AbortSignal): Promise<Uint8Array>;
@@ -341,11 +343,14 @@ async function hydrateTelegramAttachment(
   if (!downloadDriver) {
     return attachment;
   }
+  if (isKnownOversizedTelegramFile(spec.file)) {
+    return attachment;
+  }
 
   try {
     const file = await downloadDriver.getFile(spec.file.file_id, signal);
 
-    if (!file.file_path) {
+    if (!file.file_path || isKnownOversizedTelegramFile(file)) {
       return attachment;
     }
 
@@ -355,9 +360,33 @@ async function hydrateTelegramAttachment(
       data,
       byteSize: attachment.byteSize ?? data.byteLength,
     };
-  } catch {
+  } catch (error) {
+    if (isTelegramAttachmentHydrationAbortError(error, signal)) {
+      throw error;
+    }
     return attachment;
   }
+}
+
+function isKnownOversizedTelegramFile(file: TelegramFileBase): boolean {
+  return typeof file.file_size === "number"
+    && Number.isSafeInteger(file.file_size)
+    && file.file_size > TELEGRAM_ATTACHMENT_DOWNLOAD_MAX_BYTES;
+}
+
+function isTelegramAttachmentHydrationAbortError(
+  error: unknown,
+  signal: AbortSignal | undefined,
+): boolean {
+  return signal?.aborted === true
+    || (
+      error instanceof DOMException
+      && error.name === "AbortError"
+    )
+    || (
+      error instanceof Error
+      && error.name === "AbortError"
+    );
 }
 
 async function hydrateHostedTelegramAttachment(

--- a/packages/inboxd/test/telegram-connector.test.ts
+++ b/packages/inboxd/test/telegram-connector.test.ts
@@ -303,6 +303,80 @@ test("normalizeHostedTelegramMessage stores only minimal durable Telegram captur
   assert.equal(capture.attachments[0]?.fileName, "photo-photo_unique_1.jpg");
 });
 
+test("normalizeHostedTelegramMessage rethrows aborted attachment hydration", async () => {
+  const abortError = new DOMException("Stopped", "AbortError");
+
+  await assert.rejects(
+    () =>
+      normalizeHostedTelegramMessage({
+        accountId: "bot",
+        downloadDriver: {
+          async getFile() {
+            throw abortError;
+          },
+          async downloadFile() {
+            throw new Error("download should not run");
+          },
+        },
+        externalId: "evt_hosted_telegram_abort",
+        message: {
+          attachments: [
+            {
+              fileId: "doc_1",
+              fileName: "lab.pdf",
+              kind: "document",
+              mimeType: "application/pdf",
+            },
+          ],
+          messageId: "18",
+          text: null,
+          threadId: "-100555:dm-topic:9",
+        },
+        occurredAt: "2026-04-07T09:00:00.000Z",
+      }),
+    (error) => error === abortError,
+  );
+});
+
+test("normalizeHostedTelegramMessage keeps oversized Telegram documents metadata-only", async () => {
+  const getFile = vi.fn(async () => ({
+    file_id: "doc_1",
+    file_path: "documents/large.pdf",
+    file_size: 20 * 1024 * 1024 + 1,
+  }));
+  const downloadFile = vi.fn(async () => {
+    throw new Error("oversized file should not be downloaded");
+  });
+
+  const capture = await normalizeHostedTelegramMessage({
+    accountId: "bot",
+    downloadDriver: {
+      downloadFile,
+      getFile,
+    },
+    externalId: "evt_hosted_telegram_oversized",
+    message: {
+      attachments: [
+        {
+          fileId: "doc_1",
+          fileName: "large.pdf",
+          kind: "document",
+          mimeType: "application/pdf",
+        },
+      ],
+      messageId: "19",
+      text: null,
+      threadId: "-100555:dm-topic:9",
+    },
+    occurredAt: "2026-04-07T09:00:00.000Z",
+  });
+
+  assert.equal(getFile.mock.calls.length, 1);
+  assert.equal(downloadFile.mock.calls.length, 0);
+  assert.equal(capture.attachments[0]?.fileName, "large.pdf");
+  assert.equal(capture.attachments[0]?.data, undefined);
+});
+
 test("normalizeTelegramUpdate allowlists raw update metadata and drops secret-bearing extras", async () => {
   const capture = await normalizeTelegramUpdate({
     update: {


### PR DESCRIPTION
## Summary
- Add bounded, abort-aware retries for read-only Telegram attachment getFile/downloadFile calls before falling back to metadata-only attachments.
- Classify oversized Telegram provider-effect downloads as terminal 413 with retryable=false instead of generic 502.
- Enforce Telegram download limits before/during byte reads and keep known oversized Telegram files metadata-only without downloading.
- Thread the existing runner abort signal through conversation mailbox import and provider-effect fetches, and make Telegram attachment aborts stop import work instead of becoming durable metadata-only imports.

## ReviewGPT
- Ran ReviewGPT against PR 180 and addressed its findings on production import signal propagation, abort-to-metadata fallback, and Cloudflare Telegram provider-effect cancellation.
- Ran a second ReviewGPT pass and addressed its findings on pre-buffer download limits and cancellation guards before mailbox staging/projection side effects.
- Ran a third ReviewGPT pass after rebasing; it found no blocking or high-value changes. Residual risk noted: near-20MB successful files still cross the provider-effect boundary as base64 JSON, which is an existing transport tradeoff rather than a correctness blocker for this PR.
- Ran an additional read-only Codex subagent review against the rebased diff; it found no concrete actionable production bugs.

## Verification
- pnpm --dir packages/assistant-runtime test -- hosted-runtime-telegram-event.test.ts hosted-runtime-conversation-event.test.ts hosted-runtime-mailbox-conversation-import.test.ts
- pnpm --dir packages/inboxd test -- telegram-connector.test.ts
- pnpm --dir apps/cloudflare test -- runner-platform.test.ts runner-provider-effects-contract.test.ts
- pnpm typecheck
- pnpm test:diff packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/src/hosted-runtime/events/telegram.ts packages/assistant-runtime/src/hosted-runtime/events/conversation.ts packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts packages/assistant-runtime/src/hosted-runtime/platform.ts packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts packages/assistant-runtime/test/hosted-runtime-conversation-event.test.ts packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts packages/inboxd/src/connectors/telegram/normalize.ts packages/inboxd/test/telegram-connector.test.ts apps/cloudflare/src/runner-outbound/provider-effects.ts apps/cloudflare/src/runtime-platform/effects-port.ts apps/cloudflare/src/runtime-platform/hosted-http.ts apps/cloudflare/test/runner-provider-effects-contract.test.ts apps/cloudflare/test/runner-platform.test.ts
- pnpm test:smoke
