### PR TITLE
[codex] Fix deploy smoke Codex home

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-16-deploy-smoke-codex-home.md
+++ b/agent-docs/exec-plans/completed/2026-06-16-deploy-smoke-codex-home.md
@@ -1,0 +1,47 @@
+Goal (incl. success criteria):
+- Reproduce and fix the deployed Cloudflare runner live-model smoke failure where `codex exec` exits after refusing to create helper binaries under the smoke temp `CODEX_HOME`.
+- Success means the smoke uses a Codex home/PATH layout accepted by current Codex, has regression coverage, and passes scoped Cloudflare verification.
+
+Constraints/Assumptions:
+- Keep the fix scoped to deploy-smoke behavior unless reproduction proves the production hosted runtime path is affected.
+- Do not expose secrets, raw provider payloads, local user identifiers, or home-directory paths in committed files or logs.
+- Preserve Worker-owned OpenAI credential injection; the container still receives only the injected-credential sentinel.
+
+Key decisions:
+- Keep the deploy-smoke vault/temp workspace under the system temp directory, but move the smoke `CODEX_HOME` under the runner-owned non-temp home root so Linux Codex 0.135.0 can create helper binaries.
+
+State:
+- Ready to close after scoped commit.
+
+Done:
+- Read hosted runtime triage docs, read-first docs, security/reliability docs, deploy docs, and CI failure log.
+- Reproduced the Codex helper-binary refusal in a Linux Node 24.14.1 container with pinned Codex 0.135.0 and a temp-dir `CODEX_HOME`.
+- Proved the warning disappears when only `CODEX_HOME` moves to a non-temp runner-owned directory.
+- Patched deploy-smoke workspace creation and added focused resolver coverage.
+- Coverage-write added fallback coverage for non-temp `HOME` when `HOSTED_HOME` is absent.
+- Verification passed:
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts --no-coverage apps/cloudflare/test/container-entrypoint.test.ts`
+  - `pnpm --dir apps/cloudflare verify`
+- Required audits completed:
+  - `security-privacy-review`: no findings.
+  - `coverage-write`: added one focused assertion; focused test and typecheck passed in the pass.
+  - `deep-review`: no production-breaking findings.
+
+Now:
+- Close plan and create scoped commit.
+
+Next:
+- Commit with `scripts/finish-task` if verification/audits pass.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- `apps/cloudflare/src/container-entrypoint.ts`
+- `apps/cloudflare/test/container-entrypoint.test.ts`
+- CI run: `27586406774`, job `81558422027`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts --no-coverage apps/cloudflare/test/container-entrypoint.test.ts`
+- `pnpm --dir apps/cloudflare verify`
+Status: completed
+Updated: 2026-06-15
+Completed: 2026-06-15

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -8,7 +8,7 @@ import {
 import { request as httpsRequest } from "node:https";
 import { spawn } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
@@ -94,6 +94,7 @@ const HOSTED_CONTAINER_DIRECT_R2_PRESIGNED_PUT_MAX_BYTES = 512 * 1024 * 1024;
 const HOSTED_CONTAINER_DIRECT_R2_PRESIGNED_PUT_CHUNK_BYTES = 1024 * 1024;
 const HOSTED_CONTAINER_CLOUDFLARE_CA_CERT_PATH =
   "/etc/cloudflare/certs/cloudflare-containers-ca.crt";
+const HOSTED_CONTAINER_CODEX_SMOKE_HOME_DIRECTORY = ".codex-deploy-smoke";
 
 interface HostedContainerProcessDirectoryEntryLike {
   isDirectory(): boolean;
@@ -1477,8 +1478,19 @@ async function withHostedContainerCodexSmokeWorkspace<T>(
   run: (workspace: { codexHome: string; smokeVaultRoot: string }) => Promise<T>,
 ): Promise<T> {
   const workspaceRoot = await mkdtemp(path.join(tmpdir(), "hosted-codex-shell-smoke-"));
+  let codexWorkspaceRoot: string | null = null;
   try {
-    const codexHome = path.join(workspaceRoot, ".codex-smoke");
+    const codexSmokeHomeRoot = resolveHostedContainerCodexSmokeHomeRoot();
+    await mkdir(codexSmokeHomeRoot, {
+      mode: 0o700,
+      recursive: true,
+    });
+    await chmod(codexSmokeHomeRoot, 0o700);
+    codexWorkspaceRoot = await mkdtemp(path.join(
+      codexSmokeHomeRoot,
+      "hosted-codex-shell-smoke-",
+    ));
+    const codexHome = path.join(codexWorkspaceRoot, ".codex-smoke");
     const smokeVaultRoot = path.join(workspaceRoot, "vault");
     await mkdir(codexHome, {
       mode: 0o700,
@@ -1525,11 +1537,46 @@ async function withHostedContainerCodexSmokeWorkspace<T>(
       smokeVaultRoot,
     });
   } finally {
-    await rm(workspaceRoot, {
-      force: true,
-      recursive: true,
-    });
+    await Promise.all([
+      rm(workspaceRoot, {
+        force: true,
+        recursive: true,
+      }),
+      ...(codexWorkspaceRoot ? [rm(codexWorkspaceRoot, {
+        force: true,
+        recursive: true,
+      })] : []),
+    ]);
   }
+}
+
+export function resolveHostedContainerCodexSmokeHomeRoot(
+  source: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  const base = normalizeAbsoluteHostedContainerPath(source.HOSTED_HOME)
+    ?? normalizeAbsoluteHostedContainerPath(source.HOME)
+    ?? normalizeAbsoluteHostedContainerPath(homedir());
+  if (!base) {
+    throw new Error("Hosted Codex shell smoke requires an absolute runner home directory.");
+  }
+  const smokeHomeRoot = path.join(base, HOSTED_CONTAINER_CODEX_SMOKE_HOME_DIRECTORY);
+  if (isPathInside(smokeHomeRoot, tmpdir())) {
+    throw new Error("Hosted Codex shell smoke CODEX_HOME parent must not be under the system temporary directory.");
+  }
+  return smokeHomeRoot;
+}
+
+function normalizeAbsoluteHostedContainerPath(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized || !path.isAbsolute(normalized)) {
+    return null;
+  }
+  return path.resolve(normalized);
+}
+
+function isPathInside(candidate: string, parent: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(candidate));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 function buildHostedContainerCodexShellSmokeConfig(model: string): string {

--- a/apps/cloudflare/test/container-entrypoint.test.ts
+++ b/apps/cloudflare/test/container-entrypoint.test.ts
@@ -54,6 +54,7 @@ vi.mock("@murphai/assistant-runtime/hosted-invocation", async () => {
 import {
   classifyRunnerJobError,
   createRequestAbortController,
+  resolveHostedContainerCodexSmokeHomeRoot,
   startHostedContainerEntrypoint,
 } from "../src/container-entrypoint.js";
 import { HOSTED_RUNTIME_ARCHITECTURE_VERSION } from "../src/hosted-runtime-architecture.js";
@@ -855,6 +856,28 @@ describe("startHostedContainerEntrypoint", () => {
       model: "gpt-5.4-nano",
       signal: expect.any(AbortSignal),
     });
+  });
+
+  it("keeps deploy-smoke Codex home outside the system temporary directory", () => {
+    const hostedHome = path.join(path.sep, "home", "runner", ".murph");
+    const runnerHome = path.join(path.sep, "home", "runner");
+
+    expect(resolveHostedContainerCodexSmokeHomeRoot({
+      HOME: path.join(tmpdir(), "hosted-codex-shell-smoke-home"),
+      HOSTED_HOME: hostedHome,
+    })).toBe(path.join(hostedHome, ".codex-deploy-smoke"));
+    expect(resolveHostedContainerCodexSmokeHomeRoot({
+      HOME: runnerHome,
+    })).toBe(path.join(runnerHome, ".codex-deploy-smoke"));
+  });
+
+  it("rejects deploy-smoke Codex home parents under the system temporary directory", () => {
+    expect(() => resolveHostedContainerCodexSmokeHomeRoot({
+      HOME: path.join(tmpdir(), "hosted-codex-shell-smoke-home"),
+      HOSTED_HOME: "relative-hosted-home",
+    })).toThrow(
+      "Hosted Codex shell smoke CODEX_HOME parent must not be under the system temporary directory.",
+    );
   });
 
   it("surfaces capped ASCII-only live model turn smoke failure diagnostics", async () => {


### PR DESCRIPTION
## Summary

Fixes the Cloudflare deployed live-model smoke failure where Linux Codex 0.135.0 refused to create helper binaries because deploy smoke put `CODEX_HOME` under the system temp workspace.

The smoke vault and `TMPDIR` still use the temporary workspace, but smoke `CODEX_HOME` now lives under the runner-owned non-temp home root and the per-smoke Codex directory is removed in `finally`.

## Root Cause

The production runner image pins Codex 0.135.0. On Linux, that Codex version refuses to create helper binaries under a temporary-dir parent such as `/tmp/hosted-codex-shell-smoke-*`. The deployed smoke used that temp root for both the vault and `CODEX_HOME`, so the live `codex exec` smoke could exit before producing the expected `OK`.

## Validation

- Reproduced locally in a Linux Node 24.14.1 container with `@openai/codex@0.135.0`: temp `CODEX_HOME` emitted the helper-binary refusal.
- Re-ran the same Linux repro with only `CODEX_HOME` moved under a non-temp runner-owned directory: the helper warning disappeared.
- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts --no-coverage apps/cloudflare/test/container-entrypoint.test.ts`
- `pnpm --dir apps/cloudflare verify`

## Audits

- security/privacy review: no findings
- coverage-write: added fallback coverage for non-temp `HOME`
- deep review: no production-breaking findings

## Residual Risk

The final production proof is the deployed managed-container smoke itself, because static/local checks cannot prove the exact Cloudflare managed runtime environment. The checked-in runner image sets `HOSTED_HOME` and `HOME` to non-temp runner-owned paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784164934&installation_id=127572939&pr_number=181&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F181&signature=c8716f69f61a77a8e2fbe2f708a3ff4231941412b91436528f7de98cb7857190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->