### PR TITLE
Handle Junction source reconnect state

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-16-whoop-source-reconnect.md
+++ b/agent-docs/exec-plans/completed/2026-06-16-whoop-source-reconnect.md
@@ -1,0 +1,42 @@
+Goal (incl. success criteria):
+- Fix Junction-backed WHOOP source errors so the website no longer shows the source as connected/green when Junction reports a reconnect-required token refresh failure.
+- Add a manual operator CLI path to create a source-specific reconnect link; no automatic outreach or background reconnect attempts.
+
+Constraints/Assumptions:
+- Keep the parent Junction account active when only a nested source is broken.
+- Use existing `device_connection_source` error fields as product truth; do not add new persisted state or source-health services.
+- Reconnect link creation must use the existing hosted device connect intent and normal Junction Link flow.
+- Avoid exposing member identifiers or credentials in code, docs, logs, or command examples.
+
+Key decisions:
+- Treat Junction source `TOKEN_REFRESH_FAILED` as a source-level reconnect-needed state in settings/connect surfaces.
+- Keep the fix local to projection/UI and a thin operator script.
+
+State:
+- Implementation complete; final commit/PR in progress.
+
+Done:
+- Static analysis confirmed Junction source errors are already stored on `device_connection_source.lastErrorCode`.
+- Browser source projection now exposes a boolean reconnect-needed flag instead of raw provider error codes.
+- Settings/connect surfaces treat Junction source reconnect flags as source-level attention/reconnect state while leaving the parent Junction account active.
+- Added a manual hosted-web operator command for creating source-specific reconnect links.
+- Focused tests, full hosted-web tests, lint, diff check, and CLI help command were run.
+
+Now:
+- Commit through `scripts/finish-task` and open the PR.
+
+Next:
+- Push branch and create PR.
+
+Open questions (UNCONFIRMED if needed):
+- `pnpm --dir apps/web typecheck` is blocked by pre-existing `app/api/internal/device-sync/junction/workouts/raw/route.ts` import resolution for `@murphai/device-syncd/providers/junction-client`.
+
+Working set (files/ids/commands):
+- `apps/web/src/lib/device-sync/public-ingress-service.ts`
+- `apps/web/src/lib/device-sync/settings-surface.ts`
+- `apps/web/app/(dashboard)/connect/page.tsx`
+- `apps/web/scripts/*`
+- Relevant `apps/web/test/*`
+Status: completed
+Updated: 2026-06-16
+Completed: 2026-06-16

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -454,8 +454,8 @@ function resolveConnectSourceConnectionMatches(
     )
       ? source.state
       : null;
-    const requiresReconnect = source.primaryAction?.kind === "reconnect"
-      || isReauthorizationRequiredConnectSourceState(source.state);
+    const parentRequiresReconnect = isReauthorizationRequiredConnectSourceState(source.state);
+    const requiresReconnect = source.primaryAction?.kind === "reconnect" || parentRequiresReconnect;
     const connectionId = typeof source.connectionId === "string" && source.connectionId.trim()
       ? source.connectionId
       : null;
@@ -494,7 +494,13 @@ function resolveConnectSourceConnectionMatches(
     }
 
     for (const upstreamSource of source.upstreamSources) {
-      if (sourceState === "active" && upstreamSource.status !== "connected") {
+      const upstreamRequiresReconnect = parentRequiresReconnect
+        || upstreamSource.requiresReconnect === true;
+      if (
+        sourceState === "active"
+        && upstreamSource.status !== "connected"
+        && !upstreamRequiresReconnect
+      ) {
         continue;
       }
 
@@ -506,8 +512,8 @@ function resolveConnectSourceConnectionMatches(
         upsertConnectSourceConnection(connectedConnections, {
           connectionId,
           connectProvider: provider,
-          connectTarget,
-          requiresReconnect,
+          connectTarget: upstreamRequiresReconnect ? connectTarget : null,
+          requiresReconnect: upstreamRequiresReconnect,
           sourceId,
           state: sourceState,
         });

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -496,6 +496,14 @@ function resolveConnectSourceConnectionMatches(
     for (const upstreamSource of source.upstreamSources) {
       const upstreamRequiresReconnect = parentRequiresReconnect
         || upstreamSource.requiresReconnect === true;
+      const upstreamConnectProvider = upstreamSource.connectProvider
+        ? normalizeDeviceSyncConnectTargetKey(upstreamSource.connectProvider)
+        : provider;
+      const upstreamConnectTarget =
+        typeof upstreamSource.connectTarget === "string" && upstreamSource.connectTarget.trim()
+          ? upstreamSource.connectTarget
+          : connectTarget;
+
       if (
         sourceState === "active"
         && upstreamSource.status !== "connected"
@@ -511,8 +519,8 @@ function resolveConnectSourceConnectionMatches(
       if (sourceId) {
         upsertConnectSourceConnection(connectedConnections, {
           connectionId,
-          connectProvider: provider,
-          connectTarget: upstreamRequiresReconnect ? connectTarget : null,
+          connectProvider: upstreamRequiresReconnect ? upstreamConnectProvider : provider,
+          connectTarget: upstreamRequiresReconnect ? upstreamConnectTarget : null,
           requiresReconnect: upstreamRequiresReconnect,
           sourceId,
           state: sourceState,

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -550,12 +550,12 @@ function compareConnectSourceStatePriority(
 }
 
 function connectSourceStatePriority(connection: ConnectSourceConnectionState): number {
-  if (connection.state === "active" && !connection.requiresReconnect) {
-    return 4;
+  if (connection.state === "active" && connection.requiresReconnect) {
+    return 5;
   }
 
   if (connection.state === "active") {
-    return 3;
+    return 4;
   }
 
   return 2;

--- a/apps/web/app/device/connect/[claim]/route.ts
+++ b/apps/web/app/device/connect/[claim]/route.ts
@@ -1,7 +1,7 @@
 import { isDeviceSyncError } from "@murphai/device-syncd/errors";
 import {
+  listConfiguredDeviceSyncReconnectTargets,
   readConfiguredDeviceSyncConnectTargetConfigs,
-  resolveConfiguredDeviceSyncConnectTarget,
 } from "@murphai/device-syncd/connect-config";
 
 import { buildHostedDeviceConnectCompletionReturnTo } from "@/src/lib/device-sync/connect-completion-return";
@@ -122,21 +122,14 @@ export async function POST(
 }
 
 function resolveHostedDeviceConnectIntentTarget(intent: HostedDeviceConnectIntentRecord) {
-  const target = resolveConfiguredDeviceSyncConnectTarget(
+  return listConfiguredDeviceSyncReconnectTargets(
     readConfiguredDeviceSyncConnectTargetConfigs(process.env),
-    intent.connectTarget,
-  );
-
-  if (
-    !target
-    || target.provider !== intent.provider
-    || target.connectSourceId !== intent.connectSourceId
-    || (target.sourceProviderSlug ?? null) !== intent.sourceProviderSlug
-  ) {
-    return null;
-  }
-
-  return target;
+  ).find((target) =>
+    target.provider === intent.provider
+    && target.connectSourceId === intent.connectSourceId
+    && target.connectTarget === intent.connectTarget
+    && (target.sourceProviderSlug ?? null) === intent.sourceProviderSlug
+  ) ?? null;
 }
 
 function describeUnavailableIntentStatus(status: string): string {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint .",
     "start": "next start",
     "dev:smoke": "pnpm --dir ../.. exec tsx apps/web/scripts/dev-smoke.ts",
+    "device:reconnect-link": "pnpm --dir ../.. exec tsx --tsconfig apps/web/tsconfig.json apps/web/scripts/create-device-reconnect-link.ts",
     "pitch:pdf": "pnpm --dir ../.. exec tsx apps/web/scripts/export-pitch-pdf.ts",
     "legal:pdf": "pnpm --dir ../.. exec tsx apps/web/scripts/generate-legal-pdfs.ts",
     "typecheck": "pnpm health-commons:generate && pnpm --dir ../.. exec tsx scripts/ensure-next-route-type-stubs.ts apps/web && pnpm prisma:generate && tsc -p tsconfig.json --pretty false",

--- a/apps/web/scripts/create-device-reconnect-link.ts
+++ b/apps/web/scripts/create-device-reconnect-link.ts
@@ -1,0 +1,39 @@
+import {
+  createHostedDeviceReconnectLink,
+  parseHostedDeviceReconnectLinkCliArgs,
+} from "../src/lib/device-sync/reconnect-link-tool";
+
+const USAGE = `Usage:
+  pnpm --dir apps/web device:reconnect-link -- --member-id <member-id> --source-provider-slug whoop_v2
+
+Options:
+  --member-id <id>                 Hosted member id that owns the reconnect link.
+  --source-provider-slug <slug>    Junction source slug, for example whoop_v2.
+  --connect-source <id>            Optional public source id, for example whoop.
+  --connect-target <target>        Optional connect target, for example whoop.
+  --base-url <url>                 Optional hosted web origin when env is not configured.
+`;
+
+async function main(): Promise<void> {
+  const args = parseHostedDeviceReconnectLinkCliArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(USAGE.trim());
+    return;
+  }
+
+  const result = await createHostedDeviceReconnectLink({ args });
+  console.log(`Created ${result.target.label} reconnect link.`);
+  console.log(`Provider: ${result.target.provider}`);
+  if (result.target.sourceProviderSlug) {
+    console.log(`Source provider slug: ${result.target.sourceProviderSlug}`);
+  }
+  console.log(`Expires at: ${result.expiresAt}`);
+  console.log(`Connect URL: ${result.connectUrl}`);
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/apps/web/src/lib/device-sync/connect-intent-core.ts
+++ b/apps/web/src/lib/device-sync/connect-intent-core.ts
@@ -1,0 +1,169 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import {
+  configuredDeviceSyncProviderKeys,
+  type ConfiguredDeviceSyncProviderKey,
+} from "@murphai/device-syncd/connect-config";
+
+import { resolveHostedPublicBaseUrl } from "../hosted-web/public-url";
+import type { HostedPrismaTransactionClient } from "./prisma-store";
+
+export interface HostedDeviceConnectIntentRecord {
+  claimHash: string;
+  memberId: string;
+  provider: ConfiguredDeviceSyncProviderKey;
+  connectSourceId: string;
+  connectTarget: string;
+  sourceProviderSlug: string | null;
+  createdAt: Date;
+  expiresAt: Date;
+  startedAt: Date | null;
+}
+
+const HOSTED_DEVICE_CONNECT_INTENT_CLAIM_PREFIX = "dc_";
+const HOSTED_DEVICE_CONNECT_INTENT_CLAIM_BYTES = 24;
+const HOSTED_DEVICE_CONNECT_INTENT_TTL_MS = 15 * 60 * 1000;
+export const HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS = 72 * 60 * 60 * 1000;
+
+export async function createHostedDeviceConnectIntentTx(input: {
+  connectSourceId: string;
+  connectTarget: string;
+  memberId: string;
+  now?: Date;
+  provider: ConfiguredDeviceSyncProviderKey;
+  request: Request;
+  sourceProviderSlug: string | null;
+  ttlMs?: number;
+  tx: HostedPrismaTransactionClient;
+}): Promise<{
+  claim: string;
+  connectUrl: string;
+  deviceConnectUrl: string;
+  expiresAt: string;
+}> {
+  const now = input.now ?? new Date();
+  const expiresAt = new Date(now.getTime() + normalizeHostedDeviceConnectIntentTtlMs(input.ttlMs));
+  const claim = generateHostedDeviceConnectIntentClaim();
+  const claimHash = hashHostedDeviceConnectIntentClaim(claim);
+
+  await input.tx.deviceConnectIntent.deleteMany({
+    where: {
+      expiresAt: {
+        lte: now,
+      },
+    },
+  });
+
+  await input.tx.deviceConnectIntent.create({
+    data: {
+      claimHash,
+      memberId: input.memberId,
+      provider: input.provider,
+      connectSourceId: input.connectSourceId,
+      connectTarget: input.connectTarget,
+      sourceProviderSlug: input.sourceProviderSlug,
+      createdAt: now,
+      expiresAt,
+    },
+  });
+
+  return {
+    claim,
+    connectUrl: buildHostedDeviceConnectIntentUrl({
+      claim,
+      connectSourceId: input.connectSourceId,
+      request: input.request,
+    }),
+    deviceConnectUrl: buildHostedDeviceConnectIntentDirectUrl({
+      claim,
+      request: input.request,
+    }),
+    expiresAt: expiresAt.toISOString(),
+  };
+}
+
+export function normalizeHostedDeviceConnectIntentClaimHash(claim: string): string | null {
+  if (
+    !claim.startsWith(HOSTED_DEVICE_CONNECT_INTENT_CLAIM_PREFIX)
+    || !/^dc_[A-Za-z0-9_-]{32}$/u.test(claim)
+  ) {
+    return null;
+  }
+
+  return hashHostedDeviceConnectIntentClaim(claim);
+}
+
+export function toHostedDeviceConnectIntentRecord(record: {
+  claimHash: string;
+  memberId: string;
+  provider: string;
+  connectSourceId: string;
+  connectTarget: string;
+  sourceProviderSlug: string | null;
+  createdAt: Date;
+  expiresAt: Date;
+  startedAt: Date | null;
+}): HostedDeviceConnectIntentRecord {
+  return {
+    claimHash: record.claimHash,
+    memberId: record.memberId,
+    provider: requireConfiguredDeviceSyncProviderKey(record.provider),
+    connectSourceId: record.connectSourceId,
+    connectTarget: record.connectTarget,
+    sourceProviderSlug: record.sourceProviderSlug,
+    createdAt: record.createdAt,
+    expiresAt: record.expiresAt,
+    startedAt: record.startedAt,
+  };
+}
+
+function buildHostedDeviceConnectIntentUrl(input: {
+  claim: string;
+  connectSourceId: string;
+  request: Request;
+}): string {
+  const baseUrl = resolveHostedPublicBaseUrl() ?? new URL(input.request.url).origin;
+  const url = new URL("/connect", `${baseUrl}/`);
+  const fragment = new URLSearchParams();
+  fragment.set("deviceConnectIntent", input.claim);
+  fragment.set("connectSource", input.connectSourceId);
+  url.hash = fragment.toString();
+  return url.toString();
+}
+
+function buildHostedDeviceConnectIntentDirectUrl(input: {
+  claim: string;
+  request: Request;
+}): string {
+  const baseUrl = resolveHostedPublicBaseUrl() ?? new URL(input.request.url).origin;
+  const url = new URL(`/device/connect/${encodeURIComponent(input.claim)}`, `${baseUrl}/`);
+  return url.toString();
+}
+
+function normalizeHostedDeviceConnectIntentTtlMs(value: number | null | undefined): number {
+  if (!Number.isFinite(value) || value === undefined || value === null) {
+    return HOSTED_DEVICE_CONNECT_INTENT_TTL_MS;
+  }
+
+  return Math.max(60_000, Math.min(Math.trunc(value), HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS));
+}
+
+function generateHostedDeviceConnectIntentClaim(): string {
+  return `${HOSTED_DEVICE_CONNECT_INTENT_CLAIM_PREFIX}${
+    randomBytes(HOSTED_DEVICE_CONNECT_INTENT_CLAIM_BYTES).toString("base64url")
+  }`;
+}
+
+function hashHostedDeviceConnectIntentClaim(claim: string): string {
+  return createHash("sha256").update(claim).digest("hex");
+}
+
+function requireConfiguredDeviceSyncProviderKey(value: string): ConfiguredDeviceSyncProviderKey {
+  for (const key of configuredDeviceSyncProviderKeys) {
+    if (key === value) {
+      return key;
+    }
+  }
+
+  throw new TypeError("Stored device connect intent provider is not supported.");
+}

--- a/apps/web/src/lib/device-sync/connect-intents.ts
+++ b/apps/web/src/lib/device-sync/connect-intents.ts
@@ -1,27 +1,20 @@
 import "server-only";
 
-import { createHash, randomBytes } from "node:crypto";
+import type { ConfiguredDeviceSyncProviderKey } from "@murphai/device-syncd/connect-config";
 
 import {
-  configuredDeviceSyncProviderKeys,
-  type ConfiguredDeviceSyncProviderKey,
-} from "@murphai/device-syncd/connect-config";
-
-import { resolveHostedPublicBaseUrl } from "../hosted-web/public-url";
+  createHostedDeviceConnectIntentTx,
+  normalizeHostedDeviceConnectIntentClaimHash,
+  toHostedDeviceConnectIntentRecord,
+  type HostedDeviceConnectIntentRecord,
+} from "./connect-intent-core";
 import { getPrisma } from "../prisma";
-import type { HostedPrismaTransactionClient } from "./prisma-store";
 
-export interface HostedDeviceConnectIntentRecord {
-  claimHash: string;
-  memberId: string;
-  provider: ConfiguredDeviceSyncProviderKey;
-  connectSourceId: string;
-  connectTarget: string;
-  sourceProviderSlug: string | null;
-  createdAt: Date;
-  expiresAt: Date;
-  startedAt: Date | null;
-}
+export {
+  createHostedDeviceConnectIntentTx,
+  HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS,
+  type HostedDeviceConnectIntentRecord,
+} from "./connect-intent-core";
 
 export type HostedDeviceConnectIntentReadResult =
   | { status: "available"; intent: HostedDeviceConnectIntentRecord }
@@ -31,11 +24,6 @@ export type HostedDeviceConnectIntentClaimResult =
   | { status: "claimed"; intent: HostedDeviceConnectIntentRecord }
   | { status: "expired" | "missing" | "owner_mismatch" | "used" };
 
-const HOSTED_DEVICE_CONNECT_INTENT_CLAIM_PREFIX = "dc_";
-const HOSTED_DEVICE_CONNECT_INTENT_CLAIM_BYTES = 24;
-const HOSTED_DEVICE_CONNECT_INTENT_TTL_MS = 15 * 60 * 1000;
-export const HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS = 72 * 60 * 60 * 1000;
-
 export async function createHostedDeviceConnectIntent(input: {
   connectSourceId: string;
   connectTarget: string;
@@ -44,6 +32,7 @@ export async function createHostedDeviceConnectIntent(input: {
   provider: ConfiguredDeviceSyncProviderKey;
   request: Request;
   sourceProviderSlug: string | null;
+  ttlMs?: number;
 }): Promise<{
   claim: string;
   connectUrl: string;
@@ -56,63 +45,6 @@ export async function createHostedDeviceConnectIntent(input: {
       tx,
     })
   );
-}
-
-export async function createHostedDeviceConnectIntentTx(input: {
-  connectSourceId: string;
-  connectTarget: string;
-  memberId: string;
-  now?: Date;
-  provider: ConfiguredDeviceSyncProviderKey;
-  request: Request;
-  sourceProviderSlug: string | null;
-  ttlMs?: number;
-  tx: HostedPrismaTransactionClient;
-}): Promise<{
-  claim: string;
-  connectUrl: string;
-  deviceConnectUrl: string;
-  expiresAt: string;
-}> {
-  const now = input.now ?? new Date();
-  const expiresAt = new Date(now.getTime() + normalizeHostedDeviceConnectIntentTtlMs(input.ttlMs));
-  const claim = generateHostedDeviceConnectIntentClaim();
-  const claimHash = hashHostedDeviceConnectIntentClaim(claim);
-
-  await input.tx.deviceConnectIntent.deleteMany({
-    where: {
-      expiresAt: {
-        lte: now,
-      },
-    },
-  });
-
-  await input.tx.deviceConnectIntent.create({
-    data: {
-      claimHash,
-      memberId: input.memberId,
-      provider: input.provider,
-      connectSourceId: input.connectSourceId,
-      connectTarget: input.connectTarget,
-      sourceProviderSlug: input.sourceProviderSlug,
-      createdAt: now,
-      expiresAt,
-    },
-  });
-
-  return {
-    claim,
-    connectUrl: buildHostedDeviceConnectIntentUrl({
-      claim,
-      connectSourceId: input.connectSourceId,
-      request: input.request,
-    }),
-    deviceConnectUrl: buildHostedDeviceConnectIntentDirectUrl({
-      claim,
-      request: input.request,
-    }),
-    expiresAt: expiresAt.toISOString(),
-  };
 }
 
 export async function readHostedDeviceConnectIntent(
@@ -250,90 +182,4 @@ export async function releaseHostedDeviceConnectIntentStart(input: {
       startedAt: null,
     },
   });
-}
-
-function buildHostedDeviceConnectIntentUrl(input: {
-  claim: string;
-  connectSourceId: string;
-  request: Request;
-}): string {
-  const baseUrl = resolveHostedPublicBaseUrl() ?? new URL(input.request.url).origin;
-  const url = new URL("/connect", `${baseUrl}/`);
-  const fragment = new URLSearchParams();
-  fragment.set("deviceConnectIntent", input.claim);
-  fragment.set("connectSource", input.connectSourceId);
-  url.hash = fragment.toString();
-  return url.toString();
-}
-
-function buildHostedDeviceConnectIntentDirectUrl(input: {
-  claim: string;
-  request: Request;
-}): string {
-  const baseUrl = resolveHostedPublicBaseUrl() ?? new URL(input.request.url).origin;
-  const url = new URL(`/device/connect/${encodeURIComponent(input.claim)}`, `${baseUrl}/`);
-  return url.toString();
-}
-
-function normalizeHostedDeviceConnectIntentTtlMs(value: number | null | undefined): number {
-  if (!Number.isFinite(value) || value === undefined || value === null) {
-    return HOSTED_DEVICE_CONNECT_INTENT_TTL_MS;
-  }
-
-  return Math.max(60_000, Math.min(Math.trunc(value), HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS));
-}
-
-function generateHostedDeviceConnectIntentClaim(): string {
-  return `${HOSTED_DEVICE_CONNECT_INTENT_CLAIM_PREFIX}${
-    randomBytes(HOSTED_DEVICE_CONNECT_INTENT_CLAIM_BYTES).toString("base64url")
-  }`;
-}
-
-function normalizeHostedDeviceConnectIntentClaimHash(claim: string): string | null {
-  if (
-    !claim.startsWith(HOSTED_DEVICE_CONNECT_INTENT_CLAIM_PREFIX)
-    || !/^dc_[A-Za-z0-9_-]{32}$/u.test(claim)
-  ) {
-    return null;
-  }
-
-  return hashHostedDeviceConnectIntentClaim(claim);
-}
-
-function hashHostedDeviceConnectIntentClaim(claim: string): string {
-  return createHash("sha256").update(claim).digest("hex");
-}
-
-function toHostedDeviceConnectIntentRecord(record: {
-  claimHash: string;
-  memberId: string;
-  provider: string;
-  connectSourceId: string;
-  connectTarget: string;
-  sourceProviderSlug: string | null;
-  createdAt: Date;
-  expiresAt: Date;
-  startedAt: Date | null;
-}): HostedDeviceConnectIntentRecord {
-  return {
-    claimHash: record.claimHash,
-    memberId: record.memberId,
-    provider: requireConfiguredDeviceSyncProviderKey(record.provider),
-    connectSourceId: record.connectSourceId,
-    connectTarget: record.connectTarget,
-    sourceProviderSlug: record.sourceProviderSlug,
-    createdAt: record.createdAt,
-    expiresAt: record.expiresAt,
-    startedAt: record.startedAt,
-  };
-}
-
-function requireConfiguredDeviceSyncProviderKey(value: string): ConfiguredDeviceSyncProviderKey {
-  for (const key of configuredDeviceSyncProviderKeys) {
-    if (key === value) {
-      return key;
-    }
-  }
-
-  throw new TypeError("Stored device connect intent provider is not supported.");
 }

--- a/apps/web/src/lib/device-sync/public-ingress-service.ts
+++ b/apps/web/src/lib/device-sync/public-ingress-service.ts
@@ -263,6 +263,7 @@ export interface HostedBrowserDeviceSyncConnectionSource {
   connectionId: string;
   firstSeenAt: string;
   lastSeenAt: string;
+  requiresReconnect?: boolean;
   resourceCount: number;
   sourceProviderSlug: string;
   status: HostedDeviceConnectionSource["status"];
@@ -276,6 +277,7 @@ function toHostedBrowserDeviceSyncConnectionSource(
     connectionId: browserConnectionId,
     firstSeenAt: source.firstSeenAt,
     lastSeenAt: source.lastSeenAt,
+    ...(requiresConnectionSourceReconnect(source) ? { requiresReconnect: true } : {}),
     resourceCount: countSourceResources(source.resourceAvailabilitySummary),
     sourceProviderSlug: source.sourceProviderSlug,
     status: source.status,
@@ -285,6 +287,7 @@ function toHostedBrowserDeviceSyncConnectionSource(
 const CONNECTION_SOURCE_SUMMARY_METADATA_KEYS = new Set([
   "sourceInstanceKeyFallback",
 ]);
+const CONNECTION_SOURCE_RECONNECT_ERROR_CODES = new Set(["TOKEN_REFRESH_FAILED"]);
 
 /**
  * True when a `resourceAvailabilitySummary` entry names an available resource
@@ -308,4 +311,10 @@ function countSourceResources(summary: HostedDeviceConnectionSource["resourceAva
   return Object.entries(summary).filter(([key, value]) =>
     isAvailableConnectionSourceResource(key, value)
   ).length;
+}
+
+function requiresConnectionSourceReconnect(source: HostedDeviceConnectionSource): boolean {
+  return source.status === "error"
+    && source.lastErrorCode !== null
+    && CONNECTION_SOURCE_RECONNECT_ERROR_CODES.has(source.lastErrorCode);
 }

--- a/apps/web/src/lib/device-sync/reconnect-link-tool.ts
+++ b/apps/web/src/lib/device-sync/reconnect-link-tool.ts
@@ -1,0 +1,203 @@
+import {
+  listConfiguredDeviceSyncReconnectTargets,
+  normalizeDeviceConnectSourceId,
+  normalizeDeviceSyncConnectTargetKey,
+  readConfiguredDeviceSyncConnectTargetConfigs,
+  type DeviceSyncConnectTarget,
+} from "@murphai/device-syncd/connect-config";
+
+import {
+  HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS,
+  createHostedDeviceConnectIntentTx,
+} from "./connect-intent-core";
+import { readHostedPublicBaseUrl } from "../hosted-web/public-url";
+import { getPrisma } from "../prisma";
+
+type EnvSource = Readonly<Record<string, string | undefined>>;
+
+export interface HostedDeviceReconnectLinkCliArgs {
+  baseUrl: string | null;
+  connectSourceId: string | null;
+  connectTarget: string | null;
+  help: boolean;
+  memberId: string | null;
+  sourceProviderSlug: string | null;
+}
+
+export type HostedDeviceReconnectLinkTargetResult =
+  | { status: "found"; target: DeviceSyncConnectTarget }
+  | { status: "ambiguous"; matches: DeviceSyncConnectTarget[] }
+  | { status: "missing" };
+
+export interface HostedDeviceReconnectLinkResult {
+  connectUrl: string;
+  expiresAt: string;
+  target: DeviceSyncConnectTarget;
+}
+
+export function parseHostedDeviceReconnectLinkCliArgs(
+  argv: readonly string[],
+): HostedDeviceReconnectLinkCliArgs {
+  const args: HostedDeviceReconnectLinkCliArgs = {
+    baseUrl: null,
+    connectSourceId: null,
+    connectTarget: null,
+    help: false,
+    memberId: null,
+    sourceProviderSlug: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === "--") {
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+      continue;
+    }
+
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("-")) {
+      throw new Error(`${arg} requires a value.`);
+    }
+
+    switch (arg) {
+      case "--base-url":
+        args.baseUrl = value;
+        break;
+      case "--connect-source":
+        args.connectSourceId = value;
+        break;
+      case "--connect-target":
+        args.connectTarget = value;
+        break;
+      case "--member-id":
+        args.memberId = value;
+        break;
+      case "--source-provider-slug":
+        args.sourceProviderSlug = value;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+
+    index += 1;
+  }
+
+  return args;
+}
+
+export function resolveHostedDeviceReconnectLinkTarget(
+  env: EnvSource,
+  input: Pick<
+    HostedDeviceReconnectLinkCliArgs,
+    "connectSourceId" | "connectTarget" | "sourceProviderSlug"
+  >,
+): HostedDeviceReconnectLinkTargetResult {
+  const connectSourceId = normalizeDeviceConnectSourceId(input.connectSourceId);
+  const connectTarget = normalizeDeviceSyncConnectTargetKey(input.connectTarget ?? "");
+  const sourceProviderSlug = normalizeDeviceSyncConnectTargetKey(input.sourceProviderSlug ?? "");
+
+  if (!connectSourceId && !connectTarget && !sourceProviderSlug) {
+    return { status: "missing" };
+  }
+
+  const matches = listConfiguredDeviceSyncReconnectTargets(
+    readConfiguredDeviceSyncConnectTargetConfigs(env),
+  ).filter((target) =>
+    (!connectSourceId || target.connectSourceId === connectSourceId)
+    && (!connectTarget || target.connectTarget === connectTarget)
+    && (!sourceProviderSlug || (target.sourceProviderSlug ?? null) === sourceProviderSlug)
+  );
+  const firstMatch = matches[0];
+
+  if (matches.length === 1 && firstMatch) {
+    return {
+      status: "found",
+      target: firstMatch,
+    };
+  }
+
+  if (matches.length > 1) {
+    return {
+      status: "ambiguous",
+      matches,
+    };
+  }
+
+  return { status: "missing" };
+}
+
+export async function createHostedDeviceReconnectLink(input: {
+  args: HostedDeviceReconnectLinkCliArgs;
+  env?: EnvSource;
+  now?: Date;
+}): Promise<HostedDeviceReconnectLinkResult> {
+  const env = input.env ?? process.env;
+  const memberId = input.args.memberId?.trim() ?? "";
+  if (!memberId) {
+    throw new Error("--member-id is required.");
+  }
+
+  const targetResult = resolveHostedDeviceReconnectLinkTarget(env, input.args);
+  if (targetResult.status === "missing") {
+    throw new Error(
+      "No configured reconnect target matched. Pass --source-provider-slug for Junction-backed sources.",
+    );
+  }
+
+  if (targetResult.status === "ambiguous") {
+    throw new Error(
+      `Reconnect target is ambiguous (${targetResult.matches.length} matches). Pass --source-provider-slug to choose the Junction source.`,
+    );
+  }
+
+  const request = new Request(resolveHostedDeviceReconnectLinkBaseUrl(env, input.args.baseUrl));
+  const intent = await getPrisma().$transaction((tx) =>
+    createHostedDeviceConnectIntentTx({
+      connectSourceId: targetResult.target.connectSourceId,
+      connectTarget: targetResult.target.connectTarget,
+      memberId,
+      now: input.now,
+      provider: targetResult.target.provider,
+      request,
+      sourceProviderSlug: targetResult.target.sourceProviderSlug ?? null,
+      ttlMs: HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS,
+      tx,
+    })
+  );
+
+  return {
+    connectUrl: intent.connectUrl,
+    expiresAt: intent.expiresAt,
+    target: targetResult.target,
+  };
+}
+
+export function resolveHostedDeviceReconnectLinkBaseUrl(
+  env: EnvSource,
+  explicitBaseUrl: string | null,
+): string {
+  const configuredBaseUrl = explicitBaseUrl?.trim()
+    ? normalizeBaseUrl(explicitBaseUrl)
+    : readHostedPublicBaseUrl(env);
+
+  if (!configuredBaseUrl) {
+    throw new Error(
+      "A hosted public base URL is required. Set HOSTED_WEB_BASE_URL or pass --base-url.",
+    );
+  }
+
+  return configuredBaseUrl;
+}
+
+function normalizeBaseUrl(value: string): string {
+  const url = new URL(value);
+  return url.origin;
+}

--- a/apps/web/src/lib/device-sync/settings-surface.ts
+++ b/apps/web/src/lib/device-sync/settings-surface.ts
@@ -59,6 +59,9 @@ export interface HostedDeviceSyncSettingsSource {
 }
 
 export interface HostedDeviceSyncSettingsUpstreamSource {
+  connectProvider?: ConfiguredDeviceSyncProviderKey | null;
+  connectSourceId?: string | null;
+  connectTarget?: string | null;
   providerLabel: string;
   requiresReconnect?: boolean;
   resourceCount: number;
@@ -137,18 +140,24 @@ export function buildHostedDeviceSyncSettingsSources(input: {
     }
 
     for (const [connectionIndex, connection] of connections.entries()) {
+      const upstreamSources = withUpstreamSourceConnectTargets({
+        connection,
+        targets: connectTargets,
+        upstreamSources: upstreamSourcesByConnectionId.get(connection.id) ?? [],
+      });
+
       sources.push(buildConnectedSource({
         connection,
         connectionIndex,
         connectTarget: resolveHostedDeviceSyncConnectTargetForConnection({
           connection,
           targets: connectTargets,
-          upstreamSources: upstreamSourcesByConnectionId.get(connection.id) ?? [],
+          upstreamSources,
         }),
         duplicateCount: connections.length,
         now,
         provider,
-        upstreamSources: upstreamSourcesByConnectionId.get(connection.id) ?? [],
+        upstreamSources,
       }));
     }
   }
@@ -159,15 +168,21 @@ export function buildHostedDeviceSyncSettingsSources(input: {
     }
 
     for (const [connectionIndex, connection] of connections.entries()) {
+      const upstreamSources = withUpstreamSourceConnectTargets({
+        connection,
+        targets: connectTargets,
+        upstreamSources: upstreamSourcesByConnectionId.get(connection.id) ?? [],
+      });
+
       sources.push(buildUnavailableSource(connection, {
         connectionIndex,
         connectTarget: resolveHostedDeviceSyncConnectTargetForConnection({
           connection,
           targets: connectTargets,
-          upstreamSources: upstreamSourcesByConnectionId.get(connection.id) ?? [],
+          upstreamSources,
         }),
         duplicateCount: connections.length,
-        upstreamSources: upstreamSourcesByConnectionId.get(connection.id) ?? [],
+        upstreamSources,
       }));
     }
   }
@@ -702,6 +717,31 @@ function findHostedDeviceSyncConnectTargetForUpstreamSources(input: {
   }
 
   return null;
+}
+
+function withUpstreamSourceConnectTargets(input: {
+  connection: Pick<HostedBrowserDeviceSyncConnection, "provider">;
+  targets: readonly HostedDeviceSyncSettingsConnectTarget[];
+  upstreamSources: readonly HostedDeviceSyncSettingsUpstreamSource[];
+}): HostedDeviceSyncSettingsUpstreamSource[] {
+  const provider = normalizeProviderKey(input.connection.provider);
+
+  return input.upstreamSources.map((source) => {
+    const target = findHostedDeviceSyncConnectTargetForUpstreamSources({
+      provider,
+      targets: input.targets,
+      upstreamSources: [source],
+    });
+
+    return target
+      ? {
+          ...source,
+          connectProvider: target.provider,
+          connectSourceId: target.connectSourceId,
+          connectTarget: target.connectTarget,
+        }
+      : source;
+  });
 }
 
 function toSettingsUpstreamSource(

--- a/apps/web/src/lib/device-sync/settings-surface.ts
+++ b/apps/web/src/lib/device-sync/settings-surface.ts
@@ -343,7 +343,7 @@ function buildConnectedSource(input: {
       primaryAction: sourceReconnectAction,
       provider: connection.provider,
       providerConfigured: true,
-      providerLabel,
+      providerLabel: reconnectSource.providerLabel,
       secondaryAction: {
         kind: "disconnect",
         label: "Disconnect",
@@ -646,20 +646,30 @@ function groupUpstreamSourcesByConnectionId(
 export function resolveHostedDeviceSyncConnectTargetForConnection(input: {
   connection: Pick<HostedBrowserDeviceSyncConnection, "provider">;
   targets: readonly HostedDeviceSyncSettingsConnectTarget[];
-  upstreamSources: readonly Pick<HostedDeviceSyncSettingsUpstreamSource, "sourceProviderSlug">[];
+  upstreamSources: readonly Pick<
+    HostedDeviceSyncSettingsUpstreamSource,
+    "requiresReconnect" | "sourceProviderSlug"
+  >[];
 }): HostedDeviceSyncSettingsConnectTarget | null {
   const provider = normalizeProviderKey(input.connection.provider);
+  const reconnectTarget = findHostedDeviceSyncConnectTargetForUpstreamSources({
+    provider,
+    targets: input.targets,
+    upstreamSources: input.upstreamSources.filter((source) => source.requiresReconnect === true),
+  });
 
-  for (const upstreamSource of input.upstreamSources) {
-    const sourceProviderSlug = normalizeProviderKey(upstreamSource.sourceProviderSlug);
-    const target = input.targets.find((candidate) =>
-      normalizeProviderKey(candidate.provider) === provider
-      && normalizeProviderKey(candidate.sourceProviderSlug ?? null) === sourceProviderSlug
-    );
+  if (reconnectTarget) {
+    return reconnectTarget;
+  }
 
-    if (target) {
-      return target;
-    }
+  const upstreamTarget = findHostedDeviceSyncConnectTargetForUpstreamSources({
+    provider,
+    targets: input.targets,
+    upstreamSources: input.upstreamSources,
+  });
+
+  if (upstreamTarget) {
+    return upstreamTarget;
   }
 
   const directTarget = input.targets.find((target) =>
@@ -669,6 +679,26 @@ export function resolveHostedDeviceSyncConnectTargetForConnection(input: {
 
   if (directTarget) {
     return directTarget;
+  }
+
+  return null;
+}
+
+function findHostedDeviceSyncConnectTargetForUpstreamSources(input: {
+  provider: string | null;
+  targets: readonly HostedDeviceSyncSettingsConnectTarget[];
+  upstreamSources: readonly Pick<HostedDeviceSyncSettingsUpstreamSource, "sourceProviderSlug">[];
+}): HostedDeviceSyncSettingsConnectTarget | null {
+  for (const upstreamSource of input.upstreamSources) {
+    const sourceProviderSlug = normalizeProviderKey(upstreamSource.sourceProviderSlug);
+    const target = input.targets.find((candidate) =>
+      normalizeProviderKey(candidate.provider) === input.provider
+      && normalizeProviderKey(candidate.sourceProviderSlug ?? null) === sourceProviderSlug
+    );
+
+    if (target) {
+      return target;
+    }
   }
 
   return null;

--- a/apps/web/src/lib/device-sync/settings-surface.ts
+++ b/apps/web/src/lib/device-sync/settings-surface.ts
@@ -60,6 +60,7 @@ export interface HostedDeviceSyncSettingsSource {
 
 export interface HostedDeviceSyncSettingsUpstreamSource {
   providerLabel: string;
+  requiresReconnect?: boolean;
   resourceCount: number;
   sourceProviderSlug: string;
   status: HostedBrowserDeviceSyncConnectionSource["status"];
@@ -213,6 +214,10 @@ function buildConnectedSource(input: {
     : null;
   const connectedAgeMs = ageInMilliseconds(connection.connectedAt, now);
   const setupPhase = connection.setupPhase ?? null;
+  const reconnectSource = findReconnectRequiredUpstreamSource(input.upstreamSources);
+  const sourceReconnectAction = reconnectSource
+    ? buildReconnectAction(input.connectTarget)
+    : null;
 
   if (connection.status === "disconnected") {
     return {
@@ -304,6 +309,38 @@ function buildConnectedSource(input: {
             label: "Reconnect",
           }
         : null,
+      provider: connection.provider,
+      providerConfigured: true,
+      providerLabel,
+      secondaryAction: {
+        kind: "disconnect",
+        label: "Disconnect",
+      },
+      state: connection.status,
+      statusLabel: "Needs access",
+      tone: "attention",
+      updatedAt: connection.updatedAt,
+      upstreamSources: input.upstreamSources,
+    } satisfies HostedDeviceSyncSettingsSource;
+  }
+
+  if (reconnectSource) {
+    return {
+      connectionId: connection.id,
+      connectedAt: connection.connectedAt,
+      connectSourceId: input.connectTarget?.connectSourceId ?? null,
+      connectTarget: input.connectTarget?.connectTarget ?? null,
+      detail: `${reconnectSource.providerLabel} needs to be reconnected before Murph can keep syncing it.`,
+      displayName,
+      guidance: sourceReconnectAction
+        ? "Reconnect this source to refresh access, or disconnect it if you no longer need it."
+        : "Disconnect this source if you no longer need it.",
+      headline: "Access needs attention",
+      lastActivityAt,
+      lastSuccessfulSyncAt,
+      lastWebhookAt: connection.lastWebhookAt,
+      nextReconcileAt: connection.nextReconcileAt,
+      primaryAction: sourceReconnectAction,
       provider: connection.provider,
       providerConfigured: true,
       providerLabel,
@@ -642,10 +679,20 @@ function toSettingsUpstreamSource(
 ): HostedDeviceSyncSettingsUpstreamSource {
   return {
     providerLabel: formatHostedDeviceSyncSourceLabel(source.sourceProviderSlug),
+    ...(source.requiresReconnect ? { requiresReconnect: true } : {}),
     resourceCount: source.resourceCount,
     sourceProviderSlug: source.sourceProviderSlug,
     status: source.status,
   };
+}
+
+function findReconnectRequiredUpstreamSource(
+  sources: readonly HostedDeviceSyncSettingsUpstreamSource[],
+): HostedDeviceSyncSettingsUpstreamSource | null {
+  return sources.find((source) =>
+    source.status === "error"
+    && source.requiresReconnect === true
+  ) ?? null;
 }
 
 function compareUpstreamSources(

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -866,6 +866,59 @@ test("ConnectPage preserves reconnect action on active source matches", async ()
   );
 });
 
+test("ConnectPage keeps healthy Junction child sources connected when another child needs reconnect", async () => {
+  const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
+
+  assert.deepEqual(
+    resolveConnectSourceConnectionStates([{ id: "garmin" }, { id: "whoop" }], [
+      {
+        connectionId: "dsc_junction_multi",
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        primaryAction: {
+          kind: "reconnect",
+          label: "Reconnect",
+        },
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Garmin",
+            resourceCount: 2,
+            sourceProviderSlug: "garmin",
+            status: "connected",
+          },
+          {
+            providerLabel: "WHOOP",
+            requiresReconnect: true,
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "error",
+          },
+        ],
+      },
+    ]),
+    [
+      {
+        connectionId: "dsc_junction_multi",
+        connectProvider: "junction",
+        connectTarget: "whoop",
+        requiresReconnect: true,
+        sourceId: "whoop",
+        state: "active",
+      },
+      {
+        connectionId: "dsc_junction_multi",
+        connectProvider: "junction",
+        connectTarget: null,
+        requiresReconnect: false,
+        sourceId: "garmin",
+        state: "active",
+      },
+    ],
+  );
+});
+
 test("ConnectPage lets active reconnect rows win over stale reconnectable rows", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -919,6 +919,66 @@ test("ConnectPage keeps healthy Junction child sources connected when another ch
   );
 });
 
+test("ConnectPage gives each reconnect-required Junction child its own target", async () => {
+  const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
+
+  assert.deepEqual(
+    resolveConnectSourceConnectionStates([{ id: "garmin" }, { id: "whoop" }], [
+      {
+        connectionId: "dsc_junction_multi",
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        primaryAction: {
+          kind: "reconnect",
+          label: "Reconnect",
+        },
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            connectProvider: "junction",
+            connectSourceId: "garmin",
+            connectTarget: "garmin",
+            providerLabel: "Garmin",
+            requiresReconnect: true,
+            resourceCount: 2,
+            sourceProviderSlug: "garmin",
+            status: "error",
+          },
+          {
+            connectProvider: "junction",
+            connectSourceId: "whoop",
+            connectTarget: "whoop",
+            providerLabel: "WHOOP",
+            requiresReconnect: true,
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "error",
+          },
+        ],
+      },
+    ]),
+    [
+      {
+        connectionId: "dsc_junction_multi",
+        connectProvider: "junction",
+        connectTarget: "whoop",
+        requiresReconnect: true,
+        sourceId: "whoop",
+        state: "active",
+      },
+      {
+        connectionId: "dsc_junction_multi",
+        connectProvider: "junction",
+        connectTarget: "garmin",
+        requiresReconnect: true,
+        sourceId: "garmin",
+        state: "active",
+      },
+    ],
+  );
+});
+
 test("ConnectPage lets active reconnect rows win over stale reconnectable rows", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -866,6 +866,46 @@ test("ConnectPage preserves reconnect action on active source matches", async ()
   );
 });
 
+test("ConnectPage lets Junction source reconnect win over healthy duplicate direct source", async () => {
+  const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
+
+  assert.deepEqual(
+    resolveConnectSourceConnectionStates([{ id: "whoop" }], [
+      {
+        connectionId: "dsc_direct_whoop",
+        provider: "whoop",
+        state: "active",
+        upstreamSources: [],
+      },
+      {
+        connectionId: "dsc_junction_whoop",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            connectProvider: "junction",
+            connectSourceId: "whoop",
+            connectTarget: "whoop",
+            providerLabel: "WHOOP",
+            requiresReconnect: true,
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "error",
+          },
+        ],
+      },
+    ]),
+    [{
+      connectionId: "dsc_junction_whoop",
+      connectProvider: "junction",
+      connectTarget: "whoop",
+      requiresReconnect: true,
+      sourceId: "whoop",
+      state: "active",
+    }],
+  );
+});
+
 test("ConnectPage keeps healthy Junction child sources connected when another child needs reconnect", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 

--- a/apps/web/test/device-connect-intent-route.test.ts
+++ b/apps/web/test/device-connect-intent-route.test.ts
@@ -138,6 +138,48 @@ describe("hosted device connect intent route", () => {
     });
   });
 
+  it("starts source-specific Junction reconnect intents when a direct target has the same public source", async () => {
+    vi.stubEnv("WHOOP_CLIENT_ID", "");
+    vi.stubEnv("WHOOP_CLIENT_SECRET", "");
+    vi.stubEnv("STRAVA_CLIENT_ID", "strava-client");
+    vi.stubEnv("STRAVA_CLIENT_SECRET", "strava-secret");
+    vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+    vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+    vi.stubEnv("JUNCTION_ENV", "sandbox");
+    vi.stubEnv("JUNCTION_PROVIDER_FILTER", "strava");
+    vi.stubEnv("JUNCTION_REGION", "us");
+    mocks.claimHostedDeviceConnectIntentForStart.mockResolvedValueOnce({
+      status: "claimed",
+      intent: createIntentRecord({
+        connectSourceId: "strava",
+        connectTarget: "strava",
+        provider: "junction",
+        sourceProviderSlug: "strava",
+        startedAt: new Date("2026-05-08T12:01:00.000Z"),
+      }),
+    });
+
+    const response = await deviceConnectIntentRoute.POST(
+      new Request("https://join.example.test/device/connect/dc_opaque", {
+        method: "POST",
+      }),
+      createRouteContext({ claim: "dc_opaque" }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(mocks.startHostedDeviceSyncConnection).toHaveBeenCalledWith({
+      defaultReturnTo:
+        "/device-sync/connect/complete?source=assistant&connectSource=strava&connectTarget=strava",
+      request: expect.any(Request),
+      target: expect.objectContaining({
+        connectSourceId: "strava",
+        connectTarget: "strava",
+        provider: "junction",
+        sourceProviderSlug: "strava",
+      }),
+    });
+  });
+
   it("returns JSON for app-page intent starts", async () => {
     const response = await deviceConnectIntentRoute.POST(
       new Request("https://join.example.test/device/connect/dc_opaque", {
@@ -234,16 +276,20 @@ describe("hosted device connect intent route", () => {
 
 function createIntentRecord(
   overrides: Partial<{
+    connectSourceId: string;
+    connectTarget: string;
+    provider: "junction" | "whoop";
+    sourceProviderSlug: string | null;
     startedAt: Date | null;
   }> = {},
 ) {
   return {
     claimHash: "claim_hash",
     memberId: "member_123",
-    provider: "whoop",
-    connectSourceId: "whoop",
-    connectTarget: "whoop",
-    sourceProviderSlug: null,
+    provider: overrides.provider ?? "whoop",
+    connectSourceId: overrides.connectSourceId ?? "whoop",
+    connectTarget: overrides.connectTarget ?? "whoop",
+    sourceProviderSlug: overrides.sourceProviderSlug ?? null,
     createdAt: new Date("2026-05-08T12:00:00.000Z"),
     expiresAt: new Date("2026-05-08T12:15:00.000Z"),
     startedAt: overrides.startedAt ?? null,

--- a/apps/web/test/device-reconnect-link-tool.test.ts
+++ b/apps/web/test/device-reconnect-link-tool.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createHostedDeviceConnectIntentTx: vi.fn(),
+  tx: {},
+}));
+
+vi.mock("@/src/lib/device-sync/connect-intent-core", () => ({
+  createHostedDeviceConnectIntentTx: mocks.createHostedDeviceConnectIntentTx,
+  HOSTED_DEVICE_RECONNECT_NOTICE_INTENT_TTL_MS: 72 * 60 * 60 * 1000,
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: () => ({
+    $transaction: (callback: (tx: typeof mocks.tx) => unknown) => callback(mocks.tx),
+  }),
+}));
+
+const configuredWhoopEnv = {
+  HOSTED_WEB_BASE_URL: "https://join.example.test",
+  JUNCTION_API_KEY: "sk_us_junction-test",
+  JUNCTION_CLIENT_USER_ID_SECRET: "junction-client-user-id-secret",
+  JUNCTION_ENV: "sandbox",
+  JUNCTION_PROVIDER_FILTER: "whoop_v2",
+  JUNCTION_REGION: "us",
+  WHOOP_CLIENT_ID: "whoop-client",
+  WHOOP_CLIENT_SECRET: "whoop-secret",
+};
+
+describe("hosted device reconnect link tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the Junction source slug to avoid choosing direct WHOOP", async () => {
+    const { resolveHostedDeviceReconnectLinkTarget } = await import(
+      "@/src/lib/device-sync/reconnect-link-tool"
+    );
+
+    expect(resolveHostedDeviceReconnectLinkTarget(configuredWhoopEnv, {
+      connectSourceId: null,
+      connectTarget: null,
+      sourceProviderSlug: "whoop_v2",
+    })).toEqual({
+      status: "found",
+      target: {
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        label: "WHOOP",
+        provider: "junction",
+        sourceProviderSlug: "whoop_v2",
+      },
+    });
+  });
+
+  it("refuses an ambiguous WHOOP target when direct and Junction routes are configured", async () => {
+    const { resolveHostedDeviceReconnectLinkTarget } = await import(
+      "@/src/lib/device-sync/reconnect-link-tool"
+    );
+
+    const result = resolveHostedDeviceReconnectLinkTarget(configuredWhoopEnv, {
+      connectSourceId: null,
+      connectTarget: "whoop",
+      sourceProviderSlug: null,
+    });
+
+    expect(result.status).toBe("ambiguous");
+    expect(result.status === "ambiguous" ? result.matches : []).toHaveLength(2);
+  });
+
+  it("creates a long-lived source-specific connect intent for the selected target", async () => {
+    mocks.createHostedDeviceConnectIntentTx.mockResolvedValueOnce({
+      claim: "dc_opaque",
+      connectUrl: "https://join.example.test/connect#deviceConnectIntent=dc_opaque&connectSource=whoop",
+      deviceConnectUrl: "https://join.example.test/device/connect/dc_opaque",
+      expiresAt: "2026-06-19T12:00:00.000Z",
+    });
+
+    const { createHostedDeviceReconnectLink } = await import(
+      "@/src/lib/device-sync/reconnect-link-tool"
+    );
+    const result = await createHostedDeviceReconnectLink({
+      args: {
+        baseUrl: null,
+        connectSourceId: null,
+        connectTarget: null,
+        help: false,
+        memberId: "member_123",
+        sourceProviderSlug: "whoop_v2",
+      },
+      env: configuredWhoopEnv,
+      now: new Date("2026-06-16T12:00:00.000Z"),
+    });
+
+    expect(mocks.createHostedDeviceConnectIntentTx).toHaveBeenCalledWith({
+      connectSourceId: "whoop",
+      connectTarget: "whoop",
+      memberId: "member_123",
+      now: new Date("2026-06-16T12:00:00.000Z"),
+      provider: "junction",
+      request: expect.any(Request),
+      sourceProviderSlug: "whoop_v2",
+      ttlMs: 72 * 60 * 60 * 1000,
+      tx: mocks.tx,
+    });
+    expect(result).toMatchObject({
+      connectUrl: "https://join.example.test/connect#deviceConnectIntent=dc_opaque&connectSource=whoop",
+      target: {
+        provider: "junction",
+        sourceProviderSlug: "whoop_v2",
+      },
+    });
+  });
+});

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -1167,6 +1167,55 @@ describe("hosted device-sync wakes", () => {
     });
   });
 
+  it("projects reconnect-needed source errors without exposing raw source error codes", async () => {
+    const controlPlane = new HostedDeviceSyncControlPlane(
+      new Request("https://control.example.test/api/settings/device-sync"),
+    );
+    mocks.listConnectionsForUser.mockResolvedValue([
+      buildHostedConnection({
+        id: "dsc_junction_whoop",
+        displayName: "Junction",
+        provider: "junction",
+      }),
+    ]);
+    mocks.listConnectionSources.mockResolvedValueOnce([
+      {
+        id: "src_whoop",
+        connectionId: "dsc_junction_whoop",
+        sourceInstanceKey: "jxn_hidden",
+        sourceProviderSlug: "whoop_v2",
+        displayName: null,
+        status: "error",
+        resourceAvailabilitySummary: {
+          activity: true,
+          sleep: true,
+          workouts: true,
+        },
+        lastErrorCode: "TOKEN_REFRESH_FAILED",
+        lastErrorMessage: "Upstream token refresh failed.",
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-06-09T08:50:48.000Z",
+        createdAt: "2026-04-01T08:00:00.000Z",
+        updatedAt: "2026-06-09T08:50:48.000Z",
+      },
+    ]);
+
+    const result = await controlPlane.listConnections("user-123");
+
+    expect(result.connectionSources).toEqual([
+      {
+        connectionId: buildPublicConnectionId("dsc_junction_whoop"),
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-06-09T08:50:48.000Z",
+        requiresReconnect: true,
+        resourceCount: 3,
+        sourceProviderSlug: "whoop_v2",
+        status: "error",
+      },
+    ]);
+    expect(JSON.stringify(result.connectionSources)).not.toContain("TOKEN_REFRESH_FAILED");
+  });
+
   it("resolves browser status reads through the opaque browser connection id", async () => {
     const controlPlane = new HostedDeviceSyncControlPlane(
       new Request("https://control.example.test/api/settings/device-sync/connections/dspc_demo/status"),

--- a/apps/web/test/device-sync-settings-surface.test.ts
+++ b/apps/web/test/device-sync-settings-surface.test.ts
@@ -434,6 +434,27 @@ describe("buildHostedDeviceSyncSettingsSources", () => {
       statusLabel: "Needs access",
       tone: "attention",
     });
+    expect(source?.upstreamSources).toEqual([
+      {
+        connectProvider: "junction",
+        connectSourceId: "garmin",
+        connectTarget: "garmin",
+        providerLabel: "Garmin",
+        resourceCount: 2,
+        sourceProviderSlug: "garmin",
+        status: "connected",
+      },
+      {
+        connectProvider: "junction",
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        providerLabel: "WHOOP",
+        requiresReconnect: true,
+        resourceCount: 3,
+        sourceProviderSlug: "whoop_v2",
+        status: "error",
+      },
+    ]);
   });
 
   it("keeps pending external-link setup separate from the active lifecycle state", () => {

--- a/apps/web/test/device-sync-settings-surface.test.ts
+++ b/apps/web/test/device-sync-settings-surface.test.ts
@@ -379,6 +379,63 @@ describe("buildHostedDeviceSyncSettingsSources", () => {
     });
   });
 
+  it("targets the reconnect-required Junction source when another child source is connected", () => {
+    const [source] = buildHostedDeviceSyncSettingsSources({
+      connectionSources: [
+        {
+          connectionId: "dspc_junction_multi",
+          firstSeenAt: "2026-04-01T08:00:00.000Z",
+          lastSeenAt: "2026-06-09T08:30:00.000Z",
+          resourceCount: 2,
+          sourceProviderSlug: "garmin",
+          status: "connected",
+        },
+        {
+          connectionId: "dspc_junction_multi",
+          firstSeenAt: "2026-04-01T08:00:00.000Z",
+          lastSeenAt: "2026-06-09T08:50:48.000Z",
+          requiresReconnect: true,
+          resourceCount: 3,
+          sourceProviderSlug: "whoop_v2",
+          status: "error",
+        },
+      ],
+      connectTargets: [
+        {
+          connectSourceId: "garmin",
+          connectTarget: "garmin",
+          provider: "junction",
+          sourceProviderSlug: "garmin",
+        },
+        {
+          connectSourceId: "whoop",
+          connectTarget: "whoop",
+          provider: "junction",
+          sourceProviderSlug: "whoop_v2",
+        },
+      ],
+      connections: [buildConnection({
+        id: "dspc_junction_multi",
+        lastSyncCompletedAt: "2026-06-09T07:00:00.000Z",
+        provider: "junction",
+        status: "active",
+        updatedAt: "2026-06-09T08:50:48.000Z",
+      })],
+      now: new Date("2026-06-09T12:00:00.000Z"),
+      providers: [JUNCTION_PROVIDER],
+    });
+
+    expect(source).toMatchObject({
+      connectSourceId: "whoop",
+      connectTarget: "whoop",
+      detail: "WHOOP needs to be reconnected before Murph can keep syncing it.",
+      primaryAction: { kind: "reconnect", label: "Reconnect" },
+      providerLabel: "WHOOP",
+      statusLabel: "Needs access",
+      tone: "attention",
+    });
+  });
+
   it("keeps pending external-link setup separate from the active lifecycle state", () => {
     const [source] = buildHostedDeviceSyncSettingsSources({
       connections: [buildConnection({

--- a/apps/web/test/device-sync-settings-surface.test.ts
+++ b/apps/web/test/device-sync-settings-surface.test.ts
@@ -336,6 +336,49 @@ describe("buildHostedDeviceSyncSettingsSources", () => {
     });
   });
 
+  it("surfaces Junction source token-refresh failures as source reconnect actions", () => {
+    const [source] = buildHostedDeviceSyncSettingsSources({
+      connectionSources: [{
+        connectionId: "dspc_junction_whoop",
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-06-09T08:50:48.000Z",
+        requiresReconnect: true,
+        resourceCount: 3,
+        sourceProviderSlug: "whoop_v2",
+        status: "error",
+      }],
+      connectTargets: [{
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        provider: "junction",
+        sourceProviderSlug: "whoop_v2",
+      }],
+      connections: [buildConnection({
+        id: "dspc_junction_whoop",
+        lastSyncCompletedAt: "2026-06-09T07:00:00.000Z",
+        provider: "junction",
+        status: "active",
+        updatedAt: "2026-06-09T08:50:48.000Z",
+      })],
+      now: new Date("2026-06-09T12:00:00.000Z"),
+      providers: [JUNCTION_PROVIDER],
+    });
+
+    expect(source).toMatchObject({
+      connectSourceId: "whoop",
+      connectTarget: "whoop",
+      detail: "WHOOP needs to be reconnected before Murph can keep syncing it.",
+      headline: "Access needs attention",
+      primaryAction: { kind: "reconnect", label: "Reconnect" },
+      provider: "junction",
+      providerLabel: "WHOOP",
+      secondaryAction: { kind: "disconnect", label: "Disconnect" },
+      state: "active",
+      statusLabel: "Needs access",
+      tone: "attention",
+    });
+  });
+
   it("keeps pending external-link setup separate from the active lifecycle state", () => {
     const [source] = buildHostedDeviceSyncSettingsSources({
       connections: [buildConnection({


### PR DESCRIPTION
## Summary
- Surface Junction child-source reconnect needs without changing the parent Junction account status.
- Map source-level `TOKEN_REFRESH_FAILED` to a browser-safe `requiresReconnect` flag and settings/connect reconnect state.
- Add `pnpm --dir apps/web device:reconnect-link` to create a manual, source-specific hosted reconnect link for operators.
- Extract the connect-intent transaction core so the standalone operator script can reuse the existing intent creation path without importing Next `server-only` modules.

## Verification
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts apps/web/test/device-sync-settings-surface.test.ts apps/web/test/device-sync-hosted-wake.test.ts apps/web/test/device-reconnect-link-tool.test.ts apps/web/test/device-connect-intents.test.ts --no-coverage`
- `pnpm --dir apps/web test:prepared`
- `pnpm --dir apps/web lint` (passes with existing warning in `apps/web/app/api/internal/hosted-mailbox/fetch/route.ts` for unused `getPrisma`)
- `pnpm --dir apps/web device:reconnect-link -- --help`
- `git diff --check`

## Known blocker
- `pnpm --dir apps/web typecheck` is blocked by existing `app/api/internal/device-sync/junction/workouts/raw/route.ts(3,32): Cannot find module '@murphai/device-syncd/providers/junction-client' or its corresponding type declarations.`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784216627&installation_id=127572939&pr_number=187&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F187&signature=777dfdc9f033105a37893303f33f5f8e556f6d77e3233fd032001184c86fa17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->