### PR TITLE
[codex] fix Linq hosted E2E cleanup flake

### DIFF
--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -88,6 +88,8 @@ const HOSTED_CONTAINER_CODEX_SHELL_SMOKE_TIMEOUT_MS = 45_000;
 const HOSTED_CONTAINER_CODEX_SHELL_SMOKE_MODEL = "gpt-5.5";
 const HOSTED_CONTAINER_LIVE_MODEL_TURN_SMOKE_TIMEOUT_MS = 60_000;
 const HOSTED_CONTAINER_LIVE_MODEL_TURN_SMOKE_STDOUT_TAIL_MAX_CHARS = 16 * 1024;
+const HOSTED_CONTAINER_PROCESS_CLEANUP_SETTLE_INTERVAL_MS = 50;
+const HOSTED_CONTAINER_PROCESS_CLEANUP_SETTLE_TIMEOUT_MS = 1_000;
 const HOSTED_CONTAINER_LIVE_MODEL_TURN_SMOKE_STDERR_EXCERPT_MAX_CHARS = 512;
 const HOSTED_CONTAINER_DIRECT_R2_PRESIGNED_PUT_DEFAULT_BYTES = 150 * 1024 * 1024;
 const HOSTED_CONTAINER_DIRECT_R2_PRESIGNED_PUT_MAX_BYTES = 512 * 1024 * 1024;
@@ -2084,25 +2086,36 @@ async function enforceHostedContainerProcessIsolation(
   const killedExpectedCodexRoot =
     expectedCodexRoot !== null && firstPass.includes(expectedCodexRoot.pid);
 
-  for (const pid of firstPass) {
-    try {
-      processApi.kill(pid, "SIGKILL");
-    } catch {
-      // Re-check after the cleanup pass.
+  let remaining = firstPass;
+  const deadlineMs = Date.now() + HOSTED_CONTAINER_PROCESS_CLEANUP_SETTLE_TIMEOUT_MS;
+
+  while (remaining.length > 0) {
+    for (const pid of remaining) {
+      try {
+        processApi.kill(pid, "SIGKILL");
+      } catch {
+        // Re-check after the cleanup pass.
+      }
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, HOSTED_CONTAINER_PROCESS_CLEANUP_SETTLE_INTERVAL_MS)
+    );
+
+    remaining = await listUnexpectedHostedContainerProcessIds(
+      process.pid,
+      processApi,
+      baseline,
+      expectedCodexRoot,
+    );
+    if (remaining.length === 0 || Date.now() >= deadlineMs) {
+      break;
     }
   }
 
-  await new Promise((resolve) => setTimeout(resolve, 25));
-
-  const secondPass = await listUnexpectedHostedContainerProcessIds(
-    process.pid,
-    processApi,
-    baseline,
-    expectedCodexRoot,
-  );
-  if (secondPass.length > 0) {
+  if (remaining.length > 0) {
     throw new HostedRunnerShellIsolationError(
-      `Hosted runner shell still has unexpected live processes after cleanup: ${secondPass.join(", ")}.`,
+      `Hosted runner shell still has unexpected live processes after cleanup: ${remaining.join(", ")}.`,
     );
   }
 

--- a/apps/cloudflare/test/container-entrypoint.test.ts
+++ b/apps/cloudflare/test/container-entrypoint.test.ts
@@ -2608,6 +2608,75 @@ describe("startHostedContainerEntrypoint", () => {
     expect(readdir).toHaveBeenCalledTimes(3);
   });
 
+  it("waits for killed warm-container processes to disappear before poisoning the shell", async () => {
+    const childPid = process.pid + 1900;
+    let runnerStarted = false;
+    let killed = false;
+    let childStateReadsAfterKill = 0;
+    const kill = vi.fn((pid: number) => {
+      if (pid === childPid) {
+        killed = true;
+      }
+    });
+    const exit = vi.fn();
+    const readdir = vi.fn(async () => [
+      { isDirectory: () => true, name: String(process.pid) },
+      ...(runnerStarted ? [{ isDirectory: () => true, name: String(childPid) }] : []),
+    ]);
+    const readFile = vi.fn(async (filePath: string) => {
+      if (String(filePath).endsWith(`/${childPid}/stat`)) {
+        if (killed) {
+          childStateReadsAfterKill += 1;
+        }
+        const state = killed && childStateReadsAfterKill >= 3 ? "Z" : "S";
+        return `${childPid} (child) ${state} ${process.pid} 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n`;
+      }
+
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    const runnerSpy = vi.spyOn(hostedInvocation, "runHostedWorkspaceInvocation").mockImplementation(
+      async () => {
+        runnerStarted = true;
+        return buildWorkspaceRunnerResult();
+      },
+    );
+
+    const server = await startHostedContainerEntrypoint({
+      port: 0,
+      runtime: {
+        exitScheduler: exit,
+        processApi: { kill, readFile, readdir },
+        processIsolation: true,
+      },
+    });
+    servers.push(server);
+    const address = server.address();
+
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the hosted container entrypoint to expose a TCP port.");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/internal/workspace-invocation`, {
+      body: JSON.stringify(buildJobBody({
+        wake: {
+          event: { kind: "runtime.timer", triggerKind: "runtime_timer", userId: "u1" },
+          eventId: "evt_delayed_cleanup",
+          occurredAt: "2026-03-26T12:00:00.000Z",
+        },
+      })),
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(runnerSpy).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenCalledWith(childPid, "SIGKILL");
+    expect(kill.mock.calls.filter(([pid]) => pid === childPid).length).toBeGreaterThan(1);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
   it("still rejects lingering descendant processes after the cleanup pass", async () => {
     const childPid = process.pid + 2000;
 


### PR DESCRIPTION
## Summary

- fix hosted runner process-isolation cleanup so killed warm-container children get a short bounded settle window before shell poison
- add regression coverage for delayed `/proc` disappearance after `SIGKILL`

## Root Cause

The flaky Linq webhook hosted E2E failures were downstream of `shell_isolation_poison`. The hosted runner cleanup sent `SIGKILL`, waited a fixed 25ms, then failed closed if the killed process was still visible in `/proc`. Under CI load, killed child processes can remain visible briefly, causing false warm-shell poison and later Linq assertions to fail in whichever test reused the hosted scenario next.

## Validation

- `pnpm --dir apps/cloudflare test:node test/container-entrypoint.test.ts`
- `pnpm --dir apps/cloudflare typecheck`
- `pnpm test:diff apps/cloudflare/src/container-entrypoint.ts apps/cloudflare/test/container-entrypoint.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784224682&installation_id=127572939&pr_number=188&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F188&signature=5d0f1ff6a1bc7ea537ae2bed90ddd0356d577fc44c415915d7e67f460bf5552b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->