### PR TITLE
Fix hosted response close cancellation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-16-hosted-response-close-not-cancel.md
+++ b/agent-docs/exec-plans/completed/2026-06-16-hosted-response-close-not-cancel.md
@@ -1,0 +1,51 @@
+# Hosted response close is not cancellation
+
+## Goal
+
+Stop pure response delivery loss after an accepted hosted workspace job from
+aborting the in-container invocation and poisoning the warm container.
+
+Success criteria:
+
+- After `/internal/workspace-invocation` accepts a workspace job, a closed
+  response by itself does not abort the workspace invocation.
+- Explicit preemption can still cancel the accepted invocation.
+- Cleanup failure and other genuinely unsafe warm-runtime states still poison
+  or stop the container.
+- Focused tests prove the transport/cancellation split.
+
+## Constraints
+
+- Keep the change deletion-first and narrow: no result store, no new queue, no
+  restore handshake, no scheduler.
+- Preserve `RunnerContainer.abortWorkspaceInvocation` semantics with a concrete
+  invocation identity.
+- Edit `apps/cloudflare/src/runner-container.ts` only where needed to keep the
+  durable recovery/liveness path coherent after response transport loss.
+- Preserve unrelated worktree edits.
+
+## Approach
+
+1. Split response-close observation from accepted-job invocation cancellation.
+2. Route semantic cancellation through a small internal abort endpoint keyed by
+   attempt, fence generation, and user.
+3. Delete ambiguous-abort poisoning so response close alone is not poison
+   authority after a job has been accepted.
+4. Add focused entrypoint regression tests.
+5. Run app-local Cloudflare verification plus required audits.
+
+## State
+
+Active.
+
+## Notes
+
+- Production incident diagnosis: Cloudflare logged network connection loss,
+  then the entrypoint emitted `ambiguous_abort_poison` with no direct invocation
+  result and exited 1.
+- ReviewGPT direction: first safe change is narrower than ignoring all
+  transport aborts; treat pure response close after acceptance as response
+  delivery failure, while preserving explicit semantic cancellation.
+Status: completed
+Updated: 2026-06-16
+Completed: 2026-06-16

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -514,6 +514,10 @@ export async function startHostedContainerEntrypoint(input: {
           userId: abortRequest.userId,
         });
         response.statusCode = 204;
+        response.setHeader(
+          "x-workspace-invocation-abort-status",
+          accepted ? "accepted" : queued ? "queued" : "stale",
+        );
         response.end();
         return;
       }

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -83,6 +83,8 @@ const HOSTED_CONTAINER_DIRECT_R2_PRESIGNED_PUT_SMOKE_PATH =
   "/internal/direct-r2-presigned-put-smoke";
 const HOSTED_CONTAINER_LIVE_MODEL_TURN_SMOKE_PATH =
   "/internal/deploy-live-model-turn-smoke";
+const HOSTED_CONTAINER_WORKSPACE_INVOCATION_ABORT_PATH =
+  "/internal/workspace-invocation/abort";
 const HOSTED_CONTAINER_RUNTIME_WAKE_PATH = "/internal/runtime-wake";
 const HOSTED_CONTAINER_CODEX_SHELL_SMOKE_TIMEOUT_MS = 45_000;
 const HOSTED_CONTAINER_CODEX_SHELL_SMOKE_MODEL = "gpt-5.5";
@@ -235,6 +237,12 @@ interface HostedContainerDirectR2PresignedPutSmokeRequest {
   tlsCaCertificatePem?: string;
 }
 
+interface HostedContainerWorkspaceInvocationAbortRequest {
+  attemptId: string;
+  leaseGeneration: string;
+  userId: string;
+}
+
 interface HostedRunnerBundleManifestSummary {
   buildSkipped?: boolean;
   bundleFingerprint?: string;
@@ -319,6 +327,12 @@ export async function startHostedContainerEntrypoint(input: {
   let activeRuntimeWakePending = false;
   let activeRuntimeWakePendingAttemptId: string | null = null;
   let activeRuntimeWakePendingNotifiedAtEpochMs: number | null = null;
+  let activeWorkspaceInvocationAbort: {
+    abort: (reason: Error) => void;
+    attemptId: string | null;
+    leaseGeneration: string | null;
+    userId: string;
+  } | null = null;
   // Node startup span (process start -> ready to accept). Computed once after the
   // port is listening and consumed by the FIRST (cold) invocation only; a warm
   // process predates its message so its startup is not attributable to that turn.
@@ -333,28 +347,21 @@ export async function startHostedContainerEntrypoint(input: {
   const server = createServer(async (request, response) => {
     response.setHeader("connection", "close");
     const requestAbort = createRequestAbortController(request, response);
-    // Once shutdown began, the runtime must finish its immediate idle
-    // checkpoint even if the DO connection drops (the same deploy restarts the
-    // DO). Snapshot durability must not depend on response deliverability, so
-    // request aborts stop propagating to the runtime after the shutdown signal.
+    // Once a workspace job is accepted, HTTP transport state is no longer the
+    // owner of invocation lifetime. A closed caller connection means the caller
+    // may miss the result; explicit aborts arrive through the internal abort
+    // endpoint below.
     const invocationAbort = new AbortController();
-    const relayInvocationAbort = () => {
-      if (!containerShutdownController.signal.aborted) {
-        invocationAbort.abort(requestAbort.signal.reason);
-      }
-    };
-    if (requestAbort.signal.aborted) {
-      relayInvocationAbort();
-    } else {
-      requestAbort.signal.addEventListener("abort", relayInvocationAbort, { once: true });
-    }
     let claimedRunnerSlot = false;
     let runtimeWakeForRequest: ((notifiedAtEpochMs?: number) => boolean) | null = null;
     let job: HostedExecutionRunnerJobInput | null = null;
     let stopActiveJobDiagnostics: (() => void) | null = null;
-    let cleanupPassedForRequest = false;
-    let directInvocationReturned = false;
-    let resultDelivered = false;
+    let activeAbortRecord: {
+      abort: (reason: Error) => void;
+      attemptId: string | null;
+      leaseGeneration: string | null;
+      userId: string;
+    } | null = null;
 
     try {
       const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -441,9 +448,13 @@ export async function startHostedContainerEntrypoint(input: {
         && requestUrl.pathname === HOSTED_CONTAINER_DIRECT_R2_PRESIGNED_PUT_SMOKE_PATH;
       const isWorkspaceInvocationRequest =
         request.method === "POST" && requestUrl.pathname === "/internal/workspace-invocation";
+      const isWorkspaceInvocationAbortRequest =
+        request.method === "POST"
+        && requestUrl.pathname === HOSTED_CONTAINER_WORKSPACE_INVOCATION_ABORT_PATH;
 
       if (
         !isWorkspaceInvocationRequest
+        && !isWorkspaceInvocationAbortRequest
         && !isCodexShellSmokeRequest
         && !isLiveModelTurnSmokeRequest
         && !isDirectR2PresignedPutSmokeRequest
@@ -451,6 +462,52 @@ export async function startHostedContainerEntrypoint(input: {
         discardUnreadRequestBody(request);
         response.statusCode = 404;
         response.end("Not found");
+        return;
+      }
+
+      if (isWorkspaceInvocationAbortRequest) {
+        let abortRequest: HostedContainerWorkspaceInvocationAbortRequest;
+        try {
+          abortRequest = parseHostedContainerWorkspaceInvocationAbortRequest(
+            JSON.parse(await readHostedContainerInvocationRequestBody(request)),
+          );
+        } catch (error) {
+          emitHostedExecutionStructuredLog({
+            component: "container",
+            error,
+            level: "warn",
+            message: "Hosted container entrypoint rejected the workspace invocation abort request body.",
+            phase: "failed",
+          });
+          const classified = classifyRequestDecodeError(error);
+          writeJsonResponse(response, classified.statusCode, classified.payload);
+          return;
+        }
+
+        const activeAbort = activeWorkspaceInvocationAbort;
+        const accepted = activeAbort !== null
+          && activeAbort.attemptId === abortRequest.attemptId
+          && activeAbort.leaseGeneration === abortRequest.leaseGeneration
+          && activeAbort.userId === abortRequest.userId;
+        if (accepted) {
+          activeAbort.abort(new Error("workspace invocation preempted"));
+        }
+        emitHostedExecutionStructuredLog({
+          component: "container",
+          details: {
+            abortAccepted: accepted,
+            workspaceAttemptId: abortRequest.attemptId,
+            workspaceLeaseGeneration: abortRequest.leaseGeneration,
+          },
+          level: accepted ? "info" : "warn",
+          message: accepted
+            ? "Hosted container entrypoint accepted workspace invocation abort."
+            : "Hosted container entrypoint ignored stale workspace invocation abort.",
+          phase: accepted ? "wake.running" : "failed",
+          userId: abortRequest.userId,
+        });
+        response.statusCode = 204;
+        response.end();
         return;
       }
 
@@ -635,6 +692,17 @@ export async function startHostedContainerEntrypoint(input: {
         userId: readHostedExecutionRunnerJobUserId(job),
       });
       activeRuntimeWakePendingAttemptId = readHostedContainerWorkspaceAttemptId(job);
+      activeAbortRecord = {
+        abort(reason: Error) {
+          if (!containerShutdownController.signal.aborted && !invocationAbort.signal.aborted) {
+            invocationAbort.abort(reason);
+          }
+        },
+        attemptId: readHostedContainerWorkspaceAttemptId(job),
+        leaseGeneration: readHostedContainerWorkspaceLeaseGeneration(job),
+        userId: readHostedExecutionRunnerJobUserId(job),
+      };
+      activeWorkspaceInvocationAbort = activeAbortRecord;
       stopActiveJobDiagnostics = startHostedContainerActiveJobDiagnostics({
         job,
         processApi: runtime.processApi,
@@ -668,7 +736,6 @@ export async function startHostedContainerEntrypoint(input: {
         },
         onCleanupStatus(status) {
           lastCleanupStatus = status;
-          cleanupPassedForRequest = status === "passed";
           if (status === "failed") {
             hostedContainerPoisoned = true;
           }
@@ -679,7 +746,6 @@ export async function startHostedContainerEntrypoint(input: {
         shutdownSignal: containerShutdownController.signal,
         signal: invocationAbort.signal,
       });
-      directInvocationReturned = true;
 
       if (requestAbort.signal.aborted || response.destroyed) {
         return;
@@ -697,7 +763,6 @@ export async function startHostedContainerEntrypoint(input: {
       response.statusCode = 200;
       response.setHeader("content-type", "application/json; charset=utf-8");
       response.end(JSON.stringify(result));
-      resultDelivered = true;
     } catch (error) {
       if (requestAbort.signal.aborted || response.destroyed) {
         return;
@@ -723,41 +788,6 @@ export async function startHostedContainerEntrypoint(input: {
       const classified = classifyRunnerJobError(error);
       writeJsonResponse(response, classified.statusCode, classified.payload);
     } finally {
-      if (
-        job
-        && !resultDelivered
-        && (requestAbort.signal.aborted || response.destroyed)
-        && !(directInvocationReturned && cleanupPassedForRequest)
-      ) {
-        hostedContainerPoisoned = true;
-        emitHostedExecutionStructuredLog({
-          component: "container",
-          details: {
-            cleanupPassed: cleanupPassedForRequest,
-            directInvocationReturned,
-            resultDelivered,
-          },
-          level: "error",
-          message: "Hosted container entrypoint poisoned after an ambiguous aborted runner job.",
-          phase: "failed",
-          userId: readHostedExecutionRunnerJobUserId(job),
-        });
-        await reportHostedContainerFatalBestEffort({
-          boundUserId: readHostedExecutionRunnerJobUserId(job),
-          error: Object.assign(
-            new Error("Hosted container entrypoint poisoned after an ambiguous aborted runner job."),
-            {
-              details: {
-                cleanupPassed: cleanupPassedForRequest,
-                directInvocationReturned,
-                resultDelivered,
-              },
-            },
-          ),
-          stage: "ambiguous_abort_poison",
-        });
-        runtime.exitScheduler();
-      }
       stopActiveJobDiagnostics?.();
       if (runtimeWakeForRequest && activeRuntimeWake === runtimeWakeForRequest) {
         activeRuntimeWake = null;
@@ -770,6 +800,12 @@ export async function startHostedContainerEntrypoint(input: {
         activeRuntimeWakePending = false;
         activeRuntimeWakePendingAttemptId = null;
         activeRuntimeWakePendingNotifiedAtEpochMs = null;
+      }
+      if (
+        activeAbortRecord
+        && activeWorkspaceInvocationAbort === activeAbortRecord
+      ) {
+        activeWorkspaceInvocationAbort = null;
       }
       if (claimedRunnerSlot) {
         activeHostedRunnerJobCount = Math.max(0, activeHostedRunnerJobCount - 1);
@@ -1145,6 +1181,41 @@ function parseHostedContainerDirectR2PresignedPutSmokeRequest(
   };
 }
 
+function parseHostedContainerWorkspaceInvocationAbortRequest(
+  value: unknown,
+): HostedContainerWorkspaceInvocationAbortRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Workspace invocation abort request must be an object.");
+  }
+
+  const record = value as Record<string, unknown>;
+  const attemptId = typeof record.attemptId === "string"
+    ? record.attemptId.trim()
+    : "";
+  const leaseGeneration = typeof record.leaseGeneration === "string"
+    ? record.leaseGeneration.trim()
+    : "";
+  const userId = typeof record.userId === "string"
+    ? record.userId.trim()
+    : "";
+
+  if (!attemptId) {
+    throw new TypeError("Workspace invocation abort request requires attemptId.");
+  }
+  if (!leaseGeneration) {
+    throw new TypeError("Workspace invocation abort request requires leaseGeneration.");
+  }
+  if (!userId) {
+    throw new TypeError("Workspace invocation abort request requires userId.");
+  }
+
+  return {
+    attemptId,
+    leaseGeneration,
+    userId,
+  };
+}
+
 function readHostedExecutionRunnerResultPhase(result: unknown): string | null {
   if (!result || typeof result !== "object" || Array.isArray(result)) {
     return null;
@@ -1158,6 +1229,12 @@ function readHostedContainerWorkspaceAttemptId(
   job: HostedExecutionRunnerJobInput,
 ): string | null {
   return job.kind === "workspace-invocation" ? job.request.attemptId : null;
+}
+
+function readHostedContainerWorkspaceLeaseGeneration(
+  job: HostedExecutionRunnerJobInput,
+): string | null {
+  return job.kind === "workspace-invocation" ? job.request.leaseGeneration : null;
 }
 
 function assertHostedContainerArchitectureVersion(value: unknown): void {
@@ -2338,10 +2415,14 @@ export function createRequestAbortController(
   response: HostedAbortResponseLike,
 ): {
   cleanup: () => void;
+  requestSignal: AbortSignal;
+  responseClosed: () => boolean;
   signal: AbortSignal;
 } {
   const controller = new AbortController();
+  const requestController = new AbortController();
   let exitLogged = false;
+  let responseClosed = false;
 
   const emitRequestExitLog = (exitReason: "request.aborted" | "response.closed"): void => {
     if (exitLogged) {
@@ -2363,24 +2444,33 @@ export function createRequestAbortController(
     });
   };
 
-  const abort = (exitReason: "request.aborted" | "response.closed") => {
-    if (!controller.signal.aborted) {
-      emitRequestExitLog(exitReason);
-      controller.abort(
-        new Error(
-          exitReason === "response.closed"
-            ? "Hosted runner response closed before completion."
-            : "Hosted runner request aborted before completion.",
-        ),
-      );
+  const abortRequest = () => {
+    if (!requestController.signal.aborted) {
+      const error = new Error("Hosted runner request aborted before completion.");
+      emitRequestExitLog("request.aborted");
+      requestController.abort(error);
+      if (!controller.signal.aborted) {
+        controller.abort(error);
+      }
+    }
+  };
+
+  const abortResponse = () => {
+    if (!responseClosed) {
+      responseClosed = true;
+      const error = new Error("Hosted runner response closed before completion.");
+      emitRequestExitLog("response.closed");
+      if (!controller.signal.aborted) {
+        controller.abort(error);
+      }
     }
   };
   const handleRequestAbort = () => {
-    abort("request.aborted");
+    abortRequest();
   };
   const handleResponseClose = () => {
     if (!response.writableEnded) {
-      abort("response.closed");
+      abortResponse();
     }
   };
 
@@ -2392,6 +2482,8 @@ export function createRequestAbortController(
       request.off("aborted", handleRequestAbort);
       response.off("close", handleResponseClose);
     },
+    requestSignal: requestController.signal,
+    responseClosed: () => responseClosed,
     signal: controller.signal,
   };
 }

--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -333,6 +333,7 @@ export async function startHostedContainerEntrypoint(input: {
     leaseGeneration: string | null;
     userId: string;
   } | null = null;
+  let pendingWorkspaceInvocationAbort: HostedContainerWorkspaceInvocationAbortRequest | null = null;
   // Node startup span (process start -> ready to accept). Computed once after the
   // port is listening and consumed by the FIRST (cold) invocation only; a warm
   // process predates its message so its startup is not attributable to that turn.
@@ -491,19 +492,25 @@ export async function startHostedContainerEntrypoint(input: {
           && activeAbort.userId === abortRequest.userId;
         if (accepted) {
           activeAbort.abort(new Error("workspace invocation preempted"));
+        } else if (activeAbort === null) {
+          pendingWorkspaceInvocationAbort = abortRequest;
         }
+        const queued = !accepted && activeAbort === null;
         emitHostedExecutionStructuredLog({
           component: "container",
           details: {
             abortAccepted: accepted,
+            abortQueued: queued,
             workspaceAttemptId: abortRequest.attemptId,
             workspaceLeaseGeneration: abortRequest.leaseGeneration,
           },
-          level: accepted ? "info" : "warn",
+          level: accepted || queued ? "info" : "warn",
           message: accepted
             ? "Hosted container entrypoint accepted workspace invocation abort."
-            : "Hosted container entrypoint ignored stale workspace invocation abort.",
-          phase: accepted ? "wake.running" : "failed",
+            : queued
+              ? "Hosted container entrypoint queued workspace invocation abort."
+              : "Hosted container entrypoint ignored stale workspace invocation abort.",
+          phase: accepted || queued ? "wake.running" : "failed",
           userId: abortRequest.userId,
         });
         response.statusCode = 204;
@@ -703,6 +710,15 @@ export async function startHostedContainerEntrypoint(input: {
         userId: readHostedExecutionRunnerJobUserId(job),
       };
       activeWorkspaceInvocationAbort = activeAbortRecord;
+      if (
+        pendingWorkspaceInvocationAbort
+        && activeAbortRecord.attemptId === pendingWorkspaceInvocationAbort.attemptId
+        && activeAbortRecord.leaseGeneration === pendingWorkspaceInvocationAbort.leaseGeneration
+        && activeAbortRecord.userId === pendingWorkspaceInvocationAbort.userId
+      ) {
+        pendingWorkspaceInvocationAbort = null;
+        activeAbortRecord.abort(new Error("workspace invocation preempted"));
+      }
       stopActiveJobDiagnostics = startHostedContainerActiveJobDiagnostics({
         job,
         processApi: runtime.processApi,

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -39,6 +39,8 @@ const RUNNER_PORT = 8080;
 const RUNNER_PING_ENDPOINT = "container/health";
 const RUNNER_HEALTH_URL = "http://container/health";
 const RUNNER_EXECUTE_URL = "http://container/internal/workspace-invocation";
+const RUNNER_ABORT_WORKSPACE_INVOCATION_URL =
+  "http://container/internal/workspace-invocation/abort";
 const RUNNER_CODEX_SHELL_SMOKE_URL =
   "http://container/internal/deploy-codex-shell-smoke";
 const RUNNER_LIVE_MODEL_TURN_SMOKE_URL =
@@ -52,6 +54,8 @@ const RUNNER_WAIT_INTERVAL_MS = 250;
 const RUNNER_STOPPED_REQUEST_SETTLE_MS = 1_000;
 const RUNNER_DESTROY_SETTLE_TIMEOUT_MS = 5_000;
 const DEFAULT_RUNNER_READY_TIMEOUT_MS = 20_000;
+const DEFAULT_RUNNER_ABORT_WORKSPACE_INVOCATION_TIMEOUT_MS = 1_000;
+const DEFAULT_RUNNER_ACTIVE_LIVENESS_TIMEOUT_MS = 1_000;
 const DEFAULT_RUNNER_RUNTIME_WAKE_TIMEOUT_MS = 5_000;
 const RUNNER_RECENT_READINESS_PROOF_MAX_AGE_MS = 5_000;
 const RUNNER_METADATA_RESPONSE_BODY_MAX_BYTES = 64 * 1024;
@@ -164,7 +168,11 @@ interface HostedExecutionContainerRunnerInput {
 }
 
 export interface HostedExecutionContainerStubLike {
-  abortWorkspaceInvocation?(input: { attemptId: string; userId: string }): Promise<void>;
+  abortWorkspaceInvocation?(input: {
+    attemptId: string;
+    leaseGeneration: string;
+    userId: string;
+  }): Promise<void>;
   destroyInstance(): Promise<void>;
   ensureReadyForProcessing?(
     input: RunnerContainerEnsureReadyForProcessingInput,
@@ -347,6 +355,8 @@ export class RunnerContainer extends Container {
   private warmShellInvalidatedByUnsettledDestroy = false;
   private workspaceInvocationAbortController: AbortController | null = null;
   private workspaceInvocationActiveOperation: RunnerActiveOperationRecord | null = null;
+  private workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
+  private workspaceInvocationAbortEndpointReady = false;
 
   constructor(state: unknown, env: RunnerContainerEnvironmentSource) {
     super(state as never, env as never);
@@ -375,14 +385,29 @@ export class RunnerContainer extends Container {
 
   async readActiveRuntimeUserFence(): Promise<WorkerActiveRuntimeUserFenceResult> {
     const active = this.workspaceInvocationActiveOperation;
-    return active
-      ? {
-          active: true,
-          attemptId: active.attemptId,
-          leaseGeneration: active.leaseGeneration,
-          userId: active.userId,
-        }
-      : { active: false, reason: "no_active_runtime" };
+    if (!active) {
+      return { active: false, reason: "no_active_runtime" };
+    }
+
+    if (
+      this.workspaceInvocationActiveOperationPreservedAfterTransportFailure
+      && !await this.readWorkspaceInvocationActiveFromHealth()
+    ) {
+      if (this.workspaceInvocationActiveOperation === active) {
+        this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
+        this.workspaceInvocationAbortEndpointReady = false;
+        this.workspaceInvocationActiveOperation = null;
+        this.workspaceInvocationAbortController = null;
+      }
+      return { active: false, reason: "no_active_runtime" };
+    }
+
+    return {
+      active: true,
+      attemptId: active.attemptId,
+      leaseGeneration: active.leaseGeneration,
+      userId: active.userId,
+    };
   }
 
   async ensureReadyForProcessing(
@@ -408,14 +433,25 @@ export class RunnerContainer extends Container {
     });
   }
 
-  async abortWorkspaceInvocation(input: { attemptId: string; userId: string }): Promise<void> {
+  async abortWorkspaceInvocation(input: {
+    attemptId: string;
+    leaseGeneration: string;
+    userId: string;
+  }): Promise<void> {
     const active = this.workspaceInvocationActiveOperation;
     const abortController = this.workspaceInvocationAbortController;
     if (!active || !abortController) {
       return;
     }
-    if (active.attemptId !== input.attemptId || active.userId !== input.userId) {
+    if (
+      active.attemptId !== input.attemptId
+      || active.leaseGeneration !== input.leaseGeneration
+      || active.userId !== input.userId
+    ) {
       return;
+    }
+    if (this.workspaceInvocationAbortEndpointReady) {
+      await this.postWorkspaceInvocationAbort(input);
     }
     if (!abortController.signal.aborted) {
       abortController.abort(new Error(WORKSPACE_INVOCATION_PREEMPTED_ABORT_MESSAGE));
@@ -473,6 +509,24 @@ export class RunnerContainer extends Container {
       || active.leaseGeneration !== input.leaseGeneration
     ) {
       return { kind: "not-wakeable", reason: "no-active-child" };
+    }
+
+    if (this.workspaceInvocationActiveOperationPreservedAfterTransportFailure) {
+      let activeInContainer = true;
+      try {
+        activeInContainer = await this.readWorkspaceInvocationActiveFromHealth();
+      } catch {
+        activeInContainer = true;
+      }
+      if (!activeInContainer) {
+        if (this.workspaceInvocationActiveOperation === active) {
+          this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
+          this.workspaceInvocationAbortEndpointReady = false;
+          this.workspaceInvocationActiveOperation = null;
+          this.workspaceInvocationAbortController = null;
+        }
+        return { kind: "not-wakeable", reason: "no-active-child" };
+      }
     }
 
     this.noteRunnerActivity("runtime-wake");
@@ -879,9 +933,11 @@ export class RunnerContainer extends Container {
     const operationAbortController = new AbortController();
     let activeOperationAcquired = false;
     let cleanupWarmContainerOnFailure = false;
+    let preserveActiveOperationAfterTransportFailure = false;
     let stopRunnerActivityRenewal: (() => void) | null = null;
     this.workspaceInvocationAbortController = operationAbortController;
     this.workspaceInvocationActiveOperation = activeOperation;
+    this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
 
     try {
       emitHostedExecutionStructuredLog({
@@ -907,6 +963,7 @@ export class RunnerContainer extends Container {
       throwIfRunnerContainerOperationAborted(operationAbortController.signal);
 
       activeOperationAcquired = true;
+      this.workspaceInvocationAbortEndpointReady = true;
       stopRunnerActivityRenewal = this.startRunnerActivityRenewal();
       this.noteRunnerActivity("invoke-started");
       this.noteRunnerActivity("runner-request-starting");
@@ -947,6 +1004,11 @@ export class RunnerContainer extends Container {
           Promise.race([runnerRequest, stoppedContainer]),
           operationAbortController.signal,
         );
+      } catch (error) {
+        if (!operationAbortController.signal.aborted) {
+          preserveActiveOperationAfterTransportFailure = true;
+        }
+        throw error;
       } finally {
         stopWatcherAbortController.abort();
         void stoppedContainer.catch(() => undefined);
@@ -980,7 +1042,15 @@ export class RunnerContainer extends Container {
         userId: routeUserId,
       });
 
-      const responsePayload = await response.json();
+      let responsePayload: unknown;
+      try {
+        responsePayload = await response.json();
+      } catch (error) {
+        if (!operationAbortController.signal.aborted) {
+          preserveActiveOperationAfterTransportFailure = true;
+        }
+        throw error;
+      }
       const result = assertHostedExecutionRunnerJobResult(responsePayload, input.job);
       completedSuccessfully = true;
       return result;
@@ -998,10 +1068,12 @@ export class RunnerContainer extends Container {
       try {
         if (activeOperationAcquired) {
           if (!completedSuccessfully) {
-            await this.stopWarmContainer({
-              failClosed: true,
-              reason: "invoke-failure",
-            });
+            if (!preserveActiveOperationAfterTransportFailure) {
+              await this.stopWarmContainer({
+                failClosed: true,
+                reason: "invoke-failure",
+              });
+            }
           } else if (this.recordSuccessfulWarmInvocationShouldRecycle()) {
             emitHostedExecutionStructuredLog({
               component: "container",
@@ -1031,13 +1103,88 @@ export class RunnerContainer extends Container {
         if (this.currentLogContext === logContext) {
           this.currentLogContext = null;
         }
-        if (this.workspaceInvocationAbortController === operationAbortController) {
-          this.workspaceInvocationAbortController = null;
-        }
-        if (this.workspaceInvocationActiveOperation === activeOperation) {
+        if (
+          this.workspaceInvocationActiveOperation === activeOperation
+          && !preserveActiveOperationAfterTransportFailure
+        ) {
+          this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
+          this.workspaceInvocationAbortEndpointReady = false;
           this.workspaceInvocationActiveOperation = null;
         }
+        if (
+          this.workspaceInvocationActiveOperation === activeOperation
+          && preserveActiveOperationAfterTransportFailure
+        ) {
+          this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = true;
+        }
+        if (
+          this.workspaceInvocationAbortController === operationAbortController
+          && !preserveActiveOperationAfterTransportFailure
+        ) {
+          this.workspaceInvocationAbortController = null;
+        }
       }
+    }
+  }
+
+  private async readWorkspaceInvocationActiveFromHealth(): Promise<boolean> {
+    const signal = AbortSignal.timeout(DEFAULT_RUNNER_ACTIVE_LIVENESS_TIMEOUT_MS);
+    const response = await this.containerFetch(RUNNER_HEALTH_URL, {
+      method: "GET",
+      signal,
+    });
+    const payload = await readRunnerContainerMetadataJsonObject(response, { signal });
+    if (!response.ok) {
+      throw new Error(`Hosted runner container health returned HTTP ${response.status}.`);
+    }
+    return typeof payload.activeJobCount === "number" && payload.activeJobCount > 0;
+  }
+
+  private async postWorkspaceInvocationAbort(input: {
+    attemptId: string;
+    leaseGeneration: string;
+    userId: string;
+  }): Promise<void> {
+    try {
+      const response = await this.containerFetch(
+        RUNNER_ABORT_WORKSPACE_INVOCATION_URL,
+        {
+          body: JSON.stringify(input),
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          method: "POST",
+          signal: AbortSignal.timeout(DEFAULT_RUNNER_ABORT_WORKSPACE_INVOCATION_TIMEOUT_MS),
+        },
+      );
+      await drainRunnerContainerMetadataResponseBody(response).catch(() => undefined);
+      if (!response.ok) {
+        emitHostedExecutionStructuredLog({
+          component: "container",
+          details: {
+            abortStatus: response.status,
+            workspaceAttemptId: input.attemptId,
+            workspaceLeaseGeneration: input.leaseGeneration,
+          },
+          level: "warn",
+          message: "Hosted execution container rejected the workspace invocation abort request.",
+          phase: "failed",
+          userId: input.userId,
+        });
+      }
+    } catch (error) {
+      emitHostedExecutionStructuredLog({
+        component: "container",
+        details: {
+          workspaceAttemptId: input.attemptId,
+          workspaceLeaseGeneration: input.leaseGeneration,
+        },
+        error,
+        level: "warn",
+        message: "Hosted execution container failed to post workspace invocation abort request.",
+        phase: "failed",
+        userId: input.userId,
+      });
     }
   }
 
@@ -1862,6 +2009,7 @@ export async function invokeHostedExecutionContainerRunner(
         ) {
           await container.abortWorkspaceInvocation({
             attemptId: input.job.request.attemptId,
+            leaseGeneration: input.job.request.leaseGeneration,
             userId: jobUserId,
           }).catch((error: unknown) => {
             emitHostedExecutionStructuredLog({

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -208,6 +208,12 @@ type RunnerContainerStartObservation =
   | "deploy-smoke-ready"
   | "onStart";
 
+type RunnerWorkspaceInvocationAbortPostStatus =
+  | "accepted"
+  | "failed"
+  | "queued"
+  | "stale";
+
 type RunnerContainerDestroyReason =
   | "activity-expired"
   | "cold-start-failure"
@@ -389,17 +395,22 @@ export class RunnerContainer extends Container {
       return { active: false, reason: "no_active_runtime" };
     }
 
-    if (
-      this.workspaceInvocationActiveOperationPreservedAfterTransportFailure
-      && !await this.readWorkspaceInvocationActiveFromHealth()
-    ) {
-      if (this.workspaceInvocationActiveOperation === active) {
-        this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
-        this.workspaceInvocationAbortEndpointReady = false;
-        this.workspaceInvocationActiveOperation = null;
-        this.workspaceInvocationAbortController = null;
+    if (this.workspaceInvocationActiveOperationPreservedAfterTransportFailure) {
+      let activeInContainer = true;
+      try {
+        activeInContainer = await this.readWorkspaceInvocationActiveFromHealth();
+      } catch {
+        activeInContainer = true;
       }
-      return { active: false, reason: "no_active_runtime" };
+      if (!activeInContainer) {
+        if (this.workspaceInvocationActiveOperation === active) {
+          this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
+          this.workspaceInvocationAbortEndpointReady = false;
+          this.workspaceInvocationActiveOperation = null;
+          this.workspaceInvocationAbortController = null;
+        }
+        return { active: false, reason: "no_active_runtime" };
+      }
     }
 
     return {
@@ -450,8 +461,30 @@ export class RunnerContainer extends Container {
     ) {
       return;
     }
+    let abortPostStatus: RunnerWorkspaceInvocationAbortPostStatus = "failed";
     if (this.workspaceInvocationAbortEndpointReady) {
-      await this.postWorkspaceInvocationAbort(input);
+      abortPostStatus = await this.postWorkspaceInvocationAbort(input);
+    }
+    if (
+      this.workspaceInvocationActiveOperationPreservedAfterTransportFailure
+      && abortPostStatus !== "accepted"
+    ) {
+      if (!abortController.signal.aborted) {
+        abortController.abort(new Error(WORKSPACE_INVOCATION_PREEMPTED_ABORT_MESSAGE));
+      }
+      if (this.workspaceInvocationActiveOperation === active) {
+        this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
+        this.workspaceInvocationAbortEndpointReady = false;
+        this.workspaceInvocationActiveOperation = null;
+      }
+      if (this.workspaceInvocationAbortController === abortController) {
+        this.workspaceInvocationAbortController = null;
+      }
+      await this.stopWarmContainer({
+        failClosed: true,
+        reason: "invoke-failure",
+      });
+      return;
     }
     if (!abortController.signal.aborted) {
       abortController.abort(new Error(WORKSPACE_INVOCATION_PREEMPTED_ABORT_MESSAGE));
@@ -1144,7 +1177,7 @@ export class RunnerContainer extends Container {
     attemptId: string;
     leaseGeneration: string;
     userId: string;
-  }): Promise<void> {
+  }): Promise<RunnerWorkspaceInvocationAbortPostStatus> {
     try {
       const response = await this.containerFetch(
         RUNNER_ABORT_WORKSPACE_INVOCATION_URL,
@@ -1171,7 +1204,17 @@ export class RunnerContainer extends Container {
           phase: "failed",
           userId: input.userId,
         });
+        return "failed";
       }
+      const abortStatus = response.headers.get("x-workspace-invocation-abort-status");
+      if (
+        abortStatus === "accepted"
+        || abortStatus === "queued"
+        || abortStatus === "stale"
+      ) {
+        return abortStatus;
+      }
+      return "accepted";
     } catch (error) {
       emitHostedExecutionStructuredLog({
         component: "container",
@@ -1185,6 +1228,7 @@ export class RunnerContainer extends Container {
         phase: "failed",
         userId: input.userId,
       });
+      return "failed";
     }
   }
 

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -228,35 +228,13 @@ export class RuntimeInvocationService {
 
       if (input.acceptedProcessingAttempt) {
         const committedResult =
-          await this.readAcceptedRuntimeCommittedProgressAfterTransportFailure({
+          await this.recoverAcceptedRuntimeCompletionAfterTransportFailure({
             executionInput,
+            transportError: error,
+            token,
             workspaceVersion,
           });
         if (committedResult) {
-          const completion = await this.recordRuntimeCompletionAfterInvoke({
-            input: executionInput,
-            token,
-            workspaceVersion,
-          });
-          await this.syncRunnerAlarmAfterCompletion({
-            executionInput,
-            record: completion.record,
-            token,
-            workspaceVersion,
-          });
-          emitHostedExecutionStructuredLog({
-            component: "hosted.runner",
-            details: {
-              ...buildHostedRunnerMetadataOnlyErrorDetails(error),
-              orchestrationAttemptId: executionInput.orchestrationAttemptId,
-              workspaceAttemptId: token.attemptId,
-              workspaceVersion,
-            },
-            level: "warn",
-            message: "Hosted runner accepted runtime attempt committed progress despite transport failure.",
-            phase: "checkpoint",
-            userId: executionInput.userId,
-          });
           return committedResult;
         }
       }
@@ -322,6 +300,53 @@ export class RuntimeInvocationService {
     });
 
     return result;
+  }
+
+  async recoverAcceptedRuntimeCompletionAfterTransportFailure(input: {
+    executionInput: RuntimeInvocationInput;
+    token: RunnerWriteFenceToken;
+    transportError?: unknown;
+    workspaceVersion: string | null;
+  }): Promise<HostedWorkspaceInvocationResult | null> {
+    if (input.workspaceVersion === null) {
+      return null;
+    }
+    const committedResult =
+      await this.readAcceptedRuntimeCommittedProgressAfterTransportFailure({
+        executionInput: input.executionInput,
+        workspaceVersion: input.workspaceVersion,
+      });
+    if (!committedResult) {
+      return null;
+    }
+
+    const completion = await this.recordRuntimeCompletionAfterInvoke({
+      input: input.executionInput,
+      token: input.token,
+      workspaceVersion: input.workspaceVersion,
+    });
+    await this.syncRunnerAlarmAfterCompletion({
+      executionInput: input.executionInput,
+      record: completion.record,
+      token: input.token,
+      workspaceVersion: input.workspaceVersion,
+    });
+    emitHostedExecutionStructuredLog({
+      component: "hosted.runner",
+      details: {
+        ...(input.transportError === undefined
+          ? {}
+          : buildHostedRunnerMetadataOnlyErrorDetails(input.transportError)),
+        orchestrationAttemptId: input.executionInput.orchestrationAttemptId,
+        workspaceAttemptId: input.token.attemptId,
+        workspaceVersion: input.workspaceVersion,
+      },
+      level: "warn",
+      message: "Hosted runner accepted runtime attempt committed progress despite transport failure.",
+      phase: "checkpoint",
+      userId: input.executionInput.userId,
+    });
+    return committedResult;
   }
 
   private async readAcceptedRuntimeCommittedProgressAfterTransportFailure(input: {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -213,6 +213,33 @@ export class RuntimeProcessingController {
         });
       }
 
+      const recoveredCompletion =
+        await this.input.invocationService.recoverAcceptedRuntimeCompletionAfterTransportFailure({
+          executionInput: toRuntimeInvocationInput(input.input),
+          token: {
+            attemptId: activeFence.attemptId,
+            expiresAt: activeFence.expiresAt,
+            generation: String(activeFence.generation),
+            kind: activeFence.kind,
+            leaseGeneration: String(activeFence.generation),
+            providerEgressToken: null,
+            runnerContainerName: activeFence.runnerContainerName,
+            startedAt: activeFence.startedAt,
+            userId: record.userId,
+            workspaceVersion: activeFence.workspaceVersion,
+          },
+          workspaceVersion: activeFence.workspaceVersion,
+        });
+      if (recoveredCompletion) {
+        return {
+          action: "already_running",
+          kind: "runtime_processing_accepted",
+          recommendedRecheckAt:
+            this.computeRuntimeProcessingOwnerRecheckAt(),
+          runtimeAttemptId: activeFence.attemptId,
+        };
+      }
+
       const cleared = await this.input.stateStore.clearWriteFenceForReplacement({
         attemptId: activeFence.attemptId,
         finishedAt: new Date().toISOString(),

--- a/apps/cloudflare/test/container-entrypoint-abort.test.ts
+++ b/apps/cloudflare/test/container-entrypoint-abort.test.ts
@@ -362,6 +362,84 @@ describe("container entrypoint abort boundary", () => {
     expect(mocks.runHostedWorkspaceInvocation).toHaveBeenCalledTimes(1);
   });
 
+  it("applies an abort that arrives before the matching workspace invocation is accepted", async () => {
+    const invocationAborted = createDeferred<AbortSignal>();
+    const exit = vi.fn();
+    mocks.runHostedWorkspaceInvocation.mockImplementation(
+      async (_job, options) => {
+        const signal = options?.signal;
+        if (!signal) {
+          throw new Error("Expected hosted workspace invocation signal.");
+        }
+
+        expect(signal.aborted).toBe(true);
+        invocationAborted.resolve(signal);
+        throw signal.reason instanceof Error
+          ? signal.reason
+          : new Error("workspace invocation preempted");
+      },
+    );
+
+    const server = await startHostedContainerEntrypoint({
+      port: 0,
+      runtime: {
+        exitScheduler: exit,
+      },
+    });
+    servers.push(server);
+    const address = server.address();
+
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the hosted container entrypoint to expose a TCP port.");
+    }
+
+    const requestBody = buildWorkspaceJobBody({ eventId: "evt_abort_before_accept" });
+    const abortResponse = await fetch(
+      `http://127.0.0.1:${address.port}/internal/workspace-invocation/abort`,
+      {
+        body: JSON.stringify({
+          attemptId: requestBody.job.request.attemptId,
+          leaseGeneration: requestBody.job.request.leaseGeneration,
+          userId: requestBody.job.request.userId,
+        }),
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        method: "POST",
+      },
+    );
+    expect(abortResponse.status).toBe(204);
+
+    const invocationResponse = await fetch(
+      `http://127.0.0.1:${address.port}/internal/workspace-invocation`,
+      {
+        body: JSON.stringify(requestBody),
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        method: "POST",
+      },
+    );
+    expect(invocationResponse.ok).toBe(false);
+    const signal = await invocationAborted.promise;
+    expect(signal.reason).toBeInstanceOf(Error);
+    expect((signal.reason as Error).message).toBe("workspace invocation preempted");
+
+    await waitForAssertion(async () => {
+      const health = await sendHostedContainerGetRequest({
+        path: "/health",
+        port: address.port,
+      });
+      expect(health.status).toBe(200);
+      expect(health.json).toMatchObject({
+        activeJobCount: 0,
+        poisoned: false,
+      });
+    });
+    expect(exit).not.toHaveBeenCalled();
+    expect(mocks.reportHostedContainerFatalBestEffort).not.toHaveBeenCalled();
+  });
+
   it("ignores stale workspace invocation abort requests with a mismatched lease", async () => {
     const invocationStarted = createDeferred<AbortSignal>();
     const finishInvocation = createDeferred();

--- a/apps/cloudflare/test/container-entrypoint-abort.test.ts
+++ b/apps/cloudflare/test/container-entrypoint-abort.test.ts
@@ -130,6 +130,51 @@ async function sendHostedContainerGetRequest(input: {
   });
 }
 
+function sendHostedContainerPostRequest(input: {
+  body: unknown;
+  path: string;
+  port: number;
+}): {
+  close: () => void;
+  done: Promise<void>;
+} {
+  const body = JSON.stringify(input.body);
+  let requestClosed = false;
+  let request!: ReturnType<typeof httpRequest>;
+  const done = new Promise<void>((resolve) => {
+    request = httpRequest({
+      headers: {
+        "connection": "close",
+        "content-length": Buffer.byteLength(body),
+        "content-type": "application/json; charset=utf-8",
+      },
+      host: "127.0.0.1",
+      method: "POST",
+      path: input.path,
+      port: input.port,
+    }, (response) => {
+      response.resume();
+      response.on("end", resolve);
+      response.on("close", resolve);
+    });
+    request.on("error", () => resolve());
+    request.on("close", () => {
+      requestClosed = true;
+      resolve();
+    });
+    request.end(body);
+  });
+
+  return {
+    close: () => {
+      if (!requestClosed) {
+        request.destroy();
+      }
+    },
+    done,
+  };
+}
+
 async function waitForAssertion(
   assertion: () => Promise<void> | void,
   timeoutMs = 1000,
@@ -151,16 +196,89 @@ async function waitForAssertion(
 }
 
 describe("container entrypoint abort boundary", () => {
-  it("poisons the warm container when a workspace request aborts before a durable result", async () => {
+  it("keeps an accepted workspace invocation running when only the response closes", async () => {
+    const invocationStarted = createDeferred<AbortSignal>();
+    const finishInvocation = createDeferred();
+    const exit = vi.fn();
+    const readdir = vi.fn(async () => [
+      { isDirectory: () => true, name: String(process.pid) },
+    ]);
+    const readFile = vi.fn(async () => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    mocks.runHostedWorkspaceInvocation.mockImplementation(
+      async (_job, options) => {
+        const signal = options?.signal;
+        if (!signal) {
+          throw new Error("Expected hosted workspace invocation signal.");
+        }
+
+        invocationStarted.resolve(signal);
+        await finishInvocation.promise;
+        expect(signal.aborted).toBe(false);
+        return buildWorkspaceRunnerResult();
+      },
+    );
+
+    const server = await startHostedContainerEntrypoint({
+      port: 0,
+      runtime: {
+        exitScheduler: exit,
+        processApi: { readFile, readdir },
+        processIsolation: true,
+      },
+    });
+    servers.push(server);
+    const address = server.address();
+
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the hosted container entrypoint to expose a TCP port.");
+    }
+
+    const request = sendHostedContainerPostRequest({
+      body: buildWorkspaceJobBody({ eventId: "evt_response_close_after_accept" }),
+      path: "/internal/workspace-invocation",
+      port: address.port,
+    });
+
+    const signal = await invocationStarted.promise;
+    request.close();
+    await request.done;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(signal.aborted).toBe(false);
+
+    finishInvocation.resolve();
+
+    await waitForAssertion(async () => {
+      const health = await sendHostedContainerGetRequest({
+        path: "/health",
+        port: address.port,
+      });
+      expect(health.status).toBe(200);
+      expect(health.json).toMatchObject({
+        activeJobCount: 0,
+        lastCleanupStatus: "passed",
+        poisoned: false,
+      });
+    });
+    expect(exit).not.toHaveBeenCalled();
+    expect(mocks.reportHostedContainerFatalBestEffort).not.toHaveBeenCalled();
+
+    const nextInvocation = await fetch(`http://127.0.0.1:${address.port}/internal/workspace-invocation`, {
+      body: JSON.stringify(buildWorkspaceJobBody({ eventId: "evt_after_response_close" })),
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+      },
+      method: "POST",
+    });
+    expect(nextInvocation.status).toBe(200);
+    expect(mocks.runHostedWorkspaceInvocation).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts an accepted workspace invocation through the internal abort endpoint", async () => {
     const invocationStarted = createDeferred<AbortSignal>();
     const invocationAborted = createDeferred();
-    const exitCalled = createDeferred();
-    let fatalReportCallsWhenExitScheduled = -1;
-    const exit = vi.fn(() => {
-      fatalReportCallsWhenExitScheduled =
-        mocks.reportHostedContainerFatalBestEffort.mock.calls.length;
-      exitCalled.resolve();
-    });
+    const exit = vi.fn();
     mocks.runHostedWorkspaceInvocation.mockImplementation(
       async (_job, options) => {
         const signal = options?.signal;
@@ -198,23 +316,38 @@ describe("container entrypoint abort boundary", () => {
       throw new Error("Expected the hosted container entrypoint to expose a TCP port.");
     }
 
-    const controller = new AbortController();
-    const requestPromise = fetch(`http://127.0.0.1:${address.port}/internal/workspace-invocation`, {
-      body: JSON.stringify(buildWorkspaceJobBody({ eventId: "evt_abort_before_result" })),
-      headers: {
-        "content-type": "application/json; charset=utf-8",
+    const requestBody = buildWorkspaceJobBody({ eventId: "evt_semantic_abort" });
+    const request = sendHostedContainerPostRequest({
+      body: requestBody,
+      path: "/internal/workspace-invocation",
+      port: address.port,
+    });
+
+    const signal = await invocationStarted.promise;
+    expect(signal.aborted).toBe(false);
+    const abortResponse = await fetch(
+      `http://127.0.0.1:${address.port}/internal/workspace-invocation/abort`,
+      {
+        body: JSON.stringify({
+          attemptId: requestBody.job.request.attemptId,
+          leaseGeneration: requestBody.job.request.leaseGeneration,
+          userId: requestBody.job.request.userId,
+        }),
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        method: "POST",
       },
-      method: "POST",
-      signal: controller.signal,
-    }).catch((error: unknown) => error);
-
-    await invocationStarted.promise;
-    controller.abort();
+    );
+    expect(abortResponse.status).toBe(204);
     await invocationAborted.promise;
-    await requestPromise;
-    await exitCalled.promise;
+    await request.done;
 
-    expect(exit).toHaveBeenCalledTimes(1);
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBeInstanceOf(Error);
+    expect((signal.reason as Error).message).toBe("workspace invocation preempted");
+    expect(exit).not.toHaveBeenCalled();
+    expect(mocks.reportHostedContainerFatalBestEffort).not.toHaveBeenCalled();
     await waitForAssertion(async () => {
       const health = await sendHostedContainerGetRequest({
         path: "/health",
@@ -223,44 +356,99 @@ describe("container entrypoint abort boundary", () => {
       expect(health.status).toBe(200);
       expect(health.json).toMatchObject({
         activeJobCount: 0,
-        poisoned: true,
+        poisoned: false,
       });
     });
+    expect(mocks.runHostedWorkspaceInvocation).toHaveBeenCalledTimes(1);
+  });
 
-    const rejectedAfterPoison = await fetch(
-      `http://127.0.0.1:${address.port}/internal/workspace-invocation`,
+  it("ignores stale workspace invocation abort requests with a mismatched lease", async () => {
+    const invocationStarted = createDeferred<AbortSignal>();
+    const finishInvocation = createDeferred();
+    const exit = vi.fn();
+    mocks.runHostedWorkspaceInvocation.mockImplementation(
+      async (_job, options) => {
+        const signal = options?.signal;
+        if (!signal) {
+          throw new Error("Expected hosted workspace invocation signal.");
+        }
+
+        invocationStarted.resolve(signal);
+        await finishInvocation.promise;
+        expect(signal.aborted).toBe(false);
+        return buildWorkspaceRunnerResult();
+      },
+    );
+
+    const server = await startHostedContainerEntrypoint({
+      port: 0,
+      runtime: {
+        exitScheduler: exit,
+      },
+    });
+    servers.push(server);
+    const address = server.address();
+
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the hosted container entrypoint to expose a TCP port.");
+    }
+
+    const requestBody = buildWorkspaceJobBody({ eventId: "evt_stale_abort_lease" });
+    const request = sendHostedContainerPostRequest({
+      body: requestBody,
+      path: "/internal/workspace-invocation",
+      port: address.port,
+    });
+
+    const signal = await invocationStarted.promise;
+    const abortResponse = await fetch(
+      `http://127.0.0.1:${address.port}/internal/workspace-invocation/abort`,
       {
-        body: JSON.stringify(buildWorkspaceJobBody({ eventId: "evt_after_poisoned_container" })),
+        body: JSON.stringify({
+          attemptId: requestBody.job.request.attemptId,
+          leaseGeneration: "stale",
+          userId: requestBody.job.request.userId,
+        }),
         headers: {
           "content-type": "application/json; charset=utf-8",
         },
         method: "POST",
       },
     );
-    expect(rejectedAfterPoison.status).toBe(503);
-    await expect(rejectedAfterPoison.json()).resolves.toMatchObject({
-      error: "Hosted runner container is poisoned.",
+    expect(abortResponse.status).toBe(204);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(signal.aborted).toBe(false);
+
+    finishInvocation.resolve();
+    await request.done;
+
+    await waitForAssertion(async () => {
+      const health = await sendHostedContainerGetRequest({
+        path: "/health",
+        port: address.port,
+      });
+      expect(health.status).toBe(200);
+      expect(health.json).toMatchObject({
+        activeJobCount: 0,
+        poisoned: false,
+      });
     });
-    expect(mocks.runHostedWorkspaceInvocation).toHaveBeenCalledTimes(1);
-    // The poison must leave a durable fatal trace before the exit scheduler
-    // runs — this is the only attributable record once the process dies.
-    expect(mocks.reportHostedContainerFatalBestEffort).toHaveBeenCalledWith(
-      expect.objectContaining({
-        boundUserId: "u1",
-        stage: "ambiguous_abort_poison",
-      }),
-    );
-    expect(fatalReportCallsWhenExitScheduled).toBe(1);
+    expect(exit).not.toHaveBeenCalled();
   });
 
-  it("keeps the warm container when an aborted workspace request returns safely and cleanup passes", async () => {
+  it("keeps cleanup failure as poison even when the response is already closed", async () => {
     const invocationStarted = createDeferred<AbortSignal>();
-    const invocationFinished = createDeferred();
+    const failCleanup = createDeferred();
     const exit = vi.fn();
+    const kill = vi.fn();
     const readdir = vi.fn(async () => [
       { isDirectory: () => true, name: String(process.pid) },
+      { isDirectory: () => true, name: String(process.pid + 1) },
     ]);
-    const readFile = vi.fn(async () => {
+    const readFile = vi.fn(async (filePath: string) => {
+      if (String(filePath).endsWith(`/${process.pid + 1}/stat`)) {
+        return `${process.pid + 1} (node) S ${process.pid}`;
+      }
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     });
     mocks.runHostedWorkspaceInvocation.mockImplementation(
@@ -271,15 +459,8 @@ describe("container entrypoint abort boundary", () => {
         }
 
         invocationStarted.resolve(signal);
-        await new Promise<void>((resolve) => {
-          if (signal.aborted) {
-            resolve();
-            return;
-          }
-
-          signal.addEventListener("abort", () => resolve(), { once: true });
-        });
-        invocationFinished.resolve();
+        await failCleanup.promise;
+        expect(signal.aborted).toBe(false);
         return buildWorkspaceRunnerResult();
       },
     );
@@ -288,7 +469,7 @@ describe("container entrypoint abort boundary", () => {
       port: 0,
       runtime: {
         exitScheduler: exit,
-        processApi: { readFile, readdir },
+        processApi: { kill, readFile, readdir },
         processIsolation: true,
       },
     });
@@ -299,20 +480,19 @@ describe("container entrypoint abort boundary", () => {
       throw new Error("Expected the hosted container entrypoint to expose a TCP port.");
     }
 
-    const controller = new AbortController();
-    const requestPromise = fetch(`http://127.0.0.1:${address.port}/internal/workspace-invocation`, {
-      body: JSON.stringify(buildWorkspaceJobBody({ eventId: "evt_abort_after_safe_return" })),
-      headers: {
-        "content-type": "application/json; charset=utf-8",
-      },
-      method: "POST",
-      signal: controller.signal,
-    }).catch((error: unknown) => error);
+    const request = sendHostedContainerPostRequest({
+      body: buildWorkspaceJobBody({ eventId: "evt_response_close_cleanup_failure" }),
+      path: "/internal/workspace-invocation",
+      port: address.port,
+    });
 
-    await invocationStarted.promise;
-    controller.abort();
-    await invocationFinished.promise;
-    await requestPromise;
+    const signal = await invocationStarted.promise;
+    request.close();
+    await request.done;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(signal.aborted).toBe(false);
+
+    failCleanup.resolve();
 
     await waitForAssertion(async () => {
       const health = await sendHostedContainerGetRequest({
@@ -322,10 +502,10 @@ describe("container entrypoint abort boundary", () => {
       expect(health.status).toBe(200);
       expect(health.json).toMatchObject({
         activeJobCount: 0,
-        lastCleanupStatus: "passed",
-        poisoned: false,
+        lastCleanupStatus: "failed",
+        poisoned: true,
       });
-    });
+    }, 3000);
     expect(exit).not.toHaveBeenCalled();
   });
 });

--- a/apps/cloudflare/test/container-entrypoint.test.ts
+++ b/apps/cloudflare/test/container-entrypoint.test.ts
@@ -2097,7 +2097,7 @@ describe("startHostedContainerEntrypoint", () => {
     });
   });
 
-  it("aborts the hosted job when the response closes before completion", async () => {
+  it("observes response close separately from request abort", async () => {
     const request = new EventEmitter();
     const response = new EventEmitter() as EventEmitter & { writableEnded: boolean };
     response.writableEnded = false;
@@ -2109,6 +2109,8 @@ describe("startHostedContainerEntrypoint", () => {
     expect(controller.signal.aborted).toBe(true);
     expect(controller.signal.reason).toBeInstanceOf(Error);
     expect((controller.signal.reason as Error).message).toMatch(/response closed before completion/u);
+    expect(controller.requestSignal.aborted).toBe(false);
+    expect(controller.responseClosed()).toBe(true);
     expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
       expect.objectContaining({
         component: "container",

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -2912,6 +2912,7 @@ describe("RunnerContainer", () => {
     expect(signal.aborted).toBe(false);
     await expect(container.abortWorkspaceInvocation({
       attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
       userId: "member_123",
     })).resolves.toBeUndefined();
 
@@ -2940,6 +2941,15 @@ describe("RunnerContainer", () => {
           },
           status: 200,
         });
+      }
+
+      if (url.endsWith("/internal/workspace-invocation/abort")) {
+        expect(JSON.parse(String(init?.body))).toEqual({
+          attemptId: request.attemptId,
+          leaseGeneration: request.leaseGeneration,
+          userId: "member_123",
+        });
+        return new Response(null, { status: 204 });
       }
 
       if (!url.endsWith("/internal/workspace-invocation")) {
@@ -2979,14 +2989,139 @@ describe("RunnerContainer", () => {
     expect(signal.aborted).toBe(false);
     await expect(container.abortWorkspaceInvocation({
       attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
       userId: "member_123",
     })).resolves.toBeUndefined();
 
     await expect(invokeResultPromise).resolves.toMatchObject({
       message: "workspace invocation preempted",
     });
+    expect(containerFetch.mock.calls.some(([url]) =>
+      String(url).endsWith("/internal/workspace-invocation/abort")
+    )).toBe(true);
     expect(startAndWaitForPorts).not.toHaveBeenCalled();
     expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps active liveness when an accepted workspace response is lost", async () => {
+    let runnerResponseLost = false;
+    const containerFetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({
+          ...createRunnerHealthResult(),
+          activeJobCount: runnerResponseLost ? 1 : 0,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+
+      if (!url.endsWith("/internal/workspace-invocation")) {
+        throw new Error(`Unexpected runner request URL: ${url}`);
+      }
+
+      runnerResponseLost = true;
+      throw new Error("Network connection lost");
+    });
+    const { container, destroy, startAndWaitForPorts } = createContainerDouble({
+      containerFetch,
+      initialStatus: "running",
+    });
+    const request = createRunnerRequest("evt_response_lost_after_accept");
+
+    await expect(container.invoke({
+      job: {
+        kind: "workspace-invocation",
+        request,
+      },
+      timeoutMs: 30_000,
+      userId: "member_123",
+    })).rejects.toThrow("Network connection lost");
+
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: true,
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    });
+
+    const callsBeforeStaleWake = containerFetch.mock.calls.length;
+    runnerResponseLost = false;
+    await expect(container.wakeRuntime({
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    })).resolves.toEqual({
+      kind: "not-wakeable",
+      reason: "no-active-child",
+    });
+    expect(containerFetch.mock.calls.slice(callsBeforeStaleWake).some(([url]) =>
+      String(url).endsWith("/internal/runtime-wake")
+    )).toBe(false);
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: false,
+      reason: "no_active_runtime",
+    });
+  });
+
+  it("keeps active liveness when an accepted workspace response body is lost", async () => {
+    let runnerBodyLost = false;
+    const containerFetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({
+          ...createRunnerHealthResult(),
+          activeJobCount: runnerBodyLost ? 1 : 0,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+
+      if (!url.endsWith("/internal/workspace-invocation")) {
+        throw new Error(`Unexpected runner request URL: ${url}`);
+      }
+
+      runnerBodyLost = true;
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error("Response body lost"));
+        },
+      }), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        status: 200,
+      });
+    });
+    const { container, destroy, startAndWaitForPorts } = createContainerDouble({
+      containerFetch,
+      initialStatus: "running",
+    });
+    const request = createRunnerRequest("evt_response_body_lost_after_accept");
+
+    await expect(container.invoke({
+      job: {
+        kind: "workspace-invocation",
+        request,
+      },
+      timeoutMs: 30_000,
+      userId: "member_123",
+    })).rejects.toThrow("Response body lost");
+
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: true,
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    });
   });
 
   it("uses the remaining caller timeout budget when a warm-shell health check fails", async () => {
@@ -4820,6 +4955,7 @@ describe("RunnerContainer", () => {
     await expect(invocation).rejects.toThrow("stale local active invocation");
     expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
       attemptId: job.request.attemptId,
+      leaseGeneration: job.request.leaseGeneration,
       userId: "member_foreground_abort",
     });
     expect(destroyInstance).not.toHaveBeenCalled();

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3005,8 +3005,12 @@ describe("RunnerContainer", () => {
 
   it("keeps active liveness when an accepted workspace response is lost", async () => {
     let runnerResponseLost = false;
+    let healthProbeFails = false;
     const containerFetch = vi.fn(async (url: string) => {
       if (url.endsWith("/health")) {
+        if (healthProbeFails) {
+          throw new Error("health probe unavailable");
+        }
         return new Response(JSON.stringify({
           ...createRunnerHealthResult(),
           activeJobCount: runnerResponseLost ? 1 : 0,
@@ -3049,7 +3053,16 @@ describe("RunnerContainer", () => {
       userId: "member_123",
     });
 
+    healthProbeFails = true;
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: true,
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    });
+
     const callsBeforeStaleWake = containerFetch.mock.calls.length;
+    healthProbeFails = false;
     runnerResponseLost = false;
     await expect(container.wakeRuntime({
       attemptId: request.attemptId,
@@ -3062,6 +3075,68 @@ describe("RunnerContainer", () => {
     expect(containerFetch.mock.calls.slice(callsBeforeStaleWake).some(([url]) =>
       String(url).endsWith("/internal/runtime-wake")
     )).toBe(false);
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: false,
+      reason: "no_active_runtime",
+    });
+  });
+
+  it("destroys and clears preserved liveness when explicit abort is not delivered", async () => {
+    let runnerResponseLost = false;
+    const containerFetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({
+          ...createRunnerHealthResult(),
+          activeJobCount: runnerResponseLost ? 1 : 0,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+
+      if (url.endsWith("/internal/workspace-invocation/abort")) {
+        return new Response(JSON.stringify({ error: "abort endpoint unavailable" }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 503,
+        });
+      }
+
+      if (!url.endsWith("/internal/workspace-invocation")) {
+        throw new Error(`Unexpected runner request URL: ${url}`);
+      }
+
+      runnerResponseLost = true;
+      throw new Error("Network connection lost");
+    });
+    const { container, destroy, startAndWaitForPorts } = createContainerDouble({
+      containerFetch,
+      initialStatus: "running",
+    });
+    const request = createRunnerRequest("evt_abort_after_response_lost");
+
+    await expect(container.invoke({
+      job: {
+        kind: "workspace-invocation",
+        request,
+      },
+      timeoutMs: 30_000,
+      userId: "member_123",
+    })).rejects.toThrow("Network connection lost");
+
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+
+    await expect(container.abortWorkspaceInvocation({
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    })).resolves.toBeUndefined();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
     await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
       active: false,
       reason: "no_active_runtime",

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1513,6 +1513,49 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
+  it("records committed progress before replacing a non-wakeable accepted fence", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "start-required" as const,
+        reason: "no-active-child" as const,
+      }),
+    );
+    const onStatusRead = vi.fn();
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-recover-committed",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "already_running",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: token.attemptId,
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: null,
+      last_invocation_at: "2026-04-27T00:00:31.000Z",
+      wake_at: null,
+    });
+  });
+
   it("does not give a replacement start a fresh caller command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));


### PR DESCRIPTION
## Summary
- stop treating accepted workspace response-close as invocation cancellation or warm-container poison
- add an explicit internal abort path keyed by attempt, lease generation, and user, including pre-accept abort delivery
- preserve and reconcile runner liveness after accepted response transport loss so durable recovery owns fence cleanup/completion

## Verification
- pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/container-entrypoint-abort.test.ts apps/cloudflare/test/container-entrypoint.test.ts apps/cloudflare/test/runner-container.test.ts apps/cloudflare/test/user-runner-alarm.test.ts apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
- pnpm --dir apps/cloudflare typecheck
- pnpm --dir apps/cloudflare verify
- pnpm verify:acceptance (failed on unrelated CLI coverage timeouts: assistant-cli import-surface tests and packages/cli health-tail timeout)
- pnpm --dir packages/assistant-cli test:coverage (rerun passed)
- pnpm --dir packages/cli test:coverage (rerun passed)

## Reviews
- Local security follow-up: no blockers
- Local coverage follow-up: no blockers
- Local runtime follow-up: no blockers
- ReviewGPT rounds 1-3: accepted findings fixed
- ReviewGPT round 4: no blocking findings
