### PR TITLE
[codex] Capture assistant runtime issues

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-17-runtime-issue-feedback-capture.md
+++ b/agent-docs/exec-plans/completed/2026-06-17-runtime-issue-feedback-capture.md
@@ -1,0 +1,53 @@
+# Runtime Issue Feedback Capture
+
+## Goal
+
+Land the implementation plan from `agent-docs/exec-plans/completed/feedback.md` by routing already-observed Codex/provider/action failures into the existing assistant-runtime issue pipeline.
+
+## Success Criteria
+
+- No model-visible feedback tool, prompt self-reporting, new DB table, new queue, or daily LLM job is added.
+- Assistant-engine carries privacy-safe `runtimeIssueInputs` metadata that stays out of transcripts and model-visible events.
+- Failed Codex command/tool actions, dynamic tool failures, dynamic tool validation failures, and terminal provider failures produce bounded issue inputs without raw command, output, path, prompt, transcript, vault content, URL, email, or phone details.
+- Dynamic tool validation failures include a parser-owned, value-free validation digest with safe keys/paths, missing/invalid/unknown structural facts, and a digest fingerprint for SQL grouping.
+- Runtime issue writes are fire-and-forget on the successful reply path.
+- Hosted pending issue export is verified or wired after durable workspace checkpoint work, with export failure non-fatal.
+- Focused tests and required repo verification pass or have a documented unrelated blocker.
+
+## Non-Goals
+
+- No generalized feedback abstraction.
+- No Prisma migration.
+- No member-level drilldown or per-member relation on issue rows.
+- No cleanup-only removal of `rawToolEvents` unless it is proven unused and low-risk inside this task.
+
+## Scope
+
+Expected files:
+
+- `packages/assistant-engine/src/assistant/issue-reporting.ts`
+- `packages/assistant-engine/src/assistant/tool-validation-digest.ts`
+- `packages/assistant-engine/src/assistant/providers/types.ts`
+- `packages/assistant-engine/src/assistant/providers/codex-cli.ts`
+- `packages/assistant-engine/src/assistant/codex-runtime.ts`
+- `packages/assistant-engine/src/assistant/codex-turn-runner.ts`
+- `packages/assistant-engine/src/assistant-codex.ts`
+- `packages/assistant-engine/src/assistant-codex/action-diagnostics.ts`
+- focused tests under `packages/assistant-engine/test/**`
+- `packages/assistant-runtime/src/hosted-runtime.ts` and focused hosted-runtime tests only if export wiring is missing
+
+## Verification Plan
+
+- Run focused assistant-engine tests covering issue recording, Codex action extraction/metadata, and turn-runner best-effort behavior.
+- Run hosted-runtime issue tests if export wiring changes.
+- Run `pnpm typecheck`.
+- Run the required completion audit passes for the final routed task class.
+
+## State
+
+- Done: Source plan read. Existing issue writer/export/import surfaces found. Metadata capture, best-effort recording, hosted issue export, parser-owned validation digests, and focused tests are implemented.
+- Now: Resolve completion-audit findings for idle-time write flushing, durable export/checkpoint ordering, and string exit-code command failures.
+- Next: Rerun focused verification/audits, close the active plan, and create the scoped commit.
+Status: completed
+Updated: 2026-06-16
+Completed: 2026-06-16

--- a/agent-docs/exec-plans/completed/feedback.md
+++ b/agent-docs/exec-plans/completed/feedback.md
@@ -1,0 +1,946 @@
+Yes — with your simplicity constraint, I would land this as a **migration to better use the existing assistant-runtime issue pipeline**, not as a new feedback system.
+
+The key migration principle:
+
+> **Do not teach Murph to report friction. Teach the runtime to record hard failures it already observes.**
+
+That means no assistant feedback tool, no prompt change, no daily LLM introspection job, no new DB table, no new service, no new queue, and no new user-path model behavior.
+
+## Target end state
+
+The final architecture should be this:
+
+```txt
+Codex/app-server action or provider turn fails
+  -> assistant-engine builds bounded AssistantRuntimeIssueInput
+  -> assistant-engine writes existing pending runtime issue record, best-effort
+  -> hosted-runtime exports existing pending issue files after durable workspace work
+  -> apps/web imports into existing HostedAssistantRuntimeIssue
+  -> daily SQL/admin rollup groups by fingerprint
+```
+
+The existing runtime issue record shape is already enough: `component`, `operation`, `phase`, `issueKind`, `severity`, `errorCode`, `fingerprint`, `details`, `surface`, and `environment`. No schema migration is required for v0.
+
+The existing writer already writes pending issue records under the assistant runtime issue directory using `writePendingAssistantRuntimeIssueRecord`.  Hosted export already lists pending issue records, batches them, sends them through `issueExportPort`, and deletes only acknowledged rows.    Web import already parses records, applies 30-day retention, and upserts into `HostedAssistantRuntimeIssue`.
+
+So the migration is mostly about **capturing the right issue inputs at the right boundary**.
+
+---
+
+# Non-goals
+
+Do **not** build these in v0:
+
+1. No `assistant_report_friction` tool.
+2. No “call a tool before final reply” pattern.
+3. No “after every response, self-review” step.
+4. No prompt instruction asking Murph to self-report.
+5. No daily Murph/LLM inspection job.
+6. No new telemetry service.
+7. No new DB table.
+8. No raw stdout/stderr storage.
+9. No full command string storage.
+10. No prompt, transcript, vault content, local path, email, phone, or URL storage.
+11. No per-member relation on issue rows.
+12. No generalized “feedback” abstraction.
+
+The existing hosted issue table is already anonymized enough for v0: it stores issue metadata and details JSON, has indexes for grouping by fingerprint/severity/kind, and does not include a member relation in the model.
+
+---
+
+# Important correction: do not use `rawToolEvents` for this
+
+There is a tempting path: populate `rawToolEvents` and let `recordAssistantToolFailureRuntimeIssues` consume it.
+
+I would **not** do that.
+
+`rawToolEvents` is also consumed by transcript audit code. Transcript audit turns `assistant.tool.*` events into transcript entries, including failed tool audit text.   That is the wrong place for private runtime issue telemetry, especially command failures.
+
+Instead, add a separate internal provider metadata field:
+
+```ts
+runtimeIssueInputs: readonly AssistantRuntimeIssueInput[]
+```
+
+This field is not model-visible and not transcript-visible. It is just a list of already-sanitized issue drafts for the runtime issue pipeline.
+
+Current Codex metadata already has `rawToolEvents`, but Codex currently sets it to `[]` in both failure and success paths.   So this is a good chance to avoid reviving the wrong concept.
+
+---
+
+# Migration guide
+
+## Phase 0 — freeze scope
+
+Before code changes, write this into the task/PR description:
+
+```txt
+This migration only records automatic, privacy-safe assistant-runtime issues
+from already-observed runtime/provider/action failures.
+
+It does not add model-visible feedback tools, prompt self-reporting, raw logs,
+a new database table, a new queue, or a daily LLM job.
+```
+
+Also decide the v0 capture set:
+
+```txt
+v0 captures:
+- terminal provider turn failure
+- failed Codex command.execution action
+- failed Codex dynamic.tool.call action
+- failed Codex mcp/tool.call action
+- dynamic tool invalid/unsupported/failed result
+
+v0 does not capture:
+- subjective "this was annoying"
+- successful but long workflows
+- raw command contents
+- raw command output
+- arbitrary model-written explanations
+```
+
+That keeps the product useful but intentionally narrow.
+
+---
+
+## Phase 1 — add one internal metadata field
+
+Update:
+
+```txt
+packages/assistant-engine/src/assistant/providers/types.ts
+```
+
+Add to `AssistantProviderAttemptMetadata`:
+
+```ts
+runtimeIssueInputs: readonly AssistantRuntimeIssueInput[]
+```
+
+Use the existing `AssistantRuntimeIssueInput` type from `issue-reporting.ts`.
+
+Then update all empty metadata constructors:
+
+```ts
+{
+  activityLabels: [],
+  executedToolCount: 0,
+  providerActionCount: 0,
+  rawToolEvents: [],
+  runtimeIssueInputs: [],
+}
+```
+
+The `codex-turn-runner` currently initializes metadata with `rawToolEvents: []`; add `runtimeIssueInputs: []` there too.
+
+Do **not** remove `rawToolEvents` in the same first patch unless it is obviously safe. The first migration should be additive at the metadata boundary. Deleting `rawToolEvents` can be a cleanup patch once tests prove no one needs it.
+
+---
+
+## Phase 2 — add one tiny plural recorder
+
+In:
+
+```txt
+packages/assistant-engine/src/assistant/issue-reporting.ts
+```
+
+Keep the existing `recordAssistantRuntimeIssue`. It already creates a sanitized record and writes to pending issue state.
+
+Add a small plural helper:
+
+```ts
+export function recordAssistantRuntimeIssueInputsBestEffort(input: {
+  issues: readonly AssistantRuntimeIssueInput[]
+  policy: AssistantDiagnosticsPolicy
+  vault: string
+}): void {
+  if (!input.policy.privateIssueCaptureEnabled || input.issues.length === 0) {
+    return
+  }
+
+  for (const issue of input.issues.slice(0, 8)) {
+    void recordAssistantRuntimeIssue({
+      issue,
+      policy: input.policy,
+      vault: input.vault,
+    }).catch(() => undefined)
+  }
+}
+```
+
+This helper should deliberately return `void`.
+
+That is the reply-path safety guarantee: issue writes are best-effort and cannot block final user delivery.
+
+Then delete or stop using:
+
+```ts
+recordAssistantToolFailureRuntimeIssues(...)
+```
+
+after callers are migrated. It currently parses pseudo-events of type `assistant.tool.failed` into issue records.   For the new design, producing `AssistantRuntimeIssueInput` directly is simpler and avoids an extra fake event format.
+
+If deleting the old helper in the same PR causes too much churn, leave it temporarily but remove all production calls. Do not route new issue capture through it.
+
+---
+
+## Phase 3 — collect runtime issue inputs inside Codex app-server execution
+
+Update:
+
+```txt
+packages/assistant-engine/src/assistant-codex.ts
+```
+
+The correct boundary is `runCodexAppServerTurnOnProcess`. It already has the facts we need: `jsonEvents`, `providerActionCount`, dynamic tool execution, `codexThreadId`, and `turnId`.
+
+Add local state:
+
+```ts
+const runtimeIssueInputs: AssistantRuntimeIssueInput[] = []
+
+function pushRuntimeIssueInput(issue: AssistantRuntimeIssueInput): void {
+  if (runtimeIssueInputs.length >= 8) {
+    return
+  }
+
+  runtimeIssueInputs.push(issue)
+}
+```
+
+Do not create a durable queue. Do not persist anything here. This is just per-turn memory.
+
+Then add `runtimeIssueInputs` to:
+
+```ts
+CodexAppServerTurnResult
+CodexAppServerTurnFailureContext
+```
+
+The failure context already carries `jsonEvents`, `additionalUsages`, `providerActionCount`, `codexThreadId`, and `providerTurnId`; add `runtimeIssueInputs` to the same context.
+
+At successful return, include:
+
+```ts
+runtimeIssueInputs
+```
+
+next to `jsonEvents` and `providerActionCount`. The turn result already returns those fields.
+
+---
+
+## Phase 4 — capture dynamic tool failures
+
+In `handleAcceptedServerRequest`, dynamic tool requests currently produce failed RPC responses for unsupported tools, invalid args, and caught execution errors.
+
+Add issue inputs in those same branches.
+
+### Unsupported dynamic tool
+
+When `dynamicToolRequest.kind === 'unsupported-dynamic-tool'`, push:
+
+```ts
+{
+  component: 'assistant.codex-dynamic-tool',
+  operation: 'unsupported-dynamic-tool',
+  phase: 'tool_call',
+  issueKind: 'schema_rejection',
+  severity: 'warning',
+  errorCode: 'ASSISTANT_DYNAMIC_TOOL_UNSUPPORTED',
+  summary: 'Codex requested an unsupported Murph dynamic tool.',
+  details: {
+    requestKind: 'unsupported-dynamic-tool',
+    namespacePresent: dynamicToolRequest.namespace !== null,
+    toolPresent: dynamicToolRequest.tool !== null,
+  },
+}
+```
+
+Do not store the raw namespace/tool unless it passes a strict safe identifier check. Even then, optional.
+
+### Invalid dynamic tool arguments
+
+For:
+
+```ts
+invalid-generate-image-arguments
+invalid-progress-arguments
+invalid-response-media-arguments
+```
+
+push:
+
+```ts
+{
+  component: 'assistant.codex-dynamic-tool',
+  operation: dynamicToolRequest.kind,
+  phase: 'tool_call',
+  issueKind: 'schema_rejection',
+  severity: 'warning',
+  errorCode: 'ASSISTANT_DYNAMIC_TOOL_INVALID_ARGUMENTS',
+  summary: 'Codex requested a Murph dynamic tool with invalid arguments.',
+  details: {
+    requestKind: dynamicToolRequest.kind,
+  },
+}
+```
+
+### Dynamic tool execution catch
+
+Where the code currently catches and returns `"dynamic tool failed"`, push:
+
+```ts
+{
+  component: 'assistant.codex-dynamic-tool',
+  operation: dynamicToolRequest.kind,
+  phase: 'tool_call',
+  issueKind: 'tool_error',
+  severity: 'warning',
+  errorCode: 'ASSISTANT_DYNAMIC_TOOL_FAILED',
+  summary: 'Murph dynamic tool execution failed.',
+  details: {
+    requestKind: dynamicToolRequest.kind,
+  },
+}
+```
+
+Do not include the thrown error message in v0. Error messages are often where paths, URLs, or provider details leak.
+
+---
+
+## Phase 5 — capture failed command/action events
+
+Codex action diagnostics already classifies action kinds such as `command.execution`, `dynamic.tool.call`, `mcp.tool.call`, `file.change`, and `web.search`.  It also already counts failed actions.  The failure predicate is already privacy-safe: it looks at normalized exit code, status, success boolean, or exitCode fields.
+
+Do not duplicate the full diagnostics reducer. Add one small pure helper, either inline in `assistant-codex.ts` or next to action diagnostics if reuse is clean:
+
+```ts
+function buildRuntimeIssueInputForFailedCodexAction(input: {
+  normalizedEvent: CodexNormalizedEvent
+  rawEvent: CodexRpcMessage
+}): AssistantRuntimeIssueInput | null
+```
+
+Start with only `item.completed` / `item.completed`-equivalent events. Skip started events.
+
+For `command.execution` with nonzero exit code:
+
+```ts
+{
+  component: 'assistant.codex-action',
+  operation: 'command.execution',
+  phase: 'provider_turn',
+  issueKind: 'tool_error',
+  severity: 'warning',
+  errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+  summary: 'Codex command execution failed during provider turn.',
+  details: {
+    actionKind: 'command.execution',
+    exitCode,
+    durationMsBucket,
+    outputBytesBucket,
+  },
+}
+```
+
+For failed MCP/tool calls:
+
+```ts
+{
+  component: 'assistant.codex-action',
+  operation: 'mcp.tool.call',
+  phase: 'tool_call',
+  issueKind: 'tool_error',
+  severity: 'warning',
+  errorCode: 'CODEX_TOOL_CALL_FAILED',
+  summary: 'Codex tool call failed during provider turn.',
+  details: {
+    actionKind: 'mcp.tool.call',
+    durationMsBucket,
+    outputBytesBucket,
+  },
+}
+```
+
+For failed dynamic tool call item events:
+
+```ts
+{
+  component: 'assistant.codex-action',
+  operation: 'dynamic.tool.call',
+  phase: 'tool_call',
+  issueKind: 'tool_error',
+  severity: 'warning',
+  errorCode: 'CODEX_DYNAMIC_TOOL_CALL_FAILED',
+  summary: 'Codex dynamic tool call failed during provider turn.',
+  details: {
+    actionKind: 'dynamic.tool.call',
+    durationMsBucket,
+    outputBytesBucket,
+  },
+}
+```
+
+Do **not** include:
+
+```txt
+commandLabel
+stdout
+stderr
+aggregatedOutput
+formattedOutput
+filePaths
+query
+prompt
+arguments
+workingDirectory
+```
+
+Action diagnostics already measures output bytes without preserving output text, so copy that idea.
+
+### Bucketing helpers
+
+Use coarse buckets:
+
+```ts
+function durationMsBucket(value: number | null):
+  | 'unknown'
+  | 'lt_1s'
+  | '1_5s'
+  | '5_30s'
+  | '30_120s'
+  | 'gt_120s'
+
+function bytesBucket(value: number | null):
+  | 'unknown'
+  | '0'
+  | 'lt_1kb'
+  | '1_10kb'
+  | '10_100kb'
+  | 'gt_100kb'
+```
+
+This keeps the record useful without high-cardinality telemetry.
+
+---
+
+## Phase 6 — map Codex result/failure context into provider metadata
+
+Update:
+
+```txt
+packages/assistant-engine/src/assistant/providers/codex-cli.ts
+```
+
+Success path currently creates metadata with `providerActionCount: result.providerActionCount` and `rawToolEvents: []`.  Change it to:
+
+```ts
+metadata: {
+  activityLabels: [],
+  executedToolCount: 0,
+  providerActionCount: result.providerActionCount,
+  rawToolEvents: [],
+  runtimeIssueInputs: result.runtimeIssueInputs,
+}
+```
+
+Failure path currently gets `failureContext?.jsonEvents`, usage, provider action count, and returns metadata with `rawToolEvents: []`.  Change it to:
+
+```ts
+metadata: {
+  activityLabels: [],
+  executedToolCount: 0,
+  providerActionCount: failureContext?.providerActionCount ?? 0,
+  rawToolEvents: [],
+  runtimeIssueInputs: failureContext?.runtimeIssueInputs ?? [],
+}
+```
+
+Again: leave `rawToolEvents` empty. Do not use it for private issue reporting.
+
+---
+
+## Phase 7 — write runtime issue inputs best-effort from the turn runner
+
+Update:
+
+```txt
+packages/assistant-engine/src/assistant/codex-turn-runner.ts
+```
+
+Today, after the provider attempt returns, the turn runner awaits `recordAssistantToolFailureRuntimeIssues(...)`.  Replace that with fire-and-forget recording of the new metadata field:
+
+```ts
+recordAssistantRuntimeIssueInputsBestEffort({
+  issues: attemptMetadata.runtimeIssueInputs,
+  policy: attemptPlan.routePlan.diagnosticsPolicy,
+  vault: executionPlan.input.vault,
+})
+```
+
+Do not `await`.
+
+If the recorder fails, user delivery must continue.
+
+### Terminal provider failure issue
+
+In the catch path, after deriving `errorCode`, also record a terminal provider issue:
+
+```ts
+recordAssistantRuntimeIssueInputsBestEffort({
+  issues: [
+    {
+      component: 'assistant.codex-provider',
+      operation: attemptPlan.route.provider,
+      phase: 'provider_turn',
+      issueKind: classifyProviderIssueKind(error),
+      severity: 'error',
+      errorCode,
+      summary: 'Codex provider turn failed.',
+      details: {
+        providerRequestOutcome:
+          failedAttemptOutcome ?? 'failed',
+        providerActionCount:
+          attemptMetadata.providerActionCount,
+        rawEventCountBucket:
+          countBucket(failedAttemptRawEvents.length),
+      },
+    },
+  ],
+  policy: attemptPlan.routePlan.diagnosticsPolicy,
+  vault: executionPlan.input.vault,
+})
+```
+
+Do not include `errorMessage(error)` in the issue details. The existing attempt observability can keep its local detail if already intended, but the hosted issue sink should stay structured and low-risk.
+
+The catch path already records Codex attempt failure for local observability.  This new issue record is the privacy-safe product/admin aggregate, not a replacement for local debugging.
+
+---
+
+## Phase 8 — keep summary/fingerprint stable
+
+This is important.
+
+`createAssistantRuntimeIssueFingerprint` hashes `component`, `errorCode`, `issueKind`, `operation`, `phase`, and `summary`.  So if the summary includes dynamic text, you will create high-cardinality fingerprints and ruin aggregation.
+
+Bad:
+
+```ts
+summary: `Command failed: ${rawCommand}`
+```
+
+Good:
+
+```ts
+summary: 'Codex command execution failed during provider turn.'
+```
+
+Bad:
+
+```ts
+summary: `Tool ${toolName} failed because ${error.message}`
+```
+
+Good:
+
+```ts
+summary: 'Codex tool call failed during provider turn.'
+```
+
+Put only safe, bounded enum-ish details into `details`.
+
+Also remember that issue detail values are sanitized and bounded, but that is a last line of defense, not permission to pass raw data. The issue reporter already redacts strings, URLs, paths, emails, and phone-like numbers before writing.
+
+---
+
+## Phase 9 — verify hosted export is actually wired
+
+The export function exists and is tested.  But before assuming production export is happening, grep for:
+
+```txt
+exportHostedPendingAssistantRuntimeIssues
+```
+
+If it is only referenced by the function and test, wire it once in the hosted runtime.
+
+Preferred location:
+
+```txt
+packages/assistant-runtime/src/hosted-runtime.ts
+```
+
+Place it **after** successful durable workspace checkpoint / idle shutdown work, not before final delivery. The hosted runtime already has an idle shutdown checkpoint flow that returns invocation status afterward.
+
+Pseudo-shape:
+
+```ts
+await checkpointHostedRuntimeDirtyWorkspace(...)
+
+await exportHostedPendingAssistantRuntimeIssues({
+  issueExportPort: runnerPlatform.issueExportPort ?? null,
+  vaultRoot: restored.vaultRoot,
+}).catch((error) => {
+  console.warn(`Failed to export hosted assistant runtime issues: ${summarizeHostedExecutionError(error)}`)
+})
+```
+
+It is acceptable to `await` here because the user-visible response should already be delivered and the workspace should already be durable. If export fails, pending files remain and can be retried later. The exporter already leaves unacknowledged records pending.
+
+Do not add a new retry queue. The pending issue files are the queue.
+
+---
+
+## Phase 10 — do not add a DB migration
+
+No Prisma migration for v0.
+
+Use:
+
+```txt
+HostedAssistantRuntimeIssue
+```
+
+as-is.
+
+The web importer already upserts by `issueId` and stores the record fields plus `detailsJson`.
+
+Do not fill `releaseSha` / `runtimeName` in v0 unless those values already arrive naturally at this boundary. They are useful, but not required to solve the current problem. The migration should not widen into runtime identity plumbing.
+
+---
+
+# Daily rollup
+
+Start with SQL only.
+
+No LLM. No new service.
+
+```sql
+select
+  fingerprint,
+  component,
+  operation,
+  phase,
+  issue_kind,
+  severity,
+  error_code,
+  count(*) as occurrences,
+  min(occurred_at) as first_seen_at,
+  max(occurred_at) as last_seen_at,
+  jsonb_agg(details_json order by occurred_at desc) -> 0 as latest_details
+from hosted_assistant_runtime_issue
+where occurred_at >= now() - interval '1 day'
+group by
+  fingerprint,
+  component,
+  operation,
+  phase,
+  issue_kind,
+  severity,
+  error_code
+order by
+  occurrences desc,
+  max(occurred_at) desc;
+```
+
+That gives the team a daily “what is breaking Murph?” view.
+
+Only after this is useful should you add:
+
+```txt
+admin dashboard
+Slack digest
+GitHub issue creation
+LLM summary over top clusters
+```
+
+Do not build those first.
+
+---
+
+# Data contract v0
+
+Every stored issue should satisfy:
+
+```ts
+type V0AssistantRuntimeIssueDetails =
+  | {
+      actionKind: 'command.execution'
+      exitCode: number
+      durationMsBucket: string
+      outputBytesBucket: string
+    }
+  | {
+      actionKind: 'dynamic.tool.call' | 'mcp.tool.call'
+      durationMsBucket: string
+      outputBytesBucket: string
+      toolName?: string
+    }
+  | {
+      requestKind:
+        | 'invalid-generate-image-arguments'
+        | 'invalid-progress-arguments'
+        | 'invalid-response-media-arguments'
+        | 'unsupported-dynamic-tool'
+        | 'generate-image'
+        | 'send-progress-update'
+        | 'attach-response-media'
+    }
+  | {
+      providerRequestOutcome: 'failed' | 'partial' | 'aborted'
+      providerActionCount: number
+      rawEventCountBucket: string
+    }
+```
+
+Do not allow arbitrary `message`, `reason`, `stderr`, `stdout`, `command`, `path`, or `prompt` fields in v0 details.
+
+---
+
+# Tests to write
+
+## 1. Issue reporter tests
+
+In:
+
+```txt
+packages/assistant-engine/test/assistant-product-small-seams.test.ts
+```
+
+or a new targeted test file if that file is too crowded.
+
+Test:
+
+```txt
+recordAssistantRuntimeIssueInputsBestEffort:
+- writes at most 8 issues
+- respects privateIssueCaptureEnabled false
+- does not throw if writePendingAssistantRuntimeIssueRecord rejects
+- preserves stable operation/component/issueKind fields
+- sanitizes unsafe details through existing record path
+```
+
+The issue reporter already has mocked `writePendingAssistantRuntimeIssueRecord` available in `assistant-product-small-seams.test.ts`.
+
+## 2. Codex action extraction tests
+
+Add focused unit tests for the pure failed-action issue builder:
+
+```txt
+command.execution item.completed with exitCode 1
+  -> one issue input
+
+command.execution item.completed with exitCode 0
+  -> no issue input
+
+mcp.tool.call item.completed with status failed
+  -> one issue input
+
+dynamic.tool.call item.completed with success false
+  -> one issue input
+
+failed command with stdout/stderr/commandLabel/filePaths present
+  -> issue details do not contain those fields
+```
+
+## 3. Codex metadata tests
+
+Test:
+
+```txt
+successful Codex turn with failed command action
+  -> provider metadata.runtimeIssueInputs contains command issue
+  -> rawToolEvents remains []
+
+failed Codex turn with failure context
+  -> metadata.runtimeIssueInputs includes failure-context issue inputs
+```
+
+## 4. Turn runner best-effort test
+
+Test the user-path guarantee:
+
+```txt
+given recordAssistantRuntimeIssue throws or never resolves
+when provider turn succeeds
+then executeCodexTurnWithRecovery still returns succeeded result
+```
+
+This is the most important test for your concern.
+
+## 5. Hosted export tests
+
+Existing hosted export tests already verify that acknowledged issue files are cleared and malformed/forward-versioned files are skipped while valid files export.
+
+Add only one integration test if you wire production export:
+
+```txt
+after idle checkpoint, pending issue export is called with restored vault root
+```
+
+Do not overbuild.
+
+## 6. Web import tests
+
+Existing web import logic parses runtime issue records and upserts.  Add a single regression test if needed:
+
+```txt
+imports command.execution issue details without member relation
+```
+
+---
+
+# Rollout plan
+
+## PR 1 — internal capture only
+
+Scope:
+
+```txt
+assistant-engine only
+```
+
+Changes:
+
+```txt
+- add runtimeIssueInputs metadata field
+- add best-effort plural issue recorder
+- collect dynamic tool failure issue inputs
+- collect command/tool action failure issue inputs
+- record runtimeIssueInputs fire-and-forget from codex-turn-runner
+- record terminal provider failure fire-and-forget
+```
+
+No hosted export changes unless export is already wired and tests stay small.
+
+Acceptance:
+
+```txt
+- no model-visible tools
+- no prompt changes
+- no DB migration
+- no raw command/output details
+- final reply path does not await issue writes
+```
+
+## PR 2 — hosted export wiring verification
+
+Scope:
+
+```txt
+assistant-runtime only, unless production export is already wired
+```
+
+Changes:
+
+```txt
+- grep for exportHostedPendingAssistantRuntimeIssues
+- if missing from production path, call it after durable idle checkpoint
+- keep export failure non-fatal
+```
+
+Acceptance:
+
+```txt
+- pending issues export after durable work
+- export failure leaves pending records
+- no new queue/service
+```
+
+## PR 3 — SQL/admin rollup
+
+Scope:
+
+```txt
+apps/web or ops docs
+```
+
+Start with a saved SQL query or tiny internal route. Do not build a new dashboard until the query proves useful.
+
+Acceptance:
+
+```txt
+- top issue fingerprints over last 24h visible
+- grouped by component/operation/issueKind/severity
+- no member-level drilldown
+```
+
+## PR 4 — cleanup
+
+After PR 1 is green and no production code depends on the old pseudo-event path:
+
+```txt
+- delete recordAssistantToolFailureRuntimeIssues if unused
+- delete pseudo assistant.tool.failed issue parsing if unused
+- optionally remove rawToolEvents from provider metadata if all callers are dead
+```
+
+Do not do this cleanup before the main migration is verified.
+
+---
+
+# Verification commands
+
+Use scoped verification, not full workspace heroics unless the repo expects it.
+
+Suggested:
+
+```bash
+pnpm --dir packages/assistant-engine typecheck
+pnpm --dir packages/assistant-engine test -- --run test/assistant-product-small-seams.test.ts
+pnpm --dir packages/assistant-engine test -- --run test/assistant-codex-final-coverage.test.ts
+pnpm --dir packages/assistant-runtime exec vitest run test/hosted-runtime-issues.test.ts --config vitest.config.ts --no-coverage
+pnpm --dir ../.. exec vitest run apps/web/test/hosted-execution-runtime-issues.test.ts --project hosted-web-execution --config apps/web/vitest.workspace.ts --no-coverage
+git diff --check
+```
+
+If one of these fans into an unrelated known failure, record it explicitly and keep the patch scoped.
+
+---
+
+# Rollback plan
+
+Use the existing kill switch first:
+
+```txt
+MURPH_ASSISTANT_PRIVATE_ISSUES=0
+```
+
+The diagnostics policy already reads `MURPH_ASSISTANT_PRIVATE_ISSUES` and defaults capture to enabled when unset.
+
+Rollback levels:
+
+```txt
+Level 1: set MURPH_ASSISTANT_PRIVATE_ISSUES=0
+Level 2: revert hosted export wiring
+Level 3: revert assistant-engine capture patch
+```
+
+No DB rollback should be needed because v0 uses the existing table and retention.
+
+---
+
+# Final checklist
+
+Before merging, this should be true:
+
+```txt
+[ ] No assistant_report_friction tool exists.
+[ ] No system prompt tells Murph to report friction.
+[ ] No model turn needs to call a feedback tool.
+[ ] No runtime issue write is awaited on the success reply path.
+[ ] No raw stdout/stderr/command/prompt/path/vault content is stored.
+[ ] No Prisma migration was added.
+[ ] Existing HostedAssistantRuntimeIssue import still works.
+[ ] Hosted export is either verified already wired or wired after durable work.
+[ ] Daily rollup can group by fingerprint.
+[ ] There is a kill switch.
+```
+
+The cleanest v0 is therefore:
+
+> **Add one internal `runtimeIssueInputs` metadata path, populate it from Codex/provider failures, record it best-effort through the existing issue writer, and roll it up from the existing hosted issue table.**
+
+That gives you validated, privacy-safe, relevant feedback without making Murph think about reporting, without delaying replies, and without introducing a second diagnostics architecture.

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -44,10 +44,12 @@ import {
   resolveSupportedCodexAppServerApprovalPolicy,
 } from './assistant-codex/app-server-requests.js'
 import {
+  buildRuntimeIssueInputForFailedCodexAction,
   createCodexActionDiagnosticsReducer,
 } from './assistant-codex/action-diagnostics.js'
 import {
   executeMurphDynamicToolRequest,
+  type MurphDynamicToolRequest,
   readMurphDynamicToolRequest,
 } from './assistant-codex/dynamic-tools.js'
 import {
@@ -106,6 +108,9 @@ import type {
   AssistantProviderServiceTier,
   AssistantProviderUsageDraft,
 } from './assistant/providers/types.js'
+import type {
+  AssistantRuntimeIssueInput,
+} from './assistant/issue-reporting.js'
 import {
   normalizeAssistantResponseMediaList,
 } from './assistant/response-media.js'
@@ -417,6 +422,7 @@ export interface CodexAppServerTurnFailureContext {
   jsonEvents: unknown[]
   additionalUsages: AssistantProviderUsageDraft[]
   providerActionCount: number
+  runtimeIssueInputs: readonly AssistantRuntimeIssueInput[]
   codexThreadId: string | null
   providerTurnId: string | null
 }
@@ -449,6 +455,7 @@ export function readCodexAppServerTurnFailureContext(
     jsonEvents: [...context.jsonEvents],
     additionalUsages: [...context.additionalUsages],
     providerActionCount: context.providerActionCount,
+    runtimeIssueInputs: [...context.runtimeIssueInputs],
     codexThreadId: context.codexThreadId,
     providerTurnId: context.providerTurnId,
   }
@@ -465,6 +472,7 @@ export interface CodexAppServerTurnResult {
   responseMedia: AssistantResponseMedia[]
   jsonEvents: unknown[]
   providerActionCount: number
+  runtimeIssueInputs: readonly AssistantRuntimeIssueInput[]
   rolloutRelativePath: string | null
   sessionId: string | null
   stderr: string
@@ -1872,6 +1880,7 @@ async function runCodexAppServerTurnOnProcess(
   let providerActionCount = 0
   const providerActionItemIds = new Set<string>()
   const jsonEvents: unknown[] = []
+  const runtimeIssueInputs: AssistantRuntimeIssueInput[] = []
   const actionDiagnostics = input.onTraceEvent
     ? createCodexActionDiagnosticsReducer()
     : null
@@ -1946,6 +1955,7 @@ async function runCodexAppServerTurnOnProcess(
       jsonEvents: [...jsonEvents],
       additionalUsages: [...additionalUsages, ...buildSubagentUsageDrafts()],
       providerActionCount,
+      runtimeIssueInputs: [...runtimeIssueInputs],
       codexThreadId,
       providerTurnId: turnId,
     } satisfies CodexAppServerTurnFailureContext
@@ -2099,6 +2109,14 @@ async function runCodexAppServerTurnOnProcess(
     payload: Record<string, unknown>,
   ): VaultCliError | null => {
     return codexProcess.writeRpcMessage(payload)
+  }
+
+  const pushRuntimeIssueInput = (issue: AssistantRuntimeIssueInput): void => {
+    if (runtimeIssueInputs.length >= 8) {
+      return
+    }
+
+    runtimeIssueInputs.push(issue)
   }
 
   cleanupAbortListener = attachCodexAbortListener({
@@ -2375,6 +2393,10 @@ async function runCodexAppServerTurnOnProcess(
     }
 
     if (dynamicToolRequest.kind === 'unsupported-dynamic-tool') {
+      pushRuntimeIssueInput(createDynamicToolRuntimeIssueInput({
+        request: dynamicToolRequest,
+        reason: 'unsupported',
+      }))
       void tryWriteRpcMessage({
         id: requestId,
         error: {
@@ -2383,6 +2405,13 @@ async function runCodexAppServerTurnOnProcess(
         },
       })
       return
+    }
+
+    if (isInvalidDynamicToolRequest(dynamicToolRequest)) {
+      pushRuntimeIssueInput(createDynamicToolRuntimeIssueInput({
+        request: dynamicToolRequest,
+        reason: 'invalid_arguments',
+      }))
     }
 
     const runDynamicTool = () => executeMurphDynamicToolRequest({
@@ -2426,6 +2455,10 @@ async function runCodexAppServerTurnOnProcess(
         result: result.rpcResult,
       })
     }).catch(() => {
+      pushRuntimeIssueInput(createDynamicToolRuntimeIssueInput({
+        request: dynamicToolRequest,
+        reason: 'execution_failed',
+      }))
       void tryWriteRpcMessage({
         id: requestId,
         result: {
@@ -2468,6 +2501,13 @@ async function runCodexAppServerTurnOnProcess(
     }
 
     const normalizedEvent = normalizeCodexEvent(message)
+    const runtimeIssueInput = buildRuntimeIssueInputForFailedCodexAction({
+      normalizedEvent,
+      rawEvent: message,
+    })
+    if (runtimeIssueInput) {
+      pushRuntimeIssueInput(runtimeIssueInput)
+    }
     actionDiagnostics?.recordEvent({
       activeTurnId: turnId,
       normalizedEvent,
@@ -3036,6 +3076,7 @@ async function runCodexAppServerTurnOnProcess(
     responseMedia: trailingSteerCandidateMedia ?? responseMedia,
     jsonEvents,
     providerActionCount,
+    runtimeIssueInputs,
     rolloutRelativePath,
     sessionId: codexThreadId,
     stderr: stderr.trim(),
@@ -3059,6 +3100,79 @@ function notifyCodexAppServerProviderRequestStartedBestEffort(input: {
     })
   } catch {
     // Provider-start hooks are diagnostic-only and must not block turns.
+  }
+}
+
+function isInvalidDynamicToolRequest(
+  request: MurphDynamicToolRequest,
+): request is Extract<
+  MurphDynamicToolRequest,
+  {
+    kind:
+      | 'invalid-generate-image-arguments'
+      | 'invalid-progress-arguments'
+      | 'invalid-response-media-arguments'
+  }
+> {
+  return (
+    request.kind === 'invalid-generate-image-arguments' ||
+    request.kind === 'invalid-progress-arguments' ||
+    request.kind === 'invalid-response-media-arguments'
+  )
+}
+
+function createDynamicToolRuntimeIssueInput(input: {
+  request: MurphDynamicToolRequest
+  reason: 'execution_failed' | 'invalid_arguments' | 'unsupported'
+}): AssistantRuntimeIssueInput {
+  if (input.reason === 'unsupported') {
+    return {
+      component: 'assistant.codex-dynamic-tool',
+      operation: 'unsupported-dynamic-tool',
+      phase: 'tool_call',
+      issueKind: 'schema_rejection',
+      severity: 'warning',
+      errorCode: 'ASSISTANT_DYNAMIC_TOOL_UNSUPPORTED',
+      summary: 'Codex requested an unsupported Murph dynamic tool.',
+      details: {
+        requestKind: 'unsupported-dynamic-tool',
+        namespacePresent:
+          input.request.kind === 'unsupported-dynamic-tool'
+            ? input.request.namespace !== null
+            : false,
+        toolPresent:
+          input.request.kind === 'unsupported-dynamic-tool'
+            ? input.request.tool !== null
+            : false,
+      },
+    }
+  }
+
+  if (input.reason === 'invalid_arguments' && isInvalidDynamicToolRequest(input.request)) {
+    const validationDigest = input.request.validationDigest
+    return {
+      component: 'assistant.tool-validation',
+      operation: validationDigest.toolName ?? input.request.kind,
+      phase: 'tool_call',
+      issueKind: 'schema_rejection',
+      severity: 'warning',
+      errorCode: 'TOOL_INPUT_SCHEMA_REJECTION',
+      summary: 'Tool input failed schema validation.',
+      details: validationDigest,
+    }
+  }
+
+  return {
+    component: 'assistant.codex-dynamic-tool',
+    operation: input.request.kind,
+    phase: 'tool_call',
+    issueKind: 'tool_error',
+    severity: 'warning',
+    errorCode: 'ASSISTANT_DYNAMIC_TOOL_FAILED',
+    summary: 'Murph dynamic tool execution failed.',
+    details: {
+      requestKind: input.request.kind,
+    },
   }
 }
 

--- a/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
+++ b/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
@@ -1,6 +1,9 @@
 import { Buffer } from 'node:buffer'
 
 import type { CodexNormalizedEvent } from '../assistant-codex-events.js'
+import type {
+  AssistantRuntimeIssueInput,
+} from '../assistant/issue-reporting.js'
 
 export const CODEX_ACTION_DIAGNOSTICS_TRACE_SCHEMA =
   'murph.assistant-codex-action-diagnostics.v1'
@@ -21,6 +24,22 @@ type CodexActionKind =
   | 'file.change'
   | 'mcp.tool.call'
   | 'web.search'
+
+type DurationMsBucket =
+  | 'unknown'
+  | 'lt_1s'
+  | '1_5s'
+  | '5_30s'
+  | '30_120s'
+  | 'gt_120s'
+
+type BytesBucket =
+  | 'unknown'
+  | '0'
+  | 'lt_1kb'
+  | '1_10kb'
+  | '10_100kb'
+  | 'gt_100kb'
 
 type TokenUsageSample = {
   cachedInputTokens: number | null
@@ -333,6 +352,137 @@ export function createCodexActionDiagnosticsReducer(): CodexActionDiagnosticsRed
       })
     },
   }
+}
+
+export function buildRuntimeIssueInputForFailedCodexAction(input: {
+  normalizedEvent: CodexNormalizedEvent
+  rawEvent: unknown
+}): AssistantRuntimeIssueInput | null {
+  if (readEventType(input.rawEvent) !== 'item.completed') {
+    return null
+  }
+
+  const kind = resolveActionKind(input.normalizedEvent, input.rawEvent)
+  if (
+    kind !== 'command.execution' &&
+    kind !== 'dynamic.tool.call' &&
+    kind !== 'mcp.tool.call'
+  ) {
+    return null
+  }
+
+  const item = readEventItem(input.rawEvent)
+  if (!isFailedAction(item, input.normalizedEvent)) {
+    return null
+  }
+
+  const durationMs = readItemDurationMs(item)
+  const output = measureActionOutput(item)
+  const commonDetails = {
+    actionKind: kind,
+    durationMsBucket: durationMsBucket(durationMs),
+    outputBytesBucket: bytesBucket(output.bytesTotal),
+  }
+
+  if (kind === 'command.execution') {
+    const exitCode = readCommandExitCode({
+      item,
+      normalizedEvent: input.normalizedEvent,
+    })
+    if (exitCode === null || exitCode === 0) {
+      return null
+    }
+
+    return {
+      component: 'assistant.codex-action',
+      operation: 'command.execution',
+      phase: 'provider_turn',
+      issueKind: 'tool_error',
+      severity: 'warning',
+      errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+      summary: 'Codex command execution failed during provider turn.',
+      details: {
+        ...commonDetails,
+        exitCode,
+      },
+    }
+  }
+
+  if (kind === 'dynamic.tool.call') {
+    return {
+      component: 'assistant.codex-action',
+      operation: 'dynamic.tool.call',
+      phase: 'tool_call',
+      issueKind: 'tool_error',
+      severity: 'warning',
+      errorCode: 'CODEX_DYNAMIC_TOOL_CALL_FAILED',
+      summary: 'Codex dynamic tool call failed during provider turn.',
+      details: commonDetails,
+    }
+  }
+
+  return {
+    component: 'assistant.codex-action',
+    operation: 'mcp.tool.call',
+    phase: 'tool_call',
+    issueKind: 'tool_error',
+    severity: 'warning',
+    errorCode: 'CODEX_TOOL_CALL_FAILED',
+    summary: 'Codex tool call failed during provider turn.',
+    details: commonDetails,
+  }
+}
+
+function readCommandExitCode(input: {
+  item: Record<string, unknown> | null
+  normalizedEvent: CodexNormalizedEvent
+}): number | null {
+  if (
+    input.normalizedEvent.kind === 'status_item' &&
+    input.normalizedEvent.exitCode !== null
+  ) {
+    return input.normalizedEvent.exitCode
+  }
+
+  return readInteger(input.item?.exitCode, input.item?.exit_code)
+}
+
+function durationMsBucket(value: number | null): DurationMsBucket {
+  if (value === null) {
+    return 'unknown'
+  }
+  if (value < 1_000) {
+    return 'lt_1s'
+  }
+  if (value < 5_000) {
+    return '1_5s'
+  }
+  if (value < 30_000) {
+    return '5_30s'
+  }
+  if (value < 120_000) {
+    return '30_120s'
+  }
+  return 'gt_120s'
+}
+
+function bytesBucket(value: number | null): BytesBucket {
+  if (value === null) {
+    return 'unknown'
+  }
+  if (value === 0) {
+    return '0'
+  }
+  if (value < 1_024) {
+    return 'lt_1kb'
+  }
+  if (value < 10 * 1_024) {
+    return '1_10kb'
+  }
+  if (value < 100 * 1_024) {
+    return '10_100kb'
+  }
+  return 'gt_100kb'
 }
 
 function recordToolMetrics(
@@ -851,6 +1001,15 @@ function readInteger(...values: unknown[]): number | null {
   for (const value of values) {
     if (typeof value === 'number' && Number.isInteger(value)) {
       return value
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim()
+      if (/^-?\d+$/u.test(trimmed)) {
+        const parsed = Number(trimmed)
+        if (Number.isSafeInteger(parsed)) {
+          return parsed
+        }
+      }
     }
   }
   return null

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -11,6 +11,10 @@ import type {
   AssistantProviderUsageDraft,
 } from '../assistant/providers/types.js'
 import { normalizeAssistantResponseMediaList } from '../assistant/response-media.js'
+import {
+  buildSafeToolCallValidationDigest,
+  type SafeToolCallValidationDigest,
+} from '../assistant/tool-validation-digest.js'
 import type {
   AssistantProgressDelivery,
 } from '../assistant/turn-progress.js'
@@ -152,6 +156,12 @@ const attachResponseMediaArgumentsSchema = z
   })
   .strict()
 
+const sendProgressUpdateArgumentsSchema = z
+  .object({
+    text: z.string().trim().min(1),
+  })
+  .strict()
+
 const generateImageArgumentsSchema = z
   .object({
     alt: z.string().trim().min(1).max(500).nullable().default(null),
@@ -198,12 +208,15 @@ export type MurphDynamicToolRequest =
     }
   | {
       kind: 'invalid-generate-image-arguments'
+      validationDigest: SafeToolCallValidationDigest
     }
   | {
       kind: 'invalid-response-media-arguments'
+      validationDigest: SafeToolCallValidationDigest
     }
   | {
       kind: 'invalid-progress-arguments'
+      validationDigest: SafeToolCallValidationDigest
     }
   | {
       kind: 'send-progress-update'
@@ -241,6 +254,7 @@ export function readMurphDynamicToolRequest(
       if (!parsed.ok) {
         return {
           kind: 'invalid-progress-arguments',
+          validationDigest: parsed.validationDigest,
         }
       }
 
@@ -254,6 +268,7 @@ export function readMurphDynamicToolRequest(
       if (!parsed.ok) {
         return {
           kind: 'invalid-response-media-arguments',
+          validationDigest: parsed.validationDigest,
         }
       }
 
@@ -267,6 +282,7 @@ export function readMurphDynamicToolRequest(
       if (!parsed.ok) {
         return {
           kind: 'invalid-generate-image-arguments',
+          validationDigest: parsed.validationDigest,
         }
       }
 
@@ -422,35 +438,44 @@ function parseDynamicToolCallRequest(
 
 function parseSendProgressUpdateArguments(
   value: unknown,
-): { ok: true; text: string } | { ok: false } {
-  const record = asRecord(value)
-  if (!record) {
-    return { ok: false }
-  }
-  if (Object.keys(record).some((key) => key !== 'text')) {
-    return { ok: false }
-  }
-  if (typeof record.text !== 'string') {
-    return { ok: false }
-  }
-
-  const text = normalizeNullableString(record.text)
-  if (!text) {
-    return { ok: false }
+):
+  | { ok: true; text: string }
+  | { ok: false; validationDigest: SafeToolCallValidationDigest } {
+  const parsed = sendProgressUpdateArgumentsSchema.safeParse(value)
+  if (!parsed.success) {
+    return {
+      ok: false,
+      validationDigest: buildDynamicToolValidationDigest({
+        error: parsed.error,
+        rawInput: value,
+        schemaName: 'murph.send_progress_update.input',
+        toolName: 'murph.send_progress_update',
+      }),
+    }
   }
 
   return {
     ok: true,
-    text,
+    text: parsed.data.text,
   }
 }
 
 function parseGenerateImageArguments(
   value: unknown,
-): { ok: true; args: GenerateImageToolArgs } | { ok: false } {
+):
+  | { ok: true; args: GenerateImageToolArgs }
+  | { ok: false; validationDigest: SafeToolCallValidationDigest } {
   const parsed = generateImageArgumentsSchema.safeParse(value)
   if (!parsed.success) {
-    return { ok: false }
+    return {
+      ok: false,
+      validationDigest: buildDynamicToolValidationDigest({
+        error: parsed.error,
+        rawInput: value,
+        schemaName: 'murph.generate_image.input',
+        toolName: 'murph.generate_image',
+      }),
+    }
   }
   return {
     args: parsed.data,
@@ -460,20 +485,55 @@ function parseGenerateImageArguments(
 
 function parseAttachResponseMediaArguments(
   value: unknown,
-): { ok: true; media: AssistantResponseMedia[] } | { ok: false } {
+):
+  | { ok: true; media: AssistantResponseMedia[] }
+  | { ok: false; validationDigest: SafeToolCallValidationDigest } {
+  const schemaName = 'murph.attach_response_media.input'
+  const toolName = 'murph.attach_response_media'
   try {
     const parsed = attachResponseMediaArgumentsSchema.safeParse(value)
     if (!parsed.success) {
-      return { ok: false }
+      return {
+        ok: false,
+        validationDigest: buildDynamicToolValidationDigest({
+          error: parsed.error,
+          rawInput: value,
+          schemaName,
+          toolName,
+        }),
+      }
     }
 
     return {
       ok: true,
       media: normalizeAssistantResponseMediaList(parsed.data.media),
     }
-  } catch {
-    return { ok: false }
+  } catch (error) {
+    return {
+      ok: false,
+      validationDigest: buildDynamicToolValidationDigest({
+        error,
+        rawInput: value,
+        schemaName,
+        toolName,
+      }),
+    }
   }
+}
+
+function buildDynamicToolValidationDigest(input: {
+  error: unknown
+  rawInput: unknown
+  schemaName: string
+  toolName: string
+}): SafeToolCallValidationDigest {
+  return buildSafeToolCallValidationDigest({
+    error: input.error,
+    rawInput: input.rawInput,
+    requestedToolName: input.toolName,
+    schemaName: input.schemaName,
+    toolName: input.toolName,
+  })
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -449,6 +449,7 @@ function parseSendProgressUpdateArguments(
         error: parsed.error,
         rawInput: value,
         schemaName: 'murph.send_progress_update.input',
+        schemaRootKeys: readZodObjectRootKeys(sendProgressUpdateArgumentsSchema),
         toolName: 'murph.send_progress_update',
       }),
     }
@@ -473,6 +474,7 @@ function parseGenerateImageArguments(
         error: parsed.error,
         rawInput: value,
         schemaName: 'murph.generate_image.input',
+        schemaRootKeys: readZodObjectRootKeys(generateImageArgumentsSchema),
         toolName: 'murph.generate_image',
       }),
     }
@@ -499,6 +501,7 @@ function parseAttachResponseMediaArguments(
           error: parsed.error,
           rawInput: value,
           schemaName,
+          schemaRootKeys: readZodObjectRootKeys(attachResponseMediaArgumentsSchema),
           toolName,
         }),
       }
@@ -515,6 +518,7 @@ function parseAttachResponseMediaArguments(
         error,
         rawInput: value,
         schemaName,
+        schemaRootKeys: readZodObjectRootKeys(attachResponseMediaArgumentsSchema),
         toolName,
       }),
     }
@@ -525,6 +529,7 @@ function buildDynamicToolValidationDigest(input: {
   error: unknown
   rawInput: unknown
   schemaName: string
+  schemaRootKeys: readonly string[]
   toolName: string
 }): SafeToolCallValidationDigest {
   return buildSafeToolCallValidationDigest({
@@ -532,8 +537,13 @@ function buildDynamicToolValidationDigest(input: {
     rawInput: input.rawInput,
     requestedToolName: input.toolName,
     schemaName: input.schemaName,
+    schemaRootKeys: input.schemaRootKeys,
     toolName: input.toolName,
   })
+}
+
+function readZodObjectRootKeys(schema: { shape: Record<string, unknown> }): string[] {
+  return Object.keys(schema.shape)
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/packages/assistant-engine/src/assistant/codex-runtime.ts
+++ b/packages/assistant-engine/src/assistant/codex-runtime.ts
@@ -200,6 +200,7 @@ function createEmptyAssistantProviderAttemptMetadata(): AssistantProviderAttempt
     executedToolCount: 0,
     providerActionCount: 0,
     rawToolEvents: [],
+    runtimeIssueInputs: [],
   }
 }
 

--- a/packages/assistant-engine/src/assistant/codex-turn-runner.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn-runner.ts
@@ -23,7 +23,10 @@ import type {
 } from './providers/types.js'
 import { errorMessage } from './shared.js'
 import {
-  recordAssistantToolFailureRuntimeIssues,
+  recordAssistantRuntimeIssueInputsBestEffort,
+} from './issue-reporting.js'
+import type {
+  AssistantRuntimeIssueInput,
 } from './issue-reporting.js'
 import type { CodexThreadIdentity } from './codex-thread-route.js'
 import { maybeThrowInjectedAssistantFault } from './fault-injection.js'
@@ -317,6 +320,7 @@ async function executeAssistantCodexAttempt(input: {
     executedToolCount: 0,
     providerActionCount: 0,
     rawToolEvents: [] as readonly unknown[],
+    runtimeIssueInputs: [] as readonly AssistantRuntimeIssueInput[],
   }
 
   const attemptAt = new Date().toISOString()
@@ -441,12 +445,12 @@ async function executeAssistantCodexAttempt(input: {
       onTraceEvent: executionPlan.input.onTraceEvent,
       showThinkingTraces: executionPlan.input.showThinkingTraces ?? false,
     })
-    attemptMetadata = attemptResult.metadata
-    await recordAssistantToolFailureRuntimeIssues({
+    attemptMetadata = normalizeAssistantProviderAttemptMetadata(attemptResult.metadata)
+    recordAssistantRuntimeIssueInputsBestEffort({
+      issues: attemptMetadata.runtimeIssueInputs,
       policy: attemptPlan.routePlan.diagnosticsPolicy,
-      rawToolEvents: attemptMetadata.rawToolEvents,
       vault: executionPlan.input.vault,
-    }).catch(() => undefined)
+    })
     if (!attemptResult.ok) {
       failedAttemptCodexThreadId = attemptResult.codexThreadId ?? null
       failedAttemptProviderTurnId = attemptResult.providerTurnId ?? null
@@ -500,6 +504,32 @@ async function executeAssistantCodexAttempt(input: {
       annotateRecoveredCodexThreadIdForDiagnostics(error)
     }
     const session = attemptPlan.session
+    recordAssistantRuntimeIssueInputsBestEffort({
+      issues: [
+        {
+          component: 'assistant.codex-provider',
+          operation: attemptPlan.route.provider,
+          phase: 'provider_turn',
+          issueKind: classifyProviderRuntimeIssueKind(error),
+          severity: 'error',
+          errorCode: errorCode ?? 'ASSISTANT_CODEX_PROVIDER_FAILED',
+          summary: 'Codex provider turn failed.',
+          details: {
+            providerRequestOutcome:
+              failedAttemptOutcome ??
+              resolveFailedAssistantProviderRequestOutcome({
+                error,
+                rawEvents: failedAttemptRawEvents,
+                usage: failedAttemptUsage,
+              }),
+            providerActionCount: attemptMetadata.providerActionCount,
+            rawEventCountBucket: countBucket(failedAttemptRawEvents.length),
+          },
+        },
+      ],
+      policy: attemptPlan.routePlan.diagnosticsPolicy,
+      vault: executionPlan.input.vault,
+    })
     void appendAssistantTranscriptEntries(
       executionPlan.input.vault,
       session.sessionId,
@@ -541,6 +571,16 @@ async function executeAssistantCodexAttempt(input: {
       additionalUsages: failedAttemptAdditionalUsages,
       usageAttribution,
     }
+  }
+}
+
+function normalizeAssistantProviderAttemptMetadata(
+  metadata: AssistantProviderAttemptMetadata,
+): AssistantProviderAttemptMetadata {
+  return {
+    ...metadata,
+    rawToolEvents: metadata.rawToolEvents ?? [],
+    runtimeIssueInputs: metadata.runtimeIssueInputs ?? [],
   }
 }
 
@@ -598,6 +638,40 @@ function isAssistantProviderAbortError(error: unknown): boolean {
 
   const name = 'name' in error ? (error as { name?: unknown }).name : null
   return typeof name === 'string' && name === 'AbortError'
+}
+
+function classifyProviderRuntimeIssueKind(error: unknown): AssistantRuntimeIssueInput['issueKind'] {
+  if (isAssistantProviderAbortError(error)) {
+    return 'timeout'
+  }
+
+  const code = readAssistantErrorCode(error)?.toLowerCase() ?? ''
+  if (/\b(?:schema|contract|validation|invalid|parse|strict|rejected|unsupported)\b/u.test(code)) {
+    return 'schema_rejection'
+  }
+
+  return 'tool_error'
+}
+
+function countBucket(value: number):
+  | '0'
+  | '1'
+  | '2_5'
+  | '6_20'
+  | 'gt_20' {
+  if (value <= 0) {
+    return '0'
+  }
+  if (value === 1) {
+    return '1'
+  }
+  if (value <= 5) {
+    return '2_5'
+  }
+  if (value <= 20) {
+    return '6_20'
+  }
+  return 'gt_20'
 }
 
 function resolveCodexAttemptServiceTier(input: {

--- a/packages/assistant-engine/src/assistant/issue-reporting.ts
+++ b/packages/assistant-engine/src/assistant/issue-reporting.ts
@@ -39,6 +39,7 @@ const SUMMARY_MAX_LENGTH = 240
 const FIELD_MAX_LENGTH = 96
 const DETAIL_MAX_KEYS = 24
 const DETAIL_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/u
+const pendingIssueWritePromises = new Set<Promise<void>>()
 
 export function resolveAssistantDiagnosticsPolicy(input: {
   channel: string | null
@@ -94,6 +95,34 @@ export async function recordAssistantToolFailureRuntimeIssues(input: {
       policy: input.policy,
       vault: input.vault,
     })
+  }
+}
+
+export function recordAssistantRuntimeIssueInputsBestEffort(input: {
+  issues: readonly AssistantRuntimeIssueInput[]
+  policy: AssistantDiagnosticsPolicy
+  vault: string
+}): void {
+  if (!input.policy.privateIssueCaptureEnabled || input.issues.length === 0) {
+    return
+  }
+
+  for (const issue of input.issues.slice(0, 8)) {
+    const write = recordAssistantRuntimeIssue({
+      issue,
+      policy: input.policy,
+      vault: input.vault,
+    }).catch(() => undefined)
+    pendingIssueWritePromises.add(write)
+    void write.finally(() => {
+      pendingIssueWritePromises.delete(write)
+    })
+  }
+}
+
+export async function flushPendingAssistantRuntimeIssueWrites(): Promise<void> {
+  while (pendingIssueWritePromises.size > 0) {
+    await Promise.allSettled([...pendingIssueWritePromises])
   }
 }
 

--- a/packages/assistant-engine/src/assistant/providers/codex-cli.ts
+++ b/packages/assistant-engine/src/assistant/providers/codex-cli.ts
@@ -382,6 +382,7 @@ export async function executeCodexAssistantTurnAttempt(
           executedToolCount: 0,
           providerActionCount: failureContext?.providerActionCount ?? 0,
           rawToolEvents: [],
+          runtimeIssueInputs: failureContext?.runtimeIssueInputs ?? [],
         },
         ok: false,
         ...(failureContext
@@ -407,6 +408,7 @@ export async function executeCodexAssistantTurnAttempt(
       executedToolCount: 0,
       providerActionCount: result.providerActionCount,
       rawToolEvents: [],
+      runtimeIssueInputs: result.runtimeIssueInputs ?? [],
     },
     ok: true,
     result: {

--- a/packages/assistant-engine/src/assistant/providers/types.ts
+++ b/packages/assistant-engine/src/assistant/providers/types.ts
@@ -25,6 +25,9 @@ import type {
   AssistantHostedGeneratedImageUploader,
 } from '../execution-context.js'
 import type {
+  AssistantRuntimeIssueInput,
+} from '../issue-reporting.js'
+import type {
   AssistantUsageTokenPricingBasis,
 } from '@murphai/hosted-execution/assistant-usage'
 
@@ -227,6 +230,7 @@ export interface AssistantProviderAttemptMetadata {
   executedToolCount: number
   providerActionCount: number
   rawToolEvents: readonly unknown[]
+  runtimeIssueInputs: readonly AssistantRuntimeIssueInput[]
 }
 
 export type AssistantProviderTurnAttemptResult =

--- a/packages/assistant-engine/src/assistant/tool-validation-digest.ts
+++ b/packages/assistant-engine/src/assistant/tool-validation-digest.ts
@@ -1,0 +1,425 @@
+import { createHash } from 'node:crypto'
+
+import { z } from 'zod'
+
+export const SAFE_TOOL_CALL_VALIDATION_DIGEST_SCHEMA =
+  'murph.tool-call-validation-digest.v1'
+
+export interface SafeToolCallValidationDigest {
+  [key: string]: unknown
+  detailsSchema: typeof SAFE_TOOL_CALL_VALIDATION_DIGEST_SCHEMA
+  toolName?: string
+  requestedToolNameSafe?: string
+  schemaName?: string
+  schemaFingerprint?: string
+  validationFingerprint: string
+  rootType: 'object' | 'array' | 'string' | 'number' | 'boolean' | 'null' | 'unknown'
+  rootKeysPresent?: string[]
+  rootKeyCount?: number
+  unsafeRootKeyCount?: number
+  missingPaths?: string[]
+  unknownKeys?: string[]
+  unknownKeyCount?: number
+  invalidPaths?: string[]
+  issueCodes?: string[]
+  pathIssues?: Array<{
+    path: string
+    code: string
+    expected?: string
+    received?: string
+  }>
+  inputShape?: string[]
+}
+
+interface BuildSafeToolCallValidationDigestInput {
+  error: unknown
+  rawInput: unknown
+  requestedToolName?: string | null
+  schemaFingerprint?: string | null
+  schemaName?: string | null
+  toolName?: string | null
+}
+
+interface ValidationFacts {
+  invalidPaths: string[]
+  issueCodes: string[]
+  missingPaths: string[]
+  pathIssues: NonNullable<SafeToolCallValidationDigest['pathIssues']>
+  unknownKeyCount: number
+  unknownKeys: string[]
+}
+
+const MAX_ROOT_KEYS = 16
+const MAX_PATHS = 16
+const MAX_ISSUE_CODES = 12
+const MAX_PATH_ISSUES = 12
+const MAX_INPUT_SHAPE = 16
+
+export function buildSafeToolCallValidationDigest(
+  input: BuildSafeToolCallValidationDigestInput,
+): SafeToolCallValidationDigest {
+  const rootType = getRootType(input.rawInput)
+  const rootRecord = asRecord(input.rawInput)
+  const rootKeys = rootRecord ? Object.keys(rootRecord) : []
+  const safeRootKeys = uniqueSorted(rootKeys.filter(isSafeSchemaLikeKey))
+  const inputShape = buildInputShape(input.rawInput, safeRootKeys)
+  const facts = readValidationFacts(input.error, input.rawInput)
+
+  const fingerprintFacts = {
+    invalidPaths: facts.invalidPaths,
+    issueCodes: facts.issueCodes,
+    missingPaths: facts.missingPaths,
+    pathIssues: facts.pathIssues,
+    rootKeysPresent: safeRootKeys.slice(0, MAX_ROOT_KEYS),
+    rootType,
+    schemaFingerprint: normalizeSafeIdentifier(input.schemaFingerprint),
+    toolName: normalizeSafeIdentifier(input.toolName),
+    unknownKeys: facts.unknownKeys,
+  }
+  const validationFingerprint = `tvd_${hashJson(fingerprintFacts).slice(0, 12)}`
+
+  return omitEmptyFields({
+    detailsSchema: SAFE_TOOL_CALL_VALIDATION_DIGEST_SCHEMA,
+    toolName: normalizeSafeIdentifier(input.toolName),
+    requestedToolNameSafe: normalizeSafeIdentifier(input.requestedToolName),
+    schemaName: normalizeSafeIdentifier(input.schemaName),
+    schemaFingerprint: normalizeSafeIdentifier(input.schemaFingerprint),
+    validationFingerprint,
+    rootType,
+    rootKeysPresent: safeRootKeys.slice(0, MAX_ROOT_KEYS),
+    rootKeyCount: rootKeys.length > 0 ? rootKeys.length : undefined,
+    unsafeRootKeyCount: rootKeys.length - safeRootKeys.length > 0
+      ? rootKeys.length - safeRootKeys.length
+      : undefined,
+    missingPaths: facts.missingPaths,
+    unknownKeys: facts.unknownKeys,
+    unknownKeyCount: facts.unknownKeyCount > 0 ? facts.unknownKeyCount : undefined,
+    invalidPaths: facts.invalidPaths,
+    issueCodes: facts.issueCodes,
+    pathIssues: facts.pathIssues,
+    inputShape,
+  })
+}
+
+export function isSafeSchemaLikeKey(key: string): boolean {
+  if (key.length < 2 || key.length > 64) {
+    return false
+  }
+  return (
+    /^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$/.test(key) ||
+    /^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$/.test(key)
+  )
+}
+
+function readValidationFacts(error: unknown, rawInput: unknown): ValidationFacts {
+  if (!(error instanceof z.ZodError)) {
+    return {
+      invalidPaths: [],
+      issueCodes: ['validation_failed'],
+      missingPaths: [],
+      pathIssues: [],
+      unknownKeyCount: 0,
+      unknownKeys: [],
+    }
+  }
+
+  const missingPaths: string[] = []
+  const unknownKeys: string[] = []
+  let unknownKeyCount = 0
+  const invalidPaths: string[] = []
+  const issueCodes: string[] = []
+  const pathIssues: NonNullable<SafeToolCallValidationDigest['pathIssues']> = []
+
+  for (const issue of error.issues) {
+    const issueRecord = asRecord(issue)
+    const path = normalizeIssuePath(issueRecord?.path)
+    const rawCode = typeof issueRecord?.code === 'string' ? issueRecord.code : null
+
+    if (rawCode === 'unrecognized_keys') {
+      const parentPath = path && path !== 'root' ? path : null
+      const keys = Array.isArray(issueRecord?.keys) ? issueRecord.keys : []
+      for (const keyValue of keys) {
+        if (typeof keyValue !== 'string') {
+          continue
+        }
+        unknownKeyCount += 1
+        if (!isSafeSchemaLikeKey(keyValue)) {
+          continue
+        }
+        const keyPath = parentPath ? `${parentPath}.${keyValue}` : keyValue
+        unknownKeys.push(keyPath)
+        pathIssues.push({
+          path: keyPath,
+          code: 'unrecognized_key',
+          received: 'present',
+        })
+      }
+      issueCodes.push('unrecognized_key')
+      continue
+    }
+
+    if (!path) {
+      issueCodes.push(normalizeIssueCode(rawCode, null))
+      continue
+    }
+
+    const received = describeValueShape(readValueAtPath(rawInput, issueRecord?.path))
+    const code = normalizeIssueCode(rawCode, received)
+    issueCodes.push(code)
+
+    if (code === 'missing_required') {
+      missingPaths.push(path)
+    } else {
+      invalidPaths.push(path)
+    }
+
+    pathIssues.push(omitEmptyFields({
+      path,
+      code,
+      expected: describeExpectedShape(issueRecord),
+      received: received ?? undefined,
+    }))
+  }
+
+  return {
+    invalidPaths: uniqueSorted(invalidPaths).slice(0, MAX_PATHS),
+    issueCodes: uniqueSorted(issueCodes).slice(0, MAX_ISSUE_CODES),
+    missingPaths: uniqueSorted(missingPaths).slice(0, MAX_PATHS),
+    pathIssues: dedupePathIssues(pathIssues).slice(0, MAX_PATH_ISSUES),
+    unknownKeyCount,
+    unknownKeys: uniqueSorted(unknownKeys).slice(0, MAX_PATHS),
+  }
+}
+
+function normalizeIssueCode(
+  rawCode: string | null,
+  received: string | null,
+): string {
+  if (rawCode === 'invalid_type' && received === 'undefined') {
+    return 'missing_required'
+  }
+  if (!rawCode) {
+    return 'validation_failed'
+  }
+  const normalized = rawCode.replace(/[^a-z0-9_]+/g, '_').replace(/^_+|_+$/g, '')
+  return normalized.length > 0 && normalized.length <= 64
+    ? normalized
+    : 'validation_failed'
+}
+
+function describeExpectedShape(issue: Record<string, unknown> | null): string | undefined {
+  const code = typeof issue?.code === 'string' ? issue.code : null
+  const origin = typeof issue?.origin === 'string' ? normalizeShapeToken(issue.origin) : null
+  if ((code === 'too_small' || code === 'too_big') && origin) {
+    const bound = typeof issue?.minimum === 'number'
+      ? issue.minimum
+      : typeof issue?.maximum === 'number'
+        ? issue.maximum
+        : null
+    if (bound !== null && Number.isFinite(bound)) {
+      return `${origin}.${code === 'too_small' ? 'min' : 'max'}_${Math.max(0, Math.min(10_000, Math.trunc(bound)))}`
+    }
+    return origin
+  }
+
+  if (typeof issue?.expected === 'string') {
+    return normalizeShapeToken(issue.expected) ?? undefined
+  }
+
+  return origin ?? undefined
+}
+
+function buildInputShape(rawInput: unknown, safeRootKeys: string[]): string[] | undefined {
+  const shape = [`root.${describeValueShape(rawInput) ?? 'unknown'}`]
+  const rootRecord = asRecord(rawInput)
+  if (rootRecord) {
+    for (const key of safeRootKeys.slice(0, MAX_INPUT_SHAPE - 1)) {
+      shape.push(`${key}.${describeValueShape(rootRecord[key]) ?? 'unknown'}`)
+    }
+  }
+  return shape.length > 0 ? shape.slice(0, MAX_INPUT_SHAPE) : undefined
+}
+
+function readValueAtPath(rawInput: unknown, rawPath: unknown): unknown {
+  if (!Array.isArray(rawPath) || rawPath.length === 0) {
+    return rawInput
+  }
+
+  let current = rawInput
+  for (const segment of rawPath) {
+    if (typeof segment === 'string') {
+      const record = asRecord(current)
+      if (!record || !(segment in record)) {
+        return undefined
+      }
+      current = record[segment]
+      continue
+    }
+    if (typeof segment === 'number' && Number.isInteger(segment)) {
+      if (!Array.isArray(current) || segment < 0 || segment >= current.length) {
+        return undefined
+      }
+      current = current[segment]
+      continue
+    }
+    return undefined
+  }
+  return current
+}
+
+function normalizeIssuePath(rawPath: unknown): string | null {
+  if (!Array.isArray(rawPath) || rawPath.length === 0) {
+    return 'root'
+  }
+
+  const segments: string[] = []
+  for (const segment of rawPath) {
+    if (typeof segment === 'string') {
+      if (!isSafeSchemaLikeKey(segment)) {
+        return null
+      }
+      segments.push(segment)
+      continue
+    }
+    if (typeof segment === 'number' && Number.isInteger(segment) && segment >= 0) {
+      segments.push('[]')
+      continue
+    }
+    return null
+  }
+
+  return segments.join('.')
+}
+
+function describeValueShape(value: unknown): string | null {
+  if (value === undefined) {
+    return 'undefined'
+  }
+  if (value === null) {
+    return 'null'
+  }
+  if (typeof value === 'string') {
+    return `string.${bucketLength(value.length)}`
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? 'number' : 'number.nonfinite'
+  }
+  if (typeof value === 'boolean') {
+    return 'boolean'
+  }
+  if (Array.isArray(value)) {
+    return `array.${bucketCount(value.length)}`
+  }
+  if (typeof value === 'object') {
+    return `object.${bucketCount(Object.keys(value).length)}`
+  }
+  return 'unknown'
+}
+
+function getRootType(
+  value: unknown,
+): SafeToolCallValidationDigest['rootType'] {
+  if (value === null) {
+    return 'null'
+  }
+  if (Array.isArray(value)) {
+    return 'array'
+  }
+  switch (typeof value) {
+    case 'object':
+      return 'object'
+    case 'string':
+      return 'string'
+    case 'number':
+      return 'number'
+    case 'boolean':
+      return 'boolean'
+  }
+  return 'unknown'
+}
+
+function bucketLength(length: number): string {
+  if (length === 0) {
+    return 'len_0'
+  }
+  if (length <= 32) {
+    return 'len_1_32'
+  }
+  if (length <= 128) {
+    return 'len_33_128'
+  }
+  if (length <= 512) {
+    return 'len_129_512'
+  }
+  return 'len_gt_512'
+}
+
+function bucketCount(count: number): string {
+  if (count === 0) {
+    return 'count_0'
+  }
+  if (count <= 10) {
+    return 'count_1_10'
+  }
+  if (count <= 100) {
+    return 'count_11_100'
+  }
+  return 'count_gt_100'
+}
+
+function normalizeSafeIdentifier(value: string | null | undefined): string | undefined {
+  if (!value || value.length > 128) {
+    return undefined
+  }
+  return /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/.test(value)
+    ? value
+    : undefined
+}
+
+function normalizeShapeToken(value: string): string | null {
+  const normalized = value.replace(/[^a-z0-9_]+/gi, '_').toLowerCase().replace(/^_+|_+$/g, '')
+  return normalized.length > 0 && normalized.length <= 64 ? normalized : null
+}
+
+function dedupePathIssues(
+  issues: NonNullable<SafeToolCallValidationDigest['pathIssues']>,
+): NonNullable<SafeToolCallValidationDigest['pathIssues']> {
+  const byKey = new Map<string, NonNullable<SafeToolCallValidationDigest['pathIssues']>[number]>()
+  for (const issue of issues) {
+    const key = JSON.stringify(issue)
+    if (!byKey.has(key)) {
+      byKey.set(key, issue)
+    }
+  }
+  return [...byKey.values()].sort((left, right) =>
+    `${left.path}:${left.code}`.localeCompare(`${right.path}:${right.code}`),
+  )
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort()
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex')
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function omitEmptyFields<T extends Record<string, unknown>>(value: T): T {
+  for (const key of Object.keys(value)) {
+    const current = value[key]
+    if (current === undefined) {
+      delete value[key]
+      continue
+    }
+    if (Array.isArray(current) && current.length === 0) {
+      delete value[key]
+    }
+  }
+  return value
+}

--- a/packages/assistant-engine/src/assistant/tool-validation-digest.ts
+++ b/packages/assistant-engine/src/assistant/tool-validation-digest.ts
@@ -18,7 +18,6 @@ export interface SafeToolCallValidationDigest {
   rootKeyCount?: number
   unsafeRootKeyCount?: number
   missingPaths?: string[]
-  unknownKeys?: string[]
   unknownKeyCount?: number
   invalidPaths?: string[]
   issueCodes?: string[]
@@ -37,6 +36,7 @@ interface BuildSafeToolCallValidationDigestInput {
   requestedToolName?: string | null
   schemaFingerprint?: string | null
   schemaName?: string | null
+  schemaRootKeys?: readonly string[] | null
   toolName?: string | null
 }
 
@@ -46,7 +46,6 @@ interface ValidationFacts {
   missingPaths: string[]
   pathIssues: NonNullable<SafeToolCallValidationDigest['pathIssues']>
   unknownKeyCount: number
-  unknownKeys: string[]
 }
 
 const MAX_ROOT_KEYS = 16
@@ -61,20 +60,28 @@ export function buildSafeToolCallValidationDigest(
   const rootType = getRootType(input.rawInput)
   const rootRecord = asRecord(input.rawInput)
   const rootKeys = rootRecord ? Object.keys(rootRecord) : []
-  const safeRootKeys = uniqueSorted(rootKeys.filter(isSafeSchemaLikeKey))
-  const inputShape = buildInputShape(input.rawInput, safeRootKeys)
-  const facts = readValidationFacts(input.error, input.rawInput)
+  const schemaRootKeySet = normalizeSchemaRootKeySet(input.schemaRootKeys)
+  const schemaRootKeysPresent = schemaRootKeySet
+    ? uniqueSorted(rootKeys.filter((key) => schemaRootKeySet.has(key))).slice(0, MAX_ROOT_KEYS)
+    : []
+  const unsafeRootKeyCount = schemaRootKeySet
+    ? rootKeys.length - schemaRootKeysPresent.length
+    : rootKeys.length
+  const inputShape = buildInputShape(input.rawInput, schemaRootKeysPresent)
+  const facts = readValidationFacts(input.error, input.rawInput, schemaRootKeySet)
 
   const fingerprintFacts = {
     invalidPaths: facts.invalidPaths,
     issueCodes: facts.issueCodes,
     missingPaths: facts.missingPaths,
     pathIssues: facts.pathIssues,
-    rootKeysPresent: safeRootKeys.slice(0, MAX_ROOT_KEYS),
+    rootKeyCount: rootKeys.length,
+    rootKeysPresent: schemaRootKeysPresent,
     rootType,
     schemaFingerprint: normalizeSafeIdentifier(input.schemaFingerprint),
     toolName: normalizeSafeIdentifier(input.toolName),
-    unknownKeys: facts.unknownKeys,
+    unknownKeyCount: facts.unknownKeyCount,
+    unsafeRootKeyCount,
   }
   const validationFingerprint = `tvd_${hashJson(fingerprintFacts).slice(0, 12)}`
 
@@ -86,13 +93,12 @@ export function buildSafeToolCallValidationDigest(
     schemaFingerprint: normalizeSafeIdentifier(input.schemaFingerprint),
     validationFingerprint,
     rootType,
-    rootKeysPresent: safeRootKeys.slice(0, MAX_ROOT_KEYS),
+    rootKeysPresent: schemaRootKeysPresent,
     rootKeyCount: rootKeys.length > 0 ? rootKeys.length : undefined,
-    unsafeRootKeyCount: rootKeys.length - safeRootKeys.length > 0
-      ? rootKeys.length - safeRootKeys.length
+    unsafeRootKeyCount: unsafeRootKeyCount > 0
+      ? unsafeRootKeyCount
       : undefined,
     missingPaths: facts.missingPaths,
-    unknownKeys: facts.unknownKeys,
     unknownKeyCount: facts.unknownKeyCount > 0 ? facts.unknownKeyCount : undefined,
     invalidPaths: facts.invalidPaths,
     issueCodes: facts.issueCodes,
@@ -111,7 +117,11 @@ export function isSafeSchemaLikeKey(key: string): boolean {
   )
 }
 
-function readValidationFacts(error: unknown, rawInput: unknown): ValidationFacts {
+function readValidationFacts(
+  error: unknown,
+  rawInput: unknown,
+  schemaRootKeySet: ReadonlySet<string> | null,
+): ValidationFacts {
   if (!(error instanceof z.ZodError)) {
     return {
       invalidPaths: [],
@@ -119,12 +129,10 @@ function readValidationFacts(error: unknown, rawInput: unknown): ValidationFacts
       missingPaths: [],
       pathIssues: [],
       unknownKeyCount: 0,
-      unknownKeys: [],
     }
   }
 
   const missingPaths: string[] = []
-  const unknownKeys: string[] = []
   let unknownKeyCount = 0
   const invalidPaths: string[] = []
   const issueCodes: string[] = []
@@ -132,26 +140,25 @@ function readValidationFacts(error: unknown, rawInput: unknown): ValidationFacts
 
   for (const issue of error.issues) {
     const issueRecord = asRecord(issue)
-    const path = normalizeIssuePath(issueRecord?.path)
+    const path = normalizeIssuePath(issueRecord?.path, schemaRootKeySet)
     const rawCode = typeof issueRecord?.code === 'string' ? issueRecord.code : null
 
     if (rawCode === 'unrecognized_keys') {
       const parentPath = path && path !== 'root' ? path : null
       const keys = Array.isArray(issueRecord?.keys) ? issueRecord.keys : []
+      let recognizedUnknownKeyCount = 0
       for (const keyValue of keys) {
         if (typeof keyValue !== 'string') {
           continue
         }
         unknownKeyCount += 1
-        if (!isSafeSchemaLikeKey(keyValue)) {
-          continue
-        }
-        const keyPath = parentPath ? `${parentPath}.${keyValue}` : keyValue
-        unknownKeys.push(keyPath)
+        recognizedUnknownKeyCount += 1
+      }
+      if (recognizedUnknownKeyCount > 0) {
         pathIssues.push({
-          path: keyPath,
+          path: parentPath ?? 'root',
           code: 'unrecognized_key',
-          received: 'present',
+          received: `keys.${bucketCount(recognizedUnknownKeyCount)}`,
         })
       }
       issueCodes.push('unrecognized_key')
@@ -187,7 +194,6 @@ function readValidationFacts(error: unknown, rawInput: unknown): ValidationFacts
     missingPaths: uniqueSorted(missingPaths).slice(0, MAX_PATHS),
     pathIssues: dedupePathIssues(pathIssues).slice(0, MAX_PATH_ISSUES),
     unknownKeyCount,
-    unknownKeys: uniqueSorted(unknownKeys).slice(0, MAX_PATHS),
   }
 }
 
@@ -267,15 +273,25 @@ function readValueAtPath(rawInput: unknown, rawPath: unknown): unknown {
   return current
 }
 
-function normalizeIssuePath(rawPath: unknown): string | null {
+function normalizeIssuePath(
+  rawPath: unknown,
+  schemaRootKeySet: ReadonlySet<string> | null,
+): string | null {
   if (!Array.isArray(rawPath) || rawPath.length === 0) {
     return 'root'
   }
 
   const segments: string[] = []
-  for (const segment of rawPath) {
+  for (const [index, segment] of rawPath.entries()) {
     if (typeof segment === 'string') {
       if (!isSafeSchemaLikeKey(segment)) {
+        return null
+      }
+      if (index === 0) {
+        if (!schemaRootKeySet || !schemaRootKeySet.has(segment)) {
+          return null
+        }
+      } else {
         return null
       }
       segments.push(segment)
@@ -289,6 +305,13 @@ function normalizeIssuePath(rawPath: unknown): string | null {
   }
 
   return segments.join('.')
+}
+
+function normalizeSchemaRootKeySet(keys: readonly string[] | null | undefined): ReadonlySet<string> | null {
+  if (!keys || keys.length === 0) {
+    return null
+  }
+  return new Set(keys.filter(isSafeSchemaLikeKey).slice(0, MAX_ROOT_KEYS))
 }
 
 function describeValueShape(value: unknown): string | null {

--- a/packages/assistant-engine/src/index.ts
+++ b/packages/assistant-engine/src/index.ts
@@ -12,6 +12,9 @@ export * from './assistant-context-snapshot.js'
 export {
   readAssistantCliSurfaceBootstrapContext,
 } from './assistant/cli-surface-bootstrap.js'
+export {
+  flushPendingAssistantRuntimeIssueWrites,
+} from './assistant/issue-reporting.js'
 export * from './assistant/device-activity-automations.js'
 export * from './assistant/managed-automations.js'
 export * from './assistant-cron.js'

--- a/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
@@ -40,7 +40,7 @@ const providerMocks = vi.hoisted(() => ({
 const providerTurnRunnerMocks = vi.hoisted(() => ({
   buildCodexTurnExecutionPlan: vi.fn(),
   buildCodexTurnAttemptPlan: vi.fn(),
-  recordAssistantToolFailureRuntimeIssues: vi.fn(),
+  recordAssistantRuntimeIssueInputsBestEffort: vi.fn(),
   recordCodexAttemptFailed: vi.fn(),
   recordCodexAttemptStarted: vi.fn(),
   recordCodexAttemptSucceeded: vi.fn(),
@@ -74,8 +74,8 @@ vi.mock('../src/assistant/codex-turn/attempt-observability.js', () => ({
 }))
 
 vi.mock('../src/assistant/issue-reporting.js', () => ({
-  recordAssistantToolFailureRuntimeIssues:
-    providerTurnRunnerMocks.recordAssistantToolFailureRuntimeIssues,
+  recordAssistantRuntimeIssueInputsBestEffort:
+    providerTurnRunnerMocks.recordAssistantRuntimeIssueInputsBestEffort,
 }))
 
 import { createAssistantModelTarget } from '@murphai/operator-config/assistant-backend'
@@ -119,7 +119,7 @@ afterEach(() => {
   providerMocks.resolveCodexStaticModels.mockReset()
   providerTurnRunnerMocks.buildCodexTurnExecutionPlan.mockReset()
   providerTurnRunnerMocks.buildCodexTurnAttemptPlan.mockReset()
-  providerTurnRunnerMocks.recordAssistantToolFailureRuntimeIssues.mockReset()
+  providerTurnRunnerMocks.recordAssistantRuntimeIssueInputsBestEffort.mockReset()
   providerTurnRunnerMocks.recordCodexAttemptFailed.mockReset()
   providerTurnRunnerMocks.recordCodexAttemptStarted.mockReset()
   providerTurnRunnerMocks.recordCodexAttemptSucceeded.mockReset()
@@ -308,6 +308,7 @@ function createProviderAttemptResult(): AssistantProviderTurnAttemptResult {
       executedToolCount: 0,
       providerActionCount: 0,
       rawToolEvents: [],
+      runtimeIssueInputs: [],
     },
     ok: true,
     result,
@@ -641,6 +642,264 @@ describe('Codex model catalog', () => {
     )
   })
 
+  it('does not wait for runtime issue recording on a successful turn', async () => {
+    const route = createRoute()
+    const session = createAssistantSession({
+      providerOptions: route.providerOptions,
+    })
+    const input = {
+      prompt: 'Run the turn.',
+      vault: '/vaults/test',
+    } satisfies Parameters<typeof executeCodexTurnWithRecovery>[0]['input']
+    const runtimeIssueInput = {
+      component: 'assistant.codex-action',
+      details: {
+        actionKind: 'command.execution',
+        durationMsBucket: 'lt_1s',
+        exitCode: 1,
+        outputBytesBucket: '0',
+      },
+      errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+      issueKind: 'tool_error' as const,
+      operation: 'command.execution',
+      phase: 'provider_turn' as const,
+      severity: 'warning' as const,
+      summary: 'Codex command execution failed during provider turn.',
+    }
+    const providerAttempt = createProviderAttemptResult()
+    providerMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
+      supportedUserMessageContentTypes: ['text'],
+      supportsReasoningEffort: true,
+    })
+    providerMocks.executeCodexAssistantTurnAttemptFromInput.mockResolvedValue({
+      ...providerAttempt,
+      metadata: {
+        ...providerAttempt.metadata,
+        runtimeIssueInputs: [runtimeIssueInput],
+      },
+    })
+    providerTurnRunnerMocks.recordAssistantRuntimeIssueInputsBestEffort.mockReturnValue(
+      new Promise(() => undefined),
+    )
+    providerTurnRunnerMocks.buildCodexTurnExecutionPlan.mockResolvedValue({
+      activeTurnSteering: null,
+      executionContext: {
+        hosted: {
+          memberId: 'member-runtime-issue',
+          userEnvKeys: [],
+        },
+      },
+      input,
+      profile: {
+        promptProfile: 'conversation',
+        toolProfile: 'provider-turn',
+        threadScope: 'session-thread',
+      },
+      promptTimeContext: {
+        currentLocalDate: '2026-04-29',
+        currentTimeZone: 'UTC',
+      },
+      route,
+      sharedPlan: createSharedPlan(),
+      turnId: 'turn-runtime-issue',
+    } satisfies AssistantCodexTurnExecutionPlan)
+    providerTurnRunnerMocks.buildCodexTurnAttemptPlan.mockResolvedValue({
+      attemptCount: 1,
+      route,
+      routePlan: {
+        assistantContractFingerprint:
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        assistantCliContract: null,
+        cliEnv: {},
+        developerInstructions: null,
+        diagnosticsPolicy: {
+          environment: 'local',
+          privateIssueCaptureEnabled: true,
+          surface: null,
+        },
+        onboardingGuidanceInjected: false,
+        codexContinuation: {
+          kind: 'explicit-structured-history',
+        } satisfies AssistantCodexContinuation,
+        planningDiagnostics: createRoutePlanningDiagnostics(),
+        promptCacheMetadata: null,
+        resume: null,
+        sessionContext: undefined,
+        systemPrompt: null,
+        turnContextPrompt: null,
+        workingDirectory: '/work',
+      } satisfies AssistantRouteTurnPlan,
+      session,
+    } satisfies AssistantCodexAttemptPlan)
+
+    const outcome = await executeCodexTurnWithRecovery({
+      input,
+      plan: createSharedPlan(),
+      resolvedSession: session,
+      route,
+      turnCreatedAt: '2026-04-29T00:00:00.000Z',
+      turnId: 'turn-runtime-issue',
+    })
+
+    expect(outcome.kind).toBe('succeeded')
+    expect(
+      providerTurnRunnerMocks.recordAssistantRuntimeIssueInputsBestEffort,
+    ).toHaveBeenCalledWith({
+      issues: [runtimeIssueInput],
+      policy: {
+        environment: 'local',
+        privateIssueCaptureEnabled: true,
+        surface: null,
+      },
+      vault: '/vaults/test',
+    })
+  })
+
+  it('records a terminal provider runtime issue when a Codex attempt fails', async () => {
+    const route = createRoute()
+    const session = createAssistantSession({
+      providerOptions: route.providerOptions,
+    })
+    const input = {
+      prompt: 'Run the turn.',
+      vault: '/vaults/test',
+    } satisfies Parameters<typeof executeCodexTurnWithRecovery>[0]['input']
+    const providerError = Object.assign(new Error('Codex failed.'), {
+      code: 'ASSISTANT_CODEX_FAILED',
+    })
+    const failedProviderAttempt: AssistantProviderTurnAttemptResult = {
+      codexThreadId: 'thread-terminal-provider-failure',
+      error: providerError,
+      metadata: {
+        activityLabels: ['Run Command'],
+        executedToolCount: 0,
+        providerActionCount: 3,
+        rawToolEvents: [],
+        runtimeIssueInputs: [],
+      },
+      ok: false,
+      providerRequestOutcome: 'failed',
+      providerTurnId: 'turn-terminal-provider-failure',
+      rawEvents: [
+        { event: 'item.started' },
+        { event: 'item.completed' },
+      ],
+      usage: null,
+    }
+
+    providerMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
+      supportedUserMessageContentTypes: ['text'],
+      supportsReasoningEffort: true,
+    })
+    providerMocks.executeCodexAssistantTurnAttemptFromInput.mockResolvedValue(
+      failedProviderAttempt,
+    )
+    providerTurnRunnerMocks.buildCodexTurnExecutionPlan.mockResolvedValue({
+      activeTurnSteering: null,
+      executionContext: {
+        hosted: {
+          memberId: 'member-terminal-provider-failure',
+          userEnvKeys: [],
+        },
+      },
+      input,
+      profile: {
+        promptProfile: 'conversation',
+        toolProfile: 'provider-turn',
+        threadScope: 'session-thread',
+      },
+      promptTimeContext: {
+        currentLocalDate: '2026-04-29',
+        currentTimeZone: 'UTC',
+      },
+      route,
+      sharedPlan: createSharedPlan(),
+      turnId: 'turn-terminal-provider-failure',
+    } satisfies AssistantCodexTurnExecutionPlan)
+    providerTurnRunnerMocks.buildCodexTurnAttemptPlan.mockResolvedValue({
+      attemptCount: 1,
+      route,
+      routePlan: {
+        assistantContractFingerprint:
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        assistantCliContract: null,
+        cliEnv: {},
+        developerInstructions: null,
+        diagnosticsPolicy: {
+          environment: 'hosted',
+          privateIssueCaptureEnabled: true,
+          surface: 'linq',
+        },
+        onboardingGuidanceInjected: false,
+        codexContinuation: {
+          kind: 'explicit-structured-history',
+        } satisfies AssistantCodexContinuation,
+        planningDiagnostics: createRoutePlanningDiagnostics(),
+        promptCacheMetadata: null,
+        resume: null,
+        sessionContext: undefined,
+        systemPrompt: null,
+        turnContextPrompt: null,
+        workingDirectory: '/work',
+      } satisfies AssistantRouteTurnPlan,
+      session,
+    } satisfies AssistantCodexAttemptPlan)
+
+    const outcome = await executeCodexTurnWithRecovery({
+      input,
+      plan: createSharedPlan(),
+      providerRequestOrdinal: 1,
+      resolvedSession: session,
+      route,
+      turnCreatedAt: '2026-04-29T00:00:00.000Z',
+      turnId: 'turn-terminal-provider-failure',
+    })
+
+    expect(outcome).toMatchObject({
+      kind: 'failed_terminal',
+      codexThreadId: 'thread-terminal-provider-failure',
+      providerRequestOutcome: 'failed',
+      providerTurnId: 'turn-terminal-provider-failure',
+    })
+    expect(
+      providerTurnRunnerMocks.recordAssistantRuntimeIssueInputsBestEffort,
+    ).toHaveBeenNthCalledWith(1, {
+      issues: [],
+      policy: {
+        environment: 'hosted',
+        privateIssueCaptureEnabled: true,
+        surface: 'linq',
+      },
+      vault: '/vaults/test',
+    })
+    expect(
+      providerTurnRunnerMocks.recordAssistantRuntimeIssueInputsBestEffort,
+    ).toHaveBeenNthCalledWith(2, {
+      issues: [
+        {
+          component: 'assistant.codex-provider',
+          details: {
+            providerActionCount: 3,
+            providerRequestOutcome: 'failed',
+            rawEventCountBucket: '2_5',
+          },
+          errorCode: 'ASSISTANT_CODEX_FAILED',
+          issueKind: 'tool_error',
+          operation: 'codex-cli',
+          phase: 'provider_turn',
+          severity: 'error',
+          summary: 'Codex provider turn failed.',
+        },
+      ],
+      policy: {
+        environment: 'hosted',
+        privateIssueCaptureEnabled: true,
+        surface: 'linq',
+      },
+      vault: '/vaults/test',
+    })
+  })
+
   it('drops flex service tier for hosted OpenAI routes without catalog evidence', async () => {
     const route = createRoute({
       providerOptions: {
@@ -903,10 +1162,6 @@ describe('Codex model catalog', () => {
     providerMocks.executeCodexAssistantTurnAttemptFromInput.mockResolvedValue(
       createProviderAttemptResult(),
     )
-    providerTurnRunnerMocks.recordAssistantToolFailureRuntimeIssues.mockResolvedValue(
-      undefined,
-    )
-
     const outcome = await executeCodexTurnWithRecovery({
       input,
       plan: createSharedPlan(),

--- a/packages/assistant-engine/test/assistant-codex-generate-image-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-generate-image-tool.test.ts
@@ -383,11 +383,10 @@ describe('murph.generate_image dynamic tool execution', () => {
         toolName: 'murph.generate_image',
         schemaName: 'murph.generate_image.input',
         rootType: 'object',
-        rootKeysPresent: ['imageUrl', 'prompt', 'promptText'],
+        rootKeysPresent: ['prompt'],
         rootKeyCount: 4,
-        unsafeRootKeyCount: 1,
+        unsafeRootKeyCount: 3,
         invalidPaths: ['prompt'],
-        unknownKeys: ['imageUrl', 'promptText'],
         unknownKeyCount: 3,
       },
     })
@@ -404,11 +403,14 @@ describe('murph.generate_image dynamic tool execution', () => {
         received: 'number',
       }),
       expect.objectContaining({
-        path: 'promptText',
+        path: 'root',
         code: 'unrecognized_key',
+        received: 'keys.count_1_10',
       }),
     ]))
     const serialized = JSON.stringify(request.validationDigest)
+    expect(serialized).not.toContain('promptText')
+    expect(serialized).not.toContain('imageUrl')
     expect(serialized).not.toContain('Render a private product label.')
     expect(serialized).not.toContain('https://private.example.test/image.png')
     expect(serialized).not.toContain('AG1')

--- a/packages/assistant-engine/test/assistant-codex-generate-image-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-generate-image-tool.test.ts
@@ -360,6 +360,61 @@ describe('executeGenerateImageTool', () => {
 })
 
 describe('murph.generate_image dynamic tool execution', () => {
+  it('returns a value-free validation digest for invalid image arguments', () => {
+    const request = readMurphDynamicToolRequest({
+      id: 10,
+      method: 'item/tool/call',
+      params: {
+        arguments: {
+          prompt: 12,
+          promptText: 'Render a private product label.',
+          imageUrl: 'https://private.example.test/image.png',
+          AG1: 'unsafe key value',
+        },
+        namespace: 'murph',
+        tool: 'generate_image',
+      },
+    })
+
+    expect(request).toMatchObject({
+      kind: 'invalid-generate-image-arguments',
+      validationDigest: {
+        detailsSchema: 'murph.tool-call-validation-digest.v1',
+        toolName: 'murph.generate_image',
+        schemaName: 'murph.generate_image.input',
+        rootType: 'object',
+        rootKeysPresent: ['imageUrl', 'prompt', 'promptText'],
+        rootKeyCount: 4,
+        unsafeRootKeyCount: 1,
+        invalidPaths: ['prompt'],
+        unknownKeys: ['imageUrl', 'promptText'],
+        unknownKeyCount: 3,
+      },
+    })
+    if (!request || request.kind !== 'invalid-generate-image-arguments') {
+      throw new Error('expected invalid generate image arguments')
+    }
+
+    expect(request.validationDigest.validationFingerprint).toMatch(/^tvd_[a-f0-9]{12}$/)
+    expect(request.validationDigest.pathIssues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: 'prompt',
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'number',
+      }),
+      expect.objectContaining({
+        path: 'promptText',
+        code: 'unrecognized_key',
+      }),
+    ]))
+    const serialized = JSON.stringify(request.validationDigest)
+    expect(serialized).not.toContain('Render a private product label.')
+    expect(serialized).not.toContain('https://private.example.test/image.png')
+    expect(serialized).not.toContain('AG1')
+    expect(serialized).not.toContain('unsafe key value')
+  })
+
   it('parses a Codex dynamic tool call and appends hosted media with image usage', async () => {
     const uploader = {
       uploadGeneratedImage: vi.fn(async (input) => ({

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -42,6 +42,7 @@ import {
 } from '../src/assistant-codex.ts'
 import type { CodexAppServerLiveTurn } from '../src/assistant-codex.ts'
 import {
+  buildRuntimeIssueInputForFailedCodexAction,
   CODEX_ACTION_DIAGNOSTICS_TRACE_SCHEMA,
   CODEX_ACTION_DIAGNOSTICS_TRACE_TYPE,
   createCodexActionDiagnosticsReducer,
@@ -5029,6 +5030,175 @@ describe('assistant codex runtime', () => {
     expect(JSON.stringify(trace)).not.toContain('raw output')
   })
 
+  it('builds privacy-safe runtime issues for failed Codex action events', () => {
+    const failedCommandEvent = {
+      event: 'item.completed',
+      data: {
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          exitCode: 2,
+          durationMs: 6_000,
+          commandLabel: 'cat /tmp/private-file',
+          filePaths: ['/tmp/private-file'],
+          stdout: 'private stdout',
+          stderr: 'private stderr',
+          aggregatedOutput: 'private aggregate',
+        },
+      },
+    }
+    expect(
+      buildRuntimeIssueInputForFailedCodexAction({
+        normalizedEvent: normalizeCodexEvent(failedCommandEvent),
+        rawEvent: failedCommandEvent,
+      }),
+    ).toEqual({
+      component: 'assistant.codex-action',
+      operation: 'command.execution',
+      phase: 'provider_turn',
+      issueKind: 'tool_error',
+      severity: 'warning',
+      errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+      summary: 'Codex command execution failed during provider turn.',
+      details: {
+        actionKind: 'command.execution',
+        durationMsBucket: '5_30s',
+        exitCode: 2,
+        outputBytesBucket: 'lt_1kb',
+      },
+    })
+
+    const successfulCommandEvent = {
+      event: 'item.completed',
+      data: {
+        item: {
+          id: 'cmd-2',
+          type: 'commandExecution',
+          exitCode: 0,
+          stdout: 'ok',
+        },
+      },
+    }
+    expect(
+      buildRuntimeIssueInputForFailedCodexAction({
+        normalizedEvent: normalizeCodexEvent(successfulCommandEvent),
+        rawEvent: successfulCommandEvent,
+      }),
+    ).toBeNull()
+
+    const failedSnakeCaseCommandEvent = {
+      event: 'item.completed',
+      data: {
+        item: {
+          id: 'cmd-3',
+          type: 'command_execution',
+          exit_code: '2',
+          duration_ms: '120',
+        },
+      },
+    }
+    expect(
+      buildRuntimeIssueInputForFailedCodexAction({
+        normalizedEvent: normalizeCodexEvent(failedSnakeCaseCommandEvent),
+        rawEvent: failedSnakeCaseCommandEvent,
+      }),
+    ).toMatchObject({
+      component: 'assistant.codex-action',
+      operation: 'command.execution',
+      errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+      details: {
+        exitCode: 2,
+      },
+    })
+
+    const failedMcpEvent = {
+      event: 'item.completed',
+      data: {
+        item: {
+          id: 'mcp-1',
+          type: 'mcpToolCall',
+          status: 'failed',
+          server_name: 'web',
+          name: 'search_query',
+          result: {
+            content: [
+              {
+                type: 'text',
+                text: 'mcp private output',
+              },
+            ],
+          },
+        },
+      },
+    }
+    expect(
+      buildRuntimeIssueInputForFailedCodexAction({
+        normalizedEvent: normalizeCodexEvent(failedMcpEvent),
+        rawEvent: failedMcpEvent,
+      }),
+    ).toEqual({
+      component: 'assistant.codex-action',
+      operation: 'mcp.tool.call',
+      phase: 'tool_call',
+      issueKind: 'tool_error',
+      severity: 'warning',
+      errorCode: 'CODEX_TOOL_CALL_FAILED',
+      summary: 'Codex tool call failed during provider turn.',
+      details: {
+        actionKind: 'mcp.tool.call',
+        durationMsBucket: 'unknown',
+        outputBytesBucket: 'lt_1kb',
+      },
+    })
+
+    const failedDynamicEvent = {
+      event: 'item.completed',
+      data: {
+        item: {
+          id: 'dynamic-1',
+          type: 'dynamicToolCall',
+          success: false,
+          arguments: {
+            prompt: 'private prompt',
+          },
+          formattedOutput: 'dynamic private output',
+        },
+      },
+    }
+    const dynamicIssue = buildRuntimeIssueInputForFailedCodexAction({
+      normalizedEvent: normalizeCodexEvent(failedDynamicEvent),
+      rawEvent: failedDynamicEvent,
+    })
+    expect(dynamicIssue).toEqual({
+      component: 'assistant.codex-action',
+      operation: 'dynamic.tool.call',
+      phase: 'tool_call',
+      issueKind: 'tool_error',
+      severity: 'warning',
+      errorCode: 'CODEX_DYNAMIC_TOOL_CALL_FAILED',
+      summary: 'Codex dynamic tool call failed during provider turn.',
+      details: {
+        actionKind: 'dynamic.tool.call',
+        durationMsBucket: 'unknown',
+        outputBytesBucket: 'lt_1kb',
+      },
+    })
+
+    const encodedIssues = JSON.stringify([
+      dynamicIssue,
+      buildRuntimeIssueInputForFailedCodexAction({
+        normalizedEvent: normalizeCodexEvent(failedCommandEvent),
+        rawEvent: failedCommandEvent,
+      }),
+    ])
+    expect(encodedIssues).not.toContain('private stdout')
+    expect(encodedIssues).not.toContain('private stderr')
+    expect(encodedIssues).not.toContain('private aggregate')
+    expect(encodedIssues).not.toContain('/tmp/private-file')
+    expect(encodedIssues).not.toContain('private prompt')
+    expect(encodedIssues).not.toContain('dynamic private output')
+  })
+
   it('dedupes Codex action diagnostics without item ids when normalized identity is available', () => {
     const reducer = createCodexActionDiagnosticsReducer()
     const activeTurnId = 'turn-current'
@@ -9325,16 +9495,40 @@ describe('assistant codex runtime', () => {
       return child
     })
 
-    await expect(
-      executeCodexAppServerTurn({
-        prompt: 'try invalid progress tool',
-        progressDelivery,
-        workingDirectory,
-      }),
-    ).resolves.toMatchObject({
+    const result = await executeCodexAppServerTurn({
+      prompt: 'try invalid progress tool',
+      progressDelivery,
+      workingDirectory,
+    })
+    expect(result).toMatchObject({
       sessionId: 'thread-progress-invalid',
     })
     expect(progressDelivery.send).not.toHaveBeenCalled()
+    expect(result.runtimeIssueInputs).toEqual([
+      expect.objectContaining({
+        component: 'assistant.tool-validation',
+        operation: 'murph.send_progress_update',
+        phase: 'tool_call',
+        issueKind: 'schema_rejection',
+        severity: 'warning',
+        errorCode: 'TOOL_INPUT_SCHEMA_REJECTION',
+        summary: 'Tool input failed schema validation.',
+        details: expect.objectContaining({
+          detailsSchema: 'murph.tool-call-validation-digest.v1',
+          toolName: 'murph.send_progress_update',
+          schemaName: 'murph.send_progress_update.input',
+          rootType: 'object',
+          rootKeysPresent: ['text'],
+          invalidPaths: ['text'],
+          issueCodes: ['too_small'],
+          inputShape: [
+            'root.object.count_1_10',
+            'text.string.len_0',
+          ],
+        }),
+      }),
+    ])
+    expect(JSON.stringify(result.runtimeIssueInputs)).not.toContain('arguments')
   })
 
   it('handles progress dynamic tool calls on resumed threads when a real sink exists', async () => {

--- a/packages/assistant-engine/test/assistant-product-small-seams.test.ts
+++ b/packages/assistant-engine/test/assistant-product-small-seams.test.ts
@@ -15,6 +15,8 @@ import {
   resolveAssistantConversationPolicy,
 } from '../src/assistant/conversation-policy.ts'
 import {
+  flushPendingAssistantRuntimeIssueWrites,
+  recordAssistantRuntimeIssueInputsBestEffort,
   recordAssistantRuntimeIssue,
   recordAssistantToolFailureRuntimeIssues,
   resolveAssistantDiagnosticsPolicy,
@@ -751,6 +753,126 @@ describe('assistant product small seams', () => {
         operation: 'cleanup',
       }),
     })
+  })
+
+  it('records runtime issue inputs best-effort without blocking or exceeding the cap', async () => {
+    runtimeStateMocks.writePendingAssistantRuntimeIssueRecord.mockRejectedValue(
+      new Error('write failed'),
+    )
+
+    const policy = resolveAssistantDiagnosticsPolicy({
+      channel: 'telegram',
+      env: {
+        MURPH_ASSISTANT_PRIVATE_ISSUES: 'true',
+      },
+      executionContext: null,
+    })
+    const issues = Array.from({ length: 10 }, (_, index) => ({
+      component: 'assistant.codex-action',
+      details: {
+        unsafeText: `token=secret-value /tmp/private-${index}.log`,
+      },
+      errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+      issueKind: 'tool_error' as const,
+      operation: 'command.execution',
+      phase: 'provider_turn' as const,
+      severity: 'warning' as const,
+      summary: 'Codex command execution failed during provider turn.',
+    }))
+
+    expect(() => {
+      recordAssistantRuntimeIssueInputsBestEffort({
+        issues,
+        policy,
+        vault: '/vaults/test',
+      })
+    }).not.toThrow()
+
+    expect(
+      runtimeStateMocks.writePendingAssistantRuntimeIssueRecord,
+    ).toHaveBeenCalledTimes(8)
+    const firstRecord =
+      runtimeStateMocks.writePendingAssistantRuntimeIssueRecord.mock.calls[0]?.[0]?.record
+    expect(firstRecord).toMatchObject({
+      component: 'assistant.codex-action',
+      details: {
+        unsafeText: expect.stringContaining('[path]'),
+      },
+      errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+      issueKind: 'tool_error',
+      operation: 'command.execution',
+      phase: 'provider_turn',
+      severity: 'warning',
+      surface: 'telegram',
+      summary: 'Codex command execution failed during provider turn.',
+    })
+    expect(JSON.stringify(firstRecord)).not.toContain('secret-value')
+    expect(JSON.stringify(firstRecord)).not.toContain('/tmp/private')
+
+    runtimeStateMocks.writePendingAssistantRuntimeIssueRecord.mockClear()
+    recordAssistantRuntimeIssueInputsBestEffort({
+      issues,
+      policy: {
+        ...policy,
+        privateIssueCaptureEnabled: false,
+      },
+      vault: '/vaults/test',
+    })
+    expect(
+      runtimeStateMocks.writePendingAssistantRuntimeIssueRecord,
+    ).not.toHaveBeenCalled()
+    await flushPendingAssistantRuntimeIssueWrites()
+  })
+
+  it('flushes pending best-effort runtime issue writes on demand', async () => {
+    let resolveWrite!: () => void
+    runtimeStateMocks.writePendingAssistantRuntimeIssueRecord.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        resolveWrite = resolve
+      }),
+    )
+
+    const policy = resolveAssistantDiagnosticsPolicy({
+      channel: 'linq',
+      env: {
+        MURPH_ASSISTANT_PRIVATE_ISSUES: 'true',
+      },
+      executionContext: null,
+    })
+
+    recordAssistantRuntimeIssueInputsBestEffort({
+      issues: [
+        {
+          component: 'assistant.codex-provider',
+          details: {
+            providerActionCount: 1,
+            providerRequestOutcome: 'failed',
+            rawEventCountBucket: '1',
+          },
+          errorCode: 'ASSISTANT_CODEX_PROVIDER_FAILED',
+          issueKind: 'tool_error',
+          operation: 'codex-cli',
+          phase: 'provider_turn',
+          severity: 'error',
+          summary: 'Codex provider turn failed.',
+        },
+      ],
+      policy,
+      vault: '/vaults/test',
+    })
+
+    expect(runtimeStateMocks.writePendingAssistantRuntimeIssueRecord).toHaveBeenCalledOnce()
+
+    let flushed = false
+    const flush = flushPendingAssistantRuntimeIssueWrites().then(() => {
+      flushed = true
+    })
+    await Promise.resolve()
+    expect(flushed).toBe(false)
+
+    resolveWrite()
+    await flush
+    expect(flushed).toBe(true)
   })
 
   it('extracts and classifies tool failure runtime issues from provider events', async () => {

--- a/packages/assistant-engine/test/codex-runtime-helpers.test.ts
+++ b/packages/assistant-engine/test/codex-runtime-helpers.test.ts
@@ -1999,8 +1999,109 @@ describe('Codex assistant registry helpers', () => {
       executedToolCount: 0,
       rawToolEvents: [],
       providerActionCount: 1,
+      runtimeIssueInputs: [],
     })
     expect(attempt.result).toEqual(executionResult)
+  })
+
+  it('propagates app-server runtime issue inputs through provider metadata', async () => {
+    const runtimeIssueInput = {
+      component: 'assistant.codex-action',
+      details: {
+        actionKind: 'command.execution',
+        durationMsBucket: 'lt_1s',
+        exitCode: 1,
+        outputBytesBucket: '0',
+      },
+      errorCode: 'CODEX_COMMAND_EXIT_NONZERO',
+      issueKind: 'tool_error' as const,
+      operation: 'command.execution',
+      phase: 'provider_turn' as const,
+      severity: 'warning' as const,
+      summary: 'Codex command execution failed during provider turn.',
+    }
+
+    codexAppServerMocks.executeCodexAppServerTurn.mockResolvedValueOnce({
+      finalMessage: 'Final answer.',
+      jsonEvents: [],
+      providerActionCount: 1,
+      responseMedia: [],
+      runtimeIssueInputs: [runtimeIssueInput],
+      sessionId: 'provider-session-issues',
+      stderr: '',
+      stdout: '',
+      threadId: 'provider-session-issues',
+      turnId: 'turn-issues',
+    })
+
+    const attempt = await executeCodexAssistantTurnAttempt({
+      providerConfig: normalizeAssistantProviderConfig({
+        provider: 'codex-cli',
+      }),
+      userPrompt: 'Run the turn.',
+      workingDirectory: '/tmp/provider-tests',
+    })
+
+    expect(attempt.ok).toBe(true)
+    if (!attempt.ok) {
+      throw new Error('expected successful provider attempt')
+    }
+
+    expect(attempt.metadata).toMatchObject({
+      providerActionCount: 1,
+      rawToolEvents: [],
+      runtimeIssueInputs: [runtimeIssueInput],
+    })
+  })
+
+  it('propagates failure-context runtime issue inputs through failed provider metadata', async () => {
+    const runtimeIssueInput = {
+      component: 'assistant.codex-action',
+      details: {
+        actionKind: 'mcp.tool.call',
+        durationMsBucket: 'unknown',
+        outputBytesBucket: 'lt_1kb',
+      },
+      errorCode: 'CODEX_TOOL_CALL_FAILED',
+      issueKind: 'tool_error' as const,
+      operation: 'mcp.tool.call',
+      phase: 'tool_call' as const,
+      severity: 'warning' as const,
+      summary: 'Codex tool call failed during provider turn.',
+    }
+    const error = new VaultCliError('ASSISTANT_CODEX_FAILED', 'Codex failed.')
+
+    codexAppServerMocks.executeCodexAppServerTurn.mockRejectedValueOnce(error)
+    codexAppServerMocks.readCodexAppServerTurnFailureContext.mockReturnValueOnce({
+      additionalUsages: [],
+      codexThreadId: 'thread-failed-issues',
+      jsonEvents: [],
+      providerActionCount: 1,
+      providerTurnId: 'turn-failed-issues',
+      runtimeIssueInputs: [runtimeIssueInput],
+    })
+
+    const attempt = await executeCodexAssistantTurnAttempt({
+      providerConfig: normalizeAssistantProviderConfig({
+        provider: 'codex-cli',
+      }),
+      userPrompt: 'Run the turn.',
+      workingDirectory: '/tmp/provider-tests',
+    })
+
+    expect(attempt.ok).toBe(false)
+    if (attempt.ok) {
+      throw new Error('expected failed provider attempt')
+    }
+
+    expect(attempt.metadata).toMatchObject({
+      providerActionCount: 1,
+      rawToolEvents: [],
+      runtimeIssueInputs: [runtimeIssueInput],
+    })
+    expect(attempt.rawEvents).toEqual([])
+    expect(attempt.codexThreadId).toBe('thread-failed-issues')
+    expect(attempt.providerTurnId).toBe('turn-failed-issues')
   })
 
   it('preserves pre-steer segment delivery ordinals across the provider adapter', async () => {
@@ -2788,6 +2889,7 @@ describe('Codex assistant registry helpers', () => {
         executedToolCount: 0,
         rawToolEvents: [],
         providerActionCount: 0,
+        runtimeIssueInputs: [],
       },
       ok: false,
     })

--- a/packages/assistant-engine/test/tool-validation-digest.test.ts
+++ b/packages/assistant-engine/test/tool-validation-digest.test.ts
@@ -29,6 +29,7 @@ describe('buildSafeToolCallValidationDigest', () => {
       error: parsed.error,
       rawInput,
       schemaName: 'murph.supplement_lookup.input',
+      schemaRootKeys: Object.keys(schema.shape),
       toolName: 'murph.supplement_lookup',
     })
 
@@ -37,17 +38,15 @@ describe('buildSafeToolCallValidationDigest', () => {
       toolName: 'murph.supplement_lookup',
       schemaName: 'murph.supplement_lookup.input',
       rootType: 'object',
-      rootKeysPresent: ['brandName', 'servingSize'],
+      rootKeysPresent: ['servingSize'],
       rootKeyCount: 4,
-      unsafeRootKeyCount: 2,
+      unsafeRootKeyCount: 3,
       missingPaths: ['brand', 'product'],
-      unknownKeys: ['brandName'],
       unknownKeyCount: 3,
       invalidPaths: ['servingSize'],
       issueCodes: ['invalid_type', 'missing_required', 'unrecognized_key'],
       inputShape: [
         'root.object.count_1_10',
-        'brandName.string.len_1_32',
         'servingSize.string.len_1_32',
       ],
     })
@@ -66,13 +65,14 @@ describe('buildSafeToolCallValidationDigest', () => {
         received: 'string.len_1_32',
       }),
       expect.objectContaining({
-        path: 'brandName',
+        path: 'root',
         code: 'unrecognized_key',
-        received: 'present',
+        received: 'keys.count_1_10',
       }),
     ]))
 
     const serialized = JSON.stringify(digest)
+    expect(serialized).not.toContain('brandName')
     expect(serialized).not.toContain('PrivateBrand')
     expect(serialized).not.toContain('two scoops')
     expect(serialized).not.toContain('AG1')
@@ -108,6 +108,7 @@ describe('buildSafeToolCallValidationDigest', () => {
           brandName: 'FirstPrivateValue',
           servingSize: 'one scoop',
         },
+        schemaRootKeys: Object.keys(schema.shape),
         toolName: 'murph.supplement_lookup',
       }).validationFingerprint,
     ).toBe(
@@ -117,18 +118,63 @@ describe('buildSafeToolCallValidationDigest', () => {
           brandName: 'SecondPrivateValue',
           servingSize: 'two scoops',
         },
+        schemaRootKeys: Object.keys(schema.shape),
         toolName: 'murph.supplement_lookup',
       }).validationFingerprint,
     )
   })
+
+  it('does not serialize or fingerprint schema-like unknown key names', () => {
+    const schema = z.object({
+      servingSize: z.number().optional(),
+    }).strict()
+
+    const first = schema.safeParse({
+      clientAcmeCancerReport: 'private',
+      servingSize: 'one scoop',
+    })
+    const second = schema.safeParse({
+      privateProjectPhoenix: 'private',
+      servingSize: 'two scoops',
+    })
+    expect(first.success).toBe(false)
+    expect(second.success).toBe(false)
+    if (first.success || second.success) {
+      throw new Error('expected schema validation to fail')
+    }
+
+    const firstDigest = buildSafeToolCallValidationDigest({
+      error: first.error,
+      rawInput: {
+        clientAcmeCancerReport: 'private',
+        servingSize: 'one scoop',
+      },
+      schemaRootKeys: Object.keys(schema.shape),
+      toolName: 'murph.supplement_lookup',
+    })
+    const secondDigest = buildSafeToolCallValidationDigest({
+      error: second.error,
+      rawInput: {
+        privateProjectPhoenix: 'private',
+        servingSize: 'two scoops',
+      },
+      schemaRootKeys: Object.keys(schema.shape),
+      toolName: 'murph.supplement_lookup',
+    })
+
+    expect(firstDigest.validationFingerprint).toBe(secondDigest.validationFingerprint)
+    expect(JSON.stringify(firstDigest)).not.toContain('clientAcmeCancerReport')
+    expect(JSON.stringify(secondDigest)).not.toContain('privateProjectPhoenix')
+  })
 })
 
 describe('isSafeSchemaLikeKey', () => {
-  it('accepts schema-like keys and rejects likely value-like keys', () => {
+  it('validates schema identifier syntax only', () => {
     expect(isSafeSchemaLikeKey('brandName')).toBe(true)
     expect(isSafeSchemaLikeKey('servingSize')).toBe(true)
     expect(isSafeSchemaLikeKey('product_name')).toBe(true)
     expect(isSafeSchemaLikeKey('dose-mg')).toBe(true)
+    expect(isSafeSchemaLikeKey('clientAcmeCancerReport')).toBe(true)
     expect(isSafeSchemaLikeKey('AG1')).toBe(false)
     expect(isSafeSchemaLikeKey('PrivateSupplement')).toBe(false)
     expect(isSafeSchemaLikeKey('https://private.example.test')).toBe(false)

--- a/packages/assistant-engine/test/tool-validation-digest.test.ts
+++ b/packages/assistant-engine/test/tool-validation-digest.test.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod'
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSafeToolCallValidationDigest,
+  isSafeSchemaLikeKey,
+} from '../src/assistant/tool-validation-digest.ts'
+
+describe('buildSafeToolCallValidationDigest', () => {
+  it('records structural Zod validation facts without raw argument values', () => {
+    const schema = z.object({
+      brand: z.string(),
+      product: z.string(),
+      servingSize: z.number().optional(),
+    }).strict()
+    const rawInput = {
+      brandName: 'PrivateBrand',
+      servingSize: 'two scoops',
+      AG1: 'unsafe key value',
+      'https://private.example.test': 'unsafe url key value',
+    }
+    const parsed = schema.safeParse(rawInput)
+    expect(parsed.success).toBe(false)
+    if (parsed.success) {
+      throw new Error('expected schema validation to fail')
+    }
+
+    const digest = buildSafeToolCallValidationDigest({
+      error: parsed.error,
+      rawInput,
+      schemaName: 'murph.supplement_lookup.input',
+      toolName: 'murph.supplement_lookup',
+    })
+
+    expect(digest).toMatchObject({
+      detailsSchema: 'murph.tool-call-validation-digest.v1',
+      toolName: 'murph.supplement_lookup',
+      schemaName: 'murph.supplement_lookup.input',
+      rootType: 'object',
+      rootKeysPresent: ['brandName', 'servingSize'],
+      rootKeyCount: 4,
+      unsafeRootKeyCount: 2,
+      missingPaths: ['brand', 'product'],
+      unknownKeys: ['brandName'],
+      unknownKeyCount: 3,
+      invalidPaths: ['servingSize'],
+      issueCodes: ['invalid_type', 'missing_required', 'unrecognized_key'],
+      inputShape: [
+        'root.object.count_1_10',
+        'brandName.string.len_1_32',
+        'servingSize.string.len_1_32',
+      ],
+    })
+    expect(digest.validationFingerprint).toMatch(/^tvd_[a-f0-9]{12}$/)
+    expect(digest.pathIssues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: 'brand',
+        code: 'missing_required',
+        expected: 'string',
+        received: 'undefined',
+      }),
+      expect.objectContaining({
+        path: 'servingSize',
+        code: 'invalid_type',
+        expected: 'number',
+        received: 'string.len_1_32',
+      }),
+      expect.objectContaining({
+        path: 'brandName',
+        code: 'unrecognized_key',
+        received: 'present',
+      }),
+    ]))
+
+    const serialized = JSON.stringify(digest)
+    expect(serialized).not.toContain('PrivateBrand')
+    expect(serialized).not.toContain('two scoops')
+    expect(serialized).not.toContain('AG1')
+    expect(serialized).not.toContain('https://private.example.test')
+    expect(serialized).not.toContain('unsafe key value')
+  })
+
+  it('keeps the validation fingerprint stable across value changes with the same shape', () => {
+    const schema = z.object({
+      brand: z.string(),
+      product: z.string(),
+      servingSize: z.number().optional(),
+    }).strict()
+
+    const first = schema.safeParse({
+      brandName: 'FirstPrivateValue',
+      servingSize: 'one scoop',
+    })
+    const second = schema.safeParse({
+      brandName: 'SecondPrivateValue',
+      servingSize: 'two scoops',
+    })
+    expect(first.success).toBe(false)
+    expect(second.success).toBe(false)
+    if (first.success || second.success) {
+      throw new Error('expected schema validation to fail')
+    }
+
+    expect(
+      buildSafeToolCallValidationDigest({
+        error: first.error,
+        rawInput: {
+          brandName: 'FirstPrivateValue',
+          servingSize: 'one scoop',
+        },
+        toolName: 'murph.supplement_lookup',
+      }).validationFingerprint,
+    ).toBe(
+      buildSafeToolCallValidationDigest({
+        error: second.error,
+        rawInput: {
+          brandName: 'SecondPrivateValue',
+          servingSize: 'two scoops',
+        },
+        toolName: 'murph.supplement_lookup',
+      }).validationFingerprint,
+    )
+  })
+})
+
+describe('isSafeSchemaLikeKey', () => {
+  it('accepts schema-like keys and rejects likely value-like keys', () => {
+    expect(isSafeSchemaLikeKey('brandName')).toBe(true)
+    expect(isSafeSchemaLikeKey('servingSize')).toBe(true)
+    expect(isSafeSchemaLikeKey('product_name')).toBe(true)
+    expect(isSafeSchemaLikeKey('dose-mg')).toBe(true)
+    expect(isSafeSchemaLikeKey('AG1')).toBe(false)
+    expect(isSafeSchemaLikeKey('PrivateSupplement')).toBe(false)
+    expect(isSafeSchemaLikeKey('https://private.example.test')).toBe(false)
+  })
+})

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -289,6 +289,7 @@ export {
 const HOSTED_INITIAL_CONVERSATION_MAILBOX_IMPORT_LANES = ["conversation"] as const;
 const HOSTED_INITIAL_BOOTSTRAP_MAILBOX_IMPORT_LANES = ["system", "conversation"] as const;
 const HOSTED_INITIAL_BOOTSTRAP_PENDING_REASON_CODE = "bootstrap.pending";
+const HOSTED_RUNTIME_ISSUE_POST_CHECKPOINT_EXPORT_TIMEOUT_MS = 2_500;
 
 interface HostedInitialMailboxImportResult {
   bootstrapPending: boolean;
@@ -2230,25 +2231,6 @@ async function checkpointHostedRuntimeDirtyWorkspace(input: {
     redactedStatus: input.redactedStatus ?? null,
   };
   input.assertRuntimeNotAborted();
-  await flushPendingAssistantRuntimeIssueWrites().catch((error) => {
-    console.warn(
-      `Failed to flush assistant runtime issue writes before idle checkpoint: ${summarizeHostedExecutionError(error)}`,
-    );
-  });
-  if (input.issueExportPort) {
-    // Export before the idle snapshot so acknowledged pending-file deletions are
-    // part of the durable checkpoint. If the checkpoint later fails, web import
-    // upserts by issueId, so a restored retry is idempotent.
-    await exportHostedPendingAssistantRuntimeIssues({
-      issueExportPort: input.issueExportPort,
-      vaultRoot: input.vaultRoot,
-    }).catch((error) => {
-      console.warn(
-        `Failed to export hosted assistant runtime issues before idle checkpoint: ${summarizeHostedExecutionError(error)}`,
-      );
-    });
-  }
-  input.assertRuntimeNotAborted();
   const checkpoint = input.checkpointRequestBuilder.checkpoint
     ? await raceHostedRuntimeCancellation(
       Promise.resolve(input.checkpointRequestBuilder.checkpoint(
@@ -2265,7 +2247,62 @@ async function checkpointHostedRuntimeDirtyWorkspace(input: {
   input.assertRuntimeNotAborted();
   assertIdleShutdownCheckpointAccepted(checkpoint, input.expectedUserId);
   await input.onCheckpointValidated?.(checkpoint);
+  await flushAndExportHostedRuntimeIssuesAfterCheckpointBestEffort({
+    issueExportPort: input.issueExportPort ?? null,
+    runtimeAbortSignal: input.runtimeAbortSignal,
+    vaultRoot: input.vaultRoot,
+  });
   return checkpoint;
+}
+
+async function flushAndExportHostedRuntimeIssuesAfterCheckpointBestEffort(input: {
+  issueExportPort: HostedRuntimePlatform["issueExportPort"] | null;
+  runtimeAbortSignal: AbortSignal;
+  vaultRoot: string;
+}): Promise<void> {
+  const work = async () => {
+    await flushPendingAssistantRuntimeIssueWrites();
+    if (!input.issueExportPort) {
+      return;
+    }
+    await exportHostedPendingAssistantRuntimeIssues({
+      issueExportPort: input.issueExportPort,
+      vaultRoot: input.vaultRoot,
+    });
+  };
+
+  await withHostedRuntimeTimeout(
+    raceHostedRuntimeCancellation(work(), input.runtimeAbortSignal),
+    HOSTED_RUNTIME_ISSUE_POST_CHECKPOINT_EXPORT_TIMEOUT_MS,
+    "Timed out exporting hosted assistant runtime issues after idle checkpoint.",
+  ).catch((error) => {
+    console.warn(
+      `Failed to export hosted assistant runtime issues after idle checkpoint: ${summarizeHostedExecutionError(error)}`,
+    );
+  });
+}
+
+async function withHostedRuntimeTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(message));
+        }, timeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 function assertIdleShutdownCheckpointAccepted(

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -24,10 +24,12 @@ import {
   buildHostedExecutionSafeErrorDiagnostics,
   emitHostedExecutionStructuredLog,
   readHostedExecutionSafeErrorName,
+  summarizeHostedExecutionError,
   type HostedExecutionLogPhase,
   type HostedExecutionStructuredLogDetails,
 } from "@murphai/hosted-execution";
 import {
+  flushPendingAssistantRuntimeIssueWrites,
   findAssistantSessionIdByCodexThreadId,
   readAssistantInputEvent,
 } from "@murphai/assistant-engine";
@@ -128,6 +130,9 @@ import {
 import {
   computeHostedRuntimeElapsedMs,
 } from "./hosted-runtime/utils.ts";
+import {
+  exportHostedPendingAssistantRuntimeIssues,
+} from "./hosted-runtime/issues.ts";
 import {
   normalizeHostedFutureWakeAt,
 } from "./hosted-runtime/wake-time.ts";
@@ -910,8 +915,10 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           expectedUserId: input.request.userId,
           nextWakeAt: nextWake.nextWakeAt,
           nextWakeReason: nextWake.nextWakeReason,
+          issueExportPort: runtime.platform.issueExportPort ?? null,
           redactedStatus,
           runtimeAbortSignal: runtimeAbortController.signal,
+          vaultRoot: restored.vaultRoot,
           workspacePort: foregroundWorkspacePort,
         });
         emitPhaseLog({
@@ -1491,8 +1498,10 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             expectedUserId: input.request.userId,
             nextWakeAt: accumulatedProjection.nextWakeAt,
             nextWakeReason: accumulatedProjection.nextWakeReason,
+            issueExportPort: runtime.platform.issueExportPort ?? null,
             redactedStatus: accumulatedProjection.redactedStatus,
             runtimeAbortSignal: runtimeAbortController.signal,
+            vaultRoot: restored.vaultRoot,
             workspacePort: foregroundWorkspacePort,
           });
         } catch (error) {
@@ -2200,11 +2209,13 @@ async function checkpointHostedRuntimeDirtyWorkspace(input: {
   assertRuntimeNotAborted: () => void;
   checkpointRequestBuilder: ReturnType<typeof createHostedWorkspaceSnapshotCheckpointRequestBuilder>;
   expectedUserId: string;
+  issueExportPort?: HostedRuntimePlatform["issueExportPort"] | null;
   nextWakeAt: string | null;
   nextWakeReason: string | null;
   runtimeAbortSignal: AbortSignal;
   onCheckpointValidated?: (checkpoint: HostedWorkspaceCheckpointResponse) => Promise<void> | void;
   redactedStatus: HostedWorkspaceInvocationResult["redactedStatus"] | null;
+  vaultRoot: string;
   workspacePort: HostedRuntimePlatform["workspacePort"];
 }): Promise<HostedWorkspaceCheckpointResponse> {
   if (!input.workspacePort) {
@@ -2218,6 +2229,25 @@ async function checkpointHostedRuntimeDirtyWorkspace(input: {
     reason: "idle_shutdown" as const,
     redactedStatus: input.redactedStatus ?? null,
   };
+  input.assertRuntimeNotAborted();
+  await flushPendingAssistantRuntimeIssueWrites().catch((error) => {
+    console.warn(
+      `Failed to flush assistant runtime issue writes before idle checkpoint: ${summarizeHostedExecutionError(error)}`,
+    );
+  });
+  if (input.issueExportPort) {
+    // Export before the idle snapshot so acknowledged pending-file deletions are
+    // part of the durable checkpoint. If the checkpoint later fails, web import
+    // upserts by issueId, so a restored retry is idempotent.
+    await exportHostedPendingAssistantRuntimeIssues({
+      issueExportPort: input.issueExportPort,
+      vaultRoot: input.vaultRoot,
+    }).catch((error) => {
+      console.warn(
+        `Failed to export hosted assistant runtime issues before idle checkpoint: ${summarizeHostedExecutionError(error)}`,
+      );
+    });
+  }
   input.assertRuntimeNotAborted();
   const checkpoint = input.checkpointRequestBuilder.checkpoint
     ? await raceHostedRuntimeCancellation(

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -1563,7 +1563,7 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
-  test("exports pending assistant runtime issues before an idle checkpoint", async () => {
+  test("exports pending assistant runtime issues after an idle checkpoint", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
@@ -1609,7 +1609,11 @@ describe("hosted workspace runtime entrypoint", () => {
           async createCheckpointSnapshot(snapshotInput) {
             events.push("snapshot");
             assert.equal(await readCheckpointConversationWatermark(snapshotInput, vaultRoot), "1");
-            assert.deepEqual(await listPendingAssistantRuntimeIssueRecords({ vault: vaultRoot }), []);
+            assert.deepEqual(
+              (await listPendingAssistantRuntimeIssueRecords({ vault: vaultRoot }))
+                .map((record) => record.issueId),
+              [issueRecord.issueId],
+            );
             return {
               snapshotRef: createBundleRef({
                 hash: "b".repeat(64),
@@ -1669,12 +1673,12 @@ describe("hosted workspace runtime entrypoint", () => {
       ]);
       assert.deepEqual(exportedIssueIds, [issueRecord.issueId]);
       assert.ok(
-        events.indexOf("issue.export") < events.indexOf("snapshot"),
-        "issue export should run before workspace snapshot",
+        events.indexOf("snapshot") < events.indexOf("workspace.checkpoint"),
+        "workspace checkpoint should commit the dirty workspace snapshot before telemetry",
       );
       assert.ok(
-        events.indexOf("snapshot") < events.indexOf("workspace.checkpoint"),
-        "workspace checkpoint should commit the post-export snapshot",
+        events.indexOf("workspace.checkpoint") < events.indexOf("issue.export"),
+        "issue export should run after the durable workspace checkpoint",
       );
       assert.deepEqual(await listPendingAssistantRuntimeIssueRecords({ vault: vaultRoot }), []);
     } finally {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -21,9 +21,11 @@ import {
   resolveAssistantStatePaths,
   sha256HostedBundleHex,
   createHostedPortableWorkspaceManifestFromBundle,
+  listPendingAssistantRuntimeIssueRecords,
   snapshotHostedPortableWorkspaceDelta,
   snapshotHostedAssistantRuntimeHotState,
   snapshotHostedBundleRoots,
+  writePendingAssistantRuntimeIssueRecord,
   writeHostedBundleTextFile,
 } from "@murphai/runtime-state/node";
 import {
@@ -1556,6 +1558,125 @@ describe("hosted workspace runtime entrypoint", () => {
         },
         status: "idle",
       });
+    } finally {
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
+  test("exports pending assistant runtime issues before an idle checkpoint", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const exportedIssueIds: string[] = [];
+    const issueRecord = {
+      component: "assistant.codex-action",
+      details: {
+        actionKind: "command.execution",
+        durationMsBucket: "lt_1s",
+        exitCode: 1,
+        outputBytesBucket: "0",
+      },
+      environment: "hosted" as const,
+      errorCode: "CODEX_COMMAND_EXIT_NONZERO",
+      fingerprint: "abcdef123456abcdef123456",
+      issueId: "ari_0123456789abcdef_abcdef123456abcdef123456",
+      issueKind: "tool_error" as const,
+      occurredAt: "2026-04-27T00:00:00.000Z",
+      operation: "command.execution",
+      phase: "provider_turn" as const,
+      schema: "murph.assistant-runtime-issue.v1" as const,
+      severity: "warning" as const,
+      summary: "Codex command execution failed during provider turn.",
+      surface: null,
+    };
+
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+
+      await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_issue_export",
+            budget: {
+              maxMailboxItems: 10,
+            },
+            leaseGeneration: "7",
+            userId: TEST_USER_ID,
+            workspaceVersion: "0",
+          },
+        }),
+        {
+          async createCheckpointSnapshot(snapshotInput) {
+            events.push("snapshot");
+            assert.equal(await readCheckpointConversationWatermark(snapshotInput, vaultRoot), "1");
+            assert.deepEqual(await listPendingAssistantRuntimeIssueRecords({ vault: vaultRoot }), []);
+            return {
+              snapshotRef: createBundleRef({
+                hash: "b".repeat(64),
+                key: "users/bundles/member-synthetic/issue-export.bundle.json",
+                size: 256,
+              }),
+            };
+          },
+          async importItem() {
+            events.push("import");
+            await writePendingAssistantRuntimeIssueRecord({
+              record: issueRecord,
+              vault: vaultRoot,
+            });
+            return { status: "imported" };
+          },
+          platform: createPlatform({
+            events,
+            issueExportPort: {
+              async recordIssues(issues) {
+                events.push("issue.export");
+                const issueIds = issues.map((issue) => {
+                  const issueId = (issue as { issueId?: unknown }).issueId;
+                  if (typeof issueId !== "string") {
+                    throw new Error("expected exported issue id");
+                  }
+                  return issueId;
+                });
+                exportedIssueIds.push(...issueIds);
+                return {
+                  issueIds,
+                  recorded: issues.length,
+                };
+              },
+            },
+            mailboxPort: createMailboxPort({
+              events,
+              items: [
+                createMailboxItem({
+                  id: "mailbox_item_issue_export_001",
+                  laneSeq: "1",
+                }),
+              ],
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({ version: "0" }),
+            }),
+          }),
+          vaultRoot,
+        },
+      );
+
+      assert.deepEqual(checkpointRequests.map((request) => request.reason), [
+        "idle_shutdown",
+      ]);
+      assert.deepEqual(exportedIssueIds, [issueRecord.issueId]);
+      assert.ok(
+        events.indexOf("issue.export") < events.indexOf("snapshot"),
+        "issue export should run before workspace snapshot",
+      );
+      assert.ok(
+        events.indexOf("snapshot") < events.indexOf("workspace.checkpoint"),
+        "workspace checkpoint should commit the post-export snapshot",
+      );
+      assert.deepEqual(await listPendingAssistantRuntimeIssueRecords({ vault: vaultRoot }), []);
     } finally {
       await removeTempRoot(vaultRoot);
     }
@@ -7937,6 +8058,7 @@ function createPlatform(input: {
   events?: string[];
   latencyTraceRequests?: HostedRuntimeLatencyTraceRequest[];
   logRequests?: HostedRuntimeLogRequest[];
+  issueExportPort?: HostedRuntimePlatform["issueExportPort"] | null;
   mailboxPort: HostedRuntimeMailboxPort | null;
   runtimeLivenessIntervalMs?: number | null;
   runtimeLivenessPort?: RuntimeLivenessPort | null;
@@ -8004,6 +8126,7 @@ function createPlatform(input: {
           },
         }
       : {}),
+    ...(input.issueExportPort ? { issueExportPort: input.issueExportPort } : {}),
     ...(input.mailboxPort ? { mailboxPort: input.mailboxPort } : {}),
     ...(input.runtimeLivenessIntervalMs
       ? { runtimeLivenessIntervalMs: input.runtimeLivenessIntervalMs }


### PR DESCRIPTION
## Summary
- Add value-free tool-call validation digests for parser-owned schema rejections.
- Thread best-effort runtime issue inputs through assistant/Codex execution and hosted export/checkpoint flow.
- Add focused coverage for digest privacy, dynamic-tool schema rejections, nonblocking issue writes, provider failures, and hosted export ordering.

## ReviewGPT
- Round 1: accepted 2 high findings; fixed checkpoint-first telemetry export and raw unknown-key digest leakage.
- Round 2: zero accepted findings.

## Validation
- `pnpm typecheck`
- `pnpm test:diff $(git diff --name-only main...HEAD)`
- `pnpm test:smoke`
- `git diff --check`
- PR checks green, including rerun Vercel preview after initial Vercel OOM.