### PR TITLE
docs: add metric window invariant

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-17-metric-window-invariant.md
+++ b/agent-docs/exec-plans/completed/2026-06-17-metric-window-invariant.md
@@ -1,0 +1,18 @@
+# Metric Window Invariant
+
+## Goal
+
+Add the durable invariant that metric-window comparisons use normalized metric points/window comparison rather than wearable day summaries.
+
+## Scope
+
+- `docs/contracts/00-invariants.md`
+
+## Verification
+
+- Read back touched docs.
+- Run `pnpm typecheck` for the docs/process fast path.
+
+Status: completed
+Updated: 2026-06-16
+Completed: 2026-06-16

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -18,6 +18,10 @@
 - Machine-facing truth lives in JSONL: `ledger/events`, display-grade `ledger/metric-samples`, explicit raw/debug `ledger/samples`, and `audit`. Generic `ledger/samples` shards are not part of the default query/read/browser model.
 - Imported originals live in `raw/` and are immutable once copied into the vault, except for explicit core-owned repair tombstones that prove the old manifest byte/SHA and preserve durable product facts.
 
+## Query Metrics
+
+- Any feature that compares a metric across a date window must use normalized metric points plus the shared metric series/window comparison primitives. Wearable day summaries are presentation/context summaries and must not be the source of truth for metric-window comparisons.
+
 ## Write Authority
 
 - Only `packages/core` may mutate canonical vault data.

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -20,7 +20,7 @@
 
 ## Query Metrics
 
-- Any feature that compares a metric across a date window must use normalized metric points plus the shared metric series/window comparison primitives. Wearable day summaries are presentation/context summaries and must not be the source of truth for metric-window comparisons.
+- Experiment progress, protocol outcome, and other decision-grade metric-window comparisons must use normalized metric points plus the shared metric series/window comparison primitives. Wearable day summaries are presentation/context summaries and must not be the source of truth for those analysis windows.
 
 ## Write Authority
 


### PR DESCRIPTION
## Summary
- Document that metric-window comparisons must use normalized metric points and shared metric series/window comparison primitives
- Clarify that wearable day summaries are presentation/context summaries, not metric-window comparison source of truth

## Verification
- pnpm typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784254975&installation_id=127572939&pr_number=197&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F197&signature=6479d6df7a900f453cf914feba2fae3b993f4987c61de01502880a05c778105c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->