### PR TITLE
[codex] Tighten onboarding follow-up automation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-17-onboarding-daily-automation.md
+++ b/agent-docs/exec-plans/completed/2026-06-17-onboarding-daily-automation.md
@@ -1,0 +1,50 @@
+Goal (incl. success criteria):
+- Ensure hosted signup installs a daily managed onboarding follow-up automation that starts after the signup day.
+- The scheduled instructions must check assistant onboarding state through the onboarding CLI context command, ask only while onboarding is still open, and archive the automation permanently once onboarding is complete or declined.
+- Success means the existing signup welcome seed keeps routing/idempotency behavior, tests assert the new instructions, and the daily first occurrence remains deferred until the next local day.
+
+Constraints/Assumptions:
+- Reuse the existing hosted signup welcome follow-up seed and canonical automation/cron runtime; do not add a new scheduler or web cron.
+- Preserve route validation and archived-record behavior in `upsertAssistantCronAutomation`.
+- Keep automatic outbound copy prompt-driven, not hard-coded final user text.
+- Preserve unrelated working-tree edits and active ledger rows.
+
+Key decisions:
+- Update the existing `finish-onboarding-followup` automation instructions rather than adding another automation.
+- Keep `firstOccurrencePolicy: "after-current-local-day"` as the signup-day skip mechanism.
+
+State:
+- Complete; ready to archive and commit.
+
+Done:
+- Confirmed current runtime already seeds `finish-onboarding-followup` after successful signup welcome delivery.
+- Confirmed first occurrence is deferred to the next local day.
+- Updated the managed automation instructions to use onboarding resume context, archive after completion, and ask only for the next unresolved onboarding step.
+- Updated focused runtime and hosted-local test expectations.
+- Ran security/privacy and coverage audit passes; security found no medium-or-higher issue, and coverage added hosted-local proof that acceleration preserves the production instruction/tag contract.
+- Accepted the deep-review finding that scheduled notification turns should not infer/mark onboarding complete without the full onboarding criteria prompt; simplified the automation so it archives only when onboarding is already marked completed and otherwise asks the next unresolved question.
+- Reran focused assistant-runtime tests, `pnpm test:diff`, and `pnpm typecheck` successfully after the final instruction/test changes.
+- Deep-review recheck found no remaining medium-or-higher issue.
+
+Now:
+- Close the active plan and create the scoped commit.
+
+Next:
+- Handoff to user.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/assistant-runtime/src/hosted-runtime/events.ts
+- packages/assistant-runtime/test/hosted-runtime-events.test.ts
+- apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
+- packages/assistant-runtime/README.md
+- pnpm --dir packages/assistant-runtime test -- hosted-runtime-events.test.ts
+- pnpm test:diff -- packages/assistant-runtime/src/hosted-runtime/events.ts packages/assistant-runtime/test/hosted-runtime-events.test.ts apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts packages/assistant-runtime/README.md
+- pnpm typecheck
+- agent-docs/exec-plans/active/2026-06-17-onboarding-daily-automation.md
+- agent-docs/exec-plans/active/COORDINATION_LEDGER.md
+Status: completed
+Updated: 2026-06-17
+Completed: 2026-06-17

--- a/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
@@ -34,6 +34,24 @@ const linqWebhookSecret = "linq-local-onboarding-followup-secret";
 const followupSlug = "finish-onboarding-followup";
 const followupTitle = "Finish Murph onboarding follow-up";
 const followupSummary = "Daily setup continuation check until Murph onboarding is complete.";
+const followupInstructions = [
+  "This daily scheduled check continues Murph onboarding after hosted signup. The first scheduled occurrence is intentionally deferred until after the signup day.",
+  "",
+  "Before deciding, run `vault-cli assistant onboarding resume-context --format json`.",
+  "",
+  "Inspect `onboarding.status` first. If it is `completed`, run `vault-cli automation set-status finish-onboarding-followup --status archived`, then return skip. If the archive command fails, still return skip without messaging the user so this check can retry later.",
+  "",
+  "If `onboarding.status` is `open`, do not archive this automation and do not run `vault-cli assistant onboarding complete`. Use the resume-context output only as saved setup evidence so you do not re-ask facts the vault already knows.",
+  "",
+  "If onboarding is still genuinely open, send one brief, natural in-chat question for the next unresolved onboarding step. Keep it low-pressure, do not mention internal state or this automation, and do not use a fixed script. The user's answer will be handled by the next normal Murph onboarding turn.",
+].join("\n");
+const followupTags = [
+  "assistant",
+  "scheduled",
+  "onboarding",
+  "murph-managed",
+  "murph-managed:onboarding-followup",
+] as const;
 const followupReminderText = "Want to finish setup? Send me where you left off and we can continue.";
 const accelerationReplyText = "Done - I will check back soon so we can finish setup.";
 const onboardingCompleteReplyText = "Setup is marked complete.";
@@ -521,17 +539,10 @@ function buildHostedAssistantAccelerateFollowupResponses(input: {
       "--status",
       "active",
       "--instructions",
-      [
-        "First inspect onboarding status with `vault-cli assistant onboarding status`.",
-        "If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.",
-        "If onboarding is still open, send a short message inviting setup to continue.",
-      ].join(" "),
+      followupInstructions,
       "--summary",
       followupSummary,
-      "--tags",
-      "assistant",
-      "--tags",
-      "onboarding",
+      ...followupTags.flatMap((tag) => ["--tags", tag]),
       "--continuity-policy",
       "preserve",
       "--channel",

--- a/packages/assistant-runtime/README.md
+++ b/packages/assistant-runtime/README.md
@@ -13,6 +13,7 @@ Current responsibilities:
   typed parser toolchain validation, commit timeout, and child-env projection helpers
 - keep hosted execution local-runtime-first: normal hosted turns write mailbox and assistant input state into the warm container, may defer intermediate foreground checkpoints, and keep dirty state dirty until the runtime-owned idle/scheduled-wake `idle_shutdown` checkpoint succeeds
 - collect and deliver due hosted side effects from live container state without waiting for foreground hosted workspace checkpointing
+- seed the hosted signup onboarding follow-up automation after successful signup welcome delivery; its first run is deferred until the next local day, then the scheduled assistant checks onboarding resume context and archives the automation once onboarding is complete
 - export sanitized pending assistant-runtime issue records through the injected host platform after commit instead of persisting raw hosted diagnostics in the worker
 - expose the method-based `HostedRuntimePlatform` seam that hosted apps inject at runtime
 - provide shared hosted runtime env sanitization so host apps can build their own launcher policy without forwarding control-plane secrets

--- a/packages/assistant-runtime/src/hosted-runtime/events.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events.ts
@@ -58,14 +58,23 @@ const DIRECT_CONVERSATION_WAKE_ERROR_MESSAGE =
   "Hosted conversation wakes must be imported through mailbox AssistantInputEvent staging.";
 const ONBOARDING_FOLLOWUP_AUTOMATION_SLUG = "finish-onboarding-followup";
 const ONBOARDING_FOLLOWUP_AUTOMATION_TITLE = "Finish Murph onboarding follow-up";
+const ONBOARDING_FOLLOWUP_AUTOMATION_TAGS = [
+  "assistant",
+  "scheduled",
+  "onboarding",
+  "murph-managed",
+  "murph-managed:onboarding-followup",
+];
 const ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS = [
-  "This scheduled check helps continue Murph setup.",
+  "This daily scheduled check continues Murph onboarding after hosted signup. The first scheduled occurrence is intentionally deferred until after the signup day.",
   "",
-  "First inspect onboarding status with `vault-cli assistant onboarding status`.",
+  "Before deciding, run `vault-cli assistant onboarding resume-context --format json`.",
   "",
-  "If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.",
+  "Inspect `onboarding.status` first. If it is `completed`, run `vault-cli automation set-status finish-onboarding-followup --status archived`, then return skip. If the archive command fails, still return skip without messaging the user so this check can retry later.",
   "",
-  "If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.",
+  "If `onboarding.status` is `open`, do not archive this automation and do not run `vault-cli assistant onboarding complete`. Use the resume-context output only as saved setup evidence so you do not re-ask facts the vault already knows.",
+  "",
+  "If onboarding is still genuinely open, send one brief, natural in-chat question for the next unresolved onboarding step. Keep it low-pressure, do not mention internal state or this automation, and do not use a fixed script. The user's answer will be handled by the next normal Murph onboarding turn.",
 ].join("\n");
 const ASSISTANT_PROVIDER_PLAN_TRACE_SCHEMA =
   "murph.assistant-provider-plan-diagnostics.v1";
@@ -695,7 +704,7 @@ async function maybeSeedOnboardingFollowupAutomation(input: {
       },
       slug: ONBOARDING_FOLLOWUP_AUTOMATION_SLUG,
       summary: "Daily setup continuation check until Murph onboarding is complete.",
-      tags: ["assistant", "onboarding"],
+      tags: ONBOARDING_FOLLOWUP_AUTOMATION_TAGS,
       title: ONBOARDING_FOLLOWUP_AUTOMATION_TITLE,
       vault: input.vaultRoot,
     });

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -1317,7 +1317,9 @@ describe("executeHostedMailboxEvent", () => {
     });
     expect(mocks.upsertAssistantCronAutomation).toHaveBeenCalledWith({
       firstOccurrencePolicy: "after-current-local-day",
-      instructions: expect.stringContaining("vault-cli assistant onboarding status"),
+      instructions: expect.stringContaining(
+        "vault-cli assistant onboarding resume-context --format json",
+      ),
       route: {
         channel: "linq",
         deliverySource: null,
@@ -1332,7 +1334,13 @@ describe("executeHostedMailboxEvent", () => {
       },
       slug: "finish-onboarding-followup",
       summary: "Daily setup continuation check until Murph onboarding is complete.",
-      tags: ["assistant", "onboarding"],
+      tags: [
+        "assistant",
+        "scheduled",
+        "onboarding",
+        "murph-managed",
+        "murph-managed:onboarding-followup",
+      ],
       title: "Finish Murph onboarding follow-up",
       vault: "/tmp/assistant-runtime-events",
     });
@@ -1340,6 +1348,17 @@ describe("executeHostedMailboxEvent", () => {
     expect(seedInput?.instructions).toContain(
       "vault-cli automation set-status finish-onboarding-followup --status archived",
     );
+    expect(seedInput?.instructions).toContain("Inspect `onboarding.status` first");
+    expect(seedInput?.instructions).toContain(
+      "do not archive this automation and do not run `vault-cli assistant onboarding complete`",
+    );
+    expect(seedInput?.instructions).not.toContain(
+      "vault-cli assistant onboarding complete --reason user_answered",
+    );
+    expect(seedInput?.instructions).toContain(
+      "The user's answer will be handled by the next normal Murph onboarding turn",
+    );
+    expect(seedInput?.instructions).toContain("next unresolved onboarding step");
     expect(seedInput?.instructions).toContain("return skip");
     expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenNthCalledWith(
       1,


### PR DESCRIPTION
## Summary

- Tightens the existing hosted signup onboarding follow-up automation to run from onboarding resume context instead of the older status-only check.
- Keeps the first occurrence deferred until after the signup day and tags the automation as scheduled/Murph-managed.
- Archives the automation only when onboarding is already marked completed; when onboarding is still open, it asks one natural next unresolved onboarding question and explicitly avoids auto-completing or archiving.
- Updates hosted runtime tests and hosted-local E2E acceleration fixtures so the accelerated follow-up preserves the production instruction/tag contract.

## Root Cause

The daily follow-up seed already existed, but its prompt was too thin for the desired lifecycle: it did not use resume context, did not identify itself as Murph-managed, and did not clearly separate completed-status archival from open-onboarding follow-up.

## Validation

- `pnpm --dir packages/assistant-runtime test -- hosted-runtime-events.test.ts`
- `pnpm test:diff -- packages/assistant-runtime/src/hosted-runtime/events.ts packages/assistant-runtime/test/hosted-runtime-events.test.ts apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts packages/assistant-runtime/README.md`
- `pnpm typecheck`
- `git diff --check`
- Local security/privacy audit: no medium-or-higher findings
- Local coverage/proof pass: added hosted-local fixture proof for production instruction/tag preservation
- Local deep-review pass: accepted and fixed the scheduled auto-completion risk; recheck found no remaining medium-or-higher issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784268178&installation_id=127572939&pr_number=202&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F202&signature=24fb938bcfab1a13b87f18e01785b6c4a3312d84e0c5cffa4be1a5743d69872c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->