### PR TITLE
Fix device activity immediate wake

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-17-device-activity-immediate-wake.md
+++ b/agent-docs/exec-plans/completed/2026-06-17-device-activity-immediate-wake.md
@@ -1,0 +1,25 @@
+# Device Activity Immediate Wake
+
+## Goal
+
+Fix hosted system-mailbox processing so an immediate assistant follow-up wake reliably remains armed after the mailbox item is recorded.
+
+## Evidence
+
+- Hosted device-sync mailbox wake for the affected member was imported and processed.
+- Pre-record system mailbox log had a next wake present, but the post-record log did not.
+- Later assistant scans only saw the daily automation, so the device-activity follow-up was not armed for delivery.
+
+## Plan
+
+1. Add a regression for a system-mailbox metrics result that returns an immediate assistant wake.
+2. Preserve immediate assistant wakes across the system-mailbox post-checkpoint path.
+3. Run the focused hosted runtime test and required typecheck/test verification.
+
+## Working Set
+
+- `packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts`
+- `packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts`
+Status: completed
+Updated: 2026-06-17
+Completed: 2026-06-17

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -1774,15 +1774,17 @@ async function runSystemMailboxMaintenancePhase(input: {
     : await resolveHostedSystemMailboxNextWakeAt({
         vaultRoot: phaseInput.restored.vaultRoot,
       });
-  const systemMailboxMetricsWakeAt = "metrics" in systemMailboxPreparation
-    ? resolveHostedAssistantAutomationNextWakeAt({
-        input: phaseInput,
-        nextWakeAt: systemMailboxPreparation.metrics.nextWakeAt ?? null,
-      })
+  const rawSystemMailboxMetricsWakeAt = "metrics" in systemMailboxPreparation
+    ? systemMailboxPreparation.metrics.nextWakeAt ?? null
     : null;
   const systemMailboxMetricsWakeReason = resolveHostedSystemMailboxMetricsWakeReason({
-    metricsWakeAt: systemMailboxMetricsWakeAt,
+    metricsWakeAt: rawSystemMailboxMetricsWakeAt,
     systemMailboxPreparation,
+  });
+  const systemMailboxMetricsWakeAt = resolveHostedSystemMailboxMetricsWakeAt({
+    input: phaseInput,
+    metricsWakeAt: rawSystemMailboxMetricsWakeAt,
+    metricsWakeReason: systemMailboxMetricsWakeReason,
   });
   const systemMailboxDeviceSyncRan =
     systemMailboxPreparationRanDeviceSync(systemMailboxPreparation);
@@ -2140,6 +2142,34 @@ function resolveHostedSystemMailboxMetricsWakeReason(input: {
   return input.systemMailboxPreparation.item.routeAction === "run-device-sync-wake"
     ? HOSTED_DEVICE_SYNC_RECONCILE_WAKE_REASON
     : null;
+}
+
+function resolveHostedSystemMailboxMetricsWakeAt(input: {
+  input: HostedWorkspaceRuntimeAssistantPhaseInput;
+  metricsWakeAt: string | null;
+  metricsWakeReason: string | null;
+}): string | null {
+  const futureWakeAt = resolveHostedAssistantAutomationNextWakeAt({
+    input: input.input,
+    nextWakeAt: input.metricsWakeAt,
+  });
+  if (futureWakeAt) {
+    return futureWakeAt;
+  }
+
+  if (
+    input.metricsWakeReason !== HOSTED_ASSISTANT_WAKE_REASON
+  ) {
+    return null;
+  }
+
+  const wakeMs = Date.parse(input.metricsWakeAt ?? "");
+  if (!Number.isFinite(wakeMs)) {
+    return null;
+  }
+
+  const nowMs = resolveHostedAssistantPhaseNowMs(input.input);
+  return wakeMs <= nowMs ? new Date(nowMs).toISOString() : null;
 }
 
 async function runProviderCleanupPhase(input: {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -3367,6 +3367,90 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
   });
 
+  it("preserves an immediate assistant wake after recording a system mailbox item", async () => {
+    const nextWakeAt = "2026-04-27T00:00:00.000Z";
+    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce({
+      item: createSystemMailboxItem(),
+      itemId: "system_mailbox_item_immediate_assistant_wake",
+      metrics: {
+        bootstrapResult: null,
+        conversationMetrics: null,
+        mailboxLane: "assistant-notification",
+        nextWakeAt,
+        nextWakeReason: "assistant",
+        postCheckpointRecord: null,
+        redactedLogEntries: [],
+      },
+      status: "processed",
+    });
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      now: () => nextWakeAt,
+    }));
+    const postCheckpoint = await result.afterCheckpoint?.();
+
+    expect(mocks.runHostedAssistantAutomationLane).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({
+      checkpointReason: "system_mailbox_receipt",
+      nextWakeAt,
+      progressed: true,
+    }));
+    expect(postCheckpoint).toEqual(expect.objectContaining({
+      checkpointReason: "system_mailbox_receipt",
+      nextWakeAt,
+      nextWakeReason: "assistant",
+      redactedStatus: expect.objectContaining({
+        hostedSystemMailboxRecorded: 1,
+      }),
+    }));
+  });
+
+  it("drops an immediate non-assistant system mailbox metrics wake", async () => {
+    const nextWakeAt = "2026-04-27T00:00:00.000Z";
+    const deviceSyncItem = {
+      ...createSystemMailboxItem(),
+      routeAction: "run-device-sync-wake" as const,
+      wake: {
+        eventId: "evt_synthetic_device_sync_immediate_reconcile_wake",
+        kind: "device-sync.wake" as const,
+        occurredAt: "2026-04-27T00:00:00.000Z",
+        reason: "webhook" as const,
+        userId: "member_synthetic_phase",
+      },
+    };
+    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce({
+      item: deviceSyncItem,
+      itemId: "system_mailbox_item_immediate_reconcile_wake",
+      metrics: {
+        bootstrapResult: null,
+        conversationMetrics: null,
+        mailboxLane: "device-sync",
+        nextWakeAt,
+        postCheckpointRecord: null,
+        redactedLogEntries: [],
+      },
+      status: "processed",
+    });
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      now: () => nextWakeAt,
+    }));
+    const postCheckpoint = await result.afterCheckpoint?.();
+
+    expect(result).toEqual(expect.objectContaining({
+      checkpointReason: "system_mailbox_receipt",
+      progressed: true,
+    }));
+    expect(result).not.toHaveProperty("nextWakeAt");
+    expect(postCheckpoint).toEqual(expect.objectContaining({
+      checkpointReason: "system_mailbox_receipt",
+      nextWakeAt: null,
+      redactedStatus: expect.objectContaining({
+        hostedSystemMailboxRecorded: 1,
+      }),
+    }));
+  });
+
   it("keeps an armed assistant cron wake when a device-sync mailbox wake is processed", async () => {
     // Prod regression (2026-06-10): an `at` reminder automation armed next_wake_at=02:45,
     // then WHOOP device-sync wakes at 01:59/02:03 early-returned a device-sync-only result


### PR DESCRIPTION
## Summary
- Preserve system-mailbox metric wakes that are explicitly assistant-labeled, even when the returned timestamp is immediate/at-now.
- Keep existing stale-drop behavior for non-assistant metric wakes, including device-sync reconcile wakes.
- Add paired hosted-runtime regressions for preserving immediate assistant wakes and dropping immediate non-assistant wakes.

## Verification
- pnpm exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-workspace-assistant-phase.test.ts
- pnpm --dir packages/assistant-runtime test
- pnpm build:test-runtime
- pnpm --dir packages/assistant-runtime typecheck

## Notes
- Initial package typecheck in the fresh worktree failed before `pnpm build:test-runtime` because built workspace package entrypoints were missing; reruns passed after the build.