### PR TITLE
[codex] unblock package release readiness

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-17-release-readiness-fixes.md
+++ b/agent-docs/exec-plans/completed/2026-06-17-release-readiness-fixes.md
@@ -1,0 +1,58 @@
+# Release Readiness Fixes
+
+## Goal
+
+Make the package release gate green enough to cut the next minor release and
+prove the generated Murph package installs from local tarballs before publish.
+
+Success means:
+
+- Fresh-worktree `pnpm release:check` no longer fails on the known release
+  blockers.
+- Generated publishable tarballs install in a fresh consumer project.
+- The `murph`/`vault-cli` global install path works from the generated tarball
+  set, matching the public install posture.
+
+## Constraints
+
+- Do not publish to npm or push a release tag without explicit approval.
+- Keep fixes narrowly scoped to release tooling, package payload shape, and
+  the failing tests.
+- Preserve the five-package public release set and the existing shared-version
+  release flow.
+- Do not weaken CLI startup/import guards or device control-plane behavior just
+  to make tests pass.
+
+## Working Set
+
+- `scripts/pack-publishables.mjs`
+- `packages/assistant-engine/test/assistant-cli-surface-bootstrap.test.ts`
+- `packages/assistant-cli/test/assistant-command-startup-imports.test.ts`
+- `packages/cli/test/device-cli.test.ts`
+- release/package smoke commands against generated tarballs
+
+## Verification Plan
+
+- Focused package tests for the three failing tests.
+- Package-shape or packer tests proving bundled external dependency metadata
+  does not break installed payloads.
+- `pnpm release:check` from a clean/fresh checkout when focused checks are
+  green.
+- Local tarball install smoke for both fresh consumer project and isolated
+  global prefix.
+
+## Progress
+
+- Fixed the three known release-check test blockers and verified each focused
+  test.
+- Updated publishable packing so the bundled external `incur` package does not
+  retain dependency metadata that can break isolated global installs.
+- Verified the generated five-tarball set installs in both an isolated global
+  prefix and a blank consumer project.
+- `pnpm typecheck` passed.
+- `pnpm release:check` passed end to end after the timeout and packaging fixes.
+- Re-ran the five-tarball smoke after the green release check; isolated global
+  install and blank consumer project install both passed.
+Status: completed
+Updated: 2026-06-17
+Completed: 2026-06-17

--- a/packages/assistant-cli/test/assistant-command-startup-imports.test.ts
+++ b/packages/assistant-cli/test/assistant-command-startup-imports.test.ts
@@ -10,6 +10,7 @@ const forbiddenStartupModules = [
   '../src/assistant-chat-ink.js',
   '../src/assistant/ui/ink.js',
 ] as const
+const STARTUP_IMPORT_GUARD_TIMEOUT_MS = 30_000
 
 afterEach(() => {
   vi.resetModules()
@@ -54,35 +55,43 @@ test('forbidden startup module mocks intercept their module ids', async () => {
   }
 })
 
-test('assistant command registration does not import the ink chat surface at module load', async () => {
-  mockForbiddenStartupModules()
+test(
+  'assistant command registration does not import the ink chat surface at module load',
+  async () => {
+    mockForbiddenStartupModules()
 
-  await import('../src/commands/assistant.js')
-})
+    await import('../src/commands/assistant.js')
+  },
+  STARTUP_IMPORT_GUARD_TIMEOUT_MS,
+)
 
 // Module-load guarding alone would miss an eager import added inside the
 // registration body, so run the real registration with unwired services.
-test('registering assistant commands does not load the ink chat surface', async () => {
-  mockForbiddenStartupModules()
+test(
+  'registering assistant commands does not load the ink chat surface',
+  async () => {
+    mockForbiddenStartupModules()
 
-  const [
-    { registerAssistantCommands },
-    { Cli },
-    { createIntegratedInboxServices },
-    { createUnwiredVaultServices },
-  ] = await Promise.all([
-    import('../src/commands/assistant.js'),
-    import('incur'),
-    import('@murphai/inbox-services'),
-    import('@murphai/vault-usecases'),
-  ])
+    const [
+      { registerAssistantCommands },
+      { Cli },
+      { createIntegratedInboxServices },
+      { createUnwiredVaultServices },
+    ] = await Promise.all([
+      import('../src/commands/assistant.js'),
+      import('incur'),
+      import('@murphai/inbox-services'),
+      import('@murphai/vault-usecases'),
+    ])
 
-  const cli = Cli.create('vault-cli', {
-    description: 'startup import guard host',
-  })
-  registerAssistantCommands(
-    cli,
-    createIntegratedInboxServices(),
-    createUnwiredVaultServices(),
-  )
-})
+    const cli = Cli.create('vault-cli', {
+      description: 'startup import guard host',
+    })
+    registerAssistantCommands(
+      cli,
+      createIntegratedInboxServices(),
+      createUnwiredVaultServices(),
+    )
+  },
+  STARTUP_IMPORT_GUARD_TIMEOUT_MS,
+)

--- a/packages/assistant-engine/test/assistant-cli-surface-bootstrap.test.ts
+++ b/packages/assistant-engine/test/assistant-cli-surface-bootstrap.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { afterEach, beforeEach, test, vi } from 'vitest'
 
@@ -15,6 +16,10 @@ import {
 import { createTempVaultContext } from './test-helpers.js'
 
 const cleanupPaths: string[] = []
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+)
 const prebuiltArtifactPathEnv = 'MURPH_ASSISTANT_CLI_SURFACE_PREBUILT_ARTIFACT_PATH'
 const originalPrebuiltArtifactPathEnv = process.env[prebuiltArtifactPathEnv]
 
@@ -672,9 +677,11 @@ test('generate-cli-surface-contract builds the prebuilt artifact from the full m
 
   assert.equal(readAssistantCliLlmsManifest.mock.calls.length, 0)
   assert.equal(readAssistantCliLlmsFullManifest.mock.calls.length, 1)
-  assert.match(
-    readAssistantCliLlmsFullManifest.mock.calls[0]?.[0]?.workingDirectory ?? '',
-    /murph(?:-[^/]+)?$/u,
+  assert.equal(
+    path.resolve(
+      readAssistantCliLlmsFullManifest.mock.calls[0]?.[0]?.workingDirectory ?? '',
+    ),
+    repoRoot,
   )
   assert.equal(writeFileMock.mock.calls.length, 1)
 

--- a/packages/cli/test/device-cli.test.ts
+++ b/packages/cli/test/device-cli.test.ts
@@ -1351,6 +1351,7 @@ deviceControlPlaneTest(
       await rm(vaultRoot, { recursive: true, force: true })
     }
   },
+  DEVICE_HOSTED_BRIDGE_SMOKE_TIMEOUT_MS,
 )
 
 async function readJsonBody(

--- a/packages/cli/test/incur-smoke.test.ts
+++ b/packages/cli/test/incur-smoke.test.ts
@@ -33,6 +33,7 @@ const packageJson = require('../package.json') as { version?: string }
 const INCUR_ROOT_HELP_TIMEOUT_MS = 90_000
 const INCUR_HELP_TIMEOUT_MS = 45_000
 const INCUR_SCHEMA_TIMEOUT_MS = 45_000
+const INCUR_KNOWLEDGE_BOUNDARY_TIMEOUT_MS = 120_000
 const DELETED_COMMONS_COMMANDS = [
   'commons search',
   'commons get',
@@ -1458,7 +1459,7 @@ test('knowledge upsert persists assistant-authored pages through the built CLI b
   } finally {
     await rm(vaultRoot, { recursive: true, force: true })
   }
-})
+}, INCUR_KNOWLEDGE_BOUNDARY_TIMEOUT_MS)
 
 test('knowledge append-section appends one dated page section through the built CLI boundary', async () => {
   const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-knowledge-cli-append-'))

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1086,6 +1086,8 @@ exit 1
     expect(cliPackageJson.bundleDependencies).toContain('incur')
     expect(packPublishables).toContain('resolveBundledExternalDependencies')
     expect(packPublishables).toContain('copyExternalBundledDependency')
+    expect(packPublishables).toContain('stripBundledDependencyMetadata')
+    expect(packPublishables).toContain("path.join(targetDir, 'package.json')")
     expect(packPublishables).toContain('shouldSkipExternalPayloadArtifact')
     expect(packPublishables).toContain("path.basename(sourcePath) === 'node_modules'")
     expect(cliPackageJson.scripts?.['release:check']).toBeUndefined()

--- a/scripts/pack-publishables.mjs
+++ b/scripts/pack-publishables.mjs
@@ -182,6 +182,22 @@ async function copyExternalBundledDependency(entry, dependencyName, targetDir) {
   }
 
   await copyExternalPackagePayload(dependencyName, packageJson, sourceDir, targetDir);
+  await writeJson(
+    path.join(targetDir, 'package.json'),
+    stripBundledDependencyMetadata(packageJson),
+  );
+}
+
+function stripBundledDependencyMetadata(packageJson) {
+  const tarballPackageJson = { ...packageJson };
+  delete tarballPackageJson.dependencies;
+  delete tarballPackageJson.optionalDependencies;
+  delete tarballPackageJson.peerDependencies;
+  delete tarballPackageJson.devDependencies;
+  delete tarballPackageJson.scripts;
+  delete tarballPackageJson.bundleDependencies;
+  delete tarballPackageJson.bundledDependencies;
+  return tarballPackageJson;
 }
 
 function buildTarballPackageJson(
@@ -199,12 +215,7 @@ function buildTarballPackageJson(
   delete tarballPackageJson.scripts;
 
   if (options.stripBundledDependencyMetadata === true) {
-    delete tarballPackageJson.dependencies;
-    delete tarballPackageJson.optionalDependencies;
-    delete tarballPackageJson.peerDependencies;
-    delete tarballPackageJson.bundleDependencies;
-    delete tarballPackageJson.bundledDependencies;
-    return tarballPackageJson;
+    return stripBundledDependencyMetadata(tarballPackageJson);
   }
 
   if (bundledDependencies.length > 0) {


### PR DESCRIPTION
## Summary

- Strip dependency/script metadata from bundled external package payloads so the generated `@murphai/murph` tarball installs cleanly through npm's global layout.
- Stabilize the release gate tests that were timing out or assuming checkout names under fresh worktrees.
- Add release-script guard coverage for the bundled external metadata rewrite path.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm release:check`
- Focused assistant-engine, assistant-cli, CLI device, CLI release-script audit, and CLI knowledge boundary smoke tests
- Local five-tarball smoke, run twice: packed all publishables, inspected bundled `incur/package.json`, installed all five tarballs into an isolated global prefix, and installed all five tarballs into a blank consumer project
- Required `coverage-write` audit: no findings

## Release Notes

No npm publish, release tag, or version bump was performed in this PR. After this lands, the release script should be run from `main`; because `v1.1.0` already exists as a tag while npm latest is still `1.0.0`, the next public release should be prepared as a new minor version instead of reusing `1.1.0`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784327015&installation_id=127572939&pr_number=211&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F211&signature=e85f0ac430076dc6afb0ac90c0dd8c5a066abd000a81d32f1e0a09ab6b0ce53b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->