### PR TITLE
[codex] Add exact contaminant threshold applications

### DIFF
--- a/agent-docs/exec-plans/active/contaminants.md
+++ b/agent-docs/exec-plans/active/contaminants.md
@@ -343,8 +343,8 @@ Simple deterministic rule:
 2. A test is threshold-comparable only when:
    - `result_operator` is `eq`, or a lower-bound `gt` / `gte` result whose bound proves threshold exceedance
    - `normalized_value IS NOT NULL`
-   - `normalized_unit = threshold_unit`
-   - `normalized_basis = threshold_basis`
+   - `normalized_unit` matches an active threshold's normalized unit
+   - `normalized_basis` matches an active threshold's normalized basis
    - `contaminant_key` matches
    - threshold is active
 3. A comparable `eq` test exceeds a threshold only when `normalized_value > threshold_value`. A `gt` lower bound proves exceedance when `normalized_value >= threshold_value`; a `gte` lower bound proves exceedance when `normalized_value > threshold_value`.
@@ -377,6 +377,8 @@ murphConcernLevel = "none"
 ```
 
 The API does no unit conversion. Ingestion normalizes test values and thresholds into comparable units and bases. If ingestion cannot normalize confidently, it leaves `normalized_value` null and the API returns `unknown`.
+
+Implementation note, 2026-06-18: global threshold comparisons use the threshold row's normalized triplet only when the threshold is already an explicit product-mass concentration limit. Scoped legal or commodity thresholds, such as EU commodity limits, remain source references unless a reviewed exact-product row in `product_contaminant_threshold_applications` links that threshold to one Murph food or supplement. For those application rows, the API derives the comparable normalized triplet from the current active threshold row's concentration unit so threshold refreshes cannot leave stale product limits behind. EU 2023/915 threshold imports canonicalize new rows to stable semantic IDs and retire older versioned rows as inactive/non-comparable; reviewed application imports are additive unless an operator explicitly runs guarded replacement with an expected row count. The API never falls back to raw threshold units/bases, categories, brands, or names.
 
 This is intentionally conservative. It avoids false reassurance from censored results and keeps runtime logic small.
 

--- a/agent-docs/exec-plans/completed/2026-06-18-threshold-normalizer.md
+++ b/agent-docs/exec-plans/completed/2026-06-18-threshold-normalizer.md
@@ -1,0 +1,54 @@
+# Contaminant Threshold Normalizer
+
+## Goal
+
+Make contaminant thresholds usable without adding API-side inference:
+
+- backfill normalized threshold triplets only for threshold rows that are already explicit product-mass concentration limits;
+- clear stale normalized fields from non-comparable threshold rows;
+- add a reviewed exact-product threshold application import path for scoped commodity thresholds;
+- keep `/api/foods` and `/api/supplements` exact-product only.
+
+## Constraints
+
+- Do not infer threshold applicability from product names, brands, categories, ingredients, or source families.
+- Do not add API-side raw threshold unit fallback.
+- Keep source threshold rows as regulatory references unless import-time data says they are comparable.
+- Use `MURPH_LABELS_DB_URL`; never print or commit database URLs.
+
+## Decisions
+
+- ReviewGPT recommended schema-boundary normalization instead of broad API inference.
+- `contaminant_thresholds.normalized_*` remains the global comparable path for true product-mass concentration rows.
+- Scoped thresholds use `product_contaminant_threshold_applications`, which links one reviewed threshold to exactly one Murph food or supplement; the API derives the comparable triplet from the current active threshold row so application rows do not carry stale threshold values.
+- The reviewed threshold application TSV is authoritative; a header-only TSV can clear rows only with `--allow-empty`.
+
+## Current State
+
+- Implementation complete on branch `codex/threshold-applications`; ready for commit/PR.
+- Existing app/data DB role can update existing threshold rows but cannot create new schema objects; actual table creation needs the normal migration/deploy role.
+- Labels DB cleanup/backfill was applied through the secret-safe psql helper. It updated 0 rows because no existing product-mass concentration thresholds were stale, and there are currently 0 active global comparable threshold rows.
+- Reviewed Trader Joe's beet threshold applications simulate to 2 application rows joining 4 existing exact product-test rows once the new application table is created.
+- Local audit found and fixed malformed-TSV destructive-delete risk, stale denormalized threshold values in application rows, inactive-threshold imports, and supplement alias application matching against the wrong product id.
+
+## Verification Plan
+
+- Focused Vitest for product-test schema/import tests and label query tests.
+- `pnpm --dir apps/web typecheck`.
+- `pnpm test:diff` for the touched app/docs slice.
+- DB simulation with the labels DB URL from local env, without printing secrets.
+- Required security/privacy, coverage, and deep-review passes before PR.
+- ReviewGPT PR loop after pushing the PR head.
+
+## Verification So Far
+
+- Passed: `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/product-tests-schema.test.ts apps/web/test/foods-lib.test.ts apps/web/test/supplements-lib.test.ts`
+- Passed: `pnpm --dir apps/web lint`
+- Passed: `pnpm --dir apps/web typecheck`
+- Passed: `git diff --check`
+- Passed: `pnpm test:diff`
+- Passed: security/privacy review, coverage/proof pass, and targeted deep re-review. No medium-or-higher findings remain locally.
+- Full workspace `pnpm typecheck` is blocked by unrelated assistant/operator-config workspace resolution failures outside this diff.
+Status: completed
+Updated: 2026-06-18
+Completed: 2026-06-18

--- a/apps/web/scripts/check-product-label-runtime-env.ts
+++ b/apps/web/scripts/check-product-label-runtime-env.ts
@@ -45,6 +45,9 @@ const REQUIRED_PRODUCT_LABEL_SCHEMA_COLUMNS = [
   ["contaminant_thresholds", "threshold_name"],
   ["contaminant_thresholds", "threshold_url"],
   ["contaminant_thresholds", "concern_level_if_exceeded"],
+  ["product_contaminant_threshold_applications", "threshold_id"],
+  ["product_contaminant_threshold_applications", "food_id"],
+  ["product_contaminant_threshold_applications", "supplement_id"],
 ] as const;
 
 type EnvSource = Readonly<Record<string, string | undefined>>;

--- a/apps/web/sql/product-tests/README.md
+++ b/apps/web/sql/product-tests/README.md
@@ -309,6 +309,10 @@ omit `imported_at`; the database sets that timestamp when rows are imported.
 NSRL/MADL exposure type, EU commodity clause, or FDA commodity key. It is not
 the product-test measurement basis. The import derives separate normalized
 comparison fields only for explicitly product-mass-scoped concentration rows;
+EU 2023/915 threshold IDs are canonicalized to stable semantic IDs by removing
+date/version suffixes so product threshold applications keep following threshold
+refreshes. Historical versioned EU 2023/915 rows are retained but marked
+inactive/non-comparable instead of being renamed in place.
 equivalent mass concentration units (`mg/kg`, `ppb`, `ug/kg`, and `ng/g`) are
 stored in the comparison triplet as canonical `ppm` values while the source
 unit remains on the raw result or threshold field. Product-mass `mg/kg-dry`
@@ -316,12 +320,17 @@ rows are left as `mg/kg-dry` because dry-weight measurements are not equivalent
 to as-sold product-mass concentrations without source-specific moisture data.
 They compare only to explicitly dry-weight `mg/kg-dry` threshold rows.
 The current public threshold snapshots stay non-comparable until product
-applicability is modeled explicitly. Active comparable threshold rows are unique by
+applicability is modeled explicitly. Public threshold snapshots can validly
+produce zero active comparable rows when they contain scoped legal,
+commodity-specific, daily-exposure, water, or leaching references rather than
+globally applicable product-mass concentration limits. Active comparable
+threshold rows are unique by
 `contaminant_key + normalized_unit + normalized_basis` so a product observation
 can match at most one threshold row. The schema migration backfills normalized
 fields for any existing explicit `product_mass` concentration thresholds and
 product-test observations so already-deployed comparable rows keep working
-before the next import.
+before the next import. It also clears stale normalized threshold fields from
+rows that are not eligible for direct product-test comparison.
 
 Import one local threshold CSV with:
 
@@ -332,7 +341,9 @@ apps/web/sql/product-tests/import-thresholds.sh
 ```
 
 Threshold imports are additive by default: contained rows are upserted without
-deactivating other active thresholds for the same authority.
+deactivating other active thresholds for the same authority. Reviewed threshold
+applications should reference stable semantic threshold IDs, not one-off
+versioned source-export IDs.
 
 Apply schemas only with:
 
@@ -361,3 +372,62 @@ normalized comparison triplet and `contaminant_key`, `normalized_unit`, and
 `normalized_basis` match exactly. Scoped legal, commodity, daily-exposure,
 water, and leaching-solution thresholds remain visible as source references but
 are not product alerts without explicit product-applicability mapping.
+
+## Reviewed Threshold Applications
+
+Use `product_contaminant_threshold_applications` only when a reviewed threshold
+row applies to one exact Murph food or supplement label. The application row
+links a scoped threshold to exactly one `food_id` or `supplement_id` and carries
+the review note that explains why the threshold applies to that product. It does
+not store threshold comparison values. The hosted label API derives the
+application's normalized comparison triplet from the current active threshold
+row's concentration unit, so threshold refreshes cannot leave stale product
+application limits behind. The threshold row's raw `threshold_basis` still
+preserves the legal or commodity scope; the application row is only the reviewed
+bridge to product-mass comparison for one exact product.
+
+The hosted label API returns at most one comparison per observation. When more
+than one threshold can compare to a test row, it chooses proven exceedances and
+then higher concern thresholds before using exactness as a tie-breaker. Exact
+product applications only participate when the product test and application
+match on exact product id, contaminant key, and the normalized unit/basis
+derived from the current active threshold row. Do not add API-side raw threshold
+fallback, category/brand/name inference, or stale denormalized threshold values;
+new comparability belongs in reviewed import data or schema-owned normalization.
+
+The initial reviewed applications live at:
+
+```text
+apps/web/sql/product-tests/threshold-applications/reviewed.tsv
+```
+
+Import them with:
+
+```sh
+PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH=apps/web/sql/product-tests/threshold-applications/reviewed.tsv \
+MURPH_LABELS_DB_URL=postgres://... \
+apps/web/sql/product-tests/import-threshold-applications.sh
+```
+
+Reviewed threshold application imports are additive by default: contained rows
+are inserted or updated without pruning other reviewed applications. To treat a
+TSV as the complete reviewed application set and delete rows absent from it, pass
+`--replace-applications` with `PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS`
+set to the exact TSV data-row count. A header-only replacement with expected row
+count `0` intentionally clears all reviewed applications; without replacement
+mode, the runner refuses zero-row imports. Every import validates the final
+reviewed application set has no duplicate comparable threshold for the same
+product, contaminant, normalized unit, and normalized basis.
+
+Apply schemas only with:
+
+```sh
+MURPH_LABELS_DB_URL=postgres://... \
+apps/web/sql/product-tests/import-threshold-applications.sh --schema-only
+```
+
+Deployment order for a fresh environment is: product label schemas, product-test
+schema, contaminant source imports/remaps, threshold imports, then reviewed
+threshold applications. A labels database role that cannot create schema objects
+may run threshold cleanup/backfill updates, but the new application table needs
+the normal migration/deploy role before the application import can succeed.

--- a/apps/web/sql/product-tests/import-threshold-applications.sh
+++ b/apps/web/sql/product-tests/import-threshold-applications.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: apps/web/sql/product-tests/import-threshold-applications.sh [--schema-only] [--legacy-supplement-db] [--replace-applications]
+
+Imports reviewed exact-product contaminant threshold applications.
+
+Required env:
+  MURPH_LABELS_DB_URL
+  PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH
+
+Optional env:
+  PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS
+                                 Required with --replace-applications. Must
+                                 equal the TSV data row count before the import
+                                 can delete rows absent from the input.
+  PSQL_BIN                       psql binary to use. Defaults to psql.
+
+Flags:
+  --schema-only                  Apply schemas without importing applications.
+  --legacy-supplement-db         Use the legacy supplement-only foods stub
+                                 instead of the full foods search schema.
+  --replace-applications         Treat the TSV as the complete reviewed
+                                 application set and delete absent rows.
+
+The runner never prints the database URL or passes it to psql argv.
+USAGE
+}
+
+schema_only=false
+legacy_supplement_db=false
+replace_applications=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --schema-only)
+      schema_only=true
+      ;;
+    --legacy-supplement-db)
+      legacy_supplement_db=true
+      ;;
+    --replace-applications)
+      replace_applications=true
+      ;;
+    *)
+      usage
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+if [ "$replace_applications" = true ] && [ "$schema_only" = true ]; then
+  echo "--replace-applications cannot be used with --schema-only" >&2
+  exit 64
+fi
+
+applications_tsv_path="${PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH:-}"
+replace_applications_expected_rows="${PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS:-}"
+
+script_dir_abs="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir_abs/../../../.." && pwd)"
+script_dir="apps/web/sql/product-tests"
+
+# shellcheck source=apps/web/sql/product-tests/labels-db-psql.sh
+. "$script_dir_abs/labels-db-psql.sh"
+
+cleanup_threshold_application_import() {
+  cleanup_labels_db_psql_env
+}
+
+trap cleanup_threshold_application_import EXIT
+prepare_labels_db_psql_env
+
+cd "$repo_root"
+
+apply_product_test_schemas() {
+  echo "Applying product label and test schemas..."
+  if [ "$legacy_supplement_db" = true ]; then
+    run_labels_psql -v ON_ERROR_STOP=1 -f "$script_dir/legacy-supplement-foods-stub.sql"
+  else
+    run_labels_psql -v ON_ERROR_STOP=1 -f "apps/web/sql/foods/schema.sql"
+    run_labels_psql -v ON_ERROR_STOP=1 -f "apps/web/sql/supplements/schema.sql"
+  fi
+  run_labels_psql -v ON_ERROR_STOP=1 -f "$script_dir/schema.sql"
+}
+
+if [ "$schema_only" = true ]; then
+  apply_product_test_schemas
+  echo "Applied product label and test schemas."
+  exit 0
+fi
+
+if [ -z "$applications_tsv_path" ]; then
+  echo "PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH is required" >&2
+  exit 64
+fi
+
+case "$applications_tsv_path" in
+  /*|../*|*/../*|..)
+    echo "PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH must be repo-relative" >&2
+    exit 64
+    ;;
+esac
+
+applications_tsv="$applications_tsv_path"
+if [ ! -f "$applications_tsv" ]; then
+  echo "Product threshold applications TSV not found" >&2
+  exit 66
+fi
+
+work_dir=".product-tests-work/threshold-applications"
+mkdir -p "$work_dir"
+run_work_dir="$(mktemp -d "$work_dir/run.XXXXXX")"
+prepared_applications_tsv="$run_work_dir/product-threshold-applications.tsv"
+rows_count_file="$run_work_dir/rows-in-file.count"
+rendered_import_sql="$run_work_dir/import-threshold-applications.sql"
+prepared_row_count=0
+
+IFS= read -r header < "$applications_tsv" || {
+  echo "Product threshold applications TSV is empty" >&2
+  exit 65
+}
+header="${header%$'\r'}"
+printf '%s\n' "$header" > "$prepared_applications_tsv"
+
+awk -v count_file="$rows_count_file" '
+  NR > 1 {
+    count += 1
+    print
+  }
+
+  END {
+    print count + 0 > count_file
+  }
+' "$applications_tsv" >> "$prepared_applications_tsv"
+prepared_row_count="$(cat "$rows_count_file")"
+
+if [ "$replace_applications" = true ]; then
+  if ! [[ "$replace_applications_expected_rows" =~ ^[0-9]+$ ]]; then
+    echo "PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS is required with --replace-applications" >&2
+    exit 64
+  fi
+
+  if [ "$prepared_row_count" -ne "$replace_applications_expected_rows" ]; then
+    echo "Product threshold applications --replace-applications expected $replace_applications_expected_rows rows but found $prepared_row_count; refusing destructive import." >&2
+    exit 65
+  fi
+elif [ "$prepared_row_count" -le 0 ]; then
+  echo "Product threshold applications import prepared zero rows; refusing to run no-op import. Use --replace-applications with PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS=0 only to intentionally clear all reviewed applications." >&2
+  exit 65
+fi
+
+apply_product_test_schemas
+
+awk \
+  -v applications_tsv="$(labels_db_psql_copy_literal "$prepared_applications_tsv")" \
+  '{ gsub(/__THRESHOLD_APPLICATIONS_TSV__/, applications_tsv); print }' \
+  "$script_dir/import-threshold-applications.sql" > "$rendered_import_sql"
+
+echo "Importing $prepared_row_count product threshold application rows..."
+run_labels_psql \
+  -v ON_ERROR_STOP=1 \
+  -v replace_applications="$replace_applications" \
+  -f "$rendered_import_sql"
+
+echo "Imported product threshold applications TSV."

--- a/apps/web/sql/product-tests/import-threshold-applications.sql
+++ b/apps/web/sql/product-tests/import-threshold-applications.sql
@@ -1,0 +1,290 @@
+BEGIN;
+
+SELECT pg_advisory_xact_lock(hashtext('murph:contaminant_threshold_applications:import'));
+
+CREATE TEMP TABLE product_threshold_applications_import (
+  threshold_id TEXT,
+  food_id TEXT,
+  supplement_id TEXT,
+  review_note TEXT
+) ON COMMIT DROP;
+
+\copy product_threshold_applications_import FROM __THRESHOLD_APPLICATIONS_TSV__ WITH (FORMAT csv, DELIMITER E'\t', HEADER true, NULL '')
+
+CREATE TEMP TABLE product_threshold_applications_cleaned AS
+  SELECT
+    btrim(threshold_id) AS threshold_id,
+    NULLIF(btrim(food_id), '') AS food_id,
+    NULLIF(btrim(supplement_id), '') AS supplement_id,
+    btrim(review_note) AS review_note
+  FROM product_threshold_applications_import;
+
+DO $$
+DECLARE
+  invalid_rows INTEGER;
+BEGIN
+  SELECT COUNT(*)
+  INTO invalid_rows
+  FROM product_threshold_applications_cleaned
+  WHERE (
+    CASE WHEN food_id IS NULL THEN 0 ELSE 1 END
+    + CASE WHEN supplement_id IS NULL THEN 0 ELSE 1 END
+  ) <> 1
+    OR threshold_id IS NULL
+    OR threshold_id = ''
+    OR review_note IS NULL
+    OR review_note = '';
+
+  IF invalid_rows > 0 THEN
+    RAISE EXCEPTION
+      'product threshold application rows must include threshold_id, review_note, and exactly one food_id or supplement_id';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  missing_food_ids TEXT;
+BEGIN
+  SELECT string_agg(DISTINCT current_import.food_id, ', ' ORDER BY current_import.food_id)
+  INTO missing_food_ids
+  FROM product_threshold_applications_cleaned current_import
+  LEFT JOIN foods
+    ON foods.id = current_import.food_id
+  WHERE current_import.food_id IS NOT NULL
+    AND foods.id IS NULL;
+
+  IF missing_food_ids IS NOT NULL THEN
+    RAISE EXCEPTION
+      'product threshold application row references missing food_id: %',
+      missing_food_ids;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  missing_supplement_ids TEXT;
+BEGIN
+  SELECT string_agg(DISTINCT current_import.supplement_id, ', ' ORDER BY current_import.supplement_id)
+  INTO missing_supplement_ids
+  FROM product_threshold_applications_cleaned current_import
+  LEFT JOIN supplements
+    ON supplements.id = current_import.supplement_id
+  WHERE current_import.supplement_id IS NOT NULL
+    AND supplements.id IS NULL;
+
+  IF missing_supplement_ids IS NOT NULL THEN
+    RAISE EXCEPTION
+      'product threshold application row references missing supplement_id: %',
+      missing_supplement_ids;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  missing_threshold_ids TEXT;
+BEGIN
+  SELECT string_agg(DISTINCT current_import.threshold_id, ', ' ORDER BY current_import.threshold_id)
+  INTO missing_threshold_ids
+  FROM product_threshold_applications_cleaned current_import
+  LEFT JOIN contaminant_thresholds
+    ON contaminant_thresholds.id = current_import.threshold_id
+  WHERE contaminant_thresholds.id IS NULL;
+
+  IF missing_threshold_ids IS NOT NULL THEN
+    RAISE EXCEPTION
+      'product threshold application row references missing threshold_id: %',
+      missing_threshold_ids;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  inactive_threshold_ids TEXT;
+BEGIN
+  SELECT string_agg(DISTINCT current_import.threshold_id, ', ' ORDER BY current_import.threshold_id)
+  INTO inactive_threshold_ids
+  FROM product_threshold_applications_cleaned current_import
+  JOIN contaminant_thresholds
+    ON contaminant_thresholds.id = current_import.threshold_id
+  WHERE contaminant_thresholds.active IS DISTINCT FROM true;
+
+  IF inactive_threshold_ids IS NOT NULL THEN
+    RAISE EXCEPTION
+      'product threshold application row references inactive threshold_id: %',
+      inactive_threshold_ids;
+  END IF;
+END $$;
+
+CREATE TEMP TABLE product_threshold_applications_normalized AS
+  SELECT
+    'threshold_application:' || md5(jsonb_build_array(
+      current_import.threshold_id,
+      current_import.food_id,
+      current_import.supplement_id
+    )::text) AS id,
+    current_import.threshold_id,
+    thresholds.contaminant_key,
+    current_import.food_id,
+    current_import.supplement_id,
+    CASE
+      WHEN thresholds.threshold_unit IN ('ppm', 'mg/kg') THEN thresholds.threshold_value
+      WHEN thresholds.threshold_unit IN ('ppb', 'ug/kg', 'ng/g') THEN thresholds.threshold_value / 1000
+      WHEN thresholds.threshold_unit = 'mg/kg-dry' THEN thresholds.threshold_value
+      ELSE NULL
+    END AS normalized_value,
+    CASE
+      WHEN thresholds.threshold_unit = 'mg/kg-dry' THEN 'mg/kg-dry'
+      ELSE 'ppm'
+    END AS normalized_unit,
+    'product_mass' AS normalized_basis,
+    current_import.review_note
+  FROM product_threshold_applications_cleaned current_import
+  JOIN contaminant_thresholds thresholds
+    ON thresholds.id = current_import.threshold_id;
+
+DO $$
+DECLARE
+  cleaned_row_count INTEGER;
+  normalized_row_count INTEGER;
+BEGIN
+  SELECT COUNT(*)
+  INTO cleaned_row_count
+  FROM product_threshold_applications_cleaned;
+
+  SELECT COUNT(*)
+  INTO normalized_row_count
+  FROM product_threshold_applications_normalized;
+
+  IF normalized_row_count <> cleaned_row_count THEN
+    RAISE EXCEPTION
+      'product threshold application normalization dropped rows before import mutation';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  unsupported_threshold_ids TEXT;
+BEGIN
+  SELECT string_agg(DISTINCT current_import.threshold_id, ', ' ORDER BY current_import.threshold_id)
+  INTO unsupported_threshold_ids
+  FROM product_threshold_applications_cleaned current_import
+  LEFT JOIN product_threshold_applications_normalized normalized
+    ON normalized.threshold_id = current_import.threshold_id
+    AND normalized.food_id IS NOT DISTINCT FROM current_import.food_id
+    AND normalized.supplement_id IS NOT DISTINCT FROM current_import.supplement_id
+  WHERE normalized.normalized_value IS NULL
+    OR normalized.normalized_unit IS NULL;
+
+  IF unsupported_threshold_ids IS NOT NULL THEN
+    RAISE EXCEPTION
+      'product threshold application row references threshold without supported concentration unit: %',
+      unsupported_threshold_ids;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  duplicate_keys TEXT;
+BEGIN
+  SELECT string_agg(duplicate_key, ', ' ORDER BY duplicate_key)
+  INTO duplicate_keys
+  FROM (
+    SELECT
+      COALESCE(food_id, '') || ':' || COALESCE(supplement_id, '') || ':' || contaminant_key || ':' || normalized_unit || ':' || normalized_basis AS duplicate_key
+    FROM product_threshold_applications_normalized
+    GROUP BY food_id, supplement_id, contaminant_key, normalized_unit, normalized_basis
+    HAVING COUNT(*) > 1
+  ) duplicate_product_threshold_applications;
+
+  IF duplicate_keys IS NOT NULL THEN
+    RAISE EXCEPTION
+      'duplicate product threshold applications for comparable product/contaminant/unit/basis: %',
+      duplicate_keys;
+  END IF;
+END $$;
+
+DELETE FROM product_contaminant_threshold_applications
+WHERE id NOT IN (
+  SELECT id
+  FROM product_threshold_applications_normalized
+)
+  AND :'replace_applications' = 'true';
+
+DELETE FROM product_contaminant_threshold_applications existing_applications
+USING product_threshold_applications_normalized current_import
+WHERE existing_applications.id <> current_import.id
+  AND existing_applications.threshold_id = current_import.threshold_id
+  AND existing_applications.food_id IS NOT DISTINCT FROM current_import.food_id
+  AND existing_applications.supplement_id IS NOT DISTINCT FROM current_import.supplement_id;
+
+INSERT INTO product_contaminant_threshold_applications (
+  id,
+  threshold_id,
+  food_id,
+  supplement_id,
+  review_note
+)
+SELECT
+  id,
+  threshold_id,
+  food_id,
+  supplement_id,
+  review_note
+FROM product_threshold_applications_normalized
+ON CONFLICT (id) DO UPDATE SET
+  threshold_id = EXCLUDED.threshold_id,
+  food_id = EXCLUDED.food_id,
+  supplement_id = EXCLUDED.supplement_id,
+  review_note = EXCLUDED.review_note,
+  imported_at = now();
+
+DO $$
+DECLARE
+  duplicate_keys TEXT;
+BEGIN
+  SELECT string_agg(duplicate_key, ', ' ORDER BY duplicate_key)
+  INTO duplicate_keys
+  FROM (
+    SELECT
+      COALESCE(applications.food_id, '') || ':'
+        || COALESCE(applications.supplement_id, '') || ':'
+        || thresholds.contaminant_key || ':'
+        || application_threshold.normalized_unit || ':'
+        || application_threshold.normalized_basis AS duplicate_key
+    FROM product_contaminant_threshold_applications applications
+    JOIN contaminant_thresholds thresholds
+      ON thresholds.id = applications.threshold_id
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN thresholds.threshold_unit IN ('ppm', 'mg/kg') THEN thresholds.threshold_value
+          WHEN thresholds.threshold_unit IN ('ppb', 'ug/kg', 'ng/g') THEN thresholds.threshold_value / 1000
+          WHEN thresholds.threshold_unit = 'mg/kg-dry' THEN thresholds.threshold_value
+          ELSE NULL
+        END AS normalized_value,
+        CASE
+          WHEN thresholds.threshold_unit = 'mg/kg-dry' THEN 'mg/kg-dry'
+          ELSE 'ppm'
+        END AS normalized_unit,
+        'product_mass' AS normalized_basis
+    ) application_threshold
+    WHERE thresholds.active
+      AND application_threshold.normalized_value IS NOT NULL
+      AND application_threshold.normalized_unit IS NOT NULL
+    GROUP BY
+      applications.food_id,
+      applications.supplement_id,
+      thresholds.contaminant_key,
+      application_threshold.normalized_unit,
+      application_threshold.normalized_basis
+    HAVING COUNT(*) > 1
+  ) duplicate_product_threshold_applications;
+
+  IF duplicate_keys IS NOT NULL THEN
+    RAISE EXCEPTION
+      'duplicate product threshold applications after import for comparable product/contaminant/unit/basis: %',
+      duplicate_keys;
+  END IF;
+END $$;
+
+COMMIT;

--- a/apps/web/sql/product-tests/import-thresholds.sql
+++ b/apps/web/sql/product-tests/import-thresholds.sql
@@ -28,7 +28,11 @@ END $$;
 
 CREATE TEMP TABLE contaminant_thresholds_cleaned AS
   SELECT
-    btrim(id) AS id,
+    CASE
+      WHEN btrim(id) LIKE 'eu_2023_915_%'
+        THEN regexp_replace(btrim(id), '_[0-9]{8}_v[0-9]{8}$', '')
+      ELSE btrim(id)
+    END AS id,
     btrim(contaminant_key) AS contaminant_key,
     btrim(authority_key) AS authority_key,
     btrim(authority_name) AS authority_name,
@@ -73,6 +77,12 @@ CREATE TEMP TABLE contaminant_thresholds_normalized AS
       ELSE NULL
     END AS normalized_basis
   FROM contaminant_thresholds_cleaned;
+
+UPDATE contaminant_thresholds versioned_thresholds
+SET active = false
+WHERE versioned_thresholds.id LIKE 'eu_2023_915_%'
+  AND versioned_thresholds.id ~ '_[0-9]{8}_v[0-9]{8}$'
+  AND versioned_thresholds.active IS DISTINCT FROM false;
 
 DO $$
 DECLARE

--- a/apps/web/sql/product-tests/schema.sql
+++ b/apps/web/sql/product-tests/schema.sql
@@ -121,6 +121,21 @@ WHERE threshold_basis = 'product_mass'
     OR normalized_basis IS DISTINCT FROM 'product_mass'
   );
 
+UPDATE contaminant_thresholds
+SET
+  normalized_value = NULL,
+  normalized_unit = NULL,
+  normalized_basis = NULL
+WHERE NOT (
+    threshold_basis = 'product_mass'
+    AND threshold_unit IN ('ppm', 'mg/kg', 'ppb', 'ug/kg', 'ng/g', 'mg/kg-dry')
+  )
+  AND (
+    normalized_value IS NOT NULL
+    OR normalized_unit IS NOT NULL
+    OR normalized_basis IS NOT NULL
+  );
+
 ALTER TABLE contaminant_thresholds
   DROP CONSTRAINT IF EXISTS contaminant_thresholds_contaminant_key_check,
   ADD CONSTRAINT contaminant_thresholds_contaminant_key_check
@@ -146,6 +161,46 @@ ALTER TABLE contaminant_thresholds
   DROP CONSTRAINT IF EXISTS contaminant_thresholds_normalized_value_check,
   ADD CONSTRAINT contaminant_thresholds_normalized_value_check
     CHECK (normalized_value IS NULL OR normalized_value > 0);
+
+DO $$
+BEGIN
+  IF to_regclass('public.product_contaminant_threshold_applications') IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'product_contaminant_threshold_applications'
+        AND column_name = 'threshold_id'
+    )
+  THEN
+    ALTER TABLE product_contaminant_threshold_applications
+      DROP CONSTRAINT IF EXISTS product_contaminant_threshold_applications_threshold_id_fkey;
+
+    ALTER TABLE product_contaminant_threshold_applications
+      ADD CONSTRAINT product_contaminant_threshold_applications_threshold_id_fkey
+        FOREIGN KEY (threshold_id) REFERENCES contaminant_thresholds(id) ON UPDATE CASCADE;
+
+    UPDATE product_contaminant_threshold_applications
+    SET threshold_id = regexp_replace(threshold_id, '_[0-9]{8}_v[0-9]{8}$', '')
+    WHERE threshold_id LIKE 'eu_2023_915_%'
+      AND threshold_id ~ '_[0-9]{8}_v[0-9]{8}$'
+      AND EXISTS (
+        SELECT 1
+        FROM contaminant_thresholds stable_thresholds
+        WHERE stable_thresholds.id = regexp_replace(
+          product_contaminant_threshold_applications.threshold_id,
+          '_[0-9]{8}_v[0-9]{8}$',
+          ''
+        )
+      );
+  END IF;
+END $$;
+
+UPDATE contaminant_thresholds versioned_thresholds
+SET active = false
+WHERE versioned_thresholds.id LIKE 'eu_2023_915_%'
+  AND versioned_thresholds.id ~ '_[0-9]{8}_v[0-9]{8}$'
+  AND versioned_thresholds.active IS DISTINCT FROM false;
 
 DO $$
 DECLARE
@@ -181,6 +236,52 @@ CREATE UNIQUE INDEX IF NOT EXISTS contaminant_thresholds_active_comparable_idx
 
 DROP INDEX IF EXISTS contaminant_thresholds_active_identity_idx;
 DROP INDEX IF EXISTS contaminant_thresholds_lookup_idx;
+
+CREATE TABLE IF NOT EXISTS product_contaminant_threshold_applications (
+  id TEXT PRIMARY KEY,
+  threshold_id TEXT NOT NULL REFERENCES contaminant_thresholds(id) ON UPDATE CASCADE,
+  food_id TEXT REFERENCES foods(id),
+  supplement_id TEXT REFERENCES supplements(id),
+  review_note TEXT NOT NULL,
+  imported_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT product_contaminant_threshold_applications_id_check
+    CHECK (btrim(id) <> ''),
+  CONSTRAINT product_contaminant_threshold_applications_product_link_check
+    CHECK (
+      (
+        CASE WHEN food_id IS NULL THEN 0 ELSE 1 END
+        + CASE WHEN supplement_id IS NULL THEN 0 ELSE 1 END
+      ) = 1
+    ),
+  CONSTRAINT product_contaminant_threshold_applications_review_note_check
+    CHECK (btrim(review_note) <> '')
+);
+
+DROP INDEX IF EXISTS product_contaminant_threshold_applications_food_comparable_idx;
+DROP INDEX IF EXISTS product_contaminant_threshold_applications_supplement_comparable_idx;
+DROP INDEX IF EXISTS product_contaminant_threshold_applications_food_lookup_idx;
+DROP INDEX IF EXISTS product_contaminant_threshold_applications_supplement_lookup_idx;
+
+ALTER TABLE product_contaminant_threshold_applications
+  DROP CONSTRAINT IF EXISTS product_contaminant_threshold_applications_contaminant_key_check,
+  DROP CONSTRAINT IF EXISTS product_contaminant_threshold_applications_threshold_id_fkey,
+  ADD CONSTRAINT product_contaminant_threshold_applications_threshold_id_fkey
+    FOREIGN KEY (threshold_id) REFERENCES contaminant_thresholds(id) ON UPDATE CASCADE,
+  DROP COLUMN IF EXISTS contaminant_key,
+  DROP COLUMN IF EXISTS normalized_value,
+  DROP COLUMN IF EXISTS normalized_unit,
+  DROP COLUMN IF EXISTS normalized_basis;
+
+CREATE INDEX IF NOT EXISTS product_contaminant_threshold_applications_threshold_idx
+  ON product_contaminant_threshold_applications (threshold_id);
+
+CREATE INDEX IF NOT EXISTS product_contaminant_threshold_applications_food_lookup_idx
+  ON product_contaminant_threshold_applications (food_id)
+  WHERE food_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS product_contaminant_threshold_applications_supplement_lookup_idx
+  ON product_contaminant_threshold_applications (supplement_id)
+  WHERE supplement_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS product_tests (
   id TEXT PRIMARY KEY,

--- a/apps/web/sql/product-tests/threshold-applications/reviewed.tsv
+++ b/apps/web/sql/product-tests/threshold-applications/reviewed.tsv
@@ -1,0 +1,3 @@
+threshold_id	food_id	supplement_id	review_note
+eu_2023_915_cadmium_3_2_2_2_beetroots	tj:072774		Trader Joe's Steamed and Peeled Baby Beets; exact beetroot food product reviewed against EU 2023/915 cadmium beetroot limit.
+eu_2023_915_lead_3_1_2_1_root_and_tuber_vegetables_except_listed_products	tj:072774		Trader Joe's Steamed and Peeled Baby Beets; exact beetroot food product reviewed against EU 2023/915 lead root and tuber vegetable limit.

--- a/apps/web/src/lib/product-labels.ts
+++ b/apps/web/src/lib/product-labels.ts
@@ -479,6 +479,9 @@ async function loadProductContaminantSummaries(
     ? ""
     : `
     WHERE product_tests.${productColumnSql} = ANY($1::text[])`;
+  const productThresholdApplicationWhereSql = useCanonicalAliases
+    ? "product_threshold_applications.supplement_id = linked_labels.product_id"
+    : `product_threshold_applications.${productColumnSql} = product_tests.${productColumnSql}`;
   const queryValues = useCanonicalAliases
     ? [
         targets.map((target) => target.productId),
@@ -512,24 +515,109 @@ async function loadProductContaminantSummaries(
       product_tests.normalized_value::double precision AS "normalizedValue",
       product_tests.normalized_unit AS "normalizedUnit",
       product_tests.normalized_basis AS "normalizedBasis",
-      contaminant_thresholds.normalized_value::double precision AS "thresholdNormalizedValue",
-      contaminant_thresholds.normalized_unit AS "thresholdNormalizedUnit",
-      contaminant_thresholds.normalized_basis AS "thresholdNormalizedBasis",
-      contaminant_thresholds.authority_name AS "thresholdAuthorityName",
-      contaminant_thresholds.threshold_name AS "thresholdName",
-      contaminant_thresholds.threshold_url AS "thresholdUrl",
-      contaminant_thresholds.concern_level_if_exceeded AS "concernLevelIfExceeded"
+      applicable_thresholds.normalized_value::double precision AS "thresholdNormalizedValue",
+      applicable_thresholds.normalized_unit AS "thresholdNormalizedUnit",
+      applicable_thresholds.normalized_basis AS "thresholdNormalizedBasis",
+      applicable_thresholds.authority_name AS "thresholdAuthorityName",
+      applicable_thresholds.threshold_name AS "thresholdName",
+      applicable_thresholds.threshold_url AS "thresholdUrl",
+      applicable_thresholds.concern_level_if_exceeded AS "concernLevelIfExceeded"
     ${productTestsFromSql}
-    LEFT JOIN contaminant_thresholds
-      ON contaminant_thresholds.active = true
-      AND product_tests.result_operator IN ('eq', 'gt', 'gte')
-      AND product_tests.normalized_value IS NOT NULL
-      AND product_tests.normalized_unit IS NOT NULL
-      AND product_tests.normalized_basis IS NOT NULL
-      AND contaminant_thresholds.contaminant_key = product_tests.contaminant_key
-      AND contaminant_thresholds.normalized_value IS NOT NULL
-      AND contaminant_thresholds.normalized_unit = product_tests.normalized_unit
-      AND contaminant_thresholds.normalized_basis = product_tests.normalized_basis
+    LEFT JOIN LATERAL (
+      SELECT
+        thresholds.id AS threshold_id,
+        application_threshold.normalized_value,
+        application_threshold.normalized_unit,
+        application_threshold.normalized_basis,
+        thresholds.authority_name,
+        thresholds.threshold_name,
+        thresholds.threshold_url,
+        thresholds.concern_level_if_exceeded,
+        CASE
+          WHEN product_tests.result_operator = 'eq'
+            AND product_tests.normalized_value > application_threshold.normalized_value THEN 0
+          WHEN product_tests.result_operator = 'gt'
+            AND product_tests.normalized_value >= application_threshold.normalized_value THEN 0
+          WHEN product_tests.result_operator = 'gte'
+            AND product_tests.normalized_value > application_threshold.normalized_value THEN 0
+          WHEN product_tests.result_operator = 'eq' THEN 1
+          ELSE 2
+        END AS comparison_rank,
+        CASE thresholds.concern_level_if_exceeded
+          WHEN 'high' THEN 3
+          WHEN 'medium' THEN 2
+          WHEN 'low' THEN 1
+          WHEN 'none' THEN 0
+          ELSE -1
+        END AS concern_rank,
+        0 AS priority
+      FROM product_contaminant_threshold_applications product_threshold_applications
+      JOIN contaminant_thresholds thresholds
+        ON thresholds.id = product_threshold_applications.threshold_id
+      CROSS JOIN LATERAL (
+        SELECT
+          CASE
+            WHEN thresholds.threshold_unit IN ('ppm', 'mg/kg') THEN thresholds.threshold_value
+            WHEN thresholds.threshold_unit IN ('ppb', 'ug/kg', 'ng/g') THEN thresholds.threshold_value / 1000
+            WHEN thresholds.threshold_unit = 'mg/kg-dry' THEN thresholds.threshold_value
+          END AS normalized_value,
+          CASE
+            WHEN thresholds.threshold_unit = 'mg/kg-dry' THEN 'mg/kg-dry'
+            ELSE 'ppm'
+          END AS normalized_unit,
+          'product_mass' AS normalized_basis
+      ) application_threshold
+      WHERE thresholds.active = true
+        AND thresholds.threshold_unit IN ('ppm', 'mg/kg', 'ppb', 'ug/kg', 'ng/g', 'mg/kg-dry')
+        AND product_tests.result_operator IN ('eq', 'gt', 'gte')
+        AND product_tests.normalized_value IS NOT NULL
+        AND product_tests.normalized_unit IS NOT NULL
+        AND product_tests.normalized_basis IS NOT NULL
+        AND thresholds.contaminant_key = product_tests.contaminant_key
+        AND application_threshold.normalized_unit = product_tests.normalized_unit
+        AND application_threshold.normalized_basis = product_tests.normalized_basis
+        AND ${productThresholdApplicationWhereSql}
+      UNION ALL
+      SELECT
+        thresholds.id AS threshold_id,
+        thresholds.normalized_value,
+        thresholds.normalized_unit,
+        thresholds.normalized_basis,
+        thresholds.authority_name,
+        thresholds.threshold_name,
+        thresholds.threshold_url,
+        thresholds.concern_level_if_exceeded,
+        CASE
+          WHEN product_tests.result_operator = 'eq'
+            AND product_tests.normalized_value > thresholds.normalized_value THEN 0
+          WHEN product_tests.result_operator = 'gt'
+            AND product_tests.normalized_value >= thresholds.normalized_value THEN 0
+          WHEN product_tests.result_operator = 'gte'
+            AND product_tests.normalized_value > thresholds.normalized_value THEN 0
+          WHEN product_tests.result_operator = 'eq' THEN 1
+          ELSE 2
+        END AS comparison_rank,
+        CASE thresholds.concern_level_if_exceeded
+          WHEN 'high' THEN 3
+          WHEN 'medium' THEN 2
+          WHEN 'low' THEN 1
+          WHEN 'none' THEN 0
+          ELSE -1
+        END AS concern_rank,
+        1 AS priority
+      FROM contaminant_thresholds thresholds
+      WHERE thresholds.active = true
+        AND product_tests.result_operator IN ('eq', 'gt', 'gte')
+        AND product_tests.normalized_value IS NOT NULL
+        AND product_tests.normalized_unit IS NOT NULL
+        AND product_tests.normalized_basis IS NOT NULL
+        AND thresholds.contaminant_key = product_tests.contaminant_key
+        AND thresholds.normalized_value IS NOT NULL
+        AND thresholds.normalized_unit = product_tests.normalized_unit
+        AND thresholds.normalized_basis = product_tests.normalized_basis
+      ORDER BY comparison_rank ASC, concern_rank DESC, priority ASC, threshold_id ASC
+      LIMIT 1
+    ) applicable_thresholds ON true
     ${productTestsWhereSql}
     ORDER BY
       ${productIdSql} ASC,

--- a/apps/web/test/foods-lib.test.ts
+++ b/apps/web/test/foods-lib.test.ts
@@ -137,6 +137,44 @@ describe("foods query helpers", () => {
       "labels.canonical_key = lookup_targets.canonical_key",
     );
     expect(contaminantsCall?.text).toContain("product_tests.food_id");
+    expect(contaminantsCall?.text).toContain("LEFT JOIN LATERAL");
+    expect(contaminantsCall?.text).toContain("CROSS JOIN LATERAL");
+    expect(contaminantsCall?.text).toContain("product_contaminant_threshold_applications");
+    expect(contaminantsCall?.text).toContain("JOIN contaminant_thresholds thresholds");
+    expect(contaminantsCall?.text).toContain(
+      'applicable_thresholds.normalized_value::double precision AS "thresholdNormalizedValue"',
+    );
+    expect(contaminantsCall?.text).toContain(
+      "application_threshold.normalized_unit = product_tests.normalized_unit",
+    );
+    expect(contaminantsCall?.text).toContain(
+      "application_threshold.normalized_basis = product_tests.normalized_basis",
+    );
+    expect(contaminantsCall?.text).toContain(
+      "thresholds.threshold_unit IN ('ppm', 'mg/kg', 'ppb', 'ug/kg', 'ng/g', 'mg/kg-dry')",
+    );
+    expect(contaminantsCall?.text).toContain(
+      "thresholds.contaminant_key = product_tests.contaminant_key",
+    );
+    expect(contaminantsCall?.text).not.toContain(
+      "product_threshold_applications.contaminant_key",
+    );
+    expect(contaminantsCall?.text).toContain("comparison_rank");
+    expect(contaminantsCall?.text).toContain("concern_rank");
+    expect(contaminantsCall?.text).toContain(
+      "product_threshold_applications.food_id = product_tests.food_id",
+    );
+    expect(contaminantsCall?.text).not.toContain(
+      "product_threshold_applications.supplement_id = product_tests.supplement_id",
+    );
+    expect(contaminantsCall?.text).toContain(
+      "ORDER BY comparison_rank ASC, concern_rank DESC, priority ASC, threshold_id ASC",
+    );
+    expect(contaminantsCall?.text).toContain("LIMIT 1");
+    expect(contaminantsCall?.text).not.toContain(
+      "thresholds.threshold_unit = product_tests.normalized_unit",
+    );
+    expect(contaminantsCall?.text).not.toContain("threshold_basis IN");
     expect(contaminantsCall?.values).toEqual([["fdc:123"]]);
   });
 

--- a/apps/web/test/product-label-runtime-env.test.ts
+++ b/apps/web/test/product-label-runtime-env.test.ts
@@ -86,6 +86,10 @@ describe("product label runtime env preflight", () => {
                 columnName: "threshold_name",
               },
               {
+                tableName: "product_contaminant_threshold_applications",
+                columnName: "threshold_id",
+              },
+              {
                 tableName: "product_tests",
                 columnName: "source_key",
               },
@@ -94,7 +98,7 @@ describe("product label runtime env preflight", () => {
         },
       ),
     ).rejects.toThrow(
-      `${PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE} Missing columns: contaminant_thresholds.threshold_name, product_tests.source_key.`,
+      `${PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE} Missing columns: contaminant_thresholds.threshold_name, product_contaminant_threshold_applications.threshold_id, product_tests.source_key.`,
     );
   });
 

--- a/apps/web/test/product-tests-schema.test.ts
+++ b/apps/web/test/product-tests-schema.test.ts
@@ -67,6 +67,38 @@ describe("product test contaminant schema", () => {
     expect(schemaSql).toContain("normalized_unit = 'ppm'");
     expect(schemaSql).toContain("WHEN threshold_unit = 'mg/kg-dry' THEN threshold_value");
     expect(schemaSql).toContain("WHEN threshold_unit = 'mg/kg-dry' THEN 'mg/kg-dry'");
+    expect(schemaSql).toContain("SET\n  normalized_value = NULL");
+    expect(schemaSql).toContain("WHERE NOT (\n    threshold_basis = 'product_mass'");
+    expect(schemaSql).toContain("CREATE TABLE IF NOT EXISTS product_contaminant_threshold_applications");
+    expect(schemaSql).toContain("threshold_id TEXT NOT NULL REFERENCES contaminant_thresholds(id) ON UPDATE CASCADE");
+    expect(schemaSql).toContain("product_contaminant_threshold_applications_product_link_check");
+    expect(schemaSql).toContain("DROP INDEX IF EXISTS product_contaminant_threshold_applications_food_comparable_idx");
+    expect(schemaSql).toContain("DROP INDEX IF EXISTS product_contaminant_threshold_applications_supplement_comparable_idx");
+    expect(schemaSql).toContain("DROP INDEX IF EXISTS product_contaminant_threshold_applications_food_lookup_idx");
+    expect(schemaSql).toContain("DROP INDEX IF EXISTS product_contaminant_threshold_applications_supplement_lookup_idx");
+    expect(schemaSql).toContain("DROP COLUMN IF EXISTS contaminant_key");
+    expect(schemaSql).toContain("DROP COLUMN IF EXISTS normalized_value");
+    expect(schemaSql).toContain("DROP COLUMN IF EXISTS normalized_unit");
+    expect(schemaSql).toContain("DROP COLUMN IF EXISTS normalized_basis");
+    expect(schemaSql).not.toContain("SET id = regexp_replace(id, '_[0-9]{8}_v[0-9]{8}$', '')");
+    expect(schemaSql).toContain("product_contaminant_threshold_applications_threshold_idx");
+    expect(schemaSql).toContain("product_contaminant_threshold_applications_food_lookup_idx");
+    expect(schemaSql).toContain("product_contaminant_threshold_applications_supplement_lookup_idx");
+    expect(schemaSql).toContain("SET threshold_id = regexp_replace(threshold_id, '_[0-9]{8}_v[0-9]{8}$', '')");
+    expect(schemaSql).toContain("UPDATE contaminant_thresholds versioned_thresholds");
+    expect(schemaSql.indexOf("UPDATE contaminant_thresholds versioned_thresholds")).toBeLessThan(
+      schemaSql.indexOf("duplicate active normalized contaminant thresholds"),
+    );
+    const foodThresholdApplicationLookupIndexSql = schemaSql.slice(
+      schemaSql.indexOf("CREATE INDEX IF NOT EXISTS product_contaminant_threshold_applications_food_lookup_idx"),
+      schemaSql.indexOf("CREATE INDEX IF NOT EXISTS product_contaminant_threshold_applications_supplement_lookup_idx"),
+    );
+    const supplementThresholdApplicationLookupIndexSql = schemaSql.slice(
+      schemaSql.indexOf("CREATE INDEX IF NOT EXISTS product_contaminant_threshold_applications_supplement_lookup_idx"),
+      schemaSql.indexOf("CREATE TABLE IF NOT EXISTS product_tests"),
+    );
+    expect(foodThresholdApplicationLookupIndexSql).not.toContain("contaminant_key");
+    expect(supplementThresholdApplicationLookupIndexSql).not.toContain("contaminant_key");
     expect(schemaSql).toContain("UPDATE product_tests");
     expect(schemaSql).toContain("normalized_unit IN ('mg/kg', 'ppb', 'ug/kg', 'ng/g')");
     expect(schemaSql).toContain("threshold_basis = 'product_mass'");
@@ -116,6 +148,13 @@ describe("product test contaminant schema", () => {
       new URL("../sql/product-tests/import-thresholds.sh", import.meta.url),
       "utf8",
     );
+    const importThresholdApplicationsScript = await readFile(
+      new URL(
+        "../sql/product-tests/import-threshold-applications.sh",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     const importOpenProductSourcesScript = await readFile(
       new URL(
         "../sql/product-tests/import-open-product-sources.sh",
@@ -153,6 +192,13 @@ describe("product test contaminant schema", () => {
     );
     const importThresholdsSql = await readFile(
       new URL("../sql/product-tests/import-thresholds.sql", import.meta.url),
+      "utf8",
+    );
+    const importThresholdApplicationsSql = await readFile(
+      new URL(
+        "../sql/product-tests/import-threshold-applications.sql",
+        import.meta.url,
+      ),
       "utf8",
     );
     const importOpenProductSourcesSql = await readFile(
@@ -290,6 +336,15 @@ describe("product test contaminant schema", () => {
     expect(readme).toContain("canonical `ppm` values");
     expect(readme).toContain("rows are left as `mg/kg-dry`");
     expect(readme).toContain("They compare only to explicitly dry-weight `mg/kg-dry` threshold rows");
+    expect(readme).toContain("Public threshold snapshots can validly");
+    expect(readme).toContain("produce zero active comparable rows");
+    expect(readme).toContain("product_contaminant_threshold_applications");
+    expect(readme).toContain("import-threshold-applications.sh");
+    expect(readme).toContain("threshold-applications/reviewed.tsv");
+    expect(readme).toContain("--replace-applications");
+    expect(readme).toContain("PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS");
+    expect(readme).toContain("Do not add");
+    expect(readme).toMatch(/API-side raw threshold\s+fallback/u);
     expect(importScript).toContain("PLASTICLIST_SAMPLES_TSV_PATH is required");
     expect(importScript).toContain("PLASTICLIST_REPLACE_SOURCE_EXPECTED_PRODUCT_TEST_ROWS");
     expect(importScript).toContain("is required with --replace-source");
@@ -394,6 +449,23 @@ describe("product test contaminant schema", () => {
     expect(importThresholdsScript).toContain("legacy-supplement-foods-stub.sql");
     expect(importThresholdsScript).not.toContain("apps/web/sql/product-tests/thresholds/");
     expect(importThresholdsScript).toContain("import-thresholds.sql");
+    expect(importThresholdApplicationsScript).toContain("PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH");
+    expect(importThresholdApplicationsScript).toContain("PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH is required");
+    expect(importThresholdApplicationsScript).toContain("PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH must be repo-relative");
+    expect(importThresholdApplicationsScript).toContain("PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS");
+    expect(importThresholdApplicationsScript).toContain("--replace-applications");
+    expect(importThresholdApplicationsScript).toContain("[ \"$replace_applications\" = true ]");
+    expect(importThresholdApplicationsScript).toContain("refusing destructive import");
+    expect(importThresholdApplicationsScript).toContain("refusing to run no-op import");
+    expect(importThresholdApplicationsScript).toContain("labels-db-psql.sh");
+    expect(importThresholdApplicationsScript).toContain("apps/web/sql/foods/schema.sql");
+    expect(importThresholdApplicationsScript).toContain("apps/web/sql/supplements/schema.sql");
+    expect(importThresholdApplicationsScript).toContain("import-threshold-applications.sql");
+    expect(importThresholdApplicationsScript).toContain("labels_db_psql_copy_literal \"$prepared_applications_tsv\"");
+    expect(importThresholdApplicationsScript).toContain("-v replace_applications=\"$replace_applications\"");
+    expect(importThresholdApplicationsScript).toContain("NR > 1");
+    expect(importThresholdApplicationsScript).toContain("print count + 0 > count_file");
+    expect(importThresholdApplicationsScript).not.toContain("echo \"$labels_db_url\"");
     expect(importOpenProductSourcesScript).not.toContain("OPEN_PRODUCT_SOURCES_PRODUCTS_CSV_PATH");
     expect(importOpenProductSourcesScript).toContain("OPEN_PRODUCT_SOURCES_PRODUCT_TESTS_CSV_PATH is required");
     expect(importOpenProductSourcesScript).toContain("OPEN_PRODUCT_SOURCES_PRODUCT_TESTS_CSV_PATH must be repo-relative");
@@ -450,9 +522,64 @@ describe("product test contaminant schema", () => {
     expect(importThresholdsSql).not.toContain("authority_key = 'eu_commission') <> 529");
     expect(importThresholdsSql).not.toContain("authority_key = 'fda') <> 303");
     expect(importThresholdsSql).not.toContain("authority_key = 'fda_cfr') <> 103");
-    expect(importThresholdsSql).not.toContain("UPDATE contaminant_thresholds");
     expect(importThresholdsSql).not.toContain("SELECT DISTINCT authority_key");
+    expect(importThresholdsSql).toContain("regexp_replace(btrim(id), '_[0-9]{8}_v[0-9]{8}$', '')");
+    expect(importThresholdsSql).toContain("UPDATE contaminant_thresholds versioned_thresholds");
+    expect(importThresholdsSql.indexOf("UPDATE contaminant_thresholds versioned_thresholds")).toBeLessThan(
+      importThresholdsSql.indexOf("duplicate active normalized contaminant thresholds after import"),
+    );
     expect(importThresholdsSql).toContain("ON CONFLICT (id) DO UPDATE");
+    expect(importThresholdApplicationsSql).toContain("CREATE TEMP TABLE product_threshold_applications_import");
+    expect(importThresholdApplicationsSql).toContain("product_contaminant_threshold_applications");
+    expect(importThresholdApplicationsSql).toContain("pg_advisory_xact_lock");
+    expect(importThresholdApplicationsSql).toContain("murph:contaminant_threshold_applications:import");
+    expect(importThresholdApplicationsSql).toContain(
+      "\\copy product_threshold_applications_import FROM __THRESHOLD_APPLICATIONS_TSV__",
+    );
+    expect(importThresholdApplicationsSql).toContain("jsonb_build_array");
+    expect(importThresholdApplicationsSql).toContain("'product_mass' AS normalized_basis");
+    expect(importThresholdApplicationsSql).toContain("OR threshold_id IS NULL");
+    expect(importThresholdApplicationsSql).toContain("OR review_note IS NULL");
+    expect(importThresholdApplicationsSql).toContain("WHEN thresholds.threshold_unit IN ('ppm', 'mg/kg') THEN thresholds.threshold_value");
+    expect(importThresholdApplicationsSql).toContain("WHEN thresholds.threshold_unit IN ('ppb', 'ug/kg', 'ng/g') THEN thresholds.threshold_value / 1000");
+    expect(importThresholdApplicationsSql).toContain("WHEN thresholds.threshold_unit = 'mg/kg-dry' THEN thresholds.threshold_value");
+    expect(importThresholdApplicationsSql).not.toContain("WHERE thresholds.threshold_basis = 'product_mass'");
+    expect(importThresholdApplicationsSql).toContain(
+      "product threshold application normalization dropped rows before import mutation",
+    );
+    expect(importThresholdApplicationsSql).toContain(
+      "product threshold application row references inactive threshold_id",
+    );
+    expect(importThresholdApplicationsSql).toContain(
+      "contaminant_thresholds.active IS DISTINCT FROM true",
+    );
+    expect(importThresholdApplicationsSql).toContain("DELETE FROM product_contaminant_threshold_applications");
+    expect(importThresholdApplicationsSql).toContain("WHERE id NOT IN");
+    expect(importThresholdApplicationsSql).toContain(":'replace_applications' = 'true'");
+    expect(importThresholdApplicationsSql).toContain("existing_applications.id <> current_import.id");
+    expect(importThresholdApplicationsSql).toContain("duplicate product threshold applications after import");
+    expect(importThresholdApplicationsSql).toContain("duplicate product threshold applications");
+    expect(importThresholdApplicationsSql).toContain("ON CONFLICT (id) DO UPDATE");
+    const productThresholdApplicationsInsertSql = importThresholdApplicationsSql.slice(
+      importThresholdApplicationsSql.indexOf("INSERT INTO product_contaminant_threshold_applications"),
+      importThresholdApplicationsSql.indexOf("DO $$\nDECLARE", importThresholdApplicationsSql.indexOf("ON CONFLICT (id) DO UPDATE")),
+    );
+    expect(productThresholdApplicationsInsertSql).not.toContain("contaminant_key");
+    expect(importThresholdApplicationsSql).not.toContain("contaminant_key = EXCLUDED.contaminant_key");
+    expect(importThresholdApplicationsSql).not.toContain("normalized_value = EXCLUDED.normalized_value");
+    expect(importThresholdApplicationsSql).not.toContain("normalized_unit = EXCLUDED.normalized_unit");
+    expect(importThresholdApplicationsSql).not.toContain("normalized_basis = EXCLUDED.normalized_basis");
+    expect(importThresholdApplicationsSql).not.toContain("product threshold application import prepared zero rows");
+    expect(importThresholdApplicationsSql.indexOf(
+      "product threshold application normalization dropped rows before import mutation",
+    )).toBeLessThan(importThresholdApplicationsSql.indexOf(
+      "DELETE FROM product_contaminant_threshold_applications",
+    ));
+    expect(importThresholdApplicationsSql.indexOf(
+      "product threshold application row references inactive threshold_id",
+    )).toBeLessThan(importThresholdApplicationsSql.indexOf(
+      "DELETE FROM product_contaminant_threshold_applications",
+    ));
     expect(importOpenProductSourcesSql).toContain("CREATE TEMP TABLE source_only_product_tests_import");
     expect(importOpenProductSourcesSql).toContain(
       "\\copy source_only_product_tests_import FROM __PRODUCT_TESTS_CSV__",
@@ -1404,6 +1531,235 @@ describe("product test contaminant schema", () => {
     }
   });
 
+  it("imports exact-product threshold applications through the secret-safe psql path", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-threshold-applications-"));
+    try {
+      const tempRepoRoot = path.join(tempRoot, "repo");
+      const tempScriptDir = path.join(
+        tempRepoRoot,
+        "apps/web/sql/product-tests",
+      );
+      const tempApplicationsDir = path.join(
+        tempRepoRoot,
+        "apps/web/sql/product-tests/threshold-applications",
+      );
+      await mkdir(tempScriptDir, { recursive: true });
+      await mkdir(tempApplicationsDir, { recursive: true });
+      const tempScriptPath = await copyProductTestImportScript(
+        tempScriptDir,
+        "import-threshold-applications.sh",
+      );
+      await writeFile(
+        path.join(tempApplicationsDir, "reviewed.tsv"),
+        [
+          "threshold_id\tfood_id\tsupplement_id\treview_note",
+          "local_lead\tfdc:123\t\tManual exact product threshold application.",
+          "",
+        ].join("\n"),
+      );
+
+      const fakePsqlPath = path.join(tempRoot, "fake-psql.mjs");
+      const fakePsqlLogPath = path.join(tempRoot, "psql.log");
+      await writeFile(
+        fakePsqlPath,
+        [
+          "#!/usr/bin/env node",
+          "import { appendFileSync } from 'node:fs';",
+          "if (process.env.MURPH_LABELS_DB_URL || process.env.PGPASSWORD) {",
+          "  throw new Error('database credentials leaked into psql environment');",
+          "}",
+          "appendFileSync(process.env.PSQL_FAKE_LOG, `${process.argv.slice(2).join(' ')}\\n`);",
+        ].join("\n"),
+      );
+      await chmod(fakePsqlPath, 0o755);
+
+      await execFileAsync(tempScriptPath, {
+        env: {
+          ...process.env,
+          PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH:
+            "apps/web/sql/product-tests/threshold-applications/reviewed.tsv",
+          MURPH_LABELS_DB_URL: "postgres://example.invalid/labels",
+          PSQL_BIN: fakePsqlPath,
+          PSQL_FAKE_LOG: fakePsqlLogPath,
+        },
+      });
+
+      const fakePsqlLog = await readFile(fakePsqlLogPath, "utf8");
+      expect(fakePsqlLog.split("\n").filter(Boolean).every((line) => line.startsWith("-X "))).toBe(true);
+      expect(fakePsqlLog).toContain("foods/schema.sql");
+      expect(fakePsqlLog).toContain("supplements/schema.sql");
+      expect(fakePsqlLog).toContain("product-tests/schema.sql");
+      expect(fakePsqlLog).toContain("import-threshold-applications.sql");
+      expect(fakePsqlLog).toContain("-f .product-tests-work/threshold-applications/run.");
+      expect(fakePsqlLog).not.toContain(tempRoot);
+      expect(fakePsqlLog).not.toContain("postgres://");
+
+      const workDir = await readOnlyThresholdApplicationRunDir(tempRepoRoot);
+      const preparedTsv = await readFile(
+        path.join(workDir, "product-threshold-applications.tsv"),
+        "utf8",
+      );
+      expect(parseTsv(preparedTsv)).toEqual([
+        {
+          threshold_id: "local_lead",
+          food_id: "fdc:123",
+          supplement_id: "",
+          review_note: "Manual exact product threshold application.",
+        },
+      ]);
+      const renderedSql = await readFile(
+        path.join(workDir, "import-threshold-applications.sql"),
+        "utf8",
+      );
+      expect(renderedSql).toContain(
+        "\\copy product_threshold_applications_import FROM '.product-tests-work/threshold-applications/run.",
+      );
+      expect(renderedSql).not.toContain("__THRESHOLD_APPLICATIONS_TSV__");
+      expect(renderedSql).not.toContain(tempRoot);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("allows an explicit header-only threshold application replacement to clear reviewed rows", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-threshold-applications-empty-"));
+    try {
+      const tempRepoRoot = path.join(tempRoot, "repo");
+      const tempScriptDir = path.join(
+        tempRepoRoot,
+        "apps/web/sql/product-tests",
+      );
+      const tempApplicationsDir = path.join(
+        tempRepoRoot,
+        "apps/web/sql/product-tests/threshold-applications",
+      );
+      await mkdir(tempScriptDir, { recursive: true });
+      await mkdir(tempApplicationsDir, { recursive: true });
+      const tempScriptPath = await copyProductTestImportScript(
+        tempScriptDir,
+        "import-threshold-applications.sh",
+      );
+      await writeFile(
+        path.join(tempApplicationsDir, "reviewed.tsv"),
+        "threshold_id\tfood_id\tsupplement_id\treview_note\n",
+      );
+
+      const fakePsqlPath = path.join(tempRoot, "fake-psql.mjs");
+      const fakePsqlLogPath = path.join(tempRoot, "psql.log");
+      await writeFile(
+        fakePsqlPath,
+        [
+          "#!/usr/bin/env node",
+          "import { appendFileSync } from 'node:fs';",
+          "if (process.env.MURPH_LABELS_DB_URL || process.env.PGPASSWORD) {",
+          "  throw new Error('database credentials leaked into psql environment');",
+          "}",
+          "appendFileSync(process.env.PSQL_FAKE_LOG, `${process.argv.slice(2).join(' ')}\\n`);",
+        ].join("\n"),
+      );
+      await chmod(fakePsqlPath, 0o755);
+
+      await execFileAsync(tempScriptPath, ["--replace-applications"], {
+        env: {
+          ...process.env,
+          PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS: "0",
+          PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH:
+            "apps/web/sql/product-tests/threshold-applications/reviewed.tsv",
+          MURPH_LABELS_DB_URL: "postgres://example.invalid/labels",
+          PSQL_BIN: fakePsqlPath,
+          PSQL_FAKE_LOG: fakePsqlLogPath,
+        },
+      });
+
+      const fakePsqlLog = await readFile(fakePsqlLogPath, "utf8");
+      expect(fakePsqlLog).toContain("import-threshold-applications.sql");
+      expect(fakePsqlLog).not.toContain("postgres://");
+
+      const workDir = await readOnlyThresholdApplicationRunDir(tempRepoRoot);
+      const preparedTsv = await readFile(
+        path.join(workDir, "product-threshold-applications.tsv"),
+        "utf8",
+      );
+      expect(parseTsv(preparedTsv)).toEqual([]);
+      const renderedSql = await readFile(
+        path.join(workDir, "import-threshold-applications.sql"),
+        "utf8",
+      );
+      expect(renderedSql).toContain("DELETE FROM product_contaminant_threshold_applications");
+      expect(fakePsqlLog).toContain("-v replace_applications=true");
+      expect(renderedSql).not.toContain("product threshold application import prepared zero rows");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses header-only threshold application imports without replacement mode", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-threshold-applications-refuse-empty-"));
+    try {
+      const tempRepoRoot = path.join(tempRoot, "repo");
+      const tempScriptDir = path.join(
+        tempRepoRoot,
+        "apps/web/sql/product-tests",
+      );
+      const tempApplicationsDir = path.join(
+        tempRepoRoot,
+        "apps/web/sql/product-tests/threshold-applications",
+      );
+      await mkdir(tempScriptDir, { recursive: true });
+      await mkdir(tempApplicationsDir, { recursive: true });
+      const tempScriptPath = await copyProductTestImportScript(
+        tempScriptDir,
+        "import-threshold-applications.sh",
+      );
+      await writeFile(
+        path.join(tempApplicationsDir, "reviewed.tsv"),
+        "threshold_id\tfood_id\tsupplement_id\treview_note\n",
+      );
+
+      const fakePsqlPath = path.join(tempRoot, "fake-psql.mjs");
+      const fakePsqlLogPath = path.join(tempRoot, "psql.log");
+      await writeFile(
+        fakePsqlPath,
+        [
+          "#!/usr/bin/env node",
+          "import { appendFileSync } from 'node:fs';",
+          "appendFileSync(process.env.PSQL_FAKE_LOG, `${process.argv.slice(2).join(' ')}\\n`);",
+          "throw new Error('psql should not run for zero-row threshold application imports');",
+        ].join("\n"),
+      );
+      await chmod(fakePsqlPath, 0o755);
+
+      let stderr = "";
+      try {
+        await execFileAsync(tempScriptPath, {
+          env: {
+            ...process.env,
+            PRODUCT_THRESHOLD_APPLICATIONS_TSV_PATH:
+              "apps/web/sql/product-tests/threshold-applications/reviewed.tsv",
+            MURPH_LABELS_DB_URL: "postgres://example.invalid/labels",
+            PSQL_BIN: fakePsqlPath,
+            PSQL_FAKE_LOG: fakePsqlLogPath,
+          },
+        });
+      } catch (error) {
+        stderr = error instanceof Error && "stderr" in error
+          ? String(error.stderr)
+          : String(error);
+      }
+
+      expect(stderr).toContain("Product threshold applications import prepared zero rows");
+      expect(stderr).toContain("refusing to run no-op import");
+      expect(stderr).toContain("--replace-applications");
+      expect(stderr).toContain("PRODUCT_THRESHOLD_APPLICATIONS_REPLACE_EXPECTED_ROWS=0");
+      expect(stderr).not.toContain("postgres://");
+      await expect(readFile(fakePsqlLogPath, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("imports open product source CSVs through the secret-safe psql path", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-open-product-sources-"));
     try {
@@ -2283,6 +2639,16 @@ async function readOnlyPlasticListRunDir(repoRoot: string): Promise<string> {
 
 async function readOnlyThresholdRunDir(repoRoot: string): Promise<string> {
   const workDir = path.join(repoRoot, ".product-tests-work/thresholds");
+  const runDirs = (await readdir(workDir, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("run."))
+    .map((entry) => entry.name);
+
+  expect(runDirs).toHaveLength(1);
+  return path.join(workDir, runDirs[0] ?? "");
+}
+
+async function readOnlyThresholdApplicationRunDir(repoRoot: string): Promise<string> {
+  const workDir = path.join(repoRoot, ".product-tests-work/threshold-applications");
   const runDirs = (await readdir(workDir, { withFileTypes: true }))
     .filter((entry) => entry.isDirectory() && entry.name.startsWith("run."))
     .map((entry) => entry.name);

--- a/apps/web/test/supplements-lib.test.ts
+++ b/apps/web/test/supplements-lib.test.ts
@@ -211,28 +211,56 @@ describe("supplements query helpers", () => {
     expect(contaminantsCall?.text).toContain(
       'product_tests.report_date::text AS "reportDate"',
     );
-    expect(contaminantsCall?.text).toContain("LEFT JOIN contaminant_thresholds");
+    expect(contaminantsCall?.text).toContain("LEFT JOIN LATERAL");
+    expect(contaminantsCall?.text).toContain("CROSS JOIN LATERAL");
+    expect(contaminantsCall?.text).toContain("product_contaminant_threshold_applications");
+    expect(contaminantsCall?.text).toContain("JOIN contaminant_thresholds thresholds");
     expect(contaminantsCall?.text).toContain(
       "product_tests.result_operator IN ('eq', 'gt', 'gte')",
     );
     expect(contaminantsCall?.text).toContain(
-      'contaminant_thresholds.normalized_value::double precision AS "thresholdNormalizedValue"',
+      'applicable_thresholds.normalized_value::double precision AS "thresholdNormalizedValue"',
     );
     expect(contaminantsCall?.text).not.toContain(
-      'contaminant_thresholds.threshold_value::double precision AS "thresholdValue"',
+      'thresholds.threshold_value::double precision AS "thresholdValue"',
     );
     expect(contaminantsCall?.text).toContain(
-      "contaminant_thresholds.normalized_unit = product_tests.normalized_unit",
+      "application_threshold.normalized_unit = product_tests.normalized_unit",
     );
     expect(contaminantsCall?.text).toContain(
-      "contaminant_thresholds.normalized_basis = product_tests.normalized_basis",
+      "application_threshold.normalized_basis = product_tests.normalized_basis",
+    );
+    expect(contaminantsCall?.text).toContain(
+      "thresholds.threshold_unit IN ('ppm', 'mg/kg', 'ppb', 'ug/kg', 'ng/g', 'mg/kg-dry')",
+    );
+    expect(contaminantsCall?.text).toContain(
+      "thresholds.contaminant_key = product_tests.contaminant_key",
     );
     expect(contaminantsCall?.text).not.toContain(
-      "contaminant_thresholds.threshold_basis = product_tests.normalized_basis",
+      "product_threshold_applications.contaminant_key",
+    );
+    expect(contaminantsCall?.text).toContain("comparison_rank");
+    expect(contaminantsCall?.text).toContain("concern_rank");
+    expect(contaminantsCall?.text).toContain(
+      "product_threshold_applications.supplement_id = linked_labels.product_id",
     );
     expect(contaminantsCall?.text).not.toContain(
-      "contaminant_thresholds.threshold_unit = product_tests.normalized_unit",
+      "product_threshold_applications.supplement_id = product_tests.supplement_id",
     );
+    expect(contaminantsCall?.text).not.toContain(
+      "product_threshold_applications.food_id = product_tests.food_id",
+    );
+    expect(contaminantsCall?.text).toContain(
+      "ORDER BY comparison_rank ASC, concern_rank DESC, priority ASC, threshold_id ASC",
+    );
+    expect(contaminantsCall?.text).toContain("LIMIT 1");
+    expect(contaminantsCall?.text).not.toContain(
+      "thresholds.threshold_basis = product_tests.normalized_basis",
+    );
+    expect(contaminantsCall?.text).not.toContain(
+      "thresholds.threshold_unit = product_tests.normalized_unit",
+    );
+    expect(contaminantsCall?.text).not.toContain("threshold_basis IN");
     expect(contaminantsCall?.values).toEqual([["82118"], ["82118"]]);
   });
 
@@ -393,6 +421,12 @@ describe("supplements query helpers", () => {
           );
           expect(text).toContain(
             "product_tests.supplement_id = linked_labels.label_id",
+          );
+          expect(text).toContain(
+            "product_threshold_applications.supplement_id = linked_labels.product_id",
+          );
+          expect(text).not.toContain(
+            "product_threshold_applications.supplement_id = product_tests.supplement_id",
           );
           expect(values).toEqual([
             ["brand:creatine"],


### PR DESCRIPTION
## Summary
- add reviewed exact-product threshold applications for scoped contaminant thresholds
- backfill/clear global threshold normalized triplets only for true product-mass concentration thresholds
- update food/supplement contaminant lookup to prefer exact reviewed applications, deriving application limits from the current active threshold row
- add a guarded threshold-application importer and initial reviewed Trader Joe's beet applications

## Validation
- pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/product-tests-schema.test.ts apps/web/test/foods-lib.test.ts apps/web/test/supplements-lib.test.ts
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web verify
- git diff --check HEAD~1..HEAD
- local security/privacy, coverage/proof, and targeted deep-review passes

## Notes
- pnpm test:diff is currently blocked after rebase by unrelated assistantd/operator-config workspace resolution failures outside this diff.
- Existing labels DB cleanup/backfill updated 0 rows; current public thresholds have 0 active global comparable rows. Reviewed beet applications simulate to 2 application rows joining 4 existing exact product-test rows once the migration role creates the new table.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784406698&installation_id=127572939&pr_number=218&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F218&signature=5370c42e516592b9964abaef5bcb6153abcf36d62d814397ff148bb7a6e2ada3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->