### PR TITLE
[codex] Compact query metric projection payloads

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-21-query-sqlite-compact.md
+++ b/agent-docs/exec-plans/completed/2026-06-21-query-sqlite-compact.md
@@ -1,0 +1,53 @@
+Goal (incl. success criteria):
+- Reproduce the oversized local query projection with deterministic fixture data.
+- Slim `.runtime/projections/query.sqlite` by removing repeated rich metric-point JSON blobs from the query projection while preserving queryable scalar columns.
+- Success means existing query/read paths still round-trip needed values, old projections rebuild, focused size tests show metric-point rows no longer store provenance/context-heavy blobs, and the existing wearable-summary compact codec remains intact.
+
+Constraints/Assumptions:
+- Query projection state is rebuildable local projection state, not canonical vault truth.
+- Do not reduce canonical vault evidence, raw imports, or product-visible health facts.
+- Prefer deletion/simplification over a new side store or compatibility layer.
+- Preserve lexical search behavior unless direct evidence shows search documents are part of the same root cause and can be safely bounded.
+
+Key decisions:
+- Store compact metric-point supplemental JSON that contains only non-scalar metadata needed by runtime readers instead of the original rich `MetricPoint`.
+- Reconstruct metric points from scalar columns plus compact supplemental metadata on read.
+- Bump the SQLite projection user version so existing local query projections rebuild.
+- Leave wearable summaries on the existing stored codec; it already compacts per-metric envelopes and has stale-projection rebuild coverage.
+
+State:
+- Implementation, verification, and required local audits complete; final commit pending.
+
+Done:
+- Read required repo routing, architecture, invariants, verification, completion, security, and query docs.
+- Created isolated task worktree and branch from current `origin/main`.
+- Added a deterministic rich-provider metric observation fixture that reproduced the old oversized `metric_point_json` behavior before the fix.
+- Compact metric-point projection storage now drops bulky repeated provenance/source details while preserving scalar query columns and selected metadata.
+- Added read-path reconstruction from scalar columns plus compact metadata, plus stale v11 projection rebuild coverage.
+- Focused package query tests passed.
+- Root `pnpm typecheck` passed after preparing ignored workspace build artifacts with `pnpm build:workspace:incremental`.
+- Scoped `bash scripts/workspace-verify.sh test:diff <task files>` passed.
+- `pnpm test:smoke` passed.
+- `git diff --check -- <task files>` passed.
+- Security/privacy audit returned no medium-or-higher findings.
+- Coverage-write audit reran the scoped `test:diff` lane, made no changes, and found no meaningful proof gap.
+- Deep-review audit returned no confirmed production-breaking bugs; residual risk is the manual metric context allowlist needing tests/versioning if future context keys become runtime-significant.
+
+Now:
+- Commit through `scripts/finish-task`.
+
+Next:
+- Push the branch, open a PR, and run the external PR review loop if available.
+
+Open questions (UNCONFIRMED if needed):
+- Whether entity/search stored payloads need a separate future slimming pass; not needed for this targeted metric-point fix.
+
+Working set (files/ids/commands):
+- `packages/query/src/projection/schema.ts`
+- `packages/query/src/projection/metric-store.ts`
+- `packages/query/src/projection/wearable-summary-stored-codec.ts`
+- `packages/query/test/query.test.ts`
+- `packages/query/test/browser-vault-metric-points-labs-measurements.test.ts`
+Status: completed
+Updated: 2026-06-21
+Completed: 2026-06-21

--- a/packages/query/src/projection/metric-store.ts
+++ b/packages/query/src/projection/metric-store.ts
@@ -5,6 +5,7 @@ import {
   resolveMetricDefinitionForBiomarker,
   type GoalMetricTarget,
   type MetricConfidence,
+  type MetricComparator,
   type MetricGrain,
   type MetricPoint,
   type MetricPointContext,
@@ -21,7 +22,10 @@ import type {
 } from "../query-projection-types.ts";
 import {
   assertQueryProjectionTables,
+  expectEnumString,
   expectNullableString,
+  expectNumber,
+  expectString,
   openQueryProjectionDatabase,
   parseJsonValue,
   type DatabaseSync,
@@ -29,32 +33,20 @@ import {
   type SqliteRow,
 } from "./schema.ts";
 
-const METRIC_POINT_CONTEXT_STORAGE_KEYS = [
-  "aggregatePointCount",
-  "aggregation",
-  "candidateCount",
-  "conflictingProviders",
-  "contributingRecordIds",
-  "exactDuplicateCount",
-  "fastingStatus",
-  "flag",
-  "latestWindowDays",
-  "measurementMethodKey",
-  "observationGrain",
-  "qualifiers",
-  "quality",
-  "recordedAt",
-  "referenceRange",
-  "sampleCount",
-  "source",
-  "sourceFamily",
-  "sourceKind",
-  "sourceStream",
-  "syntheticRecordId",
-  "timeZone",
-  "windowEnd",
-  "windowStart",
-] as const;
+const METRIC_COMPARATOR_VALUES = ["<", "<=", ">", ">="] as const satisfies readonly MetricComparator[];
+const METRIC_CONFIDENCE_VALUES = ["none", "low", "medium", "high"] as const satisfies readonly MetricConfidence[];
+const METRIC_GRAIN_VALUES = ["instant", "event", "day", "week", "month", "window"] as const satisfies readonly MetricGrain[];
+const METRIC_SOURCE_FAMILY_VALUES = ["derived", "event", "sample"] as const satisfies readonly MetricSourceFamily[];
+const METRIC_STATISTIC_VALUES = [
+  "value",
+  "latest",
+  "mean",
+  "median",
+  "min",
+  "max",
+  "sum",
+  "count",
+] as const satisfies readonly MetricStatistic[];
 
 interface StoredMetricPointPayload {
   context?: MetricPointContext;
@@ -308,13 +300,12 @@ function normalizeMetricPointLimit(value: number): number {
 
 function stringifyStoredMetricPointPayload(point: MetricPoint): string {
   const payload: StoredMetricPointPayload = {};
-  const context = compactStoredMetricPointContext(point.context);
   const provenance = compactStoredMetricPointProvenance(point);
   const storedValue = point.canonicalValue ?? point.value;
   const storedUnit = point.canonicalUnit ?? point.unit;
 
-  if (!isEmptyRecord(context)) {
-    payload.context = context;
+  if (!isEmptyRecord(point.context)) {
+    payload.context = point.context;
   }
   if (!isEmptyRecord(provenance)) {
     payload.provenance = provenance;
@@ -327,21 +318,6 @@ function stringifyStoredMetricPointPayload(point: MetricPoint): string {
   }
 
   return JSON.stringify(payload);
-}
-
-function compactStoredMetricPointContext(context: MetricPointContext): MetricPointContext {
-  const compact: MetricPointContext = {};
-  const compactRecord = compact as Record<string, unknown>;
-  const record = context as Record<string, unknown>;
-
-  for (const key of METRIC_POINT_CONTEXT_STORAGE_KEYS) {
-    const value = record[key];
-    if (value !== undefined) {
-      compactRecord[key] = value;
-    }
-  }
-
-  return compact;
 }
 
 function compactStoredMetricPointProvenance(point: MetricPoint): StoredMetricPointProvenance {
@@ -408,11 +384,19 @@ function readStoredMetricPointPayload(value: string, sourceKind: string): {
   const record = isRecord(parsed) ? parsed : {};
 
   return {
-    context: compactStoredMetricPointContext(isRecord(record.context) ? record.context : {}),
+    context: readStoredMetricPointContext(record.context),
     provenance: readStoredMetricPointProvenance(record.provenance, sourceKind),
     unit: Object.hasOwn(record, "unit") ? readNullableString(record.unit) : undefined,
     value: Object.hasOwn(record, "value") ? readNullableNumber(record.value) : undefined,
   };
+}
+
+function readStoredMetricPointContext(value: unknown): MetricPointContext {
+  const context: MetricPointContext = {};
+  if (isRecord(value)) {
+    Object.assign(context, value);
+  }
+  return context;
 }
 
 function readStoredMetricPointProvenance(value: unknown, sourceKind: string): MetricPointProvenance {
@@ -427,94 +411,34 @@ function readStoredMetricPointProvenance(value: unknown, sourceKind: string): Me
   };
 }
 
-function expectString(value: unknown, field: string): string {
-  if (typeof value !== "string") {
-    throw new TypeError(`Expected ${field} to be a string.`);
-  }
-  return value;
-}
-
 function expectNullableNumber(value: unknown, field: string): number | null {
   if (value === null) {
     return null;
   }
-  if (typeof value !== "number") {
-    throw new TypeError(`Expected ${field} to be a number or null.`);
-  }
-  return value;
+  return expectNumber(value, field);
 }
 
 function expectMetricConfidence(value: unknown): MetricConfidence {
-  const confidence = expectString(value, "query_metric_points.confidence");
-  switch (confidence) {
-    case "none":
-    case "low":
-    case "medium":
-    case "high":
-      return confidence;
-    default:
-      throw new TypeError(`Expected query_metric_points.confidence to be a metric confidence.`);
-  }
+  return expectEnumString(value, "query_metric_points.confidence", METRIC_CONFIDENCE_VALUES);
 }
 
 function expectMetricComparator(value: unknown): MetricPoint["comparator"] {
   if (value === null) {
     return null;
   }
-  const comparator = expectString(value, "query_metric_points.comparator");
-  switch (comparator) {
-    case "<":
-    case "<=":
-    case ">":
-    case ">=":
-      return comparator;
-    default:
-      throw new TypeError(`Expected query_metric_points.comparator to be a metric comparator.`);
-  }
+  return expectEnumString(value, "query_metric_points.comparator", METRIC_COMPARATOR_VALUES);
 }
 
 function expectMetricGrain(value: unknown): MetricGrain {
-  const grain = expectString(value, "query_metric_points.grain");
-  switch (grain) {
-    case "instant":
-    case "event":
-    case "day":
-    case "week":
-    case "month":
-    case "window":
-      return grain;
-    default:
-      throw new TypeError(`Expected query_metric_points.grain to be a metric grain.`);
-  }
+  return expectEnumString(value, "query_metric_points.grain", METRIC_GRAIN_VALUES);
 }
 
 function expectMetricSourceFamily(value: unknown): MetricSourceFamily {
-  const family = expectString(value, "query_metric_points.source_family");
-  switch (family) {
-    case "derived":
-    case "event":
-    case "sample":
-      return family;
-    default:
-      throw new TypeError(`Expected query_metric_points.source_family to be a metric source family.`);
-  }
+  return expectEnumString(value, "query_metric_points.source_family", METRIC_SOURCE_FAMILY_VALUES);
 }
 
 function expectMetricStatistic(value: unknown): MetricStatistic {
-  const statistic = expectString(value, "query_metric_points.statistic");
-  switch (statistic) {
-    case "value":
-    case "latest":
-    case "mean":
-    case "median":
-    case "min":
-    case "max":
-    case "sum":
-    case "count":
-      return statistic;
-    default:
-      throw new TypeError(`Expected query_metric_points.statistic to be a metric statistic.`);
-  }
+  return expectEnumString(value, "query_metric_points.statistic", METRIC_STATISTIC_VALUES);
 }
 
 function readOptionalString(value: unknown): string | undefined {

--- a/packages/query/src/projection/metric-store.ts
+++ b/packages/query/src/projection/metric-store.ts
@@ -1,9 +1,16 @@
 import {
+  METRIC_POINT_SCHEMA_VERSION,
   normalizeMetricKey,
   resolveMetricDefinition,
   resolveMetricDefinitionForBiomarker,
   type GoalMetricTarget,
+  type MetricConfidence,
+  type MetricGrain,
   type MetricPoint,
+  type MetricPointContext,
+  type MetricPointProvenance,
+  type MetricSourceFamily,
+  type MetricStatistic,
 } from "@murphai/health-metrics";
 
 import type { CanonicalEntity } from "../canonical-entities.ts";
@@ -14,11 +21,54 @@ import type {
 } from "../query-projection-types.ts";
 import {
   assertQueryProjectionTables,
+  expectNullableString,
   openQueryProjectionDatabase,
   parseJsonValue,
   type DatabaseSync,
   type QueryProjectionLocation,
+  type SqliteRow,
 } from "./schema.ts";
+
+const METRIC_POINT_CONTEXT_STORAGE_KEYS = [
+  "aggregatePointCount",
+  "aggregation",
+  "candidateCount",
+  "conflictingProviders",
+  "contributingRecordIds",
+  "exactDuplicateCount",
+  "fastingStatus",
+  "flag",
+  "latestWindowDays",
+  "measurementMethodKey",
+  "observationGrain",
+  "qualifiers",
+  "quality",
+  "recordedAt",
+  "referenceRange",
+  "sampleCount",
+  "source",
+  "sourceFamily",
+  "sourceKind",
+  "sourceStream",
+  "syntheticRecordId",
+  "timeZone",
+  "windowEnd",
+  "windowStart",
+] as const;
+
+interface StoredMetricPointPayload {
+  context?: MetricPointContext;
+  provenance?: StoredMetricPointProvenance;
+  unit?: string | null;
+  value?: number | null;
+}
+
+interface StoredMetricPointProvenance {
+  labName?: string;
+  provider?: string;
+  rawRefs?: string[];
+  sourceLabel?: string;
+}
 
 export function insertMetricPoints(
   database: DatabaseSync,
@@ -76,7 +126,7 @@ export function insertMetricPoints(
       point.source.resultIndex,
       point.source.path,
       point.confidence,
-      JSON.stringify(point),
+      stringifyStoredMetricPointPayload(point),
     );
   });
 }
@@ -151,15 +201,37 @@ export function listStoredMetricPoints(
     }
     const whereSql = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
     const rows = database.prepare(`
-      SELECT metric_point_json
+      SELECT
+        id,
+        metric_key,
+        biomarker_key,
+        value,
+        text_value,
+        comparator,
+        unit,
+        canonical_value,
+        canonical_unit,
+        observed_at,
+        effective_date,
+        recorded_at,
+        reported_at,
+        grain,
+        statistic,
+        source_family,
+        source_kind,
+        source_record_id,
+        source_result_index,
+        source_path,
+        confidence,
+        metric_point_json
       FROM query_metric_points
       ${whereSql}
       ORDER BY effective_date DESC, observed_at DESC, id ASC
       ${limitSql}
-    `).all(...parameters) as Array<{ metric_point_json: string }>;
+    `).all(...parameters);
 
     return rows
-      .map((row) => parseJsonValue<MetricPoint | null>(row.metric_point_json, null))
+      .map(decodeStoredMetricPoint)
       .filter((point): point is MetricPoint => point !== null);
   } finally {
     database.close();
@@ -232,6 +304,249 @@ function normalizeMetricPointLimit(value: number): number {
     return 1_000;
   }
   return Math.min(value, 10_000);
+}
+
+function stringifyStoredMetricPointPayload(point: MetricPoint): string {
+  const payload: StoredMetricPointPayload = {};
+  const context = compactStoredMetricPointContext(point.context);
+  const provenance = compactStoredMetricPointProvenance(point);
+  const storedValue = point.canonicalValue ?? point.value;
+  const storedUnit = point.canonicalUnit ?? point.unit;
+
+  if (!isEmptyRecord(context)) {
+    payload.context = context;
+  }
+  if (!isEmptyRecord(provenance)) {
+    payload.provenance = provenance;
+  }
+  if (point.value !== storedValue) {
+    payload.value = point.value;
+  }
+  if (point.unit !== storedUnit) {
+    payload.unit = point.unit;
+  }
+
+  return JSON.stringify(payload);
+}
+
+function compactStoredMetricPointContext(context: MetricPointContext): MetricPointContext {
+  const compact: MetricPointContext = {};
+  const compactRecord = compact as Record<string, unknown>;
+  const record = context as Record<string, unknown>;
+
+  for (const key of METRIC_POINT_CONTEXT_STORAGE_KEYS) {
+    const value = record[key];
+    if (value !== undefined) {
+      compactRecord[key] = value;
+    }
+  }
+
+  return compact;
+}
+
+function compactStoredMetricPointProvenance(point: MetricPoint): StoredMetricPointProvenance {
+  const compact: StoredMetricPointProvenance = {};
+  if (point.provenance.labName) {
+    compact.labName = point.provenance.labName;
+  }
+  if (point.provenance.provider) {
+    compact.provider = point.provenance.provider;
+  }
+  if (point.source.kind === "test-result" && point.provenance.rawRefs.length > 0) {
+    compact.rawRefs = point.provenance.rawRefs;
+  }
+  if (point.provenance.sourceLabel) {
+    compact.sourceLabel = point.provenance.sourceLabel;
+  }
+  return compact;
+}
+
+function decodeStoredMetricPoint(row: SqliteRow): MetricPoint | null {
+  const sourceKind = expectString(row.source_kind, "query_metric_points.source_kind");
+  const payload = readStoredMetricPointPayload(
+    expectString(row.metric_point_json, "query_metric_points.metric_point_json"),
+    sourceKind,
+  );
+
+  return {
+    biomarkerKey: expectNullableString(row.biomarker_key, "query_metric_points.biomarker_key"),
+    canonicalUnit: expectNullableString(row.canonical_unit, "query_metric_points.canonical_unit"),
+    canonicalValue: expectNullableNumber(row.canonical_value, "query_metric_points.canonical_value"),
+    comparator: expectMetricComparator(row.comparator),
+    confidence: expectMetricConfidence(row.confidence),
+    context: payload.context,
+    effectiveDate: expectString(row.effective_date, "query_metric_points.effective_date"),
+    grain: expectMetricGrain(row.grain),
+    id: expectString(row.id, "query_metric_points.id"),
+    metricKey: expectString(row.metric_key, "query_metric_points.metric_key"),
+    observedAt: expectString(row.observed_at, "query_metric_points.observed_at"),
+    provenance: payload.provenance,
+    recordedAt: expectNullableString(row.recorded_at, "query_metric_points.recorded_at"),
+    reportedAt: expectNullableString(row.reported_at, "query_metric_points.reported_at"),
+    schemaVersion: METRIC_POINT_SCHEMA_VERSION,
+    source: {
+      family: expectMetricSourceFamily(row.source_family),
+      kind: sourceKind,
+      path: expectString(row.source_path, "query_metric_points.source_path"),
+      recordId: expectString(row.source_record_id, "query_metric_points.source_record_id"),
+      resultIndex: expectNullableNumber(row.source_result_index, "query_metric_points.source_result_index"),
+    },
+    statistic: expectMetricStatistic(row.statistic),
+    textValue: expectNullableString(row.text_value, "query_metric_points.text_value"),
+    unit: payload.unit === undefined ? expectNullableString(row.unit, "query_metric_points.unit") : payload.unit,
+    value: payload.value === undefined ? expectNullableNumber(row.value, "query_metric_points.value") : payload.value,
+  };
+}
+
+function readStoredMetricPointPayload(value: string, sourceKind: string): {
+  context: MetricPointContext;
+  provenance: MetricPointProvenance;
+  unit: string | null | undefined;
+  value: number | null | undefined;
+} {
+  const parsed = parseJsonValue<unknown>(value, null);
+  const record = isRecord(parsed) ? parsed : {};
+
+  return {
+    context: compactStoredMetricPointContext(isRecord(record.context) ? record.context : {}),
+    provenance: readStoredMetricPointProvenance(record.provenance, sourceKind),
+    unit: Object.hasOwn(record, "unit") ? readNullableString(record.unit) : undefined,
+    value: Object.hasOwn(record, "value") ? readNullableNumber(record.value) : undefined,
+  };
+}
+
+function readStoredMetricPointProvenance(value: unknown, sourceKind: string): MetricPointProvenance {
+  const record = isRecord(value) ? value : {};
+  return {
+    dataOrigin: null,
+    externalRef: null,
+    labName: readOptionalString(record.labName) ?? null,
+    provider: readOptionalString(record.provider) ?? null,
+    rawRefs: sourceKind === "test-result" ? readStringArray(record.rawRefs) : [],
+    sourceLabel: readOptionalString(record.sourceLabel) ?? null,
+  };
+}
+
+function expectString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(`Expected ${field} to be a string.`);
+  }
+  return value;
+}
+
+function expectNullableNumber(value: unknown, field: string): number | null {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== "number") {
+    throw new TypeError(`Expected ${field} to be a number or null.`);
+  }
+  return value;
+}
+
+function expectMetricConfidence(value: unknown): MetricConfidence {
+  const confidence = expectString(value, "query_metric_points.confidence");
+  switch (confidence) {
+    case "none":
+    case "low":
+    case "medium":
+    case "high":
+      return confidence;
+    default:
+      throw new TypeError(`Expected query_metric_points.confidence to be a metric confidence.`);
+  }
+}
+
+function expectMetricComparator(value: unknown): MetricPoint["comparator"] {
+  if (value === null) {
+    return null;
+  }
+  const comparator = expectString(value, "query_metric_points.comparator");
+  switch (comparator) {
+    case "<":
+    case "<=":
+    case ">":
+    case ">=":
+      return comparator;
+    default:
+      throw new TypeError(`Expected query_metric_points.comparator to be a metric comparator.`);
+  }
+}
+
+function expectMetricGrain(value: unknown): MetricGrain {
+  const grain = expectString(value, "query_metric_points.grain");
+  switch (grain) {
+    case "instant":
+    case "event":
+    case "day":
+    case "week":
+    case "month":
+    case "window":
+      return grain;
+    default:
+      throw new TypeError(`Expected query_metric_points.grain to be a metric grain.`);
+  }
+}
+
+function expectMetricSourceFamily(value: unknown): MetricSourceFamily {
+  const family = expectString(value, "query_metric_points.source_family");
+  switch (family) {
+    case "derived":
+    case "event":
+    case "sample":
+      return family;
+    default:
+      throw new TypeError(`Expected query_metric_points.source_family to be a metric source family.`);
+  }
+}
+
+function expectMetricStatistic(value: unknown): MetricStatistic {
+  const statistic = expectString(value, "query_metric_points.statistic");
+  switch (statistic) {
+    case "value":
+    case "latest":
+    case "mean":
+    case "median":
+    case "min":
+    case "max":
+    case "sum":
+    case "count":
+      return statistic;
+    default:
+      throw new TypeError(`Expected query_metric_points.statistic to be a metric statistic.`);
+  }
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNullableString(value: unknown): string | null {
+  if (value === null) {
+    return null;
+  }
+  return readOptionalString(value) ?? null;
+}
+
+function readNullableNumber(value: unknown): number | null {
+  if (value === null) {
+    return null;
+  }
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isEmptyRecord(value: object): boolean {
+  return Object.keys(value).length === 0;
 }
 
 function metricTargetDateRange(

--- a/packages/query/src/projection/schema.ts
+++ b/packages/query/src/projection/schema.ts
@@ -13,8 +13,8 @@ export type DatabaseSync = import("node:sqlite").DatabaseSync;
 export type SqliteRow = Record<string, unknown>;
 
 export const QUERY_PROJECTION_SCHEMA_ID = "murph.query-projection";
-// 11: wearable public-provider conflict evidence and generic observation metric extraction.
-export const QUERY_PROJECTION_SQLITE_VERSION = 11;
+// 12: compact metric point supplemental payloads.
+export const QUERY_PROJECTION_SQLITE_VERSION = 12;
 
 export interface QueryProjectionLocation {
   absolutePath: string;

--- a/packages/query/test/browser-vault-metric-points-labs-measurements.test.ts
+++ b/packages/query/test/browser-vault-metric-points-labs-measurements.test.ts
@@ -707,10 +707,14 @@ test("query projection rebuild stores shared event and wearable metric points in
       );
       const stepsPoint = JSON.parse(
         rows.find((row) => row.metricKey === "steps")?.metricPointJson ?? "null",
-      ) as { context?: { contributingRecordIds?: unknown }; source?: { recordId?: string } } | null;
+      ) as { context?: { contributingRecordIds?: unknown }; source?: unknown } | null;
       assert.ok(stepsPoint);
-      assert.equal(stepsPoint.source?.recordId, "smp_projection_steps");
+      assert.equal(Object.hasOwn(stepsPoint, "source"), false);
       assert.equal(stepsPoint.context?.contributingRecordIds, undefined);
+      assert.doesNotMatch(
+        rows.find((row) => row.metricKey === "steps")?.metricPointJson ?? "",
+        /smp_projection_steps/u,
+      );
     } finally {
       database.close();
     }

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -3591,6 +3591,50 @@ async function createMetricObservationVault(
   return vaultRoot;
 }
 
+interface MetricSampleInput {
+  id: string;
+  metric: string;
+  recordedAt: string;
+  unit: string;
+  value: number;
+}
+
+async function createMetricSampleVault(samples: readonly MetricSampleInput[]): Promise<string> {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-query-metric-samples-"));
+
+  await mkdir(path.join(vaultRoot, "ledger/metric-samples/glucose/2026"), { recursive: true });
+  await writeFile(
+    path.join(vaultRoot, "vault.json"),
+    `${JSON.stringify({
+      formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+      vaultId: "vault_01JNV40W8VFYQ2H7CMJY5A9R4K",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      title: "Metric sample vault",
+      timezone: "UTC",
+    })}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(vaultRoot, "ledger/metric-samples/glucose/2026/2026-04.jsonl"),
+    `${samples.map((sample) =>
+      JSON.stringify({
+        schemaVersion: "murph.metric-sample.v1",
+        id: sample.id,
+        metric: sample.metric,
+        recordedAt: sample.recordedAt,
+        dayKey: sample.recordedAt.slice(0, 10),
+        source: "device",
+        quality: "derived",
+        value: sample.value,
+        unit: sample.unit,
+      })
+    ).join("\n")}\n`,
+    "utf8",
+  );
+
+  return vaultRoot;
+}
+
 async function createSparseVault(): Promise<string> {
   const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-query-sparse-"));
 
@@ -4591,6 +4635,41 @@ test("rebuildQueryProjection stores compact metric point payloads for rich provi
     assert.equal(points[0]?.provenance.dataOrigin, null);
     assert.equal(points[0]?.provenance.externalRef, null);
     assert.deepEqual(points[0]?.provenance.rawRefs, []);
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("listMetricPointsRuntime preserves full compact metric point context from rebuilt sample summaries", async () => {
+  const vaultRoot = await createMetricSampleVault([
+    {
+      id: "smp_query_context_glucose_01",
+      metric: "glucose",
+      recordedAt: "2026-04-01T08:00:00Z",
+      unit: "mg_dL",
+      value: 92,
+    },
+    {
+      id: "smp_query_context_glucose_02",
+      metric: "glucose",
+      recordedAt: "2026-04-01T12:15:00Z",
+      unit: "mg_dL",
+      value: 100,
+    },
+  ]);
+
+  try {
+    await rebuildQueryProjection(vaultRoot);
+
+    const points = await listMetricPointsRuntime(vaultRoot, { limit: null, metricKey: "glucose" });
+    const sampleSummary = points.find((point) => point.source.kind === "sample-summary");
+
+    assert.ok(sampleSummary);
+    assert.equal(sampleSummary.context.firstSampleAt, "2026-04-01T08:00:00Z");
+    assert.equal(sampleSummary.context.lastSampleAt, "2026-04-01T12:15:00Z");
+    assert.equal(sampleSummary.context.numericSampleCount, 2);
+    assert.equal(sampleSummary.context.sampleCount, 2);
+    assert.equal(sampleSummary.context.sourceStream, "glucose");
   } finally {
     await rm(vaultRoot, { recursive: true, force: true });
   }

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -3535,6 +3535,7 @@ Light walk and early bedtime.
 }
 
 interface MetricObservationEventInput {
+  dataOrigin?: Record<string, unknown>;
   dayKey?: string | null;
   deleted?: boolean;
   endAt?: string;
@@ -3543,6 +3544,8 @@ interface MetricObservationEventInput {
   metric: string;
   observationGrain?: string;
   occurredAt: string;
+  qualifiers?: Record<string, string | number | boolean>;
+  rawRefs?: string[];
   recordedAt?: string;
   source: "device" | "manual";
   title: string;
@@ -4482,12 +4485,10 @@ test("rebuildQueryProjection creates the compact metric point schema", async () 
     });
 
     try {
-      // Pin the literal version: a revert of the 10 -> 11 bump would keep every
-      // constant-relative assertion green while legacy v10 stores, which lack
-      // either generic observation metric points or rebuilt wearable public
-      // conflict evidence depending on their source branch, were treated as
-      // current instead of being rebuilt.
-      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 11);
+      // Pin the literal version: a revert of the 11 -> 12 bump would keep every
+      // constant-relative assertion green while legacy v11 stores still carried
+      // full metric point JSON payloads.
+      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 12);
       assert.equal(readSqliteRuntimeUserVersion(database), QUERY_PROJECTION_SQLITE_VERSION);
 
       const columnRows = database
@@ -4501,6 +4502,95 @@ test("rebuildQueryProjection creates the compact metric point schema", async () 
     } finally {
       database.close();
     }
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("rebuildQueryProjection stores compact metric point payloads for rich provider observations", async () => {
+  const vaultRoot = await createMetricObservationVault(
+    Array.from({ length: 24 }, (_, index) => ({
+      dataOrigin: {
+        exportBatch: `provider-export-batch-${index}`,
+        marker: "provider-data-origin-marker-should-not-repeat-in-query-projection",
+        nested: {
+          payload: "provider-nested-origin-payload-".repeat(8),
+        },
+      },
+      externalRef: {
+        facet: "caffeine",
+        marker: "provider-external-ref-marker-should-not-repeat-in-query-projection",
+        resourceId: `provider-resource-${String(index).padStart(2, "0")}`,
+        resourceType: "daily_readiness",
+        system: "fixture-provider",
+      },
+      id: `evt_metric_observation_rich_provider_${String(index).padStart(2, "0")}`,
+      metric: "caffeine",
+      observationGrain: "summary",
+      occurredAt: `2026-04-${String((index % 8) + 1).padStart(2, "0")}T07:00:00Z`,
+      qualifiers: { summary: true },
+      rawRefs: [
+        `raw/provider/rich-payload-${String(index).padStart(2, "0")}.json`,
+        "raw-provider-marker-should-not-repeat-in-query-projection",
+      ],
+      source: "device",
+      title: "Fixture provider caffeine",
+      unit: "mg",
+      value: 45 + index,
+    })),
+  );
+  const runtimeDatabasePath = path.join(vaultRoot, QUERY_DB_RELATIVE_PATH);
+
+  try {
+    await rebuildQueryProjection(vaultRoot);
+
+    const database = openSqliteRuntimeDatabase(runtimeDatabasePath, {
+      create: false,
+      readOnly: true,
+    });
+
+    try {
+      const stats = database
+        .prepare(`
+          SELECT
+            AVG(LENGTH(metric_point_json)) AS averageBytes,
+            MAX(LENGTH(metric_point_json)) AS maxBytes,
+            COUNT(*) AS rowCount
+          FROM query_metric_points
+          WHERE metric_key = 'caffeine'
+        `)
+        .get() as { averageBytes: number; maxBytes: number; rowCount: number };
+      const joinedPayload = (database
+        .prepare(`
+          SELECT GROUP_CONCAT(metric_point_json, '\n') AS payload
+          FROM query_metric_points
+          WHERE metric_key = 'caffeine'
+        `)
+        .get() as { payload: string }).payload;
+
+      assert.equal(stats.rowCount, 24);
+      assert.ok(
+        stats.averageBytes < 360,
+        `expected compact metric point payloads, got ${stats.averageBytes} average bytes`,
+      );
+      assert.ok(stats.maxBytes < 420, `expected compact max payload, got ${stats.maxBytes} bytes`);
+      assert.doesNotMatch(
+        joinedPayload,
+        /provider-data-origin-marker|provider-external-ref-marker|raw-provider-marker/u,
+      );
+    } finally {
+      database.close();
+    }
+
+    const points = await listMetricPointsRuntime(vaultRoot, { limit: null, metricKey: "caffeine" });
+
+    assert.equal(points.length, 24);
+    assert.equal(points[0]?.context.observationGrain, "summary");
+    assert.equal(points[0]?.source.kind, "observation");
+    assert.equal(points[0]?.source.recordId.startsWith("evt_metric_observation_rich_provider_"), true);
+    assert.equal(points[0]?.provenance.dataOrigin, null);
+    assert.equal(points[0]?.provenance.externalRef, null);
+    assert.deepEqual(points[0]?.provenance.rawRefs, []);
   } finally {
     await rm(vaultRoot, { recursive: true, force: true });
   }
@@ -5070,7 +5160,7 @@ test("importer sleep keys, canonical day keys, and losing providers all resolve 
   }
 });
 
-test("listMetricPointsRuntime rebuilds previous-version projections before serving observation metrics", async () => {
+test("listMetricPointsRuntime rebuilds v11 full-payload projections before serving metric points", async () => {
   const vaultRoot = await createMetricObservationVault([
     {
       id: "evt_metric_observation_caffeine_rebuild_01",
@@ -5090,7 +5180,7 @@ test("listMetricPointsRuntime rebuilds previous-version projections before servi
     const staleDatabase = openSqliteRuntimeDatabase(runtimeDatabasePath, { create: false });
     try {
       staleDatabase.exec(`
-        PRAGMA user_version = 9;
+        PRAGMA user_version = 11;
         DELETE FROM query_metric_points;
       `);
     } finally {
@@ -5507,7 +5597,7 @@ test("runtime wearable summaries read identically from compact and legacy full-f
   }
 });
 
-test("listMetricPointsRuntime round-trips stored metric points purely from metric_point_json", async () => {
+test("listMetricPointsRuntime reconstructs stored metric points from scalar columns and compact metadata", async () => {
   const vaultRoot = await createFixtureVault();
   const runtimeDatabasePath = path.join(vaultRoot, QUERY_DB_RELATIVE_PATH);
   const point: MetricPoint = {
@@ -5552,13 +5642,26 @@ test("listMetricPointsRuntime round-trips stored metric points purely from metri
     const database = openSqliteRuntimeDatabase(runtimeDatabasePath, { create: false });
     try {
       insertProjectionMetricPoints(database, [point]);
+      const storedPayload = database
+        .prepare("SELECT metric_point_json AS metricPointJson FROM query_metric_points WHERE id = ?")
+        .get(point.id) as { metricPointJson: string } | undefined;
+      assert.ok(storedPayload);
+      assert.doesNotMatch(storedPayload.metricPointJson, /resourceId|function-health|externalRef|dataOrigin/u);
+      assert.match(storedPayload.metricPointJson, /fastingStatus|sourceLabel/u);
     } finally {
       database.close();
     }
 
     const points = await listMetricPointsRuntime(vaultRoot, { metricKey: "apob" });
     const stored = points.find((candidate) => candidate.id === point.id);
-    assert.deepEqual(stored, point);
+    assert.deepEqual(stored, {
+      ...point,
+      provenance: {
+        ...point.provenance,
+        dataOrigin: null,
+        externalRef: null,
+      },
+    });
   } finally {
     await rm(vaultRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Store compact supplemental metadata in `query_metric_points.metric_point_json` instead of the full rich `MetricPoint` object.
- Reconstruct runtime metric points from scalar projection columns plus compact metadata.
- Bump the query projection SQLite version to `12` so existing v11 full-payload projections rebuild.
- Add a deterministic rich-provider observation repro/regression that pins the compact payload size and readback behavior.

## Root Cause
`query.sqlite` was large because the rebuildable query projection duplicated full metric point JSON per row, including repeated provenance, context, raw refs, and source-ish metadata that already exists in canonical vault/source records or scalar projection columns.

## Validation
- `pnpm --dir packages/query test` passed post-rebase: 47 files, 376 tests.
- `pnpm build:workspace:incremental` passed.
- `pnpm typecheck` passed.
- `bash scripts/workspace-verify.sh test:diff packages/query/src/projection/metric-store.ts packages/query/src/projection/schema.ts packages/query/test/query.test.ts packages/query/test/browser-vault-metric-points-labs-measurements.test.ts agent-docs/exec-plans/active/2026-06-21-query-sqlite-compact.md agent-docs/exec-plans/active/COORDINATION_LEDGER.md` passed before commit.
- `pnpm test:smoke` passed.
- `git diff --check -- <task files>` passed.
- Local security/privacy, coverage-write, and deep-review audit passes returned no required changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784661640&installation_id=127572939&pr_number=235&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F235&signature=9fdb6f4ba96282a224978b680abdc290e9ada45b33229f264f935b9042e4a3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->