### PR TITLE
[codex] Prune terminal write-operation records

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-21-prune-terminal-write-ops.md
+++ b/agent-docs/exec-plans/completed/2026-06-21-prune-terminal-write-ops.md
@@ -1,0 +1,46 @@
+# Prune Terminal Write Operations
+
+## Goal
+
+Reduce hosted workspace snapshot file count by pruning stale clean committed write-operation metadata once a newer durable checkpoint already proves the committed records are recoverable.
+
+Success criteria:
+
+- Keep non-terminal write-operation records for recovery.
+- Keep rolled-back, failed, active, errored, and stage-residue records for recovery/debugging.
+- Keep the newest 100 clean committed records, plus any clean committed records from the last 24 hours.
+- Delete only clean committed write-operation metadata older than both retention gates.
+- Run cleanup before archive planning, but only when a previous successful checkpoint timestamp proves the terminal record has already been snapshotted.
+- Prove behavior with focused tests and typecheck.
+
+## Constraints
+
+- Preserve foreground priority; cleanup must be best-effort and must not block or fail hosted idle checkpoint publication.
+- Do not delete staged payload directories; remaining stage directories are a cleanup-incomplete signal and keep their metadata.
+- Keep logs metadata-only.
+- Avoid new schedulers, queues, or broad maintenance frameworks.
+
+## Plan
+
+1. Inspect write-operation record schema and snapshot inclusion policy.
+2. Add a small owner-level pruning helper.
+3. Call it during idle checkpoint preparation before archive planning, gated by the previous successful checkpoint timestamp.
+4. Add focused tests for retention and checkpoint integration.
+5. Run scoped verification and required completion review.
+
+## Verification
+
+- `pnpm exec vitest run packages/core/test/write-operation-pruning.test.ts --no-coverage`
+- `pnpm exec vitest run packages/assistant-runtime/test/hosted-invocation-bridge.test.ts --isolate=true --no-coverage`
+- `pnpm --dir packages/core typecheck`
+- `pnpm --dir packages/assistant-runtime typecheck`
+- `pnpm --dir packages/core test`
+- `pnpm --dir packages/assistant-runtime test`
+- `pnpm exec vitest run packages/core/test/write-operation-pruning.test.ts --coverage`
+- `pnpm exec vitest run packages/assistant-runtime/test/hosted-invocation-bridge.test.ts --isolate=true --coverage`
+- `pnpm typecheck`
+- `pnpm test:smoke`
+- `git diff --check`
+Status: completed
+Updated: 2026-06-21
+Completed: 2026-06-21

--- a/packages/assistant-runtime/src/hosted-runtime/snapshot-bridge.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/snapshot-bridge.ts
@@ -6,6 +6,10 @@ import {
   type HostedWorkspaceRuntimeJobOptions,
 } from "../hosted-runtime.ts";
 import {
+  pruneTerminalWriteOperationRecords,
+  type PruneTerminalWriteOperationRecordsResult,
+} from "@murphai/core";
+import {
   collectHostedWorkspaceSnapshotArchivePlan,
   createHostedWorkspaceSnapshotArchivePlanSizeDiagnostics,
   type HostedWorkspaceSnapshotArchiveEntry,
@@ -157,6 +161,7 @@ export function createHostedWorkspaceRuntimeBridgeJobOptions(
           redactedStatus: checkpointInput.redactedStatus ?? null,
           snapshotRef: null,
         },
+        previousWorkspaceCheckpointedAt: input.request.workspace?.checkpointedAt ?? null,
         snapshotDiagnosticsHashSecret:
           normalizeHostedWorkspaceSnapshotDiagnosticsHashSecret(
             input.snapshotDiagnosticsHashSecret,
@@ -191,6 +196,7 @@ export function createHostedRuntimeBridgeLeaseFromWorkspaceRequest(
 async function createHostedWorkspaceBridgeCheckpointSnapshot(input: {
   consumePendingRuntimeWake?: () => RuntimeWakeNotification | null;
   platform: HostedWorkspaceRuntimeJobOptions["platform"];
+  previousWorkspaceCheckpointedAt: string | null;
   readCurrentLease: HostedRuntimeBridgeReadCurrentLease;
   request: HostedWorkspaceCheckpointRequest;
   snapshotArchiveBuilder: HostedWorkspaceSnapshotArchiveBuilder;
@@ -254,6 +260,7 @@ interface HostedWorkspaceBridgeV2SnapshotInput {
     ReturnType<typeof prepareLegacyWorkspaceRefsForV2SnapshotMaterialization>
   >;
   platform: HostedWorkspaceRuntimeJobOptions["platform"];
+  previousWorkspaceCheckpointedAt: string | null;
   readCurrentLease: HostedRuntimeBridgeReadCurrentLease;
   request: HostedWorkspaceIdleCheckpointRequest;
   snapshotArchiveBuilder: HostedWorkspaceSnapshotArchiveBuilder;
@@ -304,6 +311,7 @@ async function createHostedWorkspaceV2Snapshot(
   let checkpointAttempted = false;
   let localWorkspaceCleanForWarmReuse = false;
   let prunedRuntimeSymlinkCount = 0;
+  let terminalWriteOperationPruneResult: PruneTerminalWriteOperationRecordsResult | null = null;
   const snapshotTimings: HostedWorkspaceSnapshotTimingDetails = {};
   try {
     leaseCheckCount += 1;
@@ -335,6 +343,40 @@ async function createHostedWorkspaceV2Snapshot(
         },
         level: "warn",
         message: "Hosted workspace snapshot pruned runtime-owned symlinks.",
+        phase: "checkpoint",
+        userId: input.userId,
+      });
+    }
+    try {
+      terminalWriteOperationPruneResult = await pruneTerminalWriteOperationRecords({
+        checkpointedAfter: input.previousWorkspaceCheckpointedAt,
+        vaultRoot: input.vaultRoot,
+      });
+      if (terminalWriteOperationPruneResult.prunedCount > 0) {
+        emitHostedExecutionStructuredLog({
+          component: "runner",
+          details: {
+            ...createTerminalWriteOperationPruneLogDetails(
+              terminalWriteOperationPruneResult,
+            ),
+            snapshotMode: HOSTED_WORKSPACE_V2_SNAPSHOT_MODE,
+          },
+          level: "info",
+          message: "Hosted workspace snapshot pruned terminal write-operation records.",
+          phase: "checkpoint",
+          userId: input.userId,
+        });
+      }
+    } catch (cleanupError) {
+      emitHostedExecutionStructuredLog({
+        component: "runner",
+        details: {
+          snapshotMode: HOSTED_WORKSPACE_V2_SNAPSHOT_MODE,
+          terminalWriteOperationPruneFailed: true,
+        },
+        error: cleanupError,
+        level: "warn",
+        message: "Hosted workspace terminal write-operation cleanup failed.",
         phase: "checkpoint",
         userId: input.userId,
       });
@@ -550,6 +592,9 @@ async function createHostedWorkspaceV2Snapshot(
               runtimeSymlinkPruneScope: "operator-home",
             }
           : {}),
+        ...createTerminalWriteOperationPruneLogDetails(
+          terminalWriteOperationPruneResult,
+        ),
         ...snapshotTimings,
         ...(workspaceSnapshotFileCount > 0
           ? { workspaceSnapshotFileCount }
@@ -600,6 +645,7 @@ async function createHostedWorkspaceV2Snapshot(
     plainByteSize: workspaceSnapshotPlainBytes,
     platform: input.platform,
     prunedRuntimeSymlinkCount,
+    terminalWriteOperationPruneResult,
     request: input.request,
     snapshotElapsedMs: Date.now() - startedAt,
     snapshotMode: HOSTED_WORKSPACE_V2_SNAPSHOT_MODE,
@@ -817,6 +863,25 @@ function createHostedWorkspaceSnapshotSizeDiagnosticLogDetails(
   };
 }
 
+function createTerminalWriteOperationPruneLogDetails(
+  result: PruneTerminalWriteOperationRecordsResult | null,
+): HostedRuntimeRedactedJson {
+  if (!result || result.prunedCount === 0) {
+    return {};
+  }
+
+  return {
+    prunedTerminalWriteOperationBytes: result.prunedByteCount,
+    prunedTerminalWriteOperationCount: result.prunedCount,
+    prunedTerminalWriteOperationFileCount: result.prunedFileCount,
+    terminalWriteOperationPruneErroredCount: result.retainedErroredTerminalCount,
+    terminalWriteOperationPruneInvalidCount: result.invalidCount,
+    terminalWriteOperationPruneNewestRetainedCount: result.retainedNewestTerminalCount,
+    terminalWriteOperationPruneScannedCount: result.scannedCount,
+    terminalWriteOperationPruneStageDirectoryCount: result.retainedStageDirectoryCount,
+  };
+}
+
 async function writeHostedCheckpointSnapshotMetricLog(input: {
   encryptedByteSize: number;
   fileCount: number;
@@ -824,6 +889,7 @@ async function writeHostedCheckpointSnapshotMetricLog(input: {
   plainByteSize: number;
   platform: HostedWorkspaceRuntimeJobOptions["platform"];
   prunedRuntimeSymlinkCount: number;
+  terminalWriteOperationPruneResult: PruneTerminalWriteOperationRecordsResult | null;
   request: HostedWorkspaceIdleCheckpointRequest;
   snapshotElapsedMs: number;
   snapshotMode: typeof HOSTED_WORKSPACE_V2_SNAPSHOT_MODE;
@@ -844,6 +910,9 @@ async function writeHostedCheckpointSnapshotMetricLog(input: {
           runtimeSymlinkPruneScope: "operator-home",
         }
       : {}),
+    ...createTerminalWriteOperationPruneLogDetails(
+      input.terminalWriteOperationPruneResult,
+    ),
     ...input.timingDetails,
     snapshotElapsedMs: input.snapshotElapsedMs,
     workspaceSnapshotEncryptedBytes: input.encryptedByteSize,

--- a/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
+++ b/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -44,6 +44,8 @@ const TEST_REQUEST = {
   userId: "member_bridge",
   workspaceVersion: "7",
 } satisfies HostedWorkspaceInvocationRequest;
+
+const WRITE_OPERATION_SCHEMA_VERSION = "murph.write-operation.v1";
 
 const cleanupPaths: string[] = [];
 
@@ -295,6 +297,76 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     expect(calls.abortSnapshotSession).not.toHaveBeenCalled();
   });
 
+  it("prunes stale terminal write-operation records before v2 snapshot archive planning", async () => {
+    const vaultRoot = await createVaultRoot();
+    const { platform } = createRuntimePlatform();
+    const snapshotArchiveBuilder = createSnapshotArchiveBuilder();
+    const staleOperationPaths = await writeManyStaleCommittedOperationRecords(vaultRoot);
+    const activeOperationPath = await writeOperationRecord(vaultRoot, {
+      operationId: "op_active_protected",
+      status: "staged",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    const request = createInvocationRequestWithWorkspaceCheckpoint("2026-06-10T00:00:00.000Z");
+    const options = createBridgeOptions({
+      platform,
+      request,
+      snapshotArchiveBuilder,
+      vaultRoot,
+    });
+
+    await options.createCheckpointSnapshot(createCheckpointInput("idle_shutdown"));
+
+    const archiveEntries =
+      vi.mocked(snapshotArchiveBuilder.buildEncryptedSnapshot).mock.calls[0]?.[0]
+        .archiveEntries ?? [];
+    expect(archiveEntries.some((entry) => entry.relativePath === staleOperationPaths.oldest)).toBe(false);
+    expect(archiveEntries.some((entry) => entry.relativePath === staleOperationPaths.newest)).toBe(true);
+    expect(archiveEntries.some((entry) => entry.relativePath === activeOperationPath)).toBe(true);
+    await expectMissing(path.join(vaultRoot, staleOperationPaths.oldest));
+    await expectPresent(path.join(vaultRoot, staleOperationPaths.newest));
+    await expectPresent(path.join(vaultRoot, activeOperationPath));
+  });
+
+  it("continues checkpoint publication when terminal write-operation pruning fails", async () => {
+    const vaultRoot = await createVaultRoot();
+    const { calls, platform } = createRuntimePlatform();
+    const snapshotArchiveBuilder = createSnapshotArchiveBuilder();
+    const staleOperationPaths = await writeManyStaleCommittedOperationRecords(vaultRoot);
+    const operationDirectory = path.join(vaultRoot, ".runtime", "operations");
+    const request = createInvocationRequestWithWorkspaceCheckpoint("2026-06-10T00:00:00.000Z");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const options = createBridgeOptions({
+      platform,
+      request,
+      snapshotArchiveBuilder,
+      vaultRoot,
+    });
+
+    await chmod(operationDirectory, 0o500);
+    try {
+      await expect(options.createCheckpointSnapshot(
+        createCheckpointInput("idle_shutdown"),
+      )).resolves.toMatchObject({
+        localWorkspaceCleanForWarmReuse: true,
+      });
+    } finally {
+      await chmod(operationDirectory, 0o700);
+    }
+
+    const archiveEntries =
+      vi.mocked(snapshotArchiveBuilder.buildEncryptedSnapshot).mock.calls[0]?.[0]
+        .archiveEntries ?? [];
+    expect(archiveEntries.some((entry) => entry.relativePath === staleOperationPaths.oldest)).toBe(true);
+    await expectPresent(path.join(vaultRoot, staleOperationPaths.oldest));
+    expect(calls.completeSnapshotSession).toHaveBeenCalledOnce();
+    expect(calls.abortSnapshotSession).not.toHaveBeenCalled();
+    expect(warnSpy.mock.calls.some(([payload]) =>
+      typeof payload === "string" &&
+      payload.includes("Hosted workspace terminal write-operation cleanup failed.")
+    )).toBe(true);
+  });
+
   it("keeps mailbox decode mismatches blocked and route mismatches deferred", async () => {
     const vaultRoot = await createVaultRoot();
     const { platform } = createRuntimePlatform();
@@ -349,6 +421,25 @@ function createBridgeOptions(input: {
   });
 }
 
+function createInvocationRequestWithWorkspaceCheckpoint(
+  checkpointedAt: string,
+): HostedWorkspaceInvocationRequest {
+  return {
+    ...TEST_REQUEST,
+    workspace: {
+      checkpointedAt,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      nextWakeAt: null,
+      nextWakeReason: null,
+      redactedStatus: null,
+      snapshotRef: null,
+      updatedAt: checkpointedAt,
+      userId: TEST_REQUEST.userId,
+      version: TEST_REQUEST.workspaceVersion,
+    },
+  };
+}
+
 async function createVaultRoot(): Promise<string> {
   const workspaceRoot = await mkdtemp(path.join(tmpdir(), "hosted-invocation-bridge-"));
   cleanupPaths.push(workspaceRoot);
@@ -358,6 +449,64 @@ async function createVaultRoot(): Promise<string> {
   await mkdir(vaultRoot, { recursive: true });
   await writeFile(path.join(vaultRoot, "note.md"), "workspace snapshot\n", "utf8");
   return vaultRoot;
+}
+
+async function writeManyStaleCommittedOperationRecords(
+  vaultRoot: string,
+): Promise<{ newest: string; oldest: string }> {
+  let newest = "";
+  let oldest = "";
+  for (let index = 0; index < 101; index += 1) {
+    const relativePath = await writeOperationRecord(vaultRoot, {
+      operationId: `op_stale_terminal_${String(index).padStart(3, "0")}`,
+      status: "committed",
+      updatedAt: new Date(Date.UTC(2026, 5, 1, 0, index, 0)).toISOString(),
+    });
+    if (index === 0) {
+      oldest = relativePath;
+    }
+    newest = relativePath;
+  }
+  return { newest, oldest };
+}
+
+async function writeOperationRecord(
+  vaultRoot: string,
+  input: {
+    operationId: string;
+    status: "committed" | "rolled_back" | "staged";
+    updatedAt: string;
+  },
+): Promise<string> {
+  const operationDirectory = path.join(vaultRoot, ".runtime", "operations");
+  await mkdir(operationDirectory, { recursive: true });
+  const relativePath = `.runtime/operations/${input.operationId}.json`;
+  await writeFile(
+    path.join(vaultRoot, relativePath),
+    `${JSON.stringify({
+      actions: [],
+      createdAt: input.updatedAt,
+      occurredAt: input.updatedAt,
+      operationId: input.operationId,
+      operationType: "test_operation",
+      schemaVersion: WRITE_OPERATION_SCHEMA_VERSION,
+      status: input.status,
+      summary: "test operation",
+      updatedAt: input.updatedAt,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  return relativePath;
+}
+
+async function expectPresent(absolutePath: string): Promise<void> {
+  await access(absolutePath);
+}
+
+async function expectMissing(absolutePath: string): Promise<void> {
+  await expect(access(absolutePath)).rejects.toMatchObject({
+    code: "ENOENT",
+  });
 }
 
 function createLease(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -189,6 +189,7 @@ export {
   isProtectedCanonicalPath,
   listProtectedCanonicalPaths,
   listWriteOperationMetadataPaths,
+  pruneTerminalWriteOperationRecords,
   readRecoverableStoredWriteOperation,
   readStoredWriteOperation,
   resolveHostedCanonicalWritePayloadFilePath,
@@ -208,6 +209,8 @@ export type {
   HostedCanonicalWriteReceipt,
   HostedCanonicalWriteReceiptAction,
   HostedCanonicalWriteReceiptContentRef,
+  PruneTerminalWriteOperationRecordsInput,
+  PruneTerminalWriteOperationRecordsResult,
   RecoverableStoredWriteOperation,
 } from "./operations/index.ts";
 export {

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -31,6 +31,7 @@ export {
   HOSTED_CANONICAL_WRITE_RECEIPT_DIRECTORY_ENV,
   HOSTED_CANONICAL_WRITE_RECEIPT_SCHEMA_VERSION,
   listProtectedCanonicalPaths,
+  pruneTerminalWriteOperationRecords,
   readRecoverableStoredWriteOperation,
   isTerminalWriteOperationStatus,
   listWriteOperationMetadataPaths,
@@ -40,6 +41,8 @@ export {
   runCanonicalWrite,
   withHostedCanonicalWritePort,
   WriteBatch,
+  TERMINAL_WRITE_OPERATION_PRUNE_MIN_RETAINED_COUNT,
+  TERMINAL_WRITE_OPERATION_PRUNE_RETENTION_MS,
   WRITE_OPERATION_DIRECTORY,
   WRITE_OPERATION_SCHEMA_VERSION,
 } from "./write-batch.ts";
@@ -50,5 +53,7 @@ export type {
   HostedCanonicalWriteReceipt,
   HostedCanonicalWriteReceiptAction,
   HostedCanonicalWriteReceiptContentRef,
+  PruneTerminalWriteOperationRecordsInput,
+  PruneTerminalWriteOperationRecordsResult,
   RecoverableStoredWriteOperation,
 } from "./write-batch.ts";

--- a/packages/core/src/operations/write-batch.ts
+++ b/packages/core/src/operations/write-batch.ts
@@ -9,7 +9,7 @@ import {
   writeTextFileAtomic,
 } from "../atomic-write.ts";
 import { VaultError } from "../errors.ts";
-import { ensureDirectory, pathExists, walkVaultFiles } from "../fs.ts";
+import { ensureDirectory, pathExists } from "../fs.ts";
 import { VAULT_LAYOUT } from "../constants.ts";
 import {
   isJsonlRelativePath,
@@ -19,6 +19,7 @@ import {
   normalizeRelativeVaultPathForComparison,
   normalizeVaultRoot,
   resolveVaultPath,
+  resolveVaultPathOnDisk,
   type VaultPathComparisonOptions,
 } from "../path-safety.ts";
 import { toIsoTimestamp } from "../time.ts";
@@ -39,6 +40,8 @@ import type { DateInput } from "../types.ts";
 
 export const WRITE_OPERATION_SCHEMA_VERSION = "murph.write-operation.v1";
 export const WRITE_OPERATION_DIRECTORY = ".runtime/operations";
+export const TERMINAL_WRITE_OPERATION_PRUNE_MIN_RETAINED_COUNT = 100;
+export const TERMINAL_WRITE_OPERATION_PRUNE_RETENTION_MS = 24 * 60 * 60 * 1000;
 
 type WriteOperationStatus = "staged" | "committing" | "committed" | "rolled_back" | "failed";
 type WriteOperationActionState = "staged" | "applied" | "reused" | "rolled_back";
@@ -292,6 +295,35 @@ export interface RecoverableStoredWriteOperation {
   createdAt: string;
   updatedAt: string;
   actions: StoredWriteAction[];
+}
+
+export interface PruneTerminalWriteOperationRecordsInput {
+  checkpointedAfter: DateInput | null | undefined;
+  now?: DateInput;
+  retainedOperationCount?: number;
+  retentionMs?: number;
+  vaultRoot: string;
+}
+
+export interface PruneTerminalWriteOperationRecordsResult {
+  invalidCount: number;
+  prunedByteCount: number;
+  prunedCount: number;
+  prunedFileCount: number;
+  retainedErroredTerminalCount: number;
+  retainedNewestTerminalCount: number;
+  retainedProtectedCount: number;
+  retainedRecentTerminalCount: number;
+  retainedStageDirectoryCount: number;
+  retainedUncheckpointedTerminalCount: number;
+  scannedCount: number;
+}
+
+interface PrunableTerminalWriteOperationRecord {
+  metadataRelativePath: string;
+  operationId: string;
+  stageRoot: string;
+  updatedAtMs: number;
 }
 
 function isStoredWriteOperationStatus(value: unknown): value is WriteOperationStatus {
@@ -813,11 +845,207 @@ export function isTerminalWriteOperationStatus(status: string): boolean {
 }
 
 export async function listWriteOperationMetadataPaths(vaultRoot: string): Promise<string[]> {
-  const operationFiles = await walkVaultFiles(vaultRoot, WRITE_OPERATION_DIRECTORY, {
-    extension: ".json",
-  });
+  const operationDirectory = await resolveVaultPathOnDisk(vaultRoot, WRITE_OPERATION_DIRECTORY);
+  if (!(await pathExists(operationDirectory.absolutePath))) {
+    return [];
+  }
 
-  return operationFiles.filter((relativePath) => path.posix.dirname(relativePath) === WRITE_OPERATION_DIRECTORY);
+  const stats = await fs.lstat(operationDirectory.absolutePath);
+  if (!stats.isDirectory()) {
+    return [];
+  }
+
+  const entries = await fs.readdir(operationDirectory.absolutePath, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.posix.join(WRITE_OPERATION_DIRECTORY, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export async function pruneTerminalWriteOperationRecords(
+  input: PruneTerminalWriteOperationRecordsInput,
+): Promise<PruneTerminalWriteOperationRecordsResult> {
+  const checkpointedAfterMs = parsePruneBoundaryMs(input.checkpointedAfter);
+  const nowMs = parsePruneBoundaryMs(input.now ?? new Date());
+  const retainedOperationCount = normalizeTerminalWriteOperationRetainedCount(
+    input.retainedOperationCount,
+  );
+  const retentionMs = normalizeTerminalWriteOperationRetentionMs(input.retentionMs);
+  const result: PruneTerminalWriteOperationRecordsResult = {
+    invalidCount: 0,
+    prunedByteCount: 0,
+    prunedCount: 0,
+    prunedFileCount: 0,
+    retainedErroredTerminalCount: 0,
+    retainedNewestTerminalCount: 0,
+    retainedProtectedCount: 0,
+    retainedRecentTerminalCount: 0,
+    retainedStageDirectoryCount: 0,
+    retainedUncheckpointedTerminalCount: 0,
+    scannedCount: 0,
+  };
+
+  if (checkpointedAfterMs === null || nowMs === null) {
+    return result;
+  }
+
+  const candidates: PrunableTerminalWriteOperationRecord[] = [];
+  const cutoffMs = nowMs - retentionMs;
+  for (const relativePath of await listWriteOperationMetadataPaths(input.vaultRoot)) {
+    result.scannedCount += 1;
+    const operationId = operationIdFromMetadataPath(relativePath);
+    if (!operationId) {
+      result.invalidCount += 1;
+      continue;
+    }
+
+    const operation = await readStrictPrunableWriteOperation(input.vaultRoot, relativePath);
+    if (!operation || operation.operationId !== operationId) {
+      result.invalidCount += 1;
+      continue;
+    }
+
+    if (operation.status !== "committed") {
+      result.retainedProtectedCount += 1;
+      continue;
+    }
+
+    if (operation.error) {
+      result.retainedErroredTerminalCount += 1;
+      continue;
+    }
+
+    const updatedAtMs = parsePruneBoundaryMs(operation.updatedAt);
+    if (updatedAtMs === null) {
+      result.invalidCount += 1;
+      continue;
+    }
+
+    if (updatedAtMs >= checkpointedAfterMs) {
+      result.retainedUncheckpointedTerminalCount += 1;
+      continue;
+    }
+
+    await resolveVaultPathOnDisk(input.vaultRoot, relativePath);
+    const stageRoot = (await resolveVaultPathOnDisk(
+      input.vaultRoot,
+      path.posix.join(WRITE_OPERATION_DIRECTORY, operationId),
+    )).absolutePath;
+    if (await pathExists(stageRoot)) {
+      result.retainedStageDirectoryCount += 1;
+      continue;
+    }
+
+    candidates.push({
+      metadataRelativePath: relativePath,
+      operationId,
+      stageRoot,
+      updatedAtMs,
+    });
+  }
+
+  candidates.sort((left, right) =>
+    right.updatedAtMs - left.updatedAtMs ||
+    left.operationId.localeCompare(right.operationId),
+  );
+
+  for (const [index, candidate] of candidates.entries()) {
+    if (index < retainedOperationCount) {
+      result.retainedNewestTerminalCount += 1;
+      continue;
+    }
+
+    if (candidate.updatedAtMs > cutoffMs) {
+      result.retainedRecentTerminalCount += 1;
+      continue;
+    }
+
+    if (await pathExists(candidate.stageRoot)) {
+      result.retainedStageDirectoryCount += 1;
+      continue;
+    }
+
+    const metadataPath = (await resolveVaultPathOnDisk(
+      input.vaultRoot,
+      candidate.metadataRelativePath,
+    )).absolutePath;
+    const measured = await measureExistingFile(metadataPath);
+    await safeUnlink(metadataPath);
+    result.prunedCount += 1;
+    result.prunedFileCount += measured.fileCount;
+    result.prunedByteCount += measured.byteCount;
+  }
+
+  return result;
+}
+
+async function readStrictPrunableWriteOperation(
+  vaultRoot: string,
+  relativePath: string,
+): Promise<StoredWriteOperation | null> {
+  try {
+    return await readStoredWriteOperation(vaultRoot, relativePath);
+  } catch (error) {
+    if (
+      (error instanceof VaultError && error.code === "OPERATION_INVALID") ||
+      error instanceof SyntaxError ||
+      (isErrnoException(error) && error.code === "ENOENT")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function normalizeTerminalWriteOperationRetainedCount(value: number | undefined): number {
+  if (typeof value !== "number") {
+    return TERMINAL_WRITE_OPERATION_PRUNE_MIN_RETAINED_COUNT;
+  }
+  return Number.isSafeInteger(value) && value >= 0
+    ? value
+    : TERMINAL_WRITE_OPERATION_PRUNE_MIN_RETAINED_COUNT;
+}
+
+function normalizeTerminalWriteOperationRetentionMs(value: number | undefined): number {
+  if (typeof value !== "number") {
+    return TERMINAL_WRITE_OPERATION_PRUNE_RETENTION_MS;
+  }
+  return Number.isSafeInteger(value) && value >= 0
+    ? value
+    : TERMINAL_WRITE_OPERATION_PRUNE_RETENTION_MS;
+}
+
+function parsePruneBoundaryMs(value: DateInput | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const time = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+function operationIdFromMetadataPath(relativePath: string): string | null {
+  const basename = path.posix.basename(relativePath);
+  if (!basename.endsWith(".json")) {
+    return null;
+  }
+  const operationId = basename.slice(0, -".json".length);
+  return /^op_[A-Za-z0-9_-]+$/u.test(operationId) ? operationId : null;
+}
+
+async function measureExistingFile(
+  absolutePath: string,
+): Promise<{ byteCount: number; fileCount: number }> {
+  try {
+    const stats = await fs.lstat(absolutePath);
+    return stats.isFile()
+      ? { byteCount: stats.size, fileCount: 1 }
+      : { byteCount: 0, fileCount: 0 };
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      return { byteCount: 0, fileCount: 0 };
+    }
+    throw error;
+  }
 }
 
 function parseStoredAction(value: unknown): StoredWriteAction | null {

--- a/packages/core/test/write-operation-pruning.test.ts
+++ b/packages/core/test/write-operation-pruning.test.ts
@@ -1,0 +1,454 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, test } from "vitest";
+
+import {
+  initializeVault,
+  listWriteOperationMetadataPaths,
+  pruneTerminalWriteOperationRecords,
+  readStoredWriteOperation,
+  resolveVaultPath,
+  VaultError,
+} from "../src/index.ts";
+import {
+  WriteBatch,
+  WRITE_OPERATION_DIRECTORY,
+  WRITE_OPERATION_SCHEMA_VERSION,
+} from "../src/operations/write-batch.ts";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((directory) =>
+      fs.rm(directory, {
+        force: true,
+        recursive: true,
+      }),
+    ),
+  );
+});
+
+test("pruneTerminalWriteOperationRecords removes only clean committed records covered by a newer checkpoint and retention window", async () => {
+  const vaultRoot = await makeVaultRoot();
+  const staleCommitted = await createCommittedOperation(vaultRoot, "bank/prune-committed.md");
+  const retainedRolledBack = await createRolledBackOperation(vaultRoot, "bank/retain-rolled-back.md");
+  const staged = await createStagedOperation(vaultRoot, "bank/retain-staged.md");
+  const committing = await createProtectedOperation(vaultRoot, {
+    operationId: "op_committing_protected",
+    status: "committing",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  });
+  const failed = await createProtectedOperation(vaultRoot, {
+    operationId: "op_failed_protected",
+    status: "failed",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  });
+  const recentCommitted = await createCommittedOperation(vaultRoot, "bank/retain-recent.md");
+  const uncheckpointedCommitted = await createCommittedOperation(vaultRoot, "bank/retain-uncheckpointed.md");
+  const erroredCommitted = await createCommittedOperation(vaultRoot, "bank/retain-error.md");
+  const stageResidueCommitted = await createCommittedOperation(vaultRoot, "bank/retain-stage-residue.md");
+
+  await markOperationUpdatedAt(vaultRoot, staleCommitted.metadataRelativePath, "2026-06-01T00:00:00.000Z");
+  await markOperationUpdatedAt(vaultRoot, retainedRolledBack.metadataRelativePath, "2026-06-01T00:00:00.000Z");
+  await markOperationUpdatedAt(vaultRoot, staged.metadataRelativePath, "2026-06-01T00:00:00.000Z");
+  await markOperationUpdatedAt(vaultRoot, recentCommitted.metadataRelativePath, "2026-06-21T06:00:00.000Z");
+  await markOperationUpdatedAt(vaultRoot, uncheckpointedCommitted.metadataRelativePath, "2026-06-21T13:00:00.000Z");
+  await markOperation(vaultRoot, erroredCommitted.metadataRelativePath, {
+    error: { message: "hosted canonical persistence failed" },
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  });
+  await markOperationUpdatedAt(
+    vaultRoot,
+    stageResidueCommitted.metadataRelativePath,
+    "2026-06-01T00:00:00.000Z",
+  );
+  await writeStageResidue(
+    vaultRoot,
+    stageResidueCommitted.stageRootRelativePath,
+    "payloads/residue.txt",
+    "leftover\n",
+  );
+
+  const result = await pruneTerminalWriteOperationRecords({
+    checkpointedAfter: "2026-06-21T12:00:00.000Z",
+    now: "2026-06-22T00:00:00.000Z",
+    retainedOperationCount: 0,
+    vaultRoot,
+  });
+
+  assert.equal(result.scannedCount, 9);
+  assert.equal(result.prunedCount, 1);
+  assert.equal(result.prunedFileCount, 1);
+  assert.equal(result.prunedByteCount > 0, true);
+  assert.equal(result.retainedProtectedCount, 4);
+  assert.equal(result.retainedErroredTerminalCount, 1);
+  assert.equal(result.retainedNewestTerminalCount, 0);
+  assert.equal(result.retainedRecentTerminalCount, 1);
+  assert.equal(result.retainedStageDirectoryCount, 1);
+  assert.equal(result.retainedUncheckpointedTerminalCount, 1);
+  assert.equal(result.invalidCount, 0);
+
+  await assertMissing(vaultRoot, staleCommitted.metadataRelativePath);
+  await assertMissing(vaultRoot, staleCommitted.stageRootRelativePath);
+  assert.equal(
+    await fs.readFile(resolveVaultPath(vaultRoot, "bank/prune-committed.md").absolutePath, "utf8"),
+    "committed\n",
+  );
+  await assertPresent(vaultRoot, retainedRolledBack.metadataRelativePath);
+  await assertPresent(vaultRoot, staged.metadataRelativePath);
+  await assertPresent(vaultRoot, staged.stageRootRelativePath);
+  await assertPresent(vaultRoot, committing.metadataRelativePath);
+  await assertPresent(vaultRoot, failed.metadataRelativePath);
+  await assertPresent(vaultRoot, recentCommitted.metadataRelativePath);
+  await assertPresent(vaultRoot, uncheckpointedCommitted.metadataRelativePath);
+  await assertPresent(vaultRoot, erroredCommitted.metadataRelativePath);
+  await assertPresent(vaultRoot, stageResidueCommitted.metadataRelativePath);
+  await assertPresent(vaultRoot, stageResidueCommitted.stageRootRelativePath);
+
+  assert.deepEqual((await listWriteOperationMetadataPaths(vaultRoot)).sort(), [
+    committing.metadataRelativePath,
+    erroredCommitted.metadataRelativePath,
+    failed.metadataRelativePath,
+    recentCommitted.metadataRelativePath,
+    retainedRolledBack.metadataRelativePath,
+    stageResidueCommitted.metadataRelativePath,
+    staged.metadataRelativePath,
+    uncheckpointedCommitted.metadataRelativePath,
+  ].sort());
+});
+
+test("pruneTerminalWriteOperationRecords is inert without checkpoint proof and skips malformed records", async () => {
+  const vaultRoot = await makeVaultRoot();
+  const staleCommitted = await createCommittedOperation(vaultRoot, "bank/retain-without-checkpoint.md");
+  await markOperationUpdatedAt(vaultRoot, staleCommitted.metadataRelativePath, "2026-06-01T00:00:00.000Z");
+  await writeMalformedOperation(vaultRoot, "op_malformed", "2026-06-01T00:00:00.000Z");
+  await writeWrongSchemaTerminalOperation(vaultRoot, "op_wrong_schema", "2026-06-01T00:00:00.000Z");
+
+  assert.deepEqual(await pruneTerminalWriteOperationRecords({
+    checkpointedAfter: null,
+    now: "2026-06-22T00:00:00.000Z",
+    retainedOperationCount: 0,
+    vaultRoot,
+  }), {
+    invalidCount: 0,
+    prunedByteCount: 0,
+    prunedCount: 0,
+    prunedFileCount: 0,
+    retainedErroredTerminalCount: 0,
+    retainedNewestTerminalCount: 0,
+    retainedProtectedCount: 0,
+    retainedRecentTerminalCount: 0,
+    retainedStageDirectoryCount: 0,
+    retainedUncheckpointedTerminalCount: 0,
+    scannedCount: 0,
+  });
+
+  const result = await pruneTerminalWriteOperationRecords({
+    checkpointedAfter: "2026-06-10T00:00:00.000Z",
+    now: "2026-06-22T00:00:00.000Z",
+    retainedOperationCount: 0,
+    vaultRoot,
+  });
+
+  assert.equal(result.scannedCount, 3);
+  assert.equal(result.prunedCount, 1);
+  assert.equal(result.invalidCount, 2);
+  await assertMissing(vaultRoot, staleCommitted.metadataRelativePath);
+  await assertPresent(vaultRoot, `${WRITE_OPERATION_DIRECTORY}/op_malformed.json`);
+  await assertPresent(vaultRoot, `${WRITE_OPERATION_DIRECTORY}/op_wrong_schema.json`);
+});
+
+test("pruneTerminalWriteOperationRecords retains the newest clean committed records", async () => {
+  const vaultRoot = await makeVaultRoot();
+  const operationIds = Array.from({ length: 101 }, (_, index) =>
+    `op_clean_committed_${String(index).padStart(3, "0")}`);
+  for (const [index, operationId] of operationIds.entries()) {
+    await writeCommittedOperationRecord(vaultRoot, {
+      operationId,
+      updatedAt: new Date(Date.UTC(2026, 5, 1, 0, index, 0)).toISOString(),
+    });
+  }
+
+  const result = await pruneTerminalWriteOperationRecords({
+    checkpointedAfter: "2026-06-10T00:00:00.000Z",
+    now: "2026-06-22T00:00:00.000Z",
+    vaultRoot,
+  });
+
+  assert.equal(result.scannedCount, 101);
+  assert.equal(result.prunedCount, 1);
+  assert.equal(result.retainedNewestTerminalCount, 100);
+  assert.equal(result.retainedRecentTerminalCount, 0);
+  await assertMissing(vaultRoot, `${WRITE_OPERATION_DIRECTORY}/op_clean_committed_000.json`);
+  await assertPresent(vaultRoot, `${WRITE_OPERATION_DIRECTORY}/op_clean_committed_001.json`);
+  await assertPresent(vaultRoot, `${WRITE_OPERATION_DIRECTORY}/op_clean_committed_100.json`);
+});
+
+test("pruneTerminalWriteOperationRecords rejects symlinked operation directories without deleting external records", async () => {
+  const vaultRoot = await makeVaultRoot();
+  const externalOperationDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "murph-core-write-operation-prune-external-"),
+  );
+  tempRoots.push(externalOperationDirectory);
+  const operationDirectory = resolveVaultPath(vaultRoot, WRITE_OPERATION_DIRECTORY).absolutePath;
+  const operationIds = Array.from({ length: 101 }, (_, index) =>
+    `op_external_committed_${String(index).padStart(3, "0")}`);
+
+  for (const [index, operationId] of operationIds.entries()) {
+    await writeCommittedOperationRecordInDirectory(externalOperationDirectory, {
+      operationId,
+      updatedAt: new Date(Date.UTC(2026, 5, 1, 0, index, 0)).toISOString(),
+    });
+  }
+
+  await fs.rm(operationDirectory, { force: true, recursive: true });
+  await fs.mkdir(path.dirname(operationDirectory), { recursive: true });
+  await fs.symlink(externalOperationDirectory, operationDirectory, "dir");
+
+  await assert.rejects(
+    () => pruneTerminalWriteOperationRecords({
+      checkpointedAfter: "2026-06-10T00:00:00.000Z",
+      now: "2026-06-22T00:00:00.000Z",
+      vaultRoot,
+    }),
+    (error: unknown) => error instanceof VaultError && error.code === "VAULT_PATH_SYMLINK",
+  );
+
+  const externalEntries = await fs.readdir(externalOperationDirectory);
+  assert.equal(externalEntries.filter((entry) => entry.endsWith(".json")).length, operationIds.length);
+  for (const operationId of operationIds) {
+    await fs.access(path.join(externalOperationDirectory, `${operationId}.json`));
+  }
+});
+
+async function makeVaultRoot(): Promise<string> {
+  const vaultRoot = await fs.mkdtemp(path.join(os.tmpdir(), "murph-core-write-operation-prune-"));
+  tempRoots.push(vaultRoot);
+  await initializeVault({ vaultRoot });
+  await fs.rm(resolveVaultPath(vaultRoot, WRITE_OPERATION_DIRECTORY).absolutePath, {
+    force: true,
+    recursive: true,
+  });
+  return vaultRoot;
+}
+
+async function createCommittedOperation(
+  vaultRoot: string,
+  targetRelativePath: string,
+): Promise<WriteBatch> {
+  const batch = await WriteBatch.create({
+    operationType: "test_commit",
+    summary: `test commit ${targetRelativePath}`,
+    vaultRoot,
+  });
+  await batch.stageTextWrite(targetRelativePath, "committed\n");
+  await batch.commit();
+  return batch;
+}
+
+async function createRolledBackOperation(
+  vaultRoot: string,
+  targetRelativePath: string,
+): Promise<WriteBatch> {
+  const batch = await WriteBatch.create({
+    operationType: "test_rollback",
+    summary: `test rollback ${targetRelativePath}`,
+    vaultRoot,
+  });
+  await batch.stageTextWrite(targetRelativePath, "rolled back\n");
+  await batch.rollback();
+  return batch;
+}
+
+async function createStagedOperation(
+  vaultRoot: string,
+  targetRelativePath: string,
+): Promise<WriteBatch> {
+  const batch = await WriteBatch.create({
+    operationType: "test_staged",
+    summary: `test staged ${targetRelativePath}`,
+    vaultRoot,
+  });
+  await batch.stageTextWrite(targetRelativePath, "staged\n");
+  return batch;
+}
+
+async function createProtectedOperation(
+  vaultRoot: string,
+  input: {
+    operationId: string;
+    status: "committing" | "failed";
+    updatedAt: string;
+  },
+): Promise<{ metadataRelativePath: string }> {
+  const metadataRelativePath = `${WRITE_OPERATION_DIRECTORY}/${input.operationId}.json`;
+  await fs.mkdir(resolveVaultPath(vaultRoot, WRITE_OPERATION_DIRECTORY).absolutePath, {
+    recursive: true,
+  });
+  await fs.writeFile(
+    resolveVaultPath(vaultRoot, metadataRelativePath).absolutePath,
+    `${JSON.stringify({
+      actions: [],
+      createdAt: input.updatedAt,
+      ...(input.status === "failed"
+        ? {
+            error: {
+              message: "retained failed operation",
+            },
+          }
+        : {}),
+      occurredAt: input.updatedAt,
+      operationId: input.operationId,
+      operationType: `test_${input.status}`,
+      schemaVersion: WRITE_OPERATION_SCHEMA_VERSION,
+      status: input.status,
+      summary: `retained ${input.status} operation`,
+      updatedAt: input.updatedAt,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  return { metadataRelativePath };
+}
+
+async function writeMalformedOperation(
+  vaultRoot: string,
+  operationId: string,
+  updatedAt: string,
+): Promise<void> {
+  const metadataRelativePath = `${WRITE_OPERATION_DIRECTORY}/${operationId}.json`;
+  await fs.mkdir(resolveVaultPath(vaultRoot, WRITE_OPERATION_DIRECTORY).absolutePath, {
+    recursive: true,
+  });
+  await fs.writeFile(
+    resolveVaultPath(vaultRoot, metadataRelativePath).absolutePath,
+    `${JSON.stringify({
+      actions: [],
+      createdAt: updatedAt,
+      occurredAt: updatedAt,
+      operationId: `${operationId}_mismatch`,
+      operationType: "test_malformed",
+      schemaVersion: WRITE_OPERATION_SCHEMA_VERSION,
+      status: "committed",
+      summary: "malformed operation",
+      updatedAt,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function writeWrongSchemaTerminalOperation(
+  vaultRoot: string,
+  operationId: string,
+  updatedAt: string,
+): Promise<void> {
+  const metadataRelativePath = `${WRITE_OPERATION_DIRECTORY}/${operationId}.json`;
+  await fs.mkdir(resolveVaultPath(vaultRoot, WRITE_OPERATION_DIRECTORY).absolutePath, {
+    recursive: true,
+  });
+  await fs.writeFile(
+    resolveVaultPath(vaultRoot, metadataRelativePath).absolutePath,
+    `${JSON.stringify({
+      actions: [],
+      createdAt: updatedAt,
+      occurredAt: updatedAt,
+      operationId,
+      operationType: "test_malformed_schema",
+      schemaVersion: "murph.write-operation.legacy",
+      status: "committed",
+      summary: "malformed schema operation",
+      updatedAt,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function markOperationUpdatedAt(
+  vaultRoot: string,
+  metadataRelativePath: string,
+  updatedAt: string,
+): Promise<void> {
+  await markOperation(vaultRoot, metadataRelativePath, { updatedAt });
+}
+
+async function markOperation(
+  vaultRoot: string,
+  metadataRelativePath: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const operation = await readStoredWriteOperation(vaultRoot, metadataRelativePath);
+  await fs.writeFile(
+    resolveVaultPath(vaultRoot, metadataRelativePath).absolutePath,
+    `${JSON.stringify({
+      ...operation,
+      ...patch,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function writeCommittedOperationRecord(
+  vaultRoot: string,
+  input: {
+    operationId: string;
+    updatedAt: string;
+  },
+): Promise<void> {
+  await writeCommittedOperationRecordInDirectory(
+    resolveVaultPath(vaultRoot, WRITE_OPERATION_DIRECTORY).absolutePath,
+    input,
+  );
+}
+
+async function writeCommittedOperationRecordInDirectory(
+  operationDirectory: string,
+  input: {
+    operationId: string;
+    updatedAt: string;
+  },
+): Promise<void> {
+  await fs.mkdir(operationDirectory, { recursive: true });
+  await fs.writeFile(
+    path.join(operationDirectory, `${input.operationId}.json`),
+    `${JSON.stringify({
+      actions: [],
+      createdAt: input.updatedAt,
+      occurredAt: input.updatedAt,
+      operationId: input.operationId,
+      operationType: "test_committed",
+      schemaVersion: WRITE_OPERATION_SCHEMA_VERSION,
+      status: "committed",
+      summary: "clean committed operation",
+      updatedAt: input.updatedAt,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function writeStageResidue(
+  vaultRoot: string,
+  stageRootRelativePath: string,
+  residueRelativePath: string,
+  content: string,
+): Promise<void> {
+  const absolutePath = resolveVaultPath(
+    vaultRoot,
+    path.posix.join(stageRootRelativePath, residueRelativePath),
+  ).absolutePath;
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, content, "utf8");
+}
+
+async function assertPresent(vaultRoot: string, relativePath: string): Promise<void> {
+  await fs.access(resolveVaultPath(vaultRoot, relativePath).absolutePath);
+}
+
+async function assertMissing(vaultRoot: string, relativePath: string): Promise<void> {
+  await assert.rejects(
+    () => fs.access(resolveVaultPath(vaultRoot, relativePath).absolutePath),
+    (error: unknown) => error instanceof Error && (error as { code?: string }).code === "ENOENT",
+  );
+}


### PR DESCRIPTION
## Summary

Prunes stale clean `committed` write-operation metadata before hosted v2 checkpoint archive planning. Cleanup only runs when the request includes a previous successful workspace checkpoint timestamp, so deletion is gated by hosted checkpoint acknowledgement.

## Why

Finished `.runtime/operations/op_*.json` records were staying portable indefinitely after their staged payloads were gone. They are small in bytes, but many tiny files increase snapshot extraction overhead.

## Safety

- Only strict current-schema top-level `op_*.json` metadata is eligible.
- Only clean `committed` records are deletion candidates.
- Keeps `staged`, `committing`, `failed`, and `rolled_back` records.
- Keeps committed records with `error` or any remaining stage directory.
- Keeps the newest 100 clean committed records, plus all clean committed records from the last 24 hours.
- Deletes metadata only; it does not delete staged payload directories.
- Lists only top-level operation metadata instead of recursively walking staged payload/runtime subtrees.
- Validates `.runtime/operations` on disk before listing, re-checks metadata before deletion, and uses file-only `unlink`.
- Hosted checkpoint publication continues if pruning fails; the failure is logged as metadata-only structured warning.

## Verification

- `git diff --check`
- `pnpm exec vitest run packages/core/test/write-operation-pruning.test.ts --no-coverage`
- `pnpm exec vitest run packages/assistant-runtime/test/hosted-invocation-bridge.test.ts --isolate=true --no-coverage`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/assistant-runtime typecheck`
- `pnpm --dir packages/core test`
- `pnpm --dir packages/assistant-runtime test`
- `pnpm exec vitest run packages/core/test/write-operation-pruning.test.ts --coverage`
- `pnpm exec vitest run packages/assistant-runtime/test/hosted-invocation-bridge.test.ts --isolate=true --coverage`
- `pnpm typecheck`
- `pnpm test:smoke`

## Audit

- Security/privacy: no medium-or-higher findings.
- Deep runtime correctness: no production-breaking findings.
- Coverage/proof: added direct proof that pruning metadata leaves the committed vault document intact.
- Task-finish/simplification: fixed recursive operation metadata walking by switching to a top-level metadata lister.
- ReviewGPT round 1: accepted symlinked operation-directory finding and fixed it with on-disk containment checks plus a regression test.
- ReviewGPT round 2: zero Critical, High, or Complexity Collapse findings.
