### PR TITLE
[codex] Hash encrypted snapshots during restore

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-21-restore-stream-hash.md
+++ b/agent-docs/exec-plans/completed/2026-06-21-restore-stream-hash.md
@@ -1,0 +1,33 @@
+# Restore Stream Hash
+
+## Goal
+
+Hash hosted workspace snapshot encrypted bytes during restore decryption instead
+of reading the encrypted object once only for SHA-256 before decrypting it.
+
+## Scope
+
+- `apps/cloudflare/src/workspace-snapshot-local.ts`
+- focused restore tests in `apps/cloudflare/test/workspace-snapshot-local.test.ts`
+
+## Constraints
+
+- Keep encrypted object size, SHA-256, AES-GCM tag, plaintext archive SHA-256,
+  tar safety, and scratch cleanup fail-closed.
+- Do not move decrypted output outside restore scratch before all integrity and
+  archive safety checks pass.
+- Preserve the direct-R2 v2 snapshot contract and legacy restore behavior.
+
+## Verification Plan
+
+- Focused Cloudflare workspace snapshot tests.
+- `pnpm typecheck`.
+- `pnpm test:diff` scoped to touched files if it truthfully covers the app slice.
+
+## Completion
+
+- Required security/privacy, coverage, and deep-review audit passes.
+- Close this plan with `scripts/finish-task`.
+Status: completed
+Updated: 2026-06-21
+Completed: 2026-06-21

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -343,10 +343,6 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
   if (encryptedStat.size !== input.ref.archive.encryptedByteSize) {
     throw new Error("Hosted workspace snapshot encrypted size does not match its ref.");
   }
-  const encryptedObjectSha256 = await sha256FileHex(encryptedFilePath);
-  if (encryptedObjectSha256 !== input.ref.archive.encryptedObjectSha256) {
-    throw new Error("Hosted workspace snapshot encrypted digest does not match its ref.");
-  }
   if (encryptedStat.size <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
     throw new Error("Hosted workspace snapshot encrypted object is too small.");
   }
@@ -393,6 +389,7 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     decipher.setAAD(Buffer.from(serializeHostedWorkspaceSnapshotV2Aad(input.ref.encryption.aad)));
     decipher.setAuthTag(authTag);
 
+    const encryptedObjectHash = createHash("sha256");
     const plaintextArchiveHash = createHash("sha256");
     const plaintextArchivePath = path.join(scratchTempDir, "workspace.snapshot.tar.zst");
     await pipeline(
@@ -400,11 +397,17 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
         end: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
         start: 0,
       }),
+      createHashTransform(encryptedObjectHash),
       decipher,
       createHashTransform(plaintextArchiveHash),
       createWriteStream(plaintextArchivePath, { mode: 0o600 }),
     );
 
+    encryptedObjectHash.update(authTag);
+    const encryptedObjectSha256 = encryptedObjectHash.digest("hex");
+    if (encryptedObjectSha256 !== input.ref.archive.encryptedObjectSha256) {
+      throw new Error("Hosted workspace snapshot encrypted digest does not match its ref.");
+    }
     const plaintextArchiveSha256 = plaintextArchiveHash.digest("hex");
     if (plaintextArchiveSha256 !== input.ref.archive.plaintextArchiveSha256) {
       throw new Error("Hosted workspace snapshot plaintext archive digest does not match its ref.");
@@ -896,14 +899,6 @@ function createHashTransform(hash: ReturnType<typeof createHash>): Transform {
       callback(null, chunk);
     },
   });
-}
-
-async function sha256FileHex(filePath: string): Promise<string> {
-  const hash = createHash("sha256");
-  for await (const chunk of createReadStream(filePath)) {
-    hash.update(chunk);
-  }
-  return hash.digest("hex");
 }
 
 async function readHostedWorkspaceSnapshotAuthTag(

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -155,76 +155,15 @@ describe("workspace snapshot local restore", () => {
   });
 
   it("rejects encrypted digest mismatches without replacing durable state", async () => {
-    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-test-"));
-    const sourceDurableRoot = path.join(tempRoot, "source", "durable");
-    const sourceVaultRoot = path.join(sourceDurableRoot, "vault");
-    const restoredDurableRoot = path.join(tempRoot, "restored", "durable");
-    const existingDurableFile = path.join(restoredDurableRoot, "existing.txt");
-    const scratchRoot = path.join(tempRoot, "restore-scratch");
-    const snapshotId = "snapshot_bad_encrypted_digest";
-    const objectKey = "users/hsn_test/workspace-snapshots/snapshot_bad_encrypted_digest.snapshot.enc";
-    const userId = "member_123";
-    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
-
-    try {
-      await mkdir(sourceVaultRoot, { recursive: true });
-      await writeFile(path.join(sourceVaultRoot, "note.md"), "new workspace\n", "utf8");
-      await mkdir(restoredDurableRoot, { mode: 0o700, recursive: true });
-      await writeFile(existingDurableFile, "existing durable root\n", { mode: 0o600 });
-
-      const aad = buildHostedWorkspaceSnapshotV2Aad({
-        objectKey,
-        snapshotId,
-        userId,
-      });
-      const encrypted = await createEncryptedWorkspaceSnapshotFile({
-        aad,
-        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
-        durableRoot: sourceDurableRoot,
-        ivBase64: Buffer.from(Uint8Array.from({ length: 12 }, (_, index) => index + 10))
-          .toString("base64url"),
-        maxEncryptedBytes: 16 * 1024 * 1024,
-        outputDir: path.join(tempRoot, "scratch"),
-      });
-      const ref: HostedWorkspaceSnapshotV2Ref = {
-        archive: {
-          compression: encrypted.compression,
-          encryptedByteSize: encrypted.encryptedByteSize,
-          encryptedObjectSha256: "0".repeat(64),
-          fileCount: encrypted.fileCount,
-          format: "tar",
-          plaintextArchiveSha256: encrypted.plaintextArchiveSha256,
-          totalPlainBytes: encrypted.totalPlainBytes,
-        },
-        createdAt: "2026-05-20T00:00:00.000Z",
-        encryption: {
-          aad,
-          ivBase64: encrypted.ivBase64,
-          rootKeyId: "root_key_test",
-          scheme: HOSTED_WORKSPACE_SNAPSHOT_ENCRYPTION_SCHEME,
-          wrappedDataKey: "wrapped_data_key_test",
-        },
-        objectKey,
-        schema: HOSTED_WORKSPACE_SNAPSHOT_REF_SCHEMA,
-        snapshotId,
-        upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
-        userId,
-      };
-
-      await expect(restoreEncryptedWorkspaceSnapshot({
-        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
-        durableRoot: restoredDurableRoot,
-        encryptedFilePath: encrypted.encryptedFilePath,
-        ref,
-        scratchRoot,
-      })).rejects.toThrow("Hosted workspace snapshot encrypted digest does not match its ref.");
-      await expect(readFile(existingDurableFile, "utf8")).resolves.toBe("existing durable root\n");
-      await expect(access(path.join(restoredDurableRoot, "vault", "note.md"))).rejects.toThrow();
-      await expect(readdir(scratchRoot)).resolves.toEqual([]);
-    } finally {
-      await rm(tempRoot, { force: true, recursive: true });
-      dataKey.fill(0);
-    }
+    await expectUnsafeTarArchive({
+      archiveOverride: () => ({ encryptedObjectSha256: "0".repeat(64) }),
+      entries: [{
+        body: Buffer.from("new workspace\n", "utf8"),
+        name: "vault/note.md",
+      }],
+      expectedError: "Hosted workspace snapshot encrypted digest does not match its ref.",
+      unwrittenRelativePath: "vault/note.md",
+    });
   });
 
   it("rejects selected archive entries that traverse symlink parents or path aliases", async () => {
@@ -381,6 +320,7 @@ async function expectUnsafeTarArchive(input: {
   const durableRoot = path.join(tempRoot, "durable");
   const existingDurableFile = path.join(durableRoot, "existing.txt");
   const encryptedFilePath = path.join(tempRoot, "snapshot.enc");
+  const scratchRoot = path.join(tempRoot, "restore-scratch");
   const snapshotId = "snapshot_unsafe_tar";
   const objectKey = "users/hsn_test/workspace-snapshots/snapshot_unsafe_tar.snapshot.enc";
   const userId = "member_123";
@@ -441,8 +381,10 @@ async function expectUnsafeTarArchive(input: {
       durableRoot,
       encryptedFilePath,
       ref,
+      scratchRoot,
     })).rejects.toThrow(input.expectedError);
     await expect(access(path.join(tempRoot, "escape.txt"))).rejects.toThrow();
+    await expect(readdir(scratchRoot)).resolves.toEqual([]);
     if (input.unwrittenRelativePath) {
       await expect(access(path.join(durableRoot, input.unwrittenRelativePath))).rejects.toThrow();
       await expect(readFile(existingDurableFile, "utf8")).resolves.toBe("existing durable root\n");

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -1,6 +1,6 @@
 import { createCipheriv, createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { writeFile, mkdtemp, rm, access, mkdir, readFile, symlink } from "node:fs/promises";
+import { writeFile, mkdtemp, rm, access, mkdir, readFile, readdir, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -148,6 +148,79 @@ describe("workspace snapshot local restore", () => {
       await expect(access(path.join(restoredVaultRoot, ".git", "config"))).rejects.toThrow();
       await expect(access(path.join(restoredOperatorHomeRoot, ".codex-hosted", "cache", "runtime-cache.txt")))
         .rejects.toThrow();
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+      dataKey.fill(0);
+    }
+  });
+
+  it("rejects encrypted digest mismatches without replacing durable state", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-test-"));
+    const sourceDurableRoot = path.join(tempRoot, "source", "durable");
+    const sourceVaultRoot = path.join(sourceDurableRoot, "vault");
+    const restoredDurableRoot = path.join(tempRoot, "restored", "durable");
+    const existingDurableFile = path.join(restoredDurableRoot, "existing.txt");
+    const scratchRoot = path.join(tempRoot, "restore-scratch");
+    const snapshotId = "snapshot_bad_encrypted_digest";
+    const objectKey = "users/hsn_test/workspace-snapshots/snapshot_bad_encrypted_digest.snapshot.enc";
+    const userId = "member_123";
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+
+    try {
+      await mkdir(sourceVaultRoot, { recursive: true });
+      await writeFile(path.join(sourceVaultRoot, "note.md"), "new workspace\n", "utf8");
+      await mkdir(restoredDurableRoot, { mode: 0o700, recursive: true });
+      await writeFile(existingDurableFile, "existing durable root\n", { mode: 0o600 });
+
+      const aad = buildHostedWorkspaceSnapshotV2Aad({
+        objectKey,
+        snapshotId,
+        userId,
+      });
+      const encrypted = await createEncryptedWorkspaceSnapshotFile({
+        aad,
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: sourceDurableRoot,
+        ivBase64: Buffer.from(Uint8Array.from({ length: 12 }, (_, index) => index + 10))
+          .toString("base64url"),
+        maxEncryptedBytes: 16 * 1024 * 1024,
+        outputDir: path.join(tempRoot, "scratch"),
+      });
+      const ref: HostedWorkspaceSnapshotV2Ref = {
+        archive: {
+          compression: encrypted.compression,
+          encryptedByteSize: encrypted.encryptedByteSize,
+          encryptedObjectSha256: "0".repeat(64),
+          fileCount: encrypted.fileCount,
+          format: "tar",
+          plaintextArchiveSha256: encrypted.plaintextArchiveSha256,
+          totalPlainBytes: encrypted.totalPlainBytes,
+        },
+        createdAt: "2026-05-20T00:00:00.000Z",
+        encryption: {
+          aad,
+          ivBase64: encrypted.ivBase64,
+          rootKeyId: "root_key_test",
+          scheme: HOSTED_WORKSPACE_SNAPSHOT_ENCRYPTION_SCHEME,
+          wrappedDataKey: "wrapped_data_key_test",
+        },
+        objectKey,
+        schema: HOSTED_WORKSPACE_SNAPSHOT_REF_SCHEMA,
+        snapshotId,
+        upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
+        userId,
+      };
+
+      await expect(restoreEncryptedWorkspaceSnapshot({
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: restoredDurableRoot,
+        encryptedFilePath: encrypted.encryptedFilePath,
+        ref,
+        scratchRoot,
+      })).rejects.toThrow("Hosted workspace snapshot encrypted digest does not match its ref.");
+      await expect(readFile(existingDurableFile, "utf8")).resolves.toBe("existing durable root\n");
+      await expect(access(path.join(restoredDurableRoot, "vault", "note.md"))).rejects.toThrow();
+      await expect(readdir(scratchRoot)).resolves.toEqual([]);
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
       dataKey.fill(0);


### PR DESCRIPTION
## Summary
- stream encrypted snapshot bytes through SHA-256 before AES-GCM decryption during restore
- append the auth tag to the encrypted-object digest after decrypt pipeline completion before comparing the ref digest
- add a mismatch test that confirms durable state is not replaced and scratch is cleaned up

## Verification
- pnpm install --frozen-lockfile
- pnpm build:workspace:clean
- pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/workspace-snapshot-local.test.ts
- git diff --check
- pnpm typecheck
- bash scripts/workspace-verify.sh test:diff apps/cloudflare/src/workspace-snapshot-local.ts apps/cloudflare/test/workspace-snapshot-local.test.ts

## Audits
- local security/privacy audit: no findings
- local coverage audit: no findings
- local deep review: no actionable findings

## Notes
- This PR supersedes the earlier branch that collided with unrelated snapshot-restore work; this branch is scoped to the stream-hash change only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784670146&installation_id=127572939&pr_number=244&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F244&signature=f5408c725525e917afe5dc7c020758ffbfb303797ddbfef15c419ffbe645f70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->