### PR TITLE
ui: polish dashboard and auth surfaces

### DIFF
--- a/apps/web/app/(dashboard)/biomarkers/[biomarkerId]/biomarker-layout-client.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/[biomarkerId]/biomarker-layout-client.tsx
@@ -36,7 +36,7 @@ export function BiomarkerLayoutClient({
         />
         <Link
           href="/biomarkers"
-          className="inline-flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground sm:mt-1"
+          className="relative inline-flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-[''] sm:mt-1"
         >
           <ArrowLeft className="size-3.5" strokeWidth={1.75} aria-hidden />
           All biomarkers

--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -323,7 +323,7 @@ export function ConnectSourcesGrid({
           <p className="font-mono text-[10px] font-medium uppercase tracking-[0.11em] text-muted-foreground">
             Sources
           </p>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-xs tabular-nums text-muted-foreground">
             {filteredSources.length} of {displaySources.length} sources
           </p>
         </div>

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -46,7 +46,7 @@ export function SourceCard({
           <h2 className="font-serif text-lg font-semibold text-foreground">
             {source.name}
           </h2>
-          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          <p className="mt-1 text-sm leading-relaxed text-pretty text-muted-foreground">
             {source.description}
           </p>
         </div>
@@ -59,7 +59,7 @@ export function SourceCard({
                 aria-label={`Disconnect ${source.name}`}
                 disabled={pendingDisconnect}
                 onClick={() => onDisconnectTargetChange(source)}
-                className="self-start text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+                className="relative self-start text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-['']"
               >
                 {pendingDisconnect ? "Disconnecting..." : "Disconnect"}
               </button>
@@ -73,7 +73,7 @@ export function SourceCard({
         ) : (
           <div className="flex shrink-0 flex-col items-start gap-2 sm:mt-auto sm:shrink">
             {source.requiresReconnect ? (
-              <p className="max-w-[22rem] text-sm leading-relaxed text-destructive">
+              <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
                 Please reconnect {source.name} to resume syncing.
               </p>
             ) : null}

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -126,7 +126,7 @@ export default async function SettingsPage() {
         </div>
         <Link
           href="/connect"
-          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          className="relative inline-flex items-center self-start text-sm font-medium text-primary underline-offset-4 hover:underline before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-['']"
         >
           Manage wearables
         </Link>

--- a/apps/web/app/auth-controls.tsx
+++ b/apps/web/app/auth-controls.tsx
@@ -87,11 +87,11 @@ function getLandingAuthClasses(context: LandingAuthContext) {
       return {
         container: "flex items-center gap-2 sm:gap-3",
         login:
-          "inline-flex items-center justify-center rounded-lg border border-white/25 bg-white/8 px-4 py-2 text-sm font-semibold text-white transition-colors hover:border-white/40 hover:bg-white/14 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60",
+          "inline-flex items-center justify-center rounded-lg border border-white/25 bg-white/8 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white/40 hover:bg-white/14 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60",
         settings:
-          "inline-flex items-center rounded-lg bg-[#5a6e32] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#4d5f2a]",
+          "inline-flex items-center rounded-lg bg-[#5a6e32] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#4d5f2a]",
         signup:
-          "inline-flex items-center justify-center rounded-lg bg-[#5a6e32] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#4d5f2a] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d4b87a]",
+          "inline-flex items-center justify-center rounded-lg bg-[#5a6e32] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#4d5f2a] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d4b87a]",
       };
     case "footer":
       return {

--- a/apps/web/src/components/biomarkers/biomarker-browse-card.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-browse-card.tsx
@@ -63,7 +63,7 @@ export function BiomarkerBrowseCard({
 
       <div className="flex flex-1 items-center justify-center border-t border-border/60 pt-3">
         {privateValue ? (
-          <span className="font-serif text-2xl font-semibold tracking-tight text-foreground">
+          <span className="font-serif text-2xl font-semibold tracking-tight tabular-nums text-foreground">
             {privateValue.valueLabel}{privateValue.unit ? ` ${displayUnit(privateValue.unit)}` : ""}
           </span>
         ) : privateValueSyncing ? (

--- a/apps/web/src/components/biomarkers/biomarker-detail/biomarker-experiment-card-hero.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-detail/biomarker-experiment-card-hero.tsx
@@ -26,7 +26,7 @@ export function BiomarkerExperimentCardHero({
       href={protocol.href}
       className="group flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card/90 transition-colors hover:border-border focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 lg:flex-row"
     >
-      <div className="relative aspect-[2/1] w-full shrink-0 overflow-hidden sm:aspect-[16/9] lg:aspect-auto lg:w-[320px] lg:self-stretch">
+      <div className="relative aspect-[2/1] w-full shrink-0 overflow-hidden outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10 sm:aspect-[16/9] lg:aspect-auto lg:w-[320px] lg:self-stretch">
         {imageSrc ? (
           <Image
             src={imageSrc}
@@ -50,7 +50,7 @@ export function BiomarkerExperimentCardHero({
             <span className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-chart-5">
               {protocol.category}
             </span>
-            <h3 className="font-serif text-xl/tight font-semibold tracking-tight text-foreground text-pretty sm:text-2xl/tight lg:text-[26px]">
+            <h3 className="font-serif text-xl/tight font-semibold tracking-tight text-foreground text-balance sm:text-2xl/tight lg:text-[26px]">
               {protocol.title}
             </h3>
           </div>
@@ -100,7 +100,7 @@ function Stat({
       </span>
       <span
         className={cn(
-          "font-serif text-sm/5 font-semibold text-foreground text-pretty sm:text-base/6",
+          "font-serif text-sm/5 font-semibold tabular-nums text-foreground text-pretty sm:text-base/6",
           valueClassName,
         )}
       >

--- a/apps/web/src/components/biomarkers/biomarker-detail/biomarker-experiment-card.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-detail/biomarker-experiment-card.tsx
@@ -28,7 +28,7 @@ export function BiomarkerExperimentCard({
       href={protocol.href}
       className="group flex h-full flex-col overflow-hidden rounded-xl border border-border/60 bg-card/90 transition-colors hover:border-border focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
     >
-      <div className="relative aspect-[16/9] w-full shrink-0 overflow-hidden">
+      <div className="relative aspect-[16/9] w-full shrink-0 overflow-hidden outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10">
         {imageSrc ? (
           <Image
             src={imageSrc}
@@ -51,7 +51,7 @@ export function BiomarkerExperimentCard({
             <span className="font-mono text-[10px]/3 uppercase tracking-[0.12em] text-chart-5">
               {protocol.category}
             </span>
-            <h3 className="font-serif text-xl font-semibold tracking-tight text-foreground text-pretty">
+            <h3 className="font-serif text-xl font-semibold tracking-tight text-foreground text-balance">
               {protocol.title}
             </h3>
           </div>
@@ -112,7 +112,7 @@ function StatCell({
       <span className="font-mono text-[9px]/3 uppercase tracking-[0.12em] text-muted-foreground sm:text-[10px]/3 sm:tracking-[0.14em]">
         {label}
       </span>
-      <span className={cn("text-pretty", valueClassName)}>{value}</span>
+      <span className={cn("tabular-nums text-pretty", valueClassName)}>{value}</span>
     </div>
   );
 }

--- a/apps/web/src/components/biomarkers/biomarker-detail/biomarker-experiment-row.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-detail/biomarker-experiment-row.tsx
@@ -47,7 +47,7 @@ export function BiomarkerExperimentRow({
       href={protocol.href}
       className={`group grid ${ROW_GRID} items-center gap-x-3 px-5 py-4 transition-colors hover:bg-muted/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-[-2px] md:gap-x-6`}
     >
-      <div className="relative size-10 shrink-0 overflow-hidden rounded-md">
+      <div className="relative size-10 shrink-0 overflow-hidden rounded-md outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10">
         {imageSrc ? (
           <Image
             src={imageSrc}

--- a/apps/web/src/components/biomarkers/biomarker-detail/biomarker-overview.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-detail/biomarker-overview.tsx
@@ -23,7 +23,7 @@ export function BiomarkerOverview({ biomarker }: { biomarker: BiomarkerOverviewP
       {heroProtocols.length > 0 ? (
         <section className="flex flex-col gap-6">
           <div className="flex flex-col gap-3">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-foreground sm:text-[28px]">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-balance text-foreground sm:text-[28px]">
               Experiments
             </h2>
             <p className="max-w-3xl text-sm/6 text-muted-foreground text-pretty">

--- a/apps/web/src/components/biomarkers/biomarker-detail/biomarker-private-trend-card.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-detail/biomarker-private-trend-card.tsx
@@ -388,7 +388,7 @@ function ContextMetricStrip({ metrics }: { metrics: TrendContextValue[] }) {
             ) : null}
           </dt>
           <dd className="mt-1 flex items-baseline gap-1.5">
-            <span className="font-serif text-2xl font-semibold text-foreground">
+            <span className="font-serif text-2xl font-semibold tabular-nums text-foreground">
               {formatMetricValue(metric.value, metric.valuePrecision)}
             </span>
             <span className="text-sm text-foreground/50">
@@ -396,7 +396,7 @@ function ContextMetricStrip({ metrics }: { metrics: TrendContextValue[] }) {
             </span>
           </dd>
           <div
-            className="mt-1 min-w-0 truncate text-xs text-foreground/45"
+            className="mt-1 min-w-0 truncate text-xs tabular-nums text-foreground/45"
             title={`${formatChipLabel(metric.sourceLabel)} · ${formatDateLabel(metric.date)}`}
           >
             {formatChipLabel(metric.sourceLabel)} · {formatDateLabel(metric.date)}

--- a/apps/web/src/components/experiments/experiment-browse-card.tsx
+++ b/apps/web/src/components/experiments/experiment-browse-card.tsx
@@ -50,7 +50,7 @@ export function ExperimentBrowseCard({
   const isInteractive = resolvedHref !== null;
   const cardContent = (
     <>
-      <div className="relative h-40 w-full overflow-hidden rounded-xl outline-1 -outline-offset-1 outline-black/5">
+      <div className="relative h-40 w-full overflow-hidden rounded-xl outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10">
         <Image
           src={image}
           alt=""
@@ -81,7 +81,7 @@ export function ExperimentBrowseCard({
               </Badge>
             ) : null}
             {typeof matchPercent === "number" ? (
-              <span className="text-[11px] text-muted-foreground">
+              <span className="text-[11px] tabular-nums text-muted-foreground">
                 {matchPercent}%
               </span>
             ) : null}
@@ -94,7 +94,7 @@ export function ExperimentBrowseCard({
           {metadata ?? (typeof durationDays === "number" ? `${durationDays} days` : "Protocol")}
         </span>
         {description ? (
-          <span className="line-clamp-2 text-xs text-muted-foreground/80">
+          <span className="line-clamp-2 text-xs text-pretty text-muted-foreground/80">
             {description}
           </span>
         ) : null}

--- a/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-header.tsx
@@ -85,7 +85,7 @@ export function ExperimentHeader({
             {isActive && (
               <>
                 <span className="shrink-0 text-[11px]/3.5 text-secondary">·</span>
-                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 text-chart-5">
+                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 tabular-nums text-chart-5">
                   <span className="size-1.5 rounded-full bg-amber-500" />
                   {day
                     ? inBaseline
@@ -98,7 +98,7 @@ export function ExperimentHeader({
             {isPaused && (
               <>
                 <span className="shrink-0 text-[11px]/3.5 text-secondary">·</span>
-                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 text-muted-foreground">
+                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 tabular-nums text-muted-foreground">
                   <span className="size-1.5 rounded-full bg-muted-foreground" />
                   {day
                     ? inBaseline
@@ -111,7 +111,7 @@ export function ExperimentHeader({
             {isFinished && (
               <>
                 <span className="shrink-0 text-[11px]/3.5 text-secondary">·</span>
-                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 text-ring">
+                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 tabular-nums text-ring">
                   <span className="size-1.5 rounded-full bg-ring" />
                   {dateRange ?? "Finished"}
                 </span>
@@ -120,7 +120,7 @@ export function ExperimentHeader({
             {isStopped && (
               <>
                 <span className="shrink-0 text-[11px]/3.5 text-secondary">·</span>
-                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 text-muted-foreground">
+                <span className="flex shrink-0 items-center gap-1.5 text-[11px]/3.5 tabular-nums text-muted-foreground">
                   <span className="size-1.5 rounded-full bg-muted-foreground" />
                   {dateRange ?? "Stopped"}
                 </span>
@@ -128,7 +128,7 @@ export function ExperimentHeader({
             )}
           </div>
 
-          <h1 className="font-serif text-3xl font-semibold leading-[110%] tracking-[-0.03em] text-foreground sm:text-[38px]">
+          <h1 className="font-serif text-3xl font-semibold leading-[110%] tracking-[-0.03em] text-balance text-foreground sm:text-[38px]">
             {title}
           </h1>
 
@@ -168,7 +168,7 @@ export function ExperimentHeader({
               />
             </svg>
             <div className="absolute flex flex-col items-center">
-              <span className="text-sm font-semibold text-foreground">
+              <span className="text-sm font-semibold tabular-nums text-foreground">
                 {completionPercent}%
               </span>
               <span className="text-[8px] text-ring">complete</span>

--- a/apps/web/src/components/experiments/experiment-detail/experiment-hero.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-hero.tsx
@@ -6,7 +6,7 @@ interface ExperimentHeroProps {
 
 export function ExperimentHero({ image }: ExperimentHeroProps) {
   return (
-    <div className="relative h-[180px] w-full overflow-hidden rounded-2xl border border-border/50 md:h-[220px]">
+    <div className="relative h-[180px] w-full overflow-hidden rounded-2xl outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10 md:h-[220px]">
       <Image
         src={image}
         alt=""

--- a/apps/web/src/components/experiments/experiment-detail/experiment-schedule.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/experiment-schedule.tsx
@@ -56,10 +56,10 @@ export function ExperimentScheduleSidebar({ schedule }: ExperimentScheduleProps)
       </div>
       {stats.due > 0 ? (
         <div className="flex items-baseline justify-between border-t border-border/50 pt-3">
-          <span className="text-xs text-muted-foreground">
+          <span className="text-xs tabular-nums text-muted-foreground">
             {stats.completed} of {stats.due} due
           </span>
-          <span className="font-serif text-sm font-semibold text-foreground">
+          <span className="font-serif text-sm font-semibold tabular-nums text-foreground">
             {stats.adherencePercent}%
           </span>
         </div>

--- a/apps/web/src/components/experiments/experiment-detail/expert-card.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/expert-card.tsx
@@ -25,7 +25,7 @@ export function ExpertCard({
           <img
             src={profileImageUrl}
             alt={name}
-            className="aspect-square size-full rounded-full object-cover"
+            className="aspect-square size-full rounded-full object-cover outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10"
             onError={() => {
               setImageFailed(true);
             }}

--- a/apps/web/src/components/experiments/experiment-detail/share-results-card.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/share-results-card.tsx
@@ -99,7 +99,7 @@ export function ShareResultsCard({ cardData }: ShareResultsCardProps) {
         {/* Keeps the dialog accessibly named without showing a heading. */}
         <DialogTitle className="sr-only">Share your results</DialogTitle>
 
-        <div className="overflow-hidden rounded-xl border border-border bg-muted/50 shadow-sm">
+        <div className="overflow-hidden rounded-xl bg-muted/50 shadow-sm outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10">
           {/* eslint-disable-next-line @next/next/no-img-element -- OG route output, not a static asset */}
           <img
             src={cardPath}

--- a/apps/web/src/components/experiments/experiment-detail/start-experiment-button.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/start-experiment-button.tsx
@@ -220,7 +220,7 @@ function ContactOptionLink({ option }: { option: ExperimentStartContactOption })
             {option.description}
           </span>
         </span>
-        <span className="flex shrink-0 items-center px-2 text-muted-foreground transition group-hover/channel:translate-x-0.5 group-hover/channel:text-primary sm:px-4">
+        <span className="flex shrink-0 items-center px-2 text-muted-foreground transition-[color,transform] duration-150 group-hover/channel:translate-x-0.5 group-hover/channel:text-primary sm:px-4">
           <ChevronRightIcon data-icon="inline-end" />
         </span>
       </span>

--- a/apps/web/src/components/experiments/experiment-detail/trend-chart.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/trend-chart.tsx
@@ -113,7 +113,7 @@ export function TrendChart({ data, className }: TrendChartProps) {
             type="button"
             onClick={() => setShowHistory((v) => !v)}
             className={cn(
-              "absolute left-1.5 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded-md border border-secondary/25 bg-[rgba(255,252,246,0.9)] transition-opacity duration-500 ease-in-out",
+              "absolute left-1.5 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded-md border border-secondary/25 bg-[rgba(255,252,246,0.9)] transition-opacity duration-150 ease-out",
               showHistory
                 ? "opacity-100"
                 : "opacity-0 group-hover/chart:opacity-70 hover:!opacity-100",

--- a/apps/web/src/components/experiments/experiment-hero-card.tsx
+++ b/apps/web/src/components/experiments/experiment-hero-card.tsx
@@ -45,7 +45,7 @@ export function ExperimentHeroCard({
   const isInteractive = resolvedHref !== null;
   const cardContent = (
     <>
-      <div className="relative h-56 w-full overflow-hidden rounded-t-xl outline-1 -outline-offset-1 outline-black/5 md:h-64">
+      <div className="relative h-56 w-full overflow-hidden rounded-t-xl outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10 md:h-64">
         <Image
           src={image}
           alt=""
@@ -75,7 +75,7 @@ export function ExperimentHeroCard({
               </Badge>
             ) : null}
             {typeof matchPercent === "number" ? (
-              <Badge variant="outline" className="text-[11px]">
+              <Badge variant="outline" className="text-[11px] tabular-nums">
                 {matchPercent}% match
               </Badge>
             ) : null}
@@ -88,7 +88,7 @@ export function ExperimentHeroCard({
           {metadata ?? (typeof durationDays === "number" ? `${durationDays} days` : "Protocol")}
         </span>
         {description ? (
-          <span className="line-clamp-3 text-sm text-muted-foreground">
+          <span className="line-clamp-3 text-sm text-pretty text-muted-foreground">
             {description}
           </span>
         ) : null}

--- a/apps/web/src/components/home/feature-highlights.tsx
+++ b/apps/web/src/components/home/feature-highlights.tsx
@@ -14,7 +14,7 @@ export function FeatureHighlights() {
               <p className="text-sm font-semibold text-foreground">
                 {item.title}
               </p>
-              <p className="mt-0.5 text-sm leading-relaxed text-muted-foreground">
+              <p className="mt-0.5 text-sm leading-relaxed text-pretty text-muted-foreground">
                 {item.body}
               </p>
             </div>

--- a/apps/web/src/components/home/home-experiments.tsx
+++ b/apps/web/src/components/home/home-experiments.tsx
@@ -21,7 +21,7 @@ export function HomeExperiments({ inProgress, history }: HomeExperimentsProps) {
   const browseAction = (
     <Link
       href="/experiments"
-      className="group inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      className="group relative inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-['']"
     >
       Browse experiments
       <ArrowRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5" />

--- a/apps/web/src/components/home/onboarding-steps.tsx
+++ b/apps/web/src/components/home/onboarding-steps.tsx
@@ -54,7 +54,7 @@ export interface OnboardingStepsProps {
 export function getOnboardingStepActionClass(isPrimary: boolean): string {
   return isPrimary
     ? "inline-flex items-center gap-2.5 rounded-2xl bg-[#5a6e32] px-6 py-3 text-sm font-medium text-white transition-colors duration-200 hover:bg-[#7a8c6e] focus-visible:ring-2 focus-visible:ring-[#7a8c6e] focus-visible:ring-offset-2"
-    : "inline-flex items-center gap-2.5 rounded-2xl border border-foreground/12 px-6 py-3 text-sm font-medium text-foreground transition-all duration-200 hover:border-[#7a8c6e]/30 hover:bg-[#7a8c6e]/[0.04] focus-visible:ring-2 focus-visible:ring-[#7a8c6e] focus-visible:ring-offset-2";
+    : "inline-flex items-center gap-2.5 rounded-2xl border border-foreground/12 px-6 py-3 text-sm font-medium text-foreground transition-[background-color,border-color,color] duration-200 hover:border-[#7a8c6e]/30 hover:bg-[#7a8c6e]/[0.04] focus-visible:ring-2 focus-visible:ring-[#7a8c6e] focus-visible:ring-offset-2";
 }
 
 export function OnboardingSteps({
@@ -120,10 +120,10 @@ export function OnboardingSteps({
                   <Icon className="size-8 text-[#7a8c6e]" />
                 </div>
               </div>
-              <h2 className="mb-2.5 font-serif text-[22px] font-semibold tracking-tight text-foreground">
+              <h2 className="mb-2.5 font-serif text-[22px] font-semibold tracking-tight text-balance text-foreground">
                 {step.title}
               </h2>
-              <p className="mb-8 text-[13.5px] leading-relaxed text-muted-foreground">
+              <p className="mb-8 text-[13.5px] leading-relaxed text-pretty text-muted-foreground">
                 {step.description}
               </p>
             </div>

--- a/apps/web/src/components/home/trial-billing-banner.tsx
+++ b/apps/web/src/components/home/trial-billing-banner.tsx
@@ -24,10 +24,10 @@ export function TrialBillingBanner() {
         <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[#5a6e32]">
           Pulse trial
         </p>
-        <h2 className="mt-2 font-serif text-xl font-semibold tracking-tight text-foreground">
+        <h2 className="mt-2 font-serif text-xl font-semibold tracking-tight text-balance text-foreground">
           {copy.title}
         </h2>
-        <p className="mt-1 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        <p className="mt-1 max-w-xl text-sm leading-relaxed text-pretty text-muted-foreground">
           {copy.body}
         </p>
       </div>

--- a/apps/web/src/components/home/usage-limit-banner.tsx
+++ b/apps/web/src/components/home/usage-limit-banner.tsx
@@ -59,14 +59,14 @@ export function UsageLimitBanner({ noticeCode, now, resetAt }: UsageLimitBannerP
     >
       <div className="min-w-0">
         {resetLabel ? (
-          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[#5a6e32]">
+          <p className="font-mono text-[10px] uppercase tracking-[0.12em] tabular-nums text-[#5a6e32]">
             {resetLabel}
           </p>
         ) : null}
-        <h2 className="mt-2 font-serif text-xl font-semibold tracking-tight text-foreground">
+        <h2 className="mt-2 font-serif text-xl font-semibold tracking-tight text-balance text-foreground">
           {copy.title}
         </h2>
-        <p className="mt-1 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        <p className="mt-1 max-w-xl text-sm leading-relaxed text-pretty text-muted-foreground">
           {copy.body}
         </p>
       </div>

--- a/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
@@ -269,7 +269,7 @@ function HostedResumableAuthState({
     : `You're already signed in with ${methodLabel}.`;
 
   return (
-    <Alert className="border-stone-200 bg-stone-50">
+    <Alert className="rounded-[2rem] border-stone-200 bg-stone-50">
       <AlertTitle>Continue with {methodLabel}</AlertTitle>
       <AlertDescription>{description}</AlertDescription>
       <div className="mt-3 flex flex-wrap gap-3">

--- a/apps/web/src/components/hosted-onboarding/hosted-auth-shared.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-auth-shared.tsx
@@ -72,7 +72,7 @@ export function HostedAuthFinishingNotice() {
         <p className="font-serif text-[15px] font-medium leading-tight text-[#1A1F16]">
           Setting things up
         </p>
-        <p className="mt-1 text-xs leading-snug text-[#7A7870]">
+        <p className="mt-1 text-xs leading-snug text-pretty text-[#7A7870]">
           Keep this tab open — should just be a moment.
         </p>
       </div>
@@ -128,7 +128,7 @@ export function HostedAuthLegalNotice({
   className?: string;
 }) {
   return (
-    <p className={cn("text-xs leading-relaxed text-stone-500", className)}>
+    <p className={cn("text-xs leading-relaxed text-pretty text-stone-500", className)}>
       By continuing, you agree to our{" "}
       <a href={HOSTED_TERMS_URL} target="_blank" rel="noreferrer" className="hover:underline hover:underline-offset-4">
         Terms

--- a/apps/web/src/components/hosted-onboarding/hosted-phone-auth-use-different-number-button.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-phone-auth-use-different-number-button.tsx
@@ -20,7 +20,7 @@ export function HostedUseDifferentNumberButton({
       disabled={disabled}
       variant="link"
       size={size}
-      className="h-auto p-0 text-xs font-medium text-muted-foreground hover:text-foreground"
+      className="relative h-auto p-0 text-xs font-medium text-muted-foreground hover:text-foreground before:absolute before:-inset-x-3 before:-inset-y-2.5 before:content-['']"
     >
       {pendingAction === "logout" ? "Signing out…" : "Use a different number"}
     </Button>

--- a/apps/web/src/components/hosted-onboarding/hosted-phone-auth-views.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-phone-auth-views.tsx
@@ -151,7 +151,7 @@ export function HostedAuthenticatedPhoneAuthState({
 }: AuthenticatedStateProps) {
   if (view === "loading") {
     return (
-      <Alert className="border-stone-200 bg-stone-50">
+      <Alert className="rounded-[2rem] border-stone-200 bg-stone-50">
         <AlertTitle>{title}</AlertTitle>
         <AlertDescription>{body}</AlertDescription>
       </Alert>
@@ -160,7 +160,7 @@ export function HostedAuthenticatedPhoneAuthState({
 
   if (view === "manual-resume") {
     return (
-      <Alert className="border-stone-200 bg-stone-50">
+      <Alert className="rounded-[2rem] border-stone-200 bg-stone-50">
         <AlertTitle>You already started logging in or signing up.</AlertTitle>
         <div className="mt-3 flex flex-wrap gap-3">
           <Button
@@ -185,7 +185,7 @@ export function HostedAuthenticatedPhoneAuthState({
 
   if (view === "restart") {
     return (
-      <Alert className="border-stone-200 bg-stone-50">
+      <Alert className="rounded-[2rem] border-stone-200 bg-stone-50">
         <AlertTitle>Sign in with this phone again</AlertTitle>
         <AlertDescription>{description}</AlertDescription>
         <div className="mt-3 flex flex-wrap gap-3">

--- a/apps/web/src/components/hosted-onboarding/hosted-verification-code-step.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-verification-code-step.tsx
@@ -62,7 +62,7 @@ export function HostedVerificationCodeStep({
             disabled={disabled}
             variant="link"
             size="xs"
-            className="h-auto p-0 text-sm text-muted-foreground"
+            className="relative h-auto p-0 text-sm text-muted-foreground before:absolute before:-inset-x-3 before:-inset-y-2.5 before:content-['']"
           >
             {pendingAction === "send-code" ? "Sending..." : "Resend code"}
           </Button>

--- a/apps/web/src/components/settings/hosted-billing-settings-action.tsx
+++ b/apps/web/src/components/settings/hosted-billing-settings-action.tsx
@@ -183,7 +183,7 @@ export function HostedBillingSettingsAction(props: {
       </div>
 
       <Dialog open={manageOpen} onOpenChange={setManageOpen}>
-        <DialogContent className="max-w-md gap-6 rounded-2xl border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
+        <DialogContent className="max-w-md gap-6 border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
           <DialogHeader className="pr-10">
             <DialogTitle className="font-serif text-2xl/7 font-semibold tracking-normal text-[#2d3436]">
               Manage subscription
@@ -253,7 +253,7 @@ export function HostedBillingSettingsAction(props: {
         open={confirmation === "upgrade"}
         onOpenChange={(open) => { if (!open) closeConfirmation(); }}
       >
-        <DialogContent className="max-w-md gap-6 rounded-2xl border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
+        <DialogContent className="max-w-md gap-6 border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
           <DialogHeader className="pr-10">
             <DialogTitle className="font-serif text-2xl/7 font-semibold tracking-normal text-[#2d3436]">
               Upgrade to Edge
@@ -300,7 +300,7 @@ export function HostedBillingSettingsAction(props: {
         open={confirmation === "start-pulse"}
         onOpenChange={(open) => { if (!open) closeConfirmation(); }}
       >
-        <DialogContent className="max-w-md gap-6 rounded-2xl border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
+        <DialogContent className="max-w-md gap-6 border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
           <DialogHeader className="pr-10">
             <DialogTitle className="font-serif text-2xl/7 font-semibold tracking-normal text-[#2d3436]">
               Start Pulse
@@ -367,7 +367,7 @@ export function HostedBillingSettingsAction(props: {
         open={confirmation === "switch-to-pulse"}
         onOpenChange={(open) => { if (!open) closeConfirmation(); }}
       >
-        <DialogContent className="max-w-md gap-6 rounded-2xl border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
+        <DialogContent className="max-w-md gap-6 border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7">
           <DialogHeader className="pr-10">
             <DialogTitle className="font-serif text-2xl/7 font-semibold tracking-normal text-[#2d3436]">
               Switch to Pulse

--- a/apps/web/src/components/settings/hosted-billing-settings.tsx
+++ b/apps/web/src/components/settings/hosted-billing-settings.tsx
@@ -70,7 +70,7 @@ export function HostedBillingSettings(props: {
     <div className="flex flex-col gap-3 pb-2 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <p className="font-serif text-2xl font-semibold tracking-tight text-foreground">
+          <p className="font-serif text-2xl font-semibold tracking-tight text-balance text-foreground">
             {planDisplayName}
           </p>
           {statusChip ? (
@@ -80,7 +80,7 @@ export function HostedBillingSettings(props: {
           ) : null}
         </div>
         {hasPendingPulseSwitch && pendingPulseSwitchDate ? (
-          <p className="mt-1.5 text-sm text-muted-foreground">
+          <p className="mt-1.5 text-sm text-pretty text-muted-foreground">
             Pulse starts {pendingPulseSwitchDate}{scheduledPlanPrice ? ` at ${scheduledPlanPrice}` : ""}
           </p>
         ) : null}

--- a/apps/web/src/components/settings/hosted-settings-identity-link-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-settings-identity-link-dialog.tsx
@@ -62,7 +62,7 @@ export function HostedSettingsIdentityLinkDialog({
 
   return (
     <Dialog open onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[min(30rem,calc(100vw-2rem))] gap-6 rounded-2xl border border-border/80 bg-popover p-6 text-popover-foreground ring-border sm:max-w-[30rem] md:p-8">
+      <DialogContent className="max-w-[min(30rem,calc(100vw-2rem))] gap-6 border border-border/80 bg-popover p-6 text-popover-foreground ring-border sm:max-w-[30rem] md:p-8">
         <DialogHeader className="gap-2 pr-10">
           <DialogTitle className="font-serif text-2xl/8 font-semibold tracking-normal text-popover-foreground">
             {copy.title}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/src/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,transform,opacity] outline-none select-none active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-3xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -65,7 +65,7 @@ function DialogContent({
             render={
               <Button
                 variant="ghost"
-                className="absolute top-2 right-2"
+                className="absolute top-3 right-3"
                 size="icon-sm"
               />
             }
@@ -102,7 +102,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-3xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}
@@ -122,7 +122,7 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
     <DialogPrimitive.Title
       data-slot="dialog-title"
       className={cn(
-        "font-serif text-base leading-none font-medium",
+        "font-serif text-base leading-none font-medium text-balance",
         className
       )}
       {...props}
@@ -138,7 +138,7 @@ function DialogDescription({
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        "text-sm text-pretty text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/input-otp.tsx
+++ b/apps/web/src/components/ui/input-otp.tsx
@@ -53,7 +53,7 @@ function InputOTPSlot({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        "relative flex size-8 items-center justify-center border-y border-r border-input text-sm transition-all outline-none first:rounded-l-lg first:border-l last:rounded-r-lg aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-3 data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40",
+        "relative flex size-8 items-center justify-center border-y border-r border-input text-sm tabular-nums transition-[color,background-color,border-color,box-shadow] outline-none first:rounded-l-lg first:border-l last:rounded-r-lg aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-3 data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/metric-card.tsx
+++ b/apps/web/src/components/ui/metric-card.tsx
@@ -1,9 +1,9 @@
 import { cn } from "@/src/lib/utils";
 
 const sentimentClassName: Record<string, string> = {
-  positive: "ml-2 text-sm font-semibold text-primary",
-  negative: "ml-2 text-sm font-semibold text-amber-600",
-  neutral: "ml-2 text-sm font-semibold text-muted-foreground",
+  positive: "ml-2 text-sm font-semibold tabular-nums text-primary",
+  negative: "ml-2 text-sm font-semibold tabular-nums text-amber-600",
+  neutral: "ml-2 text-sm font-semibold tabular-nums text-muted-foreground",
 };
 
 const arrows: Record<string, string> = {
@@ -52,7 +52,7 @@ export function MetricCard({
         {label}
       </span>
       <div className="flex items-baseline gap-1.5">
-        <span className="font-serif text-3xl font-semibold text-foreground">
+        <span className="font-serif text-3xl font-semibold tabular-nums text-foreground">
           {value}
         </span>
         {unit && <span className="text-sm text-foreground/50">{unit}</span>}
@@ -64,7 +64,7 @@ export function MetricCard({
       </div>
       {footer ? (
         <span
-          className="block min-w-0 max-w-full truncate text-xs text-foreground/45"
+          className="block min-w-0 max-w-full truncate text-xs tabular-nums text-foreground/45"
           title={footer}
         >
           {footer}

--- a/apps/web/src/components/ui/page-header.tsx
+++ b/apps/web/src/components/ui/page-header.tsx
@@ -18,11 +18,11 @@ export function PageHeader({
           {eyebrow}
         </span>
       ) : eyebrow ?? null}
-      <h1 className="font-serif text-3xl font-semibold tracking-tight text-foreground">
+      <h1 className="font-serif text-3xl font-semibold tracking-tight text-balance text-foreground">
         {title}
       </h1>
       {description ? (
-        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+        <p className="mt-1 max-w-2xl text-sm text-pretty text-muted-foreground">
           {description}
         </p>
       ) : null}


### PR DESCRIPTION
## Summary

- Apply the `make-interfaces-feel-better` skill across the auth flow + every dashboard page (home, biomarkers, experiments, connect, settings).
- Pure className diffs — no behavior change, no new abstractions, no new components.
- 38 files, 78/78 line edits. All edits land on shared primitives or inline className strings; no copy/dep changes.

## Why this shape

- **Cross-cutting wins on primitives:** `PageHeader`, `MetricCard`, `DialogTitle`/`DialogDescription`, and `DialogContent` carry the polish to every page that uses them. One file → reach across the whole dashboard. Avoids per-page duplication.
- **Drop redundant overrides:** settings billing dialogs (4) + identity-link dialog were locally re-rounding to `rounded-2xl` and re-bordering on top of the base ring. Removed those so they inherit the new polished base.
- **Per-page edits are surgical:** only added `tabular-nums` to numbers that actually change, `text-balance`/`text-pretty` where wrapping caused orphans or unbalanced lines, image outlines on content thumbnails (not brand wordmarks), and 40×40 pseudo-extenders on the inline text links that the skill flagged as under-target.

## What's not in this PR (deferred — discussed in chat)

- Shadows-over-borders across cards (real visual delta, want to compare on one card type first).
- Project-wide `scale(0.96)` on press (would replace existing `active:translate-y-px` everywhere — taste call).
- Concentric-radius bumps on per-page browse/source cards/banners (pushes overall feel rounder; verify the dialog roundness in this PR first).
- Contextual icon cross-fade (Copy/Check, status dots).

## Test plan

- [x] `pnpm test` (apps/web): 2779 passing, 7 skipped — all green.
- [x] `tsc --noEmit` clean.
- [ ] Manual check: auth dialog, home, /biomarkers list + detail, /experiments list + detail, /connect, /settings.
- [ ] Confirm OTP digits don't wiggle (type 111111 → backspace → 000000).
- [ ] Confirm dialog close X sits clear of the new rounded corner.

Audit reports + before/after detail in chat thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784680107&installation_id=127572939&pr_number=248&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F248&signature=e07476a4a945e2268e40ca03edbaf30b7ae83a82695943bc3883b7a00d843d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->