### PR TITLE
[codex] Fix experiment progress metric projection

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-21-experiment-progress-metric-projection.md
+++ b/agent-docs/exec-plans/completed/2026-06-21-experiment-progress-metric-projection.md
@@ -1,0 +1,26 @@
+# Experiment Progress Metric Projection
+
+## Goal
+
+Fix experiment progress, outcome analysis, and progress-card generation so they use the existing query metric projection for metric rows while keeping experiment/session records on the normal projected entity read model.
+
+## Scope
+
+- `packages/query/src/experiments.ts`
+- `packages/query/src/experiment-progress-card.ts`
+- `packages/vault-usecases/src/usecases/experiment-journal-vault.ts`
+- Focused tests covering metric projection rows feeding experiment progress/card results
+
+## Constraints
+
+- Keep the architecture simple: no new persisted state, provider-specific branching, or raw-vault fallback on the normal progress path.
+- Preserve the default sparse `readVault()` entity read model.
+- Keep sleep-onset latency unsupported/missing when no metric points exist.
+
+## Verification
+
+- Add a failing regression first.
+- Run focused package tests, then scoped repo verification required for the touched packages.
+Status: completed
+Updated: 2026-06-21
+Completed: 2026-06-21

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -213,8 +213,12 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
       if (!zstd.stdin || !zstd.stdout) {
         throw new Error("Hosted workspace snapshot zstd streams are unavailable.");
       }
-      await Promise.all([
+      const archiveInputPipe = waitForHostedWorkspaceSnapshotProcessPipe(
         pipeline(tar.stdout, zstd.stdin),
+        [tarExit, zstdExit],
+      );
+      await Promise.all([
+        archiveInputPipe,
         pipeline(
           zstd.stdout,
           createHashTransform(plaintextArchiveHash),
@@ -462,8 +466,14 @@ export async function restoreEncryptedWorkspaceSnapshotFromEncryptedStream(input
       if (!zstd.stdin) {
         throw new Error("Hosted workspace snapshot restore archive streams are unavailable.");
       }
-      zstdInputPipe = pipeline(Readable.from([plaintextArchive]), zstd.stdin);
-      archivePipe = pipeline(zstd.stdout, tar.stdin);
+      zstdInputPipe = waitForHostedWorkspaceSnapshotProcessPipe(
+        pipeline(Readable.from([plaintextArchive]), zstd.stdin),
+        [zstdExit, tarExit],
+      );
+      archivePipe = waitForHostedWorkspaceSnapshotProcessPipe(
+        pipeline(zstd.stdout, tar.stdin),
+        [zstdExit, tarExit],
+      );
       await Promise.all([
         zstdInputPipe,
         archivePipe,
@@ -798,15 +808,21 @@ async function listHostedWorkspaceSnapshotEncryptedVerboseTarEntries(input: {
   tar.stdout.setEncoding("utf8");
   const zstdExit = waitForHostedWorkspaceSnapshotProcess(zstd, "zstd");
   const tarExit = waitForHostedWorkspaceSnapshotProcess(tar, "tar");
-  const decryptPipe = pipeline(
-    createReadStream(input.encryptedFilePath, {
-      end: input.encryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
-      start: 0,
-    }),
-    decipher,
-    zstd.stdin,
+  const decryptPipe = waitForHostedWorkspaceSnapshotProcessPipe(
+    pipeline(
+      createReadStream(input.encryptedFilePath, {
+        end: input.encryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
+        start: 0,
+      }),
+      decipher,
+      zstd.stdin,
+    ),
+    [zstdExit, tarExit],
   );
-  const archivePipe = pipeline(zstd.stdout, tar.stdin);
+  const archivePipe = waitForHostedWorkspaceSnapshotProcessPipe(
+    pipeline(zstd.stdout, tar.stdin),
+    [zstdExit, tarExit],
+  );
   const lines = createInterface({
     crlfDelay: Number.POSITIVE_INFINITY,
     input: tar.stdout,
@@ -1137,12 +1153,39 @@ async function readHostedWorkspaceSnapshotProcessFailure(
   return firstFailure?.status === "rejected" ? firstFailure.reason : null;
 }
 
+export async function waitForHostedWorkspaceSnapshotProcessPipe(
+  pipe: Promise<void>,
+  processExits: readonly Promise<void>[],
+): Promise<void> {
+  try {
+    await pipe;
+  } catch (error) {
+    if (!isHostedWorkspaceSnapshotPipeCloseError(error)) {
+      throw error;
+    }
+    const processFailure = await readHostedWorkspaceSnapshotProcessFailure(processExits);
+    if (processFailure) {
+      throw processFailure;
+    }
+  }
+}
+
 function shouldPreferHostedWorkspaceSnapshotProcessFailure(error: unknown): boolean {
   if (readHostedWorkspaceSnapshotProcessFailureDiagnostics(error)) {
     return true;
   }
+  return isHostedWorkspaceSnapshotPipeCloseError(error);
+}
+
+function isHostedWorkspaceSnapshotPipeCloseError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
+  }
+  if (
+    isNodeErrorCode(error, "ERR_STREAM_PREMATURE_CLOSE")
+    || isNodeErrorCode(error, "EPIPE")
+  ) {
+    return true;
   }
   return /(?:premature close|\bEPIPE\b|write after end|stream closed|aborted)/iu
     .test(error.message);

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -25,9 +25,41 @@ import {
   type EncryptedWorkspaceSnapshotFile,
   restoreEncryptedWorkspaceSnapshot,
   restoreEncryptedWorkspaceSnapshotFromEncryptedStream,
+  waitForHostedWorkspaceSnapshotProcessPipe,
 } from "../src/workspace-snapshot-local.js";
 
 const execFileAsync = promisify(execFile);
+
+describe("workspace snapshot process pipes", () => {
+  it("ignores premature stream closes when the child commands exit cleanly", async () => {
+    await expect(waitForHostedWorkspaceSnapshotProcessPipe(
+      Promise.reject(Object.assign(new Error("Premature close"), {
+        code: "ERR_STREAM_PREMATURE_CLOSE",
+      })),
+      [Promise.resolve(), Promise.resolve()],
+    )).resolves.toBeUndefined();
+  });
+
+  it("keeps the child command failure when a premature stream close accompanies it", async () => {
+    const processError = new Error("Hosted workspace snapshot zstd command failed with exit code 1.");
+    const processExit = Promise.reject(processError);
+    processExit.catch(() => undefined);
+
+    await expect(waitForHostedWorkspaceSnapshotProcessPipe(
+      Promise.reject(Object.assign(new Error("Premature close"), {
+        code: "ERR_STREAM_PREMATURE_CLOSE",
+      })),
+      [Promise.resolve(), processExit],
+    )).rejects.toBe(processError);
+  });
+
+  it("does not hide ordinary stream errors", async () => {
+    await expect(waitForHostedWorkspaceSnapshotProcessPipe(
+      Promise.reject(new Error("snapshot stream transform failed")),
+      [Promise.resolve(), Promise.resolve()],
+    )).rejects.toThrow("snapshot stream transform failed");
+  });
+});
 
 describe("workspace snapshot local restore", () => {
   it("round-trips selected portable workspace state and Codex continuity", async () => {

--- a/apps/web/src/lib/browser-vault/experiment-run.ts
+++ b/apps/web/src/lib/browser-vault/experiment-run.ts
@@ -417,6 +417,10 @@ function buildSchedule(
   results: BrowserVaultExperimentResultsView,
 ): ExperimentRunProjection["schedule"] {
   const schedule = results.schedule;
+  if (!schedule && hasUnsupportedExplicitAdherence(results)) {
+    return undefined;
+  }
+
   const windows = results.experiment.windows;
   const firstCellDate = schedule?.cells[0]?.localDate ?? null;
   const lastCellDate = schedule?.cells.at(-1)?.localDate ?? null;
@@ -447,6 +451,12 @@ function buildSchedule(
     loggedSessions: results.progress?.adherence.loggedSessions ?? schedule?.completedSessions,
     weeks,
   };
+}
+
+function hasUnsupportedExplicitAdherence(results: BrowserVaultExperimentResultsView): boolean {
+  return results.diagnostics.some((diagnostic) =>
+    diagnostic.code === "invalid_schedule" && diagnostic.message.includes("adherence targets")
+  );
 }
 
 function buildSessionContext(

--- a/apps/web/test/experiment-detail-private-run.test.tsx
+++ b/apps/web/test/experiment-detail-private-run.test.tsx
@@ -837,6 +837,75 @@ describe("experiment detail private-run composition", () => {
     expect(scheduleMarkup).not.toContain("1 missed");
   });
 
+  it("does not synthesize a schedule grid for unsupported explicit adherence", async () => {
+    const protocol = resolveHealthCommonsExperimentProtocol("finnish-sauna");
+
+    expect(protocol).not.toBeNull();
+
+    const privateRun = resolveBrowserVaultExperimentRun({
+      client: await createClient({
+        additionalEntities: [
+          createSessionEntity({
+            date: "2026-04-08",
+            experimentId: "exp_sauna_metric_adherence",
+            experimentSlug: "finnish-sauna",
+            sessionStatus: "completed",
+          }),
+        ],
+        generatedAt: "2026-04-10T12:00:00.000Z",
+        trackedExperiments: [{
+          frontmatter: createExperimentFrontmatter({
+            analysisPlan: {
+              desiredDirection: "decrease",
+              primaryBiomarkerKey: "biomarker:resting-heart-rate",
+            },
+            id: "exp_sauna_metric_adherence",
+            runPlan: {
+              baselineEnd: "2026-04-07",
+              baselineStart: "2026-04-01",
+              interventionEnd: "2026-04-08",
+              interventionStart: "2026-04-08",
+              adherenceTargets: [{
+                targetId: "step-floor",
+                label: "Step floor",
+                phase: "intervention",
+                calendar: {
+                  kind: "daily",
+                  timeZone: "America/New_York",
+                },
+                evidence: {
+                  kind: "metricThreshold",
+                  metricKey: "steps",
+                  op: ">=",
+                  value: 8000,
+                  missing: "unknown",
+                },
+                rollup: {
+                  targetCompletions: 1,
+                  minimumUsefulCompletions: 1,
+                },
+              }],
+            },
+            slug: "finnish-sauna",
+            startedOn: "2026-04-01",
+            status: "active",
+            title: "Private sauna metric-adherence run",
+          }),
+          id: "exp_sauna_metric_adherence",
+          slug: "finnish-sauna",
+          startedOn: "2026-04-01",
+          status: "active",
+          summary: "Metric adherence is not yet supported in browser Results.",
+          tags: ["sauna"],
+          title: "Private sauna metric-adherence run",
+        }],
+      }),
+      protocol: protocol!,
+    });
+
+    expect(privateRun?.schedule).toBeUndefined();
+  });
+
   it("renders browser-vault session confounders in private results context", async () => {
     const protocol = resolveHealthCommonsExperimentProtocol("finnish-sauna");
 

--- a/packages/contracts/generated/frontmatter-experiment.schema.json
+++ b/packages/contracts/generated/frontmatter-experiment.schema.json
@@ -746,7 +746,7 @@
               },
               "recordId": {
                 "type": "string",
-                "pattern": "^(?:(?:evt|sample|batch|metric_sample)_[A-Za-z0-9][A-Za-z0-9_-]*|sample-summary:[0-9]{4}-[0-9]{2}-[0-9]{2}:[A-Za-z0-9_-]+:[A-Za-z0-9_.%/-]+)$"
+                "pattern": "^(?:(?:evt|sample|batch|metric_sample)_[A-Za-z0-9][A-Za-z0-9_-]*|sample-summary:[0-9]{4}-[0-9]{2}-[0-9]{2}:[A-Za-z0-9_-]+:[A-Za-z0-9_.%/-]+|sample-summary:[A-Za-z0-9_-]+:[0-9]{4}-[0-9]{2}-[0-9]{2})$"
               },
               "biomarkerKeys": {
                 "minItems": 1,

--- a/packages/contracts/src/zod.ts
+++ b/packages/contracts/src/zod.ts
@@ -2013,7 +2013,7 @@ export const experimentMeasurementKindSchema = z.enum([
 ]);
 
 export const experimentMeasurementAnchorRecordIdSchema = patternedString(
-  "^(?:(?:evt|sample|batch|metric_sample)_[A-Za-z0-9][A-Za-z0-9_-]*|sample-summary:[0-9]{4}-[0-9]{2}-[0-9]{2}:[A-Za-z0-9_-]+:[A-Za-z0-9_.%/-]+)$",
+  "^(?:(?:evt|sample|batch|metric_sample)_[A-Za-z0-9][A-Za-z0-9_-]*|sample-summary:[0-9]{4}-[0-9]{2}-[0-9]{2}:[A-Za-z0-9_-]+:[A-Za-z0-9_.%/-]+|sample-summary:[A-Za-z0-9_-]+:[0-9]{4}-[0-9]{2}-[0-9]{2})$",
 );
 
 export const experimentMeasurementAnchorSchema = z

--- a/packages/health-metrics/src/index.ts
+++ b/packages/health-metrics/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types.ts";
 export * from "./catalog.ts";
 export * from "./normalize.ts";
+export * from "./record-ids.ts";
 export * from "./selectors.ts";
 export * from "./series.ts";
 export * from "./goals.ts";

--- a/packages/health-metrics/src/record-ids.ts
+++ b/packages/health-metrics/src/record-ids.ts
@@ -1,4 +1,5 @@
-import type { MetricPoint } from "./metrics/index.ts";
+import { uniqueStrings } from "./catalog.ts";
+import type { MetricPoint } from "./types.ts";
 
 export function metricPointRecordIds(point: MetricPoint): string[] {
   const ids = new Set<string>();
@@ -20,7 +21,7 @@ export function metricPointRecordIds(point: MetricPoint): string[] {
     }
   }
 
-  return [...ids];
+  return uniqueStrings([...ids]);
 }
 
 function sampleSummaryRecordIdAliases(recordId: string): string[] {

--- a/packages/health-metrics/src/selectors.ts
+++ b/packages/health-metrics/src/selectors.ts
@@ -9,6 +9,7 @@ import {
 } from "./catalog.ts";
 import { formatMetricDisplayValue } from "./format.ts";
 import { unitsEquivalent } from "./normalize.ts";
+import { metricPointRecordIds } from "./record-ids.ts";
 import type {
   MetricConfidence,
   MetricDefinition,
@@ -347,18 +348,6 @@ function lowestMetricConfidence(values: readonly MetricConfidence[]): MetricConf
     high: 3,
   };
   return values.reduce<MetricConfidence>((worst, value) => rank[value] < rank[worst] ? value : worst, "high");
-}
-
-function metricPointRecordIds(point: MetricPoint): string[] {
-  const contributingRecordIds = point.context.contributingRecordIds;
-  if (Array.isArray(contributingRecordIds)) {
-    return uniqueStrings([
-      ...contributingRecordIds.filter((value): value is string => typeof value === "string" && value.length > 0),
-      point.source.recordId,
-    ]);
-  }
-
-  return [point.source.recordId];
 }
 
 function subtractIsoDays(value: string, days: number): string {

--- a/packages/health-metrics/src/series.ts
+++ b/packages/health-metrics/src/series.ts
@@ -152,6 +152,7 @@ function aggregateMetricSeriesPoints(
 
     return [{
       biomarkerKey: first.biomarkerKey,
+      comparator: null,
       confidence: highestMetricConfidence(datePoints.map((point) => point.confidence)),
       context: {
         aggregatePointCount: datePoints.length,
@@ -179,6 +180,7 @@ function aggregateMetricSeriesPoints(
 function metricPointToSeriesPoint(point: MetricPoint, definition: MetricDefinition): MetricSeriesPoint {
   return {
     biomarkerKey: point.biomarkerKey,
+    comparator: point.comparator,
     confidence: point.confidence,
     context: point.context,
     date: point.effectiveDate,

--- a/packages/health-metrics/src/series.ts
+++ b/packages/health-metrics/src/series.ts
@@ -7,6 +7,7 @@ import {
   uniqueStrings,
 } from "./catalog.ts";
 import { formatMetricDisplayValue, formatNumber } from "./format.ts";
+import { metricPointRecordIds } from "./record-ids.ts";
 import { selectMetricValue } from "./selectors.ts";
 import type {
   ListMetricPointsInput,
@@ -267,18 +268,6 @@ function groupMetricPointsByDate(points: readonly MetricPoint[]): MetricPoint[][
 
 function pointNumericValue(point: MetricPoint): number | null {
   return point.canonicalValue ?? point.value;
-}
-
-function metricPointRecordIds(point: MetricPoint): string[] {
-  const contributingRecordIds = point.context.contributingRecordIds;
-  if (Array.isArray(contributingRecordIds)) {
-    return uniqueStrings([
-      ...contributingRecordIds.filter((value): value is string => typeof value === "string" && value.length > 0),
-      point.source.recordId,
-    ]);
-  }
-
-  return [point.source.recordId];
 }
 
 function aggregateMetricValues(values: readonly number[], aggregation: MetricSeriesAggregation): number {

--- a/packages/health-metrics/src/types.ts
+++ b/packages/health-metrics/src/types.ts
@@ -161,6 +161,7 @@ export type MetricSeriesAggregation = "mean" | "median" | "min" | "max" | "sum" 
 
 export interface MetricSeriesPoint {
   biomarkerKey?: string | null;
+  comparator?: MetricComparator | null;
   confidence?: MetricConfidence;
   context?: MetricPointContext;
   date: string;

--- a/packages/query/src/browser-replica/build.ts
+++ b/packages/query/src/browser-replica/build.ts
@@ -1,5 +1,5 @@
 import type { CanonicalEntity } from "../canonical-entities.ts";
-import { metricPointRecordIds } from "../metric-point-record-ids.ts";
+import { metricPointRecordIds } from "../metrics/index.ts";
 import { isDefaultProjectedQueryEntity } from "../query-visibility.ts";
 import type { OverviewWeeklySampleSummary } from "../overview.ts";
 import { summarizeDailySamples, type DailySampleSummary } from "../summaries.ts";

--- a/packages/query/src/browser-replica/build.ts
+++ b/packages/query/src/browser-replica/build.ts
@@ -1,4 +1,7 @@
+import { experimentAdherenceTargetsSchema } from "@murphai/contracts";
+
 import type { CanonicalEntity } from "../canonical-entities.ts";
+import { resolveExperimentMetricIdentity } from "../experiment-metrics.ts";
 import { isDefaultProjectedQueryEntity } from "../query-visibility.ts";
 import type { OverviewWeeklySampleSummary } from "../overview.ts";
 import { summarizeDailySamples, type DailySampleSummary } from "../summaries.ts";
@@ -185,6 +188,7 @@ function collectRequestedBrowserVaultMetrics(entities: readonly CanonicalEntity[
 function collectExplicitBrowserVaultMetrics(entities: readonly CanonicalEntity[]): BrowserVaultRequestedMetric[] {
   return dedupeRequestedMetrics([
     ...entities.flatMap(privateMetricBindingRequests),
+    ...collectExperimentAdherenceMetricRequests(entities),
     ...entities.filter(isActiveGoalEntity).flatMap((entity) =>
       parseGoalMetricTargets(entity).map((target) => ({
         metricKey: target.metricKey,
@@ -192,6 +196,42 @@ function collectExplicitBrowserVaultMetrics(entities: readonly CanonicalEntity[]
       }))
     ),
   ]);
+}
+
+function collectExperimentAdherenceMetricRequests(
+  entities: readonly CanonicalEntity[],
+): BrowserVaultRequestedMetric[] {
+  return entities
+    .filter((entity) => entity.family === "experiment")
+    .flatMap((entity) => {
+      const source = entity.frontmatter ?? entity.attributes;
+      const runPlan = source.runPlan;
+      if (!runPlan || typeof runPlan !== "object" || Array.isArray(runPlan)) {
+        return [];
+      }
+
+      const targets = (runPlan as Record<string, unknown>).adherenceTargets;
+      if (targets === undefined || targets === null) {
+        return [];
+      }
+
+      const result = experimentAdherenceTargetsSchema.safeParse(targets);
+      if (!result.success) {
+        return [];
+      }
+
+      return result.data.flatMap((target): BrowserVaultRequestedMetric[] => {
+        if (target.evidence.kind !== "metricPresence" && target.evidence.kind !== "metricThreshold") {
+          return [];
+        }
+
+        const identity = resolveExperimentMetricIdentity(target.evidence.metricKey);
+        return [{
+          metricKey: identity.metricKey,
+          biomarkerKey: identity.biomarkerKey,
+        }];
+      });
+    });
 }
 
 function privateMetricBindingRequests(entity: CanonicalEntity): BrowserVaultRequestedMetric[] {

--- a/packages/query/src/browser-replica/build.ts
+++ b/packages/query/src/browser-replica/build.ts
@@ -255,12 +255,28 @@ function isAnchoredBrowserMetricPoint(
   point: MetricPoint,
   anchoredRecords: ReadonlyMap<string, ReadonlySet<string>>,
 ): boolean {
-  const biomarkerKeys = anchoredRecords.get(point.source.recordId);
-  if (!biomarkerKeys || !point.biomarkerKey) {
+  const biomarkerKey = point.biomarkerKey;
+  if (!biomarkerKey) {
     return false;
   }
 
-  return biomarkerKeys.has(point.biomarkerKey);
+  return browserMetricPointRecordIds(point).some((recordId) =>
+    anchoredRecords.get(recordId)?.has(biomarkerKey) ?? false
+  );
+}
+
+function browserMetricPointRecordIds(point: MetricPoint): string[] {
+  const contributingRecordIds = point.context.contributingRecordIds;
+  if (!Array.isArray(contributingRecordIds)) {
+    return [point.source.recordId];
+  }
+
+  return [...new Set([
+    ...contributingRecordIds.filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    ),
+    point.source.recordId,
+  ])];
 }
 
 function dedupeRequestedMetrics(metrics: readonly BrowserVaultRequestedMetric[]): BrowserVaultRequestedMetric[] {
@@ -421,61 +437,10 @@ function projectSafeAttributes(entity: CanonicalEntity): Record<string, unknown>
     "value",
   ]) {
     if (source[key] !== undefined && isBrowserSafeJson(source[key])) {
-      allowed[key] = key === "runPlan"
-        ? projectSafeRunPlan(source[key])
-        : cloneJson(source[key]);
+      allowed[key] = cloneJson(source[key]);
     }
   }
 
-  return allowed;
-}
-
-function projectSafeRunPlan(value: unknown): unknown {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return cloneJson(value);
-  }
-
-  const source = value as Record<string, unknown>;
-  const projected = cloneRecord(source);
-  if (Array.isArray(source.adherenceTargets)) {
-    const targets = source.adherenceTargets
-      .map(projectBrowserSafeAdherenceTarget)
-      .filter((target): target is Record<string, unknown> => target !== null);
-    if (targets.length > 0) {
-      projected.adherenceTargets = targets;
-    } else {
-      delete projected.adherenceTargets;
-    }
-  }
-
-  return projected;
-}
-
-function projectBrowserSafeAdherenceTarget(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-
-  const target = value as Record<string, unknown>;
-  const evidence = target.evidence;
-  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
-    return null;
-  }
-
-  const evidenceRecord = evidence as Record<string, unknown>;
-  if (
-    evidenceRecord.kind !== "linkedEventCount" ||
-    evidenceRecord.eventKind !== "intervention_session"
-  ) {
-    return null;
-  }
-
-  const allowed: Record<string, unknown> = {};
-  for (const key of ["targetId", "label", "phase", "calendar", "evidence", "grace", "rollup"]) {
-    if (target[key] !== undefined && isBrowserSafeJson(target[key])) {
-      allowed[key] = cloneJson(target[key]);
-    }
-  }
   return allowed;
 }
 
@@ -659,18 +624,6 @@ function previewText(value: string | null, limit: number): string | null {
 
 function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {
   return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))];
-}
-
-function cloneRecord(value: Record<string, unknown>): Record<string, unknown> {
-  const output: Record<string, unknown> = {};
-
-  for (const [key, entry] of Object.entries(value)) {
-    if (isBrowserSafeJson(entry)) {
-      output[key] = cloneJson(entry);
-    }
-  }
-
-  return output;
 }
 
 function cloneJson(value: unknown): unknown {

--- a/packages/query/src/browser-replica/build.ts
+++ b/packages/query/src/browser-replica/build.ts
@@ -1,7 +1,5 @@
-import { experimentAdherenceTargetsSchema } from "@murphai/contracts";
-
 import type { CanonicalEntity } from "../canonical-entities.ts";
-import { resolveExperimentMetricIdentity } from "../experiment-metrics.ts";
+import { metricPointRecordIds } from "../metric-point-record-ids.ts";
 import { isDefaultProjectedQueryEntity } from "../query-visibility.ts";
 import type { OverviewWeeklySampleSummary } from "../overview.ts";
 import { summarizeDailySamples, type DailySampleSummary } from "../summaries.ts";
@@ -188,7 +186,6 @@ function collectRequestedBrowserVaultMetrics(entities: readonly CanonicalEntity[
 function collectExplicitBrowserVaultMetrics(entities: readonly CanonicalEntity[]): BrowserVaultRequestedMetric[] {
   return dedupeRequestedMetrics([
     ...entities.flatMap(privateMetricBindingRequests),
-    ...collectExperimentAdherenceMetricRequests(entities),
     ...entities.filter(isActiveGoalEntity).flatMap((entity) =>
       parseGoalMetricTargets(entity).map((target) => ({
         metricKey: target.metricKey,
@@ -196,42 +193,6 @@ function collectExplicitBrowserVaultMetrics(entities: readonly CanonicalEntity[]
       }))
     ),
   ]);
-}
-
-function collectExperimentAdherenceMetricRequests(
-  entities: readonly CanonicalEntity[],
-): BrowserVaultRequestedMetric[] {
-  return entities
-    .filter((entity) => entity.family === "experiment")
-    .flatMap((entity) => {
-      const source = entity.frontmatter ?? entity.attributes;
-      const runPlan = source.runPlan;
-      if (!runPlan || typeof runPlan !== "object" || Array.isArray(runPlan)) {
-        return [];
-      }
-
-      const targets = (runPlan as Record<string, unknown>).adherenceTargets;
-      if (targets === undefined || targets === null) {
-        return [];
-      }
-
-      const result = experimentAdherenceTargetsSchema.safeParse(targets);
-      if (!result.success) {
-        return [];
-      }
-
-      return result.data.flatMap((target): BrowserVaultRequestedMetric[] => {
-        if (target.evidence.kind !== "metricPresence" && target.evidence.kind !== "metricThreshold") {
-          return [];
-        }
-
-        const identity = resolveExperimentMetricIdentity(target.evidence.metricKey);
-        return [{
-          metricKey: identity.metricKey,
-          biomarkerKey: identity.biomarkerKey,
-        }];
-      });
-    });
 }
 
 function privateMetricBindingRequests(entity: CanonicalEntity): BrowserVaultRequestedMetric[] {
@@ -300,23 +261,9 @@ function isAnchoredBrowserMetricPoint(
     return false;
   }
 
-  return browserMetricPointRecordIds(point).some((recordId) =>
+  return metricPointRecordIds(point).some((recordId) =>
     anchoredRecords.get(recordId)?.has(biomarkerKey) ?? false
   );
-}
-
-function browserMetricPointRecordIds(point: MetricPoint): string[] {
-  const contributingRecordIds = point.context.contributingRecordIds;
-  if (!Array.isArray(contributingRecordIds)) {
-    return [point.source.recordId];
-  }
-
-  return [...new Set([
-    ...contributingRecordIds.filter(
-      (value): value is string => typeof value === "string" && value.length > 0,
-    ),
-    point.source.recordId,
-  ])];
 }
 
 function dedupeRequestedMetrics(metrics: readonly BrowserVaultRequestedMetric[]): BrowserVaultRequestedMetric[] {

--- a/packages/query/src/browser-replica/experiments.ts
+++ b/packages/query/src/browser-replica/experiments.ts
@@ -13,6 +13,7 @@ import {
   type ExperimentAdherenceCellStatus,
   type ExperimentAdherenceObservation,
 } from "../experiment-adherence.ts";
+import { matchesExperimentMetricIdentity } from "../experiment-metrics.ts";
 import {
   resolveMetricDefinition,
   resolveMetricDefinitionForBiomarker,
@@ -1197,11 +1198,12 @@ function buildAdherenceObservations(
       case "metricThreshold":
         const metricEvidence = target.evidence;
         observations.push(...metricRows
-          .filter((row) => row.metricKey === metricEvidence.metricKey)
+          .filter((row) => matchesExperimentMetricIdentity(metricEvidence.metricKey, row))
           .map((row) => ({
+            comparator: row.comparator ?? null,
             evidenceId: row.id,
             localDate: row.date,
-            metricKey: row.metricKey,
+            metricKey: metricEvidence.metricKey,
             targetId: target.targetId,
             value: row.value,
           })));

--- a/packages/query/src/browser-replica/experiments.ts
+++ b/packages/query/src/browser-replica/experiments.ts
@@ -291,15 +291,16 @@ export interface BrowserVaultExperimentResultsView {
 }
 
 interface BrowserVaultExperimentRunContext {
+  adherenceTargets: ExperimentAdherenceTarget[];
   asOf: string;
   asOfDate: string;
   diagnostics: BrowserVaultExperimentResultDiagnostic[];
   entity: BrowserVaultEntity;
   events: BrowserVaultEntity[];
   eventTimeZone: string | null;
-  adherenceTargets: ExperimentAdherenceTarget[];
   expectedEffects: BrowserVaultExperimentExpectedEffectInput[];
   run: BrowserVaultExperimentResultRun;
+  unsupportedExplicitAdherenceTargets: boolean;
 }
 
 interface BrowserVaultExperimentExpectedEffectInput {
@@ -434,7 +435,7 @@ function buildRunContext(
   const schedule = readRunSchedule(attributes, diagnostics);
   const runPlanRecord = readRecord(attributes.runPlan);
   const parsedAdherenceTargets = readAdherenceTargets(attributes, diagnostics);
-  const adherenceTargets: ExperimentAdherenceTarget[] = parsedAdherenceTargets === null
+  const adherenceTargets: ExperimentAdherenceTarget[] = parsedAdherenceTargets.targets === null
     ? synthesizeLegacySessionAdherenceTargets({
         runPlan: {
           minimumUsefulSessions: readNumber(runPlanRecord, "minimumUsefulSessions") ?? undefined,
@@ -443,7 +444,7 @@ function buildRunContext(
           targetSessions: readNumber(runPlanRecord, "targetSessions") ?? undefined,
         },
       })
-    : parsedAdherenceTargets;
+    : parsedAdherenceTargets.targets;
   const runTimeZone = adherenceTargets[0]?.calendar.timeZone ?? schedule?.timeZone ?? null;
   const asOfDate = runTimeZone ? toZonedIsoDate(asOf, runTimeZone) : toIsoDate(asOf);
   const startedOn = readString(attributes.startedOn) ?? entity.date ?? extractDate(entity.occurredAt);
@@ -486,6 +487,7 @@ function buildRunContext(
     adherenceTargets,
     expectedEffects,
     run,
+    unsupportedExplicitAdherenceTargets: parsedAdherenceTargets.unsupportedExplicit,
   };
 }
 
@@ -538,11 +540,11 @@ function readRunSchedule(
 function readAdherenceTargets(
   attributes: JsonRecord,
   diagnostics: BrowserVaultExperimentResultDiagnostic[],
-): ExperimentAdherenceTarget[] | null {
+): { targets: ExperimentAdherenceTarget[] | null; unsupportedExplicit: boolean } {
   const runPlan = readRecord(attributes.runPlan);
 
   if (!runPlan || runPlan.adherenceTargets === undefined || runPlan.adherenceTargets === null) {
-    return null;
+    return { targets: null, unsupportedExplicit: false };
   }
 
   const result = experimentAdherenceTargetsSchema.safeParse(runPlan.adherenceTargets);
@@ -552,7 +554,7 @@ function readAdherenceTargets(
       message: "The experiment has adherence targets, but they are not supported by browser Results.",
       severity: "warning",
     });
-    return [];
+    return { targets: [], unsupportedExplicit: true };
   }
 
   if (!result.data.every(isBrowserSupportedAdherenceTarget)) {
@@ -561,10 +563,10 @@ function readAdherenceTargets(
       message: "The experiment has adherence targets outside the browser Results support set.",
       severity: "warning",
     });
-    return [];
+    return { targets: [], unsupportedExplicit: true };
   }
 
-  return result.data;
+  return { targets: result.data, unsupportedExplicit: false };
 }
 
 function isBrowserSupportedAdherenceTarget(target: ExperimentAdherenceTarget): boolean {
@@ -1119,6 +1121,10 @@ function buildAdherenceResult(
   const interventionStart = context.run.windows.interventionStart;
   const interventionEnd = context.run.windows.interventionEnd;
 
+  if (context.unsupportedExplicitAdherenceTargets) {
+    return null;
+  }
+
   if (adherenceTargets.length === 0 || !interventionStart || !interventionEnd) {
     context.diagnostics.push({
       code: "no_schedule",
@@ -1372,22 +1378,25 @@ function buildProgressResult(
 ): BrowserVaultExperimentProgressResult {
   const rollupTarget = resolveExperimentAdherenceRollupTarget(context.adherenceTargets);
   const hasAmbiguousTargets = context.adherenceTargets.length > 1 && !rollupTarget;
+  const hasUnsupportedExplicitTargets = context.unsupportedExplicitAdherenceTargets;
   const targetSessions =
+    hasUnsupportedExplicitTargets ? null :
     rollupTarget?.rollup?.targetCompletions ??
     (hasAmbiguousTargets ? null : context.run.runPlan.targetSessions);
   const minimumUsefulSessions =
+    hasUnsupportedExplicitTargets ? null :
     rollupTarget?.rollup?.minimumUsefulCompletions ??
     (hasAmbiguousTargets ? null : context.run.runPlan.minimumUsefulSessions);
-  const completedSessions = hasAmbiguousTargets
+  const completedSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets
     ? 0
     : schedule?.completedSessions ?? countSessionEvents(context.events, "completed");
-  const partialSessions = hasAmbiguousTargets
+  const partialSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets
     ? 0
     : schedule?.partialSessions ?? countSessionEvents(context.events, "partial");
-  const missedSessions = hasAmbiguousTargets
+  const missedSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets
     ? 0
     : schedule?.missedSessions ?? countSessionEvents(context.events, "missed");
-  const skippedSessions = hasAmbiguousTargets ? 0 : schedule?.skippedSessions ?? 0;
+  const skippedSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets ? 0 : schedule?.skippedSessions ?? 0;
   const loggedSessions = completedSessions + partialSessions;
   const progressSchedule = rollupTarget && schedule
     ? {
@@ -1395,7 +1404,7 @@ function buildProgressResult(
         cells: schedule.cells.filter((cell) => cell.targetId === rollupTarget.targetId),
       }
     : schedule;
-  const expectedSessionsByNow = hasAmbiguousTargets
+  const expectedSessionsByNow = hasUnsupportedExplicitTargets || hasAmbiguousTargets
     ? null
     : computeExpectedSessionsByNow(
         context.run,
@@ -1416,7 +1425,7 @@ function buildProgressResult(
       missedSessions,
       partialSessions,
       skippedSessions,
-      status: hasAmbiguousTargets
+      status: hasUnsupportedExplicitTargets || hasAmbiguousTargets
         ? "unknown"
         : classifyAdherenceStatus({
             expectedSessionsByNow,
@@ -1542,6 +1551,10 @@ function buildOutcomeResult(
     progress.adherence.loggedSessions < progress.adherence.minimumUsefulSessions
   ) {
     reasons.push("Logged session count stayed below the minimum useful target.");
+  }
+
+  if (context.unsupportedExplicitAdherenceTargets) {
+    reasons.push("Browser Results cannot evaluate this experiment's adherence target yet.");
   }
 
   const unsupportedCount = biomarkers.filter((entry) => entry.status === "unsupported_source").length;

--- a/packages/query/src/browser-replica/experiments.ts
+++ b/packages/query/src/browser-replica/experiments.ts
@@ -13,7 +13,6 @@ import {
   type ExperimentAdherenceCellStatus,
   type ExperimentAdherenceObservation,
 } from "../experiment-adherence.ts";
-import { matchesExperimentMetricIdentity } from "../experiment-metrics.ts";
 import {
   resolveMetricDefinition,
   resolveMetricDefinitionForBiomarker,
@@ -342,7 +341,7 @@ export function selectBrowserVaultExperimentResults(
   const context = buildRunContext(client, entity, asOf);
   const metricWindow = buildMetricWindowContext(context.run.windows, context.asOfDate);
   const biomarkers = buildBiomarkerResults(client, context, metricWindow);
-  const adherence = buildAdherenceResult(context, client.replica.metricRows);
+  const adherence = buildAdherenceResult(context);
   const schedule = buildScheduleResult(adherence);
   const progress = buildProgressResult(context, biomarkers, schedule);
   const outcome = buildOutcomeResult(context, biomarkers, progress);
@@ -556,7 +555,21 @@ function readAdherenceTargets(
     return [];
   }
 
+  if (!result.data.every(isBrowserSupportedAdherenceTarget)) {
+    diagnostics.push({
+      code: "invalid_schedule",
+      message: "The experiment has adherence targets outside the browser Results support set.",
+      severity: "warning",
+    });
+    return [];
+  }
+
   return result.data;
+}
+
+function isBrowserSupportedAdherenceTarget(target: ExperimentAdherenceTarget): boolean {
+  return target.evidence.kind === "linkedEventCount" &&
+    target.evidence.eventKind === "intervention_session";
 }
 
 function selectExperimentEvents(
@@ -1101,7 +1114,6 @@ function emptyMetricWindowSummary(
 
 function buildAdherenceResult(
   context: BrowserVaultExperimentRunContext,
-  metricRows: readonly BrowserVaultMetricRow[],
 ): BrowserVaultExperimentAdherenceResult | null {
   const adherenceTargets = context.adherenceTargets;
   const interventionStart = context.run.windows.interventionStart;
@@ -1119,7 +1131,7 @@ function buildAdherenceResult(
   try {
     const adherence = buildExperimentAdherenceCalendar({
       asOf: context.asOf,
-      observations: buildAdherenceObservations(context, metricRows, adherenceTargets),
+      observations: buildAdherenceObservations(context, adherenceTargets),
       targets: adherenceTargets,
       windows: context.run.windows,
     });
@@ -1171,7 +1183,6 @@ function buildScheduleResult(
 
 function buildAdherenceObservations(
   context: BrowserVaultExperimentRunContext,
-  metricRows: readonly BrowserVaultMetricRow[],
   targets: readonly ExperimentAdherenceTarget[],
 ): ExperimentAdherenceObservation[] {
   const observations: ExperimentAdherenceObservation[] = [];
@@ -1196,17 +1207,6 @@ function buildAdherenceObservations(
         break;
       case "metricPresence":
       case "metricThreshold":
-        const metricEvidence = target.evidence;
-        observations.push(...metricRows
-          .filter((row) => matchesExperimentMetricIdentity(metricEvidence.metricKey, row))
-          .map((row) => ({
-            comparator: row.comparator ?? null,
-            evidenceId: row.id,
-            localDate: row.date,
-            metricKey: metricEvidence.metricKey,
-            targetId: target.targetId,
-            value: row.value,
-          })));
         break;
     }
   }

--- a/packages/query/src/browser-replica/experiments.ts
+++ b/packages/query/src/browser-replica/experiments.ts
@@ -555,25 +555,7 @@ function readAdherenceTargets(
     return [];
   }
 
-  const supported = result.data.filter(isBrowserSupportedAdherenceTarget);
-  if (supported.length < result.data.length) {
-    diagnostics.push({
-      code: "invalid_schedule",
-      message: "Some adherence targets are not supported by browser Results and were left out.",
-      severity: "warning",
-    });
-  }
-
-  return supported;
-}
-
-function isBrowserSupportedAdherenceTarget(
-  target: ExperimentAdherenceTarget,
-): boolean {
-  return (
-    target.evidence.kind === "linkedEventCount" &&
-    target.evidence.eventKind === "intervention_session"
-  );
+  return result.data;
 }
 
 function selectExperimentEvents(

--- a/packages/query/src/browser-replica/experiments.ts
+++ b/packages/query/src/browser-replica/experiments.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   buildExperimentAdherenceCalendar,
+  resolveExperimentAdherenceRollupTarget,
   synthesizeLegacySessionAdherenceTargets,
   type ExperimentAdherenceCalendarResult,
   type ExperimentAdherenceCellStatus,
@@ -1162,7 +1163,9 @@ function buildScheduleResult(
     return null;
   }
 
-  return summarizeScheduleCells(adherence.timeZone, adherence.cells.map((cell) => ({
+  const rollupTarget = resolveExperimentAdherenceRollupTarget(adherence.targets);
+  const hasAmbiguousTargets = adherence.targets.length > 1 && !rollupTarget;
+  const cells: BrowserVaultExperimentScheduleCell[] = adherence.cells.map((cell) => ({
     evidenceIds: cell.evidenceIds,
     kind: mapAdherenceCellStatus(cell.status),
     label: cell.label,
@@ -1173,7 +1176,14 @@ function buildScheduleResult(
     source: cell.evidenceIds.length > 0 ? "event" : "planned",
     targetId: cell.targetId,
     timeZone: adherence.timeZone,
-  })));
+  }));
+  const countedCells = hasAmbiguousTargets
+    ? []
+    : rollupTarget
+    ? cells.filter((cell) => cell.targetId === rollupTarget.targetId)
+    : cells;
+
+  return summarizeScheduleCells(adherence.timeZone, cells, countedCells);
 }
 
 function buildAdherenceObservations(
@@ -1251,15 +1261,16 @@ function mapAdherenceCellStatus(
 function summarizeScheduleCells(
   timeZone: string,
   cells: readonly BrowserVaultExperimentScheduleCell[],
+  countedCells: readonly BrowserVaultExperimentScheduleCell[] = cells,
 ): BrowserVaultExperimentScheduleResult {
   return {
     cells: cells.slice(),
-    completedSessions: countCells(cells, "completed"),
-    failedSessions: countCells(cells, "failed"),
-    missedSessions: countCells(cells, "missed"),
-    unknownSessions: countCells(cells, "unknown"),
-    partialSessions: countCells(cells, "partial"),
-    plannedSessions: cells.filter((cell) => cell.planned).length,
+    completedSessions: countCells(countedCells, "completed"),
+    failedSessions: countCells(countedCells, "failed"),
+    missedSessions: countCells(countedCells, "missed"),
+    unknownSessions: countCells(countedCells, "unknown"),
+    partialSessions: countCells(countedCells, "partial"),
+    plannedSessions: countedCells.filter((cell) => cell.planned).length,
     skippedSessions: 0,
     timeZone,
   };
@@ -1375,23 +1386,39 @@ function buildProgressResult(
   biomarkers: readonly BrowserVaultExperimentBiomarkerResult[],
   schedule: BrowserVaultExperimentScheduleResult | null,
 ): BrowserVaultExperimentProgressResult {
+  const rollupTarget = resolveExperimentAdherenceRollupTarget(context.adherenceTargets);
+  const hasAmbiguousTargets = context.adherenceTargets.length > 1 && !rollupTarget;
   const targetSessions =
-    context.adherenceTargets[0]?.rollup?.targetCompletions ??
-    context.run.runPlan.targetSessions;
+    rollupTarget?.rollup?.targetCompletions ??
+    (hasAmbiguousTargets ? null : context.run.runPlan.targetSessions);
   const minimumUsefulSessions =
-    context.adherenceTargets[0]?.rollup?.minimumUsefulCompletions ??
-    context.run.runPlan.minimumUsefulSessions;
-  const completedSessions = schedule?.completedSessions ?? countSessionEvents(context.events, "completed");
-  const partialSessions = schedule?.partialSessions ?? countSessionEvents(context.events, "partial");
-  const missedSessions = schedule?.missedSessions ?? countSessionEvents(context.events, "missed");
-  const skippedSessions = schedule?.skippedSessions ?? 0;
+    rollupTarget?.rollup?.minimumUsefulCompletions ??
+    (hasAmbiguousTargets ? null : context.run.runPlan.minimumUsefulSessions);
+  const completedSessions = hasAmbiguousTargets
+    ? 0
+    : schedule?.completedSessions ?? countSessionEvents(context.events, "completed");
+  const partialSessions = hasAmbiguousTargets
+    ? 0
+    : schedule?.partialSessions ?? countSessionEvents(context.events, "partial");
+  const missedSessions = hasAmbiguousTargets
+    ? 0
+    : schedule?.missedSessions ?? countSessionEvents(context.events, "missed");
+  const skippedSessions = hasAmbiguousTargets ? 0 : schedule?.skippedSessions ?? 0;
   const loggedSessions = completedSessions + partialSessions;
-  const expectedSessionsByNow = computeExpectedSessionsByNow(
-    context.run,
-    context.asOfDate,
-    targetSessions,
-    schedule,
-  );
+  const progressSchedule = rollupTarget && schedule
+    ? {
+        ...schedule,
+        cells: schedule.cells.filter((cell) => cell.targetId === rollupTarget.targetId),
+      }
+    : schedule;
+  const expectedSessionsByNow = hasAmbiguousTargets
+    ? null
+    : computeExpectedSessionsByNow(
+        context.run,
+        context.asOfDate,
+        targetSessions,
+        progressSchedule,
+      );
   const primary = biomarkers[0] ?? null;
   const primaryBaselineDays = primary?.baseline.daysWithData ?? 0;
   const primaryInterventionDays = primary?.intervention.daysWithData ?? 0;
@@ -1405,12 +1432,14 @@ function buildProgressResult(
       missedSessions,
       partialSessions,
       skippedSessions,
-      status: classifyAdherenceStatus({
-        expectedSessionsByNow,
-        loggedSessions,
-        minimumUsefulSessions,
-        targetSessions,
-      }),
+      status: hasAmbiguousTargets
+        ? "unknown"
+        : classifyAdherenceStatus({
+            expectedSessionsByNow,
+            loggedSessions,
+            minimumUsefulSessions,
+            targetSessions,
+          }),
       targetSessions,
     },
     dataCoverage: {

--- a/packages/query/src/browser-replica/metric-points.ts
+++ b/packages/query/src/browser-replica/metric-points.ts
@@ -75,6 +75,7 @@ function toBrowserVaultMetricRow(point: MetricSeriesPoint): BrowserVaultMetricRo
 
   return [{
     biomarkerKey: point.biomarkerKey ?? null,
+    comparator: point.comparator ?? null,
     confidence: point.confidence ?? "none",
     context: point.context ?? {},
     date: point.date,
@@ -105,6 +106,7 @@ function dedupeEquivalentMetricRows(
       row.metricKey,
       row.date,
       row.unit,
+      row.comparator,
       String(row.value),
       [...row.recordIds].sort().join(","),
     ].join("\u0000");
@@ -126,6 +128,7 @@ function dedupeEquivalentMetricRows(
 export function browserMetricRowToSeriesPoint(row: BrowserVaultMetricRow): MetricSeriesPoint {
   return {
     biomarkerKey: row.biomarkerKey,
+    comparator: row.comparator,
     confidence: row.confidence,
     context: row.context,
     date: row.date,

--- a/packages/query/src/browser-replica/parse.ts
+++ b/packages/query/src/browser-replica/parse.ts
@@ -99,6 +99,7 @@ function parseMetricRow(value: unknown, label: string): BrowserVaultMetricRow {
   }
   return {
     biomarkerKey: readNullableString(record.biomarkerKey),
+    comparator: readNullableMetricComparator(record.comparator, `${label}.comparator`),
     confidence: requireConfidenceLevel(record.confidence, `${label}.confidence`),
     context: requireRecord(record.context, `${label}.context`),
     date: requireString(record.date, `${label}.date`),
@@ -290,6 +291,12 @@ function requireMetricStatistic(value: unknown, label: string) {
   const text = requireString(value, label);
   if (text === "value" || text === "latest" || text === "mean" || text === "median" || text === "min" || text === "max" || text === "sum" || text === "count") return text;
   throw new TypeError(`${label} must be a metric statistic.`);
+}
+function readNullableMetricComparator(value: unknown, label: string) {
+  if (value === null || value === undefined) return null;
+  const text = requireString(value, label);
+  if (text === "<" || text === "<=" || text === ">" || text === ">=") return text;
+  throw new TypeError(`${label} must be a metric comparator.`);
 }
 function requireMetricSelectionStatus(value: unknown, label: string) {
   const text = requireString(value, label);

--- a/packages/query/src/browser-replica/shared.ts
+++ b/packages/query/src/browser-replica/shared.ts
@@ -10,6 +10,7 @@ import type { VaultReadModel } from "../read-model.ts";
 import type { TimelineEntry } from "../timeline.ts";
 import type {
   MetricConfidence,
+  MetricComparator,
   MetricGoalProgressStatus,
   MetricGrain,
   MetricPoint,
@@ -97,6 +98,7 @@ export interface BrowserVaultSummaryConfidence {
 
 export interface BrowserVaultMetricRow {
   biomarkerKey: string | null;
+  comparator?: MetricComparator | null;
   confidence: MetricConfidence;
   context: Record<string, unknown>;
   date: string;

--- a/packages/query/src/experiment-adherence.ts
+++ b/packages/query/src/experiment-adherence.ts
@@ -49,6 +49,7 @@ export interface ExperimentAdherenceCalendarResult {
   targets: Array<{
     targetId: string;
     label: string;
+    rollup?: ExperimentAdherenceTarget["rollup"];
     plannedCount: number;
     satisfiedCount: number;
     partialCount: number;
@@ -232,6 +233,26 @@ export function synthesizeLegacySessionAdherenceTargets(input: {
   }
 
   return [];
+}
+
+export function resolveExperimentAdherenceRollupTarget<
+  Target extends {
+    rollup?: ExperimentAdherenceTarget["rollup"] | null;
+    targetId: string;
+  },
+>(targets: readonly Target[]): Target | null {
+  const rollupTargets = targets.filter((target) =>
+    target.rollup !== undefined && target.rollup !== null
+  );
+  if (rollupTargets.length === 1) {
+    return rollupTargets[0] ?? null;
+  }
+
+  if (rollupTargets.length > 1) {
+    return null;
+  }
+
+  return targets.length === 1 ? targets[0] ?? null : null;
 }
 
 function evaluateExperimentAdherenceExpectation(input: {
@@ -469,6 +490,7 @@ function summarizeTargetCells(
   return {
     targetId: target.targetId,
     label: target.label,
+    ...(target.rollup ? { rollup: target.rollup } : {}),
     ...countCellStatuses(cells),
     score: scoreCells(cells),
   };

--- a/packages/query/src/experiment-adherence.ts
+++ b/packages/query/src/experiment-adherence.ts
@@ -4,6 +4,7 @@ import type {
   ExperimentRunPlan,
   ExperimentRunScheduleIntent,
 } from "@murphai/contracts";
+import type { MetricComparator } from "./metrics/index.ts";
 
 export type ExperimentAdherenceCellStatus =
   | "scheduled"
@@ -21,6 +22,7 @@ export interface ExperimentAdherenceWindows {
 }
 
 export interface ExperimentAdherenceObservation {
+  comparator?: MetricComparator | null;
   evidenceId: string;
   eventKind?: string | null;
   localDate: string;
@@ -355,19 +357,31 @@ function evaluateMetricThresholdExpectation(input: {
   if (evidence.kind !== "metricThreshold") {
     throw new TypeError("Metric-threshold adherence expectation received non-threshold evidence.");
   }
-  const observations = input.observations.filter((candidate) => typeof candidate.value === "number");
-  if (observations.length === 0) {
+  const numericObservations = input.observations.filter((candidate) => typeof candidate.value === "number");
+  const exactObservations = numericObservations.filter((candidate) => !candidate.comparator);
+  if (numericObservations.length === 0) {
     return missingCell(input);
   }
 
-  const passingObservation = observations.find((observation) =>
+  const passingObservation = exactObservations.find((observation) =>
     typeof observation.value === "number" && metricValueSatisfiesRule(observation.value, evidence)
   );
   if (passingObservation) {
     return cell(input.expectation, "satisfied", 1, 1, [passingObservation], "Metric value meets the target.");
   }
 
-  return cell(input.expectation, "failed", 0, 1, observations, "Metric value did not meet the planned target.");
+  if (exactObservations.length === 0) {
+    return cell(
+      input.expectation,
+      "unknown",
+      null,
+      numericObservations.length,
+      numericObservations,
+      "Metric value is bounded by a comparator.",
+    );
+  }
+
+  return cell(input.expectation, "failed", 0, 1, exactObservations, "Metric value did not meet the planned target.");
 }
 
 function missingCell(input: {

--- a/packages/query/src/experiment-metrics.ts
+++ b/packages/query/src/experiment-metrics.ts
@@ -15,10 +15,17 @@ export interface ResolvedExperimentMetricIdentity {
 }
 
 export function resolveExperimentMetricIdentity(metricKey: string): ResolvedExperimentMetricIdentity {
-  const candidate = buildExperimentMetricCandidates(metricKey);
+  const trimmedMetricKey = metricKey.trim();
+  const metricSlug = trimmedMetricKey.split(":").at(-1) ?? trimmedMetricKey;
+  const definition = trimmedMetricKey.startsWith("biomarker:")
+    ? resolveMetricDefinitionForBiomarker(trimmedMetricKey) ?? resolveMetricDefinition(metricSlug)
+    : resolveMetricDefinition(trimmedMetricKey);
+
   return {
-    biomarkerKey: candidate.resolvedBiomarkerKey,
-    metricKey: candidate.resolvedMetricKey,
+    biomarkerKey: definition?.biomarkerKey ?? (trimmedMetricKey.startsWith("biomarker:") ? trimmedMetricKey : null),
+    metricKey: definition?.key ?? normalizeMetricKey(
+      trimmedMetricKey.startsWith("biomarker:") ? metricSlug : trimmedMetricKey,
+    ),
   };
 }
 
@@ -26,58 +33,5 @@ export function matchesExperimentMetricIdentity(
   metricKey: string,
   point: ExperimentMetricIdentity,
 ): boolean {
-  const candidate = buildExperimentMetricCandidates(metricKey);
-  if (candidate.metricKeySet.has(point.metricKey)) {
-    return true;
-  }
-
-  return point.biomarkerKey !== null &&
-    point.biomarkerKey !== undefined &&
-    candidate.biomarkerKeySet.has(point.biomarkerKey);
-}
-
-function buildExperimentMetricCandidates(metricKey: string) {
-  const trimmedMetricKey = metricKey.trim();
-  const normalizedMetricKey = normalizeMetricKey(trimmedMetricKey);
-  const metricSlug = trimmedMetricKey.split(":").at(-1) ?? trimmedMetricKey;
-  const definition = resolveMetricDefinition(trimmedMetricKey);
-  const biomarkerDefinition = resolveMetricDefinitionForBiomarker(trimmedMetricKey);
-  const slugDefinition = resolveMetricDefinition(metricSlug);
-  const resolvedDefinition = definition ?? biomarkerDefinition ?? slugDefinition ?? null;
-  const resolvedMetricKey = resolvedDefinition?.key ?? normalizeMetricKey(metricSlug || trimmedMetricKey);
-  const resolvedBiomarkerKey = resolvedDefinition?.biomarkerKey ??
-    (trimmedMetricKey.startsWith("biomarker:") ? trimmedMetricKey : null);
-  const metricKeys = uniqueNonEmptyStrings([
-    trimmedMetricKey,
-    normalizedMetricKey,
-    definition?.key,
-    biomarkerDefinition?.key,
-    slugDefinition?.key,
-    normalizeMetricKey(metricSlug),
-  ]);
-  const biomarkerKeys = uniqueNonEmptyStrings([
-    trimmedMetricKey,
-    normalizedMetricKey,
-    normalizedMetricKey.startsWith("biomarker:")
-      ? normalizedMetricKey
-      : `biomarker:${normalizedMetricKey}`,
-    definition?.biomarkerKey,
-    biomarkerDefinition?.biomarkerKey,
-  ]);
-
-  return {
-    biomarkerKeys,
-    biomarkerKeySet: new Set(biomarkerKeys),
-    definition: resolvedDefinition,
-    metricKeys,
-    metricKeySet: new Set(metricKeys),
-    resolvedBiomarkerKey,
-    resolvedMetricKey,
-  };
-}
-
-function uniqueNonEmptyStrings(values: readonly (string | null | undefined)[]): string[] {
-  return [...new Set(values.filter((value): value is string =>
-    typeof value === "string" && value.length > 0
-  ))];
+  return point.metricKey === resolveExperimentMetricIdentity(metricKey).metricKey;
 }

--- a/packages/query/src/experiment-metrics.ts
+++ b/packages/query/src/experiment-metrics.ts
@@ -1,0 +1,83 @@
+import {
+  normalizeMetricKey,
+  resolveMetricDefinition,
+  resolveMetricDefinitionForBiomarker,
+} from "./metrics/index.ts";
+
+export interface ExperimentMetricIdentity {
+  biomarkerKey?: string | null;
+  metricKey: string;
+}
+
+export interface ResolvedExperimentMetricIdentity {
+  biomarkerKey: string | null;
+  metricKey: string;
+}
+
+export function resolveExperimentMetricIdentity(metricKey: string): ResolvedExperimentMetricIdentity {
+  const candidate = buildExperimentMetricCandidates(metricKey);
+  return {
+    biomarkerKey: candidate.resolvedBiomarkerKey,
+    metricKey: candidate.resolvedMetricKey,
+  };
+}
+
+export function matchesExperimentMetricIdentity(
+  metricKey: string,
+  point: ExperimentMetricIdentity,
+): boolean {
+  const candidate = buildExperimentMetricCandidates(metricKey);
+  if (candidate.metricKeySet.has(point.metricKey)) {
+    return true;
+  }
+
+  return point.biomarkerKey !== null &&
+    point.biomarkerKey !== undefined &&
+    candidate.biomarkerKeySet.has(point.biomarkerKey);
+}
+
+function buildExperimentMetricCandidates(metricKey: string) {
+  const trimmedMetricKey = metricKey.trim();
+  const normalizedMetricKey = normalizeMetricKey(trimmedMetricKey);
+  const metricSlug = trimmedMetricKey.split(":").at(-1) ?? trimmedMetricKey;
+  const definition = resolveMetricDefinition(trimmedMetricKey);
+  const biomarkerDefinition = resolveMetricDefinitionForBiomarker(trimmedMetricKey);
+  const slugDefinition = resolveMetricDefinition(metricSlug);
+  const resolvedDefinition = definition ?? biomarkerDefinition ?? slugDefinition ?? null;
+  const resolvedMetricKey = resolvedDefinition?.key ?? normalizeMetricKey(metricSlug || trimmedMetricKey);
+  const resolvedBiomarkerKey = resolvedDefinition?.biomarkerKey ??
+    (trimmedMetricKey.startsWith("biomarker:") ? trimmedMetricKey : null);
+  const metricKeys = uniqueNonEmptyStrings([
+    trimmedMetricKey,
+    normalizedMetricKey,
+    definition?.key,
+    biomarkerDefinition?.key,
+    slugDefinition?.key,
+    normalizeMetricKey(metricSlug),
+  ]);
+  const biomarkerKeys = uniqueNonEmptyStrings([
+    trimmedMetricKey,
+    normalizedMetricKey,
+    normalizedMetricKey.startsWith("biomarker:")
+      ? normalizedMetricKey
+      : `biomarker:${normalizedMetricKey}`,
+    definition?.biomarkerKey,
+    biomarkerDefinition?.biomarkerKey,
+  ]);
+
+  return {
+    biomarkerKeys,
+    biomarkerKeySet: new Set(biomarkerKeys),
+    definition: resolvedDefinition,
+    metricKeys,
+    metricKeySet: new Set(metricKeys),
+    resolvedBiomarkerKey,
+    resolvedMetricKey,
+  };
+}
+
+function uniqueNonEmptyStrings(values: readonly (string | null | undefined)[]): string[] {
+  return [...new Set(values.filter((value): value is string =>
+    typeof value === "string" && value.length > 0
+  ))];
+}

--- a/packages/query/src/experiment-progress-card.ts
+++ b/packages/query/src/experiment-progress-card.ts
@@ -126,7 +126,11 @@ function buildCardWeeks(input: {
   windows: ExperimentProgressSummary["windows"];
 }): Array<{ start: string; cells: string }> {
   const statusesByDate = new Map<string, ExperimentAdherenceCellStatus[]>();
+  const rollupTargetId = input.calendar?.targets[0]?.targetId ?? null;
   for (const cell of input.calendar?.cells ?? []) {
+    if (rollupTargetId && cell.targetId !== rollupTargetId) {
+      continue;
+    }
     const statuses = statusesByDate.get(cell.localDate) ?? [];
     statuses.push(cell.status);
     statusesByDate.set(cell.localDate, statuses);

--- a/packages/query/src/experiment-progress-card.ts
+++ b/packages/query/src/experiment-progress-card.ts
@@ -12,6 +12,7 @@ import type {
   ExperimentAdherenceCalendarResult,
   ExperimentAdherenceCellStatus,
 } from "./experiment-adherence.ts";
+import { resolveExperimentAdherenceRollupTarget } from "./experiment-adherence.ts";
 import {
   collectExperimentAdherenceCalendar,
   summarizeExperimentProgress,
@@ -126,9 +127,14 @@ function buildCardWeeks(input: {
   windows: ExperimentProgressSummary["windows"];
 }): Array<{ start: string; cells: string }> {
   const statusesByDate = new Map<string, ExperimentAdherenceCellStatus[]>();
-  const rollupTargetId = input.calendar?.targets[0]?.targetId ?? null;
+  const targets = input.calendar?.targets ?? [];
+  const rollupTarget = resolveExperimentAdherenceRollupTarget(targets);
+  const hasAmbiguousTargets = targets.length > 1 && !rollupTarget;
+  if (hasAmbiguousTargets) {
+    input.warnings.push("calendar omitted because multiple adherence targets define no single rollup");
+  }
   for (const cell of input.calendar?.cells ?? []) {
-    if (rollupTargetId && cell.targetId !== rollupTargetId) {
+    if (hasAmbiguousTargets || (rollupTarget && cell.targetId !== rollupTarget.targetId)) {
       continue;
     }
     const statuses = statusesByDate.get(cell.localDate) ?? [];

--- a/packages/query/src/experiment-progress-card.ts
+++ b/packages/query/src/experiment-progress-card.ts
@@ -18,6 +18,7 @@ import {
   type ExperimentMetricResult,
   type ExperimentProgressSummary,
 } from "./experiments.ts";
+import type { MetricPoint } from "./metrics/index.ts";
 import type { VaultReadModel } from "./read-model.ts";
 
 /**
@@ -39,6 +40,7 @@ export interface ExperimentProgressCardConfounderInput {
 export interface BuildExperimentProgressCardOptions {
   asOf?: string;
   confounders?: readonly ExperimentProgressCardConfounderInput[];
+  metricPoints?: readonly MetricPoint[];
 }
 
 export interface ExperimentProgressCardBuildResult {
@@ -54,7 +56,10 @@ export function buildExperimentProgressCard(
   options: BuildExperimentProgressCardOptions = {},
 ): ExperimentProgressCardBuildResult {
   const warnings: string[] = [];
-  const progress = summarizeExperimentProgress(vault, slug, { asOf: options.asOf });
+  const progress = summarizeExperimentProgress(vault, slug, {
+    asOf: options.asOf,
+    metricPoints: options.metricPoints,
+  });
   const calendar = collectExperimentAdherenceCalendar(vault, slug, { asOf: options.asOf });
   const windows = progress.windows;
   const runStart = windows.baselineStart ?? windows.interventionStart;

--- a/packages/query/src/experiment-progress-card.ts
+++ b/packages/query/src/experiment-progress-card.ts
@@ -60,7 +60,10 @@ export function buildExperimentProgressCard(
     asOf: options.asOf,
     metricPoints: options.metricPoints,
   });
-  const calendar = collectExperimentAdherenceCalendar(vault, slug, { asOf: options.asOf });
+  const calendar = collectExperimentAdherenceCalendar(vault, slug, {
+    asOf: options.asOf,
+    metricPoints: options.metricPoints,
+  });
   const windows = progress.windows;
   const runStart = windows.baselineStart ?? windows.interventionStart;
   if (!runStart) {

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -695,23 +695,13 @@ function buildAdherenceObservations(
       case "metricPresence":
       case "metricThreshold":
         const metricEvidence = target.evidence;
-        for (const point of context.metricPoints) {
-          if (point.effectiveDate > context.asOf) {
-            continue;
-          }
-          if (!matchesAdherenceMetric(metricEvidence.metricKey, point)) {
-            continue;
-          }
-          const value = point.canonicalValue ?? point.value;
-          if (typeof value !== "number" || !Number.isFinite(value)) {
-            continue;
-          }
+        for (const row of selectMetricAdherenceRows(context, metricEvidence.metricKey)) {
           observations.push({
-            evidenceId: point.id,
-            localDate: point.effectiveDate,
+            evidenceId: row.id,
+            localDate: row.date,
             metricKey: metricEvidence.metricKey,
             targetId: target.targetId,
-            value,
+            value: row.value,
           });
         }
         break;
@@ -719,6 +709,28 @@ function buildAdherenceObservations(
   }
 
   return observations;
+}
+
+function selectMetricAdherenceRows(
+  context: ExperimentSummaryContext,
+  metricKey: string,
+): Array<{ date: string; id: string; value: number }> {
+  const points = context.metricPoints.filter((point) =>
+    point.effectiveDate <= context.asOf && matchesAdherenceMetric(metricKey, point)
+  );
+  const selectedMetricKey = points[0]?.metricKey ?? normalizeMetricKey(metricKey);
+  return selectMetricSeries({
+    metricKey: selectedMetricKey,
+    points,
+  }).rows.flatMap((row) =>
+    typeof row.value === "number" && Number.isFinite(row.value)
+      ? [{
+          date: row.date,
+          id: row.id ?? row.pointIds?.[0] ?? `metric-series:${row.metricKey}:${row.date}`,
+          value: row.value,
+        }]
+      : []
+  );
 }
 
 function matchesAdherenceMetric(metricKey: string, point: MetricPoint): boolean {

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -227,9 +227,13 @@ interface ExperimentSummaryContext {
   experiment: CanonicalEntity;
   frontmatter: QueryExperimentFrontmatter;
   interventionDates: string[];
-  metricPoints: MetricPoint[];
+  metricPoints: readonly MetricPoint[];
   progressPhase: ExperimentProgressPhase;
   summariesByDate: Map<string, WearableDaySummary | null>;
+}
+
+interface ExperimentMetricPointOptions {
+  metricPoints?: readonly MetricPoint[];
 }
 
 interface MetricWindowPair {
@@ -253,7 +257,7 @@ interface MetricWindowSelection {
 export function summarizeExperimentProgress(
   vault: VaultReadModel,
   slug: string,
-  options: { asOf?: string } = {},
+  options: { asOf?: string } & ExperimentMetricPointOptions = {},
 ): ExperimentProgressSummary {
   const context = buildExperimentSummaryContext(vault, slug, options);
   const signals = buildMetricResults(context);
@@ -264,12 +268,17 @@ export function summarizeExperimentProgress(
   const primaryBiomarkerKey = context.frontmatter.analysisPlan?.primaryBiomarkerKey ?? null;
   const hasPrimarySignal =
     primaryBiomarkerKey !== null && primarySignal?.biomarkerKey === primaryBiomarkerKey;
-  const baselineDaysAvailable = hasPrimarySignal
-    ? primarySignal.baselineDayCount
-    : countDatesWithWearableData(context.baselineDates, context.summariesByDate);
-  const interventionDaysAvailable = hasPrimarySignal
-    ? primarySignal.interventionDayCount
-    : countDatesWithWearableData(context.interventionDates, context.summariesByDate);
+  const metricDaysAvailable = summarizeSignalDayCoverage(signals);
+  const baselineDaysAvailable = metricDaysAvailable.baselineDaysAvailable > 0
+    ? metricDaysAvailable.baselineDaysAvailable
+    : hasPrimarySignal
+      ? primarySignal.baselineDayCount
+      : countDatesWithWearableData(context.baselineDates, context.summariesByDate);
+  const interventionDaysAvailable = metricDaysAvailable.interventionDaysAvailable > 0
+    ? metricDaysAvailable.interventionDaysAvailable
+    : hasPrimarySignal
+      ? primarySignal.interventionDayCount
+      : countDatesWithWearableData(context.interventionDates, context.summariesByDate);
   const adherence = {
     ...buildAdherenceSummary(context),
     sessionEventIds: completedSessionEventIds,
@@ -280,6 +289,7 @@ export function summarizeExperimentProgress(
     primarySignal,
     progressPhase: context.progressPhase,
     frontmatter: context.frontmatter,
+    signals,
     summariesByDate: context.summariesByDate,
   });
   const setupReadiness = buildSetupReadiness(context.frontmatter);
@@ -332,7 +342,7 @@ export function summarizeExperimentProgress(
 export function analyzeExperimentOutcome(
   vault: VaultReadModel,
   slug: string,
-  options: { asOf?: string } = {},
+  options: { asOf?: string } & ExperimentMetricPointOptions = {},
 ): ExperimentOutcomeSummary {
   const context = buildExperimentSummaryContext(vault, slug, options);
   const metricResults = buildMetricResults(context);
@@ -391,11 +401,15 @@ export function decideExperimentFollowupDue(
   options: {
     date?: string;
     kind: ExperimentFollowupKind;
+    metricPoints?: readonly MetricPoint[];
     now?: string | number | Date;
   },
 ): ExperimentFollowupDueDecision {
   const date = options.date ?? resolveVaultLocalDate(vault, options.now ?? new Date());
-  const context = buildExperimentSummaryContext(vault, slug, { asOf: date });
+  const context = buildExperimentSummaryContext(vault, slug, {
+    asOf: date,
+    metricPoints: options.metricPoints,
+  });
 
   if (options.kind === "weekly-digest") {
     return decideWeeklyDigestDue(context, date);
@@ -407,7 +421,7 @@ export function decideExperimentFollowupDue(
 function buildExperimentSummaryContext(
   vault: VaultReadModel,
   slug: string,
-  options: { asOf?: string },
+  options: { asOf?: string } & ExperimentMetricPointOptions,
 ): ExperimentSummaryContext {
   const experiment = getExperiment(vault, slug);
   if (!experiment) {
@@ -444,7 +458,7 @@ function buildExperimentSummaryContext(
       frontmatter.runPlan?.interventionStart,
       minIsoDate(frontmatter.runPlan?.interventionEnd, asOf),
     ),
-    metricPoints: buildMetricProjection(vault).metricPoints,
+    metricPoints: options.metricPoints ?? buildMetricProjection(vault).metricPoints,
     progressPhase,
     summariesByDate,
   };
@@ -682,11 +696,18 @@ function buildCoverageSummary(input: {
   frontmatter: ExperimentFrontmatter;
   primarySignal: ExperimentMetricResult | null;
   progressPhase: ExperimentProgressPhase;
+  signals: readonly ExperimentMetricResult[];
   summariesByDate: Map<string, WearableDaySummary | null>;
 }): ExperimentProgressSummary["dataCoverage"] {
   const primaryMetricDaysAvailable =
     (input.primarySignal?.baselineDayCount ?? 0) +
     (input.primarySignal?.interventionDayCount ?? 0);
+  const anySignalMetricData = input.signals.some(
+    (signal) => signal.baselineDayCount + signal.interventionDayCount > 0,
+  );
+  const anyWearableSummaryData = [...input.summariesByDate.values()].some(
+    (summary) => summary !== null && summary.providers.length > 0,
+  );
   let status: ExperimentCoverageStatus = "insufficient";
 
   const hasCompleteMetricWindow = hasAnalysisMetricWindow(input.frontmatter);
@@ -698,7 +719,9 @@ function buildCoverageSummary(input: {
   if (
     input.primarySignal !== null &&
     hasCompleteMetricWindow &&
-    primaryMetricDaysAvailable === 0
+    primaryMetricDaysAvailable === 0 &&
+    !anySignalMetricData &&
+    !anyWearableSummaryData
   ) {
     status = "no_wearable_data";
   } else if (
@@ -717,7 +740,7 @@ function buildCoverageSummary(input: {
     (input.primarySignal?.interventionDayCount ?? 0) >= 2
   ) {
     status = "sufficient_for_progress";
-  } else if (primaryMetricDaysAvailable > 0) {
+  } else if (primaryMetricDaysAvailable > 0 || anySignalMetricData) {
     status = "partial";
   } else {
     status = "insufficient";
@@ -735,6 +758,25 @@ function buildCoverageSummary(input: {
     status,
     wearableProviders,
   };
+}
+
+function summarizeSignalDayCoverage(signals: readonly ExperimentMetricResult[]) {
+  return signals.reduce(
+    (summary, signal) => ({
+      baselineDaysAvailable: Math.max(
+        summary.baselineDaysAvailable,
+        signal.baselineDayCount,
+      ),
+      interventionDaysAvailable: Math.max(
+        summary.interventionDaysAvailable,
+        signal.interventionDayCount,
+      ),
+    }),
+    {
+      baselineDaysAvailable: 0,
+      interventionDaysAvailable: 0,
+    },
+  );
 }
 
 function readinessResult(blockingReasons: ExperimentProgressReadinessReason[]) {

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -26,6 +26,7 @@ import {
 import {
   resolveMetricDefinition,
   resolveMetricDefinitionForBiomarker,
+  normalizeMetricKey,
   selectMetricSeries,
   selectMetricValue,
   selectMetricWindowComparison,
@@ -623,9 +624,15 @@ function buildAdherenceSummary(context: ExperimentSummaryContext): ExperimentPro
     context.frontmatter.runPlan?.minimumUsefulSessions ??
     null;
   const adherenceCalendar = buildAdherenceCalendarFromContext(context);
-  const completedSessions = adherenceCalendar?.summary.satisfiedCount ?? context.completedSessions;
+  const rollupTargetId = targets[0]?.targetId ?? null;
+  const rollupCells = rollupTargetId && adherenceCalendar
+    ? adherenceCalendar.cells.filter((cell) => cell.targetId === rollupTargetId)
+    : null;
+  const completedSessions = rollupCells
+    ? rollupCells.filter((cell) => cell.status === "satisfied").length
+    : context.completedSessions;
   const expectedSessionsByNow = adherenceCalendar
-    ? adherenceCalendar.cells.filter((cell) => cell.status !== "scheduled").length
+    ? (rollupCells ?? adherenceCalendar.cells).filter((cell) => cell.status !== "scheduled").length
     : computeExpectedSessionsByNow(
         context.frontmatter,
         context.asOf,
@@ -716,14 +723,18 @@ function buildAdherenceObservations(
 
 function matchesAdherenceMetric(metricKey: string, point: MetricPoint): boolean {
   const trimmedMetricKey = metricKey.trim();
-  const normalizedMetricKey = trimmedMetricKey.toLowerCase().replaceAll("_", "-");
+  const normalizedMetricKey = normalizeMetricKey(trimmedMetricKey);
+  const metricSlug = trimmedMetricKey.split(":").at(-1) ?? trimmedMetricKey;
   const definition = resolveMetricDefinition(trimmedMetricKey);
   const biomarkerDefinition = resolveMetricDefinitionForBiomarker(trimmedMetricKey);
+  const slugDefinition = resolveMetricDefinition(metricSlug);
   const candidateMetricKeys = new Set([
     trimmedMetricKey,
     normalizedMetricKey,
     definition?.key,
     biomarkerDefinition?.key,
+    slugDefinition?.key,
+    normalizeMetricKey(metricSlug),
   ].filter((value): value is string => typeof value === "string" && value.length > 0));
 
   if (candidateMetricKeys.has(point.metricKey)) {
@@ -1439,7 +1450,6 @@ function collectRunMetricWindows(
     comparisonWindow: metricWindowRangeFromDates(context.interventionDates),
     metricKey,
     points: selectMetricSeries({
-      duplicatePolicy: "keep-all",
       metricKey,
       points: context.metricPoints,
     }).rows,
@@ -1502,25 +1512,51 @@ function collectAnchoredMetricWindow(
     return null;
   }
 
+  const metricKey = resolveMetricKeyForBiomarker(biomarkerKey);
   const values: number[] = [];
   let unit: string | null = null;
   for (const anchor of anchors) {
+    const anchoredPoints = context.metricPoints.filter(
+      (point) =>
+        point.effectiveDate <= context.asOf &&
+        metricPointRecordIds(point).includes(anchor.recordId) &&
+        (metricKey ? point.metricKey === metricKey : point.biomarkerKey === biomarkerKey),
+    );
     const selection = selectMetricValue({
       biomarkerKey,
       now: context.asOf,
-      points: context.metricPoints.filter(
-        (point) => point.source.recordId === anchor.recordId,
-      ),
+      points: anchoredPoints,
     });
-    if (typeof selection.value !== "number" || !Number.isFinite(selection.value)) {
+    const fallbackPoint = anchoredPoints.find((point) =>
+      typeof (point.canonicalValue ?? point.value) === "number" &&
+      Number.isFinite(point.canonicalValue ?? point.value)
+    );
+    const value = typeof selection.value === "number"
+      ? selection.value
+      : fallbackPoint?.canonicalValue ?? fallbackPoint?.value ?? null;
+    if (typeof value !== "number" || !Number.isFinite(value)) {
       continue;
     }
 
-    values.push(selection.value);
-    unit ??= selection.unit ?? null;
+    values.push(value);
+    unit ??= selection.unit ?? fallbackPoint?.canonicalUnit ?? fallbackPoint?.unit ?? null;
   }
 
   return metricWindowSelectionFromValues(values, anchors.length, unit);
+}
+
+function metricPointRecordIds(point: MetricPoint): string[] {
+  const contributingRecordIds = point.context.contributingRecordIds;
+  if (!Array.isArray(contributingRecordIds)) {
+    return [point.source.recordId];
+  }
+
+  return [...new Set([
+    ...contributingRecordIds.filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    ),
+    point.source.recordId,
+  ])];
 }
 
 function emptyMetricWindowSelection(totalDays: number): MetricWindowSelection {

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -1540,18 +1540,18 @@ function collectAnchoredMetricWindow(
       points: anchoredPoints,
     });
     const fallbackPoint = anchoredPoints.find((point) =>
-      typeof (point.canonicalValue ?? point.value) === "number" &&
-      Number.isFinite(point.canonicalValue ?? point.value)
+      typeof point.canonicalValue === "number" &&
+      Number.isFinite(point.canonicalValue) &&
+      typeof point.canonicalUnit === "string" &&
+      point.canonicalUnit.length > 0
     );
-    const value = typeof selection.value === "number"
-      ? selection.value
-      : fallbackPoint?.canonicalValue ?? fallbackPoint?.value ?? null;
+    const value = typeof selection.value === "number" ? selection.value : fallbackPoint?.canonicalValue ?? null;
     if (typeof value !== "number" || !Number.isFinite(value)) {
       continue;
     }
 
     values.push(value);
-    unit ??= selection.unit ?? fallbackPoint?.canonicalUnit ?? fallbackPoint?.unit ?? null;
+    unit ??= typeof selection.value === "number" ? selection.unit : fallbackPoint?.canonicalUnit ?? null;
   }
 
   return metricWindowSelectionFromValues(values, anchors.length, unit);

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -15,6 +15,7 @@ import {
 import { getExperiment, type VaultReadModel } from "./read-model.ts";
 import {
   buildExperimentAdherenceCalendar,
+  resolveExperimentAdherenceRollupTarget,
   synthesizeLegacySessionAdherenceTargets,
   type ExperimentAdherenceCalendarResult,
   type ExperimentAdherenceObservation,
@@ -615,23 +616,26 @@ function buildAdherenceCalendarFromContext(
 
 function buildAdherenceSummary(context: ExperimentSummaryContext): ExperimentProgressSummary["adherence"] {
   const targets = resolveAdherenceTargets(context);
+  const rollupTarget = resolveExperimentAdherenceRollupTarget(targets);
+  const hasAmbiguousTargets = targets.length > 1 && !rollupTarget;
   const targetSessions =
-    targets[0]?.rollup?.targetCompletions ??
-    context.frontmatter.runPlan?.targetSessions ??
-    null;
+    rollupTarget?.rollup?.targetCompletions ??
+    (hasAmbiguousTargets ? null : context.frontmatter.runPlan?.targetSessions ?? null);
   const minimumUsefulSessions =
-    targets[0]?.rollup?.minimumUsefulCompletions ??
-    context.frontmatter.runPlan?.minimumUsefulSessions ??
-    null;
+    rollupTarget?.rollup?.minimumUsefulCompletions ??
+    (hasAmbiguousTargets ? null : context.frontmatter.runPlan?.minimumUsefulSessions ?? null);
   const adherenceCalendar = buildAdherenceCalendarFromContext(context);
-  const rollupTargetId = targets[0]?.targetId ?? null;
-  const rollupCells = rollupTargetId && adherenceCalendar
-    ? adherenceCalendar.cells.filter((cell) => cell.targetId === rollupTargetId)
+  const rollupCells = rollupTarget && adherenceCalendar
+    ? adherenceCalendar.cells.filter((cell) => cell.targetId === rollupTarget.targetId)
     : null;
-  const completedSessions = rollupCells
+  const completedSessions = hasAmbiguousTargets
+    ? 0
+    : rollupCells
     ? rollupCells.filter((cell) => cell.status === "satisfied").length
     : context.completedSessions;
-  const expectedSessionsByNow = adherenceCalendar
+  const expectedSessionsByNow = hasAmbiguousTargets
+    ? null
+    : adherenceCalendar
     ? (rollupCells ?? adherenceCalendar.cells).filter((cell) => cell.status !== "scheduled").length
     : computeExpectedSessionsByNow(
         context.frontmatter,
@@ -640,7 +644,9 @@ function buildAdherenceSummary(context: ExperimentSummaryContext): ExperimentPro
       );
 
   let status: ExperimentAdherenceStatus = "unknown";
-  if (completedSessions === 0) {
+  if (hasAmbiguousTargets) {
+    status = "unknown";
+  } else if (completedSessions === 0) {
     status = "not_started";
   } else if (targetSessions !== null && completedSessions >= targetSessions) {
     status = "met_target";

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -689,6 +689,9 @@ function buildAdherenceObservations(
       case "metricThreshold":
         const metricEvidence = target.evidence;
         for (const point of context.metricPoints) {
+          if (point.effectiveDate > context.asOf) {
+            continue;
+          }
           if (!matchesAdherenceMetric(metricEvidence.metricKey, point)) {
             continue;
           }

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -20,6 +20,7 @@ import {
   type ExperimentAdherenceCalendarResult,
   type ExperimentAdherenceObservation,
 } from "./experiment-adherence.ts";
+import { matchesExperimentMetricIdentity } from "./experiment-metrics.ts";
 import {
   readExperimentProtocolProjectionFields,
   type ExperimentProtocolProjectionFields,
@@ -703,6 +704,7 @@ function buildAdherenceObservations(
         const metricEvidence = target.evidence;
         for (const row of selectMetricAdherenceRows(context, metricEvidence.metricKey)) {
           observations.push({
+            comparator: row.comparator,
             evidenceId: row.id,
             localDate: row.date,
             metricKey: metricEvidence.metricKey,
@@ -720,9 +722,9 @@ function buildAdherenceObservations(
 function selectMetricAdherenceRows(
   context: ExperimentSummaryContext,
   metricKey: string,
-): Array<{ date: string; id: string; value: number }> {
+): Array<{ comparator: MetricPoint["comparator"]; date: string; id: string; value: number }> {
   const points = context.metricPoints.filter((point) =>
-    point.effectiveDate <= context.asOf && matchesAdherenceMetric(metricKey, point)
+    point.effectiveDate <= context.asOf && matchesExperimentMetricIdentity(metricKey, point)
   );
   const selectedMetricKey = points[0]?.metricKey ?? normalizeMetricKey(metricKey);
   return selectMetricSeries({
@@ -731,45 +733,13 @@ function selectMetricAdherenceRows(
   }).rows.flatMap((row) =>
     typeof row.value === "number" && Number.isFinite(row.value)
       ? [{
+          comparator: row.comparator ?? null,
           date: row.date,
           id: row.id ?? row.pointIds?.[0] ?? `metric-series:${row.metricKey}:${row.date}`,
           value: row.value,
         }]
       : []
   );
-}
-
-function matchesAdherenceMetric(metricKey: string, point: MetricPoint): boolean {
-  const trimmedMetricKey = metricKey.trim();
-  const normalizedMetricKey = normalizeMetricKey(trimmedMetricKey);
-  const metricSlug = trimmedMetricKey.split(":").at(-1) ?? trimmedMetricKey;
-  const definition = resolveMetricDefinition(trimmedMetricKey);
-  const biomarkerDefinition = resolveMetricDefinitionForBiomarker(trimmedMetricKey);
-  const slugDefinition = resolveMetricDefinition(metricSlug);
-  const candidateMetricKeys = new Set([
-    trimmedMetricKey,
-    normalizedMetricKey,
-    definition?.key,
-    biomarkerDefinition?.key,
-    slugDefinition?.key,
-    normalizeMetricKey(metricSlug),
-  ].filter((value): value is string => typeof value === "string" && value.length > 0));
-
-  if (candidateMetricKeys.has(point.metricKey)) {
-    return true;
-  }
-
-  const candidateBiomarkerKeys = new Set([
-    trimmedMetricKey,
-    normalizedMetricKey,
-    normalizedMetricKey.startsWith("biomarker:")
-      ? normalizedMetricKey
-      : `biomarker:${normalizedMetricKey}`,
-    definition?.biomarkerKey,
-    biomarkerDefinition?.biomarkerKey,
-  ].filter((value): value is string => typeof value === "string" && value.length > 0));
-
-  return point.biomarkerKey !== null && candidateBiomarkerKeys.has(point.biomarkerKey);
 }
 
 function buildCoverageSummary(input: {

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -24,7 +24,7 @@ import {
   matchesExperimentMetricIdentity,
   resolveExperimentMetricIdentity,
 } from "./experiment-metrics.ts";
-import { metricPointRecordIds } from "./metric-point-record-ids.ts";
+import { metricPointRecordIds } from "./metrics/index.ts";
 import {
   readExperimentProtocolProjectionFields,
   type ExperimentProtocolProjectionFields,

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -33,7 +33,7 @@ import {
   type MetricWindowSummary,
 } from "./metrics/index.ts";
 import { buildMetricProjection } from "./metrics/projection.ts";
-import { summarizeWearableDay, type WearableDaySummary, type WearableResolvedMetric } from "./wearables.ts";
+import { summarizeWearableDay, type WearableDaySummary } from "./wearables.ts";
 
 import type { CanonicalEntity } from "./canonical-entities.ts";
 
@@ -232,6 +232,11 @@ interface ExperimentSummaryContext {
   summariesByDate: Map<string, WearableDaySummary | null>;
 }
 
+type ExperimentFollowupContext = Pick<
+  ExperimentSummaryContext,
+  "events" | "frontmatter" | "progressPhase"
+>;
+
 interface ExperimentMetricPointOptions {
   metricPoints?: readonly MetricPoint[];
 }
@@ -401,15 +406,11 @@ export function decideExperimentFollowupDue(
   options: {
     date?: string;
     kind: ExperimentFollowupKind;
-    metricPoints?: readonly MetricPoint[];
     now?: string | number | Date;
   },
 ): ExperimentFollowupDueDecision {
   const date = options.date ?? resolveVaultLocalDate(vault, options.now ?? new Date());
-  const context = buildExperimentSummaryContext(vault, slug, {
-    asOf: date,
-    metricPoints: options.metricPoints,
-  });
+  const context = buildExperimentFollowupContext(vault, slug, date);
 
   if (options.kind === "weekly-digest") {
     return decideWeeklyDigestDue(context, date);
@@ -461,6 +462,24 @@ function buildExperimentSummaryContext(
     metricPoints: options.metricPoints ?? buildMetricProjection(vault).metricPoints,
     progressPhase,
     summariesByDate,
+  };
+}
+
+function buildExperimentFollowupContext(
+  vault: VaultReadModel,
+  slug: string,
+  asOf: string,
+): ExperimentFollowupContext {
+  const experiment = getExperiment(vault, slug);
+  if (!experiment) {
+    throw new Error(`Experiment "${slug}" was not found in the query read model.`);
+  }
+
+  const frontmatter = requireExperimentFrontmatter(experiment);
+  return {
+    events: findExperimentEvents(vault, experiment, frontmatter, asOf),
+    frontmatter,
+    progressPhase: resolveProgressPhase(frontmatter, asOf),
   };
 }
 
@@ -559,7 +578,7 @@ function resolveExpectedDirection(
 export function collectExperimentAdherenceCalendar(
   vault: VaultReadModel,
   slug: string,
-  options: { asOf?: string } = {},
+  options: { asOf?: string } & ExperimentMetricPointOptions = {},
 ): ExperimentAdherenceCalendarResult | null {
   return buildAdherenceCalendarFromContext(
     buildExperimentSummaryContext(vault, slug, options),
@@ -669,15 +688,17 @@ function buildAdherenceObservations(
       case "metricPresence":
       case "metricThreshold":
         const metricEvidence = target.evidence;
-        for (const [date, summary] of context.summariesByDate) {
-          const metric = resolveAdherenceMetric(metricEvidence.metricKey, summary);
-          if (!metric || typeof metric.selection.value !== "number") {
+        for (const point of context.metricPoints) {
+          if (!matchesAdherenceMetric(metricEvidence.metricKey, point)) {
             continue;
           }
-          const value = metric.selection.value;
+          const value = point.canonicalValue ?? point.value;
+          if (typeof value !== "number" || !Number.isFinite(value)) {
+            continue;
+          }
           observations.push({
-            evidenceId: metric.selection.recordIds[0] ?? `${metricEvidence.metricKey}:${date}`,
-            localDate: date,
+            evidenceId: point.id,
+            localDate: point.effectiveDate,
             metricKey: metricEvidence.metricKey,
             targetId: target.targetId,
             value,
@@ -688,6 +709,35 @@ function buildAdherenceObservations(
   }
 
   return observations;
+}
+
+function matchesAdherenceMetric(metricKey: string, point: MetricPoint): boolean {
+  const trimmedMetricKey = metricKey.trim();
+  const normalizedMetricKey = trimmedMetricKey.toLowerCase().replaceAll("_", "-");
+  const definition = resolveMetricDefinition(trimmedMetricKey);
+  const biomarkerDefinition = resolveMetricDefinitionForBiomarker(trimmedMetricKey);
+  const candidateMetricKeys = new Set([
+    trimmedMetricKey,
+    normalizedMetricKey,
+    definition?.key,
+    biomarkerDefinition?.key,
+  ].filter((value): value is string => typeof value === "string" && value.length > 0));
+
+  if (candidateMetricKeys.has(point.metricKey)) {
+    return true;
+  }
+
+  const candidateBiomarkerKeys = new Set([
+    trimmedMetricKey,
+    normalizedMetricKey,
+    normalizedMetricKey.startsWith("biomarker:")
+      ? normalizedMetricKey
+      : `biomarker:${normalizedMetricKey}`,
+    definition?.biomarkerKey,
+    biomarkerDefinition?.biomarkerKey,
+  ].filter((value): value is string => typeof value === "string" && value.length > 0));
+
+  return point.biomarkerKey !== null && candidateBiomarkerKeys.has(point.biomarkerKey);
 }
 
 function buildCoverageSummary(input: {
@@ -991,7 +1041,7 @@ function buildWindowSummary(
 }
 
 function buildFollowupBase(
-  context: ExperimentSummaryContext,
+  context: ExperimentFollowupContext,
   date: string,
   kind: ExperimentFollowupKind,
   reason: ExperimentFollowupReason,
@@ -1026,7 +1076,7 @@ function buildFollowupBase(
 }
 
 function decideMissedLogDue(
-  context: ExperimentSummaryContext,
+  context: ExperimentFollowupContext,
   date: string,
 ): ExperimentFollowupDueDecision {
   const assistantSupport = context.frontmatter.assistantSupport;
@@ -1087,7 +1137,7 @@ function decideMissedLogDue(
 }
 
 function decideWeeklyDigestDue(
-  context: ExperimentSummaryContext,
+  context: ExperimentFollowupContext,
   date: string,
 ): ExperimentFollowupDueDecision {
   if (context.frontmatter.status !== "active") {
@@ -1515,65 +1565,6 @@ function metricWindowRangeFromDates(
     start: dates[0] ?? null,
     totalDays: dates.length,
   };
-}
-
-function resolveBiomarkerMetric(
-  biomarkerKey: string,
-  summary: WearableDaySummary | null,
-): WearableResolvedMetric | null {
-  if (!summary) {
-    return null;
-  }
-
-  const normalized = biomarkerKey.trim().toLowerCase();
-  if (normalized.includes("resting-heart-rate")) {
-    return summary.recovery?.restingHeartRate ?? null;
-  }
-
-  if (normalized.includes("hrv")) {
-    return summary.recovery?.hrv ?? summary.sleep?.hrv ?? null;
-  }
-
-  if (normalized.includes("sleep-efficiency")) {
-    return summary.sleep?.sleepEfficiency ?? null;
-  }
-
-  if (normalized.includes("deep-sleep")) {
-    return summary.sleep?.deepMinutes ?? null;
-  }
-
-  if (normalized.includes("respiratory-rate")) {
-    return summary.recovery?.respiratoryRate ?? summary.sleep?.respiratoryRate ?? null;
-  }
-
-  if (normalized.includes("temperature")) {
-    return summary.recovery?.temperatureDeviation ?? summary.bodyState?.temperature ?? null;
-  }
-
-  return null;
-}
-
-function resolveAdherenceMetric(
-  metricKey: string,
-  summary: WearableDaySummary | null,
-): WearableResolvedMetric | null {
-  if (!summary) {
-    return null;
-  }
-
-  switch (metricKey.trim()) {
-    case "steps":
-      return summary.activity?.steps ?? null;
-    case "resting-heart-rate":
-    case "resting_heart_rate":
-      return summary.recovery?.restingHeartRate ?? null;
-    case "hrv":
-      return summary.recovery?.hrv ?? summary.sleep?.hrv ?? null;
-    case "sleep-efficiency":
-      return summary.sleep?.sleepEfficiency ?? null;
-    default:
-      return resolveBiomarkerMetric(metricKey, summary);
-  }
 }
 
 function readStringAttribute(entity: CanonicalEntity, key: string): string | null {

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -20,7 +20,11 @@ import {
   type ExperimentAdherenceCalendarResult,
   type ExperimentAdherenceObservation,
 } from "./experiment-adherence.ts";
-import { matchesExperimentMetricIdentity } from "./experiment-metrics.ts";
+import {
+  matchesExperimentMetricIdentity,
+  resolveExperimentMetricIdentity,
+} from "./experiment-metrics.ts";
+import { metricPointRecordIds } from "./metric-point-record-ids.ts";
 import {
   readExperimentProtocolProjectionFields,
   type ExperimentProtocolProjectionFields,
@@ -723,10 +727,10 @@ function selectMetricAdherenceRows(
   context: ExperimentSummaryContext,
   metricKey: string,
 ): Array<{ comparator: MetricPoint["comparator"]; date: string; id: string; value: number }> {
+  const selectedMetricKey = resolveExperimentMetricIdentity(metricKey).metricKey;
   const points = context.metricPoints.filter((point) =>
     point.effectiveDate <= context.asOf && matchesExperimentMetricIdentity(metricKey, point)
   );
-  const selectedMetricKey = points[0]?.metricKey ?? normalizeMetricKey(metricKey);
   return selectMetricSeries({
     metricKey: selectedMetricKey,
     points,
@@ -1531,20 +1535,6 @@ function collectAnchoredMetricWindow(
   }
 
   return metricWindowSelectionFromValues(values, anchors.length, unit);
-}
-
-function metricPointRecordIds(point: MetricPoint): string[] {
-  const contributingRecordIds = point.context.contributingRecordIds;
-  if (!Array.isArray(contributingRecordIds)) {
-    return [point.source.recordId];
-  }
-
-  return [...new Set([
-    ...contributingRecordIds.filter(
-      (value): value is string => typeof value === "string" && value.length > 0,
-    ),
-    point.source.recordId,
-  ])];
 }
 
 function emptyMetricWindowSelection(totalDays: number): MetricWindowSelection {

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -372,6 +372,14 @@ export async function listMetricPoints(
   return mod.listMetricPointsRuntime(vaultRoot, filters);
 }
 
+export async function listMetricPointsBatch(
+  vaultRoot: string,
+  filtersList: readonly QueryMetricPointFilters[],
+): Promise<import("@murphai/health-metrics").MetricPoint[]> {
+  const mod = await import("./query-projection.ts");
+  return mod.listMetricPointsBatchRuntime(vaultRoot, filtersList);
+}
+
 export async function selectMetric(input: {
   biomarkerKey?: string;
   metricKey?: string;

--- a/packages/query/src/metric-point-record-ids.ts
+++ b/packages/query/src/metric-point-record-ids.ts
@@ -1,0 +1,37 @@
+import type { MetricPoint } from "./metrics/index.ts";
+
+export function metricPointRecordIds(point: MetricPoint): string[] {
+  const ids = new Set<string>();
+  const contributingRecordIds = point.context.contributingRecordIds;
+  if (Array.isArray(contributingRecordIds)) {
+    for (const value of contributingRecordIds) {
+      if (typeof value === "string" && value.length > 0) {
+        ids.add(value);
+      }
+    }
+  }
+
+  ids.add(point.source.recordId);
+  if (point.source.kind === "sample-summary") {
+    for (const id of [...ids]) {
+      for (const alias of sampleSummaryRecordIdAliases(id)) {
+        ids.add(alias);
+      }
+    }
+  }
+
+  return [...ids];
+}
+
+function sampleSummaryRecordIdAliases(recordId: string): string[] {
+  const [prefix, first, second] = recordId.split(":");
+  if (prefix !== "sample-summary" || !first || !second) {
+    return [];
+  }
+
+  return isIsoDate(first) ? [`sample-summary:${second}:${first}`] : [];
+}
+
+function isIsoDate(value: string): boolean {
+  return /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/u.test(value);
+}

--- a/packages/query/src/metrics/index.ts
+++ b/packages/query/src/metrics/index.ts
@@ -19,6 +19,7 @@ import {
   inferWearableObservationGrain,
 } from "../wearables/observation.ts";
 import { isDeletionSentinelObservation } from "../observation-sentinels.ts";
+import { buildSampleSummaryId } from "../sample-summary-id.ts";
 
 export { parseGoalMetricTargets } from "./goals.ts";
 
@@ -168,7 +169,7 @@ function metricPointFromSampleSummary(summary: SampleSummaryMetricEvidence): Met
       family: "sample",
       kind: "sample-summary",
       path: "",
-      recordId: `sample-summary:${summary.stream}:${summary.date}`,
+      recordId: buildSampleSummaryId(summary),
       resultIndex: null,
     },
     statistic: "mean",

--- a/packages/query/src/metrics/index.ts
+++ b/packages/query/src/metrics/index.ts
@@ -55,6 +55,7 @@ export {
   formatMetricDisplayValue,
   listMetricPoints,
   listMetricDefinitions,
+  metricPointRecordIds,
   normalizeMetricKey,
   normalizeMetricValue,
   resolveMetricDefinition,

--- a/packages/query/src/projection/metric-store.ts
+++ b/packages/query/src/projection/metric-store.ts
@@ -158,6 +158,13 @@ export function listStoredMetricPoints(
   location: QueryProjectionLocation,
   filters: QueryMetricPointFilters,
 ): MetricPoint[] {
+  return listStoredMetricPointsBatch(location, [filters]);
+}
+
+export function listStoredMetricPointsBatch(
+  location: QueryProjectionLocation,
+  filtersList: readonly QueryMetricPointFilters[],
+): MetricPoint[] {
   const database = openQueryProjectionDatabase(location, {
     create: false,
     readOnly: true,
@@ -166,68 +173,81 @@ export function listStoredMetricPoints(
   try {
     assertQueryProjectionTables(database, location);
 
-    const whereClauses: string[] = [];
-    const parameters: Array<string | number> = [];
-
-    if (filters.metricKey) {
-      whereClauses.push("metric_key = ?");
-      parameters.push(filters.metricKey);
+    const pointsById = new Map<string, MetricPoint>();
+    for (const filters of filtersList) {
+      for (const point of queryStoredMetricPoints(database, filters)) {
+        pointsById.set(point.id, point);
+      }
     }
-    if (filters.biomarkerKey) {
-      whereClauses.push("biomarker_key = ?");
-      parameters.push(filters.biomarkerKey);
-    }
-    if (filters.from) {
-      whereClauses.push("effective_date >= ?");
-      parameters.push(filters.from);
-    }
-    if (filters.to) {
-      whereClauses.push("effective_date <= ?");
-      parameters.push(filters.to);
-    }
-
-    const limit = filters.limit === null ? null : normalizeMetricPointLimit(filters.limit ?? 1_000);
-    const limitSql = limit === null ? "" : "LIMIT ?";
-    if (limit !== null) {
-      parameters.push(limit);
-    }
-    const whereSql = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
-    const rows = database.prepare(`
-      SELECT
-        id,
-        metric_key,
-        biomarker_key,
-        value,
-        text_value,
-        comparator,
-        unit,
-        canonical_value,
-        canonical_unit,
-        observed_at,
-        effective_date,
-        recorded_at,
-        reported_at,
-        grain,
-        statistic,
-        source_family,
-        source_kind,
-        source_record_id,
-        source_result_index,
-        source_path,
-        confidence,
-        metric_point_json
-      FROM query_metric_points
-      ${whereSql}
-      ORDER BY effective_date DESC, observed_at DESC, id ASC
-      ${limitSql}
-    `).all(...parameters);
-
-    return rows
-      .map(decodeStoredMetricPoint)
-      .filter((point): point is MetricPoint => point !== null);
+    return [...pointsById.values()];
   } finally {
     database.close();
   }
+}
+
+function queryStoredMetricPoints(
+  database: DatabaseSync,
+  filters: QueryMetricPointFilters,
+): MetricPoint[] {
+  const whereClauses: string[] = [];
+  const parameters: Array<string | number> = [];
+
+  if (filters.metricKey) {
+    whereClauses.push("metric_key = ?");
+    parameters.push(filters.metricKey);
+  }
+  if (filters.biomarkerKey) {
+    whereClauses.push("biomarker_key = ?");
+    parameters.push(filters.biomarkerKey);
+  }
+  if (filters.from) {
+    whereClauses.push("effective_date >= ?");
+    parameters.push(filters.from);
+  }
+  if (filters.to) {
+    whereClauses.push("effective_date <= ?");
+    parameters.push(filters.to);
+  }
+
+  const limit = filters.limit === null ? null : normalizeMetricPointLimit(filters.limit ?? 1_000);
+  const limitSql = limit === null ? "" : "LIMIT ?";
+  if (limit !== null) {
+    parameters.push(limit);
+  }
+  const whereSql = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
+  const rows = database.prepare(`
+    SELECT
+      id,
+      metric_key,
+      biomarker_key,
+      value,
+      text_value,
+      comparator,
+      unit,
+      canonical_value,
+      canonical_unit,
+      observed_at,
+      effective_date,
+      recorded_at,
+      reported_at,
+      grain,
+      statistic,
+      source_family,
+      source_kind,
+      source_record_id,
+      source_result_index,
+      source_path,
+      confidence,
+      metric_point_json
+    FROM query_metric_points
+    ${whereSql}
+    ORDER BY effective_date DESC, observed_at DESC, id ASC
+    ${limitSql}
+  `).all(...parameters);
+
+  return rows
+    .map(decodeStoredMetricPoint)
+    .filter((point): point is MetricPoint => point !== null);
 }
 
 export function normalizeMetricPointFilters(filters: QueryMetricPointFilters): QueryMetricPointFilters {

--- a/packages/query/src/projection/schema.ts
+++ b/packages/query/src/projection/schema.ts
@@ -13,8 +13,8 @@ export type DatabaseSync = import("node:sqlite").DatabaseSync;
 export type SqliteRow = Record<string, unknown>;
 
 export const QUERY_PROJECTION_SCHEMA_ID = "murph.query-projection";
-// 12: compact metric point supplemental payloads.
-export const QUERY_PROJECTION_SQLITE_VERSION = 12;
+// 13: canonical sample-summary metric point source ids.
+export const QUERY_PROJECTION_SQLITE_VERSION = 13;
 
 export interface QueryProjectionLocation {
   absolutePath: string;

--- a/packages/query/src/query-projection.ts
+++ b/packages/query/src/query-projection.ts
@@ -60,6 +60,7 @@ import {
 } from "./projection/wearable-summary-compose.ts";
 import {
   listStoredMetricPoints,
+  listStoredMetricPointsBatch,
   listStoredMetricTargets,
   metricPointFiltersForGoalTarget,
   normalizeMetricPointFilters,
@@ -145,6 +146,21 @@ export async function listMetricPointsRuntime(
 ): Promise<MetricPoint[]> {
   const location = await ensureFreshQueryProjection(vaultRoot);
   return listStoredMetricPoints(location, normalizeMetricPointFilters(filters));
+}
+
+export async function listMetricPointsBatchRuntime(
+  vaultRoot: string,
+  filtersList: readonly QueryMetricPointFilters[],
+): Promise<MetricPoint[]> {
+  if (filtersList.length === 0) {
+    return [];
+  }
+
+  const location = await ensureFreshQueryProjection(vaultRoot);
+  return listStoredMetricPointsBatch(
+    location,
+    filtersList.map(normalizeMetricPointFilters),
+  );
 }
 
 export async function summarizeWearableDayRuntime(

--- a/packages/query/src/sample-summary-id.ts
+++ b/packages/query/src/sample-summary-id.ts
@@ -1,0 +1,9 @@
+export interface SampleSummaryIdInput {
+  date: string;
+  stream: string;
+  unit?: string | null;
+}
+
+export function buildSampleSummaryId(summary: SampleSummaryIdInput): string {
+  return `sample-summary:${summary.date}:${summary.stream}:${summary.unit ?? "none"}`;
+}

--- a/packages/query/src/search-shared.ts
+++ b/packages/query/src/search-shared.ts
@@ -6,6 +6,7 @@ import {
   type CanonicalEntityFamily,
 } from "./canonical-entities.ts";
 import { isSearchIndexedQueryEntity } from "./query-visibility.ts";
+import { buildSampleSummaryId } from "./sample-summary-id.ts";
 import type { DailySampleSummary } from "./summaries.ts";
 
 const DEFAULT_LIMIT = 20;
@@ -309,7 +310,7 @@ function buildSampleSummarySearchDocument(
   },
 ): SearchableDocument {
   const unit = summary.unit ?? "none";
-  const recordId = `sample-summary:${summary.date}:${summary.stream}:${unit}`;
+  const recordId = buildSampleSummaryId(summary);
   const title = `${summary.stream} daily summary`;
   const tags = ["sample_summary", summary.stream, unit];
   const structuredText = compactStrings([

--- a/packages/query/src/timeline.ts
+++ b/packages/query/src/timeline.ts
@@ -9,6 +9,7 @@ import {
   summarizeDailySamples,
   type DailySampleSummary,
 } from "./summaries.ts";
+import { buildSampleSummaryId } from "./sample-summary-id.ts";
 
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 500;
@@ -243,10 +244,6 @@ function summaryToTimelineEntry(summary: DailySampleSummary): TimelineEntry {
       sourcePaths: summary.sourcePaths,
     },
   };
-}
-
-function buildSampleSummaryId(summary: DailySampleSummary): string {
-  return `sample-summary:${summary.date}:${summary.stream}:${summary.unit ?? "none"}`;
 }
 
 function compareTimelineEntries(left: TimelineEntry, right: TimelineEntry): number {

--- a/packages/query/test/browser-vault-experiment-results.test.ts
+++ b/packages/query/test/browser-vault-experiment-results.test.ts
@@ -1147,7 +1147,7 @@ test("returns null schedule when the run has no structured schedule", () => {
   assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"));
 });
 
-test("uses explicit metric adherence targets instead of legacy schedule synthesis", () => {
+test("does not synthesize legacy schedules for unsupported explicit metric adherence targets", () => {
   const client = createBrowserVaultQueryClient(
     createReplica({
       entities: [
@@ -1187,64 +1187,9 @@ test("uses explicit metric adherence targets instead of legacy schedule synthesi
   const result = selectBrowserVaultExperimentResults(client, "finnish-sauna-run");
 
   assert.ok(result);
-  assert.ok(result.schedule);
-  assert.equal(result.schedule.cells.every((cell) => cell.targetId === "step-floor"), true);
-  assert.equal(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"), false);
-});
-
-test("matches browser metric adherence targets through biomarker aliases", () => {
-  const client = createBrowserVaultQueryClient(
-    createReplica({
-      generatedAt: "2026-04-10T12:00:00.000Z",
-      entities: [
-        experimentEntity({
-          runPlan: {
-            baselineStart: "2026-04-01",
-            baselineEnd: "2026-04-07",
-            interventionStart: "2026-04-08",
-            interventionEnd: "2026-04-08",
-            adherenceTargets: [{
-              targetId: "sleep-efficiency-floor",
-              label: "Sleep efficiency floor",
-              phase: "intervention",
-              calendar: {
-                kind: "daily",
-                timeZone: "America/New_York",
-              },
-              evidence: {
-                kind: "metricThreshold",
-                metricKey: "biomarker:sleep-efficiency",
-                op: ">=",
-                value: 90,
-                missing: "unknown",
-              },
-              rollup: {
-                minimumUsefulCompletions: 1,
-                targetCompletions: 1,
-              },
-            }],
-          },
-        }),
-      ],
-      metricRows: [
-        metricRow({
-          biomarkerKey: "biomarker:sleep-efficiency",
-          date: "2026-04-08",
-          metricKey: "sleep-efficiency",
-          unit: "%",
-          value: 91,
-        }),
-      ],
-    }),
-  );
-
-  const result = selectBrowserVaultExperimentResults(client, "finnish-sauna-run");
-
-  assert.ok(result);
-  assert.equal(result.schedule?.cells[0]?.kind, "completed");
-  assert.equal(result.schedule?.completedSessions, 1);
-  assert.equal(result.progress?.adherence.completedSessions, 1);
-  assert.equal(result.progress?.adherence.status, "met_target");
+  assert.equal(result.schedule, null);
+  assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "invalid_schedule"));
+  assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"));
 });
 
 test("keeps comparator-bounded metric thresholds unknown", () => {
@@ -1412,15 +1357,12 @@ test("does not replace metric adherence rollups with auxiliary session targets",
   const result = selectBrowserVaultExperimentResults(client, "finnish-sauna-run");
 
   assert.ok(result);
-  assert.equal(result.schedule?.cells.length, 2);
-  assert.equal(result.schedule?.cells.find((cell) => cell.targetId === "session-marker")?.kind, "completed");
-  assert.equal(result.schedule?.completedSessions, 0);
-  assert.equal(result.schedule?.unknownSessions, 1);
-  assert.equal(result.schedule?.plannedSessions, 1);
-  assert.equal(result.progress?.adherence.completedSessions, 0);
-  assert.equal(result.progress?.adherence.loggedSessions, 0);
-  assert.equal(result.progress?.adherence.targetSessions, 1);
-  assert.equal(result.progress?.adherence.status, "not_started");
+  assert.equal(result.schedule, null);
+  assert.equal(result.progress?.adherence.completedSessions, 1);
+  assert.equal(result.progress?.adherence.loggedSessions, 1);
+  assert.equal(result.progress?.adherence.targetSessions, null);
+  assert.equal(result.progress?.adherence.status, "on_track");
+  assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "invalid_schedule"));
 });
 
 test("treats measurement anchors as browser analysis windows when run windows are absent", () => {

--- a/packages/query/test/browser-vault-experiment-results.test.ts
+++ b/packages/query/test/browser-vault-experiment-results.test.ts
@@ -1144,7 +1144,7 @@ test("returns null schedule when the run has no structured schedule", () => {
   assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"));
 });
 
-test("does not synthesize a legacy schedule when explicit browser targets are unsupported", () => {
+test("uses explicit metric adherence targets instead of legacy schedule synthesis", () => {
   const client = createBrowserVaultQueryClient(
     createReplica({
       entities: [
@@ -1184,8 +1184,9 @@ test("does not synthesize a legacy schedule when explicit browser targets are un
   const result = selectBrowserVaultExperimentResults(client, "finnish-sauna-run");
 
   assert.ok(result);
-  assert.equal(result.schedule, null);
-  assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"));
+  assert.ok(result.schedule);
+  assert.equal(result.schedule.cells.every((cell) => cell.targetId === "step-floor"), true);
+  assert.equal(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"), false);
 });
 
 test("uses adherence target rollups for browser progress targets", () => {
@@ -1251,6 +1252,74 @@ test("uses adherence target rollups for browser progress targets", () => {
   assert.equal(result.schedule?.plannedSessions, 3);
   assert.equal(result.schedule?.cells.length, 6);
   assert.equal(result.schedule?.cells.filter((cell) => cell.targetId === "sauna").length, 3);
+});
+
+test("does not replace metric adherence rollups with auxiliary session targets", () => {
+  const client = createBrowserVaultQueryClient(
+    createReplica({
+      generatedAt: "2026-04-10T12:00:00.000Z",
+      entities: [
+        experimentEntity({
+          runPlan: {
+            baselineStart: "2026-04-01",
+            baselineEnd: "2026-04-07",
+            interventionStart: "2026-04-08",
+            interventionEnd: "2026-04-08",
+            adherenceTargets: [
+              {
+                targetId: "step-floor",
+                label: "Step floor",
+                phase: "intervention",
+                calendar: {
+                  kind: "daily",
+                  timeZone: "America/New_York",
+                },
+                evidence: {
+                  kind: "metricThreshold",
+                  metricKey: "steps",
+                  op: ">=",
+                  value: 8000,
+                  missing: "unknown",
+                },
+                rollup: {
+                  targetCompletions: 1,
+                  minimumUsefulCompletions: 1,
+                },
+              },
+              {
+                targetId: "session-marker",
+                label: "Session marker",
+                phase: "intervention",
+                calendar: {
+                  kind: "daily",
+                  timeZone: "America/New_York",
+                },
+                evidence: {
+                  kind: "linkedEventCount",
+                  eventKind: "intervention_session",
+                  missing: "missed_after_grace",
+                },
+              },
+            ],
+          },
+        }),
+        sessionEvent("2026-04-08", "completed"),
+      ],
+    }),
+  );
+
+  const result = selectBrowserVaultExperimentResults(client, "finnish-sauna-run");
+
+  assert.ok(result);
+  assert.equal(result.schedule?.cells.length, 2);
+  assert.equal(result.schedule?.cells.find((cell) => cell.targetId === "session-marker")?.kind, "completed");
+  assert.equal(result.schedule?.completedSessions, 0);
+  assert.equal(result.schedule?.unknownSessions, 1);
+  assert.equal(result.schedule?.plannedSessions, 1);
+  assert.equal(result.progress?.adherence.completedSessions, 0);
+  assert.equal(result.progress?.adherence.loggedSessions, 0);
+  assert.equal(result.progress?.adherence.targetSessions, 1);
+  assert.equal(result.progress?.adherence.status, "not_started");
 });
 
 test("treats measurement anchors as browser analysis windows when run windows are absent", () => {

--- a/packages/query/test/browser-vault-experiment-results.test.ts
+++ b/packages/query/test/browser-vault-experiment-results.test.ts
@@ -12,7 +12,10 @@ import {
   type BrowserVaultMetricRow,
   type BrowserVaultReplica,
 } from "../src/browser.ts";
-import { buildExperimentAdherenceCalendar } from "../src/experiment-adherence.ts";
+import {
+  buildExperimentAdherenceCalendar,
+  type ExperimentAdherenceObservation,
+} from "../src/experiment-adherence.ts";
 
 test("returns null when no matching private run exists", () => {
   const client = createBrowserVaultQueryClient(createReplica());
@@ -1187,6 +1190,104 @@ test("uses explicit metric adherence targets instead of legacy schedule synthesi
   assert.ok(result.schedule);
   assert.equal(result.schedule.cells.every((cell) => cell.targetId === "step-floor"), true);
   assert.equal(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"), false);
+});
+
+test("matches browser metric adherence targets through biomarker aliases", () => {
+  const client = createBrowserVaultQueryClient(
+    createReplica({
+      generatedAt: "2026-04-10T12:00:00.000Z",
+      entities: [
+        experimentEntity({
+          runPlan: {
+            baselineStart: "2026-04-01",
+            baselineEnd: "2026-04-07",
+            interventionStart: "2026-04-08",
+            interventionEnd: "2026-04-08",
+            adherenceTargets: [{
+              targetId: "sleep-efficiency-floor",
+              label: "Sleep efficiency floor",
+              phase: "intervention",
+              calendar: {
+                kind: "daily",
+                timeZone: "America/New_York",
+              },
+              evidence: {
+                kind: "metricThreshold",
+                metricKey: "biomarker:sleep-efficiency",
+                op: ">=",
+                value: 90,
+                missing: "unknown",
+              },
+              rollup: {
+                minimumUsefulCompletions: 1,
+                targetCompletions: 1,
+              },
+            }],
+          },
+        }),
+      ],
+      metricRows: [
+        metricRow({
+          biomarkerKey: "biomarker:sleep-efficiency",
+          date: "2026-04-08",
+          metricKey: "sleep-efficiency",
+          unit: "%",
+          value: 91,
+        }),
+      ],
+    }),
+  );
+
+  const result = selectBrowserVaultExperimentResults(client, "finnish-sauna-run");
+
+  assert.ok(result);
+  assert.equal(result.schedule?.cells[0]?.kind, "completed");
+  assert.equal(result.schedule?.completedSessions, 1);
+  assert.equal(result.progress?.adherence.completedSessions, 1);
+  assert.equal(result.progress?.adherence.status, "met_target");
+});
+
+test("keeps comparator-bounded metric thresholds unknown", () => {
+  const target = {
+    targetId: "glucose-ceiling",
+    label: "Glucose ceiling",
+    phase: "intervention",
+    calendar: {
+      kind: "daily",
+      timeZone: "UTC",
+    },
+    evidence: {
+      kind: "metricThreshold",
+      metricKey: "glucose",
+      op: "<=",
+      value: 100,
+      missing: "unknown",
+    },
+  } satisfies ExperimentAdherenceTarget;
+  const observations: Array<ExperimentAdherenceObservation & { comparator: ">" }> = [{
+    comparator: ">",
+    evidenceId: "evt_glucose_1",
+    localDate: "2026-04-08",
+    metricKey: "glucose",
+    targetId: "glucose-ceiling",
+    value: 100,
+  }];
+
+  const result = buildExperimentAdherenceCalendar({
+    asOf: "2026-04-10",
+    observations,
+    targets: [target],
+    windows: {
+      baselineEnd: null,
+      baselineStart: null,
+      interventionEnd: "2026-04-08",
+      interventionStart: "2026-04-08",
+    },
+  });
+
+  assert.equal(result.cells[0]?.status, "unknown");
+  assert.equal(result.cells[0]?.score, null);
+  assert.deepEqual(result.cells[0]?.evidenceIds, ["evt_glucose_1"]);
 });
 
 test("uses adherence target rollups for browser progress targets", () => {

--- a/packages/query/test/browser-vault-experiment-results.test.ts
+++ b/packages/query/test/browser-vault-experiment-results.test.ts
@@ -1199,24 +1199,40 @@ test("uses adherence target rollups for browser progress targets", () => {
             baselineEnd: "2026-04-07",
             interventionStart: "2026-04-08",
             interventionEnd: "2026-04-10",
-            adherenceTargets: [{
-              targetId: "sauna",
-              label: "Sauna",
-              phase: "intervention",
-              calendar: {
-                kind: "daily",
-                timeZone: "America/New_York",
+            adherenceTargets: [
+              {
+                targetId: "session-marker",
+                label: "Session marker",
+                phase: "intervention",
+                calendar: {
+                  kind: "daily",
+                  timeZone: "America/New_York",
+                },
+                evidence: {
+                  kind: "linkedEventCount",
+                  eventKind: "intervention_session",
+                  missing: "missed_after_grace",
+                },
               },
-              evidence: {
-                kind: "linkedEventCount",
-                eventKind: "intervention_session",
-                missing: "missed_after_grace",
+              {
+                targetId: "sauna",
+                label: "Sauna",
+                phase: "intervention",
+                calendar: {
+                  kind: "daily",
+                  timeZone: "America/New_York",
+                },
+                evidence: {
+                  kind: "linkedEventCount",
+                  eventKind: "intervention_session",
+                  missing: "missed_after_grace",
+                },
+                rollup: {
+                  targetCompletions: 2,
+                  minimumUsefulCompletions: 1,
+                },
               },
-              rollup: {
-                targetCompletions: 2,
-                minimumUsefulCompletions: 1,
-              },
-            }],
+            ],
           },
         }),
         sessionEvent("2026-04-08", "completed"),
@@ -1231,6 +1247,10 @@ test("uses adherence target rollups for browser progress targets", () => {
   assert.equal(result.progress?.adherence.targetSessions, 2);
   assert.equal(result.progress?.adherence.minimumUsefulSessions, 1);
   assert.equal(result.progress?.adherence.status, "met_target");
+  assert.equal(result.schedule?.completedSessions, 2);
+  assert.equal(result.schedule?.plannedSessions, 3);
+  assert.equal(result.schedule?.cells.length, 6);
+  assert.equal(result.schedule?.cells.filter((cell) => cell.targetId === "sauna").length, 3);
 });
 
 test("treats measurement anchors as browser analysis windows when run windows are absent", () => {

--- a/packages/query/test/browser-vault-experiment-results.test.ts
+++ b/packages/query/test/browser-vault-experiment-results.test.ts
@@ -1189,7 +1189,8 @@ test("does not synthesize legacy schedules for unsupported explicit metric adher
   assert.ok(result);
   assert.equal(result.schedule, null);
   assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "invalid_schedule"));
-  assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "no_schedule"));
+  assert.equal(result.progress?.adherence.status, "unknown");
+  assert.equal(result.progress?.adherence.loggedSessions, 0);
 });
 
 test("keeps comparator-bounded metric thresholds unknown", () => {
@@ -1351,6 +1352,14 @@ test("does not replace metric adherence rollups with auxiliary session targets",
         }),
         sessionEvent("2026-04-08", "completed"),
       ],
+      metricRows: restingHeartRateRows([
+        ["2026-04-01", 62],
+        ["2026-04-02", 61],
+        ["2026-04-03", 63],
+        ["2026-04-08", 58],
+        ["2026-04-09", 57],
+        ["2026-04-10", 59],
+      ]),
     }),
   );
 
@@ -1358,11 +1367,14 @@ test("does not replace metric adherence rollups with auxiliary session targets",
 
   assert.ok(result);
   assert.equal(result.schedule, null);
-  assert.equal(result.progress?.adherence.completedSessions, 1);
-  assert.equal(result.progress?.adherence.loggedSessions, 1);
+  assert.equal(result.progress?.adherence.completedSessions, 0);
+  assert.equal(result.progress?.adherence.loggedSessions, 0);
   assert.equal(result.progress?.adherence.targetSessions, null);
-  assert.equal(result.progress?.adherence.status, "on_track");
+  assert.equal(result.progress?.adherence.status, "unknown");
   assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "invalid_schedule"));
+  assert.ok(result.outcome?.confidence.reasons.includes(
+    "Browser Results cannot evaluate this experiment's adherence target yet.",
+  ));
 });
 
 test("treats measurement anchors as browser analysis windows when run windows are absent", () => {

--- a/packages/query/test/browser-vault-replica.test.ts
+++ b/packages/query/test/browser-vault-replica.test.ts
@@ -301,6 +301,62 @@ test("browser vault replica keeps metric adherence targets", async () => {
   assert.equal((targets[1] as Record<string, unknown>).targetId, "steps");
 });
 
+test("browser vault replica includes custom metric adherence target rows", async () => {
+  const replica = await createBrowserVaultReplicaFromVault({
+    generatedAt: "2026-04-20T12:00:00.000Z",
+    sourceBundleHash: "d".repeat(64),
+    vault: createVaultReadModel({
+      entities: [
+        createEntity("experiment", "exp_custom_metric_adherence", {
+          frontmatter: {
+            runPlan: {
+              baselineStart: "2026-04-01",
+              baselineEnd: "2026-04-07",
+              interventionStart: "2026-04-08",
+              interventionEnd: "2026-04-14",
+              adherenceTargets: [{
+                targetId: "custom-score",
+                label: "Custom score",
+                phase: "intervention",
+                calendar: {
+                  kind: "daily",
+                  timeZone: "UTC",
+                },
+                evidence: {
+                  kind: "metricThreshold",
+                  metricKey: "custom-reaction-time",
+                  op: "<=",
+                  value: 300,
+                  missing: "unknown",
+                },
+              }],
+            },
+          },
+        }),
+        createEntity("sample", "smp_custom_reaction_time", {
+          attributes: {
+            metric: "custom-reaction-time",
+            source: "manual",
+            unit: "ms",
+            value: 280,
+          },
+          kind: "metric_sample",
+          occurredAt: "2026-04-08T08:00:00.000Z",
+          path: "ledger/metric-samples/custom-reaction-time/2026/2026-04.jsonl",
+          stream: "custom-reaction-time",
+        }),
+      ],
+      metadata: null,
+      vaultRoot: "browser://vault",
+    }),
+  });
+
+  assert.ok(replica.metricRows.some((row) =>
+    row.metricKey === "custom-reaction-time" &&
+    row.recordIds.includes("smp_custom_reaction_time")
+  ));
+});
+
 test("browser vault replica keeps old anchored metric points by contributing record id", async () => {
   const replica = await createBrowserVaultReplica({
     generatedAt: "2026-06-01T12:00:00.000Z",

--- a/packages/query/test/browser-vault-replica.test.ts
+++ b/packages/query/test/browser-vault-replica.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import { test } from "vitest";
 
+import type { MetricPoint } from "../src/metrics/index.ts";
 import {
   BROWSER_VAULT_REPLICA_SCHEMA,
   createBrowserVaultQueryClient,
@@ -236,7 +237,7 @@ test("browser vault replicas validate schema", () => {
   );
 });
 
-test("browser vault replica keeps only browser-supported adherence targets", async () => {
+test("browser vault replica keeps metric adherence targets", async () => {
   const replica = await createBrowserVaultReplicaFromVault({
     generatedAt: "2026-04-20T12:00:00.000Z",
     sourceBundleHash: "c".repeat(64),
@@ -295,8 +296,58 @@ test("browser vault replica keeps only browser-supported adherence targets", asy
   assert.ok(runPlan && typeof runPlan === "object" && !Array.isArray(runPlan));
   const targets = (runPlan as Record<string, unknown>).adherenceTargets;
   assert.ok(Array.isArray(targets));
-  assert.equal(targets.length, 1);
+  assert.equal(targets.length, 2);
   assert.equal((targets[0] as Record<string, unknown>).targetId, "sauna");
+  assert.equal((targets[1] as Record<string, unknown>).targetId, "steps");
+});
+
+test("browser vault replica keeps old anchored metric points by contributing record id", async () => {
+  const replica = await createBrowserVaultReplica({
+    generatedAt: "2026-06-01T12:00:00.000Z",
+    metricPoints: [
+      createMetricPoint({
+        biomarkerKey: "biomarker:resting-heart-rate",
+        contributingRecordIds: ["sample_anchor_rhr_baseline"],
+        effectiveDate: "2025-01-01",
+        metricKey: "resting-heart-rate",
+        recordId: "summary_rhr_baseline",
+        unit: "bpm",
+        value: 62,
+      }),
+    ],
+    sourceBundleHash: "d".repeat(64),
+    vault: createVaultReadModel({
+      entities: [
+        createEntity("experiment", "exp_anchor_rhr", {
+          frontmatter: {
+            analysisPlan: {
+              primaryBiomarkerKey: "biomarker:resting-heart-rate",
+              measurementAnchors: [{
+                role: "baseline",
+                kind: "wearable_summary",
+                recordId: "sample_anchor_rhr_baseline",
+                biomarkerKeys: ["biomarker:resting-heart-rate"],
+              }],
+            },
+            runPlan: {
+              baselineStart: "2026-05-01",
+              baselineEnd: "2026-05-07",
+              interventionStart: "2026-05-08",
+              interventionEnd: "2026-05-14",
+            },
+          },
+          kind: "experiment",
+        }),
+      ],
+      metadata: null,
+      vaultRoot: "browser://vault",
+    }),
+  });
+
+  const row = replica.metricRows.find((entry) => entry.metricKey === "resting-heart-rate");
+  assert.ok(row);
+  assert.equal(row.date, "2025-01-01");
+  assert.equal(row.recordIds.includes("sample_anchor_rhr_baseline"), true);
 });
 
 test("browser vault replica projects experiment event fields only for relevant event kinds", async () => {
@@ -543,6 +594,54 @@ function createEntity(
     stream,
     tags: overrides.tags ?? [],
     title,
+  };
+}
+
+function createMetricPoint(input: {
+  biomarkerKey: string | null;
+  contributingRecordIds?: readonly string[];
+  effectiveDate: string;
+  metricKey: string;
+  recordId: string;
+  unit: string;
+  value: number;
+}): MetricPoint {
+  return {
+    biomarkerKey: input.biomarkerKey,
+    canonicalUnit: input.unit,
+    canonicalValue: input.value,
+    comparator: null,
+    confidence: "medium",
+    context: input.contributingRecordIds
+      ? { contributingRecordIds: input.contributingRecordIds.slice() }
+      : {},
+    effectiveDate: input.effectiveDate,
+    grain: "day",
+    id: `metric-point:${input.metricKey}:${input.effectiveDate}`,
+    metricKey: input.metricKey,
+    observedAt: `${input.effectiveDate}T00:00:00.000Z`,
+    provenance: {
+      dataOrigin: null,
+      externalRef: null,
+      labName: null,
+      provider: null,
+      rawRefs: [],
+      sourceLabel: "Wearable summary",
+    },
+    recordedAt: null,
+    reportedAt: null,
+    schemaVersion: "murph.metric-point.v1",
+    source: {
+      family: "derived",
+      kind: "wearable-summary",
+      path: "",
+      recordId: input.recordId,
+      resultIndex: null,
+    },
+    statistic: "value",
+    textValue: null,
+    unit: input.unit,
+    value: input.value,
   };
 }
 

--- a/packages/query/test/browser-vault-replica.test.ts
+++ b/packages/query/test/browser-vault-replica.test.ts
@@ -9,6 +9,7 @@ import {
   createBrowserVaultReplica,
   createVaultReadModel,
   parseBrowserVaultReplica,
+  selectBrowserVaultExperimentResults,
   selectBrowserVaultHistory,
   selectBrowserVaultOverview,
   selectBrowserVaultTrackedExperiments,
@@ -404,6 +405,88 @@ test("browser vault replica keeps old anchored metric points by contributing rec
   assert.ok(row);
   assert.equal(row.date, "2025-01-01");
   assert.equal(row.recordIds.includes("sample_anchor_rhr_baseline"), true);
+});
+
+test("browser vault results match legacy sample-summary anchors after replica projection", async () => {
+  const baselinePoint = createMetricPoint({
+    biomarkerKey: "biomarker:blood-glucose",
+    effectiveDate: "2025-01-01",
+    metricKey: "glucose",
+    recordId: "sample-summary:2025-01-01:glucose:mg_dL",
+    unit: "mg/dL",
+    value: 100,
+  });
+  const followupPoint = createMetricPoint({
+    biomarkerKey: "biomarker:blood-glucose",
+    effectiveDate: "2025-01-02",
+    metricKey: "glucose",
+    recordId: "sample-summary:2025-01-02:glucose:mg_dL",
+    unit: "mg/dL",
+    value: 96,
+  });
+  const replica = await createBrowserVaultReplica({
+    generatedAt: "2026-06-01T12:00:00.000Z",
+    metricPoints: [
+      {
+        ...baselinePoint,
+        source: { ...baselinePoint.source, kind: "sample-summary" },
+      },
+      {
+        ...followupPoint,
+        source: { ...followupPoint.source, kind: "sample-summary" },
+      },
+    ],
+    sourceBundleHash: "d".repeat(64),
+    vault: createVaultReadModel({
+      entities: [
+        createEntity("experiment", "exp_legacy_glucose", {
+          frontmatter: {
+            analysisPlan: {
+              primaryBiomarkerKey: "biomarker:blood-glucose",
+              desiredDirection: "decrease",
+              measurementAnchors: [
+                {
+                  role: "baseline",
+                  kind: "wearable_summary",
+                  recordId: "sample-summary:glucose:2025-01-01",
+                  biomarkerKeys: ["biomarker:blood-glucose"],
+                },
+                {
+                  role: "followup",
+                  kind: "wearable_summary",
+                  recordId: "sample-summary:glucose:2025-01-02",
+                  biomarkerKeys: ["biomarker:blood-glucose"],
+                },
+              ],
+            },
+            runPlan: {
+              baselineStart: "2026-05-01",
+              baselineEnd: "2026-05-07",
+              interventionStart: "2026-05-08",
+              interventionEnd: "2026-05-14",
+            },
+            slug: "legacy-glucose-anchor",
+            status: "completed",
+          },
+          experimentSlug: "legacy-glucose-anchor",
+          kind: "experiment",
+          lookupIds: ["exp_legacy_glucose", "legacy-glucose-anchor"],
+          status: "completed",
+        }),
+      ],
+      metadata: null,
+      vaultRoot: "browser://vault",
+    }),
+  });
+
+  const result = selectBrowserVaultExperimentResults(
+    createBrowserVaultQueryClient(replica),
+    "legacy-glucose-anchor",
+  );
+
+  assert.equal(result?.biomarkers[0]?.baseline.mean, 100);
+  assert.equal(result?.biomarkers[0]?.intervention.mean, 96);
+  assert.equal(result?.biomarkers[0]?.deltaAbs, -4);
 });
 
 test("browser vault replica projects experiment event fields only for relevant event kinds", async () => {

--- a/packages/query/test/browser-vault-replica.test.ts
+++ b/packages/query/test/browser-vault-replica.test.ts
@@ -301,7 +301,7 @@ test("browser vault replica keeps metric adherence targets", async () => {
   assert.equal((targets[1] as Record<string, unknown>).targetId, "steps");
 });
 
-test("browser vault replica includes custom metric adherence target rows", async () => {
+test("browser vault replica does not request custom metric rows for unsupported adherence targets", async () => {
   const replica = await createBrowserVaultReplicaFromVault({
     generatedAt: "2026-04-20T12:00:00.000Z",
     sourceBundleHash: "d".repeat(64),
@@ -351,10 +351,10 @@ test("browser vault replica includes custom metric adherence target rows", async
     }),
   });
 
-  assert.ok(replica.metricRows.some((row) =>
+  assert.equal(replica.metricRows.some((row) =>
     row.metricKey === "custom-reaction-time" &&
     row.recordIds.includes("smp_custom_reaction_time")
-  ));
+  ), false);
 });
 
 test("browser vault replica keeps old anchored metric points by contributing record id", async () => {

--- a/packages/query/test/experiment-analysis.test.ts
+++ b/packages/query/test/experiment-analysis.test.ts
@@ -287,6 +287,8 @@ function makeProjectedGlucosePoint(input: {
 
 function makeProjectedMetricPoint(input: {
   biomarkerKey: string;
+  canonicalUnit?: string | null;
+  canonicalValue?: number | null;
   contributingRecordIds?: string[];
   date: string;
   metricKey: string;
@@ -299,8 +301,8 @@ function makeProjectedMetricPoint(input: {
   return {
     schemaVersion: "murph.metric-point.v1",
     biomarkerKey: input.biomarkerKey,
-    canonicalUnit: input.unit,
-    canonicalValue: input.value,
+    canonicalUnit: input.canonicalUnit === undefined ? input.unit : input.canonicalUnit,
+    canonicalValue: input.canonicalValue === undefined ? input.value : input.canonicalValue,
     comparator: null,
     confidence: "medium",
     context: {
@@ -771,6 +773,78 @@ test("experiment analysis matches anchors against contributing metric records", 
   assert.equal(outcome.metricResults[0]?.baselineMean, 100);
   assert.equal(outcome.metricResults[0]?.interventionMean, 96);
   assert.equal(outcome.metricResults[0]?.deltaAbs, -4);
+});
+
+test("experiment analysis skips uncanonicalized anchored metric fallback values", () => {
+  const experiment = makeExperiment("completed", {
+    experimentId: "exp_01JNV4458HYPP53JDQCBP1QJGW",
+    slug: "glucose-uncanonicalized-anchors",
+    runPlan: {
+      baselineStart: "2026-06-01",
+      baselineEnd: "2026-06-01",
+      interventionStart: "2026-06-02",
+      interventionEnd: "2026-06-02",
+    },
+    analysisPlan: {
+      primaryBiomarkerKey: "biomarker:blood-glucose",
+      desiredDirection: "decrease",
+      measurementAnchors: [
+        {
+          role: "baseline",
+          kind: "wearable_summary",
+          recordId: "sample_glucose_canonical_baseline",
+          biomarkerKeys: ["biomarker:blood-glucose"],
+          observedOn: "2026-06-01",
+        },
+        {
+          role: "followup",
+          kind: "wearable_summary",
+          recordId: "sample_glucose_raw_followup",
+          biomarkerKeys: ["biomarker:blood-glucose"],
+          observedOn: "2026-06-02",
+        },
+      ],
+    },
+  });
+  const vault = createVaultReadModel({
+    vaultRoot: "/virtual/experiment-analysis-uncanonicalized-anchors",
+    metadata: null,
+    entities: [experiment],
+  });
+
+  const outcome = analyzeExperimentOutcome(vault, "glucose-uncanonicalized-anchors", {
+    asOf: "2026-06-02",
+    metricPoints: [
+      makeProjectedMetricPoint({
+        biomarkerKey: "biomarker:blood-glucose",
+        contributingRecordIds: ["sample_glucose_canonical_baseline"],
+        date: "2026-06-01",
+        metricKey: "glucose",
+        sourceKind: "wearable-summary",
+        sourceLabel: "Wearable summary",
+        sourceRecordId: "summary_glucose_canonical_baseline",
+        unit: "mg/dL",
+        value: 100,
+      }),
+      makeProjectedMetricPoint({
+        biomarkerKey: "biomarker:blood-glucose",
+        canonicalUnit: null,
+        canonicalValue: null,
+        contributingRecordIds: ["sample_glucose_raw_followup"],
+        date: "2026-06-02",
+        metricKey: "glucose",
+        sourceKind: "wearable-summary",
+        sourceLabel: "Wearable summary",
+        sourceRecordId: "summary_glucose_raw_followup",
+        unit: "g/L",
+        value: 0.9,
+      }),
+    ],
+  });
+
+  assert.equal(outcome.metricResults[0]?.baselineMean, 100);
+  assert.equal(outcome.metricResults[0]?.interventionMean, null);
+  assert.equal(outcome.metricResults[0]?.deltaAbs, null);
 });
 
 test("metric adherence uses the selected same-day metric point", () => {

--- a/packages/query/test/experiment-analysis.test.ts
+++ b/packages/query/test/experiment-analysis.test.ts
@@ -922,6 +922,81 @@ test("metric adherence uses the selected same-day metric point", () => {
   assert.equal(progress.adherence.status, "not_started");
 });
 
+test("metric adherence exact-matches metrics that share a biomarker", () => {
+  const experiment = makeExperiment("active", {
+    experimentId: "exp_01JNV4458HYPP53JDQCBP1QJGD",
+    slug: "lowest-spo2-adherence",
+    runPlan: {
+      baselineStart: "2026-06-01",
+      baselineEnd: "2026-06-01",
+      interventionStart: "2026-06-02",
+      interventionEnd: "2026-06-02",
+      adherenceTargets: [
+        {
+          targetId: "lowest-spo2-threshold",
+          label: "Lowest SpO2 threshold",
+          phase: "intervention",
+          calendar: {
+            kind: "daily",
+            timeZone: "UTC",
+          },
+          evidence: {
+            kind: "metricThreshold",
+            metricKey: "lowest-spo2",
+            op: ">=",
+            value: 90,
+            missing: "unknown",
+          },
+          rollup: {
+            targetCompletions: 1,
+            minimumUsefulCompletions: 1,
+          },
+        },
+      ],
+    },
+    analysisPlan: {
+      primaryBiomarkerKey: "biomarker:blood-oxygen-spo2",
+      desiredDirection: "increase",
+    },
+  });
+  const vault = createVaultReadModel({
+    vaultRoot: "/virtual/experiment-adherence-exact-metric",
+    metadata: null,
+    entities: [experiment],
+  });
+  const metricPoints: MetricPoint[] = [
+    makeProjectedMetricPoint({
+      biomarkerKey: "biomarker:blood-oxygen-spo2",
+      date: "2026-06-02",
+      metricKey: "spo2",
+      sourceKind: "wearable-summary",
+      sourceLabel: "Oxygen summary",
+      sourceRecordId: "spo2_2026_06_02",
+      unit: "%",
+      value: 96,
+    }),
+    makeProjectedMetricPoint({
+      biomarkerKey: "biomarker:blood-oxygen-spo2",
+      date: "2026-06-02",
+      metricKey: "lowest-spo2",
+      sourceKind: "sleep-summary",
+      sourceLabel: "Sleep oxygen summary",
+      sourceRecordId: "lowest_spo2_2026_06_02",
+      unit: "%",
+      value: 85,
+    }),
+  ];
+
+  const progress = summarizeExperimentProgress(vault, "lowest-spo2-adherence", {
+    asOf: "2026-06-02",
+    metricPoints,
+  });
+
+  assert.equal(progress.adherence.completedSessions, 0);
+  assert.equal(progress.adherence.expectedSessionsByNow, 1);
+  assert.equal(progress.adherence.status, "not_started");
+});
+
 test("incomplete point measurement plans do not mix lab anchors with run windows", () => {
   const experiment = makeExperiment("completed", {
     experimentId: "exp_01JNV4458HYPP53JDQCBP1QJFK",

--- a/packages/query/test/experiment-analysis.test.ts
+++ b/packages/query/test/experiment-analysis.test.ts
@@ -9,6 +9,7 @@ import {
   buildExperimentProgressCard,
   decideExperimentFollowupDue,
   summarizeExperimentProgress,
+  type MetricPoint,
 } from "../src/index.ts";
 import {
   buildExperimentProgressCardPath,
@@ -263,6 +264,52 @@ function makeMetricSample(input: {
       value: input.value,
     },
   });
+}
+
+function makeProjectedGlucosePoint(input: {
+  contributingRecordIds: string[];
+  date: string;
+  sourceRecordId: string;
+  value: number;
+}): MetricPoint {
+  return {
+    schemaVersion: "murph.metric-point.v1",
+    biomarkerKey: "biomarker:blood-glucose",
+    canonicalUnit: "mg/dL",
+    canonicalValue: input.value,
+    comparator: null,
+    confidence: "medium",
+    context: {
+      contributingRecordIds: input.contributingRecordIds,
+      syntheticRecordId: input.sourceRecordId,
+    },
+    effectiveDate: input.date,
+    grain: "day",
+    id: `metric-point:${input.sourceRecordId}`,
+    metricKey: "glucose",
+    observedAt: `${input.date}T12:00:00.000Z`,
+    provenance: {
+      dataOrigin: null,
+      externalRef: null,
+      labName: null,
+      provider: "whoop",
+      rawRefs: [],
+      sourceLabel: "Wearable summary",
+    },
+    recordedAt: `${input.date}T12:00:00.000Z`,
+    reportedAt: null,
+    source: {
+      family: "derived",
+      kind: "wearable-summary",
+      path: "derived/wearable-summary",
+      recordId: input.sourceRecordId,
+      resultIndex: null,
+    },
+    statistic: "value",
+    textValue: null,
+    unit: "mg/dL",
+    value: input.value,
+  };
 }
 
 function makeSession(input: {
@@ -619,6 +666,87 @@ test("experiment analysis uses lab measurement anchors separately from run basel
   assert.equal(outcome.metricResults[0]?.baselineMean, 140);
   assert.equal(outcome.metricResults[0]?.interventionMean, 120);
   assert.equal(outcome.metricResults[0]?.deltaAbs, -20);
+
+  const historicalProgress = summarizeExperimentProgress(vault, "psyllium-ldl", {
+    asOf: "2026-06-01",
+  });
+  assert.equal(historicalProgress.signals[0]?.baselineMean, 140);
+  assert.equal(historicalProgress.signals[0]?.interventionMean, null);
+  assert.equal(historicalProgress.signals[0]?.deltaAbs, null);
+
+  const historicalOutcome = analyzeExperimentOutcome(vault, "psyllium-ldl", {
+    asOf: "2026-06-01",
+  });
+  assert.equal(historicalOutcome.metricResults[0]?.baselineMean, 140);
+  assert.equal(historicalOutcome.metricResults[0]?.interventionMean, null);
+  assert.equal(historicalOutcome.metricResults[0]?.deltaAbs, null);
+});
+
+test("experiment analysis matches anchors against contributing metric records", () => {
+  const experiment = makeExperiment("completed", {
+    experimentId: "exp_01JNV4458HYPP53JDQCBP1QJGP",
+    slug: "glucose-summary-anchors",
+    runPlan: {
+      baselineStart: "2026-06-01",
+      baselineEnd: "2026-06-01",
+      interventionStart: "2026-06-02",
+      interventionEnd: "2026-06-02",
+    },
+    analysisPlan: {
+      primaryBiomarkerKey: "biomarker:blood-glucose",
+      desiredDirection: "decrease",
+      measurementAnchors: [
+        {
+          role: "baseline",
+          kind: "wearable_summary",
+          recordId: "sample_glucose_baseline_selected",
+          biomarkerKeys: ["biomarker:blood-glucose"],
+          observedOn: "2026-06-01",
+        },
+        {
+          role: "followup",
+          kind: "wearable_summary",
+          recordId: "sample_glucose_followup_selected",
+          biomarkerKeys: ["biomarker:blood-glucose"],
+          observedOn: "2026-06-02",
+        },
+      ],
+    },
+  });
+  const vault = createVaultReadModel({
+    vaultRoot: "/virtual/experiment-analysis-contributing-anchors",
+    metadata: null,
+    entities: [experiment],
+  });
+  const metricPoints: MetricPoint[] = [
+    makeProjectedGlucosePoint({
+      date: "2026-06-01",
+      sourceRecordId: "wearable-summary:blood-glucose:2026-06-01",
+      contributingRecordIds: [
+        "sample_glucose_baseline_other",
+        "sample_glucose_baseline_selected",
+      ],
+      value: 100,
+    }),
+    makeProjectedGlucosePoint({
+      date: "2026-06-02",
+      sourceRecordId: "wearable-summary:blood-glucose:2026-06-02",
+      contributingRecordIds: [
+        "sample_glucose_followup_other",
+        "sample_glucose_followup_selected",
+      ],
+      value: 96,
+    }),
+  ];
+
+  const outcome = analyzeExperimentOutcome(vault, "glucose-summary-anchors", {
+    asOf: "2026-06-02",
+    metricPoints,
+  });
+
+  assert.equal(outcome.metricResults[0]?.baselineMean, 100);
+  assert.equal(outcome.metricResults[0]?.interventionMean, 96);
+  assert.equal(outcome.metricResults[0]?.deltaAbs, -4);
 });
 
 test("incomplete point measurement plans do not mix lab anchors with run windows", () => {

--- a/packages/query/test/experiment-analysis.test.ts
+++ b/packages/query/test/experiment-analysis.test.ts
@@ -272,21 +272,45 @@ function makeProjectedGlucosePoint(input: {
   sourceRecordId: string;
   value: number;
 }): MetricPoint {
+  return makeProjectedMetricPoint({
+    biomarkerKey: "biomarker:blood-glucose",
+    contributingRecordIds: input.contributingRecordIds,
+    date: input.date,
+    metricKey: "glucose",
+    sourceKind: "wearable-summary",
+    sourceLabel: "Wearable summary",
+    sourceRecordId: input.sourceRecordId,
+    unit: "mg/dL",
+    value: input.value,
+  });
+}
+
+function makeProjectedMetricPoint(input: {
+  biomarkerKey: string;
+  contributingRecordIds?: string[];
+  date: string;
+  metricKey: string;
+  sourceKind: MetricPoint["source"]["kind"];
+  sourceLabel: string;
+  sourceRecordId: string;
+  unit: string;
+  value: number;
+}): MetricPoint {
   return {
     schemaVersion: "murph.metric-point.v1",
-    biomarkerKey: "biomarker:blood-glucose",
-    canonicalUnit: "mg/dL",
+    biomarkerKey: input.biomarkerKey,
+    canonicalUnit: input.unit,
     canonicalValue: input.value,
     comparator: null,
     confidence: "medium",
     context: {
-      contributingRecordIds: input.contributingRecordIds,
+      contributingRecordIds: input.contributingRecordIds ?? [input.sourceRecordId],
       syntheticRecordId: input.sourceRecordId,
     },
     effectiveDate: input.date,
     grain: "day",
     id: `metric-point:${input.sourceRecordId}`,
-    metricKey: "glucose",
+    metricKey: input.metricKey,
     observedAt: `${input.date}T12:00:00.000Z`,
     provenance: {
       dataOrigin: null,
@@ -294,20 +318,20 @@ function makeProjectedGlucosePoint(input: {
       labName: null,
       provider: "whoop",
       rawRefs: [],
-      sourceLabel: "Wearable summary",
+      sourceLabel: input.sourceLabel,
     },
     recordedAt: `${input.date}T12:00:00.000Z`,
     reportedAt: null,
     source: {
       family: "derived",
-      kind: "wearable-summary",
-      path: "derived/wearable-summary",
+      kind: input.sourceKind,
+      path: `derived/${input.sourceKind}`,
       recordId: input.sourceRecordId,
       resultIndex: null,
     },
     statistic: "value",
     textValue: null,
-    unit: "mg/dL",
+    unit: input.unit,
     value: input.value,
   };
 }
@@ -747,6 +771,81 @@ test("experiment analysis matches anchors against contributing metric records", 
   assert.equal(outcome.metricResults[0]?.baselineMean, 100);
   assert.equal(outcome.metricResults[0]?.interventionMean, 96);
   assert.equal(outcome.metricResults[0]?.deltaAbs, -4);
+});
+
+test("metric adherence uses the selected same-day metric point", () => {
+  const experiment = makeExperiment("active", {
+    experimentId: "exp_01JNV4458HYPP53JDQCBP1QJGS",
+    slug: "hrv-adherence-selection",
+    runPlan: {
+      baselineStart: "2026-06-01",
+      baselineEnd: "2026-06-01",
+      interventionStart: "2026-06-02",
+      interventionEnd: "2026-06-02",
+      adherenceTargets: [
+        {
+          targetId: "hrv-threshold",
+          label: "HRV threshold",
+          phase: "intervention",
+          calendar: {
+            kind: "daily",
+            timeZone: "UTC",
+          },
+          evidence: {
+            kind: "metricThreshold",
+            metricKey: "hrv-rmssd",
+            op: ">=",
+            value: 50,
+            missing: "unknown",
+          },
+          rollup: {
+            targetCompletions: 1,
+            minimumUsefulCompletions: 1,
+          },
+        },
+      ],
+    },
+    analysisPlan: {
+      primaryBiomarkerKey: "biomarker:hrv-rmssd",
+      desiredDirection: "increase",
+    },
+  });
+  const vault = createVaultReadModel({
+    vaultRoot: "/virtual/experiment-adherence-selected-metric",
+    metadata: null,
+    entities: [experiment],
+  });
+  const metricPoints: MetricPoint[] = [
+    makeProjectedMetricPoint({
+      biomarkerKey: "biomarker:hrv-rmssd",
+      date: "2026-06-02",
+      metricKey: "hrv-rmssd",
+      sourceKind: "wearable-summary",
+      sourceLabel: "Recovery summary",
+      sourceRecordId: "recovery_hrv_2026_06_02",
+      unit: "ms",
+      value: 40,
+    }),
+    makeProjectedMetricPoint({
+      biomarkerKey: "biomarker:hrv-rmssd",
+      date: "2026-06-02",
+      metricKey: "hrv-rmssd",
+      sourceKind: "sleep-summary",
+      sourceLabel: "Sleep summary",
+      sourceRecordId: "sleep_hrv_2026_06_02",
+      unit: "ms",
+      value: 55,
+    }),
+  ];
+
+  const progress = summarizeExperimentProgress(vault, "hrv-adherence-selection", {
+    asOf: "2026-06-02",
+    metricPoints,
+  });
+
+  assert.equal(progress.adherence.completedSessions, 0);
+  assert.equal(progress.adherence.expectedSessionsByNow, 1);
+  assert.equal(progress.adherence.status, "not_started");
 });
 
 test("incomplete point measurement plans do not mix lab anchors with run windows", () => {

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -4529,10 +4529,10 @@ test("rebuildQueryProjection creates the compact metric point schema", async () 
     });
 
     try {
-      // Pin the literal version: a revert of the 11 -> 12 bump would keep every
-      // constant-relative assertion green while legacy v11 stores still carried
-      // full metric point JSON payloads.
-      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 12);
+      // Pin the literal version: a revert of the latest bump would keep every
+      // constant-relative assertion green while legacy stores still carried old
+      // projected metric point identities.
+      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 13);
       assert.equal(readSqliteRuntimeUserVersion(database), QUERY_PROJECTION_SQLITE_VERSION);
 
       const columnRows = database
@@ -4665,6 +4665,7 @@ test("listMetricPointsRuntime preserves full compact metric point context from r
     const sampleSummary = points.find((point) => point.source.kind === "sample-summary");
 
     assert.ok(sampleSummary);
+    assert.equal(sampleSummary.source.recordId, "sample-summary:2026-04-01:glucose:mg_dL");
     assert.equal(sampleSummary.context.firstSampleAt, "2026-04-01T08:00:00Z");
     assert.equal(sampleSummary.context.lastSampleAt, "2026-04-01T12:15:00Z");
     assert.equal(sampleSummary.context.numericSampleCount, 2);

--- a/packages/vault-usecases/src/option-utils.ts
+++ b/packages/vault-usecases/src/option-utils.ts
@@ -237,7 +237,7 @@ function normalizeInternalRecordIdField(value: string, optionName: string) {
     /[\\/@]/u.test(normalized) ||
     normalized.includes('://') ||
     normalized.includes('..') ||
-    !/^(?:evt|sample|batch|metric_sample)_[A-Za-z0-9][A-Za-z0-9_-]*$|^sample-summary:[0-9]{4}-[0-9]{2}-[0-9]{2}:[A-Za-z0-9_-]+:[A-Za-z0-9_.%/-]+$/u.test(normalized)
+    !/^(?:evt|sample|batch|metric_sample)_[A-Za-z0-9][A-Za-z0-9_-]*$|^sample-summary:[0-9]{4}-[0-9]{2}-[0-9]{2}:[A-Za-z0-9_-]+:[A-Za-z0-9_.%/-]+$|^sample-summary:[A-Za-z0-9_-]+:[0-9]{4}-[0-9]{2}-[0-9]{2}$/u.test(normalized)
   ) {
     throw new VaultCliError(
       'invalid_option',

--- a/packages/vault-usecases/src/query-runtime.ts
+++ b/packages/vault-usecases/src/query-runtime.ts
@@ -10,6 +10,7 @@ import type {
   MealNutritionTotals as SharedMealNutritionTotals,
   MealNutritionTotalsOptions as SharedMealNutritionTotalsOptions,
   MealNutritionTotalsResult as SharedMealNutritionTotalsResult,
+  QueryMetricPointFilters as SharedQueryMetricPointFilters,
   QueryProjectionStatus as SharedQueryProjectionStatus,
   RebuildQueryProjectionResult as SharedQueryProjectionRebuildResult,
   SearchCitation as SharedSearchCitation,
@@ -47,6 +48,7 @@ export type QuerySearchFilters = SharedSearchFilters
 export type QuerySearchResult = SharedSearchResult
 export type QueryProjectionStatus = SharedQueryProjectionStatus
 export type QueryProjectionRebuildResult = SharedQueryProjectionRebuildResult
+export type QueryMetricPointFilters = SharedQueryMetricPointFilters
 export type QueryTimelineFilters = SharedTimelineFilters
 export type QueryTimelineEntry = SharedTimelineEntry
 export type QueryExportPackFile = SharedExportPackFile

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2063,26 +2063,15 @@ function buildExperimentMetricPointFilters(
   const dateFilter = buildExperimentMetricPointDateFilter(frontmatter, asOf)
   const anchorMetricKeys = collectExperimentAnchorMetricKeys(query, frontmatter)
   return metricKeys.flatMap((metricKey) => {
-    const anchorDateFilters = anchorMetricKeys.has(metricKey)
-      ? buildExperimentAnchorMetricPointDateFilters(query, frontmatter, metricKey, asOf)
-      : []
-    const dateFilters = [
-      ...(hasMetricPointDateFilter(dateFilter) ? [dateFilter] : []),
-      ...anchorDateFilters,
-    ]
-    const filters = dateFilters.length > 0 ? dateFilters : [dateFilter]
+    const filters = anchorMetricKeys.has(metricKey)
+      ? [buildExperimentAnchorMetricPointDateFilter(asOf)]
+      : [dateFilter]
     return filters.map((filter) => ({
       ...filter,
       limit: null,
       metricKey,
     }))
   })
-}
-
-function hasMetricPointDateFilter(
-  filter: Pick<QueryMetricPointFilters, 'from' | 'to'>,
-): boolean {
-  return typeof filter.from === 'string' || typeof filter.to === 'string'
 }
 
 function collectExperimentMetricKeys(
@@ -2190,35 +2179,10 @@ function buildExperimentMetricPointDateFilter(
   }
 }
 
-function buildExperimentAnchorMetricPointDateFilters(
-  query: QueryRuntimeModule,
-  frontmatter: ExperimentFrontmatter,
-  metricKey: string,
+function buildExperimentAnchorMetricPointDateFilter(
   asOf?: string,
-): Array<Pick<QueryMetricPointFilters, 'from' | 'to'>> {
-  const dates = new Set<string>()
-  let needsHistory = false
-  for (const anchor of frontmatter.analysisPlan?.measurementAnchors ?? []) {
-    const matchesMetricKey = anchor.biomarkerKeys.some(
-      (biomarkerKey) => resolveExperimentBiomarkerMetricKey(query, biomarkerKey) === metricKey,
-    )
-    if (!matchesMetricKey) {
-      continue
-    }
-
-    if (!anchor.observedOn) {
-      needsHistory = true
-      continue
-    }
-    if (!asOf || anchor.observedOn <= asOf) {
-      dates.add(anchor.observedOn)
-    }
-  }
-
-  return [
-    ...(needsHistory ? [{ ...(asOf ? { to: asOf } : {}) }] : []),
-    ...sortedIsoDates([...dates]).map((date) => ({ from: date, to: date })),
-  ]
+): Pick<QueryMetricPointFilters, 'to'> {
+  return asOf ? { to: asOf } : {}
 }
 
 function capExperimentMetricEndDate(

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2061,8 +2061,11 @@ function buildExperimentMetricPointFilters(
   }
 
   const dateFilter = buildExperimentMetricPointDateFilter(frontmatter, asOf)
+  const anchorMetricKeys = collectExperimentAnchorMetricKeys(query, frontmatter)
   return metricKeys.map((metricKey) => ({
-    ...dateFilter,
+    ...(anchorMetricKeys.has(metricKey)
+      ? buildExperimentAnchorMetricPointDateFilter(asOf)
+      : dateFilter),
     limit: null,
     metricKey,
   }))
@@ -2078,13 +2081,7 @@ function collectExperimentMetricKeys(
     analysisPlan?.primaryBiomarkerKey,
     ...(analysisPlan?.secondaryBiomarkerKeys ?? []),
   ]) {
-    if (!biomarkerKey) {
-      continue
-    }
-
-    const metricKey =
-      query.resolveMetricDefinitionForBiomarker(biomarkerKey)?.key ??
-      query.resolveMetricDefinition(biomarkerKey.split(':').at(-1) ?? biomarkerKey)?.key
+    const metricKey = resolveExperimentBiomarkerMetricKey(query, biomarkerKey)
     if (metricKey) {
       metricKeys.add(metricKey)
     }
@@ -2109,6 +2106,38 @@ function collectExperimentMetricKeys(
   return [...metricKeys].sort((left, right) => left.localeCompare(right))
 }
 
+function collectExperimentAnchorMetricKeys(
+  query: QueryRuntimeModule,
+  frontmatter: ExperimentFrontmatter,
+): Set<string> {
+  const metricKeys = new Set<string>()
+  for (const anchor of frontmatter.analysisPlan?.measurementAnchors ?? []) {
+    for (const biomarkerKey of anchor.biomarkerKeys) {
+      const metricKey = resolveExperimentBiomarkerMetricKey(query, biomarkerKey)
+      if (metricKey) {
+        metricKeys.add(metricKey)
+      }
+    }
+  }
+
+  return metricKeys
+}
+
+function resolveExperimentBiomarkerMetricKey(
+  query: QueryRuntimeModule,
+  biomarkerKey: string | null | undefined,
+): string | null {
+  if (!biomarkerKey) {
+    return null
+  }
+
+  return (
+    query.resolveMetricDefinitionForBiomarker(biomarkerKey)?.key ??
+    query.resolveMetricDefinition(biomarkerKey.split(':').at(-1) ?? biomarkerKey)?.key ??
+    null
+  )
+}
+
 function buildExperimentMetricPointDateFilter(
   frontmatter: ExperimentFrontmatter,
   asOf?: string,
@@ -2124,20 +2153,47 @@ function buildExperimentMetricPointDateFilter(
     }
   }
 
-  addRange(frontmatter.runPlan?.baselineStart, frontmatter.runPlan?.baselineEnd)
+  addRange(
+    frontmatter.runPlan?.baselineStart,
+    capExperimentMetricEndDate(frontmatter.runPlan?.baselineEnd, asOf),
+  )
   addRange(
     frontmatter.runPlan?.interventionStart,
-    frontmatter.runPlan?.interventionEnd ?? asOf,
+    capExperimentMetricEndDate(frontmatter.runPlan?.interventionEnd, asOf),
   )
 
   for (const measurement of frontmatter.analysisPlan?.plannedMeasurements ?? []) {
-    addRange(measurement.targetWindow?.start, measurement.targetWindow?.end)
+    addRange(
+      measurement.targetWindow?.start,
+      capExperimentMetricEndDate(measurement.targetWindow?.end, asOf),
+    )
   }
 
   return {
     ...(starts.length > 0 ? { from: sortedIsoDates(starts)[0] } : {}),
     ...(ends.length > 0 ? { to: sortedIsoDates(ends).at(-1) } : {}),
   }
+}
+
+function buildExperimentAnchorMetricPointDateFilter(
+  asOf?: string,
+): Pick<QueryMetricPointFilters, 'to'> {
+  return asOf ? { to: asOf } : {}
+}
+
+function capExperimentMetricEndDate(
+  configuredEnd: string | null | undefined,
+  asOf: string | undefined,
+): string | null | undefined {
+  if (!asOf) {
+    return configuredEnd
+  }
+
+  if (!configuredEnd) {
+    return asOf
+  }
+
+  return configuredEnd < asOf ? configuredEnd : asOf
 }
 
 function sortedIsoDates(values: readonly string[]) {

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2037,14 +2037,7 @@ async function readExperimentJournalMetricPoints(input: {
   }
 
   try {
-    const pointsById = new Map<string, Awaited<ReturnType<QueryRuntimeModule['listMetricPoints']>>[number]>()
-    for (const filter of filters) {
-      for (const point of await input.query.listMetricPoints(input.vault, filter)) {
-        pointsById.set(point.id, point)
-      }
-    }
-
-    return [...pointsById.values()]
+    return await input.query.listMetricPointsBatch(input.vault, filters)
   } catch (error) {
     throw toVaultMetadataCliError(error)
   }

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -1428,9 +1428,11 @@ export async function showExperimentProgress(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
+  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
 
   const progress = query.summarizeExperimentProgress(readModel, slug, {
     asOf: input.asOf,
+    metricPoints,
   })
 
   return {
@@ -1454,10 +1456,12 @@ export async function showExperimentProgressCard(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
+  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
 
   const { card, warnings } = query.buildExperimentProgressCard(readModel, slug, {
     asOf: input.asOf,
     confounders: input.confounders,
+    metricPoints,
   })
 
   return {
@@ -1482,10 +1486,12 @@ export async function showExperimentFollowupDue(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
+  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
 
   const decision = query.decideExperimentFollowupDue(readModel, slug, {
     kind: input.kind,
     date: input.date,
+    metricPoints,
   })
 
   return {
@@ -1508,9 +1514,11 @@ export async function analyzeExperimentOutcomeRecord(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
+  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
 
   const outcome = query.analyzeExperimentOutcome(readModel, slug, {
     asOf: input.asOf,
+    metricPoints,
   })
 
   return {
@@ -1997,6 +2005,17 @@ async function readExperimentJournalVault(vault: string) {
 
   try {
     return await query.readVault(vault)
+  } catch (error) {
+    throw toVaultMetadataCliError(error)
+  }
+}
+
+async function readExperimentJournalMetricPoints(
+  query: QueryRuntimeModule,
+  vault: string,
+) {
+  try {
+    return await query.listMetricPoints(vault, { limit: null })
   } catch (error) {
     throw toVaultMetadataCliError(error)
   }

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2197,19 +2197,28 @@ function buildExperimentAnchorMetricPointDateFilters(
   asOf?: string,
 ): Array<Pick<QueryMetricPointFilters, 'from' | 'to'>> {
   const dates = new Set<string>()
+  let needsHistory = false
   for (const anchor of frontmatter.analysisPlan?.measurementAnchors ?? []) {
-    if (!anchor.observedOn || (asOf && anchor.observedOn > asOf)) {
-      continue
-    }
     const matchesMetricKey = anchor.biomarkerKeys.some(
       (biomarkerKey) => resolveExperimentBiomarkerMetricKey(query, biomarkerKey) === metricKey,
     )
-    if (matchesMetricKey) {
+    if (!matchesMetricKey) {
+      continue
+    }
+
+    if (!anchor.observedOn) {
+      needsHistory = true
+      continue
+    }
+    if (!asOf || anchor.observedOn <= asOf) {
       dates.add(anchor.observedOn)
     }
   }
 
-  return sortedIsoDates([...dates]).map((date) => ({ from: date, to: date }))
+  return [
+    ...(needsHistory ? [{ ...(asOf ? { to: asOf } : {}) }] : []),
+    ...sortedIsoDates([...dates]).map((date) => ({ from: date, to: date })),
+  ]
 }
 
 function capExperimentMetricEndDate(

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2062,13 +2062,17 @@ function buildExperimentMetricPointFilters(
 
   const dateFilter = buildExperimentMetricPointDateFilter(frontmatter, asOf)
   const anchorMetricKeys = collectExperimentAnchorMetricKeys(query, frontmatter)
-  return metricKeys.map((metricKey) => ({
-    ...(anchorMetricKeys.has(metricKey)
-      ? buildExperimentAnchorMetricPointDateFilter(asOf)
-      : dateFilter),
-    limit: null,
-    metricKey,
-  }))
+  return metricKeys.flatMap((metricKey) => {
+    const anchorDateFilters = anchorMetricKeys.has(metricKey)
+      ? buildExperimentAnchorMetricPointDateFilters(query, frontmatter, metricKey, asOf)
+      : []
+    const dateFilters = anchorDateFilters.length > 0 ? anchorDateFilters : [dateFilter]
+    return dateFilters.map((filter) => ({
+      ...filter,
+      limit: null,
+      metricKey,
+    }))
+  })
 }
 
 function collectExperimentMetricKeys(
@@ -2096,8 +2100,9 @@ function collectExperimentMetricKeys(
     }
 
     const metricKey =
+      resolveExperimentBiomarkerMetricKey(query, target.evidence.metricKey) ??
       query.resolveMetricDefinition(target.evidence.metricKey)?.key ??
-      target.evidence.metricKey.trim().toLowerCase().replaceAll('_', '-')
+      query.normalizeMetricKey(target.evidence.metricKey)
     if (metricKey.length > 0) {
       metricKeys.add(metricKey)
     }
@@ -2175,10 +2180,26 @@ function buildExperimentMetricPointDateFilter(
   }
 }
 
-function buildExperimentAnchorMetricPointDateFilter(
+function buildExperimentAnchorMetricPointDateFilters(
+  query: QueryRuntimeModule,
+  frontmatter: ExperimentFrontmatter,
+  metricKey: string,
   asOf?: string,
-): Pick<QueryMetricPointFilters, 'to'> {
-  return asOf ? { to: asOf } : {}
+): Array<Pick<QueryMetricPointFilters, 'from' | 'to'>> {
+  const dates = new Set<string>()
+  for (const anchor of frontmatter.analysisPlan?.measurementAnchors ?? []) {
+    if (!anchor.observedOn || (asOf && anchor.observedOn > asOf)) {
+      continue
+    }
+    const matchesMetricKey = anchor.biomarkerKeys.some(
+      (biomarkerKey) => resolveExperimentBiomarkerMetricKey(query, biomarkerKey) === metricKey,
+    )
+    if (matchesMetricKey) {
+      dates.add(anchor.observedOn)
+    }
+  }
+
+  return sortedIsoDates([...dates]).map((date) => ({ from: date, to: date }))
 }
 
 function capExperimentMetricEndDate(

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2066,13 +2066,23 @@ function buildExperimentMetricPointFilters(
     const anchorDateFilters = anchorMetricKeys.has(metricKey)
       ? buildExperimentAnchorMetricPointDateFilters(query, frontmatter, metricKey, asOf)
       : []
-    const dateFilters = anchorDateFilters.length > 0 ? anchorDateFilters : [dateFilter]
-    return dateFilters.map((filter) => ({
+    const dateFilters = [
+      ...(hasMetricPointDateFilter(dateFilter) ? [dateFilter] : []),
+      ...anchorDateFilters,
+    ]
+    const filters = dateFilters.length > 0 ? dateFilters : [dateFilter]
+    return filters.map((filter) => ({
       ...filter,
       limit: null,
       metricKey,
     }))
   })
+}
+
+function hasMetricPointDateFilter(
+  filter: Pick<QueryMetricPointFilters, 'from' | 'to'>,
+): boolean {
+  return typeof filter.from === 'string' || typeof filter.to === 'string'
 }
 
 function collectExperimentMetricKeys(

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2091,10 +2091,7 @@ function collectExperimentMetricKeys(
       continue
     }
 
-    const metricKey =
-      resolveExperimentBiomarkerMetricKey(query, target.evidence.metricKey) ??
-      query.resolveMetricDefinition(target.evidence.metricKey)?.key ??
-      query.normalizeMetricKey(target.evidence.metricKey)
+    const metricKey = resolveExperimentMetricKey(query, target.evidence.metricKey)
     if (metricKey.length > 0) {
       metricKeys.add(metricKey)
     }
@@ -2128,10 +2125,22 @@ function resolveExperimentBiomarkerMetricKey(
     return null
   }
 
-  return (
-    query.resolveMetricDefinitionForBiomarker(biomarkerKey)?.key ??
-    query.resolveMetricDefinition(biomarkerKey.split(':').at(-1) ?? biomarkerKey)?.key ??
-    null
+  return resolveExperimentMetricKey(query, biomarkerKey)
+}
+
+function resolveExperimentMetricKey(
+  query: QueryRuntimeModule,
+  metricKey: string,
+): string {
+  const trimmedMetricKey = metricKey.trim()
+  const metricSlug = trimmedMetricKey.split(':').at(-1) ?? trimmedMetricKey
+  const definition = trimmedMetricKey.startsWith('biomarker:')
+    ? query.resolveMetricDefinitionForBiomarker(trimmedMetricKey) ??
+      query.resolveMetricDefinition(metricSlug)
+    : query.resolveMetricDefinition(trimmedMetricKey)
+
+  return definition?.key ?? query.normalizeMetricKey(
+    trimmedMetricKey.startsWith('biomarker:') ? metricSlug : trimmedMetricKey,
   )
 }
 

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -17,6 +17,7 @@ import {
   jsonObjectSchema,
   protocolRefSchema,
   safeParseContract,
+  type ExperimentFrontmatter,
   type ExperimentRunScheduleIntent,
 } from '@murphai/contracts'
 import { stringifyFrontmatterDocument } from '@murphai/core'
@@ -25,6 +26,7 @@ import { z } from 'zod'
 import {
   loadQueryRuntime,
   type QueryCanonicalEntity,
+  type QueryMetricPointFilters,
   type QueryRuntimeModule,
 } from '../query-runtime.js'
 import { loadRuntimeModule } from '../runtime-import.js'
@@ -1428,7 +1430,12 @@ export async function showExperimentProgress(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
-  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
+  const metricPoints = await readExperimentJournalMetricPoints({
+    asOf: input.asOf,
+    frontmatter: requireExperimentFrontmatter(entity),
+    query,
+    vault: input.vault,
+  })
 
   const progress = query.summarizeExperimentProgress(readModel, slug, {
     asOf: input.asOf,
@@ -1456,7 +1463,12 @@ export async function showExperimentProgressCard(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
-  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
+  const metricPoints = await readExperimentJournalMetricPoints({
+    asOf: input.asOf,
+    frontmatter: requireExperimentFrontmatter(entity),
+    query,
+    vault: input.vault,
+  })
 
   const { card, warnings } = query.buildExperimentProgressCard(readModel, slug, {
     asOf: input.asOf,
@@ -1486,12 +1498,10 @@ export async function showExperimentFollowupDue(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
-  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
 
   const decision = query.decideExperimentFollowupDue(readModel, slug, {
     kind: input.kind,
     date: input.date,
-    metricPoints,
   })
 
   return {
@@ -1514,7 +1524,12 @@ export async function analyzeExperimentOutcomeRecord(input: {
     lookup: input.lookup,
     vault: input.vault,
   })
-  const metricPoints = await readExperimentJournalMetricPoints(query, input.vault)
+  const metricPoints = await readExperimentJournalMetricPoints({
+    asOf: input.asOf,
+    frontmatter: requireExperimentFrontmatter(entity),
+    query,
+    vault: input.vault,
+  })
 
   const outcome = query.analyzeExperimentOutcome(readModel, slug, {
     asOf: input.asOf,
@@ -2010,15 +2025,123 @@ async function readExperimentJournalVault(vault: string) {
   }
 }
 
-async function readExperimentJournalMetricPoints(
-  query: QueryRuntimeModule,
-  vault: string,
-) {
+async function readExperimentJournalMetricPoints(input: {
+  asOf?: string
+  frontmatter: ExperimentFrontmatter
+  query: QueryRuntimeModule
+  vault: string
+}) {
+  const filters = buildExperimentMetricPointFilters(input.query, input.frontmatter, input.asOf)
+  if (filters.length === 0) {
+    return []
+  }
+
   try {
-    return await query.listMetricPoints(vault, { limit: null })
+    const pointsById = new Map<string, Awaited<ReturnType<QueryRuntimeModule['listMetricPoints']>>[number]>()
+    for (const filter of filters) {
+      for (const point of await input.query.listMetricPoints(input.vault, filter)) {
+        pointsById.set(point.id, point)
+      }
+    }
+
+    return [...pointsById.values()]
   } catch (error) {
     throw toVaultMetadataCliError(error)
   }
+}
+
+function buildExperimentMetricPointFilters(
+  query: QueryRuntimeModule,
+  frontmatter: ExperimentFrontmatter,
+  asOf?: string,
+): QueryMetricPointFilters[] {
+  const metricKeys = collectExperimentMetricKeys(query, frontmatter)
+  if (metricKeys.length === 0) {
+    return []
+  }
+
+  const dateFilter = buildExperimentMetricPointDateFilter(frontmatter, asOf)
+  return metricKeys.map((metricKey) => ({
+    ...dateFilter,
+    limit: null,
+    metricKey,
+  }))
+}
+
+function collectExperimentMetricKeys(
+  query: QueryRuntimeModule,
+  frontmatter: ExperimentFrontmatter,
+): string[] {
+  const metricKeys = new Set<string>()
+  const analysisPlan = frontmatter.analysisPlan
+  for (const biomarkerKey of [
+    analysisPlan?.primaryBiomarkerKey,
+    ...(analysisPlan?.secondaryBiomarkerKeys ?? []),
+  ]) {
+    if (!biomarkerKey) {
+      continue
+    }
+
+    const metricKey =
+      query.resolveMetricDefinitionForBiomarker(biomarkerKey)?.key ??
+      query.resolveMetricDefinition(biomarkerKey.split(':').at(-1) ?? biomarkerKey)?.key
+    if (metricKey) {
+      metricKeys.add(metricKey)
+    }
+  }
+
+  for (const target of frontmatter.runPlan?.adherenceTargets ?? []) {
+    if (
+      target.evidence.kind !== 'metricPresence' &&
+      target.evidence.kind !== 'metricThreshold'
+    ) {
+      continue
+    }
+
+    const metricKey =
+      query.resolveMetricDefinition(target.evidence.metricKey)?.key ??
+      target.evidence.metricKey.trim().toLowerCase().replaceAll('_', '-')
+    if (metricKey.length > 0) {
+      metricKeys.add(metricKey)
+    }
+  }
+
+  return [...metricKeys].sort((left, right) => left.localeCompare(right))
+}
+
+function buildExperimentMetricPointDateFilter(
+  frontmatter: ExperimentFrontmatter,
+  asOf?: string,
+): Pick<QueryMetricPointFilters, 'from' | 'to'> {
+  const starts: string[] = []
+  const ends: string[] = []
+  const addRange = (start: string | null | undefined, end: string | null | undefined) => {
+    if (start) {
+      starts.push(start)
+    }
+    if (end) {
+      ends.push(end)
+    }
+  }
+
+  addRange(frontmatter.runPlan?.baselineStart, frontmatter.runPlan?.baselineEnd)
+  addRange(
+    frontmatter.runPlan?.interventionStart,
+    frontmatter.runPlan?.interventionEnd ?? asOf,
+  )
+
+  for (const measurement of frontmatter.analysisPlan?.plannedMeasurements ?? []) {
+    addRange(measurement.targetWindow?.start, measurement.targetWindow?.end)
+  }
+
+  return {
+    ...(starts.length > 0 ? { from: sortedIsoDates(starts)[0] } : {}),
+    ...(ends.length > 0 ? { to: sortedIsoDates(ends).at(-1) } : {}),
+  }
+}
+
+function sortedIsoDates(values: readonly string[]) {
+  return [...values].sort((left, right) => left.localeCompare(right))
 }
 
 async function loadExperimentJournalVaultCoreRuntime(): Promise<ExperimentJournalVaultCoreRuntime> {

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -388,6 +388,104 @@ analysisPlan:
   return vaultRoot;
 }
 
+async function createIncompleteAnchorRunWindowVault(): Promise<string> {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-experiment-incomplete-anchor-"));
+  createdVaultRoots.push(vaultRoot);
+
+  await mkdir(path.join(vaultRoot, "bank/experiments"), { recursive: true });
+  await mkdir(path.join(vaultRoot, "ledger/events/2026"), { recursive: true });
+  await mkdir(path.join(vaultRoot, "ledger/metric-samples/resting-heart-rate/2026"), { recursive: true });
+
+  await writeFile(
+    path.join(vaultRoot, "vault.json"),
+    `${JSON.stringify({
+      formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+      vaultId: "vault_01JNV40W8VFYQ2H7CMJY5A9R4Q",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      title: "Experiment Incomplete Anchor",
+      timezone: "UTC",
+    })}\n`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/rhr-baseline-anchor-only.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJGR
+slug: rhr-baseline-anchor-only
+status: completed
+title: RHR Baseline Anchor Only
+startedOn: 2026-04-01
+runPlan:
+  baselineStart: 2026-04-01
+  baselineEnd: 2026-04-03
+  interventionStart: 2026-04-08
+  interventionEnd: 2026-04-10
+analysisPlan:
+  primaryBiomarkerKey: biomarker:resting-heart-rate
+  desiredDirection: decrease
+  measurementAnchors:
+    - role: baseline
+      kind: lab_panel
+      recordId: evt_rhr_lab_baseline
+      biomarkerKeys:
+        - biomarker:resting-heart-rate
+      observedOn: 2026-03-25
+---
+# RHR Baseline Anchor Only
+`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "ledger/events/2026/2026-rhr-anchor.jsonl"),
+    `${JSON.stringify({
+      schemaVersion: "murph.event.v1",
+      id: "evt_rhr_lab_baseline",
+      kind: "test",
+      occurredAt: "2026-03-25T08:00:00.000Z",
+      collectedAt: "2026-03-25T08:00:00.000Z",
+      source: "manual",
+      title: "RHR baseline lab",
+      results: [{
+        biomarkerSlug: "resting-heart-rate",
+        unit: "bpm",
+        value: 70,
+      }],
+    })}\n`,
+    "utf8",
+  );
+
+  const samples = [
+    ["smp_rhr_daily_baseline_1", "2026-04-01", 62],
+    ["smp_rhr_daily_baseline_2", "2026-04-02", 61],
+    ["smp_rhr_daily_baseline_3", "2026-04-03", 60],
+    ["smp_rhr_daily_intervention_1", "2026-04-08", 59],
+    ["smp_rhr_daily_intervention_2", "2026-04-09", 58],
+    ["smp_rhr_daily_intervention_3", "2026-04-10", 59],
+  ] as const;
+  await writeFile(
+    path.join(vaultRoot, "ledger/metric-samples/resting-heart-rate/2026/2026-04.jsonl"),
+    `${samples.map(([id, date, value]) => JSON.stringify({
+      schemaVersion: "murph.metric-sample.v1",
+      id,
+      metric: "resting-heart-rate",
+      recordedAt: `${date}T06:00:00.000Z`,
+      dayKey: date,
+      source: "import",
+      quality: "normalized",
+      qualifiers: { summary: true },
+      value,
+      unit: "bpm",
+    })).join("\n")}\n`,
+    "utf8",
+  );
+
+  return vaultRoot;
+}
+
 async function createAnchoredLabMetricProjectionVault(): Promise<string> {
   const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-experiment-anchor-metrics-"));
   createdVaultRoots.push(vaultRoot);
@@ -635,4 +733,28 @@ test("experiment outcome usecases match anchors against projected metric records
   assert.equal(outcome.outcome.metricResults[0]?.baselineMean, 100);
   assert.equal(outcome.outcome.metricResults[0]?.interventionMean, 96);
   assert.equal(outcome.outcome.metricResults[0]?.deltaAbs, -4);
+});
+
+test("experiment progress usecases keep run-window metrics for incomplete anchor plans", async () => {
+  const vaultRoot = await createIncompleteAnchorRunWindowVault();
+
+  const progress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "rhr-baseline-anchor-only",
+    asOf: "2026-04-25",
+  });
+  assert.equal(progress.progress.analysisReadiness.status, "ready");
+  assert.equal(progress.progress.dataCoverage.status, "ready_for_review");
+  assert.equal(progress.progress.signals[0]?.baselineDayCount, 3);
+  assert.equal(progress.progress.signals[0]?.baselineMean, 61);
+  assert.equal(progress.progress.signals[0]?.interventionDayCount, 3);
+  assert.equal(progress.progress.signals[0]?.interventionMean, 58.67);
+
+  const outcome = await analyzeExperimentOutcomeRecord({
+    vault: vaultRoot,
+    lookup: "rhr-baseline-anchor-only",
+    asOf: "2026-04-25",
+  });
+  assert.equal(outcome.outcome.metricResults[0]?.baselineMean, 61);
+  assert.equal(outcome.outcome.metricResults[0]?.interventionMean, 58.67);
 });

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -402,13 +402,13 @@ analysisPlan:
   measurementAnchors:
     - role: baseline
       kind: wearable_summary
-      recordId: sample-summary:2026-06-01:glucose:mg_dL
+      recordId: sample-summary:glucose:2026-06-01
       biomarkerKeys:
         - biomarker:blood-glucose
       observedOn: 2026-06-01
     - role: followup
       kind: wearable_summary
-      recordId: sample-summary:2026-06-02:glucose:mg_dL
+      recordId: sample-summary:glucose:2026-06-02
       biomarkerKeys:
         - biomarker:blood-glucose
       observedOn: 2026-06-02

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -402,13 +402,13 @@ analysisPlan:
   measurementAnchors:
     - role: baseline
       kind: wearable_summary
-      recordId: metric_sample_anchor_glucose_baseline_02
+      recordId: sample-summary:2026-06-01:glucose:mg_dL
       biomarkerKeys:
         - biomarker:blood-glucose
       observedOn: 2026-06-01
     - role: followup
       kind: wearable_summary
-      recordId: metric_sample_anchor_glucose_followup_02
+      recordId: sample-summary:2026-06-02:glucose:mg_dL
       biomarkerKeys:
         - biomarker:blood-glucose
       observedOn: 2026-06-02
@@ -419,10 +419,12 @@ analysisPlan:
   );
 
   const samples = [
-    ["metric_sample_anchor_glucose_baseline_01", "2026-06-01", "08:00:00", 92],
-    ["metric_sample_anchor_glucose_baseline_02", "2026-06-01", "12:00:00", 100],
-    ["metric_sample_anchor_glucose_followup_01", "2026-06-02", "08:00:00", 88],
-    ["metric_sample_anchor_glucose_followup_02", "2026-06-02", "12:00:00", 96],
+    ["smp_anchor_glucose_baseline_01", "2026-06-01", "08:00:00", 92],
+    ["smp_anchor_glucose_baseline_02", "2026-06-01", "12:00:00", 100],
+    ["smp_anchor_glucose_baseline_03", "2026-06-01", "18:00:00", 108],
+    ["smp_anchor_glucose_followup_01", "2026-06-02", "08:00:00", 88],
+    ["smp_anchor_glucose_followup_02", "2026-06-02", "12:00:00", 96],
+    ["smp_anchor_glucose_followup_03", "2026-06-02", "18:00:00", 104],
   ] as const;
   await writeFile(
     path.join(vaultRoot, "ledger/metric-samples/glucose/2026/2026-06.jsonl"),
@@ -432,9 +434,8 @@ analysisPlan:
       metric: "glucose",
       recordedAt: `${date}T${time}.000Z`,
       dayKey: date,
-      source: "import",
-      quality: "normalized",
-      qualifiers: { summary: true },
+      source: "device",
+      quality: "derived",
       value,
       unit: "mg_dL",
     })).join("\n")}\n`,

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -118,6 +118,91 @@ analysisPlan:
   return vaultRoot;
 }
 
+async function createAnchoredLabMetricProjectionVault(): Promise<string> {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-experiment-anchor-metrics-"));
+  createdVaultRoots.push(vaultRoot);
+
+  await mkdir(path.join(vaultRoot, "bank/experiments"), { recursive: true });
+  await mkdir(path.join(vaultRoot, "ledger/events/2026"), { recursive: true });
+
+  await writeFile(
+    path.join(vaultRoot, "vault.json"),
+    `${JSON.stringify({
+      formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+      vaultId: "vault_01JNV40W8VFYQ2H7CMJY5A9R4M",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      title: "Experiment Anchor Metrics",
+      timezone: "UTC",
+    })}\n`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/psyllium-ldl.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJFK
+slug: psyllium-ldl
+status: completed
+title: Psyllium LDL
+startedOn: 2026-05-09
+runPlan:
+  baselineStart: 2026-05-02
+  baselineEnd: 2026-05-08
+  interventionStart: 2026-05-09
+  interventionEnd: 2026-08-01
+analysisPlan:
+  primaryBiomarkerKey: biomarker:ldl-c
+  desiredDirection: decrease
+  measurementAnchors:
+    - role: baseline
+      kind: lab_panel
+      recordId: evt_lipid_baseline
+      biomarkerKeys:
+        - biomarker:ldl-c
+      observedOn: 2026-04-23
+    - role: followup
+      kind: lab_panel
+      recordId: evt_lipid_followup
+      biomarkerKeys:
+        - biomarker:ldl-c
+      observedOn: 2026-08-02
+---
+# Psyllium LDL
+`,
+    "utf8",
+  );
+
+  const results = [
+    ["evt_lipid_baseline", "2026-04-23", 140],
+    ["evt_lipid_followup", "2026-08-02", 120],
+  ] as const;
+  const events = results.map(([id, date, value]) => JSON.stringify({
+    schemaVersion: "murph.event.v1",
+    id,
+    kind: "test",
+    occurredAt: `${date}T08:00:00.000Z`,
+    collectedAt: `${date}T08:00:00.000Z`,
+    source: "manual",
+    title: "Lab result",
+    results: [{
+      analyte: "ldl-c",
+      biomarkerSlug: "ldl-c",
+      unit: "mg/dL",
+      value,
+    }],
+  }));
+
+  await writeFile(
+    path.join(vaultRoot, "ledger/events/2026/2026-labs.jsonl"),
+    `${events.join("\n")}\n`,
+    "utf8",
+  );
+
+  return vaultRoot;
+}
+
 afterEach(async () => {
   await Promise.all(
     createdVaultRoots.splice(0).map((vaultRoot) =>
@@ -158,6 +243,14 @@ test("experiment progress usecases read metrics from the query metric projection
   assert.equal(progress.progress.adherence.expectedSessionsByNow, 3);
   assert.equal(progress.progress.adherence.status, "met_target");
 
+  const midRunProgress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency",
+    asOf: "2026-06-04",
+  });
+  assert.equal(midRunProgress.progress.adherence.completedSessions, 1);
+  assert.equal(midRunProgress.progress.adherence.expectedSessionsByNow, 1);
+
   const outcome = await analyzeExperimentOutcomeRecord({
     vault: vaultRoot,
     lookup: "sleep-efficiency",
@@ -181,4 +274,34 @@ test("experiment progress usecases read metrics from the query metric projection
   assert.equal(card.card.movers[0]?.label, "Sleep Efficiency");
   assert.equal(card.card.sessions.logged, 3);
   assert.equal(card.card.weeks[0]?.cells, "CCCOOOO");
+
+  const midRunCard = await showExperimentProgressCard({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency",
+    asOf: "2026-06-04",
+  });
+  assert.equal(midRunCard.card.sessions.logged, 1);
+  assert.equal(midRunCard.card.weeks[0]?.cells, "CSSOOOO");
+});
+
+test("experiment progress usecases keep anchored lab metrics outside run windows", async () => {
+  const vaultRoot = await createAnchoredLabMetricProjectionVault();
+
+  const progress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "psyllium-ldl",
+    asOf: "2026-08-02",
+  });
+  assert.equal(progress.progress.signals[0]?.baselineMean, 140);
+  assert.equal(progress.progress.signals[0]?.interventionMean, 120);
+  assert.equal(progress.progress.signals[0]?.deltaAbs, -20);
+
+  const outcome = await analyzeExperimentOutcomeRecord({
+    vault: vaultRoot,
+    lookup: "psyllium-ldl",
+    asOf: "2026-08-02",
+  });
+  assert.equal(outcome.outcome.metricResults[0]?.baselineMean, 140);
+  assert.equal(outcome.outcome.metricResults[0]?.interventionMean, 120);
+  assert.equal(outcome.outcome.metricResults[0]?.deltaAbs, -20);
 });

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -542,6 +542,41 @@ analysisPlan:
     "utf8",
   );
 
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/psyllium-ldl-undated-anchors.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJGT
+slug: psyllium-ldl-undated-anchors
+status: completed
+title: Psyllium LDL Undated Anchors
+startedOn: 2026-05-09
+runPlan:
+  baselineStart: 2026-05-02
+  baselineEnd: 2026-05-08
+  interventionStart: 2026-05-09
+  interventionEnd: 2026-08-01
+analysisPlan:
+  primaryBiomarkerKey: biomarker:ldl-c
+  desiredDirection: decrease
+  measurementAnchors:
+    - role: baseline
+      kind: lab_panel
+      recordId: evt_lipid_baseline
+      biomarkerKeys:
+        - biomarker:ldl-c
+    - role: followup
+      kind: lab_panel
+      recordId: evt_lipid_followup
+      biomarkerKeys:
+        - biomarker:ldl-c
+---
+# Psyllium LDL Undated Anchors
+`,
+    "utf8",
+  );
+
   const results = [
     ["evt_lipid_baseline", "2026-04-23", 140],
     ["evt_lipid_followup", "2026-08-02", 120],
@@ -705,6 +740,24 @@ test("experiment progress usecases keep anchored lab metrics outside run windows
   assert.equal(outcome.outcome.metricResults[0]?.baselineMean, 140);
   assert.equal(outcome.outcome.metricResults[0]?.interventionMean, 120);
   assert.equal(outcome.outcome.metricResults[0]?.deltaAbs, -20);
+
+  const undatedAnchorProgress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "psyllium-ldl-undated-anchors",
+    asOf: "2026-08-02",
+  });
+  assert.equal(undatedAnchorProgress.progress.signals[0]?.baselineMean, 140);
+  assert.equal(undatedAnchorProgress.progress.signals[0]?.interventionMean, 120);
+  assert.equal(undatedAnchorProgress.progress.signals[0]?.deltaAbs, -20);
+
+  const undatedAnchorOutcome = await analyzeExperimentOutcomeRecord({
+    vault: vaultRoot,
+    lookup: "psyllium-ldl-undated-anchors",
+    asOf: "2026-08-02",
+  });
+  assert.equal(undatedAnchorOutcome.outcome.metricResults[0]?.baselineMean, 140);
+  assert.equal(undatedAnchorOutcome.outcome.metricResults[0]?.interventionMean, 120);
+  assert.equal(undatedAnchorOutcome.outcome.metricResults[0]?.deltaAbs, -20);
 });
 
 test("experiment outcome usecases keep metric selection policy for run windows", async () => {

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, test } from "vitest";
+
+import { CURRENT_VAULT_FORMAT_VERSION } from "@murphai/contracts";
+import { listMetricPoints } from "@murphai/query";
+
+import {
+  analyzeExperimentOutcomeRecord,
+  showExperimentProgress,
+  showExperimentProgressCard,
+} from "../src/usecases/experiment-journal-vault.ts";
+
+const createdVaultRoots: string[] = [];
+
+async function createExperimentMetricProjectionVault(): Promise<string> {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-experiment-progress-metrics-"));
+  createdVaultRoots.push(vaultRoot);
+
+  await mkdir(path.join(vaultRoot, "bank/experiments"), { recursive: true });
+  await mkdir(path.join(vaultRoot, "ledger/events/2026"), { recursive: true });
+
+  await writeFile(
+    path.join(vaultRoot, "vault.json"),
+    `${JSON.stringify({
+      formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+      vaultId: "vault_01JNV40W8VFYQ2H7CMJY5A9R4K",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      title: "Experiment Progress Metrics",
+      timezone: "UTC",
+    })}\n`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/sleep-efficiency.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJFM
+slug: sleep-efficiency
+status: active
+title: Sleep Efficiency
+startedOn: 2026-06-01
+runPlan:
+  baselineStart: 2026-06-01
+  baselineEnd: 2026-06-03
+  interventionStart: 2026-06-04
+  interventionEnd: 2026-06-06
+analysisPlan:
+  primaryBiomarkerKey: biomarker:sleep-onset-latency
+  secondaryBiomarkerKeys:
+    - biomarker:sleep-efficiency
+  expectedDirections:
+    - biomarkerKey: biomarker:sleep-efficiency
+      direction: increase
+---
+# Sleep Efficiency
+`,
+    "utf8",
+  );
+
+  const values = [
+    ["2026-06-01", 90],
+    ["2026-06-02", 91],
+    ["2026-06-03", 92],
+    ["2026-06-04", 95],
+    ["2026-06-05", 96],
+    ["2026-06-06", 97],
+  ] as const;
+  const observations = values.map(([date, value], index) => JSON.stringify({
+    schemaVersion: "murph.event.v1",
+    id: `evt_progress_metric_projection_${String(index + 1).padStart(2, "0")}`,
+    kind: "observation",
+    dayKey: date,
+    occurredAt: `${date}T07:00:00Z`,
+    recordedAt: `${date}T07:01:00Z`,
+    source: "device",
+    title: "WHOOP sleep efficiency",
+    metric: "sleep-efficiency",
+    value,
+    unit: "percent",
+    externalRef: {
+      system: "whoop",
+      resourceType: "sleep",
+      resourceId: `whoop-sleep-${date}`,
+      facet: "sleep_efficiency",
+    },
+  }));
+
+  await writeFile(
+    path.join(vaultRoot, "ledger/events/2026/2026-06.jsonl"),
+    `${observations.join("\n")}\n`,
+    "utf8",
+  );
+
+  return vaultRoot;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    createdVaultRoots.splice(0).map((vaultRoot) =>
+      rm(vaultRoot, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+test("experiment progress usecases read metrics from the query metric projection", async () => {
+  const vaultRoot = await createExperimentMetricProjectionVault();
+
+  const metricPoints = await listMetricPoints(vaultRoot, {
+    limit: null,
+    metricKey: "sleep-efficiency",
+  });
+  assert.equal(metricPoints.length, 6);
+
+  const progress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency",
+    asOf: "2026-06-06",
+  });
+
+  const sleepEfficiency = progress.progress.signals.find(
+    (signal: { biomarkerKey: string }) =>
+      signal.biomarkerKey === "biomarker:sleep-efficiency",
+  );
+  assert.equal(sleepEfficiency?.baselineDayCount, 3);
+  assert.equal(sleepEfficiency?.interventionDayCount, 3);
+  assert.equal(progress.progress.dataCoverage.baselineDaysAvailable, 3);
+  assert.equal(progress.progress.dataCoverage.interventionDaysAvailable, 3);
+  assert.equal(progress.progress.dataCoverage.primaryMetricDaysAvailable, 0);
+  assert.equal(progress.progress.dataCoverage.status, "partial");
+
+  const outcome = await analyzeExperimentOutcomeRecord({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency",
+    asOf: "2026-06-06",
+  });
+  const outcomeSleepEfficiency = outcome.outcome.metricResults.find(
+    (signal: { biomarkerKey: string }) =>
+      signal.biomarkerKey === "biomarker:sleep-efficiency",
+  );
+  assert.equal(outcomeSleepEfficiency?.baselineDayCount, 3);
+  assert.equal(outcomeSleepEfficiency?.interventionDayCount, 3);
+  assert.equal(outcomeSleepEfficiency?.baselineMean, 91);
+  assert.equal(outcomeSleepEfficiency?.interventionMean, 96);
+
+  const card = await showExperimentProgressCard({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency",
+    asOf: "2026-06-06",
+  });
+  assert.equal(card.card.movers.length, 1);
+  assert.equal(card.card.movers[0]?.label, "Sleep Efficiency");
+});

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -61,7 +61,7 @@ runPlan:
         timeZone: UTC
       evidence:
         kind: metricThreshold
-        metricKey: sleep-efficiency
+        metricKey: biomarker:sleep-efficiency
         op: ">="
         value: 90
         missing: unknown
@@ -77,6 +77,103 @@ analysisPlan:
       direction: increase
 ---
 # Sleep Efficiency
+`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/sleep-efficiency-mixed.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJFN
+slug: sleep-efficiency-mixed
+status: active
+title: Sleep Efficiency Mixed
+startedOn: 2026-06-01
+runPlan:
+  baselineStart: 2026-06-01
+  baselineEnd: 2026-06-03
+  interventionStart: 2026-06-04
+  interventionEnd: 2026-06-06
+  targetSessions: 3
+  minimumUsefulSessions: 2
+  adherenceTargets:
+    - targetId: meditation-session
+      label: Meditation session
+      phase: intervention
+      calendar:
+        kind: daily
+        timeZone: UTC
+      evidence:
+        kind: linkedEventCount
+        eventKind: intervention_session
+        missing: missed_after_grace
+      rollup:
+        targetCompletions: 3
+        minimumUsefulCompletions: 2
+    - targetId: sleep-efficiency-threshold
+      label: Sleep efficiency threshold
+      phase: intervention
+      calendar:
+        kind: daily
+        timeZone: UTC
+      evidence:
+        kind: metricThreshold
+        metricKey: biomarker:sleep-efficiency
+        op: ">="
+        value: 90
+        missing: unknown
+analysisPlan:
+  primaryBiomarkerKey: biomarker:sleep-onset-latency
+  secondaryBiomarkerKeys:
+    - biomarker:sleep-efficiency
+  expectedDirections:
+    - biomarkerKey: biomarker:sleep-efficiency
+      direction: increase
+---
+# Sleep Efficiency Mixed
+`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/sleep-efficiency-adherence-only.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJFP
+slug: sleep-efficiency-adherence-only
+status: active
+title: Sleep Efficiency Adherence Only
+startedOn: 2026-06-01
+runPlan:
+  baselineStart: 2026-06-01
+  baselineEnd: 2026-06-03
+  interventionStart: 2026-06-04
+  interventionEnd: 2026-06-06
+  targetSessions: 3
+  minimumUsefulSessions: 2
+  adherenceTargets:
+    - targetId: sleep-efficiency-threshold
+      label: Sleep efficiency threshold
+      phase: intervention
+      calendar:
+        kind: daily
+        timeZone: UTC
+      evidence:
+        kind: metricThreshold
+        metricKey: biomarker:sleep-efficiency
+        op: ">="
+        value: 90
+        missing: unknown
+      rollup:
+        targetCompletions: 3
+        minimumUsefulCompletions: 2
+analysisPlan:
+  primaryBiomarkerKey: biomarker:sleep-onset-latency
+---
+# Sleep Efficiency Adherence Only
 `,
     "utf8",
   );
@@ -112,6 +209,179 @@ analysisPlan:
   await writeFile(
     path.join(vaultRoot, "ledger/events/2026/2026-06.jsonl"),
     `${observations.join("\n")}\n`,
+    "utf8",
+  );
+
+  return vaultRoot;
+}
+
+async function createGlucoseSelectionPolicyVault(): Promise<string> {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-experiment-glucose-policy-"));
+  createdVaultRoots.push(vaultRoot);
+
+  await mkdir(path.join(vaultRoot, "bank/experiments"), { recursive: true });
+  await mkdir(path.join(vaultRoot, "ledger/events/2026"), { recursive: true });
+  await mkdir(path.join(vaultRoot, "ledger/samples/glucose/2026"), { recursive: true });
+
+  await writeFile(
+    path.join(vaultRoot, "vault.json"),
+    `${JSON.stringify({
+      formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+      vaultId: "vault_01JNV40W8VFYQ2H7CMJY5A9R4N",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      title: "Experiment Glucose Policy",
+      timezone: "UTC",
+    })}\n`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/glucose-policy.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJGM
+slug: glucose-policy
+status: completed
+title: Glucose Policy
+startedOn: 2026-06-02
+runPlan:
+  baselineStart: 2026-06-01
+  baselineEnd: 2026-06-01
+  interventionStart: 2026-06-02
+  interventionEnd: 2026-06-02
+analysisPlan:
+  primaryBiomarkerKey: biomarker:blood-glucose
+  desiredDirection: decrease
+---
+# Glucose Policy
+`,
+    "utf8",
+  );
+
+  const labEvents = [
+    ["evt_glucose_policy_baseline", "2026-06-01", 90],
+    ["evt_glucose_policy_followup", "2026-06-02", 85],
+  ] as const;
+  await writeFile(
+    path.join(vaultRoot, "ledger/events/2026/2026-glucose-policy.jsonl"),
+    `${labEvents.map(([id, date, value]) => JSON.stringify({
+      schemaVersion: "murph.event.v1",
+      id,
+      kind: "test",
+      occurredAt: `${date}T08:00:00.000Z`,
+      collectedAt: `${date}T08:00:00.000Z`,
+      fastingStatus: "fasting",
+      source: "manual",
+      title: "Glucose lab",
+      results: [{
+        biomarkerSlug: "glucose",
+        unit: "mg_dL",
+        value,
+      }],
+    })).join("\n")}\n`,
+    "utf8",
+  );
+
+  const samples = [
+    ["smp_glucose_policy_baseline", "2026-06-01", "12:00:00", 150],
+    ["smp_glucose_policy_followup", "2026-06-02", "12:00:00", 160],
+  ] as const;
+  await writeFile(
+    path.join(vaultRoot, "ledger/samples/glucose/2026/2026-06.jsonl"),
+    `${samples.map(([id, date, time, value]) => JSON.stringify({
+      schemaVersion: "murph.sample.v1",
+      id,
+      stream: "glucose",
+      recordedAt: `${date}T${time}.000Z`,
+      dayKey: date,
+      source: "device",
+      quality: "raw",
+      value,
+      unit: "mg_dL",
+    })).join("\n")}\n`,
+    "utf8",
+  );
+
+  return vaultRoot;
+}
+
+async function createAnchoredSampleSummaryVault(): Promise<string> {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-experiment-anchor-samples-"));
+  createdVaultRoots.push(vaultRoot);
+
+  await mkdir(path.join(vaultRoot, "bank/experiments"), { recursive: true });
+  await mkdir(path.join(vaultRoot, "ledger/metric-samples/glucose/2026"), { recursive: true });
+
+  await writeFile(
+    path.join(vaultRoot, "vault.json"),
+    `${JSON.stringify({
+      formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+      vaultId: "vault_01JNV40W8VFYQ2H7CMJY5A9R4P",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      title: "Experiment Anchor Samples",
+      timezone: "UTC",
+    })}\n`,
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/glucose-sample-anchors.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJGN
+slug: glucose-sample-anchors
+status: completed
+title: Glucose Sample Anchors
+startedOn: 2026-06-02
+runPlan:
+  baselineStart: 2026-06-01
+  baselineEnd: 2026-06-01
+  interventionStart: 2026-06-02
+  interventionEnd: 2026-06-02
+analysisPlan:
+  primaryBiomarkerKey: biomarker:blood-glucose
+  desiredDirection: decrease
+  measurementAnchors:
+    - role: baseline
+      kind: wearable_summary
+      recordId: metric_sample_anchor_glucose_baseline_02
+      biomarkerKeys:
+        - biomarker:blood-glucose
+      observedOn: 2026-06-01
+    - role: followup
+      kind: wearable_summary
+      recordId: metric_sample_anchor_glucose_followup_02
+      biomarkerKeys:
+        - biomarker:blood-glucose
+      observedOn: 2026-06-02
+---
+# Glucose Sample Anchors
+`,
+    "utf8",
+  );
+
+  const samples = [
+    ["metric_sample_anchor_glucose_baseline_01", "2026-06-01", "08:00:00", 92],
+    ["metric_sample_anchor_glucose_baseline_02", "2026-06-01", "12:00:00", 100],
+    ["metric_sample_anchor_glucose_followup_01", "2026-06-02", "08:00:00", 88],
+    ["metric_sample_anchor_glucose_followup_02", "2026-06-02", "12:00:00", 96],
+  ] as const;
+  await writeFile(
+    path.join(vaultRoot, "ledger/metric-samples/glucose/2026/2026-06.jsonl"),
+    `${samples.map(([id, date, time, value]) => JSON.stringify({
+      schemaVersion: "murph.metric-sample.v1",
+      id,
+      metric: "glucose",
+      recordedAt: `${date}T${time}.000Z`,
+      dayKey: date,
+      source: "import",
+      quality: "normalized",
+      qualifiers: { summary: true },
+      value,
+      unit: "mg_dL",
+    })).join("\n")}\n`,
     "utf8",
   );
 
@@ -282,6 +552,39 @@ test("experiment progress usecases read metrics from the query metric projection
   });
   assert.equal(midRunCard.card.sessions.logged, 1);
   assert.equal(midRunCard.card.weeks[0]?.cells, "CSSOOOO");
+
+  const mixedProgress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency-mixed",
+    asOf: "2026-06-06",
+  });
+  assert.equal(mixedProgress.progress.adherence.completedSessions, 0);
+  assert.equal(mixedProgress.progress.adherence.expectedSessionsByNow, 1);
+  assert.equal(mixedProgress.progress.adherence.status, "not_started");
+
+  const mixedCard = await showExperimentProgressCard({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency-mixed",
+    asOf: "2026-06-06",
+  });
+  assert.equal(mixedCard.card.sessions.logged, 0);
+  assert.equal(mixedCard.card.weeks[0]?.cells, "MSSOOOO");
+
+  const adherenceOnlyProgress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency-adherence-only",
+    asOf: "2026-06-06",
+  });
+  assert.equal(adherenceOnlyProgress.progress.adherence.completedSessions, 3);
+  assert.equal(adherenceOnlyProgress.progress.adherence.expectedSessionsByNow, 3);
+  assert.equal(adherenceOnlyProgress.progress.adherence.status, "met_target");
+
+  const adherenceOnlyCard = await showExperimentProgressCard({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency-adherence-only",
+    asOf: "2026-06-06",
+  });
+  assert.equal(adherenceOnlyCard.card.sessions.logged, 3);
 });
 
 test("experiment progress usecases keep anchored lab metrics outside run windows", async () => {
@@ -304,4 +607,32 @@ test("experiment progress usecases keep anchored lab metrics outside run windows
   assert.equal(outcome.outcome.metricResults[0]?.baselineMean, 140);
   assert.equal(outcome.outcome.metricResults[0]?.interventionMean, 120);
   assert.equal(outcome.outcome.metricResults[0]?.deltaAbs, -20);
+});
+
+test("experiment outcome usecases keep metric selection policy for run windows", async () => {
+  const vaultRoot = await createGlucoseSelectionPolicyVault();
+
+  const outcome = await analyzeExperimentOutcomeRecord({
+    vault: vaultRoot,
+    lookup: "glucose-policy",
+    asOf: "2026-06-02",
+  });
+
+  assert.equal(outcome.outcome.metricResults[0]?.baselineMean, 90);
+  assert.equal(outcome.outcome.metricResults[0]?.interventionMean, 85);
+  assert.equal(outcome.outcome.metricResults[0]?.deltaAbs, -5);
+});
+
+test("experiment outcome usecases match anchors against projected metric records", async () => {
+  const vaultRoot = await createAnchoredSampleSummaryVault();
+
+  const outcome = await analyzeExperimentOutcomeRecord({
+    vault: vaultRoot,
+    lookup: "glucose-sample-anchors",
+    asOf: "2026-06-02",
+  });
+
+  assert.equal(outcome.outcome.metricResults[0]?.baselineMean, 100);
+  assert.equal(outcome.outcome.metricResults[0]?.interventionMean, 96);
+  assert.equal(outcome.outcome.metricResults[0]?.deltaAbs, -4);
 });

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -178,6 +178,62 @@ analysisPlan:
     "utf8",
   );
 
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/sleep-efficiency-mixed-reordered.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJFQ
+slug: sleep-efficiency-mixed-reordered
+status: active
+title: Sleep Efficiency Mixed Reordered
+startedOn: 2026-06-01
+runPlan:
+  baselineStart: 2026-06-01
+  baselineEnd: 2026-06-03
+  interventionStart: 2026-06-04
+  interventionEnd: 2026-06-06
+  targetSessions: 3
+  minimumUsefulSessions: 2
+  adherenceTargets:
+    - targetId: sleep-efficiency-threshold
+      label: Sleep efficiency threshold
+      phase: intervention
+      calendar:
+        kind: daily
+        timeZone: UTC
+      evidence:
+        kind: metricThreshold
+        metricKey: biomarker:sleep-efficiency
+        op: ">="
+        value: 90
+        missing: unknown
+    - targetId: meditation-session
+      label: Meditation session
+      phase: intervention
+      calendar:
+        kind: daily
+        timeZone: UTC
+      evidence:
+        kind: linkedEventCount
+        eventKind: intervention_session
+        missing: missed_after_grace
+      rollup:
+        targetCompletions: 3
+        minimumUsefulCompletions: 2
+analysisPlan:
+  primaryBiomarkerKey: biomarker:sleep-onset-latency
+  secondaryBiomarkerKeys:
+    - biomarker:sleep-efficiency
+  expectedDirections:
+    - biomarkerKey: biomarker:sleep-efficiency
+      direction: increase
+---
+# Sleep Efficiency Mixed Reordered
+`,
+    "utf8",
+  );
+
   const values = [
     ["2026-06-01", 90],
     ["2026-06-02", 91],
@@ -739,6 +795,23 @@ test("experiment progress usecases read metrics from the query metric projection
   });
   assert.equal(mixedCard.card.sessions.logged, 0);
   assert.equal(mixedCard.card.weeks[0]?.cells, "MSSOOOO");
+
+  const reorderedMixedProgress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency-mixed-reordered",
+    asOf: "2026-06-06",
+  });
+  assert.equal(reorderedMixedProgress.progress.adherence.completedSessions, 0);
+  assert.equal(reorderedMixedProgress.progress.adherence.expectedSessionsByNow, 1);
+  assert.equal(reorderedMixedProgress.progress.adherence.status, "not_started");
+
+  const reorderedMixedCard = await showExperimentProgressCard({
+    vault: vaultRoot,
+    lookup: "sleep-efficiency-mixed-reordered",
+    asOf: "2026-06-06",
+  });
+  assert.equal(reorderedMixedCard.card.sessions.logged, 0);
+  assert.equal(reorderedMixedCard.card.weeks[0]?.cells, "MSSOOOO");
 
   const adherenceOnlyProgress = await showExperimentProgress({
     vault: vaultRoot,

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -577,6 +577,43 @@ analysisPlan:
     "utf8",
   );
 
+  await writeFile(
+    path.join(vaultRoot, "bank/experiments/psyllium-ldl-cross-date-anchors.md"),
+    `---
+schemaVersion: murph.frontmatter.experiment.v1
+docType: experiment
+experimentId: exp_01JNV4458HYPP53JDQCBP1QJGV
+slug: psyllium-ldl-cross-date-anchors
+status: completed
+title: Psyllium LDL Cross Date Anchors
+startedOn: 2026-05-09
+runPlan:
+  baselineStart: 2026-05-02
+  baselineEnd: 2026-05-08
+  interventionStart: 2026-05-09
+  interventionEnd: 2026-08-01
+analysisPlan:
+  primaryBiomarkerKey: biomarker:ldl-c
+  desiredDirection: decrease
+  measurementAnchors:
+    - role: baseline
+      kind: lab_panel
+      recordId: evt_lipid_baseline
+      biomarkerKeys:
+        - biomarker:ldl-c
+      observedOn: 2026-04-22
+    - role: followup
+      kind: lab_panel
+      recordId: evt_lipid_followup
+      biomarkerKeys:
+        - biomarker:ldl-c
+      observedOn: 2026-08-01
+---
+# Psyllium LDL Cross Date Anchors
+`,
+    "utf8",
+  );
+
   const results = [
     ["evt_lipid_baseline", "2026-04-23", 140],
     ["evt_lipid_followup", "2026-08-02", 120],
@@ -758,6 +795,24 @@ test("experiment progress usecases keep anchored lab metrics outside run windows
   assert.equal(undatedAnchorOutcome.outcome.metricResults[0]?.baselineMean, 140);
   assert.equal(undatedAnchorOutcome.outcome.metricResults[0]?.interventionMean, 120);
   assert.equal(undatedAnchorOutcome.outcome.metricResults[0]?.deltaAbs, -20);
+
+  const crossDateAnchorProgress = await showExperimentProgress({
+    vault: vaultRoot,
+    lookup: "psyllium-ldl-cross-date-anchors",
+    asOf: "2026-08-02",
+  });
+  assert.equal(crossDateAnchorProgress.progress.signals[0]?.baselineMean, 140);
+  assert.equal(crossDateAnchorProgress.progress.signals[0]?.interventionMean, 120);
+  assert.equal(crossDateAnchorProgress.progress.signals[0]?.deltaAbs, -20);
+
+  const crossDateAnchorOutcome = await analyzeExperimentOutcomeRecord({
+    vault: vaultRoot,
+    lookup: "psyllium-ldl-cross-date-anchors",
+    asOf: "2026-08-02",
+  });
+  assert.equal(crossDateAnchorOutcome.outcome.metricResults[0]?.baselineMean, 140);
+  assert.equal(crossDateAnchorOutcome.outcome.metricResults[0]?.interventionMean, 120);
+  assert.equal(crossDateAnchorOutcome.outcome.metricResults[0]?.deltaAbs, -20);
 });
 
 test("experiment outcome usecases keep metric selection policy for run windows", async () => {

--- a/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
+++ b/packages/vault-usecases/test/experiment-progress-metric-projection.test.ts
@@ -50,6 +50,24 @@ runPlan:
   baselineEnd: 2026-06-03
   interventionStart: 2026-06-04
   interventionEnd: 2026-06-06
+  targetSessions: 3
+  minimumUsefulSessions: 2
+  adherenceTargets:
+    - targetId: sleep-efficiency-threshold
+      label: Sleep efficiency threshold
+      phase: intervention
+      calendar:
+        kind: daily
+        timeZone: UTC
+      evidence:
+        kind: metricThreshold
+        metricKey: sleep-efficiency
+        op: ">="
+        value: 90
+        missing: unknown
+      rollup:
+        targetCompletions: 3
+        minimumUsefulCompletions: 2
 analysisPlan:
   primaryBiomarkerKey: biomarker:sleep-onset-latency
   secondaryBiomarkerKeys:
@@ -136,6 +154,9 @@ test("experiment progress usecases read metrics from the query metric projection
   assert.equal(progress.progress.dataCoverage.interventionDaysAvailable, 3);
   assert.equal(progress.progress.dataCoverage.primaryMetricDaysAvailable, 0);
   assert.equal(progress.progress.dataCoverage.status, "partial");
+  assert.equal(progress.progress.adherence.completedSessions, 3);
+  assert.equal(progress.progress.adherence.expectedSessionsByNow, 3);
+  assert.equal(progress.progress.adherence.status, "met_target");
 
   const outcome = await analyzeExperimentOutcomeRecord({
     vault: vaultRoot,
@@ -158,4 +179,6 @@ test("experiment progress usecases read metrics from the query metric projection
   });
   assert.equal(card.card.movers.length, 1);
   assert.equal(card.card.movers[0]?.label, "Sleep Efficiency");
+  assert.equal(card.card.sessions.logged, 3);
+  assert.equal(card.card.weeks[0]?.cells, "CCCOOOO");
 });

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -1603,6 +1603,132 @@ describe("record service seams", () => {
       },
     });
     expect(journalQuery.listMetricPoints).not.toHaveBeenCalled();
+
+    const anchoredExperimentId = "exp_01JNV4458HYPP53JDQCBP1QJAN";
+    const anchoredExperiment = sampleQueryRecord({
+      entityId: anchoredExperimentId,
+      primaryLookupId: anchoredExperimentId,
+      family: "experiment",
+      recordClass: "bank",
+      kind: "experiment",
+      status: "active",
+      experimentSlug: "glucose-anchors",
+      attributes: {
+        schemaVersion: "murph.frontmatter.experiment.v1",
+        docType: "experiment",
+        experimentId: anchoredExperimentId,
+        slug: "glucose-anchors",
+        status: "active",
+        title: "Glucose Anchors",
+        startedOn: "2026-06-01",
+        runPlan: {
+          baselineStart: "2026-06-01",
+          baselineEnd: "2026-06-03",
+          interventionStart: "2026-06-04",
+          interventionEnd: "2026-06-18",
+        },
+        analysisPlan: {
+          primaryBiomarkerKey: "biomarker:blood-glucose",
+          desiredDirection: "decrease",
+          measurementAnchors: [
+            {
+              role: "baseline",
+              kind: "wearable_summary",
+              recordId: "metric_sample_glucose_baseline",
+              biomarkerKeys: ["biomarker:blood-glucose"],
+              observedOn: "2026-05-29",
+            },
+            {
+              role: "followup",
+              kind: "wearable_summary",
+              recordId: "metric_sample_glucose_followup",
+              biomarkerKeys: ["biomarker:blood-glucose"],
+              observedOn: "2026-06-18",
+            },
+          ],
+        },
+      },
+    });
+    const anchoredMetricPointFilters: unknown[] = [];
+    const anchoredMetricQuery = {
+      readVault: vi.fn(async () => journalQuery.readVault()),
+      lookupEntityById: vi.fn(() => anchoredExperiment),
+      listMetricPoints: vi.fn(async (_vault: string, filters: unknown) => {
+        anchoredMetricPointFilters.push(filters);
+        return [];
+      }),
+      normalizeMetricKey: queryRuntime.normalizeMetricKey,
+      resolveMetricDefinition: queryRuntime.resolveMetricDefinition,
+      resolveMetricDefinitionForBiomarker: queryRuntime.resolveMetricDefinitionForBiomarker,
+      summarizeExperimentProgress: vi.fn(() => ({
+        schemaVersion: "murph.experiment-progress.v1",
+        asOf: "2026-06-18",
+        experiment: {
+          id: anchoredExperimentId,
+          slug: "glucose-anchors",
+          status: "active",
+          title: "Glucose Anchors",
+        },
+        phase: "review_due",
+        windows: {
+          baselineStart: "2026-06-01",
+          baselineEnd: "2026-06-03",
+          interventionStart: "2026-06-04",
+          interventionEnd: "2026-06-18",
+        },
+        setupReadiness: { status: "ready", blockingReasons: [] },
+        analysisReadiness: { status: "ready", blockingReasons: [] },
+        dataCoverage: {
+          status: "ready_for_review",
+          baselineDaysAvailable: 1,
+          interventionDaysAvailable: 1,
+          primaryBiomarkerKey: "biomarker:blood-glucose",
+          primaryMetricDaysAvailable: 2,
+          wearableProviders: [],
+        },
+        adherence: {
+          completedSessions: 0,
+          expectedSessionsByNow: null,
+          minimumUsefulSessions: null,
+          status: "unknown",
+          targetSessions: null,
+        },
+        signals: [],
+        earlySignals: [],
+        confounders: [],
+        recommendation: null,
+        commonsProtocolRef: null,
+        protocolRef: null,
+      })),
+    };
+    const anchoredJournal = await importWithMocks<
+      typeof import("../src/usecases/experiment-journal-vault.ts")
+    >("../src/usecases/experiment-journal-vault.ts", {
+      "../src/query-runtime.ts": mockActualModule("../src/query-runtime.ts", (actual) => ({
+        ...actual,
+        loadQueryRuntime: vi.fn(async () => anchoredMetricQuery),
+      })),
+    });
+    await anchoredJournal.showExperimentProgress({
+      vault: "./vault",
+      lookup: "glucose-anchors",
+      asOf: "2026-06-18",
+    });
+    expect(anchoredMetricPointFilters).toEqual([
+      {
+        from: "2026-05-29",
+        limit: null,
+        metricKey: "glucose",
+        to: "2026-05-29",
+      },
+      {
+        from: "2026-06-18",
+        limit: null,
+        metricKey: "glucose",
+        to: "2026-06-18",
+      },
+    ]);
+
     assert.deepEqual(await journal.showVaultSummary("./vault"), {
       vault: "./vault",
       formatVersion: 1,

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -1716,19 +1716,6 @@ describe("record service seams", () => {
     });
     expect(anchoredMetricPointFilters).toEqual([
       {
-        from: "2026-06-01",
-        limit: null,
-        metricKey: "glucose",
-        to: "2026-06-18",
-      },
-      {
-        from: "2026-05-29",
-        limit: null,
-        metricKey: "glucose",
-        to: "2026-05-29",
-      },
-      {
-        from: "2026-06-18",
         limit: null,
         metricKey: "glucose",
         to: "2026-06-18",

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -1502,6 +1502,9 @@ describe("record service seams", () => {
       listMetricPoints: vi.fn(async () => {
         throw new Error("Experiment follow-up should not read metric points.");
       }),
+      listMetricPointsBatch: vi.fn(async () => {
+        throw new Error("Experiment follow-up should not read metric points.");
+      }),
       decideExperimentFollowupDue: vi.fn(() => ({
         schema: "murph.experiment-followup-due.v1",
         kind: "missed-log",
@@ -1657,6 +1660,10 @@ describe("record service seams", () => {
         anchoredMetricPointFilters.push(filters);
         return [];
       }),
+      listMetricPointsBatch: vi.fn(async (_vault: string, filtersList: readonly unknown[]) => {
+        anchoredMetricPointFilters.push(...filtersList);
+        return [];
+      }),
       normalizeMetricKey: queryRuntime.normalizeMetricKey,
       resolveMetricDefinition: queryRuntime.resolveMetricDefinition,
       resolveMetricDefinitionForBiomarker: queryRuntime.resolveMetricDefinitionForBiomarker,
@@ -1786,6 +1793,7 @@ describe("record service seams", () => {
           frontmatter: null,
         })),
         listMetricPoints: vi.fn(async () => []),
+        listMetricPointsBatch: vi.fn(async () => []),
         analyzeExperimentOutcome: vi.fn(() => ({
           schemaVersion: "murph.experiment-outcome.v1",
           asOf: "2026-04-08",

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -1627,6 +1627,7 @@ describe("record service seams", () => {
           tags: [],
           frontmatter: null,
         })),
+        listMetricPoints: vi.fn(async () => []),
         analyzeExperimentOutcome: vi.fn(() => ({
           schemaVersion: "murph.experiment-outcome.v1",
           asOf: "2026-04-08",

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -1499,6 +1499,30 @@ describe("record service seams", () => {
         family: "experiment",
         kind: "experiment",
       })]),
+      listMetricPoints: vi.fn(async () => {
+        throw new Error("Experiment follow-up should not read metric points.");
+      }),
+      decideExperimentFollowupDue: vi.fn(() => ({
+        schema: "murph.experiment-followup-due.v1",
+        kind: "missed-log",
+        action: "notify",
+        reason: "planned_session_log_missing",
+        date: "2026-04-08",
+        dedupeKey: "experiment-followup:exp_1:missed-log:2026-04-08",
+        experiment: {
+          id: "exp_1",
+          slug: "focus-sprint",
+          status: "active",
+          title: "Focus Sprint",
+        },
+        window: {
+          sessionDate: "2026-04-08",
+          baselineStart: null,
+          baselineEnd: null,
+          interventionStart: null,
+          interventionEnd: null,
+        },
+      })),
       showVaultSummary: vi.fn(async () => ({ title: "Vault", timezone: "UTC" })),
       showVaultStats: vi.fn(async () => ({ vault: "./vault" })),
     };
@@ -1564,6 +1588,21 @@ describe("record service seams", () => {
         },
       ],
     });
+    expect(await journal.showExperimentFollowupDue({
+      vault: "./vault",
+      lookup: "exp_1",
+      kind: "missed-log",
+      date: "2026-04-08",
+    })).toMatchObject({
+      experimentId: "exp_1",
+      lookupId: "exp_1",
+      slug: "focus-sprint",
+      kind: "missed-log",
+      decision: {
+        action: "notify",
+      },
+    });
+    expect(journalQuery.listMetricPoints).not.toHaveBeenCalled();
     assert.deepEqual(await journal.showVaultSummary("./vault"), {
       vault: "./vault",
       formatVersion: 1,

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -1716,6 +1716,12 @@ describe("record service seams", () => {
     });
     expect(anchoredMetricPointFilters).toEqual([
       {
+        from: "2026-06-01",
+        limit: null,
+        metricKey: "glucose",
+        to: "2026-06-18",
+      },
+      {
         from: "2026-05-29",
         limit: null,
         metricKey: "glucose",


### PR DESCRIPTION
## Summary

- Thread existing query metric projection rows into experiment progress, outcome analysis, follow-up decisions, and progress-card generation.
- Keep the normal projected entity read model sparse; no raw-vault fallback, provider-specific mapping, or new persisted state.
- Adjust progress coverage so secondary analysis metrics with data prevent an incorrect `no_wearable_data` status when the primary biomarker is legitimately missing.

## Root Cause

Experiment progress/card code rebuilt metric points from the default `readVault()` entity model. That model intentionally excludes hidden/default metric observations, while the query projection already stores those observations in `query_metric_points`. Vault-backed experiment usecases now load those stored metric points explicitly and pass them into the pure query analysis functions.

## Validation

- `pnpm build:workspace:incremental`
- `pnpm --dir packages/query typecheck`
- `pnpm --dir packages/vault-usecases typecheck`
- `pnpm --dir packages/query test`
- `pnpm --dir packages/vault-usecases test`
- `pnpm typecheck`
- `bash scripts/workspace-verify.sh test:diff packages/query/src/experiments.ts packages/query/src/experiment-progress-card.ts packages/vault-usecases/src/usecases/experiment-journal-vault.ts packages/vault-usecases/test/experiment-progress-metric-projection.test.ts packages/vault-usecases/test/record-service-coverage.test.ts`
- `pnpm test:smoke`
- Post-rebase focused rerun: `pnpm --dir packages/vault-usecases test -- experiment-progress-metric-projection.test.ts`
- Post-rebase focused rerun: `pnpm --dir packages/query test -- experiment-analysis.test.ts`
- Post-rebase focused rerun: `pnpm --dir packages/query typecheck`
- Post-rebase focused rerun: `pnpm --dir packages/vault-usecases typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784682045&installation_id=127572939&pr_number=250&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F250&signature=730441b9f37cd992d38c1cc9b5bf881852cf441d36a1d547580ca06f4dc43437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->