### PR TITLE
[codex] Stream hosted snapshot restore from R2

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-21-stream-r2-snapshot-restore.md
+++ b/agent-docs/exec-plans/completed/2026-06-21-stream-r2-snapshot-restore.md
@@ -1,0 +1,61 @@
+Goal (incl. success criteria):
+- Stack a narrow follow-up on PR #246 that restores hosted v2 workspace snapshots from the presigned R2 response stream instead of first writing `workspace.snapshot.enc`.
+- Keep PR #246's useful common-path behavior: decrypt/authenticate into one bounded plaintext archive buffer, validate the encrypted SHA, validate the plaintext archive SHA, and extract only after `decipher.final()` authenticates.
+- Success means the normal hosted restore path overlaps object-body read with AES-GCM decrypt/hash work, uses no temporary ciphertext file, leaves durable-root replacement behind the existing auth/hash/tar-safety gates, and does not add a new scheduler, storage owner, snapshot schema, or compatibility layer.
+
+Constraints/Assumptions:
+- Clean, simple, long-term maintainable architecture is the priority. Performance work is only worth doing if it removes redundant I/O without widening ownership or control flow.
+- PR #246 is the right base. It already removes the normal-path plaintext scratch archive; this follow-up should not duplicate or replace that work.
+- `apps/cloudflare` remains a thin execution adapter around encrypted object plumbing. `apps/web`, Temporal, mailbox ordering, checkpoint refs, and R2 object metadata stay unchanged.
+- Preserve fail-closed restore semantics: expected byte count, encrypted object SHA, AES-GCM auth, plaintext archive SHA, safe tar-entry validation, and durable-root replacement ordering.
+- Preserve existing large-snapshot compatibility, but the hosted R2 restore path should not download ciphertext to disk first. If a large fallback is needed, stream decrypted archive bytes to the existing plaintext fallback path and still extract only after auth/digest validation.
+- Do not add dependencies, snapshot ref fields, env flags, R2 bucket conventions, or generalized stream frameworks unless a failing test proves they are necessary.
+
+Key decisions:
+- Add one owning primitive in `apps/cloudflare/src/workspace-snapshot-local.ts`, `restoreEncryptedWorkspaceSnapshotFromEncryptedStream`.
+- Keep the current file-path restore function as a small wrapper/compatibility entrypoint for tests and local callers that already have an encrypted file. The hosted R2 path should call the stream primitive directly.
+- Use a straightforward async chunk loop instead of a Transform pipeline stack. The loop keeps the final 16 AES-GCM bytes as the auth-tag tail, hashes every encrypted chunk, decrypts only ciphertext bytes, writes decrypted output to the existing fixed-size collector, and calls `decipher.final()` before any archive listing or extraction.
+- Reuse PR #246's fixed-size plaintext archive collector for the common path. Size it from `ref.archive.encryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES`; for current snapshot sizes this is the one preallocated compressed archive buffer.
+- Keep timing/diagnostic churn minimal. `objectFetchMs` now measures response open/validation, while `archive_restore` owns body consumption, decrypt/hash, auth, tar safety, and extraction.
+
+State:
+- Implementation and verification complete on branch `codex/stream-r2-snapshot-restore`, stacked on PR #246.
+
+Done:
+- Rechecked PR #246 on 2026-06-21. It is still open and still writes the hosted R2 response body to `workspace.snapshot.enc` before calling `restoreEncryptedWorkspaceSnapshot`.
+- Confirmed PR #246 partially overlaps the goal by decrypting normal-size archives into memory and extracting from the authenticated buffer, but it does not overlap R2 fetch with decrypt and does not remove the ciphertext temp file.
+- Rechecked hosted runtime ownership docs: Cloudflare owns encrypted object plumbing and restore; web/Temporal/checkpoint ownership should not change for this optimization.
+
+Now:
+- Commit, push, and open a stacked PR against PR #246's branch.
+
+Next:
+- Monitor PR CI and review feedback.
+
+Verification:
+- `pnpm --dir apps/cloudflare typecheck` passed.
+- `pnpm --dir apps/cloudflare test:node -- apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts` passed after the audit fix: 91 files, 1520 tests.
+- `bash scripts/workspace-verify.sh test:diff apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts apps/cloudflare/src/runtime-platform/diagnostics.ts apps/cloudflare/src/workspace-snapshot-local.ts apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts` passed, including `apps/cloudflare verify`.
+- `git diff --check` passed.
+
+Audit outcomes:
+- `security-privacy-review`: no critical/high/medium findings.
+- `coverage-write`: added/confirmed test-only proof that `scratchPrepareMs` is absent after removing the hosted ciphertext scratch step.
+- `deep-review`: accepted finding that an already-open R2 response body could be left open if data-key unwrap failed before `archive_restore`; fixed by returning a cancellable body handle and canceling it on unwrap failure and archive-restore exit, with a focused regression test.
+- Run the Cloudflare-focused verification lane first, then the repo-required verification/audit lane for a high-risk hosted-runtime change.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- PR #246 `[codex] Restore workspace snapshots from memory buffer`
+- `apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts`
+- `apps/cloudflare/src/workspace-snapshot-local.ts`
+- `apps/cloudflare/test/workspace-snapshot-local.test.ts`
+- `apps/cloudflare/test/runner-outbound.test.ts`
+- `apps/cloudflare/test/runner-platform.test.ts`
+- `apps/cloudflare/README.md` only if the durable storage/restore wording would otherwise become stale
+- `agent-docs/references/hosted-runtime-protocol.md` only if the restore contract wording would otherwise become stale
+Status: completed
+Updated: 2026-06-21
+Completed: 2026-06-21

--- a/apps/cloudflare/src/runtime-platform/diagnostics.ts
+++ b/apps/cloudflare/src/runtime-platform/diagnostics.ts
@@ -25,7 +25,6 @@ export type HostedWorkspaceSnapshotRestoreStep =
   | "data_key_unwrap"
   | "object_fetch"
   | "presign_get"
-  | "scratch_prepare"
   | "size_guard";
 
 const HOSTED_WORKSPACE_SNAPSHOT_RESTORE_STEPS =
@@ -34,7 +33,6 @@ const HOSTED_WORKSPACE_SNAPSHOT_RESTORE_STEPS =
     "data_key_unwrap",
     "object_fetch",
     "presign_get",
-    "scratch_prepare",
     "size_guard",
   ]);
 

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -1,10 +1,6 @@
-import { createReadStream, createWriteStream } from "node:fs";
-import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { Readable, Transform } from "node:stream";
-import { pipeline } from "node:stream/promises";
-import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { Readable } from "node:stream";
 
 import type {
   HostedRuntimePlatform,
@@ -32,7 +28,7 @@ import {
   encodeHostedWorkspaceSnapshotSha256Base64,
   HOSTED_WORKSPACE_SNAPSHOT_CONTENT_TYPE,
 } from "../workspace-snapshot-store.ts";
-import { restoreEncryptedWorkspaceSnapshot } from "../workspace-snapshot-local.ts";
+import { restoreEncryptedWorkspaceSnapshotFromEncryptedStream } from "../workspace-snapshot-local.ts";
 import { requireHostedRuntimeWriteFenceHeaders, type HostedWorkspaceCheckpointBridgeAuthority } from "./authority-headers.ts";
 import {
   HostedRuntimeControlPlaneFetchError,
@@ -247,135 +243,117 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
         step: "size_guard",
       });
       timing.sizeGuardMs = readHostedRuntimeStepElapsedMs(sizeGuardStartedAt);
-      const scratchRoot = path.resolve(request.scratchRoot ?? tmpdir());
-      const scratchPrepareStartedAt = Date.now();
-      const tempDir = await runHostedWorkspaceSnapshotRestoreStep({
-        details: restoreLogDetails,
-        run: async () => {
-          await mkdir(scratchRoot, { mode: 0o700, recursive: true });
-          return await mkdtemp(path.join(scratchRoot, "workspace-snapshot-fetch-"));
-        },
-        step: "scratch_prepare",
+      // The data-key unwrap (worker KMS round trip) and the encrypted-object
+      // leg (presign GET -> R2 response open) share no inputs. Run them
+      // concurrently, then let archive_restore consume the response body
+      // directly so R2 body reads overlap with decrypt/hash work instead of
+      // first writing ciphertext to a temp file.
+      const dataKeyPromise = (async () => {
+        const dataKeyUnwrapStartedAt = Date.now();
+        const dataKey = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
+          details: restoreLogDetails,
+          run: async () => await unwrapWorkspaceSnapshotDataKey({
+            aad: request.ref.encryption.aad,
+            fetchImpl: input.fetchImpl,
+            rootKeyId: request.ref.encryption.rootKeyId,
+            timeoutMs: input.timeoutMs,
+            workspaceCheckpointBridge: input.workspaceCheckpointBridge,
+            wrappedDataKey: request.ref.encryption.wrappedDataKey,
+          }),
+          step: "data_key_unwrap",
+        });
+        timing.dataKeyUnwrapMs = readHostedRuntimeStepElapsedMs(dataKeyUnwrapStartedAt);
+        return dataKey;
+      })();
+      const encryptedObjectAbort = new AbortController();
+      void dataKeyPromise.catch(() => {
+        encryptedObjectAbort.abort(
+          new Error("Hosted workspace snapshot data key unwrap failed; object fetch is unnecessary."),
+        );
       });
-      timing.scratchPrepareMs = readHostedRuntimeStepElapsedMs(scratchPrepareStartedAt);
-      const encryptedFilePath = path.join(tempDir, "workspace.snapshot.enc");
-      try {
-        // The data-key unwrap (worker KMS round trip) and the encrypted-object
-        // leg (presign GET -> R2 download) share no inputs, and the dominant
-        // cold-restore cost is exactly these two network legs run back to
-        // back. Run them concurrently and only join before archive_restore,
-        // which needs both. Per-step timings keep their own wall-clock, so
-        // concurrent step durations no longer sum to the restore total.
-        const dataKeyPromise = (async () => {
-          const dataKeyUnwrapStartedAt = Date.now();
-          const dataKey = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
-            details: restoreLogDetails,
-            run: async () => await unwrapWorkspaceSnapshotDataKey({
-              aad: request.ref.encryption.aad,
+      const encryptedObjectPromise = (async () => {
+        const presignGetStartedAt = Date.now();
+        const presignedGet = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
+          details: restoreLogDetails,
+          run: async () => {
+            const result = await presignWorkspaceSnapshotGet({
               fetchImpl: input.fetchImpl,
-              rootKeyId: request.ref.encryption.rootKeyId,
+              objectKey: request.ref.objectKey,
+              ref: request.ref,
+              signal: encryptedObjectAbort.signal,
+              snapshotId: request.ref.snapshotId,
               timeoutMs: input.timeoutMs,
               workspaceCheckpointBridge: input.workspaceCheckpointBridge,
-              wrappedDataKey: request.ref.encryption.wrappedDataKey,
-            }),
-            step: "data_key_unwrap",
-          });
-          timing.dataKeyUnwrapMs = readHostedRuntimeStepElapsedMs(dataKeyUnwrapStartedAt);
-          return dataKey;
-        })();
-        // A failed unwrap makes the (potentially large) R2 download useless;
-        // abort it instead of letting it run to completion before the join
-        // surfaces the unwrap error to the retry path.
-        const encryptedObjectAbort = new AbortController();
-        void dataKeyPromise.catch(() => {
-          encryptedObjectAbort.abort(
-            new Error("Hosted workspace snapshot data key unwrap failed; object fetch is unnecessary."),
-          );
+            });
+            const expiresAtMs = Date.parse(result.expiresAt);
+            if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+              throw new Error("Hosted workspace snapshot direct R2 download URL is expired.");
+            }
+            return {
+              ...result,
+              expiresAtMs,
+            };
+          },
+          step: "presign_get",
         });
-        const encryptedObjectPromise = (async () => {
-          const presignGetStartedAt = Date.now();
-          const presignedGet = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
-            details: restoreLogDetails,
-            run: async () => {
-              const result = await presignWorkspaceSnapshotGet({
-                fetchImpl: input.fetchImpl,
-                objectKey: request.ref.objectKey,
-                ref: request.ref,
-                signal: encryptedObjectAbort.signal,
-                snapshotId: request.ref.snapshotId,
-                timeoutMs: input.timeoutMs,
-                workspaceCheckpointBridge: input.workspaceCheckpointBridge,
-              });
-              const expiresAtMs = Date.parse(result.expiresAt);
-              if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
-                throw new Error("Hosted workspace snapshot direct R2 download URL is expired.");
-              }
-              return {
-                ...result,
-                expiresAtMs,
-              };
-            },
-            step: "presign_get",
-          });
-          timing.presignGetMs = readHostedRuntimeStepElapsedMs(presignGetStartedAt);
-          const objectFetchStartedAt = Date.now();
-          await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
-            details: restoreLogDetails,
-            run: async () => {
-              const fetched = await fetchHostedWorkspaceSnapshotEncryptedObjectToFile({
-                encryptedFilePath,
-                expectedEncryptedByteSize: request.ref.archive.encryptedByteSize,
-                fetchImpl: input.fetchImpl,
-                getUrl: presignedGet.getUrl,
-                signal: encryptedObjectAbort.signal,
-                timeoutMs: Math.max(1, presignedGet.expiresAtMs - Date.now() - 5_000),
-              });
-              if (!fetched) {
-                throw new Error("Hosted workspace snapshot encrypted object is unavailable.");
-              }
-            },
-            step: "object_fetch",
-          });
-          timing.objectFetchMs = readHostedRuntimeStepElapsedMs(objectFetchStartedAt);
-        })();
-        // Settle both legs before throwing so a failed leg never leaves the
-        // other writing into a scratch dir that the finally block already
-        // removed. Prefer the unwrap failure deterministically.
-        const [dataKeySettled, encryptedObjectSettled] = await Promise.allSettled([
-          dataKeyPromise,
-          encryptedObjectPromise,
-        ]);
-        if (dataKeySettled.status === "rejected") {
-          throw dataKeySettled.reason;
-        }
-        if (encryptedObjectSettled.status === "rejected") {
-          throw encryptedObjectSettled.reason;
-        }
-        const dataKey = dataKeySettled.value;
-        const archiveTimings = await runHostedWorkspaceSnapshotRestoreStep({
+        timing.presignGetMs = readHostedRuntimeStepElapsedMs(presignGetStartedAt);
+        const objectFetchStartedAt = Date.now();
+        const fetched = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
           details: restoreLogDetails,
-          run: async () => await restoreEncryptedWorkspaceSnapshot({
-            dataKey,
-            durableRoot: request.durableRoot,
-            encryptedFilePath,
-            ref: request.ref,
-          }),
-          step: "archive_restore",
+          run: async () => {
+            const encryptedStream = await fetchHostedWorkspaceSnapshotEncryptedObjectStream({
+              expectedEncryptedByteSize: request.ref.archive.encryptedByteSize,
+              fetchImpl: input.fetchImpl,
+              getUrl: presignedGet.getUrl,
+              signal: encryptedObjectAbort.signal,
+              timeoutMs: Math.max(1, presignedGet.expiresAtMs - Date.now() - 5_000),
+            });
+            if (!encryptedStream) {
+              throw new Error("Hosted workspace snapshot encrypted object is unavailable.");
+            }
+            return encryptedStream;
+          },
+          step: "object_fetch",
         });
-        timing.decryptMs = archiveTimings.decryptMs;
-        timing.archiveExtractMs = archiveTimings.archiveExtractMs;
-        timing.restorePreflightMs = archiveTimings.restorePreflightMs;
-        timing.durableRootReplaceMs = archiveTimings.durableRootReplaceMs;
-        timing.cleanupMs = archiveTimings.cleanupMs;
-        timing.extractMs = archiveTimings.extractMs;
-      } finally {
-        const cleanupStartedAt = Date.now();
-        try {
-          await rm(tempDir, { force: true, recursive: true });
-        } finally {
-          timing.cleanupMs = (timing.cleanupMs ?? 0) + readHostedRuntimeStepElapsedMs(cleanupStartedAt);
+        timing.objectFetchMs = readHostedRuntimeStepElapsedMs(objectFetchStartedAt);
+        return fetched;
+      })();
+      const [dataKeySettled, encryptedObjectSettled] = await Promise.allSettled([
+        dataKeyPromise,
+        encryptedObjectPromise,
+      ]);
+      if (dataKeySettled.status === "rejected") {
+        if (encryptedObjectSettled.status === "fulfilled") {
+          await encryptedObjectSettled.value.cancel();
         }
+        throw dataKeySettled.reason;
       }
+      if (encryptedObjectSettled.status === "rejected") {
+        throw encryptedObjectSettled.reason;
+      }
+      const encryptedObject = encryptedObjectSettled.value;
+      const archiveTimings = await runHostedWorkspaceSnapshotRestoreStep({
+        details: restoreLogDetails,
+        run: async () => {
+          try {
+            return await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+              dataKey: dataKeySettled.value,
+              durableRoot: request.durableRoot,
+              encryptedStream: encryptedObject.encryptedStream,
+              ref: request.ref,
+            });
+          } finally {
+            await encryptedObject.cancel();
+          }
+        },
+        step: "archive_restore",
+      });
+      timing.decryptMs = archiveTimings.decryptMs;
+      timing.archiveExtractMs = archiveTimings.archiveExtractMs;
+      timing.restorePreflightMs = archiveTimings.restorePreflightMs;
+      timing.durableRootReplaceMs = archiveTimings.durableRootReplaceMs;
+      timing.cleanupMs = archiveTimings.cleanupMs;
+      timing.extractMs = archiveTimings.extractMs;
       return timing;
     },
 
@@ -403,6 +381,12 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
   };
   return port;
 }
+
+interface HostedWorkspaceSnapshotEncryptedObjectBody {
+  cancel(): Promise<void>;
+  encryptedStream: AsyncIterable<Uint8Array>;
+}
+
 function parseHostedWorkspaceSnapshotStartPayload(
   value: unknown,
   boundUserId: string,
@@ -609,14 +593,13 @@ async function unwrapWorkspaceSnapshotDataKey(input: {
   return dataKey;
 }
 
-async function fetchHostedWorkspaceSnapshotEncryptedObjectToFile(input: {
-  encryptedFilePath: string;
+async function fetchHostedWorkspaceSnapshotEncryptedObjectStream(input: {
   expectedEncryptedByteSize: number;
   fetchImpl: typeof fetch;
   getUrl: string;
   signal?: AbortSignal | null;
   timeoutMs: number;
-}): Promise<boolean> {
+}): Promise<HostedWorkspaceSnapshotEncryptedObjectBody | null> {
   const response = await fetchHostedResponse({
     description: "Hosted workspace snapshot fetch",
     fetchImpl: input.fetchImpl,
@@ -630,7 +613,11 @@ async function fetchHostedWorkspaceSnapshotEncryptedObjectToFile(input: {
     url: new URL(input.getUrl),
   });
   if (response.status === 404) {
-    return false;
+    await cancelHostedWorkspaceSnapshotResponseBody(response.body);
+    return null;
+  }
+  if (!response.ok) {
+    await cancelHostedWorkspaceSnapshotResponseBody(response.body);
   }
   assertHostedOk(response, "Hosted workspace snapshot fetch");
   if (!response.body) {
@@ -638,60 +625,94 @@ async function fetchHostedWorkspaceSnapshotEncryptedObjectToFile(input: {
   }
   const contentLength = response.headers.get("content-length");
   if (contentLength !== null && contentLength !== String(input.expectedEncryptedByteSize)) {
+    await cancelHostedWorkspaceSnapshotResponseBody(response.body);
     throw new Error("Hosted workspace snapshot fetch content-length does not match its ref.");
   }
-  try {
-    await pipeline(
-      Readable.fromWeb(response.body as NodeReadableStream<Uint8Array>),
-      createExpectedByteCountTransform({
-        expectedBytes: input.expectedEncryptedByteSize,
-        label: "Hosted workspace snapshot fetch",
-      }),
-      createWriteStream(input.encryptedFilePath, { mode: 0o600 }),
-    );
-  } catch (error) {
-    const wrappedError = new HostedRuntimeControlPlaneFetchError({
-      cause: error,
-      description: "Hosted workspace snapshot fetch response body read",
-      signalState: {
-        callerSignalAborted: false,
-        requestSignalAborted: false,
-        timeoutMs: input.timeoutMs,
-        timeoutSignalAborted: false,
-      },
-    });
-
-    if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
-      throw wrappedError;
-    }
-
-    throw error;
-  }
-  return true;
+  return createHostedWorkspaceSnapshotEncryptedObjectBody({
+    expectedEncryptedByteSize: input.expectedEncryptedByteSize,
+    responseBody: response.body,
+    timeoutMs: input.timeoutMs,
+  });
 }
 
-function createExpectedByteCountTransform(input: {
-  expectedBytes: number;
-  label: string;
-}): Transform {
+function createHostedWorkspaceSnapshotEncryptedObjectBody(input: {
+  expectedEncryptedByteSize: number;
+  responseBody: ReadableStream<Uint8Array>;
+  timeoutMs: number;
+}): HostedWorkspaceSnapshotEncryptedObjectBody {
   let byteCount = 0;
-  return new Transform({
-    flush(callback) {
-      if (byteCount !== input.expectedBytes) {
-        callback(new Error(`${input.label} byte count does not match its ref.`));
-        return;
+  let cancelPromise: Promise<void> | null = null;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let streamDone = false;
+
+  const cancel = async (): Promise<void> => {
+    if (streamDone) {
+      return;
+    }
+    cancelPromise ??= (reader
+      ? reader.cancel()
+      : input.responseBody.cancel())
+      .catch(() => undefined);
+    await cancelPromise;
+  };
+
+  async function* readBody(): AsyncIterable<Uint8Array> {
+    try {
+      reader = input.responseBody.getReader();
+      while (true) {
+        const next = await reader.read();
+        if (next.done) {
+          break;
+        }
+        byteCount += next.value.byteLength;
+        if (byteCount > input.expectedEncryptedByteSize) {
+          throw new Error("Hosted workspace snapshot fetch exceeded its ref byte count.");
+        }
+        yield next.value;
       }
-      callback();
-    },
-    transform(chunk: Buffer, _encoding, callback) {
-      byteCount += chunk.byteLength;
-      if (byteCount > input.expectedBytes) {
-        callback(new Error(`${input.label} exceeded its ref byte count.`));
-        return;
+      if (byteCount !== input.expectedEncryptedByteSize) {
+        throw new Error("Hosted workspace snapshot fetch byte count does not match its ref.");
       }
-      callback(null, chunk);
-    },
-  });
+      streamDone = true;
+    } catch (error) {
+      const wrappedError = new HostedRuntimeControlPlaneFetchError({
+        cause: error,
+        description: "Hosted workspace snapshot fetch response body read",
+        signalState: {
+          callerSignalAborted: false,
+          requestSignalAborted: false,
+          timeoutMs: input.timeoutMs,
+          timeoutSignalAborted: false,
+        },
+      });
+
+      if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
+        throw wrappedError;
+      }
+
+      throw error;
+    } finally {
+      if (!streamDone) {
+        await cancel();
+      }
+      reader?.releaseLock();
+    }
+  }
+
+  return {
+    cancel,
+    encryptedStream: readBody(),
+  };
+}
+
+async function cancelHostedWorkspaceSnapshotResponseBody(
+  body: ReadableStream<Uint8Array> | null,
+): Promise<void> {
+  try {
+    await body?.cancel();
+  } catch {
+    // Best-effort cleanup only; preserve the original restore failure.
+  }
 }
 
 function parseHostedWorkspaceSnapshotCompletePayload(

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -359,7 +359,6 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
             durableRoot: request.durableRoot,
             encryptedFilePath,
             ref: request.ref,
-            scratchRoot: request.scratchRoot ?? null,
           }),
           step: "archive_restore",
         });

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { createCipheriv, createDecipheriv, createHash, type Hash } from "node:crypto";
+import { createCipheriv, createDecipheriv, createHash, type DecipherGCM, type Hash } from "node:crypto";
 import { createReadStream, createWriteStream, type Stats } from "node:fs";
 import {
   access,
@@ -7,7 +7,6 @@ import {
   lstat,
   mkdir,
   mkdtemp,
-  open,
   readdir,
   realpath,
   rename,
@@ -345,18 +344,34 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
   postExtractIntegrityCheck?: boolean;
   ref: HostedWorkspaceSnapshotV2Ref;
 }): Promise<RestoreEncryptedWorkspaceSnapshotTimings> {
-  if (input.ref.archive.compression !== HOSTED_WORKSPACE_SNAPSHOT_COMPRESSION) {
-    throw new Error("Hosted workspace snapshot restore only supports zstd archives.");
-  }
   const encryptedFilePath = path.resolve(input.encryptedFilePath);
   const encryptedStat = await stat(encryptedFilePath);
   if (encryptedStat.size !== input.ref.archive.encryptedByteSize) {
     throw new Error("Hosted workspace snapshot encrypted size does not match its ref.");
   }
-  if (encryptedStat.size <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
+  return await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+    dataKey: input.dataKey,
+    durableRoot: input.durableRoot,
+    encryptedStream: createReadStream(encryptedFilePath),
+    postExtractIntegrityCheck: input.postExtractIntegrityCheck,
+    ref: input.ref,
+  });
+}
+
+export async function restoreEncryptedWorkspaceSnapshotFromEncryptedStream(input: {
+  dataKey: string;
+  durableRoot: string;
+  encryptedStream: AsyncIterable<Uint8Array>;
+  postExtractIntegrityCheck?: boolean;
+  ref: HostedWorkspaceSnapshotV2Ref;
+}): Promise<RestoreEncryptedWorkspaceSnapshotTimings> {
+  if (input.ref.archive.compression !== HOSTED_WORKSPACE_SNAPSHOT_COMPRESSION) {
+    throw new Error("Hosted workspace snapshot restore only supports zstd archives.");
+  }
+  const expectedEncryptedByteSize = input.ref.archive.encryptedByteSize;
+  if (expectedEncryptedByteSize <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
     throw new Error("Hosted workspace snapshot encrypted object is too small.");
   }
-
   const durableRoot = path.resolve(input.durableRoot);
   const durableParent = path.dirname(durableRoot);
   await mkdir(durableParent, { mode: 0o700, recursive: true });
@@ -377,10 +392,6 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
   try {
     const decryptStartedAt = Date.now();
     await mkdir(restoreRoot, { mode: 0o700, recursive: true });
-    const authTag = await readHostedWorkspaceSnapshotAuthTag(
-      encryptedFilePath,
-      encryptedStat.size,
-    );
     dataKey = decodeHostedWorkspaceSnapshotV2DataKey(input.dataKey);
     const decipher = createDecipheriv(
       "aes-256-gcm",
@@ -388,25 +399,23 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
       Buffer.from(input.ref.encryption.ivBase64, "base64url"),
     );
     decipher.setAAD(Buffer.from(serializeHostedWorkspaceSnapshotV2Aad(input.ref.encryption.aad)));
-    decipher.setAuthTag(authTag);
 
     const encryptedObjectHash = createHash("sha256");
     const plaintextArchiveHash = createHash("sha256");
-    if (encryptedStat.size < HOSTED_WORKSPACE_SNAPSHOT_MAX_IN_MEMORY_ENCRYPTED_BYTES) {
+    if (expectedEncryptedByteSize < HOSTED_WORKSPACE_SNAPSHOT_MAX_IN_MEMORY_ENCRYPTED_BYTES) {
       const plaintextArchiveCollector = createFixedSizeArchiveBufferCollector({
-        byteLength: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
+        byteLength: expectedEncryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
         hash: plaintextArchiveHash,
       });
       try {
-        await pipeline(
-          createReadStream(encryptedFilePath, {
-            end: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
-            start: 0,
-          }),
-          createHashTransform(encryptedObjectHash),
+        await decryptHostedWorkspaceSnapshotEncryptedStream({
           decipher,
+          encryptedObjectHash,
+          encryptedStream: input.encryptedStream,
+          expectedEncryptedByteSize,
+          plaintextArchiveHash,
           plaintextArchiveCollector,
-        );
+        });
         plaintextArchiveBuffer = plaintextArchiveCollector.readBuffer();
       } catch (error) {
         plaintextArchiveCollector.clear();
@@ -414,23 +423,26 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
       }
     } else {
       plaintextArchivePath = path.join(restoreTempDir, "workspace.snapshot.tar.zst");
-      await pipeline(
-        createReadStream(encryptedFilePath, {
-          end: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
-          start: 0,
-        }),
-        createHashTransform(encryptedObjectHash),
-        decipher,
-        createHashTransform(plaintextArchiveHash),
-        createWriteStream(plaintextArchivePath, { mode: 0o600 }),
-      );
+      const plaintextArchiveFile = createWriteStream(plaintextArchivePath, { mode: 0o600 });
+      try {
+        await decryptHostedWorkspaceSnapshotEncryptedStream({
+          decipher,
+          encryptedObjectHash,
+          encryptedStream: input.encryptedStream,
+          expectedEncryptedByteSize,
+          plaintextArchiveFile,
+          plaintextArchiveHash,
+        });
+      } catch (error) {
+        plaintextArchiveFile.destroy();
+        throw error;
+      }
     }
     const plaintextArchive = plaintextArchiveBuffer ?? plaintextArchivePath;
     if (plaintextArchive === null) {
       throw new Error("Hosted workspace snapshot decrypted archive is unavailable.");
     }
 
-    encryptedObjectHash.update(authTag);
     const encryptedObjectSha256 = encryptedObjectHash.digest("hex");
     if (encryptedObjectSha256 !== input.ref.archive.encryptedObjectSha256) {
       throw new Error("Hosted workspace snapshot encrypted digest does not match its ref.");
@@ -549,6 +561,132 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     cleanupMs,
     extractMs,
   };
+}
+
+async function decryptHostedWorkspaceSnapshotEncryptedStream(input: {
+  decipher: DecipherGCM;
+  encryptedObjectHash: Hash;
+  encryptedStream: AsyncIterable<Uint8Array>;
+  expectedEncryptedByteSize: number;
+  plaintextArchiveCollector?: Writable & {
+    clear(): void;
+    readBuffer(): Buffer;
+  };
+  plaintextArchiveFile?: Writable;
+  plaintextArchiveHash: Hash;
+}): Promise<void> {
+  let encryptedByteCount = 0;
+  let encryptedTail = Buffer.alloc(0);
+  let plaintextArchiveFileOpen = Boolean(input.plaintextArchiveFile);
+  try {
+    for await (const rawChunk of input.encryptedStream) {
+      const chunk = Buffer.isBuffer(rawChunk)
+        ? rawChunk
+        : Buffer.from(rawChunk);
+      if (chunk.byteLength === 0) {
+        continue;
+      }
+      encryptedByteCount += chunk.byteLength;
+      if (encryptedByteCount > input.expectedEncryptedByteSize) {
+        throw new Error("Hosted workspace snapshot encrypted stream exceeded its ref byte count.");
+      }
+      input.encryptedObjectHash.update(chunk);
+
+      const encrypted = encryptedTail.byteLength > 0
+        ? Buffer.concat([encryptedTail, chunk])
+        : chunk;
+      if (encrypted.byteLength <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
+        encryptedTail = Buffer.from(encrypted);
+        continue;
+      }
+
+      const ciphertextEnd =
+        encrypted.byteLength - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES;
+      encryptedTail = Buffer.from(encrypted.subarray(ciphertextEnd));
+      await writeHostedWorkspaceSnapshotPlaintextArchiveChunk({
+        chunk: input.decipher.update(encrypted.subarray(0, ciphertextEnd)),
+        plaintextArchiveCollector: input.plaintextArchiveCollector,
+        plaintextArchiveFile: input.plaintextArchiveFile,
+        plaintextArchiveHash: input.plaintextArchiveHash,
+      });
+    }
+
+    if (encryptedByteCount !== input.expectedEncryptedByteSize) {
+      throw new Error("Hosted workspace snapshot encrypted stream byte count does not match its ref.");
+    }
+    if (encryptedTail.byteLength !== HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
+      throw new Error("Hosted workspace snapshot auth tag is incomplete.");
+    }
+
+    input.decipher.setAuthTag(encryptedTail);
+    await writeHostedWorkspaceSnapshotPlaintextArchiveChunk({
+      chunk: input.decipher.final(),
+      plaintextArchiveCollector: input.plaintextArchiveCollector,
+      plaintextArchiveFile: input.plaintextArchiveFile,
+      plaintextArchiveHash: input.plaintextArchiveHash,
+    });
+
+    if (input.plaintextArchiveFile) {
+      await finishHostedWorkspaceSnapshotWritable(input.plaintextArchiveFile);
+      plaintextArchiveFileOpen = false;
+    }
+  } finally {
+    encryptedTail.fill(0);
+    if (plaintextArchiveFileOpen && input.plaintextArchiveFile) {
+      input.plaintextArchiveFile.destroy();
+    }
+  }
+}
+
+async function writeHostedWorkspaceSnapshotPlaintextArchiveChunk(input: {
+  chunk: Buffer;
+  plaintextArchiveCollector?: Writable;
+  plaintextArchiveFile?: Writable;
+  plaintextArchiveHash: Hash;
+}): Promise<void> {
+  if (input.chunk.byteLength === 0) {
+    return;
+  }
+  if (input.plaintextArchiveCollector) {
+    await writeHostedWorkspaceSnapshotWritable(input.plaintextArchiveCollector, input.chunk);
+    return;
+  }
+  if (!input.plaintextArchiveFile) {
+    throw new Error("Hosted workspace snapshot decrypted archive output is unavailable.");
+  }
+  input.plaintextArchiveHash.update(input.chunk);
+  await writeHostedWorkspaceSnapshotWritable(input.plaintextArchiveFile, input.chunk);
+}
+
+async function writeHostedWorkspaceSnapshotWritable(
+  writable: Writable,
+  chunk: Buffer,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    writable.write(chunk, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function finishHostedWorkspaceSnapshotWritable(writable: Writable): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      writable.off("finish", onFinish);
+      reject(error);
+    };
+    const onFinish = () => {
+      writable.off("error", onError);
+      resolve();
+    };
+    writable.once("error", onError);
+    writable.once("finish", onFinish);
+    writable.end();
+  });
 }
 
 export async function preflightHostedWorkspaceSnapshotDurableRoot(
@@ -1078,28 +1216,6 @@ function createFixedSizeArchiveBufferCollector(input: {
       return buffer;
     },
   });
-}
-
-async function readHostedWorkspaceSnapshotAuthTag(
-  filePath: string,
-  encryptedSize: number,
-): Promise<Buffer> {
-  const handle = await open(filePath, "r");
-  try {
-    const authTag = Buffer.alloc(HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES);
-    const result = await handle.read(
-      authTag,
-      0,
-      HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
-      encryptedSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
-    );
-    if (result.bytesRead !== HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
-      throw new Error("Hosted workspace snapshot auth tag is incomplete.");
-    }
-    return authTag;
-  } finally {
-    await handle.close();
-  }
 }
 
 async function replaceHostedWorkspaceSnapshotDurableRoot(input: {

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { createCipheriv, createDecipheriv, createHash } from "node:crypto";
+import { createCipheriv, createDecipheriv, createHash, type Hash } from "node:crypto";
 import { createReadStream, createWriteStream, type Stats } from "node:fs";
 import {
   access,
@@ -17,7 +17,7 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline";
-import { Transform, type Readable } from "node:stream";
+import { Readable, Transform, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import {
@@ -34,6 +34,8 @@ const HOSTED_WORKSPACE_SNAPSHOT_ZSTD_ARGS = [
   "--no-progress",
   "-T2",
 ] as const;
+const HOSTED_WORKSPACE_SNAPSHOT_MAX_IN_MEMORY_ENCRYPTED_BYTES =
+  512 * 1024 * 1024;
 const HOSTED_WORKSPACE_SNAPSHOT_MAX_TAR_ENTRIES = 20_000;
 const HOSTED_WORKSPACE_SNAPSHOT_PROCESS_FAILURE_MARKER =
   Symbol("hosted.workspace-snapshot.process-failure");
@@ -342,7 +344,6 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
   encryptedFilePath: string;
   postExtractIntegrityCheck?: boolean;
   ref: HostedWorkspaceSnapshotV2Ref;
-  scratchRoot?: string | null;
 }): Promise<RestoreEncryptedWorkspaceSnapshotTimings> {
   if (input.ref.archive.compression !== HOSTED_WORKSPACE_SNAPSHOT_COMPRESSION) {
     throw new Error("Hosted workspace snapshot restore only supports zstd archives.");
@@ -358,27 +359,14 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
 
   const durableRoot = path.resolve(input.durableRoot);
   const durableParent = path.dirname(durableRoot);
-  const scratchRoot = input.scratchRoot ? path.resolve(input.scratchRoot) : null;
-  if (scratchRoot && isSameOrDescendantPath(scratchRoot, durableRoot)) {
-    throw new Error("Hosted workspace snapshot restore scratchRoot must be outside durableRoot.");
-  }
   await mkdir(durableParent, { mode: 0o700, recursive: true });
-  if (scratchRoot) {
-    await mkdir(scratchRoot, { mode: 0o700, recursive: true });
-    await assertHostedWorkspaceSnapshotPathOutsideRoot({
-      candidate: scratchRoot,
-      message: "Hosted workspace snapshot restore scratchRoot must be outside durableRoot.",
-      root: durableRoot,
-    });
-  }
   await assertHostedWorkspaceSnapshotZstdCliAvailable();
   const restoreTempDir = await mkdtemp(path.join(durableParent, ".workspace-snapshot-restore-"));
-  const scratchTempDir = scratchRoot
-    ? await mkdtemp(path.join(scratchRoot, "workspace-snapshot-restore-"))
-    : restoreTempDir;
   const restoreRoot = path.join(restoreTempDir, "durable-root");
   const backupRoot = path.join(restoreTempDir, "previous-durable-root");
   let dataKey: Uint8Array | null = null;
+  let plaintextArchiveBuffer: Buffer | null = null;
+  let plaintextArchivePath: string | null = null;
   let decryptMs = 0;
   let archiveExtractMs = 0;
   let restorePreflightMs = 0;
@@ -404,17 +392,43 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
 
     const encryptedObjectHash = createHash("sha256");
     const plaintextArchiveHash = createHash("sha256");
-    const plaintextArchivePath = path.join(scratchTempDir, "workspace.snapshot.tar.zst");
-    await pipeline(
-      createReadStream(encryptedFilePath, {
-        end: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
-        start: 0,
-      }),
-      createHashTransform(encryptedObjectHash),
-      decipher,
-      createHashTransform(plaintextArchiveHash),
-      createWriteStream(plaintextArchivePath, { mode: 0o600 }),
-    );
+    if (encryptedStat.size < HOSTED_WORKSPACE_SNAPSHOT_MAX_IN_MEMORY_ENCRYPTED_BYTES) {
+      const plaintextArchiveCollector = createFixedSizeArchiveBufferCollector({
+        byteLength: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
+        hash: plaintextArchiveHash,
+      });
+      try {
+        await pipeline(
+          createReadStream(encryptedFilePath, {
+            end: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
+            start: 0,
+          }),
+          createHashTransform(encryptedObjectHash),
+          decipher,
+          plaintextArchiveCollector,
+        );
+        plaintextArchiveBuffer = plaintextArchiveCollector.readBuffer();
+      } catch (error) {
+        plaintextArchiveCollector.clear();
+        throw error;
+      }
+    } else {
+      plaintextArchivePath = path.join(restoreTempDir, "workspace.snapshot.tar.zst");
+      await pipeline(
+        createReadStream(encryptedFilePath, {
+          end: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
+          start: 0,
+        }),
+        createHashTransform(encryptedObjectHash),
+        decipher,
+        createHashTransform(plaintextArchiveHash),
+        createWriteStream(plaintextArchivePath, { mode: 0o600 }),
+      );
+    }
+    const plaintextArchive = plaintextArchiveBuffer ?? plaintextArchivePath;
+    if (plaintextArchive === null) {
+      throw new Error("Hosted workspace snapshot decrypted archive is unavailable.");
+    }
 
     encryptedObjectHash.update(authTag);
     const encryptedObjectSha256 = encryptedObjectHash.digest("hex");
@@ -425,7 +439,7 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     if (plaintextArchiveSha256 !== input.ref.archive.plaintextArchiveSha256) {
       throw new Error("Hosted workspace snapshot plaintext archive digest does not match its ref.");
     }
-    await assertHostedWorkspaceSnapshotTarEntriesSafe(plaintextArchivePath, {
+    await assertHostedWorkspaceSnapshotTarEntriesSafe(plaintextArchive, {
       expectedFileCount: input.ref.archive.fileCount,
       expectedTotalPlainBytes: input.ref.archive.totalPlainBytes,
     });
@@ -433,13 +447,20 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
 
     const extractStartedAt = Date.now();
     const archiveExtractStartedAt = Date.now();
-    const zstd = spawn("zstd", [
-      "-d",
-      "--stdout",
-      plaintextArchivePath,
-    ], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const zstd = Buffer.isBuffer(plaintextArchive)
+      ? spawn("zstd", [
+          "-d",
+          "--stdout",
+        ], {
+          stdio: ["pipe", "pipe", "pipe"],
+        })
+      : spawn("zstd", [
+          "-d",
+          "--stdout",
+          plaintextArchive,
+        ], {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
     const tar = spawn("tar", [
       "-C",
       restoreRoot,
@@ -452,12 +473,22 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     });
     const zstdExit = waitForHostedWorkspaceSnapshotProcess(zstd, "zstd");
     const tarExit = waitForHostedWorkspaceSnapshotProcess(tar, "tar");
+    let zstdInputPipe: Promise<void> | null = null;
+    let archivePipe: Promise<void> | null = null;
     try {
       if (!zstd.stdout || !tar.stdin) {
         throw new Error("Hosted workspace snapshot restore archive streams are unavailable.");
       }
+      if (Buffer.isBuffer(plaintextArchive)) {
+        if (!zstd.stdin) {
+          throw new Error("Hosted workspace snapshot restore archive streams are unavailable.");
+        }
+        zstdInputPipe = pipeline(Readable.from([plaintextArchive]), zstd.stdin);
+      }
+      archivePipe = pipeline(zstd.stdout, tar.stdin);
       await Promise.all([
-        pipeline(zstd.stdout, tar.stdin),
+        ...(zstdInputPipe ? [zstdInputPipe] : []),
+        archivePipe,
         zstdExit,
         tarExit,
       ]);
@@ -468,6 +499,7 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
         zstdExit,
         tarExit,
       ]);
+      await Promise.allSettled([zstdInputPipe, archivePipe].filter((promise) => promise !== null));
       if (
         processFailure
         && shouldPreferHostedWorkspaceSnapshotProcessFailure(error)
@@ -499,12 +531,10 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     durableRootReplaceMs = Date.now() - durableRootReplaceStartedAt;
     extractMs = Date.now() - extractStartedAt;
   } finally {
+    plaintextArchiveBuffer?.fill(0);
     dataKey?.fill(0);
     const cleanupStartedAt = Date.now();
     try {
-      if (scratchTempDir !== restoreTempDir) {
-        await rm(scratchTempDir, { force: true, recursive: true });
-      }
       await rm(restoreTempDir, { force: true, recursive: true });
     } finally {
       cleanupMs = Date.now() - cleanupStartedAt;
@@ -544,6 +574,8 @@ interface HostedWorkspaceSnapshotDurableRootFileState {
   mtimeMs: number;
   size: number;
 }
+
+type HostedWorkspaceSnapshotArchiveSource = Buffer | string;
 
 async function readHostedWorkspaceSnapshotState(input: {
   archiveEntries?: readonly WorkspaceSnapshotArchiveEntryInput[];
@@ -769,7 +801,7 @@ function assertHostedWorkspaceSnapshotRelativePathSafe(
 }
 
 async function assertHostedWorkspaceSnapshotTarEntriesSafe(
-  archivePath: string,
+  archiveSource: HostedWorkspaceSnapshotArchiveSource,
   limits: {
     expectedFileCount: number;
     expectedTotalPlainBytes: number;
@@ -783,7 +815,7 @@ async function assertHostedWorkspaceSnapshotTarEntriesSafe(
   ) {
     throw new Error("Hosted workspace snapshot archive manifest is unsafe.");
   }
-  const entries = await listHostedWorkspaceSnapshotVerboseTarEntries(archivePath);
+  const entries = await listHostedWorkspaceSnapshotVerboseTarEntries(archiveSource);
   let fileCount = 0;
   const seen = new Set<string>();
   let totalPlainBytes = 0;
@@ -874,7 +906,7 @@ function parseHostedWorkspaceSnapshotBooleanEnv(value: string | undefined): bool
 }
 
 async function listHostedWorkspaceSnapshotVerboseTarEntries(
-  archivePath: string,
+  archiveSource: HostedWorkspaceSnapshotArchiveSource,
 ): Promise<string[]> {
   const tar = spawn("tar", [
     "-tvf",
@@ -882,13 +914,20 @@ async function listHostedWorkspaceSnapshotVerboseTarEntries(
   ], {
     stdio: ["pipe", "pipe", "pipe"],
   });
-  const zstd = spawn("zstd", [
-    "-d",
-    "--stdout",
-    archivePath,
-  ], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const zstd = Buffer.isBuffer(archiveSource)
+    ? spawn("zstd", [
+        "-d",
+        "--stdout",
+      ], {
+        stdio: ["pipe", "pipe", "pipe"],
+      })
+    : spawn("zstd", [
+        "-d",
+        "--stdout",
+        archiveSource,
+      ], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
   if (!zstd.stdout || !tar.stdin) {
     throw new Error("Hosted workspace snapshot tar list streams are unavailable.");
   }
@@ -898,6 +937,13 @@ async function listHostedWorkspaceSnapshotVerboseTarEntries(
   tar.stdout.setEncoding("utf8");
   const zstdExit = waitForHostedWorkspaceSnapshotProcess(zstd, "zstd");
   const tarExit = waitForHostedWorkspaceSnapshotProcess(tar, "tar");
+  let zstdInputPipe: Promise<void> | null = null;
+  if (Buffer.isBuffer(archiveSource)) {
+    if (!zstd.stdin) {
+      throw new Error("Hosted workspace snapshot tar list streams are unavailable.");
+    }
+    zstdInputPipe = pipeline(Readable.from([archiveSource]), zstd.stdin);
+  }
   const archivePipe = pipeline(zstd.stdout, tar.stdin);
   const lines = createInterface({
     crlfDelay: Number.POSITIVE_INFINITY,
@@ -915,7 +961,11 @@ async function listHostedWorkspaceSnapshotVerboseTarEntries(
       }
     }
     await archivePipe;
-    await Promise.all([zstdExit, tarExit]);
+    await Promise.all([
+      ...(zstdInputPipe ? [zstdInputPipe] : []),
+      zstdExit,
+      tarExit,
+    ]);
   } catch (error) {
     zstd.kill("SIGTERM");
     tar.kill("SIGTERM");
@@ -923,7 +973,7 @@ async function listHostedWorkspaceSnapshotVerboseTarEntries(
       zstdExit,
       tarExit,
     ]);
-    await Promise.allSettled([archivePipe]);
+    await Promise.allSettled([zstdInputPipe, archivePipe].filter((promise) => promise !== null));
     if (
       processFailure
       && shouldPreferHostedWorkspaceSnapshotProcessFailure(error)
@@ -983,11 +1033,49 @@ function decodeHostedWorkspaceSnapshotIv(value: string): Buffer {
   return iv;
 }
 
-function createHashTransform(hash: ReturnType<typeof createHash>): Transform {
+function createHashTransform(hash: Hash): Transform {
   return new Transform({
     transform(chunk: Buffer, _encoding, callback) {
       hash.update(chunk);
       callback(null, chunk);
+    },
+  });
+}
+
+function createFixedSizeArchiveBufferCollector(input: {
+  byteLength: number;
+  hash: Hash;
+}): Writable & {
+  clear(): void;
+  readBuffer(): Buffer;
+} {
+  if (!Number.isSafeInteger(input.byteLength) || input.byteLength < 0) {
+    throw new Error("Hosted workspace snapshot decrypted archive size is unsafe.");
+  }
+  const buffer = Buffer.allocUnsafe(input.byteLength);
+  let offset = 0;
+  const collector = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      const nextOffset = offset + chunk.byteLength;
+      if (nextOffset > buffer.byteLength) {
+        callback(new Error("Hosted workspace snapshot decrypted archive size accounting failed."));
+        return;
+      }
+      input.hash.update(chunk);
+      chunk.copy(buffer, offset);
+      offset = nextOffset;
+      callback();
+    },
+  });
+  return Object.assign(collector, {
+    clear: () => {
+      buffer.fill(0);
+    },
+    readBuffer: () => {
+      if (offset !== buffer.byteLength) {
+        throw new Error("Hosted workspace snapshot decrypted archive size accounting failed.");
+      }
+      return buffer;
     },
   });
 }

--- a/apps/cloudflare/test/hosted-runtime-checkpoint-baseline-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-runtime-checkpoint-baseline-e2e.test.ts
@@ -129,7 +129,6 @@ describe("hosted runtime checkpoint baseline", () => {
       durableRoot: restoreRoot,
       encryptedFilePath,
       ref: snapshotRef,
-      scratchRoot: encryptedScratchRoot,
     });
     await expect(readFile(path.join(restoreRoot, "note.md"), "utf8"))
       .resolves.toBe("idle compacted state\n");

--- a/apps/cloudflare/test/runner-outbound.test.ts
+++ b/apps/cloudflare/test/runner-outbound.test.ts
@@ -46,6 +46,7 @@ import {
   buildHostedWorkspaceSnapshotV2Aad,
   createHostedWorkspaceSnapshotV2DataKey,
   HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES,
+  HOSTED_WORKSPACE_SNAPSHOT_WARN_BYTES,
   HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
   HOSTED_WORKSPACE_SNAPSHOT_V2_ENCRYPTION_SCHEME,
   HOSTED_WORKSPACE_SNAPSHOT_V2_REF_SCHEMA,
@@ -3163,8 +3164,8 @@ describe("handleRunnerOutboundRequest", () => {
     }));
     expect(body).not.toHaveProperty("putUrl");
     expect(body.limits).toEqual({
-      maxSinglePartEncryptedBytes: 4 * 1024 * 1024 * 1024,
-      warnEncryptedBytes: 128 * 1024 * 1024,
+      maxSinglePartEncryptedBytes: HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES,
+      warnEncryptedBytes: HOSTED_WORKSPACE_SNAPSHOT_WARN_BYTES,
     });
     expect(body.encryption).toEqual(expect.objectContaining({
       aad: expect.objectContaining({
@@ -3271,6 +3272,41 @@ describe("handleRunnerOutboundRequest", () => {
     expect(putUrl.searchParams.get("X-Amz-Signature")).toEqual(expect.stringMatching(/^[0-9a-f]{64}$/u));
     expect(presignBody.expiresAt).toEqual(expect.stringMatching(/^20/u));
     expect(runner.createHostedWorkspaceSnapshotUploadSession).toHaveBeenCalledOnce();
+  });
+
+  it("rejects direct-R2 workspace snapshot PUT presigns at the single-part limit before session lookup", async () => {
+    const runner = createWorkspaceVersionAwareUserRunner();
+    const env = createRunnerOutboundEnv({
+      USER_RUNNER: {
+        getByName: runner.getByName,
+      },
+    });
+    const snapshotId = "snapshot_presign_oversized";
+    const objectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId,
+      userId: "member_123",
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleRunnerOutboundRequest(
+      createWorkspaceSnapshotPresignPutRequest({
+        encryptedByteSize: HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES,
+        encryptedObjectSha256: "a".repeat(64),
+        objectKey,
+        snapshotId,
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: "Hosted workspace snapshot exceeds the single-part size limit.",
+    });
+    expect(runner.readHostedWorkspaceSnapshotUploadSession).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("presigns direct-R2 workspace snapshot PUT URLs with hosted-local dev MinIO env", async () => {

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -475,6 +475,63 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
   }, 15_000);
 
+  it("cancels an opened snapshot object body when the data-key unwrap fails", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-open-body-cancel-"));
+    const ref = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 128,
+    });
+    const getUrl = `https://r2.example.test/bundles/${ref.objectKey}?X-Amz-Signature=fixture-get`;
+    let objectBodyCanceled = false;
+    const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
+      const request = requireFetchRequest(args, "workspace snapshot open body cancel fetch");
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
+        await delayWithAbort(50, request.signal);
+        return new Response("unwrap denied", { status: 403 });
+      }
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/presign-get`)) {
+        return new Response(JSON.stringify({
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          getUrl,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      if (request.url === getUrl) {
+        return new Response(new ReadableStream<Uint8Array>({
+          cancel: () => {
+            objectBodyCanceled = true;
+          },
+        }), {
+          headers: {
+            "content-length": String(ref.archive.encryptedByteSize),
+            "content-type": "application/octet-stream",
+          },
+          status: 200,
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    try {
+      await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
+        durableRoot: path.join(tempRoot, "durable"),
+        ref,
+        scratchRoot: path.join(tempRoot, "scratch"),
+      })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/);
+
+      expect(objectBodyCanceled).toBe(true);
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  }, 15_000);
+
   it("aborts the in-flight presign request when the data-key unwrap fails", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-presign-abort-"));
     const ref = createWorkspaceSnapshotV2Ref({
@@ -1081,7 +1138,8 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   it("restores v2 workspace snapshots through unwrap, presigned GET, and direct R2 fetch", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-restore-"));
     const sourceRoot = path.join(tempRoot, "source");
-    const scratchRoot = path.join(tempRoot, "scratch");
+    const snapshotScratchRoot = path.join(tempRoot, "snapshot-scratch");
+    const restoreScratchRoot = path.join(tempRoot, "restore-scratch");
     const durableRoot = path.join(tempRoot, "durable");
     const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
     const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
@@ -1106,7 +1164,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         durableRoot: sourceRoot,
         ivBase64: "AQIDBAUGBwgJCgsM",
         maxEncryptedBytes: HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES,
-        outputDir: scratchRoot,
+        outputDir: snapshotScratchRoot,
       });
       const encryptedBytes = await readFile(encrypted.encryptedFilePath);
       const getUrl = `https://r2.example.test/bundles/${objectKey}?X-Amz-Signature=fixture-get`;
@@ -1189,12 +1247,11 @@ describe("buildHostedExecutionRuntimePlatform", () => {
           upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
           userId: "member_123",
         },
-        scratchRoot,
+        scratchRoot: restoreScratchRoot,
       });
       for (const key of [
         "sizeGuardMs",
         "dataKeyUnwrapMs",
-        "scratchPrepareMs",
         "presignGetMs",
         "objectFetchMs",
         "decryptMs",
@@ -1210,6 +1267,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       }
       expect(restoreTimings?.encryptedBytes).toBe(encrypted.encryptedByteSize);
       expect(restoreTimings?.plainBytes).toBe(encrypted.totalPlainBytes);
+      expect(restoreTimings?.scratchPrepareMs).toBeUndefined();
 
       expect(fetchMock).toHaveBeenCalledTimes(3);
       // The data-key unwrap runs concurrently with the presign/fetch chain,
@@ -1241,6 +1299,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       });
       expect(restoreRequests.some((request) => request.url === getUrl)).toBe(true);
       await expect(access(path.join(durableRoot, "note.md"))).resolves.toBeUndefined();
+      await expect(access(restoreScratchRoot)).rejects.toThrow();
       const workspaceSnapshotLogs = readWorkspaceSnapshotDiagnosticLogs();
       const completedSteps = workspaceSnapshotLogs
         .filter((log) => log.message === "Hosted workspace snapshot restore step completed.")
@@ -1252,12 +1311,10 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         "data_key_unwrap",
         "object_fetch",
         "presign_get",
-        "scratch_prepare",
         "size_guard",
       ]);
       expect(completedSteps[0]).toBe("size_guard");
       expect(completedSteps.at(-1)).toBe("archive_restore");
-      expect(completedSteps.indexOf("scratch_prepare")).toBeLessThan(completedSteps.indexOf("presign_get"));
       expect(completedSteps.indexOf("presign_get")).toBeLessThan(completedSteps.indexOf("object_fetch"));
       expect(workspaceSnapshotLogs[0]?.details).toEqual(expect.objectContaining({
         archiveEncryptedByteSize: encrypted.encryptedByteSize,
@@ -1274,7 +1331,8 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(serializedLogs).not.toContain(dataKeyBase64);
       expect(serializedLogs).not.toContain(sourceRoot);
       expect(serializedLogs).not.toContain(durableRoot);
-      expect(serializedLogs).not.toContain(scratchRoot);
+      expect(serializedLogs).not.toContain(snapshotScratchRoot);
+      expect(serializedLogs).not.toContain(restoreScratchRoot);
       expect(serializedLogs).not.toContain("note.md");
       expect(serializedLogs).not.toContain("restored through direct r2");
     } finally {

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -21,6 +21,7 @@ import {
   HOSTED_WORKSPACE_SNAPSHOT_REF_SCHEMA,
   HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
   serializeHostedWorkspaceSnapshotV2Aad,
+  type HostedWorkspaceSnapshotV2Aad,
   type HostedWorkspaceSnapshotV2Ref,
 } from "@murphai/hosted-execution/workspace-snapshot-v2";
 import {
@@ -29,6 +30,7 @@ import {
 import {
   createEncryptedWorkspaceSnapshotFile,
   restoreEncryptedWorkspaceSnapshot,
+  restoreEncryptedWorkspaceSnapshotFromEncryptedStream,
 } from "../src/workspace-snapshot-local.js";
 
 describe("workspace snapshot local restore", () => {
@@ -162,6 +164,119 @@ describe("workspace snapshot local restore", () => {
       await expect(access(path.join(restoredVaultRoot, ".git", "config"))).rejects.toThrow();
       await expect(access(path.join(restoredOperatorHomeRoot, ".codex-hosted", "cache", "runtime-cache.txt")))
         .rejects.toThrow();
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+      dataKey.fill(0);
+    }
+  });
+
+  it("restores encrypted snapshots from an encrypted byte stream", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-stream-test-"));
+    const sourceDurableRoot = path.join(tempRoot, "source", "durable");
+    const restoredDurableRoot = path.join(tempRoot, "restored", "durable");
+    const snapshotId = "snapshot_stream_restore";
+    const objectKey = "users/hsn_test/workspace-snapshots/snapshot_stream_restore.snapshot.enc";
+    const userId = "member_123";
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+
+    try {
+      await mkdir(path.join(sourceDurableRoot, "vault"), { recursive: true });
+      await writeFile(path.join(sourceDurableRoot, "vault", "note.md"), "stream restored\n", "utf8");
+
+      const aad = buildHostedWorkspaceSnapshotV2Aad({
+        objectKey,
+        snapshotId,
+        userId,
+      });
+      const encrypted = await createEncryptedWorkspaceSnapshotFile({
+        aad,
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: sourceDurableRoot,
+        ivBase64: Buffer.from(Uint8Array.from({ length: 12 }, (_, index) => index + 10))
+          .toString("base64url"),
+        maxEncryptedBytes: 16 * 1024 * 1024,
+        outputDir: path.join(tempRoot, "scratch"),
+      });
+      const encryptedBytes = await readFile(encrypted.encryptedFilePath);
+      const ref = buildWorkspaceSnapshotRef({
+        aad,
+        encrypted,
+        objectKey,
+        snapshotId,
+        userId,
+      });
+
+      const restoreTimings = await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: restoredDurableRoot,
+        encryptedStream: streamEncryptedChunks(splitEncryptedSnapshotAcrossAuthTagBoundary(encryptedBytes)),
+        postExtractIntegrityCheck: true,
+        ref,
+      });
+
+      expect(typeof restoreTimings.decryptMs).toBe("number");
+      expect(Number.isFinite(restoreTimings.decryptMs)).toBe(true);
+      await expect(readFile(path.join(restoredDurableRoot, "vault", "note.md"), "utf8"))
+        .resolves.toBe("stream restored\n");
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+      dataKey.fill(0);
+    }
+  });
+
+  it("rejects encrypted stream auth failures without replacing durable state", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-stream-auth-test-"));
+    const sourceDurableRoot = path.join(tempRoot, "source", "durable");
+    const durableRoot = path.join(tempRoot, "durable");
+    const existingDurableFile = path.join(durableRoot, "existing.txt");
+    const snapshotId = "snapshot_stream_auth_fail";
+    const objectKey = "users/hsn_test/workspace-snapshots/snapshot_stream_auth_fail.snapshot.enc";
+    const userId = "member_123";
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+
+    try {
+      await mkdir(path.join(sourceDurableRoot, "vault"), { recursive: true });
+      await writeFile(path.join(sourceDurableRoot, "vault", "note.md"), "should not restore\n", "utf8");
+      await mkdir(durableRoot, { mode: 0o700, recursive: true });
+      await writeFile(existingDurableFile, "existing durable root\n", { mode: 0o600 });
+
+      const aad = buildHostedWorkspaceSnapshotV2Aad({
+        objectKey,
+        snapshotId,
+        userId,
+      });
+      const encrypted = await createEncryptedWorkspaceSnapshotFile({
+        aad,
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: sourceDurableRoot,
+        ivBase64: Buffer.from(Uint8Array.from({ length: 12 }, (_, index) => index + 10))
+          .toString("base64url"),
+        maxEncryptedBytes: 16 * 1024 * 1024,
+        outputDir: path.join(tempRoot, "scratch"),
+      });
+      const encryptedBytes = await readFile(encrypted.encryptedFilePath);
+      const tamperedEncryptedBytes = Buffer.from(encryptedBytes);
+      tamperedEncryptedBytes[tamperedEncryptedBytes.byteLength - 1] ^= 0xff;
+      const ref = buildWorkspaceSnapshotRef({
+        aad,
+        encrypted,
+        objectKey,
+        snapshotId,
+        userId,
+      });
+
+      await expect(restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot,
+        encryptedStream: streamEncryptedChunks([
+          tamperedEncryptedBytes.subarray(0, tamperedEncryptedBytes.byteLength - 2),
+          tamperedEncryptedBytes.subarray(tamperedEncryptedBytes.byteLength - 2),
+        ]),
+        ref,
+      })).rejects.toThrow();
+
+      await expect(readFile(existingDurableFile, "utf8")).resolves.toBe("existing durable root\n");
+      await expect(access(path.join(durableRoot, "vault", "note.md"))).rejects.toThrow();
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
       dataKey.fill(0);
@@ -501,6 +616,60 @@ function writeTarOctal(buffer: Buffer, offset: number, length: number, value: nu
 
 function sha256Hex(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function buildWorkspaceSnapshotRef(input: {
+  aad: HostedWorkspaceSnapshotV2Aad;
+  encrypted: Awaited<ReturnType<typeof createEncryptedWorkspaceSnapshotFile>>;
+  objectKey: string;
+  snapshotId: string;
+  userId: string;
+}): HostedWorkspaceSnapshotV2Ref {
+  return {
+    archive: {
+      compression: input.encrypted.compression,
+      encryptedByteSize: input.encrypted.encryptedByteSize,
+      encryptedObjectSha256: input.encrypted.encryptedObjectSha256,
+      fileCount: input.encrypted.fileCount,
+      format: "tar",
+      plaintextArchiveSha256: input.encrypted.plaintextArchiveSha256,
+      totalPlainBytes: input.encrypted.totalPlainBytes,
+    },
+    createdAt: "2026-05-20T00:00:00.000Z",
+    encryption: {
+      aad: input.aad,
+      ivBase64: input.encrypted.ivBase64,
+      rootKeyId: "root_key_test",
+      scheme: HOSTED_WORKSPACE_SNAPSHOT_ENCRYPTION_SCHEME,
+      wrappedDataKey: "wrapped_data_key_test",
+    },
+    objectKey: input.objectKey,
+    schema: HOSTED_WORKSPACE_SNAPSHOT_REF_SCHEMA,
+    snapshotId: input.snapshotId,
+    upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
+    userId: input.userId,
+  };
+}
+
+async function* streamEncryptedChunks(chunks: readonly Uint8Array[]): AsyncIterable<Uint8Array> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+const TEST_HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES = 16;
+
+function splitEncryptedSnapshotAcrossAuthTagBoundary(encryptedBytes: Buffer): Uint8Array[] {
+  const ciphertextEnd =
+    encryptedBytes.byteLength - TEST_HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES;
+  const nearAuthTag = Math.max(1, ciphertextEnd - 3);
+  return [
+    encryptedBytes.subarray(0, 1),
+    encryptedBytes.subarray(1, nearAuthTag),
+    encryptedBytes.subarray(nearAuthTag, ciphertextEnd + 1),
+    encryptedBytes.subarray(ciphertextEnd + 1, ciphertextEnd + 8),
+    encryptedBytes.subarray(ciphertextEnd + 8),
+  ].filter((chunk) => chunk.byteLength > 0);
 }
 
 function zstdCompress(bytes: Buffer): Buffer {

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -1,6 +1,14 @@
 import { createCipheriv, createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { writeFile, mkdtemp, rm, access, mkdir, readFile, readdir, symlink } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -126,7 +134,6 @@ describe("workspace snapshot local restore", () => {
         encryptedFilePath: encrypted.encryptedFilePath,
         postExtractIntegrityCheck: true,
         ref,
-        scratchRoot: path.join(tempRoot, "restore-scratch"),
       });
 
       for (const key of [
@@ -355,7 +362,6 @@ async function expectUnsafeTarArchive(input: {
   const durableRoot = path.join(tempRoot, "durable");
   const existingDurableFile = path.join(durableRoot, "existing.txt");
   const encryptedFilePath = path.join(tempRoot, "snapshot.enc");
-  const scratchRoot = path.join(tempRoot, "restore-scratch");
   const snapshotId = "snapshot_unsafe_tar";
   const objectKey = "users/hsn_test/workspace-snapshots/snapshot_unsafe_tar.snapshot.enc";
   const userId = "member_123";
@@ -416,10 +422,8 @@ async function expectUnsafeTarArchive(input: {
       durableRoot,
       encryptedFilePath,
       ref,
-      scratchRoot,
     })).rejects.toThrow(input.expectedError);
     await expect(access(path.join(tempRoot, "escape.txt"))).rejects.toThrow();
-    await expect(readdir(scratchRoot)).resolves.toEqual([]);
     if (input.unwrittenRelativePath) {
       await expect(access(path.join(durableRoot, input.unwrittenRelativePath))).rejects.toThrow();
       await expect(readFile(existingDurableFile, "utf8")).resolves.toBe("existing durable root\n");
@@ -506,5 +510,6 @@ function zstdCompress(bytes: Buffer): Buffer {
     "--stdout",
   ], {
     input: bytes,
+    maxBuffer: 64 * 1024 * 1024,
   });
 }


### PR DESCRIPTION
Stacked on #246.\n\n## Summary\n- Stream the presigned R2 response body into hosted snapshot restore instead of writing a ciphertext temp file first.\n- Add one stream restore primitive that enforces encrypted byte count, encrypted SHA, AES-GCM auth, plaintext SHA, tar safety, and durable-root replacement ordering.\n- Keep the file-based restore API as a wrapper and add explicit cancellation for opened R2 bodies when restore abandons the stream.\n\n## Verification\n- pnpm --dir apps/cloudflare typecheck\n- pnpm --dir apps/cloudflare test:node -- apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts\n- bash scripts/workspace-verify.sh test:diff apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts apps/cloudflare/src/runtime-platform/diagnostics.ts apps/cloudflare/src/workspace-snapshot-local.ts apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts\n- git diff --check\n\n## Audits\n- security-privacy-review: no critical/high/medium findings.\n- coverage-write: added/confirmed no scratch-prepare timing proof.\n- deep-review: accepted and fixed opened R2 body cancellation gap.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784684354&installation_id=127572939&pr_number=251&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F251&signature=e4cb9cafc3be2f29281a679daf464724e81dd5b644792c36998b7f7ec31d6916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->