### PR TITLE
[codex] Stream hosted snapshot restore from R2

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-21-stream-r2-snapshot-restore.md
+++ b/agent-docs/exec-plans/completed/2026-06-21-stream-r2-snapshot-restore.md
@@ -1,0 +1,61 @@
+Goal (incl. success criteria):
+- Stack a narrow follow-up on PR #246 that restores hosted v2 workspace snapshots from the presigned R2 response stream instead of first writing `workspace.snapshot.enc`.
+- Keep PR #246's useful common-path behavior: decrypt/authenticate into one bounded plaintext archive buffer, validate the encrypted SHA, validate the plaintext archive SHA, and extract only after `decipher.final()` authenticates.
+- Success means the normal hosted restore path overlaps object-body read with AES-GCM decrypt/hash work, uses no temporary ciphertext file, leaves durable-root replacement behind the existing auth/hash/tar-safety gates, and does not add a new scheduler, storage owner, snapshot schema, or compatibility layer.
+
+Constraints/Assumptions:
+- Clean, simple, long-term maintainable architecture is the priority. Performance work is only worth doing if it removes redundant I/O without widening ownership or control flow.
+- PR #246 is the right base. It already removes the normal-path plaintext scratch archive; this follow-up should not duplicate or replace that work.
+- `apps/cloudflare` remains a thin execution adapter around encrypted object plumbing. `apps/web`, Temporal, mailbox ordering, checkpoint refs, and R2 object metadata stay unchanged.
+- Preserve fail-closed restore semantics: expected byte count, encrypted object SHA, AES-GCM auth, plaintext archive SHA, safe tar-entry validation, and durable-root replacement ordering.
+- Preserve existing large-snapshot compatibility, but the hosted R2 restore path should not download ciphertext to disk first. If a large fallback is needed, stream decrypted archive bytes to the existing plaintext fallback path and still extract only after auth/digest validation.
+- Do not add dependencies, snapshot ref fields, env flags, R2 bucket conventions, or generalized stream frameworks unless a failing test proves they are necessary.
+
+Key decisions:
+- Add one owning primitive in `apps/cloudflare/src/workspace-snapshot-local.ts`, `restoreEncryptedWorkspaceSnapshotFromEncryptedStream`.
+- Keep the current file-path restore function as a small wrapper/compatibility entrypoint for tests and local callers that already have an encrypted file. The hosted R2 path should call the stream primitive directly.
+- Use a straightforward async chunk loop instead of a Transform pipeline stack. The loop keeps the final 16 AES-GCM bytes as the auth-tag tail, hashes every encrypted chunk, decrypts only ciphertext bytes, writes decrypted output to the existing fixed-size collector, and calls `decipher.final()` before any archive listing or extraction.
+- Reuse PR #246's fixed-size plaintext archive collector for the common path. Size it from `ref.archive.encryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES`; for current snapshot sizes this is the one preallocated compressed archive buffer.
+- Keep timing/diagnostic churn minimal. `objectFetchMs` now measures response open/validation, while `archive_restore` owns body consumption, decrypt/hash, auth, tar safety, and extraction.
+
+State:
+- Implementation and verification complete on branch `codex/stream-r2-snapshot-restore`, stacked on PR #246.
+
+Done:
+- Rechecked PR #246 on 2026-06-21. It is still open and still writes the hosted R2 response body to `workspace.snapshot.enc` before calling `restoreEncryptedWorkspaceSnapshot`.
+- Confirmed PR #246 partially overlaps the goal by decrypting normal-size archives into memory and extracting from the authenticated buffer, but it does not overlap R2 fetch with decrypt and does not remove the ciphertext temp file.
+- Rechecked hosted runtime ownership docs: Cloudflare owns encrypted object plumbing and restore; web/Temporal/checkpoint ownership should not change for this optimization.
+
+Now:
+- Commit, push, and open a stacked PR against PR #246's branch.
+
+Next:
+- Monitor PR CI and review feedback.
+
+Verification:
+- `pnpm --dir apps/cloudflare typecheck` passed.
+- `pnpm --dir apps/cloudflare test:node -- apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts` passed after the audit fix: 91 files, 1520 tests.
+- `bash scripts/workspace-verify.sh test:diff apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts apps/cloudflare/src/runtime-platform/diagnostics.ts apps/cloudflare/src/workspace-snapshot-local.ts apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts` passed, including `apps/cloudflare verify`.
+- `git diff --check` passed.
+
+Audit outcomes:
+- `security-privacy-review`: no critical/high/medium findings.
+- `coverage-write`: added/confirmed test-only proof that `scratchPrepareMs` is absent after removing the hosted ciphertext scratch step.
+- `deep-review`: accepted finding that an already-open R2 response body could be left open if data-key unwrap failed before `archive_restore`; fixed by returning a cancellable body handle and canceling it on unwrap failure and archive-restore exit, with a focused regression test.
+- Run the Cloudflare-focused verification lane first, then the repo-required verification/audit lane for a high-risk hosted-runtime change.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- PR #246 `[codex] Restore workspace snapshots from memory buffer`
+- `apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts`
+- `apps/cloudflare/src/workspace-snapshot-local.ts`
+- `apps/cloudflare/test/workspace-snapshot-local.test.ts`
+- `apps/cloudflare/test/runner-outbound.test.ts`
+- `apps/cloudflare/test/runner-platform.test.ts`
+- `apps/cloudflare/README.md` only if the durable storage/restore wording would otherwise become stale
+- `agent-docs/references/hosted-runtime-protocol.md` only if the restore contract wording would otherwise become stale
+Status: completed
+Updated: 2026-06-21
+Completed: 2026-06-21

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -459,14 +459,10 @@ export class RunnerContainer extends Container {
     ) {
       return;
     }
-    let abortPostStatus: RunnerWorkspaceInvocationAbortPostStatus = "failed";
     if (this.workspaceInvocationAbortEndpointReady) {
-      abortPostStatus = await this.postWorkspaceInvocationAbort(input);
+      await this.postWorkspaceInvocationAbort(input);
     }
-    if (
-      this.workspaceInvocationActiveOperationPreservedAfterTransportFailure
-      && abortPostStatus !== "accepted"
-    ) {
+    if (this.workspaceInvocationActiveOperationPreservedAfterTransportFailure) {
       if (!abortController.signal.aborted) {
         abortController.abort(new Error(WORKSPACE_INVOCATION_PREEMPTED_ABORT_MESSAGE));
       }

--- a/apps/cloudflare/src/runtime-platform/diagnostics.ts
+++ b/apps/cloudflare/src/runtime-platform/diagnostics.ts
@@ -21,26 +21,21 @@ import {
 const HOSTED_WORKSPACE_SNAPSHOT_RESTORE_STEP_MARKER =
   "hostedWorkspaceSnapshotRestoreStep";
 export type HostedWorkspaceSnapshotRestoreStep =
-  | "archive_restore"
   | "data_key_unwrap"
   | "object_fetch"
   | "presign_get"
-  | "scratch_prepare"
   | "size_guard";
 
 const HOSTED_WORKSPACE_SNAPSHOT_RESTORE_STEPS =
   new Set<HostedWorkspaceSnapshotRestoreStep>([
-    "archive_restore",
     "data_key_unwrap",
     "object_fetch",
     "presign_get",
-    "scratch_prepare",
     "size_guard",
   ]);
 
 export function buildHostedWorkspaceSnapshotRestoreLogDetails(input: {
   ref: HostedWorkspaceSnapshotV2Ref;
-  scratchRootPresent: boolean;
   timeoutMs: number;
 }): HostedExecutionStructuredLogDetails {
   return {
@@ -49,7 +44,6 @@ export function buildHostedWorkspaceSnapshotRestoreLogDetails(input: {
     archiveFileCount: input.ref.archive.fileCount,
     archiveTotalPlainBytes: input.ref.archive.totalPlainBytes,
     operation: "workspace_snapshot_restore",
-    scratchRootPresent: input.scratchRootPresent,
     timeoutMs: input.timeoutMs,
   };
 }

--- a/apps/cloudflare/src/runtime-platform/hosted-http.ts
+++ b/apps/cloudflare/src/runtime-platform/hosted-http.ts
@@ -4,10 +4,10 @@ import { parseHostedRunnerProviderEffectErrorResponse } from "../runner-effects-
 import {
   HostedRuntimeControlPlaneFetchError,
   combineAbortSignalsWithCleanup,
-  isRetryableHostedRuntimeReplaySafeReadTransportError,
   shouldPreserveHostedRuntimeFetchError,
 } from "./control-plane-fetch.ts";
 import { buildHostedRuntimeSafeErrorMetadata } from "./diagnostics.ts";
+import { readHostedRuntimeResponseBodyChunks } from "./hosted-response-body.ts";
 import { normalizeCloudflareWorkerFetch } from "../worker-fetch.ts";
 
 export async function fetchHostedResponse(input: {
@@ -176,89 +176,18 @@ async function readHostedResponseText(input: {
     return "";
   }
 
-  const timeoutSignal = AbortSignal.timeout(input.timeoutMs);
-  const readSignal = combineAbortSignalsWithCleanup(input.signal ?? null, timeoutSignal);
-  const reader = input.response.body.getReader();
   const decoder = new TextDecoder();
-  let streamDone = false;
-  try {
-    let text = "";
-    while (true) {
-      const result = await readHostedResponseBodyChunk({
-        reader,
-        signal: readSignal.signal,
-      });
-      if (result.done) {
-        streamDone = true;
-        break;
-      }
-      text += decoder.decode(result.value, { stream: true });
-    }
-    text += decoder.decode();
-    return text;
-  } catch (error) {
-    if (shouldPreserveHostedRuntimeFetchError(error)) {
-      throw error;
-    }
-
-    const wrappedError = new HostedRuntimeControlPlaneFetchError({
-      cause: error,
-      description: `${input.description} response body read`,
-      signalState: {
-        callerSignalAborted: input.signal?.aborted ?? false,
-        requestSignalAborted: readSignal.signal.aborted,
-        timeoutMs: input.timeoutMs,
-        timeoutSignalAborted: timeoutSignal.aborted,
-      },
-    });
-
-    if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
-      throw wrappedError;
-    }
-
-    throw error;
-  } finally {
-    if (!streamDone) {
-      await reader.cancel().catch(() => undefined);
-    }
-    reader.releaseLock();
-    readSignal.dispose();
+  let text = "";
+  for await (const chunk of readHostedRuntimeResponseBodyChunks({
+    body: input.response.body,
+    description: input.description,
+    signal: input.signal ?? null,
+    timeoutMs: input.timeoutMs,
+  })) {
+    text += decoder.decode(chunk, { stream: true });
   }
-}
-
-function readHostedResponseBodyChunk(input: {
-  reader: ReadableStreamDefaultReader<Uint8Array>;
-  signal: AbortSignal;
-}): Promise<ReadableStreamReadResult<Uint8Array>> {
-  if (input.signal.aborted) {
-    return Promise.reject(readHostedResponseAbortReason(input.signal));
-  }
-
-  return new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
-    let settled = false;
-    const settle = (run: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      input.signal.removeEventListener("abort", abort);
-      run();
-    };
-    const abort = () => {
-      settle(() => reject(readHostedResponseAbortReason(input.signal)));
-    };
-    input.signal.addEventListener("abort", abort, { once: true });
-    input.reader.read().then(
-      (result) => settle(() => resolve(result)),
-      (error) => settle(() => reject(error)),
-    );
-  });
-}
-
-function readHostedResponseAbortReason(signal: AbortSignal): unknown {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+  text += decoder.decode();
+  return text;
 }
 
 export async function fetchHostedProviderEffectJson(input: {

--- a/apps/cloudflare/src/runtime-platform/hosted-http.ts
+++ b/apps/cloudflare/src/runtime-platform/hosted-http.ts
@@ -4,6 +4,7 @@ import { parseHostedRunnerProviderEffectErrorResponse } from "../runner-effects-
 import {
   HostedRuntimeControlPlaneFetchError,
   combineAbortSignalsWithCleanup,
+  isRetryableHostedRuntimeReplaySafeReadTransportError,
   shouldPreserveHostedRuntimeFetchError,
 } from "./control-plane-fetch.ts";
 import { buildHostedRuntimeSafeErrorMetadata } from "./diagnostics.ts";
@@ -68,6 +69,7 @@ export async function fetchHostedJson(input: {
   allowNotFound?: boolean;
   body?: unknown;
   description: string;
+  exposeResponseBodyInError?: boolean;
   fetchImpl: typeof fetch;
   headers?: Headers;
   redactedLogPath?: string;
@@ -102,9 +104,15 @@ export async function fetchHostedJson(input: {
   }
 
   if (!response.ok) {
-    const detail = (await response.text()).trim();
+    const detail = (await readHostedResponseText({
+      description: input.description,
+      response,
+      signal: input.signal ?? null,
+      timeoutMs: input.timeoutMs,
+    })).trim();
+    const exposeResponseBodyInError = input.exposeResponseBodyInError !== false;
     const error = new Error(
-      detail.length > 0
+      exposeResponseBodyInError && detail.length > 0
         ? `${input.description} failed with HTTP ${response.status}. ${detail}`
         : `${input.description} failed with HTTP ${response.status}.`,
     ) as Error & {
@@ -141,7 +149,12 @@ export async function fetchHostedJson(input: {
     throw error;
   }
 
-  const text = await response.text();
+  const text = await readHostedResponseText({
+    description: input.description,
+    response,
+    signal: input.signal ?? null,
+    timeoutMs: input.timeoutMs,
+  });
   if (!text.trim()) {
     return null;
   }
@@ -151,6 +164,101 @@ export async function fetchHostedJson(input: {
   } catch (error) {
     throw new Error(`${input.description} returned invalid JSON.`, { cause: error });
   }
+}
+
+async function readHostedResponseText(input: {
+  description: string;
+  response: Response;
+  signal?: AbortSignal | null;
+  timeoutMs: number;
+}): Promise<string> {
+  if (!input.response.body) {
+    return "";
+  }
+
+  const timeoutSignal = AbortSignal.timeout(input.timeoutMs);
+  const readSignal = combineAbortSignalsWithCleanup(input.signal ?? null, timeoutSignal);
+  const reader = input.response.body.getReader();
+  const decoder = new TextDecoder();
+  let streamDone = false;
+  try {
+    let text = "";
+    while (true) {
+      const result = await readHostedResponseBodyChunk({
+        reader,
+        signal: readSignal.signal,
+      });
+      if (result.done) {
+        streamDone = true;
+        break;
+      }
+      text += decoder.decode(result.value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } catch (error) {
+    if (shouldPreserveHostedRuntimeFetchError(error)) {
+      throw error;
+    }
+
+    const wrappedError = new HostedRuntimeControlPlaneFetchError({
+      cause: error,
+      description: `${input.description} response body read`,
+      signalState: {
+        callerSignalAborted: input.signal?.aborted ?? false,
+        requestSignalAborted: readSignal.signal.aborted,
+        timeoutMs: input.timeoutMs,
+        timeoutSignalAborted: timeoutSignal.aborted,
+      },
+    });
+
+    if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
+      throw wrappedError;
+    }
+
+    throw error;
+  } finally {
+    if (!streamDone) {
+      await reader.cancel().catch(() => undefined);
+    }
+    reader.releaseLock();
+    readSignal.dispose();
+  }
+}
+
+function readHostedResponseBodyChunk(input: {
+  reader: ReadableStreamDefaultReader<Uint8Array>;
+  signal: AbortSignal;
+}): Promise<ReadableStreamReadResult<Uint8Array>> {
+  if (input.signal.aborted) {
+    return Promise.reject(readHostedResponseAbortReason(input.signal));
+  }
+
+  return new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+    let settled = false;
+    const settle = (run: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      input.signal.removeEventListener("abort", abort);
+      run();
+    };
+    const abort = () => {
+      settle(() => reject(readHostedResponseAbortReason(input.signal)));
+    };
+    input.signal.addEventListener("abort", abort, { once: true });
+    input.reader.read().then(
+      (result) => settle(() => resolve(result)),
+      (error) => settle(() => reject(error)),
+    );
+  });
+}
+
+function readHostedResponseAbortReason(signal: AbortSignal): unknown {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
 }
 
 export async function fetchHostedProviderEffectJson(input: {

--- a/apps/cloudflare/src/runtime-platform/hosted-response-body.ts
+++ b/apps/cloudflare/src/runtime-platform/hosted-response-body.ts
@@ -1,0 +1,94 @@
+import {
+  HostedRuntimeControlPlaneFetchError,
+  combineAbortSignalsWithCleanup,
+  isRetryableHostedRuntimeReplaySafeReadTransportError,
+  shouldPreserveHostedRuntimeFetchError,
+} from "./control-plane-fetch.ts";
+
+export async function* readHostedRuntimeResponseBodyChunks(input: {
+  body: ReadableStream<Uint8Array>;
+  description: string;
+  signal?: AbortSignal | null;
+  timeoutMs: number;
+}): AsyncIterable<Uint8Array> {
+  const timeoutSignal = AbortSignal.timeout(input.timeoutMs);
+  const readSignal = combineAbortSignalsWithCleanup(input.signal ?? null, timeoutSignal);
+  const reader = input.body.getReader();
+  let streamDone = false;
+
+  try {
+    while (true) {
+      const next = await readHostedRuntimeResponseBodyChunk({
+        reader,
+        signal: readSignal.signal,
+      });
+      if (next.done) {
+        streamDone = true;
+        break;
+      }
+      yield next.value;
+    }
+  } catch (error) {
+    if (shouldPreserveHostedRuntimeFetchError(error)) {
+      throw error;
+    }
+
+    const wrappedError = new HostedRuntimeControlPlaneFetchError({
+      cause: error,
+      description: `${input.description} response body read`,
+      signalState: {
+        callerSignalAborted: input.signal?.aborted ?? false,
+        requestSignalAborted: readSignal.signal.aborted,
+        timeoutMs: input.timeoutMs,
+        timeoutSignalAborted: timeoutSignal.aborted,
+      },
+    });
+
+    if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
+      throw wrappedError;
+    }
+
+    throw error;
+  } finally {
+    if (!streamDone) {
+      await reader.cancel().catch(() => undefined);
+    }
+    reader.releaseLock();
+    readSignal.dispose();
+  }
+}
+
+function readHostedRuntimeResponseBodyChunk(input: {
+  reader: ReadableStreamDefaultReader<Uint8Array>;
+  signal: AbortSignal;
+}): Promise<ReadableStreamReadResult<Uint8Array>> {
+  if (input.signal.aborted) {
+    return Promise.reject(readHostedRuntimeResponseBodyAbortReason(input.signal));
+  }
+
+  return new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+    let settled = false;
+    const settle = (run: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      input.signal.removeEventListener("abort", abort);
+      run();
+    };
+    const abort = () => {
+      settle(() => reject(readHostedRuntimeResponseBodyAbortReason(input.signal)));
+    };
+    input.signal.addEventListener("abort", abort, { once: true });
+    input.reader.read().then(
+      (result) => settle(() => resolve(result)),
+      (error: unknown) => settle(() => reject(error)),
+    );
+  });
+}
+
+function readHostedRuntimeResponseBodyAbortReason(signal: AbortSignal): unknown {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -292,7 +292,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
           const objectFetchTimeoutMs =
             Math.max(1, presignedGet.expiresAtMs - Date.now() - 5_000);
           const objectFetchDeadlineMs = Date.now() + objectFetchTimeoutMs;
-          const encryptedObject = await fetchHostedWorkspaceSnapshotEncryptedObjectStream({
+          const encryptedStream = readHostedWorkspaceSnapshotEncryptedObjectStream({
             deadlineMs: objectFetchDeadlineMs,
             expectedEncryptedByteSize: request.ref.archive.encryptedByteSize,
             fetchImpl: input.fetchImpl,
@@ -300,20 +300,13 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
             signal: request.signal ?? null,
             timeoutMs: objectFetchTimeoutMs,
           });
-          if (!encryptedObject) {
-            throw new Error("Hosted workspace snapshot encrypted object is unavailable.");
-          }
-          try {
-            return await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
-              dataKey,
-              durableRoot: request.durableRoot,
-              encryptedStream: encryptedObject.encryptedStream,
-              ref: request.ref,
-              signal: request.signal ?? null,
-            });
-          } finally {
-            await encryptedObject.cancel();
-          }
+          return await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+            dataKey,
+            durableRoot: request.durableRoot,
+            encryptedStream,
+            ref: request.ref,
+            signal: request.signal ?? null,
+          });
         },
         step: "object_fetch",
       });
@@ -350,11 +343,6 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
     },
   };
   return port;
-}
-
-interface HostedWorkspaceSnapshotEncryptedObjectBody {
-  cancel(): Promise<void>;
-  encryptedStream: AsyncIterable<Uint8Array>;
 }
 
 function parseHostedWorkspaceSnapshotStartPayload(
@@ -568,14 +556,14 @@ async function unwrapWorkspaceSnapshotDataKey(input: {
   return dataKey;
 }
 
-async function fetchHostedWorkspaceSnapshotEncryptedObjectStream(input: {
+async function* readHostedWorkspaceSnapshotEncryptedObjectStream(input: {
   deadlineMs: number;
   expectedEncryptedByteSize: number;
   fetchImpl: typeof fetch;
   getUrl: string;
   signal?: AbortSignal | null;
   timeoutMs: number;
-}): Promise<HostedWorkspaceSnapshotEncryptedObjectBody | null> {
+}): AsyncIterable<Uint8Array> {
   const response = await fetchHostedResponse({
     description: "Hosted workspace snapshot fetch",
     fetchImpl: input.fetchImpl,
@@ -590,7 +578,7 @@ async function fetchHostedWorkspaceSnapshotEncryptedObjectStream(input: {
   });
   if (response.status === 404) {
     await cancelHostedWorkspaceSnapshotResponseBody(response.body);
-    return null;
+    throw new Error("Hosted workspace snapshot encrypted object is unavailable.");
   }
   if (!response.ok) {
     await cancelHostedWorkspaceSnapshotResponseBody(response.body);
@@ -604,61 +592,22 @@ async function fetchHostedWorkspaceSnapshotEncryptedObjectStream(input: {
     await cancelHostedWorkspaceSnapshotResponseBody(response.body);
     throw new Error("Hosted workspace snapshot fetch content-length does not match its ref.");
   }
-  return createHostedWorkspaceSnapshotEncryptedObjectBody({
-    expectedEncryptedByteSize: input.expectedEncryptedByteSize,
-    responseBody: response.body,
+  let byteCount = 0;
+  for await (const next of readHostedRuntimeResponseBodyChunks({
+    body: response.body,
+    description: "Hosted workspace snapshot fetch",
     signal: input.signal ?? null,
     timeoutMs: Math.max(1, input.deadlineMs - Date.now()),
-  });
-}
-
-function createHostedWorkspaceSnapshotEncryptedObjectBody(input: {
-  expectedEncryptedByteSize: number;
-  responseBody: ReadableStream<Uint8Array>;
-  signal?: AbortSignal | null;
-  timeoutMs: number;
-}): HostedWorkspaceSnapshotEncryptedObjectBody {
-  let byteCount = 0;
-  let cancelPromise: Promise<void> | null = null;
-  let streamDone = false;
-
-  const cancel = async (): Promise<void> => {
-    if (streamDone) {
-      return;
+  })) {
+    byteCount += next.byteLength;
+    if (byteCount > input.expectedEncryptedByteSize) {
+      throw new Error("Hosted workspace snapshot fetch exceeded its ref byte count.");
     }
-    cancelPromise ??= input.responseBody.cancel().catch(() => undefined);
-    await cancelPromise;
-  };
-
-  async function* readBody(): AsyncIterable<Uint8Array> {
-    try {
-      for await (const next of readHostedRuntimeResponseBodyChunks({
-        body: input.responseBody,
-        description: "Hosted workspace snapshot fetch",
-        signal: input.signal ?? null,
-        timeoutMs: input.timeoutMs,
-      })) {
-        byteCount += next.byteLength;
-        if (byteCount > input.expectedEncryptedByteSize) {
-          throw new Error("Hosted workspace snapshot fetch exceeded its ref byte count.");
-        }
-        yield next;
-      }
-      if (byteCount !== input.expectedEncryptedByteSize) {
-        throw new Error("Hosted workspace snapshot fetch byte count does not match its ref.");
-      }
-      streamDone = true;
-    } finally {
-      if (!streamDone) {
-        await cancel();
-      }
-    }
+    yield next;
   }
-
-  return {
-    cancel,
-    encryptedStream: readBody(),
-  };
+  if (byteCount !== input.expectedEncryptedByteSize) {
+    throw new Error("Hosted workspace snapshot fetch byte count does not match its ref.");
+  }
 }
 
 async function cancelHostedWorkspaceSnapshotResponseBody(

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -1,10 +1,6 @@
-import { createReadStream, createWriteStream } from "node:fs";
-import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { Readable, Transform } from "node:stream";
-import { pipeline } from "node:stream/promises";
-import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { Readable } from "node:stream";
 
 import type {
   HostedRuntimePlatform,
@@ -33,10 +29,11 @@ import {
   encodeHostedWorkspaceSnapshotSha256Base64,
   HOSTED_WORKSPACE_SNAPSHOT_CONTENT_TYPE,
 } from "../workspace-snapshot-store.ts";
-import { restoreEncryptedWorkspaceSnapshot } from "../workspace-snapshot-local.ts";
+import { restoreEncryptedWorkspaceSnapshotFromEncryptedStream } from "../workspace-snapshot-local.ts";
 import { requireHostedRuntimeWriteFenceHeaders, type HostedWorkspaceCheckpointBridgeAuthority } from "./authority-headers.ts";
 import {
   HostedRuntimeControlPlaneFetchError,
+  combineAbortSignalsWithCleanup,
   isRetryableHostedRuntimeReplaySafeReadTransportError,
 } from "./control-plane-fetch.ts";
 import {
@@ -88,6 +85,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
             snapshotId: request.snapshotId,
           },
           description: "Hosted workspace snapshot session abort",
+          exposeResponseBodyInError: false,
           fetchImpl: input.fetchImpl,
           headers,
           redactedLogPath: "/workspace-snapshots/REDACTED",
@@ -118,6 +116,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
             snapshotId: request.ref.snapshotId,
           },
           description: "Hosted workspace snapshot complete",
+          exposeResponseBodyInError: false,
           fetchImpl: input.fetchImpl,
           headers,
           redactedLogPath: "/workspace-snapshots/REDACTED/complete",
@@ -225,7 +224,6 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
     async restoreWorkspaceSnapshot(request) {
       const restoreLogDetails = buildHostedWorkspaceSnapshotRestoreLogDetails({
         ref: request.ref,
-        scratchRootPresent: request.scratchRoot !== null && request.scratchRoot !== undefined,
         timeoutMs: input.timeoutMs,
       });
       // Per-step timers wrap each restore step at the port level so they capture
@@ -251,53 +249,41 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
         step: "size_guard",
       });
       timing.sizeGuardMs = readHostedRuntimeStepElapsedMs(sizeGuardStartedAt);
-      const scratchRoot = path.resolve(request.scratchRoot ?? tmpdir());
-      const scratchPrepareStartedAt = Date.now();
-      const tempDir = await runHostedWorkspaceSnapshotRestoreStep({
-        details: restoreLogDetails,
-        run: async () => {
-          await mkdir(scratchRoot, { mode: 0o700, recursive: true });
-          return await mkdtemp(path.join(scratchRoot, "workspace-snapshot-fetch-"));
-        },
-        step: "scratch_prepare",
-      });
-      timing.scratchPrepareMs = readHostedRuntimeStepElapsedMs(scratchPrepareStartedAt);
-      const encryptedFilePath = path.join(tempDir, "workspace.snapshot.enc");
-      try {
-        // The data-key unwrap (worker KMS round trip) and the encrypted-object
-        // leg (presign GET -> R2 download) share no inputs, and the dominant
-        // cold-restore cost is exactly these two network legs run back to
-        // back. Run them concurrently and only join before archive_restore,
-        // which needs both. Per-step timings keep their own wall-clock, so
-        // concurrent step durations no longer sum to the restore total.
-        const dataKeyPromise = (async () => {
-          const dataKeyUnwrapStartedAt = Date.now();
-          const dataKey = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
-            details: restoreLogDetails,
-            run: async () => await unwrapWorkspaceSnapshotDataKey({
-              aad: request.ref.encryption.aad,
-              fetchImpl: input.fetchImpl,
-              rootKeyId: request.ref.encryption.rootKeyId,
-              timeoutMs: input.timeoutMs,
-              workspaceCheckpointBridge: input.workspaceCheckpointBridge,
-              wrappedDataKey: request.ref.encryption.wrappedDataKey,
-            }),
-            step: "data_key_unwrap",
-          });
-          timing.dataKeyUnwrapMs = readHostedRuntimeStepElapsedMs(dataKeyUnwrapStartedAt);
-          return dataKey;
-        })();
-        // A failed unwrap makes the (potentially large) R2 download useless;
-        // abort it instead of letting it run to completion before the join
-        // surfaces the unwrap error to the retry path.
-        const encryptedObjectAbort = new AbortController();
-        void dataKeyPromise.catch(() => {
-          encryptedObjectAbort.abort(
-            new Error("Hosted workspace snapshot data key unwrap failed; object fetch is unnecessary."),
-          );
+      // The data-key unwrap (worker KMS round trip) and presign GET share no
+      // inputs. Run them concurrently, then open and consume the R2 response
+      // inside the replay-safe read attempt so mid-body transport failures get
+      // a fresh response, decipher, archive buffer, and restore temp directory.
+      const dataKeyPromise = (async () => {
+        const dataKeyUnwrapStartedAt = Date.now();
+        const dataKey = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
+          details: restoreLogDetails,
+          run: async () => await unwrapWorkspaceSnapshotDataKey({
+            aad: request.ref.encryption.aad,
+            fetchImpl: input.fetchImpl,
+            rootKeyId: request.ref.encryption.rootKeyId,
+            signal: request.signal ?? null,
+            timeoutMs: input.timeoutMs,
+            workspaceCheckpointBridge: input.workspaceCheckpointBridge,
+            wrappedDataKey: request.ref.encryption.wrappedDataKey,
+          }),
+          step: "data_key_unwrap",
         });
-        const encryptedObjectPromise = (async () => {
-          const presignGetStartedAt = Date.now();
+        timing.dataKeyUnwrapMs = readHostedRuntimeStepElapsedMs(dataKeyUnwrapStartedAt);
+        return dataKey;
+      })();
+      const presignAbort = new AbortController();
+      void dataKeyPromise.catch(() => {
+        presignAbort.abort(
+          new Error("Hosted workspace snapshot data key unwrap failed; presign GET is unnecessary."),
+        );
+      });
+      const presignGetPromise = (async () => {
+        const presignGetStartedAt = Date.now();
+        const presignSignal = combineAbortSignalsWithCleanup(
+          request.signal ?? null,
+          presignAbort.signal,
+        );
+        try {
           const presignedGet = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
             details: restoreLogDetails,
             run: async () => {
@@ -305,7 +291,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
                 fetchImpl: input.fetchImpl,
                 objectKey: request.ref.objectKey,
                 ref: request.ref,
-                signal: encryptedObjectAbort.signal,
+                signal: presignSignal.signal,
                 snapshotId: request.ref.snapshotId,
                 timeoutMs: input.timeoutMs,
                 workspaceCheckpointBridge: input.workspaceCheckpointBridge,
@@ -322,63 +308,59 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
             step: "presign_get",
           });
           timing.presignGetMs = readHostedRuntimeStepElapsedMs(presignGetStartedAt);
-          const objectFetchStartedAt = Date.now();
-          await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
-            details: restoreLogDetails,
-            run: async () => {
-              const fetched = await fetchHostedWorkspaceSnapshotEncryptedObjectToFile({
-                encryptedFilePath,
-                expectedEncryptedByteSize: request.ref.archive.encryptedByteSize,
-                fetchImpl: input.fetchImpl,
-                getUrl: presignedGet.getUrl,
-                signal: encryptedObjectAbort.signal,
-                timeoutMs: Math.max(1, presignedGet.expiresAtMs - Date.now() - 5_000),
-              });
-              if (!fetched) {
-                throw new Error("Hosted workspace snapshot encrypted object is unavailable.");
-              }
-            },
-            step: "object_fetch",
-          });
-          timing.objectFetchMs = readHostedRuntimeStepElapsedMs(objectFetchStartedAt);
-        })();
-        // Settle both legs before throwing so a failed leg never leaves the
-        // other writing into a scratch dir that the finally block already
-        // removed. Prefer the unwrap failure deterministically.
-        const [dataKeySettled, encryptedObjectSettled] = await Promise.allSettled([
-          dataKeyPromise,
-          encryptedObjectPromise,
-        ]);
-        if (dataKeySettled.status === "rejected") {
-          throw dataKeySettled.reason;
-        }
-        if (encryptedObjectSettled.status === "rejected") {
-          throw encryptedObjectSettled.reason;
-        }
-        const dataKey = dataKeySettled.value;
-        const archiveTimings = await runHostedWorkspaceSnapshotRestoreStep({
-          details: restoreLogDetails,
-          run: async () => await restoreEncryptedWorkspaceSnapshot({
-            dataKey,
-            durableRoot: request.durableRoot,
-            encryptedFilePath,
-            ref: request.ref,
-          }),
-          step: "archive_restore",
-        });
-        timing.decryptMs = archiveTimings.decryptMs;
-        timing.archiveExtractMs = archiveTimings.archiveExtractMs;
-        timing.durableRootReplaceMs = archiveTimings.durableRootReplaceMs;
-        timing.cleanupMs = archiveTimings.cleanupMs;
-        timing.extractMs = archiveTimings.extractMs;
-      } finally {
-        const cleanupStartedAt = Date.now();
-        try {
-          await rm(tempDir, { force: true, recursive: true });
+          return presignedGet;
         } finally {
-          timing.cleanupMs = (timing.cleanupMs ?? 0) + readHostedRuntimeStepElapsedMs(cleanupStartedAt);
+          presignSignal.dispose();
         }
+      })();
+      const [dataKeySettled, presignGetSettled] = await Promise.allSettled([
+        dataKeyPromise,
+        presignGetPromise,
+      ]);
+      if (dataKeySettled.status === "rejected") {
+        throw dataKeySettled.reason;
       }
+      if (presignGetSettled.status === "rejected") {
+        throw presignGetSettled.reason;
+      }
+      const objectFetchStartedAt = Date.now();
+      const archiveTimings = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
+        details: restoreLogDetails,
+        run: async () => {
+          const objectFetchTimeoutMs =
+            Math.max(1, presignGetSettled.value.expiresAtMs - Date.now() - 5_000);
+          const objectFetchDeadlineMs = Date.now() + objectFetchTimeoutMs;
+          const encryptedObject = await fetchHostedWorkspaceSnapshotEncryptedObjectStream({
+            deadlineMs: objectFetchDeadlineMs,
+            expectedEncryptedByteSize: request.ref.archive.encryptedByteSize,
+            fetchImpl: input.fetchImpl,
+            getUrl: presignGetSettled.value.getUrl,
+            signal: request.signal ?? null,
+            timeoutMs: objectFetchTimeoutMs,
+          });
+          if (!encryptedObject) {
+            throw new Error("Hosted workspace snapshot encrypted object is unavailable.");
+          }
+          try {
+            return await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+              dataKey: dataKeySettled.value,
+              durableRoot: request.durableRoot,
+              encryptedStream: encryptedObject.encryptedStream,
+              ref: request.ref,
+              signal: request.signal ?? null,
+            });
+          } finally {
+            await encryptedObject.cancel();
+          }
+        },
+        step: "object_fetch",
+      });
+      timing.objectFetchMs = readHostedRuntimeStepElapsedMs(objectFetchStartedAt);
+      timing.decryptMs = archiveTimings.decryptMs;
+      timing.archiveExtractMs = archiveTimings.archiveExtractMs;
+      timing.durableRootReplaceMs = archiveTimings.durableRootReplaceMs;
+      timing.cleanupMs = archiveTimings.cleanupMs;
+      timing.extractMs = archiveTimings.extractMs;
       return timing;
     },
 
@@ -390,6 +372,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
       const payload = await fetchHostedJson({
         body: request,
         description: "Hosted workspace snapshot session start",
+        exposeResponseBodyInError: false,
         fetchImpl: input.fetchImpl,
         headers,
         method: "POST",
@@ -406,6 +389,12 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
   };
   return port;
 }
+
+interface HostedWorkspaceSnapshotEncryptedObjectBody {
+  cancel(): Promise<void>;
+  encryptedStream: AsyncIterable<Uint8Array>;
+}
+
 function parseHostedWorkspaceSnapshotStartPayload(
   value: unknown,
   boundUserId: string,
@@ -510,6 +499,7 @@ async function presignWorkspaceSnapshotPut(input: {
       snapshotId: input.snapshotId,
     },
     description: "Hosted workspace snapshot presign PUT",
+    exposeResponseBodyInError: false,
     fetchImpl: input.fetchImpl,
     headers,
     redactedLogPath: "/workspace-snapshots/REDACTED/presign-put",
@@ -543,6 +533,7 @@ async function presignWorkspaceSnapshotGet(input: {
       snapshotId: input.snapshotId,
     },
     description: "Hosted workspace snapshot presign download",
+    exposeResponseBodyInError: false,
     fetchImpl: input.fetchImpl,
     headers,
     redactedLogPath: "/workspace-snapshots/REDACTED/presign-get",
@@ -574,6 +565,7 @@ async function unwrapWorkspaceSnapshotDataKey(input: {
   aad: HostedWorkspaceSnapshotV2Aad;
   fetchImpl: typeof fetch;
   rootKeyId: string;
+  signal?: AbortSignal | null;
   timeoutMs: number;
   workspaceCheckpointBridge: HostedWorkspaceCheckpointBridgeAuthority;
   wrappedDataKey: string;
@@ -589,10 +581,12 @@ async function unwrapWorkspaceSnapshotDataKey(input: {
       wrappedDataKey: input.wrappedDataKey,
     },
     description: "Hosted workspace snapshot data key unwrap",
+    exposeResponseBodyInError: false,
     fetchImpl: input.fetchImpl,
     headers,
     redactedLogPath: "/workspace-snapshots/REDACTED/data-key/unwrap",
     method: "POST",
+    signal: input.signal ?? null,
     timeoutMs: input.timeoutMs,
     url: new URL(
       `/workspace-snapshots/${encodeURIComponent(input.aad.snapshotId)}/data-key/unwrap`,
@@ -612,14 +606,14 @@ async function unwrapWorkspaceSnapshotDataKey(input: {
   return dataKey;
 }
 
-async function fetchHostedWorkspaceSnapshotEncryptedObjectToFile(input: {
-  encryptedFilePath: string;
+async function fetchHostedWorkspaceSnapshotEncryptedObjectStream(input: {
+  deadlineMs: number;
   expectedEncryptedByteSize: number;
   fetchImpl: typeof fetch;
   getUrl: string;
   signal?: AbortSignal | null;
   timeoutMs: number;
-}): Promise<boolean> {
+}): Promise<HostedWorkspaceSnapshotEncryptedObjectBody | null> {
   const response = await fetchHostedResponse({
     description: "Hosted workspace snapshot fetch",
     fetchImpl: input.fetchImpl,
@@ -633,7 +627,11 @@ async function fetchHostedWorkspaceSnapshotEncryptedObjectToFile(input: {
     url: new URL(input.getUrl),
   });
   if (response.status === 404) {
-    return false;
+    await cancelHostedWorkspaceSnapshotResponseBody(response.body);
+    return null;
+  }
+  if (!response.ok) {
+    await cancelHostedWorkspaceSnapshotResponseBody(response.body);
   }
   assertHostedOk(response, "Hosted workspace snapshot fetch");
   if (!response.body) {
@@ -641,60 +639,137 @@ async function fetchHostedWorkspaceSnapshotEncryptedObjectToFile(input: {
   }
   const contentLength = response.headers.get("content-length");
   if (contentLength !== null && contentLength !== String(input.expectedEncryptedByteSize)) {
+    await cancelHostedWorkspaceSnapshotResponseBody(response.body);
     throw new Error("Hosted workspace snapshot fetch content-length does not match its ref.");
   }
-  try {
-    await pipeline(
-      Readable.fromWeb(response.body as NodeReadableStream<Uint8Array>),
-      createExpectedByteCountTransform({
-        expectedBytes: input.expectedEncryptedByteSize,
-        label: "Hosted workspace snapshot fetch",
-      }),
-      createWriteStream(input.encryptedFilePath, { mode: 0o600 }),
-    );
-  } catch (error) {
-    const wrappedError = new HostedRuntimeControlPlaneFetchError({
-      cause: error,
-      description: "Hosted workspace snapshot fetch response body read",
-      signalState: {
-        callerSignalAborted: false,
-        requestSignalAborted: false,
-        timeoutMs: input.timeoutMs,
-        timeoutSignalAborted: false,
-      },
-    });
-
-    if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
-      throw wrappedError;
-    }
-
-    throw error;
-  }
-  return true;
+  return createHostedWorkspaceSnapshotEncryptedObjectBody({
+    expectedEncryptedByteSize: input.expectedEncryptedByteSize,
+    responseBody: response.body,
+    signal: input.signal ?? null,
+    timeoutMs: Math.max(1, input.deadlineMs - Date.now()),
+  });
 }
 
-function createExpectedByteCountTransform(input: {
-  expectedBytes: number;
-  label: string;
-}): Transform {
+function createHostedWorkspaceSnapshotEncryptedObjectBody(input: {
+  expectedEncryptedByteSize: number;
+  responseBody: ReadableStream<Uint8Array>;
+  signal?: AbortSignal | null;
+  timeoutMs: number;
+}): HostedWorkspaceSnapshotEncryptedObjectBody {
   let byteCount = 0;
-  return new Transform({
-    flush(callback) {
-      if (byteCount !== input.expectedBytes) {
-        callback(new Error(`${input.label} byte count does not match its ref.`));
+  let cancelPromise: Promise<void> | null = null;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let streamDone = false;
+
+  const cancel = async (): Promise<void> => {
+    if (streamDone) {
+      return;
+    }
+    cancelPromise ??= (reader
+      ? reader.cancel()
+      : input.responseBody.cancel())
+      .catch(() => undefined);
+    await cancelPromise;
+  };
+
+  async function* readBody(): AsyncIterable<Uint8Array> {
+    const timeoutSignal = AbortSignal.timeout(input.timeoutMs);
+    const readSignal = combineAbortSignalsWithCleanup(input.signal ?? null, timeoutSignal);
+    try {
+      reader = input.responseBody.getReader();
+      while (true) {
+        const next = await readHostedWorkspaceSnapshotResponseBodyChunk({
+          reader,
+          signal: readSignal.signal,
+        });
+        if (next.done) {
+          break;
+        }
+        byteCount += next.value.byteLength;
+        if (byteCount > input.expectedEncryptedByteSize) {
+          throw new Error("Hosted workspace snapshot fetch exceeded its ref byte count.");
+        }
+        yield next.value;
+      }
+      if (byteCount !== input.expectedEncryptedByteSize) {
+        throw new Error("Hosted workspace snapshot fetch byte count does not match its ref.");
+      }
+      streamDone = true;
+    } catch (error) {
+      const wrappedError = new HostedRuntimeControlPlaneFetchError({
+        cause: error,
+        description: "Hosted workspace snapshot fetch response body read",
+        signalState: {
+          callerSignalAborted: input.signal?.aborted ?? false,
+          requestSignalAborted: readSignal.signal.aborted,
+          timeoutMs: input.timeoutMs,
+          timeoutSignalAborted: timeoutSignal.aborted,
+        },
+      });
+
+      if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
+        throw wrappedError;
+      }
+
+      throw error;
+    } finally {
+      readSignal.dispose();
+      if (!streamDone) {
+        await cancel();
+      }
+      reader?.releaseLock();
+    }
+  }
+
+  return {
+    cancel,
+    encryptedStream: readBody(),
+  };
+}
+
+async function readHostedWorkspaceSnapshotResponseBodyChunk(input: {
+  reader: ReadableStreamDefaultReader<Uint8Array>;
+  signal: AbortSignal;
+}): Promise<ReadableStreamReadResult<Uint8Array>> {
+  if (input.signal.aborted) {
+    throw readHostedWorkspaceSnapshotAbortReason(input.signal);
+  }
+
+  return await new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+    let settled = false;
+    const settle = (finish: () => void) => {
+      if (settled) {
         return;
       }
-      callback();
-    },
-    transform(chunk: Buffer, _encoding, callback) {
-      byteCount += chunk.byteLength;
-      if (byteCount > input.expectedBytes) {
-        callback(new Error(`${input.label} exceeded its ref byte count.`));
-        return;
-      }
-      callback(null, chunk);
-    },
+      settled = true;
+      input.signal.removeEventListener("abort", abort);
+      finish();
+    };
+    const abort = () => {
+      settle(() => reject(readHostedWorkspaceSnapshotAbortReason(input.signal)));
+    };
+    input.signal.addEventListener("abort", abort, { once: true });
+    input.reader.read().then(
+      (result) => settle(() => resolve(result)),
+      (error: unknown) => settle(() => reject(error)),
+    );
   });
+}
+
+function readHostedWorkspaceSnapshotAbortReason(signal: AbortSignal): unknown {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
+async function cancelHostedWorkspaceSnapshotResponseBody(
+  body: ReadableStream<Uint8Array> | null,
+): Promise<void> {
+  try {
+    await body?.cancel();
+  } catch {
+    // Best-effort cleanup only; preserve the original restore failure.
+  }
 }
 
 function parseHostedWorkspaceSnapshotCompletePayload(

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -8,7 +8,6 @@ import type {
   HostedRuntimeWorkspaceSnapshotRestoreTimingDetails,
   HostedRuntimeWorkspaceSnapshotSessionStart,
 } from "@murphai/assistant-runtime/hosted-runtime-contracts";
-import type { HostedExecutionStructuredLogDetails } from "@murphai/hosted-execution";
 import { parseHostedWorkspaceCheckpointResponse, parseHostedWorkspaceSnapshotV2Ref } from "@murphai/hosted-execution/parsers";
 import type { HostedWorkspaceCheckpointResponse } from "@murphai/hosted-execution/runtime-control";
 import {
@@ -32,17 +31,12 @@ import {
 import { restoreEncryptedWorkspaceSnapshotFromEncryptedStream } from "../workspace-snapshot-local.ts";
 import { requireHostedRuntimeWriteFenceHeaders, type HostedWorkspaceCheckpointBridgeAuthority } from "./authority-headers.ts";
 import {
-  HostedRuntimeControlPlaneFetchError,
-  combineAbortSignalsWithCleanup,
-  isRetryableHostedRuntimeReplaySafeReadTransportError,
-} from "./control-plane-fetch.ts";
-import {
   buildHostedWorkspaceSnapshotRestoreLogDetails,
-  buildHostedRuntimeSafeErrorMetadata,
   readHostedRuntimeStepElapsedMs,
   runHostedWorkspaceSnapshotRestoreReplaySafeReadStep,
   runHostedWorkspaceSnapshotRestoreStep,
 } from "./diagnostics.ts";
+import { readHostedRuntimeResponseBodyChunks } from "./hosted-response-body.ts";
 import {
   assertHostedOk,
   fetchHostedResponse,
@@ -249,92 +243,60 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
         step: "size_guard",
       });
       timing.sizeGuardMs = readHostedRuntimeStepElapsedMs(sizeGuardStartedAt);
-      // The data-key unwrap (worker KMS round trip) and presign GET share no
-      // inputs. Run them concurrently, then open and consume the R2 response
-      // inside the replay-safe read attempt so mid-body transport failures get
-      // a fresh response, decipher, archive buffer, and restore temp directory.
-      const dataKeyPromise = (async () => {
-        const dataKeyUnwrapStartedAt = Date.now();
-        const dataKey = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
-          details: restoreLogDetails,
-          run: async () => await unwrapWorkspaceSnapshotDataKey({
-            aad: request.ref.encryption.aad,
+      const dataKeyUnwrapStartedAt = Date.now();
+      const dataKey = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
+        details: restoreLogDetails,
+        run: async () => await unwrapWorkspaceSnapshotDataKey({
+          aad: request.ref.encryption.aad,
+          fetchImpl: input.fetchImpl,
+          rootKeyId: request.ref.encryption.rootKeyId,
+          signal: request.signal ?? null,
+          timeoutMs: input.timeoutMs,
+          workspaceCheckpointBridge: input.workspaceCheckpointBridge,
+          wrappedDataKey: request.ref.encryption.wrappedDataKey,
+        }),
+        step: "data_key_unwrap",
+      });
+      timing.dataKeyUnwrapMs = readHostedRuntimeStepElapsedMs(dataKeyUnwrapStartedAt);
+
+      const presignGetStartedAt = Date.now();
+      const presignedGet = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
+        details: restoreLogDetails,
+        run: async () => {
+          const result = await presignWorkspaceSnapshotGet({
             fetchImpl: input.fetchImpl,
-            rootKeyId: request.ref.encryption.rootKeyId,
+            objectKey: request.ref.objectKey,
+            ref: request.ref,
             signal: request.signal ?? null,
+            snapshotId: request.ref.snapshotId,
             timeoutMs: input.timeoutMs,
             workspaceCheckpointBridge: input.workspaceCheckpointBridge,
-            wrappedDataKey: request.ref.encryption.wrappedDataKey,
-          }),
-          step: "data_key_unwrap",
-        });
-        timing.dataKeyUnwrapMs = readHostedRuntimeStepElapsedMs(dataKeyUnwrapStartedAt);
-        return dataKey;
-      })();
-      const presignAbort = new AbortController();
-      void dataKeyPromise.catch(() => {
-        presignAbort.abort(
-          new Error("Hosted workspace snapshot data key unwrap failed; presign GET is unnecessary."),
-        );
-      });
-      const presignGetPromise = (async () => {
-        const presignGetStartedAt = Date.now();
-        const presignSignal = combineAbortSignalsWithCleanup(
-          request.signal ?? null,
-          presignAbort.signal,
-        );
-        try {
-          const presignedGet = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
-            details: restoreLogDetails,
-            run: async () => {
-              const result = await presignWorkspaceSnapshotGet({
-                fetchImpl: input.fetchImpl,
-                objectKey: request.ref.objectKey,
-                ref: request.ref,
-                signal: presignSignal.signal,
-                snapshotId: request.ref.snapshotId,
-                timeoutMs: input.timeoutMs,
-                workspaceCheckpointBridge: input.workspaceCheckpointBridge,
-              });
-              const expiresAtMs = Date.parse(result.expiresAt);
-              if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
-                throw new Error("Hosted workspace snapshot direct R2 download URL is expired.");
-              }
-              return {
-                ...result,
-                expiresAtMs,
-              };
-            },
-            step: "presign_get",
           });
-          timing.presignGetMs = readHostedRuntimeStepElapsedMs(presignGetStartedAt);
-          return presignedGet;
-        } finally {
-          presignSignal.dispose();
-        }
-      })();
-      const [dataKeySettled, presignGetSettled] = await Promise.allSettled([
-        dataKeyPromise,
-        presignGetPromise,
-      ]);
-      if (dataKeySettled.status === "rejected") {
-        throw dataKeySettled.reason;
-      }
-      if (presignGetSettled.status === "rejected") {
-        throw presignGetSettled.reason;
-      }
+          const expiresAtMs = Date.parse(result.expiresAt);
+          if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+            throw new Error("Hosted workspace snapshot direct R2 download URL is expired.");
+          }
+          return {
+            ...result,
+            expiresAtMs,
+          };
+        },
+        step: "presign_get",
+      });
+      timing.presignGetMs = readHostedRuntimeStepElapsedMs(presignGetStartedAt);
+
       const objectFetchStartedAt = Date.now();
       const archiveTimings = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
         details: restoreLogDetails,
         run: async () => {
           const objectFetchTimeoutMs =
-            Math.max(1, presignGetSettled.value.expiresAtMs - Date.now() - 5_000);
+            Math.max(1, presignedGet.expiresAtMs - Date.now() - 5_000);
           const objectFetchDeadlineMs = Date.now() + objectFetchTimeoutMs;
           const encryptedObject = await fetchHostedWorkspaceSnapshotEncryptedObjectStream({
             deadlineMs: objectFetchDeadlineMs,
             expectedEncryptedByteSize: request.ref.archive.encryptedByteSize,
             fetchImpl: input.fetchImpl,
-            getUrl: presignGetSettled.value.getUrl,
+            getUrl: presignedGet.getUrl,
             signal: request.signal ?? null,
             timeoutMs: objectFetchTimeoutMs,
           });
@@ -343,7 +305,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
           }
           try {
             return await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
-              dataKey: dataKeySettled.value,
+              dataKey,
               durableRoot: request.durableRoot,
               encryptedStream: encryptedObject.encryptedStream,
               ref: request.ref,
@@ -658,66 +620,38 @@ function createHostedWorkspaceSnapshotEncryptedObjectBody(input: {
 }): HostedWorkspaceSnapshotEncryptedObjectBody {
   let byteCount = 0;
   let cancelPromise: Promise<void> | null = null;
-  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
   let streamDone = false;
 
   const cancel = async (): Promise<void> => {
     if (streamDone) {
       return;
     }
-    cancelPromise ??= (reader
-      ? reader.cancel()
-      : input.responseBody.cancel())
-      .catch(() => undefined);
+    cancelPromise ??= input.responseBody.cancel().catch(() => undefined);
     await cancelPromise;
   };
 
   async function* readBody(): AsyncIterable<Uint8Array> {
-    const timeoutSignal = AbortSignal.timeout(input.timeoutMs);
-    const readSignal = combineAbortSignalsWithCleanup(input.signal ?? null, timeoutSignal);
     try {
-      reader = input.responseBody.getReader();
-      while (true) {
-        const next = await readHostedWorkspaceSnapshotResponseBodyChunk({
-          reader,
-          signal: readSignal.signal,
-        });
-        if (next.done) {
-          break;
-        }
-        byteCount += next.value.byteLength;
+      for await (const next of readHostedRuntimeResponseBodyChunks({
+        body: input.responseBody,
+        description: "Hosted workspace snapshot fetch",
+        signal: input.signal ?? null,
+        timeoutMs: input.timeoutMs,
+      })) {
+        byteCount += next.byteLength;
         if (byteCount > input.expectedEncryptedByteSize) {
           throw new Error("Hosted workspace snapshot fetch exceeded its ref byte count.");
         }
-        yield next.value;
+        yield next;
       }
       if (byteCount !== input.expectedEncryptedByteSize) {
         throw new Error("Hosted workspace snapshot fetch byte count does not match its ref.");
       }
       streamDone = true;
-    } catch (error) {
-      const wrappedError = new HostedRuntimeControlPlaneFetchError({
-        cause: error,
-        description: "Hosted workspace snapshot fetch response body read",
-        signalState: {
-          callerSignalAborted: input.signal?.aborted ?? false,
-          requestSignalAborted: readSignal.signal.aborted,
-          timeoutMs: input.timeoutMs,
-          timeoutSignalAborted: timeoutSignal.aborted,
-        },
-      });
-
-      if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
-        throw wrappedError;
-      }
-
-      throw error;
     } finally {
-      readSignal.dispose();
       if (!streamDone) {
         await cancel();
       }
-      reader?.releaseLock();
     }
   }
 
@@ -725,41 +659,6 @@ function createHostedWorkspaceSnapshotEncryptedObjectBody(input: {
     cancel,
     encryptedStream: readBody(),
   };
-}
-
-async function readHostedWorkspaceSnapshotResponseBodyChunk(input: {
-  reader: ReadableStreamDefaultReader<Uint8Array>;
-  signal: AbortSignal;
-}): Promise<ReadableStreamReadResult<Uint8Array>> {
-  if (input.signal.aborted) {
-    throw readHostedWorkspaceSnapshotAbortReason(input.signal);
-  }
-
-  return await new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
-    let settled = false;
-    const settle = (finish: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      input.signal.removeEventListener("abort", abort);
-      finish();
-    };
-    const abort = () => {
-      settle(() => reject(readHostedWorkspaceSnapshotAbortReason(input.signal)));
-    };
-    input.signal.addEventListener("abort", abort, { once: true });
-    input.reader.read().then(
-      (result) => settle(() => resolve(result)),
-      (error: unknown) => settle(() => reject(error)),
-    );
-  });
-}
-
-function readHostedWorkspaceSnapshotAbortReason(signal: AbortSignal): unknown {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
 }
 
 async function cancelHostedWorkspaceSnapshotResponseBody(

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { createCipheriv, createDecipheriv, createHash } from "node:crypto";
+import { createCipheriv, createDecipheriv, createHash, type DecipherGCM, type Hash } from "node:crypto";
 import { createReadStream, createWriteStream, type Stats } from "node:fs";
 import {
   access,
@@ -7,7 +7,6 @@ import {
   lstat,
   mkdir,
   mkdtemp,
-  open,
   realpath,
   rename,
   rm,
@@ -16,7 +15,7 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline";
-import { Transform, type Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import {
@@ -337,20 +336,37 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
   durableRoot: string;
   encryptedFilePath: string;
   ref: HostedWorkspaceSnapshotV2Ref;
-  scratchRoot?: string | null;
 }): Promise<RestoreEncryptedWorkspaceSnapshotTimings> {
-  if (input.ref.archive.compression !== HOSTED_WORKSPACE_SNAPSHOT_COMPRESSION) {
-    throw new Error("Hosted workspace snapshot restore only supports zstd archives.");
-  }
   const encryptedFilePath = path.resolve(input.encryptedFilePath);
   const encryptedStat = await stat(encryptedFilePath);
   if (encryptedStat.size !== input.ref.archive.encryptedByteSize) {
     throw new Error("Hosted workspace snapshot encrypted size does not match its ref.");
   }
-  if (encryptedStat.size <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
+
+  return await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+    dataKey: input.dataKey,
+    durableRoot: input.durableRoot,
+    encryptedStream: createReadStream(encryptedFilePath),
+    ref: input.ref,
+  });
+}
+
+export async function restoreEncryptedWorkspaceSnapshotFromEncryptedStream(input: {
+  dataKey: string;
+  durableRoot: string;
+  encryptedStream: AsyncIterable<Uint8Array>;
+  ref: HostedWorkspaceSnapshotV2Ref;
+  signal?: AbortSignal | null;
+}): Promise<RestoreEncryptedWorkspaceSnapshotTimings> {
+  assertHostedWorkspaceSnapshotRestoreLive(input.signal);
+  if (input.ref.archive.compression !== HOSTED_WORKSPACE_SNAPSHOT_COMPRESSION) {
+    throw new Error("Hosted workspace snapshot restore only supports zstd archives.");
+  }
+  const expectedEncryptedByteSize = input.ref.archive.encryptedByteSize;
+  if (expectedEncryptedByteSize <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
     throw new Error("Hosted workspace snapshot encrypted object is too small.");
   }
-  if (encryptedStat.size >= HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES) {
+  if (expectedEncryptedByteSize >= HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES) {
     throw new RangeError("Hosted workspace snapshot exceeds the single-part size limit.");
   }
   if (input.ref.archive.totalPlainBytes >= HOSTED_WORKSPACE_SNAPSHOT_MAX_TOTAL_PLAIN_BYTES) {
@@ -359,27 +375,13 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
 
   const durableRoot = path.resolve(input.durableRoot);
   const durableParent = path.dirname(durableRoot);
-  const scratchRoot = input.scratchRoot ? path.resolve(input.scratchRoot) : null;
-  if (scratchRoot && isSameOrDescendantPath(scratchRoot, durableRoot)) {
-    throw new Error("Hosted workspace snapshot restore scratchRoot must be outside durableRoot.");
-  }
   await mkdir(durableParent, { mode: 0o700, recursive: true });
-  if (scratchRoot) {
-    await mkdir(scratchRoot, { mode: 0o700, recursive: true });
-    await assertHostedWorkspaceSnapshotPathOutsideRoot({
-      candidate: scratchRoot,
-      message: "Hosted workspace snapshot restore scratchRoot must be outside durableRoot.",
-      root: durableRoot,
-    });
-  }
   await assertHostedWorkspaceSnapshotZstdCliAvailable();
   const restoreTempDir = await mkdtemp(path.join(durableParent, ".workspace-snapshot-restore-"));
-  const scratchTempDir = scratchRoot
-    ? await mkdtemp(path.join(scratchRoot, "workspace-snapshot-restore-"))
-    : restoreTempDir;
   const restoreRoot = path.join(restoreTempDir, "durable-root");
   const backupRoot = path.join(restoreTempDir, "previous-durable-root");
   let dataKey: Uint8Array | null = null;
+  let plaintextArchiveBuffer: Buffer | null = null;
   let decryptMs = 0;
   let archiveExtractMs = 0;
   let durableRootReplaceMs = 0;
@@ -387,12 +389,9 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
   let extractMs = 0;
 
   try {
+    assertHostedWorkspaceSnapshotRestoreLive(input.signal);
     const decryptStartedAt = Date.now();
     await mkdir(restoreRoot, { mode: 0o700, recursive: true });
-    const authTag = await readHostedWorkspaceSnapshotAuthTag(
-      encryptedFilePath,
-      encryptedStat.size,
-    );
     dataKey = decodeHostedWorkspaceSnapshotV2DataKey(input.dataKey);
     const decipher = createDecipheriv(
       "aes-256-gcm",
@@ -400,23 +399,29 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
       Buffer.from(input.ref.encryption.ivBase64, "base64url"),
     );
     decipher.setAAD(Buffer.from(serializeHostedWorkspaceSnapshotV2Aad(input.ref.encryption.aad)));
-    decipher.setAuthTag(authTag);
 
     const encryptedObjectHash = createHash("sha256");
     const plaintextArchiveHash = createHash("sha256");
-    const plaintextArchivePath = path.join(scratchTempDir, "workspace.snapshot.tar.zst");
-    await pipeline(
-      createReadStream(encryptedFilePath, {
-        end: encryptedStat.size - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
-        start: 0,
-      }),
-      createHashTransform(encryptedObjectHash),
-      decipher,
-      createHashTransform(plaintextArchiveHash),
-      createWriteStream(plaintextArchivePath, { mode: 0o600 }),
-    );
+    const plaintextArchiveCollector = createFixedSizeArchiveBufferCollector({
+      byteLength: expectedEncryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
+      hash: plaintextArchiveHash,
+    });
+    let plaintextArchive: Buffer;
+    try {
+      await decryptHostedWorkspaceSnapshotEncryptedStream({
+        decipher,
+        encryptedObjectHash,
+        encryptedStream: input.encryptedStream,
+        expectedEncryptedByteSize,
+        plaintextArchiveCollector,
+      });
+      plaintextArchive = plaintextArchiveCollector.readBuffer();
+      plaintextArchiveBuffer = plaintextArchive;
+    } catch (error) {
+      plaintextArchiveCollector.clear();
+      throw error;
+    }
 
-    encryptedObjectHash.update(authTag);
     const encryptedObjectSha256 = encryptedObjectHash.digest("hex");
     if (encryptedObjectSha256 !== input.ref.archive.encryptedObjectSha256) {
       throw new Error("Hosted workspace snapshot encrypted digest does not match its ref.");
@@ -425,6 +430,7 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     if (plaintextArchiveSha256 !== input.ref.archive.plaintextArchiveSha256) {
       throw new Error("Hosted workspace snapshot plaintext archive digest does not match its ref.");
     }
+    assertHostedWorkspaceSnapshotRestoreLive(input.signal);
     decryptMs = Date.now() - decryptStartedAt;
 
     const extractStartedAt = Date.now();
@@ -432,9 +438,8 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     const zstd = spawn("zstd", [
       "-d",
       "--stdout",
-      plaintextArchivePath,
     ], {
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
     const tar = spawn("tar", [
       "-C",
@@ -448,12 +453,20 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     });
     const zstdExit = waitForHostedWorkspaceSnapshotProcess(zstd, "zstd");
     const tarExit = waitForHostedWorkspaceSnapshotProcess(tar, "tar");
+    let zstdInputPipe: Promise<void> | null = null;
+    let archivePipe: Promise<void> | null = null;
     try {
       if (!zstd.stdout || !tar.stdin) {
         throw new Error("Hosted workspace snapshot restore archive streams are unavailable.");
       }
+      if (!zstd.stdin) {
+        throw new Error("Hosted workspace snapshot restore archive streams are unavailable.");
+      }
+      zstdInputPipe = pipeline(Readable.from([plaintextArchive]), zstd.stdin);
+      archivePipe = pipeline(zstd.stdout, tar.stdin);
       await Promise.all([
-        pipeline(zstd.stdout, tar.stdin),
+        zstdInputPipe,
+        archivePipe,
         zstdExit,
         tarExit,
       ]);
@@ -464,6 +477,7 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
         zstdExit,
         tarExit,
       ]);
+      await Promise.allSettled([zstdInputPipe, archivePipe].filter((promise) => promise !== null));
       if (
         processFailure
         && shouldPreferHostedWorkspaceSnapshotProcessFailure(error)
@@ -473,6 +487,7 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
       throw error;
     }
     archiveExtractMs = Date.now() - archiveExtractStartedAt;
+    assertHostedWorkspaceSnapshotRestoreLive(input.signal);
 
     const durableRootReplaceStartedAt = Date.now();
     await replaceHostedWorkspaceSnapshotDurableRoot({
@@ -483,12 +498,10 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     durableRootReplaceMs = Date.now() - durableRootReplaceStartedAt;
     extractMs = Date.now() - extractStartedAt;
   } finally {
+    plaintextArchiveBuffer?.fill(0);
     dataKey?.fill(0);
     const cleanupStartedAt = Date.now();
     try {
-      if (scratchTempDir !== restoreTempDir) {
-        await rm(scratchTempDir, { force: true, recursive: true });
-      }
       await rm(restoreTempDir, { force: true, recursive: true });
     } finally {
       cleanupMs = Date.now() - cleanupStartedAt;
@@ -502,6 +515,74 @@ export async function restoreEncryptedWorkspaceSnapshot(input: {
     cleanupMs,
     extractMs,
   };
+}
+
+async function decryptHostedWorkspaceSnapshotEncryptedStream(input: {
+  decipher: DecipherGCM;
+  encryptedObjectHash: Hash;
+  encryptedStream: AsyncIterable<Uint8Array>;
+  expectedEncryptedByteSize: number;
+  plaintextArchiveCollector: {
+    clear(): void;
+    readBuffer(): Buffer;
+    append(chunk: Buffer): void;
+  };
+}): Promise<void> {
+  let encryptedByteCount = 0;
+  let encryptedTail = Buffer.alloc(0);
+  try {
+    for await (const rawChunk of input.encryptedStream) {
+      const chunk = Buffer.isBuffer(rawChunk)
+        ? rawChunk
+        : Buffer.from(rawChunk);
+      if (chunk.byteLength === 0) {
+        continue;
+      }
+      encryptedByteCount += chunk.byteLength;
+      if (encryptedByteCount > input.expectedEncryptedByteSize) {
+        throw new Error("Hosted workspace snapshot encrypted stream exceeded its ref byte count.");
+      }
+      input.encryptedObjectHash.update(chunk);
+
+      const encrypted = encryptedTail.byteLength > 0
+        ? Buffer.concat([encryptedTail, chunk])
+        : chunk;
+      if (encrypted.byteLength <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
+        encryptedTail = Buffer.from(encrypted);
+        continue;
+      }
+
+      const ciphertextEnd =
+        encrypted.byteLength - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES;
+      encryptedTail = Buffer.from(encrypted.subarray(ciphertextEnd));
+      input.plaintextArchiveCollector.append(
+        input.decipher.update(encrypted.subarray(0, ciphertextEnd)),
+      );
+    }
+
+    if (encryptedByteCount !== input.expectedEncryptedByteSize) {
+      throw new Error("Hosted workspace snapshot encrypted stream byte count does not match its ref.");
+    }
+    if (encryptedTail.byteLength !== HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
+      throw new Error("Hosted workspace snapshot auth tag is incomplete.");
+    }
+
+    input.decipher.setAuthTag(encryptedTail);
+    input.plaintextArchiveCollector.append(input.decipher.final());
+  } finally {
+    encryptedTail.fill(0);
+  }
+}
+
+function assertHostedWorkspaceSnapshotRestoreLive(
+  signal: AbortSignal | null | undefined,
+): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Hosted workspace snapshot restore was aborted.");
 }
 
 interface HostedWorkspaceSnapshotDurableRootState {
@@ -873,7 +954,7 @@ function decodeHostedWorkspaceSnapshotIv(value: string): Buffer {
   return iv;
 }
 
-function createHashTransform(hash: ReturnType<typeof createHash>): Transform {
+function createHashTransform(hash: Hash): Transform {
   return new Transform({
     transform(chunk: Buffer, _encoding, callback) {
       hash.update(chunk);
@@ -882,26 +963,42 @@ function createHashTransform(hash: ReturnType<typeof createHash>): Transform {
   });
 }
 
-async function readHostedWorkspaceSnapshotAuthTag(
-  filePath: string,
-  encryptedSize: number,
-): Promise<Buffer> {
-  const handle = await open(filePath, "r");
-  try {
-    const authTag = Buffer.alloc(HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES);
-    const result = await handle.read(
-      authTag,
-      0,
-      HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
-      encryptedSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES,
-    );
-    if (result.bytesRead !== HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
-      throw new Error("Hosted workspace snapshot auth tag is incomplete.");
-    }
-    return authTag;
-  } finally {
-    await handle.close();
+function createFixedSizeArchiveBufferCollector(input: {
+  byteLength: number;
+  hash: Hash;
+}): {
+  append(chunk: Buffer): void;
+  clear(): void;
+  readBuffer(): Buffer;
+} {
+  if (!Number.isSafeInteger(input.byteLength) || input.byteLength < 0) {
+    throw new Error("Hosted workspace snapshot decrypted archive size is unsafe.");
   }
+  const buffer = Buffer.allocUnsafe(input.byteLength);
+  let offset = 0;
+  return {
+    append: (chunk) => {
+      if (chunk.byteLength === 0) {
+        return;
+      }
+      const nextOffset = offset + chunk.byteLength;
+      if (nextOffset > buffer.byteLength) {
+        throw new Error("Hosted workspace snapshot decrypted archive size accounting failed.");
+      }
+      input.hash.update(chunk);
+      chunk.copy(buffer, offset);
+      offset = nextOffset;
+    },
+    clear: () => {
+      buffer.fill(0);
+    },
+    readBuffer: () => {
+      if (offset !== buffer.byteLength) {
+        throw new Error("Hosted workspace snapshot decrypted archive size accounting failed.");
+      }
+      return buffer;
+    },
+  };
 }
 
 async function replaceHostedWorkspaceSnapshotDurableRoot(input: {

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3527,6 +3527,66 @@ describe("RunnerContainer", () => {
     });
   });
 
+  it("destroys and clears preserved liveness after explicit abort is accepted", async () => {
+    let abortPosted = false;
+    let runnerResponseLost = false;
+    const containerFetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({
+          ...createRunnerHealthResult(),
+          activeJobCount: runnerResponseLost ? 1 : 0,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+
+      if (url.endsWith("/internal/workspace-invocation/abort")) {
+        abortPosted = true;
+        return new Response(null, { status: 204 });
+      }
+
+      if (!url.endsWith("/internal/workspace-invocation")) {
+        throw new Error(`Unexpected runner request URL: ${url}`);
+      }
+
+      runnerResponseLost = true;
+      throw new Error("Network connection lost");
+    });
+    const { container, destroy, startAndWaitForPorts } = createContainerDouble({
+      containerFetch,
+      initialStatus: "running",
+    });
+    const request = createRunnerRequest("evt_abort_after_accepted_response_lost");
+
+    await expect(container.invoke({
+      job: {
+        kind: "workspace-invocation",
+        request,
+      },
+      timeoutMs: 30_000,
+      userId: "member_123",
+    })).rejects.toThrow("Network connection lost");
+
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+
+    await expect(container.abortWorkspaceInvocation({
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    })).resolves.toBeUndefined();
+
+    expect(abortPosted).toBe(true);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: false,
+      reason: "no_active_runtime",
+    });
+  });
+
   it("keeps active liveness when an accepted workspace response body is lost", async () => {
     let runnerBodyLost = false;
     const containerFetch = vi.fn(async (url: string) => {

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -416,8 +416,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     });
 
     try {
-      // The malformed unwrap is preferred over any concurrent presign
-      // failure, and nothing is extracted into the durable root.
+      // The malformed unwrap fails before presign or extraction work starts.
       const durableRoot = path.join(tempRoot, "durable");
       await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot,
@@ -478,48 +477,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/u);
 
       expect(objectFetchCount).toBe(0);
-    } finally {
-      await rm(tempRoot, { force: true, recursive: true });
-    }
-  }, 15_000);
-
-  it("aborts the in-flight presign request when the data-key unwrap fails", async () => {
-    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-presign-abort-"));
-    const ref = createWorkspaceSnapshotV2Ref({
-      encryptedByteSize: 128,
-    });
-    let presignSignalAborted = false;
-    const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
-      const request = requireFetchRequest(args, "workspace snapshot presign abort fetch");
-      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
-        await delayWithAbort(50, request.signal);
-        return new Response("unwrap denied", { status: 403 });
-      }
-      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/presign-get`)) {
-        // Held open far beyond the test budget: only the unwrap-failure abort
-        // can settle this leg.
-        try {
-          await delayWithAbort(30_000, request.signal);
-        } catch (error) {
-          presignSignalAborted = true;
-          throw error;
-        }
-        return new Response("unreachable", { status: 500 });
-      }
-      return new Response("unexpected", { status: 500 });
-    });
-    const platform = buildTestHostedExecutionRuntimePlatform({
-      boundUserId: "member_123",
-      fetchImpl: fetchMock as typeof fetch,
-    });
-
-    try {
-      await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
-        durableRoot: path.join(tempRoot, "durable"),
-        ref,
-      })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/u);
-
-      expect(presignSignalAborted).toBe(true);
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
     }
@@ -1369,11 +1326,14 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(restoreTimings?.plainBytes).toBe(encrypted.totalPlainBytes);
 
       expect(fetchMock).toHaveBeenCalledTimes(3);
-      // The data-key unwrap runs concurrently with presign,
-      // so look requests up by URL instead of call order.
       const restoreRequests = fetchMock.mock.calls.map((call) =>
         requireFetchRequest(call, "workspace snapshot restore request"),
       );
+      expect(restoreRequests.map((request) => request.url)).toEqual([
+        "http://workspace-snapshots.worker/workspace-snapshots/snapshot_runner_platform_restore/data-key/unwrap",
+        "http://workspace-snapshots.worker/workspace-snapshots/snapshot_runner_platform_restore/presign-get",
+        getUrl,
+      ]);
       const unwrapRequest = restoreRequests.find((request) => request.url.endsWith("/data-key/unwrap"));
       expect(unwrapRequest?.url).toBe(
         "http://workspace-snapshots.worker/workspace-snapshots/snapshot_runner_platform_restore/data-key/unwrap",
@@ -1402,17 +1362,12 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       const completedSteps = workspaceSnapshotLogs
         .filter((log) => log.message === "Hosted workspace snapshot restore step completed.")
         .map((log) => log.details?.workspaceSnapshotRestoreStep);
-      // data_key_unwrap completes concurrently with presign; assert
-      // the deterministic orderings only.
-      expect([...completedSteps].sort()).toEqual([
-        "data_key_unwrap",
-        "object_fetch",
-        "presign_get",
+      expect(completedSteps).toEqual([
         "size_guard",
+        "data_key_unwrap",
+        "presign_get",
+        "object_fetch",
       ]);
-      expect(completedSteps[0]).toBe("size_guard");
-      expect(completedSteps.at(-1)).toBe("object_fetch");
-      expect(completedSteps.indexOf("presign_get")).toBeLessThan(completedSteps.indexOf("object_fetch"));
       expect(workspaceSnapshotLogs[0]?.details).toEqual(expect.objectContaining({
         archiveEncryptedByteSize: encrypted.encryptedByteSize,
         archiveFileCount: encrypted.fileCount,
@@ -1431,164 +1386,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(serializedLogs).not.toContain(snapshotScratchRoot);
       expect(serializedLogs).not.toContain("note.md");
       expect(serializedLogs).not.toContain("restored through direct r2");
-    } finally {
-      dataKey.fill(0);
-      await rm(tempRoot, {
-        force: true,
-        recursive: true,
-      });
-    }
-  });
-
-  it("runs the data-key unwrap concurrently with the presigned GET leg during restore", async () => {
-    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-overlap-"));
-    const sourceRoot = path.join(tempRoot, "source");
-    const scratchRoot = path.join(tempRoot, "scratch");
-    const durableRoot = path.join(tempRoot, "durable");
-    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
-    const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
-
-    // Each restore leg only answers once the OTHER leg's request is already
-    // in flight. A sequential implementation never issues the second request
-    // before the first resolves, so this test fails fast (via the barrier
-    // timeout) instead of passing by accident.
-    function createOverlapBarrier(): { release: () => void; wait: () => Promise<void> } {
-      let release: () => void = () => undefined;
-      const released = new Promise<void>((resolve) => {
-        release = resolve;
-      });
-      return {
-        release,
-        wait: async () => {
-          let timer: ReturnType<typeof setTimeout> | undefined;
-          try {
-            await Promise.race([
-              released,
-              new Promise<never>((_, reject) => {
-                timer = setTimeout(
-                  () => reject(new Error(
-                    "Workspace snapshot restore legs did not overlap; restore regressed to sequential.",
-                  )),
-                  2_000,
-                );
-              }),
-            ]);
-          } finally {
-            clearTimeout(timer);
-          }
-        },
-      };
-    }
-    const unwrapInFlight = createOverlapBarrier();
-    const presignInFlight = createOverlapBarrier();
-
-    try {
-      await mkdir(sourceRoot, { mode: 0o700, recursive: true });
-      await writeFile(path.join(sourceRoot, "note.md"), "restored concurrently\n", {
-        encoding: "utf8",
-        mode: 0o600,
-      });
-      const snapshotId = "snapshot_runner_platform_overlap";
-      const objectKey =
-        `users/hsn_0123456789abcdef01234567/workspace-snapshots/${snapshotId}.snapshot.enc`;
-      const aad = buildHostedWorkspaceSnapshotV2Aad({
-        objectKey,
-        snapshotId,
-        userId: "member_123",
-      });
-      const encrypted = await createEncryptedWorkspaceSnapshotFile({
-        aad,
-        archiveEntries: [{
-          absolutePath: path.join(sourceRoot, "note.md"),
-          archivePath: "note.md",
-          kind: "file",
-        }],
-        dataKey: dataKeyBase64,
-        durableRoot: sourceRoot,
-        ivBase64: "AQIDBAUGBwgJCgsM",
-        maxEncryptedBytes: HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES,
-        outputDir: scratchRoot,
-      });
-      const encryptedBytes = await readFile(encrypted.encryptedFilePath);
-      const getUrl = `https://r2.example.test/bundles/${objectKey}?X-Amz-Signature=fixture-get`;
-      const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
-        const request = requireFetchRequest(args, "workspace snapshot overlap fetch");
-        if (request.url.includes(`/workspace-snapshots/${snapshotId}/data-key/unwrap`)) {
-          unwrapInFlight.release();
-          await presignInFlight.wait();
-          return new Response(
-            JSON.stringify({ dataKey: dataKeyBase64 }),
-            {
-              headers: {
-                "content-type": "application/json; charset=utf-8",
-              },
-              status: 200,
-            },
-          );
-        }
-        if (request.url.includes(`/workspace-snapshots/${snapshotId}/presign-get`)) {
-          presignInFlight.release();
-          await unwrapInFlight.wait();
-          return new Response(
-            JSON.stringify({
-              expiresAt: new Date(Date.now() + 60_000).toISOString(),
-              getUrl,
-            }),
-            {
-              headers: {
-                "content-type": "application/json; charset=utf-8",
-              },
-              status: 200,
-            },
-          );
-        }
-        if (request.url === getUrl) {
-          return new Response(encryptedBytes, {
-            headers: {
-              "content-length": String(encrypted.encryptedByteSize),
-              "content-type": "application/octet-stream",
-            },
-            status: 200,
-          });
-        }
-        return new Response("unexpected", { status: 500 });
-      });
-      const platform = buildTestHostedExecutionRuntimePlatform({
-        boundUserId: "member_123",
-        commitTimeoutMs: 10_000,
-        fetchImpl: fetchMock as typeof fetch,
-      });
-
-      await platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
-        durableRoot,
-        ref: {
-          archive: {
-            compression: encrypted.compression,
-            encryptedByteSize: encrypted.encryptedByteSize,
-            encryptedObjectSha256: encrypted.encryptedObjectSha256,
-            fileCount: encrypted.fileCount,
-            format: "tar",
-            plaintextArchiveSha256: encrypted.plaintextArchiveSha256,
-            totalPlainBytes: encrypted.totalPlainBytes,
-          },
-          createdAt: "2026-05-20T00:00:00.000Z",
-          encryption: {
-            aad,
-            ivBase64: encrypted.ivBase64,
-            rootKeyId: "root_key_test",
-            scheme: HOSTED_WORKSPACE_SNAPSHOT_ENCRYPTION_SCHEME,
-            wrappedDataKey: "wrapped_data_key_test",
-          },
-          objectKey,
-          schema: HOSTED_WORKSPACE_SNAPSHOT_V2_REF_SCHEMA,
-          snapshotId,
-          upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
-          userId: "member_123",
-        },
-      });
-
-      expect(fetchMock).toHaveBeenCalledTimes(3);
-      await expect(access(path.join(durableRoot, "note.md"))).resolves.toBeUndefined();
     } finally {
       dataKey.fill(0);
       await rm(tempRoot, {
@@ -2027,8 +1824,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         ref,
       })).rejects.toThrow("Hosted workspace snapshot data key unwrap failed with HTTP 500.");
 
-      // The concurrent presign leg may log its own failure; assert on
-      // the unwrap step's failure specifically.
+      // The unwrap failure stops restore before presign or object fetch work.
       const failedUnwrapLogs = readWorkspaceSnapshotDiagnosticLogs()
         .filter((log) => log.message === "Hosted workspace snapshot restore step failed.")
         .filter((log) => log.details?.workspaceSnapshotRestoreStep === "data_key_unwrap");

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -1562,7 +1562,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     const getUrl = `https://r2.example.test/bundles/${ref.objectKey}?X-Amz-Signature=fixture-get`;
     const abortController = new AbortController();
     let objectFetchCount = 0;
-    let objectBodyCanceled = false;
+    let objectBodyCancelCount = 0;
     let resolveObjectBodyOpened: (() => void) | null = null;
     const objectBodyOpened = new Promise<void>((resolve) => {
       resolveObjectBodyOpened = resolve;
@@ -1594,7 +1594,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
           objectFetchCount += 1;
           return new Response(new ReadableStream<Uint8Array>({
             cancel: () => {
-              objectBodyCanceled = true;
+              objectBodyCancelCount += 1;
             },
             start: () => {
               resolveObjectBodyOpened?.();
@@ -1625,7 +1625,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
 
       await expect(restore).rejects.toThrow("restore aborted while reading snapshot body");
       expect(objectFetchCount).toBe(1);
-      expect(objectBodyCanceled).toBe(true);
+      expect(objectBodyCancelCount).toBe(1);
       await expect(access(durableRoot)).rejects.toThrow();
       expect(readWorkspaceSnapshotDiagnosticLogs().filter((log) =>
         log.message === "Hosted workspace snapshot restore read step failed; retrying."

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createHash } from "node:crypto";
-import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -367,7 +367,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       ref: createWorkspaceSnapshotV2Ref({
         encryptedByteSize: HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES,
       }),
-      scratchRoot: "unused-scratch-root",
     })).rejects.toThrow("Hosted workspace snapshot restore exceeds the single-part size guard.");
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -386,7 +385,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         encryptedByteSize: 128,
         totalPlainBytes: HOSTED_WORKSPACE_SNAPSHOT_MAX_TOTAL_PLAIN_BYTES,
       }),
-      scratchRoot: "unused-scratch-root",
     })).rejects.toThrow("Hosted workspace snapshot restore exceeds the total plain size guard.");
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -418,13 +416,12 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     });
 
     try {
-      // The malformed unwrap is preferred over any concurrent presign/fetch
+      // The malformed unwrap is preferred over any concurrent presign
       // failure, and nothing is extracted into the durable root.
       const durableRoot = path.join(tempRoot, "durable");
       await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot,
         ref,
-        scratchRoot: path.join(tempRoot, "scratch"),
       })).rejects.toThrow("Invalid character");
 
       const unwrapRequest = fetchMock.mock.calls
@@ -439,17 +436,16 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
   });
 
-  it("aborts the in-flight snapshot object download when the data-key unwrap fails", async () => {
-    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-unwrap-abort-"));
+  it("does not open the snapshot object body when the data-key unwrap fails", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-no-body-before-unwrap-"));
     const ref = createWorkspaceSnapshotV2Ref({
       encryptedByteSize: 128,
     });
     const getUrl = `https://r2.example.test/bundles/${ref.objectKey}?X-Amz-Signature=fixture-get`;
-    let objectGetSignalAborted = false;
+    let objectFetchCount = 0;
     const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
-      const request = requireFetchRequest(args, "workspace snapshot unwrap abort fetch");
+      const request = requireFetchRequest(args, "workspace snapshot unwrap body fetch");
       if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
-        // Give the object leg time to issue the GET before the unwrap fails.
         await delayWithAbort(50, request.signal);
         return new Response("unwrap denied", { status: 403 });
       }
@@ -465,16 +461,8 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         });
       }
       if (request.url === getUrl) {
-        // Held open far beyond the test budget: only the unwrap-failure abort
-        // can settle this leg. A sequential or signal-less regression times
-        // the test out instead of passing slowly.
-        try {
-          await delayWithAbort(30_000, request.signal);
-        } catch (error) {
-          objectGetSignalAborted = true;
-          throw error;
-        }
-        return new Response("unreachable", { status: 500 });
+        objectFetchCount += 1;
+        return new Response("unexpected object fetch", { status: 500 });
       }
       return new Response("unexpected", { status: 500 });
     });
@@ -487,10 +475,9 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot: path.join(tempRoot, "durable"),
         ref,
-        scratchRoot: path.join(tempRoot, "scratch"),
-      })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/);
+      })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/u);
 
-      expect(objectGetSignalAborted).toBe(true);
+      expect(objectFetchCount).toBe(0);
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
     }
@@ -530,11 +517,157 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot: path.join(tempRoot, "durable"),
         ref,
-        scratchRoot: path.join(tempRoot, "scratch"),
-      })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/);
+      })).rejects.toThrow(/data-key\/unwrap failed with HTTP 403/u);
 
       expect(presignSignalAborted).toBe(true);
     } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  }, 15_000);
+
+  it("aborts and cancels stalled v2 workspace snapshot unwrap response bodies", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-unwrap-body-abort-"));
+    const durableRoot = path.join(tempRoot, "durable");
+    const ref = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 128,
+    });
+    const getUrl = `https://r2.example.test/bundles/${ref.objectKey}?X-Amz-Signature=fixture-get`;
+    const abortController = new AbortController();
+    let objectFetchCount = 0;
+    let unwrapBodyCanceled = false;
+    let resolveUnwrapBodyOpened: (() => void) | null = null;
+    const unwrapBodyOpened = new Promise<void>((resolve) => {
+      resolveUnwrapBodyOpened = resolve;
+    });
+    const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
+      const request = requireFetchRequest(args, "workspace snapshot stalled unwrap body fetch");
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
+        return new Response(new ReadableStream<Uint8Array>({
+          cancel: () => {
+            unwrapBodyCanceled = true;
+          },
+          start: () => {
+            resolveUnwrapBodyOpened?.();
+            resolveUnwrapBodyOpened = null;
+          },
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/presign-get`)) {
+        return new Response(JSON.stringify({
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          getUrl,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      if (request.url === getUrl) {
+        objectFetchCount += 1;
+        return new Response("unexpected object fetch", { status: 500 });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    try {
+      const restore = platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
+        durableRoot,
+        ref,
+        signal: abortController.signal,
+      });
+      await unwrapBodyOpened;
+      abortController.abort(new Error("restore aborted while reading unwrap response"));
+
+      await expect(restore).rejects.toThrow("restore aborted while reading unwrap response");
+      expect(unwrapBodyCanceled).toBe(true);
+      expect(objectFetchCount).toBe(0);
+      await expect(access(durableRoot)).rejects.toThrow();
+      expect(readWorkspaceSnapshotDiagnosticLogs().filter((log) =>
+        log.message === "Hosted workspace snapshot restore read step failed; retrying."
+      )).toHaveLength(0);
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  }, 15_000);
+
+  it("aborts and cancels stalled v2 workspace snapshot presign response bodies", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-presign-body-abort-"));
+    const durableRoot = path.join(tempRoot, "durable");
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+    const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
+    const ref = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 128,
+    });
+    const abortController = new AbortController();
+    let presignBodyCanceled = false;
+    let objectFetchCount = 0;
+    let resolvePresignBodyOpened: (() => void) | null = null;
+    const presignBodyOpened = new Promise<void>((resolve) => {
+      resolvePresignBodyOpened = resolve;
+    });
+    const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
+      const request = requireFetchRequest(args, "workspace snapshot stalled presign body fetch");
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
+        return new Response(JSON.stringify({ dataKey: dataKeyBase64 }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/presign-get`)) {
+        await delayWithAbort(50, request.signal);
+        return new Response(new ReadableStream<Uint8Array>({
+          cancel: () => {
+            presignBodyCanceled = true;
+          },
+          start: () => {
+            resolvePresignBodyOpened?.();
+            resolvePresignBodyOpened = null;
+          },
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      objectFetchCount += 1;
+      return new Response("unexpected", { status: 500 });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    try {
+      const restore = platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
+        durableRoot,
+        ref,
+        signal: abortController.signal,
+      });
+      await presignBodyOpened;
+      abortController.abort(new Error("restore aborted while reading presign response"));
+
+      await expect(restore).rejects.toThrow("restore aborted while reading presign response");
+      expect(presignBodyCanceled).toBe(true);
+      expect(objectFetchCount).toBe(0);
+      await expect(access(durableRoot)).rejects.toThrow();
+      expect(readWorkspaceSnapshotDiagnosticLogs().filter((log) =>
+        log.message === "Hosted workspace snapshot restore read step failed; retrying."
+      )).toHaveLength(0);
+    } finally {
+      dataKey.fill(0);
       await rm(tempRoot, { force: true, recursive: true });
     }
   }, 15_000);
@@ -1102,7 +1235,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   it("restores v2 workspace snapshots through unwrap, presigned GET, and direct R2 fetch", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-restore-"));
     const sourceRoot = path.join(tempRoot, "source");
-    const scratchRoot = path.join(tempRoot, "scratch");
+    const snapshotScratchRoot = path.join(tempRoot, "snapshot-scratch");
     const durableRoot = path.join(tempRoot, "durable");
     const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
     const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
@@ -1132,10 +1265,10 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         durableRoot: sourceRoot,
         ivBase64: "AQIDBAUGBwgJCgsM",
         maxEncryptedBytes: HOSTED_WORKSPACE_SNAPSHOT_MAX_SINGLE_PART_BYTES,
-        outputDir: scratchRoot,
+        outputDir: snapshotScratchRoot,
       });
       const encryptedBytes = await readFile(encrypted.encryptedFilePath);
-      await rm(scratchRoot, { force: true, recursive: true });
+      await rm(snapshotScratchRoot, { force: true, recursive: true });
       const getUrl = `https://r2.example.test/bundles/${objectKey}?X-Amz-Signature=fixture-get`;
       const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
         const request = requireFetchRequest(args, "workspace snapshot restore fetch");
@@ -1216,12 +1349,10 @@ describe("buildHostedExecutionRuntimePlatform", () => {
           upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
           userId: "member_123",
         },
-        scratchRoot,
       });
       for (const key of [
         "sizeGuardMs",
         "dataKeyUnwrapMs",
-        "scratchPrepareMs",
         "presignGetMs",
         "objectFetchMs",
         "decryptMs",
@@ -1238,7 +1369,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(restoreTimings?.plainBytes).toBe(encrypted.totalPlainBytes);
 
       expect(fetchMock).toHaveBeenCalledTimes(3);
-      // The data-key unwrap runs concurrently with the presign/fetch chain,
+      // The data-key unwrap runs concurrently with presign,
       // so look requests up by URL instead of call order.
       const restoreRequests = fetchMock.mock.calls.map((call) =>
         requireFetchRequest(call, "workspace snapshot restore request"),
@@ -1267,24 +1398,20 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       });
       expect(restoreRequests.some((request) => request.url === getUrl)).toBe(true);
       await expect(access(path.join(durableRoot, "note.md"))).resolves.toBeUndefined();
-      await expect(readdir(scratchRoot)).resolves.toEqual([]);
       const workspaceSnapshotLogs = readWorkspaceSnapshotDiagnosticLogs();
       const completedSteps = workspaceSnapshotLogs
         .filter((log) => log.message === "Hosted workspace snapshot restore step completed.")
         .map((log) => log.details?.workspaceSnapshotRestoreStep);
-      // data_key_unwrap completes concurrently with the fetch chain; assert
+      // data_key_unwrap completes concurrently with presign; assert
       // the deterministic orderings only.
       expect([...completedSteps].sort()).toEqual([
-        "archive_restore",
         "data_key_unwrap",
         "object_fetch",
         "presign_get",
-        "scratch_prepare",
         "size_guard",
       ]);
       expect(completedSteps[0]).toBe("size_guard");
-      expect(completedSteps.at(-1)).toBe("archive_restore");
-      expect(completedSteps.indexOf("scratch_prepare")).toBeLessThan(completedSteps.indexOf("presign_get"));
+      expect(completedSteps.at(-1)).toBe("object_fetch");
       expect(completedSteps.indexOf("presign_get")).toBeLessThan(completedSteps.indexOf("object_fetch"));
       expect(workspaceSnapshotLogs[0]?.details).toEqual(expect.objectContaining({
         archiveEncryptedByteSize: encrypted.encryptedByteSize,
@@ -1301,7 +1428,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(serializedLogs).not.toContain(dataKeyBase64);
       expect(serializedLogs).not.toContain(sourceRoot);
       expect(serializedLogs).not.toContain(durableRoot);
-      expect(serializedLogs).not.toContain(scratchRoot);
+      expect(serializedLogs).not.toContain(snapshotScratchRoot);
       expect(serializedLogs).not.toContain("note.md");
       expect(serializedLogs).not.toContain("restored through direct r2");
     } finally {
@@ -1458,7 +1585,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
           upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
           userId: "member_123",
         },
-        scratchRoot,
       });
 
       expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -1533,7 +1659,23 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         if (request.url === getUrl) {
           objectFetchCount += 1;
           if (objectFetchCount === 1) {
-            throw new TypeError(`fetch failed for ${getUrl} with hidden retry detail`);
+            let prefixSent = false;
+            return new Response(new ReadableStream<Uint8Array>({
+              pull(controller) {
+                if (!prefixSent) {
+                  prefixSent = true;
+                  controller.enqueue(encryptedBytes.subarray(0, 32));
+                  return;
+                }
+                controller.error(new TypeError("connection reset"));
+              },
+            }), {
+              headers: {
+                "content-length": String(encrypted.encryptedByteSize),
+                "content-type": "application/octet-stream",
+              },
+              status: 200,
+            });
           }
           return new Response(encryptedBytes, {
             headers: {
@@ -1576,18 +1718,22 @@ describe("buildHostedExecutionRuntimePlatform", () => {
           upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
           userId: "member_123",
         },
-        scratchRoot,
       });
 
       expect(objectFetchCount).toBe(2);
       await expect(access(path.join(durableRoot, "note.md"))).resolves.toBeUndefined();
+      await expect(
+        readdir(tempRoot).then((entries) =>
+          entries.filter((entry) => entry.startsWith(".workspace-snapshot-restore-")),
+        ),
+      ).resolves.toEqual([]);
       const retryLogs = readWorkspaceSnapshotDiagnosticLogs()
         .filter((log) =>
           log.message === "Hosted workspace snapshot restore read step failed; retrying."
         );
       expect(retryLogs).toHaveLength(1);
       expect(retryLogs[0]?.details).toEqual(expect.objectContaining({
-        fetchCauseKind: "fetch_failed",
+        fetchCauseKind: "network",
         retrying: true,
         workspaceSnapshotRestoreAttempt: 1,
         workspaceSnapshotRestoreStep: "object_fetch",
@@ -1596,9 +1742,97 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(serializedLogs).not.toContain(objectKey);
       expect(serializedLogs).not.toContain(snapshotId);
       expect(serializedLogs).not.toContain(getUrl);
-      expect(serializedLogs).toContain("hidden retry detail");
+      expect(serializedLogs).toContain("connection reset");
       expect(serializedLogs).not.toContain(dataKeyBase64);
       expect(serializedLogs).not.toContain(tempRoot);
+    } finally {
+      dataKey.fill(0);
+      await rm(tempRoot, {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
+  it("aborts and cancels stalled v2 workspace snapshot object body reads", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-body-abort-"));
+    const durableRoot = path.join(tempRoot, "durable");
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+    const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
+    const ref = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 128,
+    });
+    const getUrl = `https://r2.example.test/bundles/${ref.objectKey}?X-Amz-Signature=fixture-get`;
+    const abortController = new AbortController();
+    let objectFetchCount = 0;
+    let objectBodyCanceled = false;
+    let resolveObjectBodyOpened: (() => void) | null = null;
+    const objectBodyOpened = new Promise<void>((resolve) => {
+      resolveObjectBodyOpened = resolve;
+    });
+
+    try {
+      const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
+        const request = requireFetchRequest(args, "workspace snapshot stalled body fetch");
+        if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
+          return new Response(JSON.stringify({ dataKey: dataKeyBase64 }), {
+            headers: {
+              "content-type": "application/json; charset=utf-8",
+            },
+            status: 200,
+          });
+        }
+        if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/presign-get`)) {
+          return new Response(JSON.stringify({
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            getUrl,
+          }), {
+            headers: {
+              "content-type": "application/json; charset=utf-8",
+            },
+            status: 200,
+          });
+        }
+        if (request.url === getUrl) {
+          objectFetchCount += 1;
+          return new Response(new ReadableStream<Uint8Array>({
+            cancel: () => {
+              objectBodyCanceled = true;
+            },
+            start: () => {
+              resolveObjectBodyOpened?.();
+              resolveObjectBodyOpened = null;
+            },
+          }), {
+            headers: {
+              "content-length": String(ref.archive.encryptedByteSize),
+              "content-type": "application/octet-stream",
+            },
+            status: 200,
+          });
+        }
+        return new Response("unexpected", { status: 500 });
+      });
+      const platform = buildTestHostedExecutionRuntimePlatform({
+        boundUserId: "member_123",
+        fetchImpl: fetchMock as typeof fetch,
+      });
+
+      const restore = platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
+        durableRoot,
+        ref,
+        signal: abortController.signal,
+      });
+      await objectBodyOpened;
+      abortController.abort(new Error("restore aborted while reading snapshot body"));
+
+      await expect(restore).rejects.toThrow("restore aborted while reading snapshot body");
+      expect(objectFetchCount).toBe(1);
+      expect(objectBodyCanceled).toBe(true);
+      await expect(access(durableRoot)).rejects.toThrow();
+      expect(readWorkspaceSnapshotDiagnosticLogs().filter((log) =>
+        log.message === "Hosted workspace snapshot restore read step failed; retrying."
+      )).toHaveLength(0);
     } finally {
       dataKey.fill(0);
       await rm(tempRoot, {
@@ -1611,7 +1845,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   it("does not retry v2 workspace snapshot byte-count mismatches", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-byte-count-"));
     const durableRoot = path.join(tempRoot, "durable");
-    const scratchRoot = path.join(tempRoot, "scratch");
     const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
     const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
     const ref = createWorkspaceSnapshotV2Ref({
@@ -1661,7 +1894,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot,
         ref,
-        scratchRoot,
       })).rejects.toThrow("Hosted workspace snapshot fetch byte count does not match its ref.");
 
       expect(objectFetchCount).toBe(1);
@@ -1680,7 +1912,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   it("logs the failing v2 workspace snapshot restore step without object identifiers", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-restore-fail-"));
     const durableRoot = path.join(tempRoot, "durable");
-    const scratchRoot = path.join(tempRoot, "scratch");
     const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
     const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
     const ref = createWorkspaceSnapshotV2Ref({
@@ -1729,9 +1960,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot,
         ref,
-        scratchRoot,
       })).rejects.toThrow("Hosted workspace snapshot encrypted object is unavailable.");
-      await expect(readdir(scratchRoot)).resolves.toEqual([]);
 
       const failedLogs = readWorkspaceSnapshotDiagnosticLogs()
         .filter((log) => log.message === "Hosted workspace snapshot restore step failed.");
@@ -1769,7 +1998,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   it("logs v2 workspace snapshot unwrap response failures without snapshot path material", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-unwrap-fail-"));
     const durableRoot = path.join(tempRoot, "durable");
-    const scratchRoot = path.join(tempRoot, "scratch");
     const ref = createWorkspaceSnapshotV2Ref({
       encryptedByteSize: 1024,
     });
@@ -1797,10 +2025,9 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       await expect(platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot,
         ref,
-        scratchRoot,
       })).rejects.toThrow("Hosted workspace snapshot data key unwrap failed with HTTP 500.");
 
-      // The concurrent presign/fetch leg may log its own failure; assert on
+      // The concurrent presign leg may log its own failure; assert on
       // the unwrap step's failure specifically.
       const failedUnwrapLogs = readWorkspaceSnapshotDiagnosticLogs()
         .filter((log) => log.message === "Hosted workspace snapshot restore step failed.")
@@ -1848,6 +2075,9 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         ...readWorkspaceSnapshotDiagnosticLogs(),
         ...upstreamNonOkLogs,
       ]);
+      const serializedAllStructuredLogs = JSON.stringify(
+        mocks.emitHostedExecutionStructuredLog.mock.calls,
+      );
       expect(serializedLogs).not.toContain(ref.objectKey);
       expect(serializedLogs).not.toContain(ref.snapshotId);
       expect(serializedLogs).not.toContain("body-presigned");
@@ -1855,6 +2085,12 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(serializedLogs).not.toContain("root_key_test");
       expect(serializedLogs).not.toContain("wrapped_data_key_test");
       expect(serializedLogs).not.toContain(tempRoot);
+      expect(serializedAllStructuredLogs).not.toContain(responseDetail);
+      expect(serializedAllStructuredLogs).not.toContain(ref.objectKey);
+      expect(serializedAllStructuredLogs).not.toContain("body-presigned");
+      expect(serializedAllStructuredLogs).not.toContain("root_key_test");
+      expect(serializedAllStructuredLogs).not.toContain("wrapped_data_key_test");
+      expect(serializedAllStructuredLogs).not.toContain(tempRoot);
     } finally {
       await rm(tempRoot, {
         force: true,
@@ -1866,7 +2102,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   it("logs v2 workspace snapshot direct object transport errors without R2 path or query material", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-transport-fail-"));
     const durableRoot = path.join(tempRoot, "durable");
-    const scratchRoot = path.join(tempRoot, "scratch");
     const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
     const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
     const ref = createWorkspaceSnapshotV2Ref({
@@ -1917,7 +2152,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         await platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
           durableRoot,
           ref,
-          scratchRoot,
         });
       } catch (error) {
         thrown = error;
@@ -2010,7 +2244,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   it("logs archive restore tar/zstd process failures without stderr text", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-archive-process-fail-"));
     const durableRoot = path.join(tempRoot, "durable");
-    const scratchRoot = path.join(tempRoot, "scratch");
     const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
     const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(dataKey);
     const snapshotId = "snapshot_runner_platform_archive_process_fail";
@@ -2097,7 +2330,6 @@ describe("buildHostedExecutionRuntimePlatform", () => {
           upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
           userId: "member_123",
         },
-        scratchRoot,
       })).rejects.toThrow(/^Hosted workspace snapshot zstd command failed with /u);
 
       const failedLogs = readWorkspaceSnapshotDiagnosticLogs()
@@ -2112,7 +2344,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
           workspaceSnapshotProcessStderrBytes: expect.any(Number),
           workspaceSnapshotProcessStderrLineCount: expect.any(Number),
           workspaceSnapshotProcessStderrTruncated: false,
-          workspaceSnapshotRestoreStep: "archive_restore",
+          workspaceSnapshotRestoreStep: "object_fetch",
         }),
         level: "warn",
         phase: "runtime.starting",

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -24,6 +24,7 @@ import {
   createEncryptedWorkspaceSnapshotFile,
   type EncryptedWorkspaceSnapshotFile,
   restoreEncryptedWorkspaceSnapshot,
+  restoreEncryptedWorkspaceSnapshotFromEncryptedStream,
 } from "../src/workspace-snapshot-local.js";
 
 const execFileAsync = promisify(execFile);
@@ -113,7 +114,6 @@ describe("workspace snapshot local restore", () => {
         durableRoot: restoredDurableRoot,
         encryptedFilePath: encrypted.encryptedFilePath,
         ref,
-        scratchRoot: path.join(tempRoot, "restore-scratch"),
       });
 
       for (const key of [
@@ -201,7 +201,6 @@ describe("workspace snapshot local restore", () => {
         durableRoot: restoredDurableRoot,
         encryptedFilePath: encrypted.encryptedFilePath,
         ref,
-        scratchRoot: path.join(tempRoot, "restore-scratch"),
       });
 
       await expect(readFile(
@@ -362,6 +361,137 @@ describe("workspace snapshot local restore", () => {
         outputDir,
       })).rejects.toThrow("Hosted workspace snapshot exceeds the total plain size limit.");
       await expect(readdir(outputDir)).resolves.toEqual([]);
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+      dataKey.fill(0);
+    }
+  });
+
+  it("restores encrypted snapshots from an encrypted byte stream", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-stream-test-"));
+    const sourceDurableRoot = path.join(tempRoot, "source", "durable");
+    const sourceVaultRoot = path.join(sourceDurableRoot, "vault");
+    const sourceOperatorHomeRoot = path.join(sourceDurableRoot, "home");
+    const restoredDurableRoot = path.join(tempRoot, "restored", "durable");
+    const snapshotId = "snapshot_stream_restore";
+    const objectKey = "users/hsn_test/workspace-snapshots/snapshot_stream_restore.snapshot.enc";
+    const userId = "member_123";
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+
+    try {
+      await mkdir(sourceVaultRoot, { recursive: true });
+      await mkdir(sourceOperatorHomeRoot, { recursive: true });
+      await writeFile(path.join(sourceVaultRoot, "note.md"), "stream restored\n", "utf8");
+
+      const aad = buildHostedWorkspaceSnapshotV2Aad({
+        objectKey,
+        snapshotId,
+        userId,
+      });
+      const archivePlan = await collectHostedWorkspaceSnapshotArchivePlan({
+        durableRoot: sourceDurableRoot,
+        operatorHomeRoot: sourceOperatorHomeRoot,
+        vaultRoot: sourceVaultRoot,
+      });
+      const encrypted = await createEncryptedWorkspaceSnapshotFile({
+        aad,
+        archiveEntries: archivePlan.entries,
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: sourceDurableRoot,
+        ivBase64: Buffer.from(Uint8Array.from({ length: 12 }, (_, index) => index + 10))
+          .toString("base64url"),
+        maxEncryptedBytes: 16 * 1024 * 1024,
+        outputDir: path.join(tempRoot, "scratch"),
+      });
+      const encryptedBytes = await readFile(encrypted.encryptedFilePath);
+      const ref = createHostedWorkspaceSnapshotTestRef({
+        aad,
+        encrypted,
+        objectKey,
+        snapshotId,
+        userId,
+      });
+
+      const restoreTimings = await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: restoredDurableRoot,
+        encryptedStream: streamEncryptedChunks(splitEncryptedSnapshotAcrossAuthTagBoundary(encryptedBytes)),
+        ref,
+      });
+
+      expect(typeof restoreTimings.decryptMs).toBe("number");
+      expect(Number.isFinite(restoreTimings.decryptMs)).toBe(true);
+      await expect(readFile(path.join(restoredDurableRoot, "vault", "note.md"), "utf8"))
+        .resolves.toBe("stream restored\n");
+      await expect(readdir(path.dirname(restoredDurableRoot))).resolves.toEqual(["durable"]);
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+      dataKey.fill(0);
+    }
+  });
+
+  it("rejects encrypted stream auth failures without replacing durable state", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-stream-auth-test-"));
+    const sourceDurableRoot = path.join(tempRoot, "source", "durable");
+    const sourceVaultRoot = path.join(sourceDurableRoot, "vault");
+    const sourceOperatorHomeRoot = path.join(sourceDurableRoot, "home");
+    const durableRoot = path.join(tempRoot, "durable");
+    const existingDurableFile = path.join(durableRoot, "existing.txt");
+    const snapshotId = "snapshot_stream_auth_fail";
+    const objectKey = "users/hsn_test/workspace-snapshots/snapshot_stream_auth_fail.snapshot.enc";
+    const userId = "member_123";
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+
+    try {
+      await mkdir(sourceVaultRoot, { recursive: true });
+      await mkdir(sourceOperatorHomeRoot, { recursive: true });
+      await writeFile(path.join(sourceVaultRoot, "note.md"), "should not restore\n", "utf8");
+      await mkdir(durableRoot, { mode: 0o700, recursive: true });
+      await writeFile(existingDurableFile, "existing durable root\n", { mode: 0o600 });
+
+      const aad = buildHostedWorkspaceSnapshotV2Aad({
+        objectKey,
+        snapshotId,
+        userId,
+      });
+      const archivePlan = await collectHostedWorkspaceSnapshotArchivePlan({
+        durableRoot: sourceDurableRoot,
+        operatorHomeRoot: sourceOperatorHomeRoot,
+        vaultRoot: sourceVaultRoot,
+      });
+      const encrypted = await createEncryptedWorkspaceSnapshotFile({
+        aad,
+        archiveEntries: archivePlan.entries,
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: sourceDurableRoot,
+        ivBase64: Buffer.from(Uint8Array.from({ length: 12 }, (_, index) => index + 10))
+          .toString("base64url"),
+        maxEncryptedBytes: 16 * 1024 * 1024,
+        outputDir: path.join(tempRoot, "scratch"),
+      });
+      const encryptedBytes = await readFile(encrypted.encryptedFilePath);
+      const tamperedEncryptedBytes = Buffer.from(encryptedBytes);
+      tamperedEncryptedBytes[tamperedEncryptedBytes.byteLength - 1] ^= 0xff;
+      const ref = createHostedWorkspaceSnapshotTestRef({
+        aad,
+        encrypted,
+        objectKey,
+        snapshotId,
+        userId,
+      });
+
+      await expect(restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot,
+        encryptedStream: streamEncryptedChunks([
+          tamperedEncryptedBytes.subarray(0, tamperedEncryptedBytes.byteLength - 2),
+          tamperedEncryptedBytes.subarray(tamperedEncryptedBytes.byteLength - 2),
+        ]),
+        ref,
+      })).rejects.toThrow();
+
+      await expect(readFile(existingDurableFile, "utf8")).resolves.toBe("existing durable root\n");
+      await expect(access(path.join(durableRoot, "vault", "note.md"))).rejects.toThrow();
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
       dataKey.fill(0);
@@ -612,7 +742,6 @@ exec "$REAL_TAR" "$@"
             ...archivePatch,
           },
         },
-        scratchRoot: path.join(tempRoot, "restore-scratch"),
       })).rejects.toThrow(expectedError);
 
       await expect(readFile(path.join(restoredDurableRoot, "existing.txt"), "utf8"))
@@ -657,4 +786,25 @@ function createHostedWorkspaceSnapshotTestRef(input: {
     upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
     userId: input.userId,
   };
+}
+
+async function* streamEncryptedChunks(chunks: readonly Uint8Array[]): AsyncIterable<Uint8Array> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+const TEST_HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES = 16;
+
+function splitEncryptedSnapshotAcrossAuthTagBoundary(encryptedBytes: Buffer): Uint8Array[] {
+  const ciphertextEnd =
+    encryptedBytes.byteLength - TEST_HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES;
+  const nearAuthTag = Math.max(1, ciphertextEnd - 3);
+  return [
+    encryptedBytes.subarray(0, 1),
+    encryptedBytes.subarray(1, nearAuthTag),
+    encryptedBytes.subarray(nearAuthTag, ciphertextEnd + 1),
+    encryptedBytes.subarray(ciphertextEnd + 1, ciphertextEnd + 8),
+    encryptedBytes.subarray(ciphertextEnd + 8),
+  ].filter((chunk) => chunk.byteLength > 0);
 }

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -735,15 +735,14 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       stage: "workspace.restore",
       status: "start",
     });
-    const restored = await raceHostedRuntimeCancellation(
-      restoreHostedWorkspaceRuntimeJobWorkspace({
-        logContext: runtimeLogContext,
-        platform: guardedRuntime.platform,
-        vaultRoot: options.vaultRoot,
-        workspace: workspaceRead.workspace,
-      }),
-      runtimeAbortController.signal,
-    );
+    const restored = await restoreHostedWorkspaceRuntimeJobWorkspace({
+      logContext: runtimeLogContext,
+      platform: guardedRuntime.platform,
+      signal: runtimeAbortController.signal,
+      vaultRoot: options.vaultRoot,
+      workspace: workspaceRead.workspace,
+    });
+    assertRuntimeNotAborted();
     const workspaceRestoreDoneAt = new Date().toISOString();
     initialAssistantInputLatencyMilestones.workspaceRestoreDoneAt = workspaceRestoreDoneAt;
     // Attach the in-memory cold-start phase breakdown to the SAME staged-milestone

--- a/packages/assistant-runtime/src/hosted-runtime/platform.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/platform.ts
@@ -302,7 +302,6 @@ export interface HostedRuntimeWorkspaceSnapshotDirectUploadTimingDetails {
 export interface HostedRuntimeWorkspaceSnapshotRestoreTimingDetails {
   sizeGuardMs?: number;
   dataKeyUnwrapMs?: number;
-  scratchPrepareMs?: number;
   presignGetMs?: number;
   objectFetchMs?: number;
   decryptMs?: number;
@@ -333,7 +332,7 @@ export interface HostedRuntimeWorkspaceSnapshotPort {
   restoreWorkspaceSnapshot(input: {
     durableRoot: string;
     ref: HostedWorkspaceSnapshotV2Ref;
-    scratchRoot?: string | null;
+    signal?: AbortSignal | null;
   }): Promise<HostedRuntimeWorkspaceSnapshotRestoreTimingDetails | void>;
   startSnapshotSession(input: {
     expectedWorkspaceVersion: string;

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-restore.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-restore.ts
@@ -120,6 +120,7 @@ export class HostedWorkspaceRuntimeSnapshotRestoreError extends Error {
 export async function restoreHostedWorkspaceRuntimeJobWorkspace(input: {
   logContext?: HostedRuntimeLogContext | null;
   platform: HostedRuntimePlatform;
+  signal?: AbortSignal | null;
   vaultRoot: string;
   workspace: HostedWorkspaceState | null;
 }): Promise<HostedWorkspaceRuntimeRestoreResult> {
@@ -159,7 +160,7 @@ export async function restoreHostedWorkspaceRuntimeJobWorkspace(input: {
     const restoreTiming = await input.platform.workspaceSnapshotPort.restoreWorkspaceSnapshot({
       durableRoot: resolveHostedWorkspaceDurableRoot(restored.vaultRoot),
       ref: snapshotRef,
-      scratchRoot: resolveHostedWorkspaceScratchRoot(restored.vaultRoot),
+      signal: input.signal ?? null,
     });
     await Promise.all([
       createHostedWorkspaceRuntimePrivateDirectory(restored.vaultRoot),
@@ -1466,14 +1467,6 @@ function resolveHostedWorkspaceDurableRoot(vaultRoot: string): string {
     return path.dirname(resolvedVaultRoot);
   }
   return resolvedVaultRoot;
-}
-
-function resolveHostedWorkspaceScratchRoot(vaultRoot: string): string {
-  const durableRoot = resolveHostedWorkspaceDurableRoot(vaultRoot);
-  if (path.basename(durableRoot) === "durable") {
-    return path.join(path.dirname(durableRoot), "scratch");
-  }
-  return path.join(path.dirname(durableRoot), `${path.basename(durableRoot)}-scratch`);
 }
 
 function resolveHostedWorkspaceOperatorHomeRoot(vaultRoot: string): string {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-restore-codex-continuity.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-restore-codex-continuity.test.ts
@@ -96,10 +96,11 @@ describe("hosted workspace restore Codex continuity", () => {
       const restoredVaultRoot = path.join(workspaceRoot, "restored-vault");
       const artifactGetCalls: string[] = [];
       const snapshotRef = createWorkspaceSnapshotV2Ref();
+      const restoreSignal = new AbortController().signal;
       const restoreCalls: Array<{
         durableRoot: string;
         ref: HostedWorkspaceSnapshotV2Ref;
-        scratchRoot?: string | null;
+        signal?: AbortSignal | null;
       }> = [];
 
       await restoreHostedWorkspaceRuntimeJobWorkspace({
@@ -126,6 +127,7 @@ describe("hosted workspace restore Codex continuity", () => {
             },
           },
         }),
+        signal: restoreSignal,
         vaultRoot: restoredVaultRoot,
         workspace: createWorkspaceState({
           snapshotRef,
@@ -135,7 +137,7 @@ describe("hosted workspace restore Codex continuity", () => {
       assert.deepEqual(artifactGetCalls, []);
       assert.equal(restoreCalls.length, 1);
       assert.equal(restoreCalls[0]?.ref, snapshotRef);
-      assert.equal(restoreCalls[0]?.scratchRoot, path.join(workspaceRoot, "restored-vault-scratch"));
+      assert.equal(restoreCalls[0]?.signal, restoreSignal);
       assert.equal(
         await readFile(path.join(restoredVaultRoot, "note.md"), "utf8"),
         "restored from v2\n",
@@ -215,7 +217,6 @@ describe("hosted workspace restore Codex continuity", () => {
               return {
                 sizeGuardMs: 1,
                 dataKeyUnwrapMs: 2,
-                scratchPrepareMs: 3,
                 presignGetMs: 4,
                 objectFetchMs: 5,
                 decryptMs: 6,
@@ -240,7 +241,6 @@ describe("hosted workspace restore Codex continuity", () => {
       assert.deepEqual(coldRestored.restoreTiming, {
         sizeGuardMs: 1,
         dataKeyUnwrapMs: 2,
-        scratchPrepareMs: 3,
         presignGetMs: 4,
         objectFetchMs: 5,
         decryptMs: 6,


### PR DESCRIPTION
## Summary
- stream hosted workspace snapshot restores directly from the presigned R2 response body
- overlap data-key unwrap with presign/object open, then decrypt/hash ciphertext and plaintext in one bounded in-memory pass
- remove the hosted restore scratch ciphertext download path and stale scratch timing

## Validation
- `pnpm --dir apps/cloudflare typecheck`
- `pnpm --dir apps/cloudflare test:node -- apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts`
- `bash scripts/workspace-verify.sh test:diff apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts apps/cloudflare/src/runtime-platform/diagnostics.ts apps/cloudflare/src/workspace-snapshot-local.ts apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/runner-platform.test.ts`
- `git diff --check`
- privacy scan over committed diff

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784686228&installation_id=127572939&pr_number=253&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F253&signature=c2a2fb0a75010f1e94fa5efd4f59f968e9e6ce5a84a88e3cef205c92951b41cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->