### PR TITLE
Preserve retryable outbox wake across foreground reentry

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-22-retryable-outbox-wake.md
+++ b/agent-docs/exec-plans/completed/2026-06-22-retryable-outbox-wake.md
@@ -1,0 +1,68 @@
+# Retryable outbox wake preservation
+
+## Goal
+
+Prove whether a checkpoint-gated wake can strand retryable outbox work after an
+assistant pass clears the scheduler projection, then fix the issue if it is
+real.
+
+Success criteria:
+
+- A local hosted-runtime regression test reproduces the wake loss before the
+  production fix.
+- The fix preserves retryable outbox follow-up wakes without adding a second
+  scheduler or widening durable state ownership.
+- Focused assistant-runtime verification and required repo checks pass.
+- The scoped branch is committed, pushed, and opened as a PR.
+
+## Constraints
+
+- Branch from the current hosted foreground-preemption PR head.
+- Preserve foreground assistant priority over maintenance and outbox retry work.
+- Keep the architecture simple: one runtime wake projection, no new scheduler,
+  no new durable state owner, and no speculative abstractions.
+- Preserve unrelated working-tree edits and active plans.
+- Do not expose secrets, direct personal identifiers, local account names, or
+  home-directory paths in committed files or handoff text.
+
+## Approach
+
+1. Inspect the hosted runtime wake projection, checkpoint gate, and outbox retry
+   paths.
+2. Add the smallest local end-to-end regression that demonstrates the stranded
+   retryable outbox wake, if reachable.
+3. Fix the root cause at the wake merge/projection boundary.
+4. Run focused and required verification, completion audits, and local final
+   review.
+5. Commit, push, and open a PR.
+
+## State
+
+Ready for scoped commit and PR.
+
+## Notes
+
+- Triggered by a partial ReviewGPT finding: "Gated wakes after a checkpoint
+  could leave retryable outbox wakes stranded if the assistant pass clears
+  them."
+- Reproduced locally with a hosted runtime entrypoint test: a retryable outbox
+  wake staged behind the idle checkpoint was replaced by a later foreground
+  pass returning `nextWakeAt: null`.
+- Root cause was the projection merge preserving checkpoint-gated wakes only
+  for non-`assistant` reasons; retryable outbox retries use the assistant lane.
+- Verification passed:
+  - Focused retryable outbox wake repro test.
+  - Adjacent late-foreground/device-sync/stale-gate/consumed-alarm wake tests.
+  - Full hosted runtime entrypoint suite.
+  - Hosted runtime assistant phase suite.
+  - `pnpm typecheck` after preparing clean-worktree runtime build artifacts.
+  - `test:diff` for the assistant-runtime owner plus affected Cloudflare verify.
+  - `pnpm test:smoke`.
+  - `git diff --check`.
+- Completion audits passed with no required follow-up:
+  - `security-privacy-review`: no medium-or-higher findings.
+  - `coverage-write`: no additional proof gap found.
+  - `deep-review`: no actionable production bug found.
+Status: completed
+Updated: 2026-06-22
+Completed: 2026-06-22

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -2040,7 +2040,6 @@ function mergeHostedWorkspaceInvocationProjection(
     options.replaceWake === true
     && previous.projectedWakeRequiresCheckpoint
     && previous.nextWakeAt !== null
-    && previous.nextWakeReason !== "assistant"
     && next.nextWakeAt === null;
   const selectedWake = preserveCheckpointGatedWake
     ? {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -5313,6 +5313,152 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
+  test("late foreground input does not clear gate for selected retryable outbox wake", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-foreground-outbox-gate-"));
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const runtimeAbortController = new AbortController();
+    const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+    const outboxRetryWakeAt = "2026-04-27T00:00:00.000Z";
+    const mailboxItems: HostedMailboxItem[] = [];
+    let assistantPhaseCalls = 0;
+    let lateConversationInputId: string | null = null;
+
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_runtime_foreground_outbox_gate",
+            idleCheckpointDelayMs: 25,
+            leaseGeneration: "9",
+            userId: TEST_USER_ID,
+            workspaceVersion: "4",
+          },
+        }),
+        {
+          async createCheckpointSnapshot(snapshotInput) {
+            events.push(`snapshot:${snapshotInput.reason}`);
+            return {
+              snapshotRef: createBundleRef({
+                hash: "b".repeat(64),
+                key: "users/bundles/member-synthetic/runtime-foreground-outbox-gate.bundle.json",
+                size: 640,
+              }),
+            };
+          },
+          async importItem(item) {
+            events.push(`mailbox.importItem:${item.item.id}`);
+            if (item.item.lane !== "conversation") {
+              return { status: "imported" };
+            }
+
+            const inputId = await stagePendingLinqAssistantInputForMailboxItem({
+              item: item.item,
+              vaultRoot,
+            });
+            if (item.item.id === "mailbox_item_entrypoint_foreground_outbox_gate_conversation_late") {
+              lateConversationInputId = inputId;
+            }
+            return {
+              assistantInputId: inputId,
+              status: "imported",
+            };
+          },
+          platform: createPlatform({
+            mailboxPort: createMailboxPort({
+              events,
+              items: mailboxItems,
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({
+                nextWakeAt: TEST_NOW,
+                nextWakeReason: "assistant",
+                version: "4",
+              }),
+            }),
+          }),
+          runtimeWakeSignal,
+          async runAssistantPhase() {
+            assistantPhaseCalls += 1;
+            events.push(`assistant.phase:${assistantPhaseCalls}`);
+            if (assistantPhaseCalls === 1) {
+              mailboxItems.push(createMailboxItem({
+                id: "mailbox_item_entrypoint_foreground_outbox_gate_conversation_late",
+                laneSeq: "1",
+                occurredAt: "2026-04-27T00:00:01.000Z",
+              }));
+              runtimeWakeSignal.notify();
+              await waitUntil(() => {
+                assert.ok(events.includes(
+                  "mailbox.importItem:mailbox_item_entrypoint_foreground_outbox_gate_conversation_late",
+                ));
+              });
+              return {
+                afterCheckpoint: async () => {
+                  events.push("outbox.afterCheckpoint");
+                  return {
+                    checkpointReason: "outbox_receipt" as const,
+                    nextWakeAt: outboxRetryWakeAt,
+                    nextWakeReason: "assistant",
+                    redactedStatus: {
+                      hostedAssistantNextWakeAt: outboxRetryWakeAt,
+                    },
+                  };
+                },
+                checkpointReason: "outbox_sending" as const,
+                progressed: true,
+                redactedStatus: {
+                  hostedAssistantProgressed: true,
+                },
+              };
+            }
+
+            if (lateConversationInputId) {
+              assert.ok(await readAssistantInputEvent({
+                inputId: lateConversationInputId,
+                vault: vaultRoot,
+              }));
+              await writeSyntheticAssistantAutoReplyTerminalEvidence({
+                inputId: lateConversationInputId,
+                vaultRoot,
+              });
+            }
+            return {
+              checkpointReason: "assistant_runtime_commit" as const,
+              nextWakeAt: null,
+              progressed: true,
+              redactedStatus: {
+                hostedAssistantProgressed: true,
+              },
+            };
+          },
+          signal: runtimeAbortController.signal,
+          vaultRoot,
+        },
+      );
+
+      assert.equal(assistantPhaseCalls, 2);
+      assert.ok(lateConversationInputId);
+      assert.ok(events.includes("outbox.afterCheckpoint"));
+      assert.ok(events.includes("snapshot:idle_shutdown"));
+      assert.ok(
+        requireEventIndex(events, "assistant.phase:2")
+          < requireEventIndex(events, "snapshot:idle_shutdown"),
+      );
+      assert.equal(checkpointRequests.length, 1);
+      assert.equal(checkpointRequests[0]?.nextWakeAt, outboxRetryWakeAt);
+      assert.equal(checkpointRequests[0]?.nextWakeReason, "assistant");
+      assert.equal(result.status, "scheduled");
+      assert.equal(result.nextWakeAt, outboxRetryWakeAt);
+    } finally {
+      runtimeAbortController.abort();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("same selected device-sync wake keeps checkpoint gate across idle wake", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-same-device-gate-"));
     const events: string[] = [];


### PR DESCRIPTION
## Summary
- preserve checkpoint-gated assistant-lane wakes when a later foreground pass returns no wake
- add an end-to-end hosted-runtime regression for late foreground input during retryable outbox follow-up scheduling
- archive the task execution plan with verification/audit evidence

## Verification
- pnpm exec vitest run packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts -t "late foreground input does not clear gate for selected retryable outbox wake" --no-coverage
- pnpm exec vitest run packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts --no-coverage
- pnpm exec vitest run packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts --no-coverage
- pnpm build:test-runtime:prepared
- pnpm typecheck
- bash scripts/workspace-verify.sh test:diff packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts agent-docs/exec-plans/active/2026-06-22-retryable-outbox-wake.md agent-docs/exec-plans/active/COORDINATION_LEDGER.md
- pnpm test:smoke
- git diff --check

## Local audits
- security-privacy-review: no medium-or-higher findings
- coverage-write: no additional proof gap found
- deep-review: no actionable production bug found

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784774808&installation_id=127572939&pr_number=260&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F260&signature=42bb7a978d8a2e760056ab1144fddb830c5d13a2d9bcf459ba300563c926cc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->