### PR TITLE
[codex] Reconcile onboarding follow-up automation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-23-onboarding-followup-managed.md
+++ b/agent-docs/exec-plans/completed/2026-06-23-onboarding-followup-managed.md
@@ -1,0 +1,34 @@
+# Onboarding Follow-Up Managed Definition
+
+## Goal
+
+Make the hosted onboarding follow-up automation use one managed definition and reconcile existing Murph-owned records without changing signup-specific creation behavior.
+
+## Constraints
+
+- Preserve signup-only creation: create the follow-up only after welcome delivery is accepted.
+- Preserve signup route and first-occurrence local-day deferral.
+- Do not create missing onboarding follow-ups from background maintenance.
+- Do not retarget, reactivate, or revive archived automations.
+- Keep the primitive narrow and reusable for managed definition drift only.
+
+## Plan
+
+1. Move onboarding follow-up slug/title/summary/tags/schedule/instructions into assistant-engine as a shared managed definition.
+2. Add an update-only managed automation reconciliation helper that finds an existing Murph-owned automation by slug and updates definition-owned fields while preserving route/status/runtime state.
+3. Use the shared definition from hosted signup seeding.
+4. Call the update-only reconciliation from hosted managed automation maintenance.
+5. Add focused assistant-engine, assistant-runtime, and core integration tests.
+6. Point the hosted-local onboarding follow-up E2E fixture at the shared definition.
+
+## Validation
+
+- Focused assistant-engine managed automation tests.
+- Focused assistant-engine core integration tests.
+- Focused assistant-runtime hosted notification/workspace phase tests.
+- Cloudflare package typecheck for the hosted-local E2E fixture import.
+- Typecheck.
+- PR-lane completion audits required by workflow routing.
+Status: completed
+Updated: 2026-06-23
+Completed: 2026-06-23

--- a/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
@@ -1,5 +1,9 @@
 import { createHmac } from "node:crypto";
 import {
+  MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+  resolveMurphManagedAutomationDefinition,
+} from "@murphai/assistant-engine";
+import {
   MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE,
 } from "@murphai/contracts";
 import {
@@ -31,33 +35,13 @@ import {
 
 const userId = `member_local_linq_onboarding_followup_${Date.now()}`;
 const linqWebhookSecret = "linq-local-onboarding-followup-secret";
-const followupSlug = "finish-onboarding-followup";
-const followupTitle = "Finish Murph onboarding follow-up";
-const followupSummary = "Daily setup continuation check until Murph onboarding is complete.";
-const followupInstructions = [
-  "Goal: close or gently advance Murph onboarding after hosted signup without re-asking setup context the vault already knows. The first scheduled occurrence is intentionally deferred until after the signup day.",
-  "",
-  "Before deciding, run `vault-cli assistant onboarding resume-context --format json`.",
-  "",
-  "Success criteria: onboarding is no longer open, or the user receives one brief question for the smallest genuinely unresolved onboarding step.",
-  "",
-  "If `onboarding.status` is `completed`, archive this automation with `vault-cli automation set-status finish-onboarding-followup --status archived`, then return skip. If archiving fails, still return skip without messaging the user so this check can retry later.",
-  "",
-  "If `onboarding.status` is `open` but resume-context or the available recent user messages show the onboarding completion criteria are already satisfied through answers, saved setup facts, skipped individual fields, or deferrals, run `vault-cli assistant onboarding complete --reason user_answered`. If recent user messages show a clear overall onboarding opt-out, run `vault-cli assistant onboarding complete --reason user_declined` instead. If the output shows completed, archive this automation, then return skip. If completion or archiving fails, return skip without messaging the user so this check can retry later.",
-  "",
-  "If onboarding is still genuinely open, use resume-context and the available recent user messages as saved setup evidence. Open status alone is not evidence that setup facts are missing. Treat saved, skipped, declined individual fields, not-relevant, or clearly answered-in-chat setup context as resolved. If most setup context is already present, ask about the next meaningful first-experiment setup or deferral decision instead of more intake.",
-  "",
-  "Before sending, triple-check resume-context and the available recent user messages for an answer to the question you would ask. The last thing we want is to bug the user after they already answered onboarding. If there is no useful next unresolved question, return skip rather than sending a generic setup nudge.",
-  "",
-  "Output: send one brief, natural, low-pressure in-chat question only when a real unresolved step remains. Do not mention internal state or this automation, and do not use a fixed script. The user's answer will be handled by the next normal Murph onboarding turn.",
-].join("\n");
-const followupTags = [
-  "assistant",
-  "scheduled",
-  "onboarding",
-  "murph-managed",
-  "murph-managed:onboarding-followup",
-] as const;
+const followupAutomationDefinition =
+  resolveMurphManagedAutomationDefinition(MURPH_ONBOARDING_FOLLOWUP_AUTOMATION);
+const followupSlug = followupAutomationDefinition.slug;
+const followupTitle = followupAutomationDefinition.title;
+const followupSummary = followupAutomationDefinition.summary ?? "";
+const followupInstructions = followupAutomationDefinition.instructions;
+const followupTags = followupAutomationDefinition.tags;
 const followupReminderText = "Want to finish setup? Send me where you left off and we can continue.";
 const accelerationReplyText = "Done - I will check back soon so we can finish setup.";
 const onboardingCompleteReplyText = "Setup is marked complete.";

--- a/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
@@ -1,7 +1,6 @@
 import { createHmac } from "node:crypto";
 import {
   MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
-  resolveMurphManagedAutomationDefinition,
 } from "@murphai/assistant-engine";
 import {
   MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE,
@@ -35,13 +34,11 @@ import {
 
 const userId = `member_local_linq_onboarding_followup_${Date.now()}`;
 const linqWebhookSecret = "linq-local-onboarding-followup-secret";
-const followupAutomationDefinition =
-  resolveMurphManagedAutomationDefinition(MURPH_ONBOARDING_FOLLOWUP_AUTOMATION);
-const followupSlug = followupAutomationDefinition.slug;
-const followupTitle = followupAutomationDefinition.title;
-const followupSummary = followupAutomationDefinition.summary ?? "";
-const followupInstructions = followupAutomationDefinition.instructions;
-const followupTags = followupAutomationDefinition.tags;
+const followupSlug = MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug;
+const followupTitle = MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title;
+const followupSummary = MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary;
+const followupInstructions = MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions;
+const followupTags = MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags;
 const followupReminderText = "Want to finish setup? Send me where you left off and we can continue.";
 const accelerationReplyText = "Done - I will check back soon so we can finish setup.";
 const onboardingCompleteReplyText = "Setup is marked complete.";

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -93,6 +93,12 @@ const LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS = [
   'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
 ].join('\n')
 
+const LEGACY_ACCELERATED_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS = [
+  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
+  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
+  'If onboarding is still open, send a short message inviting setup to continue.',
+].join(' ')
+
 const LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_TAGS = [
   'assistant',
   'onboarding',
@@ -518,10 +524,9 @@ function isLegacySeededOnboardingFollowupAutomation(
   return automation.slug === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug &&
     automation.title === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title &&
     automation.summary === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary &&
-    automation.instructions === LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS &&
-    murphManagedAutomationValuesEqual(
-      automation.schedule,
-      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
+    (
+      automation.instructions === LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS ||
+      automation.instructions === LEGACY_ACCELERATED_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS
     ) &&
     murphManagedAutomationValuesEqual(
       automation.tags,

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -1,4 +1,5 @@
 import {
+  patchAutomation,
   showAutomation,
   upsertAutomation,
   type AutomationRecord,
@@ -30,29 +31,15 @@ export type MurphManagedAutomationSchedule = Exclude<
   { kind: 'deviceActivity' }
 >
 
-export interface MurphManagedAutomationDefinition {
+export interface MurphManagedAutomationSeed {
+  automationId: string
   continuityPolicy?: AutomationContinuityPolicy
   instructions: string
+  requiredRuntimeEnvKeys?: readonly string[]
   schedule: MurphManagedAutomationSchedule
   slug: string
   summary?: string
   tags?: readonly string[]
-  title: string
-}
-
-export interface MurphManagedAutomationSeed
-  extends MurphManagedAutomationDefinition {
-  automationId: string
-  requiredRuntimeEnvKeys?: readonly string[]
-}
-
-export interface ResolvedMurphManagedAutomationDefinition {
-  continuityPolicy: AutomationContinuityPolicy
-  instructions: string
-  schedule: MurphManagedAutomationSchedule
-  slug: string
-  summary: string | null
-  tags: string[]
   title: string
 }
 
@@ -70,23 +57,6 @@ export interface ApplyMurphManagedAutomationsResult {
   created: number
   skipped: number
   updated: number
-}
-
-export interface ReconcileExistingMurphManagedAutomationDefinitionInput {
-  definition: MurphManagedAutomationDefinition
-  now?: Date
-  requiredTags?: readonly string[]
-  syncSchedule?: boolean
-  vaultRoot: string
-}
-
-export interface ReconcileExistingMurphManagedAutomationDefinitionResult {
-  updated: boolean
-}
-
-interface MurphExistingManagedAutomationReconciliation {
-  definition: MurphManagedAutomationDefinition
-  syncSchedule?: boolean
 }
 
 export const MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID =
@@ -111,6 +81,21 @@ const MURPH_MANAGED_AUTOMATION_BASE_TAGS = [
   'assistant',
   'scheduled',
   'murph-managed',
+] as const
+
+const LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS = [
+  'This scheduled check helps continue Murph setup.',
+  '',
+  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
+  '',
+  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
+  '',
+  'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
+].join('\n')
+
+const LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_TAGS = [
+  'assistant',
+  'onboarding',
 ] as const
 
 export const MURPH_MANAGED_AUTOMATIONS = [
@@ -301,15 +286,6 @@ export const MURPH_MANAGED_AUTOMATIONS = [
   },
 ] satisfies readonly MurphManagedAutomationSeed[]
 
-const MURPH_EXISTING_MANAGED_AUTOMATION_RECONCILIATIONS = [
-  {
-    definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
-    // Signup chooses the first occurrence and later turns may accelerate it.
-    // Keep schedule user/runtime-owned once the follow-up already exists.
-    syncSchedule: false,
-  },
-] satisfies readonly MurphExistingManagedAutomationReconciliation[]
-
 export async function applyMurphManagedAutomations(
   input: ApplyMurphManagedAutomationsInput,
 ): Promise<ApplyMurphManagedAutomationsResult> {
@@ -402,7 +378,7 @@ export async function applyMurphManagedAutomations(
       continue
     }
 
-    if (!murphManagedAutomationDefinitionChanged(existing, seed)) {
+    if (!murphManagedAutomationSeedChanged(existing, seed)) {
       result.skipped += 1
       continue
     }
@@ -431,81 +407,48 @@ export async function applyMurphManagedAutomations(
     result.updated += 1
   }
 
-  for (const reconciliation of MURPH_EXISTING_MANAGED_AUTOMATION_RECONCILIATIONS) {
-    const reconciled = await reconcileExistingMurphManagedAutomationDefinition({
-      definition: reconciliation.definition,
-      now,
-      syncSchedule: reconciliation.syncSchedule,
-      vaultRoot: input.vaultRoot,
-    })
-    if (reconciled.updated) {
-      result.updated += 1
-    }
+  if (await reconcileExistingOnboardingFollowupAutomation({
+    now,
+    vaultRoot: input.vaultRoot,
+  })) {
+    result.updated += 1
   }
 
   return result
 }
 
-export async function reconcileExistingMurphManagedAutomationDefinition(
-  input: ReconcileExistingMurphManagedAutomationDefinitionInput,
-): Promise<ReconcileExistingMurphManagedAutomationDefinitionResult> {
+async function reconcileExistingOnboardingFollowupAutomation(input: {
+  now: Date
+  vaultRoot: string
+}): Promise<boolean> {
   const existing = await showAutomation({
-    slug: input.definition.slug,
+    slug: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug,
     vaultRoot: input.vaultRoot,
   })
   if (!existing || existing.status === 'archived') {
-    return { updated: false }
+    return false
   }
 
-  const requiredTags =
-    input.requiredTags ??
-    resolveMurphManagedAutomationOwnershipTags(input.definition)
-  if (!murphManagedAutomationHasTags(existing, requiredTags)) {
-    return { updated: false }
+  if (!isManagedOnboardingFollowupAutomation(existing)) {
+    return false
   }
 
-  if (!murphManagedAutomationDefinitionChanged(existing, input.definition, {
-    syncSchedule: input.syncSchedule,
-  })) {
-    return { updated: false }
+  if (!onboardingFollowupAutomationDefinitionChanged(existing)) {
+    return false
   }
 
-  const definition = resolveMurphManagedAutomationDefinition(input.definition)
-  const schedule = input.syncSchedule === false
-    ? existing.schedule
-    : definition.schedule
-  await upsertAutomation({
-    automationId: existing.automationId,
-    continuityPolicy: definition.continuityPolicy,
-    instructions: definition.instructions,
+  await patchAutomation({
+    continuityPolicy: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.continuityPolicy,
+    instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
+    lookup: existing.automationId,
     now: input.now,
-    route: existing.route,
-    schedule,
-    slug: existing.slug,
-    status: existing.status,
-    ...(definition.summary === null
-      ? {}
-      : { summary: definition.summary }),
-    tags: definition.tags,
-    title: definition.title,
+    summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+    tags: [...MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags],
+    title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
     vaultRoot: input.vaultRoot,
   })
 
-  return { updated: true }
-}
-
-export function resolveMurphManagedAutomationDefinition(
-  definition: MurphManagedAutomationDefinition,
-): ResolvedMurphManagedAutomationDefinition {
-  return {
-    continuityPolicy: resolveMurphManagedAutomationContinuity(definition),
-    instructions: definition.instructions,
-    schedule: definition.schedule,
-    slug: definition.slug,
-    summary: normalizeMurphManagedAutomationSummary(definition),
-    tags: buildMurphManagedAutomationTags(definition),
-    title: definition.title,
-  }
+  return true
 }
 
 async function resolveMurphManagedAutomationCreateRoute(
@@ -541,43 +484,86 @@ async function resolveMurphManagedAutomationCreateRoute(
   )
 }
 
-function murphManagedAutomationDefinitionChanged(
+function onboardingFollowupAutomationDefinitionChanged(
   existing: AutomationRecord,
-  definition: MurphManagedAutomationDefinition,
-  options?: { syncSchedule?: boolean },
+): boolean {
+  return existing.title !== MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title ||
+    existing.summary !== MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary ||
+    existing.continuityPolicy !== MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.continuityPolicy ||
+    existing.instructions !== MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions ||
+    !murphManagedAutomationValuesEqual(
+      existing.tags,
+      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+    )
+}
+
+function isManagedOnboardingFollowupAutomation(
+  automation: AutomationRecord,
+): boolean {
+  return isCurrentManagedOnboardingFollowupAutomation(automation) ||
+    isLegacySeededOnboardingFollowupAutomation(automation)
+}
+
+function isCurrentManagedOnboardingFollowupAutomation(
+  automation: AutomationRecord,
+): boolean {
+  const tags = new Set(automation.tags)
+  return tags.has('murph-managed') &&
+    tags.has('murph-managed:onboarding-followup')
+}
+
+function isLegacySeededOnboardingFollowupAutomation(
+  automation: AutomationRecord,
+): boolean {
+  return automation.slug === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug &&
+    automation.title === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title &&
+    automation.summary === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary &&
+    automation.instructions === LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS &&
+    murphManagedAutomationValuesEqual(
+      automation.schedule,
+      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
+    ) &&
+    murphManagedAutomationValuesEqual(
+      automation.tags,
+      LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_TAGS,
+    )
+}
+
+function murphManagedAutomationSeedChanged(
+  existing: AutomationRecord,
+  seed: MurphManagedAutomationSeed,
 ): boolean {
   // A seed without a summary leaves the stored summary unmanaged. This must
   // match upsertAutomation's omitted-field semantics (an omitted summary
   // preserves the existing one); comparing against null here would report
   // "changed" on every run and rewrite the record forever.
-  const summary = normalizeMurphManagedAutomationSummary(definition)
-  return existing.title !== definition.title ||
+  const summary = normalizeMurphManagedAutomationSummary(seed)
+  return existing.title !== seed.title ||
     (summary !== null && existing.summary !== summary) ||
-    existing.continuityPolicy !== resolveMurphManagedAutomationContinuity(definition) ||
-    existing.instructions !== definition.instructions ||
-    (options?.syncSchedule !== false &&
-      !murphManagedAutomationValuesEqual(existing.schedule, definition.schedule)) ||
+    existing.continuityPolicy !== resolveMurphManagedAutomationContinuity(seed) ||
+    existing.instructions !== seed.instructions ||
+    !murphManagedAutomationValuesEqual(existing.schedule, seed.schedule) ||
     !murphManagedAutomationValuesEqual(
       existing.tags,
-      buildMurphManagedAutomationTags(definition),
+      buildMurphManagedAutomationTags(seed),
     )
 }
 
 function buildMurphManagedAutomationTags(
-  definition: MurphManagedAutomationDefinition,
+  seed: MurphManagedAutomationSeed,
 ): string[] {
   return [
     ...new Set([
       ...MURPH_MANAGED_AUTOMATION_BASE_TAGS,
-      ...(definition.tags ?? []),
+      ...(seed.tags ?? []),
     ].flatMap((tag) => normalizeMurphManagedAutomationText(tag) ?? [])),
   ]
 }
 
 function resolveMurphManagedAutomationContinuity(
-  definition: MurphManagedAutomationDefinition,
+  seed: MurphManagedAutomationSeed,
 ): AutomationContinuityPolicy {
-  return definition.continuityPolicy ?? 'preserve'
+  return seed.continuityPolicy ?? 'preserve'
 }
 
 function murphManagedAutomationRuntimeRequirementsMet(
@@ -594,9 +580,9 @@ function murphManagedAutomationRuntimeRequirementsMet(
 }
 
 function normalizeMurphManagedAutomationSummary(
-  definition: MurphManagedAutomationDefinition,
+  seed: MurphManagedAutomationSeed,
 ): string | null {
-  return normalizeMurphManagedAutomationText(definition.summary)
+  return normalizeMurphManagedAutomationText(seed.summary)
 }
 
 function normalizeMurphManagedAutomationText(
@@ -611,22 +597,6 @@ function murphManagedAutomationValuesEqual(
   right: unknown,
 ): boolean {
   return JSON.stringify(left) === JSON.stringify(right)
-}
-
-function resolveMurphManagedAutomationOwnershipTags(
-  definition: MurphManagedAutomationDefinition,
-): string[] {
-  return buildMurphManagedAutomationTags(definition).filter((tag) =>
-    tag === 'murph-managed' || tag.startsWith('murph-managed:')
-  )
-}
-
-function murphManagedAutomationHasTags(
-  automation: AutomationRecord,
-  requiredTags: readonly string[],
-): boolean {
-  const existingTags = new Set(automation.tags)
-  return requiredTags.every((tag) => existingTags.has(tag))
 }
 
 function isStaleMurphManagedOneShotSeed(

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -93,12 +93,6 @@ const LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS = [
   'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
 ].join('\n')
 
-const LEGACY_ACCELERATED_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS = [
-  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
-  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
-  'If onboarding is still open, send a short message inviting setup to continue.',
-].join(' ')
-
 const LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_TAGS = [
   'assistant',
   'onboarding',
@@ -522,12 +516,7 @@ function isLegacySeededOnboardingFollowupAutomation(
   automation: AutomationRecord,
 ): boolean {
   return automation.slug === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug &&
-    automation.title === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title &&
-    automation.summary === MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary &&
-    (
-      automation.instructions === LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS ||
-      automation.instructions === LEGACY_ACCELERATED_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS
-    ) &&
+    automation.instructions === LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS &&
     murphManagedAutomationValuesEqual(
       automation.tags,
       LEGACY_ONBOARDING_FOLLOWUP_AUTOMATION_TAGS,

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -21,21 +21,38 @@ import {
   type AssistantCronDeliveryRouteValidationProfile,
 } from './cron/targets.js'
 import { buildExperimentFinalResultsSeeds } from './experiment-support-automations.js'
+import { MURPH_ONBOARDING_FOLLOWUP_AUTOMATION } from './onboarding-followup-automation.js'
+
+export { MURPH_ONBOARDING_FOLLOWUP_AUTOMATION }
 
 export type MurphManagedAutomationSchedule = Exclude<
   AutomationSchedule,
   { kind: 'deviceActivity' }
 >
 
-export interface MurphManagedAutomationSeed {
-  automationId: string
+export interface MurphManagedAutomationDefinition {
   continuityPolicy?: AutomationContinuityPolicy
   instructions: string
-  requiredRuntimeEnvKeys?: readonly string[]
   schedule: MurphManagedAutomationSchedule
   slug: string
   summary?: string
   tags?: readonly string[]
+  title: string
+}
+
+export interface MurphManagedAutomationSeed
+  extends MurphManagedAutomationDefinition {
+  automationId: string
+  requiredRuntimeEnvKeys?: readonly string[]
+}
+
+export interface ResolvedMurphManagedAutomationDefinition {
+  continuityPolicy: AutomationContinuityPolicy
+  instructions: string
+  schedule: MurphManagedAutomationSchedule
+  slug: string
+  summary: string | null
+  tags: string[]
   title: string
 }
 
@@ -53,6 +70,23 @@ export interface ApplyMurphManagedAutomationsResult {
   created: number
   skipped: number
   updated: number
+}
+
+export interface ReconcileExistingMurphManagedAutomationDefinitionInput {
+  definition: MurphManagedAutomationDefinition
+  now?: Date
+  requiredTags?: readonly string[]
+  syncSchedule?: boolean
+  vaultRoot: string
+}
+
+export interface ReconcileExistingMurphManagedAutomationDefinitionResult {
+  updated: boolean
+}
+
+interface MurphExistingManagedAutomationReconciliation {
+  definition: MurphManagedAutomationDefinition
+  syncSchedule?: boolean
 }
 
 export const MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID =
@@ -267,6 +301,15 @@ export const MURPH_MANAGED_AUTOMATIONS = [
   },
 ] satisfies readonly MurphManagedAutomationSeed[]
 
+const MURPH_EXISTING_MANAGED_AUTOMATION_RECONCILIATIONS = [
+  {
+    definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+    // Signup chooses the first occurrence and later turns may accelerate it.
+    // Keep schedule user/runtime-owned once the follow-up already exists.
+    syncSchedule: false,
+  },
+] satisfies readonly MurphExistingManagedAutomationReconciliation[]
+
 export async function applyMurphManagedAutomations(
   input: ApplyMurphManagedAutomationsInput,
 ): Promise<ApplyMurphManagedAutomationsResult> {
@@ -359,7 +402,7 @@ export async function applyMurphManagedAutomations(
       continue
     }
 
-    if (!murphManagedAutomationSeedChanged(existing, seed)) {
+    if (!murphManagedAutomationDefinitionChanged(existing, seed)) {
       result.skipped += 1
       continue
     }
@@ -388,7 +431,81 @@ export async function applyMurphManagedAutomations(
     result.updated += 1
   }
 
+  for (const reconciliation of MURPH_EXISTING_MANAGED_AUTOMATION_RECONCILIATIONS) {
+    const reconciled = await reconcileExistingMurphManagedAutomationDefinition({
+      definition: reconciliation.definition,
+      now,
+      syncSchedule: reconciliation.syncSchedule,
+      vaultRoot: input.vaultRoot,
+    })
+    if (reconciled.updated) {
+      result.updated += 1
+    }
+  }
+
   return result
+}
+
+export async function reconcileExistingMurphManagedAutomationDefinition(
+  input: ReconcileExistingMurphManagedAutomationDefinitionInput,
+): Promise<ReconcileExistingMurphManagedAutomationDefinitionResult> {
+  const existing = await showAutomation({
+    slug: input.definition.slug,
+    vaultRoot: input.vaultRoot,
+  })
+  if (!existing || existing.status === 'archived') {
+    return { updated: false }
+  }
+
+  const requiredTags =
+    input.requiredTags ??
+    resolveMurphManagedAutomationOwnershipTags(input.definition)
+  if (!murphManagedAutomationHasTags(existing, requiredTags)) {
+    return { updated: false }
+  }
+
+  if (!murphManagedAutomationDefinitionChanged(existing, input.definition, {
+    syncSchedule: input.syncSchedule,
+  })) {
+    return { updated: false }
+  }
+
+  const definition = resolveMurphManagedAutomationDefinition(input.definition)
+  const schedule = input.syncSchedule === false
+    ? existing.schedule
+    : definition.schedule
+  await upsertAutomation({
+    automationId: existing.automationId,
+    continuityPolicy: definition.continuityPolicy,
+    instructions: definition.instructions,
+    now: input.now,
+    route: existing.route,
+    schedule,
+    slug: existing.slug,
+    status: existing.status,
+    ...(definition.summary === null
+      ? {}
+      : { summary: definition.summary }),
+    tags: definition.tags,
+    title: definition.title,
+    vaultRoot: input.vaultRoot,
+  })
+
+  return { updated: true }
+}
+
+export function resolveMurphManagedAutomationDefinition(
+  definition: MurphManagedAutomationDefinition,
+): ResolvedMurphManagedAutomationDefinition {
+  return {
+    continuityPolicy: resolveMurphManagedAutomationContinuity(definition),
+    instructions: definition.instructions,
+    schedule: definition.schedule,
+    slug: definition.slug,
+    summary: normalizeMurphManagedAutomationSummary(definition),
+    tags: buildMurphManagedAutomationTags(definition),
+    title: definition.title,
+  }
 }
 
 async function resolveMurphManagedAutomationCreateRoute(
@@ -424,41 +541,43 @@ async function resolveMurphManagedAutomationCreateRoute(
   )
 }
 
-function murphManagedAutomationSeedChanged(
+function murphManagedAutomationDefinitionChanged(
   existing: AutomationRecord,
-  seed: MurphManagedAutomationSeed,
+  definition: MurphManagedAutomationDefinition,
+  options?: { syncSchedule?: boolean },
 ): boolean {
   // A seed without a summary leaves the stored summary unmanaged. This must
   // match upsertAutomation's omitted-field semantics (an omitted summary
   // preserves the existing one); comparing against null here would report
   // "changed" on every run and rewrite the record forever.
-  const summary = normalizeMurphManagedAutomationSummary(seed)
-  return existing.title !== seed.title ||
+  const summary = normalizeMurphManagedAutomationSummary(definition)
+  return existing.title !== definition.title ||
     (summary !== null && existing.summary !== summary) ||
-    existing.continuityPolicy !== resolveMurphManagedAutomationContinuity(seed) ||
-    existing.instructions !== seed.instructions ||
-    !murphManagedAutomationValuesEqual(existing.schedule, seed.schedule) ||
+    existing.continuityPolicy !== resolveMurphManagedAutomationContinuity(definition) ||
+    existing.instructions !== definition.instructions ||
+    (options?.syncSchedule !== false &&
+      !murphManagedAutomationValuesEqual(existing.schedule, definition.schedule)) ||
     !murphManagedAutomationValuesEqual(
       existing.tags,
-      buildMurphManagedAutomationTags(seed),
+      buildMurphManagedAutomationTags(definition),
     )
 }
 
 function buildMurphManagedAutomationTags(
-  seed: MurphManagedAutomationSeed,
+  definition: MurphManagedAutomationDefinition,
 ): string[] {
   return [
     ...new Set([
       ...MURPH_MANAGED_AUTOMATION_BASE_TAGS,
-      ...(seed.tags ?? []),
+      ...(definition.tags ?? []),
     ].flatMap((tag) => normalizeMurphManagedAutomationText(tag) ?? [])),
   ]
 }
 
 function resolveMurphManagedAutomationContinuity(
-  seed: MurphManagedAutomationSeed,
+  definition: MurphManagedAutomationDefinition,
 ): AutomationContinuityPolicy {
-  return seed.continuityPolicy ?? 'preserve'
+  return definition.continuityPolicy ?? 'preserve'
 }
 
 function murphManagedAutomationRuntimeRequirementsMet(
@@ -475,9 +594,9 @@ function murphManagedAutomationRuntimeRequirementsMet(
 }
 
 function normalizeMurphManagedAutomationSummary(
-  seed: MurphManagedAutomationSeed,
+  definition: MurphManagedAutomationDefinition,
 ): string | null {
-  return normalizeMurphManagedAutomationText(seed.summary)
+  return normalizeMurphManagedAutomationText(definition.summary)
 }
 
 function normalizeMurphManagedAutomationText(
@@ -492,6 +611,22 @@ function murphManagedAutomationValuesEqual(
   right: unknown,
 ): boolean {
   return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function resolveMurphManagedAutomationOwnershipTags(
+  definition: MurphManagedAutomationDefinition,
+): string[] {
+  return buildMurphManagedAutomationTags(definition).filter((tag) =>
+    tag === 'murph-managed' || tag.startsWith('murph-managed:')
+  )
+}
+
+function murphManagedAutomationHasTags(
+  automation: AutomationRecord,
+  requiredTags: readonly string[],
+): boolean {
+  const existingTags = new Set(automation.tags)
+  return requiredTags.every((tag) => existingTags.has(tag))
 }
 
 function isStaleMurphManagedOneShotSeed(

--- a/packages/assistant-engine/src/assistant/onboarding-followup-automation.ts
+++ b/packages/assistant-engine/src/assistant/onboarding-followup-automation.ts
@@ -1,0 +1,33 @@
+import type { MurphManagedAutomationDefinition } from './managed-automations.js'
+
+export const MURPH_ONBOARDING_FOLLOWUP_AUTOMATION =
+  {
+    slug: 'finish-onboarding-followup',
+    title: 'Finish Murph onboarding follow-up',
+    summary: 'Daily setup continuation check until Murph onboarding is complete.',
+    schedule: {
+      kind: 'dailyLocal',
+      localTime: '13:30',
+    },
+    tags: [
+      'onboarding',
+      'murph-managed:onboarding-followup',
+    ],
+    instructions: [
+      'Goal: close or gently advance Murph onboarding after hosted signup without re-asking setup context the vault already knows. The first scheduled occurrence is intentionally deferred until after the signup day.',
+      '',
+      'Before deciding, run `vault-cli assistant onboarding resume-context --format json`.',
+      '',
+      'Success criteria: onboarding is no longer open, or the user receives one brief question for the smallest genuinely unresolved onboarding step.',
+      '',
+      'If `onboarding.status` is `completed`, archive this automation with `vault-cli automation set-status finish-onboarding-followup --status archived`, then return skip. If archiving fails, still return skip without messaging the user so this check can retry later.',
+      '',
+      'If `onboarding.status` is `open` but resume-context or the available recent user messages show the onboarding completion criteria are already satisfied through answers, saved setup facts, skipped individual fields, or deferrals, run `vault-cli assistant onboarding complete --reason user_answered`. If recent user messages show a clear overall onboarding opt-out, run `vault-cli assistant onboarding complete --reason user_declined` instead. If the output shows completed, archive this automation, then return skip. If completion or archiving fails, return skip without messaging the user so this check can retry later.',
+      '',
+      'If onboarding is still genuinely open, use resume-context and the available recent user messages as saved setup evidence. Open status alone is not evidence that setup facts are missing. Treat saved, skipped, declined individual fields, not-relevant, or clearly answered-in-chat setup context as resolved. If most setup context is already present, ask about the next meaningful first-experiment setup or deferral decision instead of more intake.',
+      '',
+      'Before sending, triple-check resume-context and the available recent user messages for an answer to the question you would ask. The last thing we want is to bug the user after they already answered onboarding. If there is no useful next unresolved question, return skip rather than sending a generic setup nudge.',
+      '',
+      "Output: send one brief, natural, low-pressure in-chat question only when a real unresolved step remains. Do not mention internal state or this automation, and do not use a fixed script. The user's answer will be handled by the next normal Murph onboarding turn.",
+    ].join('\n'),
+  } satisfies MurphManagedAutomationDefinition

--- a/packages/assistant-engine/src/assistant/onboarding-followup-automation.ts
+++ b/packages/assistant-engine/src/assistant/onboarding-followup-automation.ts
@@ -1,15 +1,37 @@
-import type { MurphManagedAutomationDefinition } from './managed-automations.js'
+import type {
+  AutomationContinuityPolicy,
+  AutomationSchedule,
+} from '@murphai/contracts'
+
+export type MurphOnboardingFollowupAutomationSchedule = Exclude<
+  AutomationSchedule,
+  { kind: 'deviceActivity' }
+>
+
+export interface MurphOnboardingFollowupAutomationDefinition {
+  continuityPolicy: AutomationContinuityPolicy
+  instructions: string
+  schedule: MurphOnboardingFollowupAutomationSchedule
+  slug: string
+  summary: string
+  tags: readonly string[]
+  title: string
+}
 
 export const MURPH_ONBOARDING_FOLLOWUP_AUTOMATION =
   {
     slug: 'finish-onboarding-followup',
     title: 'Finish Murph onboarding follow-up',
     summary: 'Daily setup continuation check until Murph onboarding is complete.',
+    continuityPolicy: 'preserve',
     schedule: {
       kind: 'dailyLocal',
       localTime: '13:30',
     },
     tags: [
+      'assistant',
+      'scheduled',
+      'murph-managed',
       'onboarding',
       'murph-managed:onboarding-followup',
     ],
@@ -30,4 +52,4 @@ export const MURPH_ONBOARDING_FOLLOWUP_AUTOMATION =
       '',
       "Output: send one brief, natural, low-pressure in-chat question only when a real unresolved step remains. Do not mention internal state or this automation, and do not use a fixed script. The user's answer will be handled by the next normal Murph onboarding turn.",
     ].join('\n'),
-  } satisfies MurphManagedAutomationDefinition
+  } satisfies MurphOnboardingFollowupAutomationDefinition

--- a/packages/assistant-engine/src/index.ts
+++ b/packages/assistant-engine/src/index.ts
@@ -17,6 +17,7 @@ export {
 } from './assistant/issue-reporting.js'
 export * from './assistant/device-activity-automations.js'
 export * from './assistant/managed-automations.js'
+export * from './assistant/onboarding-followup-automation.js'
 export * from './assistant-cron.js'
 export * from './assistant-outbox.js'
 export * from './assistant-runtime.js'

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -14,7 +14,6 @@ import {
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
-  resolveMurphManagedAutomationDefinition,
 } from '../src/assistant/managed-automations.ts'
 import { ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG } from '../src/assistant/automation-tags.ts'
 import { createTempVaultContext } from './test-helpers.ts'
@@ -28,6 +27,16 @@ const defaultRoute = {
   participantId: null,
   threadId: null,
 }
+
+const legacyOnboardingFollowupInstructions = [
+  'This scheduled check helps continue Murph setup.',
+  '',
+  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
+  '',
+  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
+  '',
+  'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
+].join('\n')
 
 afterEach(async () => {
   await Promise.all(
@@ -386,16 +395,13 @@ describe('applyMurphManagedAutomations core integration', () => {
       updated: 1,
     })
 
-    const resolved = resolveMurphManagedAutomationDefinition(
-      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
-    )
     await expect(showAutomation({
       automationId: 'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FC',
       vaultRoot,
     })).resolves.toMatchObject({
       automationId: 'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FC',
-      continuityPolicy: resolved.continuityPolicy,
-      instructions: resolved.instructions,
+      continuityPolicy: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.continuityPolicy,
+      instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
       route: existingRoute,
       schedule: {
         kind: 'dailyLocal',
@@ -403,9 +409,49 @@ describe('applyMurphManagedAutomations core integration', () => {
       },
       slug: 'finish-onboarding-followup',
       status: 'paused',
-      summary: resolved.summary,
-      tags: resolved.tags,
-      title: resolved.title,
+      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+    })
+  })
+
+  it('migrates the original unmarked onboarding follow-up seed', async () => {
+    const vaultRoot = await createVaultRoot()
+
+    await upsertAutomation({
+      automationId: 'automation_01KCM5T5J4VB7D63T0Y29Q6R7A',
+      continuityPolicy: 'preserve',
+      instructions: legacyOnboardingFollowupInstructions,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      route: defaultRoute,
+      schedule: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
+      slug: 'finish-onboarding-followup',
+      status: 'active',
+      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      tags: ['assistant', 'onboarding'],
+      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+      vaultRoot,
+    })
+
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-23T13:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 1,
+    })
+
+    await expect(showAutomation({
+      automationId: 'automation_01KCM5T5J4VB7D63T0Y29Q6R7A',
+      vaultRoot,
+    })).resolves.toMatchObject({
+      instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
+      route: defaultRoute,
+      schedule: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
+      status: 'active',
+      tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
     })
   })
 

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -38,12 +38,6 @@ const legacyOnboardingFollowupInstructions = [
   'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
 ].join('\n')
 
-const legacyAcceleratedOnboardingFollowupInstructions = [
-  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
-  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
-  'If onboarding is still open, send a short message inviting setup to continue.',
-].join(' ')
-
 afterEach(async () => {
   await Promise.all(
     tempRoots.splice(0, tempRoots.length).map((root) =>
@@ -430,12 +424,15 @@ describe('applyMurphManagedAutomations core integration', () => {
       instructions: legacyOnboardingFollowupInstructions,
       now: new Date('2026-06-23T12:00:00.000Z'),
       route: defaultRoute,
-      schedule: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
+      schedule: {
+        everyMs: 90_000,
+        kind: 'every',
+      },
       slug: 'finish-onboarding-followup',
       status: 'active',
-      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      summary: 'User-edited setup follow-up summary.',
       tags: ['assistant', 'onboarding'],
-      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+      title: 'User-edited setup follow-up',
       vaultRoot,
     })
 
@@ -455,55 +452,14 @@ describe('applyMurphManagedAutomations core integration', () => {
     })).resolves.toMatchObject({
       instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
       route: defaultRoute,
-      schedule: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
-      status: 'active',
-      tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
-    })
-  })
-
-  it('migrates an accelerated unmarked onboarding follow-up and preserves its schedule', async () => {
-    const vaultRoot = await createVaultRoot()
-
-    await upsertAutomation({
-      automationId: 'automation_01KCM609FBJ2S8HJ1W40C647A4',
-      continuityPolicy: 'preserve',
-      instructions: legacyAcceleratedOnboardingFollowupInstructions,
-      now: new Date('2026-06-23T12:00:00.000Z'),
-      route: defaultRoute,
       schedule: {
         everyMs: 90_000,
         kind: 'every',
       },
-      slug: 'finish-onboarding-followup',
       status: 'active',
       summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
-      tags: ['assistant', 'onboarding'],
-      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
-      vaultRoot,
-    })
-
-    await expect(applyMurphManagedAutomations({
-      defaultRoute,
-      now: new Date('2026-06-23T13:00:00.000Z'),
-      vaultRoot,
-    })).resolves.toEqual({
-      created: 4,
-      skipped: 0,
-      updated: 1,
-    })
-
-    await expect(showAutomation({
-      automationId: 'automation_01KCM609FBJ2S8HJ1W40C647A4',
-      vaultRoot,
-    })).resolves.toMatchObject({
-      instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
-      route: defaultRoute,
-      schedule: {
-        everyMs: 90_000,
-        kind: 'every',
-      },
-      status: 'active',
       tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
     })
   })
 

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -8,11 +8,13 @@ import { serializeHostedEmailThreadTarget } from '@murphai/runtime-state'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
+  MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
+  resolveMurphManagedAutomationDefinition,
 } from '../src/assistant/managed-automations.ts'
 import { ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG } from '../src/assistant/automation-tags.ts'
 import { createTempVaultContext } from './test-helpers.ts'
@@ -319,6 +321,91 @@ describe('applyMurphManagedAutomations core integration', () => {
       created: 0,
       skipped: 4,
       updated: 0,
+    })
+  })
+
+  it('does not create onboarding follow-up during managed automation maintenance', async () => {
+    const vaultRoot = await createVaultRoot()
+
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 0,
+    })
+
+    await expect(showAutomation({
+      slug: 'finish-onboarding-followup',
+      vaultRoot,
+    })).resolves.toBeNull()
+  })
+
+  it('updates an existing owned onboarding follow-up without changing route, status, or schedule', async () => {
+    const vaultRoot = await createVaultRoot()
+    const existingRoute = {
+      channel: 'linq' as const,
+      deliveryTarget: 'existing-onboarding-thread',
+      identityId: 'existing-onboarding-identity',
+      participantId: null,
+      threadId: null,
+    }
+
+    await upsertAutomation({
+      automationId: 'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FC',
+      continuityPolicy: 'preserve',
+      instructions: 'old onboarding follow-up instructions',
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      route: existingRoute,
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '08:00',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'paused',
+      summary: 'Old onboarding follow-up summary.',
+      tags: [
+        'assistant',
+        'scheduled',
+        'murph-managed',
+        'murph-managed:onboarding-followup',
+      ],
+      title: 'Old onboarding follow-up',
+      vaultRoot,
+    })
+
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-23T13:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 1,
+    })
+
+    const resolved = resolveMurphManagedAutomationDefinition(
+      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+    )
+    await expect(showAutomation({
+      automationId: 'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FC',
+      vaultRoot,
+    })).resolves.toMatchObject({
+      automationId: 'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FC',
+      continuityPolicy: resolved.continuityPolicy,
+      instructions: resolved.instructions,
+      route: existingRoute,
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '08:00',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'paused',
+      summary: resolved.summary,
+      tags: resolved.tags,
+      title: resolved.title,
     })
   })
 

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -38,6 +38,12 @@ const legacyOnboardingFollowupInstructions = [
   'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
 ].join('\n')
 
+const legacyAcceleratedOnboardingFollowupInstructions = [
+  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
+  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
+  'If onboarding is still open, send a short message inviting setup to continue.',
+].join(' ')
+
 afterEach(async () => {
   await Promise.all(
     tempRoots.splice(0, tempRoots.length).map((root) =>
@@ -450,6 +456,52 @@ describe('applyMurphManagedAutomations core integration', () => {
       instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
       route: defaultRoute,
       schedule: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
+      status: 'active',
+      tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+    })
+  })
+
+  it('migrates an accelerated unmarked onboarding follow-up and preserves its schedule', async () => {
+    const vaultRoot = await createVaultRoot()
+
+    await upsertAutomation({
+      automationId: 'automation_01KCM609FBJ2S8HJ1W40C647A4',
+      continuityPolicy: 'preserve',
+      instructions: legacyAcceleratedOnboardingFollowupInstructions,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      route: defaultRoute,
+      schedule: {
+        everyMs: 90_000,
+        kind: 'every',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'active',
+      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      tags: ['assistant', 'onboarding'],
+      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+      vaultRoot,
+    })
+
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-23T13:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 1,
+    })
+
+    await expect(showAutomation({
+      automationId: 'automation_01KCM609FBJ2S8HJ1W40C647A4',
+      vaultRoot,
+    })).resolves.toMatchObject({
+      instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
+      route: defaultRoute,
+      schedule: {
+        everyMs: 90_000,
+        kind: 'every',
+      },
       status: 'active',
       tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
     })

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -121,6 +121,12 @@ const legacyOnboardingFollowupInstructions = [
   'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
 ].join('\n')
 
+const legacyAcceleratedOnboardingFollowupInstructions = [
+  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
+  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
+  'If onboarding is still open, send a short message inviting setup to continue.',
+].join(' ')
+
 beforeEach(() => {
   managedAutomationMocks.records.clear()
   managedAutomationMocks.getAssistantChannelAdapter
@@ -750,6 +756,46 @@ describe('applyMurphManagedAutomations', () => {
         schedule: {
           kind: 'dailyLocal',
           localTime: '13:30',
+        },
+        status: 'active',
+        tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+      })
+  })
+
+  it('migrates an accelerated unmarked onboarding follow-up without changing its schedule', async () => {
+    managedAutomationMocks.records.set('automation_legacy_accelerated_onboarding_followup', {
+      automationId: 'automation_legacy_accelerated_onboarding_followup',
+      continuityPolicy: 'preserve',
+      instructions: legacyAcceleratedOnboardingFollowupInstructions,
+      route: defaultRoute,
+      schedule: {
+        everyMs: 90_000,
+        kind: 'every',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'active',
+      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      tags: ['assistant', 'onboarding'],
+      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+    })
+
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 1,
+    })
+
+    expect(managedAutomationMocks.records.get('automation_legacy_accelerated_onboarding_followup'))
+      .toMatchObject({
+        instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
+        route: defaultRoute,
+        schedule: {
+          everyMs: 90_000,
+          kind: 'every',
         },
         status: 'active',
         tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -88,11 +88,14 @@ vi.mock('../src/assistant/channel-adapters.ts', () => ({
 
 import {
   MURPH_MANAGED_AUTOMATIONS,
+  MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
+  reconcileExistingMurphManagedAutomationDefinition,
+  resolveMurphManagedAutomationDefinition,
   type MurphManagedAutomationSeed,
 } from '../src/assistant/managed-automations.ts'
 import { ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG } from '../src/assistant/automation-tags.ts'
@@ -555,6 +558,145 @@ describe('applyMurphManagedAutomations', () => {
       .toMatchObject({
         status: 'paused',
       })
+  })
+
+  it('reconciles an existing active onboarding follow-up definition by owned slug', async () => {
+    const existingRoute = {
+      channel: 'linq',
+      deliveryTarget: 'existing-thread',
+      identityId: 'identity-1',
+      participantId: null,
+      threadId: null,
+    }
+    managedAutomationMocks.records.set('automation_onboarding_followup', {
+      automationId: 'automation_onboarding_followup',
+      continuityPolicy: 'preserve',
+      instructions: 'old onboarding follow-up instructions',
+      route: existingRoute,
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '08:00',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'active',
+      summary: 'Old summary',
+      tags: ['assistant', 'scheduled', 'murph-managed', 'murph-managed:onboarding-followup'],
+      title: 'Old onboarding follow-up',
+    })
+
+    await expect(reconcileExistingMurphManagedAutomationDefinition({
+      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      syncSchedule: false,
+      vaultRoot,
+    })).resolves.toEqual({ updated: true })
+
+    const resolved = resolveMurphManagedAutomationDefinition(
+      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+    )
+    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        automationId: 'automation_onboarding_followup',
+        continuityPolicy: resolved.continuityPolicy,
+        instructions: resolved.instructions,
+        route: existingRoute,
+        schedule: {
+          kind: 'dailyLocal',
+          localTime: '08:00',
+        },
+        slug: 'finish-onboarding-followup',
+        status: 'active',
+        summary: resolved.summary,
+        tags: resolved.tags,
+        title: resolved.title,
+      }),
+    )
+  })
+
+  it('updates a paused onboarding follow-up without reactivating it', async () => {
+    managedAutomationMocks.records.set('automation_onboarding_followup', {
+      automationId: 'automation_onboarding_followup',
+      continuityPolicy: 'preserve',
+      instructions: 'old onboarding follow-up instructions',
+      route: defaultRoute,
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '08:00',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'paused',
+      summary: 'Old summary',
+      tags: ['assistant', 'scheduled', 'murph-managed', 'murph-managed:onboarding-followup'],
+      title: 'Old onboarding follow-up',
+    })
+
+    await expect(reconcileExistingMurphManagedAutomationDefinition({
+      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      syncSchedule: false,
+      vaultRoot,
+    })).resolves.toEqual({ updated: true })
+
+    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        automationId: 'automation_onboarding_followup',
+        route: defaultRoute,
+        schedule: {
+          kind: 'dailyLocal',
+          localTime: '08:00',
+        },
+        status: 'paused',
+      }),
+    )
+  })
+
+  it('does not reconcile archived or user-owned onboarding follow-up slugs', async () => {
+    managedAutomationMocks.records.set('automation_archived_onboarding_followup', {
+      automationId: 'automation_archived_onboarding_followup',
+      continuityPolicy: 'preserve',
+      instructions: 'old onboarding follow-up instructions',
+      route: defaultRoute,
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '08:00',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'archived',
+      summary: 'Old summary',
+      tags: ['assistant', 'scheduled', 'murph-managed', 'murph-managed:onboarding-followup'],
+      title: 'Old onboarding follow-up',
+    })
+
+    await expect(reconcileExistingMurphManagedAutomationDefinition({
+      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({ updated: false })
+
+    managedAutomationMocks.records.clear()
+    managedAutomationMocks.upsertAutomation.mockClear()
+    managedAutomationMocks.records.set('automation_user_onboarding_followup', {
+      automationId: 'automation_user_onboarding_followup',
+      continuityPolicy: 'preserve',
+      instructions: 'user-owned follow-up instructions',
+      route: defaultRoute,
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '08:00',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'active',
+      summary: 'User summary',
+      tags: ['assistant', 'scheduled'],
+      title: 'User follow-up',
+    })
+
+    await expect(reconcileExistingMurphManagedAutomationDefinition({
+      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({ updated: false })
+    expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
   })
 
   it('updates active seed-owned fields while preserving the existing route', async () => {

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -26,12 +26,14 @@ type StoredAutomationRecord = {
 const managedAutomationMocks = vi.hoisted(() => ({
   applyAssistantSelfDeliveryTargetDefaults: vi.fn(),
   getAssistantChannelAdapter: vi.fn(),
+  patchAutomation: vi.fn(),
   records: new Map<string, StoredAutomationRecord>(),
   showAutomation: vi.fn(),
   upsertAutomation: vi.fn(),
 }))
 
 vi.mock('@murphai/core', () => ({
+  patchAutomation: managedAutomationMocks.patchAutomation,
   showAutomation: managedAutomationMocks.showAutomation,
   upsertAutomation: managedAutomationMocks.upsertAutomation,
 }))
@@ -94,8 +96,6 @@ import {
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
-  reconcileExistingMurphManagedAutomationDefinition,
-  resolveMurphManagedAutomationDefinition,
   type MurphManagedAutomationSeed,
 } from '../src/assistant/managed-automations.ts'
 import { ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG } from '../src/assistant/automation-tags.ts'
@@ -110,6 +110,16 @@ const defaultRoute = {
   participantId: null,
   threadId: null,
 }
+
+const legacyOnboardingFollowupInstructions = [
+  'This scheduled check helps continue Murph setup.',
+  '',
+  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
+  '',
+  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
+  '',
+  'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
+].join('\n')
 
 beforeEach(() => {
   managedAutomationMocks.records.clear()
@@ -170,6 +180,48 @@ beforeEach(() => {
       return {
         auditPath: 'audit/mock.jsonl',
         created: !existing,
+        record,
+      }
+    })
+  managedAutomationMocks.patchAutomation
+    .mockReset()
+    .mockImplementation(async (input: {
+      continuityPolicy?: 'fresh' | 'preserve'
+      instructions?: string
+      lookup: string
+      route?: StoredAutomationRecord['route']
+      schedule?: StoredAutomationRecord['schedule']
+      slug?: string
+      status?: StoredAutomationRecord['status']
+      summary?: string | null
+      tags?: string[]
+      title?: string
+    }) => {
+      const existing = [...managedAutomationMocks.records.values()]
+        .find((record) =>
+          record.automationId === input.lookup || record.slug === input.lookup
+        )
+      if (!existing) {
+        throw new Error('Automation was not found.')
+      }
+
+      const record: StoredAutomationRecord = {
+        ...existing,
+        continuityPolicy: input.continuityPolicy ?? existing.continuityPolicy,
+        instructions: input.instructions ?? existing.instructions,
+        route: input.route ?? existing.route,
+        schedule: input.schedule ?? existing.schedule,
+        slug: input.slug ?? existing.slug,
+        status: input.status ?? existing.status,
+        summary: input.summary === undefined ? existing.summary : input.summary,
+        tags: input.tags ?? existing.tags,
+        title: input.title ?? existing.title,
+      }
+
+      managedAutomationMocks.records.set(record.automationId, record)
+      return {
+        auditPath: 'audit/mock.jsonl',
+        created: false,
         record,
       }
     })
@@ -584,33 +636,41 @@ describe('applyMurphManagedAutomations', () => {
       title: 'Old onboarding follow-up',
     })
 
-    await expect(reconcileExistingMurphManagedAutomationDefinition({
-      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
       now: new Date('2026-06-23T12:00:00.000Z'),
-      syncSchedule: false,
       vaultRoot,
-    })).resolves.toEqual({ updated: true })
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 1,
+    })
 
-    const resolved = resolveMurphManagedAutomationDefinition(
-      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
-    )
-    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledWith(
+    expect(managedAutomationMocks.patchAutomation).toHaveBeenCalledWith(
       expect.objectContaining({
-        automationId: 'automation_onboarding_followup',
-        continuityPolicy: resolved.continuityPolicy,
-        instructions: resolved.instructions,
+        continuityPolicy: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.continuityPolicy,
+        instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
+        lookup: 'automation_onboarding_followup',
+        summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+        tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+        title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+      }),
+    )
+    expect(managedAutomationMocks.patchAutomation.mock.calls[0]?.[0])
+      .not.toHaveProperty('route')
+    expect(managedAutomationMocks.patchAutomation.mock.calls[0]?.[0])
+      .not.toHaveProperty('schedule')
+    expect(managedAutomationMocks.patchAutomation.mock.calls[0]?.[0])
+      .not.toHaveProperty('status')
+    expect(managedAutomationMocks.records.get('automation_onboarding_followup'))
+      .toMatchObject({
         route: existingRoute,
         schedule: {
           kind: 'dailyLocal',
           localTime: '08:00',
         },
-        slug: 'finish-onboarding-followup',
         status: 'active',
-        summary: resolved.summary,
-        tags: resolved.tags,
-        title: resolved.title,
-      }),
-    )
+      })
   })
 
   it('updates a paused onboarding follow-up without reactivating it', async () => {
@@ -630,24 +690,70 @@ describe('applyMurphManagedAutomations', () => {
       title: 'Old onboarding follow-up',
     })
 
-    await expect(reconcileExistingMurphManagedAutomationDefinition({
-      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
       now: new Date('2026-06-23T12:00:00.000Z'),
-      syncSchedule: false,
       vaultRoot,
-    })).resolves.toEqual({ updated: true })
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 1,
+    })
 
-    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledWith(
+    expect(managedAutomationMocks.patchAutomation).toHaveBeenCalledWith(
       expect.objectContaining({
-        automationId: 'automation_onboarding_followup',
+        lookup: 'automation_onboarding_followup',
+      }),
+    )
+    expect(managedAutomationMocks.records.get('automation_onboarding_followup'))
+      .toMatchObject({
         route: defaultRoute,
         schedule: {
           kind: 'dailyLocal',
           localTime: '08:00',
         },
         status: 'paused',
-      }),
-    )
+      })
+  })
+
+  it('migrates the original unmarked onboarding follow-up seed by exact fingerprint', async () => {
+    managedAutomationMocks.records.set('automation_legacy_onboarding_followup', {
+      automationId: 'automation_legacy_onboarding_followup',
+      continuityPolicy: 'preserve',
+      instructions: legacyOnboardingFollowupInstructions,
+      route: defaultRoute,
+      schedule: {
+        kind: 'dailyLocal',
+        localTime: '13:30',
+      },
+      slug: 'finish-onboarding-followup',
+      status: 'active',
+      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      tags: ['assistant', 'onboarding'],
+      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+    })
+
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-23T12:00:00.000Z'),
+      vaultRoot,
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 1,
+    })
+
+    expect(managedAutomationMocks.records.get('automation_legacy_onboarding_followup'))
+      .toMatchObject({
+        instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
+        route: defaultRoute,
+        schedule: {
+          kind: 'dailyLocal',
+          localTime: '13:30',
+        },
+        status: 'active',
+        tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+      })
   })
 
   it('does not reconcile archived or user-owned onboarding follow-up slugs', async () => {
@@ -667,13 +773,18 @@ describe('applyMurphManagedAutomations', () => {
       title: 'Old onboarding follow-up',
     })
 
-    await expect(reconcileExistingMurphManagedAutomationDefinition({
-      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
-    })).resolves.toEqual({ updated: false })
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 0,
+    })
 
     managedAutomationMocks.records.clear()
+    managedAutomationMocks.patchAutomation.mockClear()
     managedAutomationMocks.upsertAutomation.mockClear()
     managedAutomationMocks.records.set('automation_user_onboarding_followup', {
       automationId: 'automation_user_onboarding_followup',
@@ -691,12 +802,16 @@ describe('applyMurphManagedAutomations', () => {
       title: 'User follow-up',
     })
 
-    await expect(reconcileExistingMurphManagedAutomationDefinition({
-      definition: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+    await expect(applyMurphManagedAutomations({
+      defaultRoute,
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
-    })).resolves.toEqual({ updated: false })
-    expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
+    })).resolves.toEqual({
+      created: 4,
+      skipped: 0,
+      updated: 0,
+    })
+    expect(managedAutomationMocks.patchAutomation).not.toHaveBeenCalled()
   })
 
   it('updates active seed-owned fields while preserving the existing route', async () => {

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -121,12 +121,6 @@ const legacyOnboardingFollowupInstructions = [
   'If onboarding is still open, offer one brief, natural in-chat message inviting setup to continue. Keep it low-pressure, do not mention internal state, and do not use a fixed script.',
 ].join('\n')
 
-const legacyAcceleratedOnboardingFollowupInstructions = [
-  'First inspect onboarding status with `vault-cli assistant onboarding status`.',
-  'If onboarding is completed or declined, run `vault-cli automation set-status finish-onboarding-followup --status archived` and return skip.',
-  'If onboarding is still open, send a short message inviting setup to continue.',
-].join(' ')
-
 beforeEach(() => {
   managedAutomationMocks.records.clear()
   managedAutomationMocks.getAssistantChannelAdapter
@@ -729,14 +723,14 @@ describe('applyMurphManagedAutomations', () => {
       instructions: legacyOnboardingFollowupInstructions,
       route: defaultRoute,
       schedule: {
-        kind: 'dailyLocal',
-        localTime: '13:30',
+        everyMs: 90_000,
+        kind: 'every',
       },
       slug: 'finish-onboarding-followup',
       status: 'active',
-      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      summary: 'User-edited setup follow-up summary.',
       tags: ['assistant', 'onboarding'],
-      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
+      title: 'User-edited setup follow-up',
     })
 
     await expect(applyMurphManagedAutomations({
@@ -754,51 +748,13 @@ describe('applyMurphManagedAutomations', () => {
         instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
         route: defaultRoute,
         schedule: {
-          kind: 'dailyLocal',
-          localTime: '13:30',
-        },
-        status: 'active',
-        tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
-      })
-  })
-
-  it('migrates an accelerated unmarked onboarding follow-up without changing its schedule', async () => {
-    managedAutomationMocks.records.set('automation_legacy_accelerated_onboarding_followup', {
-      automationId: 'automation_legacy_accelerated_onboarding_followup',
-      continuityPolicy: 'preserve',
-      instructions: legacyAcceleratedOnboardingFollowupInstructions,
-      route: defaultRoute,
-      schedule: {
-        everyMs: 90_000,
-        kind: 'every',
-      },
-      slug: 'finish-onboarding-followup',
-      status: 'active',
-      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
-      tags: ['assistant', 'onboarding'],
-      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
-    })
-
-    await expect(applyMurphManagedAutomations({
-      defaultRoute,
-      now: new Date('2026-06-23T12:00:00.000Z'),
-      vaultRoot,
-    })).resolves.toEqual({
-      created: 4,
-      skipped: 0,
-      updated: 1,
-    })
-
-    expect(managedAutomationMocks.records.get('automation_legacy_accelerated_onboarding_followup'))
-      .toMatchObject({
-        instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
-        route: defaultRoute,
-        schedule: {
           everyMs: 90_000,
           kind: 'every',
         },
         status: 'active',
+        summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
         tags: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags,
+        title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
       })
   })
 

--- a/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import type { AutomationRoute } from "@murphai/contracts";
 import {
   buildHostedAssistantContextFingerprintDetails,
+  MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+  resolveMurphManagedAutomationDefinition,
   sendAssistantNotification,
   upsertAssistantCronAutomation,
   type AssistantExecutionContext,
@@ -35,32 +37,9 @@ import { emitHostedAssistantProviderTraceLog } from "./provider-trace-log.ts";
 
 type AssistantNotificationInput = Parameters<typeof sendAssistantNotification>[0];
 
-const ONBOARDING_FOLLOWUP_AUTOMATION_SLUG = "finish-onboarding-followup";
-const ONBOARDING_FOLLOWUP_AUTOMATION_TITLE = "Finish Murph onboarding follow-up";
-const ONBOARDING_FOLLOWUP_AUTOMATION_TAGS = [
-  "assistant",
-  "scheduled",
-  "onboarding",
-  "murph-managed",
-  "murph-managed:onboarding-followup",
-];
-const ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS = [
-  "Goal: close or gently advance Murph onboarding after hosted signup without re-asking setup context the vault already knows. The first scheduled occurrence is intentionally deferred until after the signup day.",
-  "",
-  "Before deciding, run `vault-cli assistant onboarding resume-context --format json`.",
-  "",
-  "Success criteria: onboarding is no longer open, or the user receives one brief question for the smallest genuinely unresolved onboarding step.",
-  "",
-  "If `onboarding.status` is `completed`, archive this automation with `vault-cli automation set-status finish-onboarding-followup --status archived`, then return skip. If archiving fails, still return skip without messaging the user so this check can retry later.",
-  "",
-  "If `onboarding.status` is `open` but resume-context or the available recent user messages show the onboarding completion criteria are already satisfied through answers, saved setup facts, skipped individual fields, or deferrals, run `vault-cli assistant onboarding complete --reason user_answered`. If recent user messages show a clear overall onboarding opt-out, run `vault-cli assistant onboarding complete --reason user_declined` instead. If the output shows completed, archive this automation, then return skip. If completion or archiving fails, return skip without messaging the user so this check can retry later.",
-  "",
-  "If onboarding is still genuinely open, use resume-context and the available recent user messages as saved setup evidence. Open status alone is not evidence that setup facts are missing. Treat saved, skipped, declined individual fields, not-relevant, or clearly answered-in-chat setup context as resolved. If most setup context is already present, ask about the next meaningful first-experiment setup or deferral decision instead of more intake.",
-  "",
-  "Before sending, triple-check resume-context and the available recent user messages for an answer to the question you would ask. The last thing we want is to bug the user after they already answered onboarding. If there is no useful next unresolved question, return skip rather than sending a generic setup nudge.",
-  "",
-  "Output: send one brief, natural, low-pressure in-chat question only when a real unresolved step remains. Do not mention internal state or this automation, and do not use a fixed script. The user's answer will be handled by the next normal Murph onboarding turn.",
-].join("\n");
+const ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION =
+  resolveMurphManagedAutomationDefinition(MURPH_ONBOARDING_FOLLOWUP_AUTOMATION);
+
 export async function executeHostedMemberActivatedWake(input: {
   wake: HostedExecutionMemberActivatedWake;
   executionContext: AssistantExecutionContext;
@@ -234,16 +213,13 @@ async function maybeSeedOnboardingFollowupAutomation(input: {
     // validation; an undeliverable route lands in the catch below.
     const job = await upsertAssistantCronAutomation({
       firstOccurrencePolicy: "after-current-local-day",
-      instructions: ONBOARDING_FOLLOWUP_AUTOMATION_INSTRUCTIONS,
+      instructions: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.instructions,
       route: buildOnboardingFollowupAutomationRoute(input.route),
-      schedule: {
-        kind: "dailyLocal",
-        localTime: "13:30",
-      },
-      slug: ONBOARDING_FOLLOWUP_AUTOMATION_SLUG,
-      summary: "Daily setup continuation check until Murph onboarding is complete.",
-      tags: ONBOARDING_FOLLOWUP_AUTOMATION_TAGS,
-      title: ONBOARDING_FOLLOWUP_AUTOMATION_TITLE,
+      schedule: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.schedule,
+      slug: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.slug,
+      summary: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.summary,
+      tags: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.tags,
+      title: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.title,
       vault: input.vaultRoot,
     });
     return job?.enabled ? job.state.nextRunAt : null;

--- a/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
@@ -4,7 +4,6 @@ import type { AutomationRoute } from "@murphai/contracts";
 import {
   buildHostedAssistantContextFingerprintDetails,
   MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
-  resolveMurphManagedAutomationDefinition,
   sendAssistantNotification,
   upsertAssistantCronAutomation,
   type AssistantExecutionContext,
@@ -36,9 +35,6 @@ import {
 import { emitHostedAssistantProviderTraceLog } from "./provider-trace-log.ts";
 
 type AssistantNotificationInput = Parameters<typeof sendAssistantNotification>[0];
-
-const ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION =
-  resolveMurphManagedAutomationDefinition(MURPH_ONBOARDING_FOLLOWUP_AUTOMATION);
 
 export async function executeHostedMemberActivatedWake(input: {
   wake: HostedExecutionMemberActivatedWake;
@@ -213,13 +209,13 @@ async function maybeSeedOnboardingFollowupAutomation(input: {
     // validation; an undeliverable route lands in the catch below.
     const job = await upsertAssistantCronAutomation({
       firstOccurrencePolicy: "after-current-local-day",
-      instructions: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.instructions,
+      instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
       route: buildOnboardingFollowupAutomationRoute(input.route),
-      schedule: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.schedule,
-      slug: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.slug,
-      summary: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.summary,
-      tags: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.tags,
-      title: ONBOARDING_FOLLOWUP_AUTOMATION_DEFINITION.title,
+      schedule: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
+      slug: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug,
+      summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
+      tags: [...MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.tags],
+      title: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.title,
       vault: input.vaultRoot,
     });
     return job?.enabled ? job.state.nextRunAt : null;

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -1338,8 +1338,8 @@ describe("executeHostedMailboxEvent", () => {
       tags: [
         "assistant",
         "scheduled",
-        "onboarding",
         "murph-managed",
+        "onboarding",
         "murph-managed:onboarding-followup",
       ],
       title: "Finish Murph onboarding follow-up",


### PR DESCRIPTION
## Summary

- move the hosted onboarding follow-up prompt/schedule metadata into a shared assistant-engine managed definition
- add an update-only reconciliation primitive for existing Murph-owned managed automations by slug
- preserve signup-only creation, hosted route, status, automation id, archived records, user-owned same-slug records, and existing onboarding follow-up schedules
- point hosted signup seeding and the hosted-local E2E fixture at the shared definition

## Validation

- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts test/managed-automations.test.ts test/managed-automations-core.test.ts --no-coverage`
- `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts test/hosted-runtime-events.test.ts --no-coverage`
- `pnpm typecheck`
- `git diff --check`
- `bash scripts/workspace-verify.sh test:diff <changed files>` passed changed-owner package tests and hosted-local E2E coverage, then failed in `apps/cloudflare/test/runner-bundle-process.test.ts` because the synthetic Corepack home was missing `pnpm.cjs`; this is unrelated to the onboarding automation diff.

## Audit Notes

- coverage-write added core integration proof for the canonical automation registry path
- deep-review finding accepted and fixed: onboarding follow-up reconciliation now preserves existing schedules so signup-day deferral and accelerated follow-ups are not disturbed
- deep-review seed-failure repair suggestion rejected as pre-existing/out of scope; adding retry state would widen this PR beyond the requested existing-record reconciliation primitive

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784828458&installation_id=127572939&pr_number=264&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F264&signature=a095143513d5d169c8ed69babe5a84d028602966ddd81bedd7fcb6ef53401662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->