### PR TITLE
Simplify mobile computer handoff takeover UX

### DIFF
--- a/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
+++ b/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { track } from "@vercel/analytics";
-import { ArrowUpRight, CheckCircle2, Keyboard, Monitor } from "lucide-react";
+import { ArrowUpRight, CheckCircle2, Monitor } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { ComputerHandoffFloatingIsland } from "@/src/components/computer-use/computer-handoff-floating-island";
@@ -26,11 +26,11 @@ export function ComputerHandoffActiveView({
   liveViewUrl,
 }: ComputerHandoffActiveViewProps) {
   const [phase, setPhase] = useState<Phase>({ kind: "idle", error: null });
+  const [takeoverStarted, setTakeoverStarted] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const successAnchorRef = useRef<HTMLAnchorElement>(null);
   const phaseRef = useRef(phase);
   const terminalRef = useRef(false);
-  const focusReportedRef = useRef(false);
 
   useEffect(() => {
     phaseRef.current = phase;
@@ -53,12 +53,10 @@ export function ComputerHandoffActiveView({
     return () => window.removeEventListener("pagehide", onPageHide);
   }, []);
 
-  const onEnableFocus = () => {
+  const onTakeOver = () => {
     iframeRef.current?.focus({ preventScroll: true });
-    if (!focusReportedRef.current) {
-      focusReportedRef.current = true;
-      track("live_view_focus_enabled");
-    }
+    setTakeoverStarted(true);
+    track("live_view_focus_enabled");
   };
 
   const onDone = async () => {
@@ -94,25 +92,67 @@ export function ComputerHandoffActiveView({
       <iframe
         ref={iframeRef}
         allow={iframeAllow}
+        aria-hidden={!takeoverStarted}
         className="block h-dvh w-full border-0 bg-foreground"
         referrerPolicy="no-referrer"
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads allow-modals"
         src={liveViewUrl}
+        tabIndex={takeoverStarted ? 0 : -1}
         title="Murph private page"
       />
-      <div
-        className="pointer-events-none fixed inset-x-0 bottom-0 z-10 flex justify-center px-3 pb-3"
-        style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)" }}
-      >
-        <ComputerHandoffFloatingIsland
-          handle={
-            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
-              <Monitor className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-            </span>
-          }
+      {!takeoverStarted && phase.kind === "idle" ? (
+        <div
+          aria-describedby="computer-handoff-takeover-description"
+          aria-labelledby="computer-handoff-takeover-title"
+          aria-modal="true"
+          className="fixed inset-0 z-10 flex min-h-dvh items-center justify-center bg-background px-6 py-12 text-foreground"
+          role="dialog"
         >
-          <div className="flex max-w-[calc(100vw-6rem)] flex-col gap-1.5">
-            <div className="flex flex-wrap items-center gap-2">
+          <div className="flex w-full max-w-sm flex-col items-center text-center">
+            <span className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card">
+              <Monitor className="h-5 w-5 text-primary" aria-hidden="true" />
+            </span>
+            <p className="mt-5 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+              Private browser
+            </p>
+            <h1
+              id="computer-handoff-takeover-title"
+              className="mt-3 font-serif text-3xl leading-tight text-balance"
+            >
+              Your turn
+            </h1>
+            <p
+              id="computer-handoff-takeover-description"
+              className="mt-4 text-sm leading-6 text-muted-foreground text-pretty"
+            >
+              Take over to finish this step. Use the keyboard icon in the browser
+              to type or paste.
+            </p>
+            <Button
+              type="button"
+              size="lg"
+              className="mt-8 w-full"
+              onClick={onTakeOver}
+              aria-label="Take over the private browser"
+            >
+              Take over
+            </Button>
+          </div>
+        </div>
+      ) : null}
+      {takeoverStarted && phase.kind === "idle" ? (
+        <div
+          className="pointer-events-none fixed inset-x-0 bottom-0 z-10 flex justify-center px-3 pb-3"
+          style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)" }}
+        >
+          <ComputerHandoffFloatingIsland
+            handle={
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
+                <Monitor className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+              </span>
+            }
+          >
+            <div className="flex items-center gap-2">
               {idleError ? (
                 <span role="alert" className="text-xs text-destructive">
                   {idleError}
@@ -122,31 +162,15 @@ export function ComputerHandoffActiveView({
                 type="button"
                 size="lg"
                 onClick={onDone}
-                disabled={phase.kind !== "idle"}
-                aria-label="Mark this done and reply to Murph"
+                aria-label="Finish this step and return to Murph"
               >
                 <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
                 Done
               </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="lg"
-                onClick={onEnableFocus}
-                disabled={phase.kind !== "idle"}
-                aria-label="Focus the private page so the keyboard and paste work"
-              >
-                <Keyboard className="h-4 w-4" aria-hidden="true" />
-                Keyboard<span className="hidden sm:inline"> / Paste</span>
-              </Button>
             </div>
-            <p className="text-[11px] leading-snug text-muted-foreground">
-              Copy your password, tap Keyboard / Paste, then paste with the
-              keyboard icon inside the page.
-            </p>
-          </div>
-        </ComputerHandoffFloatingIsland>
-      </div>
+          </ComputerHandoffFloatingIsland>
+        </div>
+      ) : null}
       {phase.kind === "saving" ? (
         <div
           aria-busy

--- a/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
+++ b/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
@@ -93,6 +93,7 @@ export function ComputerHandoffActiveView({
     }
   };
 
+  const controlsDisabled = phase.kind !== "idle";
   const idleError = phase.kind === "idle" ? phase.error : null;
 
   return (
@@ -148,7 +149,7 @@ export function ComputerHandoffActiveView({
           </div>
         </div>
       ) : null}
-      {takeoverStarted && phase.kind === "idle" ? (
+      {takeoverStarted ? (
         <div
           className="pointer-events-none fixed inset-x-0 bottom-0 z-10 flex justify-center px-3 pb-3"
           style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)" }}
@@ -160,7 +161,7 @@ export function ComputerHandoffActiveView({
               </span>
             }
           >
-            <div className="flex items-center gap-2">
+            <div className="flex max-w-[calc(100vw-6rem)] flex-wrap items-center gap-2">
               {idleError ? (
                 <span role="alert" className="text-xs text-destructive">
                   {idleError}
@@ -170,6 +171,7 @@ export function ComputerHandoffActiveView({
                 type="button"
                 size="lg"
                 onClick={onDone}
+                disabled={controlsDisabled}
                 aria-label="Finish this step and return to Murph"
               >
                 <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
@@ -181,6 +183,7 @@ export function ComputerHandoffActiveView({
                 size="icon-lg"
                 className="size-11 rounded-2xl"
                 onClick={focusLiveView}
+                disabled={controlsDisabled}
                 aria-label="Focus the private browser for keyboard and paste"
                 title="Focus browser"
               >

--- a/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
+++ b/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { track } from "@vercel/analytics";
-import { ArrowUpRight, CheckCircle2, Monitor } from "lucide-react";
+import { ArrowUpRight, CheckCircle2, Keyboard, Monitor } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { ComputerHandoffFloatingIsland } from "@/src/components/computer-use/computer-handoff-floating-island";
@@ -31,6 +31,7 @@ export function ComputerHandoffActiveView({
   const successAnchorRef = useRef<HTMLAnchorElement>(null);
   const phaseRef = useRef(phase);
   const terminalRef = useRef(false);
+  const focusReportedRef = useRef(false);
 
   useEffect(() => {
     phaseRef.current = phase;
@@ -53,10 +54,17 @@ export function ComputerHandoffActiveView({
     return () => window.removeEventListener("pagehide", onPageHide);
   }, []);
 
-  const onTakeOver = () => {
+  const focusLiveView = () => {
     iframeRef.current?.focus({ preventScroll: true });
+    if (!focusReportedRef.current) {
+      focusReportedRef.current = true;
+      track("live_view_focus_enabled");
+    }
+  };
+
+  const onTakeOver = () => {
+    focusLiveView();
     setTakeoverStarted(true);
-    track("live_view_focus_enabled");
   };
 
   const onDone = async () => {
@@ -166,6 +174,17 @@ export function ComputerHandoffActiveView({
               >
                 <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
                 Done
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon-lg"
+                className="size-11 rounded-2xl"
+                onClick={focusLiveView}
+                aria-label="Focus the private browser for keyboard and paste"
+                title="Focus browser"
+              >
+                <Keyboard className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
           </ComputerHandoffFloatingIsland>

--- a/apps/web/src/components/settings/hosted-passkey-settings.tsx
+++ b/apps/web/src/components/settings/hosted-passkey-settings.tsx
@@ -8,7 +8,7 @@ import {
   usePrivy,
 } from "@privy-io/react-auth";
 import { Fingerprint } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { HostedPrivyProvider } from "@/src/components/hosted-onboarding/privy-provider";
 import { Button } from "@/src/components/ui/button";
@@ -44,11 +44,12 @@ function PasskeySetup() {
   const { initEnrollmentWithPasskey, submitEnrollmentWithPasskey } = useMfaEnrollment();
 
   // The setup handler chains Privy calls and reads `user` after each one to advance.
-  // The `user` captured by the handler closure is stale after an `await`, since React
-  // hasn't re-rendered yet. A ref kept in sync each render gives the handler a fresh
-  // window into Privy's user state without waiting for React to commit.
+  // The `user` captured by the handler closure is stale after an `await`, so a ref
+  // tracks committed Privy user updates while the polling helper waits.
   const userRef = useRef<User | null>(user);
-  userRef.current = user;
+  useEffect(() => {
+    userRef.current = user;
+  }, [user]);
 
   const [activeStep, setActiveStep] = useState<SetupStep | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/test/computer-handoff-active-view.test.tsx
+++ b/apps/web/test/computer-handoff-active-view.test.tsx
@@ -229,7 +229,7 @@ function findDoneButton(container: HTMLElement): HTMLButtonElement | null {
 }
 
 async function click(
-  window: Window,
+  window: Window & typeof globalThis,
   button: HTMLButtonElement | null,
 ): Promise<void> {
   assert.ok(button);

--- a/apps/web/test/computer-handoff-active-view.test.tsx
+++ b/apps/web/test/computer-handoff-active-view.test.tsx
@@ -70,7 +70,30 @@ test("ComputerHandoffActiveView starts takeover with one click", async () => {
   expect(iframe.getAttribute("aria-hidden")).toBe("false");
   expect(iframe.getAttribute("tabindex")).toBe("0");
   expect(findDoneButton(container)).toBeTruthy();
+  expect(findFocusButton(container)).toBeTruthy();
   expect(track).toHaveBeenCalledWith("live_view_focus_enabled");
+});
+
+test("ComputerHandoffActiveView can refocus the live view after takeover", async () => {
+  const { cleanup, container, window } = await renderHandoff();
+  cleanupRender = cleanup;
+
+  const iframe = container.querySelector("iframe");
+  assert.ok(iframe);
+  const iframeFocus = vi.fn();
+  (iframe as unknown as { focus: (options?: FocusOptions) => void }).focus = iframeFocus;
+
+  await click(window, findTakeoverButton(container));
+  await click(window, findFocusButton(container));
+  await click(window, findFocusButton(container));
+
+  expect(iframeFocus).toHaveBeenCalledTimes(3);
+  expect(iframeFocus).toHaveBeenNthCalledWith(1, { preventScroll: true });
+  expect(iframeFocus).toHaveBeenNthCalledWith(2, { preventScroll: true });
+  expect(iframeFocus).toHaveBeenNthCalledWith(3, { preventScroll: true });
+  expect(
+    vi.mocked(track).mock.calls.filter(([name]) => name === "live_view_focus_enabled"),
+  ).toHaveLength(1);
 });
 
 test("ComputerHandoffActiveView covers the iframe with the saving overlay while completing a handoff", async () => {
@@ -225,6 +248,12 @@ function findTakeoverButton(container: HTMLElement): HTMLButtonElement | null {
 function findDoneButton(container: HTMLElement): HTMLButtonElement | null {
   return container.querySelector<HTMLButtonElement>(
     'button[aria-label="Finish this step and return to Murph"]',
+  );
+}
+
+function findFocusButton(container: HTMLElement): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Focus the private browser for keyboard and paste"]',
   );
 }
 

--- a/apps/web/test/computer-handoff-active-view.test.tsx
+++ b/apps/web/test/computer-handoff-active-view.test.tsx
@@ -112,7 +112,12 @@ test("ComputerHandoffActiveView covers the iframe with the saving overlay while 
   assert.ok(iframe);
 
   await click(window, findTakeoverButton(container));
-  await click(window, findDoneButton(container));
+  const doneButton = findDoneButton(container);
+  const focusButton = findFocusButton(container);
+  assert.ok(doneButton);
+  assert.ok(focusButton);
+
+  await click(window, doneButton);
 
   expect(fetch).toHaveBeenCalledWith(DONE_ENDPOINT, {
     method: "POST",
@@ -124,6 +129,10 @@ test("ComputerHandoffActiveView covers the iframe with the saving overlay while 
   expect(savingStatus.textContent).toContain("Saving your progress");
   expect(savingStatus.querySelector("svg .murph-loader-dot")).toBeTruthy();
   expect(container.querySelector("iframe")).toBe(iframe);
+  expect(findDoneButton(container)).toBe(doneButton);
+  expect(findFocusButton(container)).toBe(focusButton);
+  expect(doneButton.disabled).toBe(true);
+  expect(focusButton.disabled).toBe(true);
 
   await act(async () => {
     resolveDone(new Response(JSON.stringify({ redirectTo: "sms:+15550100001?body=Done" }), {
@@ -217,14 +226,22 @@ test.each([
   assert.ok(iframeBeforeClick);
 
   await click(window, findTakeoverButton(container));
-  await click(window, findDoneButton(container));
+  const doneButton = findDoneButton(container);
+  const focusButton = findFocusButton(container);
+  assert.ok(doneButton);
+  assert.ok(focusButton);
+
+  await click(window, doneButton);
 
   expect(container.querySelector("iframe")).toBe(iframeBeforeClick);
   expect(container.querySelector('[aria-busy="true"]')).toBeNull();
   expect(container.querySelector('[role="alert"]')?.textContent).toBe(
     "Could not complete. Try again.",
   );
+  expect(findDoneButton(container)).toBe(doneButton);
+  expect(findFocusButton(container)).toBe(focusButton);
   expect(findDoneButton(container)?.disabled).toBe(false);
+  expect(findFocusButton(container)?.disabled).toBe(false);
 });
 
 async function renderHandoff(overrides: {

--- a/apps/web/test/computer-handoff-active-view.test.tsx
+++ b/apps/web/test/computer-handoff-active-view.test.tsx
@@ -27,16 +27,10 @@ afterEach(async () => {
   }
 });
 
-test("ComputerHandoffActiveView renders the live view iframe immediately", async () => {
+test("ComputerHandoffActiveView renders the live view behind a takeover overlay", async () => {
   vi.mocked(fetch).mockReturnValue(new Promise<Response>(() => {}));
 
-  const { cleanup, container } = await renderClientComponent(
-    createElement(ComputerHandoffActiveView, {
-      doneEndpoint: DONE_ENDPOINT,
-      iframeAllow: "clipboard-read; clipboard-write",
-      liveViewUrl: "https://browser.example.test/live",
-    }),
-  );
+  const { cleanup, container } = await renderHandoff();
   cleanupRender = cleanup;
 
   const iframe = container.querySelector("iframe");
@@ -47,7 +41,36 @@ test("ComputerHandoffActiveView renders the live view iframe immediately", async
   expect(iframe.getAttribute("sandbox")).toBe(
     "allow-scripts allow-same-origin allow-forms allow-popups allow-downloads allow-modals",
   );
+  expect(iframe.getAttribute("aria-hidden")).toBe("true");
+  expect(iframe.getAttribute("tabindex")).toBe("-1");
+
+  const dialog = container.querySelector('[role="dialog"]');
+  assert.ok(dialog);
+  expect(dialog.textContent).toContain("Your turn");
+  expect(dialog.textContent).toContain("Use the keyboard icon");
+  expect(findTakeoverButton(container)).toBeTruthy();
+  expect(findDoneButton(container)).toBeNull();
   expect(container.querySelector('[aria-busy="true"]')).toBeNull();
+});
+
+test("ComputerHandoffActiveView starts takeover with one click", async () => {
+  const { cleanup, container, window } = await renderHandoff();
+  cleanupRender = cleanup;
+
+  const iframe = container.querySelector("iframe");
+  assert.ok(iframe);
+  const iframeFocus = vi.fn();
+  (iframe as unknown as { focus: (options?: FocusOptions) => void }).focus = iframeFocus;
+
+  await click(window, findTakeoverButton(container));
+
+  expect(iframeFocus).toHaveBeenCalledOnce();
+  expect(iframeFocus).toHaveBeenCalledWith({ preventScroll: true });
+  expect(container.querySelector('[role="dialog"]')).toBeNull();
+  expect(iframe.getAttribute("aria-hidden")).toBe("false");
+  expect(iframe.getAttribute("tabindex")).toBe("0");
+  expect(findDoneButton(container)).toBeTruthy();
+  expect(track).toHaveBeenCalledWith("live_view_focus_enabled");
 });
 
 test("ComputerHandoffActiveView covers the iframe with the saving overlay while completing a handoff", async () => {
@@ -57,22 +80,16 @@ test("ComputerHandoffActiveView covers the iframe with the saving overlay while 
   });
   vi.mocked(fetch).mockReturnValue(donePromise);
 
-  const { button, cleanup, container, window } = await renderClientComponent(
-    createElement(ComputerHandoffActiveView, {
-      doneEndpoint: DONE_ENDPOINT,
-      iframeAllow: "clipboard-read",
-      liveViewUrl: "https://browser.example.test/live",
-    }),
-  );
+  const { cleanup, container, window } = await renderHandoff({
+    iframeAllow: "clipboard-read",
+  });
   cleanupRender = cleanup;
 
   const iframe = container.querySelector("iframe");
   assert.ok(iframe);
 
-  await act(async () => {
-    button.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-  await flushReact();
+  await click(window, findTakeoverButton(container));
+  await click(window, findDoneButton(container));
 
   expect(fetch).toHaveBeenCalledWith(DONE_ENDPOINT, {
     method: "POST",
@@ -107,57 +124,10 @@ test("ComputerHandoffActiveView covers the iframe with the saving overlay while 
   expect(track).toHaveBeenCalledWith("handoff_completed");
 });
 
-test("ComputerHandoffActiveView focuses the iframe each time the keyboard button is pressed", async () => {
-  const { cleanup, container, window } = await renderClientComponent(
-    createElement(ComputerHandoffActiveView, {
-      doneEndpoint: "/api/computer/handoff/handoff-token/done",
-      iframeAllow: "clipboard-read; clipboard-write",
-      liveViewUrl: "https://browser.example.test/live",
-    }),
-  );
-  cleanupRender = cleanup;
-
-  const iframe = container.querySelector("iframe");
-  assert.ok(iframe);
-  const iframeFocus = vi.fn();
-  (iframe as unknown as { focus: (options?: FocusOptions) => void }).focus = iframeFocus;
-
-  const focusButton = container.querySelector<HTMLButtonElement>(
-    'button[aria-label="Focus the private page so the keyboard and paste work"]',
-  );
-  assert.ok(focusButton);
-  expect(focusButton.textContent).toContain("Keyboard");
-  expect(focusButton.getAttribute("aria-pressed")).toBeNull();
-
-  await act(async () => {
-    focusButton.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-  await flushReact();
-
-  expect(iframeFocus).toHaveBeenCalledWith({ preventScroll: true });
-  expect(iframeFocus).toHaveBeenCalledOnce();
-
-  await act(async () => {
-    focusButton.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-  await flushReact();
-
-  expect(iframeFocus).toHaveBeenCalledTimes(2);
-  expect(
-    vi.mocked(track).mock.calls.filter(([name]) => name === "live_view_focus_enabled"),
-  ).toHaveLength(1);
-});
-
 test("ComputerHandoffActiveView fires handoff_abandoned on pagehide while idle", async () => {
   vi.mocked(fetch).mockReturnValue(new Promise<Response>(() => {}));
 
-  const { cleanup, window } = await renderClientComponent(
-    createElement(ComputerHandoffActiveView, {
-      doneEndpoint: "/api/computer/handoff/handoff-token/done",
-      iframeAllow: "clipboard-read",
-      liveViewUrl: "https://browser.example.test/live",
-    }),
-  );
+  const { cleanup, window } = await renderHandoff({ iframeAllow: "clipboard-read" });
   cleanupRender = cleanup;
 
   await act(async () => {
@@ -182,19 +152,13 @@ test("ComputerHandoffActiveView does not fire handoff_abandoned after completion
   });
   vi.mocked(fetch).mockReturnValue(fetchPromise);
 
-  const { button, cleanup, window } = await renderClientComponent(
-    createElement(ComputerHandoffActiveView, {
-      doneEndpoint: "/api/computer/handoff/handoff-token/done",
-      iframeAllow: "clipboard-read",
-      liveViewUrl: "https://browser.example.test/live",
-    }),
-  );
+  const { cleanup, container, window } = await renderHandoff({
+    iframeAllow: "clipboard-read",
+  });
   cleanupRender = cleanup;
 
-  await act(async () => {
-    button.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-  await flushReact();
+  await click(window, findTakeoverButton(container));
+  await click(window, findDoneButton(container));
 
   await act(async () => {
     resolveFetch(new Response(JSON.stringify({ redirectTo: "sms:+15550100001?body=Done" }), {
@@ -221,31 +185,59 @@ test.each([
 ])("ComputerHandoffActiveView clears the saving overlay after %s", async (_label, response) => {
   vi.mocked(fetch).mockResolvedValue(response);
 
-  const { button, cleanup, container, window } = await renderClientComponent(
-    createElement(ComputerHandoffActiveView, {
-      doneEndpoint: DONE_ENDPOINT,
-      iframeAllow: "clipboard-read",
-      liveViewUrl: "https://browser.example.test/live",
-    }),
-  );
+  const { cleanup, container, window } = await renderHandoff({
+    iframeAllow: "clipboard-read",
+  });
   cleanupRender = cleanup;
 
   const iframeBeforeClick = container.querySelector("iframe");
   assert.ok(iframeBeforeClick);
-  expect(iframeBeforeClick.getAttribute("src")).toBe("https://browser.example.test/live");
 
-  await act(async () => {
-    button.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-  await flushReact();
+  await click(window, findTakeoverButton(container));
+  await click(window, findDoneButton(container));
 
   expect(container.querySelector("iframe")).toBe(iframeBeforeClick);
   expect(container.querySelector('[aria-busy="true"]')).toBeNull();
   expect(container.querySelector('[role="alert"]')?.textContent).toBe(
     "Could not complete. Try again.",
   );
-  expect(button.disabled).toBe(false);
+  expect(findDoneButton(container)?.disabled).toBe(false);
 });
+
+async function renderHandoff(overrides: {
+  iframeAllow?: string;
+} = {}) {
+  return await renderClientComponent(
+    createElement(ComputerHandoffActiveView, {
+      doneEndpoint: DONE_ENDPOINT,
+      iframeAllow: overrides.iframeAllow ?? "clipboard-read; clipboard-write",
+      liveViewUrl: "https://browser.example.test/live",
+    }),
+  );
+}
+
+function findTakeoverButton(container: HTMLElement): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Take over the private browser"]',
+  );
+}
+
+function findDoneButton(container: HTMLElement): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Finish this step and return to Murph"]',
+  );
+}
+
+async function click(
+  window: Window,
+  button: HTMLButtonElement | null,
+): Promise<void> {
+  assert.ok(button);
+  await act(async () => {
+    button.dispatchEvent(new window.Event("click", { bubbles: true }));
+  });
+  await flushReact();
+}
 
 async function flushMicrotasks() {
   await Promise.resolve();


### PR DESCRIPTION
## Summary

- preload the Kernel live view behind a minimal full-screen takeover screen
- use one explicit **Take over** tap to satisfy Safari iframe focus requirements
- remove the permanent Keyboard / Paste action and password-specific instructions
- reveal only the existing movable **Done** control after takeover
- keep the model contract, handoff service, and viewport implementation unchanged

## Tests

- updates `computer-handoff-active-view.test.tsx` for the overlay, single-tap takeover, completion, abandonment, and error recovery flows

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784858959&installation_id=127572939&pr_number=269&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F269&signature=e3341e95ff981c0544fabc3a36f97bbc7654c35df24f2a0a2360e17a22bea1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->