### PR TITLE
feat(assistant): add Typst PDF skill

### DIFF
--- a/Dockerfile.cloudflare-hosted-runner-base
+++ b/Dockerfile.cloudflare-hosted-runner-base
@@ -1,12 +1,36 @@
 ARG NODE_VERSION=24.14.1
 ARG NODE_IMAGE_DIGEST=sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c
 ARG CODEX_CLI_VERSION=0.135.0
+ARG TYPST_VERSION=0.15.0
+ARG TYPST_SHA256=59b207df01be2dab9f13e80f73d04d7ff8273ffd46b3dd1b9eef5c60f3eeabea
+
+FROM node:${NODE_VERSION}-bookworm-slim@${NODE_IMAGE_DIGEST} AS typst-installer
+
+ARG TYPST_VERSION
+ARG TYPST_SHA256
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    xz-utils \
+  && curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+    --retry 3 --retry-all-errors \
+    --output /tmp/typst.tar.xz \
+    "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" \
+  && echo "${TYPST_SHA256}  /tmp/typst.tar.xz" | sha256sum --check --strict \
+  && tar --extract --xz --file /tmp/typst.tar.xz --directory /tmp \
+  && install -m 0755 \
+    /tmp/typst-x86_64-unknown-linux-musl/typst \
+    /usr/local/bin/typst
 
 FROM node:${NODE_VERSION}-bookworm-slim@${NODE_IMAGE_DIGEST}
 
 ARG NODE_VERSION
 ARG NODE_IMAGE_DIGEST
 ARG CODEX_CLI_VERSION
+
+COPY --from=typst-installer /usr/local/bin/typst /usr/local/bin/typst
 
 ENV DEBIAN_FRONTEND=noninteractive \
     HOME=/home/runner \
@@ -56,6 +80,12 @@ RUN python3 --version \
   && ffmpeg -hide_banner -loglevel error -f lavfi -i anullsrc=channel_layout=mono:sample_rate=16000 -t 0.1 -codec:a libmp3lame -b:a 64k /tmp/murph-libmp3lame-smoke.mp3 \
   && test -s /tmp/murph-libmp3lame-smoke.mp3 \
   && rm -f /tmp/murph-libmp3lame-smoke.mp3 \
+  && typst --version \
+  && printf '= Murph PDF smoke\n' > /tmp/murph-typst-smoke.typ \
+  && typst compile --root /tmp --ignore-system-fonts /tmp/murph-typst-smoke.typ /tmp/murph-typst-smoke.pdf \
+  && qpdf --check /tmp/murph-typst-smoke.pdf >/dev/null \
+  && pdftotext -enc UTF-8 -nopgbrk /tmp/murph-typst-smoke.pdf - | grep -Fq 'Murph PDF smoke' \
+  && rm -f /tmp/murph-typst-smoke.typ /tmp/murph-typst-smoke.pdf \
   && codex --version \
   && codex app-server --help >/dev/null \
   && codex doctor --help >/dev/null

--- a/packages/assistant-engine/skills/pdf/SKILL.md
+++ b/packages/assistant-engine/skills/pdf/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: pdf
+description: Create polished PDF documents with the installed Typst CLI; not for reading incoming PDFs.
+---
+
+# PDF creation
+
+Create a readable, polished PDF that satisfies the user's requested content and can be checked before delivery. Use this skill when the user asks for a PDF or when a substantial health-relevant report is best delivered as a document.
+
+## Outcome
+
+Finish with:
+
+- one valid `.pdf` file
+- a clear, safe filename
+- content that matches the requested scope
+- a brief final reply that attaches or points to the PDF without claiming delivery unless the runtime actually delivered it
+
+## Workflow
+
+1. Check availability with `command -v typst`. If it is unavailable, do not install anything at runtime; explain that PDF generation is unavailable in this runtime.
+2. Create a bounded workspace artifact directory with a short lowercase slug:
+   `workdir="$(pwd)/.artifacts/pdf/<short-slug>"; mkdir -p "$workdir"`
+3. Write the source to `$workdir/report.typ`. Copy only required local assets into the same directory. Keep the final PDF there so the runtime can publish it.
+4. Compile inside that bounded root:
+   `typst compile --root "$workdir" --ignore-system-fonts "$workdir/report.typ" "$workdir/report.pdf"`
+5. If compilation fails, use the diagnostic to fix the source and compile again.
+6. Validate the result:
+   - `test -s "$workdir/report.pdf"`
+   - `qpdf --check "$workdir/report.pdf"`
+   - `pdfinfo "$workdir/report.pdf"`
+   - `pdftotext -enc UTF-8 -nopgbrk "$workdir/report.pdf" -`
+7. For multi-page or visually complex documents, render representative pages with `pdftoppm` and inspect them for clipping, awkward breaks, tiny text, crowded tables, or missing images. Revise and recompile when needed.
+8. Attach or return the final PDF through the available file-delivery surface. If the runtime has no file-delivery surface, state that clearly and provide the safe local output path; do not claim it was sent.
+
+## Authoring rules
+
+- Lead with the user's requested outcome. Do not add sections simply to make the report longer.
+- Use a clear title, a short executive summary for longer reports, descriptive headings, page numbers, and a sources section when research is included.
+- Prefer prose and short lists. Use tables only when comparison is easier to read in columns.
+- Keep body text around 10–11 pt with comfortable margins and line spacing.
+- Use semantic Typst headings, lists, figures, links, and tables so the tagged PDF retains useful structure.
+- Add alternative descriptions for meaningful images.
+- Keep source titles readable and clickable. Include raw source URLs only when the user requested links or when the document itself needs them.
+- Use page breaks deliberately; avoid orphaned headings and nearly empty pages.
+- Use only Typst built-ins and local assets. Do not import remote Typst packages.
+- Do not fetch remote images during compilation. Download necessary public images through the approved web path first, then use the local copy.
+- Use the embedded fonts for ordinary documents. When the content needs glyphs they do not cover, include an appropriate local `.ttf` or `.otf` and pass a bounded `--font-path` inside the working directory.
+- Preserve evidence boundaries. Do not invent sources, quotations, metrics, medical certainty, or user health facts to make the document feel complete.
+- Never include secrets, credentials, environment values, sensitive local paths, or unrelated private data.
+
+## Starter source
+
+```typst
+#set document(
+  title: "Report title",
+  author: "Murph",
+)
+
+#set page(
+  paper: "us-letter",
+  margin: (x: 0.85in, y: 0.8in),
+  numbering: "1",
+  number-align: center,
+)
+
+#set text(font: "Libertinus Serif", size: 10.5pt, lang: "en")
+#set par(justify: true, leading: 0.7em)
+#set heading(numbering: "1.")
+
+#align(center)[
+  #text(size: 24pt, weight: "bold")[Report title]
+  #v(0.35em)
+  #text(size: 12pt, fill: luma(40%))[Short subtitle]
+  #v(0.9em)
+  #text(size: 9pt, fill: luma(55%))[Prepared by Murph]
+]
+
+#pagebreak()
+
+= Executive summary
+
+State the central conclusion first.
+
+= Findings
+
+== First finding
+
+Explain the evidence and uncertainty.
+
+#table(
+  columns: (1.2fr, 1fr, 2fr),
+  inset: 6pt,
+  stroke: 0.5pt + luma(82%),
+  [*Item*], [*Status*], [*Notes*],
+  [Example], [Current], [Concise supporting detail],
+)
+
+= Sources
+
++ #link("https://example.com")[Source title]
+```
+
+Stop when the requested content is complete, validation passes, and representative pages look clean.

--- a/packages/assistant-engine/src/assistant-skill-assets.ts
+++ b/packages/assistant-engine/src/assistant-skill-assets.ts
@@ -37,6 +37,12 @@ export const ASSISTANT_SKILLS = [
     triggerHint:
       'Use when Murph needs to operate a live website for a health-relevant task, including booking, rescheduling, or canceling care; ordering contacts, supplements, OTC products, health equipment, groceries, or meals; using provider, insurer, pharmacy, optical, retailer, or meal-service portals; checkout, forms, refill requests, bills, authenticated websites, browser inspection, or other Playwright-driven external browser actions.',
   },
+  {
+    slug: 'pdf',
+    name: 'pdf',
+    triggerHint:
+      'Use when the user asks for a PDF or when a substantial health-relevant report is best delivered as one. Follow the skill and use the installed Typst CLI.',
+  },
 ] as const
 
 export type AssistantSkillSlug = typeof ASSISTANT_SKILLS[number]['slug']

--- a/packages/assistant-engine/test/assistant-pdf-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-pdf-skill.test.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveAssistantSkillsRoot } from '../src/assistant-skill-assets.js'
+import { buildAssistantSystemPrompt } from '../src/assistant/system-prompt.js'
+
+describe('assistant PDF skill', () => {
+  it('adds the concise PDF skill route to the system prompt', () => {
+    const prompt = buildAssistantSystemPrompt({
+      assistantCliContract: null,
+      assistantHostedDeviceConnectAvailable: false,
+      assistantHostedDeviceConnectProviders: [],
+      assistantKnowledgeToolsAvailable: false,
+      channel: 'telegram',
+      cliAccess: {
+        rawCommand: 'vault-cli',
+        setupCommand: 'murph',
+      },
+      currentLocalDate: '2026-06-24',
+      currentTimeZone: 'America/New_York',
+      onboardingGuidance: false,
+      modelBehaviorProfile: 'gpt5-agentic',
+      turnTrigger: null,
+      assistantContextSnapshotPrompt: null,
+    })
+
+    expect(prompt).toContain(
+      'pdf: Use when the user asks for a PDF or when a substantial health-relevant report is best delivered as one.',
+    )
+    expect(prompt).toContain(
+      '$MURPH_ASSISTANT_SKILLS_ROOT/pdf/SKILL.md',
+    )
+    expect(prompt).toContain(
+      'Follow the skill and use the installed Typst CLI.',
+    )
+  })
+
+  it('ships a bounded Typst authoring and validation workflow', async () => {
+    const skill = await readFile(
+      path.join(resolveAssistantSkillsRoot(), 'pdf', 'SKILL.md'),
+      'utf8',
+    )
+
+    expect(skill).toContain('typst compile --root')
+    expect(skill).toContain('--ignore-system-fonts')
+    expect(skill).toContain('qpdf --check')
+    expect(skill).toContain('pdftotext -enc UTF-8 -nopgbrk')
+    expect(skill).toContain('pdftoppm')
+    expect(skill).toContain('.artifacts/pdf')
+    expect(skill).toContain('Do not import remote Typst packages')
+    expect(skill).toContain('do not claim it was sent')
+    expect(skill).toContain(
+      'Stop when the requested content is complete',
+    )
+  })
+})


### PR DESCRIPTION
## Why this PR exists

Murph has no first-class way to deliver a polished PDF when a user asks for one (a longer report, a print-ready summary, a shareable health write-up). Today the assistant either fakes attachment or hands back markdown, so the user request "send me a PDF" silently degrades.

## User goal

A user can ask Murph for a PDF — a report, summary, plan, lab write-up, or other multi-page document — and Murph composes it locally with the installed Typst CLI, validates the artifact, and returns the real `.pdf` file through whatever file-delivery surface the runtime exposes. When no delivery surface exists the assistant says so plainly and surfaces the safe local path; it never claims to have sent a file it did not send.

## What is in the diff

- Install a checksum-pinned Typst `0.15.0` static binary in the hosted runner via a disposable build stage (`Dockerfile.cloudflare-hosted-runner-base`).
- Smoke-test the compiler during the image build: `typst compile` + `qpdf --check` + `pdftotext` on a tiny throwaway document. An invalid install fails the image build.
- Add `packages/assistant-engine/skills/pdf/SKILL.md` covering bounded local authoring, deterministic fonts, validation, representative-page inspection, evidence boundaries, and truthful delivery.
- Register the skill in `ASSISTANT_SKILLS` so the existing skill registry projects exactly one PDF route note into the stable system prompt. No duplicate PDF prompt block, no new framework, no document AST, no service.
- Add `packages/assistant-engine/test/assistant-pdf-skill.test.ts` covering the generated system-prompt route and the skill contract (bounded `--root`, ignore system fonts, `qpdf` + `pdftotext` validation, `pdftoppm` page inspection, `.artifacts/pdf` workspace, no remote Typst packages, no false delivery claims, explicit stop condition). The existing `assistant-skill-assets.test.ts` already covers "every registered skill has SKILL.md" and unique slugs — those checks still pass.

## Typst pin

- version: `0.15.0`
- asset: `typst-x86_64-unknown-linux-musl.tar.xz`
- SHA-256: `59b207df01be2dab9f13e80f73d04d7ff8273ffd46b3dd1b9eef5c60f3eeabea`

## Invariants the PR preserves

- **No runtime install.** PDF generation only works when `typst` is present (built into the runner image). The skill explicitly forbids runtime installs; it says so and explains the limitation when unavailable.
- **No remote Typst packages, no remote image fetches at compile time.** Compilation runs inside a bounded `--root` with `--ignore-system-fonts`.
- **No false delivery claims.** When the runtime has no file-delivery surface the assistant must say so and surface the safe local path; it must not claim it sent a file.
- **Evidence boundaries.** The skill explicitly prohibits inventing sources, quotes, metrics, medical certainty, or user health facts to pad a document.
- **No secrets in artifacts.** The skill bans secrets, credentials, environment values, sensitive local paths, and unrelated private data from generated PDFs.
- **Stable system-prompt cache.** The skill registers through the existing `ASSISTANT_SKILLS` table and prompt builder; no new prompt block or rendering branch.

## Validation performed

- `pnpm --dir packages/assistant-engine exec vitest run test/assistant-pdf-skill.test.ts --config vitest.config.ts --no-coverage` → 2 passed
- `pnpm --dir packages/assistant-engine exec vitest run test/assistant-skill-assets.test.ts --config vitest.config.ts --no-coverage` → 13 passed (covers new pdf SKILL.md + unique slug invariants)
- `pnpm --dir packages/assistant-engine typecheck` → clean

## Validation deferred to CI

- Hosted runner Docker build (`docker buildx build -f Dockerfile.cloudflare-hosted-runner-base ...`). The image build itself performs the compile + `qpdf` + `pdftotext` smoke, so an invalid Typst install fails the build.

## DEPLOYMENT CONCERNS

Only the hosted runner image changes. The new skill file and prompt route ship with the next deploy of `apps/web` and the hosted runner together; both surfaces continue to work without Typst (the skill self-detects unavailability). No tandem-deploy ordering required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784869697&installation_id=127572939&pr_number=272&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F272&signature=c7b594e98633373def8e6862167b6820d497ac58ed20c631110d7aab367bf82e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->