### PR TITLE
fix(computer-use): restore desktop Kernel viewport size

### DIFF
--- a/apps/web/src/lib/computer-use/viewport.ts
+++ b/apps/web/src/lib/computer-use/viewport.ts
@@ -1,6 +1,8 @@
 export const COMPUTER_BROWSER_VIEWPORTS = {
   mobile: { width: 390, height: 844, refresh_rate: 60 },
-  desktop: { width: 1280, height: 800, refresh_rate: 60 },
+  // Match Kernel's standard-image default so desktop handoffs do not shrink
+  // browser sessions when the live view opens.
+  desktop: { width: 1920, height: 1080, refresh_rate: 25 },
 } as const;
 
 export type ComputerBrowserViewportPreset = keyof typeof COMPUTER_BROWSER_VIEWPORTS;

--- a/apps/web/test/hosted-computer-kernel-client.test.ts
+++ b/apps/web/test/hosted-computer-kernel-client.test.ts
@@ -118,9 +118,9 @@ describe("KernelComputerClient", () => {
       {
         viewport: {
           force: true,
-          height: 800,
-          refresh_rate: 60,
-          width: 1280,
+          height: 1080,
+          refresh_rate: 25,
+          width: 1920,
         },
       },
     );


### PR DESCRIPTION
## Summary
- restore desktop handoff browsers from `1280×800@60` to Kernel's standard-image default of `1920×1080@25`
- preserve the new `390×844` mobile handoff behavior from #268
- update the Kernel client regression expectation for the restored desktop viewport

## Root cause
#268 started force-resizing every desktop handoff to `1280×800@60`. Before that change, browser creation intentionally left Kernel's viewport untouched, which uses `1920×1080@25` for the standard image. The new desktop preset cut the rendered browser area by about half, producing the smaller centered live view shown in the report.

## Test plan
- [ ] CI
- [ ] Open a desktop handoff and confirm the live view again occupies the expected desktop area
- [ ] Open a mobile handoff and confirm it remains phone-shaped

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784875533&installation_id=127572939&pr_number=276&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F276&signature=75d3a567e8807c2673445250c6148736178165e26a87c5bebb4ccaa974548347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->