### PR TITLE
Fix Telegram formatting for punctuated spans

### DIFF
--- a/packages/operator-config/src/message-formatting.ts
+++ b/packages/operator-config/src/message-formatting.ts
@@ -175,7 +175,7 @@ function isValidDecorationContent(
     return false
   }
 
-  if (content.length > 160 || /[/?&=\\`<>]/u.test(content)) {
+  if (content.length > 160) {
     return false
   }
 

--- a/packages/operator-config/test/message-formatting.test.ts
+++ b/packages/operator-config/test/message-formatting.test.ts
@@ -53,6 +53,35 @@ test('message formatting renders star italics and underline spans', () => {
   )
 })
 
+test('message formatting accepts punctuation inside explicit decoration spans', () => {
+  assert.deepEqual(
+    renderMarkdownMessageText(
+      'Choose **mobile/home/work**, *yes/no*, ++on/off++, or ~~old/new~~.',
+    ),
+    {
+      decorations: [
+        {
+          range: [7, 23],
+          style: 'bold',
+        },
+        {
+          range: [25, 31],
+          style: 'italic',
+        },
+        {
+          range: [33, 39],
+          style: 'underline',
+        },
+        {
+          range: [44, 51],
+          style: 'strikethrough',
+        },
+      ],
+      text: 'Choose mobile/home/work, yes/no, on/off, or old/new.',
+    },
+  )
+})
+
 test('message formatting leaves star and plus lookalikes untouched', () => {
   const value = 'Keep C++, a++b++, counter++, standalone ++, and * bullet markers intact.'
 


### PR DESCRIPTION
## Summary

- honor punctuation inside explicitly delimited rich-text spans
- preserve the existing boundary, multiline, length, and underscore-ambiguity guards
- add a regression covering bold, italic, underline, and strikethrough slash-delimited phrases

## Root cause

The shared message-formatting parser recognized `**mobile/home/work**` as a valid bold span, then rejected it because its content contained `/`. Telegram therefore received the original markers instead of marker-free text plus a bold entity.

The delimiter boundary checks already distinguish intentional spans from path globs, URLs, identifiers, and lookalike markers. Content punctuation does not need a second blacklist once a span has passed those syntax checks.

## Testing

- focused `packages/operator-config/test/message-formatting.test.ts` regression added
- repository CI will run on this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784876303&installation_id=127572939&pr_number=277&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F277&signature=5d6850a43738d759c634c801f22f74c6843c0f0f9f80053eac276f51cd7c7350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->