### PR TITLE
[codex] Parallelize hosted runtime startup

### DIFF
--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1007,126 +1007,153 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       vaultRoot: restored.vaultRoot,
       workspace: workspaceRead.workspace,
     };
-    emitPhaseLog({
-      input,
-      requestId,
-      stage: "cli.bridge",
-      status: "start",
-    });
-    const hostedCliBridge = await raceHostedRuntimeCancellation(
-      getOrCreateHostedCliRuntimeBridge(),
-      runtimeAbortController.signal,
-    );
-    emitPhaseLog({
-      details: {
-        bridgeStarted: true,
-      },
-      input,
-      requestId,
-      stage: "cli.bridge",
-      status: "done",
-    });
-    const imageCodexModelCatalogJson =
-      process.env[HOSTED_RUNTIME_CODEX_MODEL_CATALOG_JSON_ENV]?.trim();
-    const baseRuntimeEnv = {
-      ...projectHostedRuntimeTrustStoreEnv(process.env),
-      ...guardedRuntime.forwardedEnv,
-      ...guardedRuntime.userEnv,
-      ...hostedCliBridge.env,
-      ...(imageCodexModelCatalogJson
-        ? { [HOSTED_RUNTIME_CODEX_MODEL_CATALOG_JSON_ENV]: imageCodexModelCatalogJson }
-        : {}),
-    };
-    emitPhaseLog({
-      details: {
-        runtimeEnvKeyCount: Object.keys(baseRuntimeEnv).length,
-        voiceMemoElevenLabsApiKeyConfigured:
-          hasHostedRuntimeEnvValue(baseRuntimeEnv, "ELEVENLABS_API_KEY"),
-        voiceMemoElevenLabsModelConfigured:
-          hasHostedRuntimeEnvValue(baseRuntimeEnv, "MURPH_ELEVENLABS_MODEL_ID"),
-        voiceMemoElevenLabsVoiceConfigured:
-          hasHostedRuntimeEnvValue(baseRuntimeEnv, "MURPH_ELEVENLABS_VOICE_ID"),
-      },
-      input,
-      requestId,
-      stage: "codex.prepare",
-      status: "start",
-    });
-    const hostedCodexRuntime = await raceHostedRuntimeCancellation(
-      prepareHostedCodexRuntimeEnvironment({
-        operatorHomeRoot: restored.operatorHomeRoot,
-        runtimeEnv: baseRuntimeEnv,
-      }),
-      runtimeAbortController.signal,
-    );
-    emitPhaseLog({
-      details: {
-        runtimeEnvKeyCount: Object.keys(hostedCodexRuntime.runtimeEnv).length,
-        voiceMemoElevenLabsApiKeyConfigured:
-          hasHostedRuntimeEnvValue(hostedCodexRuntime.runtimeEnv, "ELEVENLABS_API_KEY"),
-        voiceMemoElevenLabsModelConfigured:
-          hasHostedRuntimeEnvValue(hostedCodexRuntime.runtimeEnv, "MURPH_ELEVENLABS_MODEL_ID"),
-        voiceMemoElevenLabsVoiceConfigured:
-          hasHostedRuntimeEnvValue(hostedCodexRuntime.runtimeEnv, "MURPH_ELEVENLABS_VOICE_ID"),
-      },
-      input,
-      requestId,
-      stage: "codex.prepare",
-      status: "done",
-    });
-    assertRuntimeNotAborted();
-    const initialMailboxImportPlan = resolveHostedInitialMailboxImportPlan({
-      vaultRoot: restored.vaultRoot,
-    });
-    const initialMailboxImportContext = createHostedRuntimeWakeInitialImportContext(
-      mergeHostedRuntimeWakeLatencySeeds(
-        invocationOrchestrationLatencySeed,
-        consumePendingHostedRuntimeWake(options.runtimeWakeSignal ?? null),
-      ),
-    );
-    emitPhaseLog({
-      details: {
-        foregroundMailboxLimitPerLane: foregroundMailboxBudget.fetchLimitPerLane,
-        initialMailboxImportLanes: [...initialMailboxImportPlan.lanes],
-        mailboxLimitPerLane: mailboxBudget.fetchLimitPerLane,
-      },
-      input,
-      requestId,
-      stage: "mailbox.import.initial",
-      status: "start",
-    });
-    const initialMailboxImportResult = await raceHostedRuntimeCancellation(
-      importHostedInitialMailboxForWorkspaceRunner({
-        checkpointRequestBuilder,
-        importItemContext: initialMailboxImportContext,
-        runnerInput: baseRunnerInput,
+    const prepareTurnRuntime = async () => {
+      emitPhaseLog({
+        input,
         requestId,
-      }),
-      runtimeAbortController.signal,
-    );
+        stage: "cli.bridge",
+        status: "start",
+      });
+      const hostedCliBridge = await raceHostedRuntimeCancellation(
+        getOrCreateHostedCliRuntimeBridge(),
+        runtimeAbortController.signal,
+      );
+      emitPhaseLog({
+        details: {
+          bridgeStarted: true,
+        },
+        input,
+        requestId,
+        stage: "cli.bridge",
+        status: "done",
+      });
+      const imageCodexModelCatalogJson =
+        process.env[HOSTED_RUNTIME_CODEX_MODEL_CATALOG_JSON_ENV]?.trim();
+      const baseRuntimeEnv = {
+        ...projectHostedRuntimeTrustStoreEnv(process.env),
+        ...guardedRuntime.forwardedEnv,
+        ...guardedRuntime.userEnv,
+        ...hostedCliBridge.env,
+        ...(imageCodexModelCatalogJson
+          ? { [HOSTED_RUNTIME_CODEX_MODEL_CATALOG_JSON_ENV]: imageCodexModelCatalogJson }
+          : {}),
+      };
+      emitPhaseLog({
+        details: {
+          runtimeEnvKeyCount: Object.keys(baseRuntimeEnv).length,
+          voiceMemoElevenLabsApiKeyConfigured:
+            hasHostedRuntimeEnvValue(baseRuntimeEnv, "ELEVENLABS_API_KEY"),
+          voiceMemoElevenLabsModelConfigured:
+            hasHostedRuntimeEnvValue(baseRuntimeEnv, "MURPH_ELEVENLABS_MODEL_ID"),
+          voiceMemoElevenLabsVoiceConfigured:
+            hasHostedRuntimeEnvValue(baseRuntimeEnv, "MURPH_ELEVENLABS_VOICE_ID"),
+        },
+        input,
+        requestId,
+        stage: "codex.prepare",
+        status: "start",
+      });
+      const hostedCodexRuntime = await raceHostedRuntimeCancellation(
+        prepareHostedCodexRuntimeEnvironment({
+          operatorHomeRoot: restored.operatorHomeRoot,
+          runtimeEnv: baseRuntimeEnv,
+        }),
+        runtimeAbortController.signal,
+      );
+      emitPhaseLog({
+        details: {
+          runtimeEnvKeyCount: Object.keys(hostedCodexRuntime.runtimeEnv).length,
+          voiceMemoElevenLabsApiKeyConfigured:
+            hasHostedRuntimeEnvValue(hostedCodexRuntime.runtimeEnv, "ELEVENLABS_API_KEY"),
+          voiceMemoElevenLabsModelConfigured:
+            hasHostedRuntimeEnvValue(hostedCodexRuntime.runtimeEnv, "MURPH_ELEVENLABS_MODEL_ID"),
+          voiceMemoElevenLabsVoiceConfigured:
+            hasHostedRuntimeEnvValue(hostedCodexRuntime.runtimeEnv, "MURPH_ELEVENLABS_VOICE_ID"),
+        },
+        input,
+        requestId,
+        stage: "codex.prepare",
+        status: "done",
+      });
+      assertRuntimeNotAborted();
+      return {
+        hostedCliBridge,
+        hostedCodexRuntime,
+      };
+    };
+    const importInitialMailbox = async () => {
+      const initialMailboxImportPlan = resolveHostedInitialMailboxImportPlan({
+        vaultRoot: restored.vaultRoot,
+      });
+      const initialMailboxImportContext = createHostedRuntimeWakeInitialImportContext(
+        mergeHostedRuntimeWakeLatencySeeds(
+          invocationOrchestrationLatencySeed,
+          consumePendingHostedRuntimeWake(options.runtimeWakeSignal ?? null),
+        ),
+      );
+      emitPhaseLog({
+        details: {
+          foregroundMailboxLimitPerLane: foregroundMailboxBudget.fetchLimitPerLane,
+          initialMailboxImportLanes: [...initialMailboxImportPlan.lanes],
+          mailboxLimitPerLane: mailboxBudget.fetchLimitPerLane,
+        },
+        input,
+        requestId,
+        stage: "mailbox.import.initial",
+        status: "start",
+      });
+      const initialMailboxImportResult = await raceHostedRuntimeCancellation(
+        importHostedInitialMailboxForWorkspaceRunner({
+          checkpointRequestBuilder,
+          importItemContext: initialMailboxImportContext,
+          runnerInput: baseRunnerInput,
+          requestId,
+        }),
+        runtimeAbortController.signal,
+      );
+      const initialMailboxImport = initialMailboxImportResult.result;
+      const mailboxImportDoneAt = new Date().toISOString();
+      emitPhaseLog({
+        details: {
+          bootstrapPending: initialMailboxImportResult.bootstrapPending,
+          checkpointDeferred: initialMailboxImport.checkpointDeferred,
+          checkpointed: initialMailboxImport.checkpoint?.checkpointed ?? false,
+          fetchedCount: initialMailboxImport.importResult.fetchedCount,
+          importedCount: initialMailboxImport.importResult.importedCount,
+          stateChanged: initialMailboxImport.stateChanged,
+        },
+        input,
+        requestId,
+        stage: "mailbox.import.initial",
+        status: "done",
+      });
+      recordHostedRuntimeLatencyMilestoneBestEffort({
+        at: mailboxImportDoneAt,
+        latencyTracePort: guardedRuntime.platform.latencyTracePort ?? null,
+        milestone: "mailbox_import_done",
+        runtimeAttemptId: input.request.attemptId,
+      });
+      assertRuntimeNotAborted();
+      return initialMailboxImportResult;
+    };
+
+    // Assistant admission requires both independent prerequisites. Wait for
+    // both branches to settle so one failure cannot race sibling startup/import work.
+    const [initialMailboxImportSettled, turnRuntimeSettled] =
+      await Promise.allSettled([
+        importInitialMailbox(),
+        prepareTurnRuntime(),
+      ]);
+    // Preserve the former serial path's error precedence.
+    if (turnRuntimeSettled.status === "rejected") {
+      throw turnRuntimeSettled.reason;
+    }
+    if (initialMailboxImportSettled.status === "rejected") {
+      throw initialMailboxImportSettled.reason;
+    }
+    const { hostedCliBridge, hostedCodexRuntime } = turnRuntimeSettled.value;
+    const initialMailboxImportResult = initialMailboxImportSettled.value;
     const initialMailboxImport = initialMailboxImportResult.result;
-    const mailboxImportDoneAt = new Date().toISOString();
-    emitPhaseLog({
-      details: {
-        bootstrapPending: initialMailboxImportResult.bootstrapPending,
-        checkpointDeferred: initialMailboxImport.checkpointDeferred,
-        checkpointed: initialMailboxImport.checkpoint?.checkpointed ?? false,
-        fetchedCount: initialMailboxImport.importResult.fetchedCount,
-        importedCount: initialMailboxImport.importResult.importedCount,
-        stateChanged: initialMailboxImport.stateChanged,
-      },
-      input,
-      requestId,
-      stage: "mailbox.import.initial",
-      status: "done",
-    });
-    recordHostedRuntimeLatencyMilestoneBestEffort({
-      at: mailboxImportDoneAt,
-      latencyTracePort: guardedRuntime.platform.latencyTracePort ?? null,
-      milestone: "mailbox_import_done",
-      runtimeAttemptId: input.request.attemptId,
-    });
-    assertRuntimeNotAborted();
     const returnInitialMailboxImportBeforeForeground = async () => {
       const redactedStatus = buildHostedMailboxImportRedactedStatus(
         initialMailboxImport.importResult,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -385,10 +385,11 @@ describe("hosted workspace runtime entrypoint", () => {
         spy: consoleInfo,
       });
 
-      assert.deepEqual(phaseLogs.map((entry) => [
+      const phaseStatusPairs = phaseLogs.map((entry) => [
         entry.details.runtimePhase,
         entry.details.runtimePhaseStatus,
-      ]), [
+      ]);
+      const expectedPhaseStatusPairs = [
         ["workspace.read", "start"],
         ["workspace.read", "done"],
         ["workspace.restore", "start"],
@@ -404,7 +405,48 @@ describe("hosted workspace runtime entrypoint", () => {
         ["foreground.pass", "start"],
         ["foreground.pass", "done"],
         ["runtime.return", "done"],
-      ]);
+      ];
+      expect(phaseStatusPairs).toEqual(expect.arrayContaining(expectedPhaseStatusPairs));
+      expect(phaseStatusPairs).toHaveLength(expectedPhaseStatusPairs.length);
+
+      const phaseStatusIndex = (phase: string, status: string) => {
+        const index = phaseStatusPairs.findIndex(([entryPhase, entryStatus]) =>
+          entryPhase === phase && entryStatus === status
+        );
+        assert.notEqual(index, -1, `Missing phase log for ${phase}:${status}`);
+        return index;
+      };
+      const workspaceReadStart = phaseStatusIndex("workspace.read", "start");
+      const workspaceReadDone = phaseStatusIndex("workspace.read", "done");
+      const workspaceRestoreStart = phaseStatusIndex("workspace.restore", "start");
+      const workspaceRestoreDone = phaseStatusIndex("workspace.restore", "done");
+      const cliBridgeStart = phaseStatusIndex("cli.bridge", "start");
+      const cliBridgeDone = phaseStatusIndex("cli.bridge", "done");
+      const codexPrepareStart = phaseStatusIndex("codex.prepare", "start");
+      const codexPrepareDone = phaseStatusIndex("codex.prepare", "done");
+      const mailboxImportStart = phaseStatusIndex("mailbox.import.initial", "start");
+      const mailboxImportDone = phaseStatusIndex("mailbox.import.initial", "done");
+      const inboxSidecarStart = phaseStatusIndex("inbox.sidecar", "start");
+      const inboxSidecarDone = phaseStatusIndex("inbox.sidecar", "done");
+      const foregroundPassStart = phaseStatusIndex("foreground.pass", "start");
+      const foregroundPassDone = phaseStatusIndex("foreground.pass", "done");
+      const runtimeReturnDone = phaseStatusIndex("runtime.return", "done");
+
+      expect(workspaceReadStart).toBeLessThan(workspaceReadDone);
+      expect(workspaceReadDone).toBeLessThan(workspaceRestoreStart);
+      expect(workspaceRestoreStart).toBeLessThan(workspaceRestoreDone);
+      expect(workspaceRestoreDone).toBeLessThan(mailboxImportStart);
+      expect(workspaceRestoreDone).toBeLessThan(cliBridgeStart);
+      expect(mailboxImportStart).toBeLessThan(mailboxImportDone);
+      expect(cliBridgeStart).toBeLessThan(cliBridgeDone);
+      expect(cliBridgeDone).toBeLessThan(codexPrepareStart);
+      expect(codexPrepareStart).toBeLessThan(codexPrepareDone);
+      expect(mailboxImportDone).toBeLessThan(inboxSidecarStart);
+      expect(codexPrepareDone).toBeLessThan(inboxSidecarStart);
+      expect(inboxSidecarStart).toBeLessThan(inboxSidecarDone);
+      expect(inboxSidecarDone).toBeLessThan(foregroundPassStart);
+      expect(foregroundPassStart).toBeLessThan(foregroundPassDone);
+      expect(foregroundPassDone).toBeLessThan(runtimeReturnDone);
       expect(phaseLogs.map((entry) => entry.details.runtimePhaseOrdinal)).toEqual(
         Array.from({ length: phaseLogs.length }, (_value, index) => index + 1),
       );


### PR DESCRIPTION
## Why this PR exists

Hosted foreground startup currently serializes initial mailbox import after Codex runtime preparation. This PR overlaps the independent initial mailbox import with hosted CLI bridge/Codex environment preparation to reduce startup latency without adding a new scheduler, service, protocol, or state owner.

## User goal / user-visible behavior

Fresh hosted conversation work can reach assistant admission sooner because mailbox staging and Codex runtime preparation no longer wait on each other after workspace restore and vault migration complete.

## Invariants to preserve

- Workspace restore and hosted vault migration still complete before either branch starts.
- CLI bridge startup still feeds its URL/token into the Codex runtime environment before Codex preparation runs.
- Mailbox import only stages local assistant input and remains replay-safe if runtime preparation fails.
- `runWithInvocation` still binds the hosted CLI bridge only after both branches have joined.
- Runtime-preparation failures keep the old serial path's error precedence over mailbox-import failures.

## Validation

- `pnpm install --frozen-lockfile` to prepare the isolated worktree dependencies.
- `pnpm build:test-runtime:prepared` after the fresh worktree lacked built workspace artifacts for package-local typecheck.
- `pnpm --filter @murphai/assistant-runtime typecheck`
- `pnpm --filter @murphai/assistant-runtime exec vitest run --config vitest.config.ts test/hosted-runtime-workspace-entrypoint.test.ts`
- `pnpm test:diff packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784934654&installation_id=127572939&pr_number=286&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F286&signature=d3b2adeb1b30ae64c64a73c176f4f9eaa1a7a0884f0b97790835a987d6d83734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->