### PR TITLE
Add ops managed automation repair

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-24-ops-managed-automation-repair.md
+++ b/agent-docs/exec-plans/completed/2026-06-24-ops-managed-automation-repair.md
@@ -1,0 +1,51 @@
+Goal (incl. success criteria):
+- Add an ops-controlled repair that wakes a hosted workspace and seeds Murph-managed automations using the member's current hosted delivery route.
+- Keep web as the owner of hosted route lookup and mailbox append, Temporal pointer-only, and assistant-runtime as the owner of executable automation state.
+- Success means an operator can enqueue a route-aware repair from `/ops/runtime-maintenance`, the runtime seeds or idempotently updates managed automations, and tests prove the mailbox contract plus runtime handler.
+
+Constraints/Assumptions:
+- Do not repair by directly mutating hosted workspace snapshots, Temporal state, or automation files from web.
+- Do not add a new scheduler, queue, or fallback owner.
+- Keep mailbox payloads bounded and metadata logs redacted.
+- Preserve unrelated active ledger rows and avoid the hosted ingress repair lane's webhook files.
+
+Key decisions:
+- Represent the repair as a dedicated hosted mailbox system wake carrying the existing assistant notification route shape.
+- Resolve the route in web from existing hosted member routing state, then signal Temporal with only the mailbox pointer.
+- Seed managed automations in assistant-runtime with the route as the default delivery target.
+
+State:
+- Complete.
+
+Done:
+- Production evidence identified route-less maintenance as the failing boundary for stuck workspaces.
+- Existing ops page, hosted execution wake contracts, and managed automation seeding paths were inspected.
+- Added the hosted execution `assistant.managed-automation.seed-requested` mailbox wake contract.
+- Added `/ops/runtime-maintenance` UI/API support for route-aware managed automation repair.
+- Added assistant-runtime system wake handling that seeds managed automations with the web-resolved hosted route.
+- Added focused hosted-execution, assistant-runtime, and hosted-web tests.
+
+Now:
+- Ready for commit.
+
+Next:
+- Deploy consumers before web emits the new mailbox kind.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/app/(dashboard)/ops/runtime-maintenance/*
+- apps/web/app/api/ops/runtime-maintenance/route.ts
+- apps/web/src/lib/hosted-ops/runtime-maintenance.ts
+- apps/web/test/hosted-runtime-maintenance-ops.test.ts
+- packages/hosted-execution/src/{contracts,builders,parsers}.ts
+- packages/hosted-execution/test/*
+- packages/assistant-runtime/src/hosted-runtime/events*
+- packages/assistant-runtime/test/hosted-runtime-events.test.ts
+- `pnpm --dir packages/hosted-execution typecheck`
+- `pnpm --dir packages/assistant-runtime typecheck`
+- `pnpm --dir apps/web typecheck:prepared`
+Status: completed
+Updated: 2026-06-24
+Completed: 2026-06-24

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -310,6 +310,15 @@ can wake one explicit workspace, and caps batch wakes to a tiny window that
 stops on the first signal failure. It is not a scheduler, queue, or generic
 admin job framework.
 
+Managed automation repair uses the same operator surface with a distinct
+`assistant.managed-automation.seed-requested` system-mailbox wake. Web owns the
+route lookup from hosted member routing facts, appends the encrypted mailbox
+item, and signals Temporal by mailbox pointer only. The assistant runtime then
+converts that route into the existing `AutomationRoute` and runs the same
+hosted managed-automation seeding primitive used by idle maintenance. The wake
+must not put route payloads, prompts, transcripts, provider responses, or
+secrets into Temporal workflow state.
+
 For hard-cut rollouts, deploy consumers before producers: Cloudflare and the
 runtime parser must understand the new mailbox kind before web emits it. After
 deploy, set `HOSTED_OPS_MEMBER_IDS`, open `/ops/runtime-maintenance`, wake a

--- a/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-maintenance-client.tsx
+++ b/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-maintenance-client.tsx
@@ -5,12 +5,14 @@ import {
   CheckCircle2Icon,
   PlayIcon,
   RefreshCwIcon,
+  WrenchIcon,
 } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
+import { Input } from "@/src/components/ui/input";
 import {
   Table,
   TableBody,
@@ -20,6 +22,7 @@ import {
   TableRow,
 } from "@/src/components/ui/table";
 import type {
+  HostedRuntimeManagedAutomationRepairResult,
   HostedRuntimeMaintenanceOverview,
   HostedRuntimeMaintenanceWakeResult,
   HostedRuntimeMaintenanceWorkspace,
@@ -31,6 +34,8 @@ interface RuntimeMaintenanceClientProps {
 
 type PendingAction =
   | { kind: "refresh" }
+  | { kind: "seed-batch"; limit: number }
+  | { kind: "seed-user"; userId: string }
   | { kind: "wake-batch"; limit: number }
   | { kind: "wake-user"; userId: string };
 
@@ -39,6 +44,9 @@ export function RuntimeMaintenanceClient({
 }: RuntimeMaintenanceClientProps) {
   const [overview, setOverview] = useState(initialOverview);
   const [currentCursor, setCurrentCursor] = useState<string | null>(null);
+  const [repairResult, setRepairResult] =
+    useState<HostedRuntimeManagedAutomationRepairResult | null>(null);
+  const [repairUserId, setRepairUserId] = useState("");
   const [wakeResult, setWakeResult] = useState<HostedRuntimeMaintenanceWakeResult | null>(null);
   const [pending, setPending] = useState<PendingAction | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -72,6 +80,7 @@ export function RuntimeMaintenanceClient({
         "/api/ops/runtime-maintenance",
         {
           body: JSON.stringify({
+            action: "wake-maintenance",
             cursor: currentCursor,
             limit,
           }),
@@ -99,7 +108,10 @@ export function RuntimeMaintenanceClient({
       setWakeResult(await requestJson<HostedRuntimeMaintenanceWakeResult>(
         "/api/ops/runtime-maintenance",
         {
-          body: JSON.stringify({ userId }),
+          body: JSON.stringify({
+            action: "wake-maintenance",
+            userId,
+          }),
           headers: {
             "Content-Type": "application/json",
           },
@@ -112,6 +124,69 @@ export function RuntimeMaintenanceClient({
       }));
     } catch (wakeError) {
       setError(describeClientError(wakeError));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function seedBatch(limit: number): Promise<void> {
+    setPending({ kind: "seed-batch", limit });
+    setError(null);
+    try {
+      setRepairResult(await requestJson<HostedRuntimeManagedAutomationRepairResult>(
+        "/api/ops/runtime-maintenance",
+        {
+          body: JSON.stringify({
+            action: "seed-managed-automations",
+            cursor: currentCursor,
+            limit,
+          }),
+          headers: {
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        },
+      ));
+      setOverview(await fetchOverview({
+        cursor: currentCursor,
+        limit: overview.limit,
+      }));
+    } catch (seedError) {
+      setError(describeClientError(seedError));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function seedUser(userId: string): Promise<void> {
+    const normalizedUserId = userId.trim();
+    if (!normalizedUserId) {
+      setError("Enter a hosted user id to seed.");
+      return;
+    }
+
+    setPending({ kind: "seed-user", userId: normalizedUserId });
+    setError(null);
+    try {
+      setRepairResult(await requestJson<HostedRuntimeManagedAutomationRepairResult>(
+        "/api/ops/runtime-maintenance",
+        {
+          body: JSON.stringify({
+            action: "seed-managed-automations",
+            userId: normalizedUserId,
+          }),
+          headers: {
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        },
+      ));
+      setOverview(await fetchOverview({
+        cursor: currentCursor,
+        limit: overview.limit,
+      }));
+    } catch (seedError) {
+      setError(describeClientError(seedError));
     } finally {
       setPending(null);
     }
@@ -187,8 +262,54 @@ export function RuntimeMaintenanceClient({
               <PlayIcon data-icon="inline-start" />
               {isBatchWakePending(pending, 3) ? "Waking..." : "Wake 3"}
             </Button>
+            <Button
+              disabled={pending !== null}
+              onClick={() => seedBatch(1)}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <WrenchIcon data-icon="inline-start" />
+              {isBatchSeedPending(pending, 1) ? "Seeding..." : "Seed 1"}
+            </Button>
+            <Button
+              disabled={pending !== null}
+              onClick={() => seedBatch(3)}
+              size="sm"
+              type="button"
+              variant="secondary"
+            >
+              <WrenchIcon data-icon="inline-start" />
+              {isBatchSeedPending(pending, 3) ? "Seeding..." : "Seed 3"}
+            </Button>
           </div>
         </div>
+        <form
+          className="flex max-w-2xl flex-col gap-2 sm:flex-row"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void seedUser(repairUserId);
+          }}
+        >
+          <Input
+            aria-label="Hosted user id"
+            className="font-mono text-xs"
+            disabled={pending !== null}
+            onChange={(event) => setRepairUserId(event.target.value)}
+            placeholder="hbm_..."
+            value={repairUserId}
+          />
+          <Button
+            className="shrink-0"
+            disabled={pending !== null}
+            size="sm"
+            type="submit"
+            variant="outline"
+          >
+            <WrenchIcon data-icon="inline-start" />
+            Seed user
+          </Button>
+        </form>
         <div aria-live="polite" className="min-h-5 text-sm text-muted-foreground">
           {pendingLabel}
         </div>
@@ -202,6 +323,10 @@ export function RuntimeMaintenanceClient({
 
         {wakeResult ? (
           <WakeResultPanel result={wakeResult} />
+        ) : null}
+
+        {repairResult ? (
+          <RepairResultPanel result={repairResult} />
         ) : null}
       </section>
 
@@ -239,10 +364,10 @@ export function RuntimeMaintenanceClient({
         <Table className="text-[13px]">
           <TableHeader>
             <TableRow>
-            <TableHead>User</TableHead>
-            <TableHead>Version</TableHead>
-            <TableHead>Checkpointed</TableHead>
-            <TableHead>Updated</TableHead>
+              <TableHead>User</TableHead>
+              <TableHead>Version</TableHead>
+              <TableHead>Checkpointed</TableHead>
+              <TableHead>Updated</TableHead>
               <TableHead className="text-right">Action</TableHead>
             </TableRow>
           </TableHeader>
@@ -252,8 +377,10 @@ export function RuntimeMaintenanceClient({
                   <WorkspaceRow
                     key={workspace.userId}
                     disabled={pending !== null}
+                    onSeed={() => seedUser(workspace.userId)}
                     onWake={() => wakeUser(workspace.userId)}
-                    pending={isUserWakePending(pending, workspace.userId)}
+                    seedPending={isUserSeedPending(pending, workspace.userId)}
+                    wakePending={isUserWakePending(pending, workspace.userId)}
                     workspace={workspace}
                   />
                 ))
@@ -337,15 +464,93 @@ function WakeResultPanel({
   );
 }
 
+function RepairResultPanel({
+  result,
+}: {
+  result: HostedRuntimeManagedAutomationRepairResult;
+}) {
+  const enqueuedCount = result.results.filter((entry) => entry.status === "enqueued").length;
+  const routeMissingCount =
+    result.results.filter((entry) => entry.status === "route_missing").length;
+  const failedCount = result.results.filter((entry) => entry.status === "failed").length;
+
+  return (
+    <div className="rounded-xl border border-border/70 bg-card/90">
+      <div className="flex flex-col gap-2 border-b border-border/70 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
+            Seed result
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Generated {formatDateTime(result.generatedAt)}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="secondary">{formatInteger(enqueuedCount)} enqueued</Badge>
+          {routeMissingCount > 0 ? (
+            <Badge variant="outline">{formatInteger(routeMissingCount)} no route</Badge>
+          ) : null}
+          {failedCount > 0 ? (
+            <Badge variant="destructive">{formatInteger(failedCount)} failed</Badge>
+          ) : null}
+        </div>
+      </div>
+      <Table className="text-[13px]">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Status</TableHead>
+            <TableHead>User</TableHead>
+            <TableHead>Version</TableHead>
+            <TableHead>Detail</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {result.results.map((entry) => (
+            <TableRow key={entry.userId}>
+              <TableCell>
+                {entry.status === "enqueued" ? (
+                  <Badge variant="secondary">
+                    <CheckCircle2Icon data-icon="inline-start" />
+                    Enqueued
+                  </Badge>
+                ) : entry.status === "route_missing" ? (
+                  <Badge variant="outline">
+                    <AlertCircleIcon data-icon="inline-start" />
+                    No route
+                  </Badge>
+                ) : (
+                  <Badge variant="destructive">
+                    <AlertCircleIcon data-icon="inline-start" />
+                    Failed
+                  </Badge>
+                )}
+              </TableCell>
+              <TableCell className="font-mono text-xs text-foreground">{entry.userId}</TableCell>
+              <TableCell className="font-mono text-xs">{entry.version}</TableCell>
+              <TableCell className="max-w-[32rem] whitespace-normal break-words text-sm text-muted-foreground">
+                {renderRepairResultDetail(entry)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
 function WorkspaceRow({
   disabled,
+  onSeed,
   onWake,
-  pending,
+  seedPending,
+  wakePending,
   workspace,
 }: {
   disabled: boolean;
+  onSeed: () => void;
   onWake: () => void;
-  pending: boolean;
+  seedPending: boolean;
+  wakePending: boolean;
   workspace: HostedRuntimeMaintenanceWorkspace;
 }) {
   return (
@@ -357,16 +562,28 @@ function WorkspaceRow({
       </TableCell>
       <TableCell className="font-mono text-xs">{formatDateTime(workspace.updatedAt)}</TableCell>
       <TableCell className="text-right">
-        <Button
-          disabled={disabled}
-          onClick={onWake}
-          size="sm"
-          type="button"
-          variant="outline"
-        >
-          <PlayIcon data-icon="inline-start" />
-          {pending ? "Waking..." : "Wake"}
-        </Button>
+        <div className="flex justify-end gap-2">
+          <Button
+            disabled={disabled}
+            onClick={onSeed}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <WrenchIcon data-icon="inline-start" />
+            {seedPending ? "Seeding..." : "Seed"}
+          </Button>
+          <Button
+            disabled={disabled}
+            onClick={onWake}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <PlayIcon data-icon="inline-start" />
+            {wakePending ? "Waking..." : "Wake"}
+          </Button>
+        </div>
       </TableCell>
     </TableRow>
   );
@@ -445,15 +662,41 @@ function describePendingAction(pending: PendingAction | null): string {
   if (pending.kind === "wake-batch") {
     return `Waking ${formatInteger(pending.limit)} workspace${pending.limit === 1 ? "" : "s"}.`;
   }
-  return `Waking ${pending.userId}.`;
+  if (pending.kind === "wake-user") {
+    return `Waking ${pending.userId}.`;
+  }
+  if (pending.kind === "seed-batch") {
+    return `Seeding ${formatInteger(pending.limit)} workspace${pending.limit === 1 ? "" : "s"}.`;
+  }
+  return `Seeding ${pending.userId}.`;
+}
+
+function isBatchSeedPending(pending: PendingAction | null, limit: number): boolean {
+  return pending?.kind === "seed-batch" && pending.limit === limit;
 }
 
 function isBatchWakePending(pending: PendingAction | null, limit: number): boolean {
   return pending?.kind === "wake-batch" && pending.limit === limit;
 }
 
+function isUserSeedPending(pending: PendingAction | null, userId: string): boolean {
+  return pending?.kind === "seed-user" && pending.userId === userId;
+}
+
 function isUserWakePending(pending: PendingAction | null, userId: string): boolean {
   return pending?.kind === "wake-user" && pending.userId === userId;
+}
+
+function renderRepairResultDetail(
+  entry: HostedRuntimeManagedAutomationRepairResult["results"][number],
+): string {
+  if (entry.status === "enqueued") {
+    return `${entry.workflowId} / ${entry.inserted ? "inserted" : "deduped"} / ${entry.mailboxItemId}`;
+  }
+  if (entry.status === "route_missing") {
+    return "No hosted delivery route could be resolved.";
+  }
+  return entry.errorMessage;
 }
 
 function formatInteger(value: number): string {

--- a/apps/web/app/api/ops/runtime-maintenance/route.ts
+++ b/apps/web/app/api/ops/runtime-maintenance/route.ts
@@ -1,8 +1,10 @@
 import {
   readHostedRuntimeMaintenanceOverview,
+  repairHostedRuntimeManagedAutomationsBatch,
   signalHostedRuntimeMaintenanceBatch,
 } from "@/src/lib/hosted-ops/runtime-maintenance";
 import { requireHostedOpsRequestAccess } from "@/src/lib/hosted-ops/access";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import {
   jsonOk,
   readHostedOnboardingJsonObject,
@@ -35,11 +37,25 @@ export const POST = withJsonError(async (request: Request) => {
     tooLargeErrorMessage: "Hosted runtime maintenance request body is too large.",
   });
 
-  return jsonOk(await signalHostedRuntimeMaintenanceBatch({
+  const action = readOptionalStringField(body, "action") ?? "wake-maintenance";
+  const maintenanceRequest = {
     cursor: readOptionalStringField(body, "cursor"),
     limit: readOptionalLimitField(body),
     userId: readOptionalStringField(body, "userId"),
-  }));
+  };
+
+  switch (action) {
+    case "wake-maintenance":
+      return jsonOk(await signalHostedRuntimeMaintenanceBatch(maintenanceRequest));
+    case "seed-managed-automations":
+      return jsonOk(await repairHostedRuntimeManagedAutomationsBatch(maintenanceRequest));
+    default:
+      throw hostedOnboardingError({
+        code: "HOSTED_RUNTIME_MAINTENANCE_ACTION_UNSUPPORTED",
+        httpStatus: 400,
+        message: "Unsupported hosted runtime maintenance action.",
+      });
+  }
 });
 
 function readOptionalStringField(

--- a/apps/web/src/lib/hosted-ops/runtime-maintenance.ts
+++ b/apps/web/src/lib/hosted-ops/runtime-maintenance.ts
@@ -1,12 +1,30 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
+
 import { HostedBillingStatus, Prisma, type PrismaClient } from "@prisma/client";
+import {
+  buildHostedExecutionManagedAutomationSeedRequestedWake,
+  type HostedExecutionAssistantNotificationRoute,
+} from "@murphai/hosted-execution";
 
 import {
+  signalHostedMailboxAppendRuntime,
   signalHostedRuntimeMaintenanceRuntime,
   type HostedRuntimeSignalResult,
 } from "../hosted-orchestration/signal-runtime";
+import {
+  appendHostedMailboxEnvelopeTx,
+  type AppendHostedMailboxItemResult,
+} from "../hosted-mailbox/store";
 import { hostedOnboardingError } from "../hosted-onboarding/errors";
+import {
+  readHostedMemberSnapshot,
+} from "../hosted-onboarding/hosted-member-store";
+import {
+  resolveHostedMemberAssistantNotificationRoute,
+  resolveHostedMemberMessagingState,
+} from "../hosted-onboarding/messaging-state";
 import { getPrisma } from "../prisma";
 
 export const HOSTED_RUNTIME_MAINTENANCE_DEFAULT_READ_LIMIT = 20;
@@ -37,6 +55,13 @@ export interface HostedRuntimeMaintenanceWakeResult {
   results: HostedRuntimeMaintenanceWakeUserResult[];
 }
 
+export interface HostedRuntimeManagedAutomationRepairResult {
+  generatedAt: string;
+  limit: number;
+  nextCursor: string | null;
+  results: HostedRuntimeManagedAutomationRepairUserResult[];
+}
+
 export type HostedRuntimeMaintenanceWakeUserResult =
   | {
       checkpointedAt: string | null;
@@ -56,8 +81,50 @@ export type HostedRuntimeMaintenanceWakeUserResult =
       version: string;
     };
 
+export type HostedRuntimeManagedAutomationRepairUserResult =
+  | {
+      checkpointedAt: string | null;
+      inserted: boolean;
+      mailboxItemId: string;
+      status: "enqueued";
+      updatedAt: string;
+      userId: string;
+      version: string;
+      workflowId: string;
+    }
+  | {
+      checkpointedAt: string | null;
+      status: "route_missing";
+      updatedAt: string;
+      userId: string;
+      version: string;
+    }
+  | {
+      checkpointedAt: string | null;
+      errorMessage: string;
+      errorName: string;
+      status: "failed";
+      updatedAt: string;
+      userId: string;
+      version: string;
+    };
+
 type HostedRuntimeMaintenanceSignal =
   (input: Parameters<typeof signalHostedRuntimeMaintenanceRuntime>[0]) => Promise<HostedRuntimeSignalResult>;
+
+type HostedManagedAutomationSeedAppender = (input: {
+  prisma: PrismaClient;
+  route: HostedExecutionAssistantNotificationRoute;
+  userId: string;
+}) => Promise<AppendHostedMailboxItemResult>;
+
+type HostedRuntimeMailboxAppendSignal =
+  (input: Parameters<typeof signalHostedMailboxAppendRuntime>[0]) => Promise<HostedRuntimeSignalResult>;
+
+type HostedManagedAutomationRepairRouteReader = (input: {
+  prisma: PrismaClient;
+  userId: string;
+}) => Promise<HostedExecutionAssistantNotificationRoute | null>;
 
 export async function readHostedRuntimeMaintenanceOverview(input: {
   cursor?: string | null;
@@ -174,6 +241,159 @@ export async function signalHostedRuntimeMaintenanceBatch(input: {
   };
 }
 
+export async function repairHostedRuntimeManagedAutomationsBatch(input: {
+  appendSeedWake?: HostedManagedAutomationSeedAppender;
+  cursor?: string | null;
+  limit?: number | string | null;
+  prisma?: PrismaClient;
+  readRepairRoute?: HostedManagedAutomationRepairRouteReader;
+  signalMailboxAppendRuntime?: HostedRuntimeMailboxAppendSignal;
+  userId?: string | null;
+} = {}): Promise<HostedRuntimeManagedAutomationRepairResult> {
+  const prisma = input.prisma ?? getPrisma();
+  const appendSeedWake = input.appendSeedWake ?? appendHostedManagedAutomationSeedWake;
+  const readRepairRoute = input.readRepairRoute ?? readHostedManagedAutomationRepairRoute;
+  const signalMailboxAppendRuntime =
+    input.signalMailboxAppendRuntime ?? signalHostedMailboxAppendRuntime;
+  const explicitUserId = normalizeOptionalIdentifier(input.userId);
+  const limit = explicitUserId
+    ? 1
+    : normalizePositiveInteger(
+        input.limit,
+        HOSTED_RUNTIME_MAINTENANCE_DEFAULT_WAKE_LIMIT,
+        HOSTED_RUNTIME_MAINTENANCE_MAX_WAKE_LIMIT,
+      );
+  const overview = explicitUserId
+    ? null
+    : await readHostedRuntimeMaintenanceOverview({
+        cursor: input.cursor,
+        limit,
+        prisma,
+      });
+  const candidates = explicitUserId
+    ? [await readHostedRuntimeMaintenanceCandidateForUser({
+        prisma,
+        userId: explicitUserId,
+      })]
+    : overview?.candidates ?? [];
+  const results: HostedRuntimeManagedAutomationRepairUserResult[] = [];
+
+  for (const candidate of candidates) {
+    try {
+      const route = await readRepairRoute({
+        prisma,
+        userId: candidate.userId,
+      });
+      if (!route) {
+        results.push({
+          checkpointedAt: candidate.checkpointedAt,
+          status: "route_missing",
+          updatedAt: candidate.updatedAt,
+          userId: candidate.userId,
+          version: candidate.version,
+        });
+        continue;
+      }
+
+      const append = await appendSeedWake({
+        prisma,
+        route,
+        userId: candidate.userId,
+      });
+      const signal = await signalMailboxAppendRuntime({
+        expectedUserId: candidate.userId,
+        mailboxItemId: append.item.id,
+        prisma,
+      });
+      results.push({
+        checkpointedAt: candidate.checkpointedAt,
+        inserted: append.inserted,
+        mailboxItemId: append.item.id,
+        status: "enqueued",
+        updatedAt: candidate.updatedAt,
+        userId: candidate.userId,
+        version: candidate.version,
+        workflowId: signal.workflowId,
+      });
+    } catch (error) {
+      results.push({
+        checkpointedAt: candidate.checkpointedAt,
+        errorMessage: describeManagedAutomationRepairError(error),
+        errorName: error instanceof Error ? error.name : typeof error,
+        status: "failed",
+        updatedAt: candidate.updatedAt,
+        userId: candidate.userId,
+        version: candidate.version,
+      });
+      break;
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    limit,
+    nextCursor: overview?.nextCursor ?? null,
+    results,
+  };
+}
+
+export async function appendHostedManagedAutomationSeedWake(input: {
+  now?: Date;
+  prisma: PrismaClient;
+  route: HostedExecutionAssistantNotificationRoute;
+  userId: string;
+}): Promise<AppendHostedMailboxItemResult> {
+  const wake = buildHostedManagedAutomationSeedWake({
+    now: input.now ?? new Date(),
+    route: input.route,
+    userId: input.userId,
+  });
+
+  return await input.prisma.$transaction((tx) =>
+    appendHostedMailboxEnvelopeTx({
+      envelope: wake,
+      tx,
+    }));
+}
+
+export async function readHostedManagedAutomationRepairRoute(input: {
+  prisma: PrismaClient;
+  userId: string;
+}): Promise<HostedExecutionAssistantNotificationRoute | null> {
+  const member = await readHostedMemberSnapshot({
+    memberId: input.userId,
+    prisma: input.prisma,
+  });
+  if (
+    !member
+    || member.core.billingStatus !== HostedBillingStatus.active
+    || member.core.suspendedAt
+  ) {
+    return null;
+  }
+
+  const routing = member.routing;
+  const messaging = resolveHostedMemberMessagingState({
+    identity: member.identity,
+    routing,
+  });
+  const linqContactLookupKey =
+    member.identity?.phoneLookupKey
+    ?? routing?.pendingLinqParticipantContact?.lookupKey
+    ?? member.emailAuthorization?.verifiedEmail?.lookupKey
+    ?? null;
+
+  return resolveHostedMemberAssistantNotificationRoute({
+    linqChatId: routing?.linqChatId ?? routing?.pendingLinqChatId ?? null,
+    linqContactLookupKey,
+    linqRecipientPhone:
+      routing?.linqRecipientPhone ?? routing?.pendingLinqRecipientPhone ?? null,
+    memberId: input.userId,
+    memberPhoneNumber: member.identity?.phoneNumber ?? null,
+    messaging,
+  });
+}
+
 async function readHostedRuntimeMaintenanceCandidateForUser(input: {
   prisma: PrismaClient;
   userId: string;
@@ -235,6 +455,26 @@ function projectHostedRuntimeMaintenanceWorkspace(row: {
   };
 }
 
+function buildHostedManagedAutomationSeedWake(input: {
+  now: Date;
+  route: HostedExecutionAssistantNotificationRoute;
+  userId: string;
+}) {
+  const bucketMs = Math.floor(input.now.getTime() / 60_000) * 60_000;
+  const routeFingerprint = createHash("sha256")
+    .update(JSON.stringify(input.route))
+    .digest("hex")
+    .slice(0, 16);
+
+  return buildHostedExecutionManagedAutomationSeedRequestedWake({
+    eventId:
+      `assistant.managed-automation.seed-requested:${input.userId}:${routeFingerprint}:${bucketMs}`,
+    memberId: input.userId,
+    occurredAt: new Date(bucketMs).toISOString(),
+    route: input.route,
+  });
+}
+
 function normalizePositiveInteger(
   value: number | string | null | undefined,
   fallback: number,
@@ -265,4 +505,10 @@ function describeMaintenanceSignalError(error: unknown): string {
   return error instanceof Error
     ? "Maintenance signal failed. Check server logs for details."
     : "Maintenance signal failed.";
+}
+
+function describeManagedAutomationRepairError(error: unknown): string {
+  return error instanceof Error
+    ? "Managed automation repair failed. Check server logs for details."
+    : "Managed automation repair failed.";
 }

--- a/apps/web/test/hosted-runtime-maintenance-ops.test.ts
+++ b/apps/web/test/hosted-runtime-maintenance-ops.test.ts
@@ -1,18 +1,24 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostedBillingStatus, Prisma } from "@prisma/client";
+import type {
+  HostedExecutionAssistantNotificationRoute,
+} from "@murphai/hosted-execution";
 
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
   assertHostedOnboardingMutationOrigin: vi.fn(),
   getPrisma: vi.fn(),
+  appendHostedMailboxEnvelopeTx: vi.fn(),
   hostedWorkspace: {
     count: vi.fn(),
     findFirst: vi.fn(),
     findMany: vi.fn(),
   },
+  readHostedMemberSnapshot: vi.fn(),
   requireActiveHostedAppSession: vi.fn(),
   requireActiveHostedAppSessionFromRequest: vi.fn(),
+  signalHostedMailboxAppendRuntime: vi.fn(),
   signalHostedRuntimeMaintenanceRuntime: vi.fn(),
 }));
 
@@ -30,8 +36,18 @@ vi.mock("@/src/lib/prisma", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
+  signalHostedMailboxAppendRuntime:
+    mocks.signalHostedMailboxAppendRuntime,
   signalHostedRuntimeMaintenanceRuntime:
     mocks.signalHostedRuntimeMaintenanceRuntime,
+}));
+
+vi.mock("@/src/lib/hosted-mailbox/store", () => ({
+  appendHostedMailboxEnvelopeTx: mocks.appendHostedMailboxEnvelopeTx,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
+  readHostedMemberSnapshot: mocks.readHostedMemberSnapshot,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -56,6 +72,7 @@ let opsAccess: OpsAccessModule;
 const originalHostedOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
 const prisma = {
   hostedWorkspace: mocks.hostedWorkspace,
+  $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback({})),
 };
 
 describe("hosted runtime maintenance ops", () => {
@@ -80,9 +97,22 @@ describe("hosted runtime maintenance ops", () => {
       signalAccepted: true,
       workflowId: "hosted-user-runtime:member_001",
     });
+    mocks.signalHostedMailboxAppendRuntime.mockResolvedValue({
+      signalAccepted: true,
+      workflowId: "hosted-user-runtime:member_001",
+    });
+    mocks.appendHostedMailboxEnvelopeTx.mockResolvedValue({
+      dedupeConflict: false,
+      duplicate: false,
+      inserted: true,
+      item: {
+        id: "mailbox_seed_item",
+      },
+    });
     mocks.hostedWorkspace.count.mockResolvedValue(0);
     mocks.hostedWorkspace.findMany.mockResolvedValue([]);
     mocks.hostedWorkspace.findFirst.mockResolvedValue(null);
+    mocks.readHostedMemberSnapshot.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -218,6 +248,64 @@ describe("hosted runtime maintenance ops", () => {
     });
   });
 
+  it("enqueues managed automation seed wakes with resolved routes", async () => {
+    const route = linqThreadRoute();
+    mocks.hostedWorkspace.count.mockResolvedValue(3);
+    mocks.hostedWorkspace.findMany.mockResolvedValue([
+      workspaceRow("member_001", "10"),
+      workspaceRow("member_002", "11"),
+      workspaceRow("member_003", "12"),
+    ]);
+    const readRepairRoute = vi.fn(async (input: { userId: string }) =>
+      input.userId === "member_002" ? null : route);
+    const appendSeedWake = vi.fn(async (input: { userId: string }) =>
+      mailboxAppendResult(`mailbox_seed_${input.userId}`, input.userId));
+    const signalMailboxAppendRuntime = vi.fn(async (input: { expectedUserId?: string | null }) => ({
+      signalAccepted: true as const,
+      workflowId: `hosted-user-runtime:${input.expectedUserId ?? "unknown"}`,
+    }));
+
+    const result = await runtimeMaintenanceService.repairHostedRuntimeManagedAutomationsBatch({
+      appendSeedWake,
+      limit: 3,
+      readRepairRoute,
+      signalMailboxAppendRuntime,
+    });
+
+    expect(result).toMatchObject({
+      limit: 3,
+      nextCursor: null,
+      results: [
+        {
+          inserted: true,
+          mailboxItemId: "mailbox_seed_member_001",
+          status: "enqueued",
+          userId: "member_001",
+          workflowId: "hosted-user-runtime:member_001",
+        },
+        {
+          status: "route_missing",
+          userId: "member_002",
+        },
+        {
+          inserted: true,
+          mailboxItemId: "mailbox_seed_member_003",
+          status: "enqueued",
+          userId: "member_003",
+          workflowId: "hosted-user-runtime:member_003",
+        },
+      ],
+    });
+    expect(readRepairRoute).toHaveBeenCalledTimes(3);
+    expect(appendSeedWake).toHaveBeenCalledTimes(2);
+    expect(signalMailboxAppendRuntime).toHaveBeenCalledTimes(2);
+    expect(signalMailboxAppendRuntime).toHaveBeenCalledWith({
+      expectedUserId: "member_001",
+      mailboxItemId: "mailbox_seed_member_001",
+      prisma,
+    });
+  });
+
   it("requires an active checkpointed workspace for explicit user wakes", async () => {
     mocks.hostedWorkspace.findFirst.mockResolvedValue(null);
 
@@ -272,6 +360,91 @@ describe("hosted runtime maintenance ops", () => {
           workflowId: "hosted-user-runtime:member_002",
         },
       ],
+    });
+  });
+
+  it("seeds managed automations for an explicit workspace through the ops route", async () => {
+    mocks.hostedWorkspace.findFirst.mockResolvedValue(workspaceRow("member_002", "11"));
+    mocks.readHostedMemberSnapshot.mockResolvedValue(hostedMemberSnapshot("member_002"));
+    mocks.appendHostedMailboxEnvelopeTx.mockResolvedValue(
+      mailboxAppendResult("mailbox_seed_member_002", "member_002"),
+    );
+    mocks.signalHostedMailboxAppendRuntime.mockResolvedValueOnce({
+      signalAccepted: true,
+      workflowId: "hosted-user-runtime:member_002",
+    });
+
+    const request = new Request("https://join.example.test/api/ops/runtime-maintenance", {
+      body: JSON.stringify({
+        action: "seed-managed-automations",
+        userId: "member_002",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        origin: "https://join.example.test",
+      },
+      method: "POST",
+    });
+    const response = await runtimeMaintenanceRoute.POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.readHostedMemberSnapshot).toHaveBeenCalledWith({
+      memberId: "member_002",
+      prisma,
+    });
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith(expect.objectContaining({
+      envelope: expect.objectContaining({
+        kind: "assistant.managed-automation.seed-requested",
+        route: expect.objectContaining({
+          channel: "linq",
+          delivery: {
+            kind: "thread",
+            target: "linq_chat_member_002",
+          },
+        }),
+        userId: "member_002",
+      }),
+    }));
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      expectedUserId: "member_002",
+      mailboxItemId: "mailbox_seed_member_002",
+      prisma,
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      limit: 1,
+      results: [
+        {
+          mailboxItemId: "mailbox_seed_member_002",
+          status: "enqueued",
+          userId: "member_002",
+          workflowId: "hosted-user-runtime:member_002",
+        },
+      ],
+    });
+  });
+
+  it("rejects unsupported runtime maintenance actions", async () => {
+    const response = await runtimeMaintenanceRoute.POST(
+      new Request("https://join.example.test/api/ops/runtime-maintenance", {
+        body: JSON.stringify({
+          action: "not-a-real-action",
+          userId: "member_002",
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.signalHostedRuntimeMaintenanceRuntime).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_RUNTIME_MAINTENANCE_ACTION_UNSUPPORTED",
+      },
     });
   });
 
@@ -418,5 +591,69 @@ function workspaceRow(userId: string, version: string) {
     updatedAt: new Date("2026-06-01T12:05:00.000Z"),
     userId,
     version: BigInt(version),
+  };
+}
+
+function linqThreadRoute(): HostedExecutionAssistantNotificationRoute {
+  return {
+    actorId: "actor_member",
+    channel: "linq",
+    delivery: {
+      kind: "thread",
+      target: "linq_chat_member",
+    },
+    identityId: "identity_member",
+    threadId: "thread_member",
+    threadIsDirect: true,
+  };
+}
+
+function mailboxAppendResult(id: string, userId: string) {
+  return {
+    dedupeConflict: false,
+    duplicate: false,
+    inserted: true,
+    item: {
+      createdAt: "2026-06-01T12:00:00.000Z",
+      dedupeKey: `dedupe_${id}`,
+      expiresAt: null,
+      id,
+      kind: "assistant.managed-automation.seed-requested" as const,
+      lane: "system" as const,
+      laneSeq: "1",
+      occurredAt: "2026-06-01T12:00:00.000Z",
+      payloadBytes: 256,
+      payloadInlineCiphertext: "ciphertext",
+      payloadRef: null,
+      payloadSchema: "murph.hosted-mailbox-item.v1",
+      updatedAt: "2026-06-01T12:00:00.000Z",
+      userId,
+    },
+  };
+}
+
+function hostedMemberSnapshot(memberId: string) {
+  return {
+    billingRef: null,
+    core: {
+      billingStatus: HostedBillingStatus.active,
+      id: memberId,
+      suspendedAt: null,
+    },
+    emailAuthorization: null,
+    identity: {
+      phoneLookupKey: `phone_lookup_${memberId}`,
+      phoneNumber: "+15550002222",
+    },
+    routing: {
+      linqChatId: `linq_chat_${memberId}`,
+      linqRecipientPhone: null,
+      memberId,
+      pendingLinqChatId: null,
+      pendingLinqParticipantContact: null,
+      pendingLinqRecipientPhone: null,
+      telegramThreadId: null,
+      telegramUserId: null,
+    },
   };
 }

--- a/packages/assistant-runtime/src/hosted-runtime/events.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events.ts
@@ -24,6 +24,9 @@ import {
   type HostedMailboxOutcome,
 } from "./events/mailbox-outcome.ts";
 import { executeHostedCodexAuthWake } from "./events/codex-auth.ts";
+import {
+  executeHostedManagedAutomationSeedWake,
+} from "./events/managed-automation-seed.ts";
 import { runHostedDeviceSyncWakeLane } from "./maintenance.ts";
 import type {
   HostedMailboxExecutionMetrics,
@@ -179,6 +182,17 @@ async function executeHostedSystemWake(input: {
           vaultRoot: input.vaultRoot,
         }),
         vaultRoot: input.vaultRoot,
+      });
+    case "assistant.managed-automation.seed-requested":
+      return await executeHostedManagedAutomationSeedWake({
+        operatorHomeRoot: input.operatorHomeRoot,
+        runtime: input.runtime,
+        runtimeEnv: input.runtimeEnv,
+        ...(input.shouldYieldDeviceSync
+          ? { shouldYieldBackgroundMaintenance: input.shouldYieldDeviceSync }
+          : {}),
+        vaultRoot: input.vaultRoot,
+        wake: input.wake,
       });
     case "device-sync.wake":
       const deviceSyncMetrics = await runHostedDeviceSyncWakeLane({

--- a/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 
-import type { AutomationRoute } from "@murphai/contracts";
 import {
   buildHostedAssistantContextFingerprintDetails,
   MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
@@ -32,6 +31,7 @@ import {
   createNoopMailboxEffect,
   type HostedMailboxOutcome,
 } from "./mailbox-outcome.ts";
+import { buildHostedAssistantAutomationRoute } from "./automation-route.ts";
 import { emitHostedAssistantProviderTraceLog } from "./provider-trace-log.ts";
 
 type AssistantNotificationInput = Parameters<typeof sendAssistantNotification>[0];
@@ -210,7 +210,7 @@ async function maybeSeedOnboardingFollowupAutomation(input: {
     const job = await upsertAssistantCronAutomation({
       firstOccurrencePolicy: "after-current-local-day",
       instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
-      route: buildOnboardingFollowupAutomationRoute(input.route),
+      route: buildHostedAssistantAutomationRoute(input.route),
       schedule: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.schedule,
       slug: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug,
       summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
@@ -236,32 +236,6 @@ function didAssistantNotificationAcceptDelivery(
 ): boolean {
   const outcomeKind = result?.deliveryOutcome?.kind;
   return outcomeKind === "sent" || outcomeKind === "queued";
-}
-
-function buildOnboardingFollowupAutomationRoute(
-  route: HostedExecutionAssistantNotificationRoute,
-): AutomationRoute {
-  const delivery = route.delivery;
-  if (route.channel === "linq") {
-    return {
-      channel: route.channel,
-      deliverySource: delivery.source ?? null,
-      deliveryTarget: delivery.kind === "participant" ? null : delivery.target,
-      identityId: route.identityId,
-      participantId: delivery.kind === "participant" ? delivery.target : null,
-      threadId: null,
-    };
-  }
-
-  return {
-    channel: route.channel,
-    deliverySource: delivery.source ?? null,
-    deliveryTarget: delivery.kind === "explicit" ? delivery.target : null,
-    identityId: route.identityId,
-    participantId: delivery.kind === "participant" ? delivery.target : null,
-    threadId:
-      route.threadId ?? (delivery.kind === "thread" ? delivery.target : null),
-  };
 }
 
 function emitHostedOnboardingFollowupSeedFailureLog(input: {

--- a/packages/assistant-runtime/src/hosted-runtime/events/automation-route.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/automation-route.ts
@@ -1,0 +1,32 @@
+import type {
+  AutomationRoute,
+} from "@murphai/contracts";
+import type {
+  HostedExecutionAssistantNotificationRoute,
+} from "@murphai/hosted-execution";
+
+export function buildHostedAssistantAutomationRoute(
+  route: HostedExecutionAssistantNotificationRoute,
+): AutomationRoute {
+  const delivery = route.delivery;
+  if (route.channel === "linq") {
+    return {
+      channel: route.channel,
+      deliverySource: delivery.source ?? null,
+      deliveryTarget: delivery.kind === "participant" ? null : delivery.target,
+      identityId: route.identityId,
+      participantId: delivery.kind === "participant" ? delivery.target : null,
+      threadId: null,
+    };
+  }
+
+  return {
+    channel: route.channel,
+    deliverySource: delivery.source ?? null,
+    deliveryTarget: delivery.kind === "explicit" ? delivery.target : null,
+    identityId: route.identityId,
+    participantId: delivery.kind === "participant" ? delivery.target : null,
+    threadId:
+      route.threadId ?? (delivery.kind === "thread" ? delivery.target : null),
+  };
+}

--- a/packages/assistant-runtime/src/hosted-runtime/events/managed-automation-seed.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/managed-automation-seed.ts
@@ -1,0 +1,53 @@
+import type {
+  HostedExecutionManagedAutomationSeedRequestedWake,
+} from "@murphai/hosted-execution";
+
+import {
+  seedHostedManagedAutomationsBestEffort,
+  resolveHostedManagedAutomationSeedNextWakeAt,
+} from "../managed-automation-seeding.ts";
+import type {
+  NormalizedHostedAssistantRuntimeConfig,
+} from "../models.ts";
+import { HOSTED_ASSISTANT_WAKE_REASON } from "../wake-candidates.ts";
+import { buildHostedAssistantAutomationRoute } from "./automation-route.ts";
+import {
+  createNoopMailboxEffect,
+  type HostedMailboxOutcome,
+} from "./mailbox-outcome.ts";
+
+export async function executeHostedManagedAutomationSeedWake(input: {
+  operatorHomeRoot: string | null;
+  runtime: Pick<NormalizedHostedAssistantRuntimeConfig, "platform">;
+  runtimeEnv: Readonly<Record<string, string>>;
+  shouldYieldBackgroundMaintenance?: (() => boolean) | null;
+  vaultRoot: string;
+  wake: HostedExecutionManagedAutomationSeedRequestedWake;
+}): Promise<HostedMailboxOutcome> {
+  const nowMs = Date.now();
+  const seedResult = await seedHostedManagedAutomationsBestEffort({
+    defaultRoute: buildHostedAssistantAutomationRoute(input.wake.route),
+    nowMs,
+    operatorHomeRoot: input.operatorHomeRoot,
+    runtimeEnv: input.runtimeEnv,
+    runtimeLog: {
+      context: null,
+      platform: input.runtime.platform,
+    },
+    shouldYieldBackgroundMaintenance: input.shouldYieldBackgroundMaintenance ?? null,
+    vaultRoot: input.vaultRoot,
+  });
+  const nextWakeAt = seedResult
+    ? await resolveHostedManagedAutomationSeedNextWakeAt({
+        nowMs,
+        vaultRoot: input.vaultRoot,
+      })
+    : null;
+
+  return createNoopMailboxEffect({
+    conversationMetrics: null,
+    mailboxLane: "managed-automation-seed",
+    nextWakeAt,
+    nextWakeReason: nextWakeAt ? HOSTED_ASSISTANT_WAKE_REASON : null,
+  });
+}

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-routing.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-routing.ts
@@ -14,6 +14,7 @@ export const HOSTED_MAILBOX_IMPORT_ACTIONS = [
   "apply-member-activation",
   "apply-member-channels-update",
   "dispatch-assistant-notification",
+  "seed-managed-automations",
   "run-device-sync-wake",
   "apply-runtime-control-request",
   "import-vault-share-delivery",
@@ -57,6 +58,7 @@ const SUPPORTED_MAILBOX_KINDS: readonly string[] = HOSTED_MAILBOX_KINDS;
 const SUPPORTED_MAILBOX_LANES: readonly string[] = HOSTED_MAILBOX_LANES;
 
 const ACTION_BY_KIND = {
+  "assistant.managed-automation.seed-requested": "seed-managed-automations",
   "assistant.notification.requested": "dispatch-assistant-notification",
   "conversation.message": "import-conversation-message",
   "device-sync.wake": "run-device-sync-wake",

--- a/packages/assistant-runtime/src/hosted-runtime/managed-automation-seeding.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/managed-automation-seeding.ts
@@ -1,0 +1,181 @@
+import {
+  applyMurphManagedAutomations,
+  getAssistantCronStatus,
+} from "@murphai/assistant-engine";
+import type {
+  AutomationRoute,
+} from "@murphai/contracts";
+import {
+  buildHostedExecutionSafeErrorDiagnostics,
+  deriveHostedExecutionErrorCode,
+  sanitizeHostedExecutionStructuredLogText,
+} from "@murphai/hosted-execution";
+import type {
+  HostedRuntimeLogEntry,
+  HostedRuntimeRedactedJson,
+} from "@murphai/hosted-execution/runtime-control";
+
+import type {
+  HostedRuntimePlatform,
+} from "./platform.ts";
+import {
+  buildHostedRuntimeLogContextFields,
+  toHostedRuntimeLogCode,
+  type HostedRuntimeLogContext,
+  writeHostedRuntimeLogBestEffort,
+} from "./runtime-logs.ts";
+import { normalizeHostedFutureWakeAt } from "./wake-time.ts";
+
+const HOSTED_ASSISTANT_CRON_STATUS_RETRY_DELAY_MS = 30_000;
+
+export interface HostedManagedAutomationSeedResult {
+  checkpointReason: "assistant_runtime_commit";
+  progressed: true;
+  redactedStatus: HostedRuntimeRedactedJson;
+}
+
+export async function seedHostedManagedAutomationsBestEffort(input: {
+  defaultRoute?: AutomationRoute | null;
+  nowMs: number;
+  operatorHomeRoot: string | null;
+  runtimeEnv: Readonly<Record<string, string>>;
+  runtimeLog?: {
+    context?: HostedRuntimeLogContext | null;
+    platform: Pick<HostedRuntimePlatform, "logPort">;
+  } | null;
+  shouldYieldBackgroundMaintenance?: (() => boolean) | null;
+  vaultRoot: string;
+}): Promise<HostedManagedAutomationSeedResult | null> {
+  if (input.shouldYieldBackgroundMaintenance?.() === true) {
+    return null;
+  }
+
+  try {
+    const result = await applyMurphManagedAutomations({
+      now: new Date(input.nowMs),
+      operatorHomeRoot: input.operatorHomeRoot,
+      ...(input.defaultRoute !== undefined
+        ? { defaultRoute: input.defaultRoute }
+        : {}),
+      routeValidationProfile: "hosted",
+      runtimeEnv: input.runtimeEnv,
+      vaultRoot: input.vaultRoot,
+    });
+    const changed = result.created + result.updated;
+    if (changed === 0) {
+      return null;
+    }
+
+    await writeHostedManagedAutomationSeedLog({
+      eventCode: "assistant.pass_finished",
+      level: "info",
+      redactedJson: {
+        murphManagedAutomationCreated: result.created,
+        murphManagedAutomationSkipped: result.skipped,
+        murphManagedAutomationUpdated: result.updated,
+      },
+      runtimeLog: input.runtimeLog ?? null,
+    });
+
+    return {
+      checkpointReason: "assistant_runtime_commit",
+      progressed: true,
+      redactedStatus: {
+        murphManagedAutomationCreated: result.created,
+        murphManagedAutomationSkipped: result.skipped,
+        murphManagedAutomationUpdated: result.updated,
+      },
+    };
+  } catch (error) {
+    const failure = buildHostedManagedAutomationFailureDiagnostics(
+      error,
+      "Hosted managed automation setup failed.",
+    );
+    await writeHostedManagedAutomationSeedLog({
+      errorCode: failure.errorCode,
+      eventCode: "runner.error",
+      level: "warn",
+      phase: "error",
+      redactedJson: {
+        ...failure.redactedJson,
+        murphManagedAutomationFailed: true,
+      },
+      runtimeLog: input.runtimeLog ?? null,
+    });
+    return null;
+  }
+}
+
+export async function resolveHostedManagedAutomationSeedNextWakeAt(input: {
+  nowMs: number;
+  vaultRoot: string;
+}): Promise<string | null> {
+  try {
+    const cronStatus = await getAssistantCronStatus(input.vaultRoot);
+    if (cronStatus.dueJobs > 0) {
+      return new Date(input.nowMs).toISOString();
+    }
+    return normalizeHostedFutureWakeAt(cronStatus.nextRunAt, input.nowMs);
+  } catch {
+    return new Date(input.nowMs + HOSTED_ASSISTANT_CRON_STATUS_RETRY_DELAY_MS).toISOString();
+  }
+}
+
+function buildHostedManagedAutomationFailureDiagnostics(
+  error: unknown,
+  fallbackMessage: string,
+): {
+  errorCode: string;
+  redactedJson: HostedRuntimeRedactedJson;
+} {
+  const diagnostics = buildHostedExecutionSafeErrorDiagnostics(error);
+  const diagnosticErrorCode = typeof diagnostics?.errorCode === "string"
+    ? diagnostics.errorCode
+    : null;
+  const diagnosticErrorMessage = typeof diagnostics?.errorMessage === "string"
+    ? diagnostics.errorMessage
+    : null;
+  const errorCode = toHostedRuntimeLogCode(
+    diagnosticErrorCode ?? deriveHostedExecutionErrorCode(error),
+  );
+  const safeErrorMessage = sanitizeHostedExecutionStructuredLogText(
+    diagnosticErrorMessage ?? fallbackMessage,
+  ) ?? fallbackMessage;
+
+  return {
+    errorCode,
+    redactedJson: {
+      errorCode,
+      safeErrorMessage,
+    },
+  };
+}
+
+async function writeHostedManagedAutomationSeedLog(input: {
+  errorCode?: string | null;
+  eventCode: HostedRuntimeLogEntry["eventCode"];
+  level: "info" | "warn";
+  phase?: "error" | "invoke";
+  redactedJson: HostedRuntimeRedactedJson;
+  runtimeLog: {
+    context?: HostedRuntimeLogContext | null;
+    platform: Pick<HostedRuntimePlatform, "logPort">;
+  } | null;
+}): Promise<void> {
+  if (!input.runtimeLog) {
+    return;
+  }
+
+  await writeHostedRuntimeLogBestEffort({
+    entry: {
+      ...buildHostedRuntimeLogContextFields(input.runtimeLog.context ?? null),
+      component: "runtime",
+      ...(input.errorCode ? { errorCode: input.errorCode } : {}),
+      eventCode: input.eventCode,
+      level: input.level,
+      phase: input.phase ?? "invoke",
+      redactedJson: input.redactedJson,
+    },
+    platform: input.runtimeLog.platform,
+  });
+}

--- a/packages/assistant-runtime/src/hosted-runtime/models.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/models.ts
@@ -170,6 +170,7 @@ export type HostedMailboxLane =
   | "assistant-notification"
   | "conversation-message"
   | "device-sync"
+  | "managed-automation-seed"
   | "member-activated"
   | "member-channels-updated"
   | "runtime-control";

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
@@ -47,6 +47,7 @@ export type HostedSystemMailboxRouteAction =
   | "apply-member-activation"
   | "apply-member-channels-update"
   | "dispatch-assistant-notification"
+  | "seed-managed-automations"
   | "run-device-sync-wake"
   | "apply-runtime-control-request";
 
@@ -404,6 +405,7 @@ function parseHostedSystemMailboxRouteAction(value: unknown): HostedSystemMailbo
     value === "apply-member-activation"
     || value === "apply-member-channels-update"
     || value === "dispatch-assistant-notification"
+    || value === "seed-managed-automations"
     || value === "run-device-sync-wake"
     || value === "apply-runtime-control-request"
   ) {

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -407,6 +407,7 @@ function readHostedSystemMailboxRouteAction(
     item.route.action === "apply-member-activation"
     || item.route.action === "apply-member-channels-update"
     || item.route.action === "dispatch-assistant-notification"
+    || item.route.action === "seed-managed-automations"
     || item.route.action === "run-device-sync-wake"
     || item.route.action === "apply-runtime-control-request"
   ) {

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -14,7 +14,6 @@ import type {
   HostedRuntimeRedactedScalar,
 } from "@murphai/hosted-execution/runtime-control";
 import {
-  applyMurphManagedAutomations,
   getAssistantCronStatus,
   readAssistantOutboxIntent,
   readAssistantInputEvent,
@@ -63,6 +62,9 @@ import {
   runHostedDeviceSyncWakeLane,
   resolveHostedDeviceSyncNextWakeAt,
 } from "./maintenance.ts";
+import {
+  seedHostedManagedAutomationsBestEffort,
+} from "./managed-automation-seeding.ts";
 import {
   resolveHostedPendingAssistantInputWakeAt,
 } from "./pending-assistant-input.ts";
@@ -710,81 +712,24 @@ async function applyHostedManagedAutomationsBestEffort(input: {
   defaultRoute?: AutomationRoute | null;
   input: HostedWorkspaceRuntimeAssistantPhaseInput;
 }): Promise<HostedWorkspaceRunnerAssistantPhaseResult | null> {
-  if (input.input.shouldYieldBackgroundMaintenance?.() === true) {
-    return null;
-  }
-
-  try {
-    const result = await applyMurphManagedAutomations({
-      now: new Date(resolveHostedAssistantPhaseNowMs(input.input)),
-      operatorHomeRoot: input.input.restored.operatorHomeRoot,
-      ...(input.defaultRoute !== undefined
-        ? { defaultRoute: input.defaultRoute }
-        : {}),
-      routeValidationProfile: "hosted",
-      runtimeEnv: input.input.runtimeEnv,
-      vaultRoot: input.input.restored.vaultRoot,
-    });
-    const changed = result.created + result.updated;
-    if (changed === 0) {
-      return null;
-    }
-
-    await writeHostedRuntimeLogBestEffort({
-      entry: {
-        ...buildHostedRuntimeLogContextFields({
-          attemptId: input.input.request.attemptId,
-          leaseGeneration: input.input.request.leaseGeneration,
-          workspaceVersion: input.input.request.workspaceVersion,
-        }),
-        component: "runtime",
-        eventCode: "assistant.pass_finished",
-        level: "info",
-        phase: "invoke",
-        redactedJson: {
-          murphManagedAutomationCreated: result.created,
-          murphManagedAutomationSkipped: result.skipped,
-          murphManagedAutomationUpdated: result.updated,
-        },
+  return await seedHostedManagedAutomationsBestEffort({
+    ...(input.defaultRoute !== undefined
+      ? { defaultRoute: input.defaultRoute }
+      : {}),
+    nowMs: resolveHostedAssistantPhaseNowMs(input.input),
+    operatorHomeRoot: input.input.restored.operatorHomeRoot,
+    runtimeEnv: input.input.runtimeEnv,
+    runtimeLog: {
+      context: {
+        attemptId: input.input.request.attemptId,
+        leaseGeneration: input.input.request.leaseGeneration,
+        workspaceVersion: input.input.request.workspaceVersion,
       },
       platform: input.input.runtime.platform,
-    });
-
-    return {
-      checkpointReason: "assistant_runtime_commit",
-      progressed: true,
-      redactedStatus: {
-        murphManagedAutomationCreated: result.created,
-        murphManagedAutomationSkipped: result.skipped,
-        murphManagedAutomationUpdated: result.updated,
-      },
-    };
-  } catch (error) {
-    const failure = buildHostedRuntimeFailureDiagnostics(
-      error,
-      "Hosted managed automation setup failed.",
-    );
-    await writeHostedRuntimeLogBestEffort({
-      entry: {
-        ...buildHostedRuntimeLogContextFields({
-          attemptId: input.input.request.attemptId,
-          leaseGeneration: input.input.request.leaseGeneration,
-          workspaceVersion: input.input.request.workspaceVersion,
-        }),
-        component: "runtime",
-        errorCode: failure.errorCode,
-        eventCode: "runner.error",
-        level: "warn",
-        phase: "error",
-        redactedJson: {
-          ...failure.redactedJson,
-          murphManagedAutomationFailed: true,
-        },
-      },
-      platform: input.input.runtime.platform,
-    });
-    return null;
-  }
+    },
+    shouldYieldBackgroundMaintenance: input.input.shouldYieldBackgroundMaintenance ?? null,
+    vaultRoot: input.input.restored.vaultRoot,
+  });
 }
 
 function withFreshHostedManagedAutomationsAfterCheckpoint(input: {

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildHostedExecutionAssistantNotificationRequestedWake,
   buildHostedExecutionLinqConversationMessageWake,
+  buildHostedExecutionManagedAutomationSeedRequestedWake,
   buildHostedExecutionMemberActivatedWake,
   buildHostedExecutionMemberChannelsUpdatedWake,
 } from "@murphai/hosted-execution";
@@ -15,6 +16,8 @@ import {
 
 const mocks = vi.hoisted(() => ({
   emitHostedExecutionStructuredLog: vi.fn(),
+  applyMurphManagedAutomations: vi.fn(),
+  getAssistantCronStatus: vi.fn(),
   hydrateHostedExecutionDefaultTarget: vi.fn(async (value) => value),
   prepareHostedWakeContext: vi.fn(),
   sendAssistantNotification: vi.fn(),
@@ -33,6 +36,8 @@ vi.mock("@murphai/assistant-engine", async () => {
 
   return {
     ...actual,
+    applyMurphManagedAutomations: mocks.applyMurphManagedAutomations,
+    getAssistantCronStatus: mocks.getAssistantCronStatus,
     sendAssistantNotification: mocks.sendAssistantNotification,
     upsertAssistantCronAutomation: mocks.upsertAssistantCronAutomation,
   };
@@ -2516,6 +2521,78 @@ describe("executeHostedMailboxEvent", () => {
       conversationMetrics: null,
       mailboxLane: "member-channels-updated",
       nextWakeAt: null,
+      postCheckpointRecord: null,
+      redactedLogEntries: [],
+    });
+  });
+
+  it("seeds managed automations from route-aware repair wakes", async () => {
+    const nextWakeAt = "2026-07-09T14:00:00.000Z";
+    mocks.applyMurphManagedAutomations.mockResolvedValueOnce({
+      created: 3,
+      skipped: 0,
+      updated: 0,
+    });
+    mocks.getAssistantCronStatus.mockResolvedValueOnce({
+      dueJobs: 0,
+      enabledJobs: 3,
+      nextRunAt: nextWakeAt,
+      runningJobs: 0,
+      totalJobs: 3,
+    });
+    const wake = buildHostedExecutionManagedAutomationSeedRequestedWake({
+      eventId: "assistant.managed-automation.seed-requested:member_123:route:1",
+      memberId: "member_123",
+      occurredAt: "2026-04-08T00:03:00.000Z",
+      route: {
+        actorId: "hid_linq_actor_123",
+        channel: "linq",
+        delivery: {
+          kind: "thread",
+          target: "thread_123",
+        },
+        identityId: "hid_linq_identity_123",
+        threadId: "hid_linq_thread_123",
+        threadIsDirect: true,
+      },
+    });
+    const runtime = createRuntime();
+
+    const result = await executeHostedMailboxEvent({
+      wake,
+      executionContext,
+      operatorHomeRoot: "/tmp/operator-home",
+      runtime,
+      runtimeEnv: {
+        OPENAI_API_KEY: "secret",
+      },
+      vaultRoot: "/tmp/assistant-runtime-events",
+    });
+
+    expect(mocks.applyMurphManagedAutomations).toHaveBeenCalledWith({
+      defaultRoute: {
+        channel: "linq",
+        deliverySource: null,
+        deliveryTarget: "thread_123",
+        identityId: "hid_linq_identity_123",
+        participantId: null,
+        threadId: null,
+      },
+      now: expect.any(Date),
+      operatorHomeRoot: "/tmp/operator-home",
+      routeValidationProfile: "hosted",
+      runtimeEnv: {
+        OPENAI_API_KEY: "secret",
+      },
+      vaultRoot: "/tmp/assistant-runtime-events",
+    });
+    expect(mocks.getAssistantCronStatus).toHaveBeenCalledWith("/tmp/assistant-runtime-events");
+    assert.deepEqual(result, {
+      bootstrapResult: null,
+      conversationMetrics: null,
+      mailboxLane: "managed-automation-seed",
+      nextWakeAt,
+      nextWakeReason: "assistant",
       postCheckpointRecord: null,
       redactedLogEntries: [],
     });

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-routing.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-routing.test.ts
@@ -43,6 +43,11 @@ describe("hosted mailbox routing", () => {
         lane: "system",
       },
       {
+        action: "seed-managed-automations",
+        kind: "assistant.managed-automation.seed-requested",
+        lane: "system",
+      },
+      {
         action: "run-device-sync-wake",
         kind: "device-sync.wake",
         lane: "system",
@@ -99,6 +104,7 @@ describe("hosted mailbox routing", () => {
     assert.equal(resolveExpectedLaneForHostedMailboxKind("member.activated"), "system");
     assert.equal(resolveExpectedLaneForHostedMailboxKind("member.channels.updated"), "system");
     assert.equal(resolveExpectedLaneForHostedMailboxKind("assistant.notification.requested"), "system");
+    assert.equal(resolveExpectedLaneForHostedMailboxKind("assistant.managed-automation.seed-requested"), "system");
     assert.equal(resolveExpectedLaneForHostedMailboxKind("device-sync.wake"), "system");
     assert.equal(resolveExpectedLaneForHostedMailboxKind("runtime.manual-requested"), "system");
     assert.equal(resolveExpectedLaneForHostedMailboxKind("runtime.maintenance-requested"), "system");

--- a/packages/hosted-execution/src/builders.ts
+++ b/packages/hosted-execution/src/builders.ts
@@ -2,7 +2,9 @@ import type {
   HostedExecutionConversationMessagePayload,
   HostedExecutionConversationMessageWake,
   HostedExecutionAssistantNotificationRequestedPayload,
+  HostedExecutionAssistantNotificationRoute,
   HostedExecutionAssistantNotificationRequestedWake,
+  HostedExecutionManagedAutomationSeedRequestedWake,
   HostedExecutionDeviceSyncWake,
   HostedExecutionDeviceSyncWakeEvent,
   HostedExecutionEmailConversationMessagePayload,
@@ -102,6 +104,7 @@ function cloneConversationMessagePayload(
 
 type HostedExecutionMemberOwnedWake =
   | HostedExecutionAssistantNotificationRequestedWake
+  | HostedExecutionManagedAutomationSeedRequestedWake
   | HostedExecutionMemberActivatedWake
   | HostedExecutionMemberChannelsUpdatedWake
   | HostedExecutionVaultShareDeliveryWake;
@@ -316,8 +319,8 @@ function cloneAssistantNotificationPayload(
 }
 
 function cloneAssistantNotificationRoute(
-  value: HostedExecutionAssistantNotificationRequestedPayload["route"],
-): HostedExecutionAssistantNotificationRequestedPayload["route"] {
+  value: HostedExecutionAssistantNotificationRoute,
+): HostedExecutionAssistantNotificationRoute {
   return {
     ...value,
     delivery: {
@@ -347,6 +350,23 @@ export function buildHostedExecutionAssistantNotificationRequestedWake(input: {
       occurredAt: input.occurredAt,
     }),
     notification: cloneAssistantNotificationPayload(input.notification),
+  };
+}
+
+export function buildHostedExecutionManagedAutomationSeedRequestedWake(input: {
+  eventId: string;
+  memberId: string;
+  occurredAt: string;
+  route: HostedExecutionAssistantNotificationRoute;
+}): HostedExecutionManagedAutomationSeedRequestedWake {
+  return {
+    ...buildHostedExecutionMemberOwnedWakeBase({
+      eventId: input.eventId,
+      kind: "assistant.managed-automation.seed-requested",
+      memberId: input.memberId,
+      occurredAt: input.occurredAt,
+    }),
+    route: cloneAssistantNotificationRoute(input.route),
   };
 }
 

--- a/packages/hosted-execution/src/contracts.ts
+++ b/packages/hosted-execution/src/contracts.ts
@@ -52,6 +52,7 @@ export const HOSTED_EXECUTION_EVENT_KINDS = [
   "member.activated",
   "member.channels.updated",
   "assistant.notification.requested",
+  "assistant.managed-automation.seed-requested",
   "device-sync.wake",
   ...HOSTED_EXECUTION_RUNTIME_CONTROL_WAKE_KINDS,
 ] as const;
@@ -68,6 +69,7 @@ export const HOSTED_EXECUTION_WAKE_KINDS = [
   "member.activated",
   "member.channels.updated",
   "assistant.notification.requested",
+  "assistant.managed-automation.seed-requested",
   "device-sync.wake",
   "vault-share.delivery",
   ...HOSTED_EXECUTION_RUNTIME_CONTROL_WAKE_KINDS,
@@ -166,6 +168,12 @@ export interface HostedExecutionAssistantNotificationRequestedEvent
   notification: HostedExecutionAssistantNotificationRequestedPayload;
 }
 
+export interface HostedExecutionManagedAutomationSeedRequestedEvent
+  extends HostedExecutionBaseEvent {
+  kind: "assistant.managed-automation.seed-requested";
+  route: HostedExecutionAssistantNotificationRoute;
+}
+
 export const HOSTED_EXECUTION_TELEGRAM_MESSAGE_SCHEMA =
   "murph.hosted-telegram-message.v1";
 
@@ -223,6 +231,7 @@ export type HostedExecutionEvent =
   | HostedExecutionMemberActivatedEvent
   | HostedExecutionMemberChannelsUpdatedEvent
   | HostedExecutionAssistantNotificationRequestedEvent
+  | HostedExecutionManagedAutomationSeedRequestedEvent
   | HostedExecutionDeviceSyncWakeEvent
   | HostedExecutionRuntimeControlRequestedEvent;
 
@@ -391,6 +400,12 @@ export interface HostedExecutionAssistantNotificationRequestedWake
   notification: HostedExecutionAssistantNotificationRequestedPayload;
 }
 
+export interface HostedExecutionManagedAutomationSeedRequestedWake
+  extends HostedExecutionBaseWake {
+  kind: "assistant.managed-automation.seed-requested";
+  route: HostedExecutionAssistantNotificationRoute;
+}
+
 export interface HostedExecutionMemberChannelsUpdatedWake extends HostedExecutionBaseWake {
   kind: "member.channels.updated";
   memberChannels: HostedExecutionMemberChannels;
@@ -433,6 +448,7 @@ export type HostedExecutionWake =
   | HostedExecutionMemberActivatedWake
   | HostedExecutionMemberChannelsUpdatedWake
   | HostedExecutionAssistantNotificationRequestedWake
+  | HostedExecutionManagedAutomationSeedRequestedWake
   | HostedExecutionDeviceSyncWake
   | HostedExecutionVaultShareDeliveryWake
   | HostedExecutionRuntimeControlWake;

--- a/packages/hosted-execution/src/parsers.ts
+++ b/packages/hosted-execution/src/parsers.ts
@@ -46,6 +46,7 @@ import {
   buildHostedExecutionAssistantNotificationRequestedWake,
   buildHostedExecutionEmailConversationMessageWake,
   buildHostedExecutionLinqConversationMessageWake,
+  buildHostedExecutionManagedAutomationSeedRequestedWake,
   buildHostedExecutionMemberActivatedWake,
   buildHostedExecutionMemberChannelsUpdatedWake,
   buildHostedExecutionConversationMessageWake,
@@ -222,6 +223,16 @@ export function parseHostedExecutionWake(value: unknown): HostedExecutionWake {
           "Hosted execution wake assistant.notification.requested notification",
         ),
         occurredAt,
+      });
+    case "assistant.managed-automation.seed-requested":
+      return buildHostedExecutionManagedAutomationSeedRequestedWake({
+        eventId,
+        memberId: wireUserId,
+        occurredAt,
+        route: parseHostedExecutionAssistantNotificationRoute(
+          record.route,
+          "Hosted execution wake assistant.managed-automation.seed-requested route",
+        ),
       });
     case "device-sync.wake":
       return buildHostedExecutionDeviceSyncWake({
@@ -731,6 +742,15 @@ export function parseHostedExecutionEvent(value: unknown): HostedExecutionEvent 
         notification: parseHostedExecutionAssistantNotificationRequestedPayload(
           record.notification,
           "Hosted execution assistant.notification.requested notification",
+        ),
+        userId,
+      };
+    case "assistant.managed-automation.seed-requested":
+      return {
+        kind,
+        route: parseHostedExecutionAssistantNotificationRoute(
+          record.route,
+          "Hosted execution assistant.managed-automation.seed-requested route",
         ),
         userId,
       };

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -33,6 +33,7 @@ export const HOSTED_MAILBOX_KINDS = [
   "member.activated",
   "member.channels.updated",
   "assistant.notification.requested",
+  "assistant.managed-automation.seed-requested",
   "device-sync.wake",
   "vault-share.delivery",
   ...HOSTED_EXECUTION_RUNTIME_CONTROL_WAKE_KINDS,

--- a/packages/hosted-execution/test/hosted-execution-contract-guards.test.ts
+++ b/packages/hosted-execution/test/hosted-execution-contract-guards.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildHostedExecutionDeviceSyncWake,
   buildHostedExecutionEmailConversationMessageWake,
+  buildHostedExecutionManagedAutomationSeedRequestedWake,
   buildHostedExecutionLinqConversationMessageWake,
   buildHostedExecutionRuntimeControlWake,
   buildHostedExecutionTelegramConversationMessageWake,
@@ -22,6 +23,7 @@ describe("hosted execution wake guards", () => {
   it("accepts canonical wake kinds only", () => {
     expect(isHostedExecutionWakeKind("conversation.message")).toBe(true);
     expect(isHostedExecutionWakeKind("member.activated")).toBe(true);
+    expect(isHostedExecutionWakeKind("assistant.managed-automation.seed-requested")).toBe(true);
     expect(isHostedExecutionWakeKind("runtime.manual-requested")).toBe(true);
     expect(isHostedExecutionWakeKind("runtime.maintenance-requested")).toBe(true);
     expect(isHostedExecutionWakeKind("unsupported.kind")).toBe(false);
@@ -91,6 +93,22 @@ describe("hosted execution wake guards", () => {
       occurredAt: "2026-04-18T00:00:00.000Z",
       userId: "user_guard",
     });
+    const managedAutomationSeedWake = buildHostedExecutionManagedAutomationSeedRequestedWake({
+      eventId: "managed-automation-seed-wake-1",
+      memberId: "user_guard",
+      occurredAt: "2026-04-18T00:00:00.000Z",
+      route: {
+        actorId: null,
+        channel: "linq",
+        delivery: {
+          kind: "thread",
+          target: "chat_guard",
+        },
+        identityId: "identity_guard",
+        threadId: "thread_guard",
+        threadIsDirect: true,
+      },
+    });
 
     expect(isHostedConversationMessageWake(linqWake)).toBe(true);
     expect(isHostedConversationMessageWake(telegramWake)).toBe(true);
@@ -117,6 +135,7 @@ describe("hosted execution wake guards", () => {
 
     expect(isHostedSystemWake(systemWake)).toBe(true);
     expect(isHostedSystemWake(controlWake)).toBe(true);
+    expect(isHostedSystemWake(managedAutomationSeedWake)).toBe(true);
     expect(isHostedSystemWake(emailWake)).toBe(false);
   });
 });

--- a/packages/hosted-execution/test/hosted-execution.test.ts
+++ b/packages/hosted-execution/test/hosted-execution.test.ts
@@ -472,6 +472,7 @@ describe("hosted execution coverage gaps", () => {
       "member.activated",
       "member.channels.updated",
       "assistant.notification.requested",
+      "assistant.managed-automation.seed-requested",
       "device-sync.wake",
       "runtime.manual-requested",
       "runtime.maintenance-requested",

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -105,6 +105,7 @@ describe("hosted runtime control contracts", () => {
       "member.activated",
       "member.channels.updated",
       "assistant.notification.requested",
+      "assistant.managed-automation.seed-requested",
       "device-sync.wake",
       "vault-share.delivery",
       "runtime.manual-requested",

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -219,6 +219,40 @@ describe("parseHostedExecutionEvent", () => {
     });
   });
 
+  it("parses managed automation seed requests with delivery routes", () => {
+    expect(
+      parseHostedExecutionEvent({
+        kind: "assistant.managed-automation.seed-requested",
+        route: {
+          actorId: null,
+          channel: "linq",
+          delivery: {
+            kind: "thread",
+            target: "chat_home_123",
+          },
+          identityId: "hbidx:phone:v1:test",
+          threadId: "thread_home_123",
+          threadIsDirect: true,
+        },
+        userId: "user-1",
+      }),
+    ).toEqual({
+      kind: "assistant.managed-automation.seed-requested",
+      route: {
+        actorId: null,
+        channel: "linq",
+        delivery: {
+          kind: "thread",
+          target: "chat_home_123",
+        },
+        identityId: "hbidx:phone:v1:test",
+        threadId: "thread_home_123",
+        threadIsDirect: true,
+      },
+      userId: "user-1",
+    });
+  });
+
   it("parses device-sync wake events with hint jobs and revoke warnings", () => {
     expect(
       parseHostedExecutionEvent({
@@ -390,6 +424,44 @@ describe("parseHostedExecutionWake", () => {
       eventId: "evt_runtime_control",
       kind: "runtime.maintenance-requested",
       occurredAt: "2026-04-18T00:00:00.000Z",
+      userId: "user-1",
+    });
+  });
+
+  it("parses managed automation seed request wakes", () => {
+    expect(
+      parseHostedExecutionWake({
+        eventId: "assistant.managed-automation.seed-requested:user-1:route:1",
+        kind: "assistant.managed-automation.seed-requested",
+        occurredAt: "2026-04-18T00:00:00.000Z",
+        route: {
+          actorId: null,
+          channel: "linq",
+          delivery: {
+            kind: "thread",
+            target: "chat_home_123",
+          },
+          identityId: "hbidx:phone:v1:test",
+          threadId: "thread_home_123",
+          threadIsDirect: true,
+        },
+        userId: "user-1",
+      }),
+    ).toEqual({
+      eventId: "assistant.managed-automation.seed-requested:user-1:route:1",
+      kind: "assistant.managed-automation.seed-requested",
+      occurredAt: "2026-04-18T00:00:00.000Z",
+      route: {
+        actorId: null,
+        channel: "linq",
+        delivery: {
+          kind: "thread",
+          target: "chat_home_123",
+        },
+        identityId: "hbidx:phone:v1:test",
+        threadId: "thread_home_123",
+        threadIsDirect: true,
+      },
       userId: "user-1",
     });
   });


### PR DESCRIPTION
## Why
Some hosted workspaces can have valid hosted routing state but no fresh assistant input or default automation route inside the restored runtime. The existing runtime-maintenance wake only poked idle maintenance, so those workspaces could wake without seeding Murph-managed automations.

## User-visible Goal
Give operators a route-aware repair action on /ops/runtime-maintenance that can enqueue managed-automation seeding for a specific hosted workspace or a small batch, so stuck hosted users can get the expected Murph-managed automation setup without direct DB or snapshot edits.

## Invariants
- Web remains the owner of hosted member routing lookup and encrypted mailbox append.
- Temporal receives only the mailbox pointer signal, not route payloads, prompts, transcripts, provider responses, or secrets.
- Assistant-runtime remains the owner of executable automation state and uses the existing hosted managed-automation seeding primitive.
- The existing generic maintenance wake remains available and unchanged for runtime idle maintenance.

## Verification
- pnpm --dir packages/hosted-execution exec vitest run --config vitest.config.ts test/hosted-execution-contract-guards.test.ts test/hosted-runtime-control.test.ts test/hosted-execution.test.ts test/parsers.test.ts --no-coverage
- pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts test/hosted-runtime-mailbox-routing.test.ts test/hosted-runtime-events.test.ts --no-coverage
- pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/hosted-runtime-maintenance-ops.test.ts --no-coverage
- pnpm --dir packages/hosted-execution typecheck
- pnpm --dir packages/assistant-runtime typecheck
- pnpm --dir apps/web typecheck:prepared

## Deployment
Deploy consumers before producers: hosted-execution parser/runtime/Cloudflare runner support for the new mailbox kind must be live before web operators use the new seed action.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784950849&installation_id=127572939&pr_number=289&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F289&signature=e32cfad4167fe044b810c578315bc417bef6b32549ef1d5bd9154f209cb17f88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->