### PR TITLE
fix(assistant): hand off vault approval links

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-25-approval-link-handoff.md
+++ b/agent-docs/exec-plans/completed/2026-06-25-approval-link-handoff.md
@@ -1,0 +1,14 @@
+# Approval link handoff
+
+- Goal (incl. success criteria): remove the hard-coded vault-file approval SMS/iMessage copy and ISO expiry line; when a vault-file send needs approval, return the approval link/context to Murph so the normal assistant reply can phrase the request.
+- Constraints/Assumptions: preserve exact file/destination binding, passkey approval flow, no file bytes in prompts, no direct sends before approval, no raw identifiers/secrets/local paths in committed artifacts.
+- Key decisions: keep approval creation in the existing hosted action-approval path; delete the hard-coded approval-message helper and extra send side effect; return the link through the existing tool-result-to-final-reply path instead of adding a new abstraction.
+- State: Done; ready to archive with scoped commit.
+- Done: Read required routing, hosted runtime, security, reliability, and package docs; created isolated worktree/branch; located and removed the hard-coded approval message helper and extra approval-link send; added focused assistant-engine coverage and doc note; ran root typecheck and diff-aware verification.
+- Now: Close plan with scoped commit.
+- Next: Rebase on current `origin/main`, push branch, open draft PR.
+- Open questions: None.
+- Working set (files/ids/commands): `packages/assistant-engine/src/assistant/vault-file-send.ts`, `packages/assistant-engine/src/assistant/hosted-tool-context.ts`, `packages/assistant-engine/src/assistant/local-service.ts`, `packages/assistant-engine/src/assistant-codex/dynamic-tools.ts`, `packages/assistant-engine/test/assistant-vault-file-send.test.ts`, `docs/hosted-sensitive-action-approvals.md`.
+Status: completed
+Updated: 2026-06-25
+Completed: 2026-06-25

--- a/docs/hosted-sensitive-action-approvals.md
+++ b/docs/hosted-sensitive-action-approvals.md
@@ -51,6 +51,7 @@ A request contains:
 4. Later calls return `approved`, `denied`, or derived `expired`.
 
 The caller owns action execution, retries, and completion. It must recompute the fingerprint and call `request` again at the final effect boundary. Approval has no claimed, executing, completed, or provider-error state.
+When `pending` is returned, the approval URL is handed to the normal assistant reply path; the approval system must not send a separate hard-coded user message.
 
 ## Browser decision flow
 

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -246,7 +246,7 @@ export const MURPH_SEND_VAULT_FILE_TOOL = {
   namespace: 'murph',
   name: 'send_vault_file',
   description:
-    "Securely send one existing file from the user's vault to the current iMessage conversation. Use a normalized vault-relative file path. This queues the exact file and destination behind passkey approval; it does not reveal file bytes to the model and does not support arbitrary recipients.",
+    "Securely send one existing file from the user's vault to the current iMessage conversation. Use a normalized vault-relative file path. This queues the exact file and destination behind passkey approval; when approval is pending, include the returned approval link in your normal reply. It does not reveal file bytes to the model and does not support arbitrary recipients.",
   inputSchema: {
     type: 'object',
     additionalProperties: false,
@@ -1276,8 +1276,14 @@ export async function executeMurphDynamicToolRequest(input: {
         switch (result.status) {
           case 'pending':
             return {
-              ...toolTextResult(true, 'secure approval requested'),
-              finalActionPatch: { kind: 'none' },
+              ...toolTextResult(
+                true,
+                JSON.stringify({
+                  approvalUrl: result.approvalUrl,
+                  filename: result.filename,
+                  status: result.status,
+                }),
+              ),
             }
           case 'approved':
             return {

--- a/packages/assistant-engine/src/assistant/hosted-tool-context.ts
+++ b/packages/assistant-engine/src/assistant/hosted-tool-context.ts
@@ -17,10 +17,16 @@ export interface AssistantHostedDeliveryContext {
   recipientKey: string | null
 }
 
-export interface AssistantHostedVaultFileSendResult {
-  filename: string
-  status: 'approved' | 'denied' | 'expired' | 'pending'
-}
+export type AssistantHostedVaultFileSendResult =
+  | {
+      approvalUrl: string
+      filename: string
+      status: 'pending'
+    }
+  | {
+      filename: string
+      status: 'approved' | 'denied' | 'expired'
+    }
 
 export interface AssistantHostedToolContext {
   readonly connectedApps?: AssistantConnectedAppsPort | null

--- a/packages/assistant-engine/src/assistant/hosted-tool-context.ts
+++ b/packages/assistant-engine/src/assistant/hosted-tool-context.ts
@@ -6,9 +6,6 @@ import type {
   AssistantMessageInput,
 } from './service-contracts.js'
 import type {
-  AssistantProgressDeliveryResult,
-} from './turn-progress.js'
-import type {
   AssistantConnectedAppsPort,
 } from './connected-apps-port.js'
 
@@ -33,9 +30,7 @@ export interface AssistantHostedToolContext {
   currentHostedDeliveryContext(): AssistantHostedDeliveryContext | null
   currentHostedMailboxItemIds(): readonly string[]
   readonly computerToolsAvailable: boolean
-  readonly requiredUserMessageDeliveryAvailable: boolean
   readonly vaultFileSendAvailable: boolean
-  sendRequiredUserMessage(text: string): Promise<AssistantProgressDeliveryResult>
   sendVaultFile(ref: string): Promise<AssistantHostedVaultFileSendResult>
 }
 
@@ -49,8 +44,6 @@ export function createAssistantHostedToolContext(input: {
   computerToolsAvailable?: boolean
   getDeliveryContext?: () => AssistantHostedToolDeliveryContext
   messageInput: AssistantMessageInput
-  requiredUserMessageDeliveryAvailable?: boolean
-  sendRequiredUserMessage?: (text: string) => Promise<AssistantProgressDeliveryResult>
   sendVaultFile?: (ref: string) => Promise<AssistantHostedVaultFileSendResult>
   session: AssistantSession
 }): AssistantHostedToolContext {
@@ -76,12 +69,6 @@ export function createAssistantHostedToolContext(input: {
       return deliveryContext.messageInput.hostedDeliveryIdempotency
         ?.inboundMailboxItemIds ?? []
     },
-    requiredUserMessageDeliveryAvailable:
-      input.requiredUserMessageDeliveryAvailable ?? true,
-    sendRequiredUserMessage: input.sendRequiredUserMessage ?? (async () => ({
-      kind: 'failed',
-      source: 'model',
-    })),
     sendVaultFile: input.sendVaultFile ?? (async () => {
       throw new Error('Vault-file sending is unavailable for this turn.')
     }),

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -111,7 +111,6 @@ import {
 } from './hosted-tool-context.js'
 import { createAssistantRuntimeStateService } from './runtime-state-service.js'
 import {
-  buildAssistantVaultFileApprovalMessage,
   requestAssistantVaultFileSend,
 } from './vault-file-send.js'
 import type {
@@ -654,18 +653,10 @@ export async function sendAssistantMessageLocal(
                         vault: currentInput.vault,
                       })
                       if (result.status === 'pending') {
-                        const delivery = await sendRequiredUserMessage(
-                          buildAssistantVaultFileApprovalMessage({
-                            approvalUrl: result.approvalUrl,
-                            expiresAt: result.expiresAt,
-                            filename: result.filename,
-                          }),
-                        )
-                        if (delivery.kind === 'failed') {
-                          throw new VaultCliError(
-                            'ASSISTANT_VAULT_FILE_APPROVAL_LINK_DELIVERY_FAILED',
-                            'The secure approval link could not be delivered.',
-                          )
+                        return {
+                          approvalUrl: result.approvalUrl,
+                          filename: result.filename,
+                          status: 'pending',
                         }
                       }
                       return {

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -102,9 +102,7 @@ import {
 } from './channel-typing.js'
 import {
   createAssistantProgressDelivery,
-  normalizeAssistantProgressText,
   shouldCreateAssistantProgressDelivery,
-  type AssistantProgressDeliveryResult,
 } from './turn-progress.js'
 import {
   createAssistantHostedToolContext,
@@ -129,7 +127,6 @@ import {
 } from './active-turn-input-controller.js'
 import {
   normalizeNullableString,
-  warnAssistantBestEffortFailure,
 } from './shared.js'
 import type {
   AssistantMessageInput,
@@ -194,7 +191,7 @@ function isHostedOptionalProgressDeliveryAvailable(input: {
   })
 }
 
-function isRequiredUserMessageDeliveryAvailable(input: {
+function isHostedCurrentAudienceReplyDeliveryAvailable(input: {
   executionContext: AssistantExecutionContext | null
   session: AssistantSession
   sharedPlan: AssistantTurnSharedPlan
@@ -215,52 +212,6 @@ function isHostedComputerToolTransportAvailable(input: {
   executionContext: AssistantExecutionContext | null
 }): boolean {
   return typeof input.executionContext?.hosted?.providerFetch === 'function'
-}
-
-async function sendHostedRequiredUserMessage(input: {
-  dependencies?: AssistantHostedProgressDeliveryDependencies | null
-  getDeliveryContext: () => {
-    messageInput: AssistantMessageInput
-    session: AssistantSession
-  }
-  sharedPlan: AssistantTurnSharedPlan
-  text: string
-  turnId: string
-}): Promise<AssistantProgressDeliveryResult> {
-  const text = normalizeAssistantProgressText(input.text)
-  if (!text) {
-    return {
-      kind: 'skipped',
-      reason: 'empty',
-      source: 'model',
-    }
-  }
-
-  const deliveryContext = input.getDeliveryContext()
-  try {
-    await deliverAssistantProgressUpdate({
-      dependencies: input.dependencies ?? undefined,
-      input: deliveryContext.messageInput,
-      ordinal: 0,
-      session: deliveryContext.session,
-      sharedPlan: input.sharedPlan,
-      text,
-      turnId: input.turnId,
-    })
-    return {
-      kind: 'sent',
-      source: 'model',
-    }
-  } catch (error) {
-    warnAssistantBestEffortFailure({
-      error,
-      operation: 'required hosted user-message delivery',
-    })
-    return {
-      kind: 'failed',
-      source: 'model',
-    }
-  }
 }
 
 async function appendUserTranscriptEntryForTurn(input: {
@@ -502,8 +453,8 @@ export async function sendAssistantMessageLocal(
         })
         let currentInput = input
         let currentSession = resolved.session
-        const requiredUserMessageDeliveryAvailable =
-          isRequiredUserMessageDeliveryAvailable({
+        const currentAudienceReplyDeliveryAvailable =
+          isHostedCurrentAudienceReplyDeliveryAvailable({
             executionContext,
             session: resolved.session,
             sharedPlan,
@@ -518,7 +469,7 @@ export async function sendAssistantMessageLocal(
           input.deliverResponse === true &&
           isHostedComputerToolTransportAvailable({
             executionContext,
-          }) && requiredUserMessageDeliveryAvailable
+          }) && currentAudienceReplyDeliveryAvailable
         const hostedExecutionContext = executionContext?.hosted ?? null
         const progressDelivery =
           shouldCreateAssistantProgressDelivery(input) &&
@@ -563,30 +514,6 @@ export async function sendAssistantMessageLocal(
               turnId: currentUserTurn.turnId,
             })
           : null
-        const sendRequiredUserMessage = async (
-          text: string,
-        ): Promise<AssistantProgressDeliveryResult> =>
-          progressDelivery
-            ? await progressDelivery.send(text, {
-                required: true,
-                source: 'model',
-              })
-            : requiredUserMessageDeliveryAvailable && hostedExecutionContext
-              ? await sendHostedRequiredUserMessage({
-                  dependencies:
-                    hostedExecutionContext.progressDeliveryDependencies,
-                  getDeliveryContext: () => ({
-                    messageInput: currentInput,
-                    session: currentSession,
-                  }),
-                  sharedPlan,
-                  text,
-                  turnId: currentUserTurn.turnId,
-                })
-              : {
-                  kind: 'failed',
-                  source: 'model',
-                }
         const currentDeliveryFields = resolveAssistantCurrentAudienceDeliveryFields({
           input: currentInput,
           session: currentSession,
@@ -598,7 +525,7 @@ export async function sendAssistantMessageLocal(
         const actionApprovalPort = hostedExecutionContext?.actionApprovalPort ?? null
         const vaultFileSendAvailable =
           input.deliverResponse === true
-          && requiredUserMessageDeliveryAvailable
+          && currentAudienceReplyDeliveryAvailable
           && actionApprovalPort != null
           && currentDeliveryFields.channel?.trim().toLowerCase() === 'linq'
         const hostedToolContext = hostedExecutionContext
@@ -610,8 +537,6 @@ export async function sendAssistantMessageLocal(
                 session: currentSession,
               }),
               messageInput: input,
-              requiredUserMessageDeliveryAvailable,
-              sendRequiredUserMessage,
               ...(vaultFileSendAvailable && actionApprovalPort
                 ? {
                     sendVaultFile: async (ref: string) => {

--- a/packages/assistant-engine/src/assistant/vault-file-send.ts
+++ b/packages/assistant-engine/src/assistant/vault-file-send.ts
@@ -133,25 +133,6 @@ export async function requestAssistantVaultFileSend(input: {
   }
 }
 
-export function buildAssistantVaultFileApprovalMessage(input: {
-  approvalUrl: string
-  filename: string
-  expiresAt: string
-}): string {
-  const expiresAt = new Date(input.expiresAt)
-  const expiryText = Number.isNaN(expiresAt.getTime())
-    ? 'This request expires soon.'
-    : `This request expires at ${expiresAt.toISOString()}.`
-  return [
-    `I need your secure approval before sending “${input.filename}” to this iMessage conversation.`,
-    '',
-    `Approve here: ${input.approvalUrl}`,
-    '',
-    'This approval applies only to that file and destination.',
-    expiryText,
-  ].join('\n')
-}
-
 export async function resolveAssistantVaultFileResponseMedia(input: {
   ref: string
   vaultRoot: string

--- a/packages/assistant-engine/test/assistant-codex-computer-tools.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-computer-tools.test.ts
@@ -822,7 +822,6 @@ describe("murph computer dynamic tools", () => {
     });
 
     expect(result.rpcResult.success).toBe(true);
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled();
     expect(JSON.parse(result.rpcResult.contentItems[0]!.text)).toEqual({
       awaitingReason: "final_confirmation",
       handoffCreated: true,
@@ -863,7 +862,6 @@ describe("murph computer dynamic tools", () => {
     });
 
     expect(result.rpcResult.success).toBe(true);
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled();
     expect(result.rpcResult.contentItems[0]!.text).toContain("raw-token");
     expect(JSON.parse(result.rpcResult.contentItems[0]!.text)).toEqual({
       awaitingReason: "login_needed",
@@ -880,7 +878,6 @@ describe("murph computer dynamic tools", () => {
     );
     const hostedToolContext = createHostedToolContext({
       computerToolsAvailable: false,
-      requiredUserMessageDeliveryAvailable: false,
     });
 
     const result = await executeMurphDynamicToolRequest({
@@ -906,7 +903,6 @@ describe("murph computer dynamic tools", () => {
       "computer tools are unavailable without hosted computer-use transport",
     );
     expect(fetchImpl).not.toHaveBeenCalled();
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled();
   });
 
   it("preserves the run if pause transport outcome is unknown before user delivery", async () => {
@@ -950,11 +946,10 @@ describe("murph computer dynamic tools", () => {
       "computer API outcome is unknown after a transport or browser execution failure; observe the computer run state before retrying Playwright code or taking another step",
     );
     expect(result.computerRunPausedForUser).toBe(true);
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("pauses even when required user-message delivery is unavailable", async () => {
+  it("returns hosted pause handoff data through the tool result", async () => {
     const fetchImpl = vi.fn(async (
       url: string | URL | Request,
     ): Promise<Response> => {
@@ -972,9 +967,7 @@ describe("murph computer dynamic tools", () => {
 
       throw new Error("unexpected finish call");
     });
-    const hostedToolContext = createHostedToolContext({
-      requiredUserMessageDeliveryAvailable: false,
-    });
+    const hostedToolContext = createHostedToolContext();
 
     const result = await executeMurphDynamicToolRequest({
       env: {},
@@ -1003,7 +996,6 @@ describe("murph computer dynamic tools", () => {
       runId: "run_123",
       status: "awaiting_user",
     });
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });
@@ -1029,18 +1021,11 @@ function createHostedToolContext(input: {
     recipientKey: string | null;
   };
   hostedMailboxItemIds?: string[];
-  requiredUserMessageDeliveryAvailable?: boolean;
-  sendResult?: Awaited<ReturnType<AssistantHostedToolContext["sendRequiredUserMessage"]>>;
 } = {}): AssistantHostedToolContext {
   return {
     currentHostedDeliveryContext: () => input.deliveryContext ?? null,
     currentHostedMailboxItemIds: () => input.hostedMailboxItemIds ?? [],
     computerToolsAvailable: input.computerToolsAvailable ?? true,
-    requiredUserMessageDeliveryAvailable:
-      input.requiredUserMessageDeliveryAvailable ?? true,
-    sendRequiredUserMessage: vi.fn(async () =>
-      input.sendResult ?? { kind: "sent" as const, source: "model" as const }
-    ),
     sendVaultFile: vi.fn(async () => {
       throw new Error("Vault-file sending is unavailable for this turn.");
     }),

--- a/packages/assistant-engine/test/assistant-codex-connected-apps.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-connected-apps.test.ts
@@ -316,11 +316,6 @@ function createHostedToolContext(
     computerToolsAvailable: false,
     currentHostedDeliveryContext: () => null,
     currentHostedMailboxItemIds: () => [],
-    requiredUserMessageDeliveryAvailable: false,
-    sendRequiredUserMessage: async () => ({
-      kind: "failed",
-      source: "model",
-    }),
     sendVaultFile: async () => {
       throw new Error("Vault-file sending is unavailable for this turn.");
     },

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -142,16 +142,11 @@ function createProgressDeliveryMock(
 
 function createHostedToolContext(input: {
   computerToolsAvailable?: boolean
-  sendResult?: Awaited<ReturnType<AssistantHostedToolContext['sendRequiredUserMessage']>>
 } = {}): AssistantHostedToolContext {
   return {
     computerToolsAvailable: input.computerToolsAvailable ?? true,
     currentHostedDeliveryContext: () => null,
     currentHostedMailboxItemIds: () => [],
-    requiredUserMessageDeliveryAvailable: true,
-    sendRequiredUserMessage: vi.fn(async () =>
-      input.sendResult ?? { kind: 'sent' as const, source: 'model' as const }
-    ),
     sendVaultFile: vi.fn(async () => {
       throw new Error('Vault-file sending is unavailable for this turn.')
     }),
@@ -1481,7 +1476,6 @@ describe('assistant codex runtime', () => {
       finalMessage: 'Paused for confirmation.',
     })
     expect(fetchOrder).toEqual(['act:start', 'act:end', 'pause'])
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled()
   })
 
   it('closes live steering before saving a computer pause', async () => {
@@ -1638,7 +1632,6 @@ describe('assistant codex runtime', () => {
       finalMessage: 'Paused for confirmation.',
     })
     expect(liveTurnReleased).toBe(1)
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled()
   })
 
   it('allows finish_without_reply after pausing a computer run for the user', async () => {
@@ -1774,7 +1767,6 @@ describe('assistant codex runtime', () => {
       finalAction: { kind: 'none' },
       finalMessage: '',
     })
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled()
   })
 
   it('aborts and drains in-flight image generation when the turn fails', async () => {
@@ -4886,7 +4878,6 @@ describe('assistant codex runtime', () => {
       turnId: 'turn-prestart-pause-live-turn-2',
     })
     expect(liveTurnRegistrations).toBe(0)
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled()
   })
 
   it('preserves reused turn/start JSON-RPC errors instead of reporting missing turn ids', async () => {

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -4811,7 +4811,6 @@ test('sendAssistantMessageLocal exposes hosted progress and computer context for
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
   assert.ok(progressDelivery)
   assert.ok(hostedToolContext)
-  assert.equal(hostedToolContext.requiredUserMessageDeliveryAvailable, true)
   assert.equal(hostedToolContext.computerToolsAvailable, true)
   await progressDelivery.send('Checking the iMessage thread.')
   assert.equal(mocks.deliverAssistantProgressUpdate.mock.calls.length, 1)
@@ -4859,7 +4858,6 @@ test('sendAssistantMessageLocal routes hosted Linq model progress through progre
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
   assert.ok(progressDelivery)
   assert.ok(hostedToolContext)
-  assert.equal(hostedToolContext.requiredUserMessageDeliveryAvailable, true)
   assert.equal(hostedToolContext.computerToolsAvailable, false)
   await progressDelivery.send('Checking the iMessage thread.')
 
@@ -4915,7 +4913,6 @@ test('sendAssistantMessageLocal requires hosted Linq text delivery for model pro
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
   assert.equal(progressDelivery, null)
   assert.ok(hostedToolContext)
-  assert.equal(hostedToolContext.requiredUserMessageDeliveryAvailable, false)
   assert.equal(hostedToolContext.computerToolsAvailable, false)
   assert.equal(mocks.deliverAssistantProgressUpdate.mock.calls.length, 0)
   assert.equal(progressDeliveryDependencies.sendLinqVoiceMemo.mock.calls.length, 0)
@@ -4962,7 +4959,6 @@ test('sendAssistantMessageLocal enables hosted computer tools for Telegram when 
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
   assert.ok(progressDelivery)
   assert.ok(hostedToolContext)
-  assert.equal(hostedToolContext.requiredUserMessageDeliveryAvailable, true)
   assert.equal(hostedToolContext.computerToolsAvailable, true)
   await progressDelivery.send('Checking the Telegram thread.')
 
@@ -5018,7 +5014,6 @@ test('sendAssistantMessageLocal does not expose hosted progress or computer deli
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
   assert.equal(progressDelivery, null)
   assert.ok(hostedToolContext)
-  assert.equal(hostedToolContext.requiredUserMessageDeliveryAvailable, false)
   assert.equal(hostedToolContext.computerToolsAvailable, false)
   assert.equal(mocks.deliverAssistantProgressUpdate.mock.calls.length, 0)
   assert.equal(progressDeliveryDependencies.sendTelegram.mock.calls.length, 0)
@@ -5242,7 +5237,6 @@ test('sendAssistantMessageLocal uses resolved audience channel for hosted model 
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
   assert.ok(progressDelivery)
   assert.ok(hostedToolContext)
-  assert.equal(hostedToolContext.requiredUserMessageDeliveryAvailable, true)
   assert.equal(hostedToolContext.computerToolsAvailable, true)
   const result = await progressDelivery.send('Checking the iMessage thread.')
 
@@ -5297,25 +5291,8 @@ test('sendAssistantMessageLocal does not expose optional progress delivery for h
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
   assert.equal(progressDelivery, null)
   assert.ok(hostedToolContext)
-  assert.equal(hostedToolContext.requiredUserMessageDeliveryAvailable, true)
   assert.equal(hostedToolContext.computerToolsAvailable, true)
-  const result = await hostedToolContext.sendRequiredUserMessage(
-    'Open this handoff link?',
-  )
-
-  assert.deepEqual(result, {
-    kind: 'sent',
-    source: 'model',
-  })
-  assert.equal(mocks.deliverAssistantProgressUpdate.mock.calls.length, 1)
-  assert.equal(
-    mocks.deliverAssistantProgressUpdate.mock.calls[0]?.[0]?.dependencies,
-    progressDeliveryDependencies,
-  )
-  assert.equal(
-    mocks.deliverAssistantProgressUpdate.mock.calls[0]?.[0]?.text,
-    'Open this handoff link?',
-  )
+  assert.equal(mocks.deliverAssistantProgressUpdate.mock.calls.length, 0)
 })
 
 test('sendAssistantMessageLocal runs best-effort failure cleanup and rethrows terminal provider failures', async () => {

--- a/packages/assistant-engine/test/assistant-protocol-index-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-protocol-index-planning.test.ts
@@ -1702,11 +1702,6 @@ function createHostedToolContext(): AssistantHostedToolContext {
     computerToolsAvailable: true,
     currentHostedDeliveryContext: () => null,
     currentHostedMailboxItemIds: () => [],
-    requiredUserMessageDeliveryAvailable: true,
-    sendRequiredUserMessage: vi.fn(async () => ({
-      kind: 'sent' as const,
-      source: 'model' as const,
-    })),
     sendVaultFile: vi.fn(async () => {
       throw new Error('Vault-file sending is unavailable for this turn.')
     }),

--- a/packages/assistant-engine/test/assistant-vault-file-send.test.ts
+++ b/packages/assistant-engine/test/assistant-vault-file-send.test.ts
@@ -188,11 +188,6 @@ describe('assistant vault-file send', () => {
       computerToolsAvailable: false,
       currentHostedDeliveryContext: () => null,
       currentHostedMailboxItemIds: () => [],
-      requiredUserMessageDeliveryAvailable: true,
-      sendRequiredUserMessage: vi.fn(async () => ({
-        kind: 'sent' as const,
-        source: 'model' as const,
-      })),
       sendVaultFile: vi.fn(async () => ({
         approvalUrl: 'https://murph.test/approve/haa_test',
         filename: 'report.pdf',
@@ -214,7 +209,6 @@ describe('assistant vault-file send', () => {
       },
     })
 
-    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled()
     expect(result.finalActionPatch).toBeUndefined()
     expect(result.rpcResult).toMatchObject({ success: true })
     expect(result.rpcResult.contentItems[0]?.text).toBe(JSON.stringify({

--- a/packages/assistant-engine/test/assistant-vault-file-send.test.ts
+++ b/packages/assistant-engine/test/assistant-vault-file-send.test.ts
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { executeMurphDynamicToolRequest } from '../src/assistant-codex/dynamic-tools.ts'
+import type { AssistantHostedToolContext } from '../src/assistant/hosted-tool-context.ts'
 import {
   dispatchAssistantOutboxIntent,
   listAssistantOutboxIntents,
@@ -179,6 +181,47 @@ describe('assistant vault-file send', () => {
 
     expect(result.intent.status).toBe('awaiting_approval')
     expect(sendLinq).not.toHaveBeenCalled()
+  })
+
+  it('hands the approval link back to the normal assistant reply path', async () => {
+    const hostedToolContext: AssistantHostedToolContext = {
+      computerToolsAvailable: false,
+      currentHostedDeliveryContext: () => null,
+      currentHostedMailboxItemIds: () => [],
+      requiredUserMessageDeliveryAvailable: true,
+      sendRequiredUserMessage: vi.fn(async () => ({
+        kind: 'sent' as const,
+        source: 'model' as const,
+      })),
+      sendVaultFile: vi.fn(async () => ({
+        approvalUrl: 'https://murph.test/approve/haa_test',
+        filename: 'report.pdf',
+        status: 'pending' as const,
+      })),
+      vaultFileSendAvailable: true,
+    }
+
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext,
+      nextUsageOrdinal: () => 1,
+      progressDelivery: null,
+      publicFetchImpl: fetch,
+      request: {
+        kind: 'send-vault-file',
+        ref: 'documents/report.pdf',
+      },
+    })
+
+    expect(hostedToolContext.sendRequiredUserMessage).not.toHaveBeenCalled()
+    expect(result.finalActionPatch).toBeUndefined()
+    expect(result.rpcResult).toMatchObject({ success: true })
+    expect(result.rpcResult.contentItems[0]?.text).toBe(JSON.stringify({
+      approvalUrl: 'https://murph.test/approve/haa_test',
+      filename: 'report.pdf',
+      status: 'pending',
+    }))
   })
 })
 


### PR DESCRIPTION
## Why

Vault-file sends that needed passkey approval were sending a separate canned approval message with a fixed timestamp format before the assistant could respond. That made the iMessage copy feel hard-coded and exposed implementation phrasing instead of letting Murph answer naturally.

## User-visible goal

When a vault-file send is pending approval, Murph receives the approval URL as tool-result data and can include it in the normal assistant reply. The approval system no longer sends a separate hard-coded user message or ISO expiry line.

## Invariants preserved

- Approval is still bound to the exact file and current iMessage destination.
- File bytes are still not exposed to the model.
- Files are still not sent until passkey approval succeeds.
- Web/passkey approval authority, outbox delivery, and hosted runner lifecycle are unchanged.
- No new queue, workflow, or abstraction was added.

## Verification

- `pnpm typecheck`
- `pnpm test:diff packages/assistant-engine/src/assistant/vault-file-send.ts packages/assistant-engine/src/assistant/hosted-tool-context.ts packages/assistant-engine/src/assistant/local-service.ts packages/assistant-engine/src/assistant-codex/dynamic-tools.ts packages/assistant-engine/test/assistant-vault-file-send.test.ts docs/hosted-sensitive-action-approvals.md`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784961131&installation_id=127572939&pr_number=293&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F293&signature=b50831d0a9b8a374c14a97a69bcab999e791400849bdcd4a120e69b730a0ef9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->