### PR TITLE
Remove static image computer handoff preview

### DIFF
--- a/apps/web/app/computer/handoff/[token]/page.tsx
+++ b/apps/web/app/computer/handoff/[token]/page.tsx
@@ -56,7 +56,7 @@ export default async function ComputerHandoffPage({
             </h1>
             <p className="mt-4 text-sm text-muted-foreground text-pretty">
               {isRetry
-                ? "Try again. If the site still cannot connect, return to Murph and ask for browser takeover."
+                ? "Try again. If the site still cannot connect, return to Murph and ask for a live browser link."
                 : "Kernel is still finishing this sign-in. Check again in a moment."}
             </p>
             <a
@@ -139,14 +139,17 @@ export default async function ComputerHandoffPage({
 
   if (state.interaction === "view_only") {
     return (
-      <main className="relative min-h-dvh bg-foreground text-foreground">
-        {/* eslint-disable-next-line @next/next/no-img-element -- Ephemeral data URL screenshot; next/image optimization does not apply. */}
-        <img
-          alt="Murph private page preview"
-          className="block h-dvh w-full object-contain bg-foreground"
-          draggable={false}
-          src={state.screenshotDataUrl}
-        />
+      <main className="min-h-screen bg-background px-4 py-8 text-foreground sm:px-6">
+        <section className="mx-auto flex min-h-[70vh] max-w-2xl flex-col justify-center">
+          <div className="rounded-2xl border border-border bg-card p-6">
+            <Clock3 className="mb-4 h-8 w-8 text-muted-foreground" aria-hidden="true" />
+            <h1 className="font-serif text-3xl text-balance">Open a live browser link</h1>
+            <p className="mt-4 text-sm text-muted-foreground text-pretty">
+              Static page previews are no longer supported. Return to Murph and ask
+              for a live browser handoff if you want to inspect or control this step.
+            </p>
+          </div>
+        </section>
       </main>
     );
   }

--- a/apps/web/test/computer-handoff-route-page.test.tsx
+++ b/apps/web/test/computer-handoff-route-page.test.tsx
@@ -293,7 +293,7 @@ describe("computer handoff route and page", () => {
     assert.equal(markup.includes("finished_browser_step"), false);
   });
 
-  it("renders inspection handoffs as a static screenshot", async () => {
+  it("retires view-only inspection screenshots", async () => {
     mocks.service.readHandoffPageState.mockResolvedValueOnce({
       handoffId: "hch_open",
       interaction: "view_only",
@@ -307,8 +307,9 @@ describe("computer handoff route and page", () => {
       params: Promise.resolve({ token: "handoff-token" }),
     }));
 
-    assert.match(markup, /<img[^>]+alt="Murph private page preview"/);
-    assert.match(markup, /<img[^>]+src="data:image\/jpeg;base64,aW1hZ2U="/);
+    assert.match(markup, /Open a live browser link/);
+    assert.match(markup, /Static page previews are no longer supported/);
+    assert.doesNotMatch(markup, /<img/u);
     assert.doesNotMatch(markup, /<iframe/u);
     assert.doesNotMatch(markup, /<button/u);
     expect(mocks.headers).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Retire the view-only computer handoff branch that rendered a bare static screenshot data URL.
- Show a simple recovery state for any already-issued view-only inspection links, directing the user back to Murph for a live browser handoff.
- Update the route-page regression so view-only inspection links no longer render an image preview.

## Notes
- This was the smallest UI-safe change to remove the broken clipped screenshot surface without touching the handoff/store state machine.
- Follow-up PR needed to change assistant generation so it stops minting `screen_inspection` links and uses normal live browser handoff instead.

## Verification
- Not run locally; repository access was through the GitHub connector only.