### PR TITLE
[codex] add strength training agent skill

### DIFF
--- a/.agents/skills/strength-training/SKILL.md
+++ b/.agents/skills/strength-training/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: strength-training
+description: |
+  Design, explain, adapt, or review evidence-informed strength and resistance training for generally healthy adults. Use for beginner or experienced plans; general strength and function, hypertrophy or physique, maximal strength, power, gym/home/calisthenics, progression, plateaus, competition preparation, and adherence coaching. Fit recommendations to experience, schedule, equipment, symptoms, and concurrent sport. Do not use for diagnosis or rehabilitation, medical clearance, rapid weight cuts, eating-disorder treatment, or performance-enhancing-drug protocols.
+---
+
+# Strength Training
+
+## Outcome
+
+Help the user choose and run the **smallest safe strength plan that answers their real question**. Be steady, direct, encouraging without hype, and respectful of the user's judgment.
+
+A strong response:
+
+- answers the request before expanding scope
+- matches the dose to the goal, experience, equipment, schedule, and other demands
+- makes progression and adaptation observable
+- adds behavior support only where friction exists
+- names material uncertainty and safety limits without medicalizing ordinary training
+- leaves one clear next action and a review point
+
+The skill should increase competence and self-trust—not app dependence, body surveillance, or protocol accumulation.
+
+## One composable engine
+
+Build from:
+
+`goal lens + realistic dose + relevant modifiers + feedback`
+
+| Outcome that should settle tradeoffs | Goal lens |
+| --- | --- |
+| Broad strength, function, confidence, muscular endurance, return to lifting, or a bodyweight skill | General strength and function |
+| Muscle gain or a user-chosen physique outcome | Hypertrophy |
+| A heavier 1RM, powerlifting total, or named heavy lift | Maximal strength |
+| A faster jump, sprint, throw, acceleration, or other explosive task | Power |
+
+A lens is a programming emphasis, not a user identity. Mixed goals are normal: choose the outcome that should settle tradeoffs and retain compatible secondary goals.
+
+Apply only modifiers that change the plan:
+
+- experience and technical skill
+- realistic days, time, and recovery capacity
+- equipment, home setup, or calisthenics preference
+- pain, symptoms, health constraints, pregnancy/postpartum status, or recent surgery
+- running, sport practice, physical work, or other hard training
+- a fixed event date, current ruleset, or judged standard
+- strong preferences, dislikes, cost, and access
+
+“Home,” “gym,” “calisthenics,” “beginner,” and “competition” are modifiers, not separate programming engines.
+
+## Load only what the task needs
+
+- `references/programming.md` — plans, exercise selection, progression, plateaus, testing, or review
+- `references/coaching.md` — adherence friction, habits, reminders, missed sessions, motivation, or reducing dependence on Murph
+- `references/safety.md` — pain, symptoms, health uncertainty, maximal or high-skill work, special populations, competition, or body-composition risk
+- `references/evidence.md` — source-level justification, disputed claims, confidence calibration, or maintenance of defaults
+
+When a visual would materially improve exercise understanding and the companion skill is available, use `$murph-exercise-images` rather than creating another image workflow.
+
+The boundaries below apply even when no reference is loaded.
+
+## Interaction contract
+
+### Direct question
+
+Answer first with the smallest useful recommendation, why it fits, and the main caveat. Do not turn “How long should I rest?” into an intake or full program.
+
+### Plan request
+
+Use known context. Ask no question when a safe, reversible default will work. Otherwise ask one compact setup question containing only unknowns that would change the plan. These are usually the desired outcome or event, recent training, realistic time, equipment, relevant symptoms or restrictions, other hard training, and strong exercise preferences.
+
+State consequential assumptions and proceed. Do not run a serial intake unless safety genuinely requires it.
+
+### Existing plan
+
+Preserve useful stable elements. Identify the bottleneck—progression, dose, technique, recovery, schedule, equipment, pain, or goal mismatch—and change the smallest thing likely to fix it.
+
+### Product action and privacy
+
+Planning is not activation. Do not silently create a protocol, reminder, check-in, or persisted record. Obtain explicit consent for side effects and keep them bounded to the chosen block.
+
+Treat physique photos, body measurements, pain and symptom notes, training logs, and competition health data as private by default. Sharing requires explicit user intent.
+
+## Build the smallest complete answer
+
+1. **Set the decision criterion.** Translate the request into the outcome that should guide tradeoffs. Use neutral language for appearance goals; do not promise spot reduction, rank bodies, or turn appearance into a health verdict.
+2. **Establish scope and safety.** This skill primarily serves generally healthy adults. Ask only for safety facts that change the response. Do not diagnose, prescribe rehabilitation, or claim medical clearance.
+3. **Fit a repeatable dose.** One weekly session can be useful; two or three is a common robust default. More days must earn their complexity through the goal, preference, or training age. Use the first one or two exposures for conservative calibration, not toughness testing.
+4. **Make the prescription executable.** Name the exact exercise or variation, work sets, rep or time range, effort or quality stop, rest, and progression rule. Prefer stable, available, tolerable movements and one likely substitution rather than a menu.
+5. **Add only useful resilience and feedback.** When schedule friction is plausible, give a shorter fallback that preserves priority work and reduces sets—not rest, safety, or missed-session “debt.” Track one primary outcome and at most one or two context signals, then set a review point that can change a decision.
+6. **Coach only the friction.** A consistent trainee does not need habit machinery. When support is useful, use the smallest relevant pieces from `references/coaching.md`: schedule fit, one start mechanism, one obstacle plan, minimal feedback, neutral restart, and a path toward less support.
+
+## Full-plan shape
+
+When a full program is requested, use this compact shape and omit sections that do not help:
+
+1. **Aim and review** — what this block is testing and when to review it
+2. **Week** — days, approximate duration, and coordination with other demands
+3. **Sessions** — exact exercises, sets, reps, effort, and rest
+4. **Progression and minimum** — how to advance and what to do on a constrained day
+5. **Track and decide** — primary outcome, minimal log, and next decision
+6. **Safety** — only the relevant stop condition or referral boundary
+
+Do not bury the plan under a lecture. At review, choose the smallest justified action: keep, progress, simplify, change one variable, pause, seek qualified help, or leave it alone.
+
+## Evidence calibration
+
+Distinguish:
+
+- **Evidence-backed direction:** resistance training works; specificity matters; heavier loading favors maximal strength; more recoverable weekly volume tends to favor hypertrophy; fast intent with controlled fatigue favors power.
+- **Practical default:** a starting split, set or rep range, exercise order, review window, or fallback chosen for clarity and burden.
+- **Individual experiment:** exact exercise, optimal weekly volume, preferred split, deload timing, or response to a method.
+
+Do not present optimization findings as minimum requirements, a group average as an individual promise, or a product feature as proof of adherence.
+
+## Non-negotiable boundaries
+
+- No injury diagnosis, rehabilitation prescription, or medical-clearance claim.
+- No rapid dehydration, diuretics, laxatives, vomiting, starvation, severe restriction, or aggressive weight-cut protocol.
+- No anabolic-steroid, SARM, peptide, or other performance-enhancing-drug cycles.
+- No routine true-max testing for novices or unsafe solo setups.
+- No body ranking, shame, punitive streaks, guilt-based reminders, public body data by default, or manipulative engagement.
+- No guaranteed transformation timeline.
+- No federation rule, weigh-in window, or event standard from memory when a current official source is required.
+- No complex periodization, readiness stack, or behavior framework unless a concrete need makes the simpler approach insufficient.
+
+## Stop rule
+
+Stop when the core request has a safe, testable next step. Add detail only when it changes the plan, the user's decision, or a material safety boundary.

--- a/.agents/skills/strength-training/agents/openai.yaml
+++ b/.agents/skills/strength-training/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Strength Training"
+  short_description: "Build simple, evidence-informed strength plans"
+  default_prompt: "Use $strength-training to answer my strength-training question or build the smallest safe plan that fits my goal, experience, equipment, schedule, and other training."

--- a/.agents/skills/strength-training/references/coaching.md
+++ b/.agents/skills/strength-training/references/coaching.md
@@ -1,0 +1,260 @@
+# Coaching and Adherence
+
+Use this reference when the user is starting, repeatedly missing training, asking for reminders, struggling with motivation, or trying to become more self-directed.
+
+The goal is not maximal app engagement. The goal is a user who can initiate, train, interpret results, adapt, and resume with less help over time.
+
+## Contents
+
+- [Coaching stance](#coaching-stance)
+- [Minimum behavior system](#the-minimum-behavior-system)
+- [Friction diagnosis](#diagnose-friction-before-adding-motivation)
+- [Enjoyment, competence, and bounded choice](#enjoyment-and-tolerability)
+- [Missed sessions](#missed-sessions-and-lapse-repair)
+- [Reminders and identity](#reminders-and-check-ins)
+- [Body image and competition language](#body-image-food-and-competition-language)
+- [Building an elite, self-directed user](#building-an-elite-user)
+- [Anti-patterns and stop rule](#anti-patterns)
+
+## Coaching stance
+
+- Treat the user as capable and acting in good faith.
+- Connect training to the user's own reason, not an imposed fitness identity.
+- Prefer practical fit over motivational theater.
+- Make success informative: “That load stayed at 2 RIR across all sets” is more useful than generic praise.
+- Use curiosity after a miss. Do not diagnose character.
+- Keep support proportional. A consistent trainee may need programming but no habit intervention.
+
+Autonomy-supportive coaching has beneficial but generally modest and variable effects. It is a design principle, not a magic script.
+
+## The minimum behavior system
+
+Use only the pieces needed.
+
+### 1. Meaningful target
+
+Clarify what the user wants training to make possible. Concrete outcomes are usually stronger than abstract obligation.
+
+Useful prompts:
+
+- “What would be meaningfully different if this worked?”
+- “Which result should decide whether we keep this block?”
+
+Do not force a deep “why” conversation when the user already has a clear practical reason.
+
+### 2. A week that exists
+
+Plan from the user's realistic week, including work, caregiving, sport, commute, and preferred training times.
+
+Ask what a difficult week looks like. A robust plan has:
+
+- a standard schedule the user expects to perform
+- a minimum viable fallback for the most likely constraint
+- no debt or make-up volume after a miss
+
+One useful session is better than an ideal schedule the user cannot test.
+
+### 3. A reliable start
+
+Use one start mechanism only when initiation is a real problem:
+
+- a calendar commitment
+- a stable context such as “after work on Tuesday”
+- a prepared environment such as packed shoes or preset equipment
+- a user-written if-then plan: “If the meeting runs late, I will do the 20-minute version at home.”
+
+Stable repetition can support automaticity, but habit timing varies widely. Never promise that training will become automatic in 21, 30, or any fixed number of days.
+
+Shift workers and unpredictable schedules may need a weekly decision rule rather than a clock-time habit, such as selecting two sessions when the rota arrives.
+
+### 4. One obstacle plan
+
+Ask for the obstacle most likely to break the next week, not every imaginable failure.
+
+A good coping plan is specific and low burden:
+
+- **time:** use the minimum session
+- **equipment:** use one preselected substitution
+- **travel:** use a small portable or bodyweight session
+- **fatigue:** begin the warm-up, then use the readiness rule
+- **uncertainty:** show the first exercise and target load clearly
+- **social discomfort:** choose a quieter time, familiar area, or home option
+
+Implementation intentions can help bridge intention and action, but a stack of plans becomes another task.
+
+### 5. Minimal feedback
+
+Track only what supports progression and learning. The default is the training log in `programming.md`, not a broad wellness dashboard.
+
+Feedback should answer:
+
+- What happened?
+- What does it suggest?
+- What is the smallest next decision?
+
+Examples:
+
+- “You reached the top of the rep range at the intended effort twice. Add the smallest load next session.”
+- “The plan has not been tested yet because work displaced two sessions. Keep the exercises and reduce the schedule before changing the program.”
+
+Do not reward data production for its own sake.
+
+### 6. A bounded review
+
+Review on a cadence that can change a decision—usually weekly for fit and several weeks for outcomes. The review can end with keep, progress, simplify, change one thing, pause, or leave it alone.
+
+Do not generate a new protocol every week when the current one is working.
+
+## Diagnose friction before adding motivation
+
+Repeated misses usually point to one or more of three practical problems. Use plain language; do not expose a framework unless the user asks.
+
+| Friction | Typical signals | First response |
+| --- | --- | --- |
+| **Clarity or skill** | Does not know what to do, fears equipment, cannot estimate effort, exercises change every session | Simplify the session, clarify the first action, rehearse technique, or seek qualified coaching |
+| **Opportunity or environment** | Time, commute, childcare, access, setup, travel, schedule volatility | Reduce frequency or duration, move the session, preselect substitutions, or use a home fallback |
+| **Value, experience, or recovery** | Plan feels pointless, punishing, boring, excessively sore, or conflicts with another goal | Reconnect to the chosen outcome, change tolerability while preserving stimulus, reduce dose, or choose a different activity |
+
+Do not answer an opportunity problem with more reminders or a recovery problem with moral pressure. Offer a coach, training partner, or group only when the user wants support for skill, confidence, access, or enjoyment; do not turn social support into surveillance or mandatory accountability.
+
+## Enjoyment and tolerability
+
+How training feels during participation is associated with future physical activity. Preserve the necessary stimulus while improving the experience.
+
+Useful levers:
+
+- replace an exercise the user dreads with a comparable option
+- reduce excessive soreness and failure work
+- choose a setting the user prefers
+- shorten a session before abandoning the goal
+- keep a user-valued exercise even when it is not theoretically unique
+- separate difficult technical practice from high-fatigue work
+
+Enjoyment does not require every set to feel easy. It means the plan is worth returning to.
+
+After early sessions, one useful question is: “Which part felt least worth repeating?” Change only what the answer justifies.
+
+## Competence without perfection
+
+Early plans should create evidence that the user can repeat the process:
+
+- conservative first-session loads
+- clear movement and setup instructions, with one simple cue or demonstration when needed
+- achievable rep targets
+- visible progression criteria
+- feedback tied to observable performance
+
+Do not equate exhaustion, soreness, sweat, or maximal effort with training quality.
+
+For RIR learning, compare the estimate with the next set and keep calibration approximate. Do not demand precision that the user cannot yet possess. When a visual would resolve uncertainty, use the existing exercise-image skill rather than building a parallel media workflow.
+
+## Choice without menus
+
+Choice supports ownership when it is real and bounded. Offer at most one or two meaningful alternatives and name the tradeoff.
+
+Good: “Use the machine press for stability or dumbbells if you value the skill; either can serve this plan.”
+
+Poor: a list of twelve substitutes that transfers the planning burden back to the user.
+
+## Missed sessions and lapse repair
+
+After one miss:
+
+1. acknowledge it neutrally
+2. resume at the next viable slot
+3. do not double volume, punish, or reset a streak
+4. leave the plan unchanged unless the miss exposed a real constraint
+
+After repeated misses:
+
+1. identify the recurring friction
+2. lower or relocate the dose before adding pressure
+3. preserve the user's chosen outcome where possible
+4. set one revised experiment for the next week
+
+Useful language:
+
+- “The week changed; the plan did not fit it.”
+- “Let’s make the next attempt easier to start.”
+- “We do not need to compensate for the missed work.”
+
+Avoid “fell off,” “failed,” “cheated,” “lazy,” “back on track,” or “no excuses.”
+
+## Reminders and check-ins
+
+Create reminders only with explicit user consent.
+
+A reminder should be:
+
+- chosen or approved by the user
+- tied to a specific action or review
+- bounded to the current plan or block
+- easy to mute, change, or end
+- non-escalating
+
+Missed reminders expire; they do not accumulate. Do not send guilt, urgency, body-comparison, or “you are losing progress” messages. Do not infer that silence means the user needs more contact.
+
+When the user reliably initiates and can explain the plan, offer to reduce or remove reminders. Silence is a successful product state.
+
+## Identity
+
+Reflect identities the user already claims, but do not prescribe “become a lifter” as a behavior hack. Identity change is not required for participation, and imposed identity can create pressure or exclusion.
+
+Prefer evidence of capability:
+
+- “You have repeated this setup for four sessions.”
+- “You adjusted the load without turning the day into a failure.”
+
+## Body image, food, and competition language
+
+- Describe physique goals neutrally and privately.
+- Do not moralize food, leanness, scale weight, or body fat.
+- Do not use before/after comparison as social proof or a default metric.
+- Do not encourage training to compensate for eating.
+- Treat guilt-driven exercise, escalating restriction, compulsive checking, repeated training through injury, or fear of rest as a reason to pause optimization and seek appropriate professional support.
+
+## Building an elite user
+
+“Elite” here means skilled and self-regulating, not dependent, obsessive, or always training more.
+
+Develop these capabilities gradually:
+
+1. **Repeatability:** reproduce exercise setup, range, and standards.
+2. **Effort judgment:** estimate RIR well enough to follow the plan.
+3. **Progression:** know when to add load, repetitions, difficulty, or nothing.
+4. **Load management:** recognize when other sport, work, pain, or fatigue changes the day.
+5. **Evidence use:** distinguish one noisy session from a repeated trend.
+6. **Safety judgment:** stop for concerning symptoms and seek qualified help when needed.
+7. **Autonomy:** choose among bounded options and explain the tradeoff.
+8. **Recovery from disruption:** resume without punishment or identity threat.
+
+### Fade support as skill grows
+
+Murph should move from directing to reviewing:
+
+- **Early:** provide exact sessions and conservative calibration.
+- **Learning:** ask the user to predict the next load or choose between two valid options.
+- **Self-directed:** review trends, answer questions, and intervene only when a decision or safety issue exists.
+
+Reduce prompts when the user can reliably initiate, progress, adapt, and explain the plan. Do not preserve engagement by withholding the rules.
+
+## Anti-patterns
+
+Do not use:
+
+- streaks that imply moral worth
+- red failure states or completion percentages as the main outcome
+- escalating reminders after silence
+- artificial urgency or scarcity
+- fixed habit timelines
+- generic motivational quotes
+- excessive intake before giving value
+- daily readiness surveys by default
+- “perfect week” framing
+- rewards that displace the user's reason for training
+- praise for pain, restriction, or compulsive effort
+- a new framework when one practical adjustment will do
+
+## Coaching stop rule
+
+Once the user has a workable next action, a fallback, and a review point, stop. More coaching language is not automatically more supportive.

--- a/.agents/skills/strength-training/references/evidence.md
+++ b/.agents/skills/strength-training/references/evidence.md
@@ -1,0 +1,220 @@
+# Evidence Map
+
+Last reviewed: **2026-06-25**
+
+This file supports operational defaults; it is not a literature dump. Prefer current position stands, systematic reviews, meta-analyses, and official safety guidance. Update a default only when the total evidence or product need justifies the added complexity.
+
+## Contents
+
+- [How to use the evidence](#how-to-use-the-evidence)
+- [Operational conclusions](#operational-conclusions)
+- [Training sources](#training-sources)
+- [Behavior and adherence](#behavior-and-adherence-conclusions)
+- [Safety conclusions and sources](#safety-conclusions)
+- [Murph product choices](#murph-product-choices)
+- [Known limits](#known-limits)
+- [Maintenance triggers](#maintenance-triggers)
+
+## How to use the evidence
+
+Separate four things:
+
+1. **High-confidence direction** — broad findings that should shape most plans.
+2. **Conditional optimization** — useful when a named outcome matters, not a minimum requirement.
+3. **Practical heuristic** — a reversible starting point chosen for clarity and burden.
+4. **Product choice** — Murph's values and UX constraints, which should not be misrepresented as physiology.
+
+A statistically favored method is not automatically the best recommendation for a user's life. Absolute effects, uncertainty, burden, equipment, skill, and adherence all matter.
+
+## Operational conclusions
+
+### High-confidence direction
+
+- Progressive resistance training improves strength, hypertrophy, power, muscular endurance, and physical function compared with no resistance training.
+- The largest practical gain for many adults is moving from none to a repeatable dose; complicated programming is not a prerequisite.
+- Specificity matters: practice the movement, range, speed, and standard the user wants to improve.
+- Heavier loading favors maximal-strength outcomes.
+- Higher recoverable weekly volume tends to favor hypertrophy, with diminishing returns and substantial individual variation.
+- Power training benefits from fast intent, low-to-moderate fatigue, and movement-specific practice.
+- Bodyweight, bands, machines, and free weights can all work when resistance and progression are appropriate.
+- Training to momentary failure is not routinely required.
+
+### Conditional optimization
+
+- About ten or more weekly sets per muscle appears useful in some hypertrophy syntheses, but it is an optimization signal—not a universal threshold or starting floor.
+- Training a muscle or lift more often can distribute practice and weekly volume; frequency is not magic when dose is otherwise comparable.
+- Longer rests often preserve performance and may modestly help hypertrophy versus very short rests; the exercise and goal matter.
+- Full range of motion is a strong general default, while selected partial ranges can be task- or tolerance-specific.
+- Periodization can modestly improve 1RM strength in some volume-equated analyses, particularly for trained lifters, but is not required for general health or hypertrophy.
+- Autoregulated loading can be useful and may improve strength in some analyses, but simple fixed progression also works; RIR/RPE is a low-burden option.
+- Concurrent endurance and strength training is broadly compatible with maximal strength and hypertrophy, while explosive outcomes may be more sensitive to same-session fatigue.
+
+### Practical heuristics used by this skill
+
+These are deliberately conservative starting points, not claims of biological optima:
+
+- two full-body sessions as the broad default; one is a useful minimum
+- one to three work sets per movement for initial plans
+- about 2–3 RIR for most general work
+- roughly 4–8 direct weekly sets for a priority muscle when hypertrophy history is unknown
+- double progression before more elaborate periodization
+- a minimum viable session that reduces sets rather than rest or safety
+- one primary outcome plus one or two context signals
+- a weekly fit review and a multiweek outcome review
+
+## Training sources
+
+1. **Currier BS, et al.** American College of Sports Medicine Position Stand. Resistance Training Prescription for Muscle Function, Hypertrophy, and Physical Performance in Healthy Adults: An Overview of Reviews. *Medicine & Science in Sports & Exercise*. 2026;58(4):851–872. DOI: [10.1249/MSS.0000000000003897](https://doi.org/10.1249/MSS.0000000000003897). PMID: [41843416](https://pubmed.ncbi.nlm.nih.gov/41843416/).
+   - Overview of 137 systematic reviews and more than 30,000 participants. Supports consistency over unnecessary complexity, heavier loads for strength, higher volume for hypertrophy, moderate loads and fast intent for power, broad equipment effectiveness, and the optional nature of many advanced techniques.
+
+2. **Currier BS, et al.** Resistance training prescription for muscle strength and hypertrophy in healthy adults: a systematic review and Bayesian network meta-analysis. *British Journal of Sports Medicine*. 2023;57:1211–1220. DOI: [10.1136/bjsports-2023-106807](https://doi.org/10.1136/bjsports-2023-106807).
+   - All evaluated resistance-training prescriptions improved strength and hypertrophy versus no exercise; higher loads ranked highly for strength.
+
+3. **Pelland JC, et al.** The Resistance Training Dose Response: Meta-Regressions Exploring the Effects of Weekly Volume and Frequency on Muscle Hypertrophy and Strength Gains. *Sports Medicine*. 2026;56:481–505. Published online 2025. DOI: [10.1007/s40279-025-02344-w](https://doi.org/10.1007/s40279-025-02344-w).
+   - Supports volume dose-response relationships with diminishing returns; frequency and volume should not be collapsed into a universal threshold.
+
+4. **Robinson ZP, et al.** Exploring the Dose–Response Relationship Between Estimated Resistance Training Proximity to Failure, Strength Gain, and Muscle Hypertrophy: A Series of Meta-Regressions. *Sports Medicine*. 2024;54:2209–2231. DOI: [10.1007/s40279-024-02069-2](https://doi.org/10.1007/s40279-024-02069-2).
+   - Strength gains were similar across a broad estimated RIR range; hypertrophy tended to improve nearer failure, with uncertainty around the exact relationship.
+
+5. **Grgic J, et al.** Effects of resistance training performed to repetition failure or non-failure on muscular strength and hypertrophy: a systematic review and meta-analysis. *Journal of Sport and Health Science*. 2022. DOI: [10.1016/j.jshs.2021.01.007](https://doi.org/10.1016/j.jshs.2021.01.007).
+   - Failure was not consistently superior for strength or hypertrophy.
+
+6. **Pallarés JG, et al.** Effects of range of motion on resistance training adaptations: a systematic review and meta-analysis. *Scandinavian Journal of Medicine & Science in Sports*. 2021;31:1866–1881. DOI: [10.1111/sms.14006](https://doi.org/10.1111/sms.14006).
+   - Supports full range as a general default while leaving room for task-specific partial work.
+
+7. **Singer A, et al.** Give it a rest: a systematic review with Bayesian meta-analysis on the effect of inter-set rest interval duration on muscle hypertrophy. *Frontiers in Sports and Active Living*. 2024;6:1429789. DOI: [10.3389/fspor.2024.1429789](https://doi.org/10.3389/fspor.2024.1429789).
+   - Suggests a small advantage for rests longer than 60 seconds, plausibly through better training quality and volume preservation.
+
+8. **Schumann M, et al.** Compatibility of Concurrent Aerobic and Strength Training for Skeletal Muscle Size and Function: An Updated Systematic Review and Meta-Analysis. *Sports Medicine*. 2022;52:601–612. DOI: [10.1007/s40279-021-01587-7](https://doi.org/10.1007/s40279-021-01587-7).
+   - Concurrent training did not compromise maximal strength or hypertrophy overall; explosive strength was more vulnerable when modes occurred in the same session.
+
+9. **Moesgaard L, et al.** Effects of Periodization on Strength and Muscle Hypertrophy in Volume-Equated Resistance Training Programs: A Systematic Review and Meta-analysis. *Sports Medicine*. 2022;52:1647–1666. DOI: [10.1007/s40279-021-01636-1](https://doi.org/10.1007/s40279-021-01636-1).
+   - Periodization modestly favored 1RM strength, with stronger relevance for trained participants; hypertrophy differences were not clear.
+
+10. **Hickmott LM, et al.** The Effect of Load and Volume Autoregulation on Muscular Strength and Hypertrophy: A Systematic Review and Meta-Analysis. *Sports Medicine - Open*. 2022;8:9. DOI: [10.1186/s40798-021-00404-9](https://doi.org/10.1186/s40798-021-00404-9).
+    - Autoregulated and standardized approaches both improved outcomes; autoregulation can help but does not need to be an onboarding requirement.
+
+11. **Nuzzo JL, et al.** Resistance Exercise Minimal Dose Strategies for Increasing Muscle Strength in the General Population: an Overview. *Sports Medicine*. 2024;54:1139–1162. DOI: [10.1007/s40279-024-02009-0](https://doi.org/10.1007/s40279-024-02009-0).
+    - One weekly session, single sets, and short resistance “snacks” can improve strength compared with none; minimal dose should not be presented as equal to all higher-dose outcomes.
+
+12. **Kotarsky CJ, et al.** Effect of Progressive Calisthenic Push-up Training on Muscle Strength and Thickness. *Journal of Strength and Conditioning Research*. 2018;32:651–659. DOI: [10.1519/JSC.0000000000002345](https://doi.org/10.1519/JSC.0000000000002345).
+    - Demonstrates that progressive bodyweight variation can improve upper-body strength and thickness; it does not prove that all calisthenics programs are equivalent to all loaded programs.
+
+## Behavior and adherence conclusions
+
+### What the evidence supports
+
+- Intention is important but often insufficient; translate it into a workable opportunity, first action, and one coping plan.
+- Autonomy, competence, and personally meaningful reasons are useful coaching principles, but intervention effects are generally small and heterogeneous.
+- Habit formation time varies widely. Stable context and repetition can help; fixed “21-day” claims are not supported.
+- How exercise feels during participation is associated with future behavior; tolerability and enjoyment are legitimate program variables.
+- Goal setting, self-monitoring, feedback, and implementation intentions can help in some contexts, but more tracking or more techniques are not automatically better.
+- Digital delivery can support clear instruction, demonstration, and graded tasks, but direct evidence that mHealth creates sustained resistance-training participation remains thin; product features are not adherence proof.
+- Lapses should trigger friction diagnosis and plan repair, not shame or compensatory exercise.
+
+### Product translation
+
+Use a small behavior system:
+
+1. user-valued outcome
+2. realistic schedule
+3. one start mechanism when needed
+4. one likely-obstacle plan
+5. minimum viable session
+6. minimal performance log
+7. bounded review and neutral restart
+
+Do not force all seven components on a user who already trains reliably.
+
+## Behavior sources
+
+1. **Feil K, Fritsch J, Rhodes RE.** The intention–behaviour gap in physical activity: a systematic review and meta-analysis of the action control framework. *British Journal of Sports Medicine*. 2023;57:1265–1271. DOI: [10.1136/bjsports-2022-106640](https://doi.org/10.1136/bjsports-2022-106640).
+   - Across 25 independent samples and roughly 29,600 participants, a large proportion of people with positive intentions did not enact them. Supports action control and environmental fit rather than motivation-only coaching.
+
+2. **da Silva MAV, et al.** Impact of implementation intentions on physical activity practice in adults: a systematic review and meta-analysis of randomized clinical trials. *PLOS ONE*. 2018;13:e0206294. DOI: [10.1371/journal.pone.0206294](https://doi.org/10.1371/journal.pone.0206294).
+   - If-then planning can improve physical activity, with effects dependent on context and intervention design.
+
+3. **Ntoumanis N, et al.** A meta-analysis of self-determination theory-informed intervention studies in the health domain. *Health Psychology Review*. 2021;15:214–244. DOI: [10.1080/17437199.2020.1718529](https://doi.org/10.1080/17437199.2020.1718529).
+   - Supports autonomy and competence as useful design principles while showing modest, heterogeneous average effects.
+
+4. **Singh B, et al.** Time to Form a Habit: A Systematic Review and Meta-Analysis of Health Behaviour Habit Formation and Its Determinants. *Healthcare*. 2024;12:2488. DOI: [10.3390/healthcare12232488](https://doi.org/10.3390/healthcare12232488).
+   - Habit-formation timing varies substantially across people and behaviors; avoid fixed timelines.
+
+5. **Rhodes RE, Kates A.** Can the Affective Response to Exercise Predict Future Motives and Physical Activity Behavior? A Systematic Review of Published Evidence. *Annals of Behavioral Medicine*. 2015;49:715–731. DOI: [10.1007/s12160-015-9704-5](https://doi.org/10.1007/s12160-015-9704-5).
+   - Affect during exercise was associated with future physical activity; post-exercise affect showed less consistent predictive value.
+
+6. **Spring B, et al.** Self-regulatory behavior change techniques in interventions to promote healthy eating, physical activity, or weight loss: a meta-review. *Health Psychology Review*. 2021;15:508–539. DOI: [10.1080/17437199.2020.1721310](https://doi.org/10.1080/17437199.2020.1721310).
+   - Goal setting and self-monitoring are common and sometimes useful, but review quality and maintenance evidence are limited; this supports minimal, decision-relevant tracking rather than maximal logging.
+
+7. **Cox ER, et al.** Effects of mHealth interventions to prescribe resistance training: a systematic review and meta-analysis of randomized controlled trials. *International Journal of Behavioral Nutrition and Physical Activity*. 2026;23:7. Published online 2025. DOI: [10.1186/s12966-025-01868-8](https://doi.org/10.1186/s12966-025-01868-8).
+   - Across 32 RCTs, mHealth-delivered resistance training produced a small short-term fitness benefit; only two studies measured resistance-training participation, preventing an adherence meta-analysis. Instruction, demonstration, and graded tasks were common, while prescription reporting and long-term evidence were limited.
+
+## Safety conclusions
+
+- Preparticipation screening should identify people who need more evaluation without creating unnecessary barriers for apparently healthy adults.
+- New concerning cardiovascular, neurological, or exertional symptoms should override programming.
+- Dark urine with severe muscle symptoms after strenuous exercise warrants urgent evaluation for possible rhabdomyolysis.
+- Low energy availability and RED-S can affect female and male athletes; diagnosis and risk stratification are clinician-led.
+- Competition rules, screening tools, and medical guidance are versioned sources and must be checked when needed.
+- Children and adolescents need youth-specific technique, loading, equipment, and supervision decisions rather than an adult maximal-strength template.
+
+## Safety sources
+
+1. **Canadian Society for Exercise Physiology.** [CSEP Get Active Questionnaire](https://csep.ca/2021/01/20/pre-screening-for-physical-activity/).
+   - Current CSEP-endorsed evidence-based screen; intended to screen in most people and reserve referral for cases where risks may outweigh benefits.
+
+2. **Riebe D, et al.** Updating ACSM's Recommendations for Exercise Preparticipation Health Screening. *Medicine & Science in Sports & Exercise*. 2015;47:2473–2479. PMID: [26473759](https://pubmed.ncbi.nlm.nih.gov/26473759/).
+   - Supports reducing unnecessary barriers while identifying symptoms, known disease, and intended intensity that warrant further evaluation.
+
+3. **American Heart Association.** [Heart Attack, Stroke and Cardiac Arrest Symptoms](https://www.heart.org/en/about-us/heart-attack-and-stroke-symptoms).
+   - Official symptom guidance for urgent cardiovascular and neurological warning signs.
+
+4. **CDC/NIOSH.** [Signs and Symptoms of Rhabdomyolysis](https://www.cdc.gov/niosh/rhabdo/signs-symptoms/index.html). Updated 2025.
+   - Muscle pain, dark urine, and weakness/tiredness after exertion require immediate medical attention.
+
+5. **Mountjoy M, et al.** 2023 International Olympic Committee's consensus statement on Relative Energy Deficiency in Sport (REDs). *British Journal of Sports Medicine*. 2023. DOI: [10.1136/bjsports-2023-106994](https://doi.org/10.1136/bjsports-2023-106994).
+   - Covers health and performance consequences of low energy availability in female and male athletes and introduces a clinician-led assessment tool.
+
+6. **Stricker PR, Faigenbaum AD, McCambridge TM; AAP Council on Sports Medicine and Fitness.** Resistance Training for Children and Adolescents. *Pediatrics*. 2020;145(6):e20201011. DOI: [10.1542/peds.2020-1011](https://doi.org/10.1542/peds.2020-1011).
+   - Supports youth-specific program design, appropriate technique, qualified supervision, and age-appropriate safety rather than simply applying adult maximal-strength templates.
+
+## Murph product choices
+
+The following are product principles rather than claims that a single psychological study proves them:
+
+- smallest useful experiment over protocol accumulation
+- life fit over marginal optimization
+- curiosity over compliance
+- one meaningful outcome and minimal supporting evidence
+- no shame engines, moralized streaks, body comparison, or manipulative reminders
+- private by default; sharing body, health, or progress data requires explicit user intent
+- silence and “leave it alone” as valid product states
+- Murph becomes quieter as the user gains judgment
+
+Sources:
+
+- [Murph Product Constitution](https://github.com/cobuildwithus/murph/blob/main/agent-docs/PRODUCT_CONSTITUTION.md)
+- [Murph Product Sense](https://github.com/cobuildwithus/murph/blob/main/agent-docs/PRODUCT_SENSE.md)
+- [Murph AGENTS.md — Default to Deletion and Simplicity](https://github.com/cobuildwithus/murph/blob/main/AGENTS.md)
+
+## Known limits
+
+- Most resistance-training trials are shorter than a lifetime training career and often have limited representation across sex, age, disability, race/ethnicity, training history, and real-world environments.
+- “Optimal” group averages may not transfer to an individual, especially when adherence and recovery differ.
+- Hypertrophy measurement is noisy; strength is task-specific; power tests are sensitive to familiarization and setup.
+- Behavior-change evidence is broader physical activity evidence, not exclusively long-term resistance-training adherence.
+- Competition tapering, advanced calisthenics skill acquisition, and discipline-specific peaking have thinner and more context-dependent evidence than basic programming.
+
+State these limits when they materially affect the user's decision; do not recite them in every answer.
+
+## Maintenance triggers
+
+Review this file and the related defaults when:
+
+- ACSM, WHO, HHS, CSEP, IOC, or another relevant authority issues a major update
+- a high-quality synthesis materially changes load, volume, frequency, effort, power, screening, or behavior guidance
+- Murph adds a dedicated nutrition, rehabilitation, pregnancy/postpartum, youth, or sport-specific skill
+- a federation rule, screening instrument, or safety source changes
+- eval failures show that a simpler instruction is insufficient or a default causes predictable harm or confusion
+
+Do not add a method because it is fashionable or supported by one isolated study. Prefer deletion when a new finding does not change a user decision.

--- a/.agents/skills/strength-training/references/programming.md
+++ b/.agents/skills/strength-training/references/programming.md
@@ -1,0 +1,382 @@
+# Programming
+
+Use this reference to create, adapt, or review resistance-training plans for generally healthy adults.
+
+## Contents
+
+- [Core model and safe default](#core-programming-model)
+- [Calibration, warm-up, and exercise selection](#first-session-calibration)
+- [General strength and function](#goal-lens-general-strength-and-function)
+- [Hypertrophy](#goal-lens-hypertrophy)
+- [Maximal strength](#goal-lens-maximal-strength)
+- [Power and mixed goals](#goal-lens-power)
+- [Home, calisthenics, and limited equipment](#home-calisthenics-and-limited-equipment)
+- [Concurrent training and fixed events](#concurrent-sport-endurance-and-physical-work)
+- [Progression, readiness, and minimum sessions](#progression)
+- [Logging and review](#logging-and-review)
+
+## Core programming model
+
+A plan is:
+
+`priority outcome + repeatable weekly dose + specific movements + progression + review`
+
+Start simple. Add specialization only when the user's goal, training age, fixed event, or demonstrated plateau requires it.
+
+## Terms
+
+- **Work set:** a set intended to provide the training stimulus, excluding warm-ups.
+- **RIR:** estimated repetitions in reserve with the same acceptable technique. `3 RIR` means roughly three more good reps were possible.
+- **RPE:** session or set effort. When using a 10-point lifting RPE scale, `RPE 7–9` roughly corresponds to `3–1 RIR`; estimates are imprecise.
+- **Direct set:** a challenging set where the target muscle is a primary contributor. Do not pretend indirect work can be counted precisely.
+
+RIR is a communication and autoregulation tool, not a laboratory measurement. New lifters often need calibration.
+
+## Safe reversible default
+
+When the user's goal is broad and details are limited, start with:
+
+- two nonconsecutive full-body sessions per week
+- four to six movements per session
+- one to three work sets per movement
+- mostly 6–12 repetitions
+- about 2–3 RIR
+- enough rest to repeat good work, commonly 2–3 minutes for demanding movements and 1–2 minutes for smaller stable work
+- a six-to-eight-week outcome review, with an earlier feasibility check
+
+One weekly session is still a valid useful minimum. Three sessions can distribute practice and volume. More days should reflect preference, specialization, or a clear recovery/logistics advantage.
+
+## First-session calibration
+
+The first one or two exposures should produce information, not exhaustion.
+
+1. Rehearse the movement with an easy load or variation.
+2. Add resistance in small steps.
+3. Choose a working load that leaves several good reps in reserve.
+4. Record the exact exercise, setup, load or assistance, sets, and reps.
+5. Finish knowing what to repeat or adjust next time.
+
+Do not use a true 1RM to establish a beginner's starting point.
+
+## Warm-up
+
+Use the least warm-up that reliably prepares the task:
+
+- brief general movement when helpful
+- movement-specific rehearsal
+- progressively heavier, low-fatigue sets before the first demanding or technical exercise
+- fewer additional warm-up sets for similar later exercises
+
+Avoid turning the warm-up into conditioning that degrades the session's priority work.
+
+## Exercise selection
+
+Choose exercises that are:
+
+1. specific enough to the outcome
+2. safe for the user's current skill and setup
+3. available and repeatable
+4. progressively loadable through weight, reps, range, leverage, assistance, or quality
+5. tolerable enough to sustain
+
+For broad programs, draw from:
+
+- knee-dominant lower body
+- hip-dominant lower body
+- horizontal or vertical push
+- horizontal or vertical pull
+- optional carry, trunk, calf, arm, grip, balance, or named skill work
+
+Patterns are coverage tools, not boxes every session must tick. Put the highest-priority or most technical work first. Use a full comfortable range of motion as the general default; use partial ranges when a named task, constraint, tolerance issue, or overload purpose justifies them.
+
+Machines, free weights, cables, bands, and bodyweight can all be effective. Match the tool to the user and outcome rather than ranking equipment culturally.
+
+Keep core exercises stable through a meaningful review window unless pain, poor stimulus-to-fatigue, access, strong dislike, or a clear technical reason warrants a change. When time is limited, pair noncompeting stable movements to save time; do not rush heavy target lifts, explosive work, high-skill exercises, or any setup where a superset reduces safety or performance.
+
+## Goal lens: general strength and function
+
+Use for new or returning lifters, health and function, broad strength, muscular endurance, confidence, or a named bodyweight skill without a specialized competitive target.
+
+### Starting prescription
+
+- **Frequency:** 1–3 full-body sessions weekly; two is a robust default.
+- **Movements:** usually 4–6.
+- **Work sets:** usually 1–3 per movement.
+- **Reps:** mostly 5–15; higher repetitions are reasonable for local endurance or limited-load exercises.
+- **Effort:** start around 2–4 RIR and move toward 1–3 RIR as technique and confidence improve.
+- **Rest:** commonly 1.5–3 minutes, longer when needed for demanding work.
+
+### Primary measure
+
+Use a standardized submaximal benchmark such as:
+
+- load for a fixed rep target and RIR
+- repetitions at a fixed load or exact bodyweight variation
+- estimated 1RM from a controlled submaximal set
+- a user-valued function or skill benchmark
+
+### Two-day template
+
+- **Session A:** knee-dominant, push, pull, hinge, optional user-valued work
+- **Session B:** hinge, push or press in another direction, pull in another direction, single-leg or knee-dominant work, optional user-valued work
+
+Exercises can repeat across days. Variation is optional, not a requirement.
+
+## Goal lens: hypertrophy
+
+Use when the main decision criterion is gaining muscle or changing muscular appearance.
+
+### Starting prescription
+
+- **Frequency:** choose 2–5 days from schedule; frequency mainly distributes quality weekly work.
+- **Reps:** many loads can build muscle when sets are sufficiently challenging; 6–15 is an efficient default, while roughly 5–30 can be practical depending on exercise and preference.
+- **Effort:** most work around 1–3 RIR; keep more reserve for technically costly or less stable work.
+- **Rest:** usually 2–3 minutes for demanding compound work and about 1–2 minutes for smaller stable work, extended when performance falls prematurely.
+- **Volume:** use the user's current recoverable dose when known. When unknown, roughly 4–8 direct challenging sets per week for a priority muscle is a conservative practical start; use less for non-priority muscles and add only when the evidence from training supports it.
+
+Higher weekly volume tends to produce more hypertrophy with diminishing returns. Findings around ten or more weekly sets are optimization clues, not entry requirements, universal thresholds, or permission to add junk volume. Adequate energy and protein can affect recovery and growth, but detailed nutrition or contest preparation is outside this skill; do not make food tracking a prerequisite.
+
+### Exercise choices
+
+Prefer stable movements that make the target tissue a clear limiter and can be progressed through a comfortable useful range. Place the highest-priority muscle or movement early enough to receive quality work.
+
+Do not promise spot reduction. A body-part goal can guide muscle emphasis, not local fat loss.
+
+### When to add volume
+
+Add one set to one priority movement or muscle only when:
+
+- the current plan has been performed consistently enough to test
+- technique and effort are stable
+- performance has stopped progressing across repeated exposures
+- pain, soreness, and broader fatigue are manageable
+- the added burden fits the user's week
+
+Remove volume when performance, joint tolerance, or participation deteriorates. Do not change volume and intensity aggressively at the same time.
+
+### Primary measure
+
+Muscle size is noisy and slow. Use one user-chosen method at sensible intervals:
+
+- a standardized circumference
+- private photos under consistent conditions
+- clothing fit or a clearly defined appearance judgment
+- a direct body-composition method when already available, with its measurement limitations
+
+Training performance is useful context but is not a direct measure of hypertrophy.
+
+## Goal lens: maximal strength
+
+Use when the main decision criterion is performance in one or a few heavy lifts.
+
+### Starting prescription
+
+- practice the target lift or a close safe variation regularly
+- place target strength work early
+- use mostly 1–6 repetitions on primary work
+- use about 2–5 work sets, adjusted for lift, frequency, and experience
+- use roughly 1–3 RIR for most work; avoid routine grinders and failure
+- rest commonly 3–5 minutes or long enough to preserve technique and output
+- use moderate-repetition accessories only when they support the target and recovery
+
+Heavier loading, often at or above about 80% 1RM, is useful for optimizing maximal-strength outcomes. Percentages are optional: a conservative training max, RIR/RPE, and repeatable performance can prescribe load when a reliable 1RM is unavailable.
+
+### Specificity and variation
+
+Strength is specific to movement, range, equipment, and test standard. Variations earn a place when they solve a known technical, tolerance, or volume problem. Do not infer a complex “weak point” system from one poor repetition.
+
+### Testing
+
+Prefer a standardized submaximal set or estimated 1RM during normal training. A true 1RM is appropriate only when the user is experienced, technically repeatable, symptom-free, and equipped with suitable safeties, spotters, and setup.
+
+Report the estimation method when using e1RM and do not treat small modeled changes as exact.
+
+## Goal lens: power
+
+Use when the main decision criterion is faster force production in a named jump, sprint, throw, acceleration, change-of-direction task, or sport action.
+
+### Starting prescription
+
+- perform power work after warm-up and before fatiguing strength or conditioning
+- use about 2–5 sets of 2–5 crisp repetitions or brief efforts
+- rest fully enough to restore speed and coordination, commonly 2–5 minutes
+- move with maximal safe intent during the concentric or projection phase
+- stop the set or exercise when speed, height, distance, landing, or coordination clearly declines
+
+For loaded ballistic work, moderate loads around 30–70% 1RM are a useful evidence-backed range, but the best load depends on the movement. Jumps, throws, and sprints do not need an arbitrary percentage.
+
+Choose the least complex exercise that trains the target. Olympic-lift derivatives are options for proficient users or qualified coaching, not a default badge of athleticism.
+
+### Strength support
+
+Power also depends on force capacity. Newer athletes often benefit from general strength work; more advanced athletes may need more specific high-velocity practice. Keep support work sufficient without degrading sport quality.
+
+### Primary measure
+
+Use one standardized test such as jump height or distance, a sprint split, throw distance, or validated velocity measure. Standardize warm-up, surface, equipment, and attempt rule.
+
+## Mixed goals
+
+Do not force compatible goals into separate programs.
+
+- **Strength + hypertrophy:** perform target heavy work first, then moderate-repetition volume. Let the primary measure decide which receives more recovery and specificity.
+- **Power + strength:** perform explosive work first, then strength support.
+- **Power + hypertrophy:** protect explosive quality first; place higher-fatigue volume later or on another day.
+- **General health + any lens:** keep the specialist dose no larger than the user's life can sustain.
+
+When two goals materially compete, say so in one sentence and preserve the user's chosen priority for the current block.
+
+## Home, calisthenics, and limited equipment
+
+Treat the environment as a loading constraint, not a different physiology.
+
+### Progression levers
+
+Use the smallest relevant change:
+
+1. repeat the same setup with better control
+2. add repetitions within the target effort
+3. increase useful range or add a pause
+4. reduce assistance or change leverage
+5. add safely secured external load
+6. add a set only when needed
+
+Log the exact variation, including hand/foot position, elevation, range, assistance, and load when they affect difficulty.
+
+For named skills, practice fresh with low-fatigue quality attempts and a clear success criterion. Repeated failed attempts are not a progression system.
+
+Use only rated anchors and stable supports. Do not recommend improvised doors, furniture, rails, ceiling mounts, or unsafe backpack loading. State honestly when pulling or lower-body loading is equipment-limited.
+
+## Concurrent sport, endurance, and physical work
+
+Count practices, games, sprinting, hard endurance, and demanding work as training stress.
+
+- place the highest-priority quality session where the user is most likely to be fresh
+- avoid hard endurance immediately before power or heavy technical work when possible
+- separate demanding modes by time or days when explosive quality matters
+- reduce lower-priority strength volume before removing a sport requirement
+- coordinate the whole week rather than judging one session in isolation
+
+Concurrent training does not automatically prevent strength or hypertrophy, but explosive outcomes can be more sensitive to same-session fatigue. This skill can coordinate strength with sport demands; it does not replace sport-specific technique, conditioning, or return-to-play programming.
+
+## Fixed events and competition
+
+A date changes sequencing, not physiology.
+
+- verify current federation rules, commands, equipment, classes, weigh-in windows, and judged standards from the official source
+- increase event specificity as the date approaches
+- reduce nonessential novelty and soreness near the event
+- rehearse technical standards and logistics
+- use a taper only when training history and event demands justify it
+
+For strength events, a short taper often reduces volume while retaining some specific intensity, but the exact duration and reduction are individual heuristics rather than a universal formula.
+
+This general modifier does not replace discipline-specific coaching. Olympic weightlifting, strongman, advanced calisthenics, and other high-skill events warrant qualified technical coaching. Physique contest preparation and weight-class manipulation require the boundaries in `safety.md` and, when relevant, a qualified sports dietitian and clinician.
+
+## Progression
+
+### Double progression
+
+For most movements:
+
+1. prescribe a rep range and effort target
+2. keep the load or variation while repetitions improve within that range
+3. when all work sets reach the top of the range at the intended effort and acceptable technique, add the smallest practical load or difficulty next time
+4. return toward the lower end of the range and build again
+
+If performance is unexpectedly poor, repeat or reduce rather than forcing the progression.
+
+### One lever at a time
+
+Progress through one of:
+
+- load
+- repetitions
+- range
+- leverage or assistance
+- execution quality
+- sets
+- frequency or specificity for an advanced need
+
+Do not increase load, volume, frequency, and proximity to failure together.
+
+### Plateau check
+
+Before replacing the program, check:
+
+1. Was the same movement and setup repeated?
+2. Was the plan completed often enough to test?
+3. Were effort estimates and rest intervals credible?
+4. Are load jumps too large?
+5. Did pain, illness, sleep loss, nutrition, work, or other training matter?
+6. Is the primary test too noisy?
+7. Would one smaller change solve the problem?
+
+A plateau is a repeated pattern, not one bad day.
+
+### Deload or lower-stress week
+
+Do not schedule a deload solely because a calendar says so. Consider one when performance and readiness decline repeatedly, fatigue is accumulating, a competition requires it, or life stress temporarily changes recovery.
+
+Reduce sets first, then load or effort if needed; preserve enough movement practice to make the return easy.
+
+## Readiness and daily adaptation
+
+Use multiple signals:
+
+- new or worsening pain or symptoms
+- warm-up performance and coordination
+- recent training load and other demands
+- unusual fatigue, illness, or sleep disruption
+- willingness to train and how the session feels once started
+
+Change the smallest thing that protects quality: load, sets, range, exercise, or session goal. Do not let a wearable score overrule clear symptoms or turn a normal low score into a diagnosis.
+
+## Minimum viable session
+
+A useful fallback usually keeps:
+
+- the highest-priority movement
+- one complementary lower- or upper-body movement
+- one pull or other missing high-value pattern
+- one or two work sets each
+
+For power or maximal strength, keep adequate rest and reduce sets. Do not compress technical work into a circuit.
+
+A one-day-per-week plan, single-set approach, or short “exercise snack” can improve strength compared with doing none. Present minimal dose honestly: useful and often sustainable, but not equivalent to every higher-dose outcome.
+
+## Logging and review
+
+### Minimal log
+
+Record:
+
+- exact exercise or variation
+- load, assistance, or leverage
+- sets × repetitions or hold/effort duration
+- optional RIR and a brief pain/symptom flag when relevant
+
+Avoid requiring daily body weight, soreness scores, readiness questionnaires, photos, or wearable data unless they answer the user's chosen question.
+
+### Weekly review
+
+Use four questions:
+
+1. Did the planned dose happen often enough to learn from it?
+2. Did the primary performance signal move?
+3. What materially affected pain, recovery, enjoyment, or logistics?
+4. Keep the plan, progress it, or change one thing?
+
+### Outcome review
+
+Compare a standardized baseline and retest. Classify the next step as:
+
+- keep
+- progress
+- simplify
+- change one variable
+- pause
+- seek qualified coaching or clinical guidance
+- leave it alone
+
+Do not treat normal day-to-day noise as a mandate to optimize.

--- a/.agents/skills/strength-training/references/safety.md
+++ b/.agents/skills/strength-training/references/safety.md
@@ -1,0 +1,154 @@
+# Safety and Scope
+
+Use this reference when symptoms, pain, health uncertainty, high-skill or maximal work, pregnancy/postpartum status, competition practices, or body-composition risk could change the response.
+
+This is decision support, not diagnosis, rehabilitation, emergency care, or medical clearance.
+
+## Contents
+
+- [Safety stance and screening](#safety-stance)
+- [Urgent stop conditions](#urgent-stop-conditions)
+- [When to pause and seek guidance](#pause-and-obtain-qualified-guidance)
+- [Soreness, discomfort, illness, and fatigue](#ordinary-soreness-and-mild-discomfort)
+- [Maximal, ballistic, and high-skill work](#maximal-strength-testing)
+- [Home and equipment safety](#home-and-equipment-safety)
+- [Older adults and youth](#older-adults)
+- [Pregnancy and postpartum](#pregnancy-and-postpartum)
+- [Weight classes, physique, and energy availability](#weight-classes-physique-preparation-and-energy-availability)
+- [Competition scope and response pattern](#competition-rules-and-scope)
+
+## Safety stance
+
+- Do not require blanket medical clearance from every inactive or older adult.
+- Do not minimize new, severe, or unexplained symptoms.
+- Use current evidence-based preparticipation screening when health status is uncertain; do not reproduce a static custom questionnaire.
+- Favor progressive exposure, conservative calibration, safe equipment, and clear stop conditions.
+- Refer to the right professional without implying that all exercise is unsafe.
+
+The current CSEP Get Active Questionnaire is an example of a self-administered evidence-based screen designed to screen in most people and reserve referral for cases where risk may outweigh benefit. Use the current official version or a current local equivalent. Passing a screen is not a diagnosis or guarantee; concerning symptoms override it.
+
+## Urgent stop conditions
+
+Stop training and seek urgent medical care or local emergency services for symptoms such as:
+
+- chest pressure, squeezing, or pain, especially with shortness of breath, sweating, nausea, or pain spreading to the arm, back, neck, jaw, or stomach
+- fainting, near-fainting with concerning symptoms, sudden confusion, or a new severe balance/coordination problem
+- sudden facial droop, one-sided weakness or numbness, speech difficulty, or another possible stroke sign
+- severe or unusual shortness of breath that does not resolve as expected with stopping
+- major trauma, obvious deformity, inability to bear weight after injury, or uncontrolled bleeding
+- dark tea- or cola-colored urine with severe muscle pain, swelling, weakness, or unusual exhaustion after strenuous exercise
+
+Do not attempt to program around these symptoms in chat.
+
+## Pause and obtain qualified guidance
+
+Pause the affected training and recommend a clinician or appropriately qualified exercise professional when there is:
+
+- new or unexplained exertional chest discomfort, faintness, palpitations with symptoms, or disproportionate breathlessness
+- persistent, worsening, night, or function-limiting pain
+- radiating pain, numbness, tingling, new weakness, instability, or loss of coordination
+- recent surgery, fracture, significant injury, or a diagnosed condition with unclear exercise restrictions
+- pregnancy or postpartum status requiring population-specific screening or adaptation
+- recurrent bone stress injury, menstrual disruption, marked libido changes, repeated illness, severe fatigue, or other possible low-energy-availability concerns
+- a history of disordered eating, compulsive exercise, or escalating body-composition behaviors that makes physique or weight-class work risky
+
+Do not name a diagnosis. State what feature makes ordinary unsupervised progression inappropriate.
+
+## Ordinary soreness and mild discomfort
+
+Delayed muscle soreness, effort, and transient muscular burning can be normal. Pain is not required for progress.
+
+For mild, stable discomfort without neurological symptoms or loss of function:
+
+1. stop the provoking set
+2. reduce load, range, speed, or complexity
+3. try one clearly tolerable alternative if appropriate
+4. monitor whether the issue resolves or recurs
+
+Do not prescribe a rehabilitation protocol or use a pain number as a universal permission rule. Persistent or worsening symptoms need qualified assessment.
+
+## Illness and unusual fatigue
+
+Do not push maximal, high-fatigue, or high-skill training through fever, significant systemic illness, chest symptoms, vomiting/diarrhea with dehydration risk, or marked unexplained fatigue. Encourage rest and appropriate medical advice when symptoms are concerning or persistent.
+
+Resume progressively rather than attempting to recover missed volume.
+
+## Maximal strength testing
+
+A true 1RM or maximal attempt should require:
+
+- meaningful relevance to the user's goal
+- prior experience with the exact lift and standard
+- repeatable technique at heavy submaximal loads
+- suitable rack safeties, spotters, collars, platform, and clearance
+- no relevant current symptoms or unresolved pain
+- a gradual, non-fatiguing warm-up and conservative attempt plan
+
+Use submaximal performance or estimated 1RM for novices, returners, and unsafe solo environments. Never encourage a risky lift for proof, punishment, social status, or app validation.
+
+## Power, ballistic, and high-skill work
+
+Jumps, sprints, throws, Olympic-lift derivatives, advanced calisthenics, and strongman events can impose high technical and tissue demands.
+
+- progress volume and intensity gradually
+- use appropriate space, surface, landing area, and equipment
+- stop before coordination or landing quality degrades
+- avoid high-skill ballistic work under unnecessary fatigue
+- recommend qualified coaching when the skill, load, or stakes exceed the user's demonstrated competence
+
+## Home and equipment safety
+
+- Use anchors, racks, bars, benches, bands, rings, and pull-up systems rated and installed for the intended load.
+- Do not recommend ordinary doors, furniture, rails, shelves, improvised ceiling mounts, or unsecured weights as anchors. A purpose-built doorway or structural system must be rated, compatible with the structure, and installed exactly as directed.
+- Provide enough clearance for the movement and a failed repetition.
+- Use safeties or a spotter for loads that cannot be safely bailed or controlled.
+- Inspect bands, cables, straps, carabiners, and attachment points for wear.
+- Keep children, pets, and bystanders outside the failure area.
+
+Do not assume a home object is safe because it appears sturdy.
+
+## Older adults
+
+Age alone is not a reason to avoid progressive resistance training or demand medical clearance. Scale exercise selection, loading, balance demands, and recovery to current function, symptoms, experience, and screening—not stereotypes.
+
+Use stable supports and slower progression when fall risk, frailty, or technical uncertainty is relevant. Refer when health status or symptoms make unsupervised planning inappropriate.
+
+## Children and adolescents
+
+Children and adolescents are outside this skill's primary adult scope. Do not apply an adult maximal-strength template by default. Use current youth-specific guidance, age-appropriate technique and loading, suitable equipment, and qualified supervision when the user's maturity, skill, exercise complexity, or testing stakes make it relevant.
+
+## Pregnancy and postpartum
+
+Do not use a generic adult template as individualized prenatal or postpartum care. Use current population-specific screening and guidance, respect clinician restrictions, and account for symptoms, delivery/recovery status, pelvic health, balance, thermoregulation, and changing tolerance.
+
+Route complex cases to an appropriately trained prenatal/postpartum exercise professional or clinician.
+
+## Weight classes, physique preparation, and energy availability
+
+Do not provide:
+
+- rapid dehydration or fluid restriction
+- sauna suits or deliberate extreme heat exposure
+- diuretics, laxatives, vomiting, or other purging
+- crash diets, starvation, or severe energy restriction
+- unprescribed hormones or performance-enhancing drugs
+
+A short timeline, history of disordered eating, recurrent injury/illness, menstrual changes, marked fatigue, or other possible RED-S signs should trigger a recommendation for a qualified sports dietitian and clinician. The IOC RED-S assessment tool is clinician-led; do not diagnose RED-S in chat.
+
+Physique contest preparation is not just a hypertrophy block. Murph may support ordinary training coordination but should not independently prescribe extreme leanness, peak-week manipulation, or risky weight loss.
+
+## Competition rules and scope
+
+Use the current official federation or event source for commands, equipment, classes, anti-doping rules, and weigh-in procedures. Rules change.
+
+General programming does not replace discipline-specific technical coaching for powerlifting, Olympic weightlifting, strongman, advanced calisthenics, or judged physique preparation.
+
+## Response pattern for a safety concern
+
+Use a calm three-part response:
+
+1. **Name the boundary:** “I cannot determine the cause of that symptom here.”
+2. **Give the immediate training decision:** stop, pause the movement, reduce exposure, or seek urgent care.
+3. **Give the next appropriate source of help:** emergency services, clinician, physiotherapist, sports dietitian, or qualified coach.
+
+Do not bury urgent guidance under programming detail. Do not use alarmist language when a simple modification is appropriate.

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ apps/web/next-env.d.ts
 !/.agents/skills/research-supplements/scripts/*.mjs
 !/.agents/skills/research-supplements/scripts/*.d.mts
 !/.agents/skills/research-supplements/scripts/*.py
+!/.agents/skills/strength-training/
+!/.agents/skills/strength-training/SKILL.md
+!/.agents/skills/strength-training/agents/
+!/.agents/skills/strength-training/agents/openai.yaml
+!/.agents/skills/strength-training/references/
+!/.agents/skills/strength-training/references/*.md
 .claude/
 .windsurf/
 /skills/

--- a/.vercelignore
+++ b/.vercelignore
@@ -15,6 +15,8 @@
 .turbo/
 .vercel/
 .windsurf/
+.agents/
+agent-docs/exec-plans/completed/
 
 .next/
 .next-dev/

--- a/agent-docs/exec-plans/completed/2026-06-25-strength-training-skill.md
+++ b/agent-docs/exec-plans/completed/2026-06-25-strength-training-skill.md
@@ -1,0 +1,92 @@
+# Add strength training agent skill
+
+Status: completed
+Created: 2026-06-25
+Updated: 2026-06-25
+
+## Goal
+
+- Add the prepared `strength-training` agent skill to the repo-local `.agents/skills`
+  catalog so future agents can answer strength-training planning, coaching,
+  safety, and evidence questions through one small composable skill.
+
+## Success criteria
+
+- Install only the skill directory from the supplied packet at
+  `.agents/skills/strength-training/`.
+- Preserve the repo's existing skill shape: `SKILL.md`, `agents/openai.yaml`,
+  and task-loaded `references/*.md`.
+- Validate skill metadata, referenced files, UTF-8/path/secret hygiene, and
+  repo checks.
+- Open a draft PR from an isolated worktree branch.
+
+## Scope
+
+- In scope:
+  - `.agents/skills/strength-training/**`
+  - `.gitignore` allowlist entries needed to track that skill directory
+  - plan/ledger lifecycle files required by the repo workflow
+- Out of scope:
+  - Runtime code, persisted state, reminders, protocols, app UI, or database
+    changes.
+  - Copying the packet-level README over the repository README.
+  - Creating a new durable docs home for the packet-level eval notes.
+
+## Constraints
+
+- Technical constraints:
+  - Keep the skill file set minimal; no extra script or runtime subsystem.
+  - Do not include local paths, usernames, secrets, or raw credentials.
+- Product/process constraints:
+  - Keep recommendations aligned with Murph's low-burden, private-by-default,
+    no-shame product posture.
+
+## Risks and mitigations
+
+1. Risk: importing the whole archive could overwrite root repo files.
+   Mitigation: copy only the archive's installable skill directory.
+2. Risk: training guidance can drift into medical, weight-cut, or body-shame
+   behavior.
+   Mitigation: preserve explicit safety/product boundaries and run structural
+   validation plus repo checks.
+
+## Tasks
+
+1. Done: inspect the archive contents and decide the installed payload.
+2. Done: add the skill directory.
+3. Done: validate skill structure and hygiene.
+4. Done: run required repo checks.
+5. Next: commit through `scripts/finish-task`, push, and open a draft PR.
+
+## Decisions
+
+- The packet README states the installable payload is
+  `.agents/skills/strength-training/`; do not copy the packet root README into
+  the repository root.
+- Do not add the packet root `EVALS.md` unless a durable repo home is explicitly
+  chosen later; the current skill catalog does not store per-skill eval docs.
+- The repo ignore policy allowlists committed `.agents/skills` entries
+  explicitly; add matching allowlist lines for the new skill.
+
+## Verification
+
+- Commands to run:
+  - skill metadata/resource validation
+  - `pnpm typecheck`
+  - `pnpm test:diff .agents/skills/strength-training .gitignore agent-docs/exec-plans/active/2026-06-25-strength-training-skill.md agent-docs/exec-plans/active/COORDINATION_LEDGER.md`
+  - `git diff --check`
+- Expected outcomes:
+  - validation and repo checks pass.
+- Results:
+  - `quick_validate.py` passed after installing `PyYAML` into a temporary
+    ignored validation venv.
+  - Custom structural validation passed for frontmatter keys, skill name,
+    `agents/openai.yaml`, referenced resources, and UTF-8 readability.
+  - Identifier/secret and hidden-bidirectional-Unicode searches found no
+    matches.
+  - `git diff --check` passed.
+  - `pnpm test:diff ...` passed on the no-owner repo tooling/content lane.
+  - Initial `pnpm typecheck` failed in unrelated assistant package resolution
+    because the fresh worktree lacked built workspace artifacts. After
+    `pnpm build:test-runtime:prepared`, `pnpm typecheck` passed.
+Completed: 2026-06-25


### PR DESCRIPTION
## Why this PR exists

Adds the prepared `strength-training` agent skill to Murph's repo-local `.agents/skills` catalog so future agents can answer strength-training planning, coaching, safety, and evidence questions through one composable skill.

## User goal / user-visible behavior

When a user asks for strength or resistance-training help, an agent can load `$strength-training` and use a small, evidence-informed workflow that fits recommendations to goals, experience, equipment, schedule, symptoms, and concurrent training while avoiding medical diagnosis, risky weight-cutting, PED protocols, and shame-based coaching.

## Invariants to preserve

- The installed payload stays limited to `.agents/skills/strength-training/**`; no runtime code, persisted state, reminders, protocols, app UI, or database changes.
- The skill keeps product actions explicit: planning must not silently create protocols, reminders, check-ins, or persisted records.
- Sensitive training, physique, symptom, and body-measurement data remains private by default, with sharing only after explicit user intent.
- The skill composes with `murph-exercise-images` for visuals instead of adding a second media workflow.
- The repo `.agents/skills` ignore allowlist tracks only the intended skill files.

## Validation

- System skill validator passed after using a temporary ignored validation environment for the validator dependency.
- Custom structural validation passed for frontmatter keys, skill name, `agents/openai.yaml`, referenced resources, and UTF-8 readability.
- Identifier/secret and hidden-bidirectional-Unicode searches found no matches in the touched files.
- Installed skill files match the archive payload byte-for-byte.
- `git diff --check` passed.
- `pnpm test:diff .agents/skills/strength-training .gitignore agent-docs/exec-plans/active/2026-06-25-strength-training-skill.md agent-docs/exec-plans/active/COORDINATION_LEDGER.md` passed.
- `pnpm typecheck` initially failed in unrelated assistant package resolution because the fresh worktree lacked built workspace artifacts; after `pnpm build:test-runtime:prepared`, `pnpm typecheck` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784995471&installation_id=127572939&pr_number=298&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F298&signature=f5718fc7e0973775efc3cbde481a752d8accd388dd69039b863cdd899fafb485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->