### PR TITLE
feat(assistant-outbox): preflight prerequisite checks; non-retryable internal codes

### DIFF
--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -1,4 +1,7 @@
 import type { InboxServices } from '@murphai/inbox-services'
+import {
+  readAssistantDeliveryFailureClass,
+} from '@murphai/operator-config/assistant/delivery-failure'
 import type {
   AssistantSession,
 } from '@murphai/operator-config/assistant-cli-contracts'
@@ -2666,6 +2669,14 @@ function resolveAssistantAutoReplySendResult(input: {
         writable: true,
       })
     }
+    if (input.result.deliveryError?.diagnosticContext) {
+      Object.defineProperty(error, 'context', {
+        configurable: true,
+        enumerable: false,
+        value: input.result.deliveryError.diagnosticContext,
+        writable: true,
+      })
+    }
     throw markAssistantAutoReplyDeliveryFailure(error)
   }
 
@@ -2794,6 +2805,16 @@ function classifyAssistantAutoReplyFailure(input: {
   }
 
   const detail = errorMessage(input.error)
+  const failureClass = readAssistantDeliveryFailureClass(input.error)
+  if (failureClass === 'blocked' || failureClass === 'terminal') {
+    return createSkippedGroupOutcome({
+      inputCount: input.inputCount,
+      reason: detail,
+      stopScanning: true,
+      terminalSuppression: true,
+    })
+  }
+
   if (isAssistantProviderConnectionLostError(input.error)) {
     return createDeferredGroupOutcome({
       inputCount: input.inputCount,

--- a/packages/assistant-engine/src/assistant/channels/runtime.ts
+++ b/packages/assistant-engine/src/assistant/channels/runtime.ts
@@ -41,6 +41,9 @@ import {
 } from '@murphai/operator-config/http-retry'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import {
+  createAssistantDeliveryTransientError,
+} from '@murphai/operator-config/assistant/delivery-failure'
+import {
   renderMarkdownMessageText,
   splitDecoratedMessageText,
   type MessageTextDecoration,
@@ -2089,25 +2092,32 @@ function resolveTelegramSendAttemptOutcome(input: {
     }
   }
 
-  const failure = new VaultCliError(
-    'ASSISTANT_TELEGRAM_DELIVERY_FAILED',
-    errorContext.description ??
-      `Telegram Bot API ${input.operation} failed with HTTP ${input.result.response.status}.`,
-    {
-      errorCode: errorContext.errorCode,
-      migrateToChatId: errorContext.migrateToChatId,
-      operation: input.operation,
-      status: input.result.response.status,
-      target: input.targetLabel,
-    },
+  const retryable = shouldRetryTelegramSend(
+    input.result.response.status,
+    errorContext.errorCode,
   )
-
-  if (
-    shouldRetryTelegramSend(
-      input.result.response.status,
-      errorContext.errorCode,
+  const failureMessage = errorContext.description ??
+    `Telegram Bot API ${input.operation} failed with HTTP ${input.result.response.status}.`
+  const failureContext = {
+    errorCode: errorContext.errorCode,
+    migrateToChatId: errorContext.migrateToChatId,
+    operation: input.operation,
+    status: input.result.response.status,
+    target: input.targetLabel,
+  }
+  const failure = retryable
+    ? createAssistantDeliveryTransientError(
+      'ASSISTANT_TELEGRAM_DELIVERY_FAILED',
+      failureMessage,
+      failureContext,
     )
-  ) {
+    : new VaultCliError(
+      'ASSISTANT_TELEGRAM_DELIVERY_FAILED',
+      failureMessage,
+      failureContext,
+    )
+
+  if (retryable) {
     return {
       kind: 'retry',
       failure,

--- a/packages/assistant-engine/src/assistant/outbox.ts
+++ b/packages/assistant-engine/src/assistant/outbox.ts
@@ -157,6 +157,11 @@ export type {
   AssistantOutboxIntentMirrorState,
 } from './outbox/dispatch-state.js'
 
+export type AssistantOutboxDispatchPreflightResult =
+  | { action: 'continue' }
+  | { action: 'defer'; intent: AssistantOutboxIntent }
+  | { action: 'stop'; intent: AssistantOutboxIntent }
+
 export interface AssistantOutboxDispatchHooks {
   clearPreparedIntent?: (input: {
     intent: AssistantOutboxIntent
@@ -167,6 +172,16 @@ export interface AssistantOutboxDispatchHooks {
     intent: AssistantOutboxIntent
     vault: string
   }) => Promise<void>
+  /**
+   * Runs before an outbox intent is claimed as `sending`. Preflight owns
+   * local/security/control-plane prerequisites that must not increment
+   * delivery attempt counters or enter timed provider retry.
+   */
+  preflightDispatchIntent?: (input: {
+    intent: AssistantOutboxIntent
+    now: Date
+    vault: string
+  }) => Promise<AssistantOutboxDispatchPreflightResult | void>
   prepareDispatchIntent?: (input: {
     intent: AssistantOutboxIntent
     vault: string
@@ -505,7 +520,7 @@ export async function listAssistantOutboxIntentsLocal(
   return listAssistantOutboxIntentsLocalStore(vault)
 }
 
-export async function dispatchAssistantOutboxIntent(input: {
+export interface DispatchAssistantOutboxIntentInput {
   allowPreparedSending?: boolean
   dependencies?: AssistantChannelDependencies
   dispatchHooks?: AssistantOutboxDispatchHooks
@@ -519,6 +534,19 @@ export async function dispatchAssistantOutboxIntent(input: {
   }
   signal?: AbortSignal
   vault: string
+}
+
+export async function dispatchAssistantOutboxIntent(
+  input: DispatchAssistantOutboxIntentInput,
+): Promise<DispatchAssistantOutboxIntentResult> {
+  return dispatchAssistantOutboxIntentInternal({
+    ...input,
+    preflightCompleted: false,
+  })
+}
+
+async function dispatchAssistantOutboxIntentInternal(input: DispatchAssistantOutboxIntentInput & {
+  preflightCompleted: boolean
 }): Promise<DispatchAssistantOutboxIntentResult> {
   const now = input.now ?? new Date()
   const prepared = await withAssistantRuntimeWriteLock(input.vault, async (paths) => {
@@ -567,6 +595,14 @@ export async function dispatchAssistantOutboxIntent(input: {
     if (shouldReconcileAssistantOutboxIntent(intent)) {
       return {
         action: 'reconcile' as const,
+        intent,
+        intentPath,
+      }
+    }
+
+    if (!input.preflightCompleted && input.dispatchHooks?.preflightDispatchIntent) {
+      return {
+        action: 'preflight' as const,
         intent,
         intentPath,
       }
@@ -621,6 +657,30 @@ export async function dispatchAssistantOutboxIntent(input: {
       deliveryError: prepared.intent.lastError,
       session: null,
     }
+  }
+
+  if (prepared.action === 'preflight') {
+    const preflight = await input.dispatchHooks?.preflightDispatchIntent?.({
+      intent: prepared.intent,
+      now,
+      vault: input.vault,
+    })
+    if (preflight?.action === 'defer' || preflight?.action === 'stop') {
+      await repairAssistantOutboxReceiptForIntent({
+        intent: preflight.intent,
+        vault: input.vault,
+      })
+      return {
+        intent: preflight.intent,
+        deliveryError: preflight.intent.lastError,
+        session: null,
+      }
+    }
+
+    return dispatchAssistantOutboxIntentInternal({
+      ...input,
+      preflightCompleted: true,
+    })
   }
 
   if (prepared.action === 'recover-stale-non-idempotent') {
@@ -1000,6 +1060,7 @@ export async function deliverAssistantOutboxMessage(input: {
   }
 
   if (
+    dispatched.intent.status === 'awaiting_approval' ||
     dispatched.intent.status === 'pending' ||
     dispatched.intent.status === 'retryable' ||
     dispatched.intent.status === 'sending'
@@ -1117,6 +1178,7 @@ export async function deliverAssistantOutboxReaction(input: {
   }
 
   if (
+    dispatched.intent.status === 'awaiting_approval' ||
     dispatched.intent.status === 'pending' ||
     dispatched.intent.status === 'retryable' ||
     dispatched.intent.status === 'sending'

--- a/packages/assistant-engine/src/assistant/outbox/retry-policy.ts
+++ b/packages/assistant-engine/src/assistant/outbox/retry-policy.ts
@@ -4,6 +4,9 @@ import {
   type AssistantOutboxIntent,
 } from '@murphai/operator-config/assistant-cli-contracts'
 import {
+  readAssistantDeliveryFailureClass,
+} from '@murphai/operator-config/assistant/delivery-failure'
+import {
   redactAssistantStateString,
   sanitizeAssistantPortableStateString,
 } from '../redaction.js'
@@ -74,6 +77,14 @@ export function shouldBeginAssistantOutboxDispatch(
 }
 
 export function isAssistantOutboxRetryableError(error: unknown): boolean {
+  const failureClass = readAssistantDeliveryFailureClass(error)
+  if (failureClass === 'transient') {
+    return true
+  }
+  if (failureClass === 'blocked' || failureClass === 'terminal') {
+    return false
+  }
+
   const explicitRetryable = readAssistantOutboxRetryableFlag(error)
   if (explicitRetryable !== null) {
     return explicitRetryable
@@ -83,6 +94,9 @@ export function isAssistantOutboxRetryableError(error: unknown): boolean {
   const code = deliveryError.code?.toUpperCase() ?? ''
   const message = deliveryError.message.toLowerCase()
   if (assistantOutboxErrorCodeLooksPermanent(code)) {
+    return false
+  }
+  if (assistantOutboxErrorCodeIsInternal(code)) {
     return false
   }
 
@@ -254,6 +268,15 @@ function assistantOutboxErrorCodeLooksPermanent(code: string): boolean {
 
 function assistantOutboxErrorCodeLooksRetryable(code: string): boolean {
   return includesAny(code, RETRYABLE_OUTBOX_ERROR_CODE_MARKERS)
+}
+
+function assistantOutboxErrorCodeIsInternal(code: string): boolean {
+  return code.startsWith('ASSISTANT_') ||
+    code.startsWith('HOSTED_') ||
+    code.startsWith('LINQ_') ||
+    code.startsWith('TELEGRAM_') ||
+    code.startsWith('WHATSAPP_') ||
+    code.startsWith('AGENTMAIL_')
 }
 
 function assistantOutboxErrorMessageLooksRetryable(message: string): boolean {

--- a/packages/assistant-engine/src/assistant/vault-file-send.ts
+++ b/packages/assistant-engine/src/assistant/vault-file-send.ts
@@ -411,8 +411,13 @@ export function deferAssistantVaultFileApprovalCheck(input: {
   return assistantOutboxIntentSchema.parse({
     ...input.intent,
     lastError: {
-      code: 'ASSISTANT_VAULT_FILE_APPROVAL_UNAVAILABLE',
-      message: 'Secure approval could not be checked yet.',
+      code: 'ASSISTANT_VAULT_FILE_APPROVAL_CHECK_DEFERRED',
+      diagnosticContext: {
+        assistantDeliveryFailureClass: 'blocked',
+        assistantDeliveryResumeTrigger: 'approval_state_change',
+        retryable: false,
+      },
+      message: 'Secure vault-file approval could not be checked yet.',
     },
     nextAttemptAt,
     status: 'awaiting_approval',

--- a/packages/assistant-engine/test/assistant-outbox-retry-policy.test.ts
+++ b/packages/assistant-engine/test/assistant-outbox-retry-policy.test.ts
@@ -62,21 +62,37 @@ describe('assistant outbox retry policy', () => {
     expect(shouldBeginAssistantOutboxDispatch(staleSending, now, false)).toBe(true)
   })
 
-  it('detects retryable delivery errors from context, direct flags, and normalized fallback signals', () => {
+  it('detects retryable delivery errors from context, direct flags, failure-class hints, and normalized fallback signals', () => {
     expect(isAssistantOutboxRetryableError({ context: { retryable: true } })).toBe(true)
     expect(isAssistantOutboxRetryableError({ retryable: false })).toBe(false)
+    expect(
+      isAssistantOutboxRetryableError({
+        context: { assistantDeliveryFailureClass: 'transient' },
+      }),
+    ).toBe(true)
+    expect(
+      isAssistantOutboxRetryableError({
+        context: { assistantDeliveryFailureClass: 'blocked' },
+        retryable: true,
+      }),
+    ).toBe(false)
+    expect(
+      isAssistantOutboxRetryableError({
+        context: { assistantDeliveryFailureClass: 'terminal' },
+      }),
+    ).toBe(false)
     expect(
       isAssistantOutboxRetryableError({
         code: 'assistant_delivery_failed',
         message: 'temporary network issue',
       }),
-    ).toBe(true)
+    ).toBe(false)
     expect(
       isAssistantOutboxRetryableError({
         code: 'assistant_request_failed',
         message: 'bad gateway',
       }),
-    ).toBe(true)
+    ).toBe(false)
     expect(
       isAssistantOutboxRetryableError({
         code: 'assistant_channel_required',

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -43,6 +43,7 @@ import {
   shouldDispatchAssistantOutboxIntent,
   type AssistantChannelDelivery,
   type AssistantHostedProgressDeliveryDependencies,
+  type AssistantOutboxDispatchPreflightResult,
   type AssistantOutboxPreparedDispatchState,
 } from "@murphai/assistant-engine";
 import {
@@ -60,6 +61,10 @@ import {
   assistantChannelDeliverySchema,
 } from "@murphai/operator-config/assistant-cli-contracts";
 import { VaultCliError } from "@murphai/operator-config/vault-cli-errors";
+import {
+  createAssistantDeliveryBlockedError,
+  createAssistantDeliveryTerminalError,
+} from "@murphai/operator-config/assistant/delivery-failure";
 
 import type {
   HostedAssistantDeliveryErrorDetails,
@@ -153,6 +158,7 @@ export async function collectHostedAssistantDeliverySideEffects(
     const reconciliation = await reconcileHostedAssistantVaultFileApproval({
       actionApprovalPort: input.actionApprovalPort ?? null,
       intent,
+      missingApprovalPort: "skip",
       now,
       vaultRoot: request.vaultRoot,
     });
@@ -270,9 +276,9 @@ export async function collectHostedAssistantDeliverySideEffects(
 }
 
 /**
- * Bounds the set of intents reconciled per collect. The dispatch-time gate in
- * `preloadApprovedHostedAssistantVaultFiles` is the security invariant; this
- * pass exists only so freshly-decided approvals transition out of
+ * Bounds the set of intents reconciled per collect. The dispatch preflight
+ * gate is the security invariant; this pass exists only so freshly-decided
+ * approvals transition out of
  * `awaiting_approval` promptly. Reconciling every stored intent would add an
  * O(n) sequence of web-control round trips to the foreground delivery path.
  */
@@ -299,6 +305,7 @@ function selectHostedAssistantApprovalReconcileTargets(input: {
 async function reconcileHostedAssistantVaultFileApproval(input: {
   actionApprovalPort: HostedRuntimeActionApprovalPort | null;
   intent: AssistantOutboxIntent;
+  missingApprovalPort: "block" | "skip";
   now: Date;
   vaultRoot: string;
 }): Promise<{ blocked: boolean; intent: AssistantOutboxIntent }> {
@@ -329,6 +336,13 @@ async function reconcileHostedAssistantVaultFileApproval(input: {
   }
 
   if (!input.actionApprovalPort) {
+    if (input.missingApprovalPort === "skip") {
+      return {
+        blocked: true,
+        intent: input.intent,
+      };
+    }
+
     const deferred = deferAssistantVaultFileApprovalCheck({
       intent: input.intent,
       now: input.now,
@@ -343,11 +357,37 @@ async function reconcileHostedAssistantVaultFileApproval(input: {
     };
   }
 
+  if (
+    file.approvalId
+    && file.approvalGeneration
+    && input.intent.status !== "awaiting_approval"
+  ) {
+    return { blocked: false, intent: input.intent };
+  }
+
+  let approvalRequest: ReturnType<typeof buildAssistantVaultFileSendApprovalRequest>;
+  try {
+    approvalRequest = buildAssistantVaultFileSendApprovalRequest(input.intent);
+  } catch (error) {
+    const failed = await markAssistantOutboxIntentMirrorTerminalById({
+      error: createAssistantDeliveryTerminalError(
+        "ASSISTANT_VAULT_FILE_APPROVAL_TARGET_INVALID",
+        "Secure vault-file approval could not be requested because the delivery target is invalid.",
+        { cause: error instanceof Error ? error.message : String(error) },
+      ),
+      intentId: input.intent.intentId,
+      status: "failed",
+      vault: input.vaultRoot,
+    });
+    return {
+      blocked: true,
+      intent: failed ?? input.intent,
+    };
+  }
+
   let approval: HostedActionApprovalResult;
   try {
-    approval = await input.actionApprovalPort.request(
-      buildAssistantVaultFileSendApprovalRequest(input.intent),
-    );
+    approval = await input.actionApprovalPort.request(approvalRequest);
   } catch {
     const deferred = deferAssistantVaultFileApprovalCheck({
       intent: input.intent,
@@ -378,6 +418,29 @@ async function reconcileHostedAssistantVaultFileApproval(input: {
       approval.status !== "approved"
       || persisted.status === "awaiting_approval",
     intent: persisted,
+  };
+}
+
+async function preflightHostedAssistantVaultFileDispatch(input: {
+  actionApprovalPort: HostedRuntimeActionApprovalPort | null;
+  intent: AssistantOutboxIntent;
+  now: Date;
+  vaultRoot: string;
+}): Promise<AssistantOutboxDispatchPreflightResult> {
+  const reconciled = await reconcileHostedAssistantVaultFileApproval({
+    actionApprovalPort: input.actionApprovalPort,
+    intent: input.intent,
+    missingApprovalPort: "block",
+    now: input.now,
+    vaultRoot: input.vaultRoot,
+  });
+  if (!reconciled.blocked) {
+    return { action: "continue" };
+  }
+
+  return {
+    action: reconciled.intent.status === "awaiting_approval" ? "defer" : "stop",
+    intent: reconciled.intent,
   };
 }
 
@@ -949,16 +1012,23 @@ export async function prepareHostedAssistantDeliveryEffectsForDispatch(input: {
 function shouldPrepareHostedAssistantDeliveryEffectForDispatch(
   effect: HostedAssistantDeliveryEffect,
 ): boolean {
-  return effect.payload.transportIdempotent
-    || isHostedAssistantReactionOnlyEffect(effect)
-    || hasHostedAssistantVoiceMemoMedia(effect.payload)
-    || isHostedSignupWelcomeDeliveryPayload(effect.payload);
+  return !hasHostedAssistantVaultFileMedia(effect.payload)
+    && (effect.payload.transportIdempotent
+      || isHostedAssistantReactionOnlyEffect(effect)
+      || hasHostedAssistantVoiceMemoMedia(effect.payload)
+      || isHostedSignupWelcomeDeliveryPayload(effect.payload));
 }
 
 function hasHostedAssistantVoiceMemoMedia(
   payload: HostedAssistantDeliveryPayload,
 ): boolean {
   return payload.media.some((item) => item.kind === "voice_memo");
+}
+
+function hasHostedAssistantVaultFileMedia(
+  payload: HostedAssistantDeliveryPayload,
+): boolean {
+  return payload.media.some((item) => item.kind === "vault_file");
 }
 
 export function createHostedAssistantProgressDeliveryDependencies(input: {
@@ -1214,10 +1284,17 @@ function shouldBlockLaterHostedAssistantForegroundDeliveries(input: {
   effect: HostedAssistantDeliveryEffect;
   outcome: HostedAssistantDeliveryOutcome;
 }): boolean {
-  return input.effect.deliveryPhase === "foreground_current_turn"
-    && !isHostedAssistantReactionOnlyEffect(input.effect)
-    && input.outcome.deliveryStatus !== "sent"
-    && input.outcome.retryable === true;
+  if (input.effect.deliveryPhase !== "foreground_current_turn") {
+    return false;
+  }
+  if (isHostedAssistantReactionOnlyEffect(input.effect)) {
+    return false;
+  }
+  if (input.outcome.deliveryStatus === "sent") {
+    return false;
+  }
+  return input.outcome.retryable === true
+    || input.outcome.deliveryStatus === "pending";
 }
 
 function isHostedLinqTransportFailure(error: unknown): boolean {
@@ -1340,6 +1417,15 @@ async function deliverHostedPreparedAssistantDelivery(input: {
       return disabledAutoReplyOutcome;
     }
     const dispatched = await dispatchAssistantOutboxIntent({
+      dispatchHooks: {
+        preflightDispatchIntent: async ({ intent, now: preflightNow, vault }) =>
+          preflightHostedAssistantVaultFileDispatch({
+            actionApprovalPort: input.actionApprovalPort,
+            intent,
+            now: preflightNow,
+            vaultRoot: vault,
+          }),
+      },
       dependencies: {
         sendEmail: async (request) => {
           if (request.targetKind === "participant") {
@@ -1796,14 +1882,13 @@ async function preloadApprovedHostedAssistantVaultFiles(input: {
   if (
     vaultFiles.length !== 1
     || input.media.length !== 1
-    || !input.actionApprovalPort
     || !input.expectedDedupeKey
     || !input.intentId
     || !input.vaultRoot
   ) {
-    throw createRetryableHostedVaultFileError(
-      "ASSISTANT_VAULT_FILE_APPROVAL_UNAVAILABLE",
-      "Secure approval could not be verified before vault-file delivery.",
+    throw createAssistantDeliveryTerminalError(
+      "ASSISTANT_VAULT_FILE_APPROVAL_INVARIANT_FAILED",
+      "Secure vault-file delivery reached provider dispatch without complete approval prerequisites.",
     );
   }
 
@@ -1831,6 +1916,13 @@ async function preloadApprovedHostedAssistantVaultFiles(input: {
     );
   }
 
+  if (!input.actionApprovalPort) {
+    throw createAssistantDeliveryTerminalError(
+      "ASSISTANT_VAULT_FILE_APPROVAL_INVARIANT_FAILED",
+      "Secure vault-file delivery reached provider dispatch without an approval boundary.",
+    );
+  }
+
   let approval: HostedActionApprovalResult;
   try {
     approval = await input.actionApprovalPort.consume({
@@ -1838,20 +1930,21 @@ async function preloadApprovedHostedAssistantVaultFiles(input: {
       consumerId: intent.deliveryIdempotencyKey ?? `assistant-outbox:${intent.intentId}`,
       request: buildAssistantVaultFileSendApprovalRequest(intent),
     });
-  } catch {
-    throw createRetryableHostedVaultFileError(
-      "ASSISTANT_VAULT_FILE_APPROVAL_UNAVAILABLE",
-      "Secure approval could not be verified before vault-file delivery.",
+  } catch (error) {
+    throw createAssistantDeliveryTerminalError(
+      "ASSISTANT_VAULT_FILE_APPROVAL_INVARIANT_FAILED",
+      "Secure vault-file approval could not be consumed at provider dispatch.",
+      { cause: error instanceof Error ? error.message : String(error) },
     );
   }
   if (approval.status === "pending") {
-    throw createRetryableHostedVaultFileError(
-      "ASSISTANT_VAULT_FILE_APPROVAL_PENDING",
-      "Vault-file delivery is still awaiting secure approval.",
+    throw createAssistantDeliveryTerminalError(
+      "ASSISTANT_VAULT_FILE_APPROVAL_INVARIANT_FAILED",
+      "Vault-file delivery reached provider dispatch while approval was still pending.",
     );
   }
   if (approval.status !== "approved") {
-    throw new VaultCliError(
+    throw createAssistantDeliveryTerminalError(
       approval.status === "denied"
         ? "ASSISTANT_VAULT_FILE_APPROVAL_DENIED"
         : "ASSISTANT_VAULT_FILE_APPROVAL_EXPIRED",
@@ -1888,15 +1981,6 @@ function buildHostedVaultFileMediaIdentity(input: {
     input.approvalId ?? null,
     input.approvalGeneration ?? null,
   ]);
-}
-
-function createRetryableHostedVaultFileError(
-  code: string,
-  message: string,
-): VaultCliError & { retryable: true } {
-  return Object.assign(new VaultCliError(code, message), {
-    retryable: true as const,
-  });
 }
 
 function createHostedAssistantLinqVoiceMemoSendDependency(input: {
@@ -1971,9 +2055,13 @@ function requireHostedAssistantLinqRouteAuthorityAssert(
 ) => Promise<void> {
   const assertAuthority = effectsPort?.assertLinqThreadRouteAuthority;
   if (!assertAuthority) {
-    throw new VaultCliError(
-      "ASSISTANT_LINQ_ROUTE_AUTHORITY_UNAVAILABLE",
+    throw createAssistantDeliveryBlockedError(
+      "ASSISTANT_LINQ_ROUTE_AUTHORITY_ASSERT_BLOCKED",
       "Hosted Linq route authority cannot be revalidated before provider delivery.",
+      {
+        blockKind: "linq_route_authority_assert_missing",
+        resume: "deploy_or_config_change",
+      },
     );
   }
 
@@ -2328,6 +2416,7 @@ function emitHostedAssistantDeliveryDispatchOutcome(input: {
     | "failed"
     | "failed_ambiguous"
     | "missing-result"
+    | "pending"
     | "retryable"
     | "sending";
   wake: HostedRuntimeEvent;
@@ -2415,6 +2504,24 @@ async function buildHostedAssistantDeliveryDispatchResult(input: {
         deliveryErrorDetails,
         deliveryErrorMessage: deliveryError.message,
         deliveryStatus: "failed",
+        effect: assistantDeliveryEffect,
+        retryable: false,
+      });
+    case "awaiting_approval":
+      emitHostedAssistantDeliveryDispatchOutcome({
+        deliveryError,
+        deliveryErrorDetails,
+        deliveryStatus: "pending",
+        wake: input.wake,
+        effect: assistantDeliveryEffect,
+        retryable: false,
+        userId: input.userId,
+      });
+      return buildHostedAssistantDeliveryOutcome({
+        deliveryErrorCode: deliveryError.code,
+        deliveryErrorDetails,
+        deliveryErrorMessage: deliveryError.message,
+        deliveryStatus: "pending",
         effect: assistantDeliveryEffect,
         retryable: false,
       });

--- a/packages/assistant-runtime/src/hosted-runtime/provider-fetch.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/provider-fetch.ts
@@ -1,12 +1,28 @@
+import {
+  createAssistantDeliveryBlockedError,
+} from "@murphai/operator-config/assistant/delivery-failure";
+
 export const HOSTED_PROVIDER_FETCH_UNAVAILABLE_CODE =
   "HOSTED_PROVIDER_FETCH_UNAVAILABLE";
 
 export class HostedProviderFetchUnavailableError extends Error {
   readonly code = HOSTED_PROVIDER_FETCH_UNAVAILABLE_CODE;
+  readonly context: Record<string, boolean | string>;
+  readonly retryable = false;
 
   constructor(operation: string) {
     super(`${operation} requires the hosted provider fetch boundary.`);
     this.name = "HostedProviderFetchUnavailableError";
+    const blocked = createAssistantDeliveryBlockedError(
+      HOSTED_PROVIDER_FETCH_UNAVAILABLE_CODE,
+      this.message,
+      {
+        blockKind: "hosted_provider_fetch_missing",
+        details: { operation },
+        resume: "deploy_or_config_change",
+      },
+    );
+    this.context = blocked.context as Record<string, boolean | string>;
   }
 }
 

--- a/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
@@ -3661,6 +3661,9 @@ describe("hosted runtime callbacks", () => {
 
     expect(mocks.dispatchAssistantOutboxIntent).toHaveBeenCalledWith({
       dependencies: expect.any(Object),
+      dispatchHooks: expect.objectContaining({
+        preflightDispatchIntent: expect.any(Function),
+      }),
       intentId: effect.effectId,
       now: expect.any(Date),
       vault: HOSTED_WAKE.vaultRoot,
@@ -3705,6 +3708,9 @@ describe("hosted runtime callbacks", () => {
     const dispatchRequest = mocks.dispatchAssistantOutboxIntent.mock.calls[0]?.[0];
     expect(dispatchRequest).toEqual({
       dependencies: expect.any(Object),
+      dispatchHooks: expect.objectContaining({
+        preflightDispatchIntent: expect.any(Function),
+      }),
       intentId: effect.effectId,
       now: expect.any(Date),
       vault: HOSTED_WAKE.vaultRoot,
@@ -3886,6 +3892,9 @@ describe("hosted runtime callbacks", () => {
 
     expect(mocks.dispatchAssistantOutboxIntent).toHaveBeenCalledWith({
       dependencies: expect.any(Object),
+      dispatchHooks: expect.objectContaining({
+        preflightDispatchIntent: expect.any(Function),
+      }),
       intentId: effect.effectId,
       now: expect.any(Date),
       vault: HOSTED_WAKE.vaultRoot,

--- a/packages/operator-config/package.json
+++ b/packages/operator-config/package.json
@@ -158,6 +158,11 @@
       "types": "./dist/vault-cli-errors.d.ts",
       "import": "./dist/vault-cli-errors.js",
       "default": "./dist/vault-cli-errors.js"
+    },
+    "./assistant/delivery-failure": {
+      "types": "./dist/assistant/delivery-failure.d.ts",
+      "import": "./dist/assistant/delivery-failure.js",
+      "default": "./dist/assistant/delivery-failure.js"
     }
   },
   "files": [

--- a/packages/operator-config/src/assistant/delivery-failure.ts
+++ b/packages/operator-config/src/assistant/delivery-failure.ts
@@ -1,0 +1,110 @@
+import { VaultCliError, type VaultCliErrorDetails } from '../vault-cli-errors.js'
+
+export const assistantDeliveryFailureClassValues = [
+  'transient',
+  'blocked',
+  'terminal',
+] as const
+
+export type AssistantDeliveryFailureClass =
+  typeof assistantDeliveryFailureClassValues[number]
+
+export const assistantDeliveryResumeTriggerValues = [
+  'time',
+  'approval_state_change',
+  'recipient_inbound',
+  'line_health_change',
+  'manual_ops',
+  'deploy_or_config_change',
+  'never',
+] as const
+
+export type AssistantDeliveryResumeTrigger =
+  typeof assistantDeliveryResumeTriggerValues[number]
+
+export interface AssistantDeliveryFailureDetails {
+  assistantDeliveryFailureClass: AssistantDeliveryFailureClass
+  assistantDeliveryResumeTrigger: AssistantDeliveryResumeTrigger
+  retryable: boolean
+}
+
+export function createAssistantDeliveryTransientError(
+  code: string,
+  message: string,
+  details: VaultCliErrorDetails = undefined,
+): VaultCliError & { retryable: true } {
+  return Object.assign(
+    new VaultCliError(code, message, {
+      ...details,
+      assistantDeliveryFailureClass: 'transient',
+      assistantDeliveryResumeTrigger: 'time',
+      retryable: true,
+    }),
+    { retryable: true as const },
+  )
+}
+
+export function createAssistantDeliveryBlockedError(
+  code: string,
+  message: string,
+  input: {
+    blockKind: string
+    details?: VaultCliErrorDetails
+    resume: Exclude<AssistantDeliveryResumeTrigger, 'time' | 'never'>
+  },
+): VaultCliError & { retryable: false } {
+  return Object.assign(
+    new VaultCliError(code, message, {
+      ...input.details,
+      assistantDeliveryFailureClass: 'blocked',
+      assistantDeliveryResumeTrigger: input.resume,
+      blockKind: input.blockKind,
+      retryable: false,
+    }),
+    { retryable: false as const },
+  )
+}
+
+export function createAssistantDeliveryTerminalError(
+  code: string,
+  message: string,
+  details: VaultCliErrorDetails = undefined,
+): VaultCliError & { retryable: false } {
+  return Object.assign(
+    new VaultCliError(code, message, {
+      ...details,
+      assistantDeliveryFailureClass: 'terminal',
+      assistantDeliveryResumeTrigger: 'never',
+      retryable: false,
+    }),
+    { retryable: false as const },
+  )
+}
+
+export function readAssistantDeliveryFailureClass(
+  error: unknown,
+): AssistantDeliveryFailureClass | null {
+  return readAssistantDeliveryFailureClassValue(
+    readRecord(error)?.assistantDeliveryFailureClass,
+  ) ?? readAssistantDeliveryFailureClassValue(
+    readRecord(readRecord(error)?.context)?.assistantDeliveryFailureClass,
+  ) ?? readAssistantDeliveryFailureClassValue(
+    readRecord(readRecord(error)?.diagnosticContext)?.assistantDeliveryFailureClass,
+  ) ?? readAssistantDeliveryFailureClassValue(
+    readRecord(readRecord(error)?.details)?.assistantDeliveryFailureClass,
+  )
+}
+
+function readAssistantDeliveryFailureClassValue(
+  value: unknown,
+): AssistantDeliveryFailureClass | null {
+  return value === 'transient' || value === 'blocked' || value === 'terminal'
+    ? value
+    : null
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null
+    ? value as Record<string, unknown>
+    : null
+}

--- a/packages/operator-config/src/linq-runtime.ts
+++ b/packages/operator-config/src/linq-runtime.ts
@@ -26,6 +26,9 @@ import {
   type MessageTextDecoration,
 } from './message-formatting.js'
 import { VaultCliError } from './vault-cli-errors.js'
+import {
+  createAssistantDeliveryBlockedError,
+} from './assistant/delivery-failure.js'
 import type {
   AssistantMessageReaction,
 } from './assistant-cli-contracts.js'
@@ -801,10 +804,14 @@ function createLinqConfigurationError(
   code: 'LINQ_API_TOKEN_REQUIRED' | 'LINQ_UNAVAILABLE',
   message: string,
   details: LinqSafeRequestDetails,
-): VaultCliError {
-  return new VaultCliError(code, message, {
-    ...details,
-    failureStage: 'configuration',
+): VaultCliError & { retryable: false } {
+  return createAssistantDeliveryBlockedError(code, message, {
+    blockKind: 'linq_configuration',
+    details: {
+      ...details,
+      failureStage: 'configuration',
+    },
+    resume: 'deploy_or_config_change',
   })
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -331,6 +331,9 @@
       "@murphai/operator-config/assistant/current-delivery-route": [
         "packages/operator-config/src/assistant/current-delivery-route.ts"
       ],
+      "@murphai/operator-config/assistant/delivery-failure": [
+        "packages/operator-config/src/assistant/delivery-failure.ts"
+      ],
       "@murphai/operator-config/assistant-cli-contracts": [
         "packages/operator-config/src/assistant-cli-contracts.ts"
       ],


### PR DESCRIPTION
## Why this PR exists

Incident evidence showed **97 retried `ASSISTANT_VAULT_FILE_APPROVAL_UNAVAILABLE`** attempts for one dominant account/line — not provider sends, but pre-provider delivery churn for prerequisite work (secure vault-file approval not yet decided). Partner deliverability guidance is to **stop automated sending immediately when a line is flagged**, so prerequisite failures must not consume timed provider retries.

## User-visible goal

When the assistant cannot yet send (approval still pending, trust boundary missing, config gap), the outbox pauses durably **before** a delivery attempt is claimed — no attempt counter increment, no receipt churn, no auto-reply replay. Once the user approves the action (or a deploy fixes the boundary), the parked intent resumes via its normal wake/state-change path. Real provider transient failures (network/HTTP 5xx) continue to retry as before.

## What changes

- **New shared failure taxonomy** in `@murphai/operator-config/assistant/delivery-failure`: `transient` retries, `blocked`/`terminal` never timed-retry.
- **One new outbox primitive** — `preflightDispatchIntent` hook — runs before `sending` / `attemptCount++` / receipt logging / prepared-dispatch reservation. Hosted vault-file delivery wires this hook to reconcile secure approval; if pending → defer to `awaiting_approval`, if missing port/invalid target → fail closed.
- **Retry policy default-non-retry for internal codes** (`ASSISTANT_*`, `HOSTED_*`, `LINQ_*`, `TELEGRAM_*`, `WHATSAPP_*`, `AGENTMAIL_*`) unless they explicitly opt into `transient`. Linq `LINQ_API_REQUEST_FAILED` and Telegram retryable HTTP statuses opt in explicitly; everything else moves to blocked/terminal.
- **Auto-reply** stops scanning and suppresses on `blocked`/`terminal` delivery failures instead of replaying the same input.

## Invariants the PR must preserve

- One-shot vault-file approval: provider-dispatch path still calls `actionApprovalPort.consume(...)` with the persisted `approvalGeneration`. The preflight check is non-consuming (`request(...)`); the atomic burn happens at provider dispatch as PR #312 established. Consume failures are now terminal (the preflight gate already caught readiness).
- Cold-contact / line-health protections are not weakened — prerequisite blocks fail closed.
- Legitimate provider transient retries (network errors, HTTP 5xx, Linq `LINQ_API_REQUEST_FAILED`) still retry via the explicit `transient` opt-in.
- No new persisted state owners or schemas; the `awaiting_approval` status and `lastError.diagnosticContext` field both pre-exist.
- Receipt repair / reconciliation already invoked for deferred intents remains intact (`repairAssistantOutboxReceiptForIntent` runs in the preflight defer/stop branch before returning).

## Deferred / follow-up

- The patch was authored before PR #312 landed the `actionApprovalPort.consume()` one-shot. The cleanest long-term split would move `consume()` into preflight too; left for a follow-up after this lands so the failure-class rewiring is reviewable on its own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785096122&installation_id=127572939&pr_number=321&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F321&signature=3683c53d0793a5c7356fb66341135083fdbac158dae56a62967bb79ef7eb5490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->