### PR TITLE
fix(web): dedup hosted Linq home-redirect notices per wrong chat + home line

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
@@ -8,6 +8,7 @@ import {
   releaseHostedAiUsageLimitNotice,
   type HostedAiUsageGateNoticeCode,
 } from "../hosted-execution/usage-allowance";
+import { sha256Hex } from "../primitives";
 import { hostedOnboardingError } from "./errors";
 import {
   markHostedLinqDeliveryAcceptedTx,
@@ -20,8 +21,8 @@ import {
   readHostedLinqSideEffectRecentInboundDecision,
 } from "./linq-egress-engagement";
 import { sanitizeHostedOnboardingLogString } from "./http";
-import { readHostedMemberRoutingState } from "./hosted-member-routing-store";
 import { buildHostedInviteUrl } from "./invite-service";
+import { normalizePhoneNumber } from "./phone";
 import {
   claimHostedLinqOnboardingLinkNotice,
   claimHostedLinqQuotaReplyNotice,
@@ -53,8 +54,8 @@ export type HostedLinqCurrentInboundReplyProof = {
 
 export type HostedLinqConversationHomeRedirectPayload = {
   chatId: string;
-  homeRecipientPhone: string | null;
-  memberId: string | null;
+  homeRecipientPhone: string;
+  memberId: string;
   replyToMessageId: string | null;
   template: "conversation_home_redirect";
 };
@@ -133,7 +134,7 @@ export type HostedLinqMessageSideEffect = {
 export type CreateHostedWebhookLinqMessageSideEffectInput =
   | {
       chatId: string;
-      homeRecipientPhone?: string | null;
+      homeRecipientPhone: string;
       memberId: string;
       replyToMessageId?: string | null;
       sourceEventId: string;
@@ -208,7 +209,37 @@ function buildHostedWebhookLinqMessageEffectId(
     });
   }
 
+  if (input.template === "conversation_home_redirect") {
+    return buildHostedLinqConversationHomeRedirectEffectId(input);
+  }
+
   return `linq-message:${input.sourceEventId}`;
+}
+
+// One redirect per wrong Linq chat + home line + member. If the member's home
+// line changes later, the new target hashes differently and is announced once.
+// Hashes normalized raw inputs directly; the contact-privacy lookup keys are
+// not stable across keyring rotation and would let a rotation re-send a duplicate.
+function buildHostedLinqConversationHomeRedirectEffectId(
+  input: Extract<
+    CreateHostedWebhookLinqMessageSideEffectInput,
+    { template: "conversation_home_redirect" }
+  >,
+): string {
+  const chatId = input.chatId.trim();
+  const homeRecipientPhone = normalizePhoneNumber(input.homeRecipientPhone);
+  const memberId = input.memberId.trim();
+
+  if (!chatId || !homeRecipientPhone || !memberId) {
+    return `linq-message:${input.sourceEventId}`;
+  }
+
+  const hash = sha256Hex(JSON.stringify({
+    chatId,
+    homeRecipientPhone,
+    memberId,
+  })).slice(0, 32);
+  return `linq-home-redirect:${hash}`;
 }
 
 export async function drainHostedLinqSideEffectsDirect(input: {
@@ -541,12 +572,12 @@ async function buildHostedLinqSideEffectMessage(
         seed: effect.effectId,
       });
     case "conversation_home_redirect": {
-      const homeRecipientPhone = await resolveHostedHomeRecipientPhone(effect.payload, prisma);
+      const homeRecipientPhone = normalizePhoneNumber(effect.payload.homeRecipientPhone);
 
       if (!homeRecipientPhone) {
         throw hostedOnboardingError({
           code: "LINQ_HOME_PHONE_REQUIRED",
-          message: `Hosted webhook side effect ${effect.effectId} requires a home recipient phone.`,
+          message: `Hosted webhook side effect ${effect.effectId} requires a valid home recipient phone.`,
           httpStatus: 500,
           retryable: false,
         });
@@ -565,24 +596,6 @@ async function buildHostedLinqSideEffectMessage(
         prisma,
       });
   }
-}
-
-async function resolveHostedHomeRecipientPhone(
-  payload: HostedLinqConversationHomeRedirectPayload,
-  prisma: HostedLinqTransportPersistenceClient,
-): Promise<string | null> {
-  if (payload.memberId) {
-    const routing = await readHostedMemberRoutingState({
-      memberId: payload.memberId,
-      prisma,
-    });
-
-    if (routing?.linqRecipientPhone) {
-      return routing.linqRecipientPhone;
-    }
-  }
-
-  return payload.homeRecipientPhone;
 }
 
 async function buildHostedInviteSideEffectMessage(input: {
@@ -666,7 +679,7 @@ function buildHostedWebhookLinqMessagePayload(
     case "conversation_home_redirect":
       return {
         chatId: input.chatId,
-        homeRecipientPhone: input.homeRecipientPhone ?? null,
+        homeRecipientPhone: input.homeRecipientPhone,
         memberId: input.memberId,
         replyToMessageId,
         template: input.template,

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-member-routing-store", () => ({
   readHostedMemberHomeLinqRoute: vi.fn(),
-  readHostedMemberRoutingState: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
@@ -46,7 +45,6 @@ import {
   releaseHostedAiUsageLimitNotice,
 } from "@/src/lib/hosted-execution/usage-allowance";
 import { createHostedPhoneLookupKey } from "@/src/lib/hosted-onboarding/contact-privacy";
-import { readHostedMemberRoutingState } from "@/src/lib/hosted-onboarding/hosted-member-routing-store";
 import {
   buildHostedLinqConversationHomeRedirectReply,
   sendHostedLinqChatMessage,
@@ -72,8 +70,7 @@ describe("hosted Linq webhook transport", () => {
     vi.clearAllMocks();
   });
 
-  it("uses the stored redirect phone fallback when current routing is unavailable", async () => {
-    vi.mocked(readHostedMemberRoutingState).mockResolvedValue(null);
+  it("sends the planner-chosen home phone with a chat+home-line stable effect id", async () => {
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
       homeRecipientPhone: "+15555550100",
@@ -91,6 +88,7 @@ describe("hosted Linq webhook transport", () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(effect.effectId).toMatch(/^linq-home-redirect:[0-9a-f]{32}$/);
     expect(buildHostedLinqConversationHomeRedirectReply).toHaveBeenCalledWith(expect.objectContaining({
       homeRecipientPhone: "+15555550100",
     }));
@@ -102,6 +100,77 @@ describe("hosted Linq webhook transport", () => {
         replyToMessageId: "message-1",
       }),
     );
+  });
+
+  it("yields a stable effect id for repeat wrong-chat inbounds and a fresh id when the home line changes", () => {
+    const baseInput = {
+      chatId: "chat-1",
+      homeRecipientPhone: "+15555550100",
+      memberId: "member-1",
+      template: "conversation_home_redirect" as const,
+    };
+
+    const firstRedirect = createHostedWebhookLinqMessageSideEffect({
+      ...baseInput,
+      replyToMessageId: "message-1",
+      sourceEventId: "event-1",
+    });
+    const secondRedirectSameHome = createHostedWebhookLinqMessageSideEffect({
+      ...baseInput,
+      replyToMessageId: "message-2",
+      sourceEventId: "event-2",
+    });
+    const redirectAfterHomeLineChange = createHostedWebhookLinqMessageSideEffect({
+      ...baseInput,
+      homeRecipientPhone: "+15555550200",
+      replyToMessageId: "message-3",
+      sourceEventId: "event-3",
+    });
+
+    expect(firstRedirect.effectId).toMatch(/^linq-home-redirect:[0-9a-f]{32}$/);
+    expect(secondRedirectSameHome.effectId).toBe(firstRedirect.effectId);
+    expect(redirectAfterHomeLineChange.effectId).not.toBe(firstRedirect.effectId);
+    expect(redirectAfterHomeLineChange.effectId).toMatch(/^linq-home-redirect:[0-9a-f]{32}$/);
+  });
+
+  it("keeps the redirect effect id stable when the contact-privacy keyring rotates", () => {
+    const restoreV1 = configureHostedContactPrivacyKeyringForTest({
+      currentVersion: "v1",
+      entries: HOME_REDIRECT_TEST_KEYRING_ENTRIES,
+    });
+    let firstRedirect;
+    try {
+      firstRedirect = createHostedWebhookLinqMessageSideEffect({
+        chatId: "chat-1",
+        homeRecipientPhone: "+15555550100",
+        memberId: "member-1",
+        replyToMessageId: "message-1",
+        sourceEventId: "event-1",
+        template: "conversation_home_redirect",
+      });
+    } finally {
+      restoreV1();
+    }
+
+    const restoreV2 = configureHostedContactPrivacyKeyringForTest({
+      currentVersion: "v2",
+      entries: HOME_REDIRECT_TEST_KEYRING_ENTRIES,
+    });
+    let secondRedirect;
+    try {
+      secondRedirect = createHostedWebhookLinqMessageSideEffect({
+        chatId: "chat-1",
+        homeRecipientPhone: "+15555550100",
+        memberId: "member-1",
+        replyToMessageId: "message-2",
+        sourceEventId: "event-2",
+        template: "conversation_home_redirect",
+      });
+    } finally {
+      restoreV2();
+    }
+
+    expect(secondRedirect.effectId).toBe(firstRedirect.effectId);
   });
 
   it("does not block current inbound replies on delivery-attempt recording", async () => {
@@ -171,40 +240,6 @@ describe("hosted Linq webhook transport", () => {
         }),
       );
     });
-  });
-
-  it("prefers the latest routing phone over the stored redirect fallback", async () => {
-    vi.mocked(readHostedMemberRoutingState).mockResolvedValue({
-      linqChatId: "home-chat-1",
-      linqRecipientPhone: "+15555550200",
-      memberId: "member-1",
-      pendingLinqChatId: null,
-      pendingLinqParticipantContact: null,
-      pendingLinqRecipientPhone: null,
-      telegramThreadId: null,
-      telegramUserId: null,
-      telegramUserLookupKey: null,
-    });
-    const effect = createHostedWebhookLinqMessageSideEffect({
-      chatId: "chat-1",
-      homeRecipientPhone: "+15555550100",
-      memberId: "member-1",
-      replyToMessageId: "message-1",
-      sourceEventId: "event-1",
-      template: "conversation_home_redirect",
-    });
-
-    await expect(
-      drainHostedLinqSideEffectsDirect({
-        currentInboundReply,
-        prisma: {} as never,
-        sideEffects: [effect],
-      }),
-    ).resolves.toBeUndefined();
-
-    expect(buildHostedLinqConversationHomeRedirectReply).toHaveBeenCalledWith(expect.objectContaining({
-      homeRecipientPhone: "+15555550200",
-    }));
   });
 
   it("delivers legacy invite_signin side effects as invite signup replies", async () => {
@@ -706,3 +741,45 @@ describe("hosted Linq webhook transport", () => {
     expect(prisma.hostedInvite.update).not.toHaveBeenCalled();
   });
 });
+
+const HOME_REDIRECT_TEST_KEYRING_ENTRIES = {
+  v1: "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
+  v2: "MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE=",
+} as const;
+
+function configureHostedContactPrivacyKeyringForTest(input: {
+  currentVersion: string;
+  entries: Record<string, string>;
+}): () => void {
+  const previousKeys = process.env.HOSTED_CONTACT_PRIVACY_KEYS;
+  const previousCurrentVersion = process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION;
+
+  process.env.HOSTED_CONTACT_PRIVACY_KEYS = Object.entries(input.entries)
+    .map(([version, key]) => `${version}:${key}`)
+    .join(",");
+  process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = input.currentVersion;
+  clearHostedOnboardingEnvCache();
+
+  return () => {
+    restoreEnvValue("HOSTED_CONTACT_PRIVACY_KEYS", previousKeys);
+    restoreEnvValue("HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION", previousCurrentVersion);
+    clearHostedOnboardingEnvCache();
+  };
+}
+
+function clearHostedOnboardingEnvCache(): void {
+  delete (
+    globalThis as typeof globalThis & {
+      __murphHostedOnboardingEnv?: unknown;
+    }
+  ).__murphHostedOnboardingEnv;
+}
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+}


### PR DESCRIPTION
## Why
Stacked on PR #310. On main today (and on PR #310's head), every inbound message that arrives on a wrong Linq chat resolves to the same `conversation_home_redirect` side effect template but a *different* effect id (`linq-message:<sourceEventId>`), so we send a fresh home-redirect notice on every inbound until the member moves to their home line. That's noisy and undermines the redirect copy's "we'll talk over there" framing.

## User-visible goal
A member who keeps replying on the wrong line gets the "Reply on +1xxx" redirect notice once per (wrong chat × home line). If their home line later changes, the new target gets announced exactly once for the new pair.

## What changed
- `conversation_home_redirect` side effects now build a stable effect id of the form `linq-home-redirect:<sha256(linqChatLookupKey, homeRecipientPhoneLookupKey, memberId).slice(0,32)>`. The Linq API idempotency-key path and the existing `HostedLinqDelivery.idempotencyKey` unique index together collapse repeat sends into a single delivered notice.
- `HostedLinqConversationHomeRedirectPayload` now requires `homeRecipientPhone: string` and `memberId: string` (previously nullable). The planner already resolves both via `resolveHostedLinqActiveRouteDecision` before emitting the side effect, so the prior "nullable then re-read" round trip was redundant.
- The transport no longer re-reads `HostedMemberRouting` at send time. The redirect target locked in by the planner is the dispatched target.
- Refreshed `apps/web/test/hosted-onboarding-linq-transport.test.ts`: covers the stable effect id, equality across repeat inbounds for the same home line, and divergence when the home line changes. Drops the now-obsolete "prefers the latest routing phone over the stored redirect fallback" test along with the unused `readHostedMemberRoutingState` mock.

No schema, migration, or new persisted state — the existing `HostedLinqDelivery.idempotencyKey` is the dedup backstop. This deliberately does **not** re-add the `HostedLinqConversationState` model that PR #310 round 13 removed.

## Invariants to preserve
- The redirect target dispatched is exactly the target the planner chose (no later re-resolve).
- Repeat redirect attempts with the same `(chatId, homeRecipientPhone, memberId)` share an effect id; the existing `HostedLinqDelivery` upsert path treats them as the same logical attempt.
- A different `homeRecipientPhone` for the same chat + member produces a different effect id, allowing exactly one re-announcement.
- The planner contract still emits `redirect_to_home` only when both home and incoming phones exist and differ — `redirect_to_home.homeRecipientPhone` is a normalized `string`, so the tightened payload type is satisfied at the call site.
- All other Linq side-effect templates and their effect-id construction are unchanged.

## Base
This PR targets `codex/linq-observability-primitives` (PR #310). The HostedLinqDelivery idempotency-key plumbing that this PR leans on is introduced by #310.

## Verification
- PASS: `pnpm --dir apps/web exec vitest run --config vitest.workspace.ts --no-coverage test/hosted-onboarding-linq-transport.test.ts` (15 tests).
- PASS: `pnpm --dir apps/web exec vitest run --config vitest.workspace.ts --no-coverage $(ls apps/web/test | grep '^hosted-onboarding-linq' | sed 's|^|test/|') test/hosted-onboarding-webhook-idempotency.test.ts` — 18 files, 223 tests.
- PASS: `pnpm --dir apps/web typecheck`.
- PASS: `pnpm --dir apps/web exec eslint src/lib/hosted-onboarding/webhook-transport.ts test/hosted-onboarding-linq-transport.test.ts`.
- PASS: `pnpm logs:guard`.
- PASS: `git diff --check`.

## Deployment
No schema/migration changes. Deploys with web alongside #310; no compatibility window required relative to Cloudflare.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785106205&installation_id=127572939&pr_number=325&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F325&signature=40784e267ec67c2f8c32265ed870cadeeaf47603359435c5e80e012e5ecf0beb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->