### PR TITLE
Durably park hosted vault-file approval gaps

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-26-hosted-vault-file-approval-park.md
+++ b/agent-docs/exec-plans/completed/2026-06-26-hosted-vault-file-approval-park.md
@@ -1,0 +1,42 @@
+Goal (incl. success criteria):
+- Fix hosted outbox vault-file intents so a missing hosted action-approval boundary parks the intent durably during collection instead of only skipping it in memory.
+- Success means a due/preferred hosted Linq vault-file outbox intent with no approval metadata and no action-approval port is persisted as awaiting approval with a bounded retry timestamp, and the outbox next wake is no longer immediate.
+
+Constraints/Assumptions:
+- Assistant runtime owns outbox truth and next-wake projection inside the restored hosted workspace.
+- Missing action-approval authority must fail closed into durable owner state; do not add a scheduler, queue, or web-control fallback.
+- Preserve existing outbox dispatch preflight behavior and avoid broad refactors.
+- Preserve unrelated worktree edits and active ledger rows.
+
+Key decisions:
+- Reuse the existing `deferAssistantVaultFileApprovalCheck` durable parking path from dispatch preflight.
+- Remove the collection-only in-memory skip for due/preferred vault-file approval reconciliation.
+- Add a focused hosted-runtime callback regression for the production-faithful path described in the review.
+
+State:
+- Ready to commit.
+
+Done:
+- Confirmed PR #321 is merged and the finding applies to current `origin/main`.
+- Created an isolated task worktree from current `origin/main`.
+- Changed collection-time vault-file approval reconciliation to use durable blocking when the action-approval port is missing.
+- Added a hosted-runtime callback regression covering the preferred/due Linq vault-file intent path and next-wake projection.
+- Ran focused runtime tests, prepared workspace build artifacts for typecheck, full typecheck, and scoped diff verification.
+
+Now:
+- Commit the scoped fix and open the follow-up PR.
+
+Next:
+- Push the branch and hand off with PR, verification, and deployment notes.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+- packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+- packages/assistant-engine/src/assistant/vault-file-send.ts
+- PR #321 review finding at commit `4c2699a5528ba27251c86d1577df6c1679a710cf`
+Status: completed
+Updated: 2026-06-26
+Completed: 2026-06-26

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -158,7 +158,7 @@ export async function collectHostedAssistantDeliverySideEffects(
     const reconciliation = await reconcileHostedAssistantVaultFileApproval({
       actionApprovalPort: input.actionApprovalPort ?? null,
       intent,
-      missingApprovalPort: "skip",
+      missingApprovalPort: "block",
       now,
       vaultRoot: request.vaultRoot,
     });

--- a/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
@@ -749,6 +749,111 @@ describe("hosted runtime callbacks", () => {
     });
   });
 
+  it("durably parks preferred vault-file intents when the hosted approval port is missing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));
+    try {
+      const vaultFile = {
+        contentType: "application/pdf",
+        filename: "report.pdf",
+        kind: "vault_file" as const,
+        ref: "documents/report.pdf",
+        sha256: "a".repeat(64),
+        sizeBytes: 42,
+      };
+      let storedIntent = {
+        actorId: "actor_1",
+        bindingDelivery: { kind: "thread", target: "linq_chat_1" },
+        channel: "linq",
+        createdAt: "2026-04-08T00:00:00.000Z",
+        dedupeKey: "dedupe_vault_file",
+        delivery: null,
+        deliveryIdempotencyKey: "assistant-outbox:intent_vault_file",
+        deliveryTransportIdempotent: true,
+        explicitTarget: "linq_chat_1",
+        identityId: "identity_1",
+        intentId: "intent_vault_file",
+        lastAttemptAt: null,
+        lastError: null,
+        media: [vaultFile],
+        message: "Attached.",
+        nextAttemptAt: null,
+        replyToMessageId: "linq_message_1",
+        sessionId: "session_1",
+        status: "pending",
+        subject: null,
+        threadId: "thread_1",
+        threadIsDirect: true,
+        turnId: "turn_1",
+        updatedAt: "2026-04-08T00:00:00.000Z",
+      };
+      const deferredIntent = {
+        ...storedIntent,
+        lastError: {
+          code: "ASSISTANT_VAULT_FILE_APPROVAL_CHECK_DEFERRED",
+          diagnosticContext: {
+            assistantDeliveryFailureClass: "blocked",
+            assistantDeliveryResumeTrigger: "approval_state_change",
+            retryable: false,
+          },
+          message: "Secure vault-file approval could not be checked yet.",
+        },
+        nextAttemptAt: "2026-04-08T00:01:00.000Z",
+        status: "awaiting_approval",
+        updatedAt: "2026-04-08T00:00:00.000Z",
+      };
+      mocks.listAssistantOutboxIntents.mockImplementation(async () => [
+        storedIntent,
+      ]);
+      mocks.readAssistantVaultFileMedia.mockReturnValue(vaultFile);
+      mocks.deferAssistantVaultFileApprovalCheck.mockImplementationOnce(
+        ({ intent, now }) => {
+          expect(intent).toBe(storedIntent);
+          expect(now.toISOString()).toBe("2026-04-08T00:00:00.000Z");
+          return deferredIntent;
+        },
+      );
+      mocks.saveAssistantOutboxIntentIfUnchanged.mockImplementationOnce(
+        async ({ expectedDedupeKey, expectedStatus, expectedUpdatedAt, intent, vault }) => {
+          expect(expectedDedupeKey).toBe("dedupe_vault_file");
+          expect(expectedStatus).toBe("pending");
+          expect(expectedUpdatedAt).toBe("2026-04-08T00:00:00.000Z");
+          expect(vault).toBe("/tmp/vault");
+          storedIntent = intent;
+          return intent;
+        },
+      );
+
+      const sideEffects = await collectHostedAssistantDeliverySideEffects({
+        actionApprovalPort: null,
+        includeBackgroundDueIntents: true,
+        preferredIntentIds: ["intent_vault_file"],
+        vaultRoot: "/tmp/vault",
+      });
+
+      expect(sideEffects).toEqual([]);
+      expect(storedIntent).toMatchObject({
+        intentId: "intent_vault_file",
+        lastError: {
+          code: "ASSISTANT_VAULT_FILE_APPROVAL_CHECK_DEFERRED",
+        },
+        nextAttemptAt: "2026-04-08T00:01:00.000Z",
+        status: "awaiting_approval",
+      });
+      expect(mocks.buildAssistantVaultFileSendApprovalRequest).not.toHaveBeenCalled();
+      expect(mocks.saveAssistantOutboxIntentIfUnchanged).toHaveBeenCalledTimes(1);
+
+      const wakeAt = await resolveHostedAssistantOutboxNextWakeAt({
+        now: new Date("2026-04-08T00:00:00.000Z"),
+        vaultRoot: "/tmp/vault",
+      });
+
+      expect(wakeAt).toBe("2026-04-08T00:01:00.000Z");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("abandons a queued signup welcome when a foreground reply targets the same route", async () => {
     mocks.listAssistantOutboxIntents.mockResolvedValue([
       {


### PR DESCRIPTION
## Why
PR #321 fixed dispatch preflight parking, but collection still skipped vault-file approval reconciliation in memory when the hosted action-approval port was unavailable. That left due Linq vault-file intents pending without a durable diagnostic or bounded wake, which could reintroduce pre-provider collect churn.

## User-visible goal
Hosted Linq vault-file replies fail closed before any provider dispatch whenever approval authority is unavailable, and the outbox records the paused state so repair/resume paths have durable state to observe.

## What changed
- Use the existing durable block/defer path during hosted delivery collection when the action-approval port is missing.
- Add a production-faithful regression for a preferred due Linq vault-file intent with no approval metadata and no next attempt timestamp.
- Assert the stored intent moves to awaiting approval with ASSISTANT_VAULT_FILE_APPROVAL_CHECK_DEFERRED and that next wake is bounded.

## Invariants to preserve
- Vault-file media is never dispatched without secure approval authority.
- Outbox owner state remains the durable source of truth for blocked delivery state and wake projection.
- Dispatch preflight remains a second boundary; collection-time reconciliation now fails closed durably instead of only filtering in memory.

## Verification
- pnpm --dir packages/assistant-runtime test -- hosted-runtime-callbacks.test.ts
- pnpm build:test-runtime:prepared
- pnpm typecheck
- bash scripts/workspace-verify.sh test:diff packages/assistant-runtime/src/hosted-runtime/callbacks.ts packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts

## Deployment notes
Runtime-only change for the hosted assistant runner bundle. Existing pending vault-file intents are backward-compatible; after deploy, any due intent that hits this missing-authority path parks durably on collection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785106545&installation_id=127572939&pr_number=326&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F326&signature=73cdefe5edad1bd9f6babdfd6f7e6b3ec74bb65a8caabe42d43799113a6c3cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->