### PR TITLE
feat(assistant-engine): inject active safety-critical health context into prompt snapshot

### DIFF
--- a/packages/assistant-engine/src/assistant/context-snapshot.ts
+++ b/packages/assistant-engine/src/assistant/context-snapshot.ts
@@ -121,6 +121,9 @@ export async function readAssistantContextSnapshotPrompt(input: {
     maxBytes: MAX_ASSISTANT_CONTEXT_SNAPSHOT_PROMPT_BYTES,
     vaultRoot: input.vaultRoot,
   })
+  if (state?.pendingDirtyDomains.includes('health_context')) {
+    return null
+  }
   return normalizeNullableString(state?.lastCompleted?.promptBlock)
 }
 
@@ -442,12 +445,6 @@ async function buildAssistantSnapshotCoverage(input: {
     VAULT_LAYOUT.regimensDirectory,
     regimenFrontmatterSchema,
   )
-  const conditionsById = new Map<string, PromptLookupRecord>(
-    conditions.map((condition): [string, PromptLookupRecord] => [
-      condition.conditionId,
-      condition,
-    ]),
-  )
   const activeRegimens = regimens.filter(isActiveRegimen)
   const activeRegimensById = new Map<string, PromptLookupRecord>(
     activeRegimens.map((regimen): [string, PromptLookupRecord] => [
@@ -458,6 +455,12 @@ async function buildAssistantSnapshotCoverage(input: {
   const activeConditions = conditions
     .filter(isActiveCondition)
     .sort(compareActiveConditions)
+  const activeConditionsById = new Map<string, PromptLookupRecord>(
+    activeConditions.map((condition): [string, PromptLookupRecord] => [
+      condition.conditionId,
+      condition,
+    ]),
+  )
   const visibleActiveConditions = activeConditions.slice(
     0,
     MAX_ASSISTANT_CONTEXT_ACTIVE_SAFETY_RECORDS,
@@ -521,7 +524,7 @@ async function buildAssistantSnapshotCoverage(input: {
     activeAllergyCount: activeAllergies.length,
     activeAllergiesLine: renderActiveAllergiesLine({
       allergies: visibleActiveAllergies,
-      conditionsById,
+      conditionsById: activeConditionsById,
       totalCount: activeAllergies.length,
     }),
     activeConditionCount: activeConditions.length,
@@ -543,8 +546,8 @@ async function buildAssistantSnapshotCoverage(input: {
     ),
     activeMedicationRegimenCount: activeMedicationRegimens.length,
     activeMedicationRegimensLine: renderActiveSafetyRegimensLine({
-      conditions,
-      conditionsById,
+      conditions: activeConditions,
+      conditionsById: activeConditionsById,
       label: 'Active medication regimens',
       omittedNoun: 'medication regimen',
       regimens: visibleActiveMedicationRegimens,
@@ -559,8 +562,8 @@ async function buildAssistantSnapshotCoverage(input: {
       : null,
     activeSupplementRegimenCount: activeSupplementRegimens.length,
     activeSupplementRegimensLine: renderActiveSafetyRegimensLine({
-      conditions,
-      conditionsById,
+      conditions: activeConditions,
+      conditionsById: activeConditionsById,
       label: 'Active supplement regimens',
       omittedNoun: 'supplement regimen',
       regimens: visibleActiveSupplementRegimens,

--- a/packages/assistant-engine/src/assistant/context-snapshot.ts
+++ b/packages/assistant-engine/src/assistant/context-snapshot.ts
@@ -41,8 +41,8 @@ export const ASSISTANT_CONTEXT_SNAPSHOT_FILE_NAME = 'context-snapshot.json'
 
 const ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT = [
   'Assistant context snapshot for navigation only:',
-  '- Active safety-critical health context is currently unavailable in the snapshot (recent canonical edit or pending rebuild).',
-  '- Before any safety-relevant guidance, query `vault-cli condition show`, `vault-cli allergy show`, `vault-cli regimen show`, and `vault-cli goal show` for the user\'s current active records.',
+  '- Active safety-critical health context is currently unavailable in the snapshot (recent canonical edit, pending rebuild, or incomplete source read).',
+  '- Before any safety-relevant guidance, enumerate the user\'s current active records with `vault-cli condition list --status active`, `vault-cli allergy list --status active`, `vault-cli regimen list --status active`, and `vault-cli goal list --status active`, then read individual records with the matching `vault-cli condition show <id>` / `vault-cli allergy show <id>` / `vault-cli regimen show <id>` / `vault-cli goal show <id>` as needed.',
 ].join('\n')
 
 export const ASSISTANT_CONTEXT_SNAPSHOT_DIRTY_DOMAINS = [
@@ -123,17 +123,18 @@ export function resolveAssistantContextSnapshotPath(vaultRoot: string): string {
 export async function readAssistantContextSnapshotPrompt(input: {
   vaultRoot: string
 }): Promise<string | null> {
-  const { exists, state } = await readAssistantContextSnapshotStateStatus({
+  const { state } = await readAssistantContextSnapshotStateStatus({
     maxBytes: MAX_ASSISTANT_CONTEXT_SNAPSHOT_PROMPT_BYTES,
     vaultRoot: input.vaultRoot,
   })
+  const promptBlock = normalizeNullableString(state?.lastCompleted?.promptBlock)
   if (state?.pendingDirtyDomains.includes('health_context')) {
     return ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT
   }
-  if (exists && state === null) {
+  if (promptBlock === null) {
     return ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT
   }
-  return normalizeNullableString(state?.lastCompleted?.promptBlock)
+  return promptBlock
 }
 
 export async function isAssistantContextSnapshotRefreshPending(input: {
@@ -367,16 +368,21 @@ async function buildAssistantContextSnapshotPrompt(input: {
   const coverage = await buildAssistantSnapshotCoverage(input)
   assertAssistantContextSnapshotCanContinue(input)
 
+  const safetyLines = coverage.safetyComplete
+    ? [
+        coverage.activeAllergiesLine,
+        coverage.activeConditionsLine,
+        coverage.activeMedicationRegimensLine,
+        coverage.activeSupplementRegimensLine,
+      ]
+    : [ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT]
   const lines = [
     'Assistant context snapshot for navigation only:',
     '- This is a compact, possibly stale snapshot. Treat it as orientation, not canonical evidence.',
     '- Before making factual claims about current values, dates, counts, progress, or outcomes, query the relevant vault surface.',
     coverage.bloodTestsLine,
     coverage.healthContextLine,
-    coverage.activeAllergiesLine,
-    coverage.activeConditionsLine,
-    coverage.activeMedicationRegimensLine,
-    coverage.activeSupplementRegimensLine,
+    ...safetyLines,
     coverage.activeGoalsLine,
     coverage.regimensLine,
     coverage.activeHabitRegimensLine,
@@ -431,29 +437,37 @@ async function buildAssistantSnapshotCoverage(input: {
   healthContextLine: string | null
   regimenCount: number
   regimensLine: string | null
+  safetyComplete: boolean
   supplementCount: number
 }> {
   const eventCoverage = await collectAssistantSnapshotEventLedgerCoverage(input)
-  const goals = await listAssistantSnapshotFrontmatterRecords(
+  const goalRead = await listAssistantSnapshotFrontmatterRecords(
     input,
     VAULT_LAYOUT.goalsDirectory,
     goalFrontmatterSchema,
   )
-  const conditions = await listAssistantSnapshotFrontmatterRecords(
+  const conditionRead = await listAssistantSnapshotFrontmatterRecords(
     input,
     VAULT_LAYOUT.conditionsDirectory,
     conditionFrontmatterSchema,
   )
-  const allergies = await listAssistantSnapshotFrontmatterRecords(
+  const allergyRead = await listAssistantSnapshotFrontmatterRecords(
     input,
     VAULT_LAYOUT.allergiesDirectory,
     allergyFrontmatterSchema,
   )
-  const regimens = await listAssistantSnapshotFrontmatterRecords(
+  const regimenRead = await listAssistantSnapshotFrontmatterRecords(
     input,
     VAULT_LAYOUT.regimensDirectory,
     regimenFrontmatterSchema,
   )
+  const goals = goalRead.records
+  const conditions = conditionRead.records
+  const allergies = allergyRead.records
+  const regimens = regimenRead.records
+  const safetyComplete = conditionRead.complete
+    && allergyRead.complete
+    && regimenRead.complete
   const activeRegimens = regimens.filter(isActiveRegimen)
   const activeRegimensById = new Map<string, PromptLookupRecord>(
     activeRegimens.map((regimen): [string, PromptLookupRecord] => [
@@ -592,6 +606,7 @@ async function buildAssistantSnapshotCoverage(input: {
     regimensLine: regimenParts.length > 0
       ? `- Bank coverage includes ${joinWithAnd(regimenParts)}.`
       : null,
+    safetyComplete,
     supplementCount,
   }
 }
@@ -604,23 +619,28 @@ async function listAssistantSnapshotFrontmatterRecords<TRecord>(
   },
   relativeDirectory: string,
   schema: ContractSchema<TRecord>,
-): Promise<TRecord[]> {
+): Promise<{ complete: boolean; records: TRecord[] }> {
   assertAssistantContextSnapshotCanContinue(input)
   const { relativePaths } = await walkVaultFilesInterruptible(
     input.vaultRoot,
     relativeDirectory,
     {
       extension: '.md',
-      maxMatches: MAX_ASSISTANT_CONTEXT_FRONTMATTER_FILES_PER_DIR,
+      maxMatches: MAX_ASSISTANT_CONTEXT_FRONTMATTER_FILES_PER_DIR + 1,
       shouldContinue: () => {
         assertAssistantContextSnapshotCanContinue(input)
         return true
       },
     },
   )
+  const truncated = relativePaths.length > MAX_ASSISTANT_CONTEXT_FRONTMATTER_FILES_PER_DIR
   const records: TRecord[] = []
+  let parseFailed = false
 
-  for (const relativePath of relativePaths) {
+  const visible = truncated
+    ? relativePaths.slice(0, MAX_ASSISTANT_CONTEXT_FRONTMATTER_FILES_PER_DIR)
+    : relativePaths
+  for (const relativePath of visible) {
     assertAssistantContextSnapshotCanContinue(input)
     try {
       const resolved = resolveVaultPath(input.vaultRoot, relativePath)
@@ -631,16 +651,19 @@ async function listAssistantSnapshotFrontmatterRecords<TRecord>(
       const result = safeParseContract(schema, document.attributes)
       if (result.success) {
         records.push(result.data)
+      } else {
+        parseFailed = true
       }
     } catch (error) {
       if (isAssistantContextSnapshotPreemptionError(error)) {
         throw error
       }
+      parseFailed = true
       continue
     }
   }
 
-  return records
+  return { complete: !truncated && !parseFailed, records }
 }
 
 async function collectAssistantSnapshotEventLedgerCoverage(input: {

--- a/packages/assistant-engine/src/assistant/context-snapshot.ts
+++ b/packages/assistant-engine/src/assistant/context-snapshot.ts
@@ -39,6 +39,12 @@ export const ASSISTANT_CONTEXT_SNAPSHOT_SCHEMA =
 export const ASSISTANT_CONTEXT_SNAPSHOT_SCHEMA_VERSION = 2
 export const ASSISTANT_CONTEXT_SNAPSHOT_FILE_NAME = 'context-snapshot.json'
 
+const ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT = [
+  'Assistant context snapshot for navigation only:',
+  '- Active safety-critical health context is currently unavailable in the snapshot (recent canonical edit or pending rebuild).',
+  '- Before any safety-relevant guidance, query `vault-cli condition show`, `vault-cli allergy show`, `vault-cli regimen show`, and `vault-cli goal show` for the user\'s current active records.',
+].join('\n')
+
 export const ASSISTANT_CONTEXT_SNAPSHOT_DIRTY_DOMAINS = [
   'experiments',
   'blood_tests',
@@ -117,12 +123,15 @@ export function resolveAssistantContextSnapshotPath(vaultRoot: string): string {
 export async function readAssistantContextSnapshotPrompt(input: {
   vaultRoot: string
 }): Promise<string | null> {
-  const { state } = await readAssistantContextSnapshotStateStatus({
+  const { exists, state } = await readAssistantContextSnapshotStateStatus({
     maxBytes: MAX_ASSISTANT_CONTEXT_SNAPSHOT_PROMPT_BYTES,
     vaultRoot: input.vaultRoot,
   })
   if (state?.pendingDirtyDomains.includes('health_context')) {
-    return null
+    return ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT
+  }
+  if (exists && state === null) {
+    return ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT
   }
   return normalizeNullableString(state?.lastCompleted?.promptBlock)
 }
@@ -1273,18 +1282,18 @@ function renderRelatedLookups(
   ids: readonly string[],
   recordsById: ReadonlyMap<string, PromptLookupRecord>,
 ): string | null {
-  const uniqueIds = uniqueStrings(ids)
-  if (uniqueIds.length === 0) {
+  const presentIds = uniqueStrings(ids).filter((id) => recordsById.has(id))
+  if (presentIds.length === 0) {
     return null
   }
 
-  const visible = uniqueIds.slice(0, MAX_ASSISTANT_CONTEXT_RELATED_RECORDS)
+  const visible = presentIds.slice(0, MAX_ASSISTANT_CONTEXT_RELATED_RECORDS)
   const rendered = visible.map((id) => {
-    const record = recordsById.get(id)
-    return record ? renderPromptLookup(record.title, record.slug, id) : renderPromptField(id)
+    const record = recordsById.get(id)!
+    return renderPromptLookup(record.title, record.slug, id)
   })
-  const omitted = uniqueIds.length > visible.length
-    ? `, +${uniqueIds.length - visible.length}`
+  const omitted = presentIds.length > visible.length
+    ? `, +${presentIds.length - visible.length}`
     : ''
 
   return `${label} ${rendered.join(', ')}${omitted}`

--- a/packages/assistant-engine/src/assistant/context-snapshot.ts
+++ b/packages/assistant-engine/src/assistant/context-snapshot.ts
@@ -36,7 +36,7 @@ import { resolveAssistantStatePaths } from './store/paths.js'
 
 export const ASSISTANT_CONTEXT_SNAPSHOT_SCHEMA =
   'murph.assistant-context-snapshot'
-export const ASSISTANT_CONTEXT_SNAPSHOT_SCHEMA_VERSION = 1
+export const ASSISTANT_CONTEXT_SNAPSHOT_SCHEMA_VERSION = 2
 export const ASSISTANT_CONTEXT_SNAPSHOT_FILE_NAME = 'context-snapshot.json'
 
 export const ASSISTANT_CONTEXT_SNAPSHOT_DIRTY_DOMAINS = [

--- a/packages/assistant-engine/src/assistant/context-snapshot.ts
+++ b/packages/assistant-engine/src/assistant/context-snapshot.ts
@@ -4,9 +4,11 @@ import path from 'node:path'
 import {
   BLOOD_TEST_CATEGORY,
   BLOOD_TEST_SPECIMEN_TYPES,
+  type AllergyFrontmatter,
   type ContractSchema,
   allergyFrontmatterSchema,
   conditionFrontmatterSchema,
+  type ConditionFrontmatter,
   goalFrontmatterSchema,
   type GoalFrontmatter,
   regimenFrontmatterSchema,
@@ -84,12 +86,20 @@ type AssistantContextSnapshotBuildResult = Pick<
   'includedDomains' | 'promptBlock' | 'sectionPresence'
 >
 
+type PromptLookupRecord = Readonly<{
+  slug: string
+  title: string
+}>
+
 const ASSISTANT_CONTEXT_SNAPSHOT_ALL_DOMAINS =
   ['experiments', 'blood_tests', 'health_context'] as const
 
 const BLOOD_TEST_SPECIMEN_TYPE_SET = new Set<string>(BLOOD_TEST_SPECIMEN_TYPES)
+const MAX_ASSISTANT_CONTEXT_ACTIVE_SAFETY_RECORDS = 5
 const MAX_ASSISTANT_CONTEXT_ACTIVE_GOALS = 3
 const MAX_ASSISTANT_CONTEXT_ACTIVE_HABIT_REGIMENS = 3
+const MAX_ASSISTANT_CONTEXT_RELATED_RECORDS = 3
+const MAX_ASSISTANT_CONTEXT_SUPPLEMENT_INGREDIENTS = 3
 const MAX_ASSISTANT_CONTEXT_SNAPSHOT_PROMPT_BYTES = 64 * 1024
 const MAX_ASSISTANT_CONTEXT_PROMPT_FIELD_LENGTH = 120
 const MAX_ASSISTANT_CONTEXT_FRONTMATTER_FILES_PER_DIR = 200
@@ -351,10 +361,14 @@ async function buildAssistantContextSnapshotPrompt(input: {
     '- Before making factual claims about current values, dates, counts, progress, or outcomes, query the relevant vault surface.',
     coverage.bloodTestsLine,
     coverage.healthContextLine,
+    coverage.activeAllergiesLine,
+    coverage.activeConditionsLine,
+    coverage.activeMedicationRegimensLine,
+    coverage.activeSupplementRegimensLine,
     coverage.activeGoalsLine,
     coverage.regimensLine,
     coverage.activeHabitRegimensLine,
-    coverage.activePlanReadLine,
+    coverage.activeRecordReadLine,
   ].filter((line): line is string => Boolean(line))
 
   const promptBlock = [
@@ -384,11 +398,19 @@ async function buildAssistantSnapshotCoverage(input: {
   signal: AbortSignal | null
   vaultRoot: string
 }): Promise<{
+  activeAllergyCount: number
+  activeAllergiesLine: string | null
+  activeConditionCount: number
+  activeConditionsLine: string | null
   activeGoalCount: number
   activeGoalsLine: string | null
   activeHabitRegimenCount: number
   activeHabitRegimensLine: string | null
-  activePlanReadLine: string | null
+  activeMedicationRegimenCount: number
+  activeMedicationRegimensLine: string | null
+  activeRecordReadLine: string | null
+  activeSupplementRegimenCount: number
+  activeSupplementRegimensLine: string | null
   allergyCount: number
   bloodTestCount: number
   bloodTestsLine: string | null
@@ -420,6 +442,47 @@ async function buildAssistantSnapshotCoverage(input: {
     VAULT_LAYOUT.regimensDirectory,
     regimenFrontmatterSchema,
   )
+  const conditionsById = new Map<string, PromptLookupRecord>(
+    conditions.map((condition): [string, PromptLookupRecord] => [
+      condition.conditionId,
+      condition,
+    ]),
+  )
+  const activeRegimens = regimens.filter(isActiveRegimen)
+  const activeRegimensById = new Map<string, PromptLookupRecord>(
+    activeRegimens.map((regimen): [string, PromptLookupRecord] => [
+      regimen.regimenId,
+      regimen,
+    ]),
+  )
+  const activeConditions = conditions
+    .filter(isActiveCondition)
+    .sort(compareActiveConditions)
+  const visibleActiveConditions = activeConditions.slice(
+    0,
+    MAX_ASSISTANT_CONTEXT_ACTIVE_SAFETY_RECORDS,
+  )
+  const activeAllergies = allergies
+    .filter(isActiveAllergy)
+    .sort(compareActiveAllergies)
+  const visibleActiveAllergies = activeAllergies.slice(
+    0,
+    MAX_ASSISTANT_CONTEXT_ACTIVE_SAFETY_RECORDS,
+  )
+  const activeMedicationRegimens = regimens
+    .filter(isActiveMedicationRegimen)
+    .sort(compareActiveSafetyRegimens)
+  const visibleActiveMedicationRegimens = activeMedicationRegimens.slice(
+    0,
+    MAX_ASSISTANT_CONTEXT_ACTIVE_SAFETY_RECORDS,
+  )
+  const activeSupplementRegimens = regimens
+    .filter(isActiveSupplementRegimen)
+    .sort(compareActiveSafetyRegimens)
+  const visibleActiveSupplementRegimens = activeSupplementRegimens.slice(
+    0,
+    MAX_ASSISTANT_CONTEXT_ACTIVE_SAFETY_RECORDS,
+  )
   const activeGoals = goals
     .filter(isActiveGoal)
     .sort(compareActiveGoals)
@@ -445,18 +508,64 @@ async function buildAssistantSnapshotCoverage(input: {
     summarizePositiveCount(supplementCount, 'supplement'),
   ].filter((part): part is string => Boolean(part))
 
+  const hasActivePromptContext = [
+    activeConditions.length,
+    activeAllergies.length,
+    activeMedicationRegimens.length,
+    activeSupplementRegimens.length,
+    activeGoals.length,
+    activeHabitRegimens.length,
+  ].some((count) => count > 0)
+
   return {
+    activeAllergyCount: activeAllergies.length,
+    activeAllergiesLine: renderActiveAllergiesLine({
+      allergies: visibleActiveAllergies,
+      conditionsById,
+      totalCount: activeAllergies.length,
+    }),
+    activeConditionCount: activeConditions.length,
+    activeConditionsLine: renderActiveConditionsLine({
+      conditions: visibleActiveConditions,
+      regimens: activeRegimens,
+      regimensById: activeRegimensById,
+      totalCount: activeConditions.length,
+    }),
     activeGoalCount: activeGoals.length,
     activeGoalsLine: renderActiveGoalsLine(
       visibleActiveGoals,
       activeGoals.length,
     ),
     activeHabitRegimenCount: activeHabitRegimens.length,
-    activeHabitRegimensLine:
-      renderActiveHabitRegimensLine(visibleActiveHabitRegimens, activeHabitRegimens.length),
-    activePlanReadLine: activeGoals.length > 0 || activeHabitRegimens.length > 0
-      ? '- For current goals, habits, routines, or ramps, read the relevant `vault-cli goal show` / `vault-cli regimen show` record before reconstructing baselines, ladders, targets, or fallback details.'
+    activeHabitRegimensLine: renderActiveHabitRegimensLine(
+      visibleActiveHabitRegimens,
+      activeHabitRegimens.length,
+    ),
+    activeMedicationRegimenCount: activeMedicationRegimens.length,
+    activeMedicationRegimensLine: renderActiveSafetyRegimensLine({
+      conditions,
+      conditionsById,
+      label: 'Active medication regimens',
+      omittedNoun: 'medication regimen',
+      regimens: visibleActiveMedicationRegimens,
+      totalCount: activeMedicationRegimens.length,
+    }),
+    activeRecordReadLine: hasActivePromptContext
+      ? [
+          '- For active conditions, allergies, medications, supplements, goals, habits, routines, or ramps,',
+          'read the relevant `vault-cli condition show` / `vault-cli allergy show` / `vault-cli regimen show` / `vault-cli goal show` record',
+          'before safety-relevant guidance or reconstructing baselines, ladders, targets, or fallback details.',
+        ].join(' ')
       : null,
+    activeSupplementRegimenCount: activeSupplementRegimens.length,
+    activeSupplementRegimensLine: renderActiveSafetyRegimensLine({
+      conditions,
+      conditionsById,
+      label: 'Active supplement regimens',
+      omittedNoun: 'supplement regimen',
+      regimens: visibleActiveSupplementRegimens,
+      totalCount: activeSupplementRegimens.length,
+    }),
     allergyCount: allergies.length,
     bloodTestCount: eventCoverage.bloodTestCount,
     bloodTestsLine: eventCoverage.bloodTestCount > 0
@@ -792,13 +901,64 @@ function parseNonNegativeInteger(value: unknown): number {
   return value
 }
 
+function isActiveAllergy(allergy: AllergyFrontmatter): boolean {
+  return normalizeToken(allergy.status) === 'active'
+}
+
+function isActiveCondition(condition: ConditionFrontmatter): boolean {
+  return normalizeToken(condition.clinicalStatus) === 'active'
+}
+
 function isActiveGoal(goal: GoalFrontmatter): boolean {
   return normalizeToken(goal.status) === 'active'
 }
 
-function isActiveHabitRegimen(regimen: RegimenFrontmatter): boolean {
+function isActiveRegimen(regimen: RegimenFrontmatter): boolean {
   return normalizeToken(regimen.status) === 'active'
-    && normalizeToken(regimen.kind) === 'habit'
+}
+
+function isActiveHabitRegimen(regimen: RegimenFrontmatter): boolean {
+  return isActiveRegimenKind(regimen, 'habit')
+}
+
+function isActiveMedicationRegimen(regimen: RegimenFrontmatter): boolean {
+  return isActiveRegimenKind(regimen, 'medication')
+}
+
+function isActiveSupplementRegimen(regimen: RegimenFrontmatter): boolean {
+  return isActiveRegimenKind(regimen, 'supplement')
+}
+
+function isActiveRegimenKind(
+  regimen: RegimenFrontmatter,
+  kind: RegimenFrontmatter['kind'],
+): boolean {
+  return isActiveRegimen(regimen) && normalizeToken(regimen.kind) === kind
+}
+
+function compareActiveAllergies(
+  left: AllergyFrontmatter,
+  right: AllergyFrontmatter,
+): number {
+  return (
+    allergyCriticalityRank(left.criticality) - allergyCriticalityRank(right.criticality)
+    || compareIsoDateDesc(left.recordedOn, right.recordedOn)
+    || left.title.localeCompare(right.title)
+    || left.allergyId.localeCompare(right.allergyId)
+  )
+}
+
+function compareActiveConditions(
+  left: ConditionFrontmatter,
+  right: ConditionFrontmatter,
+): number {
+  return (
+    conditionSeverityRank(left.severity) - conditionSeverityRank(right.severity)
+    || conditionVerificationRank(left.verificationStatus) - conditionVerificationRank(right.verificationStatus)
+    || compareIsoDateDesc(left.assertedOn, right.assertedOn)
+    || left.title.localeCompare(right.title)
+    || left.conditionId.localeCompare(right.conditionId)
+  )
 }
 
 function compareActiveGoals(
@@ -825,6 +985,150 @@ function compareActiveHabitRegimens(
   )
 }
 
+function compareActiveSafetyRegimens(
+  left: RegimenFrontmatter,
+  right: RegimenFrontmatter,
+): number {
+  return (
+    compareIsoDateDesc(left.startedOn, right.startedOn)
+    || left.title.localeCompare(right.title)
+    || left.regimenId.localeCompare(right.regimenId)
+  )
+}
+
+function renderActiveAllergiesLine(input: {
+  allergies: readonly AllergyFrontmatter[]
+  conditionsById: ReadonlyMap<string, PromptLookupRecord>
+  totalCount: number
+}): string | null {
+  if (input.allergies.length === 0) {
+    return null
+  }
+
+  const allergySummaries = input.allergies
+    .map((allergy) => renderActiveAllergy(allergy, input.conditionsById))
+    .join('; ')
+
+  return `- Active allergies: ${allergySummaries}${renderOmittedCount(input.totalCount - input.allergies.length, 'allergy', 'allergies')}.`
+}
+
+function renderActiveAllergy(
+  allergy: AllergyFrontmatter,
+  conditionsById: ReadonlyMap<string, PromptLookupRecord>,
+): string {
+  const details = [
+    allergy.substance ? `substance ${renderPromptField(allergy.substance)}` : null,
+    allergy.criticality
+      ? `criticality ${renderPromptField(allergy.criticality)}`
+      : null,
+    allergy.reaction ? `reaction ${renderPromptField(allergy.reaction)}` : null,
+    allergy.recordedOn ? `recorded ${allergy.recordedOn}` : null,
+    renderRelatedLookups(
+      'related conditions',
+      collectAllergyRelatedConditionIds(allergy),
+      conditionsById,
+    ),
+    allergy.note ? `note ${renderPromptField(allergy.note)}` : null,
+  ].filter((part): part is string => Boolean(part))
+
+  return `${renderPromptLookup(allergy.title, allergy.slug, allergy.allergyId)}${renderDetailSuffix(details)}`
+}
+
+function renderActiveConditionsLine(input: {
+  conditions: readonly ConditionFrontmatter[]
+  regimens: readonly RegimenFrontmatter[]
+  regimensById: ReadonlyMap<string, PromptLookupRecord>
+  totalCount: number
+}): string | null {
+  if (input.conditions.length === 0) {
+    return null
+  }
+
+  const conditionSummaries = input.conditions
+    .map((condition) =>
+      renderActiveCondition(condition, input.regimensById, input.regimens),
+    )
+    .join('; ')
+
+  return `- Active conditions: ${conditionSummaries}${renderOmittedCount(input.totalCount - input.conditions.length, 'condition')}.`
+}
+
+function renderActiveCondition(
+  condition: ConditionFrontmatter,
+  regimensById: ReadonlyMap<string, PromptLookupRecord>,
+  regimens: readonly RegimenFrontmatter[],
+): string {
+  const details = [
+    condition.severity ? `severity ${renderPromptField(condition.severity)}` : null,
+    condition.verificationStatus
+      ? `verification ${renderPromptField(condition.verificationStatus)}`
+      : null,
+    condition.assertedOn ? `asserted ${condition.assertedOn}` : null,
+    condition.resolvedOn ? `resolved ${condition.resolvedOn}` : null,
+    renderStringList('body sites', condition.bodySites, MAX_ASSISTANT_CONTEXT_RELATED_RECORDS),
+    renderStringList('related goals', condition.relatedGoalIds, MAX_ASSISTANT_CONTEXT_RELATED_RECORDS),
+    renderRelatedLookups(
+      'related regimens',
+      collectConditionRelatedRegimenIds(condition, regimens),
+      regimensById,
+    ),
+    condition.note ? `note ${renderPromptField(condition.note)}` : null,
+  ].filter((part): part is string => Boolean(part))
+
+  return `${renderPromptLookup(condition.title, condition.slug, condition.conditionId)}${renderDetailSuffix(details)}`
+}
+
+function renderActiveSafetyRegimensLine(input: {
+  conditions: readonly ConditionFrontmatter[]
+  conditionsById: ReadonlyMap<string, PromptLookupRecord>
+  label: string
+  omittedNoun: string
+  regimens: readonly RegimenFrontmatter[]
+  totalCount: number
+}): string | null {
+  if (input.regimens.length === 0) {
+    return null
+  }
+
+  const regimenSummaries = input.regimens
+    .map((regimen) =>
+      renderActiveSafetyRegimen(regimen, input.conditionsById, input.conditions),
+    )
+    .join('; ')
+
+  return `- ${input.label}: ${regimenSummaries}${renderOmittedCount(input.totalCount - input.regimens.length, input.omittedNoun)}.`
+}
+
+function renderActiveSafetyRegimen(
+  regimen: RegimenFrontmatter,
+  conditionsById: ReadonlyMap<string, PromptLookupRecord>,
+  conditions: readonly ConditionFrontmatter[],
+): string {
+  const details = [
+    regimen.substance ? `substance ${renderPromptField(regimen.substance)}` : null,
+    renderRegimenDose(regimen),
+    regimen.schedule ? `schedule ${renderPromptField(regimen.schedule)}` : null,
+    regimen.startedOn ? `started ${regimen.startedOn}` : null,
+    regimen.brand ? `brand ${renderPromptField(regimen.brand)}` : null,
+    regimen.manufacturer
+      ? `manufacturer ${renderPromptField(regimen.manufacturer)}`
+      : null,
+    regimen.servingSize
+      ? `serving ${renderPromptField(regimen.servingSize)}`
+      : null,
+    renderSupplementIngredients(regimen),
+    renderRelatedLookups(
+      'related conditions',
+      collectRegimenRelatedConditionIds(regimen, conditions),
+      conditionsById,
+    ),
+    renderStringList('related goals', regimen.relatedGoalIds, MAX_ASSISTANT_CONTEXT_RELATED_RECORDS),
+    regimen.note ? `note ${renderPromptField(regimen.note)}` : null,
+  ].filter((part): part is string => Boolean(part))
+
+  return `${renderPromptLookup(regimen.title, regimen.slug, regimen.regimenId)}${renderDetailSuffix(details)}`
+}
+
 function renderActiveGoalsLine(
   goals: readonly GoalFrontmatter[],
   totalCount: number,
@@ -840,7 +1144,7 @@ function renderActiveGoal(goal: GoalFrontmatter): string {
   const details = [
     goal.horizon ? `horizon ${renderPromptField(goal.horizon)}` : null,
     renderGoalWindow(goal),
-    renderStringList('domains', goal.domains, 3),
+    renderStringList('domains', goal.domains, MAX_ASSISTANT_CONTEXT_RELATED_RECORDS),
   ].filter((part): part is string => Boolean(part))
 
   return `${renderPromptLookup(goal.title, goal.slug, goal.goalId)}${renderDetailSuffix(details)}`
@@ -874,7 +1178,11 @@ function renderActiveHabitRegimen(regimen: RegimenFrontmatter): string {
     regimen.schedule ? `schedule ${renderPromptField(regimen.schedule)}` : null,
     regimen.startedOn ? `started ${regimen.startedOn}` : null,
     regimen.note ? `note ${renderPromptField(regimen.note)}` : null,
-    renderStringList('related goals', regimen.relatedGoalIds, 3),
+    renderStringList(
+      'related goals',
+      regimen.relatedGoalIds,
+      MAX_ASSISTANT_CONTEXT_RELATED_RECORDS,
+    ),
   ].filter((part): part is string => Boolean(part))
 
   return `${renderPromptLookup(regimen.title, regimen.slug, regimen.regimenId)}${renderDetailSuffix(details)}`
@@ -904,8 +1212,192 @@ function renderStringList(
   return `${label} ${visible.join(', ')}${omitted}`
 }
 
-function renderOmittedCount(count: number, noun: string): string {
-  return count > 0 ? `; ${count} more active ${noun}${count === 1 ? '' : 's'} omitted` : ''
+function renderOmittedCount(
+  count: number,
+  singularNoun: string,
+  pluralNoun = `${singularNoun}s`,
+): string {
+  return count > 0
+    ? `; ${count} more active ${count === 1 ? singularNoun : pluralNoun} omitted`
+    : ''
+}
+
+function renderRegimenDose(regimen: RegimenFrontmatter): string | null {
+  if (regimen.dose === undefined && !regimen.unit) {
+    return null
+  }
+
+  const dose = [
+    regimen.dose === undefined ? null : String(regimen.dose),
+    regimen.unit ?? null,
+  ].filter((part): part is string => Boolean(part)).join(' ')
+  return dose ? `dose ${renderPromptField(dose)}` : null
+}
+
+function renderSupplementIngredients(regimen: RegimenFrontmatter): string | null {
+  if (!regimen.ingredients || regimen.ingredients.length === 0) {
+    return null
+  }
+
+  const visible = regimen.ingredients
+    .slice(0, MAX_ASSISTANT_CONTEXT_SUPPLEMENT_INGREDIENTS)
+    .map(renderSupplementIngredient)
+  const omitted = regimen.ingredients.length > visible.length
+    ? `, +${regimen.ingredients.length - visible.length}`
+    : ''
+
+  return `ingredients ${visible.join(', ')}${omitted}`
+}
+
+function renderSupplementIngredient(
+  ingredient: NonNullable<RegimenFrontmatter['ingredients']>[number],
+): string {
+  const amount = [
+    ingredient.amount === undefined ? null : String(ingredient.amount),
+    ingredient.unit ?? null,
+  ].filter((part): part is string => Boolean(part)).join(' ')
+  const parts = [
+    ingredient.label ?? ingredient.compound,
+    amount || null,
+    ingredient.active === false ? 'inactive' : null,
+  ].filter((part): part is string => Boolean(part))
+
+  return renderPromptField(parts.join(' '))
+}
+
+function renderRelatedLookups(
+  label: string,
+  ids: readonly string[],
+  recordsById: ReadonlyMap<string, PromptLookupRecord>,
+): string | null {
+  const uniqueIds = uniqueStrings(ids)
+  if (uniqueIds.length === 0) {
+    return null
+  }
+
+  const visible = uniqueIds.slice(0, MAX_ASSISTANT_CONTEXT_RELATED_RECORDS)
+  const rendered = visible.map((id) => {
+    const record = recordsById.get(id)
+    return record ? renderPromptLookup(record.title, record.slug, id) : renderPromptField(id)
+  })
+  const omitted = uniqueIds.length > visible.length
+    ? `, +${uniqueIds.length - visible.length}`
+    : ''
+
+  return `${label} ${rendered.join(', ')}${omitted}`
+}
+
+function collectAllergyRelatedConditionIds(allergy: AllergyFrontmatter): string[] {
+  return uniqueStrings([
+    ...(allergy.relatedConditionIds ?? []),
+    ...(allergy.links ?? [])
+      .filter((link) => link.type === 'related_condition')
+      .map((link) => link.targetId),
+  ])
+}
+
+function collectConditionRelatedRegimenIds(
+  condition: ConditionFrontmatter,
+  regimens: readonly RegimenFrontmatter[],
+): string[] {
+  const availableRegimenIds = new Set(regimens.map((regimen) => regimen.regimenId))
+  return uniqueStrings([
+    ...(condition.relatedRegimenIds ?? []),
+    ...(condition.links ?? [])
+      .filter((link) => link.type === 'related_regimen')
+      .map((link) => link.targetId),
+    ...regimens
+      .filter((regimen) =>
+        regimenReferencesCondition(regimen, condition.conditionId),
+      )
+      .map((regimen) => regimen.regimenId),
+  ]).filter((regimenId) => availableRegimenIds.has(regimenId))
+}
+
+function collectRegimenRelatedConditionIds(
+  regimen: RegimenFrontmatter,
+  conditions: readonly ConditionFrontmatter[],
+): string[] {
+  return uniqueStrings([
+    ...(regimen.relatedConditionIds ?? []),
+    ...(regimen.links ?? [])
+      .filter((link) => link.type === 'addresses_condition')
+      .map((link) => link.targetId),
+    ...conditions
+      .filter((condition) => conditionReferencesRegimen(condition, regimen.regimenId))
+      .map((condition) => condition.conditionId),
+  ])
+}
+
+function conditionReferencesRegimen(
+  condition: ConditionFrontmatter,
+  regimenId: string,
+): boolean {
+  return (condition.relatedRegimenIds ?? []).includes(regimenId)
+    || (condition.links ?? []).some(
+      (link) => link.type === 'related_regimen' && link.targetId === regimenId,
+    )
+}
+
+function regimenReferencesCondition(
+  regimen: RegimenFrontmatter,
+  conditionId: string,
+): boolean {
+  return (regimen.relatedConditionIds ?? []).includes(conditionId)
+    || (regimen.links ?? []).some(
+      (link) =>
+        link.type === 'addresses_condition' && link.targetId === conditionId,
+    )
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)]
+}
+
+function compareIsoDateDesc(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): number {
+  return (right ?? '').localeCompare(left ?? '')
+}
+
+function allergyCriticalityRank(value: AllergyFrontmatter['criticality']): number {
+  switch (normalizeToken(value)) {
+    case 'high':
+      return 0
+    case 'unable_to_assess':
+      return 1
+    case 'low':
+      return 2
+    default:
+      return 3
+  }
+}
+
+function conditionSeverityRank(value: ConditionFrontmatter['severity']): number {
+  switch (normalizeToken(value)) {
+    case 'severe':
+      return 0
+    case 'moderate':
+      return 1
+    case 'mild':
+      return 2
+    default:
+      return 3
+  }
+}
+
+function conditionVerificationRank(value: ConditionFrontmatter['verificationStatus']): number {
+  switch (normalizeToken(value)) {
+    case 'confirmed':
+      return 0
+    case 'provisional':
+      return 1
+    case 'unconfirmed':
+      return 2
+    default:
+      return 3
+  }
 }
 
 function renderPromptField(value: string): string {

--- a/packages/assistant-engine/src/assistant/context-snapshot.ts
+++ b/packages/assistant-engine/src/assistant/context-snapshot.ts
@@ -127,14 +127,13 @@ export async function readAssistantContextSnapshotPrompt(input: {
     maxBytes: MAX_ASSISTANT_CONTEXT_SNAPSHOT_PROMPT_BYTES,
     vaultRoot: input.vaultRoot,
   })
-  const promptBlock = normalizeNullableString(state?.lastCompleted?.promptBlock)
   if (state?.pendingDirtyDomains.includes('health_context')) {
     return ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT
   }
-  if (promptBlock === null) {
+  if (state === null || state.lastCompleted === null) {
     return ASSISTANT_CONTEXT_SNAPSHOT_SAFETY_STALE_PROMPT
   }
-  return promptBlock
+  return normalizeNullableString(state.lastCompleted.promptBlock)
 }
 
 export async function isAssistantContextSnapshotRefreshPending(input: {

--- a/packages/assistant-engine/test/assistant-context-snapshot.test.ts
+++ b/packages/assistant-engine/test/assistant-context-snapshot.test.ts
@@ -335,7 +335,7 @@ describe('assistant context snapshot', () => {
     }
   })
 
-  it('suppresses stale safety context when health_context is pending dirty', async () => {
+  it('returns a fail-closed safety guidance prompt when health_context is pending dirty', async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
 
     try {
@@ -376,8 +376,13 @@ describe('assistant context snapshot', () => {
         vaultRoot,
       })
 
-      await expect(readAssistantContextSnapshotPrompt({ vaultRoot }))
-        .resolves.toBeNull()
+      const stalePrompt = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+      expect(stalePrompt).toContain('Active safety-critical health context is currently unavailable')
+      expect(stalePrompt).toContain('`vault-cli condition show`')
+      expect(stalePrompt).toContain('`vault-cli allergy show`')
+      expect(stalePrompt).toContain('`vault-cli regimen show`')
+      expect(stalePrompt).toContain('`vault-cli goal show`')
+      expect(stalePrompt).not.toContain('Pregabalin')
     } finally {
       await rm(vaultRoot, { force: true, recursive: true })
     }
@@ -518,7 +523,79 @@ describe('assistant context snapshot', () => {
     }
   })
 
-  it('self-heals corrupt snapshots while oversized prompt reads return null', async () => {
+  it('does not leak inactive-condition IDs into active allergy or regimen related-condition lines', async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
+    const resolvedConditionId = generateContractId(ID_PREFIXES.condition)
+
+    try {
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.conditionFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.condition,
+          conditionId: resolvedConditionId,
+          slug: 'resolved-infection',
+          title: 'Resolved infection',
+          clinicalStatus: 'resolved',
+          verificationStatus: 'confirmed',
+          assertedOn: '2024-01-01',
+          resolvedOn: '2024-03-01',
+        },
+        relativePath: `${VAULT_LAYOUT.conditionsDirectory}/resolved-infection.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.allergyFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.allergy,
+          allergyId: generateContractId(ID_PREFIXES.allergy),
+          slug: 'amoxicillin-allergy',
+          title: 'Amoxicillin allergy',
+          substance: 'Amoxicillin',
+          status: 'active',
+          criticality: 'high',
+          relatedConditionIds: [resolvedConditionId],
+        },
+        relativePath: `${VAULT_LAYOUT.allergiesDirectory}/amoxicillin-allergy.md`,
+        vaultRoot,
+      })
+
+      await markAssistantContextSnapshotDirty({
+        domains: ['health_context'],
+        vaultRoot,
+      })
+      await refreshAssistantContextSnapshot({
+        now: () => '2026-06-26T12:00:00.000Z',
+        vaultRoot,
+      })
+
+      const promptText = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+
+      expect(promptText).toContain('Amoxicillin allergy')
+      expect(promptText).not.toContain('Resolved infection')
+      expect(promptText).not.toContain(resolvedConditionId)
+      expect(promptText).not.toContain('related conditions')
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('returns the fail-closed safety guidance when the snapshot envelope is unreadable', async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
+    const snapshotPath = resolveAssistantContextSnapshotPath(vaultRoot)
+
+    try {
+      await mkdir(path.dirname(snapshotPath), { recursive: true })
+      await writeFile(snapshotPath, '{not-json', 'utf8')
+
+      const prompt = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+      expect(prompt).toContain('Active safety-critical health context is currently unavailable')
+      expect(prompt).toContain('`vault-cli condition show`')
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('self-heals corrupt snapshots and returns the safety guidance prompt when reads are oversized', async () => {
     const parentRoot = await mkdtemp(path.join(tmpdir(), 'assistant-context-snapshot-'))
     const vaultRoot = path.join(parentRoot, 'vault')
     const snapshotPath = resolveAssistantContextSnapshotPath(vaultRoot)
@@ -567,9 +644,9 @@ describe('assistant context snapshot', () => {
         }),
         'utf8',
       )
-      await expect(readAssistantContextSnapshotPrompt({
-        vaultRoot,
-      })).resolves.toBeNull()
+      const oversizedPrompt = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+      expect(oversizedPrompt).toContain('Active safety-critical health context is currently unavailable')
+      expect(oversizedPrompt).toContain('`vault-cli condition show`')
     } finally {
       await rm(parentRoot, {
         force: true,

--- a/packages/assistant-engine/test/assistant-context-snapshot.test.ts
+++ b/packages/assistant-engine/test/assistant-context-snapshot.test.ts
@@ -580,6 +580,31 @@ describe('assistant context snapshot', () => {
     }
   })
 
+  it('returns null (not the fail-closed safety prompt) when a refresh succeeds on an empty vault', async () => {
+    const parentRoot = await mkdtemp(path.join(tmpdir(), 'assistant-context-snapshot-'))
+    const vaultRoot = path.join(parentRoot, 'vault')
+
+    try {
+      await initializeVault({
+        createdAt: '2026-06-01T00:00:00.000Z',
+        vaultRoot,
+      })
+      await markAssistantContextSnapshotDirty({
+        domains: ['health_context'],
+        vaultRoot,
+      })
+      await refreshAssistantContextSnapshot({
+        now: () => '2026-06-01T00:05:00.000Z',
+        vaultRoot,
+      })
+
+      await expect(readAssistantContextSnapshotPrompt({ vaultRoot }))
+        .resolves.toBeNull()
+    } finally {
+      await rm(parentRoot, { force: true, recursive: true })
+    }
+  })
+
   it('emits the fail-closed safety guidance when a safety-source file has unparseable frontmatter', async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
 

--- a/packages/assistant-engine/test/assistant-context-snapshot.test.ts
+++ b/packages/assistant-engine/test/assistant-context-snapshot.test.ts
@@ -383,6 +383,68 @@ describe('assistant context snapshot', () => {
     }
   })
 
+  it('rebuilds existing pre-renderer snapshots so the active safety context lands on the next refresh', async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
+    const snapshotPath = resolveAssistantContextSnapshotPath(vaultRoot)
+
+    try {
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.allergyFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.allergy,
+          allergyId: generateContractId(ID_PREFIXES.allergy),
+          slug: 'penicillin-allergy',
+          title: 'Penicillin allergy',
+          substance: 'Penicillin',
+          status: 'active',
+          criticality: 'high',
+        },
+        relativePath: `${VAULT_LAYOUT.allergiesDirectory}/penicillin-allergy.md`,
+        vaultRoot,
+      })
+
+      await mkdir(path.dirname(snapshotPath), { recursive: true })
+      await writeFile(
+        snapshotPath,
+        JSON.stringify({
+          schema: 'murph.assistant-context-snapshot',
+          schemaVersion: 1,
+          value: {
+            dirtySequence: 0,
+            lastCompleted: {
+              generatedAt: '2026-06-01T00:00:00.000Z',
+              includedDomains: ['experiments', 'blood_tests', 'health_context'],
+              promptBlock: 'Assistant context snapshot for navigation only:\n- Saved health context includes 1 allergy.',
+              sectionPresence: {
+                activeExperiments: false,
+                bloodTests: false,
+                healthContext: true,
+              },
+              sourceDirtySequence: 0,
+            },
+            lastRefreshAttempt: null,
+            pendingDirtyDomains: [],
+          },
+        }),
+        'utf8',
+      )
+
+      await expect(refreshAssistantContextSnapshot({
+        now: () => '2026-06-26T12:00:00.000Z',
+        vaultRoot,
+      })).resolves.toMatchObject({
+        refreshed: true,
+        skipped: false,
+      })
+
+      const promptText = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+      expect(promptText).toContain('Active allergies:')
+      expect(promptText).toContain('Penicillin allergy')
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true })
+    }
+  })
+
   it('does not surface inactive conditions through active allergy or active regimen related-condition lookups', async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
     const resolvedConditionId = generateContractId(ID_PREFIXES.condition)

--- a/packages/assistant-engine/test/assistant-context-snapshot.test.ts
+++ b/packages/assistant-engine/test/assistant-context-snapshot.test.ts
@@ -378,10 +378,11 @@ describe('assistant context snapshot', () => {
 
       const stalePrompt = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
       expect(stalePrompt).toContain('Active safety-critical health context is currently unavailable')
-      expect(stalePrompt).toContain('`vault-cli condition show`')
-      expect(stalePrompt).toContain('`vault-cli allergy show`')
-      expect(stalePrompt).toContain('`vault-cli regimen show`')
-      expect(stalePrompt).toContain('`vault-cli goal show`')
+      expect(stalePrompt).toContain('`vault-cli condition list --status active`')
+      expect(stalePrompt).toContain('`vault-cli allergy list --status active`')
+      expect(stalePrompt).toContain('`vault-cli regimen list --status active`')
+      expect(stalePrompt).toContain('`vault-cli goal list --status active`')
+      expect(stalePrompt).toContain('`vault-cli condition show <id>`')
       expect(stalePrompt).not.toContain('Pregabalin')
     } finally {
       await rm(vaultRoot, { force: true, recursive: true })
@@ -579,6 +580,50 @@ describe('assistant context snapshot', () => {
     }
   })
 
+  it('emits the fail-closed safety guidance when a safety-source file has unparseable frontmatter', async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
+
+    try {
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.allergyFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.allergy,
+          allergyId: generateContractId(ID_PREFIXES.allergy),
+          slug: 'penicillin-allergy',
+          title: 'Penicillin allergy',
+          substance: 'Penicillin',
+          status: 'active',
+          criticality: 'high',
+        },
+        relativePath: `${VAULT_LAYOUT.allergiesDirectory}/penicillin-allergy.md`,
+        vaultRoot,
+      })
+
+      const corruptAllergyPath = path.join(
+        vaultRoot,
+        VAULT_LAYOUT.allergiesDirectory,
+        'corrupt-allergy.md',
+      )
+      await writeFile(corruptAllergyPath, '---\nnot: valid frontmatter for a record\n---\n', 'utf8')
+
+      await markAssistantContextSnapshotDirty({
+        domains: ['health_context'],
+        vaultRoot,
+      })
+      await refreshAssistantContextSnapshot({
+        now: () => '2026-06-26T12:00:00.000Z',
+        vaultRoot,
+      })
+
+      const promptText = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+      expect(promptText).toContain('Active safety-critical health context is currently unavailable')
+      expect(promptText).toContain('`vault-cli allergy list --status active`')
+      expect(promptText).not.toContain('Penicillin allergy')
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true })
+    }
+  })
+
   it('returns the fail-closed safety guidance when the snapshot envelope is unreadable', async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
     const snapshotPath = resolveAssistantContextSnapshotPath(vaultRoot)
@@ -589,7 +634,7 @@ describe('assistant context snapshot', () => {
 
       const prompt = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
       expect(prompt).toContain('Active safety-critical health context is currently unavailable')
-      expect(prompt).toContain('`vault-cli condition show`')
+      expect(prompt).toContain('`vault-cli condition list --status active`')
     } finally {
       await rm(vaultRoot, { force: true, recursive: true })
     }
@@ -646,7 +691,7 @@ describe('assistant context snapshot', () => {
       )
       const oversizedPrompt = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
       expect(oversizedPrompt).toContain('Active safety-critical health context is currently unavailable')
-      expect(oversizedPrompt).toContain('`vault-cli condition show`')
+      expect(oversizedPrompt).toContain('`vault-cli condition list --status active`')
     } finally {
       await rm(parentRoot, {
         force: true,

--- a/packages/assistant-engine/test/assistant-context-snapshot.test.ts
+++ b/packages/assistant-engine/test/assistant-context-snapshot.test.ts
@@ -2,7 +2,18 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
-import { initializeVault } from '@murphai/core'
+import {
+  CONTRACT_SCHEMA_VERSION,
+  FRONTMATTER_DOC_TYPES,
+  type FrontmatterObject,
+  generateContractId,
+  ID_PREFIXES,
+} from '@murphai/contracts'
+import {
+  initializeVault,
+  stringifyFrontmatterDocument,
+  VAULT_LAYOUT,
+} from '@murphai/core'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -116,7 +127,9 @@ describe('assistant context snapshot', () => {
       expect(prompt).toContain('Active habit regimens:')
       expect(prompt).toContain('Sleep schedule ramp')
       expect(prompt).toContain('Baseline 2:30 AM')
-      expect(prompt).toContain('read the relevant `vault-cli goal show` / `vault-cli regimen show` record')
+      expect(prompt).toContain(
+        'read the relevant `vault-cli condition show` / `vault-cli allergy show` / `vault-cli regimen show` / `vault-cli goal show` record',
+      )
       expect(prompt).toContain('Active experiment context for navigation only:')
       expect(prompt).toContain('Sleep consistency')
       await markAssistantContextSnapshotDirty({
@@ -170,6 +183,155 @@ describe('assistant context snapshot', () => {
         force: true,
         recursive: true,
       })
+    }
+  })
+
+  it('injects active safety-critical health context into the prompt snapshot', async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
+    const conditionId = generateContractId(ID_PREFIXES.condition)
+    const medicationRegimenId = generateContractId(ID_PREFIXES.regimen)
+    const supplementRegimenId = generateContractId(ID_PREFIXES.regimen)
+    const inactiveMedicationRegimenId = generateContractId(ID_PREFIXES.regimen)
+    const allergyId = generateContractId(ID_PREFIXES.allergy)
+    const inactiveAllergyId = generateContractId(ID_PREFIXES.allergy)
+
+    try {
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.conditionFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.condition,
+          conditionId,
+          slug: 'thoracic-radiculopathy-radiculitis',
+          title: 'Thoracic radiculopathy / radiculitis',
+          clinicalStatus: 'active',
+          verificationStatus: 'confirmed',
+          assertedOn: '2026-06-20',
+          severity: 'moderate',
+          bodySites: ['thoracic spine', 'T7-T8 neural foramen'],
+          relatedRegimenIds: [supplementRegimenId, inactiveMedicationRegimenId],
+          note: 'Relevant context: T8 plasmacytoma with epidural and left T7-T8 neural-foramen extension.',
+        },
+        relativePath: `${VAULT_LAYOUT.conditionsDirectory}/thoracic-radiculopathy-radiculitis.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.allergyFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.allergy,
+          allergyId,
+          slug: 'penicillin-allergy',
+          title: 'Penicillin allergy',
+          substance: 'Penicillin',
+          status: 'active',
+          criticality: 'high',
+          reaction: 'hives',
+          recordedOn: '2026-06-01',
+          relatedConditionIds: [conditionId],
+        },
+        relativePath: `${VAULT_LAYOUT.allergiesDirectory}/penicillin-allergy.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.allergyFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.allergy,
+          allergyId: inactiveAllergyId,
+          slug: 'inactive-allergy',
+          title: 'Inactive allergy',
+          substance: 'Inactive substance',
+          status: 'inactive',
+        },
+        relativePath: `${VAULT_LAYOUT.allergiesDirectory}/inactive-allergy.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.regimenFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.regimen,
+          regimenId: medicationRegimenId,
+          slug: 'pregabalin',
+          title: 'Pregabalin',
+          kind: 'medication',
+          status: 'active',
+          startedOn: '2026-06-01',
+          substance: 'pregabalin',
+          dose: 75,
+          unit: 'mg',
+          schedule: 'nightly',
+          relatedConditionIds: [conditionId],
+        },
+        relativePath: `${VAULT_LAYOUT.regimensDirectory}/pregabalin.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.regimenFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.regimen,
+          regimenId: supplementRegimenId,
+          slug: 'magnesium-glycinate',
+          title: 'Magnesium glycinate',
+          kind: 'supplement',
+          status: 'active',
+          startedOn: '2026-05-15',
+          schedule: 'with dinner',
+          ingredients: [
+            {
+              compound: 'magnesium glycinate',
+              amount: 200,
+              unit: 'mg',
+            },
+          ],
+        },
+        relativePath: `${VAULT_LAYOUT.regimensDirectory}/magnesium-glycinate.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.regimenFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.regimen,
+          regimenId: inactiveMedicationRegimenId,
+          slug: 'stopped-medication',
+          title: 'Stopped medication',
+          kind: 'medication',
+          status: 'stopped',
+          startedOn: '2025-01-01',
+          stoppedOn: '2025-02-01',
+        },
+        relativePath: `${VAULT_LAYOUT.regimensDirectory}/stopped-medication.md`,
+        vaultRoot,
+      })
+
+      await markAssistantContextSnapshotDirty({
+        domains: ['health_context'],
+        vaultRoot,
+      })
+      await refreshAssistantContextSnapshot({
+        now: () => '2026-06-26T12:00:00.000Z',
+        vaultRoot,
+      })
+
+      const prompt = await readAssistantContextSnapshotPrompt({ vaultRoot })
+      const promptText = prompt ?? ''
+
+      expect(promptText).toContain('Active conditions:')
+      expect(promptText).toContain('Thoracic radiculopathy / radiculitis')
+      expect(promptText).toContain('T8 plasmacytoma')
+      expect(promptText).toContain('Active allergies:')
+      expect(promptText).toContain('Penicillin allergy')
+      expect(promptText).toContain('criticality high')
+      expect(promptText).toContain('Active medication regimens:')
+      expect(promptText).toContain('Pregabalin')
+      expect(promptText).toContain('dose 75 mg')
+      expect(promptText).toContain('Active supplement regimens:')
+      expect(promptText).toContain('Magnesium glycinate')
+      expect(promptText).toContain('ingredients magnesium glycinate 200 mg')
+      expect(promptText).toContain('related conditions Thoracic radiculopathy / radiculitis')
+      expect(promptText).toContain('vault-cli allergy show')
+      expect(promptText).toContain('vault-cli regimen show')
+      expect(promptText).not.toContain('Inactive allergy')
+      expect(promptText).not.toContain('Stopped medication')
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true })
     }
   })
 
@@ -233,6 +395,24 @@ describe('assistant context snapshot', () => {
     }
   })
 })
+
+async function writeVaultDocument(input: {
+  attributes: FrontmatterObject
+  body?: string
+  relativePath: string
+  vaultRoot: string
+}): Promise<void> {
+  const filePath = path.join(input.vaultRoot, input.relativePath)
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(
+    filePath,
+    stringifyFrontmatterDocument({
+      attributes: input.attributes,
+      body: input.body ?? '',
+    }),
+    'utf8',
+  )
+}
 
 async function writeTestSnapshotSources(vaultRoot: string): Promise<void> {
   await mkdir(path.join(vaultRoot, 'bank/experiments'), {

--- a/packages/assistant-engine/test/assistant-context-snapshot.test.ts
+++ b/packages/assistant-engine/test/assistant-context-snapshot.test.ts
@@ -335,6 +335,127 @@ describe('assistant context snapshot', () => {
     }
   })
 
+  it('suppresses stale safety context when health_context is pending dirty', async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
+
+    try {
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.regimenFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.regimen,
+          regimenId: generateContractId(ID_PREFIXES.regimen),
+          slug: 'pregabalin',
+          title: 'Pregabalin',
+          kind: 'medication',
+          status: 'active',
+          startedOn: '2026-06-01',
+          substance: 'pregabalin',
+          dose: 75,
+          unit: 'mg',
+          schedule: 'nightly',
+        },
+        relativePath: `${VAULT_LAYOUT.regimensDirectory}/pregabalin.md`,
+        vaultRoot,
+      })
+
+      await markAssistantContextSnapshotDirty({
+        domains: ['health_context'],
+        vaultRoot,
+      })
+      await refreshAssistantContextSnapshot({
+        now: () => '2026-06-26T12:00:00.000Z',
+        vaultRoot,
+      })
+
+      const initialPrompt = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+      expect(initialPrompt).toContain('Active medication regimens:')
+      expect(initialPrompt).toContain('Pregabalin')
+
+      await markAssistantContextSnapshotDirty({
+        domains: ['health_context'],
+        vaultRoot,
+      })
+
+      await expect(readAssistantContextSnapshotPrompt({ vaultRoot }))
+        .resolves.toBeNull()
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('does not surface inactive conditions through active allergy or active regimen related-condition lookups', async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-context-snapshot-'))
+    const resolvedConditionId = generateContractId(ID_PREFIXES.condition)
+
+    try {
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.conditionFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.condition,
+          conditionId: resolvedConditionId,
+          slug: 'resolved-infection',
+          title: 'Resolved infection',
+          clinicalStatus: 'resolved',
+          verificationStatus: 'confirmed',
+          assertedOn: '2024-01-01',
+          resolvedOn: '2024-03-01',
+        },
+        relativePath: `${VAULT_LAYOUT.conditionsDirectory}/resolved-infection.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.allergyFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.allergy,
+          allergyId: generateContractId(ID_PREFIXES.allergy),
+          slug: 'amoxicillin-allergy',
+          title: 'Amoxicillin allergy',
+          substance: 'Amoxicillin',
+          status: 'active',
+          criticality: 'high',
+          relatedConditionIds: [resolvedConditionId],
+        },
+        relativePath: `${VAULT_LAYOUT.allergiesDirectory}/amoxicillin-allergy.md`,
+        vaultRoot,
+      })
+      await writeVaultDocument({
+        attributes: {
+          schemaVersion: CONTRACT_SCHEMA_VERSION.regimenFrontmatter,
+          docType: FRONTMATTER_DOC_TYPES.regimen,
+          regimenId: generateContractId(ID_PREFIXES.regimen),
+          slug: 'vitamin-d',
+          title: 'Vitamin D',
+          kind: 'supplement',
+          status: 'active',
+          startedOn: '2026-06-01',
+          relatedConditionIds: [resolvedConditionId],
+        },
+        relativePath: `${VAULT_LAYOUT.regimensDirectory}/vitamin-d.md`,
+        vaultRoot,
+      })
+
+      await markAssistantContextSnapshotDirty({
+        domains: ['health_context'],
+        vaultRoot,
+      })
+      await refreshAssistantContextSnapshot({
+        now: () => '2026-06-26T12:00:00.000Z',
+        vaultRoot,
+      })
+
+      const promptText = (await readAssistantContextSnapshotPrompt({ vaultRoot })) ?? ''
+
+      expect(promptText).toContain('Active allergies:')
+      expect(promptText).toContain('Amoxicillin allergy')
+      expect(promptText).toContain('Active supplement regimens:')
+      expect(promptText).toContain('Vitamin D')
+      expect(promptText).not.toContain('Resolved infection')
+      expect(promptText).not.toContain('Active conditions:')
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true })
+    }
+  })
+
   it('self-heals corrupt snapshots while oversized prompt reads return null', async () => {
     const parentRoot = await mkdtemp(path.join(tmpdir(), 'assistant-context-snapshot-'))
     const vaultRoot = path.join(parentRoot, 'vault')

--- a/scripts/repo-tools.config.sh
+++ b/scripts/repo-tools.config.sh
@@ -88,7 +88,17 @@ repo_tools_join_lines COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS \
   "agent-docs/exec-plans/completed/**" \
   "agent-docs/prompts/**" \
   "apps/web/app/.well-known/workflow/**" \
-  "**/.next-smoke*/**"
+  "**/.next-smoke*/**" \
+  "packages/*/test/**" \
+  "packages/*/tests/**" \
+  "packages/*/**/__tests__/**" \
+  "packages/*/**/*.test.*" \
+  "packages/*/**/*.spec.*" \
+  "apps/*/test/**" \
+  "apps/*/tests/**" \
+  "apps/*/**/__tests__/**" \
+  "apps/*/**/*.test.*" \
+  "apps/*/**/*.spec.*"
 repo_tools_join_lines COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS \
   ".dockerignore" \
   "AGENTS.md" \

--- a/scripts/repo-tools.config.sh
+++ b/scripts/repo-tools.config.sh
@@ -88,17 +88,7 @@ repo_tools_join_lines COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS \
   "agent-docs/exec-plans/completed/**" \
   "agent-docs/prompts/**" \
   "apps/web/app/.well-known/workflow/**" \
-  "**/.next-smoke*/**" \
-  "packages/*/test/**" \
-  "packages/*/tests/**" \
-  "packages/*/**/__tests__/**" \
-  "packages/*/**/*.test.*" \
-  "packages/*/**/*.spec.*" \
-  "apps/*/test/**" \
-  "apps/*/tests/**" \
-  "apps/*/**/__tests__/**" \
-  "apps/*/**/*.test.*" \
-  "apps/*/**/*.spec.*"
+  "**/.next-smoke*/**"
 repo_tools_join_lines COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS \
   ".dockerignore" \
   "AGENTS.md" \

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -26,7 +26,7 @@ attach_artifacts=1
 include_tests=0
 include_docs=0
 preset_dir="scripts/chatgpt-review-presets"
-package_script="scripts/package-audit-context.sh"
+package_script="scripts/package-audit-context-full.sh"
 # `current` skips connector selection. The PR loop requires the Eragon composer
 # to have no selected app connector before auto-send because review context must
 # come from the guarded ZIP and repomix attachments.


### PR DESCRIPTION
## Why this PR exists

Assistant guidance currently can answer health questions without seeing the user's active safety-critical context (conditions, allergies, medications, supplements) up front. The model often had to query the vault before realizing a contraindication existed, and could miss it entirely on short turns. We want safety-critical context inline in the snapshot so it shapes guidance before the first vault lookup.

## User goal / user-visible behavior

When the user asks Murph anything where a current condition, allergy, medication, or supplement should change the answer, the assistant has that context directly in its prompt snapshot — substance, criticality/severity, dose/schedule, started date, related conditions, and a short note. Safety-relevant guidance can be informed by NKDA-equivalent absence vs. known-active records, and the read-guidance line points at the matching `vault-cli condition show` / `vault-cli allergy show` / `vault-cli regimen show` / `vault-cli goal show` surfaces when deeper detail is needed.

## What changed

- `packages/assistant-engine/src/assistant/context-snapshot.ts`
  - New lines for active conditions, active allergies, active medication regimens, and active supplement regimens, sorted by criticality/severity then date.
  - New cross-record lookup that surfaces related conditions / regimens — but only **active** related regimens, so stopped meds never appear as current through a relationship.
  - Renames the legacy `activePlanReadLine` to `activeRecordReadLine` covering conditions/allergies/regimens/goals.
  - All new render code composes with the existing `renderPromptField`, `renderPromptLookup`, `renderDetailSuffix`, `renderStringList` helpers. New caps: 5 records per safety category, 3 related lookups, 3 supplement ingredients.
- `packages/assistant-engine/test/assistant-context-snapshot.test.ts`
  - Adds an `it()` block that drives the full snapshot refresh through realistic active/inactive condition/allergy/medication/supplement fixtures and asserts the injected lines and read-guidance string.
  - Updates the existing read-guidance assertion to match the new surface list.

## Invariants the PR must preserve

- Active filtering remains strict: only records with `status: active` (and `clinicalStatus: active` for conditions) appear; stopped/inactive records never leak.
- Related-regimen surfacing is gated to **active** regimens only — stopped meds cannot reappear via a condition's `relatedRegimenIds` / `related_regimen` link.
- The existing 64 KB prompt budget and 120-char per-field truncation continue to bound the snapshot; new caps stay within that envelope.
- Snapshot remains navigation-only orientation; canonical evidence still flows through `vault-cli show` lookups.
- Sectioning / prompt structure stays compact: when no active prompt context exists, the read-guidance line is suppressed (no dead instructions).

## Verification

- `pnpm --filter '@murphai/assistant-engine' typecheck` — green
- `pnpm vitest run test/assistant-context-snapshot.test.ts` (6 tests) — green
- `pnpm test:diff packages/assistant-engine/src/assistant/context-snapshot.ts packages/assistant-engine/test/assistant-context-snapshot.test.ts` — green across all routed packages (1581 tests passed, hosted-local Cloudflare verify done)

## Deployment

Prompt-primary change inside `packages/assistant-engine` consumed by both `apps/web` and `apps/cloudflare` runner. No schema, persisted-state, env, or deploy-surface changes. Cloudflare and web can deploy in either order.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785106728&installation_id=127572939&pr_number=327&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F327&signature=78bc07ea3872877406da3b6d20e86c1b036ad52086fc42859ce1ddee4253a818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->