### PR TITLE
Admit each Linq webhook event once via single-row PK

### DIFF
--- a/apps/web/prisma/migrations/20260627150000_linq_processed_event/migration.sql
+++ b/apps/web/prisma/migrations/20260627150000_linq_processed_event/migration.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "hosted_linq_processed_event" (
+  "event_id" TEXT NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "hosted_linq_processed_event_pkey" PRIMARY KEY ("event_id")
+);
+
+CREATE INDEX "hosted_linq_processed_event_created_at_idx"
+  ON "hosted_linq_processed_event"("created_at");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -846,6 +846,14 @@ model HostedLinqFirstContactAdmissionDecision {
   @@map("hosted_linq_first_contact_admission_decision")
 }
 
+model HostedLinqProcessedEvent {
+  eventId   String   @id @map("event_id")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([createdAt])
+  @@map("hosted_linq_processed_event")
+}
+
 model HostedLinqFirstContactAdmissionBudget {
   participantContactLookupKey String   @map("participant_contact_lookup_key")
   eventId                     String   @map("event_id")

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -1,6 +1,6 @@
-import type {
+import {
   Prisma,
-  PrismaClient,
+  type PrismaClient,
 } from "@prisma/client";
 
 import { getPrisma } from "../prisma";
@@ -119,6 +119,21 @@ export async function handleHostedOnboardingLinqWebhook(input: {
     }
 
     const prisma = input.prisma ?? getPrisma();
+
+    const duplicateResponse = await admitHostedLinqWebhookEventOnce({
+      eventId: event.event_id,
+      prisma,
+    });
+    if (duplicateResponse) {
+      responseReason = duplicateResponse.reason ?? null;
+      finishHostedOnboardingTiming(timing, "completed", {
+        eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
+        eventType,
+        responseReason,
+        signalAbortedBeforeReturn: input.signal?.aborted ?? false,
+      });
+      return duplicateResponse;
+    }
     const planTiming = startHostedOnboardingTiming(
       "hosted-onboarding.webhook.linq.plan",
       {
@@ -508,4 +523,32 @@ async function runHostedOnboardingWebhookTransaction<TResult>(
   return typeof prisma.$transaction === "function"
     ? prisma.$transaction(callback)
     : callback(prisma as Prisma.TransactionClient);
+}
+
+// Admit each Linq webhook event_id exactly once. A retry with the same
+// event_id collides on the PK and returns a duplicate-event no-op response;
+// the original delivery proceeds to side effects, which carry their own
+// dedupe (mailbox keys, invite uniqueness, member upserts).
+async function admitHostedLinqWebhookEventOnce(input: {
+  eventId: string;
+  prisma: PrismaClient;
+}): Promise<HostedOnboardingLinqWebhookResponse | null> {
+  try {
+    await input.prisma.hostedLinqProcessedEvent.create({
+      data: { eventId: input.eventId },
+    });
+    return null;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError
+      && error.code === "P2002"
+    ) {
+      return {
+        ignored: true,
+        ok: true,
+        reason: "duplicate-event",
+      };
+    }
+    throw error;
+  }
 }

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -430,6 +430,7 @@ type PrismaFixtureBase = {
   hostedLinqDailyState?: HostedLinqDailyStateFixture;
   hostedLinqFirstContactAdmissionBudget?: HostedLinqFirstContactAdmissionBudgetFixture;
   hostedLinqFirstContactAdmissionDecision?: HostedLinqFirstContactAdmissionDecisionFixture;
+  hostedLinqProcessedEvent?: { create?: MockedFunction };
   hostedMember?: HostedMemberFixture;
   hostedMemberEmailAuthorization?: HostedMemberEmailAuthorizationFixture;
   hostedMemberIdentity?: HostedMemberIdentityFixture;
@@ -2587,6 +2588,9 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         count: vi.fn().mockResolvedValue(0),
         create: vi.fn(),
         findFirst: vi.fn().mockResolvedValue(null),
+      },
+      hostedLinqProcessedEvent: {
+        create: vi.fn().mockResolvedValue(undefined),
       },
       hostedLinqFirstContactAdmissionDecision: {
         create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => data),
@@ -5364,6 +5368,15 @@ function asPrismaTransactionClient<T extends PrismaFixtureBase>(
         count: vi.fn().mockResolvedValue(0),
         create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => data),
         findFirst: vi.fn().mockResolvedValue(null),
+      },
+    });
+  }
+
+  if (!prisma.hostedLinqProcessedEvent?.create) {
+    Object.defineProperty(prisma, "hostedLinqProcessedEvent", {
+      configurable: true,
+      value: {
+        create: vi.fn().mockResolvedValue(undefined),
       },
     });
   }

--- a/apps/web/test/hosted-onboarding-linq-usage-reset-e2e.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-usage-reset-e2e.test.ts
@@ -301,6 +301,9 @@ type UsageResetPrismaFixture = {
   hostedMember: {
     findUnique: MockedFunction;
   };
+  hostedLinqProcessedEvent: {
+    create: MockedFunction;
+  };
   hostedThreadRoute: {
     findMany: MockedFunction;
   };
@@ -716,6 +719,9 @@ function createUsageResetPrismaFixture(input: {
         billingRef: null,
         threadContainer: null,
       })),
+    },
+    hostedLinqProcessedEvent: {
+      create: vi.fn().mockResolvedValue(undefined),
     },
     hostedThreadRoute: {
       findMany: vi.fn().mockResolvedValue([]),

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -481,6 +481,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260626000000_linq_first_contact_admission_decision",
       "2026062600_computer_handoff_return_contact_kind",
       "20260626010000_linq_first_contact_admission_budget",
+      "20260627150000_linq_processed_event",
       "migration_lock.toml",
     ]);
     expect(hostedThreadRoutesMigrationSql).toContain('CREATE TABLE "hosted_thread_container"');

--- a/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
@@ -1,4 +1,4 @@
-import { HostedBillingStatus } from "@prisma/client";
+import { HostedBillingStatus, Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -583,6 +583,38 @@ describe("hosted onboarding Linq webhook hard-cut flows", () => {
     });
     expect(mocks.sendHostedLinqReadReceipt).not.toHaveBeenCalled();
   });
+
+  it("no-ops on a duplicate Linq webhook event_id without invoking any side effects", async () => {
+    const prisma = createPrismaStub();
+    prisma.hostedLinqProcessedEvent.create.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("duplicate", {
+        clientVersion: "test",
+        code: "P2002",
+      }),
+    );
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    await expect(
+      handleHostedOnboardingLinqWebhook({
+        rawBody: buildLinqMessageWebhookBody(),
+        signature: null,
+        timestamp: null,
+      }),
+    ).resolves.toStrictEqual({
+      ignored: true,
+      ok: true,
+      reason: "duplicate-event",
+    });
+
+    expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(mocks.issueHostedInviteTx).not.toHaveBeenCalled();
+    expect(mocks.ensureHostedMemberForPhoneTx).not.toHaveBeenCalled();
+    expect(mocks.sendHostedLinqReadReceipt).not.toHaveBeenCalled();
+    expect(mocks.nudgeHostedRunnerUserBestEffort).not.toHaveBeenCalled();
+    expect(mocks.nudgeHostedRunnerUserBestEffortResult).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+  });
 });
 
 function buildLinqMessageWebhookBody(input: {
@@ -639,6 +671,9 @@ function createPrismaStub() {
         inviteCode: "code_first_contact",
       }),
       update: vi.fn().mockResolvedValue(undefined),
+    },
+    hostedLinqProcessedEvent: {
+      create: vi.fn().mockResolvedValue(undefined),
     },
     hostedThreadRoute: {
       findMany: vi.fn().mockResolvedValue([]),

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -22,6 +22,12 @@
 - If two paths intentionally overlap — retry, replay, push+pull ingestion, warm/cold runtime restart, provider webhook reorder, outbox resend, media normalization, or migration re-entry — the shared identity must make overlap safe by construction.
 - A new write path is not complete until it names the stable identity it uses for idempotency, explains which mutable fields are excluded, and has a regression proving retry/replay/cold-start overlap does not duplicate or lose the user-visible fact.
 
+## Minimal Mechanism Bias
+
+- For "do this exactly once," start with a stable identity, a uniqueness constraint, and an idempotent write the losing caller can no-op on. Reach for processing-state columns, leases, owner tokens, or fences only when a concrete downstream failure cannot be expressed as a uniqueness or dedupe key at the layer where it actually lives.
+- Trust idempotency at the side-effect layer first. If each write, send, or row a path produces is individually retry-safe via its own unique key or upsert, a top-level processing fence usually adds failure modes (stuck leases, owner mismatch on redeploy, replay-vs-reclaim races) without removing any.
+- Treat fix-loop length as a design signal. When a single protocol picks up double-digit "fix: preserve/scope/fence/reclaim" commits chasing edge cases, the abstraction is wrong; fall back to the smallest primitive the proven failure requires. PR 320 is the named anti-pattern.
+
 ## Ordered Progress And Causal Anchors
 
 - Any persisted cursor, mailbox sequence, pending-input index, consume ack, wake gate, receipt watermark, or paginated read must use a total, transitive, owner-shared ordering primitive. Do not duplicate timestamp comparators, pick timestamp fields pairwise, or rely on ordering that can make persisted records unreachable or repeated.


### PR DESCRIPTION
## Summary

Replace PR #320's processing/consumed receipt + processing-owner-token + lease state machine with the minimal idempotency primitive: one table with one primary key on `event_id`, and an idempotent INSERT at the top of the Linq webhook handler. A retry collides on the PK and returns a duplicate-event no-op; the original delivery continues into side effects that already carry their own dedupe (mailbox dedupe keys, `HostedInvite` uniqueness, `HostedMember` upserts, daily-state counters).

## Why

PR #320 grew to **7,374 additions across 43 files** and **47 fix commits** chasing edge cases in a multi-state processing protocol — fences, lease cutoffs, owner tokens, stale-receipt reclaim, replay-vs-reclaim corner cases, explicit-route ownership preservation. The underlying invariant was real ("exactly-once Linq webhook handling"), but the abstraction was wrong: each round of review found another fence/lease/proof corner that needed a new helper, and the line count kept growing instead of shrinking.

Side effects below the webhook handler are already individually idempotent:

- Mailbox writes dedupe on `(channel, externalEventId)`.
- Invites are unique per `(memberId, channel)`.
- Member identity goes through phone/email upserts.
- Daily-state counters are upserts.

If each side effect is retry-safe, the only thing a top-level fence buys is one fewer OpenAI classifier call per duplicate — and that's already bounded by main's per-contact admission budget (#324). A single-row admit-once at the entry covers the cost concern with **one table, one INSERT, no states, no leases, no owner tokens**.

PR #320 will be closed in favor of this change.

## What changed

- **New model** `HostedLinqProcessedEvent` — `event_id @id`, `created_at` with index.
- **New migration** `20260627150000_linq_processed_event`.
- **handleHostedOnboardingLinqWebhook** now calls `admitHostedLinqWebhookEventOnce` immediately after acquiring prisma; on a Prisma `P2002` it returns `{ ignored: true, ok: true, reason: "duplicate-event" }` and skips all planning + side effects.
- **New regression** in `hosted-onboarding-webhook-idempotency.test.ts` asserts a duplicate `event_id` triggers no side effects (no mailbox append, no invite issue, no chat send, no read receipt, no runner nudge, no runtime signal).
- **New invariant** in `docs/contracts/00-invariants.md`: "Minimal Mechanism Bias" — three rules naming PR #320 as the anti-pattern so this complexity explosion doesn't repeat.

## Trade-offs (intentional)

- **Mid-processing crash forfeits the retry.** If the first delivery inserts the row but fails before completing side effects, a retry will see the row and no-op. This is acceptable because (a) Linq webhook retries are eventual-consistency, not exactly-once delivery, (b) the side-effect layer's own retries can still recover most user-visible state, and (c) the alternative (PR #320's processing/consumed state machine) was 1,000 lines of bookkeeping chasing this exact case and still missed corners.
- **Single PK, not composite.** We do not include any "claim version" or "processing owner" — exactly the columns whose accumulation drove PR #320's complexity.

## Validation

```
pnpm --dir ../.. exec vitest run --config apps/web/vitest.workspace.ts --no-coverage \
  apps/web/test/hosted-onboarding-linq-dispatch.test.ts \
  apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts \
  apps/web/test/hosted-onboarding-linq-route.test.ts \
  apps/web/test/hosted-onboarding-linq-webhook-auth.test.ts \
  apps/web/test/hosted-onboarding-linq-usage-reset-e2e.test.ts \
  apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts \
  apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
```

→ **135/135 passing.**

## Deployment

- The web deploy must run the new Prisma migration before the new web code handles Linq webhooks — same constraint as #324.
- No Cloudflare tandem deploy required.

## References

- Closes #320.
- Invariant: `docs/contracts/00-invariants.md` → "Minimal Mechanism Bias".
- Related: #324 (per-contact admission budget — keeps cost bound on classifier calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785178963&installation_id=127572939&pr_number=332&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F332&signature=37b4a7907a7733f07b8256492f7ce487a3fbb147ffb88867fdacd02a3e57535e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->