### PR TITLE
Remember handoff viewport session size

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-29-handoff-viewport-session.md
+++ b/agent-docs/exec-plans/completed/2026-06-29-handoff-viewport-session.md
@@ -1,0 +1,44 @@
+# Computer Handoff Viewport Session Hint
+
+## Goal
+
+Land the handoff viewport-session patch in an isolated PR lane so the hosted
+computer takeover surface uses concrete client/browser dimensions instead of a
+blocking server-side UA preset resize.
+
+## Constraints
+
+- Keep handoff takeover instant; viewport resize must be best-effort and must
+  not block the user taking over the browser.
+- Store only bounded viewport dimensions on the existing hosted app session.
+- Preserve hosted app-session authority for reading and writing the viewport
+  hint.
+- Keep Kernel credentials, live-view URLs, handoff tokens, and local identifiers
+  out of logs, docs, fixtures, and ReviewGPT artifacts.
+- Prefer the smallest existing ownership boundary: `apps/web` owns the app
+  session, handoff page, Kernel resize call, and tests.
+
+## Working Set
+
+- `apps/web/app/computer/handoff/[token]/page.tsx`
+- `apps/web/app/api/computer/handoff/[token]/viewport/route.ts`
+- `apps/web/src/components/computer-use/computer-handoff-active-view.tsx`
+- `apps/web/src/lib/computer-use/*`
+- `apps/web/src/lib/hosted-onboarding/app-session.ts`
+- `apps/web/prisma/schema.prisma`
+- `apps/web/prisma/migrations/*computer_handoff_viewport_session_hint*/`
+- focused hosted web tests for handoff, session, Kernel viewport, telemetry, and
+  privacy export behavior
+
+## Verification Plan
+
+- Reviewed the patch shape and kept the viewport hint on the existing hosted app
+  session boundary.
+- Ran focused hosted-web Vitest for the changed handoff/session/viewport tests.
+- Ran `pnpm test:diff`, `git diff --check`, `pnpm build:test-runtime:prepared`,
+  and `pnpm typecheck`.
+- Push the branch, open a PR with the required intent/invariant body, and run
+  the PR-lane ReviewGPT loop to zero accepted findings.
+Status: completed
+Updated: 2026-06-29
+Completed: 2026-06-29

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -154,9 +154,10 @@ The hosted Prisma schema keeps ownership sharp and nested:
   surfaces that cannot be operated through Playwright. The agent explicitly
   selects `managed_login` for Kernel Hosted UI plus a durable profile/domain
   connection, or `login` for the existing Live View takeover; CAPTCHA,
-  payment, missing-detail, and direct takeover handoffs remain Live View. Each authenticated
-  handoff matches the active browser viewport to the opening screen before
-  showing the live view.
+  payment, missing-detail, and direct takeover handoffs remain Live View. Authenticated
+  handoffs reuse the current hosted web session's last measured takeover surface
+  as a fast browser-viewport hint, then correct from the live client surface in
+  the background without blocking takeover.
 - `hosted_user_crypto_envelope` stores signed wrapped per-user/per-domain root
   envelopes; plaintext roots are never stored
 - `hosted_user_crypto_audit` records hosted crypto authority events

--- a/apps/web/app/api/computer/handoff/[token]/viewport/route.ts
+++ b/apps/web/app/api/computer/handoff/[token]/viewport/route.ts
@@ -1,0 +1,65 @@
+import {
+  saveHostedWebSessionComputerHandoffViewportSize,
+  scheduleHostedWebSessionComputerHandoffViewportApply,
+} from "@/src/lib/computer-use/handoff-viewport-session";
+import { normalizeComputerHandoffViewportObservation } from "@/src/lib/computer-use/viewport";
+import { requireActiveHostedAppSessionFromRequest } from "@/src/lib/hosted-onboarding/app-session";
+import { assertHostedOnboardingMutationOrigin } from "@/src/lib/hosted-onboarding/csrf";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import {
+  jsonOk,
+  readHostedOnboardingJsonObject,
+  withJsonError,
+} from "@/src/lib/hosted-onboarding/http";
+import { resolveDecodedRouteParam } from "@/src/lib/http";
+
+const HANDOFF_VIEWPORT_BODY_LIMIT_BYTES = 1024;
+
+export const POST = withJsonError(async (
+  request: Request,
+  context: { params: Promise<{ token: string }> },
+) => {
+  assertHostedOnboardingMutationOrigin(request);
+
+  const token = await resolveDecodedRouteParam(context.params, "token");
+  const session = await requireActiveHostedAppSessionFromRequest(request);
+  const now = new Date();
+  const observation = normalizeComputerHandoffViewportObservation(
+    await readHostedOnboardingJsonObject(request, {
+      limitBytes: HANDOFF_VIEWPORT_BODY_LIMIT_BYTES,
+      tooLargeErrorCode: "HOSTED_COMPUTER_HANDOFF_VIEWPORT_BODY_TOO_LARGE",
+      tooLargeErrorMessage:
+        "Computer handoff viewport request body is too large.",
+    }),
+    { now },
+  );
+
+  if (!observation) {
+    throw hostedOnboardingError({
+      code: "HOSTED_COMPUTER_HANDOFF_VIEWPORT_INVALID",
+      httpStatus: 400,
+      message: "Computer handoff viewport size is invalid.",
+    });
+  }
+
+  const saved = await saveHostedWebSessionComputerHandoffViewportSize({
+    memberId: session.member.id,
+    now,
+    observedAt: observation.observedAt,
+    sessionId: session.sessionId,
+    size: { height: observation.height, width: observation.width },
+  });
+
+  if (saved) {
+    scheduleHostedWebSessionComputerHandoffViewportApply({
+      memberId: session.member.id,
+      reason: "measured",
+      sessionId: session.sessionId,
+      token,
+    });
+  }
+
+  return jsonOk({ ok: true }, 202, {
+    "Cache-Control": "private, no-store",
+  });
+});

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -588,9 +588,9 @@ const VISUALS: Record<string, ReactNode> = {
   "handoff-viewport-match": (
     <StatBlock
       label="Handoff browser"
-      before="Desktop"
-      after="Phone-shaped"
-      caption="from the first frame"
+      before="Default"
+      after="Session-sized"
+      caption="remembered per device"
     />
   ),
   "handoff-mobile-takeover-overlay": (

--- a/apps/web/app/computer/handoff/[token]/page.tsx
+++ b/apps/web/app/computer/handoff/[token]/page.tsx
@@ -1,22 +1,19 @@
 import { CheckCircle2, Clock3 } from "lucide-react";
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 
 import { ComputerHandoffActiveView } from "@/src/components/computer-use/computer-handoff-active-view";
 import { ComputerHandoffAuthRequiredState } from "@/src/components/computer-use/computer-handoff-auth-required";
 import { ComputerHandoffReplyAction } from "@/src/components/computer-use/computer-handoff-reply-action";
 import { resolveHostedMurphContactOptions } from "@/src/components/murph/hosted-murph-contact-action";
 import { buttonVariants } from "@/src/components/ui/button";
+import { scheduleHostedWebSessionComputerHandoffViewportApply } from "@/src/lib/computer-use/handoff-viewport-session";
 import { createComputerUseService } from "@/src/lib/computer-use/service";
-import { resolveComputerBrowserViewportPreset } from "@/src/lib/computer-use/viewport";
 import { requireActiveHostedAppSession } from "@/src/lib/hosted-onboarding/app-session";
 import { isHostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import type { MurphContactKind, MurphContactOption } from "@/src/lib/murph-contact-routing";
 import { cn } from "@/src/lib/utils";
 
 const HANDOFF_DONE_REPLY_BODY = "Done";
-const HANDOFF_VIEWPORT_SSR_TIMEOUT_MS = 5_000;
-
 type HandoffSearchParams = {
   managed?: string | string[];
 };
@@ -139,35 +136,28 @@ export default async function ComputerHandoffPage({
     );
   }
 
-  const preset = resolveComputerBrowserViewportPreset(
-    (await headers()).get("user-agent"),
-  );
-  try {
-    await Promise.race([
-      service.ensureHandoffViewport({
-        memberId: session.member.id,
-        preset,
-        token,
-      }),
-      new Promise<never>((_, reject) => {
-        setTimeout(
-          () => reject(new Error("viewport resize timed out")),
-          HANDOFF_VIEWPORT_SSR_TIMEOUT_MS,
-        );
-      }),
-    ]);
-  } catch (error) {
-    console.warn("[computer-handoff] viewport resize failed", error);
-  }
+  const encodedToken = encodeURIComponent(token);
+  const doneEndpoint = `/api/computer/handoff/${encodedToken}/done`;
+  const viewportEndpoint = `/api/computer/handoff/${encodedToken}/viewport`;
+  const initialViewportSize = session.computerHandoffViewportSize;
 
-  const doneEndpoint = `/api/computer/handoff/${encodeURIComponent(token)}/done`;
+  if (initialViewportSize) {
+    scheduleHostedWebSessionComputerHandoffViewportApply({
+      memberId: session.member.id,
+      reason: "cached",
+      sessionId: session.sessionId,
+      token,
+    });
+  }
 
   return (
     <main className="relative min-h-dvh bg-foreground text-foreground">
       <ComputerHandoffActiveView
         doneEndpoint={doneEndpoint}
         iframeAllow={state.iframeAllow}
+        initialViewportSize={initialViewportSize}
         liveViewUrl={state.liveViewUrl}
+        viewportEndpoint={viewportEndpoint}
       />
     </main>
   );

--- a/apps/web/prisma/migrations/20260629160000_computer_handoff_viewport_session_hint/migration.sql
+++ b/apps/web/prisma/migrations/20260629160000_computer_handoff_viewport_session_hint/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "hosted_web_session"
+  ADD COLUMN "computer_handoff_viewport_width" INTEGER,
+  ADD COLUMN "computer_handoff_viewport_height" INTEGER,
+  ADD COLUMN "computer_handoff_viewport_observed_at" TIMESTAMP(3);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -408,6 +408,11 @@ model HostedWebSession {
   lastSeenAt   DateTime?    @map("last_seen_at")
   revokedAt    DateTime?    @map("revoked_at")
   revokeReason String?      @map("revoke_reason")
+
+  computerHandoffViewportWidth      Int?      @map("computer_handoff_viewport_width")
+  computerHandoffViewportHeight     Int?      @map("computer_handoff_viewport_height")
+  computerHandoffViewportObservedAt DateTime? @map("computer_handoff_viewport_observed_at")
+
   member       HostedMember @relation(fields: [memberId], references: [id], onDelete: Cascade)
 
   @@index([memberId])

--- a/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
+++ b/apps/web/src/components/computer-use/computer-handoff-active-view.tsx
@@ -7,6 +7,11 @@ import { useEffect, useRef, useState } from "react";
 import { ComputerHandoffFloatingIsland } from "@/src/components/computer-use/computer-handoff-floating-island";
 import { Button, buttonVariants } from "@/src/components/ui/button";
 import { MurphPulseLoader } from "@/src/components/ui/murph-pulse-loader";
+import {
+  isMateriallyDifferentComputerHandoffViewportSize,
+  normalizeComputerHandoffViewportSize,
+  type ComputerHandoffViewportSize,
+} from "@/src/lib/computer-use/viewport";
 import { cn } from "@/src/lib/utils";
 
 type Phase =
@@ -17,21 +22,30 @@ type Phase =
 interface ComputerHandoffActiveViewProps {
   doneEndpoint: string;
   iframeAllow: string;
+  initialViewportSize: ComputerHandoffViewportSize | null;
   liveViewUrl: string;
+  viewportEndpoint: string;
 }
 
 export function ComputerHandoffActiveView({
   doneEndpoint,
   iframeAllow,
+  initialViewportSize,
   liveViewUrl,
+  viewportEndpoint,
 }: ComputerHandoffActiveViewProps) {
   const [phase, setPhase] = useState<Phase>({ kind: "idle", error: null });
   const [takeoverStarted, setTakeoverStarted] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const surfaceRef = useRef<HTMLDivElement>(null);
   const successAnchorRef = useRef<HTMLAnchorElement>(null);
   const phaseRef = useRef(phase);
   const terminalRef = useRef(false);
   const focusReportedRef = useRef(false);
+  const lastSentViewportSizeRef = useRef<ComputerHandoffViewportSize | null>(
+    initialViewportSize,
+  );
+  const lastSentViewportObservedAtMsRef = useRef(0);
 
   useEffect(() => {
     phaseRef.current = phase;
@@ -53,6 +67,82 @@ export function ComputerHandoffActiveView({
     window.addEventListener("pagehide", onPageHide);
     return () => window.removeEventListener("pagehide", onPageHide);
   }, []);
+
+  useEffect(() => {
+    if (phase.kind !== "idle") {
+      return;
+    }
+
+    const surface = surfaceRef.current;
+    if (!surface) {
+      return;
+    }
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const syncViewport = () => {
+      const size = readMeasuredViewportSize(surface);
+      if (
+        !size
+        || !isMateriallyDifferentComputerHandoffViewportSize(
+          lastSentViewportSizeRef.current,
+          size,
+        )
+      ) {
+        return;
+      }
+
+      const previousSentViewportSize = lastSentViewportSizeRef.current;
+      lastSentViewportSizeRef.current = size;
+      void fetch(viewportEndpoint, {
+        body: JSON.stringify({
+          ...size,
+          observedAt: nextViewportObservedAtIso(
+            lastSentViewportObservedAtMsRef,
+          ),
+        }),
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }).then((response) => {
+        if (!response.ok && lastSentViewportSizeRef.current === size) {
+          lastSentViewportSizeRef.current = previousSentViewportSize;
+        }
+      }).catch(() => {
+        if (lastSentViewportSizeRef.current === size) {
+          lastSentViewportSizeRef.current = previousSentViewportSize;
+        }
+        // Viewport sync is best-effort and must never block handoff control.
+      });
+    };
+
+    const scheduleSync = () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      debounceTimer = setTimeout(syncViewport, 200);
+    };
+
+    syncViewport();
+
+    const resizeObserver =
+      typeof ResizeObserver === "function"
+        ? new ResizeObserver(scheduleSync)
+        : null;
+    resizeObserver?.observe(surface);
+    window.addEventListener("orientationchange", scheduleSync);
+
+    return () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener("orientationchange", scheduleSync);
+    };
+  }, [phase.kind, viewportEndpoint]);
 
   const focusLiveView = () => {
     iframeRef.current?.focus({ preventScroll: true });
@@ -101,17 +191,22 @@ export function ComputerHandoffActiveView({
     <>
       {showBrowserSurface ? (
         <>
-          <iframe
-            ref={iframeRef}
-            allow={iframeAllow}
-            aria-hidden={!takeoverStarted}
-            className="block h-dvh w-full border-0 bg-foreground"
-            referrerPolicy="no-referrer"
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads allow-modals"
-            src={liveViewUrl}
-            tabIndex={takeoverStarted ? 0 : -1}
-            title="Murph private page"
-          />
+          <div
+            ref={surfaceRef}
+            className="fixed left-0 top-0 h-dvh w-full bg-foreground"
+          >
+            <iframe
+              ref={iframeRef}
+              allow={iframeAllow}
+              aria-hidden={!takeoverStarted}
+              className="block h-full w-full border-0 bg-foreground"
+              referrerPolicy="no-referrer"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads allow-modals"
+              src={liveViewUrl}
+              tabIndex={takeoverStarted ? 0 : -1}
+              title="Murph private page"
+            />
+          </div>
           {!takeoverStarted && phase.kind === "idle" ? (
             <div
               aria-describedby="computer-handoff-takeover-description"
@@ -155,7 +250,9 @@ export function ComputerHandoffActiveView({
           {takeoverStarted ? (
             <div
               className="pointer-events-none fixed inset-x-0 bottom-0 z-10 flex justify-center px-3 pb-3"
-              style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)" }}
+              style={{
+                paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)",
+              }}
             >
               <ComputerHandoffFloatingIsland
                 handle={
@@ -234,4 +331,23 @@ export function ComputerHandoffActiveView({
       ) : null}
     </>
   );
+}
+
+function readMeasuredViewportSize(
+  element: HTMLElement,
+): ComputerHandoffViewportSize | null {
+  const rect = element.getBoundingClientRect();
+
+  return normalizeComputerHandoffViewportSize({
+    height: rect.height,
+    width: rect.width,
+  });
+}
+
+function nextViewportObservedAtIso(
+  lastObservedAtMsRef: { current: number },
+): string {
+  const observedAtMs = Math.max(Date.now(), lastObservedAtMsRef.current + 1);
+  lastObservedAtMsRef.current = observedAtMs;
+  return new Date(observedAtMs).toISOString();
 }

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -763,7 +763,7 @@ const RAW_CHANGELOG_EDITIONS = [
     publishedOn: "2026-06-23",
     title: "Passkeys, and a handoff that fits your phone",
     summary:
-      "Add a passkey as your second factor in one tap, computer handoff sizes to your phone from the first frame, and auto-replies remember the conversation that came before them.",
+      "Add a passkey as your second factor in one tap, computer handoff remembers each device's browser size, and auto-replies remember the conversation that came before them.",
     items: [
       {
         id: "passkey-mfa-setup",
@@ -785,9 +785,9 @@ const RAW_CHANGELOG_EDITIONS = [
         priority: 5,
         title: "Browser handoff matches your phone",
         summary:
-          "When Murph hands the browser off to you, the page now sizes to your phone or laptop from the first frame — no more zoomed-out desktop on mobile.",
+          "When Murph hands the browser off to you, the page remembers this browser session's last handoff size and corrects it from the live takeover surface.",
         details:
-          "Murph reads your screen on the server, resizes the remote browser once, then renders. A pulse loader holds the page while everything lines up.",
+          "Murph starts from the saved size for this device session, then measures the actual handoff surface and resizes the remote browser in the background without blocking takeover.",
         relevanceTags: ["browser", "automation", "mobile"],
         sourcePullRequests: [268],
       },

--- a/apps/web/src/lib/computer-use/handoff-viewport-session.ts
+++ b/apps/web/src/lib/computer-use/handoff-viewport-session.ts
@@ -1,0 +1,193 @@
+import "server-only";
+
+import { after } from "next/server";
+
+import { formatHostedExecutionSafeLogErrorDetails } from "../hosted-execution/logging";
+import { getPrisma } from "../prisma";
+import { createComputerUseService } from "./service";
+import {
+  isMateriallyDifferentComputerHandoffViewportSize,
+  normalizeComputerHandoffViewportSize,
+  toComputerBrowserViewport,
+  type ComputerHandoffViewportSize,
+} from "./viewport";
+
+type StoredComputerHandoffViewportObservation = ComputerHandoffViewportSize & {
+  observedAt: Date | null;
+};
+
+export async function saveHostedWebSessionComputerHandoffViewportSize(input: {
+  memberId: string;
+  now?: Date;
+  observedAt?: Date;
+  sessionId: string;
+  size: ComputerHandoffViewportSize;
+}): Promise<boolean> {
+  const now = input.now ?? new Date();
+  const observedAt = input.observedAt ?? now;
+  const size = normalizeComputerHandoffViewportSize(input.size);
+  if (!size) {
+    throw new TypeError("Computer handoff viewport size is invalid.");
+  }
+
+  const result = await getPrisma().hostedWebSession.updateMany({
+    where: {
+      expiresAt: { gt: now },
+      id: input.sessionId,
+      memberId: input.memberId,
+      OR: [
+        { computerHandoffViewportObservedAt: null },
+        { computerHandoffViewportObservedAt: { lt: observedAt } },
+      ],
+      revokedAt: null,
+    },
+    data: {
+      computerHandoffViewportHeight: size.height,
+      computerHandoffViewportObservedAt: observedAt,
+      computerHandoffViewportWidth: size.width,
+      updatedAt: now,
+    },
+  });
+
+  return result.count > 0;
+}
+
+export async function readHostedWebSessionComputerHandoffViewportSize(input: {
+  memberId: string;
+  now?: Date;
+  sessionId: string;
+}): Promise<ComputerHandoffViewportSize | null> {
+  const observation = await readHostedWebSessionComputerHandoffViewportObservation(input);
+  return observation
+    ? { height: observation.height, width: observation.width }
+    : null;
+}
+
+async function readHostedWebSessionComputerHandoffViewportObservation(input: {
+  memberId: string;
+  now?: Date;
+  sessionId: string;
+}): Promise<StoredComputerHandoffViewportObservation | null> {
+  const now = input.now ?? new Date();
+  const record = await getPrisma().hostedWebSession.findFirst({
+    where: {
+      expiresAt: { gt: now },
+      id: input.sessionId,
+      memberId: input.memberId,
+      revokedAt: null,
+    },
+    select: {
+      computerHandoffViewportHeight: true,
+      computerHandoffViewportObservedAt: true,
+      computerHandoffViewportWidth: true,
+    },
+  });
+
+  const size = normalizeComputerHandoffViewportSize({
+    height: record?.computerHandoffViewportHeight,
+    width: record?.computerHandoffViewportWidth,
+  });
+  if (!size) {
+    return null;
+  }
+
+  return {
+    ...size,
+    observedAt: record?.computerHandoffViewportObservedAt ?? null,
+  };
+}
+
+export async function applyHostedWebSessionComputerHandoffViewport(input: {
+  memberId: string;
+  sessionId: string;
+  token: string;
+}): Promise<void> {
+  const first = await readHostedWebSessionComputerHandoffViewportObservation({
+    memberId: input.memberId,
+    sessionId: input.sessionId,
+  });
+
+  if (!first) {
+    return;
+  }
+
+  const service = createComputerUseService();
+  await service.ensureHandoffViewport({
+    memberId: input.memberId,
+    token: input.token,
+    viewport: toComputerBrowserViewport(toComputerHandoffViewportSize(first)),
+  });
+
+  const latest = await readHostedWebSessionComputerHandoffViewportObservation({
+    memberId: input.memberId,
+    sessionId: input.sessionId,
+  });
+
+  if (
+    isNewerComputerHandoffViewportObservation(first, latest)
+    && isMateriallyDifferentComputerHandoffViewportSize(first, latest)
+  ) {
+    await service.ensureHandoffViewport({
+      memberId: input.memberId,
+      token: input.token,
+      viewport: toComputerBrowserViewport(toComputerHandoffViewportSize(latest)),
+    });
+  }
+}
+
+export function scheduleHostedWebSessionComputerHandoffViewportApply(input: {
+  memberId: string;
+  reason: "cached" | "measured";
+  sessionId: string;
+  token: string;
+}): void {
+  scheduleAfterResponseOrFireAndForget(async () => {
+    try {
+      await applyHostedWebSessionComputerHandoffViewport({
+        memberId: input.memberId,
+        sessionId: input.sessionId,
+        token: input.token,
+      });
+    } catch (error) {
+      console.warn(
+        `[computer-handoff] ${input.reason} viewport resize failed`,
+        formatHostedExecutionSafeLogErrorDetails(error, {
+          code: "HOSTED_COMPUTER_HANDOFF_VIEWPORT_RESIZE_FAILED",
+        }),
+      );
+    }
+  });
+}
+
+function scheduleAfterResponseOrFireAndForget(task: () => Promise<void>): void {
+  try {
+    after(task);
+  } catch {
+    void task();
+  }
+}
+
+function isNewerComputerHandoffViewportObservation(
+  applied: StoredComputerHandoffViewportObservation,
+  latest: StoredComputerHandoffViewportObservation | null,
+): latest is StoredComputerHandoffViewportObservation {
+  if (!latest) {
+    return false;
+  }
+
+  if (!applied.observedAt) {
+    return latest.observedAt !== null;
+  }
+
+  return latest.observedAt !== null
+    && latest.observedAt.getTime() > applied.observedAt.getTime();
+}
+
+function toComputerHandoffViewportSize(
+  observation: StoredComputerHandoffViewportObservation,
+): ComputerHandoffViewportSize {
+  return {
+    height: observation.height,
+    width: observation.width,
+  };
+}

--- a/apps/web/src/lib/computer-use/kernel-client.ts
+++ b/apps/web/src/lib/computer-use/kernel-client.ts
@@ -4,10 +4,7 @@ import type {
 } from "@murphai/hosted-execution/computer-use";
 
 import { computerUseError } from "./errors";
-import {
-  COMPUTER_BROWSER_VIEWPORTS,
-  type ComputerBrowserViewportPreset,
-} from "./viewport";
+import type { ComputerBrowserViewport } from "./viewport";
 import { isAllowedKernelManagedAuthHostedUrl } from "./managed-auth-origin";
 
 const KERNEL_REQUEST_TIMEOUT_MS = 30_000;
@@ -56,8 +53,8 @@ export interface ComputerKernelClient {
   deleteManagedAuthConnection(id: string): Promise<void>;
   deleteProfile(name: string): Promise<void>;
   ensureBrowserViewport(input: {
-    preset: ComputerBrowserViewportPreset;
     sessionId: string;
+    viewport: ComputerBrowserViewport;
   }): Promise<void>;
   ensureManagedAuthConnection(input: {
     domain: string;
@@ -112,23 +109,23 @@ export class KernelComputerClient implements ComputerKernelClient {
   }
 
   async ensureBrowserViewport(input: {
-    preset: ComputerBrowserViewportPreset;
     sessionId: string;
+    viewport: ComputerBrowserViewport;
   }): Promise<void> {
     try {
-      const viewport = COMPUTER_BROWSER_VIEWPORTS[input.preset];
       const browser = await this.kernel.browsers.retrieve(input.sessionId);
 
       if (
-        browser.viewport?.width === viewport.width
-        && browser.viewport?.height === viewport.height
+        browser.viewport?.width === input.viewport.width
+        && browser.viewport?.height === input.viewport.height
+        && browser.viewport?.refresh_rate === input.viewport.refresh_rate
       ) {
         return;
       }
 
       await this.kernel.browsers.update(input.sessionId, {
         viewport: {
-          ...viewport,
+          ...input.viewport,
           force: true,
         },
       });

--- a/apps/web/src/lib/computer-use/service.ts
+++ b/apps/web/src/lib/computer-use/service.ts
@@ -31,7 +31,7 @@ import {
   type ComputerUseStore,
   type PersistedComputerHandoffPurpose,
 } from "./store";
-import type { ComputerBrowserViewportPreset } from "./viewport";
+import type { ComputerBrowserViewport } from "./viewport";
 
 const COMPUTER_RUN_TTL_MS = 60 * 60 * 1000;
 const COMPUTER_HANDOFF_TTL_MS = 20 * 60 * 1000;
@@ -806,8 +806,8 @@ export class ComputerUseService {
 
   async ensureHandoffViewport(input: {
     memberId: string;
-    preset: ComputerBrowserViewportPreset;
     token: string;
+    viewport: ComputerBrowserViewport;
   }): Promise<void> {
     await this.store.requireMemberComputerUseAvailable({
       memberId: input.memberId,
@@ -831,8 +831,8 @@ export class ComputerUseService {
     }
 
     await this.requireKernel().ensureBrowserViewport({
-      preset: input.preset,
       sessionId: requireKernelSessionId(run),
+      viewport: input.viewport,
     });
   }
 

--- a/apps/web/src/lib/computer-use/viewport.ts
+++ b/apps/web/src/lib/computer-use/viewport.ts
@@ -1,18 +1,117 @@
-export const COMPUTER_BROWSER_VIEWPORTS = {
-  mobile: { width: 390, height: 844, refresh_rate: 60 },
-  // Match Kernel's standard-image default so desktop handoffs do not shrink
-  // browser sessions when the live view opens.
-  desktop: { width: 1920, height: 1080, refresh_rate: 25 },
-} as const;
+export interface ComputerHandoffViewportSize {
+  width: number;
+  height: number;
+}
 
-export type ComputerBrowserViewportPreset = keyof typeof COMPUTER_BROWSER_VIEWPORTS;
+export interface ComputerHandoffViewportObservation
+  extends ComputerHandoffViewportSize {
+  observedAt: Date;
+}
 
-const MOBILE_USER_AGENT_PATTERN = /Mobi/;
+export interface ComputerBrowserViewport extends ComputerHandoffViewportSize {
+  refresh_rate: 25 | 60;
+}
 
-export function resolveComputerBrowserViewportPreset(
-  userAgent: string | null | undefined,
-): ComputerBrowserViewportPreset {
-  return typeof userAgent === "string" && MOBILE_USER_AGENT_PATTERN.test(userAgent)
-    ? "mobile"
-    : "desktop";
+const MIN_HANDOFF_VIEWPORT_DIMENSION = 320;
+const MAX_HANDOFF_VIEWPORT_WIDTH = 1920;
+const MAX_HANDOFF_VIEWPORT_HEIGHT = 1200;
+const VIEWPORT_GRANULARITY_PX = 4;
+const MATERIAL_VIEWPORT_DELTA_PX = 16;
+const MOBILE_VIEWPORT_WIDTH_MAX = 1024;
+const MAX_HANDOFF_VIEWPORT_OBSERVED_AT_FUTURE_MS = 5_000;
+
+export function normalizeComputerHandoffViewportSize(
+  input: unknown,
+): ComputerHandoffViewportSize | null {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return null;
+  }
+
+  const candidate = input as Record<string, unknown>;
+  const width = normalizeComputerHandoffViewportDimension(
+    candidate.width,
+    MIN_HANDOFF_VIEWPORT_DIMENSION,
+    MAX_HANDOFF_VIEWPORT_WIDTH,
+  );
+  const height = normalizeComputerHandoffViewportDimension(
+    candidate.height,
+    MIN_HANDOFF_VIEWPORT_DIMENSION,
+    MAX_HANDOFF_VIEWPORT_HEIGHT,
+  );
+
+  return width && height ? { height, width } : null;
+}
+
+export function normalizeComputerHandoffViewportObservation(
+  input: unknown,
+  options: { now?: Date } = {},
+): ComputerHandoffViewportObservation | null {
+  const size = normalizeComputerHandoffViewportSize(input);
+  if (!size || !input || typeof input !== "object" || Array.isArray(input)) {
+    return null;
+  }
+
+  const observedAt = normalizeComputerHandoffViewportObservedAt(
+    (input as Record<string, unknown>).observedAt,
+    options.now ?? new Date(),
+  );
+  return observedAt ? { ...size, observedAt } : null;
+}
+
+export function toComputerBrowserViewport(
+  size: ComputerHandoffViewportSize,
+): ComputerBrowserViewport {
+  return {
+    ...size,
+    refresh_rate: size.width <= MOBILE_VIEWPORT_WIDTH_MAX ? 60 : 25,
+  };
+}
+
+export function isMateriallyDifferentComputerHandoffViewportSize(
+  left: ComputerHandoffViewportSize | null,
+  right: ComputerHandoffViewportSize | null,
+): boolean {
+  if (!left || !right) {
+    return true;
+  }
+
+  return (
+    Math.abs(left.width - right.width) >= MATERIAL_VIEWPORT_DELTA_PX
+    || Math.abs(left.height - right.height) >= MATERIAL_VIEWPORT_DELTA_PX
+  );
+}
+
+function normalizeComputerHandoffViewportDimension(
+  value: unknown,
+  min: number,
+  max: number,
+): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  const rounded =
+    Math.round(value / VIEWPORT_GRANULARITY_PX) * VIEWPORT_GRANULARITY_PX;
+  return Math.min(Math.max(rounded, min), max);
+}
+
+function normalizeComputerHandoffViewportObservedAt(
+  value: unknown,
+  now: Date,
+): Date {
+  const timestamp = typeof value === "number"
+    ? value
+    : typeof value === "string"
+      ? Date.parse(value)
+      : Number.NaN;
+
+  if (
+    !Number.isFinite(timestamp)
+    || timestamp <= 0
+    || timestamp > now.getTime() + MAX_HANDOFF_VIEWPORT_OBSERVED_AT_FUTURE_MS
+  ) {
+    return now;
+  }
+
+  return new Date(timestamp);
 }

--- a/apps/web/src/lib/hosted-onboarding/app-session.ts
+++ b/apps/web/src/lib/hosted-onboarding/app-session.ts
@@ -6,6 +6,10 @@ import { type Prisma } from "@prisma/client";
 import { cookies } from "next/headers";
 import { cache } from "react";
 
+import {
+  normalizeComputerHandoffViewportSize,
+  type ComputerHandoffViewportSize,
+} from "../computer-use/viewport";
 import { getPrisma } from "../prisma";
 import {
   assertHostedMemberActiveAccessAllowed,
@@ -21,6 +25,7 @@ import {
 } from "./shared";
 
 export interface HostedAppSession {
+  computerHandoffViewportSize: ComputerHandoffViewportSize | null;
   expiresAt: Date;
   member: HostedMemberCoreState;
   privyUserId: string;
@@ -190,11 +195,24 @@ async function resolveHostedAppSessionFromToken(value: string | null | undefined
   }
 
   return {
+    computerHandoffViewportSize: readComputerHandoffViewportSizeFromSessionRecord(record),
     expiresAt: record.expiresAt,
     member,
     privyUserId: record.privyUserId,
     sessionId: record.id,
   };
+}
+
+function readComputerHandoffViewportSizeFromSessionRecord(
+  record: {
+    computerHandoffViewportHeight?: number | null;
+    computerHandoffViewportWidth?: number | null;
+  },
+): ComputerHandoffViewportSize | null {
+  return normalizeComputerHandoffViewportSize({
+    height: record.computerHandoffViewportHeight,
+    width: record.computerHandoffViewportWidth,
+  });
 }
 
 function generateHostedAppSessionToken(): string {

--- a/apps/web/src/lib/hosted-privacy/account-data-service.ts
+++ b/apps/web/src/lib/hosted-privacy/account-data-service.ts
@@ -67,7 +67,7 @@ export const HOSTED_ACCOUNT_DATA_STORE_COVERAGE = [
     slug: "prisma.hosted_web_session",
     label: "Hosted web app sessions",
     deletion: "live-delete",
-    note: "Deletes active and revoked hashed app-session tokens. Export reports counts only and omits token hashes.",
+    note: "Deletes active and revoked hashed app-session tokens plus per-session computer handoff viewport hints. Export reports counts only and omits token hashes.",
   },
   {
     slug: "prisma.hosted_sensitive_action_challenge",

--- a/apps/web/src/lib/observability/analytics-redaction.ts
+++ b/apps/web/src/lib/observability/analytics-redaction.ts
@@ -1,7 +1,16 @@
 import type { BeforeSendEvent as VercelAnalyticsBeforeSendEvent } from "@vercel/analytics/next";
 
-const PRIVATE_COMPUTER_HANDOFF_PATH_PREFIX = "/computer/handoff/";
-const REDACTED_PRIVATE_COMPUTER_HANDOFF_PATH = "/computer/handoff/[token]";
+const PRIVATE_COMPUTER_HANDOFF_PATH_MARKER = "/computer/handoff/";
+const PRIVATE_COMPUTER_HANDOFF_PATH_PREFIXES = [
+  {
+    prefix: "/computer/handoff/",
+    redactedPrefix: "/computer/handoff/[token]",
+  },
+  {
+    prefix: "/api/computer/handoff/",
+    redactedPrefix: "/api/computer/handoff/[token]",
+  },
+] as const;
 const URL_PARSE_BASE = "https://murph.invalid";
 
 export type VercelSpeedInsightsBeforeSendEvent = {
@@ -36,22 +45,23 @@ export function redactVercelSpeedInsightsEvent(
 }
 
 export function redactPrivateAnalyticsUrl(value: string): string {
-  if (!value.includes(PRIVATE_COMPUTER_HANDOFF_PATH_PREFIX)) {
+  if (!value.includes(PRIVATE_COMPUTER_HANDOFF_PATH_MARKER)) {
     return value;
   }
 
   try {
     const parsed = new URL(value, URL_PARSE_BASE);
+    const redactedPathname = redactPrivateComputerHandoffPathname(parsed.pathname);
 
-    if (!isPrivateComputerHandoffPath(parsed.pathname)) {
+    if (!redactedPathname) {
       return value;
     }
 
     if (hasExplicitOrigin(value)) {
-      return `${parsed.origin}${REDACTED_PRIVATE_COMPUTER_HANDOFF_PATH}`;
+      return `${parsed.origin}${redactedPathname}`;
     }
 
-    return REDACTED_PRIVATE_COMPUTER_HANDOFF_PATH;
+    return redactedPathname;
   } catch {
     return value;
   }
@@ -74,9 +84,22 @@ function hasExplicitOrigin(value: string): boolean {
   return /^[a-z][a-z\d+.-]*:\/\//iu.test(value);
 }
 
-function isPrivateComputerHandoffPath(pathname: string): boolean {
-  return (
-    pathname.startsWith(PRIVATE_COMPUTER_HANDOFF_PATH_PREFIX)
-    && pathname.length > PRIVATE_COMPUTER_HANDOFF_PATH_PREFIX.length
-  );
+function redactPrivateComputerHandoffPathname(pathname: string): string | null {
+  for (const { prefix, redactedPrefix } of PRIVATE_COMPUTER_HANDOFF_PATH_PREFIXES) {
+    if (!pathname.startsWith(prefix)) {
+      continue;
+    }
+
+    if (pathname.length <= prefix.length) {
+      return null;
+    }
+
+    const suffixStart = pathname.indexOf("/", prefix.length);
+
+    return suffixStart === -1
+      ? redactedPrefix
+      : `${redactedPrefix}${pathname.slice(suffixStart)}`;
+  }
+
+  return null;
 }

--- a/apps/web/test/computer-handoff-active-view.test.tsx
+++ b/apps/web/test/computer-handoff-active-view.test.tsx
@@ -12,6 +12,7 @@ import { ComputerHandoffActiveView } from "@/src/components/computer-use/compute
 import { renderClientComponent } from "./render-client-component";
 
 const DONE_ENDPOINT = "/api/computer/handoff/handoff-token/done";
+const VIEWPORT_ENDPOINT = "/api/computer/handoff/handoff-token/viewport";
 
 let cleanupRender: (() => Promise<void>) | null = null;
 
@@ -73,6 +74,92 @@ test("ComputerHandoffActiveView starts takeover with one click", async () => {
   expect(findDoneButton(container)).toBeTruthy();
   expect(findFocusButton(container)).toBeTruthy();
   expect(track).toHaveBeenCalledWith("live_view_focus_enabled");
+});
+
+test("ComputerHandoffActiveView posts the first measured viewport size", async () => {
+  vi.useFakeTimers();
+  vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" },
+    status: 202,
+  }));
+  const { cleanup, container, window } = await renderHandoff();
+  cleanupRender = cleanup;
+
+  await measureViewportSurface(container, window, { height: 844, width: 390 });
+
+  expectViewportPost({ height: 844, width: 392 });
+});
+
+test("ComputerHandoffActiveView retries the same viewport size after an HTTP failure", async () => {
+  vi.useFakeTimers();
+  vi.mocked(fetch)
+    .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false }), {
+      headers: { "content-type": "application/json" },
+      status: 400,
+    }))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+      status: 202,
+    }));
+  const { cleanup, container, window } = await renderHandoff();
+  cleanupRender = cleanup;
+
+  await measureViewportSurface(container, window, { height: 844, width: 390 });
+  expect(fetch).toHaveBeenCalledTimes(1);
+
+  await measureViewportSurface(container, window, { height: 844, width: 390 });
+
+  expect(fetch).toHaveBeenCalledTimes(2);
+  expectViewportPost({ height: 844, width: 392 });
+});
+
+test("ComputerHandoffActiveView suppresses cached viewport jitter", async () => {
+  vi.useFakeTimers();
+  vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" },
+    status: 202,
+  }));
+  const { cleanup, container, window } = await renderHandoff({
+    initialViewportSize: { height: 844, width: 392 },
+  });
+  cleanupRender = cleanup;
+
+  await measureViewportSurface(container, window, { height: 852, width: 400 });
+
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+test("ComputerHandoffActiveView posts a material viewport correction", async () => {
+  vi.useFakeTimers();
+  vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" },
+    status: 202,
+  }));
+  const { cleanup, container, window } = await renderHandoff({
+    initialViewportSize: { height: 844, width: 392 },
+  });
+  cleanupRender = cleanup;
+
+  await measureViewportSurface(container, window, { height: 844, width: 430 });
+
+  expectViewportPost({ height: 844, width: 432 });
+});
+
+test("ComputerHandoffActiveView keeps viewport sync alive after takeover", async () => {
+  vi.useFakeTimers();
+  vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" },
+    status: 202,
+  }));
+  const { cleanup, container, window } = await renderHandoff({
+    initialViewportSize: { height: 844, width: 392 },
+  });
+  cleanupRender = cleanup;
+
+  await click(window, findTakeoverButton(container));
+  await measureViewportSurface(container, window, { height: 844, width: 430 });
+
+  expectViewportPost({ height: 844, width: 432 });
 });
 
 test("ComputerHandoffActiveView can refocus the live view after takeover", async () => {
@@ -260,14 +347,61 @@ test.each([
 
 async function renderHandoff(overrides: {
   iframeAllow?: string;
+  initialViewportSize?: { height: number; width: number } | null;
 } = {}) {
   return await renderClientComponent(
     createElement(ComputerHandoffActiveView, {
       doneEndpoint: DONE_ENDPOINT,
       iframeAllow: overrides.iframeAllow ?? "clipboard-read; clipboard-write",
+      initialViewportSize: overrides.initialViewportSize ?? null,
       liveViewUrl: "https://browser.example.test/live",
+      viewportEndpoint: VIEWPORT_ENDPOINT,
     }),
   );
+}
+
+async function measureViewportSurface(
+  container: HTMLElement,
+  window: Window & typeof globalThis,
+  size: { height: number; width: number },
+): Promise<void> {
+  const iframe = container.querySelector("iframe");
+  assert.ok(iframe?.parentElement);
+  iframe.parentElement.getBoundingClientRect = vi.fn(() => ({
+    bottom: size.height,
+    height: size.height,
+    left: 0,
+    right: size.width,
+    toJSON: () => ({}),
+    top: 0,
+    width: size.width,
+    x: 0,
+    y: 0,
+  }));
+
+  await act(async () => {
+    window.dispatchEvent(new window.Event("orientationchange"));
+    await vi.advanceTimersByTimeAsync(200);
+  });
+  await flushMicrotasks();
+}
+
+function expectViewportPost(expectedSize: { height: number; width: number }): void {
+  expect(fetch).toHaveBeenCalledWith(VIEWPORT_ENDPOINT, {
+    body: expect.any(String),
+    credentials: "same-origin",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  const init = vi.mocked(fetch).mock.calls.at(-1)?.[1] as RequestInit | undefined;
+  expect(JSON.parse(String(init?.body))).toEqual({
+    ...expectedSize,
+    observedAt: expect.any(String),
+  });
 }
 
 function findTakeoverButton(container: HTMLElement): HTMLButtonElement | null {

--- a/apps/web/test/computer-handoff-route-page.test.tsx
+++ b/apps/web/test/computer-handoff-route-page.test.tsx
@@ -16,14 +16,16 @@ const mocks = vi.hoisted(() => {
   };
 
   return {
+    assertHostedOnboardingMutationOrigin: vi.fn(),
     createComputerUseService: vi.fn(() => service),
     getHostedMurphContactContext: vi.fn(),
-    headers: vi.fn(),
-    requireActiveHostedAppSession: vi.fn(),
     redirect: vi.fn((url: string) => {
       throw Object.assign(new Error("NEXT_REDIRECT"), { url });
     }),
+    requireActiveHostedAppSession: vi.fn(),
     requireActiveHostedAppSessionFromRequest: vi.fn(),
+    saveHostedWebSessionComputerHandoffViewportSize: vi.fn(),
+    scheduleHostedWebSessionComputerHandoffViewportApply: vi.fn(),
     service,
   };
 });
@@ -34,18 +36,26 @@ vi.mock("next/navigation", () => ({
   redirect: mocks.redirect,
 }));
 
-vi.mock("next/headers", () => ({
-  headers: mocks.headers,
-}));
-
 vi.mock("@/src/lib/computer-use/service", () => ({
   createComputerUseService: mocks.createComputerUseService,
+}));
+
+vi.mock("@/src/lib/computer-use/handoff-viewport-session", () => ({
+  saveHostedWebSessionComputerHandoffViewportSize:
+    mocks.saveHostedWebSessionComputerHandoffViewportSize,
+  scheduleHostedWebSessionComputerHandoffViewportApply:
+    mocks.scheduleHostedWebSessionComputerHandoffViewportApply,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
   requireActiveHostedAppSession: mocks.requireActiveHostedAppSession,
   requireActiveHostedAppSessionFromRequest:
     mocks.requireActiveHostedAppSessionFromRequest,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/csrf", () => ({
+  assertHostedOnboardingMutationOrigin:
+    mocks.assertHostedOnboardingMutationOrigin,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-contact-context", () => ({
@@ -58,12 +68,16 @@ type ComputerHandoffDoneRouteModule = typeof import(
 type ComputerManagedLoginRouteModule = typeof import(
   "../app/api/computer/handoff/[token]/managed-login/route"
 );
+type ComputerHandoffViewportRouteModule = typeof import(
+  "../app/api/computer/handoff/[token]/viewport/route"
+);
 type ComputerHandoffPageModule = typeof import(
   "../app/computer/handoff/[token]/page"
 );
 
 let computerHandoffDoneRoute: ComputerHandoffDoneRouteModule;
 let computerManagedLoginRoute: ComputerManagedLoginRouteModule;
+let computerHandoffViewportRoute: ComputerHandoffViewportRouteModule;
 let computerHandoffPage: ComputerHandoffPageModule;
 
 describe("computer handoff route and page", () => {
@@ -73,6 +87,9 @@ describe("computer handoff route and page", () => {
     );
     computerManagedLoginRoute = await import(
       "../app/api/computer/handoff/[token]/managed-login/route"
+    );
+    computerHandoffViewportRoute = await import(
+      "../app/api/computer/handoff/[token]/viewport/route"
     );
     computerHandoffPage = await import("../app/computer/handoff/[token]/page");
   });
@@ -91,12 +108,12 @@ describe("computer handoff route and page", () => {
       url: "https://auth.onkernel.com/login/test",
     });
     mocks.service.ensureHandoffViewport.mockResolvedValue(undefined);
+    mocks.saveHostedWebSessionComputerHandoffViewportSize.mockResolvedValue(true);
     mocks.service.readHandoffPageState.mockResolvedValue({
       kind: "completed",
       returnContactKind: "text",
       suggestedReply: "finished_browser_step",
     });
-    mocks.headers.mockResolvedValue(createHeaders(null));
     mocks.getHostedMurphContactContext.mockResolvedValue(createContactContext());
   });
 
@@ -497,43 +514,7 @@ describe("computer handoff route and page", () => {
     assert.equal(markup.includes("finished_browser_step"), false);
   });
 
-  it.each([
-    [
-      "mobile",
-      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1",
-    ],
-    [
-      "desktop",
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
-    ],
-  ] as const)(
-    "resizes the kernel browser to %s before rendering the live view",
-    async (preset, userAgent) => {
-      mocks.service.readHandoffPageState.mockResolvedValueOnce({
-        handoffId: "hch_open",
-        iframeAllow: "clipboard-read",
-        interaction: "takeover",
-        kind: "open",
-        liveViewUrl: "https://browser.example.test/live",
-        purpose: "login",
-        suggestedReply: "done",
-      });
-      mocks.headers.mockResolvedValueOnce(createHeaders(userAgent));
-
-      const markup = renderToStaticMarkup(await computerHandoffPage.default({
-        params: Promise.resolve({ token: "handoff-token" }),
-      }));
-
-      expect(mocks.service.ensureHandoffViewport).toHaveBeenCalledWith({
-        memberId: "member_123",
-        preset,
-        token: "handoff-token",
-      });
-      assert.match(markup, /<iframe[^>]+src="https:\/\/browser\.example\.test\/live"/);
-    },
-  );
-
-  it("still renders the live view when the kernel resize fails", async () => {
+  it("renders the live view immediately without a cached viewport resize", async () => {
     mocks.service.readHandoffPageState.mockResolvedValueOnce({
       handoffId: "hch_open",
       iframeAllow: "clipboard-read",
@@ -543,35 +524,181 @@ describe("computer handoff route and page", () => {
       purpose: "login",
       suggestedReply: "done",
     });
-    mocks.service.ensureHandoffViewport.mockRejectedValueOnce(
-      new Error("kernel hiccup"),
+
+    const markup = renderToStaticMarkup(await computerHandoffPage.default({
+      params: Promise.resolve({ token: "handoff-token" }),
+    }));
+
+    expect(mocks.service.ensureHandoffViewport).not.toHaveBeenCalled();
+    expect(
+      mocks.scheduleHostedWebSessionComputerHandoffViewportApply,
+    ).not.toHaveBeenCalled();
+    assert.match(markup, /<iframe[^>]+src="https:\/\/browser\.example\.test\/live"/);
+  });
+
+  it("starts a cached viewport resize in the background when the web session has a saved handoff size", async () => {
+    mocks.requireActiveHostedAppSession.mockResolvedValueOnce(createSession({
+      computerHandoffViewportSize: { height: 844, width: 390 },
+    }));
+    mocks.service.readHandoffPageState.mockResolvedValueOnce({
+      handoffId: "hch_open",
+      iframeAllow: "clipboard-read",
+      interaction: "takeover",
+      kind: "open",
+      liveViewUrl: "https://browser.example.test/live",
+      purpose: "login",
+      suggestedReply: "done",
+    });
+
+    const markup = renderToStaticMarkup(await computerHandoffPage.default({
+      params: Promise.resolve({ token: "handoff-token" }),
+    }));
+
+    assert.match(markup, /<iframe[^>]+src="https:\/\/browser\.example\.test\/live"/);
+    expect(
+      mocks.scheduleHostedWebSessionComputerHandoffViewportApply,
+    ).toHaveBeenCalledWith({
+      memberId: "member_123",
+      reason: "cached",
+      sessionId: "hws_test",
+      token: "handoff-token",
+    });
+    expect(mocks.service.ensureHandoffViewport).not.toHaveBeenCalled();
+  });
+
+  it("saves a measured handoff viewport and schedules background apply", async () => {
+    const observedAt = "2026-06-29T12:00:00.000Z";
+    const response = await computerHandoffViewportRoute.POST(
+      new Request("https://join.example.test/api/computer/handoff/handoff-token/viewport", {
+        body: JSON.stringify({ height: 844, observedAt, width: 390 }),
+        headers: {
+          "content-type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+      createRouteContext({ token: "handoff-token" }),
     );
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    try {
-      const markup = renderToStaticMarkup(await computerHandoffPage.default({
-        params: Promise.resolve({ token: "handoff-token" }),
-      }));
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledWith(
+      expect.any(Request),
+    );
+    expect(mocks.saveHostedWebSessionComputerHandoffViewportSize).toHaveBeenCalledWith({
+      memberId: "member_123",
+      now: expect.any(Date),
+      observedAt: new Date(observedAt),
+      sessionId: "hws_test",
+      size: { height: 844, width: 392 },
+    });
+    expect(
+      mocks.scheduleHostedWebSessionComputerHandoffViewportApply,
+    ).toHaveBeenCalledWith({
+      memberId: "member_123",
+      reason: "measured",
+      sessionId: "hws_test",
+      token: "handoff-token",
+    });
+  });
 
-      assert.match(markup, /<iframe[^>]+src="https:\/\/browser\.example\.test\/live"/);
-      expect(warn).toHaveBeenCalled();
-    } finally {
-      warn.mockRestore();
-    }
+  it("does not schedule background apply for stale viewport observations", async () => {
+    mocks.saveHostedWebSessionComputerHandoffViewportSize.mockResolvedValueOnce(false);
+
+    const response = await computerHandoffViewportRoute.POST(
+      new Request("https://join.example.test/api/computer/handoff/handoff-token/viewport", {
+        body: JSON.stringify({
+          height: 844,
+          observedAt: "2026-06-29T12:00:00.000Z",
+          width: 390,
+        }),
+        headers: {
+          "content-type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+      createRouteContext({ token: "handoff-token" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(mocks.saveHostedWebSessionComputerHandoffViewportSize).toHaveBeenCalledOnce();
+    expect(
+      mocks.scheduleHostedWebSessionComputerHandoffViewportApply,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid measured handoff viewport bodies", async () => {
+    const response = await computerHandoffViewportRoute.POST(
+      new Request("https://join.example.test/api/computer/handoff/handoff-token/viewport", {
+        body: JSON.stringify({
+          height: "844",
+          observedAt: "2026-06-29T12:00:00.000Z",
+          width: 390,
+        }),
+        headers: {
+          "content-type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+      createRouteContext({ token: "handoff-token" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.saveHostedWebSessionComputerHandoffViewportSize).not.toHaveBeenCalled();
+    expect(
+      mocks.scheduleHostedWebSessionComputerHandoffViewportApply,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("clamps future measured handoff viewport observations to server time", async () => {
+    const beforeRequestMs = Date.now();
+    const response = await computerHandoffViewportRoute.POST(
+      new Request("https://join.example.test/api/computer/handoff/handoff-token/viewport", {
+        body: JSON.stringify({
+          height: 844,
+          observedAt: new Date(beforeRequestMs + 60_000).toISOString(),
+          width: 390,
+        }),
+        headers: {
+          "content-type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+      createRouteContext({ token: "handoff-token" }),
+    );
+    const afterRequestMs = Date.now();
+
+    expect(response.status).toBe(202);
+    const savedInput = mocks.saveHostedWebSessionComputerHandoffViewportSize.mock
+      .calls[0]?.[0];
+    expect(savedInput).toMatchObject({
+      memberId: "member_123",
+      sessionId: "hws_test",
+      size: { height: 844, width: 392 },
+    });
+    expect(savedInput.observedAt.getTime()).toBeGreaterThanOrEqual(beforeRequestMs);
+    expect(savedInput.observedAt.getTime()).toBeLessThanOrEqual(afterRequestMs);
+    expect(
+      mocks.scheduleHostedWebSessionComputerHandoffViewportApply,
+    ).toHaveBeenCalledWith({
+      memberId: "member_123",
+      reason: "measured",
+      sessionId: "hws_test",
+      token: "handoff-token",
+    });
   });
 
 });
 
-function createHeaders(userAgent: string | null): Headers {
-  const headers = new Headers();
-  if (userAgent !== null) {
-    headers.set("user-agent", userAgent);
-  }
-  return headers;
-}
 
-function createSession() {
+function createSession(input: {
+  computerHandoffViewportSize?: { height: number; width: number } | null;
+} = {}) {
   return {
+    computerHandoffViewportSize: input.computerHandoffViewportSize ?? null,
     expiresAt: new Date("2035-06-22T12:00:00.000Z"),
     member: {
       id: "member_123",

--- a/apps/web/test/computer-handoff-viewport-session.test.ts
+++ b/apps/web/test/computer-handoff-viewport-session.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createComputerUseService: vi.fn(),
+  getPrisma: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/server", () => ({
+  after: vi.fn((task: () => Promise<void>) => {
+    void task();
+  }),
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: mocks.getPrisma,
+}));
+
+vi.mock("@/src/lib/computer-use/service", () => ({
+  createComputerUseService: mocks.createComputerUseService,
+}));
+
+describe("computer handoff viewport session hint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores only newer viewport observations", async () => {
+    const updateMany = vi.fn(async () => ({ count: 1 }));
+    mocks.getPrisma.mockReturnValue({
+      hostedWebSession: {
+        updateMany,
+      },
+    });
+    const {
+      saveHostedWebSessionComputerHandoffViewportSize,
+    } = await import("@/src/lib/computer-use/handoff-viewport-session");
+    const now = new Date("2026-06-29T12:00:03.000Z");
+    const observedAt = new Date("2026-06-29T12:00:02.000Z");
+
+    await expect(saveHostedWebSessionComputerHandoffViewportSize({
+      memberId: "member_123",
+      now,
+      observedAt,
+      sessionId: "hws_test",
+      size: { height: 844, width: 390 },
+    })).resolves.toBe(true);
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        expiresAt: { gt: now },
+        id: "hws_test",
+        memberId: "member_123",
+        OR: [
+          { computerHandoffViewportObservedAt: null },
+          { computerHandoffViewportObservedAt: { lt: observedAt } },
+        ],
+        revokedAt: null,
+      },
+      data: {
+        computerHandoffViewportHeight: 844,
+        computerHandoffViewportObservedAt: observedAt,
+        computerHandoffViewportWidth: 392,
+        updatedAt: now,
+      },
+    });
+  });
+
+  it("reports stale viewport observations as not saved", async () => {
+    const updateMany = vi.fn(async () => ({ count: 0 }));
+    mocks.getPrisma.mockReturnValue({
+      hostedWebSession: {
+        updateMany,
+      },
+    });
+    const {
+      saveHostedWebSessionComputerHandoffViewportSize,
+    } = await import("@/src/lib/computer-use/handoff-viewport-session");
+
+    await expect(saveHostedWebSessionComputerHandoffViewportSize({
+      memberId: "member_123",
+      observedAt: new Date("2026-06-29T12:00:02.000Z"),
+      sessionId: "hws_test",
+      size: { height: 844, width: 390 },
+    })).resolves.toBe(false);
+  });
+
+  it("corrects a stale cached apply when a newer measurement lands during Kernel resize", async () => {
+    const ensureHandoffViewport = vi.fn(async () => undefined);
+    mocks.createComputerUseService.mockReturnValue({ ensureHandoffViewport });
+    const staleObservedAt = new Date("2026-06-29T12:00:00.000Z");
+    const measuredObservedAt = new Date("2026-06-29T12:00:01.000Z");
+    const findFirst = vi
+      .fn()
+      .mockResolvedValueOnce({
+        computerHandoffViewportHeight: 900,
+        computerHandoffViewportObservedAt: staleObservedAt,
+        computerHandoffViewportWidth: 1440,
+      })
+      .mockResolvedValueOnce({
+        computerHandoffViewportHeight: 844,
+        computerHandoffViewportObservedAt: measuredObservedAt,
+        computerHandoffViewportWidth: 390,
+      });
+    mocks.getPrisma.mockReturnValue({
+      hostedWebSession: {
+        findFirst,
+      },
+    });
+    const {
+      applyHostedWebSessionComputerHandoffViewport,
+    } = await import("@/src/lib/computer-use/handoff-viewport-session");
+
+    await applyHostedWebSessionComputerHandoffViewport({
+      memberId: "member_123",
+      sessionId: "hws_test",
+      token: "handoff-token",
+    });
+
+    expect(ensureHandoffViewport).toHaveBeenCalledTimes(2);
+    expect(ensureHandoffViewport).toHaveBeenNthCalledWith(1, {
+      memberId: "member_123",
+      token: "handoff-token",
+      viewport: { height: 900, refresh_rate: 25, width: 1440 },
+    });
+    expect(ensureHandoffViewport).toHaveBeenNthCalledWith(2, {
+      memberId: "member_123",
+      token: "handoff-token",
+      viewport: { height: 844, refresh_rate: 60, width: 392 },
+    });
+  });
+
+  it("logs background apply failures with sanitized structured error details", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ensureHandoffViewport = vi.fn(async () => {
+      throw new Error(
+        "operator message failed for member_sensitive and user@example.test",
+      );
+    });
+    mocks.createComputerUseService.mockReturnValue({ ensureHandoffViewport });
+    mocks.getPrisma.mockReturnValue({
+      hostedWebSession: {
+        findFirst: vi.fn(async () => ({
+          computerHandoffViewportHeight: 844,
+          computerHandoffViewportObservedAt: new Date("2026-06-29T12:00:00.000Z"),
+          computerHandoffViewportWidth: 390,
+        })),
+      },
+    });
+    const {
+      scheduleHostedWebSessionComputerHandoffViewportApply,
+    } = await import("@/src/lib/computer-use/handoff-viewport-session");
+
+    scheduleHostedWebSessionComputerHandoffViewportApply({
+      memberId: "member_123",
+      reason: "measured",
+      sessionId: "hws_test",
+      token: "handoff-token",
+    });
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalled();
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[computer-handoff] measured viewport resize failed",
+      expect.objectContaining({
+        errorCode: "HOSTED_COMPUTER_HANDOFF_VIEWPORT_RESIZE_FAILED",
+        errorMessage:
+          "operator message failed for member_<redacted-id> and [redacted-email]",
+        errorType: "Error",
+      }),
+    );
+    const loggedDetails = warn.mock.calls[0]?.[1];
+    expect(loggedDetails).not.toBeInstanceOf(Error);
+    expect(JSON.stringify(loggedDetails)).not.toContain("member_sensitive");
+    expect(JSON.stringify(loggedDetails)).not.toContain("user@example.test");
+    warn.mockRestore();
+  });
+});

--- a/apps/web/test/computer-use-viewport.test.ts
+++ b/apps/web/test/computer-use-viewport.test.ts
@@ -1,29 +1,114 @@
 import { describe, expect, test } from "vitest";
 
-import { resolveComputerBrowserViewportPreset } from "@/src/lib/computer-use/viewport";
+import {
+  isMateriallyDifferentComputerHandoffViewportSize,
+  normalizeComputerHandoffViewportObservation,
+  normalizeComputerHandoffViewportSize,
+  toComputerBrowserViewport,
+} from "@/src/lib/computer-use/viewport";
 
-describe("resolveComputerBrowserViewportPreset", () => {
+describe("normalizeComputerHandoffViewportSize", () => {
   test.each([
-    [null, "desktop"],
-    [undefined, "desktop"],
-    ["", "desktop"],
-    [
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
-      "desktop",
-    ],
-    [
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
-      "desktop",
-    ],
-    [
-      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
-      "mobile",
-    ],
-    [
-      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36",
-      "mobile",
-    ],
-  ] as const)("resolves %j to %s", (userAgent, expected) => {
-    expect(resolveComputerBrowserViewportPreset(userAgent)).toBe(expected);
+    [{ height: 725, width: 414 }, { height: 724, width: 416 }],
+    [{ height: 1, width: 1 }, { height: 320, width: 320 }],
+    [{ height: 10_000, width: 10_000 }, { height: 1200, width: 1920 }],
+    [{ height: 722.2, width: 393.9 }, { height: 724, width: 392 }],
+  ])("normalizes %j", (input, expected) => {
+    expect(normalizeComputerHandoffViewportSize(input)).toEqual(expected);
+  });
+
+  test.each([
+    null,
+    undefined,
+    {},
+    { height: 700 },
+    { width: 400 },
+    { height: 0, width: 400 },
+    { height: 700, width: 0 },
+    { height: Number.NaN, width: 400 },
+    { height: 700, width: Infinity },
+    { height: "700", width: 400 },
+  ])("rejects invalid input %j", (input) => {
+    expect(normalizeComputerHandoffViewportSize(input)).toBeNull();
+  });
+});
+
+describe("normalizeComputerHandoffViewportObservation", () => {
+  test("normalizes viewport size and observed time", () => {
+    expect(normalizeComputerHandoffViewportObservation({
+      height: 844,
+      observedAt: "2026-06-29T12:00:00.000Z",
+      width: 390,
+    }, { now: new Date("2026-06-29T12:00:01.000Z") })).toEqual({
+      height: 844,
+      observedAt: new Date("2026-06-29T12:00:00.000Z"),
+      width: 392,
+    });
+  });
+
+  test.each([
+    { height: 844, width: 390 },
+    { height: 844, observedAt: "not-a-date", width: 390 },
+    { height: 844, observedAt: 0, width: 390 },
+    { height: 844, observedAt: "2026-06-29T12:00:06.001Z", width: 390 },
+  ])("falls back to server time for unusable observation timestamps %j", (input) => {
+    expect(
+      normalizeComputerHandoffViewportObservation(input, {
+        now: new Date("2026-06-29T12:00:01.000Z"),
+      }),
+    ).toEqual({
+      height: 844,
+      observedAt: new Date("2026-06-29T12:00:01.000Z"),
+      width: 392,
+    });
+  });
+
+  test("rejects invalid viewport dimensions", () => {
+    expect(
+      normalizeComputerHandoffViewportObservation({
+        height: "844",
+        observedAt: "2026-06-29T12:00:00.000Z",
+        width: 390,
+      }, {
+        now: new Date("2026-06-29T12:00:01.000Z"),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("toComputerBrowserViewport", () => {
+  test.each([
+    [{ height: 724, width: 392 }, { height: 724, refresh_rate: 60, width: 392 }],
+    [{ height: 900, width: 1024 }, { height: 900, refresh_rate: 60, width: 1024 }],
+    [{ height: 1080, width: 1440 }, { height: 1080, refresh_rate: 25, width: 1440 }],
+  ] as const)("derives refresh rate for %j", (size, expected) => {
+    expect(toComputerBrowserViewport(size)).toEqual(expected);
+  });
+});
+
+describe("isMateriallyDifferentComputerHandoffViewportSize", () => {
+  test("treats missing values as different", () => {
+    expect(isMateriallyDifferentComputerHandoffViewportSize(null, { height: 700, width: 400 }))
+      .toBe(true);
+    expect(isMateriallyDifferentComputerHandoffViewportSize({ height: 700, width: 400 }, null))
+      .toBe(true);
+  });
+
+  test("ignores minor viewport jitter", () => {
+    expect(isMateriallyDifferentComputerHandoffViewportSize(
+      { height: 700, width: 400 },
+      { height: 715, width: 415 },
+    )).toBe(false);
+  });
+
+  test("detects material differences", () => {
+    expect(isMateriallyDifferentComputerHandoffViewportSize(
+      { height: 700, width: 400 },
+      { height: 716, width: 400 },
+    )).toBe(true);
+    expect(isMateriallyDifferentComputerHandoffViewportSize(
+      { height: 700, width: 400 },
+      { height: 700, width: 416 },
+    )).toBe(true);
   });
 });

--- a/apps/web/test/hosted-app-session.test.ts
+++ b/apps/web/test/hosted-app-session.test.ts
@@ -16,6 +16,9 @@ vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
 }));
 
 interface StoredHostedWebSession {
+  computerHandoffViewportHeight: number | null;
+  computerHandoffViewportObservedAt: Date | null;
+  computerHandoffViewportWidth: number | null;
   createdAt: Date;
   expiresAt: Date;
   id: string;
@@ -199,10 +202,33 @@ describe("hosted app session", () => {
       prisma: harness.prismaClient,
     });
     expect(session).toEqual({
+      computerHandoffViewportSize: null,
       expiresAt: new Date("2099-01-31T00:00:00.000Z"),
       member: createHostedMember(),
       privyUserId: "did:privy:user_123",
       sessionId: result.sessionId,
+    });
+  });
+
+  it("resolves a saved computer handoff viewport size from the current web session", async () => {
+    const {
+      getHostedAppSessionFromRequest,
+      issueHostedAppSession,
+    } = await import("@/src/lib/hosted-onboarding/app-session");
+    const result = await issueHostedAppSession({
+      memberId: "member_123",
+      now: new Date("2099-01-01T00:00:00.000Z"),
+      privyUserId: "did:privy:user_123",
+    });
+    const record = findStoredSession(result.sessionId);
+    record.computerHandoffViewportHeight = 843;
+    record.computerHandoffViewportWidth = 391;
+
+    const session = await getHostedAppSessionFromRequest(requestWithCookie(result.cookie));
+
+    expect(session?.computerHandoffViewportSize).toEqual({
+      height: 844,
+      width: 392,
     });
   });
 
@@ -286,6 +312,9 @@ function createHostedWebSessionDelegate(records: StoredHostedWebSession[]) {
   const create = vi.fn(async (input: HostedWebSessionCreateInput): Promise<StoredHostedWebSession> => {
     const record = {
       ...input.data,
+      computerHandoffViewportHeight: null,
+      computerHandoffViewportObservedAt: null,
+      computerHandoffViewportWidth: null,
       revokedAt: null,
       revokeReason: null,
     };
@@ -417,6 +446,9 @@ function buildStoredSession(input: {
   revokedAt?: Date | null;
 }): StoredHostedWebSession {
   return {
+    computerHandoffViewportHeight: null,
+    computerHandoffViewportObservedAt: null,
+    computerHandoffViewportWidth: null,
     createdAt: input.createdAt,
     expiresAt: input.expiresAt ?? new Date("2099-01-01T00:00:00.000Z"),
     id: input.id,

--- a/apps/web/test/hosted-computer-kernel-client.test.ts
+++ b/apps/web/test/hosted-computer-kernel-client.test.ts
@@ -96,23 +96,23 @@ describe("KernelComputerClient", () => {
     });
   });
 
-  it("updates only when the requested viewport preset differs", async () => {
+  it("updates only when the requested concrete viewport differs", async () => {
     kernelSdkMocks.browserRetrieve
       .mockResolvedValueOnce({
-        viewport: { height: 844, width: 390 },
+        viewport: { height: 844, refresh_rate: 60, width: 390 },
       })
       .mockResolvedValueOnce({
-        viewport: { height: 844, width: 390 },
+        viewport: { height: 844, refresh_rate: 60, width: 390 },
       });
     const client = new KernelComputerClient({ apiKey: "test-kernel-key" });
 
     await client.ensureBrowserViewport({
-      preset: "mobile",
       sessionId: "kernel-session-1",
+      viewport: { height: 844, refresh_rate: 60, width: 390 },
     });
     await client.ensureBrowserViewport({
-      preset: "desktop",
       sessionId: "kernel-session-1",
+      viewport: { height: 1080, refresh_rate: 25, width: 1920 },
     });
 
     expect(kernelSdkMocks.browserRetrieve).toHaveBeenNthCalledWith(
@@ -137,6 +137,30 @@ describe("KernelComputerClient", () => {
     );
   });
 
+  it("updates when only the requested refresh rate differs", async () => {
+    kernelSdkMocks.browserRetrieve.mockResolvedValueOnce({
+      viewport: { height: 844, refresh_rate: 25, width: 390 },
+    });
+    const client = new KernelComputerClient({ apiKey: "test-kernel-key" });
+
+    await client.ensureBrowserViewport({
+      sessionId: "kernel-session-1",
+      viewport: { height: 844, refresh_rate: 60, width: 390 },
+    });
+
+    expect(kernelSdkMocks.browserUpdate).toHaveBeenCalledWith(
+      "kernel-session-1",
+      {
+        viewport: {
+          force: true,
+          height: 844,
+          refresh_rate: 60,
+          width: 390,
+        },
+      },
+    );
+  });
+
   it("sanitizes viewport SDK failures", async () => {
     kernelSdkMocks.browserRetrieve.mockRejectedValueOnce(
       new Error("upstream error for kernel-session-secret"),
@@ -144,8 +168,8 @@ describe("KernelComputerClient", () => {
     const client = new KernelComputerClient({ apiKey: "test-kernel-key" });
 
     await expect(client.ensureBrowserViewport({
-      preset: "desktop",
       sessionId: "kernel-session-secret",
+      viewport: { height: 1080, refresh_rate: 25, width: 1920 },
     })).rejects.toMatchObject({
       code: "HOSTED_COMPUTER_VIEWPORT_UPDATE_FAILED",
       message: "Computer browser viewport update failed.",

--- a/apps/web/test/hosted-execution-computer-use.test.ts
+++ b/apps/web/test/hosted-execution-computer-use.test.ts
@@ -861,8 +861,8 @@ describe("ComputerUseService", () => {
     });
     await expect(service.ensureHandoffViewport({
       memberId: "member_123",
-      preset: "desktop",
       token: "handoff-token",
+      viewport: { height: 1080, refresh_rate: 25, width: 1920 },
     })).rejects.toMatchObject({
       code: "HOSTED_COMPUTER_MEMBER_SUSPENDED",
     });
@@ -3332,13 +3332,13 @@ describe("ComputerUseService", () => {
 
     await expect(service.ensureHandoffViewport({
       memberId: "member_123",
-      preset: "mobile",
       token: "handoff-token",
+      viewport: { height: 844, refresh_rate: 60, width: 390 },
     })).resolves.toBeUndefined();
     expect(kernel.ensureBrowserViewportInputs).toEqual([
       {
-        preset: "mobile",
         sessionId: "kernel-session-1",
+        viewport: { height: 844, refresh_rate: 60, width: 390 },
       },
     ]);
   });
@@ -3363,8 +3363,8 @@ describe("ComputerUseService", () => {
 
     await expect(service.ensureHandoffViewport({
       memberId: "member_123",
-      preset: "mobile",
       token: "handoff-token",
+      viewport: { height: 844, refresh_rate: 60, width: 390 },
     })).rejects.toMatchObject({
       code: "HOSTED_COMPUTER_HANDOFF_CLOSED",
     });

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -440,6 +440,13 @@ describe("hosted Prisma baseline migration", () => {
       ),
       "utf8",
     );
+    const computerHandoffViewportSessionHintMigrationSql = readFileSync(
+      new URL(
+        "../prisma/migrations/20260629160000_computer_handoff_viewport_session_hint/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     expect(migrationEntries).toEqual([
       "2026040600_init",
       "20260425000000_drop_legacy_linq_control_plane",
@@ -505,6 +512,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260627210000_linq_first_contact_admission_drop_category",
       "20260627230000_linq_first_contact_rejected_message_text",
       "20260628000000_linq_first_contact_scrub_rejected_message_text",
+      "20260629160000_computer_handoff_viewport_session_hint",
       "migration_lock.toml",
     ]);
     expect(hostedThreadRoutesMigrationSql).toContain('CREATE TABLE "hosted_thread_container"');
@@ -598,6 +606,12 @@ describe("hosted Prisma baseline migration", () => {
     );
     expect(computerHandoffReturnContactKindMigrationSql).toContain(
       'ADD CONSTRAINT "hosted_computer_handoff_return_contact_kind_check"',
+    );
+    expect(computerHandoffViewportSessionHintMigrationSql).toContain(
+      'ADD COLUMN "computer_handoff_viewport_width" INTEGER',
+    );
+    expect(computerHandoffViewportSessionHintMigrationSql).toContain(
+      'ADD COLUMN "computer_handoff_viewport_height" INTEGER',
     );
     expect(linqFirstContactAdmissionDecisionMigrationSql).toContain(
       'CREATE TABLE "hosted_linq_first_contact_admission_decision"',

--- a/apps/web/test/vercel-telemetry.test.tsx
+++ b/apps/web/test/vercel-telemetry.test.tsx
@@ -80,6 +80,29 @@ test("VercelTelemetry redacts private handoff tokens before analytics sends", ()
       url: "https://join.example.test/computer/handoff/[token]",
     },
   );
+
+  assert.equal(
+    redactPrivateAnalyticsUrl(
+      "https://join.example.test/api/computer/handoff/private-token/viewport?height=844",
+    ),
+    "https://join.example.test/api/computer/handoff/[token]/viewport",
+  );
+  assert.equal(
+    redactPrivateAnalyticsUrl("/api/computer/handoff/private-token/done"),
+    "/api/computer/handoff/[token]/done",
+  );
+  assert.deepEqual(
+    speedInsightsProps.beforeSend({
+      route: "/api/computer/handoff/private-token/viewport",
+      type: "vital",
+      url: "https://join.example.test/api/computer/handoff/private-token/viewport?width=390",
+    }),
+    {
+      route: "/api/computer/handoff/[token]/viewport",
+      type: "vital",
+      url: "https://join.example.test/api/computer/handoff/[token]/viewport",
+    },
+  );
 });
 
 test("redactPrivateAnalyticsUrl leaves unrelated routes unchanged", () => {


### PR DESCRIPTION
**Why this PR exists.**

Hosted computer handoff currently resizes the browser from a server-side user-agent preset before rendering the handoff page. That can delay takeover and still miss the actual iframe surface on mobile browsers.

**User goal / user-visible behavior.**

When a member opens a hosted computer handoff, the takeover page renders immediately while the app uses the measured handoff surface, and later the saved per-session hint, to resize the Kernel browser best-effort. The visible result should be less mobile viewport mismatch without delaying control.

**Invariants the PR must preserve.**

- Handoff takeover must not wait on Kernel viewport resize.
- Viewport writes stay scoped to the active hosted app session and bounded numeric dimensions only.
- Kernel resize still requires member ownership, a valid open handoff token, and a pending handoff run.
- Overlapping viewport measurements must not allow an older observation to overwrite or reapply after a newer observation.
- Handoff tokens, live-view URLs, Kernel credentials, and local identifiers must stay out of analytics, logs, docs, and tests.

**Deployment skew / compatibility.**

This is an `apps/web` change plus an additive nullable Prisma migration on `hosted_web_session`. Old web code is compatible with the extra columns. New web code expects the migration before it reads or writes viewport hints; production release migration should run before the new build serves traffic. No Cloudflare tandem deploy is required.

**Validation.**

- `pnpm --dir apps/web test:prepared test/computer-handoff-active-view.test.tsx test/computer-handoff-route-page.test.tsx test/computer-handoff-viewport-session.test.ts test/computer-use-viewport.test.ts test/hosted-app-session.test.ts test/hosted-computer-kernel-client.test.ts test/vercel-telemetry.test.tsx`
- `pnpm test:diff`
- `git diff --check`
- `pnpm build:test-runtime:prepared`
- `pnpm typecheck`