### PR TITLE
[codex] Recover committed runtime fences after ambiguous wake

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-abort-requested-semantics.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-abort-requested-semantics.md
@@ -1,0 +1,26 @@
+# PR 344 Abort Requested Semantics
+
+## Goal
+
+Fix ReviewGPT round 14: an abort endpoint `accepted` response is not replacement-safe when RunnerContainer has lost the local invoke/lifecycle pointer.
+
+## Constraints
+
+- No new state owner or lifecycle operation.
+- Keep exact local-pointer aborts replacement-safe because the Durable Object lifecycle lock still owns the old invoke unwind.
+- Missing-pointer abort delivery must preserve the old durable fence until liveness proves inactive or the container is stopped.
+
+## Approach
+
+- Add an explicit `requested` abort status for missing-pointer endpoint accepted/queued responses.
+- Let UserRunner retry/preserve on `requested`, `stale`, and `failed`.
+- Let UserRunner replace only on local `accepted` or inactive proof.
+
+## Verification
+
+- RunnerContainer status regression for missing-pointer endpoint accepted -> `requested`.
+- UserRunner regression proving foreground does not clear the retention fence until a later inactive proof.
+- Focused Cloudflare runtime tests and typecheck.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-inactive-fence-replacement.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-inactive-fence-replacement.md
@@ -1,0 +1,30 @@
+# PR 344 Inactive Fence Replacement
+
+## Goal
+
+Fix PR 344's stale runtime-fence recovery so a fence with a positively inactive child cannot be preserved indefinitely when committed-progress recovery is unavailable.
+
+## Constraints
+
+- Keep Cloudflare as the execution adapter and web status as recovery truth only when it is conclusively available.
+- Do not add a route, scheduler, persisted state, or second recovery owner.
+- Preserve active or indeterminate liveness as retry-only.
+- Keep direct Durable Object/container RPC call discipline intact.
+
+## Plan
+
+1. Re-read the inactive-fence controller path and tests that currently preserve unknown recovery.
+2. Make confirmed inactive fences clear/replace even when committed-progress recovery is unknown, with command-budget exhaustion clearing the dead fence and retrying for the next ensure.
+3. Update regression tests to prove inactive+unknown cannot preserve the old attempt id.
+4. Run focused Cloudflare tests and typecheck.
+5. Commit and push the PR head for the PR-lane ReviewGPT/CI gates.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runtime-invocation-transport-failure.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-container.test.ts`
+- `pnpm --dir apps/cloudflare typecheck`
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-legacy-null-container-name.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-legacy-null-container-name.md
@@ -1,0 +1,25 @@
+# PR 344 Legacy Null Container Name
+
+## Goal
+
+Fix ReviewGPT round 16: a null persisted active-fence container name must resolve to the legacy unversioned per-user container, not the current versioned fresh-start container.
+
+## Constraints
+
+- Keep fresh starts on the current versioned resolver.
+- Keep persisted non-null container names identity-checked as before.
+- No new state, route, queue, scheduler, or lifecycle owner.
+
+## Approach
+
+- Narrow `readActiveRuntimeRunnerContainerName` so null active-fence names return the legacy `userId` container name.
+- Add a versioned-env UserRunner regression proving retention preemption checks the unversioned legacy container and does not derive inactive proof from the current versioned container.
+
+## Verification
+
+- Focused UserRunner tests.
+- Focused RunnerContainer/runtime transport tests.
+- Cloudflare typecheck.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-abort-result.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-abort-result.md
@@ -1,0 +1,27 @@
+# PR 344 Retention Abort Result
+
+## Goal
+
+Fix the ReviewGPT round 13 foreground-preemption gap where default work can wait behind `inbox_media_retention` if RunnerContainer lost its local active-operation pointer while the child is still active.
+
+## Constraints
+
+- Use the existing identity-checked workspace invocation abort endpoint.
+- Do not add a new scheduler, queue, persisted state, route, or broad lifecycle owner.
+- Preserve fail-closed behavior for stale/mismatched runtime identity.
+- Preserve direct Durable Object RPC calls.
+
+## Approach
+
+- Make `abortWorkspaceInvocation` return a small explicit status.
+- Allow it to post to the existing abort endpoint when the local pointer is missing but the container may still be active.
+- Let UserRunner retention preemption clear/replace only after abort reports an accepted, queued, or inactive-safe outcome.
+
+## Verification
+
+- RunnerContainer abort regression for missing local pointer plus active child.
+- UserRunner foreground-preemption regression for indeterminate liveness plus accepted abort.
+- Focused Cloudflare runtime tests and typecheck.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-container-name-fallback.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-container-name-fallback.md
@@ -1,0 +1,26 @@
+# PR 344 Retention Container Name Fallback
+
+## Goal
+
+Fix ReviewGPT round 15: foreground/default work must not be permanently blocked by a legacy `inbox_media_retention` fence whose `runnerContainerName` is null.
+
+## Constraints
+
+- Reuse the existing active-runtime container-name fallback.
+- Do not add new state, routes, schedulers, or lifecycle owners.
+- Preserve durable authority checks on attempt id, lease generation, and user id.
+
+## Approach
+
+- Export the existing active-runtime container-name resolver from the wake helper.
+- Use it for retention liveness and abort paths before reading `activeFence.runnerContainerName` directly.
+- Add a regression for null `runnerContainerName` retention fences.
+
+## Verification
+
+- Focused UserRunner tests.
+- Focused RunnerContainer/runtime transport tests.
+- Cloudflare typecheck.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-inactive-fence.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-inactive-fence.md
@@ -1,0 +1,28 @@
+# PR 344 Retention Inactive Fence
+
+## Goal
+
+Fix the retention-mode variant where a runtime fence can be proven inactive, then preserved after a later redundant wake path loses that proof.
+
+## Constraints
+
+- Keep the inactive-fence owner singular: confirmed inactive routes through replacement.
+- Do not add a route, persisted state, scheduler, or new recovery abstraction.
+- Preserve active and indeterminate liveness as retry-only.
+
+## Plan
+
+1. Route same-mode `inbox_media_retention` inactive liveness directly to replacement.
+2. Add a focused regression proving the earlier inactive proof is not lost when the wake path would exhaust budget.
+3. Run focused Cloudflare runner tests and typecheck.
+4. Commit and push the PR head.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runtime-invocation-transport-failure.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-container.test.ts`
+- `pnpm --dir apps/cloudflare typecheck`
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-indeterminate-fence.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-retention-indeterminate-fence.md
@@ -1,0 +1,28 @@
+# PR 344 Retention Indeterminate Fence
+
+## Goal
+
+Fix same-mode retention fence handling so indeterminate liveness is retry-only, not reported as an accepted active runner.
+
+## Constraints
+
+- Keep the state model explicit: inactive -> replacement, matching -> accepted, indeterminate -> retry.
+- Do not add persisted state, scheduler, route, manager, or broader recovery abstraction.
+- Preserve the existing inactive replacement path and active matching acceptance path.
+
+## Plan
+
+1. Change the retention branch to accept only `matching`.
+2. Add a focused regression for read-active-liveness failure returning retry with the old fence preserved.
+3. Run focused Cloudflare runner tests and typecheck.
+4. Commit and push the PR head.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runtime-invocation-transport-failure.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-container.test.ts`
+- `pnpm --dir apps/cloudflare typecheck`
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-runtime-fence-liveness-collapse.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-runtime-fence-liveness-collapse.md
@@ -1,0 +1,27 @@
+# PR 344 Runtime Fence Liveness Collapse
+
+## Goal
+
+Collapse duplicated runtime-fence liveness interpretation so stale-fence recovery uses one shared primitive while preserving foreground priority and fail-closed authority behavior.
+
+## Constraints
+
+- No new scheduler, queue, persisted state, route, or ownership layer.
+- Preserve direct Cloudflare Durable Object RPC calls on container stubs.
+- Preserve foreground/default work priority over `inbox_media_retention`.
+- Mismatched runtime identity must not be treated as committed progress for the requested fence.
+
+## Approach
+
+- Add one internal runtime-fence liveness reader/classifier for exact-active, inactive, mismatched, and indeterminate outcomes.
+- Use it from both UserRunner controller recovery and runtime invocation transport-failure recovery.
+- Keep policy decisions in the callers: controller decides retry/replace/preempt; invocation decides preserve/recover/clear.
+
+## Verification
+
+- Focused Cloudflare runtime invocation transport-failure tests.
+- Focused UserRunner alarm/state-machine tests.
+- Cloudflare typecheck.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-pr344-runtime-fence-simplification.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-pr344-runtime-fence-simplification.md
@@ -1,0 +1,30 @@
+# PR 344 Runtime Fence Simplification
+
+## Goal
+
+Fix the remaining PR 344 ReviewGPT findings without adding a new scheduler,
+queue, or preemption service:
+
+- foreground/default runtime work must not wait behind active
+  `inbox_media_retention` work
+- inactive-fence replacement should have one controller owner instead of a
+  separate committed-progress completion branch
+
+## Constraints
+
+- Preserve hosted foreground priority.
+- Keep Cloudflare as the execution adapter, not mailbox/workspace truth owner.
+- Use existing wake and write-fence primitives where possible.
+- Do not add persisted state.
+
+## Plan
+
+1. Use the existing runtime liveness and abort primitive to preempt active
+   retention work for foreground/default requests only.
+2. Collapse inactive-fence replacement by clearing/replacing inactive fences
+   directly instead of asking web status whether they completed first.
+3. Update focused controller tests and hosted runtime protocol docs.
+4. Run focused Cloudflare tests and typecheck.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-inactive-collapse.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-inactive-collapse.md
@@ -1,0 +1,27 @@
+# Runtime Fence Inactive Collapse
+
+## Goal
+
+Collapse confirmed-inactive runtime fence handling so UserRunner owns stale-fence policy directly: inactive means clear/replace by the durable attempt/generation/user identity, while committed-progress recovery stays in the accepted transport-failure path.
+
+## Constraints
+
+- Do not add another recovery owner or retry branch.
+- Preserve fail-closed behavior for mismatched or indeterminate liveness.
+- Preserve exact identity checks before aborting or clearing a fence.
+- Treat an explicit null container-name resolution as rejection, not as permission to fall back to raw persisted state.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts apps/cloudflare/test/runtime-invocation-transport-failure.test.ts apps/cloudflare/test/runner-container.test.ts`
+- `pnpm --dir apps/cloudflare typecheck`
+- `git diff --check`
+- `pnpm test:diff apps/cloudflare/src/user-runner/runtime-processing-controller.ts apps/cloudflare/src/user-runner/diagnostics.ts apps/cloudflare/src/user-runner/runtime-processing-responses.ts apps/cloudflare/test/user-runner-alarm.test.ts agent-docs/references/hosted-runtime-protocol.md`
+
+## State
+
+Implementation verified locally; ready for scoped commit and push.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-legacy-liveness.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-legacy-liveness.md
@@ -1,0 +1,28 @@
+# Runtime Fence Legacy Liveness
+
+## Goal
+
+Fix the remaining PR 344 legacy active-fence gap: every existing active-fence liveness probe should resolve a null persisted runner container name to the legacy unversioned per-user container before deciding whether the fence is inactive, exact-active, mismatched, or indeterminate.
+
+## Constraints
+
+- Fresh starts must still use the current versioned runner container resolver.
+- A resolver-returned null must stay null and fail closed; do not fall back to the raw stored name after resolver rejection.
+- Inactive legacy fences should enter the same inactive recovery/replacement path added by the runtime-fence collapse.
+- Exact-active or indeterminate legacy fences must preserve/retry rather than clear.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts apps/cloudflare/test/runtime-invocation-transport-failure.test.ts apps/cloudflare/test/runner-container.test.ts`
+- `pnpm --dir apps/cloudflare typecheck`
+- `git diff --check`
+- `pnpm test:diff apps/cloudflare/src/user-runner/runtime-processing-controller.ts apps/cloudflare/test/user-runner-alarm.test.ts agent-docs/references/hosted-runtime-protocol.md`
+- PR-lane ReviewGPT after push.
+
+## State
+
+Implementation verified locally; ready for scoped commit, push, and PR-lane ReviewGPT.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-recovery-collapse.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-recovery-collapse.md
@@ -1,0 +1,28 @@
+# Runtime Fence Recovery Collapse
+
+## Goal
+
+Collapse PR 344's runtime-fence recovery logic so inactive active fences have one controller-owned path: prove completion from durable web status when available, otherwise replace the stale fence by identity. Preserve foreground priority, fail closed on ambiguous/mismatched liveness, and avoid new schedulers, queues, or recovery owners.
+
+## Constraints
+
+- `apps/web` remains the source of hosted product/control facts.
+- `apps/cloudflare` remains a thin execution coordinator over write fences and containers.
+- Container liveness is evidence only; it must not own completion policy.
+- Foreground/default work may preempt `inbox_media_retention`; ambiguous active foreground children must be preserved/retried.
+- Prefer deleting split branches and helpers over adding a new state machine.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts apps/cloudflare/test/runtime-invocation-transport-failure.test.ts apps/cloudflare/test/runner-container.test.ts` passed.
+- `pnpm --dir apps/cloudflare typecheck` passed.
+- `pnpm test:diff apps/cloudflare/src/user-runner/runtime-processing-controller.ts apps/cloudflare/src/user-runner/diagnostics.ts apps/cloudflare/src/user-runner/runtime-processing-responses.ts apps/cloudflare/test/user-runner-alarm.test.ts agent-docs/references/hosted-runtime-protocol.md` passed.
+- `git diff --check` passed.
+- PR-lane ReviewGPT after push.
+
+## State
+
+Implementation and local verification complete; PR-lane review pending after push.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-retention-abort.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-runtime-fence-retention-abort.md
@@ -1,0 +1,26 @@
+# Runtime Fence Retention Abort
+
+## Goal
+
+Fix the round 19 retention preemption race: foreground replacement behind an inactive retention fence must first make the exact queued retention attempt unable to run later.
+
+## Constraints
+
+- Reuse the existing identity-checked abort seam.
+- Do not add a new scheduler, queue, or recovery owner.
+- Keep generic inactive-fence replacement simple; only retention-to-foreground preemption needs abort-before-clear.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts apps/cloudflare/test/runtime-invocation-transport-failure.test.ts apps/cloudflare/test/runner-container.test.ts`
+- `pnpm --dir apps/cloudflare typecheck`
+- `git diff --check`
+- `pnpm test:diff apps/cloudflare/src/user-runner/runtime-processing-controller.ts apps/cloudflare/src/user-runner/diagnostics.ts apps/cloudflare/src/user-runner/runtime-processing-responses.ts apps/cloudflare/test/user-runner-alarm.test.ts agent-docs/references/hosted-runtime-protocol.md`
+
+## State
+
+Implementation verified locally; ready for scoped commit and push.
+Status: completed
+Updated: 2026-06-30
+Completed: 2026-06-30

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -174,13 +174,13 @@ Runtime-fence liveness uses one container probe vocabulary: exact-active,
 inactive, mismatched, or indeterminate. The probe only answers whether the
 container still has the requested fence identity in flight. It does not own
 completion or replacement policy: UserRunner maps inactive fences to one
-controller-owned path that first recovers completion from a successful
-web-owned status read when the workspace advanced and mailbox lag is drained,
-otherwise replaces the stale fence by identity. Ambiguous or mismatched
-foreground ownership is preserved/retried. Existing active fences that predate
-persisted container names resolve through the legacy unversioned per-user
-container name for liveness probes; fresh starts still use the current
-versioned container resolver.
+controller-owned path that clears the stale fence by identity and starts a
+replacement when command budget remains. Committed-progress recovery stays in
+the accepted transport-failure path, where the invocation service owns that
+context. Ambiguous or mismatched foreground ownership is preserved/retried.
+Existing active fences that predate persisted container names resolve through
+the legacy unversioned per-user container name for liveness probes; fresh
+starts still use the current versioned container resolver.
 For foreground/default work behind an `inbox_media_retention` fence, the
 existing workspace-invocation abort seam is the preemption authority when
 liveness is ambiguous. A local exact-pointer abort or inactive proof enters the

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -170,6 +170,13 @@ foreground/default work arrives, the runner preempts that exact child through
 the existing container abort seam, clears the old fence by identity, and starts
 foreground work. Retention remains recoverable through the workspace's projected
 retention wake instead of becoming a second scheduler concern.
+Runtime-fence liveness uses one container probe vocabulary: exact-active,
+inactive, mismatched, or indeterminate. The probe only answers whether the
+container still has the requested fence identity in flight. It does not own
+completion or replacement policy: UserRunner maps inactive fences to the
+existing clear-and-start path, preserves or retries ambiguous/mismatched
+foreground ownership, and keeps transport-failure committed-progress recovery
+limited to the exact accepted attempt.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -411,12 +411,14 @@ keeps its fence so wakes keep routing to the live invocation. If that accepted
 attempt has no durable committed progress yet and the local active-operation
 pointer is missing, the fence is preserved for the next identity-aware wake
 recheck instead of being cleared from the pointer alone; only the wake path may
-then replace the fence after it explicitly reports no active child. Mismatched
-liveness probes clear the fence because they prove the active child is not the
-fenced attempt; unsupported, error, timeout, and inactive probe outcomes preserve
-the accepted fence when durable progress is not visible yet. This prevents
-duplicate replacement while a live child may still be running and leaves
-replacement ownership in the exact identity-aware wake path.
+then replace the fence after it explicitly reports no active child. Inactive
+liveness is explicit no-active-child proof, so committed-progress recovery is a
+best-effort completion fast path before replacement rather than a dependency for
+clearing the fence. Mismatched liveness probes clear the fence because they prove
+the active child is not the fenced attempt; unsupported, error, and timeout probe
+outcomes preserve the accepted fence when durable progress is not visible yet.
+This prevents duplicate replacement while a live child may still be running and
+leaves replacement ownership in the exact identity-aware wake path.
 When the outer RunnerContainer active-operation pointer is missing, a container
 wake response must carry explicit identity-checked wake metadata before an
 accepted wake is trusted; identity-blind accepted responses from deploy-skewed

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -177,6 +177,11 @@ completion or replacement policy: UserRunner maps inactive fences to the
 existing clear-and-start path, preserves or retries ambiguous/mismatched
 foreground ownership, and keeps transport-failure committed-progress recovery
 limited to the exact accepted attempt.
+For foreground/default work behind an `inbox_media_retention` fence, the
+existing workspace-invocation abort seam is the preemption authority when
+liveness is ambiguous: accepted, queued, or inactive abort status permits the
+durable fence CAS replacement; stale or failed status preserves the fence and
+retries.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -179,9 +179,10 @@ foreground ownership, and keeps transport-failure committed-progress recovery
 limited to the exact accepted attempt.
 For foreground/default work behind an `inbox_media_retention` fence, the
 existing workspace-invocation abort seam is the preemption authority when
-liveness is ambiguous: accepted, queued, or inactive abort status permits the
-durable fence CAS replacement; stale or failed status preserves the fence and
-retries.
+liveness is ambiguous. A local exact-pointer abort or inactive proof permits
+the durable fence CAS replacement; missing-pointer abort delivery is only an
+abort request and preserves the fence until a later liveness pass proves the
+old child inactive. Stale or failed status preserves the fence and retries.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -183,11 +183,14 @@ the legacy unversioned per-user container name for liveness probes; fresh
 starts still use the current versioned container resolver.
 For foreground/default work behind an `inbox_media_retention` fence, the
 existing workspace-invocation abort seam is the preemption authority when
-liveness is ambiguous. A local exact-pointer abort or inactive proof enters the
-same inactive-fence recovery/replacement path; missing-pointer abort delivery
-is only an abort request and preserves the fence until a later liveness pass
-proves the old child inactive. Stale or failed status preserves the fence and
-retries.
+liveness is ambiguous. A local exact-pointer abort enters the same
+inactive-fence replacement path. An inactive liveness proof must still send the
+identity-checked abort first so any queued exact retention invocation is
+canceled before the fence is cleared; an inactive result or queued matching
+abort is replacement-safe. Missing-pointer abort delivery without inactive
+proof is only an abort request and preserves the fence until a later liveness
+pass proves the old child inactive. Stale or failed status preserves the fence
+and retries.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -165,6 +165,11 @@ carry forward the maintenance wake, dirty state, or retry metadata needed to
 finish later, but assistant admission, assistant automation, outbox intent
 creation, and reply delivery must stay independent of device-sync and
 maintenance completion.
+If an `inbox_media_retention` invocation is the active write-fenced child when
+foreground/default work arrives, the runner preempts that exact child through
+the existing container abort seam, clears the old fence by identity, and starts
+foreground work. Retention remains recoverable through the workspace's projected
+retention wake instead of becoming a second scheduler concern.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and
@@ -412,11 +417,13 @@ attempt has no durable committed progress yet and the local active-operation
 pointer is missing, the fence is preserved for the next identity-aware wake
 recheck instead of being cleared from the pointer alone; only the wake path may
 then replace the fence after it explicitly reports no active child. Inactive
-liveness is explicit no-active-child proof, so committed-progress recovery is a
-best-effort completion fast path before replacement rather than a dependency for
-clearing the fence. Mismatched liveness probes clear the fence because they prove
-the active child is not the fenced attempt; unsupported, error, and timeout probe
-outcomes preserve the accepted fence when durable progress is not visible yet.
+liveness is explicit no-active-child proof, so the controller clears and
+replaces that fence directly instead of asking web status to complete it first.
+Committed-progress recovery stays in the transport-failure adapter, where the
+transport outcome is the thing being reconciled. Mismatched liveness probes
+clear the fence because they prove the active child is not the fenced attempt;
+unsupported, error, and timeout probe outcomes preserve the accepted fence when
+durable progress is not visible yet.
 This prevents duplicate replacement while a live child may still be running and
 leaves replacement ownership in the exact identity-aware wake path.
 When the outer RunnerContainer active-operation pointer is missing, a container

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -173,20 +173,21 @@ retention wake instead of becoming a second scheduler concern.
 Runtime-fence liveness uses one container probe vocabulary: exact-active,
 inactive, mismatched, or indeterminate. The probe only answers whether the
 container still has the requested fence identity in flight. It does not own
-completion or replacement policy: UserRunner maps inactive fences to the
-existing clear-and-start path, preserves or retries ambiguous/mismatched
-foreground ownership, and keeps transport-failure committed-progress recovery
-limited to the exact accepted attempt.
+completion or replacement policy: UserRunner maps inactive fences to one
+controller-owned path that first recovers completion from a successful
+web-owned status read when the workspace advanced and mailbox lag is drained,
+otherwise replaces the stale fence by identity. Ambiguous or mismatched
+foreground ownership is preserved/retried.
 For foreground/default work behind an `inbox_media_retention` fence, the
 existing workspace-invocation abort seam is the preemption authority when
 liveness is ambiguous. This foreground-over-retention path uses the same
 legacy unversioned per-user runner container-name fallback as active wake for
 fences that predate persisted container names; fresh starts still use the
 current versioned container resolver. A local exact-pointer abort or inactive
-proof permits the durable fence CAS replacement; missing-pointer abort delivery
-is only an abort request and preserves the fence until a later liveness pass
-proves the old child inactive. Stale or failed status preserves the fence and
-retries.
+proof enters the same inactive-fence recovery/replacement path; missing-pointer
+abort delivery is only an abort request and preserves the fence until a later
+liveness pass proves the old child inactive. Stale or failed status preserves
+the fence and retries.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -179,10 +179,13 @@ foreground ownership, and keeps transport-failure committed-progress recovery
 limited to the exact accepted attempt.
 For foreground/default work behind an `inbox_media_retention` fence, the
 existing workspace-invocation abort seam is the preemption authority when
-liveness is ambiguous. A local exact-pointer abort or inactive proof permits
-the durable fence CAS replacement; missing-pointer abort delivery is only an
-abort request and preserves the fence until a later liveness pass proves the
-old child inactive. Stale or failed status preserves the fence and retries.
+liveness is ambiguous. This foreground-over-retention path uses the same
+deterministic per-user runner container-name fallback as active wake for legacy
+fences that predate persisted container names. A local exact-pointer abort or
+inactive proof permits the durable fence CAS replacement; missing-pointer abort
+delivery is only an abort request and preserves the fence until a later
+liveness pass proves the old child inactive. Stale or failed status preserves
+the fence and retries.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -180,12 +180,13 @@ limited to the exact accepted attempt.
 For foreground/default work behind an `inbox_media_retention` fence, the
 existing workspace-invocation abort seam is the preemption authority when
 liveness is ambiguous. This foreground-over-retention path uses the same
-deterministic per-user runner container-name fallback as active wake for legacy
-fences that predate persisted container names. A local exact-pointer abort or
-inactive proof permits the durable fence CAS replacement; missing-pointer abort
-delivery is only an abort request and preserves the fence until a later
-liveness pass proves the old child inactive. Stale or failed status preserves
-the fence and retries.
+legacy unversioned per-user runner container-name fallback as active wake for
+fences that predate persisted container names; fresh starts still use the
+current versioned container resolver. A local exact-pointer abort or inactive
+proof permits the durable fence CAS replacement; missing-pointer abort delivery
+is only an abort request and preserves the fence until a later liveness pass
+proves the old child inactive. Stale or failed status preserves the fence and
+retries.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -177,17 +177,17 @@ completion or replacement policy: UserRunner maps inactive fences to one
 controller-owned path that first recovers completion from a successful
 web-owned status read when the workspace advanced and mailbox lag is drained,
 otherwise replaces the stale fence by identity. Ambiguous or mismatched
-foreground ownership is preserved/retried.
+foreground ownership is preserved/retried. Existing active fences that predate
+persisted container names resolve through the legacy unversioned per-user
+container name for liveness probes; fresh starts still use the current
+versioned container resolver.
 For foreground/default work behind an `inbox_media_retention` fence, the
 existing workspace-invocation abort seam is the preemption authority when
-liveness is ambiguous. This foreground-over-retention path uses the same
-legacy unversioned per-user runner container-name fallback as active wake for
-fences that predate persisted container names; fresh starts still use the
-current versioned container resolver. A local exact-pointer abort or inactive
-proof enters the same inactive-fence recovery/replacement path; missing-pointer
-abort delivery is only an abort request and preserves the fence until a later
-liveness pass proves the old child inactive. Stale or failed status preserves
-the fence and retries.
+liveness is ambiguous. A local exact-pointer abort or inactive proof enters the
+same inactive-fence recovery/replacement path; missing-pointer abort delivery
+is only an abort request and preserves the fence until a later liveness pass
+proves the old child inactive. Stale or failed status preserves the fence and
+retries.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -200,7 +200,7 @@ export interface HostedExecutionContainerStubLike {
     attemptId: string;
     leaseGeneration: string;
     userId: string;
-  }): Promise<void>;
+  }): Promise<RunnerWorkspaceInvocationAbortStatus>;
   destroyInstance(): Promise<void>;
   ensureReadyForProcessing?(
     input: RunnerContainerEnsureReadyForProcessingInput,
@@ -236,11 +236,15 @@ type RunnerContainerStartObservation =
   | "deploy-smoke-ready"
   | "onStart";
 
-type RunnerWorkspaceInvocationAbortPostStatus =
+export type RunnerWorkspaceInvocationAbortStatus =
   | "accepted"
   | "failed"
+  | "inactive"
   | "queued"
   | "stale";
+
+type RunnerWorkspaceInvocationAbortPostStatus =
+  Exclude<RunnerWorkspaceInvocationAbortStatus, "inactive">;
 
 type RunnerContainerDestroyReason =
   | "activity-expired"
@@ -477,18 +481,18 @@ export class RunnerContainer extends Container {
     attemptId: string;
     leaseGeneration: string;
     userId: string;
-  }): Promise<void> {
+  }): Promise<RunnerWorkspaceInvocationAbortStatus> {
     const active = this.workspaceInvocationActiveOperation;
     const abortController = this.workspaceInvocationAbortController;
     if (!active || !abortController) {
-      return;
+      return await this.abortWorkspaceInvocationWithoutLocalPointer(input);
     }
     if (
       active.attemptId !== input.attemptId
       || active.leaseGeneration !== input.leaseGeneration
       || active.userId !== input.userId
     ) {
-      return;
+      return "stale";
     }
     if (this.workspaceInvocationAbortEndpointReady) {
       await this.postWorkspaceInvocationAbort(input);
@@ -509,11 +513,12 @@ export class RunnerContainer extends Container {
         failClosed: true,
         reason: "invoke-failure",
       });
-      return;
+      return "accepted";
     }
     if (!abortController.signal.aborted) {
       abortController.abort(new Error(WORKSPACE_INVOCATION_PREEMPTED_ABORT_MESSAGE));
     }
+    return "accepted";
   }
 
   async ensureProcessing(input: RunnerContainerEnsureProcessingInput): Promise<RunnerContainerEnsureProcessingResult> {
@@ -1277,6 +1282,18 @@ export class RunnerContainer extends Container {
     this.workspaceInvocationAbortEndpointReady = false;
     this.workspaceInvocationActiveOperation = null;
     this.workspaceInvocationAbortController = null;
+  }
+
+  private async abortWorkspaceInvocationWithoutLocalPointer(input: {
+    attemptId: string;
+    leaseGeneration: string;
+    userId: string;
+  }): Promise<RunnerWorkspaceInvocationAbortStatus> {
+    const status = await readRunnerContainerStatus(this);
+    if (isRunnerContainerStopped(status)) {
+      return "inactive";
+    }
+    return await this.postWorkspaceInvocationAbort(input);
   }
 
   private async postWorkspaceInvocationAbort(input: {

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -423,6 +423,13 @@ export class RunnerContainer extends Container {
   async readActiveRuntimeUserFence(): Promise<WorkerActiveRuntimeUserFenceResult> {
     const active = this.workspaceInvocationActiveOperation;
     if (!active) {
+      const status = readContainerStatus(await this.getState());
+      if (!isRunnerContainerStopped(status)) {
+        const activeInContainer = await this.readWorkspaceInvocationActiveFromHealth();
+        if (activeInContainer) {
+          throw new Error("Hosted runner container health still reports active workspace work.");
+        }
+      }
       return { active: false, reason: "no_active_runtime" };
     }
 

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -241,10 +241,11 @@ export type RunnerWorkspaceInvocationAbortStatus =
   | "failed"
   | "inactive"
   | "queued"
+  | "requested"
   | "stale";
 
 type RunnerWorkspaceInvocationAbortPostStatus =
-  Exclude<RunnerWorkspaceInvocationAbortStatus, "inactive">;
+  Exclude<RunnerWorkspaceInvocationAbortStatus, "inactive" | "requested">;
 
 type RunnerContainerDestroyReason =
   | "activity-expired"
@@ -1293,7 +1294,10 @@ export class RunnerContainer extends Container {
     if (isRunnerContainerStopped(status)) {
       return "inactive";
     }
-    return await this.postWorkspaceInvocationAbort(input);
+    const abortStatus = await this.postWorkspaceInvocationAbort(input);
+    return abortStatus === "accepted" || abortStatus === "queued"
+      ? "requested"
+      : abortStatus;
   }
 
   private async postWorkspaceInvocationAbort(input: {

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -423,7 +423,7 @@ export class RunnerContainer extends Container {
   async readActiveRuntimeUserFence(): Promise<WorkerActiveRuntimeUserFenceResult> {
     const active = this.workspaceInvocationActiveOperation;
     if (!active) {
-      const status = readContainerStatus(await this.getState());
+      const status = await readRunnerContainerStatus(this);
       if (!isRunnerContainerStopped(status)) {
         const activeInContainer = await this.readWorkspaceInvocationActiveFromHealth();
         if (activeInContainer) {

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -434,19 +434,10 @@ export class RunnerContainer extends Container {
     }
 
     if (this.workspaceInvocationActiveOperationPreservedAfterTransportFailure) {
-      let activeInContainer = true;
-      try {
-        activeInContainer = await this.readWorkspaceInvocationActiveFromHealth();
-      } catch {
-        activeInContainer = true;
-      }
+      const activeInContainer =
+        await this.readPreservedWorkspaceInvocationActiveFromContainer();
       if (!activeInContainer) {
-        if (this.workspaceInvocationActiveOperation === active) {
-          this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
-          this.workspaceInvocationAbortEndpointReady = false;
-          this.workspaceInvocationActiveOperation = null;
-          this.workspaceInvocationAbortController = null;
-        }
+        this.clearPreservedWorkspaceInvocationActiveOperation(active);
         return { active: false, reason: "no_active_runtime" };
       }
     }
@@ -595,19 +586,10 @@ export class RunnerContainer extends Container {
     }
 
     if (active && this.workspaceInvocationActiveOperationPreservedAfterTransportFailure) {
-      let activeInContainer = true;
-      try {
-        activeInContainer = await this.readWorkspaceInvocationActiveFromHealth();
-      } catch {
-        activeInContainer = true;
-      }
+      const activeInContainer =
+        await this.readPreservedWorkspaceInvocationActiveFromContainer();
       if (!activeInContainer) {
-        if (this.workspaceInvocationActiveOperation === active) {
-          this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
-          this.workspaceInvocationAbortEndpointReady = false;
-          this.workspaceInvocationActiveOperation = null;
-          this.workspaceInvocationAbortController = null;
-        }
+        this.clearPreservedWorkspaceInvocationActiveOperation(active);
         return { kind: "not-wakeable", reason: "no-active-child" };
       }
     }
@@ -1271,6 +1253,30 @@ export class RunnerContainer extends Container {
       throw new Error("Hosted runner container health did not include a valid active job count.");
     }
     return payload.activeJobCount > 0;
+  }
+
+  private async readPreservedWorkspaceInvocationActiveFromContainer(): Promise<boolean> {
+    try {
+      return await this.readWorkspaceInvocationActiveFromHealth();
+    } catch (error) {
+      const status = await readRunnerContainerStatus(this);
+      if (isRunnerContainerStopped(status)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private clearPreservedWorkspaceInvocationActiveOperation(
+    active: RunnerActiveOperationRecord,
+  ): void {
+    if (this.workspaceInvocationActiveOperation !== active) {
+      return;
+    }
+    this.workspaceInvocationActiveOperationPreservedAfterTransportFailure = false;
+    this.workspaceInvocationAbortEndpointReady = false;
+    this.workspaceInvocationActiveOperation = null;
+    this.workspaceInvocationAbortController = null;
   }
 
   private async postWorkspaceInvocationAbort(input: {

--- a/apps/cloudflare/src/user-runner/diagnostics.ts
+++ b/apps/cloudflare/src/user-runner/diagnostics.ts
@@ -15,6 +15,7 @@ import { readRunnerNextAlarmAt } from "./alarm-coordinator.js";
 
 export type RuntimeProcessingRetryReason =
   | "active_child_rejected"
+  | "completed_fence_recovered"
   | "container_busy"
   | "container_rpc_error"
   | "container_rpc_timeout"

--- a/apps/cloudflare/src/user-runner/diagnostics.ts
+++ b/apps/cloudflare/src/user-runner/diagnostics.ts
@@ -15,7 +15,6 @@ import { readRunnerNextAlarmAt } from "./alarm-coordinator.js";
 
 export type RuntimeProcessingRetryReason =
   | "active_child_rejected"
-  | "completed_fence_recovered"
   | "container_busy"
   | "container_rpc_error"
   | "container_rpc_timeout"

--- a/apps/cloudflare/src/user-runner/runtime-container-wake.ts
+++ b/apps/cloudflare/src/user-runner/runtime-container-wake.ts
@@ -175,10 +175,7 @@ export function readActiveRuntimeRunnerContainerName(input: {
   runnerRuntimeEnvSource: Readonly<Record<string, unknown>>;
 }): string | null {
   if (!input.runnerContainerName) {
-    return resolveHostedExecutionRunnerContainerName({
-      source: input.runnerRuntimeEnvSource,
-      userId: input.activeRuntime.userId,
-    });
+    return input.activeRuntime.userId;
   }
 
   const identity = readHostedRunnerContainerIdentity({

--- a/apps/cloudflare/src/user-runner/runtime-container-wake.ts
+++ b/apps/cloudflare/src/user-runner/runtime-container-wake.ts
@@ -169,7 +169,7 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function readActiveRuntimeRunnerContainerName(input: {
+export function readActiveRuntimeRunnerContainerName(input: {
   activeRuntime: RunnerRuntimeWakeInput;
   runnerContainerName: string | null;
   runnerRuntimeEnvSource: Readonly<Record<string, unknown>>;

--- a/apps/cloudflare/src/user-runner/runtime-fence-liveness.ts
+++ b/apps/cloudflare/src/user-runner/runtime-fence-liveness.ts
@@ -1,0 +1,134 @@
+import type {
+  HostedExecutionContainerNamespaceLike,
+} from "../runner-container.js";
+import type {
+  WorkerActiveRuntimeUserFenceResult,
+} from "../worker-contracts.js";
+import {
+  isRuntimeProcessingCommandBudgetTimeout,
+  runRuntimeProcessingCommandStep,
+  type RuntimeProcessingCommandBudget,
+} from "./runtime-command-budget.js";
+
+export type RuntimeFenceLivenessIdentity = {
+  attemptId: string;
+  leaseGeneration: string;
+  userId: string;
+};
+
+export type RuntimeFenceLivenessReadResult =
+  | {
+      outcome: "exact-active";
+    }
+  | {
+      outcome: "inactive";
+    }
+  | {
+      outcome: "mismatch";
+    }
+  | {
+      error?: unknown;
+      outcome: "indeterminate";
+      reason:
+        | "error"
+        | "missing_container_binding"
+        | "missing_container_name"
+        | "timeout"
+        | "unsupported";
+    };
+
+export function classifyRuntimeFenceLiveness(input: {
+  activeRuntime: WorkerActiveRuntimeUserFenceResult;
+  identity: RuntimeFenceLivenessIdentity;
+}): RuntimeFenceLivenessReadResult {
+  const { activeRuntime, identity } = input;
+  if (!activeRuntime.active) {
+    return { outcome: "inactive" };
+  }
+  return activeRuntime.attemptId === identity.attemptId
+    && activeRuntime.leaseGeneration === identity.leaseGeneration
+    && activeRuntime.userId === identity.userId
+    ? { outcome: "exact-active" }
+    : { outcome: "mismatch" };
+}
+
+export async function readRuntimeFenceLivenessBestEffort(input: {
+  commandBudget?: RuntimeProcessingCommandBudget | null;
+  identity: RuntimeFenceLivenessIdentity;
+  runnerContainerName: string | null | undefined;
+  runnerContainerNamespace: HostedExecutionContainerNamespaceLike | null;
+  stepTimeoutMs: number;
+}): Promise<RuntimeFenceLivenessReadResult> {
+  if (!input.runnerContainerNamespace) {
+    return {
+      outcome: "indeterminate",
+      reason: "missing_container_binding",
+    };
+  }
+  if (!input.runnerContainerName) {
+    return {
+      outcome: "indeterminate",
+      reason: "missing_container_name",
+    };
+  }
+
+  const container = input.runnerContainerNamespace.getByName(
+    input.runnerContainerName,
+  );
+  if (!container.readActiveRuntimeUserFence) {
+    return {
+      outcome: "indeterminate",
+      reason: "unsupported",
+    };
+  }
+
+  try {
+    const activeRuntime = input.commandBudget
+      ? await runRuntimeProcessingCommandStep({
+          budget: input.commandBudget,
+          operation: async () => await container.readActiveRuntimeUserFence!(),
+          stepTimeoutMs: input.stepTimeoutMs,
+        })
+      : await readRuntimeFenceLivenessWithTimeout({
+          operation: async () => await container.readActiveRuntimeUserFence!(),
+          timeoutMs: input.stepTimeoutMs,
+        });
+    if (!activeRuntime) {
+      return {
+        outcome: "indeterminate",
+        reason: "timeout",
+      };
+    }
+    return classifyRuntimeFenceLiveness({
+      activeRuntime,
+      identity: input.identity,
+    });
+  } catch (error) {
+    return {
+      error,
+      outcome: "indeterminate",
+      reason: isRuntimeProcessingCommandBudgetTimeout(error)
+        ? "timeout"
+        : "error",
+    };
+  }
+}
+
+async function readRuntimeFenceLivenessWithTimeout(input: {
+  operation: () => Promise<WorkerActiveRuntimeUserFenceResult>;
+  timeoutMs: number;
+}): Promise<WorkerActiveRuntimeUserFenceResult | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      input.operation(),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), input.timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -444,7 +444,7 @@ export class RuntimeInvocationService {
         : await readStatus();
     } catch (error) {
       if (isRuntimeProcessingCommandBudgetTimeout(error)) {
-        return { kind: "not_completed" };
+        return { kind: "unknown" };
       }
       emitHostedExecutionStructuredLog({
         component: "hosted.runner",

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -265,7 +265,11 @@ export class RuntimeInvocationService {
 
       const livenessIndeterminate =
         probeOutcome === "error" || probeOutcome === "timeout";
-      if (input.acceptedProcessingAttempt && !livenessIndeterminate) {
+      if (
+        input.acceptedProcessingAttempt
+        && !livenessIndeterminate
+        && probeOutcome !== "mismatch"
+      ) {
         const committedResult =
           await this.recoverAcceptedRuntimeCompletionFromCommittedProgress({
             executionInput,

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -369,6 +369,7 @@ export class RuntimeInvocationService {
   }
 
   async recoverAcceptedRuntimeCompletionFromCommittedProgress(input: {
+    commandBudget?: RuntimeProcessingCommandBudget;
     executionInput: RuntimeInvocationInput;
     token: RunnerWriteFenceToken;
     transportError?: unknown;
@@ -379,6 +380,7 @@ export class RuntimeInvocationService {
     }
     const committedResult =
       await this.readAcceptedRuntimeCommittedProgressAfterTransportFailure({
+        commandBudget: input.commandBudget ?? null,
         executionInput: input.executionInput,
         workspaceVersion: input.workspaceVersion,
       });
@@ -421,15 +423,27 @@ export class RuntimeInvocationService {
   }
 
   private async readAcceptedRuntimeCommittedProgressAfterTransportFailure(input: {
+    commandBudget: RuntimeProcessingCommandBudget | null;
     executionInput: RuntimeInvocationInput;
     workspaceVersion: string;
   }): Promise<AcceptedRuntimeCompletionRecoveryResult> {
     let status: HostedRuntimeWebStatusResponse;
     try {
-      status = await this.input.readHostedRuntimeStatusFromWeb(
-        input.executionInput.userId,
-      );
+      const readStatus = async () =>
+        await this.input.readHostedRuntimeStatusFromWeb(
+          input.executionInput.userId,
+        );
+      status = input.commandBudget
+        ? await runRuntimeProcessingCommandStep({
+            budget: input.commandBudget,
+            operation: readStatus,
+            stepTimeoutMs: this.input.env.webControlTimeoutMs,
+          })
+        : await readStatus();
     } catch (error) {
+      if (isRuntimeProcessingCommandBudgetTimeout(error)) {
+        return { kind: "not_completed" };
+      }
       emitHostedExecutionStructuredLog({
         component: "hosted.runner",
         details: {

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -263,7 +263,9 @@ export class RuntimeInvocationService {
         throw error;
       }
 
-      if (input.acceptedProcessingAttempt) {
+      const livenessIndeterminate =
+        probeOutcome === "error" || probeOutcome === "timeout";
+      if (input.acceptedProcessingAttempt && !livenessIndeterminate) {
         const committedResult =
           await this.recoverAcceptedRuntimeCompletionFromCommittedProgress({
             executionInput,
@@ -277,32 +279,32 @@ export class RuntimeInvocationService {
         if (committedResult.kind === "unknown") {
           throw error;
         }
-        if (probeOutcome !== "mismatch") {
-          await this.recordAcceptedRuntimeAttemptFailureBestEffort({
-            error,
-            executionInput,
-            fenceCleared: false,
-            probeOutcome,
-            token,
+      }
+      if (input.acceptedProcessingAttempt && probeOutcome !== "mismatch") {
+        await this.recordAcceptedRuntimeAttemptFailureBestEffort({
+          error,
+          executionInput,
+          fenceCleared: false,
+          probeOutcome,
+          token,
+          workspaceVersion,
+        });
+        emitHostedExecutionStructuredLog({
+          component: "hosted.runner",
+          details: {
+            ...buildHostedRunnerMetadataOnlyErrorDetails(error),
+            orchestrationAttemptId: executionInput.orchestrationAttemptId,
+            transportFailureFenceCleared: false,
+            workspaceAttemptId: token.attemptId,
             workspaceVersion,
-          });
-          emitHostedExecutionStructuredLog({
-            component: "hosted.runner",
-            details: {
-              ...buildHostedRunnerMetadataOnlyErrorDetails(error),
-              orchestrationAttemptId: executionInput.orchestrationAttemptId,
-              transportFailureFenceCleared: false,
-              workspaceAttemptId: token.attemptId,
-              workspaceVersion,
-            },
-            level: "warn",
-            message:
-            "Hosted runner accepted runtime transport failed before committed progress was visible; preserving the write fence for identity-aware wake recovery.",
-            phase: "failed",
-            userId: executionInput.userId,
-          });
-          throw error;
-        }
+          },
+          level: "warn",
+          message:
+          "Hosted runner accepted runtime transport failed before committed progress was visible; preserving the write fence for identity-aware wake recovery.",
+          phase: "failed",
+          userId: executionInput.userId,
+        });
+        throw error;
       }
 
       const failed = await this.input.stateStore.clearWriteFenceAfterTransportFailure({

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -62,6 +62,9 @@ import {
   readRuntimeProcessingCommandStepTimeoutMs,
   runRuntimeProcessingCommandStep,
 } from "./runtime-command-budget.js";
+import {
+  readRuntimeFenceLivenessBestEffort,
+} from "./runtime-fence-liveness.js";
 import type { RunnerWriteFenceToken } from "./runner-state-store.js";
 import { RunnerStateStore } from "./runner-state-store.js";
 import type { RunnerStateRecord } from "./types.js";
@@ -802,54 +805,43 @@ export class RuntimeInvocationService {
   private async readPreparedAttemptLivenessBestEffort(
     prepared: PreparedRuntimeInvocation,
   ): Promise<RuntimeAttemptLivenessProbeOutcome> {
-    const namespace = this.input.runnerContainerNamespace;
-    if (!namespace) {
-      return "unsupported";
-    }
-    let probeTimer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      const container = namespace.getByName(prepared.runnerContainerName);
-      if (!container.readActiveRuntimeUserFence) {
-        return "unsupported";
-      }
-      const active = await Promise.race([
-        container.readActiveRuntimeUserFence(),
-        new Promise<null>((resolve) => {
-          probeTimer = setTimeout(
-            () => resolve(null),
-            RUNTIME_ATTEMPT_LIVENESS_PROBE_TIMEOUT_MS,
-          );
-        }),
-      ]);
-      if (active === null) {
-        this.emitAttemptLivenessProbeUnconfirmedLog({
-          prepared,
-          probeOutcome: "timeout",
-        });
-        return "timeout";
-      }
-      if (!active.active) {
-        return "inactive";
-      }
-      return active.userId === prepared.input.userId
-        && active.attemptId === prepared.token.attemptId
+    const liveness = await readRuntimeFenceLivenessBestEffort({
+      commandBudget: null,
+      identity: {
+        attemptId: prepared.token.attemptId,
         // The container records the generation from the job request; compare
         // against that single source of truth.
-        && active.leaseGeneration === prepared.job.request.leaseGeneration
-        ? "active"
-        : "mismatch";
-    } catch (error) {
+        leaseGeneration: prepared.job.request.leaseGeneration,
+        userId: prepared.input.userId,
+      },
+      runnerContainerName: prepared.runnerContainerName,
+      runnerContainerNamespace: this.input.runnerContainerNamespace,
+      stepTimeoutMs: RUNTIME_ATTEMPT_LIVENESS_PROBE_TIMEOUT_MS,
+    });
+    if (liveness.outcome === "exact-active") {
+      return "active";
+    }
+    if (liveness.outcome === "inactive" || liveness.outcome === "mismatch") {
+      return liveness.outcome;
+    }
+
+    if (liveness.reason === "timeout") {
       this.emitAttemptLivenessProbeUnconfirmedLog({
-        error,
+        ...(liveness.error !== undefined ? { error: liveness.error } : {}),
+        prepared,
+        probeOutcome: "timeout",
+      });
+      return "timeout";
+    }
+    if (liveness.reason === "error") {
+      this.emitAttemptLivenessProbeUnconfirmedLog({
+        ...(liveness.error !== undefined ? { error: liveness.error } : {}),
         prepared,
         probeOutcome: "error",
       });
       return "error";
-    } finally {
-      if (probeTimer !== undefined) {
-        clearTimeout(probeTimer);
-      }
     }
+    return "unsupported";
   }
 
   private emitAttemptLivenessProbeUnconfirmedLog(input: {

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -265,7 +265,7 @@ export class RuntimeInvocationService {
 
       if (input.acceptedProcessingAttempt) {
         const committedResult =
-          await this.recoverAcceptedRuntimeCompletionAfterTransportFailure({
+          await this.recoverAcceptedRuntimeCompletionFromCommittedProgress({
             executionInput,
             transportError: error,
             token,
@@ -368,7 +368,7 @@ export class RuntimeInvocationService {
     return result;
   }
 
-  async recoverAcceptedRuntimeCompletionAfterTransportFailure(input: {
+  async recoverAcceptedRuntimeCompletionFromCommittedProgress(input: {
     executionInput: RuntimeInvocationInput;
     token: RunnerWriteFenceToken;
     transportError?: unknown;
@@ -408,7 +408,9 @@ export class RuntimeInvocationService {
         workspaceVersion: input.workspaceVersion,
       },
       level: "warn",
-      message: "Hosted runner accepted runtime attempt committed progress despite transport failure.",
+      message: input.transportError === undefined
+        ? "Hosted runner accepted runtime attempt committed progress; completing the active write fence."
+        : "Hosted runner accepted runtime attempt committed progress despite transport failure.",
       phase: "checkpoint",
       userId: input.executionInput.userId,
     });

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -240,16 +240,24 @@ export class RuntimeProcessingController {
           commandBudget: input.commandBudget,
           record,
         });
-      if (activeRuntimeState !== "inactive") {
-        await this.syncRunnerAlarm(record);
-        return {
-          action: "already_running",
-          kind: "runtime_processing_accepted",
-          recommendedRecheckAt:
-            this.computeRuntimeProcessingOwnerRecheckAt(),
-          runtimeAttemptId: activeFence.attemptId,
-        };
+      if (activeRuntimeState === "inactive") {
+        return await this.replaceStartRequiredRuntimeFence({
+          activeFence,
+          commandBudget: input.commandBudget,
+          input: input.input,
+          record,
+          runtimeWakeStartedAt: input.runtimeWakeStartedAt,
+        });
       }
+
+      await this.syncRunnerAlarm(record);
+      return {
+        action: "already_running",
+        kind: "runtime_processing_accepted",
+        recommendedRecheckAt:
+          this.computeRuntimeProcessingOwnerRecheckAt(),
+        runtimeAttemptId: activeFence.attemptId,
+      };
     }
 
     const activeWakeStartedAtEpochMs = Date.now();

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -301,14 +301,23 @@ export class RuntimeProcessingController {
       });
     }
 
-    const recoveredCompletion =
-      await this.recoverActiveRuntimeFenceCompletion({
+    const activeRuntimeState =
+      await this.readActiveRuntimeFenceWithoutWake({
         activeFence,
-        input: inputAfterActiveWake,
+        commandBudget: input.commandBudget,
         record,
       });
-    if (recoveredCompletion.kind === "completed") {
-      return this.createActiveRuntimeFenceCompletionResponse(activeFence);
+    if (activeRuntimeState === "inactive") {
+      const recoveredCompletion =
+        await this.recoverActiveRuntimeFenceCompletion({
+          activeFence,
+          commandBudget: input.commandBudget,
+          input: inputAfterActiveWake,
+          record,
+        });
+      if (recoveredCompletion.kind === "completed") {
+        return this.createActiveRuntimeFenceCompletionResponse(activeFence);
+      }
     }
 
     await this.syncRunnerAlarm(record);
@@ -337,6 +346,7 @@ export class RuntimeProcessingController {
     const recoveredCompletion =
       await this.recoverActiveRuntimeFenceCompletion({
         activeFence,
+        commandBudget: input.commandBudget,
         input: input.input,
         record,
       });
@@ -390,6 +400,7 @@ export class RuntimeProcessingController {
 
   private async recoverActiveRuntimeFenceCompletion(input: {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
+    commandBudget: RuntimeProcessingCommandBudget;
     input: RuntimeProcessingInput;
     record: RunnerStateRecord;
   }): Promise<AcceptedRuntimeCompletionRecoveryResult> {
@@ -409,6 +420,7 @@ export class RuntimeProcessingController {
         userId: record.userId,
         workspaceVersion: activeFence.workspaceVersion,
       },
+      commandBudget: input.commandBudget,
       workspaceVersion: activeFence.workspaceVersion,
     });
   }

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -308,16 +308,13 @@ export class RuntimeProcessingController {
         record,
       });
     if (activeRuntimeState === "inactive") {
-      const recoveredCompletion =
-        await this.recoverActiveRuntimeFenceCompletion({
-          activeFence,
-          commandBudget: input.commandBudget,
-          input: inputAfterActiveWake,
-          record,
-        });
-      if (recoveredCompletion.kind === "completed") {
-        return this.createActiveRuntimeFenceCompletionResponse(activeFence);
-      }
+      return await this.replaceStartRequiredRuntimeFence({
+        activeFence,
+        commandBudget: input.commandBudget,
+        input: inputAfterActiveWake,
+        record,
+        runtimeWakeStartedAt: input.runtimeWakeStartedAt,
+      });
     }
 
     await this.syncRunnerAlarm(record);

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -234,7 +234,7 @@ export class RuntimeProcessingController {
           record,
         });
       if (activeRuntimeState.outcome === "inactive") {
-        return await this.replaceStartRequiredRuntimeFence({
+        return await this.recoverOrReplaceInactiveRuntimeFence({
           activeFence,
           commandBudget: input.commandBudget,
           input: input.input,
@@ -258,7 +258,7 @@ export class RuntimeProcessingController {
           record,
         });
       if (activeRuntimeState.outcome === "inactive") {
-        return await this.replaceStartRequiredRuntimeFence({
+        return await this.recoverOrReplaceInactiveRuntimeFence({
           activeFence,
           commandBudget: input.commandBudget,
           input: input.input,
@@ -324,7 +324,7 @@ export class RuntimeProcessingController {
     }
 
     if (containerResult.kind === "start-required") {
-      return await this.replaceStartRequiredRuntimeFence({
+      return await this.recoverOrReplaceInactiveRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
         input: inputAfterActiveWake,
@@ -340,7 +340,7 @@ export class RuntimeProcessingController {
         record,
       });
     if (activeRuntimeState.outcome === "inactive") {
-      return await this.replaceStartRequiredRuntimeFence({
+      return await this.recoverOrReplaceInactiveRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
         input: inputAfterActiveWake,
@@ -356,7 +356,7 @@ export class RuntimeProcessingController {
     });
   }
 
-  private async replaceStartRequiredRuntimeFence(input: {
+  private async recoverOrReplaceInactiveRuntimeFence(input: {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     input: RuntimeProcessingInput;
@@ -376,6 +376,57 @@ export class RuntimeProcessingController {
       });
     }
 
+    if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
+      await this.syncRunnerAlarm(record);
+      return createRuntimeProcessingRetryLater({
+        reason: "container_rpc_timeout",
+        userId: input.input.userId,
+      });
+    }
+
+    const completionRecovery =
+      await this.input.invocationService.recoverAcceptedRuntimeCompletionFromCommittedProgress({
+        commandBudget: input.commandBudget,
+        executionInput: toRuntimeInvocationInput(input.input),
+        token: createRunnerWriteFenceToken({
+          activeFence,
+          userId: record.userId,
+        }),
+        workspaceVersion: activeFence.workspaceVersion,
+      });
+    if (completionRecovery.kind === "completed") {
+      return createRuntimeProcessingRetryLater({
+        reason: "completed_fence_recovered",
+        userId: input.input.userId,
+      });
+    }
+    if (completionRecovery.kind === "unknown") {
+      await this.syncRunnerAlarm(record);
+      return createRuntimeProcessingRetryLater({
+        reason: "container_rpc_timeout",
+        userId: input.input.userId,
+      });
+    }
+
+    return await this.replaceInactiveRuntimeFence(input);
+  }
+
+  private async replaceInactiveRuntimeFence(input: {
+    activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
+    commandBudget: RuntimeProcessingCommandBudget;
+    input: RuntimeProcessingInput;
+    record: RunnerStateRecord;
+    runtimeWakeStartedAt: number;
+  }): Promise<HostedRuntimeEnsureProcessingResponse> {
+    const { activeFence, record } = input;
+    if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
+      await this.syncRunnerAlarm(record);
+      return createRuntimeProcessingRetryLater({
+        reason: "container_rpc_timeout",
+        userId: input.input.userId,
+      });
+    }
+
     const cleared = await this.input.stateStore.clearWriteFenceForReplacement({
       attemptId: activeFence.attemptId,
       finishedAt: new Date().toISOString(),
@@ -386,12 +437,6 @@ export class RuntimeProcessingController {
     if (!cleared.cleared) {
       return createRuntimeProcessingRetryLater({
         reason: "stale_fence_replacement_race",
-        userId: input.input.userId,
-      });
-    }
-    if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
-      return createRuntimeProcessingRetryLater({
-        reason: "container_rpc_timeout",
         userId: input.input.userId,
       });
     }
@@ -424,7 +469,7 @@ export class RuntimeProcessingController {
         runnerContainerName,
       });
     if (activeRuntimeState.outcome === "inactive") {
-      return await this.replaceStartRequiredRuntimeFence({
+      return await this.recoverOrReplaceInactiveRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
         input: input.input,
@@ -451,7 +496,7 @@ export class RuntimeProcessingController {
       return abortResult.response;
     }
 
-    return await this.replaceStartRequiredRuntimeFence({
+    return await this.recoverOrReplaceInactiveRuntimeFence({
       activeFence,
       commandBudget: input.commandBudget,
       input: input.input,
@@ -1023,4 +1068,24 @@ function normalizeRuntimeProcessingMode(
   value: RuntimeProcessingInput["processingMode"],
 ): RunnerRuntimeProcessingMode {
   return value === "inbox_media_retention" ? "inbox_media_retention" : "default";
+}
+
+function createRunnerWriteFenceToken(input: {
+  activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
+  userId: string;
+}): RunnerWriteFenceToken {
+  const generation = String(input.activeFence.generation);
+  return {
+    attemptId: input.activeFence.attemptId,
+    expiresAt: input.activeFence.expiresAt,
+    generation,
+    kind: input.activeFence.kind,
+    leaseGeneration: generation,
+    processingMode: input.activeFence.processingMode,
+    providerEgressToken: null,
+    runnerContainerName: input.activeFence.runnerContainerName,
+    startedAt: input.activeFence.startedAt,
+    userId: input.userId,
+    workspaceVersion: input.activeFence.workspaceVersion,
+  };
 }

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -430,7 +430,7 @@ export class RuntimeProcessingController {
         runtimeWakeStartedAt: input.runtimeWakeStartedAt,
       });
     }
-    if (activeRuntimeState.outcome !== "exact-active") {
+    if (activeRuntimeState.outcome === "mismatch") {
       await this.syncRunnerAlarm(record);
       return createRuntimeProcessingRetryLater({
         reason: "container_rpc_error",
@@ -494,7 +494,7 @@ export class RuntimeProcessingController {
     }
 
     try {
-      await runRuntimeProcessingCommandStep({
+      const abortStatus = await runRuntimeProcessingCommandStep({
         budget: input.commandBudget,
         operation: async () =>
           await container.abortWorkspaceInvocation!({
@@ -504,7 +504,23 @@ export class RuntimeProcessingController {
           }),
         stepTimeoutMs: this.input.env.webControlTimeoutMs,
       });
-      return { aborted: true };
+      if (
+        abortStatus === "accepted"
+        || abortStatus === "queued"
+        || abortStatus === "inactive"
+      ) {
+        return { aborted: true };
+      }
+      await this.syncRunnerAlarm(input.record);
+      return {
+        aborted: false,
+        response: createRuntimeProcessingRetryLater({
+          reason: abortStatus === "failed"
+            ? "container_rpc_error"
+            : "container_busy",
+          userId: input.record.userId,
+        }),
+      };
     } catch (error) {
       emitHostedExecutionStructuredLog({
         component: "hosted.runner",

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -38,6 +38,7 @@ import {
 } from "./runtime-fence-liveness.js";
 import {
   ensureActiveRuntimeProcessing,
+  readActiveRuntimeRunnerContainerName,
 } from "./runtime-container-wake.js";
 import {
   computeRuntimeProcessingOwnerRecheckAt as computeRuntimeProcessingOwnerRecheckAtValue,
@@ -414,11 +415,13 @@ export class RuntimeProcessingController {
     runtimeWakeStartedAt: number;
   }): Promise<HostedRuntimeEnsureProcessingResponse> {
     const { activeFence, record } = input;
+    const runnerContainerName = this.readActiveRuntimeFenceContainerName(input);
     const activeRuntimeState =
       await this.readActiveRuntimeFenceLiveness({
         activeFence,
         commandBudget: input.commandBudget,
         record,
+        runnerContainerName,
       });
     if (activeRuntimeState.outcome === "inactive") {
       return await this.replaceStartRequiredRuntimeFence({
@@ -442,6 +445,7 @@ export class RuntimeProcessingController {
       activeFence,
       commandBudget: input.commandBudget,
       record,
+      runnerContainerName,
     });
     if (!abortResult.aborted) {
       return abortResult.response;
@@ -461,6 +465,7 @@ export class RuntimeProcessingController {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     record: RunnerStateRecord;
+    runnerContainerName?: string | null;
   }): Promise<
     | { aborted: true }
     | {
@@ -468,7 +473,8 @@ export class RuntimeProcessingController {
         response: HostedRuntimeEnsureProcessingResponse;
       }
   > {
-    const containerName = input.activeFence.runnerContainerName;
+    const containerName =
+      input.runnerContainerName ?? input.activeFence.runnerContainerName;
     const namespace = this.input.runnerContainerNamespace;
     if (!namespace || !containerName) {
       await this.syncRunnerAlarm(input.record);
@@ -552,6 +558,7 @@ export class RuntimeProcessingController {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     record: RunnerStateRecord;
+    runnerContainerName?: string | null;
   }): Promise<RuntimeFenceLivenessReadResult> {
     const result = await readRuntimeFenceLivenessBestEffort({
       commandBudget: input.commandBudget,
@@ -560,7 +567,8 @@ export class RuntimeProcessingController {
         leaseGeneration: String(input.activeFence.generation),
         userId: input.record.userId,
       },
-      runnerContainerName: input.activeFence.runnerContainerName,
+      runnerContainerName:
+        input.runnerContainerName ?? input.activeFence.runnerContainerName,
       runnerContainerNamespace: this.input.runnerContainerNamespace,
       stepTimeoutMs: this.input.env.webControlTimeoutMs,
     });
@@ -575,6 +583,21 @@ export class RuntimeProcessingController {
       });
     }
     return result;
+  }
+
+  private readActiveRuntimeFenceContainerName(input: {
+    activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
+    record: RunnerStateRecord;
+  }): string | null {
+    return readActiveRuntimeRunnerContainerName({
+      activeRuntime: {
+        attemptId: input.activeFence.attemptId,
+        leaseGeneration: String(input.activeFence.generation),
+        userId: input.record.userId,
+      },
+      runnerContainerName: input.activeFence.runnerContainerName,
+      runnerRuntimeEnvSource: this.input.runnerRuntimeEnvSource,
+    });
   }
 
   private async startRuntimeProcessing(input: {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -612,8 +612,9 @@ export class RuntimeProcessingController {
         leaseGeneration: String(input.activeFence.generation),
         userId: input.record.userId,
       },
-      runnerContainerName:
-        input.runnerContainerName ?? input.activeFence.runnerContainerName,
+      runnerContainerName: input.runnerContainerName === undefined
+        ? this.readActiveRuntimeFenceContainerName(input)
+        : input.runnerContainerName,
       runnerContainerNamespace: this.input.runnerContainerNamespace,
       stepTimeoutMs: this.input.env.webControlTimeoutMs,
     });

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -33,6 +33,10 @@ import {
   type RuntimeProcessingCommandBudget,
 } from "./runtime-command-budget.js";
 import {
+  readRuntimeFenceLivenessBestEffort,
+  type RuntimeFenceLivenessReadResult,
+} from "./runtime-fence-liveness.js";
+import {
   ensureActiveRuntimeProcessing,
 } from "./runtime-container-wake.js";
 import {
@@ -223,12 +227,12 @@ export class RuntimeProcessingController {
       }
 
       const activeRuntimeState =
-        await this.readActiveRuntimeFenceWithoutWake({
+        await this.readActiveRuntimeFenceLiveness({
           activeFence,
           commandBudget: input.commandBudget,
           record,
         });
-      if (activeRuntimeState === "inactive") {
+      if (activeRuntimeState.outcome === "inactive") {
         return await this.replaceStartRequiredRuntimeFence({
           activeFence,
           commandBudget: input.commandBudget,
@@ -247,12 +251,12 @@ export class RuntimeProcessingController {
 
     if (activeFence.processingMode === "inbox_media_retention") {
       const activeRuntimeState =
-        await this.readActiveRuntimeFenceWithoutWake({
+        await this.readActiveRuntimeFenceLiveness({
           activeFence,
           commandBudget: input.commandBudget,
           record,
         });
-      if (activeRuntimeState === "inactive") {
+      if (activeRuntimeState.outcome === "inactive") {
         return await this.replaceStartRequiredRuntimeFence({
           activeFence,
           commandBudget: input.commandBudget,
@@ -261,7 +265,7 @@ export class RuntimeProcessingController {
           runtimeWakeStartedAt: input.runtimeWakeStartedAt,
         });
       }
-      if (activeRuntimeState === "indeterminate") {
+      if (activeRuntimeState.outcome !== "exact-active") {
         await this.syncRunnerAlarm(record);
         return createRuntimeProcessingRetryLater({
           reason: "container_rpc_error",
@@ -329,12 +333,12 @@ export class RuntimeProcessingController {
     }
 
     const activeRuntimeState =
-      await this.readActiveRuntimeFenceWithoutWake({
+      await this.readActiveRuntimeFenceLiveness({
         activeFence,
         commandBudget: input.commandBudget,
         record,
       });
-    if (activeRuntimeState === "inactive") {
+    if (activeRuntimeState.outcome === "inactive") {
       return await this.replaceStartRequiredRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
@@ -411,12 +415,12 @@ export class RuntimeProcessingController {
   }): Promise<HostedRuntimeEnsureProcessingResponse> {
     const { activeFence, record } = input;
     const activeRuntimeState =
-      await this.readActiveRuntimeFenceWithoutWake({
+      await this.readActiveRuntimeFenceLiveness({
         activeFence,
         commandBudget: input.commandBudget,
         record,
       });
-    if (activeRuntimeState === "inactive") {
+    if (activeRuntimeState.outcome === "inactive") {
       return await this.replaceStartRequiredRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
@@ -426,7 +430,7 @@ export class RuntimeProcessingController {
         runtimeWakeStartedAt: input.runtimeWakeStartedAt,
       });
     }
-    if (activeRuntimeState === "indeterminate") {
+    if (activeRuntimeState.outcome !== "exact-active") {
       await this.syncRunnerAlarm(record);
       return createRuntimeProcessingRetryLater({
         reason: "container_rpc_error",
@@ -529,52 +533,33 @@ export class RuntimeProcessingController {
     return Date.now() < commandBudget.deadlineAtMs;
   }
 
-  private async readActiveRuntimeFenceWithoutWake(input: {
+  private async readActiveRuntimeFenceLiveness(input: {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     record: RunnerStateRecord;
-  }): Promise<"inactive" | "indeterminate" | "matching"> {
-    if (!this.input.runnerContainerNamespace) {
-      return "indeterminate";
-    }
-
-    const runnerContainerName = input.activeFence.runnerContainerName;
-    if (!runnerContainerName) {
-      return "indeterminate";
-    }
-
-    const container = this.input.runnerContainerNamespace.getByName(
-      runnerContainerName,
-    );
-    if (!container.readActiveRuntimeUserFence) {
-      return "indeterminate";
-    }
-
-    try {
-      const activeRuntime = await runRuntimeProcessingCommandStep({
-        budget: input.commandBudget,
-        operation: async () => await container.readActiveRuntimeUserFence!(),
-        stepTimeoutMs: this.input.env.webControlTimeoutMs,
-      });
-      if (!activeRuntime.active) {
-        return "inactive";
-      }
-      return activeRuntime.attemptId === input.activeFence.attemptId
-        && activeRuntime.leaseGeneration === String(input.activeFence.generation)
-        && activeRuntime.userId === input.record.userId
-        ? "matching"
-        : "indeterminate";
-    } catch (error) {
+  }): Promise<RuntimeFenceLivenessReadResult> {
+    const result = await readRuntimeFenceLivenessBestEffort({
+      commandBudget: input.commandBudget,
+      identity: {
+        attemptId: input.activeFence.attemptId,
+        leaseGeneration: String(input.activeFence.generation),
+        userId: input.record.userId,
+      },
+      runnerContainerName: input.activeFence.runnerContainerName,
+      runnerContainerNamespace: this.input.runnerContainerNamespace,
+      stepTimeoutMs: this.input.env.webControlTimeoutMs,
+    });
+    if (result.outcome === "indeterminate" && result.error !== undefined) {
       emitHostedExecutionStructuredLog({
         component: "hosted.runner",
-        details: buildHostedRunnerMetadataOnlyErrorDetails(error),
+        details: buildHostedRunnerMetadataOnlyErrorDetails(result.error),
         level: "warn",
         message: "Hosted runner active retention liveness check failed.",
         phase: "scheduled",
         userId: input.record.userId,
       });
-      return "indeterminate";
     }
+    return result;
   }
 
   private async startRuntimeProcessing(input: {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -42,7 +42,6 @@ import {
 } from "./runtime-processing-responses.js";
 import {
   RuntimeInvocationService,
-  type AcceptedRuntimeCompletionRecoveryResult,
   type PreparedRuntimeInvocation,
   type RuntimeInvocationInput,
 } from "./runtime-invocation.js";
@@ -210,6 +209,19 @@ export class RuntimeProcessingController {
 
     const requestedProcessingMode = normalizeRuntimeProcessingMode(input.input.processingMode);
     if (activeFence.processingMode !== requestedProcessingMode) {
+      if (
+        activeFence.processingMode === "inbox_media_retention"
+        && requestedProcessingMode === "default"
+      ) {
+        return await this.preemptActiveRetentionRuntimeForForegroundProcessing({
+          activeFence,
+          commandBudget: input.commandBudget,
+          input: input.input,
+          record,
+          runtimeWakeStartedAt: input.runtimeWakeStartedAt,
+        });
+      }
+
       const activeRuntimeState =
         await this.readActiveRuntimeFenceWithoutWake({
           activeFence,
@@ -343,27 +355,20 @@ export class RuntimeProcessingController {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     input: RuntimeProcessingInput;
+    preserveStartingFence?: boolean;
     record: RunnerStateRecord;
     runtimeWakeStartedAt: number;
   }): Promise<HostedRuntimeEnsureProcessingResponse> {
     const { activeFence, record } = input;
-    if (this.shouldPreserveStartingWriteFence(activeFence)) {
+    if (
+      input.preserveStartingFence !== false
+      && this.shouldPreserveStartingWriteFence(activeFence)
+    ) {
       await this.syncRunnerAlarm(record);
       return createRuntimeProcessingRetryLater({
         reason: "container_rpc_timeout",
         userId: input.input.userId,
       });
-    }
-
-    const recoveredCompletion =
-      await this.recoverActiveRuntimeFenceCompletion({
-        activeFence,
-        commandBudget: input.commandBudget,
-        input: input.input,
-        record,
-      });
-    if (recoveredCompletion.kind === "completed") {
-      return this.createActiveRuntimeFenceCompletionResponse(activeFence);
     }
 
     const cleared = await this.input.stateStore.clearWriteFenceForReplacement({
@@ -397,43 +402,124 @@ export class RuntimeProcessingController {
     });
   }
 
-  private createActiveRuntimeFenceCompletionResponse(
-    activeFence: NonNullable<RunnerStateRecord["writeFence"]>,
-  ): HostedRuntimeEnsureProcessingResponse {
-    return {
-      action: "already_running",
-      kind: "runtime_processing_accepted",
-      recommendedRecheckAt:
-        this.computeRuntimeProcessingOwnerRecheckAt(),
-      runtimeAttemptId: activeFence.attemptId,
-    };
-  }
-
-  private async recoverActiveRuntimeFenceCompletion(input: {
+  private async preemptActiveRetentionRuntimeForForegroundProcessing(input: {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     input: RuntimeProcessingInput;
     record: RunnerStateRecord;
-  }): Promise<AcceptedRuntimeCompletionRecoveryResult> {
+    runtimeWakeStartedAt: number;
+  }): Promise<HostedRuntimeEnsureProcessingResponse> {
     const { activeFence, record } = input;
-    return await this.input.invocationService.recoverAcceptedRuntimeCompletionFromCommittedProgress({
-      executionInput: toRuntimeInvocationInput(input.input),
-      token: {
-        attemptId: activeFence.attemptId,
-        expiresAt: activeFence.expiresAt,
-        generation: String(activeFence.generation),
-        kind: activeFence.kind,
-        leaseGeneration: String(activeFence.generation),
-        processingMode: activeFence.processingMode,
-        providerEgressToken: null,
-        runnerContainerName: activeFence.runnerContainerName,
-        startedAt: activeFence.startedAt,
-        userId: record.userId,
-        workspaceVersion: activeFence.workspaceVersion,
-      },
+    const activeRuntimeState =
+      await this.readActiveRuntimeFenceWithoutWake({
+        activeFence,
+        commandBudget: input.commandBudget,
+        record,
+      });
+    if (activeRuntimeState === "inactive") {
+      return await this.replaceStartRequiredRuntimeFence({
+        activeFence,
+        commandBudget: input.commandBudget,
+        input: input.input,
+        record,
+        runtimeWakeStartedAt: input.runtimeWakeStartedAt,
+      });
+    }
+    if (activeRuntimeState === "indeterminate") {
+      await this.syncRunnerAlarm(record);
+      return createRuntimeProcessingRetryLater({
+        reason: "container_rpc_error",
+        userId: input.input.userId,
+      });
+    }
+
+    const abortResult = await this.abortActiveRuntimeFence({
+      activeFence,
       commandBudget: input.commandBudget,
-      workspaceVersion: activeFence.workspaceVersion,
+      record,
     });
+    if (!abortResult.aborted) {
+      return abortResult.response;
+    }
+
+    return await this.replaceStartRequiredRuntimeFence({
+      activeFence,
+      commandBudget: input.commandBudget,
+      input: input.input,
+      preserveStartingFence: false,
+      record,
+      runtimeWakeStartedAt: input.runtimeWakeStartedAt,
+    });
+  }
+
+  private async abortActiveRuntimeFence(input: {
+    activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
+    commandBudget: RuntimeProcessingCommandBudget;
+    record: RunnerStateRecord;
+  }): Promise<
+    | { aborted: true }
+    | {
+        aborted: false;
+        response: HostedRuntimeEnsureProcessingResponse;
+      }
+  > {
+    const containerName = input.activeFence.runnerContainerName;
+    const namespace = this.input.runnerContainerNamespace;
+    if (!namespace || !containerName) {
+      await this.syncRunnerAlarm(input.record);
+      return {
+        aborted: false,
+        response: createRuntimeProcessingRetryLater({
+          reason: "container_rpc_error",
+          userId: input.record.userId,
+        }),
+      };
+    }
+
+    const container = namespace.getByName(containerName);
+    if (!container.abortWorkspaceInvocation) {
+      await this.syncRunnerAlarm(input.record);
+      return {
+        aborted: false,
+        response: createRuntimeProcessingRetryLater({
+          reason: "container_busy",
+          userId: input.record.userId,
+        }),
+      };
+    }
+
+    try {
+      await runRuntimeProcessingCommandStep({
+        budget: input.commandBudget,
+        operation: async () =>
+          await container.abortWorkspaceInvocation!({
+            attemptId: input.activeFence.attemptId,
+            leaseGeneration: String(input.activeFence.generation),
+            userId: input.record.userId,
+          }),
+        stepTimeoutMs: this.input.env.webControlTimeoutMs,
+      });
+      return { aborted: true };
+    } catch (error) {
+      emitHostedExecutionStructuredLog({
+        component: "hosted.runner",
+        details: buildHostedRunnerMetadataOnlyErrorDetails(error),
+        level: "warn",
+        message: "Hosted runner could not preempt active retention runtime processing.",
+        phase: "scheduled",
+        userId: input.record.userId,
+      });
+      await this.syncRunnerAlarm(input.record);
+      return {
+        aborted: false,
+        response: createRuntimeProcessingRetryLater({
+          reason: isRuntimeProcessingCommandBudgetTimeout(error)
+            ? "container_rpc_timeout"
+            : "container_rpc_error",
+          userId: input.record.userId,
+        }),
+      };
+    }
   }
 
   private hasRuntimeProcessingCommandBudgetRemaining(

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -350,13 +350,6 @@ export class RuntimeProcessingController {
     if (recoveredCompletion.kind === "completed") {
       return this.createActiveRuntimeFenceCompletionResponse(activeFence);
     }
-    if (recoveredCompletion.kind === "unknown") {
-      await this.syncRunnerAlarm(record);
-      return createRuntimeProcessingRetryLater({
-        reason: "container_rpc_error",
-        userId: input.input.userId,
-      });
-    }
 
     const cleared = await this.input.stateStore.clearWriteFenceForReplacement({
       attemptId: activeFence.attemptId,
@@ -368,6 +361,12 @@ export class RuntimeProcessingController {
     if (!cleared.cleared) {
       return createRuntimeProcessingRetryLater({
         reason: "stale_fence_replacement_race",
+        userId: input.input.userId,
+      });
+    }
+    if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
+      return createRuntimeProcessingRetryLater({
+        reason: "container_rpc_timeout",
         userId: input.input.userId,
       });
     }
@@ -420,6 +419,12 @@ export class RuntimeProcessingController {
       commandBudget: input.commandBudget,
       workspaceVersion: activeFence.workspaceVersion,
     });
+  }
+
+  private hasRuntimeProcessingCommandBudgetRemaining(
+    commandBudget: RuntimeProcessingCommandBudget,
+  ): boolean {
+    return Date.now() < commandBudget.deadlineAtMs;
   }
 
   private async readActiveRuntimeFenceWithoutWake(input: {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -421,6 +421,7 @@ export class RuntimeProcessingController {
         activeFence,
         commandBudget: input.commandBudget,
         input: input.input,
+        preserveStartingFence: false,
         record,
         runtimeWakeStartedAt: input.runtimeWakeStartedAt,
       });

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -234,7 +234,7 @@ export class RuntimeProcessingController {
           record,
         });
       if (activeRuntimeState.outcome === "inactive") {
-        return await this.recoverOrReplaceInactiveRuntimeFence({
+        return await this.replaceInactiveRuntimeFence({
           activeFence,
           commandBudget: input.commandBudget,
           input: input.input,
@@ -258,7 +258,7 @@ export class RuntimeProcessingController {
           record,
         });
       if (activeRuntimeState.outcome === "inactive") {
-        return await this.recoverOrReplaceInactiveRuntimeFence({
+        return await this.replaceInactiveRuntimeFence({
           activeFence,
           commandBudget: input.commandBudget,
           input: input.input,
@@ -324,7 +324,7 @@ export class RuntimeProcessingController {
     }
 
     if (containerResult.kind === "start-required") {
-      return await this.recoverOrReplaceInactiveRuntimeFence({
+      return await this.replaceInactiveRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
         input: inputAfterActiveWake,
@@ -340,7 +340,7 @@ export class RuntimeProcessingController {
         record,
       });
     if (activeRuntimeState.outcome === "inactive") {
-      return await this.recoverOrReplaceInactiveRuntimeFence({
+      return await this.replaceInactiveRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
         input: inputAfterActiveWake,
@@ -356,7 +356,7 @@ export class RuntimeProcessingController {
     });
   }
 
-  private async recoverOrReplaceInactiveRuntimeFence(input: {
+  private async replaceInactiveRuntimeFence(input: {
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     input: RuntimeProcessingInput;
@@ -369,57 +369,6 @@ export class RuntimeProcessingController {
       input.preserveStartingFence !== false
       && this.shouldPreserveStartingWriteFence(activeFence)
     ) {
-      await this.syncRunnerAlarm(record);
-      return createRuntimeProcessingRetryLater({
-        reason: "container_rpc_timeout",
-        userId: input.input.userId,
-      });
-    }
-
-    if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
-      await this.syncRunnerAlarm(record);
-      return createRuntimeProcessingRetryLater({
-        reason: "container_rpc_timeout",
-        userId: input.input.userId,
-      });
-    }
-
-    const completionRecovery =
-      await this.input.invocationService.recoverAcceptedRuntimeCompletionFromCommittedProgress({
-        commandBudget: input.commandBudget,
-        executionInput: toRuntimeInvocationInput(input.input),
-        token: createRunnerWriteFenceToken({
-          activeFence,
-          userId: record.userId,
-        }),
-        workspaceVersion: activeFence.workspaceVersion,
-      });
-    if (completionRecovery.kind === "completed") {
-      return createRuntimeProcessingRetryLater({
-        reason: "completed_fence_recovered",
-        userId: input.input.userId,
-      });
-    }
-    if (completionRecovery.kind === "unknown") {
-      await this.syncRunnerAlarm(record);
-      return createRuntimeProcessingRetryLater({
-        reason: "container_rpc_timeout",
-        userId: input.input.userId,
-      });
-    }
-
-    return await this.replaceInactiveRuntimeFence(input);
-  }
-
-  private async replaceInactiveRuntimeFence(input: {
-    activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
-    commandBudget: RuntimeProcessingCommandBudget;
-    input: RuntimeProcessingInput;
-    record: RunnerStateRecord;
-    runtimeWakeStartedAt: number;
-  }): Promise<HostedRuntimeEnsureProcessingResponse> {
-    const { activeFence, record } = input;
-    if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
       await this.syncRunnerAlarm(record);
       return createRuntimeProcessingRetryLater({
         reason: "container_rpc_timeout",
@@ -440,6 +389,13 @@ export class RuntimeProcessingController {
         userId: input.input.userId,
       });
     }
+    if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
+      return createRuntimeProcessingRetryLater({
+        reason: "container_rpc_timeout",
+        userId: input.input.userId,
+      });
+    }
+
     const replacementInput = withRuntimeProcessingOrchestration(input.input, {
       replacedStaleFence: true,
       replacementFenceClearedAtEpochMs: Date.now(),
@@ -469,7 +425,7 @@ export class RuntimeProcessingController {
         runnerContainerName,
       });
     if (activeRuntimeState.outcome === "inactive") {
-      return await this.recoverOrReplaceInactiveRuntimeFence({
+      return await this.replaceInactiveRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
         input: input.input,
@@ -496,7 +452,7 @@ export class RuntimeProcessingController {
       return abortResult.response;
     }
 
-    return await this.recoverOrReplaceInactiveRuntimeFence({
+    return await this.replaceInactiveRuntimeFence({
       activeFence,
       commandBudget: input.commandBudget,
       input: input.input,
@@ -518,8 +474,9 @@ export class RuntimeProcessingController {
         response: HostedRuntimeEnsureProcessingResponse;
       }
   > {
-    const containerName =
-      input.runnerContainerName ?? input.activeFence.runnerContainerName;
+    const containerName = input.runnerContainerName === undefined
+      ? input.activeFence.runnerContainerName
+      : input.runnerContainerName;
     const namespace = this.input.runnerContainerNamespace;
     if (!namespace || !containerName) {
       await this.syncRunnerAlarm(input.record);
@@ -1069,24 +1026,4 @@ function normalizeRuntimeProcessingMode(
   value: RuntimeProcessingInput["processingMode"],
 ): RunnerRuntimeProcessingMode {
   return value === "inbox_media_retention" ? "inbox_media_retention" : "default";
-}
-
-function createRunnerWriteFenceToken(input: {
-  activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
-  userId: string;
-}): RunnerWriteFenceToken {
-  const generation = String(input.activeFence.generation);
-  return {
-    attemptId: input.activeFence.attemptId,
-    expiresAt: input.activeFence.expiresAt,
-    generation,
-    kind: input.activeFence.kind,
-    leaseGeneration: generation,
-    processingMode: input.activeFence.processingMode,
-    providerEgressToken: null,
-    runnerContainerName: input.activeFence.runnerContainerName,
-    startedAt: input.activeFence.startedAt,
-    userId: input.userId,
-    workspaceVersion: input.activeFence.workspaceVersion,
-  };
 }

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -249,6 +249,13 @@ export class RuntimeProcessingController {
           runtimeWakeStartedAt: input.runtimeWakeStartedAt,
         });
       }
+      if (activeRuntimeState === "indeterminate") {
+        await this.syncRunnerAlarm(record);
+        return createRuntimeProcessingRetryLater({
+          reason: "container_rpc_error",
+          userId: input.input.userId,
+        });
+      }
 
       await this.syncRunnerAlarm(record);
       return {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -425,6 +425,17 @@ export class RuntimeProcessingController {
         runnerContainerName,
       });
     if (activeRuntimeState.outcome === "inactive") {
+      const abortResult = await this.abortActiveRuntimeFence({
+        acceptRequestedAbort: true,
+        activeFence,
+        commandBudget: input.commandBudget,
+        record,
+        runnerContainerName,
+      });
+      if (!abortResult.aborted) {
+        return abortResult.response;
+      }
+
       return await this.replaceInactiveRuntimeFence({
         activeFence,
         commandBudget: input.commandBudget,
@@ -463,6 +474,7 @@ export class RuntimeProcessingController {
   }
 
   private async abortActiveRuntimeFence(input: {
+    acceptRequestedAbort?: boolean;
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     record: RunnerStateRecord;
@@ -515,6 +527,7 @@ export class RuntimeProcessingController {
       if (
         abortStatus === "accepted"
         || abortStatus === "inactive"
+        || (input.acceptRequestedAbort === true && abortStatus === "requested")
       ) {
         return { aborted: true };
       }

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -42,6 +42,7 @@ import {
 } from "./runtime-processing-responses.js";
 import {
   RuntimeInvocationService,
+  type AcceptedRuntimeCompletionRecoveryResult,
   type PreparedRuntimeInvocation,
   type RuntimeInvocationInput,
 } from "./runtime-invocation.js";
@@ -300,6 +301,16 @@ export class RuntimeProcessingController {
       });
     }
 
+    const recoveredCompletion =
+      await this.recoverActiveRuntimeFenceCompletion({
+        activeFence,
+        input: inputAfterActiveWake,
+        record,
+      });
+    if (recoveredCompletion.kind === "completed") {
+      return this.createActiveRuntimeFenceCompletionResponse(activeFence);
+    }
+
     await this.syncRunnerAlarm(record);
     return createRuntimeProcessingRetryLater({
       reason: mapRunnerProcessingRetryReason(containerResult.reason),
@@ -324,31 +335,13 @@ export class RuntimeProcessingController {
     }
 
     const recoveredCompletion =
-      await this.input.invocationService.recoverAcceptedRuntimeCompletionAfterTransportFailure({
-        executionInput: toRuntimeInvocationInput(input.input),
-        token: {
-          attemptId: activeFence.attemptId,
-          expiresAt: activeFence.expiresAt,
-          generation: String(activeFence.generation),
-          kind: activeFence.kind,
-          leaseGeneration: String(activeFence.generation),
-          processingMode: activeFence.processingMode,
-          providerEgressToken: null,
-          runnerContainerName: activeFence.runnerContainerName,
-          startedAt: activeFence.startedAt,
-          userId: record.userId,
-          workspaceVersion: activeFence.workspaceVersion,
-        },
-        workspaceVersion: activeFence.workspaceVersion,
+      await this.recoverActiveRuntimeFenceCompletion({
+        activeFence,
+        input: input.input,
+        record,
       });
     if (recoveredCompletion.kind === "completed") {
-      return {
-        action: "already_running",
-        kind: "runtime_processing_accepted",
-        recommendedRecheckAt:
-          this.computeRuntimeProcessingOwnerRecheckAt(),
-        runtimeAttemptId: activeFence.attemptId,
-      };
+      return this.createActiveRuntimeFenceCompletionResponse(activeFence);
     }
     if (recoveredCompletion.kind === "unknown") {
       await this.syncRunnerAlarm(record);
@@ -380,6 +373,43 @@ export class RuntimeProcessingController {
       commandBudget: input.commandBudget,
       input: replacementInput,
       runtimeWakeStartedAt: input.runtimeWakeStartedAt,
+    });
+  }
+
+  private createActiveRuntimeFenceCompletionResponse(
+    activeFence: NonNullable<RunnerStateRecord["writeFence"]>,
+  ): HostedRuntimeEnsureProcessingResponse {
+    return {
+      action: "already_running",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt:
+        this.computeRuntimeProcessingOwnerRecheckAt(),
+      runtimeAttemptId: activeFence.attemptId,
+    };
+  }
+
+  private async recoverActiveRuntimeFenceCompletion(input: {
+    activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
+    input: RuntimeProcessingInput;
+    record: RunnerStateRecord;
+  }): Promise<AcceptedRuntimeCompletionRecoveryResult> {
+    const { activeFence, record } = input;
+    return await this.input.invocationService.recoverAcceptedRuntimeCompletionFromCommittedProgress({
+      executionInput: toRuntimeInvocationInput(input.input),
+      token: {
+        attemptId: activeFence.attemptId,
+        expiresAt: activeFence.expiresAt,
+        generation: String(activeFence.generation),
+        kind: activeFence.kind,
+        leaseGeneration: String(activeFence.generation),
+        processingMode: activeFence.processingMode,
+        providerEgressToken: null,
+        runnerContainerName: activeFence.runnerContainerName,
+        startedAt: activeFence.startedAt,
+        userId: record.userId,
+        workspaceVersion: activeFence.workspaceVersion,
+      },
+      workspaceVersion: activeFence.workspaceVersion,
     });
   }
 

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -506,7 +506,6 @@ export class RuntimeProcessingController {
       });
       if (
         abortStatus === "accepted"
-        || abortStatus === "queued"
         || abortStatus === "inactive"
       ) {
         return { aborted: true };

--- a/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
@@ -17,7 +17,6 @@ export function computeRuntimeProcessingRetryAt(
   reason: RuntimeProcessingRetryReason,
 ): string {
   const delayMs =
-    reason === "completed_fence_recovered" ? 5_000 :
     reason === "stale_fence_replacement_race" ? 5_000 :
     reason === "container_busy" ? 5_000 :
     reason === "container_rpc_timeout" ? 10_000 :

--- a/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
@@ -17,6 +17,7 @@ export function computeRuntimeProcessingRetryAt(
   reason: RuntimeProcessingRetryReason,
 ): string {
   const delayMs =
+    reason === "completed_fence_recovered" ? 5_000 :
     reason === "stale_fence_replacement_race" ? 5_000 :
     reason === "container_busy" ? 5_000 :
     reason === "container_rpc_timeout" ? 10_000 :

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3595,6 +3595,57 @@ describe("RunnerContainer", () => {
     });
   });
 
+  it("does not report inactive liveness from a missing local pointer while health reports active work", async () => {
+    const containerFetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({
+          ...createRunnerHealthResult(),
+          activeJobCount: 1,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected runner request URL: ${url}`);
+    });
+    const { container } = createContainerDouble({
+      containerFetch,
+      initialStatus: "running",
+    });
+
+    await expect(container.readActiveRuntimeUserFence()).rejects.toThrow(
+      "Hosted runner container health still reports active workspace work.",
+    );
+  });
+
+  it("reports inactive liveness from a missing local pointer only after running health is idle", async () => {
+    const containerFetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify({
+          ...createRunnerHealthResult(),
+          activeJobCount: 0,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected runner request URL: ${url}`);
+    });
+    const { container } = createContainerDouble({
+      containerFetch,
+      initialStatus: "running",
+    });
+
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: false,
+      reason: "no_active_runtime",
+    });
+  });
+
   it("destroys and clears preserved liveness when explicit abort is not delivered", async () => {
     let runnerResponseLost = false;
     const containerFetch = vi.fn(async (url: string) => {

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3644,7 +3644,7 @@ describe("RunnerContainer", () => {
       attemptId: request.attemptId,
       leaseGeneration: request.leaseGeneration,
       userId: "member_123",
-    })).resolves.toBe("accepted");
+    })).resolves.toBe("requested");
     expect(containerFetch).toHaveBeenCalledOnce();
   });
 

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3403,7 +3403,7 @@ describe("RunnerContainer", () => {
       attemptId: request.attemptId,
       leaseGeneration: request.leaseGeneration,
       userId: "member_123",
-    })).resolves.toBeUndefined();
+    })).resolves.toBe("accepted");
 
     await expect(invokeResultPromise).resolves.toMatchObject({
       message: "workspace invocation preempted",
@@ -3480,7 +3480,7 @@ describe("RunnerContainer", () => {
       attemptId: request.attemptId,
       leaseGeneration: request.leaseGeneration,
       userId: "member_123",
-    })).resolves.toBeUndefined();
+    })).resolves.toBe("accepted");
 
     await expect(invokeResultPromise).resolves.toMatchObject({
       message: "workspace invocation preempted",
@@ -3615,6 +3615,37 @@ describe("RunnerContainer", () => {
     await expect(container.readActiveRuntimeUserFence()).rejects.toThrow(
       "Hosted runner container health still reports active workspace work.",
     );
+  });
+
+  it("posts workspace abort when the local active pointer is missing but the child is running", async () => {
+    const request = createRunnerRequest("evt_missing_pointer_abort");
+    const containerFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/internal/workspace-invocation/abort")) {
+        expect(JSON.parse(String(init?.body))).toEqual({
+          attemptId: request.attemptId,
+          leaseGeneration: request.leaseGeneration,
+          userId: "member_123",
+        });
+        return new Response(null, {
+          headers: {
+            "x-workspace-invocation-abort-status": "accepted",
+          },
+          status: 204,
+        });
+      }
+      throw new Error(`Unexpected runner request URL: ${url}`);
+    });
+    const { container } = createContainerDouble({
+      containerFetch,
+      initialStatus: "running",
+    });
+
+    await expect(container.abortWorkspaceInvocation({
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    })).resolves.toBe("accepted");
+    expect(containerFetch).toHaveBeenCalledOnce();
   });
 
   it("reports inactive liveness from a missing local pointer only after running health is idle", async () => {
@@ -3752,7 +3783,7 @@ describe("RunnerContainer", () => {
       attemptId: request.attemptId,
       leaseGeneration: request.leaseGeneration,
       userId: "member_123",
-    })).resolves.toBeUndefined();
+    })).resolves.toBe("accepted");
 
     expect(destroy).toHaveBeenCalledTimes(1);
     await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
@@ -3811,7 +3842,7 @@ describe("RunnerContainer", () => {
       attemptId: request.attemptId,
       leaseGeneration: request.leaseGeneration,
       userId: "member_123",
-    })).resolves.toBeUndefined();
+    })).resolves.toBe("accepted");
 
     expect(abortPosted).toBe(true);
     expect(destroy).toHaveBeenCalledTimes(1);
@@ -5823,7 +5854,7 @@ describe("RunnerContainer", () => {
     const abortController = new AbortController();
     const abortWorkspaceInvocation = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => {});
+    >(async () => "accepted");
     const destroyInstance = vi.fn(async () => {});
     const invoke = vi.fn<HostedExecutionContainerStubLike["invoke"]>(
       async () => new Promise<never>(() => {}),
@@ -5866,7 +5897,7 @@ describe("RunnerContainer", () => {
     const abortController = new AbortController();
     const abortWorkspaceInvocation = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => {});
+    >(async () => "accepted");
     const destroyInstance = vi.fn(async () => {
       await new Promise<void>(() => undefined);
     });

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3568,12 +3568,9 @@ describe("RunnerContainer", () => {
     });
 
     healthProbeFails = true;
-    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
-      active: true,
-      attemptId: request.attemptId,
-      leaseGeneration: request.leaseGeneration,
-      userId: "member_123",
-    });
+    await expect(container.readActiveRuntimeUserFence()).rejects.toThrow(
+      "health probe unavailable",
+    );
 
     const callsBeforeStaleWake = containerFetch.mock.calls.length;
     healthProbeFails = false;
@@ -3662,6 +3659,44 @@ describe("RunnerContainer", () => {
       reason: "no_active_runtime",
     });
     expect(containerFetch).not.toHaveBeenCalled();
+  });
+
+  it("clears preserved liveness when the accepted workspace container is gone", async () => {
+    const { container, markContainerGone } =
+      await createPreservedWorkspaceInvocationAfterLostResponse(
+        "evt_response_lost_then_container_gone",
+      );
+
+    markContainerGone();
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: false,
+      reason: "no_active_runtime",
+    });
+  });
+
+  it("does not wake preserved liveness after the accepted workspace container is gone", async () => {
+    const { container, containerFetch, markContainerGone, request } =
+      await createPreservedWorkspaceInvocationAfterLostResponse(
+        "evt_response_lost_then_wake_after_gone",
+      );
+
+    const callsBeforeWake = containerFetch.mock.calls.length;
+    markContainerGone();
+    await expect(container.wakeRuntime({
+      attemptId: request.attemptId,
+      leaseGeneration: request.leaseGeneration,
+      userId: "member_123",
+    })).resolves.toEqual({
+      kind: "not-wakeable",
+      reason: "no-active-child",
+    });
+    expect(containerFetch.mock.calls.slice(callsBeforeWake).some(([url]) =>
+      String(url).endsWith("/internal/runtime-wake")
+    )).toBe(false);
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: false,
+      reason: "no_active_runtime",
+    });
   });
 
   it("destroys and clears preserved liveness when explicit abort is not delivered", async () => {
@@ -6071,6 +6106,69 @@ function createContainerDouble(input: CreateContainerDoubleInput = {}) {
     destroy,
     getState,
     startAndWaitForPorts,
+  };
+}
+
+async function createPreservedWorkspaceInvocationAfterLostResponse(eventId: string) {
+  let runnerResponseLost = false;
+  let containerGone = false;
+  const getState = vi.fn(async () => {
+    if (containerGone) {
+      throw new Error("No such container");
+    }
+    return {
+      lastChange: Date.now(),
+      status: "running",
+    };
+  });
+  const containerFetch = vi.fn(async (url: string) => {
+    if (url.endsWith("/health")) {
+      if (containerGone) {
+        throw new Error("No such container");
+      }
+      return new Response(JSON.stringify({
+        ...createRunnerHealthResult(),
+        activeJobCount: runnerResponseLost ? 1 : 0,
+      }), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        status: 200,
+      });
+    }
+
+    if (!url.endsWith("/internal/workspace-invocation")) {
+      throw new Error(`Unexpected runner request URL: ${url}`);
+    }
+
+    runnerResponseLost = true;
+    throw new Error("Network connection lost");
+  });
+  const result = createContainerDouble({
+    containerFetch,
+    getState,
+    initialStatus: "running",
+  });
+  const request = createRunnerRequest(eventId);
+
+  await expect(result.container.invoke({
+    job: {
+      kind: "workspace-invocation",
+      request,
+    },
+    timeoutMs: 30_000,
+    userId: "member_123",
+  })).rejects.toThrow("Network connection lost");
+
+  expect(result.startAndWaitForPorts).not.toHaveBeenCalled();
+  expect(result.destroy).not.toHaveBeenCalled();
+
+  return {
+    ...result,
+    markContainerGone: () => {
+      containerGone = true;
+    },
+    request,
   };
 }
 

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3646,6 +3646,24 @@ describe("RunnerContainer", () => {
     });
   });
 
+  it("reports inactive liveness from a missing local pointer when the container is already gone", async () => {
+    const containerFetch = vi.fn(async () => {
+      throw new Error("health should not be probed for missing containers");
+    });
+    const { container } = createContainerDouble({
+      containerFetch,
+      getState: vi.fn(async () => {
+        throw new Error("No such container");
+      }),
+    });
+
+    await expect(container.readActiveRuntimeUserFence()).resolves.toEqual({
+      active: false,
+      reason: "no_active_runtime",
+    });
+    expect(containerFetch).not.toHaveBeenCalled();
+  });
+
   it("destroys and clears preserved liveness when explicit abort is not delivered", async () => {
     let runnerResponseLost = false;
     const containerFetch = vi.fn(async (url: string) => {

--- a/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
+++ b/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
@@ -553,13 +553,23 @@ function createFailingInvokeContainerNamespace(input: {
     | (() => Promise<WorkerActiveRuntimeUserFenceResult>)
     | null;
 }): HostedExecutionContainerNamespaceLike {
+  const readActiveRuntimeUserFenceInput = input.readActiveRuntimeUserFence;
   const stub: HostedExecutionContainerStubLike = {
     destroyInstance: async () => {},
     invoke: async () => {
       throw new Error("container transport failed");
     },
-    ...(input.readActiveRuntimeUserFence
-      ? { readActiveRuntimeUserFence: input.readActiveRuntimeUserFence }
+    ...(readActiveRuntimeUserFenceInput
+      ? {
+          readActiveRuntimeUserFence: createDirectOnlyRpcMethod<
+            NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+          >(
+            async function (this: HostedExecutionContainerStubLike) {
+              expect(this).toBe(stub);
+              return await readActiveRuntimeUserFenceInput.call(this);
+            },
+          ),
+        }
       : {}),
     smokeHealth: async () => ({
       ok: true,
@@ -571,6 +581,20 @@ function createFailingInvokeContainerNamespace(input: {
   return {
     getByName: () => stub,
   };
+}
+
+function createDirectOnlyRpcMethod<T extends (...args: never[]) => unknown>(
+  method: T,
+): T {
+  return new Proxy(method, {
+    get(target, property, receiver) {
+      if (property === "call" || property === "apply" || property === "bind") {
+        throw new TypeError("Cloudflare Durable Object RPC methods must be invoked directly on the stub.");
+      }
+
+      return Reflect.get(target, property, receiver);
+    },
+  });
 }
 
 function createHostedExecutionEnvironment() {

--- a/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
+++ b/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
@@ -288,6 +288,20 @@ describe("runtime invocation transport failure fence handling", () => {
   });
 
   it("clears the write fence when only the lease generation differs", async () => {
+    const readHostedRuntimeStatusFromWeb = vi.fn(async (userId: string) => ({
+      mailboxLag: [],
+      userId,
+      workspace: {
+        createdAt: FIXED_NOW,
+        nextWakeAt: "2026-06-11T00:05:00.000Z",
+        nextWakeReason: "scheduled_wake",
+        redactedStatus: { lastTurn: "ok" },
+        snapshotRef: null,
+        updatedAt: FIXED_NOW,
+        userId,
+        version: "1",
+      },
+    }));
     const harness = await createTransportFailureHarness({
       readActiveRuntimeUserFence: async (token) => ({
         active: true,
@@ -295,11 +309,13 @@ describe("runtime invocation transport failure fence handling", () => {
         leaseGeneration: "999",
         userId: TEST_USER_ID,
       }),
+      readHostedRuntimeStatusFromWeb,
     });
 
     await expect(harness.invoke()).rejects.toThrow("container transport failed");
 
     await expect(harness.stateStore.readWriteFenceToken()).resolves.toBeNull();
+    expect(readHostedRuntimeStatusFromWeb).not.toHaveBeenCalled();
     expect(harness.loggedFailureEntries()).toEqual([
       expect.objectContaining({
         eventCode: "runner.accepted_attempt_failed",

--- a/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
+++ b/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
@@ -210,6 +210,49 @@ describe("runtime invocation transport failure fence handling", () => {
     ]);
   });
 
+  it("keeps the accepted write fence when liveness fails even if committed progress is visible", async () => {
+    const readHostedRuntimeStatusFromWeb = vi.fn(async (userId: string) => ({
+      mailboxLag: [],
+      userId,
+      workspace: {
+        createdAt: FIXED_NOW,
+        nextWakeAt: null,
+        nextWakeReason: null,
+        redactedStatus: {},
+        snapshotRef: null,
+        updatedAt: FIXED_NOW,
+        userId,
+        version: "1",
+      },
+    }));
+    const harness = await createTransportFailureHarness({
+      readActiveRuntimeUserFence: async () => {
+        throw new Error("container health still active");
+      },
+      readHostedRuntimeStatusFromWeb,
+    });
+
+    await expect(harness.invoke()).rejects.toThrow("container transport failed");
+
+    await expect(harness.stateStore.readWriteFenceToken()).resolves.toEqual(
+      expect.objectContaining({
+        attemptId: harness.token.attemptId,
+        userId: TEST_USER_ID,
+      }),
+    );
+    expect(harness.loggedFailureEntries()).toEqual([
+      expect.objectContaining({
+        eventCode: "runner.accepted_attempt_failed",
+        redactedJson: expect.objectContaining({
+          attemptLivenessProbeOutcome: "error",
+          attemptStillActive: false,
+          fenceCleared: false,
+        }),
+      }),
+    ]);
+    expect(readHostedRuntimeStatusFromWeb).not.toHaveBeenCalled();
+  });
+
   it("keeps the accepted write fence when the liveness probe hangs past its timeout but progress is not durable yet", async () => {
     const harness = await createTransportFailureHarness({
       readActiveRuntimeUserFence: () =>

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2210,9 +2210,10 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("preserves a non-wakeable accepted fence when committed-progress recovery is unknown", async () => {
+  it("replaces a non-wakeable accepted fence when committed-progress recovery is unknown", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
@@ -2224,6 +2225,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
+      invocationResults: [invocationResult.promise],
       onStatusRead,
       workspace: createWorkspaceState({ version: "8" }),
     });
@@ -2237,23 +2239,36 @@ describe("HostedUserRunner execution coordination", () => {
     await expect(runner.ensureRuntimeProcessingForUser({
       orchestrationAttemptId: "test-orchestration-attempt-recover-unknown",
       userId: TEST_USER_ID,
-    })).resolves.toEqual({
-      kind: "retry_later",
-      retryAt: "2026-04-27T00:01:01.000Z",
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(onStatusRead).toHaveBeenCalledOnce();
-    expect(invoke).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: token.attemptId,
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
       active_expires_at: null,
       backoff_until: null,
       wake_at: null,
     });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
   });
 
-  it("preserves a non-wakeable accepted fence when committed-progress recovery exhausts the command budget", async () => {
+  it("clears a non-wakeable accepted fence when committed-progress recovery exhausts the command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2272,7 +2287,7 @@ describe("HostedUserRunner execution coordination", () => {
       workspace: createWorkspaceState({ version: "8" }),
     });
     await runner.bindUser(TEST_USER_ID);
-    const token = writeRuntimeFenceForTest(sql, {
+    writeRuntimeFenceForTest(sql, {
       startedAt: "2026-04-27T00:00:00.000Z",
       workspaceVersion: "7",
     });
@@ -2292,14 +2307,14 @@ describe("HostedUserRunner execution coordination", () => {
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: token.attemptId,
+      active_attempt_id: null,
       active_expires_at: null,
       backoff_until: null,
       wake_at: null,
     });
   });
 
-  it("preserves a non-wakeable accepted fence when replacement recovery has no remaining command budget", async () => {
+  it("clears a non-wakeable accepted fence when replacement recovery has no remaining command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2316,7 +2331,7 @@ describe("HostedUserRunner execution coordination", () => {
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
-    const token = writeRuntimeFenceForTest(sql, {
+    writeRuntimeFenceForTest(sql, {
       workspaceVersion: "7",
     });
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
@@ -2327,13 +2342,13 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     })).resolves.toEqual({
       kind: "retry_later",
-      retryAt: "2026-04-27T00:01:10.500Z",
+      retryAt: "2026-04-27T00:00:50.500Z",
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: token.attemptId,
+      active_attempt_id: null,
       wake_at: null,
     });
   });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type {
+  HostedRuntimeEnsureProcessingResponse,
+} from "@murphai/hosted-execution/orchestration-control";
+import type {
   HostedRuntimeWebStatusResponse,
   HostedWorkspaceInvocationResult,
   HostedWorkspaceState,
@@ -2362,7 +2365,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("recovers a wake-unconfirmed runtime fence when web progress already committed", async () => {
+  it("preserves a wake-unconfirmed runtime fence when committed progress belongs to a still-active child", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2371,22 +2374,85 @@ describe("HostedUserRunner execution coordination", () => {
         reason: "active-child-rejected" as const,
       }),
     );
+    let activeAttemptId = "";
+    let activeGeneration = "";
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: true,
+      attemptId: activeAttemptId,
+      leaseGeneration: activeGeneration,
+      userId: TEST_USER_ID,
+    }));
     const onStatusRead = vi.fn();
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       mailboxLag: [createMailboxLag({ lag: "0" })],
       onStatusRead,
+      readActiveRuntimeUserFence,
       workspace: createWorkspaceState({ version: "8" }),
     });
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: TEST_USER_ID,
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    activeAttemptId = token.attemptId;
+    activeGeneration = String(token.generation);
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-recover-wake-unconfirmed",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:46.000Z",
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      wake_at: null,
+    });
+  });
+
+  it("recovers a wake-unconfirmed runtime fence only after liveness confirms no active child", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "wake-unconfirmed" as const,
+        reason: "active-child-rejected" as const,
+      }),
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: false,
+      reason: "no_active_runtime",
+    }));
+    const onStatusRead = vi.fn();
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: TEST_USER_ID,
       startedAt: "2026-04-27T00:00:00.000Z",
       workspaceVersion: "7",
     });
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
 
     await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-recover-wake-unconfirmed",
+      orchestrationAttemptId: "test-orchestration-attempt-recover-inactive-wake-unconfirmed",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
       action: "already_running",
@@ -2396,11 +2462,72 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
     expect(onStatusRead).toHaveBeenCalledOnce();
     expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: null,
       last_invocation_at: "2026-04-27T00:00:31.000Z",
+      wake_at: null,
+    });
+  });
+
+  it("does not run committed-progress recovery after the active wake spends the caller command budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+        return {
+          action: "woken" as const,
+          kind: "accepted" as const,
+        };
+      },
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: false,
+      reason: "no_active_runtime",
+    }));
+    const onStatusRead = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
+    });
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: TEST_USER_ID,
+      workspaceVersion: "7",
+    });
+
+    let settled: HostedRuntimeEnsureProcessingResponse | null = null;
+    void runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 5_000,
+      orchestrationAttemptId: "test-orchestration-attempt-budgeted-recovery",
+      userId: TEST_USER_ID,
+    }).then((response) => {
+      settled = response;
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    await Promise.resolve();
+
+    expect(settled).toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:14.000Z",
+    });
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).not.toHaveBeenCalled();
+    expect(onStatusRead).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      active_expires_at: null,
       wake_at: null,
     });
   });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -279,6 +279,9 @@ describe("HostedUserRunner execution coordination", () => {
   it("accepts runtime processing start before the invocation reaches idle", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
+    const abortWorkspaceInvocation = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+    >(async () => "requested");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const { invoke, runner, sql, waitUntilPromises } = createRunnerHarness({
       invocationResults: [invocationResult.promise],
@@ -1975,6 +1978,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledTimes(2);
+    expect(abortWorkspaceInvocation).toHaveBeenCalledTimes(2);
     expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
       attemptId: token.attemptId,
       leaseGeneration: String(token.generation),
@@ -2178,6 +2182,9 @@ describe("HostedUserRunner execution coordination", () => {
   it("preempts a fresh inactive retention-only fence for default processing", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
+    const abortWorkspaceInvocation = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+    >(async () => "requested");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const onStatusRead = vi.fn();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2193,6 +2200,7 @@ describe("HostedUserRunner execution coordination", () => {
       reason: "no_active_runtime",
     }));
     const { invoke, runner, sql } = createRunnerHarness({
+      abortWorkspaceInvocation,
       ensureProcessing,
       invocationResults: [invocationResult.promise],
       onStatusRead,
@@ -2219,6 +2227,11 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
+      attemptId: token.attemptId,
+      leaseGeneration: String(token.generation),
+      userId: TEST_USER_ID,
+    });
     expect(onStatusRead).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1938,19 +1938,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(ensureProcessing).toHaveBeenCalledWith({
-      activeRuntime: {
-        attemptId: token.attemptId,
-        leaseGeneration: String(token.generation),
-        orchestration: {
-          activeWakeStartedAtEpochMs: Date.parse("2026-04-27T00:00:31.000Z"),
-          userRunnerEnsureStartedAtEpochMs: Date.parse("2026-04-27T00:00:31.000Z"),
-        },
-        processingMode: "inbox_media_retention",
-        userId: TEST_USER_ID,
-      },
-      userId: TEST_USER_ID,
-    });
+    expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),
@@ -1968,6 +1956,65 @@ describe("HostedUserRunner execution coordination", () => {
         last_invocation_at: expect.any(String),
       })
     );
+  });
+
+  it("clears a stale retention fence when inactive proof is followed by exhausted recovery budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20_000));
+        return {
+          kind: "start-required" as const,
+          reason: "no-active-child" as const,
+        };
+      },
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: false,
+      reason: "no_active_runtime",
+    }));
+    const onStatusRead = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20_000));
+    });
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    writeRuntimeFenceForTest(sql, {
+      processingMode: "inbox_media_retention",
+      runnerContainerName: TEST_USER_ID,
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    const response = runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 5_000,
+      orchestrationAttemptId: "test-orchestration-attempt-retention-inactive-budget",
+      processingMode: "inbox_media_retention",
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(onStatusRead).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    await expect(response).resolves.toMatchObject({
+      kind: "retry_later",
+    });
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(ensureProcessing).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: null,
+      active_expires_at: null,
+      wake_at: null,
+    });
   });
 
   it("probes workspace wakes behind an active runtime write fence", async () => {

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2253,7 +2253,53 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("does not give a replacement start a fresh caller command budget", async () => {
+  it("preserves a non-wakeable accepted fence when committed-progress recovery exhausts the command budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "start-required" as const,
+        reason: "no-active-child" as const,
+      }),
+    );
+    const onStatusRead = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20_000));
+    });
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    const response = runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 5_000,
+      orchestrationAttemptId: "test-orchestration-attempt-recover-timeout-unknown",
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(onStatusRead).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    await expect(response).resolves.toMatchObject({
+      kind: "retry_later",
+    });
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      active_expires_at: null,
+      backoff_until: null,
+      wake_at: null,
+    });
+  });
+
+  it("preserves a non-wakeable accepted fence when replacement recovery has no remaining command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2270,7 +2316,7 @@ describe("HostedUserRunner execution coordination", () => {
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
-    writeRuntimeFenceForTest(sql, {
+    const token = writeRuntimeFenceForTest(sql, {
       workspaceVersion: "7",
     });
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
@@ -2281,13 +2327,13 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     })).resolves.toEqual({
       kind: "retry_later",
-      retryAt: "2026-04-27T00:00:50.500Z",
+      retryAt: "2026-04-27T00:01:10.500Z",
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
+      active_attempt_id: token.attemptId,
       wake_at: null,
     });
   });
@@ -2570,6 +2616,71 @@ describe("HostedUserRunner execution coordination", () => {
       last_invocation_at: "2026-04-27T00:00:31.000Z",
       wake_at: null,
     });
+  });
+
+  it("replaces a wake-unconfirmed inactive fence when committed progress is not durable", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "wake-unconfirmed" as const,
+        reason: "container-rpc-error" as const,
+      }),
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: false,
+      reason: "no_active_runtime",
+    }));
+    const onStatusRead = vi.fn();
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      invocationResults: [invocationResult.promise],
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: TEST_USER_ID,
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-replace-inactive-wake-unconfirmed",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
+      active_expires_at: null,
+      wake_at: null,
+    });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
   });
 
   it("does not run committed-progress recovery after the active wake spends the caller command budget", async () => {
@@ -3484,6 +3595,7 @@ function createRunnerHarness(input: {
       return await next;
     },
   );
+  const readActiveRuntimeUserFenceInput = input.readActiveRuntimeUserFence;
   const ensureReadyForProcessing = input.ensureReadyForProcessing === null
     ? null
     : createDirectOnlyRpcMethod<NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>>(
@@ -3546,8 +3658,17 @@ function createRunnerHarness(input: {
       service: "runner",
       status: 200,
     }),
-    ...(input.readActiveRuntimeUserFence
-      ? { readActiveRuntimeUserFence: input.readActiveRuntimeUserFence }
+    ...(readActiveRuntimeUserFenceInput
+      ? {
+          readActiveRuntimeUserFence: createDirectOnlyRpcMethod<
+            NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+          >(
+            async function (this: HostedExecutionContainerStubLike) {
+              expect(this).toBe(stub);
+              return await readActiveRuntimeUserFenceInput.call(this);
+            },
+          ),
+        }
       : {}),
   };
   const namespace: HostedExecutionContainerNamespaceLike = {

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1741,6 +1741,61 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
+  it("preempts a legacy retention fence with no persisted container name", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const abortWorkspaceInvocation = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+    >(async () => "accepted");
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    let activeAttemptId = "";
+    let activeGeneration = "";
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: true,
+      attemptId: activeAttemptId,
+      leaseGeneration: activeGeneration,
+      userId: TEST_USER_ID,
+    }));
+    const { invoke, runner, sql } = createRunnerHarness({
+      abortWorkspaceInvocation,
+      invocationResults: [invocationResult.promise],
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      processingMode: "inbox_media_retention",
+      runnerContainerName: null,
+      workspaceVersion: "7",
+    });
+    activeAttemptId = token.attemptId;
+    activeGeneration = String(token.generation);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-default-behind-legacy-retention",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
+    });
+
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
+      attemptId: token.attemptId,
+      leaseGeneration: String(token.generation),
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+  });
+
   it("waits for inactive proof after requesting abort for indeterminate retention liveness", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1876,6 +1876,44 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("does not preempt retention through a rejected runner container name", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const getByName = vi.fn((): HostedExecutionContainerStubLike => {
+      throw new Error("rejected container name must not be used");
+    });
+    const { invoke, runner, sql } = createRunnerHarness({
+      runnerContainerNamespace: { getByName },
+      runnerRuntimeEnvSource: {
+        ...TEST_RUNNER_RUNTIME_ENV_SOURCE,
+        CF_VERSION_METADATA: { id: "current" },
+      },
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      processingMode: "inbox_media_retention",
+      runnerContainerName: "member_other--v-current",
+      workspaceVersion: "7",
+    });
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-default-behind-rejected-retention-name",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:30.000Z",
+    });
+
+    expect(getByName).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      active_expires_at: null,
+      wake_at: null,
+    });
+  });
+
   it("waits for inactive proof after requesting abort for indeterminate retention liveness", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
@@ -2050,7 +2088,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -2116,7 +2154,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -2181,7 +2219,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -2247,7 +2285,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -2465,9 +2503,10 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("recovers a non-wakeable accepted fence when durable progress is already visible", async () => {
+  it("replaces a non-wakeable inactive fence without reading web status", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
@@ -2477,6 +2516,7 @@ describe("HostedUserRunner execution coordination", () => {
     const onStatusRead = vi.fn();
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
+      invocationResults: [invocationResult.promise],
       mailboxLag: [],
       onStatusRead,
       workspace: createWorkspaceState({ version: "8" }),
@@ -2489,31 +2529,43 @@ describe("HostedUserRunner execution coordination", () => {
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
 
     await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-recover-completed-inactive-fence",
+      orchestrationAttemptId: "test-orchestration-attempt-replace-inactive-fence-without-status",
       userId: TEST_USER_ID,
-    })).resolves.toEqual({
-      kind: "retry_later",
-      retryAt: "2026-04-27T00:00:36.000Z",
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
-    expect(invoke).not.toHaveBeenCalled();
+    expect(onStatusRead).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
       active_expires_at: null,
       backoff_until: null,
-      last_invocation_at: expect.any(String),
       wake_at: null,
     });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
   });
 
-  it("preserves a non-wakeable accepted fence when recovery has no remaining command budget", async () => {
+  it("clears a non-wakeable inactive fence when replacement has no remaining command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => {
-        vi.setSystemTime(new Date("2026-04-27T00:00:40.500Z"));
+        vi.setSystemTime(new Date("2026-04-27T00:00:41.500Z"));
         return {
           kind: "start-required" as const,
           reason: "no-active-child" as const,
@@ -2525,7 +2577,7 @@ describe("HostedUserRunner execution coordination", () => {
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
-    const token = writeRuntimeFenceForTest(sql, {
+    writeRuntimeFenceForTest(sql, {
       workspaceVersion: "7",
     });
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
@@ -2536,13 +2588,13 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     })).resolves.toEqual({
       kind: "retry_later",
-      retryAt: "2026-04-27T00:00:50.500Z",
+      retryAt: "2026-04-27T00:00:51.500Z",
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: token.attemptId,
+      active_attempt_id: null,
       wake_at: null,
     });
   });
@@ -2768,7 +2820,7 @@ describe("HostedUserRunner execution coordination", () => {
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),
@@ -2833,7 +2885,7 @@ describe("HostedUserRunner execution coordination", () => {
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1571,7 +1571,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("accepts active retention-only rechecks without waking the running retention pass", async () => {
+  it("accepts active legacy retention-only rechecks without waking the running retention pass", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -1596,7 +1596,7 @@ describe("HostedUserRunner execution coordination", () => {
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
       processingMode: "inbox_media_retention",
-      runnerContainerName: TEST_USER_ID,
+      runnerContainerName: null,
       workspaceVersion: "7",
     });
 
@@ -2005,9 +2005,11 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("keeps opposite-mode runtime busy when the persisted fence has no container name", async () => {
+  it("replaces a stale legacy default fence when retention processing has no active child", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const onStatusRead = vi.fn();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         action: "woken" as const,
@@ -2022,6 +2024,8 @@ describe("HostedUserRunner execution coordination", () => {
     }));
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
+      invocationResults: [invocationResult.promise],
+      onStatusRead,
       readActiveRuntimeUserFence,
       workspace: createWorkspaceState({ version: "7" }),
     });
@@ -2038,19 +2042,33 @@ describe("HostedUserRunner execution coordination", () => {
       orchestrationAttemptId: "test-orchestration-attempt-retention-behind-legacy-default",
       processingMode: "inbox_media_retention",
       userId: TEST_USER_ID,
-    })).resolves.toEqual({
-      kind: "retry_later",
-      retryAt: "2026-04-27T00:00:36.000Z",
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
     });
 
-    expect(readActiveRuntimeUserFence).not.toHaveBeenCalled();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).toHaveBeenCalledOnce();
     expect(ensureProcessing).not.toHaveBeenCalled();
-    expect(invoke).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: token.attemptId,
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
       active_expires_at: null,
       wake_at: null,
     });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
   });
 
   it("replaces a stale default fence when retention processing has no active child", async () => {
@@ -2184,10 +2202,11 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("replaces a stale retention-only fence when retention processing has no active child", async () => {
+  it("replaces a stale legacy retention-only fence when retention processing has no active child", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const onStatusRead = vi.fn();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
@@ -2203,13 +2222,14 @@ describe("HostedUserRunner execution coordination", () => {
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       invocationResults: [invocationResult.promise],
+      onStatusRead,
       readActiveRuntimeUserFence,
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
       processingMode: "inbox_media_retention",
-      runnerContainerName: TEST_USER_ID,
+      runnerContainerName: null,
       startedAt: "2026-04-26T23:59:20.000Z",
       workspaceVersion: "7",
     });
@@ -2227,6 +2247,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).toHaveBeenCalledOnce();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2362,6 +2362,49 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("recovers a wake-unconfirmed runtime fence when web progress already committed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "wake-unconfirmed" as const,
+        reason: "active-child-rejected" as const,
+      }),
+    );
+    const onStatusRead = vi.fn();
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-recover-wake-unconfirmed",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "already_running",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: token.attemptId,
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: null,
+      last_invocation_at: "2026-04-27T00:00:31.000Z",
+      wake_at: null,
+    });
+  });
+
   it("returns retry_later when active child wake exceeds the caller command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1748,6 +1748,10 @@ describe("HostedUserRunner execution coordination", () => {
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
     >(async () => "accepted");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const versionedContainerName = `${TEST_USER_ID}--v-current`;
+    const versionedInvoke = vi.fn<HostedExecutionContainerStubLike["invoke"]>(
+      async () => await invocationResult.promise,
+    );
     let activeAttemptId = "";
     let activeGeneration = "";
     const readActiveRuntimeUserFence = vi.fn<
@@ -1758,10 +1762,82 @@ describe("HostedUserRunner execution coordination", () => {
       leaseGeneration: activeGeneration,
       userId: TEST_USER_ID,
     }));
+    const readVersionedActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: false,
+      reason: "no_active_runtime",
+    }));
+    const legacyStub: HostedExecutionContainerStubLike = {
+      abortWorkspaceInvocation: createDirectOnlyRpcMethod<
+        NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+      >(
+        async function (this: HostedExecutionContainerStubLike, abortInput) {
+          expect(this).toBe(legacyStub);
+          return await abortWorkspaceInvocation(abortInput);
+        },
+      ),
+      destroyInstance: async () => {},
+      invoke: async () => {
+        throw new Error("legacy retention container must not receive foreground invoke");
+      },
+      readActiveRuntimeUserFence: createDirectOnlyRpcMethod<
+        NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+      >(
+        async function (this: HostedExecutionContainerStubLike) {
+          expect(this).toBe(legacyStub);
+          return await readActiveRuntimeUserFence();
+        },
+      ),
+      smokeHealth: async () => ({
+        ok: true,
+        runnerBundle: null,
+        service: "runner",
+        status: 200,
+      }),
+    };
+    const versionedStub: HostedExecutionContainerStubLike = {
+      destroyInstance: async () => {},
+      ensureReadyForProcessing: createDirectOnlyRpcMethod<
+        NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
+      >(
+        async function (this: HostedExecutionContainerStubLike) {
+          expect(this).toBe(versionedStub);
+          return { kind: "ready" };
+        },
+      ),
+      invoke: versionedInvoke,
+      readActiveRuntimeUserFence: createDirectOnlyRpcMethod<
+        NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+      >(
+        async function (this: HostedExecutionContainerStubLike) {
+          expect(this).toBe(versionedStub);
+          return await readVersionedActiveRuntimeUserFence();
+        },
+      ),
+      smokeHealth: async () => ({
+        ok: true,
+        runnerBundle: null,
+        service: "runner",
+        status: 200,
+      }),
+    };
+    const getByName = vi.fn((name: string): HostedExecutionContainerStubLike => {
+      if (name === TEST_USER_ID) {
+        return legacyStub;
+      }
+      if (name === versionedContainerName) {
+        return versionedStub;
+      }
+      throw new Error(`Unexpected runner container name: ${name}`);
+    });
     const { invoke, runner, sql } = createRunnerHarness({
-      abortWorkspaceInvocation,
       invocationResults: [invocationResult.promise],
-      readActiveRuntimeUserFence,
+      runnerContainerNamespace: { getByName },
+      runnerRuntimeEnvSource: {
+        ...TEST_RUNNER_RUNTIME_ENV_SOURCE,
+        CF_VERSION_METADATA: { id: "current" },
+      },
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
@@ -1783,12 +1859,16 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(readVersionedActiveRuntimeUserFence).not.toHaveBeenCalled();
     expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
       attemptId: token.attemptId,
       leaseGeneration: String(token.generation),
       userId: TEST_USER_ID,
     });
-    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(getByName).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(getByName).toHaveBeenCalledWith(versionedContainerName);
+    await vi.waitFor(() => expect(versionedInvoke).toHaveBeenCalledOnce());
+    expect(invoke).not.toHaveBeenCalled();
 
     invocationResult.resolve({
       nextWakeAt: null,

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1666,15 +1666,19 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("keeps default processing from waking active retention-only work", async () => {
+  it("preempts active retention-only work before starting default processing", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
+    const abortWorkspaceInvocation = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+    >(async () => {});
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         action: "woken" as const,
         kind: "accepted" as const,
       }),
     );
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     let activeAttemptId = "";
     let activeGeneration = "";
     const readActiveRuntimeUserFence = vi.fn<
@@ -1686,7 +1690,9 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     }));
     const { invoke, runner, sql } = createRunnerHarness({
+      abortWorkspaceInvocation,
       ensureProcessing,
+      invocationResults: [invocationResult.promise],
       readActiveRuntimeUserFence,
       workspace: createWorkspaceState({ version: "7" }),
     });
@@ -1702,19 +1708,37 @@ describe("HostedUserRunner execution coordination", () => {
     await expect(runner.ensureRuntimeProcessingForUser({
       orchestrationAttemptId: "test-orchestration-attempt-default-behind-retention",
       userId: TEST_USER_ID,
-    })).resolves.toEqual({
-      kind: "retry_later",
-      retryAt: "2026-04-27T00:00:05.000Z",
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:00.000Z",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
+      attemptId: token.attemptId,
+      leaseGeneration: String(token.generation),
+      userId: TEST_USER_ID,
+    });
     expect(ensureProcessing).not.toHaveBeenCalled();
-    expect(invoke).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: token.attemptId,
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
       active_expires_at: null,
       wake_at: null,
     });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
   });
 
   it("keeps opposite-mode runtime busy when the active child identity does not match the fence", async () => {
@@ -1819,6 +1843,9 @@ describe("HostedUserRunner execution coordination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const onStatusRead = vi.fn(() => {
+      throw new Error("Inactive fence replacement must not read hosted status.");
+    });
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
@@ -1834,6 +1861,7 @@ describe("HostedUserRunner execution coordination", () => {
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       invocationResults: [invocationResult.promise],
+      onStatusRead,
       readActiveRuntimeUserFence,
       workspace: createWorkspaceState({ version: "7" }),
     });
@@ -1858,6 +1886,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -1882,6 +1911,9 @@ describe("HostedUserRunner execution coordination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const onStatusRead = vi.fn(() => {
+      throw new Error("Inactive fence replacement must not read hosted status.");
+    });
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
@@ -1897,6 +1929,7 @@ describe("HostedUserRunner execution coordination", () => {
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       invocationResults: [invocationResult.promise],
+      onStatusRead,
       readActiveRuntimeUserFence,
       workspace: createWorkspaceState({ version: "7" }),
     });
@@ -1920,6 +1953,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -2001,65 +2035,6 @@ describe("HostedUserRunner execution coordination", () => {
         last_invocation_at: expect.any(String),
       })
     );
-  });
-
-  it("clears a stale retention fence when inactive proof is followed by exhausted recovery budget", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_NOW));
-    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
-      async () => {
-        await new Promise((resolve) => setTimeout(resolve, 20_000));
-        return {
-          kind: "start-required" as const,
-          reason: "no-active-child" as const,
-        };
-      },
-    );
-    const readActiveRuntimeUserFence = vi.fn<
-      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
-    >(async () => ({
-      active: false,
-      reason: "no_active_runtime",
-    }));
-    const onStatusRead = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 20_000));
-    });
-    const { invoke, runner, sql } = createRunnerHarness({
-      ensureProcessing,
-      mailboxLag: [createMailboxLag({ lag: "0" })],
-      onStatusRead,
-      readActiveRuntimeUserFence,
-      workspace: createWorkspaceState({ version: "8" }),
-    });
-    await runner.bindUser(TEST_USER_ID);
-    writeRuntimeFenceForTest(sql, {
-      processingMode: "inbox_media_retention",
-      runnerContainerName: TEST_USER_ID,
-      startedAt: "2026-04-27T00:00:00.000Z",
-      workspaceVersion: "7",
-    });
-    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
-
-    const response = runner.ensureRuntimeProcessingForUser({
-      commandTimeoutMs: 5_000,
-      orchestrationAttemptId: "test-orchestration-attempt-retention-inactive-budget",
-      processingMode: "inbox_media_retention",
-      userId: TEST_USER_ID,
-    });
-    await vi.waitFor(() => expect(onStatusRead).toHaveBeenCalledOnce());
-    await vi.advanceTimersByTimeAsync(4_000);
-
-    await expect(response).resolves.toMatchObject({
-      kind: "retry_later",
-    });
-    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(ensureProcessing).not.toHaveBeenCalled();
-    expect(invoke).not.toHaveBeenCalled();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      active_expires_at: null,
-      wake_at: null,
-    });
   });
 
   it("probes workspace wakes behind an active runtime write fence", async () => {
@@ -2259,50 +2234,7 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("records committed progress before replacing a non-wakeable accepted fence", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_NOW));
-    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
-      async () => ({
-        kind: "start-required" as const,
-        reason: "no-active-child" as const,
-      }),
-    );
-    const onStatusRead = vi.fn();
-    const { invoke, runner, sql } = createRunnerHarness({
-      ensureProcessing,
-      mailboxLag: [createMailboxLag({ lag: "0" })],
-      onStatusRead,
-      workspace: createWorkspaceState({ version: "8" }),
-    });
-    await runner.bindUser(TEST_USER_ID);
-    const token = writeRuntimeFenceForTest(sql, {
-      startedAt: "2026-04-27T00:00:00.000Z",
-      workspaceVersion: "7",
-    });
-    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
-
-    await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-recover-committed",
-      userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
-      action: "already_running",
-      kind: "runtime_processing_accepted",
-      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
-      runtimeAttemptId: token.attemptId,
-    });
-
-    expect(ensureProcessing).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
-    expect(invoke).not.toHaveBeenCalled();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      last_invocation_at: "2026-04-27T00:00:31.000Z",
-      wake_at: null,
-    });
-  });
-
-  it("replaces a non-wakeable accepted fence when committed-progress recovery is unknown", async () => {
+  it("replaces a non-wakeable accepted fence without web status recovery", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
@@ -2312,8 +2244,8 @@ describe("HostedUserRunner execution coordination", () => {
         reason: "no-active-child" as const,
       }),
     );
-    const onStatusRead = vi.fn(async () => {
-      throw new Error("status unavailable");
+    const onStatusRead = vi.fn(() => {
+      throw new Error("status recovery should not run during replacement");
     });
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
@@ -2329,7 +2261,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
 
     await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-recover-unknown",
+      orchestrationAttemptId: "test-orchestration-attempt-replace-without-status-recovery",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
       action: "replaced",
@@ -2339,7 +2271,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),
@@ -2358,52 +2290,6 @@ describe("HostedUserRunner execution coordination", () => {
         last_invocation_at: expect.any(String),
       })
     );
-  });
-
-  it("clears a non-wakeable accepted fence when committed-progress recovery exhausts the command budget", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_NOW));
-    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
-      async () => ({
-        kind: "start-required" as const,
-        reason: "no-active-child" as const,
-      }),
-    );
-    const onStatusRead = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 20_000));
-    });
-    const { invoke, runner, sql } = createRunnerHarness({
-      ensureProcessing,
-      mailboxLag: [createMailboxLag({ lag: "0" })],
-      onStatusRead,
-      workspace: createWorkspaceState({ version: "8" }),
-    });
-    await runner.bindUser(TEST_USER_ID);
-    writeRuntimeFenceForTest(sql, {
-      startedAt: "2026-04-27T00:00:00.000Z",
-      workspaceVersion: "7",
-    });
-    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
-
-    const response = runner.ensureRuntimeProcessingForUser({
-      commandTimeoutMs: 5_000,
-      orchestrationAttemptId: "test-orchestration-attempt-recover-timeout-unknown",
-      userId: TEST_USER_ID,
-    });
-    await vi.waitFor(() => expect(onStatusRead).toHaveBeenCalledOnce());
-    await vi.advanceTimersByTimeAsync(4_000);
-
-    await expect(response).resolves.toMatchObject({
-      kind: "retry_later",
-    });
-    expect(ensureProcessing).toHaveBeenCalledOnce();
-    expect(invoke).not.toHaveBeenCalled();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      active_expires_at: null,
-      backoff_until: null,
-      wake_at: null,
-    });
   });
 
   it("clears a non-wakeable accepted fence when replacement recovery has no remaining command budget", async () => {
@@ -2518,7 +2404,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("preserves a wake-unconfirmed runtime fence when committed progress belongs to a still-active child", async () => {
+  it("preserves a wake-unconfirmed runtime fence when liveness still matches the active child", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2556,7 +2442,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
 
     await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-recover-wake-unconfirmed",
+      orchestrationAttemptId: "test-orchestration-attempt-preserve-matching-wake-unconfirmed",
       userId: TEST_USER_ID,
     })).resolves.toEqual({
       kind: "retry_later",
@@ -2621,9 +2507,10 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("recovers a wake-unconfirmed runtime fence only after liveness confirms no active child", async () => {
+  it("replaces a wake-unconfirmed inactive fence after liveness confirms no active child", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "wake-unconfirmed" as const,
@@ -2636,119 +2523,16 @@ describe("HostedUserRunner execution coordination", () => {
       active: false,
       reason: "no_active_runtime",
     }));
-    const onStatusRead = vi.fn();
-    const { invoke, runner, sql } = createRunnerHarness({
-      ensureProcessing,
-      mailboxLag: [createMailboxLag({ lag: "0" })],
-      onStatusRead,
-      readActiveRuntimeUserFence,
-      workspace: createWorkspaceState({ version: "8" }),
+    const onStatusRead = vi.fn(() => {
+      throw new Error("status recovery should not run during replacement");
     });
-    await runner.bindUser(TEST_USER_ID);
-    const token = writeRuntimeFenceForTest(sql, {
-      runnerContainerName: TEST_USER_ID,
-      startedAt: "2026-04-27T00:00:00.000Z",
-      workspaceVersion: "7",
-    });
-    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
-
-    await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-recover-inactive-wake-unconfirmed",
-      userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
-      action: "already_running",
-      kind: "runtime_processing_accepted",
-      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
-      runtimeAttemptId: token.attemptId,
-    });
-
-    expect(ensureProcessing).toHaveBeenCalledOnce();
-    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
-    expect(invoke).not.toHaveBeenCalled();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      last_invocation_at: "2026-04-27T00:00:31.000Z",
-      wake_at: null,
-    });
-  });
-
-  it("recovers a wake-unconfirmed committed fence when the runner container is gone", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_NOW));
-    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
-      async () => ({
-        kind: "wake-unconfirmed" as const,
-        reason: "container-rpc-error" as const,
-      }),
-    );
-    const readActiveRuntimeUserFence = vi.fn<
-      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
-    >(async () => ({
-      active: false,
-      reason: "no_active_runtime",
-    }));
-    const onStatusRead = vi.fn();
-    const { invoke, runner, sql } = createRunnerHarness({
-      ensureProcessing,
-      mailboxLag: [createMailboxLag({ lag: "0" })],
-      onStatusRead,
-      readActiveRuntimeUserFence,
-      workspace: createWorkspaceState({ version: "8" }),
-    });
-    await runner.bindUser(TEST_USER_ID);
-    const token = writeRuntimeFenceForTest(sql, {
-      runnerContainerName: TEST_USER_ID,
-      startedAt: "2026-04-27T00:00:00.000Z",
-      workspaceVersion: "7",
-    });
-    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
-
-    await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-recover-gone-container",
-      userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
-      action: "already_running",
-      kind: "runtime_processing_accepted",
-      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
-      runtimeAttemptId: token.attemptId,
-    });
-
-    expect(ensureProcessing).toHaveBeenCalledOnce();
-    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
-    expect(invoke).not.toHaveBeenCalled();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      last_invocation_at: "2026-04-27T00:00:31.000Z",
-      wake_at: null,
-    });
-  });
-
-  it("replaces a wake-unconfirmed inactive fence when committed progress is not durable", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_NOW));
-    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
-      async () => ({
-        kind: "wake-unconfirmed" as const,
-        reason: "container-rpc-error" as const,
-      }),
-    );
-    const readActiveRuntimeUserFence = vi.fn<
-      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
-    >(async () => ({
-      active: false,
-      reason: "no_active_runtime",
-    }));
-    const onStatusRead = vi.fn();
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       invocationResults: [invocationResult.promise],
       mailboxLag: [createMailboxLag({ lag: "0" })],
       onStatusRead,
       readActiveRuntimeUserFence,
-      workspace: createWorkspaceState({ version: "7" }),
+      workspace: createWorkspaceState({ version: "8" }),
     });
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
@@ -2770,7 +2554,7 @@ describe("HostedUserRunner execution coordination", () => {
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),
@@ -2790,7 +2574,74 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("does not run committed-progress recovery after the active wake spends the caller command budget", async () => {
+  it("replaces a wake-unconfirmed inactive fence when the runner container is gone", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "wake-unconfirmed" as const,
+        reason: "container-rpc-error" as const,
+      }),
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: false,
+      reason: "no_active_runtime",
+    }));
+    const onStatusRead = vi.fn(() => {
+      throw new Error("status recovery should not run during replacement");
+    });
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      invocationResults: [invocationResult.promise],
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: TEST_USER_ID,
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-replace-gone-container",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
+      active_expires_at: null,
+      wake_at: null,
+    });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
+  });
+
+  it("does not probe inactive liveness after the active wake spends the caller command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -3674,6 +3525,7 @@ describe("HostedUserRunner execution coordination", () => {
 
 function createRunnerHarness(input: {
   alarmDeleteError?: Error;
+  abortWorkspaceInvocation?: HostedExecutionContainerStubLike["abortWorkspaceInvocation"];
   bucket?: MemoryEncryptedR2Bucket;
   destroyInstance?: HostedExecutionContainerStubLike["destroyInstance"];
   ensureReadyForProcessing?: HostedExecutionContainerStubLike["ensureReadyForProcessing"] | null;
@@ -3703,6 +3555,7 @@ function createRunnerHarness(input: {
     },
   );
   const readActiveRuntimeUserFenceInput = input.readActiveRuntimeUserFence;
+  const abortWorkspaceInvocationInput = input.abortWorkspaceInvocation;
   const ensureReadyForProcessing = input.ensureReadyForProcessing === null
     ? null
     : createDirectOnlyRpcMethod<NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>>(
@@ -3715,6 +3568,21 @@ function createRunnerHarness(input: {
       );
   const stub: HostedExecutionContainerStubLike = {
     destroyInstance: input.destroyInstance ?? (async () => {}),
+    ...(abortWorkspaceInvocationInput
+      ? {
+          abortWorkspaceInvocation: createDirectOnlyRpcMethod<
+            NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+          >(
+            async function (
+              this: HostedExecutionContainerStubLike,
+              abortInput,
+            ) {
+              expect(this).toBe(stub);
+              return await abortWorkspaceInvocationInput.call(this, abortInput);
+            },
+          ),
+        }
+      : {}),
     ...(ensureReadyForProcessing ? { ensureReadyForProcessing } : {}),
     ...(input.ensureProcessing
       ? {

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2520,6 +2520,58 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("recovers a wake-unconfirmed committed fence when the runner container is gone", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "wake-unconfirmed" as const,
+        reason: "container-rpc-error" as const,
+      }),
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: false,
+      reason: "no_active_runtime",
+    }));
+    const onStatusRead = vi.fn();
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: TEST_USER_ID,
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-recover-gone-container",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "already_running",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
+      runtimeAttemptId: token.attemptId,
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: null,
+      last_invocation_at: "2026-04-27T00:00:31.000Z",
+      wake_at: null,
+    });
+  });
+
   it("does not run committed-progress recovery after the active wake spends the caller command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1621,6 +1621,51 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("returns retry_later for retention rechecks when active child liveness is indeterminate", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        action: "woken" as const,
+        kind: "accepted" as const,
+      }),
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => {
+      throw new Error("liveness unavailable");
+    });
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      processingMode: "inbox_media_retention",
+      runnerContainerName: TEST_USER_ID,
+      workspaceVersion: "7",
+    });
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-retention-liveness-indeterminate",
+      processingMode: "inbox_media_retention",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:30.000Z",
+    });
+
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(ensureProcessing).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      active_expires_at: null,
+      wake_at: null,
+    });
+  });
+
   it("keeps default processing from waking active retention-only work", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2420,6 +2420,54 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("preserves a wake-unconfirmed runtime fence when liveness cannot prove the child is inactive", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "wake-unconfirmed" as const,
+        reason: "active-child-rejected" as const,
+      }),
+    );
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => {
+      throw new Error("container health still active");
+    });
+    const onStatusRead = vi.fn();
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      mailboxLag: [createMailboxLag({ lag: "0" })],
+      onStatusRead,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "8" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: TEST_USER_ID,
+      startedAt: "2026-04-27T00:00:00.000Z",
+      workspaceVersion: "7",
+    });
+    vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-recover-liveness-indeterminate",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:46.000Z",
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(onStatusRead).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      wake_at: null,
+    });
+  });
+
   it("recovers a wake-unconfirmed runtime fence only after liveness confirms no active child", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1741,16 +1741,23 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("preempts retention work through abort when active liveness is indeterminate", async () => {
+  it("waits for inactive proof after requesting abort for indeterminate retention liveness", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const abortWorkspaceInvocation = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => "accepted");
+    >(async () => "requested");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    let activeRuntimeState: "inactive" | "indeterminate" = "indeterminate";
     const readActiveRuntimeUserFence = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
     >(async () => {
+      if (activeRuntimeState === "inactive") {
+        return {
+          active: false,
+          reason: "no_active_runtime",
+        };
+      }
       throw new Error("container health still reports active workspace work");
     });
     const { invoke, runner, sql } = createRunnerHarness({
@@ -1770,12 +1777,31 @@ describe("HostedUserRunner execution coordination", () => {
       orchestrationAttemptId: "test-orchestration-attempt-default-behind-indeterminate-retention",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:05.000Z",
+    });
+
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(abortWorkspaceInvocation).toHaveBeenCalledOnce();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      active_expires_at: null,
+      wake_at: null,
+    });
+
+    activeRuntimeState = "inactive";
+    vi.setSystemTime(new Date("2026-04-27T00:00:05.000Z"));
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-default-behind-inactive-retention",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
       action: "replaced",
       kind: "runtime_processing_accepted",
       runtimeAttemptId: expect.not.stringMatching(token.attemptId),
     });
 
-    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledTimes(2);
     expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
       attemptId: token.attemptId,
       leaseGeneration: String(token.generation),

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1671,7 +1671,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.setSystemTime(new Date(FIXED_NOW));
     const abortWorkspaceInvocation = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => {});
+    >(async () => "accepted");
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         action: "woken" as const,
@@ -1739,6 +1739,59 @@ describe("HostedUserRunner execution coordination", () => {
         last_invocation_at: expect.any(String),
       })
     );
+  });
+
+  it("preempts retention work through abort when active liveness is indeterminate", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const abortWorkspaceInvocation = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+    >(async () => "accepted");
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => {
+      throw new Error("container health still reports active workspace work");
+    });
+    const { invoke, runner, sql } = createRunnerHarness({
+      abortWorkspaceInvocation,
+      invocationResults: [invocationResult.promise],
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      processingMode: "inbox_media_retention",
+      runnerContainerName: TEST_USER_ID,
+      workspaceVersion: "7",
+    });
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-default-behind-indeterminate-retention",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
+    });
+
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
+      attemptId: token.attemptId,
+      leaseGeneration: String(token.generation),
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
+      active_expires_at: null,
+      wake_at: null,
+    });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
   });
 
   it("keeps opposite-mode runtime busy when the active child identity does not match the fence", async () => {

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1907,7 +1907,7 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("replaces a stale retention-only fence when default processing has no active child", async () => {
+  it("preempts a fresh inactive retention-only fence for default processing", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
@@ -1937,13 +1937,13 @@ describe("HostedUserRunner execution coordination", () => {
     const token = writeRuntimeFenceForTest(sql, {
       processingMode: "inbox_media_retention",
       runnerContainerName: TEST_USER_ID,
-      startedAt: "2026-04-26T23:59:20.000Z",
+      startedAt: "2026-04-27T00:00:20.000Z",
       workspaceVersion: "7",
     });
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
 
     await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-default-replaces-stale-retention",
+      orchestrationAttemptId: "test-orchestration-attempt-default-preempts-fresh-inactive-retention",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
       action: "replaced",

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2057,9 +2057,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    const onStatusRead = vi.fn(() => {
-      throw new Error("Inactive fence replacement must not read hosted status.");
-    });
+    const onStatusRead = vi.fn();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
@@ -2100,7 +2098,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).not.toHaveBeenCalled();
+    expect(onStatusRead).toHaveBeenCalledOnce();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -2125,9 +2123,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    const onStatusRead = vi.fn(() => {
-      throw new Error("Inactive fence replacement must not read hosted status.");
-    });
+    const onStatusRead = vi.fn();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
@@ -2167,7 +2163,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).not.toHaveBeenCalled();
+    expect(onStatusRead).toHaveBeenCalledOnce();
     expect(ensureProcessing).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
@@ -2448,22 +2444,19 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("replaces a non-wakeable accepted fence without web status recovery", async () => {
+  it("recovers a non-wakeable accepted fence when durable progress is already visible", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
-    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
       async () => ({
         kind: "start-required" as const,
         reason: "no-active-child" as const,
       }),
     );
-    const onStatusRead = vi.fn(() => {
-      throw new Error("status recovery should not run during replacement");
-    });
+    const onStatusRead = vi.fn();
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
-      invocationResults: [invocationResult.promise],
+      mailboxLag: [],
       onStatusRead,
       workspace: createWorkspaceState({ version: "8" }),
     });
@@ -2475,38 +2468,26 @@ describe("HostedUserRunner execution coordination", () => {
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
 
     await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-replace-without-status-recovery",
+      orchestrationAttemptId: "test-orchestration-attempt-recover-completed-inactive-fence",
       userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
-      action: "replaced",
-      kind: "runtime_processing_accepted",
-      recommendedRecheckAt: "2026-04-27T00:01:31.000Z",
-      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:36.000Z",
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
-    expect(onStatusRead).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(onStatusRead).toHaveBeenCalledOnce();
+    expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: expect.not.stringMatching(token.attemptId),
+      active_attempt_id: null,
       active_expires_at: null,
       backoff_until: null,
+      last_invocation_at: expect.any(String),
       wake_at: null,
     });
-
-    invocationResult.resolve({
-      nextWakeAt: null,
-      status: "idle",
-    });
-    await vi.waitFor(() =>
-      expect(readRunnerMeta(sql)).toMatchObject({
-        active_attempt_id: null,
-        last_invocation_at: expect.any(String),
-      })
-    );
   });
 
-  it("clears a non-wakeable accepted fence when replacement recovery has no remaining command budget", async () => {
+  it("preserves a non-wakeable accepted fence when recovery has no remaining command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2523,7 +2504,7 @@ describe("HostedUserRunner execution coordination", () => {
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
-    writeRuntimeFenceForTest(sql, {
+    const token = writeRuntimeFenceForTest(sql, {
       workspaceVersion: "7",
     });
     vi.setSystemTime(new Date("2026-04-27T00:00:31.000Z"));
@@ -2540,7 +2521,7 @@ describe("HostedUserRunner execution coordination", () => {
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
+      active_attempt_id: token.attemptId,
       wake_at: null,
     });
   });
@@ -2737,16 +2718,14 @@ describe("HostedUserRunner execution coordination", () => {
       active: false,
       reason: "no_active_runtime",
     }));
-    const onStatusRead = vi.fn(() => {
-      throw new Error("status recovery should not run during replacement");
-    });
+    const onStatusRead = vi.fn();
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       invocationResults: [invocationResult.promise],
       mailboxLag: [createMailboxLag({ lag: "0" })],
       onStatusRead,
       readActiveRuntimeUserFence,
-      workspace: createWorkspaceState({ version: "8" }),
+      workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
@@ -2768,7 +2747,7 @@ describe("HostedUserRunner execution coordination", () => {
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).not.toHaveBeenCalled();
+    expect(onStatusRead).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),
@@ -2804,16 +2783,14 @@ describe("HostedUserRunner execution coordination", () => {
       active: false,
       reason: "no_active_runtime",
     }));
-    const onStatusRead = vi.fn(() => {
-      throw new Error("status recovery should not run during replacement");
-    });
+    const onStatusRead = vi.fn();
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       invocationResults: [invocationResult.promise],
       mailboxLag: [createMailboxLag({ lag: "0" })],
       onStatusRead,
       readActiveRuntimeUserFence,
-      workspace: createWorkspaceState({ version: "8" }),
+      workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
@@ -2835,7 +2812,7 @@ describe("HostedUserRunner execution coordination", () => {
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
     expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(onStatusRead).not.toHaveBeenCalled();
+    expect(onStatusRead).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),


### PR DESCRIPTION
## What changed

Fixes hosted runner fence recovery so stale runtime fences do not block real work.

The runner now uses one owner for inactive runtime fences: if liveness proves the fenced child is inactive, Cloudflare clears that exact fence by identity and starts a replacement. If liveness is matching or indeterminate, it preserves the fence and retries.

Foreground/default work also no longer waits behind active `inbox_media_retention` work. When liveness proves the active fenced child is the retention pass, the runner uses the existing container abort seam for that exact attempt, clears the fence by identity, and starts foreground work.

Committed-progress recovery remains in the transport-failure adapter, where it reconciles an accepted invocation whose transport result was lost. It is no longer a second controller-side owner for inactive fence replacement.

## Root cause

The previous fix path split stale-fence ownership across wake results, liveness probes, web status recovery, and replacement. That left edge cases where foreground/default processing could be stuck behind retention-only work, and where inactive-fence replacement depended on a web-status recovery branch that was not the right owner for the transition.

The cleaner state model is:

- `matching` active child: preserve the fence and retry
- `indeterminate` liveness: preserve the fence and retry
- `inactive` child: clear/replace the exact fence by identity
- `active retention + foreground request`: abort the exact retention child, then clear/replace by identity

## Validation

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runtime-invocation-transport-failure.test.ts`
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-container.test.ts`
- `pnpm --dir apps/cloudflare typecheck`

## Invariants

- No new persisted state, routes, tables, schedulers, queues, or config.
- Foreground replies stay higher priority than retention/maintenance work.
- Replacement only clears the exact active fence identity.
- Ambiguous liveness still fails closed by preserving the fence.
- Web remains the product/control source of truth; Cloudflare remains the execution adapter.
