### PR TITLE
Fix paid member Family billing upgrade

### DIFF
--- a/agent-docs/exec-plans/completed/2026-06-30-2026-06-30-family-paid-upgrade.md
+++ b/agent-docs/exec-plans/completed/2026-06-30-2026-06-30-family-paid-upgrade.md
@@ -1,0 +1,75 @@
+# Family paid plan upgrade hotfix
+
+Status: completed
+Created: 2026-06-30
+Updated: 2026-06-30
+
+## Goal
+
+- Let an existing direct paid Pulse/Edge member upgrade to Family from Settings or hosted chat tools without needing a second account, manual Stripe work, or a separate checkout when they already have an active Stripe subscription.
+
+## Success criteria
+
+- Paid direct members see an enabled Family start action when they are not already active Family owners, sponsored members, or suspended.
+- Starting Family from an active direct paid subscription converts the existing Stripe subscription to the Family seat price, preserves the customer/subscription, and activates the Family group when Stripe confirms the paid state.
+- The hosted chat tool can create the owner Family group and complete the same direct-paid conversion path instead of returning a blocked checkout error.
+- Existing invite acceptance rules still reject direct paid members who try to join someone else's Family group.
+- Focused Family billing and Settings page tests pass, plus the required web diff verification passes.
+
+## Scope
+
+- In scope:
+  - Settings Family CTA eligibility.
+  - Hosted Family billing start flow.
+  - Stripe subscription item conversion for active direct paid owners.
+  - Focused backend and Settings tests.
+- Out of scope:
+  - New billing tables, new Stripe products, or a Cloudflare runtime deploy.
+  - CI performance tuning.
+
+## Constraints
+
+- Technical constraints:
+  - Keep Stripe billing ownership in the existing hosted Family billing module.
+  - Do not weaken direct-paid member rejection for invited Family members.
+  - Avoid new persisted state; use Stripe and existing hosted billing refs as the source of truth.
+- Product/process constraints:
+  - This is a live hotfix for a paid user-facing upgrade path.
+  - Keep behavior compatible with existing Family checkout and invite flows.
+
+## Risks and mitigations
+
+1. Risk: A paid owner keeps both direct and Family entitlements after conversion.
+   Mitigation: Clear the direct member billing ref after the Family group is reconciled as paid.
+2. Risk: Stripe update enters a pending/incomplete state.
+   Mitigation: Return a Billing Portal URL instead of claiming activation until Stripe reflects a paid Family subscription.
+3. Risk: Relaxing direct-paid checks lets direct paid users join someone else's Family group.
+   Mitigation: Limit the bypass to owner billing-start paths and preserve the invite acceptance guard.
+
+## Tasks
+
+1. Inspect the current Settings and hosted Family checkout eligibility gates.
+2. Implement direct-paid owner Family conversion on the existing Stripe subscription.
+3. Add focused tests for UI eligibility and direct subscription conversion.
+4. Run scoped verification and the required web diff verification.
+5. Archive the plan, commit, push, and open the PR/deploy path.
+
+## Decisions
+
+- Convert the existing direct paid subscription in place instead of creating a second Checkout Session. This keeps Stripe customer history intact and avoids duplicate active subscriptions.
+- Use existing Family billing refs and membership activation paths; no new state is added.
+
+## Verification
+
+- Commands run:
+  - `pnpm exec vitest run apps/web/test/hosted-family-plan.test.ts --config apps/web/vitest.workspace.ts --project hosted-web-store-config`
+  - `pnpm exec vitest run apps/web/test/settings-page.test.ts --config apps/web/vitest.config.ts`
+  - `pnpm --dir apps/web typecheck`
+  - `git diff --check`
+  - `pnpm test:diff apps/web/src/lib/hosted-onboarding/family-plan.ts apps/web/src/components/settings/hosted-family-settings-actions.tsx 'apps/web/app/(dashboard)/settings/page.tsx' apps/web/test/hosted-family-plan.test.ts apps/web/test/settings-page.test.ts`
+- Expected outcomes:
+  - Focused tests pass.
+  - Typecheck passes.
+  - Diff whitespace check passes.
+  - Web diff verification exits 0.
+Completed: 2026-06-30

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -18,7 +18,6 @@ import {
   canStartHostedPulseTrialPaidPlan,
   canSwitchHostedBillingPlanToPulse,
   canUpgradeHostedBillingPlanToEdge,
-  parseHostedBillingPhase,
 } from "@/src/lib/hosted-onboarding/billing-plans";
 import {
   readHostedFamilyAccessForMember,
@@ -72,14 +71,10 @@ export default async function SettingsPage() {
       : [null, null, null, null, null, null];
   const activeFamilyOwner = familyOwner?.billingActive === true;
   const sponsoredMember = familyAccess !== null && familyOwner === null;
-  const directPaidMember =
-    authenticatedMember?.billingStatus === "active" &&
-    parseHostedBillingPhase(billingRef?.currentBillingPhase) === "paid";
   const canStartFamily =
     authenticatedMember != null &&
     !activeFamilyOwner &&
     !sponsoredMember &&
-    !directPaidMember &&
     !authenticatedMember.suspendedAt;
   const privySessionMatchesAppSession =
     freshPrivySession !== null && freshPrivySession.identity.userId === session?.privyUserId;

--- a/apps/web/src/components/settings/hosted-family-settings-actions.tsx
+++ b/apps/web/src/components/settings/hosted-family-settings-actions.tsx
@@ -81,6 +81,10 @@ export function HostedFamilyStartButton(props: {
         window.location.assign(response.url);
         return;
       }
+      if (response.alreadyActive) {
+        window.location.reload();
+        return;
+      }
       setIsSubmitting(false);
     } catch (error) {
       setIsSubmitting(false);

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -44,7 +44,7 @@ import {
   isHostedMemberSuspended,
   isHostedAccessBlockedBillingStatus,
 } from "./entitlement";
-import { hostedOnboardingError } from "./errors";
+import { hostedOnboardingError, isHostedOnboardingError } from "./errors";
 import {
   HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
   generateHostedAccountGroupId,
@@ -67,11 +67,14 @@ import {
 import {
   HOSTED_FAMILY_MAX_SEATS,
   HOSTED_FAMILY_MIN_SEATS,
+  parseHostedBillingPlanCode,
   parseHostedBillingPhase,
+  type HostedBillingPlanCode,
 } from "./billing-plans";
 import {
   requireHostedOnboardingPublicBaseUrl,
   requireHostedStripeApi,
+  requireHostedStripeBillingPlanConfig,
 } from "./runtime";
 import {
   readHostedOnboardingEnvironment,
@@ -82,12 +85,14 @@ import {
   type HostedMemberActivationResult,
 } from "./member-activation";
 import { createHostedMember } from "./hosted-member-store";
+import { readHostedMemberStripeBillingRef } from "./hosted-member-billing-store";
 import { readHostedMemberIdentity } from "./hosted-member-identity-store";
 import {
   readHostedMemberRoutingState,
   resolveHostedMemberRoutingByTelegramUserId,
   upsertHostedMemberTelegramRoutingBindingTx,
 } from "./hosted-member-routing-store";
+import { isHostedStripeLegacyAiUsageMeteredItem } from "./legacy-usage-price";
 import {
   provisionActiveHostedDomainRootEnvelopeForUserOnly,
 } from "../hosted-crypto/domain-root-store";
@@ -345,6 +350,7 @@ type HostedFamilyBillingCheckoutInput =
   | {
       alreadyActive: true;
     }
+  | HostedFamilyDirectPaidUpgradeInput
   | {
       alreadyActive: false;
       checkoutAttemptId: string;
@@ -354,6 +360,18 @@ type HostedFamilyBillingCheckoutInput =
       seatCount: number;
       stripeCustomerId: string | null;
     };
+
+type HostedFamilyDirectPaidUpgradeInput = {
+  alreadyActive: false;
+  currentPlanCode: HostedBillingPlanCode;
+  currentPriceId: string;
+  group: HostedAccountGroupAccessSnapshot;
+  mode: "directPaidUpgrade";
+  seatCount: number;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  targetPriceId: string;
+};
 
 export function hasHostedMemberEffectiveActiveAccess(
   input: HostedFamilyEntitlementInput,
@@ -1217,6 +1235,7 @@ export async function createHostedFamilyBillingCheckout(input: {
       };
     }
     await assertHostedFamilyOwnerCanStartBillingTx({
+      allowDirectPaidOwner: true,
       groupId: group.id,
       ownerMemberId: group.ownerMemberId,
       tx,
@@ -1232,6 +1251,14 @@ export async function createHostedFamilyBillingCheckout(input: {
         httpStatus: 409,
         message: "Family billing is still syncing. Try again after payment is confirmed.",
       });
+    }
+    const directPaidUpgrade = await readHostedFamilyDirectPaidUpgradeInputTx({
+      group,
+      seatCount,
+      tx,
+    });
+    if (directPaidUpgrade) {
+      return directPaidUpgrade;
     }
     const checkoutAttemptId =
       currentBillingRef?.checkoutAttemptId
@@ -1273,6 +1300,12 @@ export async function createHostedFamilyBillingCheckout(input: {
       alreadyActive: true,
       url: null,
     };
+  }
+  if (isHostedFamilyDirectPaidUpgradeInput(checkoutInput)) {
+    return upgradeHostedFamilyDirectPaidSubscription({
+      ...checkoutInput,
+      prisma,
+    });
   }
 
   const stripe = stripeApi ?? requireHostedStripeApi();
@@ -1327,6 +1360,480 @@ export async function createHostedFamilyBillingCheckout(input: {
     alreadyActive: false,
     url: buildHostedFamilyCheckoutRedirectUrl({ checkoutUrl: checkoutSession.url }) ??
       checkoutSession.url,
+  };
+}
+
+function isHostedFamilyDirectPaidUpgradeInput(
+  input: HostedFamilyBillingCheckoutInput,
+): input is HostedFamilyDirectPaidUpgradeInput {
+  return "mode" in input && input.mode === "directPaidUpgrade";
+}
+
+async function readHostedFamilyDirectPaidUpgradeInputTx(input: {
+  group: HostedAccountGroupAccessSnapshot;
+  seatCount: number;
+  tx: Prisma.TransactionClient;
+}): Promise<HostedFamilyDirectPaidUpgradeInput | null> {
+  const member = await input.tx.hostedMember.findUnique({
+    select: {
+      billingStatus: true,
+      suspendedAt: true,
+    },
+    where: {
+      id: input.group.ownerMemberId,
+    },
+  });
+  const billingRef = await readHostedMemberStripeBillingRef({
+    memberId: input.group.ownerMemberId,
+    prisma: input.tx,
+  });
+
+  if (
+    member?.billingStatus !== HostedBillingStatus.active ||
+    member.suspendedAt ||
+    parseHostedBillingPhase(billingRef?.currentBillingPhase) !== "paid"
+  ) {
+    return null;
+  }
+
+  const currentPlanCode = parseHostedBillingPlanCode(billingRef?.currentBillingPlanCode);
+  if (!currentPlanCode || !billingRef?.stripeCustomerId || !billingRef.stripeSubscriptionId) {
+    return null;
+  }
+
+  const currentConfig = requireHostedStripeBillingPlanConfig({
+    billingPlanCode: currentPlanCode,
+  });
+
+  return {
+    alreadyActive: false,
+    currentPlanCode,
+    currentPriceId: currentConfig.priceId,
+    group: input.group,
+    mode: "directPaidUpgrade",
+    seatCount: input.seatCount,
+    stripeCustomerId: billingRef.stripeCustomerId,
+    stripeSubscriptionId: billingRef.stripeSubscriptionId,
+    targetPriceId: requireHostedFamilyStripePriceId(),
+  };
+}
+
+async function upgradeHostedFamilyDirectPaidSubscription(
+  input: HostedFamilyDirectPaidUpgradeInput & { prisma: PrismaClient },
+): Promise<{ alreadyActive: boolean; url: string | null }> {
+  const stripe = requireHostedStripeApi();
+  const subscription = await callHostedFamilyDirectPaidStripeOperation(
+    "subscription.retrieve",
+    () => stripe.subscriptions.retrieve(input.stripeSubscriptionId, {
+      expand: ["items.data.price"],
+    }),
+  );
+
+  assertHostedFamilyDirectPaidSubscriptionMatchesCustomer({
+    stripeCustomerId: input.stripeCustomerId,
+    subscription,
+  });
+
+  const familyMetadata = buildHostedFamilyDirectPaidSubscriptionMetadata(input.group);
+  const appliedSubscription = isHostedFamilyDirectPaidSubscriptionApplied({
+    seatCount: input.seatCount,
+    subscription,
+    targetPriceId: input.targetPriceId,
+  })
+    ? await normalizeHostedFamilyDirectPaidSubscriptionMetadata({
+        group: input.group,
+        stripe,
+        stripeSubscriptionId: input.stripeSubscriptionId,
+        subscription,
+      })
+    : await callHostedFamilyDirectPaidStripeOperation(
+        "subscription.update.family-items",
+        () =>
+          stripe.subscriptions.update(input.stripeSubscriptionId, {
+            expand: ["items.data.price"],
+            items: buildHostedFamilyDirectPaidSubscriptionItems({
+              ...input,
+              subscription,
+            }),
+            metadata: familyMetadata,
+            payment_behavior: "pending_if_incomplete",
+            proration_behavior: "always_invoice",
+          }, {
+            idempotencyKey: buildHostedFamilyDirectPaidUpgradeIdempotencyKey(input),
+          }),
+      );
+
+  if (!isHostedFamilyDirectPaidSubscriptionApplied({
+    seatCount: input.seatCount,
+    subscription: appliedSubscription,
+    targetPriceId: input.targetPriceId,
+  })) {
+    return {
+      alreadyActive: false,
+      url: await createHostedFamilyDirectPaidUpgradePortalUrl({
+        stripe,
+        stripeCustomerId: input.stripeCustomerId,
+      }),
+    };
+  }
+
+  await reconcileHostedFamilyDirectPaidUpgrade({
+    group: input.group,
+    prisma: input.prisma,
+    subscription: appliedSubscription,
+  });
+
+  return {
+    alreadyActive: true,
+    url: null,
+  };
+}
+
+function buildHostedFamilyDirectPaidSubscriptionItems(
+  input: HostedFamilyDirectPaidUpgradeInput & { subscription: Stripe.Subscription },
+): Stripe.SubscriptionUpdateParams.Item[] {
+  const recurringItem = findHostedFamilyStripeSubscriptionItemByPriceId(
+    input.subscription,
+    input.currentPriceId,
+  );
+
+  if (!recurringItem) {
+    throw buildHostedFamilyDirectPaidSubscriptionItemsUnsupportedError();
+  }
+
+  const items: Stripe.SubscriptionUpdateParams.Item[] = [{
+    id: recurringItem.id,
+    price: input.targetPriceId,
+    quantity: input.seatCount,
+  }];
+
+  for (const item of input.subscription.items.data) {
+    if (item.id === recurringItem.id) {
+      continue;
+    }
+    if (isHostedStripeLegacyAiUsageMeteredItem(item)) {
+      items.push({
+        deleted: true,
+        id: item.id,
+      });
+      continue;
+    }
+    throw buildHostedFamilyDirectPaidSubscriptionItemsUnsupportedError();
+  }
+
+  return items;
+}
+
+async function normalizeHostedFamilyDirectPaidSubscriptionMetadata(input: {
+  group: HostedAccountGroupAccessSnapshot;
+  stripe: Stripe;
+  stripeSubscriptionId: string;
+  subscription: Stripe.Subscription;
+}): Promise<Stripe.Subscription> {
+  if (isHostedFamilyDirectPaidSubscriptionMetadataNormalized(input)) {
+    return input.subscription;
+  }
+
+  return callHostedFamilyDirectPaidStripeOperation(
+    "subscription.update.family-metadata",
+    () =>
+      input.stripe.subscriptions.update(input.stripeSubscriptionId, {
+        expand: ["items.data.price"],
+        metadata: buildHostedFamilyDirectPaidSubscriptionMetadata(input.group),
+      }, {
+        idempotencyKey: buildHostedFamilyDirectPaidMetadataIdempotencyKey({
+          groupId: input.group.id,
+          stripeSubscriptionId: input.stripeSubscriptionId,
+        }),
+      }),
+  );
+}
+
+function buildHostedFamilyDirectPaidSubscriptionMetadata(
+  group: Pick<HostedAccountGroupAccessSnapshot, "id" | "ownerMemberId">,
+): Stripe.MetadataParam {
+  return {
+    ...buildHostedFamilyStripeMetadata(group),
+    ...buildHostedFamilyStripeMetadataUnsetFields([
+      "checkoutOffer",
+      "memberId",
+      "trialDurationDays",
+      "trialPolicyVersion",
+      "trialUsageLimitUsdMicros",
+    ]),
+  };
+}
+
+function buildHostedFamilyStripeMetadataUnsetFields(keys: readonly string[]): Stripe.MetadataParam {
+  return Object.fromEntries(keys.map((key) => [key, ""]));
+}
+
+function isHostedFamilyDirectPaidSubscriptionMetadataNormalized(input: {
+  group: Pick<HostedAccountGroupAccessSnapshot, "id" | "ownerMemberId">;
+  subscription: Stripe.Subscription;
+}): boolean {
+  const metadata = input.subscription.metadata ?? {};
+
+  return metadata.accountGroupId === input.group.id &&
+    metadata.billingPlanCode === HOSTED_FAMILY_BILLING_PLAN_CODE &&
+    metadata.kind === HOSTED_FAMILY_STRIPE_METADATA_KIND &&
+    metadata.ownerMemberId === input.group.ownerMemberId &&
+    !hasOwnStripeMetadataKey(metadata, "checkoutOffer") &&
+    !hasOwnStripeMetadataKey(metadata, "memberId") &&
+    !hasOwnStripeMetadataKey(metadata, "trialDurationDays") &&
+    !hasOwnStripeMetadataKey(metadata, "trialPolicyVersion") &&
+    !hasOwnStripeMetadataKey(metadata, "trialUsageLimitUsdMicros");
+}
+
+function hasOwnStripeMetadataKey(metadata: Stripe.Metadata, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(metadata, key);
+}
+
+function isHostedFamilyDirectPaidSubscriptionApplied(input: {
+  seatCount: number;
+  subscription: Stripe.Subscription;
+  targetPriceId: string;
+}): boolean {
+  if (input.subscription.pending_update) {
+    return false;
+  }
+  if (input.subscription.status !== "active") {
+    return false;
+  }
+
+  const item = findHostedFamilyStripeSubscriptionItemByPriceId(
+    input.subscription,
+    input.targetPriceId,
+  );
+  return item?.quantity === input.seatCount;
+}
+
+function findHostedFamilyStripeSubscriptionItemByPriceId(
+  subscription: Stripe.Subscription,
+  priceId: string,
+): Stripe.SubscriptionItem | null {
+  return subscription.items.data.find((item) => item.price?.id === priceId) ?? null;
+}
+
+function assertHostedFamilyDirectPaidSubscriptionMatchesCustomer(input: {
+  stripeCustomerId: string;
+  subscription: Stripe.Subscription;
+}): void {
+  const subscriptionCustomerId = coerceStripeObjectId(input.subscription.customer);
+  if (subscriptionCustomerId === input.stripeCustomerId) {
+    return;
+  }
+
+  throw hostedOnboardingError({
+    code: "HOSTED_FAMILY_DIRECT_PAID_STRIPE_CUSTOMER_MISMATCH",
+    httpStatus: 409,
+    message: "Your subscription could not be matched to this hosted account.",
+  });
+}
+
+function buildHostedFamilyDirectPaidSubscriptionItemsUnsupportedError(): Error {
+  return hostedOnboardingError({
+    code: "HOSTED_FAMILY_DIRECT_PAID_SUBSCRIPTION_ITEMS_UNSUPPORTED",
+    httpStatus: 409,
+    message: "Your subscription items are not ready for this Family plan change.",
+  });
+}
+
+async function createHostedFamilyDirectPaidUpgradePortalUrl(input: {
+  stripe: Stripe;
+  stripeCustomerId: string;
+}): Promise<string> {
+  const publicBaseUrl = requireHostedOnboardingPublicBaseUrl();
+  const session = await callHostedFamilyDirectPaidStripeOperation(
+    "billingPortal.sessions.create",
+    () =>
+      input.stripe.billingPortal.sessions.create({
+        customer: input.stripeCustomerId,
+        return_url: new URL("/settings", publicBaseUrl).toString(),
+      }),
+  );
+
+  if (!session.url) {
+    throw hostedOnboardingError({
+      code: "STRIPE_PORTAL_SESSION_MISSING_URL",
+      httpStatus: 502,
+      message: "Stripe did not return a billing portal URL.",
+    });
+  }
+
+  return session.url;
+}
+
+async function reconcileHostedFamilyDirectPaidUpgrade(input: {
+  group: HostedAccountGroupAccessSnapshot;
+  prisma: PrismaClient;
+  subscription: Stripe.Subscription;
+}): Promise<void> {
+  const occurredAt = new Date();
+  await input.prisma.$transaction(async (tx) => {
+    const familySeatItem = readHostedFamilyStripeSeatSubscriptionItem(input.subscription);
+    if (!familySeatItem) {
+      throw hostedOnboardingError({
+        code: "HOSTED_FAMILY_DIRECT_PAID_RECONCILIATION_PENDING",
+        httpStatus: 409,
+        message: "Your Family plan change is still syncing. Try again shortly.",
+        retryable: true,
+      });
+    }
+
+    const activeMembershipCount = await tx.hostedAccountGroupMembership.count({
+      where: {
+        groupId: input.group.id,
+        status: "active",
+      },
+    });
+    const stripeBillingStatus = mapStripeSubscriptionStatusToHostedBillingStatus(
+      input.subscription.status,
+    );
+    const activeMembersFitPaidSeats = activeMembershipCount <= familySeatItem.billedSeatCount;
+    const billingStatus = stripeBillingStatus === HostedBillingStatus.active &&
+        !activeMembersFitPaidSeats
+      ? HostedBillingStatus.unpaid
+      : stripeBillingStatus;
+
+    await writeHostedAccountGroupStripeBillingTx({
+      billingStatus,
+      currentBillingPhase:
+        input.subscription.status === "active" && activeMembersFitPaidSeats ? "paid" : null,
+      currentBillingPlanCode: HOSTED_FAMILY_BILLING_PLAN_CODE,
+      ...buildHostedFamilyStripeSubscriptionPeriodSnapshot(input.subscription),
+      billedSeatCount: familySeatItem.billedSeatCount,
+      groupId: input.group.id,
+      stripeCustomerId: coerceStripeObjectId(input.subscription.customer),
+      stripeEventCreatedAt: occurredAt,
+      stripeSubscriptionItemId: familySeatItem.stripeSubscriptionItemId,
+      stripeSubscriptionId: input.subscription.id,
+      tx,
+    });
+
+    if (billingStatus === HostedBillingStatus.active) {
+      await revokeNewestHostedFamilyPendingInvitesToFitBilledSeatsTx({
+        billedSeatCount: familySeatItem.billedSeatCount,
+        groupId: input.group.id,
+        now: occurredAt,
+        tx,
+      });
+      await activateHostedFamilyGroupMembersForActiveBillingTx({
+        groupId: input.group.id,
+        occurredAt,
+        sourceEventId: `family-subscription:${input.subscription.id}`,
+        tx,
+      });
+    }
+
+    await clearHostedFamilyOwnerDirectPaidBillingTx({
+      ownerMemberId: input.group.ownerMemberId,
+      tx,
+    });
+  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+}
+
+async function clearHostedFamilyOwnerDirectPaidBillingTx(input: {
+  ownerMemberId: string;
+  tx: Prisma.TransactionClient;
+}): Promise<void> {
+  await input.tx.hostedMember.update({
+    data: {
+      billingStatus: HostedBillingStatus.not_started,
+    },
+    where: {
+      id: input.ownerMemberId,
+    },
+  });
+  await input.tx.hostedMemberBillingRef.updateMany({
+    data: {
+      currentBillingPhase: null,
+      currentBillingPlanCode: null,
+      currentCheckoutOffer: null,
+      currentPeriodEnd: null,
+      currentPeriodStart: null,
+      currentTrialEndsAt: null,
+      currentTrialStartedAt: null,
+      scheduledBillingEffectiveAt: null,
+      scheduledBillingPlanCode: null,
+      stripeCustomerIdEncrypted: null,
+      stripeCustomerLookupKey: null,
+      stripeSubscriptionIdEncrypted: null,
+      stripeSubscriptionLookupKey: null,
+      stripeSubscriptionScheduleIdEncrypted: null,
+      stripeSubscriptionScheduleLookupKey: null,
+    },
+    where: {
+      memberId: input.ownerMemberId,
+    },
+  });
+}
+
+function buildHostedFamilyDirectPaidUpgradeIdempotencyKey(
+  input: HostedFamilyDirectPaidUpgradeInput,
+): string {
+  return [
+    "hosted-family-direct-paid-upgrade",
+    input.group.id,
+    input.stripeSubscriptionId,
+    input.currentPlanCode,
+    input.currentPriceId,
+    input.targetPriceId,
+    `seats-${input.seatCount}`,
+  ].join(":");
+}
+
+function buildHostedFamilyDirectPaidMetadataIdempotencyKey(input: {
+  groupId: string;
+  stripeSubscriptionId: string;
+}): string {
+  return [
+    "hosted-family-direct-paid-metadata",
+    input.groupId,
+    input.stripeSubscriptionId,
+  ].join(":");
+}
+
+async function callHostedFamilyDirectPaidStripeOperation<T>(
+  operationName: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (isHostedOnboardingError(error)) {
+      throw error;
+    }
+    throw hostedOnboardingError({
+      code: "HOSTED_FAMILY_DIRECT_PAID_STRIPE_UNAVAILABLE",
+      details: {
+        operationName,
+        ...describeSafeHostedFamilyDirectPaidStripeError(error),
+      },
+      httpStatus: 502,
+      message: "Stripe billing is unavailable for Family plan changes right now. Try again shortly.",
+      retryable: true,
+    });
+  }
+}
+
+function describeSafeHostedFamilyDirectPaidStripeError(error: unknown): Record<string, unknown> {
+  if (typeof error !== "object" || error === null) {
+    return {
+      type: typeof error,
+    };
+  }
+
+  const code = Reflect.get(error, "code");
+  const statusCode = Reflect.get(error, "statusCode");
+  const type = Reflect.get(error, "type");
+  const requestId = Reflect.get(error, "requestId");
+
+  return {
+    ...(typeof type === "string" && type.length > 0 ? { type } : {}),
+    ...(typeof code === "string" && code.length > 0 ? { code } : {}),
+    ...(typeof statusCode === "number" ? { statusCode } : {}),
+    requestIdPresent: typeof requestId === "string" && requestId.length > 0,
   };
 }
 
@@ -1663,6 +2170,7 @@ export async function createHostedAccountGroupForOwnerTx(input: {
 
   await lockHostedMemberRow(input.tx, input.ownerMemberId);
   await assertHostedFamilyOwnerCanStartBillingTx({
+    allowDirectPaidOwner: true,
     groupId,
     ownerMemberId: input.ownerMemberId,
     tx: input.tx,
@@ -1712,6 +2220,7 @@ export async function ensureHostedAccountGroupForOwnerTx(input: {
     });
     if (!hasHostedAccountGroupAccess(existingGroup)) {
       await assertHostedFamilyMemberNotDirectPaidTx({
+        allowDirectPaidOwner: true,
         memberId: input.ownerMemberId,
         tx: input.tx,
       });
@@ -2852,6 +3361,7 @@ async function assertHostedFamilyMemberNotSponsoredElsewhereTx(input: {
 }
 
 async function assertHostedFamilyOwnerCanStartBillingTx(input: {
+  allowDirectPaidOwner?: boolean;
   groupId: string;
   ownerMemberId: string;
   tx: Prisma.TransactionClient;
@@ -2862,15 +3372,20 @@ async function assertHostedFamilyOwnerCanStartBillingTx(input: {
     tx: input.tx,
   });
   await assertHostedFamilyMemberNotDirectPaidTx({
+    allowDirectPaidOwner: input.allowDirectPaidOwner,
     memberId: input.ownerMemberId,
     tx: input.tx,
   });
 }
 
 async function assertHostedFamilyMemberNotDirectPaidTx(input: {
+  allowDirectPaidOwner?: boolean;
   memberId: string;
   tx: Prisma.TransactionClient;
 }): Promise<void> {
+  if (input.allowDirectPaidOwner) {
+    return;
+  }
   if (await hasHostedFamilyMemberDirectPaidTx(input)) {
     throw hostedOnboardingError({
       code: "HOSTED_FAMILY_DIRECT_PAID_TRANSFER_REQUIRED",

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -21,6 +21,7 @@ const identityMocks = vi.hoisted(() => ({
 const runtimeMocks = vi.hoisted(() => ({
   requireHostedOnboardingPublicBaseUrl: vi.fn(),
   requireHostedStripeApi: vi.fn(),
+  requireHostedStripeBillingPlanConfig: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-web/encryption", () => ({
@@ -43,6 +44,7 @@ vi.mock("@/src/lib/hosted-onboarding/member-identity-service", () => ({
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   requireHostedOnboardingPublicBaseUrl: runtimeMocks.requireHostedOnboardingPublicBaseUrl,
   requireHostedStripeApi: runtimeMocks.requireHostedStripeApi,
+  requireHostedStripeBillingPlanConfig: runtimeMocks.requireHostedStripeBillingPlanConfig,
 }));
 
 import {
@@ -102,6 +104,11 @@ type FamilyPlanTxMock = Prisma.TransactionClient & {
   hostedMember: Prisma.TransactionClient["hostedMember"] & {
     create: MockFn;
     findUnique: MockFn;
+    update: MockFn;
+  };
+  hostedMemberBillingRef: Prisma.TransactionClient["hostedMemberBillingRef"] & {
+    findUnique: MockFn;
+    updateMany: MockFn;
   };
   hostedMemberRouting: Prisma.TransactionClient["hostedMemberRouting"] & {
     findMany: MockFn;
@@ -125,6 +132,10 @@ describe("hosted Family plan", () => {
     process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_FAMILY_SEAT_MONTHLY;
   const previousLegacyHostedFamilyStripePriceId =
     process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_FAMILY_MONTHLY;
+  const previousHostedPulseStripePriceId =
+    process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_MONTHLY;
+  const previousHostedEdgeStripePriceId =
+    process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_EDGE_MONTHLY;
   const previousHostedOnboardingPublicBaseUrl =
     process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL;
 
@@ -133,6 +144,8 @@ describe("hosted Family plan", () => {
     process.env.HOSTED_CONTACT_PRIVACY_KEYS = `v1:${TEST_CONTACT_PRIVACY_KEY}`;
     process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = "v1";
     process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL = "https://local.withmurph.ai:3443";
+    process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_MONTHLY = "price_pulse";
+    process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_EDGE_MONTHLY = "price_edge";
     process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_FAMILY_SEAT_MONTHLY = "price_family";
     delete process.env.HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_FAMILY_MONTHLY;
     clearHostedOnboardingEnvCache();
@@ -157,6 +170,11 @@ describe("hosted Family plan", () => {
         }),
       },
     });
+    runtimeMocks.requireHostedStripeBillingPlanConfig.mockImplementation(({ billingPlanCode }) => ({
+      billingPlanCode,
+      priceId: billingPlanCode === "launch_edge_monthly" ? "price_edge" : "price_pulse",
+      stripe: runtimeMocks.requireHostedStripeApi(),
+    }));
     runtimeMocks.requireHostedOnboardingPublicBaseUrl.mockReturnValue(
       "https://local.withmurph.ai:3443",
     );
@@ -181,6 +199,14 @@ describe("hosted Family plan", () => {
     restoreEnvValue(
       "HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_FAMILY_SEAT_MONTHLY",
       previousHostedFamilyStripePriceId,
+    );
+    restoreEnvValue(
+      "HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_MONTHLY",
+      previousHostedPulseStripePriceId,
+    );
+    restoreEnvValue(
+      "HOSTED_ONBOARDING_STRIPE_PRICE_ID_LAUNCH_EDGE_MONTHLY",
+      previousHostedEdgeStripePriceId,
     );
     restoreEnvValue(
       "HOSTED_ONBOARDING_PUBLIC_BASE_URL",
@@ -1571,7 +1597,16 @@ describe("hosted Family plan", () => {
       billedSeatCount: null,
       group,
     });
-    tx.hostedAccountGroupBillingRef.findUnique.mockResolvedValueOnce(null);
+    tx.hostedAccountGroupBillingRef.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(createBillingRefMock({
+        billedSeatCount: null,
+        currentBillingPhase: null,
+        group,
+        stripeCustomerIdEncrypted: null,
+        stripeSubscriptionIdEncrypted: null,
+        stripeSubscriptionItemIdEncrypted: null,
+      }));
     const prisma = tx as FamilyPlanTxMock & {
       $transaction: ReturnType<typeof vi.fn>;
     };
@@ -1629,6 +1664,181 @@ describe("hosted Family plan", () => {
         groupId: "hbag_family",
       }),
     }));
+  });
+
+  it("converts an active direct paid owner subscription into Family billing without creating a second checkout", async () => {
+    const group = {
+      billingStatus: HostedBillingStatus.not_started,
+      id: "hbag_family",
+      ownerMemberId: "member_owner",
+      suspendedAt: null,
+    };
+    const tx = createTxMock({
+      billedSeatCount: null,
+      group,
+    });
+    tx.hostedAccountGroupBillingRef.findUnique.mockResolvedValueOnce(null);
+    tx.hostedMember.findUnique.mockResolvedValueOnce({
+      billingStatus: HostedBillingStatus.active,
+      suspendedAt: null,
+    });
+    tx.hostedMemberBillingRef.findUnique.mockResolvedValueOnce(createMemberBillingRefMock());
+
+    const prisma = tx as FamilyPlanTxMock & {
+      $transaction: ReturnType<typeof vi.fn>;
+    };
+    prisma.$transaction = vi.fn((callback) => callback(tx));
+    const checkoutCreate = vi.fn();
+    const directSubscription = makeFamilyStripeSubscription({
+      customerId: "cus_direct",
+      itemQuantity: 1,
+      metadata: {
+        billingPlanCode: "launch_monthly",
+        checkoutOffer: "standard",
+        memberId: "member_owner",
+      },
+      priceId: "price_pulse",
+      subscriptionId: "sub_direct",
+    });
+    const updatedSubscription = makeFamilyStripeSubscription({
+      customerId: "cus_direct",
+      itemQuantity: 2,
+      metadata: {
+        accountGroupId: "hbag_family",
+        billingPlanCode: "launch_family_monthly",
+        kind: "hosted_family_plan",
+        ownerMemberId: "member_owner",
+      },
+      priceId: "price_family",
+      subscriptionId: "sub_direct",
+    });
+    const subscriptionRetrieve = vi.fn().mockResolvedValue(directSubscription);
+    const subscriptionUpdate = vi.fn().mockResolvedValue(updatedSubscription);
+    runtimeMocks.requireHostedStripeApi.mockReturnValue({
+      checkout: {
+        sessions: {
+          create: checkoutCreate,
+        },
+      },
+      subscriptions: {
+        retrieve: subscriptionRetrieve,
+        update: subscriptionUpdate,
+      },
+    });
+    const result = await createHostedFamilyBillingCheckout({
+      groupId: "hbag_family",
+      ownerMemberId: "member_owner",
+      prisma: prisma as never,
+      seatCount: 2,
+    });
+    expect(result).toEqual({
+      alreadyActive: true,
+      url: null,
+    });
+
+    expect(checkoutCreate).not.toHaveBeenCalled();
+    expect(subscriptionRetrieve).toHaveBeenCalledWith("sub_direct", {
+      expand: ["items.data.price"],
+    });
+    expect(subscriptionUpdate).toHaveBeenCalledWith("sub_direct", expect.objectContaining({
+      items: [{
+        id: "si_family",
+        price: "price_family",
+        quantity: 2,
+      }],
+      metadata: expect.objectContaining({
+        accountGroupId: "hbag_family",
+        billingPlanCode: "launch_family_monthly",
+        checkoutOffer: "",
+        kind: "hosted_family_plan",
+        memberId: "",
+        ownerMemberId: "member_owner",
+      }),
+      payment_behavior: "pending_if_incomplete",
+      proration_behavior: "always_invoice",
+    }), {
+      idempotencyKey: "hosted-family-direct-paid-upgrade:hbag_family:sub_direct:launch_monthly:price_pulse:price_family:seats-2",
+    });
+    expect(tx.hostedAccountGroupBillingRef.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      create: expect.objectContaining({
+        billedSeatCount: 2,
+        currentBillingPhase: "paid",
+        stripeSubscriptionLookupKey: expect.stringMatching(/^hbidx:stripe-subscription:v1:/u),
+      }),
+    }));
+    expect(tx.hostedMember.update).toHaveBeenCalledWith({
+      data: {
+        billingStatus: HostedBillingStatus.not_started,
+      },
+      where: {
+        id: "member_owner",
+      },
+    });
+    expect(tx.hostedMemberBillingRef.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        currentBillingPhase: null,
+        currentBillingPlanCode: null,
+        stripeCustomerLookupKey: null,
+        stripeSubscriptionLookupKey: null,
+      }),
+      where: {
+        memberId: "member_owner",
+      },
+    }));
+  });
+
+  it("keeps unsupported direct paid subscription items as a non-retryable owner transfer error", async () => {
+    const group = {
+      billingStatus: HostedBillingStatus.not_started,
+      id: "hbag_family",
+      ownerMemberId: "member_owner",
+      suspendedAt: null,
+    };
+    const tx = createTxMock({
+      billedSeatCount: null,
+      group,
+    });
+    tx.hostedAccountGroupBillingRef.findUnique.mockResolvedValueOnce(null);
+    tx.hostedMember.findUnique.mockResolvedValueOnce({
+      billingStatus: HostedBillingStatus.active,
+      suspendedAt: null,
+    });
+    tx.hostedMemberBillingRef.findUnique.mockResolvedValueOnce(createMemberBillingRefMock());
+
+    const prisma = tx as FamilyPlanTxMock & {
+      $transaction: ReturnType<typeof vi.fn>;
+    };
+    prisma.$transaction = vi.fn((callback) => callback(tx));
+    const subscriptionUpdate = vi.fn();
+    runtimeMocks.requireHostedStripeApi.mockReturnValue({
+      subscriptions: {
+        retrieve: vi.fn().mockResolvedValue(makeFamilyStripeSubscription({
+          customerId: "cus_direct",
+          duplicateFamilyItems: true,
+          itemQuantity: 1,
+          metadata: {
+            billingPlanCode: "launch_monthly",
+            checkoutOffer: "standard",
+            memberId: "member_owner",
+          },
+          priceId: "price_pulse",
+          subscriptionId: "sub_direct",
+        })),
+        update: subscriptionUpdate,
+      },
+    });
+
+    await expect(createHostedFamilyBillingCheckout({
+      groupId: "hbag_family",
+      ownerMemberId: "member_owner",
+      prisma: prisma as never,
+      seatCount: 2,
+    })).rejects.toMatchObject({
+      code: "HOSTED_FAMILY_DIRECT_PAID_SUBSCRIPTION_ITEMS_UNSUPPORTED",
+      httpStatus: 409,
+      retryable: false,
+    });
+    expect(subscriptionUpdate).not.toHaveBeenCalled();
   });
 
   it("reuses a pending Family checkout attempt for duplicate checkout starts", async () => {
@@ -2162,6 +2372,35 @@ function createBillingRefMock(overrides: Partial<{
   };
 }
 
+function createMemberBillingRefMock(overrides: Partial<{
+  currentBillingPhase: string | null;
+  currentBillingPlanCode: string | null;
+  stripeCustomerIdEncrypted: string | null;
+  stripeSubscriptionIdEncrypted: string | null;
+}> = {}) {
+  return {
+    currentBillingPhase: overrides.currentBillingPhase ?? "paid",
+    currentBillingPlanCode: overrides.currentBillingPlanCode ?? "launch_monthly",
+    currentCheckoutOffer: "standard",
+    currentPeriodEnd: new Date("2026-07-18T12:00:00.000Z"),
+    currentPeriodStart: new Date("2026-06-18T12:00:00.000Z"),
+    currentTrialEndsAt: null,
+    currentTrialStartedAt: null,
+    lastStripeEventCreatedAt: null,
+    memberId: "member_owner",
+    pulseTrialPolicyVersion: null,
+    pulseTrialRedeemedAt: null,
+    scheduledBillingEffectiveAt: null,
+    scheduledBillingPlanCode: null,
+    stripeCustomerIdEncrypted: overrides.stripeCustomerIdEncrypted ?? "encrypted:cus_direct",
+    stripeCustomerLookupKey: "hbidx:stripe-customer:v1:direct",
+    stripeSubscriptionIdEncrypted: overrides.stripeSubscriptionIdEncrypted ?? "encrypted:sub_direct",
+    stripeSubscriptionLookupKey: "hbidx:stripe-subscription:v1:direct",
+    stripeSubscriptionScheduleIdEncrypted: null,
+    stripeSubscriptionScheduleLookupKey: null,
+  };
+}
+
 function createTxMock(input: {
   activeMembershipCount?: number;
   billedSeatCount?: number | null;
@@ -2281,7 +2520,17 @@ function createTxMock(input: {
           currentBillingPhase: null,
         },
         billingStatus: HostedBillingStatus.not_started,
+        suspendedAt: null,
       }),
+      update: vi.fn().mockResolvedValue({
+        billingStatus: HostedBillingStatus.not_started,
+        id: "member_owner",
+        suspendedAt: null,
+      }),
+    },
+    hostedMemberBillingRef: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     },
     hostedMemberRouting: {
       findMany: vi.fn().mockResolvedValue([]),
@@ -2333,17 +2582,20 @@ function makeFamilyStripeCheckoutSession(input: {
 }
 
 function makeFamilyStripeSubscription(input: {
+  customerId?: string;
   duplicateFamilyItems?: boolean;
   itemQuantity?: number;
   metadata?: Stripe.Metadata;
+  priceId?: string;
   subscriptionId?: string;
 } = {}): Stripe.Subscription {
   const subscriptionId = input.subscriptionId ?? "sub_family";
+  const priceId = input.priceId ?? "price_family";
   const familyItem = {
     id: "si_family",
     quantity: input.itemQuantity ?? 4,
     price: {
-      id: "price_family",
+      id: priceId,
     },
   } as Stripe.SubscriptionItem;
   const subscription: Stripe.Subscription & {
@@ -2371,7 +2623,7 @@ function makeFamilyStripeSubscription(input: {
     collection_method: "charge_automatically",
     created: 1_771_948_800,
     currency: "usd",
-    customer: "cus_family",
+    customer: input.customerId ?? "cus_family",
     customer_account: null,
     current_period_end: 1_774_540_800,
     current_period_start: 1_771_948_800,

--- a/apps/web/test/settings-page.test.ts
+++ b/apps/web/test/settings-page.test.ts
@@ -241,6 +241,7 @@ test("SettingsPage reads the app session and persisted account settings into the
   expect(mocks.prisma.hostedCodexAuthConnection.findUnique).not.toHaveBeenCalled();
   expect(mocks.HostedBillingSettings).toHaveBeenCalledWith(expect.objectContaining({
     authenticated: true,
+    canStartFamily: true,
     canStartPaidPulse: false,
     canUpgradeToEdge: true,
     currentBillingPhase: "paid",


### PR DESCRIPTION
## Why
Paid Pulse/Edge members could see Family as unavailable and hosted chat checkout could fail even though Family is live. That blocked an existing paying owner from upgrading their own account to Family.

## User-visible goal
A direct paid Pulse/Edge member can start Family from Settings or the hosted chat tool and become an active Family owner without manual Stripe work or duplicate subscriptions.

## What changed
- Enables the Family start action for eligible direct paid members.
- Converts an active direct paid Stripe subscription in place to the Family seat price and activates the Family group when Stripe confirms the paid state.
- Keeps invite acceptance protections so direct paid members cannot silently join someone else's Family group.

## Invariants to preserve
- No new persisted billing state; existing hosted Family billing refs remain the product source of truth.
- No duplicate Checkout Session for an already active direct paid owner subscription.
- Direct paid invited members are still rejected unless they are the owner starting their own Family billing.

## Verification
- pnpm exec vitest run apps/web/test/hosted-family-plan.test.ts --config apps/web/vitest.workspace.ts --project hosted-web-store-config
- pnpm exec vitest run apps/web/test/settings-page.test.ts --config apps/web/vitest.config.ts
- pnpm --dir apps/web typecheck
- git diff --check
- pnpm test:diff apps/web/src/lib/hosted-onboarding/family-plan.ts apps/web/src/components/settings/hosted-family-settings-actions.tsx 'apps/web/app/(dashboard)/settings/page.tsx' apps/web/test/hosted-family-plan.test.ts apps/web/test/settings-page.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785441290&installation_id=127572939&pr_number=346&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F346&signature=64a2d413985c1b8ce4800ab72f6cd43de24b1eb03ca5a6b1df4ac07f56c9b5bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->