### PR TITLE
[codex] Expand red light therapy device seeds

### DIFF
--- a/packages/assistant-engine/skills/red-light-therapy/SKILL.md
+++ b/packages/assistant-engine/skills/red-light-therapy/SKILL.md
@@ -97,7 +97,8 @@ Ask "what device do you have?" early when dosing depends on duration. Then:
 
 - If the user gives a Bestqool model, first check the skill-local `device-seeds.json` next to this file. Treat it as manufacturer-claim seed data, not verified Health Commons evidence.
 - Use the seed only for the exact model alias, device class, active mode, and distance/contact setting shown. Do not assume similarly named models are interchangeable, such as `BQ60` versus `BQ60Pro` or `Pro100` versus `Pro200`.
-- If the seed says `deviceClass: panel`, use the listed reading only at the listed panel distance.
+- Match the seed reading's `activeModeLabel` before duration math. If the user is using red-only, NIR-only, pulsed, a lower intensity, or another named mode and no matching reading exists, say the seed cannot support a duration calculation for that mode.
+- If the seed says `deviceClass: panel`, use the listed reading only at the listed panel distance and active-mode scope.
 - If the seed says `deviceClass: contact_wrap` or `contact_mat`, treat the reading as a surface/contact reading tied to the listed intensity label. Do not convert it to a panel distance or reuse it for a different intensity setting.
 - If the user has the device's irradiance chart, use the row for their actual distance, surface setting, or mode.
 - If the user only has a model name, ask for the intended distance/contact setting and offer to check the official manufacturer page when browser/computer-use is available.
@@ -105,7 +106,7 @@ Ask "what device do you have?" early when dosing depends on duration. Then:
 - If official specs are internally inconsistent, surface the mismatch and avoid dose math until the user supplies a manual/chart or a current page resolves it.
 - If no current spec is available, give a range only as an example and clearly label it as not device-specific.
 
-The seed file intentionally stores current official model-page values and caveats in JSON rather than prose. As of 2026-06-30, it includes Bestqool `BQ40`, `BQ60`, `BQ60Pro`, `BQ150`, `Pro100`, `Pro200`, `Pro300`, and `Redot S/M/L` manufacturer-claim examples. Use those only when the user is actually using that model with the listed distance or contact/intensity setting. Do not treat this skill as a broad device catalog; prefer the current official product page or a user-provided manual/irradiance chart.
+The seed file intentionally stores current official model-page values and caveats in JSON rather than prose. As of 2026-06-30, it includes Bestqool `BQ40`, `BQ60`, `BQ60Pro`, `BQ150`, `Pro100`, `Pro200`, `Pro300`, and `Redot S/M/L` manufacturer-claim examples. Use those only when the user is actually using that model with the listed distance, contact/intensity setting, and `activeModeLabel`. The listed panel readings are manufacturer-listed combined/all-wavelength output claims with no channel split; they cannot support red-only or NIR-only duration estimates. Do not treat this skill as a broad device catalog; prefer the current official product page or a user-provided manual/irradiance chart.
 
 Common brands worth checking by official model page when the user gives a device name: Hooga, Mito Red Light, Joovv, PlatinumLED BioMax, Red Light Man, Bon Charge, Omnilux, CurrentBody, Solawave, LightStim, HigherDOSE, Lumebox, Celluma, Kineon, and Therabody. Prefer official pages or user-provided manuals/irradiance charts over retailer listings, reviews, or blogs.
 

--- a/packages/assistant-engine/skills/red-light-therapy/SKILL.md
+++ b/packages/assistant-engine/skills/red-light-therapy/SKILL.md
@@ -16,6 +16,7 @@ Help the user make a safe, evidence-bounded red light therapy decision without p
 - Prefer existing Health Commons evidence before inventing advice. Use `vault-cli commons protocol explore "red light therapy" --format json` when protocol context would improve the answer, then show the exact protocol with `vault-cli commons protocol show <key-or-route> --format json`.
 - Help first. When the user wants practical guidance for using a lamp, answer the setup, missing device data, dosing math, safety, and stop-condition questions directly. Do not force an experiment frame or make protocol setup the main answer.
 - Existing same-family public protocols matter even when the user's device, dose, metric, or schedule differs. If the user wants to track whether it works, compose with `experiment-onboarding` after this skill resolves setup and safety basics.
+- Treat consumer device specs as setup inputs with provenance. A manufacturer irradiance claim can support a labeled duration estimate, not a clinical dose claim, and current official pages or user manuals win over seed data.
 - Do not add a red-light-specific CLI, store, score, or device primitive from this skill. Use current Health Commons protocol lookup and ordinary calculation.
 
 ## Advisor flow
@@ -25,9 +26,11 @@ Classify the user's goal before giving protocol advice:
 - `skin_photoaging`: skin texture, wrinkles, face/periocular masks, collagen/photoaging. Prefer the Health Commons skin photobiomodulation protocol and keep claims skin-specific.
 - `localized_pain_recovery`: back, neck, joint, muscle soreness, injuries, return-to-play. Treat evidence as adjacent unless Health Commons has a direct matched protocol/source; screen for medical red flags.
 - `whole_body_recovery_sleep`: whole-body panels, sleep quality, HRV/RHR, fatigue, recovery, general wellness. Use bounded experiment framing and avoid systemic benefit promises.
+- `ambient_red_light_sleep`: red bulbs, night lights, sauna/chromotherapy light, or circadian lighting. Treat as a light-environment/sleep question, not PBM dose math.
 - `brain_mood_cognition`: transcranial, intranasal, mood, TBI, dementia, focus, memory. Keep educational and clinician-guided unless a verified protocol directly matches.
 - `hair_scalp`: hair loss or scalp devices. Ask for diagnosis and scalp-specific device evidence; do not borrow skin or whole-body dosing.
 - `wound_or_medical_skin`: wounds, burns, ulcers, active rash, infection, psoriasis, eczema, scars, keloids. Default to safety triage and clinician guidance.
+- `device_selection_or_comparison`: buying, choosing, or comparing devices. Ask use case, body area, contact-versus-panel format, exact model, official manual/irradiance chart, eye protection, return policy, and safety certifications. Do not rank products from affiliate/review claims.
 
 Use evidence-fit language in answers:
 
@@ -42,25 +45,26 @@ Use evidence-fit language in answers:
 Ask only decision-changing gaps. The most useful missing items are:
 
 - Goal or target: skin/photoaging, pain/recovery, sleep/circadian, hair, general wellness, or a specific condition.
-- Device brand/model and wavelengths.
-- Irradiance at the user's actual treatment distance, in `mW/cm2`.
-- Planned distance from skin and exposed body area.
-- Target dose from a verified protocol/source, in `J/cm2`.
-- Frequency and timing constraints.
-- Safety flags: eye exposure, photosensitizing medication or supplement, active cancer treatment, pregnancy, seizure/photosensitivity history, suspicious lesions, burns, neuropathy or reduced sensation, and heat intolerance.
+- Device brand/model, form factor, wavelengths, and active mode or intensity level: red only, NIR only, combined, pulsed, or named setting.
+- Irradiance at the user's actual treatment distance or contact setting, in `mW/cm2`, with source/provenance.
+- Planned distance from skin, whether the device is contact/on-skin or free-standing, exposed body area, and front-only versus front-and-back exposure.
+- Target dose from a verified protocol/source, in `J/cm2`, or a verified protocol session duration when no matched dose target exists.
+- Frequency and timing constraints, including whether sessions happen near bedtime, after exercise, around heat/sauna/cold exposure, or near skincare actives/procedures.
+- Safety flags: eye exposure, photosensitizing medication/supplement/topical, active cancer treatment, pregnancy, seizure/photosensitivity history, suspicious lesions, burns, neuropathy or reduced sensation, impaired circulation, darker-skin hyperpigmentation concerns, and heat intolerance.
 
-If the user asks "how long should I do it?" and gives no device details, ask for device model and either a manufacturer/measured irradiance value at their intended distance. Do not ask for every item above before giving a useful next step.
+If the user asks "how long should I do it?" and gives no device details, ask for the exact device model, goal/body area, intended distance or contact setting, and either a manufacturer/measured irradiance value at that setup. Do not ask for every item above before giving a useful next step.
 
 Before calculating duration, make sure the answer has:
 
 - goal or target use case;
 - device brand and exact model;
+- device form factor and active mode or intensity level;
 - wavelengths;
-- irradiance at the planned distance in `mW/cm2`;
-- planned skin distance;
-- target dose in `J/cm2` from a verified protocol or source.
+- irradiance at the planned distance or contact setting in `mW/cm2`;
+- planned skin distance or confirmed surface/contact geometry;
+- target dose in `J/cm2` from a verified protocol or source, with a matching tissue/site context.
 
-If any of those are missing, say what is missing and give the next practical step. If the irradiance distance does not match the planned skin distance, do not calculate as if it matched.
+If any of those are missing, say what is missing and give the next practical step. If the irradiance distance, contact setting, active mode, or target tissue does not match the user's setup, do not calculate as if it matched.
 
 ## Dose math
 
@@ -71,57 +75,63 @@ seconds = target dose J/cm2 * 1000 / irradiance mW/cm2
 minutes = seconds / 60
 ```
 
-For a dose range, calculate both endpoints. Example: `12 J/cm2` at `109 mW/cm2` is about `110 seconds`, or about `2 minutes`.
+This estimates incident skin-surface fluence, not absorbed dose in deeper tissue. For a dose range, calculate both endpoints. Example: `12 J/cm2` at `109 mW/cm2` is about `110 seconds`, or about `2 minutes`.
 
 Use dose math only when:
 
 - the dose is in `J/cm2`;
 - irradiance is in `mW/cm2`;
-- the irradiance reading matches the user's distance;
+- the irradiance reading matches the user's distance or contact setting;
+- the reading matches the active channel/mode being used, especially when a panel reports combined red+NIR irradiance but the source dose is wavelength- or channel-specific;
 - the target tissue and source context are close enough to the user's goal.
 
-Do not calculate from watts, number of LEDs, marketing coverage area, battery power, "clinical strength", or a reading measured at a different distance. Do not use inverse-square extrapolation for panels unless a verified measurement chart supports it.
+If the irradiance comes from a manufacturer claim, label the output as a manufacturer-claim duration estimate and round to practical precision, such as the nearest `15-30 seconds`, rather than implying lab-grade certainty.
+
+If a product page also lists "dose after 30 min", sanity check it with `expected J/cm2 = irradiance mW/cm2 * 1800 / 1000`. If the page's dose line conflicts with the irradiance line, do not average them or combine them; mention the conflict and ask for the manual, irradiance chart, or current official page value.
+
+Do not calculate from watts, number of LEDs, total joules, "50 J" or "80 J" treatment goals without exposed area, marketing coverage area, battery power, "clinical strength", or a reading measured at a different distance. Do not use inverse-square extrapolation for panels unless a verified measurement chart supports it.
 
 ## Device handling
 
 Ask "what device do you have?" early when dosing depends on duration. Then:
 
 - If the user gives a Bestqool model, first check the skill-local `device-seeds.json` next to this file. Treat it as manufacturer-claim seed data, not verified Health Commons evidence.
-- If the user has the device's irradiance chart, use the row for their actual distance.
-- If the user only has a model name, ask for the intended distance and offer to check the official manufacturer page when browser/computer-use is available.
+- Use the seed only for the exact model alias, device class, active mode, and distance/contact setting shown. Do not assume similarly named models are interchangeable, such as `BQ60` versus `BQ60Pro` or `Pro100` versus `Pro200`.
+- If the seed says `deviceClass: panel`, use the listed reading only at the listed panel distance.
+- If the seed says `deviceClass: contact_wrap` or `contact_mat`, treat the reading as a surface/contact reading tied to the listed intensity label. Do not convert it to a panel distance or reuse it for a different intensity setting.
+- If the user has the device's irradiance chart, use the row for their actual distance, surface setting, or mode.
+- If the user only has a model name, ask for the intended distance/contact setting and offer to check the official manufacturer page when browser/computer-use is available.
 - If browser/computer-use is available and the user asks Murph to check the device online, use the browser workflow and treat product-page specs as manufacturer claims.
+- If official specs are internally inconsistent, surface the mismatch and avoid dose math until the user supplies a manual/chart or a current page resolves it.
 - If no current spec is available, give a range only as an example and clearly label it as not device-specific.
 
-Bestqool manufacturer-claim examples checked from official product pages on 2026-06-30:
+The seed file intentionally stores current official model-page values and caveats in JSON rather than prose. As of 2026-06-30, it includes Bestqool `BQ40`, `BQ60`, `BQ60Pro`, `BQ150`, `Pro100`, `Pro200`, `Pro300`, and `Redot S/M/L` manufacturer-claim examples. Use those only when the user is actually using that model with the listed distance or contact/intensity setting. Do not treat this skill as a broad device catalog; prefer the current official product page or a user-provided manual/irradiance chart.
 
-- Bestqool BQ60: `660/850 nm`, `95.6 mW/cm2` at `7.62 cm` / `3 in`.
-- Bestqool Pro100: `630/660/850/940 nm`, `109 mW/cm2` at `7.62 cm` / `3 in`.
-- Bestqool Pro300: `630/660/850/940 nm`, `106 mW/cm2` at `7.62 cm` / `3 in`.
-
-Use those only when the user is actually using that model at about `7.62 cm`. Otherwise ask for the matching row or current page value. Do not treat this skill as a broad device catalog; prefer the current official product page or a user-provided manual/irradiance chart.
-
-Common brands worth checking by official model page when the user gives a device name: Hooga, Mito Red Light, Joovv, PlatinumLED BioMax, Red Light Man, Bon Charge, Omnilux, CurrentBody, and Solawave. Prefer official pages or user-provided manuals/irradiance charts over retailer listings, reviews, or blogs.
+Common brands worth checking by official model page when the user gives a device name: Hooga, Mito Red Light, Joovv, PlatinumLED BioMax, Red Light Man, Bon Charge, Omnilux, CurrentBody, Solawave, LightStim, HigherDOSE, Lumebox, Celluma, Kineon, and Therabody. Prefer official pages or user-provided manuals/irradiance charts over retailer listings, reviews, or blogs.
 
 ## Answer shape
 
 For dosing answers, keep the response compact:
 
-1. State the assumption or missing value.
+1. State the assumption, missing value, or provenance, including whether the value is a manufacturer claim.
 2. Give the calculation when valid.
 3. Give a conservative starting suggestion when appropriate, such as starting at the low end of a verified range and watching skin/eye/heat tolerance.
-4. Name what would change the answer: goal, wavelength, dose target, distance, device irradiance, body area, or safety flags.
+4. Name what would change the answer: goal, wavelength, dose target, distance/contact setting, device irradiance, body area, active mode, or safety flags.
 
 Do not bury the user in study lists. If evidence matters, summarize the fit: direct protocol evidence, adjacent human evidence, safety/context evidence, intake-only evidence, or unknown. Mention exact PubMed details only when Health Commons source/protocol output provides them or the user asks.
 
+Do not echo manufacturer disease, hormone, fat-loss, sleep, or recovery claims as Murph claims unless Health Commons evidence directly supports that specific claim for the user's context. FDA-cleared or certification language is not proof that a device is effective for the user's goal.
+
 ## Safety boundaries
 
-- Eye exposure needs explicit caution. Do not recommend looking into panels or treating eyes without clinician guidance and eye-specific protocol evidence.
+- Eye exposure needs explicit caution. Do not recommend looking into panels, using NIR near the face without eye protection, or treating eyes without clinician guidance and eye-specific protocol evidence.
 - Do not give disease-treatment instructions for cancer, eye disease, neuropathy, inflammatory disease, wound care, pregnancy, or medication-sensitive contexts. Suggest clinician guidance and keep any self-experiment low-risk and reversible.
-- Stop or reduce exposure for burns, unusual pain, headache, eye symptoms, marked skin irritation, dizziness, or worsening symptoms.
-- Heat is not the therapeutic dose. A warm panel can still overdose skin if the session is too long.
+- Stop or reduce exposure for burns, unusual pain, headache, eye symptoms, afterimages that do not promptly resolve, marked skin irritation, dizziness, worsening sleep, agitation, mood changes, or worsening symptoms.
+- Heat is not the therapeutic dose. A warm panel, wrap, belt, or mat can still overdose skin if the session is too long or too close.
+- Contact wraps and mats add heat, pressure, sweat, and unattended-use risk. Do not suggest sleeping with an active device, stacking heat sources, or running repeated cycles unattended unless the official manual explicitly supports that use and safety flags are absent.
 - More is not automatically better; PBM can be biphasic, so higher dose or longer sessions can be less useful or more irritating.
 
-Use stronger caution for: eye exposure, photosensitizing medication or supplements, active cancer treatment, suspicious skin lesions, pregnancy, seizure/photosensitivity history, neurologic disease, head injury, active mood disorder, neuropathy, reduced sensation, impaired circulation, heat intolerance, open wounds, infection concerns, burns, ulcers, or rapidly worsening skin conditions.
+Use stronger caution for: eye exposure, photosensitizing medication, supplements, or topicals; active cancer treatment; suspicious skin lesions; pregnancy; seizure/photosensitivity history; neurologic disease; head injury; active mood disorder or bipolar-spectrum history; neuropathy; reduced sensation; impaired circulation; darker-skin hyperpigmentation concerns; heat intolerance; open wounds; infection concerns; burns; ulcers; tattoos or irritated skin in the treatment area; or rapidly worsening skin conditions.
 
 ## Experiment handoff
 
@@ -131,4 +141,4 @@ Experiment setup is optional. If the user just wants help using a lamp today, an
 - whole-body recovery, sleep, HRV/RHR, or general wellness: look for the whole-body photobiomodulation protocol;
 - sleep timing/light environment rather than panel exposure: look for evening light reduction protocols instead.
 
-Then read and follow `$MURPH_ASSISTANT_SKILLS_ROOT/experiment-onboarding/SKILL.md`. Preserve public protocol lineage and store user-specific device, distance, dose, timing, safety answers, and outcomes as setup answers or typed experiment fields.
+Then read and follow `$MURPH_ASSISTANT_SKILLS_ROOT/experiment-onboarding/SKILL.md`. Preserve public protocol lineage and store user-specific device, distance/contact setting, dose, timing, safety answers, outcomes, and device-spec provenance such as source URL, checked date, model alias, active mode, and manufacturer-claim caveats as setup answers or typed experiment fields.

--- a/packages/assistant-engine/skills/red-light-therapy/device-seeds.json
+++ b/packages/assistant-engine/skills/red-light-therapy/device-seeds.json
@@ -5,6 +5,7 @@
     "Use these entries as skill-local manufacturer-claim examples, not as verified Health Commons evidence.",
     "Prefer the user's manual, device irradiance chart, or current official manufacturer page over this file.",
     "Use a listed irradiance only when the user's exact model, device class, active mode, and treatment distance or contact setting match the reading.",
+    "Match activeModeLabel before using any irradiance reading for duration math.",
     "When distanceCm is 0, the reading is a surface/contact reading tied to the listed intensity label, not a panel-distance reading.",
     "Do not extrapolate to other distances, intensity levels, active modes, or device classes from these entries.",
     "Do not reuse manufacturer disease, hormone, fat-loss, sleep, or recovery claims as Murph evidence."
@@ -24,6 +25,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool BQ40 official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/portable-red-light-therapy-device-bq40",
+          "activeModeLabel": "manufacturer-listed combined 660/850 nm output; channel split not published",
           "measurementContext": "Panel reading at 3 in; source page also states 126 J/cm2 after 30 min at 3 in."
         }
       ],
@@ -45,6 +47,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool BQ60 official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-bq60",
+          "activeModeLabel": "manufacturer-listed combined 660/850 nm output; channel split not published",
           "measurementContext": "Panel reading at 3 in; source page also states 172.1 J/cm2 after 30 min at 3 in."
         }
       ],
@@ -66,6 +69,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool BQ60Pro official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-bq-60-pro",
+          "activeModeLabel": "manufacturer-listed combined all-wavelength output; channel split not published",
           "measurementContext": "Clamp-style panel reading at 3 in."
         }
       ],
@@ -87,6 +91,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool BQ150 official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/4-wavelengths-half-body-red-light-therapy-bq150",
+          "activeModeLabel": "manufacturer-listed combined all-wavelength output; channel split not published",
           "measurementContext": "Panel reading at 3 in."
         }
       ],
@@ -108,6 +113,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Pro100 official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-pro100",
+          "activeModeLabel": "manufacturer-listed combined all-wavelength output; channel split not published",
           "measurementContext": "Panel reading at 3 in. The same page also lists 217.8 J/cm2 after 30 min at 3 in, which does not match 109 mW/cm2 over 30 min."
         }
       ],
@@ -130,6 +136,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Pro200 official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/full-body-red-light-therapy-pro200",
+          "activeModeLabel": "manufacturer-listed combined all-wavelength output; channel split not published",
           "measurementContext": "Panel reading at 3 in."
         }
       ],
@@ -151,6 +158,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Pro300 official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/full-body-red-light-therapy-pro300",
+          "activeModeLabel": "manufacturer-listed combined all-wavelength output; channel split not published",
           "measurementContext": "Panel reading at 3 in; source page also states 190.8 J/cm2 after 30 min at 3 in."
         }
       ],
@@ -172,6 +180,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Redot S official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-belt",
+          "activeModeLabel": "surface L4 combined red+NIR intensity",
           "measurementContext": "Surface/contact reading at intensity level L4."
         }
       ],
@@ -195,6 +204,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Redot M official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-belt-medium",
+          "activeModeLabel": "surface P5 combined red+NIR intensity",
           "measurementContext": "Surface/contact reading at intensity level P5."
         }
       ],
@@ -218,6 +228,7 @@
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Redot L official product page, checked 2026-06-30",
           "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-mat-yoga-pad",
+          "activeModeLabel": "surface P5 combined red+NIR intensity",
           "measurementContext": "Surface/contact reading at intensity level P5."
         }
       ],

--- a/packages/assistant-engine/skills/red-light-therapy/device-seeds.json
+++ b/packages/assistant-engine/skills/red-light-therapy/device-seeds.json
@@ -4,14 +4,38 @@
   "sourcePolicy": [
     "Use these entries as skill-local manufacturer-claim examples, not as verified Health Commons evidence.",
     "Prefer the user's manual, device irradiance chart, or current official manufacturer page over this file.",
-    "Use a listed irradiance only when the user's exact model and treatment distance match the reading.",
-    "Do not extrapolate to other distances from these entries."
+    "Use a listed irradiance only when the user's exact model, device class, active mode, and treatment distance or contact setting match the reading.",
+    "When distanceCm is 0, the reading is a surface/contact reading tied to the listed intensity label, not a panel-distance reading.",
+    "Do not extrapolate to other distances, intensity levels, active modes, or device classes from these entries.",
+    "Do not reuse manufacturer disease, hormone, fat-loss, sleep, or recovery claims as Murph evidence."
   ],
   "devices": [
     {
       "brand": "Bestqool",
+      "model": "BQ40",
+      "deviceClass": "panel",
+      "aliases": ["Bestqool BQ40", "BQ40", "Portable Red Light Therapy BQ40"],
+      "wavelengthsNm": [660, 850],
+      "irradianceReadings": [
+        {
+          "distanceCm": 7.62,
+          "distanceLabel": "3 in",
+          "irradianceMwPerCm2": 70,
+          "sourceType": "manufacturer_claim",
+          "sourceLabel": "Bestqool BQ40 official product page, checked 2026-06-30",
+          "sourceUrl": "https://www.bestqool.com/products/portable-red-light-therapy-device-bq40",
+          "measurementContext": "Panel reading at 3 in; source page also states 126 J/cm2 after 30 min at 3 in."
+        }
+      ],
+      "notes": [
+        "Small targeted panel. Verify current manufacturer specs before making device-specific recommendations."
+      ]
+    },
+    {
+      "brand": "Bestqool",
       "model": "BQ60",
-      "aliases": ["Bestqool BQ60", "BQ60"],
+      "deviceClass": "panel",
+      "aliases": ["Bestqool BQ60", "BQ60", "Red Light Therapy BQ60"],
       "wavelengthsNm": [660, 850],
       "irradianceReadings": [
         {
@@ -20,16 +44,60 @@
           "irradianceMwPerCm2": 95.6,
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool BQ60 official product page, checked 2026-06-30",
-          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-bq60"
+          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-bq60",
+          "measurementContext": "Panel reading at 3 in; source page also states 172.1 J/cm2 after 30 min at 3 in."
         }
       ],
       "notes": [
-        "Verify current manufacturer specs before making device-specific recommendations."
+        "Do not confuse with BQ60Pro; BQ60 is the 660/850 nm base model."
+      ]
+    },
+    {
+      "brand": "Bestqool",
+      "model": "BQ60Pro",
+      "deviceClass": "panel",
+      "aliases": ["Bestqool BQ60Pro", "BQ60Pro", "6 Wavelength BQ60Pro", "Bestqool BQ60 Pro"],
+      "wavelengthsNm": [630, 660, 680, 810, 850, 940],
+      "irradianceReadings": [
+        {
+          "distanceCm": 7.62,
+          "distanceLabel": "3 in",
+          "irradianceMwPerCm2": 96.1,
+          "sourceType": "manufacturer_claim",
+          "sourceLabel": "Bestqool BQ60Pro official product page, checked 2026-06-30",
+          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-bq-60-pro",
+          "measurementContext": "Clamp-style panel reading at 3 in."
+        }
+      ],
+      "notes": [
+        "Clamp geometry can vary substantially; confirm the actual skin distance before calculating duration."
+      ]
+    },
+    {
+      "brand": "Bestqool",
+      "model": "BQ150",
+      "deviceClass": "panel",
+      "aliases": ["Bestqool BQ150", "BQ150", "4 Wavelength Red Light Therapy BQ150"],
+      "wavelengthsNm": [630, 660, 850, 940],
+      "irradianceReadings": [
+        {
+          "distanceCm": 7.62,
+          "distanceLabel": "3 in",
+          "irradianceMwPerCm2": 96.2,
+          "sourceType": "manufacturer_claim",
+          "sourceLabel": "Bestqool BQ150 official product page, checked 2026-06-30",
+          "sourceUrl": "https://www.bestqool.com/products/4-wavelengths-half-body-red-light-therapy-bq150",
+          "measurementContext": "Panel reading at 3 in."
+        }
+      ],
+      "notes": [
+        "Official page gives broad 6 in usage-time guidance but this seed has no matched 6 in irradiance row; do not calculate a 6 in dose from the 3 in value."
       ]
     },
     {
       "brand": "Bestqool",
       "model": "Pro100",
+      "deviceClass": "panel",
       "aliases": ["Bestqool Pro100", "Pro100", "Bestqool red light therapy Pro100"],
       "wavelengthsNm": [630, 660, 850, 940],
       "irradianceReadings": [
@@ -39,16 +107,40 @@
           "irradianceMwPerCm2": 109,
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Pro100 official product page, checked 2026-06-30",
-          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-pro100"
+          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-pro100",
+          "measurementContext": "Panel reading at 3 in. The same page also lists 217.8 J/cm2 after 30 min at 3 in, which does not match 109 mW/cm2 over 30 min."
         }
       ],
       "notes": [
-        "Do not infer other distances without a matching irradiance chart."
+        "Do not infer other distances without a matching irradiance chart.",
+        "Because the official page's dose-after-30-min row conflicts with the irradiance row, recheck the manual or current official page before making a device-specific dosing recommendation."
+      ]
+    },
+    {
+      "brand": "Bestqool",
+      "model": "Pro200",
+      "deviceClass": "panel",
+      "aliases": ["Bestqool Pro200", "Pro200", "Bestqool red light therapy Pro200"],
+      "wavelengthsNm": [630, 660, 850, 940],
+      "irradianceReadings": [
+        {
+          "distanceCm": 7.62,
+          "distanceLabel": "3 in",
+          "irradianceMwPerCm2": 111,
+          "sourceType": "manufacturer_claim",
+          "sourceLabel": "Bestqool Pro200 official product page, checked 2026-06-30",
+          "sourceUrl": "https://www.bestqool.com/products/full-body-red-light-therapy-pro200",
+          "measurementContext": "Panel reading at 3 in."
+        }
+      ],
+      "notes": [
+        "Panel geometry and front-only versus front-and-back exposure still need user setup confirmation."
       ]
     },
     {
       "brand": "Bestqool",
       "model": "Pro300",
+      "deviceClass": "panel",
       "aliases": ["Bestqool Pro300", "Pro300", "Bestqool red light therapy Pro300"],
       "wavelengthsNm": [630, 660, 850, 940],
       "irradianceReadings": [
@@ -58,11 +150,81 @@
           "irradianceMwPerCm2": 106,
           "sourceType": "manufacturer_claim",
           "sourceLabel": "Bestqool Pro300 official product page, checked 2026-06-30",
-          "sourceUrl": "https://www.bestqool.com/products/full-body-red-light-therapy-pro300"
+          "sourceUrl": "https://www.bestqool.com/products/full-body-red-light-therapy-pro300",
+          "measurementContext": "Panel reading at 3 in; source page also states 190.8 J/cm2 after 30 min at 3 in."
         }
       ],
       "notes": [
-        "Panel geometry and body coverage still need user setup confirmation."
+        "Panel geometry, body coverage, and front-only versus front-and-back exposure still need user setup confirmation."
+      ]
+    },
+    {
+      "brand": "Bestqool",
+      "model": "Redot S",
+      "deviceClass": "contact_wrap",
+      "aliases": ["Bestqool Redot S", "Redot S", "Bestqool Red Light Therapy Belt", "Red Light Therapy Belt - Redot S"],
+      "wavelengthsNm": [660, 850],
+      "irradianceReadings": [
+        {
+          "distanceCm": 0,
+          "distanceLabel": "surface (L4)",
+          "irradianceMwPerCm2": 72.6,
+          "sourceType": "manufacturer_claim",
+          "sourceLabel": "Bestqool Redot S official product page, checked 2026-06-30",
+          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-belt",
+          "measurementContext": "Surface/contact reading at intensity level L4."
+        }
+      ],
+      "notes": [
+        "Surface/contact reading is not interchangeable with a panel-distance reading.",
+        "Manufacturer page gives 50 J and 80 J treatment goals without area-normalized dose context; do not convert those into J/cm2 without the manual or a verified chart.",
+        "Watch heat, pressure, sweat, and unattended-use risk for contact devices."
+      ]
+    },
+    {
+      "brand": "Bestqool",
+      "model": "Redot M",
+      "deviceClass": "contact_wrap",
+      "aliases": ["Bestqool Redot M", "Redot M", "Bestqool Red Light Therapy Wrap", "Red Light Therapy Wrap - Redot M"],
+      "wavelengthsNm": [660, 850],
+      "irradianceReadings": [
+        {
+          "distanceCm": 0,
+          "distanceLabel": "surface (P5)",
+          "irradianceMwPerCm2": 59.8,
+          "sourceType": "manufacturer_claim",
+          "sourceLabel": "Bestqool Redot M official product page, checked 2026-06-30",
+          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-belt-medium",
+          "measurementContext": "Surface/contact reading at intensity level P5."
+        }
+      ],
+      "notes": [
+        "Surface/contact reading is not interchangeable with a panel-distance reading.",
+        "Do not reuse this reading for lower intensity levels without a matched chart.",
+        "Watch heat, pressure, sweat, and unattended-use risk for contact devices."
+      ]
+    },
+    {
+      "brand": "Bestqool",
+      "model": "Redot L",
+      "deviceClass": "contact_mat",
+      "aliases": ["Bestqool Redot L", "Redot L", "Bestqool Red Light Therapy Mat", "Red Light Therapy Mat - Redot L"],
+      "wavelengthsNm": [660, 850],
+      "irradianceReadings": [
+        {
+          "distanceCm": 0,
+          "distanceLabel": "surface (P5)",
+          "irradianceMwPerCm2": 56,
+          "sourceType": "manufacturer_claim",
+          "sourceLabel": "Bestqool Redot L official product page, checked 2026-06-30",
+          "sourceUrl": "https://www.bestqool.com/products/red-light-therapy-mat-yoga-pad",
+          "measurementContext": "Surface/contact reading at intensity level P5."
+        }
+      ],
+      "notes": [
+        "Surface/contact reading is not interchangeable with a panel-distance reading.",
+        "Do not reuse this reading for lower intensity levels without a matched chart.",
+        "Do not suggest sleeping with the active mat or running repeated cycles unattended unless the current manual explicitly supports that use and safety flags are absent."
       ]
     }
   ],
@@ -75,6 +237,12 @@
     "Bon Charge",
     "Omnilux",
     "CurrentBody",
-    "Solawave"
+    "Solawave",
+    "LightStim",
+    "HigherDOSE",
+    "Lumebox",
+    "Celluma",
+    "Kineon",
+    "Therabody"
   ]
 }

--- a/packages/assistant-engine/test/assistant-skill-assets.test.ts
+++ b/packages/assistant-engine/test/assistant-skill-assets.test.ts
@@ -32,6 +32,15 @@ type AssistantSkillMetadata = {
   readonly name: string
 }
 
+function expectRecord(
+  value: unknown,
+  label: string,
+): asserts value is Record<string, unknown> {
+  expect(value, `${label} must be an object`).toBeTruthy()
+  expect(typeof value, `${label} must be an object`).toBe('object')
+  expect(Array.isArray(value), `${label} must not be an array`).toBe(false)
+}
+
 function parseAssistantSkillFrontmatter(raw: string): AssistantSkillMetadata {
   const normalized = raw.replace(/\r\n/gu, '\n')
   if (!normalized.startsWith('---\n')) {
@@ -364,6 +373,122 @@ describe('assistant skill assets', () => {
     )
     expect(raw).not.toContain('/tmp/')
     expect(raw).not.toContain('.codex-hosted')
+  })
+
+  it('keeps red light device seeds parseable and manufacturer-claim scoped', async () => {
+    const redLightSkill = ASSISTANT_SKILLS.find(
+      (skill) => skill.slug === 'red-light-therapy',
+    )
+    expect(redLightSkill).toBeTruthy()
+    if (!redLightSkill) {
+      return
+    }
+
+    const raw = await readFile(
+      path.join(
+        resolveAssistantSkillsRoot(),
+        redLightSkill.slug,
+        'device-seeds.json',
+      ),
+      'utf8',
+    )
+    const parsed: unknown = JSON.parse(raw)
+    expectRecord(parsed, 'red light device seed root')
+
+    expect(parsed.schemaVersion).toBe(
+      'murph.assistant.skill.red-light-device-seeds.v1',
+    )
+    expect(Array.isArray(parsed.sourcePolicy)).toBe(true)
+    expect(JSON.stringify(parsed.sourcePolicy)).toContain(
+      'manufacturer-claim examples',
+    )
+    expect(JSON.stringify(parsed.sourcePolicy)).toContain(
+      'Do not extrapolate',
+    )
+
+    const devices = parsed.devices
+    expect(Array.isArray(devices)).toBe(true)
+    if (!Array.isArray(devices)) {
+      return
+    }
+    expect(devices.length).toBeGreaterThanOrEqual(8)
+
+    const aliases = new Set<string>()
+    const models = new Set<string>()
+
+    for (const [deviceIndex, deviceValue] of devices.entries()) {
+      expectRecord(deviceValue, `device ${deviceIndex}`)
+      expect(typeof deviceValue.brand).toBe('string')
+      expect(typeof deviceValue.model).toBe('string')
+      expect(typeof deviceValue.deviceClass).toBe('string')
+      models.add(String(deviceValue.model))
+
+      const deviceClass = deviceValue.deviceClass
+      expect(['panel', 'contact_wrap', 'contact_mat']).toContain(deviceClass)
+
+      expect(Array.isArray(deviceValue.aliases)).toBe(true)
+      if (Array.isArray(deviceValue.aliases)) {
+        for (const alias of deviceValue.aliases) {
+          expect(typeof alias).toBe('string')
+          expect(aliases.has(String(alias))).toBe(false)
+          aliases.add(String(alias))
+        }
+      }
+
+      expect(Array.isArray(deviceValue.wavelengthsNm)).toBe(true)
+      if (Array.isArray(deviceValue.wavelengthsNm)) {
+        for (const wavelength of deviceValue.wavelengthsNm) {
+          expect(typeof wavelength).toBe('number')
+          expect(wavelength).toBeGreaterThan(0)
+        }
+      }
+
+      expect(Array.isArray(deviceValue.irradianceReadings)).toBe(true)
+      if (!Array.isArray(deviceValue.irradianceReadings)) {
+        continue
+      }
+
+      for (const [
+        readingIndex,
+        readingValue,
+      ] of deviceValue.irradianceReadings.entries()) {
+        expectRecord(
+          readingValue,
+          `device ${deviceIndex} reading ${readingIndex}`,
+        )
+        expect(readingValue.sourceType).toBe('manufacturer_claim')
+        expect(String(readingValue.sourceUrl)).toMatch(
+          /^https:\/\/www\.bestqool\.com\/products\//u,
+        )
+        expect(typeof readingValue.distanceCm).toBe('number')
+        expect(typeof readingValue.distanceLabel).toBe('string')
+        expect(typeof readingValue.irradianceMwPerCm2).toBe('number')
+        expect(Number(readingValue.irradianceMwPerCm2)).toBeGreaterThan(0)
+        expect(typeof readingValue.measurementContext).toBe('string')
+
+        if (deviceClass === 'panel') {
+          expect(Number(readingValue.distanceCm)).toBeGreaterThan(0)
+        } else {
+          expect(readingValue.distanceCm).toBe(0)
+          expect(String(readingValue.distanceLabel)).toContain('surface')
+        }
+      }
+    }
+
+    expect(models).toEqual(
+      new Set([
+        'BQ40',
+        'BQ60',
+        'BQ60Pro',
+        'BQ150',
+        'Pro100',
+        'Pro200',
+        'Pro300',
+        'Redot S',
+        'Redot M',
+        'Redot L',
+      ]),
+    )
   })
 
   it('keeps behavior follow-through policy in the skill file with only compact bridges elsewhere', async () => {

--- a/packages/assistant-engine/test/assistant-skill-assets.test.ts
+++ b/packages/assistant-engine/test/assistant-skill-assets.test.ts
@@ -460,6 +460,9 @@ describe('assistant skill assets', () => {
         expect(String(readingValue.sourceUrl)).toMatch(
           /^https:\/\/www\.bestqool\.com\/products\//u,
         )
+        expect(typeof readingValue.activeModeLabel).toBe('string')
+        expect(String(readingValue.activeModeLabel).trim().length)
+          .toBeGreaterThan(0)
         expect(typeof readingValue.distanceCm).toBe('number')
         expect(typeof readingValue.distanceLabel).toBe('string')
         expect(typeof readingValue.irradianceMwPerCm2).toBe('number')


### PR DESCRIPTION
## Why this PR exists

This stacks on PR #347 to land the supplied red-light therapy skill patch without expanding Murph into a red-light-specific runtime or Health Commons code primitive.

## User goal / user-visible behavior

When a user asks about a specific Bestqool red light device, Murph can distinguish panel versus contact-device setup, use only exact-model manufacturer-claim irradiance values, and explain duration math with clearer provenance and safety caveats.

## What changed

- Expanded the red-light therapy skill guidance for device comparison, contact wraps/mats, active modes, inconsistent manufacturer specs, and safety flags.
- Expanded the skill-local `device-seeds.json` with additional Bestqool model examples, explicit manufacturer-claim caveats, and active-mode labels for every irradiance reading.
- Added an assistant skill asset test that parses the seed JSON and keeps readings manufacturer-claim and active-mode scoped.

## Invariants the PR must preserve

- Health Commons remains the durable evidence/source owner; this PR adds no Health Commons runtime primitive, CLI surface, score, or device catalog.
- Skill seed values are manufacturer-claim setup inputs only. Current official pages, user manuals, or user-provided irradiance charts override them.
- Murph must not calculate PBM duration unless dose, irradiance, distance/contact setting, active mode, and tissue/site context match.
- Seed irradiance readings must not support red-only, NIR-only, lower-intensity, pulsed, or otherwise mismatched mode duration math unless the reading's active-mode label matches that mode.
- Manufacturer disease, hormone, fat-loss, sleep, or recovery claims must not be reused as Murph efficacy claims.

## Deployment skew / compatibility

No deploy-skew-sensitive app, Worker, database, or runtime protocol boundary changes. This is packaged assistant skill content plus a package-local asset test, stacked on PR #347.

## Validation

- `python3 -m json.tool packages/assistant-engine/skills/red-light-therapy/device-seeds.json`
- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-skill-assets.test.ts`
- `pnpm build:test-runtime:prepared` before root typecheck in the fresh worktree
- `pnpm typecheck`
- `bash scripts/workspace-verify.sh test:diff packages/assistant-engine/skills/red-light-therapy/SKILL.md packages/assistant-engine/skills/red-light-therapy/device-seeds.json packages/assistant-engine/test/assistant-skill-assets.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785457899&installation_id=127572939&pr_number=351&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F351&signature=fa16008c2fde50095c90443259b5df30a3c53f8411bcabc9a021e33f022a5eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->