### PR TITLE
Narrow Junction direct sleep_cycle provider load to source-referenced records

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-01-junction-direct-sleep-cycle-provider-load.md
+++ b/agent-docs/exec-plans/completed/2026-07-01-junction-direct-sleep-cycle-provider-load.md
@@ -1,0 +1,46 @@
+# junction-direct-sleep-cycle-provider-load
+
+Status: completed
+Created: 2026-07-01
+Updated: 2026-07-01
+
+## Goal
+
+- Post-merge review fix from PR #353: direct `sleep_cycle` webhook imports should not depend on the Junction provider-list endpoint when the direct record carries no source-reference identity, so complete direct payloads still import when `/v2/user/providers/...` is transiently unavailable.
+
+## Success criteria
+
+- `shouldLoadJunctionDirectResourceSourceProviders` only returns true for `sleep_cycle` / `sleep` records that pass `hasJunctionSourceReferenceIdentity`.
+- Regression test: direct sleep_cycle payload with no source-reference ids imports exactly once even when the provider-list fetch throws, and never falls back to `/v2/summary/sleep_cycle/`.
+- Existing coverage that source-referenced direct records still load providers keeps passing.
+
+## Scope
+
+- In scope: `packages/device-syncd/src/providers/junction.ts` predicate, `packages/device-syncd/test/junction-provider.test.ts` regression test.
+- Out of scope: sanitize/projection behavior, importer/core write paths, other Junction resources.
+
+## Constraints
+
+- Technical constraints: minimal diff; no `as any`; preserve provider resolution for records with source-reference identity.
+- Product/process constraints: device sync is user-critical; do not add external failure dependencies to direct-import success paths.
+
+## Risks and mitigations
+
+1. Risk: a direct record with a nested source reference stops loading providers.
+   Mitigation: `hasJunctionSourceReferenceIdentity` already searches nested objects/arrays; existing tests for `provider_connection_id` / `connection_id` / `source_id` records assert providers are still fetched.
+
+## Tasks
+
+1. Narrow the `shouldLoadJunctionDirectResourceSourceProviders` predicate so `sleep_cycle` uses the same source-reference gate as `sleep`.
+2. Add regression test: no-source-reference direct payload imports while the provider-list endpoint throws.
+3. Confirm existing source-referenced direct sleep_cycle tests still cover the provider-load path.
+
+## Decisions
+
+- Reuse the existing `sleep` gating rule instead of adding a new predicate or try/catch around the provider call: smallest change, one source of truth.
+
+## Verification
+
+- Commands to run: `pnpm test:diff packages/device-syncd/src/providers/junction.ts packages/device-syncd/test/junction-provider.test.ts` (fallback: `pnpm --dir packages/device-syncd test:coverage`); `pnpm typecheck` if time permits.
+- Expected outcomes: device-syncd Junction provider tests pass, including the new no-source-reference regression test and the existing source-referenced provider-load tests.
+Completed: 2026-07-01

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -836,8 +836,8 @@ export function createJunctionDeviceSyncProvider(
   }
 
   function shouldLoadJunctionDirectResourceSourceProviders(input: JunctionDirectResourceJobInput): boolean {
-    return input.resource === "sleep_cycle" ||
-      (input.resource === "sleep" && hasJunctionSourceReferenceIdentity(input.record));
+    return (input.resource === "sleep_cycle" || input.resource === "sleep") &&
+      hasJunctionSourceReferenceIdentity(input.record);
   }
 
   async function diagnoseBackfill(

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -6273,6 +6273,94 @@ test("Junction resource jobs import direct Garmin sleep-cycle stage payloads wit
   assert.deepEqual(snapshot.timeseries, {});
 });
 
+test("Junction direct sleep-cycle payloads without source references import without loading providers", async () => {
+  const requests: string[] = [];
+  const importedSnapshots: unknown[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+    requests.push(url);
+
+    if (url.includes("/v2/user/providers/")) {
+      throw new Error("Junction provider-list endpoint is unavailable.");
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["sleep_cycle"],
+    timeseriesResources: [],
+    webhookSecret: "whsec_d2ViaG9vay10ZXN0LXNlY3JldA==",
+  });
+
+  const directSleepCycleData = {
+    end: "2026-06-30T11:00:00.000Z",
+    id: "sleep-cycle-no-source-reference-1",
+    sourceProviderSlug: "garmin",
+    stages: [
+      {
+        endAt: "2026-06-30T06:30:00.000Z",
+        stage: "light",
+        startAt: "2026-06-30T03:30:00.000Z",
+      },
+      {
+        endAt: "2026-06-30T11:00:00.000Z",
+        stage: "deep",
+        startAt: "2026-06-30T06:30:00.000Z",
+      },
+    ],
+    start: "2026-06-30T03:30:00.000Z",
+    timeZone: "America/New_York",
+  };
+  const webhook = createJunctionSvixWebhook({
+    body: {
+      event_type: "daily.data.sleep_cycle.created",
+      user_id: "junction-user-1",
+      client_user_id: "murph_blinded",
+      data: directSleepCycleData,
+    },
+    messageId: "msg_sleep_cycle_no_source_reference_1",
+    timestamp: String(Math.floor(Date.parse("2026-06-30T11:30:00.000Z") / 1000)),
+  });
+  const parsed = await requireJunctionWebhookHandler(provider).verifyAndParseWebhook({
+    headers: webhook.headers,
+    rawBody: webhook.rawBody,
+    now: "2026-06-30T11:31:00.000Z",
+  });
+  const parsedJob = parsed.jobs[0];
+  assert.ok(parsedJob);
+  assert.equal(parsedJob.kind, "resource");
+  const parsedPayload = parsedJob.payload;
+  assert.ok(parsedPayload);
+
+  await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      importSnapshot: async (snapshot) => {
+        importedSnapshots.push(snapshot);
+        return { imported: true };
+      },
+      upsertConnectionSource: () => {
+        throw new Error("Direct sleep_cycle imports should not project Junction source state.");
+      },
+    }),
+    createJob(parsedJob.kind, parsedPayload),
+  );
+
+  assert.equal(importedSnapshots.length, 1);
+  const snapshot = importedSnapshots[0] as {
+    summaries?: Record<string, Array<Record<string, unknown>>>;
+    timeseries?: Record<string, unknown[]>;
+  };
+  const sleepCycleRecord = snapshot.summaries?.sleep_cycle?.[0];
+  const stages = sleepCycleRecord?.stages as Array<Record<string, unknown>> | undefined;
+  assert.equal(requests.some((url) => url.includes("/v2/user/providers/")), false);
+  assert.equal(requests.some((url) => url.includes("/v2/summary/sleep_cycle/")), false);
+  assert.equal(sleepCycleRecord?.id, "sleep-cycle-no-source-reference-1");
+  assert.equal(sleepCycleRecord?.sourceProviderSlug, "garmin");
+  assert.equal(stages?.[0]?.stage, "light");
+  assert.equal(stages?.[1]?.stage, "deep");
+  assert.deepEqual(snapshot.timeseries, {});
+});
+
 test("Junction signed direct sleep-cycle source reference aliases resolve at execution", async () => {
   const requests: string[] = [];
   const importedSnapshots: unknown[] = [];


### PR DESCRIPTION
## Why this PR exists

A deep review of merged PR #353 found that the direct sleep_cycle webhook import path always awaits a Junction provider-list call (`client.listUserProviders`) before `importJunctionDirectResourceSnapshot`, even when the direct record carries no source-reference identity (`connection_id` / `provider_connection_id` / `source_id`). The provider list only feeds source-reference resolution keyed by those ids, so for records without them the call is unused, yet a transient `/v2/user/providers/...` failure fails the whole direct import job. That is an avoidable external failure dependency on the device-sync path.

## User goal / user-visible behavior

Complete direct sleep-cycle webhook payloads import compact sleep-stage facts even when the Junction provider-list endpoint is unavailable. `shouldLoadJunctionDirectResourceSourceProviders` now applies the same source-reference gate to `sleep_cycle` that `sleep` already used, so the provider list is fetched only when the record actually references a provider.

## Invariants the PR must preserve

- Direct records with source-reference identity (including nested/aliased ids) still load and resolve providers; `hasJunctionSourceReferenceIdentity` already searches nested objects and arrays, and the existing tests for `provider_connection_id` / `connection_id` / `source_id` records still pass.
- No change to sanitize/no-projection behavior for direct sleep_cycle imports (`upsertConnectionSource` is still never called on this path).
- Canonical writes still flow through importers/core via `context.importSnapshot`.

## Verification

- `pnpm test:diff packages/device-syncd/src/providers/junction.ts packages/device-syncd/test/junction-provider.test.ts` — passed (exit 0; includes device-syncd typecheck + tests and typechecks for all affected workspace packages, apps/web verify build included).
- `pnpm --dir packages/device-syncd exec vitest run test/junction-provider.test.ts --no-coverage` — 131 passed (131).
- Mutation check: temporarily reverting the predicate makes the new no-source-reference regression test fail (provider-list fetch throws and the job errors), confirming the test guards the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785532289&installation_id=127572939&pr_number=358&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F358&signature=7ab58f7467b1b8676f9049004f49d84f5f265bb9db5441322ed97f6ad211af84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->