### PR TITLE
Short-circuit hosted wake probe on verifiably stopped container shells

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-02-wake-stopped-shell-short-circuit.md
+++ b/agent-docs/exec-plans/completed/2026-07-02-wake-stopped-shell-short-circuit.md
@@ -1,0 +1,66 @@
+# Wake stopped-shell short-circuit
+
+## Why
+
+Production `hosted_ingress_latency_trace` (week of 2026-06-25) shows the single
+largest serial block in cold-reply latency is the active-wake probe on a
+stopped container shell: 3.2s p50 / 4.8s p90 on 59% of user-triggered cold
+starts. `RunnerContainer.wakeRuntime` unconditionally `containerFetch`es the
+container's `/internal/runtime-wake` endpoint; on a stopped shell the
+`@cloudflare/containers` base class boots the container inside `containerFetch`
+just for the freshly booted entrypoint to answer "absent" — a just-booted
+container can never host an active child, so the probe is a tautology that
+costs a full container boot.
+
+## User-visible goal
+
+Cold replies (user messages Murph while their container is stopped) reach the
+provider ~1.3-1.5s sooner at p50, more at p90. No behavior change on warm
+wakes or ambiguous shells.
+
+## Change
+
+In `apps/cloudflare/src/runner-container.ts`, `wakeRuntime`: when there is no
+in-memory `workspaceInvocationActiveOperation` AND the platform container
+handle reports the container is not running, return
+`{ kind: "not-wakeable", reason: "no-active-child" }` before
+`noteRunnerActivity`/`containerFetch`. Platform truth (`ctx.container.running
+=== false`) means no container process exists, so no child can exist; this is
+the same stopped-shell-as-inactive-proof standard PR #344 (f5557068d5) added to
+`readActiveRuntimeUserFence` and that
+`agent-docs/references/hosted-runtime-protocol.md` codifies as "Inactive
+liveness is explicit no-active-child proof."
+
+Add one sentence to the protocol doc's wake-path section recording that a
+verifiably stopped shell (platform running=false) is explicit no-active-child
+proof for the wake probe.
+
+## Invariants to preserve
+
+- Fail-safe direction only: any ambiguity (running, healthy, stopping,
+  unknown/null, in-memory active op present, platform handle unavailable)
+  keeps today's `containerFetch` probe path unchanged.
+- No changes to fence mutation paths, preserved-after-transport-failure
+  handling, retention/preemption paths, `ensureReadyForProcessing`, timeouts,
+  or the legacy wake fallback in `runtime-container-wake.ts`.
+- No new persisted state, config, env vars, or log keys. No `as any` /
+  lazy `as unknown` casts.
+- Verify-before-clear stays intact: fence replacement remains identity-matched
+  and owned by the wake path; this change only makes the existing
+  "no active child" verdict fast on shells that are provably stopped.
+
+## Verification
+
+- Focused `apps/cloudflare` tests for `wakeRuntime` (stopped shell + no active
+  op short-circuits without `containerFetch`; running shell still probes;
+  in-memory active-op behavior unchanged) plus the existing runner-container
+  suite and typecheck.
+
+## Status
+
+Adversarially reviewed pre-implementation (codex gpt-5.5 xhigh, read-only):
+SAFE, no counterexample; sharp edge noted is tail-only (boot >8s now hits the
+fresh-start confirm timeout and retries cleanly).
+Status: completed
+Updated: 2026-07-02
+Completed: 2026-07-02

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -440,6 +440,8 @@ recheck instead of being cleared from the pointer alone; only the wake path may
 then replace the fence after it explicitly reports no active child. Inactive
 liveness is explicit no-active-child proof, so the controller clears and
 replaces that fence directly instead of asking web status to complete it first.
+For the active-wake probe, a verifiably stopped container shell
+(`ctx.container.running === false`) is the same explicit no-active-child proof.
 Committed-progress recovery stays in the transport-failure adapter, where the
 transport outcome is the thing being reconciled. Mismatched liveness probes
 clear the fence because they prove the active child is not the fenced attempt;

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -600,6 +600,10 @@ export class RunnerContainer extends Container {
       }
     }
 
+    if (!active && this.isPlatformContainerDefinitelyStopped()) {
+      return { kind: "not-wakeable", reason: "no-active-child" };
+    }
+
     this.noteRunnerActivity("runtime-wake");
     try {
       const runtimeWakeSignal = AbortSignal.timeout(DEFAULT_RUNNER_RUNTIME_WAKE_TIMEOUT_MS);
@@ -691,6 +695,10 @@ export class RunnerContainer extends Container {
       }
       return { kind: "unknown", reason: "container-rpc-error" };
     }
+  }
+
+  private isPlatformContainerDefinitelyStopped(): boolean {
+    return this.ctx.container?.running === false;
   }
 
   async smokeHealth(input: HostedExecutionContainerSmokeHealthInput = {}): Promise<HostedExecutionContainerSmokeHealthResult> {

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -381,6 +381,117 @@ describe("RunnerContainer", () => {
     });
   });
 
+  it("short-circuits a wake probe when platform truth says a pointerless shell is stopped", async () => {
+    const { container, containerFetch, getState, startAndWaitForPorts } =
+      createContainerDouble({
+        containerFetch: vi.fn(async (url: string) => {
+          throw new Error(`Unexpected runner request URL: ${url}`);
+        }),
+        initialStatus: "running",
+        platformRunning: false,
+      });
+
+    await expect(container.wakeRuntime({
+      attemptId: "attempt_lost_pointer_stopped_shell",
+      leaseGeneration: "12",
+      userId: "member_123",
+    })).resolves.toEqual({
+      kind: "not-wakeable",
+      reason: "no-active-child",
+    });
+
+    expect(containerFetch).not.toHaveBeenCalled();
+    expect(getState).not.toHaveBeenCalled();
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+  });
+
+  it("still probes a pointerless shell when platform truth says it is running", async () => {
+    const { container, containerFetch, startAndWaitForPorts } =
+      createContainerDouble({
+        containerFetch: vi.fn(async (url: string) => {
+          if (url.endsWith("/internal/runtime-wake")) {
+            return new Response(null, {
+              headers: {
+                "x-runtime-wake-absent": "1",
+                "x-runtime-wake-accepted": "0",
+              },
+              status: 204,
+            });
+          }
+
+          throw new Error(`Unexpected runner request URL: ${url}`);
+        }),
+        initialStatus: "stopped",
+        platformRunning: true,
+      });
+
+    await expect(container.wakeRuntime({
+      attemptId: "attempt_lost_pointer_running_shell",
+      leaseGeneration: "12",
+      userId: "member_123",
+    })).resolves.toEqual({
+      kind: "not-wakeable",
+      reason: "no-active-child",
+    });
+
+    expect(containerFetch.mock.calls.some(([url]) =>
+      String(url).endsWith("/internal/runtime-wake")
+    )).toBe(true);
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+  });
+
+  it("keeps active-operation identity rejection ahead of the stopped-shell short-circuit", async () => {
+    const runnerRequestStarted = createDeferred<void>();
+    const runnerResponse = createDeferred<Response>();
+    const { container, containerFetch } = createContainerDouble({
+      containerFetch: vi.fn(async (url: string) => {
+        if (url.endsWith("/health")) {
+          return new Response(JSON.stringify(createRunnerHealthResult()), {
+            headers: {
+              "content-type": "application/json; charset=utf-8",
+            },
+            status: 200,
+          });
+        }
+
+        runnerRequestStarted.resolve();
+        return await runnerResponse.promise;
+      }),
+      platformRunning: false,
+    });
+
+    const invocation = container.invoke({
+      job: {
+        kind: "workspace-invocation",
+        request: createRunnerRequest("evt_active_op_platform_stopped"),
+      },
+      timeoutMs: 60_000,
+      userId: "member_123",
+    });
+    await runnerRequestStarted.promise;
+
+    await expect(container.wakeRuntime({
+      attemptId: "attempt_stale",
+      leaseGeneration: "10",
+      userId: "member_123",
+    })).resolves.toEqual({
+      kind: "unknown",
+      reason: "active-child-rejected",
+    });
+
+    expect(containerFetch.mock.calls.some(([url]) =>
+      String(url).endsWith("/internal/runtime-wake")
+    )).toBe(false);
+
+    runnerResponse.resolve(new Response(JSON.stringify(createRunnerResult()), {
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+      },
+      status: 200,
+    }));
+    await expect(invocation).resolves.toEqual(createRunnerResult());
+  });
+
   it("does not trust an identity-blind accepted wake when the outer active-operation pointer is missing", async () => {
     const { container } = createContainerDouble({
       containerFetch: vi.fn(async (url: string) => {
@@ -6071,14 +6182,23 @@ interface CreateContainerDoubleInput {
   env?: Record<string, unknown>;
   getState?: ReturnType<typeof vi.fn>;
   initialStatus?: "running" | "stopped" | "stopped_with_code";
+  platformRunning?: boolean;
   startAndWaitForPorts?: ReturnType<typeof vi.fn>;
   state?: Record<string, unknown>;
 }
 
 function createContainerDouble(input: CreateContainerDoubleInput = {}) {
   let currentStatus = input.initialStatus ?? "stopped";
+  const platformContainer = input.platformRunning === undefined
+    ? undefined
+    : {
+        get running(): boolean {
+          return input.platformRunning === true;
+        },
+      };
   const ContainerClass = input.containerClass ?? RunnerContainer;
   const container = new ContainerClass({
+    ...(platformContainer ? { container: platformContainer } : {}),
     storage: createContainerStorageDouble(),
     ...(input.state ?? {}),
   } as never, {

--- a/apps/cloudflare/test/stubs/cloudflare-containers.ts
+++ b/apps/cloudflare/test/stubs/cloudflare-containers.ts
@@ -5,6 +5,9 @@ interface TestContainerStorage {
 }
 
 interface TestContainerContext {
+  container?: {
+    readonly running: boolean;
+  };
   storage: TestContainerStorage;
 }
 
@@ -68,8 +71,12 @@ export class Container {
   pingEndpoint = "ping";
   sleepAfter: string | number = "10m";
 
-  constructor(ctx?: { storage?: TestContainerStorage }) {
+  constructor(ctx?: {
+    container?: TestContainerContext["container"];
+    storage?: TestContainerStorage;
+  }) {
     this.ctx = {
+      ...(ctx?.container ? { container: ctx.container } : {}),
       storage: ctx?.storage ?? createMemoryStorage(),
     };
   }


### PR DESCRIPTION
## Why

Production `hosted_ingress_latency_trace` (week of 2026-06-25) shows the single largest serial block in cold-reply latency is the active-wake probe on a stopped container shell: 3.2s p50 / 4.8s p90 on 59% of user-triggered cold starts. `RunnerContainer.wakeRuntime` unconditionally `containerFetch`es `/internal/runtime-wake`; on a stopped shell the `@cloudflare/containers` base class boots the container inside `containerFetch` just for the freshly booted entrypoint to answer "absent" — a just-booted container can never host an active child, so the probe pays a full container boot to learn nothing.

## User-visible goal

Cold replies (user messages Murph while their container is stopped) reach the provider ~1.3-1.5s sooner at p50, more at p90. No behavior change on warm wakes or ambiguous shells.

## What changed

- `wakeRuntime` returns `not-wakeable / no-active-child` before `noteRunnerActivity`/`containerFetch` when there is no in-memory active operation AND platform truth says the container is not running (`this.ctx.container?.running === false`).
- One protocol-doc sentence recording that a verifiably stopped shell is the same explicit no-active-child proof the inactive-liveness rule already codifies (the identical stopped-shell standard PR #344 added to `readActiveRuntimeUserFence`).
- Three focused tests: platform-stopped + no pointer short-circuits with zero container calls (even with stale-running tracked state); platform-running still probes (even with stale-stopped tracked state); in-memory active-op identity rejection stays ahead of the short-circuit.

## Invariants to preserve

- Fail-safe direction only: any ambiguity (running/healthy/stopping/unknown status, missing platform handle, in-memory active op present) keeps today's `containerFetch` probe unchanged.
- Verify-before-clear stays intact: fence replacement remains identity-matched, grace-protected, and owned by the wake path; this change only makes the existing "no active child" verdict fast on shells that are provably stopped.
- No changes to fence mutation paths, preserved-after-transport-failure handling, retention/preemption, `ensureReadyForProcessing`, timeouts, or the legacy wake fallback.

## Verification

- `vitest run apps/cloudflare/test/runner-container.test.ts`: 144 passed.
- `scripts/workspace-verify.sh test:diff` over the touched files: apps/cloudflare verify, 93 files / 1623 tests passed.
- `pnpm --dir apps/cloudflare typecheck`: clean.
- Pre-implementation adversarial review (codex gpt-5.5 xhigh, read-only): SAFE, no counterexample; noted tail-only sharp edge (boot >8s now hits the fresh-start confirm timeout and retries cleanly).

DEPLOYMENT CONCERNS: single-sided Cloudflare Worker deploy; no container image, web, or schema coupling, so no tandem deploy or compatibility window is needed. Worker/container skew is safe in both directions (old Workers keep probing; new Workers just skip a boot the container never observed). Post-deploy check: `hosted_ingress_latency_trace` probed cold starts (`replacedStaleFence=true`, `restoreWasCold=true`) should show the active-wake window collapse from ~3.2s to milliseconds, and watch for any rise in `container_rpc_timeout` retry responses from the fresh-start confirm path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785606033&installation_id=127572939&pr_number=364&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F364&signature=f66c398eac9eae6cb789a2dc5c36c95e333e0f6629c58f353c7e1006f983c2ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->