### PR TITLE
Disable login shells for hosted codex execs (vault-cli PATH fix)

### DIFF
--- a/apps/cloudflare/src/container-entrypoint.ts
+++ b/apps/cloudflare/src/container-entrypoint.ts
@@ -1958,6 +1958,9 @@ function buildHostedContainerCodexShellSmokeConfig(model: string): string {
     'approval_policy = "never"',
     'sandbox_mode = "danger-full-access"',
     "check_for_update_on_startup = false",
+    // Mirror the hosted runtime config: non-login shells so the smoke probe
+    // exercises the same PATH semantics as production turns.
+    "allow_login_shell = false",
     "",
     "[features]",
     "plugins = false",

--- a/apps/cloudflare/src/hosted-runner-smoke-child.ts
+++ b/apps/cloudflare/src/hosted-runner-smoke-child.ts
@@ -663,6 +663,9 @@ function buildHostedRunnerSmokeCodexConfigToml(): string {
     "model_auto_compact_token_limit = 128000",
     'approval_policy = "never"',
     'sandbox_mode = "danger-full-access"',
+    // Mirror the hosted runtime config: non-login shells so the smoke probe
+    // exercises the same PATH semantics as production turns.
+    "allow_login_shell = false",
     "",
     "[skills]",
     "include_instructions = false",

--- a/apps/cloudflare/test/container-entrypoint.test.ts
+++ b/apps/cloudflare/test/container-entrypoint.test.ts
@@ -1426,6 +1426,7 @@ describe("startHostedContainerEntrypoint", () => {
       expect(codexConfigToml).toContain("request_max_retries = 4");
       expect(codexConfigToml).toContain("stream_max_retries = 5");
       expect(codexConfigToml).toContain("multi_agent_v2 = true");
+      expectCodexConfigDisablesLoginShellAtTopLevel(codexConfigToml);
     } finally {
       if (previousHostedHome === undefined) {
         delete process.env.HOSTED_HOME;
@@ -3031,3 +3032,12 @@ describe("classifyRunnerJobError", () => {
     });
   });
 });
+
+function expectCodexConfigDisablesLoginShellAtTopLevel(config: string): void {
+  expect(config.match(/^allow_login_shell\s*=/gmu)).toEqual(["allow_login_shell ="]);
+  expect(config).toMatch(/^allow_login_shell = false$/mu);
+
+  const loginShellIndex = config.indexOf("allow_login_shell = false");
+  const firstSectionIndex = config.search(/^\[/mu);
+  expect(firstSectionIndex === -1 || loginShellIndex < firstSectionIndex).toBe(true);
+}

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -587,6 +587,11 @@ export function buildHostedCodexConfigToml(input: {
     `approval_policy = ${tomlString(DEFAULT_HOSTED_CODEX_APPROVAL_POLICY)}`,
     `sandbox_mode = ${tomlString(DEFAULT_HOSTED_CODEX_SANDBOX)}`,
     "check_for_update_on_startup = false",
+    // Login shells re-source /etc/profile, which resets PATH to the stock
+    // system dirs and drops /app/node_modules/.bin (vault-cli). The runner
+    // image has no profile.d content worth sourcing, so force non-login
+    // shells and let shell_environment_policy own the exec environment.
+    "allow_login_shell = false",
     "",
     ...providerConfigLines,
     "# Hosted runs should not perform Codex plugin marketplace or remote plugin",

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -154,7 +154,7 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
   assert.match(config, /approval_policy = "never"/u);
   assert.match(config, /sandbox_mode = "danger-full-access"/u);
   assert.match(config, /^check_for_update_on_startup = false$/mu);
-  assert.match(config, /^allow_login_shell = false$/mu);
+  assertHostedCodexConfigDisablesLoginShellAtTopLevel(config);
   assert.doesNotMatch(config, /^model_provider = "openai"$/mu);
   assert.doesNotMatch(config, /\[model_providers\."openai"\]/u);
   assert.match(config, /\[model_providers\."hosted-openai"\]/u);
@@ -453,6 +453,7 @@ test("hosted Codex runtime config uses ChatGPT subscription auth in local dev", 
   assert.match(config, /model_reasoning_effort = "low"/u);
   assert.match(config, /\[history\]\npersistence = "none"/u);
   assert.match(config, /\[shell_environment_policy\]/u);
+  assertHostedCodexConfigDisablesLoginShellAtTopLevel(config);
   assertHostedCodexAutoCompactTokenLimit(config);
 });
 
@@ -621,6 +622,7 @@ test("hosted Codex runtime config preserves managed ChatGPT auth", async () => {
   assert.match(config, /^model_provider = "openai"$/mu);
   assert.doesNotMatch(config, /\[model_providers\./u);
   assert.doesNotMatch(config, /chatgpt-refresh-token/u);
+  assertHostedCodexConfigDisablesLoginShellAtTopLevel(config);
   assertHostedCodexAutoCompactTokenLimit(config);
 });
 
@@ -1329,6 +1331,7 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
       "",
     ].join("\n"),
   );
+  assertHostedCodexConfigDisablesLoginShellAtTopLevel(config);
 });
 
 test("hosted Codex shell policy excludes ElevenLabs runtime capability env", () => {
@@ -1446,6 +1449,19 @@ function assertHostedCodexRootAgentUsageHintRetainsCodexDefaults(): void {
   assert.ok(HOSTED_CODEX_ROOT_AGENT_USAGE_HINT.endsWith(
     "Murph system-prompt and skill instructions that direct delegating work to a sub-agent, such as onboarding supplement-label or lab-result ingestion, count as explicit user requests for sub-agent work under any multi-agent mode instruction.",
   ));
+}
+
+function assertHostedCodexConfigDisablesLoginShellAtTopLevel(config: string): void {
+  const loginShellAssignments = config.match(/^allow_login_shell\s*=/gmu) ?? [];
+  assert.deepEqual(loginShellAssignments, ["allow_login_shell ="]);
+  assert.match(config, /^allow_login_shell = false$/mu);
+
+  const loginShellIndex = config.indexOf("allow_login_shell = false");
+  const firstSectionIndex = config.search(/^\[/mu);
+  assert.ok(
+    firstSectionIndex === -1 || loginShellIndex < firstSectionIndex,
+    "allow_login_shell must be a top-level Codex config key before the first TOML section",
+  );
 }
 
 function chatGptCodexAuthTokens(): Record<string, string> {

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -154,6 +154,7 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
   assert.match(config, /approval_policy = "never"/u);
   assert.match(config, /sandbox_mode = "danger-full-access"/u);
   assert.match(config, /^check_for_update_on_startup = false$/mu);
+  assert.match(config, /^allow_login_shell = false$/mu);
   assert.doesNotMatch(config, /^model_provider = "openai"$/mu);
   assert.doesNotMatch(config, /\[model_providers\."openai"\]/u);
   assert.match(config, /\[model_providers\."hosted-openai"\]/u);
@@ -1270,6 +1271,7 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
       'approval_policy = "never"',
       'sandbox_mode = "danger-full-access"',
       "check_for_update_on_startup = false",
+      "allow_login_shell = false",
       "",
       '[model_providers."openai"]',
       'name = "OpenAI"',


### PR DESCRIPTION
## Why this PR exists

Hosted Murph conversations lose `vault-cli` mid-conversation: saves work for the first turns, then every shell command fails with `bash: vault-cli: command not found` after the first workspace-invocation boundary on a warm codex app-server. Reproduced live on 2026-07-02 during onboarding (failing turn 17:21:45Z), fix verified end-to-end on the local hosted stack.

## User goal / user-visible behavior

Murph can save and read vault records on every turn of a hosted conversation — first turn, warm-reused codex turns, and turns after idle gaps — instead of silently losing its CLI after the first pause in the conversation.

## Root cause

Codex 0.142.5 defaults `allow_login_shell = true`, so `exec_command` runs `bash -lc`. In the Debian runner image a login shell re-sources `/etc/profile`, which unconditionally resets PATH to the stock system path and drops `/app/node_modules/.bin` (where the bundled `vault-cli` lives), silently defeating the `[shell_environment_policy.set]` PATH pin. Codex's shell-snapshot wrapper normally masks this (it rewrites `-lc` to `-c`, sources a login-env snapshot, then re-exports the policy PATH), but the per-invocation workspace restore deletes the snapshot file (`CODEX_HOME/shell_snapshots/` is not on the restore allowlist), so after the first invocation boundary every exec on the warm app-server is a raw login shell with a clobbered PATH.

The fix pins `allow_login_shell = false` in the generated hosted config and the deploy-smoke config: all execs become plain `bash -c`, `/etc/profile` never runs, the snapshot wrapper never engages, and `shell_environment_policy` deterministically owns the exec environment. `/etc/profile.d/` is empty in the runner image, so login shells provided nothing. With the flag off, codex also removes the `login` parameter from the exec tool schema entirely.

## Invariants to preserve

- `allow_login_shell = false` appears exactly once and before the first `[` section header (top-level TOML key) in every generated hosted config variant and in the shell-smoke config — tests pin this.
- Shell exec environment comes solely from `shell_environment_policy` (`include_only` + `set` PATH pin); no dependence on shell-snapshot capture timing or snapshot file survival across workspace restores.
- No other codex config behavior changes.

## Verification

- `pnpm test:diff` over the touched files: 93 files / 1623 tests green (includes apps/cloudflare verify lane).
- Focused: hosted-runtime-codex-config.test.ts 37 passed; container-entrypoint.test.ts 52 passed; `tsc -b` clean on both packages.
- `coverage-write` audit pass (Codex gpt-5.5) added the exactly-once/top-level assertions in both test files.
- Live scenario proof on the local hosted stack: before fix, a warm-reused turn after an invocation boundary failed `vault-cli` with "command not found"; after fix, the same warm-reused/thread-resumed turn shape on a fresh invocation with `shell_snapshots/` absent ran `vault-cli condition save` to exit 0. Image-level proof: `docker run <runner image> bash -lc 'command -v vault-cli'` fails while `bash -c` finds it.

## Deployment skew / compatibility

Runner-bundle-only change (config generator + smoke config); no Worker/web contract changes, safe in any deploy order. During gradual container rollout, warm containers on the old bundle keep today's bug until they recycle; no compatibility window needed — old and new configs are mutually compatible. Deploy with `container_rollout=immediate` (deep-review accepted finding): gradual rollout leaves old warm containers on the broken login-shell config until they drain, so an active user pinned to an old container keeps hitting the vault-cli failure while the deploy looks done. Verify convergence before declaring production fixed. Post-deploy check: run a hosted turn, pause 2+ minutes, run another save; both should succeed (previously the second failed), and the deploy smoke's codex shell probe exercises the same non-login semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785608389&installation_id=127572939&pr_number=365&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F365&signature=8b438b4c1acb4a211ac60fb037defb762b3b11010ad91037576d28d48f81a0c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
