### PR TITLE
Group chats: murph.group contact-card share + participant membership read

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-02-linq-group-vcf-contact-card.md
+++ b/agent-docs/exec-plans/completed/2026-07-02-linq-group-vcf-contact-card.md
@@ -1,0 +1,100 @@
+# Linq Group Chat Contact Card Tool
+
+## Goal
+
+In a provisioned iMessage group thread, Murph should be able to notice that some
+participants don't have their own Murph thread yet, send its contact card (.vcf) into
+the group so they can tap/save/text it, and say so in its own voice ("add me as a
+contact and shoot me a message, I'll get you set up"). The decision belongs to the
+assistant, not to deterministic send machinery: expose it through the existing
+`murph.group` dynamic tool. The existing 1:1 first-contact flow (signup link in DMs)
+finishes onboarding when a non-member texts the line.
+
+## Success Criteria
+
+- `murph.group` gains `action="read_chat_participants"` (each group-chat participant
+  handle plus whether they already have an active Murph membership) and
+  `action="share_contact_card"` (sends a Murph .vcf as a Linq media attachment into
+  this group chat).
+- Both actions are authorized by the thread-route egress authority: the runtime
+  injects `linqThread: { chatId, authority }` from the current wake's Linq delivery
+  context; the web handler asserts the authority row, container/member match, and
+  thread match before any Linq call. Without a valid authority the actions return
+  `unavailable` (fail closed).
+- The vCard carries the name "Murph", the murph_headshot.png photo (best-effort
+  embed), the group's own line number as `mobile` (taken from the Linq chat roster's
+  `is_me` handle — never a config guess), and a second healthy configured line as a
+  labeled `backup` number (provider status not AT_RISK/CRITICAL from the synced
+  `hostedLinqLine` rows; omitted when no healthy second line exists).
+- Repeat `share_contact_card` calls are throttled server-side by the existing
+  `hostedLinqContactCardShare` reservation table (48h per chat) and report
+  `already_shared`.
+- Direct 1:1 native contact-card share behavior and cadence are untouched.
+- The group-chat skill and `murph.group` guidance tell Murph when to use the actions,
+  with deliverability-safe framing (no signup/acquisition language; the join URL stays
+  in the 1:1 DM flow; Murph still never initiates a thread).
+
+## Constraints
+
+- Reuse existing seams: the `murph.group` tool, `groupToolPort`, the internal
+  `groups/tool` route with Cloudflare callback auth, `assertHostedThreadRouteEgressAuthority`,
+  the contact-card reservation table, and the Murph card identity constants. No new
+  routes, tables, tools, or delivery kinds.
+- Raw chat ids and participant handles flow only through the already-authorized
+  runtime path; the web DB continues to store hashed lookup keys only.
+- vCard photo embed is best-effort; failures degrade to a photo-less card.
+- Tool descriptions and skill copy must avoid acquisition/signup framing per
+  `agent-docs/operations/imessage-deliverability.md`.
+
+## Design
+
+1. Contracts (`packages/hosted-execution/src/runtime-control.ts` + parsers): extend
+   `HostedRuntimeGroupToolRequest`/`Response` with the two actions; requests carry an
+   optional runtime-injected `linqThread` (chat id + Linq external-thread route
+   authority). Responses: participants list with `hasOwnMurph` flag, or share result
+   `sent | already_shared | unavailable`.
+2. Engine (`packages/assistant-engine/src/assistant-codex/dynamic-tools.ts`,
+   `assistant/system-prompt.ts`): add the actions to the model-visible schema and the
+   `murph.group` description; the model never supplies `linqThread`.
+3. Runtime (`packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts`):
+   wrap `platform.groupToolPort` so the two new actions get `linqThread` injected from
+   the initial mailbox Linq delivery contexts (first context with a route authority).
+4. Web (`apps/web/src/lib/hosted-groups/group-tool.ts`): handle both actions after
+   authority assertion. Roster via new `getHostedLinqChat` (GET `chats/{id}`) in
+   `linq-client.ts`; membership via existing phone/email identity lookups + active
+   access. Share: reserve attempt in `hostedLinqContactCardShare`, build vcf
+   (`buildMurphHostedLinqContactCardVcf` in `linq-contact-card.ts`, photo from the
+   Murph card image URL), upload via `POST attachments` + presigned PUT, send one
+   `{ type: "media", attachment_id }` message part.
+5. Skill (`packages/assistant-engine/skills/group-chat/SKILL.md`): first-exchange
+   guidance — check participants, share the card once when someone doesn't have their
+   own Murph, invite them to save it and text directly.
+
+## Verification Plan
+
+- Parser round-trip tests for the new request/response variants (hosted-execution).
+- Engine tests: schema accepts the two actions, rejects extras.
+- Runtime test: wrapper injects `linqThread` only for the new actions and only when a
+  route-authorized Linq delivery context exists.
+- Web tests: authority mismatch fails closed; roster membership classification;
+  share happy path (attachment create → PUT → message send), throttled repeat, vcf
+  content shape (CRLF, TEL from is_me handle, photo fallback).
+- `pnpm test:diff` over touched paths + `pnpm typecheck`.
+
+## State
+
+Implemented and verified: contracts + parsers (strict, participants capped),
+engine schema/description, runtime linqThread injection (iMessage-group
+contexts only, distinct-authority fail-closed), web handlers (authority
+assert, roster membership classification, vcf share with 48h reservation,
+day-scoped idempotency key, 30s upload timeout, empty-roster fail-closed),
+two-number vCard (mobile = chat's line, backup = first healthy pool line),
+group-chat skill + hosted-groups prompt guidance. Focused suites green
+(parsers 25, web group-tool 19, web contact-card 17, engine 6, runtime 4,
+share/route 10); full `pnpm test:diff` lane green incl. apps/web and
+apps/cloudflare verify; c1 Codex deep review (xhigh) findings all resolved.
+Live-Linq shape of GET chats/{id} handles and vcf rendering still need a
+production smoke after deploy (web before Cloudflare).
+Status: completed
+Updated: 2026-07-02
+Completed: 2026-07-02

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -18,6 +18,7 @@ import { lookupHostedMemberIdentityByPhoneNumber } from "../hosted-onboarding/ho
 import { lookupHostedMemberByVerifiedEmailAddress } from "../hosted-onboarding/hosted-member-store";
 import {
   getHostedLinqChatHandles,
+  isHostedLinqAttachmentSendPrepareFailure,
   sendHostedLinqAttachmentMessage,
 } from "../hosted-onboarding/linq-client";
 import {
@@ -27,7 +28,10 @@ import {
   MURPH_CONTACT_CARD_VCF_FILE_NAME,
   resolveMurphHostedLinqContactCardBackupPhoneNumber,
 } from "../hosted-onboarding/linq-contact-card";
-import { reserveHostedLinqContactCardShareAttempt } from "../hosted-onboarding/linq-contact-card-share";
+import {
+  releaseHostedLinqContactCardShareAttempt,
+  reserveHostedLinqContactCardShareAttempt,
+} from "../hosted-onboarding/linq-contact-card-share";
 import { normalizePhoneNumber } from "../hosted-onboarding/phone";
 import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from "../hosted-onboarding/shared";
 import { assertHostedLinqRouteEgressAuthority } from "../hosted-routing/thread-route-store";
@@ -208,23 +212,29 @@ async function handleHostedRuntimeGroupReadChatParticipants(input: {
 
   const prisma = getPrisma();
   const participants: HostedRuntimeGroupChatParticipant[] = [];
-  for (const handle of handles) {
-    if (handle.isMe) {
-      continue;
-    }
-    if (handle.status && handle.status.trim().toLowerCase() !== "active") {
-      continue;
-    }
-    if (participants.length >= HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX) {
-      break;
-    }
-    participants.push({
-      handle: handle.handle,
-      hasOwnMurph: await hasParticipantOwnMurphMembership({
+  try {
+    for (const handle of handles) {
+      if (handle.isMe) {
+        continue;
+      }
+      if (handle.status && handle.status.trim().toLowerCase() !== "active") {
+        continue;
+      }
+      if (participants.length >= HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX) {
+        break;
+      }
+      participants.push({
         handle: handle.handle,
-        prisma,
-      }),
-    });
+        hasOwnMurph: await hasParticipantOwnMurphMembership({
+          handle: handle.handle,
+          prisma,
+        }),
+      });
+    }
+  } catch {
+    // A failed identity lookup must not degrade into a guessed hasOwnMurph
+    // value or an unstructured route error.
+    return unavailable("membership_lookup_unavailable");
   }
 
   return {
@@ -279,22 +289,28 @@ async function handleHostedRuntimeGroupShareContactCard(input: {
   }
 
   let linePhoneNumber: string | null = null;
+  let rosterPresent = false;
   try {
     const handles = await getHostedLinqChatHandles({ chatId: authorized.chatId });
+    rosterPresent = handles.length > 0;
     linePhoneNumber = normalizePhoneNumber(
       handles.find((handle) => handle.isMe)?.handle ?? null,
     );
   } catch {
     return unavailable("provider_unavailable");
   }
+  if (!rosterPresent) {
+    return unavailable("provider_unavailable");
+  }
   if (!linePhoneNumber) {
     return unavailable("line_unresolved");
   }
 
+  const prisma = getPrisma();
   const reservation = await reserveHostedLinqContactCardShareAttempt({
     chatId: authorized.chatId,
     memberId: input.memberId,
-    prisma: getPrisma(),
+    prisma,
   });
   if (reservation.action !== "share") {
     if (reservation.reason === "recent_attempt") {
@@ -329,7 +345,21 @@ async function handleHostedRuntimeGroupShareContactCard(input: {
       // The chat id is Linq's own identifier, so no new exposure.
       idempotencyKey: `group-contact-card:${authorized.chatId}:${new Date().toISOString().slice(0, 10)}`,
     });
-  } catch {
+  } catch (error) {
+    if (isHostedLinqAttachmentSendPrepareFailure(error)) {
+      // Nothing reached the chat; free the 48h reservation so a later retry
+      // is not locked out. Ambiguous message-send failures keep it.
+      try {
+        await releaseHostedLinqContactCardShareAttempt({
+          attemptedAt: reservation.attemptedAt,
+          chatId: authorized.chatId,
+          memberId: input.memberId,
+          prisma,
+        });
+      } catch {
+        // Best effort: a stuck reservation only delays the next attempt.
+      }
+    }
     return unavailable("send_failed");
   }
 

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -1,13 +1,36 @@
 import "server-only";
 
-import type {
-  HostedRuntimeGroupCreateJoinLinkRequest,
-  HostedRuntimeGroupToolRequest,
-  HostedRuntimeGroupToolResponse,
+import {
+  HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX,
+  type HostedRuntimeGroupChatParticipant,
+  type HostedRuntimeGroupCreateJoinLinkRequest,
+  type HostedRuntimeGroupToolLinqThreadContext,
+  type HostedRuntimeGroupToolRequest,
+  type HostedRuntimeGroupToolResponse,
 } from "@murphai/hosted-execution/runtime-control";
 
 import { hasHostedRuntimeActiveAccess } from "../hosted-mailbox/runtime-access";
+import {
+  hasHostedMemberActiveAccess,
+  isHostedMemberSuspended,
+} from "../hosted-onboarding/entitlement";
+import { lookupHostedMemberIdentityByPhoneNumber } from "../hosted-onboarding/hosted-member-identity-store";
+import { lookupHostedMemberByVerifiedEmailAddress } from "../hosted-onboarding/hosted-member-store";
+import {
+  getHostedLinqChatHandles,
+  sendHostedLinqAttachmentMessage,
+} from "../hosted-onboarding/linq-client";
+import {
+  buildMurphHostedLinqContactCardVcf,
+  fetchMurphHostedLinqContactCardVcfPhoto,
+  MURPH_CONTACT_CARD_VCF_CONTENT_TYPE,
+  MURPH_CONTACT_CARD_VCF_FILE_NAME,
+  resolveMurphHostedLinqContactCardBackupPhoneNumber,
+} from "../hosted-onboarding/linq-contact-card";
+import { reserveHostedLinqContactCardShareAttempt } from "../hosted-onboarding/linq-contact-card-share";
+import { normalizePhoneNumber } from "../hosted-onboarding/phone";
 import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from "../hosted-onboarding/shared";
+import { assertHostedLinqRouteEgressAuthority } from "../hosted-routing/thread-route-store";
 import { resolveHostedPublicBaseUrl } from "../hosted-web/public-url";
 import { getPrisma } from "../prisma";
 import { buildHostedGroupJoinUrl } from "./group-links";
@@ -23,6 +46,20 @@ export async function handleHostedRuntimeGroupTool(input: {
   if (input.request.action === "create_join_link") {
     return handleHostedRuntimeGroupCreateJoinLink({
       joinLink: input.request.joinLink ?? null,
+      memberId: input.memberId,
+    });
+  }
+
+  if (input.request.action === "read_chat_participants") {
+    return handleHostedRuntimeGroupReadChatParticipants({
+      linqThread: input.request.linqThread ?? null,
+      memberId: input.memberId,
+    });
+  }
+
+  if (input.request.action === "share_contact_card") {
+    return handleHostedRuntimeGroupShareContactCard({
+      linqThread: input.request.linqThread ?? null,
       memberId: input.memberId,
     });
   }
@@ -111,5 +148,193 @@ async function handleHostedRuntimeGroupCreateJoinLink(input: {
   return {
     action: "create_join_link",
     result: { group: created.group, joinUrl, status: "ok" },
+  };
+}
+
+type HostedRuntimeGroupLinqThreadAuthorization =
+  | { chatId: string }
+  | { unavailableReason: string };
+
+async function authorizeHostedRuntimeGroupLinqThread(input: {
+  linqThread: HostedRuntimeGroupToolLinqThreadContext | null;
+  memberId: string;
+}): Promise<HostedRuntimeGroupLinqThreadAuthorization> {
+  if (!input.linqThread) {
+    return { unavailableReason: "linq_thread_unavailable" };
+  }
+  const { authority, chatId } = input.linqThread;
+  if (
+    authority.containerMemberId !== input.memberId
+    || authority.threadId !== chatId
+  ) {
+    return { unavailableReason: "linq_thread_unauthorized" };
+  }
+  try {
+    await assertHostedLinqRouteEgressAuthority({
+      authority,
+      prisma: getPrisma(),
+    });
+  } catch {
+    return { unavailableReason: "linq_thread_unauthorized" };
+  }
+  return { chatId };
+}
+
+async function handleHostedRuntimeGroupReadChatParticipants(input: {
+  linqThread: HostedRuntimeGroupToolLinqThreadContext | null;
+  memberId: string;
+}): Promise<HostedRuntimeGroupToolResponse> {
+  const unavailable = (unavailableReason: string): HostedRuntimeGroupToolResponse => ({
+    action: "read_chat_participants",
+    result: { participants: null, status: "unavailable", unavailableReason },
+  });
+
+  const authorized = await authorizeHostedRuntimeGroupLinqThread(input);
+  if ("unavailableReason" in authorized) {
+    return unavailable(authorized.unavailableReason);
+  }
+
+  let handles: Awaited<ReturnType<typeof getHostedLinqChatHandles>>;
+  try {
+    handles = await getHostedLinqChatHandles({ chatId: authorized.chatId });
+  } catch {
+    return unavailable("provider_unavailable");
+  }
+  // An empty roster means the provider payload had no recognizable handles;
+  // treat that as provider trouble instead of a truthful "nobody here".
+  if (handles.length === 0) {
+    return unavailable("provider_unavailable");
+  }
+
+  const prisma = getPrisma();
+  const participants: HostedRuntimeGroupChatParticipant[] = [];
+  for (const handle of handles) {
+    if (handle.isMe) {
+      continue;
+    }
+    if (handle.status && handle.status.trim().toLowerCase() !== "active") {
+      continue;
+    }
+    if (participants.length >= HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX) {
+      break;
+    }
+    participants.push({
+      handle: handle.handle,
+      hasOwnMurph: await hasParticipantOwnMurphMembership({
+        handle: handle.handle,
+        prisma,
+      }),
+    });
+  }
+
+  return {
+    action: "read_chat_participants",
+    result: { participants, status: "ok" },
+  };
+}
+
+async function hasParticipantOwnMurphMembership(input: {
+  handle: string;
+  prisma: ReturnType<typeof getPrisma>;
+}): Promise<boolean> {
+  const lookup = await lookupParticipantMemberByHandle(input);
+  const member = lookup?.core ?? null;
+  return member !== null
+    && !isHostedMemberSuspended(member.suspendedAt)
+    && hasHostedMemberActiveAccess(member);
+}
+
+async function lookupParticipantMemberByHandle(input: {
+  handle: string;
+  prisma: ReturnType<typeof getPrisma>;
+}) {
+  if (input.handle.includes("@")) {
+    return await lookupHostedMemberByVerifiedEmailAddress({
+      address: input.handle,
+      prisma: input.prisma,
+    });
+  }
+  const phoneNumber = normalizePhoneNumber(input.handle);
+  if (!phoneNumber) {
+    return null;
+  }
+  return await lookupHostedMemberIdentityByPhoneNumber({
+    phoneNumber,
+    prisma: input.prisma,
+  });
+}
+
+async function handleHostedRuntimeGroupShareContactCard(input: {
+  linqThread: HostedRuntimeGroupToolLinqThreadContext | null;
+  memberId: string;
+}): Promise<HostedRuntimeGroupToolResponse> {
+  const unavailable = (unavailableReason: string): HostedRuntimeGroupToolResponse => ({
+    action: "share_contact_card",
+    result: { status: "unavailable", unavailableReason },
+  });
+
+  const authorized = await authorizeHostedRuntimeGroupLinqThread(input);
+  if ("unavailableReason" in authorized) {
+    return unavailable(authorized.unavailableReason);
+  }
+
+  let linePhoneNumber: string | null = null;
+  try {
+    const handles = await getHostedLinqChatHandles({ chatId: authorized.chatId });
+    linePhoneNumber = normalizePhoneNumber(
+      handles.find((handle) => handle.isMe)?.handle ?? null,
+    );
+  } catch {
+    return unavailable("provider_unavailable");
+  }
+  if (!linePhoneNumber) {
+    return unavailable("line_unresolved");
+  }
+
+  const reservation = await reserveHostedLinqContactCardShareAttempt({
+    chatId: authorized.chatId,
+    memberId: input.memberId,
+    prisma: getPrisma(),
+  });
+  if (reservation.action !== "share") {
+    if (reservation.reason === "recent_attempt") {
+      return {
+        action: "share_contact_card",
+        result: { status: "already_shared" },
+      };
+    }
+    return unavailable(reservation.reason);
+  }
+
+  const [photo, backupPhoneNumber] = await Promise.all([
+    fetchMurphHostedLinqContactCardVcfPhoto(),
+    resolveMurphHostedLinqContactCardBackupPhoneNumber({
+      excludePhoneNumber: linePhoneNumber,
+      prisma: getPrisma(),
+    }),
+  ]);
+  const vcf = buildMurphHostedLinqContactCardVcf({
+    backupPhoneNumber,
+    phoneNumber: linePhoneNumber,
+    photo,
+  });
+  try {
+    await sendHostedLinqAttachmentMessage({
+      bytes: new Uint8Array(Buffer.from(vcf, "utf8")),
+      chatId: authorized.chatId,
+      contentType: MURPH_CONTACT_CARD_VCF_CONTENT_TYPE,
+      fileName: MURPH_CONTACT_CARD_VCF_FILE_NAME,
+      // Chat id + day: dedupes duplicate provider submissions of this share
+      // without suppressing an intentional re-share after the 48h throttle.
+      // The chat id is Linq's own identifier, so no new exposure.
+      idempotencyKey: `group-contact-card:${authorized.chatId}:${new Date().toISOString().slice(0, 10)}`,
+    });
+  } catch {
+    return unavailable("send_failed");
+  }
+
+  return {
+    action: "share_contact_card",
+    result: { status: "sent" },
   };
 }

--- a/apps/web/src/lib/hosted-onboarding/linq-client.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-client.ts
@@ -76,6 +76,170 @@ export async function sendHostedLinqReadReceipt(input: {
   };
 }
 
+const HOSTED_LINQ_ATTACHMENT_UPLOAD_TIMEOUT_MS = 30_000;
+
+export type HostedLinqChatHandleSummary = {
+  handle: string;
+  isMe: boolean;
+  status: string | null;
+};
+
+export async function getHostedLinqChatHandles(input: {
+  chatId: string;
+  signal?: AbortSignal;
+}): Promise<HostedLinqChatHandleSummary[]> {
+  const response = await fetchHostedLinqApiOrThrow({
+    method: "GET",
+    operation: "chat read",
+    path: `chats/${encodeURIComponent(normalizeRequiredString(input.chatId, "chat id"))}`,
+    signal: input.signal,
+    timeoutMessage: "Linq chat read timed out.",
+  });
+
+  if (!response.ok) {
+    throw buildHostedLinqRequestFailedError({
+      operation: "chat read",
+      retryable: isRetryableHostedLinqStatus(response.status),
+      status: response.status,
+    });
+  }
+
+  const payload = await readHostedLinqOptionalJsonResponse<{
+    chat?: { handles?: unknown } | null;
+    handles?: unknown;
+  }>(response);
+  const handles = Array.isArray(payload?.handles)
+    ? payload.handles
+    : Array.isArray(payload?.chat?.handles)
+      ? payload.chat.handles
+      : [];
+
+  return handles
+    .map(parseHostedLinqChatHandleSummary)
+    .filter((handle): handle is HostedLinqChatHandleSummary => handle !== null);
+}
+
+function parseHostedLinqChatHandleSummary(value: unknown): HostedLinqChatHandleSummary | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const handle = normalizeNullableString(record.handle);
+  if (!handle) {
+    return null;
+  }
+  return {
+    handle,
+    isMe: record.is_me === true,
+    status: normalizeNullableString(record.status),
+  };
+}
+
+export async function sendHostedLinqAttachmentMessage(input: {
+  bytes: Uint8Array;
+  chatId: string;
+  contentType: string;
+  fileName: string;
+  idempotencyKey?: string | null;
+  signal?: AbortSignal;
+}): Promise<HostedLinqSendResult> {
+  const chatId = normalizeRequiredString(input.chatId, "chat id");
+  const createResponse = await fetchHostedLinqApiOrThrow({
+    body: JSON.stringify({
+      content_type: normalizeRequiredString(input.contentType, "attachment content type"),
+      filename: normalizeRequiredString(input.fileName, "attachment file name"),
+      size_bytes: input.bytes.byteLength,
+    }),
+    method: "POST",
+    operation: "attachment create",
+    path: "attachments",
+    signal: input.signal,
+    timeoutMessage: "Linq attachment create timed out.",
+  });
+  if (!createResponse.ok) {
+    throw buildHostedLinqRequestFailedError({
+      operation: "attachment create",
+      retryable: isRetryableHostedLinqStatus(createResponse.status),
+      status: createResponse.status,
+    });
+  }
+  const created = await readHostedLinqOptionalJsonResponse<{
+    attachment_id?: unknown;
+    required_headers?: unknown;
+    upload_url?: unknown;
+  }>(createResponse);
+  const attachmentId = normalizeNullableString(created?.attachment_id);
+  const uploadUrl = normalizeNullableString(created?.upload_url);
+  if (!attachmentId || !uploadUrl) {
+    throw buildHostedLinqRequestFailedError({
+      operation: "attachment create",
+      retryable: false,
+      status: 502,
+    });
+  }
+
+  const uploadTimeout = AbortSignal.timeout(HOSTED_LINQ_ATTACHMENT_UPLOAD_TIMEOUT_MS);
+  const uploadResponse = await fetch(uploadUrl, {
+    body: new Uint8Array(input.bytes).buffer,
+    headers: parseHostedLinqAttachmentUploadHeaders(created?.required_headers),
+    method: "PUT",
+    signal: input.signal ? AbortSignal.any([input.signal, uploadTimeout]) : uploadTimeout,
+  });
+  if (!uploadResponse.ok) {
+    throw buildHostedLinqRequestFailedError({
+      operation: "attachment upload",
+      retryable: isRetryableHostedLinqStatus(uploadResponse.status),
+      status: uploadResponse.status,
+    });
+  }
+
+  const idempotencyKey = normalizeNullableString(input.idempotencyKey);
+  const sendResponse = await fetchHostedLinqApiOrThrow({
+    body: JSON.stringify({
+      message: {
+        parts: [
+          {
+            attachment_id: attachmentId,
+            type: "media",
+          },
+        ],
+        ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
+      },
+    }),
+    method: "POST",
+    operation: "attachment send",
+    path: `chats/${encodeURIComponent(chatId)}/messages`,
+    signal: input.signal,
+    timeoutMessage: "Linq attachment send timed out.",
+  });
+  if (!sendResponse.ok) {
+    throw buildHostedLinqRequestFailedError({
+      operation: "attachment send",
+      retryable: isRetryableHostedLinqStatus(sendResponse.status),
+      status: sendResponse.status,
+    });
+  }
+
+  const payload = await readHostedLinqOptionalJsonResponse<MessageSendResponse>(sendResponse);
+  return {
+    chatId: normalizeNullableString(payload?.chat_id),
+    messageId: normalizeNullableString(payload?.message?.id),
+  };
+}
+
+function parseHostedLinqAttachmentUploadHeaders(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const headers: Record<string, string> = {};
+  for (const [key, headerValue] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof headerValue === "string" && key.trim()) {
+      headers[key] = headerValue;
+    }
+  }
+  return headers;
+}
+
 export async function shareHostedLinqContactCard(input: {
   chatId: string;
   signal?: AbortSignal;

--- a/apps/web/src/lib/hosted-onboarding/linq-client.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-client.ts
@@ -5,7 +5,7 @@ import type {
 } from "@linqapp/sdk/resources/chats";
 
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
-import { hostedOnboardingError } from "./errors";
+import { hostedOnboardingError, isHostedOnboardingError } from "./errors";
 import { requireHostedOnboardingLinqConfig } from "./runtime";
 import { normalizeNullableString } from "./shared";
 
@@ -144,54 +144,61 @@ export async function sendHostedLinqAttachmentMessage(input: {
   signal?: AbortSignal;
 }): Promise<HostedLinqSendResult> {
   const chatId = normalizeRequiredString(input.chatId, "chat id");
-  const createResponse = await fetchHostedLinqApiOrThrow({
-    body: JSON.stringify({
-      content_type: normalizeRequiredString(input.contentType, "attachment content type"),
-      filename: normalizeRequiredString(input.fileName, "attachment file name"),
-      size_bytes: input.bytes.byteLength,
-    }),
-    method: "POST",
-    operation: "attachment create",
-    path: "attachments",
-    signal: input.signal,
-    timeoutMessage: "Linq attachment create timed out.",
-  });
-  if (!createResponse.ok) {
-    throw buildHostedLinqRequestFailedError({
+  // Everything before the final message POST is tagged phase "prepare":
+  // failures here provably never created a chat message, so callers may undo
+  // side effects such as share reservations. The message POST itself stays
+  // untagged/ambiguous (it may have been accepted with a lost response).
+  const { attachmentId } = await withHostedLinqAttachmentPreparePhase(async () => {
+    const createResponse = await fetchHostedLinqApiOrThrow({
+      body: JSON.stringify({
+        content_type: normalizeRequiredString(input.contentType, "attachment content type"),
+        filename: normalizeRequiredString(input.fileName, "attachment file name"),
+        size_bytes: input.bytes.byteLength,
+      }),
+      method: "POST",
       operation: "attachment create",
-      retryable: isRetryableHostedLinqStatus(createResponse.status),
-      status: createResponse.status,
+      path: "attachments",
+      signal: input.signal,
+      timeoutMessage: "Linq attachment create timed out.",
     });
-  }
-  const created = await readHostedLinqOptionalJsonResponse<{
-    attachment_id?: unknown;
-    required_headers?: unknown;
-    upload_url?: unknown;
-  }>(createResponse);
-  const attachmentId = normalizeNullableString(created?.attachment_id);
-  const uploadUrl = normalizeNullableString(created?.upload_url);
-  if (!attachmentId || !uploadUrl) {
-    throw buildHostedLinqRequestFailedError({
-      operation: "attachment create",
-      retryable: false,
-      status: 502,
-    });
-  }
+    if (!createResponse.ok) {
+      throw buildHostedLinqRequestFailedError({
+        operation: "attachment create",
+        retryable: isRetryableHostedLinqStatus(createResponse.status),
+        status: createResponse.status,
+      });
+    }
+    const created = await readHostedLinqOptionalJsonResponse<{
+      attachment_id?: unknown;
+      required_headers?: unknown;
+      upload_url?: unknown;
+    }>(createResponse);
+    const createdAttachmentId = normalizeNullableString(created?.attachment_id);
+    const uploadUrl = normalizeNullableString(created?.upload_url);
+    if (!createdAttachmentId || !uploadUrl) {
+      throw buildHostedLinqRequestFailedError({
+        operation: "attachment create",
+        retryable: false,
+        status: 502,
+      });
+    }
 
-  const uploadTimeout = AbortSignal.timeout(HOSTED_LINQ_ATTACHMENT_UPLOAD_TIMEOUT_MS);
-  const uploadResponse = await fetch(uploadUrl, {
-    body: new Uint8Array(input.bytes).buffer,
-    headers: parseHostedLinqAttachmentUploadHeaders(created?.required_headers),
-    method: "PUT",
-    signal: input.signal ? AbortSignal.any([input.signal, uploadTimeout]) : uploadTimeout,
-  });
-  if (!uploadResponse.ok) {
-    throw buildHostedLinqRequestFailedError({
-      operation: "attachment upload",
-      retryable: isRetryableHostedLinqStatus(uploadResponse.status),
-      status: uploadResponse.status,
+    const uploadTimeout = AbortSignal.timeout(HOSTED_LINQ_ATTACHMENT_UPLOAD_TIMEOUT_MS);
+    const uploadResponse = await fetch(uploadUrl, {
+      body: new Uint8Array(input.bytes).buffer,
+      headers: parseHostedLinqAttachmentUploadHeaders(created?.required_headers),
+      method: "PUT",
+      signal: input.signal ? AbortSignal.any([input.signal, uploadTimeout]) : uploadTimeout,
     });
-  }
+    if (!uploadResponse.ok) {
+      throw buildHostedLinqRequestFailedError({
+        operation: "attachment upload",
+        retryable: isRetryableHostedLinqStatus(uploadResponse.status),
+        status: uploadResponse.status,
+      });
+    }
+    return { attachmentId: createdAttachmentId };
+  });
 
   const idempotencyKey = normalizeNullableString(input.idempotencyKey);
   const sendResponse = await fetchHostedLinqApiOrThrow({
@@ -225,6 +232,34 @@ export async function sendHostedLinqAttachmentMessage(input: {
     chatId: normalizeNullableString(payload?.chat_id),
     messageId: normalizeNullableString(payload?.message?.id),
   };
+}
+
+export const HOSTED_LINQ_ATTACHMENT_SEND_PHASE_PREPARE = "prepare";
+
+export function isHostedLinqAttachmentSendPrepareFailure(error: unknown): boolean {
+  return isHostedOnboardingError(error)
+    && error.details?.phase === HOSTED_LINQ_ATTACHMENT_SEND_PHASE_PREPARE;
+}
+
+async function withHostedLinqAttachmentPreparePhase<T>(run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (isHostedOnboardingError(error)) {
+      throw hostedOnboardingError({
+        cause: error,
+        code: error.code,
+        details: {
+          ...(error.details ?? {}),
+          phase: HOSTED_LINQ_ATTACHMENT_SEND_PHASE_PREPARE,
+        },
+        httpStatus: error.httpStatus,
+        message: error.message,
+        retryable: error.retryable,
+      });
+    }
+    throw error;
+  }
 }
 
 function parseHostedLinqAttachmentUploadHeaders(value: unknown): Record<string, string> {

--- a/apps/web/src/lib/hosted-onboarding/linq-client.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-client.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import type { TextPart } from "@linqapp/sdk/resources";
 import type {
   MessageSendParams,

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts
@@ -223,19 +223,32 @@ async function reserveHostedLinqContactCardShareAttemptAfterOutbound(input: {
   now?: Date;
   prisma: HostedLinqContactCardSharePersistenceClient;
 }): Promise<HostedLinqContactCardShareReserveDecision> {
+  if (!isHostedLinqContactCardShareEligible(input.eligibility)) {
+    return {
+      action: "skip",
+      reason: "ineligible_chat",
+    };
+  }
+
+  return await reserveHostedLinqContactCardShareAttempt(input);
+}
+
+/**
+ * Shared per-chat share throttle. Callers own their eligibility/authority
+ * checks; this only guards the attempt cadence (one per chat per 48h).
+ */
+export async function reserveHostedLinqContactCardShareAttempt(input: {
+  chatId: string;
+  memberId: string;
+  now?: Date;
+  prisma: HostedLinqContactCardSharePersistenceClient;
+}): Promise<HostedLinqContactCardShareReserveDecision> {
   const now = input.now ?? new Date();
   const chatLookup = resolveHostedLinqContactCardShareLookup(input.chatId);
   if (!chatLookup) {
     return {
       action: "skip",
       reason: "missing_chat_id",
-    };
-  }
-
-  if (!isHostedLinqContactCardShareEligible(input.eligibility)) {
-    return {
-      action: "skip",
-      reason: "ineligible_chat",
     };
   }
 

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts
@@ -85,7 +85,7 @@ export type HostedLinqContactCardShareDecision =
     };
 
 type HostedLinqContactCardShareReserveDecision =
-  | Extract<HostedLinqContactCardShareDecision, { action: "share" }>
+  | { action: "share"; attemptedAt: Date }
   | Extract<HostedLinqContactCardShareDecision, { action: "skip" }>;
 
 export async function maybeShareHostedLinqContactCardAfterOutboundForRuntime(input: {
@@ -322,6 +322,7 @@ export async function reserveHostedLinqContactCardShareAttempt(input: {
 
   return {
     action: "share",
+    attemptedAt: now,
   };
 }
 
@@ -426,7 +427,36 @@ async function createHostedLinqContactCardShareAttemptReservation(input: {
 
   return {
     action: "share",
+    attemptedAt: input.now,
   };
+}
+
+/**
+ * Undo a reservation whose share provably never reached the provider (for
+ * example the attachment upload failed before the message send started).
+ * Matching on the exact reservation instant keeps a concurrent newer
+ * reservation untouched. Ambiguous send failures must NOT release.
+ */
+export async function releaseHostedLinqContactCardShareAttempt(input: {
+  attemptedAt: Date;
+  chatId: string;
+  memberId: string;
+  prisma: HostedLinqContactCardSharePersistenceClient;
+}): Promise<void> {
+  const chatLookup = resolveHostedLinqContactCardShareLookup(input.chatId);
+  if (!chatLookup) {
+    return;
+  }
+  await input.prisma.hostedLinqContactCardShare.updateMany({
+    where: {
+      lastContactCardShareAttemptedAt: input.attemptedAt,
+      linqChatLookupKey: chatLookup.writeKey,
+      memberId: input.memberId,
+    },
+    data: {
+      lastContactCardShareAttemptedAt: null,
+    },
+  });
 }
 
 function logHostedLinqContactCardShareFailure(input: {

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import type { Prisma, PrismaClient } from "@prisma/client";
 
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -476,3 +476,140 @@ function uniqueNormalizedPhoneNumbers(values: readonly string[]): string[] {
 
   return phoneNumbers;
 }
+
+const MURPH_CONTACT_CARD_VCF_PHOTO_MAX_BYTES = 2 * 1024 * 1024;
+const MURPH_CONTACT_CARD_VCF_PHOTO_FETCH_TIMEOUT_MS = 5_000;
+const MURPH_CONTACT_CARD_VCF_LINE_MAX_CHARS = 75;
+
+export const MURPH_CONTACT_CARD_VCF_FILE_NAME = "Murph.vcf";
+export const MURPH_CONTACT_CARD_VCF_CONTENT_TYPE = "text/vcard";
+
+export type MurphHostedLinqContactCardVcfPhoto = {
+  base64: string;
+  type: "JPEG" | "PNG";
+};
+
+/**
+ * vCard 3.0 with CRLF line endings and 75-char folding so iMessage renders it
+ * as a native tappable contact bubble rather than a generic file. The chat's
+ * own line is the `mobile` number; a second healthy pool line, when
+ * available, rides along under a `backup` label so members keep a way to
+ * reach Murph if the primary line degrades.
+ */
+export function buildMurphHostedLinqContactCardVcf(input: {
+  backupPhoneNumber?: string | null;
+  phoneNumber: string;
+  photo?: MurphHostedLinqContactCardVcfPhoto | null;
+}): string {
+  const phoneNumber = normalizePhoneNumber(input.phoneNumber);
+  if (!phoneNumber) {
+    throw new TypeError("Murph contact-card vCard requires a line phone number.");
+  }
+  const backupPhoneNumber = normalizePhoneNumber(input.backupPhoneNumber ?? null);
+
+  const lines = [
+    "BEGIN:VCARD",
+    "VERSION:3.0",
+    `N:;${MURPH_CONTACT_CARD_FIRST_NAME};;;`,
+    `FN:${MURPH_CONTACT_CARD_FIRST_NAME}`,
+    `TEL;TYPE=CELL:${phoneNumber}`,
+    ...(backupPhoneNumber && backupPhoneNumber !== phoneNumber
+      ? [
+          `item1.TEL:${backupPhoneNumber}`,
+          "item1.X-ABLabel:backup",
+        ]
+      : []),
+    ...(input.photo
+      ? [`PHOTO;ENCODING=b;TYPE=${input.photo.type}:${input.photo.base64}`]
+      : []),
+    "END:VCARD",
+  ];
+
+  return lines.map(foldMurphContactCardVcfLine).join("\r\n") + "\r\n";
+}
+
+/**
+ * Second healthy configured conversation line (excluding the chat's own) for
+ * the vCard's `backup` slot. Reuses the contact-card cron's line listing so
+ * health comes from the synced `hostedLinqLine` provider status; lines the
+ * provider marks AT_RISK/CRITICAL are skipped. Fails soft to null.
+ */
+export async function resolveMurphHostedLinqContactCardBackupPhoneNumber(input: {
+  excludePhoneNumber: string;
+  prisma: HostedLinqContactCardClient;
+}): Promise<string | null> {
+  const excludePhoneNumber = normalizePhoneNumber(input.excludePhoneNumber);
+  try {
+    const lines = await listHostedLinqConfiguredContactCardLines({
+      observedAt: new Date(),
+      prisma: input.prisma,
+    });
+    return lines.find((line) =>
+      line.phoneNumber !== excludePhoneNumber
+      && line.providerStatus !== "AT_RISK"
+      && line.providerStatus !== "CRITICAL"
+    )?.phoneNumber ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function foldMurphContactCardVcfLine(line: string): string {
+  if (line.length <= MURPH_CONTACT_CARD_VCF_LINE_MAX_CHARS) {
+    return line;
+  }
+  const folded: string[] = [line.slice(0, MURPH_CONTACT_CARD_VCF_LINE_MAX_CHARS)];
+  for (
+    let index = MURPH_CONTACT_CARD_VCF_LINE_MAX_CHARS;
+    index < line.length;
+    index += MURPH_CONTACT_CARD_VCF_LINE_MAX_CHARS - 1
+  ) {
+    folded.push(` ${line.slice(index, index + MURPH_CONTACT_CARD_VCF_LINE_MAX_CHARS - 1)}`);
+  }
+  return folded.join("\r\n");
+}
+
+/**
+ * Best-effort fetch of the Murph headshot for embedding; any failure returns
+ * null so the card ships without a photo instead of failing the share.
+ */
+export async function fetchMurphHostedLinqContactCardVcfPhoto(input: {
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+} = {}): Promise<MurphHostedLinqContactCardVcfPhoto | null> {
+  const imageUrl = getMurphContactCardImageUrl();
+  if (!imageUrl) {
+    return null;
+  }
+
+  try {
+    const fetchImpl = input.fetchImpl ?? fetch;
+    const response = await fetchImpl(imageUrl, {
+      signal: input.signal ?? AbortSignal.timeout(MURPH_CONTACT_CARD_VCF_PHOTO_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+    const type = contentType.includes("png")
+      ? "PNG" as const
+      : contentType.includes("jpeg") || contentType.includes("jpg")
+        ? "JPEG" as const
+        : imageUrl.toLowerCase().endsWith(".png")
+          ? "PNG" as const
+          : null;
+    if (!type) {
+      return null;
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength === 0 || bytes.byteLength > MURPH_CONTACT_CARD_VCF_PHOTO_MAX_BYTES) {
+      return null;
+    }
+    return {
+      base64: Buffer.from(bytes).toString("base64"),
+      type,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   lookupHostedMemberByVerifiedEmailAddress: vi.fn(),
   lookupHostedMemberIdentityByPhoneNumber: vi.fn(),
   readHostedGroupByRuntimeMemberId: vi.fn(),
+  releaseHostedLinqContactCardShareAttempt: vi.fn(),
   reserveHostedLinqContactCardShareAttempt: vi.fn(),
   resolveMurphHostedLinqContactCardBackupPhoneNumber: vi.fn(),
   resolveHostedPublicBaseUrl: vi.fn(),
@@ -39,6 +40,12 @@ vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
 
 vi.mock("@/src/lib/hosted-onboarding/linq-client", () => ({
   getHostedLinqChatHandles: mocks.getHostedLinqChatHandles,
+  isHostedLinqAttachmentSendPrepareFailure: (error: unknown) =>
+    Boolean(
+      error
+      && typeof error === "object"
+      && (error as { details?: { phase?: string } }).details?.phase === "prepare",
+    ),
   sendHostedLinqAttachmentMessage: mocks.sendHostedLinqAttachmentMessage,
 }));
 
@@ -52,6 +59,7 @@ vi.mock("@/src/lib/hosted-onboarding/linq-contact-card", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/linq-contact-card-share", () => ({
+  releaseHostedLinqContactCardShareAttempt: mocks.releaseHostedLinqContactCardShareAttempt,
   reserveHostedLinqContactCardShareAttempt: mocks.reserveHostedLinqContactCardShareAttempt,
 }));
 
@@ -330,7 +338,11 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       core: { suspendedAt: null },
     });
     mocks.lookupHostedMemberByVerifiedEmailAddress.mockResolvedValue(null);
-    mocks.reserveHostedLinqContactCardShareAttempt.mockResolvedValue({ action: "share" });
+    mocks.releaseHostedLinqContactCardShareAttempt.mockResolvedValue(undefined);
+    mocks.reserveHostedLinqContactCardShareAttempt.mockResolvedValue({
+      action: "share",
+      attemptedAt: new Date("2026-07-02T12:00:00Z"),
+    });
     mocks.resolveMurphHostedLinqContactCardBackupPhoneNumber.mockResolvedValue("+15558880000");
     mocks.sendHostedLinqAttachmentMessage.mockResolvedValue({
       chatId: "chat_group_1",
@@ -517,8 +529,8 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     expect(mocks.sendHostedLinqAttachmentMessage).not.toHaveBeenCalled();
   });
 
-  it("reports a failed provider send without retry side effects", async () => {
-    mocks.sendHostedLinqAttachmentMessage.mockRejectedValue(new Error("upload failed"));
+  it("keeps the reservation for an ambiguous message-send failure", async () => {
+    mocks.sendHostedLinqAttachmentMessage.mockRejectedValue(new Error("send maybe delivered"));
 
     await expect(handleHostedRuntimeGroupTool({
       memberId: "member_container",
@@ -530,5 +542,66 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
         unavailableReason: "send_failed",
       },
     });
+
+    expect(mocks.releaseHostedLinqContactCardShareAttempt).not.toHaveBeenCalled();
+  });
+
+  it("releases the reservation when the failure provably happened before the send", async () => {
+    const prepareFailure = Object.assign(new Error("upload failed"), {
+      details: { phase: "prepare" },
+    });
+    mocks.sendHostedLinqAttachmentMessage.mockRejectedValue(prepareFailure);
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: {
+        status: "unavailable",
+        unavailableReason: "send_failed",
+      },
+    });
+
+    expect(mocks.releaseHostedLinqContactCardShareAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attemptedAt: new Date("2026-07-02T12:00:00Z"),
+        chatId: "chat_group_1",
+        memberId: "member_container",
+      }),
+    );
+  });
+
+  it("reports membership lookup trouble as structured unavailability", async () => {
+    mocks.lookupHostedMemberIdentityByPhoneNumber.mockRejectedValue(new Error("identity store down"));
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "membership_lookup_unavailable",
+      },
+    });
+  });
+
+  it("treats an empty roster on share as provider trouble rather than a missing line", async () => {
+    mocks.getHostedLinqChatHandles.mockResolvedValue([]);
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: {
+        status: "unavailable",
+        unavailableReason: "provider_unavailable",
+      },
+    });
+
+    expect(mocks.reserveHostedLinqContactCardShareAttempt).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -1,16 +1,62 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  assertHostedLinqRouteEgressAuthority: vi.fn(),
+  buildMurphHostedLinqContactCardVcf: vi.fn(),
   createHostedGroupJoinLinkForOwnedThreadContainerTx: vi.fn(),
+  fetchMurphHostedLinqContactCardVcfPhoto: vi.fn(),
+  getHostedLinqChatHandles: vi.fn(),
+  hasHostedMemberActiveAccess: vi.fn(),
   hasHostedRuntimeActiveAccess: vi.fn(),
   hostedMemberFindUnique: vi.fn(),
   hostedThreadContainerFindUnique: vi.fn(),
+  isHostedMemberSuspended: vi.fn(),
+  lookupHostedMemberByVerifiedEmailAddress: vi.fn(),
+  lookupHostedMemberIdentityByPhoneNumber: vi.fn(),
   readHostedGroupByRuntimeMemberId: vi.fn(),
+  reserveHostedLinqContactCardShareAttempt: vi.fn(),
+  resolveMurphHostedLinqContactCardBackupPhoneNumber: vi.fn(),
   resolveHostedPublicBaseUrl: vi.fn(),
+  sendHostedLinqAttachmentMessage: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-mailbox/runtime-access", () => ({
   hasHostedRuntimeActiveAccess: mocks.hasHostedRuntimeActiveAccess,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/entitlement", () => ({
+  hasHostedMemberActiveAccess: mocks.hasHostedMemberActiveAccess,
+  isHostedMemberSuspended: mocks.isHostedMemberSuspended,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-identity-store", () => ({
+  lookupHostedMemberIdentityByPhoneNumber: mocks.lookupHostedMemberIdentityByPhoneNumber,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
+  lookupHostedMemberByVerifiedEmailAddress: mocks.lookupHostedMemberByVerifiedEmailAddress,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/linq-client", () => ({
+  getHostedLinqChatHandles: mocks.getHostedLinqChatHandles,
+  sendHostedLinqAttachmentMessage: mocks.sendHostedLinqAttachmentMessage,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/linq-contact-card", () => ({
+  MURPH_CONTACT_CARD_VCF_CONTENT_TYPE: "text/vcard",
+  MURPH_CONTACT_CARD_VCF_FILE_NAME: "Murph.vcf",
+  buildMurphHostedLinqContactCardVcf: mocks.buildMurphHostedLinqContactCardVcf,
+  fetchMurphHostedLinqContactCardVcfPhoto: mocks.fetchMurphHostedLinqContactCardVcfPhoto,
+  resolveMurphHostedLinqContactCardBackupPhoneNumber:
+    mocks.resolveMurphHostedLinqContactCardBackupPhoneNumber,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/linq-contact-card-share", () => ({
+  reserveHostedLinqContactCardShareAttempt: mocks.reserveHostedLinqContactCardShareAttempt,
+}));
+
+vi.mock("@/src/lib/hosted-routing/thread-route-store", () => ({
+  assertHostedLinqRouteEgressAuthority: mocks.assertHostedLinqRouteEgressAuthority,
 }));
 
 vi.mock("@/src/lib/hosted-groups/group-store", () => ({
@@ -253,5 +299,236 @@ describe("hosted group join policy", () => {
       label: "Recent sleep timing",
       projectionKind: "sleep-times.v0",
     }]);
+  });
+});
+
+describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
+  const LINQ_THREAD = {
+    authority: {
+      accountLookupKey: "hplk_account",
+      channel: "linq" as const,
+      containerMemberId: "member_container",
+      threadId: "chat_group_1",
+    },
+    chatId: "chat_group_1",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.assertHostedLinqRouteEgressAuthority.mockResolvedValue({});
+    mocks.buildMurphHostedLinqContactCardVcf.mockReturnValue("BEGIN:VCARD\r\nEND:VCARD\r\n");
+    mocks.fetchMurphHostedLinqContactCardVcfPhoto.mockResolvedValue(null);
+    mocks.getHostedLinqChatHandles.mockResolvedValue([
+      { handle: "+15557770000", isMe: true, status: "active" },
+      { handle: "+15550000001", isMe: false, status: "active" },
+      { handle: "person@example.com", isMe: false, status: null },
+      { handle: "+15550000002", isMe: false, status: "left" },
+    ]);
+    mocks.hasHostedMemberActiveAccess.mockReturnValue(true);
+    mocks.isHostedMemberSuspended.mockReturnValue(false);
+    mocks.lookupHostedMemberIdentityByPhoneNumber.mockResolvedValue({
+      core: { suspendedAt: null },
+    });
+    mocks.lookupHostedMemberByVerifiedEmailAddress.mockResolvedValue(null);
+    mocks.reserveHostedLinqContactCardShareAttempt.mockResolvedValue({ action: "share" });
+    mocks.resolveMurphHostedLinqContactCardBackupPhoneNumber.mockResolvedValue("+15558880000");
+    mocks.sendHostedLinqAttachmentMessage.mockResolvedValue({
+      chatId: "chat_group_1",
+      messageId: "msg_1",
+    });
+  });
+
+  it("fails closed when the runtime supplied no linq thread context", async () => {
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants" },
+    })).resolves.toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "linq_thread_unavailable",
+      },
+    });
+
+    expect(mocks.getHostedLinqChatHandles).not.toHaveBeenCalled();
+    expect(mocks.assertHostedLinqRouteEgressAuthority).not.toHaveBeenCalled();
+  });
+
+  it("rejects an authority that does not match the bound runtime member", async () => {
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_other",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: {
+        status: "unavailable",
+        unavailableReason: "linq_thread_unauthorized",
+      },
+    });
+
+    expect(mocks.assertHostedLinqRouteEgressAuthority).not.toHaveBeenCalled();
+    expect(mocks.sendHostedLinqAttachmentMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the thread-route authority assertion fails", async () => {
+    mocks.assertHostedLinqRouteEgressAuthority.mockRejectedValue(new Error("unauthorized"));
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "linq_thread_unauthorized",
+      },
+    });
+
+    expect(mocks.getHostedLinqChatHandles).not.toHaveBeenCalled();
+  });
+
+  it("classifies chat participants by Murph membership and skips the line and departed handles", async () => {
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: [
+          { handle: "+15550000001", hasOwnMurph: true },
+          { handle: "person@example.com", hasOwnMurph: false },
+        ],
+        status: "ok",
+      },
+    });
+
+    expect(mocks.assertHostedLinqRouteEgressAuthority).toHaveBeenCalledWith(
+      expect.objectContaining({ authority: LINQ_THREAD.authority }),
+    );
+    expect(mocks.lookupHostedMemberIdentityByPhoneNumber).toHaveBeenCalledTimes(1);
+    expect(mocks.lookupHostedMemberByVerifiedEmailAddress).toHaveBeenCalledWith(
+      expect.objectContaining({ address: "person@example.com" }),
+    );
+  });
+
+  it("treats an unrecognized empty roster as provider trouble, not an empty room", async () => {
+    mocks.getHostedLinqChatHandles.mockResolvedValue([]);
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "provider_unavailable",
+      },
+    });
+  });
+
+  it("reports provider trouble as unavailable instead of throwing", async () => {
+    mocks.getHostedLinqChatHandles.mockRejectedValue(new Error("linq down"));
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "provider_unavailable",
+      },
+    });
+  });
+
+  it("sends the contact card vcf into the chat using the line's own handle", async () => {
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: { status: "sent" },
+    });
+
+    expect(mocks.buildMurphHostedLinqContactCardVcf).toHaveBeenCalledWith({
+      backupPhoneNumber: "+15558880000",
+      phoneNumber: "+15557770000",
+      photo: null,
+    });
+    expect(mocks.resolveMurphHostedLinqContactCardBackupPhoneNumber).toHaveBeenCalledWith(
+      expect.objectContaining({ excludePhoneNumber: "+15557770000" }),
+    );
+    expect(mocks.sendHostedLinqAttachmentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat_group_1",
+        contentType: "text/vcard",
+        fileName: "Murph.vcf",
+        idempotencyKey: expect.stringMatching(
+          /^group-contact-card:chat_group_1:\d{4}-\d{2}-\d{2}$/u,
+        ),
+      }),
+    );
+    expect(mocks.reserveHostedLinqContactCardShareAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat_group_1",
+        memberId: "member_container",
+      }),
+    );
+  });
+
+  it("reports already_shared when the per-chat throttle is active", async () => {
+    mocks.reserveHostedLinqContactCardShareAttempt.mockResolvedValue({
+      action: "skip",
+      reason: "recent_attempt",
+    });
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: { status: "already_shared" },
+    });
+
+    expect(mocks.sendHostedLinqAttachmentMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not reserve or send when the line handle is missing from the roster", async () => {
+    mocks.getHostedLinqChatHandles.mockResolvedValue([
+      { handle: "+15550000001", isMe: false, status: "active" },
+    ]);
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: {
+        status: "unavailable",
+        unavailableReason: "line_unresolved",
+      },
+    });
+
+    expect(mocks.reserveHostedLinqContactCardShareAttempt).not.toHaveBeenCalled();
+    expect(mocks.sendHostedLinqAttachmentMessage).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed provider send without retry side effects", async () => {
+    mocks.sendHostedLinqAttachmentMessage.mockRejectedValue(new Error("upload failed"));
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: {
+        status: "unavailable",
+        unavailableReason: "send_failed",
+      },
+    });
   });
 });

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -27,6 +27,10 @@ import {
   createHostedPhoneLookupKey,
 } from "@/src/lib/hosted-onboarding/contact-privacy";
 import {
+  isHostedLinqAttachmentSendPrepareFailure,
+  sendHostedLinqAttachmentMessage,
+} from "@/src/lib/hosted-onboarding/linq-client";
+import {
   buildMurphHostedLinqContactCardVcf,
   fetchMurphHostedLinqContactCardVcfPhoto,
   resolveMurphHostedLinqContactCardBackupPhoneNumber,
@@ -541,5 +545,55 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
       excludePhoneNumber: "+15550000001",
       prisma: {} as never,
     })).resolves.toBeNull();
+  });
+});
+
+describe("sendHostedLinqAttachmentMessage failure phases", () => {
+  it("tags pre-send failures as prepare and leaves message-send failures ambiguous", async () => {
+    const attachmentCreated = createJsonResponse({
+      attachment_id: "att_1",
+      required_headers: { "content-type": "text/vcard" },
+      upload_url: "https://uploads.example.test/att_1",
+    });
+
+    // Attachment create fails: provably nothing was sent.
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("nope", { status: 500 })));
+    let prepareError: unknown;
+    await sendHostedLinqAttachmentMessage({
+      bytes: new Uint8Array([1]),
+      chatId: "chat_group_1",
+      contentType: "text/vcard",
+      fileName: "Murph.vcf",
+    }).catch((error: unknown) => {
+      prepareError = error;
+    });
+    expect(isHostedLinqAttachmentSendPrepareFailure(prepareError)).toBe(true);
+
+    // Create + upload succeed, the final message POST fails: ambiguous.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof URL ? input : new URL(String(input));
+      if (url.pathname.endsWith("/attachments")) {
+        return attachmentCreated.clone();
+      }
+      if (url.hostname === "uploads.example.test") {
+        return new Response(null, { status: 200 });
+      }
+      if (url.pathname.endsWith("/messages")) {
+        return new Response("nope", { status: 500 });
+      }
+      throw new Error(`Unexpected Linq URL ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    let sendError: unknown;
+    await sendHostedLinqAttachmentMessage({
+      bytes: new Uint8Array([1]),
+      chatId: "chat_group_1",
+      contentType: "text/vcard",
+      fileName: "Murph.vcf",
+    }).catch((error: unknown) => {
+      sendError = error;
+    });
+    expect(sendError).toBeTruthy();
+    expect(isHostedLinqAttachmentSendPrepareFailure(sendError)).toBe(false);
   });
 });

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -27,6 +27,9 @@ import {
   createHostedPhoneLookupKey,
 } from "@/src/lib/hosted-onboarding/contact-privacy";
 import {
+  buildMurphHostedLinqContactCardVcf,
+  fetchMurphHostedLinqContactCardVcfPhoto,
+  resolveMurphHostedLinqContactCardBackupPhoneNumber,
   getHostedLinqContactCard,
   listHostedLinqContactCards,
   reconcileHostedLinqContactCards,
@@ -383,4 +386,160 @@ describe("hosted Linq contact card client", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+});
+
+describe("buildMurphHostedLinqContactCardVcf", () => {
+  it("builds a CRLF vCard 3.0 for the line without a photo", () => {
+    const vcf = buildMurphHostedLinqContactCardVcf({
+      phoneNumber: "+15557770000",
+      photo: null,
+    });
+
+    expect(vcf).toBe([
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "N:;Murph;;;",
+      "FN:Murph",
+      "TEL;TYPE=CELL:+15557770000",
+      "END:VCARD",
+    ].join("\r\n") + "\r\n");
+  });
+
+  it("adds a labeled backup number when a second line is available", () => {
+    const vcf = buildMurphHostedLinqContactCardVcf({
+      backupPhoneNumber: "+15558880000",
+      phoneNumber: "+15557770000",
+      photo: null,
+    });
+
+    expect(vcf).toBe([
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "N:;Murph;;;",
+      "FN:Murph",
+      "TEL;TYPE=CELL:+15557770000",
+      "item1.TEL:+15558880000",
+      "item1.X-ABLabel:backup",
+      "END:VCARD",
+    ].join("\r\n") + "\r\n");
+
+    expect(buildMurphHostedLinqContactCardVcf({
+      backupPhoneNumber: "+15557770000",
+      phoneNumber: "+15557770000",
+      photo: null,
+    })).not.toContain("item1.TEL");
+  });
+
+  it("embeds the photo as folded base64 that unfolds losslessly", () => {
+    const base64 = Buffer.from(new Uint8Array(512).fill(7)).toString("base64");
+    const vcf = buildMurphHostedLinqContactCardVcf({
+      phoneNumber: "+15557770000",
+      photo: { base64, type: "PNG" },
+    });
+
+    const lines = vcf.split("\r\n");
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(75);
+    }
+    const unfolded = vcf.replace(/\r\n[ ]/gu, "");
+    expect(unfolded).toContain(`PHOTO;ENCODING=b;TYPE=PNG:${base64}`);
+  });
+
+  it("rejects an unusable line phone number", () => {
+    expect(() => buildMurphHostedLinqContactCardVcf({
+      phoneNumber: "not-a-phone",
+      photo: null,
+    })).toThrow(/phone number/u);
+  });
+});
+
+describe("fetchMurphHostedLinqContactCardVcfPhoto", () => {
+  it("returns embedded base64 for a healthy png response", async () => {
+    runtimeMocks.getHostedOnboardingEnvironment.mockReturnValue({
+      publicBaseUrl: "https://www.withmurph.ai",
+    });
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(bytes, {
+      headers: { "content-type": "image/png" },
+      status: 200,
+    }));
+
+    await expect(fetchMurphHostedLinqContactCardVcfPhoto({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })).resolves.toEqual({
+      base64: Buffer.from(bytes).toString("base64"),
+      type: "PNG",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://www.withmurph.ai/murph_headshot.png",
+      expect.anything(),
+    );
+  });
+
+  it("fails soft to null on provider errors and oversized bodies", async () => {
+    runtimeMocks.getHostedOnboardingEnvironment.mockReturnValue({
+      publicBaseUrl: "https://www.withmurph.ai",
+    });
+
+    await expect(fetchMurphHostedLinqContactCardVcfPhoto({
+      fetchImpl: vi.fn().mockResolvedValue(new Response("nope", { status: 500 })) as unknown as typeof fetch,
+    })).resolves.toBeNull();
+
+    await expect(fetchMurphHostedLinqContactCardVcfPhoto({
+      fetchImpl: vi.fn().mockRejectedValue(new Error("offline")) as unknown as typeof fetch,
+    })).resolves.toBeNull();
+
+    const oversized = new Uint8Array(2 * 1024 * 1024 + 1);
+    await expect(fetchMurphHostedLinqContactCardVcfPhoto({
+      fetchImpl: vi.fn().mockResolvedValue(new Response(oversized, {
+        headers: { "content-type": "image/png" },
+        status: 200,
+      })) as unknown as typeof fetch,
+    })).resolves.toBeNull();
+  });
+});
+
+describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
+  it("returns the first healthy configured line that is not the chat's own", async () => {
+    runtimeMocks.getHostedOnboardingEnvironment.mockReturnValue({
+      contactPrivacyKeyring: {
+        currentVersion: "v1",
+        keysByVersion: { v1: Buffer.alloc(32) },
+        readVersions: ["v1"],
+      },
+      linqConversationPhoneNumbers: ["+15550000001", "+15550000002", "+15550000003"],
+      linqMaxActiveMembersPerConversationPhone: 1000,
+      publicBaseUrl: "https://app.example.test",
+    });
+    const prisma = {
+      hostedLinqLine: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            phoneNumberLookupKey: createHostedPhoneLookupKey("+15550000002"),
+            providerStatus: "AT_RISK",
+          },
+          {
+            phoneNumberLookupKey: createHostedPhoneLookupKey("+15550000003"),
+            providerStatus: "HEALTHY",
+          },
+        ]),
+      },
+    };
+
+    await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
+      excludePhoneNumber: "+15550000001",
+      prisma: prisma as never,
+    })).resolves.toBe("+15550000003");
+  });
+
+  it("fails soft to null when listing lines is unavailable", async () => {
+    runtimeMocks.getHostedOnboardingEnvironment.mockImplementation(() => {
+      throw new Error("env unavailable");
+    });
+
+    await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
+      excludePhoneNumber: "+15550000001",
+      prisma: {} as never,
+    })).resolves.toBeNull();
+  });
 });

--- a/packages/assistant-engine/skills/group-chat/SKILL.md
+++ b/packages/assistant-engine/skills/group-chat/SKILL.md
@@ -54,6 +54,29 @@ matching action.
 - If someone tells you to chill, quiet down, or stop, comply immediately and
   stay in addressed-only mode without ceremony. Do not ask for confirmation.
 
+## New rooms and people who don't have you yet
+
+When you first land in a group, or when someone new joins the conversation,
+check the room once with `murph.group` `action="read_chat_participants"`. If
+everyone already has their own Murph, skip the ceremony and just be a good
+participant.
+
+If someone in the room doesn't have their own Murph yet:
+
+- Share your card once with `action="share_contact_card"` so they can tap it,
+  save you, and text you directly. The card sends at most once per chat; never
+  try to re-send it.
+- Fold the invitation into your normal greeting, in your own voice, in the
+  same single message you were already going to send — the shape of "if you
+  don't have me saved yet, that card's me; shoot me a text and I'll get you
+  set up." Never a separate follow-up, never a link in the group, never
+  pressure. One mention, then drop it.
+- Getting someone set up happens in their own 1:1 thread once they text you.
+  Do not run setup, ask personal questions, or continue the invitation in
+  front of the room.
+- If nobody acts on it, let it go. Do not remind, re-offer, or keep track of
+  who hasn't texted you.
+
 ## Shared challenge data
 
 Everything in this runtime was shared for this group. Members granted their

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -313,14 +313,14 @@ export const MURPH_GROUP_TOOL = {
   namespace: 'murph',
   name: 'group',
   description:
-    'Read the current hosted group for the connected group-chat runtime with action="read_current", or mint the shareable group join link with action="create_join_link" and include the returned join URL plainly in your reply. Joining through that link grants group membership only. This tool does not manage members, grant Family billing access, grant private chat access, grant raw vault access, share health data, or opt anyone into email.',
+    'Read the current hosted group for the connected group-chat runtime with action="read_current", or mint the shareable group join link with action="create_join_link" and include the returned join URL plainly in your reply. Joining through that link grants group membership only. Use action="read_chat_participants" to see who is in this group chat and whether each participant already has their own Murph; use action="share_contact_card" to drop your contact card into this chat once so people who do not have you saved can tap it, save you, and text you directly. This tool does not manage members, grant Family billing access, grant private chat access, grant raw vault access, share health data, or opt anyone into email.',
   inputSchema: {
     type: 'object',
     additionalProperties: false,
     properties: {
       action: {
         type: 'string',
-        enum: ['read_current', 'create_join_link'],
+        enum: ['read_current', 'create_join_link', 'read_chat_participants', 'share_contact_card'],
       },
       displayName: {
         type: 'string',
@@ -675,6 +675,16 @@ const groupArgumentsSchema = z.discriminatedUnion('action', [
   z
     .object({
       action: z.literal('read_current'),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal('read_chat_participants'),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal('share_contact_card'),
     })
     .strict(),
   z
@@ -2505,6 +2515,12 @@ function parseGroupArguments(
           ? { action: 'create_join_link', joinLink }
           : { action: 'create_join_link' },
     }
+  }
+  if (
+    parsed.data.action === 'read_chat_participants'
+    || parsed.data.action === 'share_contact_card'
+  ) {
+    return { ok: true, request: { action: parsed.data.action } }
   }
   return { ok: true, request: { action: 'read_current' } }
 }

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -311,6 +311,7 @@ function buildAssistantHostedGroupGuidanceText(): string {
   return [
     "Hosted groups:",
     "- When `murph.group` is available, use `action=\"read_current\"` to read the current hosted group for the connected group-chat runtime, and `action=\"create_join_link\"` when the user asks to invite someone to this group chat; share the returned join URL plainly. Do not use it for member management, and do not promise a link unless the tool returns one.",
+    "- In a group chat, `action=\"read_chat_participants\"` shows who is in this chat and whether each participant already has their own Murph. `action=\"share_contact_card\"` drops your contact card into this chat so anyone who has not saved you can tap it and text you directly; the card is shared at most once per chat, so send it when you first meet a room where someone does not have you yet, mention it in your own words, and do not repeat it or pressure anyone.",
     "- Hosted groups are separate from Murph Family billing/account groups. Joining a hosted group does not grant billing access, private chat access, vault access, health-data access, or email opt-in.",
     "- Optional group health permissions are approved only through server-owned join pages and are returned through the runtime/vault-share flow.",
     "- Today, the supported group health permission is `sleep-times.v0`. Do not claim that activity, workouts, all health data, or arbitrary categories can be shared unless the tool/parser supports a closed projection kind for them.",

--- a/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
@@ -17,11 +17,39 @@ function groupToolCall(argumentsValue: unknown): Record<string, unknown> {
 }
 
 describe("murph.group dynamic tool", () => {
-  it("advertises read_current and create_join_link actions", () => {
+  it("advertises the supported actions", () => {
     expect(MURPH_GROUP_TOOL.inputSchema.properties.action.enum).toEqual([
       "read_current",
       "create_join_link",
+      "read_chat_participants",
+      "share_contact_card",
     ]);
+  });
+
+  it("parses the chat-scoped actions without accepting a model-supplied thread target", () => {
+    expect(readMurphDynamicToolRequest(groupToolCall({
+      action: "read_chat_participants",
+    }))).toEqual({
+      kind: "group",
+      request: { action: "read_chat_participants" },
+    });
+
+    expect(readMurphDynamicToolRequest(groupToolCall({
+      action: "share_contact_card",
+    }))).toEqual({
+      kind: "group",
+      request: { action: "share_contact_card" },
+    });
+
+    expect(readMurphDynamicToolRequest(groupToolCall({
+      action: "share_contact_card",
+      linqThread: { chatId: "chat_hijack" },
+    }))?.kind).toBe("invalid-group-arguments");
+
+    expect(readMurphDynamicToolRequest(groupToolCall({
+      action: "read_chat_participants",
+      chatId: "chat_hijack",
+    }))?.kind).toBe("invalid-group-arguments");
   });
 
   it("parses read_current arguments", () => {

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -8,6 +8,7 @@ import {
   type HostedExecutionStructuredLogDetails,
 } from "@murphai/hosted-execution";
 import {
+  type HostedRuntimeGroupToolLinqThreadContext,
   type HostedWorkspaceCheckpointReason,
   type HostedRuntimeRedactedJson,
   type HostedRuntimeRedactedObject,
@@ -103,6 +104,9 @@ import type {
   HostedAssistantLinqDeliveryContext,
 } from "./linq-delivery-context.ts";
 import type {
+  HostedRuntimePlatform,
+} from "./platform.ts";
+import type {
   HostedAssistantDeliveryOutcome,
   HostedAssistantWorkspaceRuntimeJobInput,
   HostedDeviceSyncDirtyProcessedPostCheckpointRecord,
@@ -187,6 +191,71 @@ export interface HostedWorkspaceRuntimeAssistantPhaseInput
 export type HostedWorkspaceRuntimeAssistantPhase = (
   input: HostedWorkspaceRuntimeAssistantPhaseInput,
 ) => Promise<HostedWorkspaceRunnerAssistantPhaseResult>;
+
+/**
+ * The chat-scoped murph.group actions need the raw Linq chat id and the
+ * thread-route egress authority, which live only in wake-derived delivery
+ * contexts (the web DB stores hashed lookup keys). Inject them here so the
+ * model never supplies its own thread target.
+ */
+export function createHostedGroupToolWithLinqThreadContext(input: {
+  groupToolPort: NonNullable<HostedRuntimePlatform["groupToolPort"]>;
+  linqDeliveryContexts: readonly HostedAssistantLinqDeliveryContext[];
+}): NonNullable<HostedRuntimePlatform["groupToolPort"]> {
+  return {
+    async request(request) {
+      if (
+        request.action !== "read_chat_participants"
+        && request.action !== "share_contact_card"
+      ) {
+        return await input.groupToolPort.request(request);
+      }
+      const linqThread = resolveHostedGroupToolLinqThreadContext(
+        input.linqDeliveryContexts,
+      );
+      return await input.groupToolPort.request(
+        linqThread ? { action: request.action, linqThread } : { action: request.action },
+      );
+    },
+  };
+}
+
+function resolveHostedGroupToolLinqThreadContext(
+  contexts: readonly HostedAssistantLinqDeliveryContext[],
+): HostedRuntimeGroupToolLinqThreadContext | null {
+  const eligible = new Map<string, HostedRuntimeGroupToolLinqThreadContext>();
+  for (const context of contexts) {
+    const authority = context.routeAuthority;
+    if (
+      !authority
+      || authority.threadId.trim().length === 0
+      || context.service?.trim().toLowerCase() !== "imessage"
+      || context.threadIsDirect !== false
+    ) {
+      continue;
+    }
+    eligible.set(
+      [
+        authority.channel,
+        authority.containerMemberId,
+        authority.accountLookupKey,
+        authority.threadId,
+      ].join(" "),
+      {
+        authority,
+        chatId: authority.threadId,
+      },
+    );
+  }
+
+  // Two distinct route-authorized threads in one turn (for example around a
+  // provider chat re-key) make the target ambiguous; fail closed and let the
+  // web handler answer linq_thread_unavailable.
+  if (eligible.size !== 1) {
+    return null;
+  }
+  return [...eligible.values()][0] ?? null;
+}
 
 function resolveHostedInitialMailboxLinqDeliveryContexts(
   importResult: HostedMailboxImportLoopResult,
@@ -283,7 +352,12 @@ export async function runHostedWorkspaceAssistantPhase(
           ? { familyPlanTool: input.runtime.platform.familyPlanToolPort }
           : {}),
         ...(input.runtime.platform.groupToolPort
-          ? { groupTool: input.runtime.platform.groupToolPort }
+          ? {
+              groupTool: createHostedGroupToolWithLinqThreadContext({
+                groupToolPort: input.runtime.platform.groupToolPort,
+                linqDeliveryContexts: initialLinqDeliveryContexts,
+              }),
+            }
           : {}),
         ...(issueDeviceConnectLink ? { issueDeviceConnectLink } : {}),
         ...(input.materializeWorkspaceArtifacts

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -235,12 +235,12 @@ function resolveHostedGroupToolLinqThreadContext(
       continue;
     }
     eligible.set(
-      [
+      JSON.stringify([
         authority.channel,
         authority.containerMemberId,
         authority.accountLookupKey,
         authority.threadId,
-      ].join(" "),
+      ]),
       {
         authority,
         chatId: authority.threadId,

--- a/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createHostedGroupToolWithLinqThreadContext } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import type { HostedAssistantLinqDeliveryContext } from "../src/hosted-runtime/linq-delivery-context.ts";
+
+const ROUTE_AUTHORITY = {
+  accountLookupKey: "hplk_account",
+  channel: "linq" as const,
+  containerMemberId: "member_container",
+  threadId: "chat_group_1",
+};
+
+function buildLinqDeliveryContext(
+  overrides: Partial<HostedAssistantLinqDeliveryContext>,
+): HostedAssistantLinqDeliveryContext {
+  return {
+    directRecipientPhoneNumber: null,
+    fromPhoneNumber: null,
+    replyToMessageId: null,
+    routeAuthority: null,
+    service: "imessage",
+    target: "chat_group_1",
+    threadIsDirect: false,
+    ...overrides,
+  };
+}
+
+describe("createHostedGroupToolWithLinqThreadContext", () => {
+  it("injects the wake-derived linq thread into chat-scoped actions only", async () => {
+    const request = vi.fn().mockResolvedValue({
+      action: "share_contact_card",
+      result: { status: "sent" },
+    });
+    const groupTool = createHostedGroupToolWithLinqThreadContext({
+      groupToolPort: { request },
+      linqDeliveryContexts: [
+        buildLinqDeliveryContext({ routeAuthority: null }),
+        buildLinqDeliveryContext({ routeAuthority: ROUTE_AUTHORITY }),
+      ],
+    });
+
+    await groupTool.request({ action: "share_contact_card" });
+    expect(request).toHaveBeenLastCalledWith({
+      action: "share_contact_card",
+      linqThread: {
+        authority: ROUTE_AUTHORITY,
+        chatId: "chat_group_1",
+      },
+    });
+
+    await groupTool.request({ action: "read_chat_participants" });
+    expect(request).toHaveBeenLastCalledWith({
+      action: "read_chat_participants",
+      linqThread: {
+        authority: ROUTE_AUTHORITY,
+        chatId: "chat_group_1",
+      },
+    });
+
+    await groupTool.request({ action: "read_current" });
+    expect(request).toHaveBeenLastCalledWith({ action: "read_current" });
+  });
+
+  it("fails closed when the turn carries two distinct route-authorized threads", async () => {
+    const request = vi.fn().mockResolvedValue({
+      action: "share_contact_card",
+      result: {
+        status: "unavailable",
+        unavailableReason: "linq_thread_unavailable",
+      },
+    });
+    const groupTool = createHostedGroupToolWithLinqThreadContext({
+      groupToolPort: { request },
+      linqDeliveryContexts: [
+        buildLinqDeliveryContext({ routeAuthority: ROUTE_AUTHORITY }),
+        buildLinqDeliveryContext({
+          routeAuthority: { ...ROUTE_AUTHORITY, threadId: "chat_group_2" },
+          target: "chat_group_2",
+        }),
+      ],
+    });
+
+    await groupTool.request({ action: "share_contact_card" });
+    expect(request).toHaveBeenLastCalledWith({ action: "share_contact_card" });
+  });
+
+  it("dedupes repeated contexts for the same thread and skips non-iMessage or direct contexts", async () => {
+    const request = vi.fn().mockResolvedValue({
+      action: "read_chat_participants",
+      result: { participants: [], status: "ok" },
+    });
+    const groupTool = createHostedGroupToolWithLinqThreadContext({
+      groupToolPort: { request },
+      linqDeliveryContexts: [
+        buildLinqDeliveryContext({ routeAuthority: ROUTE_AUTHORITY }),
+        buildLinqDeliveryContext({ routeAuthority: ROUTE_AUTHORITY }),
+        buildLinqDeliveryContext({
+          routeAuthority: { ...ROUTE_AUTHORITY, threadId: "chat_sms_group" },
+          service: "sms",
+        }),
+        buildLinqDeliveryContext({
+          routeAuthority: { ...ROUTE_AUTHORITY, threadId: "chat_direct" },
+          threadIsDirect: true,
+        }),
+      ],
+    });
+
+    await groupTool.request({ action: "read_chat_participants" });
+    expect(request).toHaveBeenLastCalledWith({
+      action: "read_chat_participants",
+      linqThread: {
+        authority: ROUTE_AUTHORITY,
+        chatId: "chat_group_1",
+      },
+    });
+  });
+
+  it("forwards chat-scoped actions without a linq thread when no route-authorized context exists", async () => {
+    const request = vi.fn().mockResolvedValue({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "linq_thread_unavailable",
+      },
+    });
+    const groupTool = createHostedGroupToolWithLinqThreadContext({
+      groupToolPort: { request },
+      linqDeliveryContexts: [buildLinqDeliveryContext({ routeAuthority: null })],
+    });
+
+    await groupTool.request({ action: "read_chat_participants" });
+    expect(request).toHaveBeenLastCalledWith({ action: "read_chat_participants" });
+  });
+});

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -88,8 +88,11 @@ import {
   type HostedRuntimeFamilyPlanToolStatusResponse,
   HOSTED_RUNTIME_GROUP_DISPLAY_NAME_MAX_LENGTH,
   HOSTED_RUNTIME_GROUP_KINDS,
+  HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX,
+  type HostedRuntimeGroupChatParticipant,
   type HostedRuntimeGroupCreateJoinLinkRequest,
   type HostedRuntimeGroupKind,
+  type HostedRuntimeGroupToolLinqThreadContext,
   type HostedRuntimeGroupToolRequest,
   type HostedRuntimeGroupToolResponse,
   type HostedRuntimeProductFeedbackRecordRequest,
@@ -765,7 +768,39 @@ export function parseHostedRuntimeGroupToolRequest(
       joinLink: parseHostedRuntimeGroupCreateJoinLinkRequest(record.joinLink),
     };
   }
+  if (action === "read_chat_participants" || action === "share_contact_card") {
+    assertAllowedObjectKeys(
+      record,
+      new Set(["action", "linqThread"]),
+      `Hosted runtime group tool ${action} request`,
+    );
+    if (record.linqThread === undefined || record.linqThread === null) {
+      return { action };
+    }
+    return {
+      action,
+      linqThread: parseHostedRuntimeGroupToolLinqThreadContext(
+        record.linqThread,
+        `Hosted runtime group tool ${action} request linqThread`,
+      ),
+    };
+  }
   throw new TypeError("Hosted runtime group tool action is not supported.");
+}
+
+function parseHostedRuntimeGroupToolLinqThreadContext(
+  value: unknown,
+  label: string,
+): HostedRuntimeGroupToolLinqThreadContext {
+  const record = requireObject(value, label);
+  assertAllowedObjectKeys(record, new Set(["authority", "chatId"]), label);
+  return {
+    authority: parseHostedRuntimeLinqExternalThreadRouteAuthority(
+      record.authority,
+      `${label} authority`,
+    ),
+    chatId: requireString(record.chatId, `${label} chatId`),
+  };
 }
 
 function parseHostedRuntimeGroupCreateJoinLinkRequest(
@@ -863,7 +898,70 @@ export function parseHostedRuntimeGroupToolResponse(
     }
   }
 
+  if (action === "read_chat_participants") {
+    const result = requireObject(record.result, "Hosted runtime group tool read_chat_participants response result");
+    const status = requireString(result.status, "Hosted runtime group tool read_chat_participants response status");
+    if (status === "ok") {
+      assertAllowedObjectKeys(result, new Set(["status", "participants"]), "Hosted runtime group tool read_chat_participants ok response result");
+      return {
+        action,
+        result: {
+          status,
+          participants: parseHostedRuntimeGroupChatParticipants(result.participants),
+        },
+      };
+    }
+    if (status === "unavailable") {
+      assertAllowedObjectKeys(result, new Set(["status", "unavailableReason", "participants"]), "Hosted runtime group tool read_chat_participants unavailable response result");
+      return {
+        action,
+        result: {
+          status,
+          unavailableReason: requireString(result.unavailableReason, "Hosted runtime group unavailableReason"),
+          participants: null,
+        },
+      };
+    }
+  }
+
+  if (action === "share_contact_card") {
+    const result = requireObject(record.result, "Hosted runtime group tool share_contact_card response result");
+    const status = requireString(result.status, "Hosted runtime group tool share_contact_card response status");
+    if (status === "sent" || status === "already_shared") {
+      assertAllowedObjectKeys(result, new Set(["status"]), "Hosted runtime group tool share_contact_card response result");
+      return { action, result: { status } };
+    }
+    if (status === "unavailable") {
+      assertAllowedObjectKeys(result, new Set(["status", "unavailableReason"]), "Hosted runtime group tool share_contact_card unavailable response result");
+      return {
+        action,
+        result: {
+          status,
+          unavailableReason: requireString(result.unavailableReason, "Hosted runtime group unavailableReason"),
+        },
+      };
+    }
+  }
+
   throw new TypeError("Hosted runtime group tool response action/status is not supported.");
+}
+
+function parseHostedRuntimeGroupChatParticipants(
+  value: unknown,
+): HostedRuntimeGroupChatParticipant[] {
+  const label = "Hosted runtime group tool read_chat_participants participants";
+  const entries = requireArray(value, label);
+  if (entries.length > HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX) {
+    throw new TypeError(`${label} must contain at most ${HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX} entries.`);
+  }
+  return entries.map((entry) => {
+    const record = requireObject(entry, `${label} entry`);
+    assertAllowedObjectKeys(record, new Set(["handle", "hasOwnMurph"]), `${label} entry`);
+    return {
+      handle: requireString(record.handle, `${label} entry handle`),
+      hasOwnMurph: requireBoolean(record.hasOwnMurph, `${label} entry hasOwnMurph`),
+    };
+  });
 }
 
 function parseHostedRuntimeGroupProjectionKindArray(
@@ -1168,6 +1266,11 @@ function parseHostedRuntimeLinqExternalThreadRouteAuthority(
   label: string,
 ): HostedExecutionLinqExternalThreadRouteAuthority {
   const record = requireObject(value, label);
+  assertAllowedObjectKeys(
+    record,
+    new Set(["accountLookupKey", "channel", "containerMemberId", "threadId"]),
+    label,
+  );
   const channel = requireString(record.channel, `${label} channel`);
   if (channel !== "linq") {
     throw new TypeError(`${label} channel must be linq.`);

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -772,7 +772,11 @@ export interface HostedRuntimeProductFeedbackRecordResponse {
   recorded: boolean;
 }
 
-export type HostedRuntimeGroupToolAction = "read_current" | "create_join_link";
+export type HostedRuntimeGroupToolAction =
+  | "read_current"
+  | "create_join_link"
+  | "read_chat_participants"
+  | "share_contact_card";
 
 export const HOSTED_RUNTIME_GROUP_KINDS = [
   "couple",
@@ -802,9 +806,28 @@ export interface HostedRuntimeGroupCreateJoinLinkRequest {
   requestedVaultShareProjectionKinds?: HostedVaultShareProjectionKind[] | null;
 }
 
+/**
+ * Injected by the hosted runtime from the current wake's Linq delivery
+ * context; never supplied by the model. The web handler asserts the authority
+ * row before touching the chat.
+ */
+export interface HostedRuntimeGroupToolLinqThreadContext {
+  authority: HostedExecutionLinqExternalThreadRouteAuthority;
+  chatId: string;
+}
+
+export const HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX = 32;
+
+export interface HostedRuntimeGroupChatParticipant {
+  handle: string;
+  hasOwnMurph: boolean;
+}
+
 export type HostedRuntimeGroupToolRequest =
   | { action: "read_current" }
-  | { action: "create_join_link"; joinLink?: HostedRuntimeGroupCreateJoinLinkRequest | null };
+  | { action: "create_join_link"; joinLink?: HostedRuntimeGroupCreateJoinLinkRequest | null }
+  | { action: "read_chat_participants"; linqThread?: HostedRuntimeGroupToolLinqThreadContext | null }
+  | { action: "share_contact_card"; linqThread?: HostedRuntimeGroupToolLinqThreadContext | null };
 
 export type HostedRuntimeGroupToolResponse =
   | {
@@ -819,6 +842,19 @@ export type HostedRuntimeGroupToolResponse =
       result:
         | { status: "ok"; group: HostedRuntimeGroupSummary; joinUrl: string }
         | { status: "unavailable"; unavailableReason: string; group: null };
+    }
+  | {
+      action: "read_chat_participants";
+      result:
+        | { status: "ok"; participants: HostedRuntimeGroupChatParticipant[] }
+        | { status: "unavailable"; unavailableReason: string; participants: null };
+    }
+  | {
+      action: "share_contact_card";
+      result:
+        | { status: "sent" }
+        | { status: "already_shared" }
+        | { status: "unavailable"; unavailableReason: string };
     };
 
 export type HostedRuntimeFamilyPlanToolAction =

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -605,6 +605,151 @@ describe("parseHostedRuntimeGroupTool", () => {
       })
     ).toThrow(/not allowed/u);
   });
+
+  const LINQ_THREAD = {
+    authority: {
+      accountLookupKey: "hplk_account",
+      channel: "linq",
+      containerMemberId: "member_container",
+      threadId: "chat_group_1",
+    },
+    chatId: "chat_group_1",
+  };
+
+  it("parses chat-scoped requests with and without the runtime-injected linqThread", () => {
+    expect(parseHostedRuntimeGroupToolRequest({
+      action: "read_chat_participants",
+    })).toEqual({
+      action: "read_chat_participants",
+    });
+    expect(parseHostedRuntimeGroupToolRequest({
+      action: "share_contact_card",
+      linqThread: LINQ_THREAD,
+    })).toEqual({
+      action: "share_contact_card",
+      linqThread: LINQ_THREAD,
+    });
+
+    expect(() =>
+      parseHostedRuntimeGroupToolRequest({
+        action: "read_chat_participants",
+        linqThread: { chatId: "chat_group_1" },
+      })
+    ).toThrow(/not allowed|authority/u);
+    expect(() =>
+      parseHostedRuntimeGroupToolRequest({
+        action: "share_contact_card",
+        linqThread: {
+          ...LINQ_THREAD,
+          authority: { ...LINQ_THREAD.authority, channel: "email" },
+        },
+      })
+    ).toThrow(/channel/u);
+    expect(() =>
+      parseHostedRuntimeGroupToolRequest({
+        action: "share_contact_card",
+        chatId: "chat_group_1",
+      })
+    ).toThrow(/not allowed/u);
+    expect(() =>
+      parseHostedRuntimeGroupToolRequest({
+        action: "share_contact_card",
+        linqThread: {
+          ...LINQ_THREAD,
+          authority: { ...LINQ_THREAD.authority, extra: "field" },
+        },
+      })
+    ).toThrow(/not allowed/u);
+  });
+
+  it("parses read_chat_participants responses and caps the participant list", () => {
+    expect(parseHostedRuntimeGroupToolResponse({
+      action: "read_chat_participants",
+      result: {
+        participants: [
+          { handle: "+15550000001", hasOwnMurph: true },
+          { handle: "person@example.com", hasOwnMurph: false },
+        ],
+        status: "ok",
+      },
+    })).toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: [
+          { handle: "+15550000001", hasOwnMurph: true },
+          { handle: "person@example.com", hasOwnMurph: false },
+        ],
+        status: "ok",
+      },
+    });
+    expect(parseHostedRuntimeGroupToolResponse({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "linq_thread_unavailable",
+      },
+    })).toEqual({
+      action: "read_chat_participants",
+      result: {
+        participants: null,
+        status: "unavailable",
+        unavailableReason: "linq_thread_unavailable",
+      },
+    });
+
+    expect(() =>
+      parseHostedRuntimeGroupToolResponse({
+        action: "read_chat_participants",
+        result: {
+          participants: Array.from({ length: 33 }, (_, index) => ({
+            handle: `+1555000${index}`,
+            hasOwnMurph: false,
+          })),
+          status: "ok",
+        },
+      })
+    ).toThrow(/at most 32/u);
+    expect(() =>
+      parseHostedRuntimeGroupToolResponse({
+        action: "read_chat_participants",
+        result: {
+          participants: [{ handle: "+15550000001", hasOwnMurph: false, memberId: "m_1" }],
+          status: "ok",
+        },
+      })
+    ).toThrow(/not allowed/u);
+  });
+
+  it("parses share_contact_card responses", () => {
+    expect(parseHostedRuntimeGroupToolResponse({
+      action: "share_contact_card",
+      result: { status: "sent" },
+    })).toEqual({
+      action: "share_contact_card",
+      result: { status: "sent" },
+    });
+    expect(parseHostedRuntimeGroupToolResponse({
+      action: "share_contact_card",
+      result: { status: "already_shared" },
+    })).toEqual({
+      action: "share_contact_card",
+      result: { status: "already_shared" },
+    });
+    expect(parseHostedRuntimeGroupToolResponse({
+      action: "share_contact_card",
+      result: { status: "unavailable", unavailableReason: "send_failed" },
+    })).toEqual({
+      action: "share_contact_card",
+      result: { status: "unavailable", unavailableReason: "send_failed" },
+    });
+    expect(() =>
+      parseHostedRuntimeGroupToolResponse({
+        action: "share_contact_card",
+        result: { status: "sent", messageId: "msg_1" },
+      })
+    ).toThrow(/not allowed/u);
+  });
 });
 
 describe("parseHostedRuntimeFamilyPlanTool", () => {


### PR DESCRIPTION
## Why this PR exists

Group chats now auto-provision their own Murph runtime (#363), but people in the room who don't have Murph yet have no smooth path in: nothing tells them who Murph is or how to reach it. Murph should notice those people and hand the room a tappable contact card.

## User goal / user-visible behavior

In a provisioned iMessage group, Murph can now (1) check who is in the chat and whether each participant already has their own Murph (`murph.group action="read_chat_participants"`), and (2) drop its contact card into the chat once (`action="share_contact_card"`) — a native .vcf with the name **Murph**, the murph_headshot.png photo, this group's own line as **mobile**, and a second healthy pool line as a labeled **backup**. Murph folds the invitation into its normal greeting ("if you don't have me saved yet, that card's me — shoot me a text and I'll get you set up"); the existing 1:1 first-contact flow finishes signup when a non-member texts the line. The group-chat skill and hosted-groups prompt guidance direct when to use both actions.

## Invariants to preserve

- The model can never target another chat: the runtime injects the chat id + thread-route egress authority from the current wake (strict tool schema rejects model-supplied targets); the web handler asserts the authority row, container/member match, and thread match before any Linq call; ambiguous (multiple distinct) or non-iMessage-group route contexts fail closed to `unavailable`.
- Card sends are throttled server-side (existing `hostedLinqContactCardShare` reservation, 48h per chat) regardless of model behavior; a day-scoped idempotency key covers duplicate provider submissions.
- The direct 1:1 native contact-card share behavior and cadence are unchanged (its reserve step was refactored into a shared helper, behavior-preserving; existing tests green).
- No signup/acquisition framing in prompt surfaces; no links into the group; one mention, no re-sends, no pressure (deliverability rules).
- Web DB keeps hashed lookup keys only; raw chat ids and handles flow exclusively through the already-authorized runtime path; roster handles returned to the runtime are the same exposure class as existing `Sender:` lines.

## Deployment skew / compatibility

Deploy **web before Cloudflare**. A new runner against old web gets HTTP 400 from the request parser for the new actions (a tool error surfaced to the model, no corruption or retries); an old runner against new web is unaffected (old actions keep old response shapes). No immediate container rollout required.

Post-deploy checks: smoke `read_chat_participants` + `share_contact_card` in a real group — verifies the live `GET chats/{id}` roster shape (`handles` + `is_me` marker, which the code tolerates in two layouts but could not be verified against production from this environment) and iMessage's rendering of the `text/vcard` media attachment. Watch hosted logs for `share_contact_card` `unavailableReason` values.

## Deliberately deferred

- **Designated backup line / failover**: the card's backup number is currently the first healthy configured line (deterministic). When line-failover gets built, promote that to an explicit line-level designation (and optionally stamp the advertised backup on the share reservation row for cohort audit). Decided 2026-07-02 not to persist per-member backup state now.
- Pairing participant flags with display names from the `group-profile-name-roster` lane's `read_current` members roster (coordinated; that lane lands first and this PR's tool description defers to it for names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785613424&installation_id=127572939&pr_number=367&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F367&signature=9ebc767577847076fe7c9412be3a6f22fa818f772eaef5c09710ea740933002e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
