### PR TITLE
feat(web): stemmed supplement search with brand-scope fallback

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-02-supplement-search-stemming.md
+++ b/agent-docs/exec-plans/completed/2026-07-02-supplement-search-stemming.md
@@ -1,0 +1,47 @@
+Goal (incl. success criteria):
+- Fix the supplement search recall gap where singular/plural product-name forms never match (live incident: "Advanced Antioxidant" could not find Blueprint's "Advanced Antioxidants" label; the reverse direction also lost all singular-name rows).
+- Use Postgres-native full-text stemming instead of more bespoke matching heuristics, keep the foods path's current latency, and close the brand-scope zero-result cliff found in the audit.
+- Success means the live regression corpus covers both directions of the incident and passes, unit suites pass, and broad foods queries keep their pre-change latency.
+
+Constraints/Assumptions:
+- The generic search SQL is shared by supplements (~239k rows) and foods (~2M rows). Stemmed matching doubles per-candidate ranking cost and widens candidate sets, so it must stay opt-in per table; foods keeps the existing single-config query shape.
+- `websearch_to_tsquery('english', ...)` drops stopword-shaped brand tokens ("NOW", "One A Day"), so the 'simple' arm must remain and the stemmed arm is additive (OR), never a replacement.
+- Both FTS arms must be GIN-indexed; the `to_tsvector('english', search_text)` expression indexes were created concurrently on the live labels DB (supplements + foods) before this code change deploys, and are recorded in the schema files.
+- No new services, columns, or import-pipeline changes; ranking changes stay inside the existing candidate CTE structure.
+
+Key decisions:
+- Dual-config FTS (`simple` OR `english`) gated by a `stemmedSearch` option enabled only for supplements.
+- New `stemmed_name_match` ranking tier ("query equals full product name up to stemming") directly below the raw phrase-containment tier, so exact-modulo-plural names beat partial-name matches.
+- Word-bound the generic path's `name_phrase_match` strpos containment (space padding) so short names can no longer phrase-match inside unrelated query words.
+- Empty brand-scoped results now fall back to the generic path instead of returning nothing (ingredient-shaped brand names could hijack a query into an exclusive empty scope).
+
+State:
+- Implementation, tests, and live verification complete; committing.
+
+Done:
+- Reproduced the incident and its mirror image against the live labels DB through the real query functions.
+- Verified planner uses BitmapOr across both GIN indexes (5.8s seq scan -> 1.3ms) and created the english expression indexes concurrently on the live DB.
+- Adversarial audit of the full search path; adopted the two cheap high-severity findings (brand-scope fallback, word-bounded phrase match), deferred brand-heuristic redesign, UPC width matrix, and diacritics as follow-ups.
+- Live corpus extended with the incident regression; all live + unit suites pass; foods latency confirmed unchanged; supplements broad queries ~2x but well under the 8s statement timeout.
+
+Now:
+- Final scoped commit via scripts/finish-task, open PR, run the PR-lane ReviewGPT loop.
+
+Next:
+- N/A (follow-ups recorded in the PR description).
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/src/lib/product-labels.ts
+- apps/web/src/lib/supplements.ts
+- apps/web/sql/supplements/schema.sql
+- apps/web/sql/foods/schema.sql
+- apps/web/test/supplements-lib.test.ts
+- apps/web/test/supplements-search-live.test.ts
+- MURPH_LABELS_DB_URL=... pnpm exec vitest run --config apps/web/vitest.workspace.ts apps/web/test/supplements-search-live.test.ts
+- pnpm test:diff apps/web/src/lib/product-labels.ts apps/web/src/lib/supplements.ts
+Status: completed
+Updated: 2026-07-02
+Completed: 2026-07-02

--- a/apps/web/sql/foods/schema.sql
+++ b/apps/web/sql/foods/schema.sql
@@ -44,6 +44,10 @@ CREATE INDEX IF NOT EXISTS foods_search_idx
   ON foods
   USING GIN (to_tsvector('simple', search_text));
 
+CREATE INDEX IF NOT EXISTS foods_search_english_idx
+  ON foods
+  USING GIN (to_tsvector('english', search_text));
+
 CREATE INDEX IF NOT EXISTS foods_name_trgm_idx
   ON foods
   USING GIN (name gin_trgm_ops);

--- a/apps/web/sql/supplements/schema.sql
+++ b/apps/web/sql/supplements/schema.sql
@@ -42,6 +42,10 @@ CREATE INDEX IF NOT EXISTS supplements_search_idx
   ON supplements
   USING GIN (to_tsvector('simple', search_text));
 
+CREATE INDEX IF NOT EXISTS supplements_search_english_idx
+  ON supplements
+  USING GIN (to_tsvector('english', search_text));
+
 CREATE INDEX IF NOT EXISTS supplements_name_trgm_idx
   ON supplements
   USING GIN (name gin_trgm_ops);

--- a/apps/web/src/components/homepage/hero-clocks-in.tsx
+++ b/apps/web/src/components/homepage/hero-clocks-in.tsx
@@ -745,7 +745,7 @@ export function HeroClocksIn({
             then build habits that stick.
           </p>
 
-          <div className="mt-8 max-w-[52ch] text-[1.0625rem] [&_a]:w-full [&_button]:w-full lg:mt-10 lg:max-w-none lg:[&_a]:w-auto lg:[&_button]:w-auto">
+          <div className="mt-10 hidden lg:block">
             <LandingAuthActions
               authLabel="Meet Murph"
               authenticated={authenticated}
@@ -845,6 +845,14 @@ export function HeroClocksIn({
           </div>
         </div>
 
+        <div className="relative mx-auto mt-2 w-full max-w-[320px] lg:hidden [&_a]:w-full [&_button]:w-full">
+          <LandingAuthActions
+            authLabel="Meet Murph"
+            authenticated={authenticated}
+            context="hero"
+            leadingIcon={channelIcon}
+          />
+        </div>
       </div>
     </section>
   );
@@ -1043,7 +1051,7 @@ function BloodworkCard({ result }: { result: BloodworkResult }) {
 
 function PhoneShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="relative rounded-[2.75rem] bg-[#0a0a0a] p-[4px] shadow-[0_30px_80px_-20px_rgba(0,0,0,0.55)]">
+    <div className="relative rounded-[2.75rem] bg-[#0a0a0a] p-[4px] shadow-[0_16px_36px_-18px_rgba(0,0,0,0.4)] lg:shadow-[0_30px_80px_-20px_rgba(0,0,0,0.55)]">
       <div className="overflow-hidden rounded-[2.5rem] bg-[#f5f0e8]">
         {children}
       </div>

--- a/apps/web/src/lib/product-labels.ts
+++ b/apps/web/src/lib/product-labels.ts
@@ -223,6 +223,7 @@ export function createProductLabelsQueries(
   options: {
     brandScoping?: boolean;
     genericSearch?: ProductLabelGenericSearchOptions;
+    stemmedSearch?: boolean;
     weakQueryTokens?: readonly string[];
   } = {},
 ): ProductLabelsQueries {
@@ -234,6 +235,11 @@ export function createProductLabelsQueries(
   // hide generic rows (brand IS NULL) whenever a query collides with a brand
   // name.
   const brandScoping = options.brandScoping ?? false;
+  // Stemmed (english-config) matching widens the FTS candidate set and adds a
+  // second on-the-fly to_tsvector ranking pass per candidate. That is cheap on
+  // the supplements catalog but multiplies broad-query latency on the ~2M-row
+  // foods table past the statement timeout, so it stays opt-in per table.
+  const stemmedSearch = options.stemmedSearch ?? false;
   const genericSearchDataOrigins = options.genericSearch?.dataOrigins ?? null;
   const weakQueryTokens = new Set(
     (options.weakQueryTokens ?? [])
@@ -369,7 +375,13 @@ export function createProductLabelsQueries(
             q: searchQ,
           });
 
-          return await attachProductContaminantSummaries(client, tableSql, rows);
+          // An exclusive brand scope can come up empty when an
+          // ingredient-shaped brand hijacks the query or the scoped brand has
+          // no such product; fall back to the generic path instead of
+          // returning nothing.
+          if (rows.length > 0) {
+            return await attachProductContaminantSummaries(client, tableSql, rows);
+          }
         }
       }
 
@@ -380,6 +392,7 @@ export function createProductLabelsQueries(
             ? genericSearchDataOrigins
             : null,
         q: searchQ,
+        stemmedSearch,
       });
 
       return await attachProductContaminantSummaries(client, tableSql, rows);
@@ -1106,14 +1119,17 @@ async function searchGenericProductLabels(
     includeOffMarket: boolean;
     limit: number;
     q: string;
+    stemmedSearch: boolean;
   },
 ): Promise<ProductLabelSearchRow[]> {
+  const stemmed = input.stemmedSearch;
   const { rows } = await client.query<ProductLabelSearchRow>(
     `
         WITH query AS (
           SELECT
             $1::text AS raw_q,
-            websearch_to_tsquery('simple', $1) AS tsq
+            websearch_to_tsquery('simple', $1) AS tsq${stemmed ? `,
+            websearch_to_tsquery('english', $1) AS stemmed_tsq` : ""}
         ),
         fts_candidates AS MATERIALIZED (
           SELECT
@@ -1125,20 +1141,35 @@ async function searchGenericProductLabels(
             brand,
             upc,
             off_market AS "offMarket",
-            ts_rank_cd(to_tsvector('simple', search_text), query.tsq) AS search_rank,
+            ${stemmed ? `greatest(
+              ts_rank_cd(to_tsvector('simple', search_text), query.tsq),
+              ts_rank_cd(to_tsvector('english', search_text), query.stemmed_tsq)
+            )` : `ts_rank_cd(to_tsvector('simple', search_text), query.tsq)`} AS search_rank,
             strict_word_similarity(query.raw_q, name) AS name_similarity,
             CASE
-              WHEN strpos(lower(query.raw_q), lower(name)) > 0 THEN 1
+              WHEN strpos(' ' || lower(query.raw_q) || ' ', ' ' || lower(name) || ' ') > 0 THEN 1
               ELSE 0
             END AS name_phrase_match,
             CASE
-              WHEN strpos(lower(query.raw_q), lower(name)) > 0 THEN char_length(name)
+              WHEN strpos(' ' || lower(query.raw_q) || ' ', ' ' || lower(name) || ' ') > 0 THEN char_length(name)
               ELSE 0
             END AS name_phrase_length,
+            ${stemmed ? `CASE
+              WHEN to_tsvector('english', name) = to_tsvector('english', query.raw_q) THEN 1
+              ELSE 0
+            END` : "0"} AS stemmed_name_match,
             data_origin_priority
           FROM ${tableSql}, query
           WHERE
-            to_tsvector('simple', search_text) @@ query.tsq
+            -- With stemming on, match both dictionaries: 'simple' keeps
+            -- exact tokens that 'english' would drop or mangle
+            -- (stopword-shaped brands like "NOW"), while 'english' stems so
+            -- singular/plural queries reach rows indexed under the other
+            -- form. Both arms are GIN-indexed.
+            ${stemmed ? `(
+              to_tsvector('simple', search_text) @@ query.tsq
+              OR to_tsvector('english', search_text) @@ query.stemmed_tsq
+            )` : `to_tsvector('simple', search_text) @@ query.tsq`}
             AND ($2::boolean OR off_market = false)
             AND ${PRODUCT_LABEL_SOURCE_FILTER_SQL}
             AND ($4::text[] IS NULL OR data_origin = ANY($4::text[]))
@@ -1156,13 +1187,17 @@ async function searchGenericProductLabels(
             0::real AS search_rank,
             strict_word_similarity(query.raw_q, name) AS name_similarity,
             CASE
-              WHEN strpos(lower(query.raw_q), lower(name)) > 0 THEN 1
+              WHEN strpos(' ' || lower(query.raw_q) || ' ', ' ' || lower(name) || ' ') > 0 THEN 1
               ELSE 0
             END AS name_phrase_match,
             CASE
-              WHEN strpos(lower(query.raw_q), lower(name)) > 0 THEN char_length(name)
+              WHEN strpos(' ' || lower(query.raw_q) || ' ', ' ' || lower(name) || ' ') > 0 THEN char_length(name)
               ELSE 0
             END AS name_phrase_length,
+            ${stemmed ? `CASE
+              WHEN to_tsvector('english', name) = to_tsvector('english', query.raw_q) THEN 1
+              ELSE 0
+            END` : "0"} AS stemmed_name_match,
             data_origin_priority
           FROM ${tableSql}, query
           WHERE
@@ -1185,6 +1220,7 @@ async function searchGenericProductLabels(
               ORDER BY
                 name_phrase_match DESC,
                 name_phrase_length DESC,
+                stemmed_name_match DESC,
                 name_similarity DESC,
                 search_rank DESC,
                 "offMarket" ASC,
@@ -1201,6 +1237,7 @@ async function searchGenericProductLabels(
               ORDER BY
                 name_phrase_match DESC,
                 name_phrase_length DESC,
+                stemmed_name_match DESC,
                 name_similarity DESC,
                 search_rank DESC,
                 data_origin_priority ASC,
@@ -1212,6 +1249,7 @@ async function searchGenericProductLabels(
           ORDER BY
             name_phrase_match DESC,
             name_phrase_length DESC,
+            stemmed_name_match DESC,
             name_similarity DESC,
             search_rank DESC,
             data_origin_priority ASC,

--- a/apps/web/src/lib/supplements.ts
+++ b/apps/web/src/lib/supplements.ts
@@ -54,6 +54,7 @@ export function createSupplementsQueries(client: ProductLabelsQueryClient): {
 } {
   const queries = createProductLabelsQueries(client, "supplements", {
     brandScoping: true,
+    stemmedSearch: true,
     weakQueryTokens: SUPPLEMENT_SEARCH_WEAK_QUERY_TOKENS,
   });
 

--- a/apps/web/test/page.test.ts
+++ b/apps/web/test/page.test.ts
@@ -119,7 +119,7 @@ test("HomePage renders the canonical landing page at the root route", async () =
   expect(mocks.getHostedPageAuthSnapshot).toHaveBeenCalledTimes(1);
   expect(mocks.getMurphGithubStarCount).toHaveBeenCalledTimes(1);
   expect(mocks.headers).toHaveBeenCalledTimes(1);
-  expect(mocks.LandingAuthActions).toHaveBeenCalledTimes(4);
+  expect(mocks.LandingAuthActions).toHaveBeenCalledTimes(5);
   expect(mocks.LandingAuthActions).toHaveBeenNthCalledWith(
     1,
     {
@@ -144,6 +144,16 @@ test("HomePage renders the canonical landing page at the root route", async () =
   );
   expect(mocks.LandingAuthActions).toHaveBeenNthCalledWith(
     3,
+    expect.objectContaining({
+      authenticated: false,
+      context: "hero",
+      authLabel: "Meet Murph",
+      leadingIcon: expect.anything(),
+    }),
+    undefined
+  );
+  expect(mocks.LandingAuthActions).toHaveBeenNthCalledWith(
+    4,
     {
       authenticated: false,
       context: "footer",
@@ -154,7 +164,7 @@ test("HomePage renders the canonical landing page at the root route", async () =
     undefined
   );
   expect(mocks.LandingAuthActions).toHaveBeenNthCalledWith(
-    4,
+    5,
     {
       authenticated: false,
       context: "footer",
@@ -267,9 +277,9 @@ test("HomePage keeps the final CTA consistent for authenticated sessions", async
   const markup = renderToStaticMarkup(await HomePage());
 
   expect(mocks.headers).toHaveBeenCalledTimes(1);
-  expect(mocks.LandingAuthActions).toHaveBeenCalledTimes(4);
+  expect(mocks.LandingAuthActions).toHaveBeenCalledTimes(5);
   expect(mocks.LandingAuthActions).toHaveBeenNthCalledWith(
-    4,
+    5,
     {
       authenticated: true,
       context: "footer",

--- a/apps/web/test/supplements-lib.test.ts
+++ b/apps/web/test/supplements-lib.test.ts
@@ -98,6 +98,9 @@ describe("supplements query helpers", () => {
     expect(schemaSql).toContain("UNIQUE (data_origin, data_origin_id)");
     expect(schemaSql).toContain("CREATE EXTENSION IF NOT EXISTS pg_trgm");
     expect(schemaSql).toContain(
+      "CREATE INDEX IF NOT EXISTS supplements_search_english_idx",
+    );
+    expect(schemaSql).toContain(
       "CREATE INDEX IF NOT EXISTS supplements_name_trgm_idx",
     );
     expect(schemaSql).toContain(
@@ -162,7 +165,11 @@ describe("supplements query helpers", () => {
     expect(calls[0]?.values).toEqual([]);
 
     const searchCall = calls[1];
-    expect(searchCall?.text).toContain("websearch_to_tsquery");
+    expect(searchCall?.text).toContain("websearch_to_tsquery('simple', $1)");
+    expect(searchCall?.text).toContain("websearch_to_tsquery('english', $1)");
+    expect(searchCall?.text).toContain(
+      "OR to_tsvector('english', search_text) @@ query.stemmed_tsq",
+    );
     expect(searchCall?.text).toContain("$1::text AS raw_q");
     expect(searchCall?.text).toContain(
       "strict_word_similarity(query.raw_q, name)",
@@ -1182,6 +1189,22 @@ describe("supplements query helpers", () => {
         if (isProductTestsQuery(text)) {
           return { rows: [] as T[] };
         }
+        if (text.includes("brand_candidates AS MATERIALIZED")) {
+          return {
+            rows: [
+              {
+                id: "1001",
+                dataOrigin: "dsld",
+                dataOriginId: "1001",
+                name: "Calcium",
+                brand: "Momentous",
+                upc: null,
+                offMarket: false,
+                label: {},
+              },
+            ] as T[],
+          };
+        }
         return { rows: [] as T[] };
       },
     });
@@ -1192,11 +1215,13 @@ describe("supplements query helpers", () => {
       includeOffMarket: false,
     });
 
-    expect(calls).toHaveLength(2);
+    // brand index + brand-scoped search + contaminant attach for the row
+    expect(calls).toHaveLength(3);
     expect(calls[0]?.text).toContain("GROUP BY brand");
     expect(calls[0]?.text).toContain("data_origin NOT IN");
     expect(calls[0]?.text).toContain("'nyc_dohmh_consumer_products'");
     expect(calls[0]?.text).toContain("'king_county_consumer_products'");
+    expect(calls[2]?.text).toContain("JOIN product_tests");
 
     const sql = calls[1]?.text ?? "";
 
@@ -1254,13 +1279,15 @@ describe("supplements query helpers", () => {
       includeOffMarket: false,
     });
 
+    // Three generic searches: the two unscoped queries, plus the empty
+    // brand-scoped "Life Magnesium" result falling back to the generic path.
     expect(
       calls.filter(
         (call) =>
           call.text.includes("fts_candidates AS MATERIALIZED") &&
           !call.text.includes("brand_candidates AS MATERIALIZED"),
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     expect(calls.filter((call) =>
       call.text.includes("brand_candidates AS MATERIALIZED"),
     )).toEqual([
@@ -1268,6 +1295,46 @@ describe("supplements query helpers", () => {
         text: expect.stringContaining("brand_candidates AS MATERIALIZED"),
         values: ["Life Magnesium", false, 1, ["Life"], "magnesium"],
       },
+    ]);
+  });
+
+  it("falls back to generic search when a brand scope matches nothing", async () => {
+    const calls: Array<{ text: string; values: unknown[] }> = [];
+    const queries = createSupplementsQueries({
+      async query<T>(text: string, values: unknown[]) {
+        calls.push({ text, values });
+        if (text.includes("GROUP BY brand")) {
+          return { rows: [{ brand: "Magnesium" }] as T[] };
+        }
+        if (isProductTestsQuery(text)) {
+          return { rows: [] as T[] };
+        }
+        return { rows: [] as T[] };
+      },
+    });
+
+    await queries.searchSupplements({
+      q: "Magnesium Glycinate",
+      limit: 5,
+      includeOffMarket: false,
+    });
+
+    const brandScopedCalls = calls.filter((call) =>
+      call.text.includes("brand_candidates AS MATERIALIZED"),
+    );
+    const genericCalls = calls.filter(
+      (call) =>
+        call.text.includes("fts_candidates AS MATERIALIZED") &&
+        !call.text.includes("brand_candidates AS MATERIALIZED"),
+    );
+
+    expect(brandScopedCalls).toHaveLength(1);
+    expect(genericCalls).toHaveLength(1);
+    expect(genericCalls[0]?.values).toEqual([
+      "Magnesium Glycinate",
+      false,
+      5,
+      null,
     ]);
   });
 

--- a/apps/web/test/supplements-search-live.test.ts
+++ b/apps/web/test/supplements-search-live.test.ts
@@ -125,6 +125,28 @@ describe.runIf(Boolean(databaseUrl))("supplements live search corpus", () => {
     expect(onceDaily[0]?.name).toBe("Women's Once Daily");
   }, 120_000);
 
+  it("matches singular and plural product-name forms both ways", async () => {
+    // Regression for the Blueprint "Advanced Antioxidants" miss: the catalog
+    // row is plural, the query was singular, and simple-config FTS has no
+    // stemming while the trigram fallback stays suppressed whenever FTS
+    // returns anything. Both directions must reach the other form now.
+    const singular = await search("Advanced Antioxidant");
+    expect(
+      singular.some(
+        (row) => row.brand === "Blueprint" && row.name === "Advanced Antioxidants",
+      ),
+    ).toBe(true);
+
+    const plural = await search("Advanced Antioxidants");
+    expect(
+      plural.some((row) => /advanced antioxidant\b/iu.test(row.name)),
+    ).toBe(true);
+
+    const branded = await search("Blueprint Advanced Antioxidant");
+    expect(branded[0]?.brand).toBe("Blueprint");
+    expect(branded[0]?.name).toBe("Advanced Antioxidants");
+  }, 120_000);
+
   it("returns results for known ranking quirks without asserting order", async () => {
     // These currently rank an off-brand or adjacent product first; tracked as
     // candidates for future ranking work. Assert coverage only so this test


### PR DESCRIPTION
## Why this PR exists

Murph keeps missing supplement label lookups on trivially different name forms. Live incident: the Blueprint product is indexed as "Advanced Antioxidants" (plural), and searching the singular "Advanced Antioxidant" could not find it at all; the reverse direction (plural query) also lost every singular-name product. Root cause: the generic search runs FTS on the 'simple' dictionary (no stemming), and the trigram fallback only fires when FTS returns zero rows, so a wrong-but-nonempty FTS result suppresses fuzzy matching entirely.

## User goal / user-visible behavior

Searching a supplement by name finds the product regardless of singular/plural form (both directions), the exact-name product still ranks first, and a query hijacked into an empty exclusive brand scope now falls back to normal search instead of returning nothing.

Live readouts through the real query functions (limit 5):
- "Advanced Antioxidant" now includes Blueprint "Advanced Antioxidants" at #2 (was: absent); plural query ranks it #1.
- "fish oils" now tops with exact "Fish Oil" products; "creatin monohydrate" (typo) now tops with exact "Creatine Monohydrate" products.
- "probiotics 50 billion" now also finds singular "Probiotic 50 Billion" rows.

## What changed

- Dual-config FTS in the generic path, gated by a new `stemmedSearch` option enabled for supplements only: `websearch_to_tsquery('simple')` OR `websearch_to_tsquery('english')`, ranked by `greatest()` of both `ts_rank_cd` arms. The 'simple' arm stays because 'english' drops stopword-shaped brand tokens ("NOW", "One A Day").
- New `stemmed_name_match` ranking tier (query equals the full product name up to stemming) directly below the raw phrase-containment tier.
- Word-bounded the generic `name_phrase_match` containment (space-padded strpos) so a short name like "Tart" no longer phrase-matches inside "cream of tartar".
- Empty brand-scoped results fall back to the generic path (audit finding: an ingredient-shaped catalog brand such as "Magnesium" could capture "Magnesium Glycinate" into an exclusive scope and return zero results).
- `supplements_search_english_idx` / `foods_search_english_idx` GIN expression indexes added to the schema files. Both were already created with `CREATE INDEX CONCURRENTLY` on the live labels DB; the planner uses BitmapOr across both arms (5.8s seq scan -> 1.3ms on supplements).

## Invariants the PR must preserve

- Foods search keeps its exact query shape and latency: stemming is opt-in per table and foods does not opt in (its ~2M rows push broad stemmed queries past the 8s statement timeout; verified live at baseline after gating: blueberries 761ms vs 698ms pre-change).
- All SQL stays parameterized; table names and source filters remain compile-time constants.
- Brand-scoped exclusivity is unchanged whenever the scope returns results; the fallback only replaces the previously-empty response.
- Search still returns off-market rows only when `includeOffMarket` is set.

## Perf note

Broadest supplement queries roughly double (magnesium 1.6s -> 3.3s, vitamin d 1.2s -> 2.6s, warm), still well under the 8s statement timeout; specific product queries stay 130-650ms. If broad-query latency ever matters, the durable fix is stored generated tsvector columns, which would also let foods opt in.

## Deferred follow-ups (from the adversarial audit of this path)

- Brand-scope heuristics: short brand aliases ("NOW" vs "NOW Foods") can be excluded from their own scope; brand-token stripping is set-wise and mangles product names containing brand words. The new generic fallback caps the damage at "degraded ranking" instead of "zero results".
- Pre-existing: broad foods queries ("chicken") already hit the 8s statement timeout on main.
- UPC variant matrix is asymmetric for EAN-8 vs 12/13-digit forms; diacritics ("Açaí") defeat both normalizers.

## Verification

- Live regression corpus (`supplements-search-live.test.ts`) extended with the incident, both directions + branded form; 10/10 pass against the live labels DB.
- `supplements-lib` / `supplements-route` / `foods-lib` / `product-labels-pool` unit suites: 75/75 pass, including a new brand-scope fallback test.
- `pnpm test:diff` over the touched paths (apps/web verify incl. build) green; `apps/web` typecheck green.

## Deployment skew / compatibility

Safe in any order: the english GIN indexes already exist on the live DB (created concurrently before this change), so old and new web deploys both work; without the code the indexes are inert, without the indexes the new SQL would still be correct but slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785618591&installation_id=127572939&pr_number=368&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F368&signature=efcc69fb4a69a40b1d0b9e0964d53df71ee3fc953b83eef48511f0b45ff35bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->