### PR TITLE
Record per-operation DB timings for hosted webhook plan transactions

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/webhook-db-timing.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-db-timing.ts
@@ -1,0 +1,29 @@
+import type { PrismaOperationTiming } from "../prisma-operation-timing";
+import type { HostedOnboardingStructuredLogDetails } from "./logging";
+
+const MAX_LOGGED_OPERATIONS = 24;
+
+/**
+ * Flattens collected Prisma operation timings into the flat key→scalar shape
+ * the hosted-onboarding structured logs use: a count, a total, and one
+ * `dbNN.<model>.<operation>` entry per operation in execution order.
+ */
+export function buildHostedWebhookDbTimingLogDetails(
+  operations: PrismaOperationTiming[],
+): HostedOnboardingStructuredLogDetails {
+  const details: HostedOnboardingStructuredLogDetails = {
+    dbOperationCount: operations.length,
+    dbTotalMs: Math.round(
+      operations.reduce((total, operation) => total + operation.ms, 0),
+    ),
+  };
+
+  operations.slice(0, MAX_LOGGED_OPERATIONS).forEach((operation, index) => {
+    details[`db${String(index).padStart(2, "0")}.${operation.key}`] = Math.round(operation.ms);
+  });
+  if (operations.length > MAX_LOGGED_OPERATIONS) {
+    details.dbOperationsTruncated = true;
+  }
+
+  return details;
+}

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -38,9 +38,17 @@ import {
 import {
   deriveHostedOnboardingTimingErrorName,
   finishHostedOnboardingTiming,
+  logHostedOnboardingDiagnostic,
   startHostedOnboardingTiming,
   toHostedOnboardingLogIdSuffix,
 } from "./logging";
+import {
+  runWithPrismaOperationTimings,
+  type PrismaOperationTiming,
+} from "../prisma-operation-timing";
+import {
+  buildHostedWebhookDbTimingLogDetails,
+} from "./webhook-db-timing";
 import {
   drainHostedLinqSideEffectsDirect,
   type HostedLinqCurrentInboundReplyProof,
@@ -692,7 +700,18 @@ async function runHostedOnboardingWebhookTransaction<TResult>(
   prisma: PrismaClient,
   callback: (transaction: Prisma.TransactionClient) => Promise<TResult>,
 ): Promise<TResult> {
-  return typeof prisma.$transaction === "function"
-    ? prisma.$transaction(callback)
-    : callback(prisma as Prisma.TransactionClient);
+  const startedAtMs = Date.now();
+  const operations: PrismaOperationTiming[] = [];
+  try {
+    return await runWithPrismaOperationTimings(operations, async () =>
+      typeof prisma.$transaction === "function"
+        ? prisma.$transaction(callback)
+        : callback(prisma as Prisma.TransactionClient),
+    );
+  } finally {
+    logHostedOnboardingDiagnostic("hosted-onboarding.webhook.plan-db", {
+      transactionMs: Date.now() - startedAtMs,
+      ...buildHostedWebhookDbTimingLogDetails(operations),
+    });
+  }
 }

--- a/apps/web/src/lib/prisma-operation-timing.ts
+++ b/apps/web/src/lib/prisma-operation-timing.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface PrismaOperationTiming {
+  key: string;
+  ms: number;
+}
+
+const prismaOperationTimingStorage = new AsyncLocalStorage<PrismaOperationTiming[]>();
+
+/**
+ * Runs the callback with the given array active as the Prisma
+ * operation-timing collector; entries recorded while it runs are pushed into
+ * it even when the callback throws. Outside a collector the client extension
+ * is a pass-through, so steady-state requests pay nothing.
+ */
+export async function runWithPrismaOperationTimings<TResult>(
+  operations: PrismaOperationTiming[],
+  run: () => Promise<TResult>,
+): Promise<TResult> {
+  return prismaOperationTimingStorage.run(operations, run);
+}
+
+export function recordPrismaOperationTiming(key: string, ms: number): void {
+  prismaOperationTimingStorage.getStore()?.push({ key, ms });
+}
+
+export function isPrismaOperationTimingActive(): boolean {
+  return prismaOperationTimingStorage.getStore() !== undefined;
+}

--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -2,6 +2,10 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 
 import { assertHostedWebDatabaseUrlConfigured } from "./hosted-web/database-env";
+import {
+  isPrismaOperationTimingActive,
+  recordPrismaOperationTiming,
+} from "./prisma-operation-timing";
 import { installHostedWebWarningFilters } from "./process-warnings";
 
 const globalForPrisma = globalThis as typeof globalThis & {
@@ -37,7 +41,7 @@ function createPrismaAdapter(input: CreatePrismaClientInput): PrismaPg {
 export function createPrismaClient(input: CreatePrismaClientInput): PrismaClient {
   const logLevels = resolvePrismaLogLevels();
 
-  return new PrismaClient({
+  const client = new PrismaClient({
     adapter: createPrismaAdapter(input),
     ...(logLevels.length > 0 ? { log: logLevels } : {}),
     transactionOptions: {
@@ -45,6 +49,38 @@ export function createPrismaClient(input: CreatePrismaClientInput): PrismaClient
       timeout: PRISMA_TRANSACTION_TIMEOUT_MS,
     },
   });
+
+  // Diagnostic-only: records per-operation wall time when a request opted in
+  // via collectPrismaOperationTimings; a pass-through everywhere else. The
+  // extension keeps the full PrismaClient surface, so the assertion below is
+  // a type-level boundary only.
+  return client.$extends({
+    query: {
+      $allOperations({ args, model, operation, query }) {
+        if (!isPrismaOperationTimingActive()) {
+          return query(args);
+        }
+
+        const startedAtMs = Date.now();
+        const record = () => {
+          recordPrismaOperationTiming(
+            model ? `${model}.${operation}` : operation,
+            Date.now() - startedAtMs,
+          );
+        };
+        return query(args).then(
+          (result) => {
+            record();
+            return result;
+          },
+          (error: unknown) => {
+            record();
+            throw error;
+          },
+        );
+      },
+    },
+  }) as PrismaClient;
 }
 
 function createPrisma(): PrismaClient {

--- a/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/src/lib/hosted-routing/thread-route-store", () => ({
 vi.mock("@/src/lib/hosted-onboarding/logging", () => ({
   deriveHostedOnboardingTimingErrorName: mocks.deriveHostedOnboardingTimingErrorName,
   finishHostedOnboardingTiming: mocks.finishHostedOnboardingTiming,
+  logHostedOnboardingDiagnostic: vi.fn(),
   startHostedOnboardingTiming: mocks.startHostedOnboardingTiming,
   toHostedOnboardingLogIdSuffix: vi.fn((value: string | null | undefined) =>
     value ? value.slice(-6) : null

--- a/apps/web/test/hosted-onboarding-signup-timezone-handoff.test.ts
+++ b/apps/web/test/hosted-onboarding-signup-timezone-handoff.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/src/lib/hosted-onboarding/logging", () => ({
   deriveHostedOnboardingTimingErrorName: () => "test_error",
   finishHostedOnboardingTiming: vi.fn(),
+  logHostedOnboardingDiagnostic: vi.fn(),
   startHostedOnboardingTiming: () => ({ startedAt: 0 }),
 }));
 

--- a/apps/web/test/hosted-onboarding-webhook-db-timing.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-db-timing.test.ts
@@ -1,0 +1,97 @@
+import {
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  buildHostedWebhookDbTimingLogDetails,
+} from "@/src/lib/hosted-onboarding/webhook-db-timing";
+import {
+  isPrismaOperationTimingActive,
+  recordPrismaOperationTiming,
+  runWithPrismaOperationTimings,
+  type PrismaOperationTiming,
+} from "@/src/lib/prisma-operation-timing";
+
+describe("prisma operation timing collector", () => {
+  it("records operations only while a collector is active", async () => {
+    expect(isPrismaOperationTimingActive()).toBe(false);
+    recordPrismaOperationTiming("hostedMailboxItem.findFirst", 12);
+
+    const operations: PrismaOperationTiming[] = [];
+    await runWithPrismaOperationTimings(operations, async () => {
+      expect(isPrismaOperationTimingActive()).toBe(true);
+      recordPrismaOperationTiming("hostedMailboxItem.findFirst", 12);
+      recordPrismaOperationTiming("hostedWorkspace.upsert", 7);
+    });
+
+    expect(isPrismaOperationTimingActive()).toBe(false);
+    expect(operations).toEqual([
+      { key: "hostedMailboxItem.findFirst", ms: 12 },
+      { key: "hostedWorkspace.upsert", ms: 7 },
+    ]);
+  });
+
+  it("keeps operations recorded before the callback throws", async () => {
+    const operations: PrismaOperationTiming[] = [];
+
+    await expect(
+      runWithPrismaOperationTimings(operations, async () => {
+        recordPrismaOperationTiming("hostedMemberIdentity.findFirst", 40);
+        throw new Error("plan failed");
+      }),
+    ).rejects.toThrow("plan failed");
+
+    expect(operations).toEqual([{ key: "hostedMemberIdentity.findFirst", ms: 40 }]);
+  });
+
+  it("isolates concurrent collectors from each other", async () => {
+    const first: PrismaOperationTiming[] = [];
+    const second: PrismaOperationTiming[] = [];
+
+    await Promise.all([
+      runWithPrismaOperationTimings(first, async () => {
+        await Promise.resolve();
+        recordPrismaOperationTiming("hostedMailboxItem.create", 3);
+      }),
+      runWithPrismaOperationTimings(second, async () => {
+        recordPrismaOperationTiming("hostedMemberRouting.findFirst", 5);
+        await Promise.resolve();
+      }),
+    ]);
+
+    expect(first).toEqual([{ key: "hostedMailboxItem.create", ms: 3 }]);
+    expect(second).toEqual([{ key: "hostedMemberRouting.findFirst", ms: 5 }]);
+  });
+});
+
+describe("hosted webhook db timing log details", () => {
+  it("builds flat details with count, total, and ordered per-operation keys", () => {
+    const details = buildHostedWebhookDbTimingLogDetails([
+      { key: "hostedMemberIdentity.findFirst", ms: 41.6 },
+      { key: "hostedMailboxItem.create", ms: 18.2 },
+    ]);
+
+    expect(details).toEqual({
+      "db00.hostedMemberIdentity.findFirst": 42,
+      "db01.hostedMailboxItem.create": 18,
+      dbOperationCount: 2,
+      dbTotalMs: 60,
+    });
+  });
+
+  it("marks truncation past the per-log operation cap", () => {
+    const operations = Array.from({ length: 30 }, (_, index) => ({
+      key: `hostedMailboxItem.op${index}`,
+      ms: 1,
+    }));
+
+    const details = buildHostedWebhookDbTimingLogDetails(operations);
+
+    expect(details.dbOperationCount).toBe(30);
+    expect(details.dbOperationsTruncated).toBe(true);
+    expect(details).toHaveProperty("db23.hostedMailboxItem.op23");
+    expect(details).not.toHaveProperty("db24.hostedMailboxItem.op24");
+  });
+});

--- a/apps/web/test/prisma-store-client.test.ts
+++ b/apps/web/test/prisma-store-client.test.ts
@@ -5,7 +5,9 @@ const {
   PrismaPg,
 } = vi.hoisted(() => {
   const PrismaClient = vi.fn().mockImplementation(function (options: unknown) {
-    return { $disconnect: vi.fn(), options };
+    const client: Record<string, unknown> = { $disconnect: vi.fn(), options };
+    client.$extends = vi.fn(() => client);
+    return client;
   });
   const PrismaPg = vi.fn().mockImplementation(function (options: unknown) {
     return { options };


### PR DESCRIPTION
## Why

The hot warm-container reply path is still ~2x too slow (~4.5s webhook→provider start; measured on prod traces from 2026-07-03 04:38 UTC and 160 warm wakes over the past week). The webhook plan transaction contributes ~0.9–1.15s of that, running ~15 serialized Prisma operations inside one interactive transaction, but current telemetry records only the step total — we cannot tell whether the cost is round-trip count or a specific slow query, so we cannot safely delete or collapse anything yet.

## What ships

- A Prisma client extension (`$allOperations`) that records each operation's wall time into an AsyncLocalStorage collector (`apps/web/src/lib/prisma-operation-timing.ts`). Pass-through when no collector is active.
- The hosted webhook plan transaction wrapper activates the collector and logs one flat `hosted-onboarding.webhook.plan-db` diagnostic per transaction: operation count, summed ms, and per-operation `dbNN.<model>.<operation>` entries in execution order (capped at 24, truncation flagged). Logs also fire when the transaction throws.
- Log content is operation names and durations only — no query text, args, or params.

## User-visible goal

Attribute the plan-transaction second precisely so the follow-up PR can cut webhook→reply latency with an evidence-backed collapse instead of guesses.

## Invariants to preserve

- No semantic change to any webhook plan path: the extension returns `query(args)` unchanged and the transaction wrapper's control flow is identical on success and failure.
- No PII or payload data in logs (operation identifiers and milliseconds only).
- Zero overhead outside webhook plan transactions (collector inactive → pass-through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785646928&installation_id=127572939&pr_number=370&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F370&signature=12e54e8c1decdb1bc7895ed4f53ef0e5182876de9c4a79f93f0aa9f147554f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->