### PR TITLE
fix(assistant): deliver progress updates in queue-only hosted auto-replies

### DIFF
--- a/packages/assistant-engine/src/assistant/delivery-service.ts
+++ b/packages/assistant-engine/src/assistant/delivery-service.ts
@@ -6,6 +6,7 @@ import {
   parseTelegramThreadTarget,
 } from '@murphai/messaging-ingress/telegram-webhook'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
+import { shouldCreateAssistantProgressDelivery } from './progress-constants.js'
 import { markAssistantFirstContactSeen } from './first-contact.js'
 import { ASSISTANT_FIRST_CONTACT_WELCOME_MESSAGE } from './first-contact-welcome.js'
 import { createHostedDeliveryId } from './hosted-delivery-id.js'
@@ -409,12 +410,19 @@ export async function deliverAssistantProgressUpdate(input: {
   turnId: string
 }): Promise<AssistantSession> {
   // Progress updates are ephemeral current-audience sends, not final-reply
-  // delivery or commit-aware outbox decisions.
-  if (!input.input.deliverResponse) {
-    return input.session
-  }
-  if (input.input.deliveryDispatchMode === 'queue-only') {
-    return input.session
+  // delivery or commit-aware outbox decisions. The caller gates on the same
+  // shared predicate before invoking, so failing it here means the delivery
+  // context diverged mid-send; fail loudly instead of returning a
+  // success-shaped no-op that the model reports to the user as "sent".
+  if (!shouldCreateAssistantProgressDelivery(input.input)) {
+    throw new VaultCliError(
+      'ASSISTANT_PROGRESS_DELIVERY_SUPPRESSED',
+      `Progress update suppressed: delivery context is not progress-eligible ` +
+      `(turn=${input.turnId} ordinal=${input.ordinal} ` +
+      `deliverResponse=${String(input.input.deliverResponse)} ` +
+      `dispatchMode=${String(input.input.deliveryDispatchMode)} ` +
+      `turnTrigger=${String(input.input.turnTrigger)}).`,
+    )
   }
 
   const deliveryFields = resolveAssistantCurrentAudienceDeliveryFields({
@@ -437,6 +445,17 @@ export async function deliverAssistantProgressUpdate(input: {
     deliveryFields,
     input: input.input,
   })
+  // Progress sends bypass the persisted outbox, so this dispatch summary is
+  // the only durable trace tying a "sent" tool result to a transport attempt.
+  const progressTurnId = input.turnId
+  const progressOrdinal = input.ordinal
+  console.warn(
+    'Assistant progress update dispatching ' +
+    `(turn=${progressTurnId} ordinal=${progressOrdinal} ` +
+    `channel=${String(messageDeliveryFields.channel)} ` +
+    `explicitTargetPresent=${Boolean(messageDeliveryFields.explicitTarget)} ` +
+    `threadIdPresent=${Boolean(messageDeliveryFields.threadId)}).`,
+  )
 
   const delivery = await sendAssistantOutboxDispatchMessage({
     ...(input.dependencies ? { dependencies: input.dependencies } : {}),
@@ -450,6 +469,16 @@ export async function deliverAssistantProgressUpdate(input: {
     vault: input.input.vault,
     signal: input.signal,
   })
+  console.warn(
+    'Assistant progress update dispatched ' +
+    `(turn=${progressTurnId} ordinal=${progressOrdinal} ` +
+    `deliveredTargetPresent=${Boolean(delivery.delivery?.target)} ` +
+    `providerMessageIdPresent=${Boolean(
+      delivery.delivery && 'providerMessageId' in delivery.delivery
+        ? delivery.delivery.providerMessageId
+        : null,
+    )}).`,
+  )
   return delivery.session ?? input.session
 }
 

--- a/packages/assistant-engine/src/assistant/progress-constants.ts
+++ b/packages/assistant-engine/src/assistant/progress-constants.ts
@@ -1,2 +1,36 @@
+import type {
+  AssistantCodexTurnPromptProfile,
+  AssistantCodexTurnToolProfile,
+} from './codex-turn/planning.js'
+import type {
+  AssistantMessageInput,
+} from './service-contracts.js'
+
 export const MAX_PROGRESS_UPDATES_PER_TURN = 2
 export const MIN_PROGRESS_UPDATE_SPACING_MS = 2 * 60 * 1000
+
+export function shouldCreateAssistantProgressDelivery(
+  input: Pick<
+    AssistantMessageInput,
+    'channel' | 'deliverResponse' | 'deliveryDispatchMode' | 'turnTrigger'
+  >,
+  profile?: {
+    promptProfile?: AssistantCodexTurnPromptProfile | null
+    toolProfile?: AssistantCodexTurnToolProfile | null
+  } | null,
+): boolean {
+  // Queue-only dispatch means the outbox owns final-reply delivery, which is
+  // how every hosted-runner turn runs. Progress updates are ephemeral
+  // current-audience sends that cannot be queued (they would arrive after the
+  // final reply), so queue-only suppresses them only when no user is actively
+  // waiting: an auto-reply turn answers a live inbound message, while cron
+  // and other background turns have no current audience.
+  const queueOnlySuppressesProgress =
+    input.deliveryDispatchMode === 'queue-only' &&
+    input.turnTrigger !== 'automation-auto-reply'
+  return input.deliverResponse === true &&
+    !queueOnlySuppressesProgress &&
+    input.channel !== 'email' &&
+    (profile?.toolProfile ?? 'provider-turn') === 'provider-turn' &&
+    (profile?.promptProfile ?? 'conversation') !== 'notification-decision'
+}

--- a/packages/assistant-engine/src/assistant/turn-progress.ts
+++ b/packages/assistant-engine/src/assistant/turn-progress.ts
@@ -16,6 +16,7 @@ import {
 import {
   MAX_PROGRESS_UPDATES_PER_TURN,
   MIN_PROGRESS_UPDATE_SPACING_MS,
+  shouldCreateAssistantProgressDelivery,
 } from './progress-constants.js'
 import {
   normalizeNullableString,
@@ -70,22 +71,23 @@ type AssistantProgressDeliveryContext = {
 }
 type AssistantProgressDeliverInput = Parameters<DeliverAssistantProgressUpdate>[0]
 
-export function shouldCreateAssistantProgressDelivery(
-  input: Pick<
-    AssistantMessageInput,
-    'channel' | 'deliverResponse' | 'deliveryDispatchMode' | 'turnTrigger'
-  >,
-  profile?: {
-    promptProfile?: AssistantCodexTurnPromptProfile | null
-    toolProfile?: AssistantCodexTurnToolProfile | null
-  } | null,
-): boolean {
-  return input.deliverResponse === true &&
-    input.deliveryDispatchMode !== 'queue-only' &&
-    input.channel !== 'email' &&
-    (profile?.toolProfile ?? 'provider-turn') === 'provider-turn' &&
-    (profile?.promptProfile ?? 'conversation') !== 'notification-decision'
+// Progress updates are best-effort and every suppressed send used to vanish
+// without a trace, which made "model says sent, user saw nothing" undebuggable.
+// Log one line per send attempt outcome; never include the update text itself.
+function logAssistantProgressSendOutcome(details: {
+  ordinal: number
+  outcome: string
+  source: string
+  textLength: number
+  turnId: string
+}): void {
+  console.warn(
+    `Assistant progress update ${details.outcome} ` +
+    `(turn=${details.turnId} ordinal=${details.ordinal} source=${details.source} textLength=${details.textLength}).`,
+  )
 }
+
+export { shouldCreateAssistantProgressDelivery } from './progress-constants.js'
 
 export function createAssistantProductFeedbackRecorder(input: {
   acceptedInputItems?: readonly AssistantAcceptedTurnInputItemInput[] | null
@@ -147,7 +149,16 @@ export function createAssistantProgressDelivery(input: {
     async send(rawText: string, options?: AssistantProgressDeliverySendOptions) {
       const source = options?.source ?? 'model'
       const required = options?.required === true
+      const logOutcome = (outcome: string) =>
+        logAssistantProgressSendOutcome({
+          ordinal: deliveryOrdinal,
+          outcome,
+          source,
+          textLength: rawText.length,
+          turnId: input.turnId,
+        })
       if (abortController.signal.aborted) {
+        logOutcome('failed: delivery already closed')
         return {
           kind: 'failed',
           source,
@@ -155,6 +166,7 @@ export function createAssistantProgressDelivery(input: {
       }
       const text = normalizeAssistantProgressText(rawText)
       if (!text || (!required && sentTexts.has(text))) {
+        logOutcome(`skipped: ${text ? 'duplicate' : 'empty'}`)
         return {
           kind: 'skipped',
           reason: text ? 'duplicate' : 'empty',
@@ -166,6 +178,12 @@ export function createAssistantProgressDelivery(input: {
         session: input.session,
       }
       if (!shouldCreateAssistantProgressDelivery(deliveryContext.messageInput)) {
+        logOutcome(
+          'skipped: unavailable ' +
+          `(deliverResponse=${String(deliveryContext.messageInput.deliverResponse)} ` +
+          `dispatchMode=${String(deliveryContext.messageInput.deliveryDispatchMode)} ` +
+          `channel=${String(deliveryContext.messageInput.channel)})`,
+        )
         return {
           kind: 'skipped',
           reason: 'unavailable',
@@ -173,6 +191,7 @@ export function createAssistantProgressDelivery(input: {
         }
       }
       if (!required && sentCount >= MAX_PROGRESS_UPDATES_PER_TURN) {
+        logOutcome(`skipped: limit (${sentCount}/${MAX_PROGRESS_UPDATES_PER_TURN})`)
         return {
           kind: 'skipped',
           reason: 'limit',
@@ -185,6 +204,10 @@ export function createAssistantProgressDelivery(input: {
         lastSentAtMs !== null &&
         currentTimeMs - lastSentAtMs < MIN_PROGRESS_UPDATE_SPACING_MS
       ) {
+        logOutcome(
+          `skipped: too-soon (${currentTimeMs - lastSentAtMs}ms since last, ` +
+          `minimum ${MIN_PROGRESS_UPDATE_SPACING_MS}ms)`,
+        )
         return {
           kind: 'skipped',
           reason: 'too-soon',
@@ -212,6 +235,7 @@ export function createAssistantProgressDelivery(input: {
         }
         const deliveredSession = await deliver(progressInput)
         input.onDeliveredSession?.(deliveredSession)
+        logOutcome('sent')
         return {
           kind: 'sent',
           source,
@@ -221,6 +245,7 @@ export function createAssistantProgressDelivery(input: {
           error,
           operation: 'progress update delivery',
         })
+        logOutcome('failed: delivery threw')
         return {
           kind: 'failed',
           source,

--- a/packages/assistant-engine/test/assistant-codex-commentary-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-commentary-real-e2e.test.ts
@@ -1,0 +1,113 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  executeCodexAppServerTurn,
+  resolveMurphDynamicTools,
+} from '../src/assistant-codex.ts'
+
+const RUN_REAL_CODEX_E2E = process.env.MURPH_RUN_REAL_CODEX_E2E === '1'
+const describeRealCodex = RUN_REAL_CODEX_E2E ? describe : describe.skip
+
+const ENV_ALLOWLIST = [
+  'PATH', 'TMPDIR', 'TMP', 'TEMP', 'LANG', 'LC_ALL', 'LC_CTYPE',
+  'SSL_CERT_FILE', 'SSL_CERT_DIR', 'NODE_EXTRA_CA_CERTS',
+] as const
+
+const temporaryPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map(async (target) => {
+    await rm(target, { force: true, recursive: true }).catch(() => undefined)
+  }))
+})
+
+// GPT-5.5 emits mid-turn user-visible updates as commentary-phase agent
+// messages rather than calling the murph.send_progress_update tool. This
+// real-binary test proves the whole chain: the app-server surfaces the phase
+// on item/completed, normalization classifies it, and the turn routes the
+// commentary text into progress delivery while keeping it out of the final
+// reply. A silent regression here strands members with no mid-turn updates.
+describeRealCodex('real Codex commentary phase progress delivery e2e', () => {
+  it('routes commentary-phase agent messages into progress delivery', async () => {
+    const codexHome = await mkdtemp(path.join(tmpdir(), 'murph-commentary-e2e-'))
+    temporaryPaths.push(codexHome)
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-commentary-e2e-wd-'),
+    )
+    temporaryPaths.push(workingDirectory)
+    await mkdir(codexHome, { recursive: true })
+    await writeFile(path.join(codexHome, 'config.toml'), [
+      'model = "gpt-5.5"',
+      'model_provider = "openai-env"',
+      'model_reasoning_effort = "low"',
+      'approval_policy = "never"',
+      'sandbox_mode = "workspace-write"',
+      'allow_login_shell = false',
+      '',
+      '[shell_environment_policy]',
+      'inherit = "all"',
+      'ignore_default_excludes = false',
+      `include_only = [${ENV_ALLOWLIST.map((key) => JSON.stringify(key)).join(', ')}]`,
+      '',
+      '[model_providers."openai-env"]',
+      'name = "OpenAI"',
+      'base_url = "https://api.openai.com/v1"',
+      'env_key = "OPENAI_API_KEY"',
+      'wire_api = "responses"',
+      'request_max_retries = 4',
+      'stream_max_retries = 5',
+      'supports_websockets = false',
+      '',
+    ].join('\n'), { encoding: 'utf8', mode: 0o600 })
+
+    const env: NodeJS.ProcessEnv = {}
+    for (const key of ENV_ALLOWLIST) {
+      if (process.env[key]?.trim()) {
+        env[key] = process.env[key]
+      }
+    }
+    env.OPENAI_API_KEY = process.env.OPENAI_API_KEY
+
+    const progressSends: Array<{ source: string; text: string }> = []
+    const progressDelivery = {
+      async send(text: string, options?: { source?: string }) {
+        const source = options?.source ?? 'model'
+        progressSends.push({ source, text })
+        return { kind: 'sent' as const, source: source as 'model' }
+      },
+      close() {},
+    }
+
+    const result = await executeCodexAppServerTurn({
+      approvalPolicy: 'never',
+      codexHome,
+      env,
+      excludeResumeTurns: true,
+      model: 'gpt-5.5',
+      modelProvider: 'openai-env',
+      progressDelivery,
+      prompt: [
+        'Multi-step task: first send a short mid-turn commentary/progress',
+        'message that says exactly PROBE_COMMENTARY_ALPHA, then run a shell',
+        'command like `echo probe`, and finally reply with the final answer',
+        'exactly PROBE_FINAL_OMEGA.',
+      ].join(' '),
+      reasoningEffort: 'low',
+      sandbox: 'workspace-write',
+      workingDirectory,
+      dynamicTools: resolveMurphDynamicTools({
+        progressUpdatesAvailable: true,
+      }),
+    })
+
+    expect(result.finalMessage).toContain('PROBE_FINAL_OMEGA')
+    expect(result.finalMessage).not.toContain('PROBE_COMMENTARY_ALPHA')
+    expect(
+      progressSends.some((send) => send.text.includes('PROBE_COMMENTARY_ALPHA')),
+    ).toBe(true)
+  }, 240_000)
+})

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -4823,7 +4823,11 @@ test('sendAssistantMessageLocal probes active-turn input once before provider st
   ])
 })
 
-test('sendAssistantMessageLocal suppresses hosted progress in queue-only auto-replies', async () => {
+// Hosted-runner turns always run queue-only (the outbox owns final-reply
+// delivery), including interactive auto-replies where a member is actively
+// waiting. Progress delivery must stay wired there so mid-turn updates and
+// commentary-phase messages reach the member instead of silently vanishing.
+test('sendAssistantMessageLocal keeps hosted progress wired in queue-only auto-replies', async () => {
   const context = await createTempVaultContext(
     'assistant-local-service-hosted-auto-reply-progress-',
   )
@@ -4872,11 +4876,9 @@ test('sendAssistantMessageLocal suppresses hosted progress in queue-only auto-re
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.progressDelivery
   const hostedToolContext =
     mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.hostedToolContext
-  assert.equal(progressDelivery, null)
+  assert.ok(progressDelivery, 'queue-only auto-reply turns keep progress delivery wired')
   assert.ok(hostedToolContext)
   assert.equal(hostedToolContext.computerToolsAvailable, true)
-  assert.equal(mocks.deliverAssistantProgressUpdate.mock.calls.length, 0)
-  assert.equal(progressDeliveryDependencies.sendLinq.mock.calls.length, 0)
   assert.equal(mocks.dispatchAssistantReply.mock.calls.length, 1)
 })
 

--- a/packages/assistant-engine/test/assistant-outbox-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-outbox-runtime.test.ts
@@ -2821,6 +2821,35 @@ describe('assistant outbox runtime', () => {
     expect(deliveryDependencies?.signal?.aborted).toBe(true)
   })
 
+  // Direct callers must get a loud typed failure for progress-ineligible
+  // contexts instead of the success-shaped silent no-op that previously made
+  // the model report undelivered updates as "sent". The only production
+  // caller invokes this inside createAssistantProgressDelivery's try/catch,
+  // which converts the throw into a structured best-effort failure, so the
+  // enclosing turn never fails.
+  it('rejects progress delivery for non-eligible contexts without dispatching', async () => {
+    const { vaultRoot } = await createAssistantVault('assistant-progress-suppressed-')
+
+    await expect(deliverAssistantProgressUpdate({
+      input: {
+        ...createMessageInput(vaultRoot),
+        deliveryDispatchMode: 'queue-only',
+        turnTrigger: 'automation-cron',
+      },
+      ordinal: 0,
+      session: createAssistantSession({
+        sessionId: 'session-progress-suppressed',
+      }),
+      sharedPlan: createSharedPlan(),
+      text: 'Checking current context.',
+      turnId: 'turn-progress-suppressed',
+    })).rejects.toMatchObject({
+      code: 'ASSISTANT_PROGRESS_DELIVERY_SUPPRESSED',
+    })
+
+    expect(mockedDeliverAssistantMessageOverBinding).not.toHaveBeenCalled()
+  })
+
   it('drains only due intents and summarizes mixed outbox states', async () => {
     const { vaultRoot } = await createAssistantVault('assistant-outbox-drain-')
     vi.useFakeTimers()

--- a/packages/assistant-engine/test/assistant-turn-progress.test.ts
+++ b/packages/assistant-engine/test/assistant-turn-progress.test.ts
@@ -380,6 +380,48 @@ describe('assistant turn progress', () => {
       ),
     ).toBe(false)
   })
+
+  it('keeps queue-only auto-reply turns progress-eligible', () => {
+    // Hosted-runner turns always dispatch final replies queue-only through the
+    // outbox, including interactive auto-replies where a user is waiting.
+    // Progress updates are ephemeral direct sends and must stay available
+    // there, while queue-only background turns (cron and similar) stay
+    // suppressed because no current audience is waiting.
+    expect(
+      shouldCreateAssistantProgressDelivery(
+        createMessageInput({
+          deliveryDispatchMode: 'queue-only',
+          turnTrigger: 'automation-auto-reply',
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      shouldCreateAssistantProgressDelivery(
+        createMessageInput({
+          deliveryDispatchMode: 'queue-only',
+          turnTrigger: 'automation-cron',
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      shouldCreateAssistantProgressDelivery(
+        createMessageInput({
+          channel: 'email',
+          deliveryDispatchMode: 'queue-only',
+          turnTrigger: 'automation-auto-reply',
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      shouldCreateAssistantProgressDelivery(
+        createMessageInput({
+          deliverResponse: false,
+          deliveryDispatchMode: 'queue-only',
+          turnTrigger: 'automation-auto-reply',
+        }),
+      ),
+    ).toBe(false)
+  })
 })
 
 function createMessageInput(


### PR DESCRIPTION
## Why this PR exists

Hosted members saw long silent waits during slow turns (onboarding lab/supplement ingestion especially): Murph's mid-turn progress updates never arrived, and the model believed it had sent them. Live container rollouts showed GPT-5.5 emitting progress text as commentary-phase agent messages that Murph normalized correctly and then dropped, because every hosted-runner turn runs `deliveryDispatchMode: queue-only` and the progress eligibility gate treated all queue-only turns as progress-ineligible. With `progressDelivery` null, the `send_progress_update` tool was never offered either, so both progress paths were dead on hosted.

## User-visible goal

During a hosted interactive reply (a member is actively waiting), Murph's mid-turn progress updates — whether sent via the `send_progress_update` tool or emitted as GPT-5.5 commentary-phase messages — are delivered to the member's channel immediately, subject to the existing per-turn limit, spacing, and dedupe rules. Verified live on the dev stack: a Telegram progress update was delivered with a provider message id before the final reply.

## What changed

- `shouldCreateAssistantProgressDelivery`: queue-only dispatch suppresses progress only when the turn has no active audience — `automation-auto-reply` turns stay progress-eligible; cron/background turns remain suppressed. The predicate moved to `progress-constants.ts` as the single source of truth.
- `deliverAssistantProgressUpdate` now shares that predicate and fails loudly (typed `ASSISTANT_PROGRESS_DELIVERY_SUPPRESSED`) instead of returning success-shaped silent no-ops the model reported to users as "sent".
- Every progress send attempt logs a metadata-only outcome line (sent / skipped with reason / failed, plus a dispatch summary with channel and target presence booleans) — the whole surface was previously unobservable.
- New gated real-binary e2e (`assistant-codex-commentary-real-e2e.test.ts`, `MURPH_RUN_REAL_CODEX_E2E=1`) proves commentary-phase agent messages route into progress delivery and stay out of the final reply.

## Invariants to preserve

- Final-reply delivery ownership is unchanged: queue-only turns still deliver final replies exclusively through the outbox with its retry/receipt machinery.
- Progress updates remain best-effort ephemeral sends: bounded by MAX_PROGRESS_UPDATES_PER_TURN (2), 2-minute spacing, and duplicate suppression; a progress failure never fails the turn.
- Background/cron turns and notification-decision/email contexts must never emit mid-turn progress sends.
- No message text, health data, or identifiers in the new log lines — metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785649153&installation_id=127572939&pr_number=372&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F372&signature=3fe2ea1534d45dd459414d6679c49781b0f4494b8de2cd2633b63c30550ef901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->