### PR TITLE
Update hosted E2E expectations to the delivered-progress contract

### DIFF
--- a/apps/cloudflare/test/hosted-local-codex-image-media-delivery-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-codex-image-media-delivery-e2e.test.ts
@@ -137,7 +137,7 @@ describe("hosted local Codex image media delivery e2e", () => {
       computerToolsAvailable: true,
       connectedAppsAvailable: true,
       phoneCallsAvailable: true,
-      progressUpdatesAvailable: false,
+      progressUpdatesAvailable: true,
       vaultFileSendAvailable: true,
     });
   }, 300_000);

--- a/apps/cloudflare/test/hosted-local-linq-first-contact-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-first-contact-e2e.test.ts
@@ -271,7 +271,7 @@ productionDescribe("hosted local Linq first-contact e2e", () => {
     });
   }, 300_000);
 
-  it("suppresses model-authored progress updates from hosted queue-only Linq auto-replies", async () => {
+  it("delivers model-authored progress updates ahead of the final reply in hosted queue-only Linq auto-replies", async () => {
     await requireScenario().seedActiveHostedLinqMember({
       homePhone: buildLinqHomePhoneNumber(progressToolUserId),
       memberId: progressToolUserId,
@@ -330,7 +330,7 @@ productionDescribe("hosted local Linq first-contact e2e", () => {
     const completionPromise = requireScenario()
       .waitForHostedCompletion(progressToolUserId);
     const matchingSends = await requireLinqStub().waitForMatchingSendCount({
-      expectedCount: outboundCountBeforeReply + 1,
+      expectedCount: outboundCountBeforeReply + 2,
       expectedPath: expectedDirectReplyChatPath,
       scenario: requireScenario(),
       userId: progressToolUserId,
@@ -342,14 +342,16 @@ productionDescribe("hosted local Linq first-contact e2e", () => {
       matchingSends
         .slice(outboundCountBeforeReply)
         .map((request) => request.authorizationStatus),
-    ).toEqual(["hosted-sentinel"]);
-    expect(newSendTexts).toEqual([progressToolFinalReplyText]);
+    ).toEqual(["hosted-sentinel", "hosted-sentinel"]);
+    // Queue-only auto-replies now deliver the mid-turn progress update
+    // (send_progress_update) before the outbox-delivered final reply.
+    expect(newSendTexts).toEqual([progressToolAttemptText, progressToolFinalReplyText]);
 
     const finalStatus = await completionPromise;
     expect(finalStatus.lastErrorCode ?? null).toBeNull();
     expect(finalStatus.mailboxLag.every((lane) => lane.lag === "0")).toBe(true);
     expect(requireLinqStub().countObservedSends(expectedDirectReplyChatPath)).toBe(
-      outboundCountBeforeReply + 1,
+      outboundCountBeforeReply + 2,
     );
   }, 300_000);
 
@@ -684,7 +686,7 @@ productionDescribe("hosted local Linq first-contact e2e", () => {
       computerToolsAvailable: true,
       connectedAppsAvailable: true,
       phoneCallsAvailable: true,
-      progressUpdatesAvailable: false,
+      progressUpdatesAvailable: true,
       vaultFileSendAvailable: true,
     });
     expect(requireScenario().runtimeEnv.HOSTED_ASSISTANT_API_KEY_ENV).toBeUndefined();

--- a/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
@@ -230,7 +230,7 @@ describe("hosted local Telegram auto-reply e2e", () => {
       connectedAppsAvailable: true,
       messageReactionsAvailable: true,
       phoneCallsAvailable: true,
-      progressUpdatesAvailable: false,
+      progressUpdatesAvailable: true,
     });
 
     const reactionRequests = await requireTelegramStub().waitForRequestCount({


### PR DESCRIPTION
## Why

PR #372 deliberately reversed progress-update suppression for hosted queue-only auto-replies (progress updates are now delivered and `send_progress_update` is advertised on interactive turns), but three hosted-local E2E scenarios still assert the old suppression contract. Main is red on those three jobs and the Cloudflare Hosted Execution deploy is blocked at its Linq delivery E2E gate.

## What ships

Test-only updates to the new intended contract:
- Linq first-contact: the queue-only auto-reply scenario now expects the mid-turn progress text delivered ahead of the outbox final reply (two sends, both sentinel-authorized), renamed accordingly.
- Linq first-contact, Telegram first-contact, Codex image-media: `progressUpdatesAvailable: true` in the advertised-tools assertion for interactive auto-reply turns. Cron/background suppression expectations are untouched.

## User-visible goal

Unblock main CI and the Cloudflare deploy gate so #372's fix (members no longer wait in silence during slow turns) actually ships, and unblock queued PRs.

## Invariants to preserve

- Only interactive auto-reply scenarios gain the progress expectation; background/cron scenarios keep suppression.
- No runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785651976&installation_id=127572939&pr_number=373&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F373&signature=5b7b17a342385e7bad8884849aee08428fe0430ffc42121b500e75215bca2b59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->