### PR TITLE
Clarify family invite sharing

### DIFF
--- a/apps/web/src/components/settings/hosted-family-settings-actions.tsx
+++ b/apps/web/src/components/settings/hosted-family-settings-actions.tsx
@@ -42,6 +42,15 @@ export interface FamilyManagerInvite {
   telegramInviteUrl: string | null;
 }
 
+interface CreatedFamilyInvite {
+  acceptUrl: string | null;
+  id: string;
+  targetLabel: string | null;
+  targetPhoneHint: string | null;
+  targetTelegramUsername?: string | null;
+  telegramInviteUrl: string | null;
+}
+
 function inviteContacts(invite: FamilyManagerInvite): string[] {
   return [
     invite.targetEmail,
@@ -52,6 +61,17 @@ function inviteContacts(invite: FamilyManagerInvite): string[] {
 
 function inviteDisplayName(invite: FamilyManagerInvite): string {
   return invite.targetLabel ?? inviteContacts(invite)[0] ?? "Pending invite";
+}
+
+function inviteShareLink(invite: {
+  acceptUrl: string | null;
+  targetTelegramUsername?: string | null;
+  telegramInviteUrl: string | null;
+}): string | null {
+  if (invite.targetTelegramUsername && invite.telegramInviteUrl) {
+    return invite.telegramInviteUrl;
+  }
+  return invite.acceptUrl ?? invite.telegramInviteUrl;
 }
 
 type PendingAction =
@@ -138,6 +158,8 @@ export function HostedFamilyManager(props: {
   const [email, setEmail] = useState("");
   const [isInviting, setIsInviting] = useState(false);
   const [inviteError, setInviteError] = useState<string | null>(null);
+  const [createdInvite, setCreatedInvite] = useState<CreatedFamilyInvite | null>(null);
+  const [createdInviteCopied, setCreatedInviteCopied] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [isActing, setIsActing] = useState(false);
@@ -151,6 +173,8 @@ export function HostedFamilyManager(props: {
   // paid CTA (and the addSeatIfNeeded flag) require a phone, email, or Telegram.
   const hasStableTarget = Boolean(phone.trim() || email.trim() || telegram.trim());
   const inviteWillAddSeat = planCanGrow && hasStableTarget;
+  const inviteNeedsStableTargetForSeat = planCanGrow && !hasStableTarget;
+  const inviteSubmitDisabled = isInviting || inviteNeedsStableTargetForSeat;
   const inviteDisabled = !props.billingActive || props.seats.used >= props.seats.max;
   const canRemoveSeat =
     props.billingActive &&
@@ -163,6 +187,8 @@ export function HostedFamilyManager(props: {
     setTelegram("");
     setEmail("");
     setInviteError(null);
+    setCreatedInvite(null);
+    setCreatedInviteCopied(false);
   }
 
   async function submitInvite() {
@@ -171,9 +197,13 @@ export function HostedFamilyManager(props: {
       return;
     }
     setInviteError(null);
+    setCreatedInvite(null);
+    setCreatedInviteCopied(false);
     setIsInviting(true);
     try {
-      await requestHostedOnboardingJson({
+      const response = await requestHostedOnboardingJson<{
+        invite: CreatedFamilyInvite;
+      }>({
         method: "POST",
         payload: {
           // Only authorize buying a seat when the dialog actually showed the
@@ -186,8 +216,10 @@ export function HostedFamilyManager(props: {
         },
         url: "/api/settings/billing/family/invite",
       });
-      setInviteOpen(false);
-      resetInviteForm();
+      setCreatedInvite({
+        ...response.invite,
+        targetTelegramUsername: telegram.trim().replace(/^@/, "") || null,
+      });
       router.refresh();
     } catch (error) {
       // The seat was added but Stripe is still confirming: refresh so the new
@@ -255,7 +287,7 @@ export function HostedFamilyManager(props: {
   }
 
   async function copyInviteLink(invite: FamilyManagerInvite) {
-    const link = invite.acceptUrl ?? invite.telegramInviteUrl;
+    const link = inviteShareLink(invite);
     if (!link) {
       return;
     }
@@ -266,6 +298,28 @@ export function HostedFamilyManager(props: {
     } catch {
       setCopiedId(null);
     }
+  }
+
+  async function copyCreatedInviteLink() {
+    if (!createdInvite) {
+      return;
+    }
+    const link = inviteShareLink(createdInvite);
+    if (!link) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(link);
+      setCreatedInviteCopied(true);
+      window.setTimeout(() => setCreatedInviteCopied(false), 2_000);
+    } catch {
+      setCreatedInviteCopied(false);
+    }
+  }
+
+  function closeInviteDialog() {
+    setInviteOpen(false);
+    resetInviteForm();
   }
 
   return (
@@ -281,7 +335,7 @@ export function HostedFamilyManager(props: {
           <p className="text-xs text-muted-foreground">
             {seatsFull
               ? planCanGrow
-                ? `No open seats. Inviting adds a paid seat at ${props.seatPrice}.`
+                ? `No open seats. Invites with a phone, email, or Telegram add a paid seat at ${props.seatPrice}.`
                 : "All seats are full. Remove a member or cancel an invite to free one."
               : `${props.seats.remaining} paid ${props.seats.remaining === 1 ? "seat" : "seats"} open`}
           </p>
@@ -371,7 +425,7 @@ export function HostedFamilyManager(props: {
         ))}
 
         {props.invites.map((invite) => {
-          const link = invite.acceptUrl ?? invite.telegramInviteUrl;
+          const link = inviteShareLink(invite);
           const secondary = invite.targetLabel ? inviteContacts(invite)[0] ?? null : null;
           return (
             <tr key={invite.id}>
@@ -437,110 +491,162 @@ export function HostedFamilyManager(props: {
         </p>
       ) : null}
 
-      <Dialog open={inviteOpen} onOpenChange={(open) => { if (!open) { setInviteOpen(false); resetInviteForm(); } }}>
+      <Dialog open={inviteOpen} onOpenChange={(open) => { if (!open) { closeInviteDialog(); } }}>
         <DialogContent className={DIALOG_CLASS}>
           <DialogHeader className="pr-10">
             <DialogTitle className="font-serif text-2xl/7 font-semibold tracking-normal text-[#2d3436]">
-              Invite a family member
+              {createdInvite ? "Invite created" : "Invite a family member"}
             </DialogTitle>
             <DialogDescription className="text-sm leading-6 text-[#736a58]">
-              They join from their own phone or Telegram. Their Murph stays private to them.
+              {createdInvite
+                ? "Murph did not text them automatically. Copy the invite and send it yourself."
+                : "Create a private invite, then send the link yourself by text, email, or Telegram. Murph will not message them automatically."}
             </DialogDescription>
           </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="family-invite-label">Name (optional)</Label>
-              <Input
-                id="family-invite-label"
-                value={label}
-                onChange={(event) => setLabel(event.target.value)}
-                placeholder="Mom"
-                autoComplete="off"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="family-invite-phone">Phone number</Label>
-              <Input
-                id="family-invite-phone"
-                value={phone}
-                onChange={(event) => setPhone(event.target.value)}
-                placeholder="+1 555 000 1234"
-                inputMode="tel"
-                autoComplete="off"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="family-invite-email">Email (optional)</Label>
-              <Input
-                id="family-invite-email"
-                type="email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                placeholder="mom@example.com"
-                inputMode="email"
-                autoComplete="off"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="family-invite-telegram">Telegram username (optional)</Label>
-              <Input
-                id="family-invite-telegram"
-                value={telegram}
-                onChange={(event) => setTelegram(event.target.value)}
-                placeholder="@username"
-                autoComplete="off"
-              />
-            </div>
-            <p className="text-xs leading-5 text-[#736a58]">
-              Add a phone, email, or Telegram username so they can join.
-            </p>
-            {inviteWillAddSeat ? (
-              <p
-                role="status"
-                className="rounded-lg border border-[#c4a882]/25 bg-[#fffcf6] p-3 text-xs leading-5 text-[#736a58]"
+          {createdInvite ? (
+            <div className="flex flex-col gap-4">
+              <div className="rounded-lg border border-[#c4a882]/25 bg-[#f5f0e8] p-4">
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
+                    <Check className="size-4" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-[#2d3436]">
+                      Send this invite to {createdInvite.targetLabel ?? createdInvite.targetPhoneHint ?? "your family member"}.
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-[#736a58]">
+                      Phone, email, and Telegram only bind who can accept the invite. They do not trigger an automatic outbound message.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <Button
+                type="button"
+                size="xl"
+                onClick={() => void copyCreatedInviteLink()}
+                disabled={!inviteShareLink(createdInvite)}
+                className="w-full"
               >
-                No open seats — inviting adds a paid seat at {props.seatPrice}.
-              </p>
-            ) : null}
-          </div>
+                {createdInviteCopied ? (
+                  <>
+                    <Check className="size-4" aria-hidden="true" /> Copied invite link
+                  </>
+                ) : (
+                  <>
+                    <Copy className="size-4" aria-hidden="true" /> Copy invite link
+                  </>
+                )}
+              </Button>
+              <Button type="button" size="xl" variant="ghost" onClick={closeInviteDialog} className="w-full">
+                Done
+              </Button>
+            </div>
+          ) : (
+            <>
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="family-invite-label">Name (optional)</Label>
+                  <Input
+                    id="family-invite-label"
+                    value={label}
+                    onChange={(event) => setLabel(event.target.value)}
+                    placeholder="Mom"
+                    autoComplete="off"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="family-invite-phone">Phone number (optional)</Label>
+                  <Input
+                    id="family-invite-phone"
+                    value={phone}
+                    onChange={(event) => setPhone(event.target.value)}
+                    placeholder="+1 555 000 1234"
+                    inputMode="tel"
+                    autoComplete="off"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="family-invite-email">Email (optional)</Label>
+                  <Input
+                    id="family-invite-email"
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    placeholder="mom@example.com"
+                    inputMode="email"
+                    autoComplete="off"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="family-invite-telegram">Telegram username (optional)</Label>
+                  <Input
+                    id="family-invite-telegram"
+                    value={telegram}
+                    onChange={(event) => setTelegram(event.target.value)}
+                    placeholder="@username"
+                    autoComplete="off"
+                  />
+                </div>
+                <p className="text-xs leading-5 text-[#736a58]">
+                  These fields bind the invite. After creation, copy the link and send it yourself.
+                </p>
+                {inviteWillAddSeat ? (
+                  <p
+                    role="status"
+                    className="rounded-lg border border-[#c4a882]/25 bg-[#fffcf6] p-3 text-xs leading-5 text-[#736a58]"
+                  >
+                    No open seats — inviting adds a paid seat at {props.seatPrice}.
+                  </p>
+                ) : null}
+                {inviteNeedsStableTargetForSeat ? (
+                  <p
+                    role="status"
+                    className="rounded-lg border border-[#c4a882]/25 bg-[#fffcf6] p-3 text-xs leading-5 text-[#736a58]"
+                  >
+                    No open seats. Add a phone, email, or Telegram username to add a paid seat safely.
+                  </p>
+                ) : null}
+              </div>
 
-          {inviteError ? (
-            <p
-              role="alert"
-              className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive [overflow-wrap:anywhere]"
-            >
-              {inviteError}
-            </p>
-          ) : null}
+              {inviteError ? (
+                <p
+                  role="alert"
+                  className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive [overflow-wrap:anywhere]"
+                >
+                  {inviteError}
+                </p>
+              ) : null}
 
-          <div className="flex flex-col gap-2">
-            <Button
-              type="button"
-              size="xl"
-              onClick={() => void submitInvite()}
-              disabled={isInviting}
-              className="w-full"
-            >
-              {isInviting ? (
-                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-              ) : inviteWillAddSeat ? (
-                `Invite & add seat · ${props.seatPrice}`
-              ) : (
-                "Create invite"
-              )}
-            </Button>
-            <Button
-              type="button"
-              size="xl"
-              variant="ghost"
-              onClick={() => { setInviteOpen(false); resetInviteForm(); }}
-              disabled={isInviting}
-              className="w-full"
-            >
-              Cancel
-            </Button>
-          </div>
+              <div className="flex flex-col gap-2">
+                <Button
+                  type="button"
+                  size="xl"
+                  onClick={() => void submitInvite()}
+                  disabled={inviteSubmitDisabled}
+                  className="w-full"
+                >
+                  {isInviting ? (
+                    <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                  ) : inviteWillAddSeat ? (
+                    `Create invite & add seat · ${props.seatPrice}`
+                  ) : (
+                    "Create invite"
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  size="xl"
+                  variant="ghost"
+                  onClick={closeInviteDialog}
+                  disabled={isInviting}
+                  className="w-full"
+                >
+                  Cancel
+                </Button>
+              </div>
+            </>
+          )}
         </DialogContent>
       </Dialog>
 

--- a/apps/web/test/settings-hosted-family-manager.test.tsx
+++ b/apps/web/test/settings-hosted-family-manager.test.tsx
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+
+import {
+  act,
+  createElement,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { renderClientComponent } from "./render-client-component";
+
+const mocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  requestHostedOnboardingJson: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mocks.refresh,
+  }),
+}));
+
+vi.mock("@/src/components/hosted-onboarding/client-api", () => ({
+  HostedOnboardingApiError: class HostedOnboardingApiError extends Error {
+    readonly code: string | null;
+
+    constructor(input: { code?: string | null; message: string }) {
+      super(input.message);
+      this.code = input.code ?? null;
+    }
+  },
+  requestHostedOnboardingJson: mocks.requestHostedOnboardingJson,
+}));
+
+vi.mock("@/src/components/ui/dialog", () => ({
+  Dialog: ({
+    children,
+    open,
+  }: {
+    children?: ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => (open ? createElement("div", { "data-dialog-open": "true" }, children) : null),
+  DialogContent: ({ children, className }: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", { className, "data-dialog-content": "true" }, children),
+  DialogDescription: (props: HTMLAttributes<HTMLParagraphElement>) =>
+    createElement("p", props),
+  DialogHeader: (props: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props),
+  DialogTitle: (props: HTMLAttributes<HTMLHeadingElement>) =>
+    createElement("h2", props),
+}));
+
+vi.mock("@/src/components/ui/input", () => ({
+  Input: ({ onChange, ...props }: InputHTMLAttributes<HTMLInputElement>) =>
+    createElement("input", {
+      ...props,
+      onChange,
+      onInput: onChange,
+    }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requestHostedOnboardingJson.mockResolvedValue({
+    invite: {
+      acceptUrl: "https://app.murph.test/family/accept/NEWCODE",
+      id: "inv_new",
+      targetLabel: "Mom",
+      targetPhoneHint: "+48 6** *** ***",
+      telegramInviteUrl: "https://t.me/withmurph_bot?start=family_NEWCODE",
+    },
+  });
+});
+
+test("HostedFamilyManager keeps the created invite visible for manual sharing", async () => {
+  const writeText = vi.fn(() => Promise.resolve());
+  vi.useFakeTimers();
+
+  try {
+    const { HostedFamilyManager } = await import(
+      "@/src/components/settings/hosted-family-settings-actions"
+    );
+    const { cleanup, container, window } = await renderClientComponent(
+      createElement(HostedFamilyManager, baseFamilyManagerProps()),
+      { requireButton: false },
+    );
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    try {
+      await clickButton(container, window, "Invite member");
+      assert.match(container.textContent ?? "", /Murph will not message them automatically/);
+
+      await act(async () => {
+        setInputValue(window, inputById(container, "family-invite-phone"), "+48600000000");
+      });
+      await clickButton(container, window, "Create invite");
+
+      assert.match(container.textContent ?? "", /Invite created/);
+      assert.match(container.textContent ?? "", /Murph did not text them automatically/);
+      assert.match(container.textContent ?? "", /copy the invite and send it yourself/i);
+      expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            targetPhoneNumber: "+48600000000",
+          }),
+          url: "/api/settings/billing/family/invite",
+        }),
+      );
+      expect(mocks.refresh).toHaveBeenCalledTimes(1);
+
+      await clickButton(container, window, "Copy invite link");
+      expect(writeText).toHaveBeenCalledWith("https://app.murph.test/family/accept/NEWCODE");
+      assert.match(container.textContent ?? "", /Copied invite link/);
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+    } finally {
+      await cleanup();
+    }
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("HostedFamilyManager copies a Telegram deep link for Telegram-bound invites", async () => {
+  const writeText = vi.fn(() => Promise.resolve());
+  const { HostedFamilyManager } = await import(
+    "@/src/components/settings/hosted-family-settings-actions"
+  );
+  const { cleanup, container, window } = await renderClientComponent(
+    createElement(HostedFamilyManager, {
+      ...baseFamilyManagerProps(),
+      invites: [
+        {
+          acceptUrl: "https://app.murph.test/family/accept/TELEGRAM",
+          channel: "family",
+          expiresAtIso: "2026-07-30T00:00:00.000Z",
+          id: "inv_telegram",
+          targetEmail: null,
+          targetLabel: "Dad",
+          targetPhoneHint: null,
+          targetTelegramUsername: "dad_username",
+          telegramInviteUrl: "https://t.me/withmurph_bot?start=family_TELEGRAM",
+        },
+      ],
+    }),
+    { requireButton: false },
+  );
+  vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+  try {
+    await clickButton(container, window, "Copy link");
+
+    expect(writeText).toHaveBeenCalledWith(
+      "https://t.me/withmurph_bot?start=family_TELEGRAM",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("HostedFamilyManager requires a stable target before adding a paid seat", async () => {
+  const { HostedFamilyManager } = await import(
+    "@/src/components/settings/hosted-family-settings-actions"
+  );
+  const { cleanup, container, window } = await renderClientComponent(
+    createElement(HostedFamilyManager, {
+      ...baseFamilyManagerProps(),
+      seats: {
+        active: 1,
+        billed: 2,
+        invited: 1,
+        max: 6,
+        min: 2,
+        remaining: 0,
+        used: 2,
+      },
+    }),
+    { requireButton: false },
+  );
+
+  try {
+    assert.match(
+      container.textContent ?? "",
+      /Invites with a phone, email, or Telegram add a paid seat/,
+    );
+
+    await clickButton(container, window, "Invite member");
+    assert.match(container.textContent ?? "", /Add a phone, email, or Telegram username/);
+
+    await act(async () => {
+      setInputValue(window, inputById(container, "family-invite-label"), "Mom");
+    });
+    const labelOnlySubmit = buttonByText(container, "Create invite");
+    assert.equal(labelOnlySubmit.disabled, true);
+    expect(mocks.requestHostedOnboardingJson).not.toHaveBeenCalled();
+
+    await act(async () => {
+      setInputValue(window, inputById(container, "family-invite-phone"), "+48600000000");
+    });
+    const contactBoundSubmit = buttonByText(container, "Create invite & add seat");
+    assert.equal(contactBoundSubmit.disabled, false);
+
+    await clickButton(container, window, "Create invite & add seat");
+
+    expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          addSeatIfNeeded: true,
+          targetLabel: "Mom",
+          targetPhoneNumber: "+48600000000",
+        }),
+      }),
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+function baseFamilyManagerProps() {
+  return {
+    billingActive: true,
+    invites: [],
+    members: [
+      {
+        isOwner: true,
+        joinedAtIso: "2026-07-01T00:00:00.000Z",
+        label: null,
+        memberId: "member_owner",
+      },
+    ],
+    seatPrice: "$7/mo",
+    seats: {
+      active: 1,
+      billed: 2,
+      invited: 0,
+      max: 6,
+      min: 2,
+      remaining: 1,
+      used: 1,
+    },
+  };
+}
+
+async function clickButton(
+  container: HTMLElement,
+  window: Window & typeof globalThis,
+  label: string,
+) {
+  const button = buttonByText(container, label);
+  await act(async () => {
+    button.dispatchEvent(new window.Event("click", { bubbles: true }));
+  });
+}
+
+function buttonByText(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.includes(label),
+  );
+  assert.ok(button, `Expected button containing "${label}"`);
+  return button;
+}
+
+function inputById(container: HTMLElement, id: string): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>(`#${id}`);
+  assert.ok(input, `Expected input #${id}`);
+  return input;
+}
+
+function setInputValue(
+  window: Window & typeof globalThis,
+  input: HTMLInputElement,
+  value: string,
+) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  );
+  descriptor?.set?.call(input, value);
+  input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  input.dispatchEvent(new window.Event("change", { bubbles: true }));
+}


### PR DESCRIPTION
## Why this PR exists
Family plan owners can create an invite from settings, but the previous modal closed after creation and made it unclear whether Murph had texted the invitee or whether the owner needed to send the invite manually.

## User goal / user-visible behavior
After creating a Family invite, the modal stays open in an `Invite created` state. It explicitly says Murph did not text the invitee automatically, explains that phone/email/Telegram fields only bind who can accept, and gives the owner a `Copy invite link` button. Existing pending invites still expose copy, with Telegram-bound invites preferring the Telegram deep link.

## Invariants to preserve
- Creating a Family invite must not trigger automatic outbound SMS, WhatsApp, Telegram, or email delivery.
- Phone/email/Telegram invite targets bind acceptance eligibility only; they are not delivery confirmation.
- Family ownership still grants sponsored access only, not access to private health data or messages.
- Invite copy should avoid implying that a message was already sent.

## Verification
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/settings-hosted-family-manager.test.tsx`
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web lint` (passes with existing warnings)
- `git diff --check`

## Deployment skew / compatibility
Web-only UI/test change. No backend, schema, runtime, or deploy-boundary compatibility concern.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785653754&installation_id=127572939&pr_number=374&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F374&signature=228b56c4fe584c0db1a55659a684b3cc3a790e59299de22e38d1dda5d05a8b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->