### PR TITLE
Supersede the canned signup welcome once conversation has started

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-03-signup-welcome-supersede.md
+++ b/agent-docs/exec-plans/completed/2026-07-03-signup-welcome-supersede.md
@@ -1,0 +1,46 @@
+# Supersede the canned signup welcome once conversation has started
+
+## Problem
+
+When a hosted member verifies their number and texts before the queued signup
+welcome dispatches (~12s cold-start window), the runtime's conversation lane
+starves the system-lane welcome item. The welcome then lands minutes later,
+out of order, after the assistant has already onboarded the user organically
+(incident debugged 2026-07-03: welcome delivered 9
+minutes after activation, mid-conversation; see
+`agent-docs/exec-plans/active/2026-07-03-mailbox-wake-collapse.md` for the
+adjacent latency work).
+
+Root cause of the redundant send: the canned welcome's implicit validity
+condition — "this is the user's first contact" — is only recorded when the
+delivered reply text is exactly `ASSISTANT_FIRST_CONTACT_WELCOME_MESSAGE`
+(`packages/assistant-engine/src/assistant/delivery-service.ts`), so an organic
+onboarding reply never marks first contact, and the existing first-contact
+skip in `notification-turn.ts` cannot fire for the queued welcome.
+
+## Change
+
+1. `packages/assistant-engine/src/assistant/delivery-service.ts` — mark
+   first contact seen when any non-empty conversation reply with onboarding
+   guidance injected reaches an accepted delivery outcome, instead of only the
+   exact canned welcome text. No new state; per-route doc scoping unchanged.
+2. `packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts`
+   — when the signup-welcome notification is superseded by prior first
+   contact (skip decision), still seed the self-archiving onboarding
+   follow-up automation (product-critical flow preservation), and log the
+   notification decision kind so skips are observable.
+3. Matching engine + runtime tests proving: welcome still sends for a silent
+   signup; welcome skips after an organic onboarding reply on the same route;
+   follow-up automation is seeded on both paths.
+
+## Invariants
+
+- Welcome delivery stays intact for members who have not received any
+  assistant reply on the welcome route (Product-Critical Flow Preservation).
+- No new persisted state, queues, or wake machinery; reuse the existing
+  first-contact marker and notification-turn skip.
+- The supersede is per-route: conversation on a different channel/route does
+  not suppress the welcome.
+Status: completed
+Updated: 2026-07-03
+Completed: 2026-07-03

--- a/packages/assistant-engine/src/assistant/delivery-service.ts
+++ b/packages/assistant-engine/src/assistant/delivery-service.ts
@@ -8,7 +8,6 @@ import {
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import { shouldCreateAssistantProgressDelivery } from './progress-constants.js'
 import { markAssistantFirstContactSeen } from './first-contact.js'
-import { ASSISTANT_FIRST_CONTACT_WELCOME_MESSAGE } from './first-contact-welcome.js'
 import { createHostedDeliveryId } from './hosted-delivery-id.js'
 import {
   type AssistantOutboxDispatchMessage,
@@ -907,9 +906,12 @@ export async function finalizeAssistantTurnFromDeliveryOutcome(input: {
   const state = createAssistantRuntimeStateService(input.vault)
   await state.turns.finalizeReceipt(plan.receipt)
   await state.diagnostics.recordEvent(plan.diagnostic)
+  // Any accepted reply on a first-contact-scoped route is first contact, not
+  // just the canned welcome text: once the user has heard from the assistant
+  // here, a queued signup welcome for this route is stale and must skip.
   const firstContactAcceptedForDelivery =
     input.firstContactGuidanceInjected === true &&
-    input.response === ASSISTANT_FIRST_CONTACT_WELCOME_MESSAGE &&
+    input.response !== '' &&
     isAssistantFirstContactAcceptedForDelivery(input.outcome)
   if (firstContactAcceptedForDelivery) {
     await markAssistantFirstContactSeen({
@@ -920,14 +922,14 @@ export async function finalizeAssistantTurnFromDeliveryOutcome(input: {
   }
 }
 
+// The first-contact marker's only reader is the hosted signup-welcome skip,
+// so it must mean "a reply actually reached (or is queued for) this route".
+// A 'not-requested' outcome delivered nothing and must not suppress the
+// welcome for a route that has never heard from the assistant.
 function isAssistantFirstContactAcceptedForDelivery(
   outcome: AssistantDeliveryOutcome,
 ): boolean {
-  return (
-    outcome.kind === 'sent' ||
-    outcome.kind === 'queued' ||
-    outcome.kind === 'not-requested'
-  )
+  return outcome.kind === 'sent' || outcome.kind === 'queued'
 }
 
 export function buildAssistantTurnDeliveryFinalizationPlan(input: {

--- a/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
@@ -921,6 +921,196 @@ test('sendAssistantNotificationLocal rejects deferred immediate exact-text deliv
   })
 })
 
+test('an organic same-route reply supersedes the exact-text signup welcome through the real first-contact state', async () => {
+  const vault = await mkdtemp(path.join(tmpdir(), 'murph-first-contact-supersede-'))
+  const routeBinding = {
+    actorId: 'hid_linq_actor_supersede',
+    channel: 'linq',
+    conversationKey: null,
+    delivery: {
+      kind: 'thread' as const,
+      target: 'hid_linq_thread_supersede',
+    },
+    identityId: 'hid_linq_identity_supersede',
+    threadId: 'hid_linq_thread_supersede',
+    threadIsDirect: true,
+  }
+  const initialSession = createAssistantSession({
+    binding: routeBinding,
+  })
+  const sharedPlan = createSharedPlan()
+  const deliverMessage = vi.fn(async () => {
+    throw new Error('superseded signup welcome must not reach the outbox')
+  })
+  const runtimeState = {
+    outbox: {
+      deliverMessage,
+    },
+    status: {
+      refreshSnapshot: vi.fn(async () => undefined),
+    },
+    turns: {
+      createReceipt: vi.fn(async () => undefined),
+      finalizeReceipt: vi.fn(async () => undefined),
+    },
+    diagnostics: {
+      recordEvent: vi.fn(async () => undefined),
+    },
+  }
+  const mocks = {
+    createAssistantRuntimeStateService: vi.fn(() => runtimeState),
+    executeCodexTurnWithRecovery: vi.fn(async () => {
+      throw new Error('provider should not run for a superseded exact-text welcome')
+    }),
+    normalizeAssistantExecutionContext: vi.fn((value) => value),
+    resolveAssistantExecutionDefaultTarget: vi.fn((input) => input.fallbackTarget),
+    resolveAssistantExecutionOperatorDefaults: vi.fn((input) => input.defaults ?? null),
+    persistAssistantTurnAndSession: vi.fn(async () => {
+      throw new Error('provider finalizer should not run for a superseded welcome')
+    }),
+    recordAdditionalAssistantUsageEvents: vi.fn(async () => undefined),
+    recordAssistantUsageEvent: vi.fn(async () => undefined),
+    resolveAssistantOperatorDefaults: vi.fn(async () => null),
+    resolveAssistantSessionForMessage: vi.fn(async () => ({
+      created: false,
+      session: initialSession,
+    })),
+    resolveAssistantTurnRoute: vi.fn(() => createRoute()),
+    resolveAssistantTurnSharedPlan: vi.fn(async () => sharedPlan),
+    withAssistantTurnLock: vi.fn(async (input: { run(): Promise<unknown> }) => await input.run()),
+  }
+
+  vi.doMock('@murphai/operator-config/operator-config', () => ({
+    resolveAssistantOperatorDefaults: mocks.resolveAssistantOperatorDefaults,
+  }))
+  vi.doMock('@murphai/operator-config/assistant-backend', () => ({
+    createDefaultLocalAssistantModelTarget: () => createCodexTarget(),
+  }))
+  vi.doMock('../src/assistant/runtime-state-service.js', () => ({
+    createAssistantRuntimeStateService: mocks.createAssistantRuntimeStateService,
+  }))
+  vi.doMock('../src/assistant/execution-context.js', () => ({
+    normalizeAssistantExecutionContext: mocks.normalizeAssistantExecutionContext,
+    resolveAssistantExecutionDefaultTarget:
+      mocks.resolveAssistantExecutionDefaultTarget,
+    resolveAssistantExecutionOperatorDefaults:
+      mocks.resolveAssistantExecutionOperatorDefaults,
+  }))
+  vi.doMock('../src/assistant/session-resolution.js', () => ({
+    resolveAssistantSessionForMessage: mocks.resolveAssistantSessionForMessage,
+    resolveAssistantSessionTarget: vi.fn(() => createCodexTarget()),
+  }))
+  vi.doMock('../src/assistant/turn-plan.js', () => ({
+    resolveAssistantTurnSharedPlan: mocks.resolveAssistantTurnSharedPlan,
+  }))
+  vi.doMock('../src/assistant/codex-turn-runner.js', () => ({
+    executeCodexTurnWithRecovery: mocks.executeCodexTurnWithRecovery,
+  }))
+  vi.doMock('../src/assistant/service-usage.js', () => ({
+    recordAdditionalAssistantUsageEvents: mocks.recordAdditionalAssistantUsageEvents,
+    recordAssistantUsageEvent: mocks.recordAssistantUsageEvent,
+  }))
+  vi.doMock('../src/assistant/turn-finalizer.js', () => ({
+    clearAssistantSessionCodexResumeState: vi.fn(async (input: { session: AssistantSession }) => input.session),
+    persistAssistantTurnAndSession: mocks.persistAssistantTurnAndSession,
+  }))
+  vi.doMock('../src/assistant/service-turn-routes.js', () => ({
+    resolveAssistantTurnRoute: mocks.resolveAssistantTurnRoute,
+  }))
+  vi.doMock('../src/assistant/turns.js', () => ({
+    createAssistantTurnId: () => 'turn-supersede',
+  }))
+  vi.doMock('../src/assistant/channel-adapters.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/assistant/channel-adapters.ts')
+    >('../src/assistant/channel-adapters.js')
+
+    return {
+      ...actual,
+      getAssistantChannelAdapter: vi.fn(() => null),
+    }
+  })
+  vi.doMock('../src/assistant/turn-lock.js', () => ({
+    withAssistantTurnLock: mocks.withAssistantTurnLock,
+  }))
+  // The first-contact module is intentionally NOT mocked: the organic reply
+  // writes the marker to the real vault state directory and the notification
+  // turn reads it back, proving both sides resolve the same route doc ids.
+
+  try {
+    const { resolveAssistantFirstContactStateDocIds } = await import(
+      '../src/assistant/first-contact.ts'
+    )
+    // Same locator shape the conversation turn resolves in
+    // resolveAssistantTurnSharedPlan (turn-plan.ts) from its
+    // conversation-policy audience / session binding.
+    const organicReplyDocIds = resolveAssistantFirstContactStateDocIds({
+      actorId: routeBinding.actorId,
+      channel: routeBinding.channel,
+      identityId: routeBinding.identityId,
+      threadId: routeBinding.threadId,
+      threadIsDirect: routeBinding.threadIsDirect,
+    })
+    expect(organicReplyDocIds.length).toBeGreaterThan(0)
+
+    const { finalizeAssistantTurnFromDeliveryOutcome } = await import(
+      '../src/assistant/delivery-service.ts'
+    )
+    await finalizeAssistantTurnFromDeliveryOutcome({
+      firstContactGuidanceInjected: true,
+      firstContactStateDocIds: organicReplyDocIds,
+      outcome: {
+        delivery: {
+          channel: 'linq',
+          idempotencyKey: null,
+          messageLength: 33,
+          providerMessageId: 'provider-organic-reply',
+          providerThreadId: null,
+          sentAt: '2026-04-08T12:00:00.000Z',
+          target: routeBinding.threadId,
+          targetKind: 'thread',
+        },
+        intentId: 'intent-organic-reply',
+        kind: 'sent',
+        media: [],
+        session: initialSession,
+      },
+      response: 'Nice. First, what should I call you?',
+      turnId: 'turn-organic-reply',
+      vault,
+    })
+
+    const { sendAssistantNotificationLocal } = await import(
+      '../src/assistant/notification-turn.ts'
+    )
+    const result = await sendAssistantNotificationLocal({
+      deliveryDedupeToken: 'signup-welcome:member_supersede',
+      deliveryDispatchMode: 'queue-only',
+      deliveryIdempotencyKey: 'signup-welcome:member_supersede',
+      firstContactPolicy: {
+        markSeenOnDeliveryAccepted: true,
+      },
+      instructions: 'Send the fixed hosted signup welcome.',
+      responsePolicy: {
+        kind: 'require_send_exact_text',
+        text: 'Fixed welcome text',
+      },
+      vault,
+    })
+
+    expect(result.decision).toEqual({
+      kind: 'skip',
+      privateSummary: 'First-contact notification already accepted for this route.',
+    })
+    expect(result.response).toBeNull()
+    expect(deliverMessage).not.toHaveBeenCalled()
+    expect(mocks.executeCodexTurnWithRecovery).not.toHaveBeenCalled()
+    expect(runtimeState.turns.createReceipt).not.toHaveBeenCalled()
+  } finally {
+    await rm(vault, { force: true, recursive: true })
+  }
+})
+
 test('sendAssistantNotificationLocal derives hosted Linq deterministic delivery keys centrally', async () => {
   const linqSession = createAssistantSession({
     binding: {

--- a/packages/assistant-engine/test/assistant-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-service-runtime.test.ts
@@ -2707,29 +2707,80 @@ describe("assistant delivery orchestration seam", () => {
 
     seamMocks.markAssistantFirstContactSeen.mockClear();
 
+    // Any accepted non-empty reply is first contact, not just the canned
+    // welcome text — an organic onboarding reply must supersede a queued
+    // signup welcome for the same route.
     await finalizeAssistantTurnFromDeliveryOutcome({
       firstContactGuidanceInjected: true,
-      firstContactStateDocIds: ["doc-not-welcome"],
+      firstContactStateDocIds: ["doc-organic-reply"],
       outcome: {
         delivery: {
           channel: "telegram",
           idempotencyKey: null,
           messageLength: 16,
-          providerMessageId: "provider-not-welcome",
+          providerMessageId: "provider-organic-reply",
           providerThreadId: null,
           sentAt: "2026-04-08T12:30:00.000Z",
           target: "thread-1",
           targetKind: "thread",
         },
-        intentId: "intent-not-welcome",
+        intentId: "intent-organic-reply",
         kind: "sent",
         media: [],
         session: createAssistantSession({
-          sessionId: "session-not-welcome",
+          sessionId: "session-organic-reply",
         }),
       },
       response: "Happy to help.",
-      turnId: "turn-not-welcome-finalize",
+      turnId: "turn-organic-reply-finalize",
+      vault: "/vault",
+    });
+
+    expect(seamMocks.markAssistantFirstContactSeen).toHaveBeenCalledWith({
+      docIds: ["doc-organic-reply"],
+      seenAt: "2026-04-08T12:30:00.000Z",
+      vault: "/vault",
+    });
+
+    seamMocks.markAssistantFirstContactSeen.mockClear();
+
+    await finalizeAssistantTurnFromDeliveryOutcome({
+      firstContactGuidanceInjected: true,
+      firstContactStateDocIds: ["doc-no-reply"],
+      outcome: {
+        kind: "not-requested",
+        media: [],
+        session: createAssistantSession({
+          sessionId: "session-no-reply",
+        }),
+      },
+      response: "",
+      turnId: "turn-no-reply-finalize",
+      vault: "/vault",
+    });
+
+    await finalizeAssistantTurnFromDeliveryOutcome({
+      firstContactStateDocIds: ["doc-no-guidance"],
+      outcome: {
+        delivery: {
+          channel: "telegram",
+          idempotencyKey: null,
+          messageLength: 16,
+          providerMessageId: "provider-no-guidance",
+          providerThreadId: null,
+          sentAt: "2026-04-08T12:30:00.000Z",
+          target: "thread-1",
+          targetKind: "thread",
+        },
+        intentId: "intent-no-guidance",
+        kind: "sent",
+        media: [],
+        session: createAssistantSession({
+          sessionId: "session-no-guidance",
+        }),
+      },
+      response: "Happy to help.",
+      turnId: "turn-no-guidance-finalize",
       vault: "/vault",
     });
 

--- a/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
@@ -59,6 +59,7 @@ export async function executeHostedMemberActivatedWake(input: {
     }),
   ];
   let seededOnboardingFollowupWakeAt: string | null = null;
+  let notificationDecisionKind: string | null = null;
 
   try {
     const notificationResult = await sendAssistantNotification(
@@ -73,6 +74,7 @@ export async function executeHostedMemberActivatedWake(input: {
         },
       ),
     );
+    notificationDecisionKind = notificationResult?.decision.kind ?? null;
     seededOnboardingFollowupWakeAt = await maybeSeedOnboardingFollowupAutomation({
       logDetails: buildHostedMemberActivationSignupWelcomeLogDetails(input.wake),
       notificationResult,
@@ -96,6 +98,7 @@ export async function executeHostedMemberActivatedWake(input: {
 
   redactedLogEntries.push(
     emitHostedMemberActivationSignupWelcomeLifecycleLog({
+      extraDetails: { notificationDecisionKind },
       message: "Hosted member activation signup welcome finished.",
       phase: "wake.running",
       wake: input.wake,
@@ -127,6 +130,7 @@ export async function executeHostedAssistantNotificationWake(input: {
     }),
   ];
   let seededOnboardingFollowupWakeAt: string | null = null;
+  let notificationDecisionKind: string | null = null;
 
   try {
     const notificationResult = await sendAssistantNotification(
@@ -142,6 +146,7 @@ export async function executeHostedAssistantNotificationWake(input: {
         },
       ),
     );
+    notificationDecisionKind = notificationResult?.decision.kind ?? null;
     if (isHostedSignupWelcomeNotification(input.wake)) {
       seededOnboardingFollowupWakeAt = await maybeSeedOnboardingFollowupAutomation({
         logDetails: buildHostedAssistantNotificationLogDetails(input.wake),
@@ -176,6 +181,7 @@ export async function executeHostedAssistantNotificationWake(input: {
 
   redactedLogEntries.push(
     emitHostedAssistantNotificationLifecycleLog({
+      extraDetails: { notificationDecisionKind },
       message: "Hosted assistant notification finished.",
       phase: "wake.running",
       wake: input.wake,
@@ -199,7 +205,10 @@ async function maybeSeedOnboardingFollowupAutomation(input: {
   vaultRoot: string;
   wake: HostedExecutionSystemWake;
 }): Promise<string | null> {
-  if (!didAssistantNotificationAcceptDelivery(input.notificationResult)) {
+  if (
+    !didAssistantNotificationAcceptDelivery(input.notificationResult)
+    && !wasAssistantNotificationSupersededByPriorFirstContact(input.notificationResult)
+  ) {
     return null;
   }
 
@@ -236,6 +245,16 @@ function didAssistantNotificationAcceptDelivery(
 ): boolean {
   const outcomeKind = result?.deliveryOutcome?.kind;
   return outcomeKind === "sent" || outcomeKind === "queued";
+}
+
+// A signup-welcome turn only skips when first contact was already accepted on
+// this route (the user is mid-conversation). Onboarding is underway in that
+// case, so the follow-up automation must still be seeded; it self-archives
+// once onboarding completes and the upsert is idempotent by slug.
+function wasAssistantNotificationSupersededByPriorFirstContact(
+  result: AssistantNotificationResult | undefined,
+): boolean {
+  return result?.decision.kind === "skip";
 }
 
 function buildOnboardingFollowupAutomationRoute(
@@ -382,6 +401,7 @@ function buildHostedAssistantNotificationRouteLogDetails(input: {
 
 function emitHostedAssistantNotificationLifecycleLog(input: {
   error?: unknown;
+  extraDetails?: HostedExecutionStructuredLogDetails;
   level?: HostedExecutionLogLevel;
   message: string;
   phase: HostedExecutionLogPhase;
@@ -389,12 +409,16 @@ function emitHostedAssistantNotificationLifecycleLog(input: {
 }): HostedExecutionRedactedLogEntry {
   return emitHostedNotificationLifecycleLog({
     ...input,
-    details: buildHostedAssistantNotificationLogDetails(input.wake),
+    details: {
+      ...buildHostedAssistantNotificationLogDetails(input.wake),
+      ...(input.extraDetails ?? {}),
+    },
   });
 }
 
 function emitHostedMemberActivationSignupWelcomeLifecycleLog(input: {
   error?: unknown;
+  extraDetails?: HostedExecutionStructuredLogDetails;
   level?: HostedExecutionLogLevel;
   message: string;
   phase: HostedExecutionLogPhase;
@@ -402,7 +426,10 @@ function emitHostedMemberActivationSignupWelcomeLifecycleLog(input: {
 }): HostedExecutionRedactedLogEntry {
   return emitHostedNotificationLifecycleLog({
     ...input,
-    details: buildHostedMemberActivationSignupWelcomeLogDetails(input.wake),
+    details: {
+      ...buildHostedMemberActivationSignupWelcomeLogDetails(input.wake),
+      ...(input.extraDetails ?? {}),
+    },
   });
 }
 

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -1644,16 +1644,22 @@ describe("executeHostedMailboxEvent", () => {
     });
   });
 
-  it("does not seed onboarding follow-up when embedded member activation welcome delivery is skipped", async () => {
+  it("still seeds onboarding follow-up when the embedded member activation welcome is superseded by prior first contact", async () => {
+    const seededNextWakeAt = "2026-04-09T17:30:00.000Z";
     mocks.sendAssistantNotification.mockResolvedValueOnce({
       decision: {
         kind: "skip",
-        reason: "First contact was already accepted.",
+        privateSummary: "First-contact notification already accepted for this route.",
       },
-      deliveryOutcome: null,
       response: null,
       session: {
         sessionId: "session_notification_skip",
+      },
+    });
+    mocks.upsertAssistantCronAutomation.mockResolvedValueOnce({
+      enabled: true,
+      state: {
+        nextRunAt: seededNextWakeAt,
       },
     });
     const wake = buildHostedExecutionMemberActivatedWake({
@@ -1691,10 +1697,15 @@ describe("executeHostedMailboxEvent", () => {
     });
 
     expect(mocks.sendAssistantNotification).toHaveBeenCalledOnce();
-    expect(mocks.upsertAssistantCronAutomation).not.toHaveBeenCalled();
+    expect(mocks.upsertAssistantCronAutomation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "finish-onboarding-followup",
+      }),
+    );
     expect(result).toMatchObject({
       mailboxLane: "member-activated",
-      nextWakeAt: null,
+      nextWakeAt: seededNextWakeAt,
+      nextWakeReason: "assistant",
     });
   });
 
@@ -1951,13 +1962,21 @@ describe("executeHostedMailboxEvent", () => {
     expect(mocks.upsertAssistantCronAutomation).not.toHaveBeenCalled();
   });
 
-  it("does not seed onboarding follow-up when signup welcome delivery is skipped", async () => {
+  it("still seeds onboarding follow-up when the signup welcome notification is superseded by prior first contact", async () => {
     const wake = buildHostedExecutionAssistantNotificationRequestedWake({
       eventId: "evt_notification_welcome_skip_result",
       memberId: "member_123",
       notification: {
+        deliveryDedupeToken: "signup-welcome:member_123",
         deliveryIdempotencyKey: "signup-welcome:member_123",
+        firstContact: {
+          markSeenOnDeliveryAccepted: true,
+        },
         instructions: "Send exactly the signup welcome.",
+        responsePolicy: {
+          kind: "require_send_exact_text",
+          text: "Welcome to Murph.",
+        },
         route: {
           actorId: "hid_telegram_actor_123",
           channel: "telegram",
@@ -1975,12 +1994,17 @@ describe("executeHostedMailboxEvent", () => {
     mocks.sendAssistantNotification.mockResolvedValueOnce({
       decision: {
         kind: "skip",
-        reason: "First contact was already accepted.",
+        privateSummary: "First-contact notification already accepted for this route.",
       },
-      deliveryOutcome: null,
       response: null,
       session: {
         sessionId: "session_notification_skip",
+      },
+    });
+    mocks.upsertAssistantCronAutomation.mockResolvedValueOnce({
+      enabled: true,
+      state: {
+        nextRunAt: "2026-04-09T17:30:00.000Z",
       },
     });
 
@@ -1993,7 +2017,11 @@ describe("executeHostedMailboxEvent", () => {
     });
 
     expect(mocks.sendAssistantNotification).toHaveBeenCalledOnce();
-    expect(mocks.upsertAssistantCronAutomation).not.toHaveBeenCalled();
+    expect(mocks.upsertAssistantCronAutomation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "finish-onboarding-followup",
+      }),
+    );
   });
 
   it("keeps signup welcome delivery successful when onboarding follow-up seeding fails", async () => {


### PR DESCRIPTION
## Why

New iMessage signups who text Murph within seconds of tapping the verify link get the canned signup welcome ("Hi, I'm Murph. Welcome...") delivered minutes late and out of order — after the assistant has already onboarded them organically. Incident debugged 2026-07-03: the user texted 11s after activation, the conversation lane starved the system-lane welcome item through four turns, and the 215s recheck backstop finally delivered the welcome 9 minutes after signup, mid-conversation, ending with a redundant "Ready to start?".

The canned welcome has an implicit validity condition that was never encoded: it is only correct as the user's first contact on that route.

## User-visible goal

- A user who texts first gets only the organic onboarding conversation; the stale canned welcome is superseded (skipped) instead of arriving late and out of order.
- A silent signup still receives the canned welcome exactly as today.
- Either way, the self-archiving `finish-onboarding-followup` automation is still seeded, so onboarding follow-up behavior is unchanged.

## How

- `packages/assistant-engine/src/assistant/delivery-service.ts`: mark first contact seen for any accepted, non-empty conversation reply when onboarding guidance was injected — previously only when the reply text was exactly `ASSISTANT_FIRST_CONTACT_WELCOME_MESSAGE`. The existing first-contact skip in `notification-turn.ts` then supersedes the queued signup welcome. No new state; the per-route first-contact doc scoping is unchanged, and both the conversation turn and the welcome notification resolve doc ids from the same conversation-policy audience.
- `packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts`: when the signup-welcome turn returns a skip decision (the only skip an exact-text welcome turn can produce is the first-contact supersede), still seed the onboarding follow-up automation (idempotent upsert by slug), and record `notificationDecisionKind` in the finished lifecycle log so superseded welcomes are observable in `hosted_runtime_log` instead of looking identical to sends.

## Invariants to preserve

- Welcome delivery remains intact for silent signups (product-critical flow): the first-contact marker is only written after an accepted assistant reply on a first-contact-scoped route.
- Supersede is per-route: conversation on another channel/route does not suppress the welcome.
- No change to the outbox-level `ASSISTANT_STALE_SIGNUP_WELCOME_SUPPRESSED` suppression, welcome dedupe identity (`signup-welcome:<memberId>`), or the live Linq first-contact e2e expectations (silent-signup welcome sends; no duplicate welcome after the first inbound greeting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785684992&installation_id=127572939&pr_number=377&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F377&signature=39f79f855c69da9aedcac614a64ae3a4618ea26422f96ccc7cd2a30f97fe99fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->