### PR TITLE
hosted: collapse webhook wake fields to a single handoff shape (PR 2b)

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -556,8 +556,7 @@ export async function planHostedOnboardingLinqWebhook(input: {
           // No checkpoint on the duplicate read: this transaction did not run
           // the append-path workspace upsert, so the retry keeps the legacy
           // signal path that repairs a missing workspace row.
-          wakeMailboxItemId: existingMailboxItem.id,
-          wakeUserId: existingMember.id,
+          wakeHandoffs: [{ eventId: input.event.event_id, mailboxItemId: existingMailboxItem.id, source: "linq", userId: existingMember.id }],
         }),
         buildHostedLinqWebhookPlannerDetails(input.event, context, {
           duplicate: true,
@@ -670,13 +669,10 @@ export async function planHostedOnboardingLinqWebhook(input: {
           ignored: false,
           reason: "wake-appended-active-member",
         },
-        wakeLinqChatId: summary.chatId,
-        wakeMailboxCheckpoint: {
-          lane: mailboxAppend.item.lane,
-          laneSeq: mailboxAppend.item.laneSeq,
-        },
-        wakeMailboxItemId: mailboxAppend.item.id,
-        wakeUserId: existingMember.id,
+        wakeHandoffs: [{
+          eventId: input.event.event_id, linqChatId: summary.chatId, mailboxItemId: mailboxAppend.item.id, source: "linq", userId: existingMember.id,
+          wakeMailboxCheckpoint: { lane: mailboxAppend.item.lane, laneSeq: mailboxAppend.item.laneSeq },
+        }],
       }),
       buildHostedLinqWebhookPlannerDetails(input.event, context, {
         dailyInboundCount: dailyState.inboundCount,
@@ -1122,12 +1118,12 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
           ok: true,
           reason: "duplicate-webhook-event",
         },
-        wakeLinqChatId: summary.chatId,
         // No checkpoint on the duplicate read: this transaction did not run
         // the append-path workspace upsert, so the retry keeps the legacy
         // signal path that repairs a missing workspace row.
-        wakeMailboxItemId: existingMailboxItem.id,
-        wakeUserId: input.route.containerMemberId,
+        wakeHandoffs: [{
+          eventId: input.event.event_id, linqChatId: summary.chatId, mailboxItemId: existingMailboxItem.id, source: "linq", userId: input.route.containerMemberId,
+        }],
         linqReadReceiptRouteAuthority: routeAuthority,
       }),
       buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
@@ -1222,13 +1218,10 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
         ok: true,
         reason: "wake-appended-thread-route",
       },
-      wakeLinqChatId: summary.chatId,
-      wakeMailboxCheckpoint: {
-        lane: mailboxAppend.item.lane,
-        laneSeq: mailboxAppend.item.laneSeq,
-      },
-      wakeMailboxItemId: mailboxAppend.item.id,
-      wakeUserId: input.route.containerMemberId,
+      wakeHandoffs: [{
+        eventId: input.event.event_id, linqChatId: summary.chatId, mailboxItemId: mailboxAppend.item.id, source: "linq", userId: input.route.containerMemberId,
+        wakeMailboxCheckpoint: { lane: mailboxAppend.item.lane, laneSeq: mailboxAppend.item.laneSeq },
+      }],
       linqReadReceiptRouteAuthority: routeAuthority,
     }),
     buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
@@ -1668,8 +1661,7 @@ function logHostedLinqWebhookPlannerDecisionAndReturn<T extends HostedOnboarding
     ...sanitizeHostedOnboardingStructuredLogDetails(details),
     desiredSideEffectCount: plan.desiredSideEffects.length,
     ...plannerResultLog,
-    wakeMailboxItemPresent: Boolean(plan.wakeMailboxItemId),
-    wakeUserPresent: Boolean(plan.wakeUserId),
+    wakeHandoffCount: plan.wakeHandoffs?.length ?? 0,
   });
 
   return plan;

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-telegram.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-telegram.ts
@@ -46,6 +46,7 @@ export async function planHostedOnboardingTelegramWebhook(input: {
   if (!summary) {
     return buildIgnoredTelegramWebhookPlan("unsupported-update");
   }
+  const eventId = buildHostedTelegramWebhookEventId(input.update);
 
   if (summary.isBotMessage) {
     return buildIgnoredTelegramWebhookPlan("own-message");
@@ -92,7 +93,7 @@ export async function planHostedOnboardingTelegramWebhook(input: {
       message: buildHostedFamilyInviteAcceptedReplyText(),
       occurredAt: summary.occurredAt,
       route,
-      sourceEventId: buildHostedTelegramWebhookEventId(input.update),
+      sourceEventId: eventId,
       tx: input.prisma,
     });
     return {
@@ -103,8 +104,7 @@ export async function planHostedOnboardingTelegramWebhook(input: {
       },
       ...(notification.mailboxItemId
         ? {
-            wakeMailboxItemId: notification.mailboxItemId,
-            wakeUserId: familyAcceptance.memberId,
+            wakeHandoffs: [{ eventId, mailboxItemId: notification.mailboxItemId, source: "telegram", userId: familyAcceptance.memberId }],
           }
         : {}),
     };
@@ -155,7 +155,7 @@ export async function planHostedOnboardingTelegramWebhook(input: {
 
   const mailboxAppend = await appendHostedMailboxEnvelopeTx({
     envelope: buildHostedExecutionTelegramConversationMessageWake({
-      eventId: buildHostedTelegramWebhookEventId(input.update),
+      eventId,
       occurredAt: summary.occurredAt,
       telegramMessage,
       userId: existingMember.id,
@@ -169,12 +169,10 @@ export async function planHostedOnboardingTelegramWebhook(input: {
       ok: true,
       reason: "wake-appended-active-member",
     },
-    wakeMailboxCheckpoint: {
-      lane: mailboxAppend.item.lane,
-      laneSeq: mailboxAppend.item.laneSeq,
-    },
-    wakeMailboxItemId: mailboxAppend.item.id,
-    wakeUserId: existingMember.id,
+    wakeHandoffs: [{
+      eventId, mailboxItemId: mailboxAppend.item.id, source: "telegram", userId: existingMember.id,
+      wakeMailboxCheckpoint: { lane: mailboxAppend.item.lane, laneSeq: mailboxAppend.item.laneSeq },
+    }],
   };
 }
 

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
@@ -20,10 +20,6 @@ export type HostedWebhookPlan<TResult, TSideEffect = never> = {
   linqReadReceiptRouteAuthority?: HostedLinqThreadRouteEgressAuthority;
   response: TResult;
   wakeHandoffs?: readonly HostedWebhookWakeHandoff[];
-  wakeLinqChatId?: string;
-  wakeMailboxCheckpoint?: HostedWebhookWakeMailboxCheckpoint;
-  wakeMailboxItemId?: string;
-  wakeUserId?: string;
 };
 
 export type HostedWebhookWakeHandoff = {

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
@@ -23,7 +23,7 @@ import {
 } from "./logging";
 import type {
   HostedWebhookServiceResponse,
-  HostedWebhookWakeMailboxCheckpoint,
+  HostedWebhookWakeHandoff,
 } from "./webhook-service-types";
 
 // Latency traces are observability only. They are scheduled after the webhook
@@ -41,44 +41,45 @@ export type HostedWebhookWakeHandoffResult =
 type HostedWebhookPostResponseScheduler = (task: () => Promise<void>) => void;
 
 export async function maybeHandoffHostedExecutionWebhookWake(input: {
-  eventId: string;
-  mailboxItemId?: string;
   response: HostedWebhookServiceResponse;
   scheduleAfterResponse?: HostedWebhookPostResponseScheduler;
-  source: "linq" | "telegram" | "whatsapp";
-  userId?: string;
-  wakeMailboxCheckpoint?: HostedWebhookWakeMailboxCheckpoint;
+  wakeHandoff?: HostedWebhookWakeHandoff;
 }): Promise<HostedWebhookWakeHandoffResult | null> {
-  if (!input.mailboxItemId) {
+  if (!input.wakeHandoff) {
     return null;
   }
-  const mailboxItemId = input.mailboxItemId;
+  const {
+    eventId,
+    mailboxItemId,
+    source,
+    userId,
+    wakeMailboxCheckpoint,
+  } = input.wakeHandoff;
   // Guarded at runtime: a checkpoint missing lane facts falls back to the
   // legacy signal path (checkpoint re-read + workspace ensure) instead of
   // failing the wake on malformed planner data.
   const knownCheckpoint =
-    input.userId
-    && typeof input.wakeMailboxCheckpoint?.lane === "string"
-    && input.wakeMailboxCheckpoint.lane.length > 0
-    && typeof input.wakeMailboxCheckpoint.laneSeq === "string"
-    && input.wakeMailboxCheckpoint.laneSeq.length > 0
+    typeof wakeMailboxCheckpoint?.lane === "string"
+    && wakeMailboxCheckpoint.lane.length > 0
+    && typeof wakeMailboxCheckpoint.laneSeq === "string"
+    && wakeMailboxCheckpoint.laneSeq.length > 0
       ? {
-          lane: input.wakeMailboxCheckpoint.lane,
-          laneSeq: input.wakeMailboxCheckpoint.laneSeq,
-          userId: input.userId,
+          lane: wakeMailboxCheckpoint.lane,
+          laneSeq: wakeMailboxCheckpoint.laneSeq,
+          userId,
         }
       : undefined;
-  const directEnsureEligible = Boolean(knownCheckpoint && input.source === "linq");
+  const directEnsureEligible = Boolean(knownCheckpoint && source === "linq");
 
   const handoffTiming = startHostedOnboardingTiming(
-    `hosted-onboarding.webhook.${input.source}.wake-handoff`,
+    `hosted-onboarding.webhook.${source}.wake-handoff`,
     {
       directEnsureWakeEligible: directEnsureEligible,
-      eventIdSuffix: toHostedOnboardingLogIdSuffix(input.eventId),
+      eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
       plannerCheckpointPresent: Boolean(knownCheckpoint),
       responseReason: input.response.reason,
-      userIdPresent: Boolean(input.userId),
-      userIdSuffix: input.userId ? toHostedOnboardingLogIdSuffix(input.userId) : null,
+      userIdPresent: true,
+      userIdSuffix: toHostedOnboardingLogIdSuffix(userId),
     },
   );
 
@@ -86,7 +87,7 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
   let temporalSignalAcceptedAt: Date | null = null;
   try {
     signal = await signalHostedMailboxAppendRuntime({
-      expectedUserId: input.userId ?? null,
+      expectedUserId: userId,
       ...(knownCheckpoint ? { knownCheckpoint } : {}),
       mailboxItemId,
     });
@@ -95,9 +96,9 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
     scheduleHostedWebhookIngressLatencyTraceWritesAfterResponse({
       mailboxItemId,
       scheduleAfterResponse: input.scheduleAfterResponse,
-      source: input.source,
+      source,
       temporalSignalAcceptedAt,
-      userId: input.userId ?? null,
+      userId,
     });
     const errorName = deriveHostedOnboardingTimingErrorName(error);
     finishHostedOnboardingTiming(handoffTiming, "failed", {
@@ -111,10 +112,10 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
   // With consumed_at live, a racing ensure is harmless: consumed mailbox items
   // restage with a null reply target, and a gap invocation that imports only
   // already-consumed work finds nothing replyable and exits.
-  const directEnsureWake = directEnsureEligible && input.userId
+  const directEnsureWake = directEnsureEligible
     ? startHostedDirectEnsureWakeBestEffort({
         source: "linq",
-        userId: input.userId,
+        userId,
       })
     : null;
   if (directEnsureWake) {
@@ -130,9 +131,9 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
   scheduleHostedWebhookIngressLatencyTraceWritesAfterResponse({
     mailboxItemId,
     scheduleAfterResponse: input.scheduleAfterResponse,
-    source: input.source,
+    source,
     temporalSignalAcceptedAt,
-    userId: input.userId ?? null,
+    userId,
   });
 
   finishHostedOnboardingTiming(handoffTiming, "temporal-signaled", {

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -9,7 +9,7 @@ import {
   sendHostedLinqReadReceipt,
   verifyAndParseHostedLinqWebhookRequest,
 } from "./linq";
-import { assertHostedTelegramWebhookSecret, buildHostedTelegramWebhookEventId, parseHostedTelegramWebhookUpdate } from "./telegram";
+import { assertHostedTelegramWebhookSecret, parseHostedTelegramWebhookUpdate } from "./telegram";
 import {
   planHostedOnboardingLinqWebhook,
   type HostedOnboardingLinqWebhookResponse,
@@ -75,6 +75,9 @@ import {
 import {
   assertHostedLinqRouteAuthorityMatchesTarget,
 } from "./linq-egress-engagement";
+import type {
+  HostedWebhookWakeHandoff,
+} from "./webhook-service-types";
 
 export {
   handleHostedStripeWebhook,
@@ -313,7 +316,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       firstContactAdmissionClassified,
       firstContactAdmissionMode,
       ok: plan.response.ok,
-      wakeUserPresent: Boolean(plan.wakeUserId),
+      wakeUserPresent: Boolean(plan.wakeHandoffs?.some((handoff) => handoff.userId)),
     });
 
     if (plan.desiredSideEffects.length > 0) {
@@ -333,14 +336,11 @@ export async function handleHostedOnboardingLinqWebhook(input: {
     });
 
     responseReason = plan.response.reason ?? null;
-    const wakeHandoff = await maybeHandoffHostedExecutionWebhookWake({
-      eventId: event.event_id,
-      mailboxItemId: plan.wakeMailboxItemId,
+    const wakeHandoff = plan.wakeHandoffs?.[0];
+    const wakeHandoffResult = await maybeHandoffHostedExecutionWebhookWake({
       response: plan.response,
       scheduleAfterResponse: input.scheduleAfterResponse,
-      source: "linq",
-      userId: plan.wakeUserId,
-      wakeMailboxCheckpoint: plan.wakeMailboxCheckpoint,
+      wakeHandoff,
     });
     const sendReadReceipt = () => maybeSendHostedLinqIngressReadReceipt({
       currentInboundReply,
@@ -348,6 +348,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       prisma,
       signal: input.signal,
       wakeHandoff,
+      wakeHandoffResult,
     });
     if (input.scheduleAfterResponse) {
       input.scheduleAfterResponse(sendReadReceipt);
@@ -361,9 +362,9 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       eventType,
       responseReason,
       signalAbortedBeforeReturn: input.signal?.aborted ?? false,
-      wakeHandoffReason: wakeHandoff?.reason ?? null,
-      wakeHandoffSignalAccepted: wakeHandoff?.signalAccepted ?? false,
-      wakeHandoffStarted: wakeHandoff?.started ?? false,
+      wakeHandoffReason: wakeHandoffResult?.reason ?? null,
+      wakeHandoffSignalAccepted: wakeHandoffResult?.signalAccepted ?? false,
+      wakeHandoffStarted: wakeHandoffResult?.started ?? false,
     });
     return plan.response;
   } catch (error) {
@@ -383,18 +384,19 @@ async function maybeSendHostedLinqIngressReadReceipt(input: {
   plan: Awaited<ReturnType<typeof planHostedOnboardingLinqWebhook>>;
   prisma: PrismaClient;
   signal?: AbortSignal;
-  wakeHandoff: Awaited<ReturnType<typeof maybeHandoffHostedExecutionWebhookWake>>;
+  wakeHandoff?: HostedWebhookWakeHandoff;
+  wakeHandoffResult: Awaited<ReturnType<typeof maybeHandoffHostedExecutionWebhookWake>>;
 }): Promise<void> {
-  const chatId = input.plan.wakeLinqChatId?.trim() ?? "";
+  const chatId = input.wakeHandoff?.linqChatId?.trim() ?? "";
 
   if (chatId.length === 0) {
     return;
   }
 
   const responseReason = input.plan.response.reason ?? null;
-  const wakeHandoffReason = input.wakeHandoff?.reason ?? null;
-  const wakeHandoffStarted = input.wakeHandoff?.started === true;
-  const wakeHandoffSignalAccepted = input.wakeHandoff?.signalAccepted ?? false;
+  const wakeHandoffReason = input.wakeHandoffResult?.reason ?? null;
+  const wakeHandoffStarted = input.wakeHandoffResult?.started === true;
+  const wakeHandoffSignalAccepted = input.wakeHandoffResult?.signalAccepted ?? false;
   const readReceiptTiming = startHostedOnboardingTiming(
     "hosted-onboarding.webhook.linq.ingress-read-receipt",
     {
@@ -586,7 +588,6 @@ export async function handleHostedOnboardingTelegramWebhook(input: {
   assertHostedTelegramWebhookSecret(input.secretToken);
 
   const update = parseHostedTelegramWebhookUpdate(input.rawBody);
-  const eventId = buildHostedTelegramWebhookEventId(update);
   const plan = await runHostedOnboardingWebhookTransaction(
     prisma,
     (transaction) =>
@@ -603,13 +604,9 @@ export async function handleHostedOnboardingTelegramWebhook(input: {
   }
 
   await maybeHandoffHostedExecutionWebhookWake({
-    eventId,
-    mailboxItemId: plan.wakeMailboxItemId,
     response: plan.response,
     scheduleAfterResponse: input.scheduleAfterResponse,
-    source: "telegram",
-    userId: plan.wakeUserId,
-    wakeMailboxCheckpoint: plan.wakeMailboxCheckpoint,
+    wakeHandoff: plan.wakeHandoffs?.[0],
   });
   return plan.response;
 }
@@ -660,7 +657,7 @@ export async function handleHostedOnboardingWhatsAppWebhook(input: {
         }),
     );
 
-    if (plan.desiredSideEffects.length > 0 || plan.wakeMailboxItemId || plan.wakeUserId) {
+    if (plan.desiredSideEffects.length > 0) {
       throw new Error(
         "Hosted WhatsApp webhook planning unexpectedly requested legacy runtime side effects.",
       );
@@ -669,13 +666,9 @@ export async function handleHostedOnboardingWhatsAppWebhook(input: {
     const wakeHandoffs = plan.wakeHandoffs ?? [];
     for (const wakeHandoff of wakeHandoffs) {
       await maybeHandoffHostedExecutionWebhookWake({
-        eventId: wakeHandoff.eventId,
-        mailboxItemId: wakeHandoff.mailboxItemId,
         response: plan.response,
         scheduleAfterResponse: input.scheduleAfterResponse,
-        source: "whatsapp",
-        userId: wakeHandoff.userId,
-        wakeMailboxCheckpoint: wakeHandoff.wakeMailboxCheckpoint,
+        wakeHandoff,
       });
     }
 

--- a/apps/web/test/hosted-execution-handoff.test.ts
+++ b/apps/web/test/hosted-execution-handoff.test.ts
@@ -58,6 +58,18 @@ import {
 } from "@/src/lib/hosted-execution/user-data-delete";
 import { maybeHandoffHostedExecutionWebhookWake } from "@/src/lib/hosted-onboarding/webhook-service-wake";
 
+function buildWakeHandoff(
+  overrides: Partial<NonNullable<Parameters<typeof maybeHandoffHostedExecutionWebhookWake>[0]["wakeHandoff"]>> = {},
+) {
+  return {
+    eventId: "evt_inline_gap",
+    mailboxItemId: "mailbox_123",
+    source: "linq" as const,
+    userId: "user-123",
+    ...overrides,
+  };
+}
+
 describe("hosted webhook Temporal handoff", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -87,15 +99,12 @@ describe("hosted webhook Temporal handoff", () => {
 
   it("signals Temporal for Linq mailbox handoff without a direct runner nudge", async () => {
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_inline_gap",
-      mailboxItemId: "mailbox_123",
       response: {
         ok: true,
         reason: "wake-appended-active-member",
       },
       scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-      source: "linq",
-      userId: "user-123",
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       signalAccepted: true,
@@ -117,15 +126,12 @@ describe("hosted webhook Temporal handoff", () => {
 
     await expect(
       maybeHandoffHostedExecutionWebhookWake({
-        eventId: "evt_inline_gap",
-        mailboxItemId: "mailbox_123",
         response: {
           ok: true,
           reason: "wake-appended-active-member",
         },
         scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-        source: "linq",
-        userId: "user-123",
+        wakeHandoff: buildWakeHandoff(),
       }),
     ).rejects.toThrow("Temporal unavailable");
 
@@ -138,15 +144,12 @@ describe("hosted webhook Temporal handoff", () => {
 
   it("does not await Linq latency-trace writes before returning a successful handoff", async () => {
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_inline_gap",
-      mailboxItemId: "mailbox_123",
       response: {
         ok: true,
         reason: "wake-appended-active-member",
       },
       scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-      source: "linq",
-      userId: "user-123",
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       workflowId: "hosted-user-runtime:user-123",
@@ -174,15 +177,12 @@ describe("hosted webhook Temporal handoff", () => {
 
     await expect(
       maybeHandoffHostedExecutionWebhookWake({
-        eventId: "evt_inline_gap",
-        mailboxItemId: "mailbox_123",
         response: {
           ok: true,
           reason: "wake-appended-active-member",
         },
         scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-        source: "linq",
-        userId: "user-123",
+        wakeHandoff: buildWakeHandoff(),
       }),
     ).rejects.toThrow("Temporal unavailable");
 
@@ -208,15 +208,16 @@ describe("hosted webhook Temporal handoff", () => {
 
     await expect(
       maybeHandoffHostedExecutionWebhookWake({
-        eventId: "evt_telegram_signal_failure",
-        mailboxItemId: "mailbox_telegram_123",
         response: {
           ok: true,
           reason: "wake-appended-active-member",
         },
         scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-        source: "telegram",
-        userId: "user-123",
+        wakeHandoff: buildWakeHandoff({
+          eventId: "evt_telegram_signal_failure",
+          mailboxItemId: "mailbox_telegram_123",
+          source: "telegram",
+        }),
       }),
     ).rejects.toThrow("Temporal unavailable");
 
@@ -245,15 +246,14 @@ describe("hosted webhook Temporal handoff", () => {
 
     await expect(
       maybeHandoffHostedExecutionWebhookWake({
-        eventId: "evt_after_throws_on_failure",
-        mailboxItemId: "mailbox_123",
         response: {
           ok: true,
           reason: "wake-appended-active-member",
         },
         scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-        source: "linq",
-        userId: "user-123",
+        wakeHandoff: buildWakeHandoff({
+          eventId: "evt_after_throws_on_failure",
+        }),
       }),
     ).rejects.toThrow("Temporal unavailable");
 
@@ -286,15 +286,12 @@ describe("hosted webhook Temporal handoff", () => {
     });
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_inline_gap",
-      mailboxItemId: "mailbox_123",
       response: {
         ok: true,
         reason: "wake-appended-active-member",
       },
       scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-      source: "linq",
-      userId: "user-123",
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       workflowId: "hosted-user-runtime:user-123",
@@ -324,15 +321,12 @@ describe("hosted webhook Temporal handoff", () => {
     });
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_inline_gap",
-      mailboxItemId: "mailbox_123",
       response: {
         ok: true,
         reason: "wake-appended-active-member",
       },
       scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-      source: "linq",
-      userId: "user-123",
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       workflowId: "hosted-user-runtime:user-123",
@@ -358,14 +352,11 @@ describe("hosted webhook Temporal handoff", () => {
   it("skips webhook handoff when no mailbox pointer exists", async () => {
     await expect(
       maybeHandoffHostedExecutionWebhookWake({
-        eventId: "evt_inline_gap",
         response: {
           ok: true,
           reason: "wake-appended-active-member",
         },
         scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-        source: "linq",
-        userId: "user-123",
       }),
     ).resolves.toBeNull();
 
@@ -375,8 +366,6 @@ describe("hosted webhook Temporal handoff", () => {
 
   it("signals Temporal for duplicate webhook handoff with an existing mailbox item", async () => {
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_duplicate",
-      mailboxItemId: "mailbox_existing",
       response: {
         duplicate: true,
         ignored: true,
@@ -384,8 +373,10 @@ describe("hosted webhook Temporal handoff", () => {
         reason: "duplicate-webhook-event",
       },
       scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-      source: "linq",
-      userId: "user-123",
+      wakeHandoff: buildWakeHandoff({
+        eventId: "evt_duplicate",
+        mailboxItemId: "mailbox_existing",
+      }),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       signalAccepted: true,
@@ -402,14 +393,11 @@ describe("hosted webhook Temporal handoff", () => {
 
   it("signals Temporal and records latency traces for Telegram handoff", async () => {
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_inline_gap",
-      mailboxItemId: "mailbox_123",
       response: {
         ok: true,
         reason: "wake-appended-active-member",
       },
-      source: "telegram",
-      userId: "user-123",
+      wakeHandoff: buildWakeHandoff({ source: "telegram" }),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       signalAccepted: true,
@@ -437,15 +425,16 @@ describe("hosted webhook Temporal handoff", () => {
 
   it("does not record ingress latency traces for WhatsApp handoff", async () => {
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_whatsapp_handoff",
-      mailboxItemId: "mailbox_whatsapp_123",
       response: {
         ok: true,
         reason: "wake-appended-active-member",
       },
       scheduleAfterResponse: schedulerMocks.scheduleAfterResponse,
-      source: "whatsapp",
-      userId: "user-123",
+      wakeHandoff: buildWakeHandoff({
+        eventId: "evt_whatsapp_handoff",
+        mailboxItemId: "mailbox_whatsapp_123",
+        source: "whatsapp",
+      }),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       workflowId: "hosted-user-runtime:user-123",

--- a/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
@@ -101,7 +101,7 @@ describe("hosted Linq read receipt route authority", () => {
       webhook_version: "2026-01-01",
     });
     mocks.maybeHandoffHostedExecutionWebhookWake.mockResolvedValue({
-      reason: null,
+      reason: "temporal-signaled",
       signalAccepted: true,
       started: true,
     });
@@ -121,9 +121,13 @@ describe("hosted Linq read receipt route authority", () => {
         ok: true,
         reason: "wake-appended-active-member",
       },
-      wakeLinqChatId: "chat_123",
-      wakeMailboxItemId: "mailbox_123",
-      wakeUserId: "member_123",
+      wakeHandoffs: [{
+        eventId: "evt_read_receipt_mismatch",
+        linqChatId: "chat_123",
+        mailboxItemId: "mailbox_123",
+        source: "linq",
+        userId: "member_123",
+      }],
     });
 
     await expect(handleHostedOnboardingLinqWebhook({

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -490,6 +490,18 @@ function buildHostedMailboxItem(input: {
   };
 }
 
+function readSingleWakeHandoff(
+  plan: Awaited<ReturnType<typeof planHostedOnboardingLinqWebhook>>,
+) {
+  const wakeHandoffs = plan.wakeHandoffs ?? [];
+  expect(wakeHandoffs).toHaveLength(1);
+  const wakeHandoff = wakeHandoffs[0];
+  if (!wakeHandoff) {
+    throw new Error("Expected a wake handoff.");
+  }
+  return wakeHandoff;
+}
+
 function configureHostedContactPrivacyKeyringForTest(input: {
   currentVersion: string;
   entries: Record<string, string>;
@@ -770,8 +782,12 @@ describe("Linq explicit external-thread routing", () => {
       ok: true,
       reason: "wake-appended-thread-route",
     });
-    expect(plan.wakeUserId).toBe("member_thread_container_123");
-    expect(plan.wakeMailboxItemId).toBe("mailbox_group_123");
+    expect(readSingleWakeHandoff(plan)).toMatchObject({
+      eventId: "evt_group_123",
+      mailboxItemId: "mailbox_group_123",
+      source: "linq",
+      userId: "member_thread_container_123",
+    });
     expect(prisma.hostedMemberRouting.upsert).not.toHaveBeenCalled();
     expect(prisma.hostedMemberRouting.updateMany).not.toHaveBeenCalled();
   });
@@ -818,9 +834,13 @@ describe("Linq explicit external-thread routing", () => {
       ok: true,
       reason: "wake-appended-thread-route",
     });
-    expect(plan.wakeUserId).toBe("member_thread_container_123");
-    expect(plan.wakeMailboxItemId).toBe("mailbox_group_123");
-    expect(plan.wakeLinqChatId).toBe("chat_group_123");
+    expect(readSingleWakeHandoff(plan)).toMatchObject({
+      eventId: "evt_group_123",
+      linqChatId: "chat_group_123",
+      mailboxItemId: "mailbox_group_123",
+      source: "linq",
+      userId: "member_thread_container_123",
+    });
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
       envelope: expect.objectContaining({
         eventId: "evt_group_123",
@@ -892,8 +912,12 @@ describe("Linq explicit external-thread routing", () => {
       ok: true,
       reason: "wake-appended-thread-route",
     });
-    expect(plan.wakeUserId).toBe("member_thread_container_123");
-    expect(plan.wakeMailboxItemId).toBe("mailbox_sponsored_owner_123");
+    expect(readSingleWakeHandoff(plan)).toMatchObject({
+      eventId: "evt_group_123",
+      mailboxItemId: "mailbox_sponsored_owner_123",
+      source: "linq",
+      userId: "member_thread_container_123",
+    });
   });
 
   it("does not match a routed thread for another Linq recipient line with the same chat id", async () => {
@@ -1244,7 +1268,14 @@ describe("Linq explicit external-thread routing", () => {
       ok: true,
       reason: "duplicate-webhook-event",
     });
-    expect(plan.wakeMailboxItemId).toBe("mailbox_existing");
+    const wakeHandoff = readSingleWakeHandoff(plan);
+    expect(wakeHandoff).toMatchObject({
+      eventId: "evt_group_123",
+      mailboxItemId: "mailbox_existing",
+      source: "linq",
+      userId: "member_thread_container_123",
+    });
+    expect(wakeHandoff).not.toHaveProperty("wakeMailboxCheckpoint");
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
   });
 });
@@ -1376,8 +1407,12 @@ describe("Linq group chat auto-provision", () => {
     expect(containerCreate.data.ownerMemberId).toBe("member_owner_123");
     expect(containerCreate.data.monthlyUsageLimitUsdMicros).toBe(4_500_000n);
     expect(prisma.hostedThreadRoute.create).toHaveBeenCalledTimes(1);
-    expect(plan.wakeUserId).toBe(containerCreate.data.memberId);
-    expect(plan.wakeLinqChatId).toBe("chat_group_123");
+    expect(readSingleWakeHandoff(plan)).toMatchObject({
+      eventId: "evt_group_123",
+      linqChatId: "chat_group_123",
+      source: "linq",
+      userId: containerCreate.data.memberId,
+    });
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(2);
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenNthCalledWith(1, {
       envelope: expect.objectContaining({
@@ -1648,7 +1683,11 @@ describe("Linq group chat concurrent provisioning race", () => {
       ok: true,
       reason: "wake-appended-thread-route",
     });
-    expect(plan.wakeUserId).toBe("member_thread_container_999");
+    expect(readSingleWakeHandoff(plan)).toMatchObject({
+      eventId: "evt_group_123",
+      source: "linq",
+      userId: "member_thread_container_999",
+    });
     expect(prisma.hostedThreadContainer.create).not.toHaveBeenCalled();
     expect(prisma.hostedThreadRoute.create).not.toHaveBeenCalled();
   });

--- a/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
@@ -40,6 +40,22 @@ const response = {
   reason: "wake-appended-active-member",
 } as never;
 
+function buildWakeHandoff(
+  overrides: Partial<NonNullable<Parameters<typeof maybeHandoffHostedExecutionWebhookWake>[0]["wakeHandoff"]>> = {},
+) {
+  return {
+    eventId: "evt_123",
+    mailboxItemId: "mailbox_123",
+    source: "linq" as const,
+    userId: "member_123",
+    wakeMailboxCheckpoint: {
+      lane: "conversation" as const,
+      laneSeq: "42",
+    },
+    ...overrides,
+  };
+}
+
 describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -79,18 +95,11 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     });
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
       scheduleAfterResponse: (task) => {
         afterResponseTasks.push(task);
       },
-      source: "linq",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: "conversation",
-        laneSeq: "42",
-      },
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toEqual({
       reason: "temporal-signaled",
       signalAccepted: true,
@@ -121,15 +130,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     mocks.ensureRuntimeProcessing.mockRejectedValue(new Error("cloudflare unreachable"));
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "linq",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: "conversation",
-        laneSeq: "42",
-      },
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       signalAccepted: true,
@@ -150,15 +152,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     mocks.ensureRuntimeProcessing.mockReturnValue(new Promise(() => undefined));
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "linq",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: "conversation",
-        laneSeq: "42",
-      },
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       signalAccepted: true,
@@ -172,15 +167,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     mocks.ensureRuntimeProcessing.mockReturnValue(new Promise(() => undefined));
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "telegram",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: "conversation",
-        laneSeq: "42",
-      },
+      wakeHandoff: buildWakeHandoff({ source: "telegram" }),
     })).resolves.toMatchObject({
       reason: "temporal-signaled",
       signalAccepted: true,
@@ -195,15 +183,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     mocks.signalHostedMailboxAppendRuntime.mockRejectedValue(new Error("temporal down"));
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "linq",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: "conversation",
-        laneSeq: "42",
-      },
+      wakeHandoff: buildWakeHandoff(),
     })).rejects.toThrow("temporal down");
 
     expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
@@ -216,15 +197,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     });
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "linq",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: "conversation",
-        laneSeq: "42",
-      },
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({ signalAccepted: true });
 
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
@@ -237,11 +211,13 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
 
   it("skips the direct ensure and lane facts when the planner checkpoint is absent", async () => {
     await maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "linq",
-      userId: "member_123",
+      wakeHandoff: {
+        eventId: "evt_123",
+        mailboxItemId: "mailbox_123",
+        source: "linq",
+        userId: "member_123",
+      },
     });
 
     expect(mocks.readHostedExecutionControlClientIfConfigured).not.toHaveBeenCalled();
@@ -254,15 +230,13 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
 
   it("falls back to the legacy signal path when checkpoint lane facts are malformed", async () => {
     await maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "linq",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: undefined,
-        laneSeq: undefined,
-      } as never,
+      wakeHandoff: buildWakeHandoff({
+        wakeMailboxCheckpoint: {
+          lane: "conversation",
+          laneSeq: "",
+        },
+      }),
     });
 
     expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
@@ -276,15 +250,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     mocks.readHostedExecutionControlClientIfConfigured.mockReturnValue(null);
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
-      eventId: "evt_123",
-      mailboxItemId: "mailbox_123",
       response,
-      source: "linq",
-      userId: "member_123",
-      wakeMailboxCheckpoint: {
-        lane: "conversation",
-        laneSeq: "42",
-      },
+      wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({ signalAccepted: true });
 
     expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();


### PR DESCRIPTION
## Why

The webhook plan (`HostedWebhookPlan`) carried five wake shapes: the `wakeHandoffs` array plus four singular fields (`wakeLinqChatId`, `wakeMailboxCheckpoint`, `wakeMailboxItemId`, `wakeUserId`). This is redundant state; the handoff already carries the equivalent of each singular field. Part 2b of `agent-docs/exec-plans/active/2026-07-03-mailbox-wake-collapse.md`.

## What ships

Collapse to `wakeHandoffs` as the sole wake shape and remove the four singular fields. Producers (Linq/Telegram/WhatsApp planners) emit handoffs; consumers (wake dispatch, the re-landed direct Linq ensure, and Linq read receipts) read from the handoff. Net deletion (about -21 lines of net production shape).

## User-visible goal

None. Pure internal simplification; wake behavior is byte-for-byte equivalent.

## Invariants to preserve

- Duplicate wakes stay checkpoint-absent per handoff (Linq duplicate branches keep the legacy repairing signal path).
- Family notifications target the accepting member with no checkpoint.
- Linq read receipts read the handoff `linqChatId`; `linqReadReceiptRouteAuthority` stays a plan-level field.
- `wakeHandoffs` stays an array (WhatsApp emits one per inbound text).

## Note

Stacked on #383 (consume `consumed_at` + direct wake); base will retarget to main after #383 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785910099&installation_id=127572939&pr_number=384&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F384&signature=70dfc9dc57e27fb0e826e8b58593d194bf79ce60e1175f5b2c5705a43d7c8d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->