### PR TITLE
fix(assistant-engine): rebind session on conversation-key audience drift

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-06-group-session-routing-rebind.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-group-session-routing-rebind.md
@@ -1,0 +1,80 @@
+# Group Session Routing Rebind
+
+## Problem
+
+A hosted group chat stopped getting replies and the runtime fell into a
+permanent ~30s wake loop (observed for 16+ hours across two group containers).
+Root cause: when a group's routed audience shape drifts — the active speaker
+changes, or the direct/group flag flips because the assistant is removed and
+re-added — `persistResolvedSession` throws `ASSISTANT_SESSION_ROUTING_CONFLICT`.
+Inbound messages resolve a session by conversation-key, and that path never
+allowed a binding rebind, so every reply attempt failed, the mailbox input
+stayed pending, the consume watermark never advanced, and the wake loop spun
+forever without replying or self-healing.
+
+## Decision
+
+Allow a binding rebind when the session was located by `conversation-key`.
+
+A conversation-key match is located BY the routing boundary itself: channel,
+identity, and the thread-or-actor scope are all encoded in the lookup key, so a
+match already proves those are equal. The only isolation fields that can still
+differ on that path are within-conversation drift (a group's active speaker, or
+`threadIsDirect` flipping as members change). That drift must update the binding,
+never fail the reply.
+
+Do not touch `getAssistantBindingIsolationConflicts` (the pure reporter stays
+correct) and do not change the `alias` or `session-id` paths: an explicit
+session-id resume still requires opt-in `allowBindingRebind`, and alias resumes
+still fail closed, because there the caller supplies the identifier and could be
+retargeting a genuinely different audience.
+
+No new state, queue, retry cap, or dead-letter mechanism. The root-cause fix
+removes the failure that produced the loop; the loop clears by construction once
+the reply succeeds and the input is consumed.
+
+## Verified Against Current Code
+
+- `packages/assistant-engine/src/assistant/bindings.ts` — isolation fields are
+  `channel | identityId | actorId | threadId | threadIsDirect`; the conversation
+  key is `channel | identity | (thread|actor)` scope, so channel/identity/scope
+  are equal by construction on any conversation-key match.
+- `packages/assistant-engine/src/assistant/store.ts` — inbound messages with no
+  sessionId/alias resolve via the conversation-key branch (`lookupSource:
+  'conversation-key'`).
+- `packages/assistant-engine/src/assistant/store/persistence.ts` — the throw
+  gate is the only place that rejected the rebind; `synchronizeAssistantIndexes`
+  already reconciles the index if the derived key changes.
+- Existing `ASSISTANT_SESSION_ROUTING_CONFLICT` tests only cover the `session-id`
+  and `alias` paths (packages/cli assistant-state / assistant-channel,
+  assistant-engine infra-final-coverage); none assert the conversation-key path
+  throws.
+
+## Files
+
+- `packages/assistant-engine/src/assistant/store/persistence.ts`
+- `packages/assistant-engine/test/assistant-session-resolution-store.test.ts`
+
+## Verification
+
+- New regression tests: group speaker + directness drift rebinds within the same
+  session (was the wedge); session-id retarget still throws.
+- `pnpm --dir packages/assistant-engine typecheck` clean.
+- Full assistant-engine suite green; packages/cli conflict suites green.
+
+## Invariants To Preserve
+
+- Replies to a current inbound message keep an authorized success path
+  (`docs/contracts/00-invariants.md` § Product-Critical Flow Preservation).
+- Cross-audience isolation on explicit `alias` / `session-id` resumes is
+  unchanged.
+
+## Deployment
+
+Assistant-engine ships in both web (Vercel) and the Cloudflare hosted runner.
+The wedge and self-heal live in the hosted runner, so the fix only takes effect
+once the Cloudflare hosted runtime is deployed. On deploy, the next wake of a
+stuck container rebinds, replies, consumes the pending input, and the loop ends.
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/packages/assistant-engine/src/assistant/bindings.ts
+++ b/packages/assistant-engine/src/assistant/bindings.ts
@@ -314,6 +314,16 @@ const assistantBindingIsolationFields = [
   'threadIsDirect',
 ] as const satisfies readonly AssistantBindingIsolationField[]
 
+// Isolation fields that may legitimately differ between two contexts that share
+// the same conversation key: the active speaker (`actorId`) in a group thread,
+// and the direct/group classification (`threadIsDirect`) as the roster changes.
+// `channel`, `identityId`, and the thread/actor scope are all encoded in the
+// conversation key, so a conversation-key match already proves those are equal —
+// a conflict on any of them signals upstream key-derivation drift and must still
+// fail closed rather than silently rebind across a routing boundary.
+export const assistantWithinConversationDriftFields: ReadonlySet<AssistantBindingIsolationField> =
+  new Set(['actorId', 'threadIsDirect'])
+
 function canUseActorScopedConversationKey(
   input: Pick<AssistantBindingInput, 'threadIsDirect'>,
 ): boolean {

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -434,13 +434,20 @@ export async function persistResolvedSession(
     session.binding,
     input.bindingPatch,
   )
-  if (
-    routingConflicts.length > 0 &&
-    !(
-      input.allowBindingRebind === true &&
-      input.lookupSource === 'session-id'
-    )
-  ) {
+  // A conversation-key match is located BY the routing boundary itself: channel,
+  // identity, and the thread-or-actor scope are all encoded in the lookup key, so
+  // a match already proves those are equal. The only isolation fields that can
+  // still differ are within-conversation drift — a group's active speaker, or the
+  // direct/group flag flipping as members are added and removed. That drift must
+  // update the binding, never fail the reply: rejecting it strands the inbound
+  // message as unhandled and wedges the whole conversation. Explicit session-id
+  // resumes stay opt-in via allowBindingRebind because the caller supplies the
+  // identifier and could be retargeting the session at a genuinely different
+  // audience; alias resumes never rebind for the same reason.
+  const bindingRebindAllowed =
+    input.lookupSource === 'conversation-key' ||
+    (input.allowBindingRebind === true && input.lookupSource === 'session-id')
+  if (routingConflicts.length > 0 && !bindingRebindAllowed) {
     throw createAssistantSessionRoutingConflictError({
       conflicts: routingConflicts,
       lookupSource: input.lookupSource,

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -14,6 +14,7 @@ import {
 } from '@murphai/operator-config/assistant-cli-contracts'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import {
+  assistantWithinConversationDriftFields,
   getAssistantBindingIsolationConflicts,
   mergeAssistantBinding,
   type AssistantBindingPatch,
@@ -440,12 +441,19 @@ export async function persistResolvedSession(
   // still differ are within-conversation drift — a group's active speaker, or the
   // direct/group flag flipping as members are added and removed. That drift must
   // update the binding, never fail the reply: rejecting it strands the inbound
-  // message as unhandled and wedges the whole conversation. Explicit session-id
-  // resumes stay opt-in via allowBindingRebind because the caller supplies the
-  // identifier and could be retargeting the session at a genuinely different
-  // audience; alias resumes never rebind for the same reason.
+  // message as unhandled and wedges the whole conversation. We enforce the drift
+  // boundary locally (not just trust the key derivation) so a conflict on any
+  // wider field still fails closed. Explicit session-id resumes stay opt-in via
+  // allowBindingRebind because the caller supplies the identifier and could be
+  // retargeting the session at a genuinely different audience; alias resumes
+  // never rebind for the same reason.
+  const conversationKeyRebindAllowed =
+    input.lookupSource === 'conversation-key' &&
+    routingConflicts.every((conflict) =>
+      assistantWithinConversationDriftFields.has(conflict.field),
+    )
   const bindingRebindAllowed =
-    input.lookupSource === 'conversation-key' ||
+    conversationKeyRebindAllowed ||
     (input.allowBindingRebind === true && input.lookupSource === 'session-id')
   if (routingConflicts.length > 0 && !bindingRebindAllowed) {
     throw createAssistantSessionRoutingConflictError({

--- a/packages/assistant-engine/test/assistant-infra-final-coverage.test.ts
+++ b/packages/assistant-engine/test/assistant-infra-final-coverage.test.ts
@@ -384,6 +384,33 @@ describe('assistant infra final coverage', () => {
     expect(rebound.binding.threadId).toBe('thread-2')
     expect(rebound.sessionId).toBe(session.sessionId)
 
+    // A conversation-key match may rebind within-conversation drift fields
+    // (here the direct/group flag) without opting in, because the key already
+    // pins channel/identity/scope.
+    const driftRebound = await persistResolvedSession(paths, session, {
+      alias: session.alias,
+      bindingPatch: {
+        threadIsDirect: false,
+      },
+      lookupSource: 'conversation-key',
+    })
+    expect(driftRebound.binding.threadIsDirect).toBe(false)
+    expect(driftRebound.sessionId).toBe(session.sessionId)
+
+    // But a conversation-key conflict on a routing-boundary field (identity)
+    // must still fail closed rather than silently rebind across the boundary.
+    await expect(
+      persistResolvedSession(paths, session, {
+        alias: session.alias,
+        bindingPatch: {
+          identityId: 'user-2',
+        },
+        lookupSource: 'conversation-key',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ASSISTANT_SESSION_ROUTING_CONFLICT',
+    })
+
     await expect(
       loadAndPersistResolvedSession({
         maxSessionAgeMs: 1,

--- a/packages/assistant-engine/test/assistant-session-resolution-store.test.ts
+++ b/packages/assistant-engine/test/assistant-session-resolution-store.test.ts
@@ -183,6 +183,89 @@ describe('assistant session resolution store integration', () => {
     ])
     expect(sessions[0]?.target).toEqual(durableTarget)
   })
+
+  it('rebinds a group conversation-key session when the active speaker and direct/group flag drift as members are added and removed', async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'assistant-session-resolution-group-rebind-',
+    )
+    cleanupPaths.push(parentRoot)
+
+    const created = await resolveAssistantSession({
+      actorId: 'linq-member-a',
+      channel: 'linq',
+      identityId: 'linq-line',
+      target: createCodexTarget(),
+      threadId: 'group-thread',
+      threadIsDirect: false,
+      vault: vaultRoot,
+    })
+    expect(created.session.binding.actorId).toBe('linq-member-a')
+    expect(created.session.binding.threadIsDirect).toBe(false)
+
+    // A later message on the SAME group thread arrives from a different member,
+    // and the direct/group flag flips because the roster changed (the assistant
+    // was removed and re-added). The conversation key (channel|identity|thread)
+    // is unchanged, so this must rebind the existing session rather than throw a
+    // routing conflict and strand the inbound message.
+    const resolved = await resolveAssistantSession({
+      actorId: 'linq-member-b',
+      channel: 'linq',
+      createIfMissing: false,
+      identityId: 'linq-line',
+      threadId: 'group-thread',
+      threadIsDirect: true,
+      vault: vaultRoot,
+    })
+
+    expect(resolved.created).toBe(false)
+    expect(resolved.session.sessionId).toBe(created.session.sessionId)
+    expect(resolved.resolutionDiagnostics).toMatchObject({
+      conversationLookupMatchedScope: 'thread',
+      sessionResolutionLookupSource: 'conversation-key',
+    })
+    expect(resolved.session.binding.actorId).toBe('linq-member-b')
+    expect(resolved.session.binding.threadIsDirect).toBe(true)
+
+    const sessions = await listAssistantSessions(vaultRoot)
+    expect(sessions.map((session) => session.sessionId)).toEqual([
+      created.session.sessionId,
+    ])
+  })
+
+  it('still rejects a session-id resume that retargets a bound audience unless rebind is explicitly allowed', async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'assistant-session-resolution-session-id-guard-',
+    )
+    cleanupPaths.push(parentRoot)
+
+    const created = await resolveAssistantSession({
+      actorId: 'linq-member-a',
+      channel: 'linq',
+      identityId: 'linq-line',
+      target: createCodexTarget(),
+      threadId: 'group-thread',
+      threadIsDirect: false,
+      vault: vaultRoot,
+    })
+
+    // Resolving BY session id is an explicit resume, not a routing-boundary
+    // match, so retargeting to a different audience must still fail closed
+    // without allowBindingRebind.
+    await expect(
+      resolveAssistantSession({
+        actorId: 'linq-member-b',
+        channel: 'linq',
+        createIfMissing: false,
+        identityId: 'different-line',
+        sessionId: created.session.sessionId,
+        threadId: 'other-thread',
+        threadIsDirect: true,
+        vault: vaultRoot,
+      }),
+    ).rejects.toMatchObject({
+      code: 'ASSISTANT_SESSION_ROUTING_CONFLICT',
+    })
+  })
 })
 
 function createCodexTarget(


### PR DESCRIPTION
## Why this PR exists

A hosted group chat stopped replying and the runtime fell into a permanent
~30s wake loop. In prod, two group containers spun this way for 16+ hours,
failing every reply attempt and burning compute continuously (100% of
reply-failures in a ~26h window were the same error).

Root cause: when a group's routed audience shape drifts — the active speaker
changes, or the direct/group flag flips because the assistant is removed and
re-added from the chat — `persistResolvedSession` threw
`ASSISTANT_SESSION_ROUTING_CONFLICT`. Inbound messages resolve their session by
**conversation-key**, and that path never allowed a binding rebind, so every
reply failed, the mailbox input stayed pending, the consume watermark never
advanced, and the wake loop never self-healed.

## User goal / user-visible behavior

Murph keeps replying in a group chat even after members (including Murph
itself) are added or removed and the active speaker changes. Audience drift on
an existing conversation updates the session binding instead of stranding the
message.

## What changed

Allow a binding rebind when the session is located by `conversation-key`. That
lookup key already encodes channel, identity, and the thread-or-actor scope, so
a match proves those are equal by construction — the only isolation fields that
can still differ are within-conversation drift (`actorId`, `threadIsDirect`),
which must update the binding rather than fail the reply. The `alias` and
`session-id` paths are unchanged: an explicit resume still requires opt-in
`allowBindingRebind`, because there the caller supplies the identifier and could
be retargeting a genuinely different audience.

No new state, queue, retry cap, or dead-letter machinery. The root-cause fix
removes the failure that produced the loop; the loop clears by construction once
the reply succeeds and the input is consumed.

## Invariants the PR must preserve

- Replies to a current inbound message keep an authorized success path
  (`docs/contracts/00-invariants.md` § Product-Critical Flow Preservation).
- Cross-audience isolation on explicit `alias` / `session-id` resumes is
  unchanged — retargeting a bound session to a different audience still fails
  closed without `allowBindingRebind`.
- The pure conflict reporter (`getAssistantBindingIsolationConflicts`) is
  untouched; only the policy at the persist gate changed.

## Verification

- New regression tests in `assistant-session-resolution-store.test.ts`: group
  speaker + directness drift rebinds within the same session (the wedge);
  session-id retarget still throws.
- Full `@murphai/assistant-engine` suite green (1861 passed); `packages/cli`
  session conflict suites green; `pnpm --dir packages/assistant-engine
  typecheck` clean.

## Deployment skew / compatibility

`@murphai/assistant-engine` ships in both web (Vercel) and the Cloudflare hosted
runner. The wedge and the self-heal both live in the hosted runner, so this fix
only takes effect once the **Cloudflare hosted runtime** is deployed
(`deploy-cloudflare-hosted.yml`, manual). No schema or persisted-state change,
so it is backward compatible during any web/Cloudflare skew window — a web-only
deploy simply has no effect on the loop. On hosted deploy, the next wake of a
stuck container rebinds, replies, consumes the pending input, and the loop ends;
no `container_rollout=immediate` required. Post-deploy check: confirm
`assistant.automation_detail` reply-failure events with
`ASSISTANT_SESSION_ROUTING_CONFLICT` stop and `mailbox.consume_ack_advanced`
resumes for the affected group containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785940905&installation_id=127572939&pr_number=388&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F388&signature=9e3a85fa22315009eef743f82691290dce0142872cfd3148678d7aa394256972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->