### PR TITLE
fix(assistant-engine): suppress summaries for stale backfilled device activity

### DIFF
--- a/packages/assistant-engine/src/assistant/device-activity-automations.ts
+++ b/packages/assistant-engine/src/assistant/device-activity-automations.ts
@@ -34,6 +34,12 @@ import { resolveAssistantStatePaths } from './store/paths.js'
 
 const DEVICE_ACTIVITY_AUTOMATION_MAX_MATCHES_PER_PASS = 25
 
+// Suppress the summary for a device activity that finished long before the sync that surfaced it
+// (e.g. a WHOOP/Junction backfill after the device was offline for a day or more). Last night's
+// sleep and this morning's workout are always well under this bound; a record from an earlier day
+// is not.
+const DEVICE_ACTIVITY_MAX_STALENESS_MS = 24 * 60 * 60_000
+
 type DeviceActivitySchedule = Extract<AutomationSchedule, { kind: 'deviceActivity' }>
 type DeviceActivityAutomation = AutomationQueryRecord & { schedule: DeviceActivitySchedule }
 type ActivityEntity = VaultReadModel['events'][number]
@@ -110,7 +116,7 @@ async function scheduleDeviceActivityTriggeredAutomationsAt(
   }
 
   const vault = await readVaultRawTolerant(input.vault)
-  const activityCandidates = listDeviceActivityCandidates(vault)
+  const activityCandidates = listDeviceActivityCandidates(vault, input.nowIso)
   let matched = 0
   let moreMatchesRemain = false
   let scheduled = 0
@@ -204,9 +210,10 @@ async function hasDueAssistantRequireSendCronJob(input: {
   )
 }
 
-function listDeviceActivityCandidates(vault: VaultReadModel): DeviceActivityCandidate[] {
+function listDeviceActivityCandidates(vault: VaultReadModel, nowIso: string): DeviceActivityCandidate[] {
   return vault.events
     .filter(isDeviceActivityEventEntity)
+    .filter((entity) => !isStaleDeviceActivity(entity, nowIso))
     .flatMap((entity) => {
       const occurredAt = resolveActivityOccurredAt(entity)
       const triggeredAt = resolveDeviceActivityTriggeredAt(entity)
@@ -305,6 +312,22 @@ function isDeviceActivityEventEntity(
   entity: ActivityEntity,
 ): entity is ActivityEntity & { kind: DeviceActivityEventKind } {
   return entity.kind === 'activity_session' || entity.kind === 'sleep_session'
+}
+
+function isStaleDeviceActivity(entity: ActivityEntity, nowIso: string): boolean {
+  // Anchor on when the activity ended. Sleep carries an explicit endAt (it runs for hours, so its
+  // start can look stale while it is genuinely last night); activity sessions have no endAt and are
+  // short, so their start time is a fine anchor.
+  const endedAt = normalizeTimestamp(readString(entity.attributes.endAt)) ?? resolveActivityOccurredAt(entity)
+  if (endedAt === null) {
+    return false
+  }
+  const endedAtMs = Date.parse(endedAt)
+  const nowMs = Date.parse(nowIso)
+  if (!Number.isFinite(endedAtMs) || !Number.isFinite(nowMs)) {
+    return false
+  }
+  return nowMs - endedAtMs > DEVICE_ACTIVITY_MAX_STALENESS_MS
 }
 
 function resolveDeviceActivityKind(entity: ActivityEntity & { kind: DeviceActivityEventKind }): string {

--- a/packages/assistant-engine/test/device-activity-automations.test.ts
+++ b/packages/assistant-engine/test/device-activity-automations.test.ts
@@ -319,6 +319,79 @@ describe('device activity triggered automations', () => {
     )
   })
 
+  it('suppresses a backfilled sleep session that ended more than a day before the sync', async () => {
+    deviceActivityMocks.automations = [
+      createDeviceActivityAutomation({
+        activityKind: 'sleep',
+        after: '2026-06-05T00:00:00.000Z',
+        automationId: 'auto_sleep',
+        instructions: 'Ask about sleep consistency.',
+        source: 'whoop_v2',
+      }),
+    ]
+    deviceActivityMocks.readModel = createVaultReadModel({
+      entities: [
+        createSleepEntity({
+          endAt: '2026-06-05T14:00:00.000Z',
+          entityId: 'evt_sleep_stale',
+          occurredAt: '2026-06-05T06:00:00.000Z',
+          startAt: '2026-06-05T06:00:00.000Z',
+          title: 'Backfilled sleep',
+        }),
+      ],
+      vaultRoot,
+    })
+
+    await expect(
+      scheduleDeviceActivityTriggeredAutomations({
+        now: () => '2026-06-07T12:01:00.000Z',
+        vault: vaultRoot,
+      }),
+    ).resolves.toEqual({
+      matched: 0,
+      nextWakeAt: null,
+      scheduled: 0,
+    })
+
+    expect(await readQueuedCronJobs(vaultRoot)).toHaveLength(0)
+  })
+
+  it('suppresses a backfilled workout that occurred more than a day before the sync', async () => {
+    deviceActivityMocks.automations = [
+      createDeviceActivityAutomation({
+        activityKind: 'workout',
+        after: '2026-06-05T00:00:00.000Z',
+        automationId: 'auto_workout',
+        instructions: 'Ask about the imported workout.',
+      }),
+    ]
+    deviceActivityMocks.readModel = createVaultReadModel({
+      entities: [
+        createActivityEntity({
+          entityId: 'evt_workout_stale',
+          occurredAt: '2026-06-05T06:00:00.000Z',
+          recordedAt: '2026-06-07T12:05:00.000Z',
+          title: 'Backfilled ride',
+          workoutType: 'Cycling',
+        }),
+      ],
+      vaultRoot,
+    })
+
+    await expect(
+      scheduleDeviceActivityTriggeredAutomations({
+        now: () => '2026-06-07T12:06:00.000Z',
+        vault: vaultRoot,
+      }),
+    ).resolves.toEqual({
+      matched: 0,
+      nextWakeAt: null,
+      scheduled: 0,
+    })
+
+    expect(await readQueuedCronJobs(vaultRoot)).toHaveLength(0)
+  })
+
   it('uses the recorded import time for trigger windows and accepts workout selectors', async () => {
     deviceActivityMocks.automations = [
       createDeviceActivityAutomation({
@@ -1416,8 +1489,10 @@ function createActivityEntity(input: {
 }
 
 function createSleepEntity(input: {
+  endAt?: string
   entityId: string
   occurredAt: string
+  startAt?: string
   title: string
 }): CanonicalEntity {
   return {
@@ -1426,12 +1501,13 @@ function createSleepEntity(input: {
         sourceProviderSlug: 'junction',
       },
       durationMinutes: 420,
+      endAt: input.endAt ?? input.occurredAt,
       externalRef: {
         resourceType: 'junction-whoop-v2-sleep',
         system: 'junction',
       },
       recordedAt: input.occurredAt,
-      startAt: '2026-06-07T04:00:00.000Z',
+      startAt: input.startAt ?? '2026-06-07T04:00:00.000Z',
     },
     body: null,
     date: '2026-06-07',


### PR DESCRIPTION
Supersedes #389, which got contaminated by a shared-checkout branch-name collision. This is the same change on a uniquely-named branch: a single commit touching only the two `assistant-engine` files.

## Problem

Device-activity automations (morning sleep summary, workout check-ins) fire on **every** sleep/workout record as it arrives. When a WHOOP-via-Junction backfill lands after the device was offline for a day or more, the user gets pinged about days-old activity. Reported case: 48h offline, then two sleep summaries on reconnect (the previous night plus last night).

## Fix

One uniform rule for the whole category: drop any device-activity record whose activity **ended more than 24h before the sync** before it becomes a candidate, so the coverage cursor never advances onto it and it stays suppressed permanently.

- Anchored on `endAt ?? occurredAt`: sleep uses its real `endAt` (it runs for hours, so its start can look stale while it's genuinely last night); workouts have no `endAt` and are short, so their start time is a fine anchor.
- **Fails open**: a missing or unparseable timestamp keeps the notification.
- 24h is generous enough that last night's sleep and this morning's workout always pass even with a late sync, while anything from an earlier day is dropped.

## Scope

Fixes the stale/backfill case only. The "woke for an hour and went back to bed" fragment (two fresh records same morning) is intentionally left alone, since that needs a settle/finality mechanism we chose not to build.

## Tests

Two staleness tests (sleep + workout), each paired against an existing fresh-scheduling test with the same selectors, so the only delta is the old timestamp producing zero scheduled jobs. The workout test uses a fresh `recordedAt` but old `occurredAt` to prove the guard measures the event's real time, not import lag. 21/21 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785945042&installation_id=127572939&pr_number=391&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F391&signature=aa248fada98797191d6c8bfd0b0437bf3be2345786e84185e3062f4e682a5914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->