### PR TITLE
collapse hosted Linq thread routing + egress authority onto the stable chat id

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-06-account-lookup-key-deploy-skew.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-account-lookup-key-deploy-skew.md
@@ -1,0 +1,52 @@
+Goal (incl. success criteria):
+- Restore `accountLookupKey` emission on new hosted Linq route-authority, mailbox-wake, and group-tool payloads while keeping readers tolerant of missing keys.
+- Preserve chat-id-based routing/authorization; `accountLookupKey` remains compatibility metadata only.
+- Success means old deployed web/runner code still receives the legacy required field during deploy skew, and new tolerant readers still accept missing fields for a later phase-2 removal.
+
+Constraints/Assumptions:
+- Do not revert optional reader/contracts changes.
+- Do not change route lookup, authorization, membership, billing, or provisioning gates.
+- No new persisted state, tables, columns, managers, or schedulers.
+- Preserve unrelated branch and ledger edits.
+
+Key decisions:
+- Populate emitted compatibility fields from the current recipient line lookup key already available in the webhook path.
+- Keep egress group-tool/delivery propagation preserving any populated authority field without using it for route assertion.
+
+State:
+- Implementation and verification complete; commit next.
+
+Done:
+- Read required repo workflow, architecture, security, reliability, verification, product, and fix-brief docs.
+- Audited the branch diff for removed `accountLookupKey` emissions.
+- Restored current-line `accountLookupKey` emission in hosted Linq route authorities and mailbox wakes.
+- Preserved populated `accountLookupKey` in runtime-injected group-tool Linq thread context while deduping by chat id.
+- Added/updated web, hosted-execution, and assistant-runtime regression coverage for emitted compatibility fields and tolerant readers.
+- Updated the stale hosted-web dispatch assertion to verify chat-id route revalidation.
+- Verified package typechecks and focused/broader touched tests.
+
+Now:
+- Commit with `scripts/finish-task`.
+
+Next:
+- Handoff with changed files, tests, verification output, and deploy-skew notes.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+- apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+- apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+- apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+- packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+- packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+- packages/hosted-execution/src/parsers.ts
+- packages/hosted-execution/src/parsers/runtime-control.ts
+- packages/hosted-execution/test/hosted-execution-builders-hosted-email.test.ts
+- packages/hosted-execution/test/parsers.test.ts
+- Verification: `pnpm --dir apps/web typecheck`; `pnpm --dir packages/hosted-execution typecheck`; `pnpm --dir packages/assistant-runtime typecheck`; `pnpm --dir packages/operator-config typecheck`; `pnpm --dir apps/web test:prepared -- hosted-onboarding-linq-thread-route.test.ts hosted-onboarding-linq-egress-engagement.test.ts hosted-runtime-linq-delivery-route.test.ts`; `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-onboarding-linq-thread-route.test.ts apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts apps/web/test/hosted-runtime-linq-delivery-route.test.ts`; `pnpm --dir packages/hosted-execution test -- hosted-execution-builders-hosted-email.test.ts parsers.test.ts`; `pnpm --dir packages/assistant-runtime test -- hosted-runtime-group-tool-linq-context.test.ts`; `pnpm --dir packages/operator-config test`; `git diff --check`.
+- agent-docs/exec-plans/active/COORDINATION_LEDGER.md
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/agent-docs/exec-plans/completed/2026-07-06-route-chatid-collapse.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-route-chatid-collapse.md
@@ -1,0 +1,59 @@
+Goal (incl. success criteria):
+- Collapse hosted Linq existing-thread routing and reply-egress authority onto the stable chat-id key: `(channel, threadIdentityLookupKey/chatId)`.
+- Delete the silent `thread-route-authority-mismatch` drop by routing existing provisioned chats through the chat-id lookup.
+- Preserve backward compatibility for already-persisted egress authorities that still include `accountLookupKey`.
+- Success means old authority payloads still authorize by `(channel, threadId, containerMemberId)`, new authority payloads may omit `accountLookupKey`, and provisioning/billing/membership gates remain unchanged.
+
+Constraints/Assumptions:
+- Do not touch billing/access gates or membership/home-line gates.
+- Do not change new group container provisioning or owner/home-line selection.
+- Preserve ambiguity, channel-validity, `isFromMe`, empty-parts, invalid-contact, and duplicate-mailbox gates.
+- No new state, tables, columns, managers, or lifecycle machinery.
+- Preserve unrelated working-tree edits and active ledger rows.
+
+Key decisions:
+- Use one chat-id-keyed route reader for existing-route lookup and egress assertion.
+- Accept and ignore `accountLookupKey` in external thread-route authority payloads for deploy and persisted-state compatibility.
+
+State:
+- Implementation complete; verification passing.
+
+Done:
+- Read repo workflow/security/reliability/deliverability docs and implementation brief.
+- Repointed hosted thread route lookup and egress assertion to the chat-id identity key.
+- Removed the silent `thread-route-authority-mismatch` ingestion drop.
+- Made external thread-route authority account lookup optional across hosted-execution and assistant outbox contracts.
+- Added/updated focused route, webhook, delivery callback, parser, and runtime context tests.
+- Verified required typechecks and tests.
+
+Now:
+- Close the plan with a scoped commit.
+
+Next:
+- Handoff with changed files, verification output, and compatibility notes.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/src/lib/hosted-routing/thread-route-store.ts
+- apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+- packages/hosted-execution/src/contracts.ts
+- packages/hosted-execution/src/parsers.ts
+- packages/hosted-execution/src/parsers/runtime-control.ts
+- packages/hosted-execution/src/builders.ts
+- packages/operator-config/src/assistant-cli-contracts.ts
+- packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+- packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+- apps/web/test/hosted-thread-route-store.test.ts
+- apps/web/test/hosted-onboarding-linq-webhook.test.ts
+- apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+- apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+- apps/web/test/hosted-runtime-linq-delivery-route.test.ts
+- packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+- packages/hosted-execution/test/hosted-execution-builders-hosted-email.test.ts
+- packages/hosted-execution/test/parsers.test.ts
+- Verification: `pnpm --dir apps/web typecheck`, `pnpm --dir packages/hosted-execution typecheck`, focused web Linq/thread-route/delivery tests, `pnpm --dir packages/hosted-execution test`, `pnpm --dir packages/operator-config typecheck`, `pnpm --dir packages/operator-config test`, `pnpm --dir packages/assistant-runtime build`, `pnpm --dir packages/assistant-runtime typecheck`, and focused assistant-runtime group-tool test.
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
@@ -134,7 +134,7 @@ async function readHostedLinqDeliveryRouteLineLookupKey(input: {
   memberId: string;
   prisma: ReturnType<typeof getPrisma>;
   routeAuthority: HostedExecutionLinqExternalThreadRouteAuthority;
-}): Promise<string> {
+}): Promise<string | null> {
   if (input.routeAuthority.containerMemberId !== input.memberId) {
     throw hostedOnboardingError({
       code: "HOSTED_LINQ_DELIVERY_ROUTE_BOUND_USER_MISMATCH",
@@ -144,11 +144,11 @@ async function readHostedLinqDeliveryRouteLineLookupKey(input: {
     });
   }
 
-  const route = await assertHostedThreadRouteEgressAuthority({
+  await assertHostedThreadRouteEgressAuthority({
     authority: input.routeAuthority,
     prisma: input.prisma,
   });
-  return route.accountLookupKey;
+  return input.routeAuthority.accountLookupKey?.trim() || null;
 }
 
 function parseAnsweredMailboxItemIds(value: unknown): string[] {

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
@@ -148,6 +148,15 @@ async function readHostedLinqDeliveryRouteLineLookupKey(input: {
     authority: input.routeAuthority,
     prisma: input.prisma,
   });
+  // This is a post-send delivery-OUTCOME callback (Cloudflare-runner
+  // authenticated), not a routing decision. Authorization is already bound to
+  // the DB route by channel + chatId + containerMemberId above; the returned
+  // line key is used only to attribute the recorded outcome to a Linq line's
+  // stats. Since a chat-id route is intentionally no longer line-pinned, the DB
+  // route carries no authoritative send line — the runner that performed the
+  // send is the source of truth for which line it used, so we read it from the
+  // (already authority-validated) request. A missing key is benign: the outcome
+  // still records without line attribution.
   return input.routeAuthority.accountLookupKey?.trim() || null;
 }
 

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -12,7 +12,7 @@ import {
 } from "@murphai/hosted-execution/parsers";
 
 import {
-  createHostedExternalThreadLookupKeyReadCandidates,
+  createHostedExternalThreadIdentityLookupKeyReadCandidates,
   createHostedLinqChatLookupKeyReadCandidates,
   createHostedPhoneLookupKeyReadCandidates,
 } from "./contact-privacy";
@@ -135,7 +135,6 @@ export async function recordHostedMemberLinqInboundEngagementTx(input: {
 export async function recordHostedThreadRouteLinqInboundEngagementTx(input: {
   chatId: string | null | undefined;
   occurredAt: Date | string;
-  linePhoneNumberLookupKey: string | null;
   memberId: string;
   now?: Date;
   prisma: HostedLinqEngagementClient;
@@ -147,12 +146,11 @@ export async function recordHostedThreadRouteLinqInboundEngagementTx(input: {
   if (!occurredAt) {
     return;
   }
-  const threadLookupKeys = createHostedExternalThreadLookupKeyReadCandidates({
-    accountLookupKey: input.linePhoneNumberLookupKey,
+  const threadIdentityLookupKeys = createHostedExternalThreadIdentityLookupKeyReadCandidates({
     channel: "linq",
     threadId: input.chatId,
   });
-  if (threadLookupKeys.length === 0) {
+  if (threadIdentityLookupKeys.length === 0) {
     return;
   }
 
@@ -160,7 +158,7 @@ export async function recordHostedThreadRouteLinqInboundEngagementTx(input: {
     where: {
       channel: "linq",
       containerMemberId: input.memberId,
-      threadLookupKey: { in: threadLookupKeys },
+      threadIdentityLookupKey: { in: threadIdentityLookupKeys },
       OR: [
         { lastInboundAt: null },
         { lastInboundAt: { lt: occurredAt } },
@@ -366,7 +364,7 @@ async function readHostedLinqCurrentInboundDecision(input: {
   memberId: string;
   now: Date;
   prisma: PrismaClient;
-  route: { accountLookupKey: string; lastInboundAt: Date | null } | null;
+  route: { lastInboundAt: Date | null } | null;
   routeAuthority: HostedExecutionLinqExternalThreadRouteAuthority | null;
   target: string | null;
 }): Promise<HostedLinqRecentInboundDecision | null> {
@@ -448,7 +446,6 @@ async function readHostedLinqCurrentInboundDecision(input: {
   if (input.routeAuthority && input.route) {
     await recordHostedThreadRouteLinqInboundEngagementTx({
       chatId: proof.target,
-      linePhoneNumberLookupKey: input.route.accountLookupKey,
       memberId: input.memberId,
       now: input.now,
       occurredAt,

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -95,7 +95,6 @@ import type {
   HostedLinqFirstContactAdmissionRequest,
 } from "./linq-first-contact-admission";
 import {
-  readHostedThreadRouteByExternalThread,
   readHostedThreadRouteByThreadIdentity,
   type HostedLinqThreadRouteEgressAuthority,
   type HostedThreadRouteSnapshot,
@@ -163,38 +162,18 @@ export async function planHostedOnboardingLinqWebhook(input: {
   const threadRouteAccountLookupKeys = createHostedPhoneLookupKeyReadCandidates(
     recipientPhoneNumber,
   );
-  if (threadRouteAccountLookupKeys.length > 0) {
-    const explicitThreadRoute = await readHostedThreadRouteByExternalThread({
-      accountLookupKeys: threadRouteAccountLookupKeys,
-      channel: "linq",
-      prisma: input.prisma,
-      threadId: summary.chatId,
-    });
-    if (explicitThreadRoute) {
-      return planHostedLinqExplicitThreadRouteWebhook({
-        context,
-        event: input.event,
-        prisma: input.prisma,
-        route: explicitThreadRoute,
-      });
-    }
-  }
-
-  const mismatchedThreadRoute = await readHostedThreadRouteByThreadIdentity({
+  const explicitThreadRoute = await readHostedThreadRouteByThreadIdentity({
     channel: "linq",
     prisma: input.prisma,
     threadId: summary.chatId,
   });
-  if (mismatchedThreadRoute) {
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildIgnoredLinqWebhookPlan("thread-route-authority-mismatch"),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        existingMemberActive: false,
-        existingMemberMatch: "none",
-        reason: "thread-route-authority-mismatch",
-        routeStage: "thread-route-authority-mismatch",
-      }),
-    );
+  if (explicitThreadRoute) {
+    return planHostedLinqExplicitThreadRouteWebhook({
+      context,
+      event: input.event,
+      prisma: input.prisma,
+      route: explicitThreadRoute,
+    });
   }
 
   if (isHostedLinqGroupChat(messageEvent)) {
@@ -1135,7 +1114,6 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
 
   await recordHostedThreadRouteLinqInboundEngagementTx({
     chatId: summary.chatId,
-    linePhoneNumberLookupKey: input.route.accountLookupKey,
     memberId: input.route.containerMemberId,
     occurredAt,
     prisma: input.prisma,
@@ -1174,8 +1152,9 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
     return admissionPlan;
   }
 
+  const currentLineAccountLookupKey = createHostedPhoneLookupKey(input.context.recipientPhoneNumber);
   const mailboxWake = buildHostedLinqConversationWakeForMailbox({
-    accountLookupKey: input.route.accountLookupKey,
+    ...(currentLineAccountLookupKey ? { accountLookupKey: currentLineAccountLookupKey } : {}),
     eventId: input.event.event_id,
     linqMessage: {
       chatId: summary.chatId,
@@ -1360,8 +1339,7 @@ async function planHostedLinqGroupChatWebhook(input: {
     // of dropping an authorized inbound; a missing route still fails closed.
   }
 
-  const route = await readHostedThreadRouteByExternalThread({
-    accountLookupKeys: input.threadRouteAccountLookupKeys,
+  const route = await readHostedThreadRouteByThreadIdentity({
     channel: "linq",
     prisma: input.prisma,
     threadId: summary.chatId,
@@ -1592,7 +1570,6 @@ function buildHostedLinqThreadRouteEgressAuthority(input: {
   threadId: string;
 }): HostedLinqThreadRouteEgressAuthority {
   return {
-    accountLookupKey: input.route.accountLookupKey,
     channel: "linq",
     containerMemberId: input.route.containerMemberId,
     threadId: input.threadId,

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -1073,7 +1073,9 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
     );
   }
 
+  const currentLineAccountLookupKey = createHostedPhoneLookupKey(input.context.recipientPhoneNumber);
   const routeAuthority = buildHostedLinqThreadRouteEgressAuthority({
+    accountLookupKey: currentLineAccountLookupKey,
     route: input.route,
     threadId: summary.chatId,
   });
@@ -1152,7 +1154,6 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
     return admissionPlan;
   }
 
-  const currentLineAccountLookupKey = createHostedPhoneLookupKey(input.context.recipientPhoneNumber);
   const mailboxWake = buildHostedLinqConversationWakeForMailbox({
     ...(currentLineAccountLookupKey ? { accountLookupKey: currentLineAccountLookupKey } : {}),
     eventId: input.event.event_id,
@@ -1566,10 +1567,12 @@ function normalizeHostedLinqFirstContactAdmissionService(
 }
 
 function buildHostedLinqThreadRouteEgressAuthority(input: {
+  accountLookupKey?: string | null;
   route: HostedThreadRouteSnapshot;
   threadId: string;
 }): HostedLinqThreadRouteEgressAuthority {
   return {
+    ...(input.accountLookupKey ? { accountLookupKey: input.accountLookupKey } : {}),
     channel: "linq",
     containerMemberId: input.route.containerMemberId,
     threadId: input.threadId,

--- a/apps/web/src/lib/hosted-routing/thread-route-store.ts
+++ b/apps/web/src/lib/hosted-routing/thread-route-store.ts
@@ -8,7 +8,6 @@ import type {
 
 import {
   createHostedExternalThreadIdentityLookupKeyReadCandidates,
-  createHostedExternalThreadLookupKeyReadCandidates,
   isHostedExternalThreadChannel,
 } from "../hosted-onboarding/contact-privacy";
 import {
@@ -34,7 +33,6 @@ export type HostedThreadRouteChannel = Extract<
 export type HostedThreadRouteOwnerState = HostedMemberCoreState & HostedMemberPersonAccessState;
 
 export interface HostedThreadRouteSnapshot {
-  accountLookupKey: string;
   channel: HostedThreadRouteChannel;
   container: HostedMemberCoreState;
   containerMemberId: string;
@@ -42,128 +40,15 @@ export interface HostedThreadRouteSnapshot {
   owner: HostedThreadRouteOwnerState;
 }
 
-export interface HostedThreadRouteIdentitySnapshot {
-  channel: HostedThreadRouteChannel;
-  container: HostedMemberCoreState;
-  containerMemberId: string;
-  owner: HostedThreadRouteOwnerState;
-}
-
 export type HostedThreadRouteEgressAuthority = HostedExecutionExternalThreadRouteAuthority;
 export type HostedLinqThreadRouteEgressAuthority =
   HostedExecutionLinqExternalThreadRouteAuthority;
-
-export async function readHostedThreadRouteByExternalThread(input: {
-  accountLookupKey?: string | null | undefined;
-  accountLookupKeys?: readonly (string | null | undefined)[];
-  channel: HostedThreadRouteChannel;
-  prisma: HostedOnboardingReadClient;
-  threadId: string | number | null | undefined;
-}): Promise<HostedThreadRouteSnapshot | null> {
-  const {
-    accountLookupKeyByThreadLookupKey,
-    threadLookupKeys,
-  } = createHostedThreadRouteLookupKeyReadCandidates({
-    accountLookupKey: input.accountLookupKey,
-    accountLookupKeys: input.accountLookupKeys,
-    channel: input.channel,
-    threadId: input.threadId,
-  });
-
-  if (threadLookupKeys.length === 0) {
-    return null;
-  }
-
-  const rows = await input.prisma.hostedThreadRoute.findMany({
-    orderBy: { createdAt: "asc" },
-    select: {
-      channel: true,
-      container: {
-        select: {
-          member: {
-            select: {
-              billingStatus: true,
-              createdAt: true,
-              id: true,
-              suspendedAt: true,
-              updatedAt: true,
-            },
-          },
-          owner: {
-            select: {
-              ...hostedMemberPersonAccessSelect,
-              createdAt: true,
-              id: true,
-              updatedAt: true,
-            },
-          },
-        },
-      },
-      containerMemberId: true,
-      lastInboundAt: true,
-      threadLookupKey: true,
-    },
-    where: {
-      channel: input.channel,
-      threadLookupKey: {
-        in: threadLookupKeys,
-      },
-    },
-  });
-
-  if (rows.length === 0) {
-    return null;
-  }
-
-  const distinctContainerIds = new Set(rows.map((row) => row.containerMemberId));
-  if (distinctContainerIds.size > 1) {
-    throw hostedOnboardingError({
-      code: "HOSTED_THREAD_ROUTE_LOOKUP_AMBIGUOUS",
-      details: {
-        channel: input.channel,
-        matchCount: rows.length,
-      },
-      httpStatus: 500,
-      message: "External thread route lookup matched multiple containers.",
-      retryable: true,
-    });
-  }
-
-  const row = rows[0]!;
-  const accountLookupKey = accountLookupKeyByThreadLookupKey.get(row.threadLookupKey);
-  if (!accountLookupKey) {
-    throw hostedOnboardingError({
-      code: "HOSTED_THREAD_ROUTE_LOOKUP_KEY_INVALID",
-      httpStatus: 500,
-      message: "External thread route matched an untracked lookup key.",
-      retryable: false,
-    });
-  }
-
-  if (!isHostedExternalThreadChannel(row.channel)) {
-    throw hostedOnboardingError({
-      code: "HOSTED_THREAD_ROUTE_CHANNEL_INVALID",
-      httpStatus: 500,
-      message: "External thread route has an unsupported channel.",
-      retryable: false,
-    });
-  }
-
-  return {
-    accountLookupKey,
-    channel: row.channel,
-    container: row.container.member,
-    containerMemberId: row.containerMemberId,
-    lastInboundAt: row.lastInboundAt,
-    owner: row.container.owner,
-  };
-}
 
 export async function readHostedThreadRouteByThreadIdentity(input: {
   channel: HostedThreadRouteChannel;
   prisma: HostedOnboardingReadClient;
   threadId: string | number | null | undefined;
-}): Promise<HostedThreadRouteIdentitySnapshot | null> {
+}): Promise<HostedThreadRouteSnapshot | null> {
   const threadIdentityLookupKeys =
     createHostedExternalThreadIdentityLookupKeyReadCandidates({
       channel: input.channel,
@@ -200,6 +85,7 @@ export async function readHostedThreadRouteByThreadIdentity(input: {
         },
       },
       containerMemberId: true,
+      lastInboundAt: true,
     },
     where: {
       channel: input.channel,
@@ -241,6 +127,7 @@ export async function readHostedThreadRouteByThreadIdentity(input: {
     channel: row.channel,
     container: row.container.member,
     containerMemberId: row.containerMemberId,
+    lastInboundAt: row.lastInboundAt,
     owner: row.container.owner,
   };
 }
@@ -249,8 +136,7 @@ export async function assertHostedThreadRouteEgressAuthority(input: {
   authority: HostedThreadRouteEgressAuthority;
   prisma: HostedOnboardingReadClient;
 }): Promise<HostedThreadRouteSnapshot> {
-  const route = await readHostedThreadRouteByExternalThread({
-    accountLookupKey: input.authority.accountLookupKey,
+  const route = await readHostedThreadRouteByThreadIdentity({
     channel: input.authority.channel,
     prisma: input.prisma,
     threadId: input.authority.threadId,
@@ -285,47 +171,4 @@ function buildHostedThreadRouteEgressUnauthorizedError() {
     message: "External thread route egress is no longer authorized.",
     retryable: false,
   });
-}
-
-function createHostedThreadRouteLookupKeyReadCandidates(input: {
-  accountLookupKey?: string | null | undefined;
-  accountLookupKeys?: readonly (string | null | undefined)[];
-  channel: HostedThreadRouteChannel;
-  threadId: string | number | null | undefined;
-}): {
-  accountLookupKeyByThreadLookupKey: Map<string, string>;
-  threadLookupKeys: string[];
-} {
-  const accountLookupKeys = normalizeHostedThreadRouteAccountLookupKeys([
-    ...(input.accountLookupKeys ?? []),
-    input.accountLookupKey,
-  ]);
-  const accountLookupKeyByThreadLookupKey = new Map<string, string>();
-
-  for (const accountLookupKey of accountLookupKeys) {
-    const threadLookupKeys = createHostedExternalThreadLookupKeyReadCandidates({
-      accountLookupKey,
-      channel: input.channel,
-      threadId: input.threadId,
-    });
-
-    for (const threadLookupKey of threadLookupKeys) {
-      accountLookupKeyByThreadLookupKey.set(threadLookupKey, accountLookupKey);
-    }
-  }
-
-  return {
-    accountLookupKeyByThreadLookupKey,
-    threadLookupKeys: [...accountLookupKeyByThreadLookupKey.keys()],
-  };
-}
-
-function normalizeHostedThreadRouteAccountLookupKeys(
-  values: readonly (string | null | undefined)[],
-): string[] {
-  const normalized = values
-    .map((value) => value?.trim() ?? "")
-    .filter((value) => value.length > 0);
-
-  return [...new Set(normalized)];
 }

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -8,6 +8,7 @@ import {
 import { encryptHostedWebNullableString } from "@/src/lib/hosted-web/encryption";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import {
+  createHostedExternalThreadIdentityLookupKey,
   createHostedExternalThreadLookupKey,
   createHostedLinqChatLookupKey,
   createHostedPhoneLookupKey,
@@ -1722,8 +1723,12 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       channel: "linq",
       threadId: "chat_123",
     });
-    if (!routeLookupKey) {
-      throw new Error("Expected test route lookup key.");
+    const routeIdentityLookupKey = createHostedExternalThreadIdentityLookupKey({
+      channel: "linq",
+      threadId: "chat_123",
+    });
+    if (!routeLookupKey || !routeIdentityLookupKey) {
+      throw new Error("Expected test route lookup keys.");
     }
     const threadContainerAccessRecord = {
       accountGroupMemberships: [],
@@ -1809,8 +1814,8 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       1,
       expect.objectContaining({
         where: expect.objectContaining({
-          threadLookupKey: {
-            in: expect.arrayContaining([routeLookupKey]),
+          threadIdentityLookupKey: {
+            in: expect.arrayContaining([routeIdentityLookupKey]),
           },
         }),
       }),
@@ -1819,8 +1824,8 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       2,
       expect.objectContaining({
         where: expect.objectContaining({
-          threadLookupKey: {
-            in: expect.arrayContaining([routeLookupKey]),
+          threadIdentityLookupKey: {
+            in: expect.arrayContaining([routeIdentityLookupKey]),
           },
         }),
       }),

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -593,6 +593,7 @@ describe("hosted Linq egress engagement", () => {
       chatId: "chat-a",
       memberId: "member-1",
       routeAuthority: {
+        accountLookupKey: "hbidx:phone:v1:account",
         channel: "linq",
         containerMemberId: "member-1",
         threadId: "chat-a",

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -372,10 +372,6 @@ describe("hosted Linq egress engagement", () => {
   });
 
   it("caps future-dated inbound thread-route engagement at server receipt time", async () => {
-    const lineLookupKey = createHostedPhoneLookupKey("+15550100001");
-    if (!lineLookupKey) {
-      throw new Error("Expected test Linq line lookup key.");
-    }
     const prisma = {
       hostedThreadRoute: {
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
@@ -384,7 +380,6 @@ describe("hosted Linq egress engagement", () => {
 
     await recordHostedThreadRouteLinqInboundEngagementTx({
       chatId: "chat-1",
-      linePhoneNumberLookupKey: lineLookupKey,
       memberId: "member-1",
       now: new Date("2026-06-25T12:00:00.000Z"),
       occurredAt: "2026-08-25T12:00:00.000Z",
@@ -399,16 +394,16 @@ describe("hosted Linq egress engagement", () => {
         where: expect.objectContaining({
           channel: "linq",
           containerMemberId: "member-1",
-          threadLookupKey: {
+          threadIdentityLookupKey: {
             in: expect.arrayContaining([
-              expect.stringMatching(/^hbidx:external-thread:/u),
+              expect.stringMatching(/^hbidx:external-thread-identity:/u),
             ]),
           },
         }),
       }),
     );
     expect(prisma.hostedThreadRoute.updateMany.mock.calls[0]?.[0]?.where)
-      .not.toHaveProperty("threadIdentityLookupKey");
+      .not.toHaveProperty("threadLookupKey");
   });
 
   it("records skipped runtime sends when no recent inbound exists", async () => {
@@ -598,7 +593,6 @@ describe("hosted Linq egress engagement", () => {
       chatId: "chat-a",
       memberId: "member-1",
       routeAuthority: {
-        accountLookupKey: "hbidx:phone:v1:account",
         channel: "linq",
         containerMemberId: "member-1",
         threadId: "chat-a",

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -985,6 +985,7 @@ describe("Linq explicit external-thread routing", () => {
             threadIsDirect: false,
           }),
           routeAuthority: expect.objectContaining({
+            accountLookupKey: createHostedPhoneLookupKey("+15550000000"),
             channel: "linq",
             containerMemberId: "member_thread_container_123",
             threadId: "chat_group_123",
@@ -1106,6 +1107,7 @@ describe("Linq explicit external-thread routing", () => {
         message: expect.objectContaining({
           accountLookupKey: createHostedPhoneLookupKey("+15559999999"),
           routeAuthority: {
+            accountLookupKey: createHostedPhoneLookupKey("+15559999999"),
             channel: "linq",
             containerMemberId: "member_thread_container_123",
             threadId: "chat_group_123",
@@ -1267,6 +1269,7 @@ describe("Linq explicit external-thread routing", () => {
       chatId: "chat_group_123",
       memberId: "member_thread_container_123",
       routeAuthority: {
+        accountLookupKey: createHostedPhoneLookupKey("+15550000000"),
         channel: "linq",
         containerMemberId: "member_thread_container_123",
         threadId: "chat_group_123",
@@ -1323,6 +1326,7 @@ describe("Linq explicit external-thread routing", () => {
       message: "Usage limit reached.",
       noticeCode: "edge_usage_limit_reached",
       routeAuthority: {
+        accountLookupKey: createHostedPhoneLookupKey("+15550000000"),
         channel: "linq",
         containerMemberId: "member_thread_container_123",
         threadId: "chat_group_123",

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -1,4 +1,4 @@
-import { HostedBillingStatus, type Prisma } from "@prisma/client";
+import { HostedBillingStatus, Prisma } from "@prisma/client";
 import type { HostedMailboxItem } from "@murphai/hosted-execution/runtime-control";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -6,7 +6,7 @@ import {
   ensureHostedThreadContainerRouteTx,
 } from "../src/lib/hosted-routing/thread-container-service";
 import {
-  readHostedThreadRouteByExternalThread,
+  readHostedThreadRouteByThreadIdentity,
 } from "../src/lib/hosted-routing/thread-route-store";
 import {
   createHostedExternalThreadIdentityLookupKey,
@@ -425,6 +425,20 @@ function createStatefulThreadRoutePrisma() {
         threadLookupKey: string;
       };
     }) => {
+      const duplicateIdentity = routes.some((route) =>
+        route.channel === data.channel
+        && route.threadIdentityLookupKey === data.threadIdentityLookupKey,
+      );
+      if (duplicateIdentity) {
+        throw new Prisma.PrismaClientKnownRequestError(
+          "Unique constraint failed on the fields: (`channel`,`threadIdentityLookupKey`)",
+          {
+            clientVersion: "test",
+            code: "P2002",
+            meta: { target: ["channel", "threadIdentityLookupKey"] },
+          },
+        );
+      }
       routes.push(data);
       return data;
     }),
@@ -785,8 +799,7 @@ describe("Linq explicit external-thread routing", () => {
         },
       });
       await expect(
-        readHostedThreadRouteByExternalThread({
-          accountLookupKeys: [currentAccountLookupKey, priorAccountLookupKey],
+        readHostedThreadRouteByThreadIdentity({
           channel: "linq",
           prisma: prisma as unknown as Prisma.TransactionClient,
           threadId: "chat_group_123",
@@ -972,7 +985,6 @@ describe("Linq explicit external-thread routing", () => {
             threadIsDirect: false,
           }),
           routeAuthority: expect.objectContaining({
-            accountLookupKey: createHostedPhoneLookupKey("+15550000000"),
             channel: "linq",
             containerMemberId: "member_thread_container_123",
             threadId: "chat_group_123",
@@ -1037,10 +1049,37 @@ describe("Linq explicit external-thread routing", () => {
     });
   });
 
-  it("does not match a routed thread for another Linq recipient line with the same chat id", async () => {
+  it("routes a bound Linq group thread even when the delivering line differs", async () => {
     const prisma = createPrisma({
       routeAccountPhone: "+15550000000",
       routeContainerMemberId: "member_thread_container_123",
+    });
+    vi.mocked(mailboxStore.readHostedMailboxItemByDedupeKey).mockResolvedValueOnce(null);
+    vi.mocked(linqDailyState.incrementHostedLinqInboundDailyState).mockResolvedValueOnce({
+      dayUtc: new Date("2026-06-24T00:00:00.000Z"),
+      inboundCount: 1,
+      memberId: "member_thread_container_123",
+      outboundCount: 0,
+      quotaReplySentAt: null,
+    } as Awaited<ReturnType<typeof linqDailyState.incrementHostedLinqInboundDailyState>>);
+    vi.mocked(usageAllowance.checkHostedAiUsageGate).mockResolvedValueOnce({
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: 4_500_000n,
+      memberId: "member_thread_container_123",
+      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+      periodStart: new Date("2026-06-01T00:00:00.000Z"),
+      remainingUsdMicros: 4_500_000n,
+      spentUsdMicros: 0n,
+    });
+    vi.mocked(mailboxStore.appendHostedMailboxEnvelopeTx).mockResolvedValueOnce({
+      dedupeConflict: false,
+      duplicate: false,
+      inserted: true,
+      item: buildHostedMailboxItem({
+        id: "mailbox_group_other_line_123",
+        userId: "member_thread_container_123",
+      }),
     });
 
     const plan = await planHostedOnboardingLinqWebhook({
@@ -1051,11 +1090,30 @@ describe("Linq explicit external-thread routing", () => {
     });
 
     expect(plan.response).toMatchObject({
-      ignored: true,
+      ignored: false,
       ok: true,
-      reason: "thread-route-authority-mismatch",
+      reason: "wake-appended-thread-route",
     });
-    expect(mailboxStore.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(readSingleWakeHandoff(plan)).toMatchObject({
+      eventId: "evt_group_123",
+      linqChatId: "chat_group_123",
+      mailboxItemId: "mailbox_group_other_line_123",
+      source: "linq",
+      userId: "member_thread_container_123",
+    });
+    expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: expect.objectContaining({
+        message: expect.objectContaining({
+          accountLookupKey: createHostedPhoneLookupKey("+15559999999"),
+          routeAuthority: {
+            channel: "linq",
+            containerMemberId: "member_thread_container_123",
+            threadId: "chat_group_123",
+          },
+        }),
+      }),
+      tx: prisma,
+    });
   });
 
   it("does not treat routed Linq traffic as direct when directness is not attested", async () => {
@@ -1209,7 +1267,6 @@ describe("Linq explicit external-thread routing", () => {
       chatId: "chat_group_123",
       memberId: "member_thread_container_123",
       routeAuthority: {
-        accountLookupKey: createHostedPhoneLookupKey("+15550000000"),
         channel: "linq",
         containerMemberId: "member_thread_container_123",
         threadId: "chat_group_123",
@@ -1266,7 +1323,6 @@ describe("Linq explicit external-thread routing", () => {
       message: "Usage limit reached.",
       noticeCode: "edge_usage_limit_reached",
       routeAuthority: {
-        accountLookupKey: createHostedPhoneLookupKey("+15550000000"),
         channel: "linq",
         containerMemberId: "member_thread_container_123",
         threadId: "chat_group_123",
@@ -2030,13 +2086,13 @@ describe("Linq group chat concurrent provisioning race", () => {
       threadIdentityLookupKey,
       threadLookupKey,
     });
-    // The planner's two initial route lookups ran before the winner committed,
-    // so they miss; every later read observes the committed route.
+    // The planner's initial route lookup ran before the winner committed, so
+    // it misses; every later read observes the committed route.
     const statefulFindMany = prisma.hostedThreadRoute.findMany.getMockImplementation()!;
     let findManyCalls = 0;
     prisma.hostedThreadRoute.findMany.mockImplementation(async (args: never) => {
       findManyCalls += 1;
-      if (findManyCalls <= 2) {
+      if (findManyCalls <= 1) {
         return [];
       }
       return statefulFindMany(args);

--- a/apps/web/test/hosted-runtime-linq-delivery-route.test.ts
+++ b/apps/web/test/hosted-runtime-linq-delivery-route.test.ts
@@ -176,9 +176,7 @@ describe("hosted runtime Linq delivery route", () => {
       containerMemberId: "member_123",
       threadId: "linq_chat_123",
     };
-    mocks.assertHostedThreadRouteEgressAuthority.mockResolvedValueOnce({
-      accountLookupKey: "hbidx:phone:v1:account",
-    });
+    mocks.assertHostedThreadRouteEgressAuthority.mockResolvedValueOnce({});
 
     const response = await route.POST(buildDeliveryRequest({
       acceptedAt: "2026-04-26T00:00:04.000Z",
@@ -232,6 +230,38 @@ describe("hosted runtime Linq delivery route", () => {
 
     expect(targetMismatch.status).toBe(403);
     expect(mocks.recordHostedLinqRuntimeDeliveryOutcomeTx).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts routed delivery authority without a line account lookup key", async () => {
+    const routeAuthority = {
+      channel: "linq",
+      containerMemberId: "member_123",
+      threadId: "linq_chat_123",
+    };
+    mocks.assertHostedThreadRouteEgressAuthority.mockResolvedValueOnce({});
+
+    const response = await route.POST(buildDeliveryRequest({
+      acceptedAt: "2026-04-26T00:00:04.000Z",
+      attemptedAt: "2026-04-26T00:00:03.000Z",
+      idempotencyKey: "assistant-outbox:intent_123",
+      providerMessageId: "linq_message_sent",
+      providerThreadId: "linq_chat_123",
+      routeAuthority,
+      target: "linq_chat_123",
+      targetKind: "thread",
+    }));
+
+    expect(response.status).toBe(200);
+    expect(mocks.assertHostedThreadRouteEgressAuthority).toHaveBeenCalledWith({
+      authority: routeAuthority,
+      prisma,
+    });
+    expect(mocks.recordHostedLinqRuntimeDeliveryOutcomeTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phoneNumber: null,
+        phoneNumberLookupKey: null,
+      }),
+    );
   });
 
   it("rejects accepted delivery outcomes with too many answered mailbox item ids", async () => {

--- a/apps/web/test/hosted-thread-route-store.test.ts
+++ b/apps/web/test/hosted-thread-route-store.test.ts
@@ -149,6 +149,9 @@ describe("hosted thread route store", () => {
         lastInboundAt: new Date("2026-06-24T12:00:00.000Z"),
       },
     ]);
+    prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({
+      ownerBillingStatus: "active",
+    }));
 
     await expect(
       assertHostedLinqRouteEgressAuthority({
@@ -209,6 +212,9 @@ describe("hosted thread route store", () => {
         lastInboundAt: null,
       },
     ]);
+    prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({
+      ownerBillingStatus: "active",
+    }));
 
     await expect(
       assertHostedLinqRouteEgressAuthority({
@@ -299,13 +305,12 @@ describe("hosted thread route store", () => {
 
   it("authorizes egress when an active participant keeps an inactive-owner group alive", async () => {
     const prisma = createPrismaMock();
-    const threadLookupKey = createHostedExternalThreadLookupKey({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+    const threadIdentityLookupKey = createHostedExternalThreadIdentityLookupKey({
       channel: "linq",
       threadId: "chat_group_abc",
     });
-    if (!threadLookupKey) {
-      throw new Error("Expected test thread lookup key.");
+    if (!threadIdentityLookupKey) {
+      throw new Error("Expected test thread identity lookup key.");
     }
     prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
       {
@@ -328,7 +333,7 @@ describe("hosted thread route store", () => {
           },
         },
         containerMemberId: "member_container_123",
-        threadLookupKey,
+        threadIdentityLookupKey,
       },
     ]);
     prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({
@@ -364,13 +369,12 @@ describe("hosted thread route store", () => {
 
   it("does not authorize egress when owner and projected participants are inactive", async () => {
     const prisma = createPrismaMock();
-    const threadLookupKey = createHostedExternalThreadLookupKey({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+    const threadIdentityLookupKey = createHostedExternalThreadIdentityLookupKey({
       channel: "linq",
       threadId: "chat_group_abc",
     });
-    if (!threadLookupKey) {
-      throw new Error("Expected test thread lookup key.");
+    if (!threadIdentityLookupKey) {
+      throw new Error("Expected test thread identity lookup key.");
     }
     prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
       {
@@ -393,7 +397,7 @@ describe("hosted thread route store", () => {
           },
         },
         containerMemberId: "member_container_123",
-        threadLookupKey,
+        threadIdentityLookupKey,
       },
     ]);
     prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({
@@ -418,13 +422,12 @@ describe("hosted thread route store", () => {
 
   it("does not authorize egress for a suspended container even with an active participant", async () => {
     const prisma = createPrismaMock();
-    const threadLookupKey = createHostedExternalThreadLookupKey({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+    const threadIdentityLookupKey = createHostedExternalThreadIdentityLookupKey({
       channel: "linq",
       threadId: "chat_group_abc",
     });
-    if (!threadLookupKey) {
-      throw new Error("Expected test thread lookup key.");
+    if (!threadIdentityLookupKey) {
+      throw new Error("Expected test thread identity lookup key.");
     }
     prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
       {
@@ -447,7 +450,7 @@ describe("hosted thread route store", () => {
           },
         },
         containerMemberId: "member_container_123",
-        threadLookupKey,
+        threadIdentityLookupKey,
       },
     ]);
     prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({

--- a/apps/web/test/hosted-thread-route-store.test.ts
+++ b/apps/web/test/hosted-thread-route-store.test.ts
@@ -3,12 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   assertHostedLinqRouteEgressAuthority,
-  readHostedThreadRouteByExternalThread,
   readHostedThreadRouteByThreadIdentity,
 } from "../src/lib/hosted-routing/thread-route-store";
 import {
   createHostedExternalThreadIdentityLookupKey,
-  createHostedExternalThreadLookupKey,
   createHostedPhoneLookupKey,
 } from "../src/lib/hosted-onboarding/contact-privacy";
 
@@ -64,76 +62,7 @@ function buildThreadContainerAccessRecord(input: {
 }
 
 describe("hosted thread route store", () => {
-  it("reads a routed external thread without exposing raw thread ids", async () => {
-    const prisma = createPrismaMock();
-    const container = {
-      billingStatus: "active",
-      createdAt: new Date("2026-06-24T00:00:00.000Z"),
-      id: "member_container_123",
-      suspendedAt: null,
-      updatedAt: new Date("2026-06-24T00:00:00.000Z"),
-    };
-    const owner = {
-      billingStatus: "active",
-      createdAt: new Date("2026-06-24T00:00:00.000Z"),
-      id: "member_owner_123",
-      suspendedAt: null,
-      updatedAt: new Date("2026-06-24T00:00:00.000Z"),
-    };
-    const threadLookupKey = createHostedExternalThreadLookupKey({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
-      channel: "linq",
-      threadId: "chat_group_abc",
-    });
-    if (!threadLookupKey) {
-      throw new Error("Expected test thread lookup key.");
-    }
-    prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
-      {
-        channel: "linq",
-        container: {
-          member: container,
-          owner,
-        },
-        containerMemberId: "member_container_123",
-        threadLookupKey,
-      },
-    ]);
-
-    await expect(
-      readHostedThreadRouteByExternalThread({
-        accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
-        channel: "linq",
-        prisma,
-        threadId: "chat_group_abc",
-      }),
-    ).resolves.toEqual({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
-      channel: "linq",
-      container,
-      containerMemberId: "member_container_123",
-      owner,
-    });
-
-    expect(prisma.hostedThreadRoute.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          channel: "linq",
-          threadLookupKey: {
-            in: expect.arrayContaining([
-              createHostedExternalThreadLookupKey({
-                accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
-                channel: "linq",
-                threadId: "chat_group_abc",
-              }),
-            ]),
-          },
-        }),
-      }),
-    );
-  });
-
-  it("reads explicit thread identity without account authority", async () => {
+  it("reads a routed external thread by stable thread identity", async () => {
     const prisma = createPrismaMock();
     const container = {
       billingStatus: "active",
@@ -164,6 +93,7 @@ describe("hosted thread route store", () => {
           owner,
         },
         containerMemberId: "member_container_123",
+        lastInboundAt: new Date("2026-06-24T12:00:00.000Z"),
       },
     ]);
 
@@ -177,6 +107,7 @@ describe("hosted thread route store", () => {
       channel: "linq",
       container,
       containerMemberId: "member_container_123",
+      lastInboundAt: new Date("2026-06-24T12:00:00.000Z"),
       owner,
     });
 
@@ -192,18 +123,8 @@ describe("hosted thread route store", () => {
     );
   });
 
-  it("matches prior account lookup-key candidates across privacy key rotation", async () => {
+  it("authorizes legacy egress authorities with stale account lookup keys by thread identity", async () => {
     const prisma = createPrismaMock();
-    const priorAccountLookupKey = "hbidx:phone:v1:prior-account";
-    const currentAccountLookupKey = "hbidx:phone:v2:current-account";
-    const priorThreadLookupKey = createHostedExternalThreadLookupKey({
-      accountLookupKey: priorAccountLookupKey,
-      channel: "linq",
-      threadId: "chat_group_abc",
-    });
-    if (!priorThreadLookupKey) {
-      throw new Error("Expected prior thread lookup key.");
-    }
     const memberState = {
       billingStatus: "active",
       createdAt: new Date("2026-06-24T00:00:00.000Z"),
@@ -225,31 +146,33 @@ describe("hosted thread route store", () => {
           },
         },
         containerMemberId: "member_container_123",
-        threadLookupKey: priorThreadLookupKey,
+        lastInboundAt: new Date("2026-06-24T12:00:00.000Z"),
       },
     ]);
 
     await expect(
-      readHostedThreadRouteByExternalThread({
-        accountLookupKeys: [currentAccountLookupKey, priorAccountLookupKey],
-        channel: "linq",
+      assertHostedLinqRouteEgressAuthority({
+        authority: {
+          accountLookupKey: "hbidx:phone:v1:stale-line",
+          channel: "linq",
+          containerMemberId: "member_container_123",
+          threadId: "chat_group_abc",
+        },
         prisma,
-        threadId: "chat_group_abc",
       }),
     ).resolves.toMatchObject({
-      accountLookupKey: priorAccountLookupKey,
       channel: "linq",
       containerMemberId: "member_container_123",
+      lastInboundAt: new Date("2026-06-24T12:00:00.000Z"),
     });
 
     expect(prisma.hostedThreadRoute.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          threadLookupKey: {
+          channel: "linq",
+          threadIdentityLookupKey: {
             in: expect.arrayContaining([
-              priorThreadLookupKey,
-              createHostedExternalThreadLookupKey({
-                accountLookupKey: currentAccountLookupKey,
+              createHostedExternalThreadIdentityLookupKey({
                 channel: "linq",
                 threadId: "chat_group_abc",
               }),
@@ -258,6 +181,49 @@ describe("hosted thread route store", () => {
         }),
       }),
     );
+  });
+
+  it("authorizes new egress authorities that omit account lookup keys", async () => {
+    const prisma = createPrismaMock();
+    const memberState = {
+      billingStatus: "active",
+      createdAt: new Date("2026-06-24T00:00:00.000Z"),
+      id: "member_state_123",
+      suspendedAt: null,
+      updatedAt: new Date("2026-06-24T00:00:00.000Z"),
+    };
+    prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
+      {
+        channel: "linq",
+        container: {
+          member: {
+            ...memberState,
+            id: "member_container_123",
+          },
+          owner: {
+            ...memberState,
+            id: "member_owner_123",
+          },
+        },
+        containerMemberId: "member_container_123",
+        lastInboundAt: null,
+      },
+    ]);
+
+    await expect(
+      assertHostedLinqRouteEgressAuthority({
+        authority: {
+          channel: "linq",
+          containerMemberId: "member_container_123",
+          threadId: "chat_group_abc",
+        },
+        prisma,
+      }),
+    ).resolves.toMatchObject({
+      channel: "linq",
+      containerMemberId: "member_container_123",
+      lastInboundAt: null,
+    });
   });
 
   it("returns matched inactive route authority instead of collapsing it to missing", async () => {
@@ -269,14 +235,6 @@ describe("hosted thread route store", () => {
       suspendedAt: null,
       updatedAt: new Date("2026-06-24T00:00:00.000Z"),
     };
-    const threadLookupKey = createHostedExternalThreadLookupKey({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
-      channel: "linq",
-      threadId: "chat_group_abc",
-    });
-    if (!threadLookupKey) {
-      throw new Error("Expected test thread lookup key.");
-    }
     prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
       {
         channel: "linq",
@@ -291,21 +249,20 @@ describe("hosted thread route store", () => {
           owner,
         },
         containerMemberId: "member_container_123",
-        threadLookupKey,
+        lastInboundAt: null,
       },
     ]);
 
     await expect(
-      readHostedThreadRouteByExternalThread({
-        accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+      readHostedThreadRouteByThreadIdentity({
         channel: "linq",
         prisma,
         threadId: "chat_group_abc",
       }),
     ).resolves.toMatchObject({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
       channel: "linq",
       containerMemberId: "member_container_123",
+      lastInboundAt: null,
       owner,
     });
   });
@@ -331,7 +288,7 @@ describe("hosted thread route store", () => {
       expect.objectContaining({
         where: expect.objectContaining({
           channel: "linq",
-          threadLookupKey: expect.any(Object),
+          threadIdentityLookupKey: expect.any(Object),
         }),
       }),
     );
@@ -525,14 +482,6 @@ describe("hosted thread route store", () => {
       suspendedAt: null,
       updatedAt: new Date("2026-06-24T00:00:00.000Z"),
     };
-    const threadLookupKey = createHostedExternalThreadLookupKey({
-      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
-      channel: "linq",
-      threadId: "chat_group_abc",
-    });
-    if (!threadLookupKey) {
-      throw new Error("Expected test thread lookup key.");
-    }
     prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
       {
         channel: "linq",
@@ -544,7 +493,7 @@ describe("hosted thread route store", () => {
           owner: memberState,
         },
         containerMemberId: "member_container_1",
-        threadLookupKey,
+        lastInboundAt: null,
       },
       {
         channel: "linq",
@@ -556,19 +505,18 @@ describe("hosted thread route store", () => {
           owner: memberState,
         },
         containerMemberId: "member_container_2",
-        threadLookupKey,
+        lastInboundAt: null,
       },
     ]);
 
     await expect(
-      readHostedThreadRouteByExternalThread({
-        accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+      readHostedThreadRouteByThreadIdentity({
         channel: "linq",
         prisma,
         threadId: "chat_group_abc",
       }),
     ).rejects.toMatchObject({
-      code: "HOSTED_THREAD_ROUTE_LOOKUP_AMBIGUOUS",
+      code: "HOSTED_THREAD_ROUTE_IDENTITY_LOOKUP_AMBIGUOUS",
     });
   });
 });

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -1101,10 +1101,8 @@ function buildHostedAssistantLinqDeliveryContextFromPreparedIntent(input: {
     return null;
   }
   const routeAuthority: HostedExecutionLinqExternalThreadRouteAuthority = {
-    accountLookupKey: authority.accountLookupKey,
+    ...authority,
     channel: "linq",
-    containerMemberId: authority.containerMemberId,
-    threadId: authority.threadId,
   };
 
   return {

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -242,6 +242,9 @@ function resolveHostedGroupToolLinqThreadContext(
     if (!eligible.has(routeKey)) {
       eligible.set(routeKey, {
         authority: {
+          ...(authority.accountLookupKey === undefined
+            ? {}
+            : { accountLookupKey: authority.accountLookupKey }),
           channel: authority.channel,
           containerMemberId: authority.containerMemberId,
           threadId: authority.threadId,

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -234,18 +234,21 @@ function resolveHostedGroupToolLinqThreadContext(
     ) {
       continue;
     }
-    eligible.set(
-      JSON.stringify([
-        authority.channel,
-        authority.containerMemberId,
-        authority.accountLookupKey,
-        authority.threadId,
-      ]),
-      {
-        authority,
+    const routeKey = JSON.stringify([
+      authority.channel,
+      authority.containerMemberId,
+      authority.threadId,
+    ]);
+    if (!eligible.has(routeKey)) {
+      eligible.set(routeKey, {
+        authority: {
+          channel: authority.channel,
+          containerMemberId: authority.containerMemberId,
+          threadId: authority.threadId,
+        },
         chatId: authority.threadId,
-      },
-    );
+      });
+    }
   }
 
   // Two distinct route-authorized threads in one turn (for example around a

--- a/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
@@ -4,7 +4,6 @@ import { createHostedGroupToolWithLinqThreadContext } from "../src/hosted-runtim
 import type { HostedAssistantLinqDeliveryContext } from "../src/hosted-runtime/linq-delivery-context.ts";
 
 const ROUTE_AUTHORITY = {
-  accountLookupKey: "hplk_account",
   channel: "linq" as const,
   containerMemberId: "member_container",
   threadId: "chat_group_1",
@@ -94,6 +93,12 @@ describe("createHostedGroupToolWithLinqThreadContext", () => {
       linqDeliveryContexts: [
         buildLinqDeliveryContext({ routeAuthority: ROUTE_AUTHORITY }),
         buildLinqDeliveryContext({ routeAuthority: ROUTE_AUTHORITY }),
+        buildLinqDeliveryContext({
+          routeAuthority: {
+            ...ROUTE_AUTHORITY,
+            accountLookupKey: "hplk_legacy_other_line",
+          },
+        }),
         buildLinqDeliveryContext({
           routeAuthority: { ...ROUTE_AUTHORITY, threadId: "chat_sms_group" },
           service: "sms",

--- a/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
@@ -4,6 +4,7 @@ import { createHostedGroupToolWithLinqThreadContext } from "../src/hosted-runtim
 import type { HostedAssistantLinqDeliveryContext } from "../src/hosted-runtime/linq-delivery-context.ts";
 
 const ROUTE_AUTHORITY = {
+  accountLookupKey: "hplk_current_line",
   channel: "linq" as const,
   containerMemberId: "member_container",
   threadId: "chat_group_1",

--- a/packages/hosted-execution/src/contracts.ts
+++ b/packages/hosted-execution/src/contracts.ts
@@ -97,7 +97,7 @@ export type HostedExecutionExternalThreadRouteChannel = Extract<
 >;
 
 export interface HostedExecutionExternalThreadRouteAuthority {
-  accountLookupKey: string;
+  accountLookupKey?: string | null;
   channel: HostedExecutionExternalThreadRouteChannel;
   containerMemberId: string;
   threadId: string;

--- a/packages/hosted-execution/src/parsers.ts
+++ b/packages/hosted-execution/src/parsers.ts
@@ -556,7 +556,14 @@ export function parseHostedExecutionExternalThreadRouteAuthority(
 ): HostedExecutionExternalThreadRouteAuthority {
   const record = requireObject(value, label);
   return {
-    accountLookupKey: requireString(record.accountLookupKey, `${label} accountLookupKey`),
+    ...(record.accountLookupKey === undefined
+      ? {}
+      : {
+          accountLookupKey: readOptionalNullableString(
+            record.accountLookupKey,
+            `${label} accountLookupKey`,
+          ),
+        }),
     channel: parseHostedExecutionExternalThreadRouteChannel(record.channel, `${label} channel`),
     containerMemberId: requireString(record.containerMemberId, `${label} containerMemberId`),
     threadId: requireString(record.threadId, `${label} threadId`),

--- a/packages/hosted-execution/src/parsers.ts
+++ b/packages/hosted-execution/src/parsers.ts
@@ -555,6 +555,8 @@ export function parseHostedExecutionExternalThreadRouteAuthority(
   label = "Hosted execution external thread route authority",
 ): HostedExecutionExternalThreadRouteAuthority {
   const record = requireObject(value, label);
+  // Phase 1 deploy skew: readers tolerate missing accountLookupKey while
+  // emitters keep sending it until both web and runner readers are rolled out.
   return {
     ...(record.accountLookupKey === undefined
       ? {}

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -1296,6 +1296,8 @@ function parseHostedRuntimeLinqExternalThreadRouteAuthority(
     throw new TypeError(`${label} channel must be linq.`);
   }
 
+  // Phase 1 deploy skew: readers tolerate missing accountLookupKey while
+  // emitters keep sending it until both web and runner readers are rolled out.
   return {
     ...(record.accountLookupKey === undefined
       ? {}

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -1297,7 +1297,14 @@ function parseHostedRuntimeLinqExternalThreadRouteAuthority(
   }
 
   return {
-    accountLookupKey: requireString(record.accountLookupKey, `${label} accountLookupKey`),
+    ...(record.accountLookupKey === undefined
+      ? {}
+      : {
+          accountLookupKey: readOptionalNullableString(
+            record.accountLookupKey,
+            `${label} accountLookupKey`,
+          ),
+        }),
     channel,
     containerMemberId: requireString(record.containerMemberId, `${label} containerMemberId`),
     threadId: requireString(record.threadId, `${label} threadId`),

--- a/packages/hosted-execution/test/hosted-execution-builders-hosted-email.test.ts
+++ b/packages/hosted-execution/test/hosted-execution-builders-hosted-email.test.ts
@@ -233,7 +233,6 @@ describe("hosted execution wake builders", () => {
       service: "SMS",
     };
     const routeAuthority = {
-      accountLookupKey: "hbidx:phone:v1:account",
       channel: "linq" as const,
       containerMemberId: "user_123",
       threadId: "chat_123",
@@ -270,7 +269,6 @@ describe("hosted execution wake builders", () => {
       },
       phoneLookupKey: "phone_lookup_123",
       routeAuthority: {
-        accountLookupKey: "hbidx:phone:v1:account",
         channel: "linq",
         containerMemberId: "user_123",
         threadId: "chat_123",

--- a/packages/hosted-execution/test/hosted-execution-builders-hosted-email.test.ts
+++ b/packages/hosted-execution/test/hosted-execution-builders-hosted-email.test.ts
@@ -233,6 +233,7 @@ describe("hosted execution wake builders", () => {
       service: "SMS",
     };
     const routeAuthority = {
+      accountLookupKey: "hbidx:phone:v1:account",
       channel: "linq" as const,
       containerMemberId: "user_123",
       threadId: "chat_123",
@@ -269,6 +270,7 @@ describe("hosted execution wake builders", () => {
       },
       phoneLookupKey: "phone_lookup_123",
       routeAuthority: {
+        accountLookupKey: "hbidx:phone:v1:account",
         channel: "linq",
         containerMemberId: "user_123",
         threadId: "chat_123",

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  parseHostedExecutionExternalThreadRouteAuthority,
   parseHostedExecutionEvent,
   parseHostedExecutionWake,
   parseHostedRuntimeFamilyPlanToolRequest,
@@ -123,7 +124,6 @@ describe("parseHostedExecutionEvent", () => {
           },
           phoneLookupKey: "hbidx:phone:v1:sender",
           routeAuthority: {
-            accountLookupKey: "hbidx:phone:v1:account",
             channel: "linq",
             containerMemberId: "member_container_123",
             threadId: "chat_123",
@@ -135,12 +135,35 @@ describe("parseHostedExecutionEvent", () => {
     ).toMatchObject({
       message: {
         routeAuthority: {
-          accountLookupKey: "hbidx:phone:v1:account",
           channel: "linq",
           containerMemberId: "member_container_123",
           threadId: "chat_123",
         },
       },
+    });
+  });
+
+  it("parses legacy external thread route authorities that still carry account lookup keys", () => {
+    expect(parseHostedExecutionExternalThreadRouteAuthority({
+      accountLookupKey: "hbidx:phone:v1:account",
+      channel: "linq",
+      containerMemberId: "member_container_123",
+      threadId: "chat_123",
+    })).toEqual({
+      accountLookupKey: "hbidx:phone:v1:account",
+      channel: "linq",
+      containerMemberId: "member_container_123",
+      threadId: "chat_123",
+    });
+
+    expect(parseHostedExecutionExternalThreadRouteAuthority({
+      channel: "linq",
+      containerMemberId: "member_container_123",
+      threadId: "chat_123",
+    })).toEqual({
+      channel: "linq",
+      containerMemberId: "member_container_123",
+      threadId: "chat_123",
     });
   });
 
@@ -669,7 +692,6 @@ describe("parseHostedRuntimeGroupTool", () => {
 
   const LINQ_THREAD = {
     authority: {
-      accountLookupKey: "hplk_account",
       channel: "linq",
       containerMemberId: "member_container",
       threadId: "chat_group_1",
@@ -689,6 +711,25 @@ describe("parseHostedRuntimeGroupTool", () => {
     })).toEqual({
       action: "share_contact_card",
       linqThread: LINQ_THREAD,
+    });
+    expect(parseHostedRuntimeGroupToolRequest({
+      action: "read_chat_participants",
+      linqThread: {
+        ...LINQ_THREAD,
+        authority: {
+          accountLookupKey: "hplk_account",
+          ...LINQ_THREAD.authority,
+        },
+      },
+    })).toEqual({
+      action: "read_chat_participants",
+      linqThread: {
+        ...LINQ_THREAD,
+        authority: {
+          accountLookupKey: "hplk_account",
+          ...LINQ_THREAD.authority,
+        },
+      },
     });
 
     expect(() =>

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -124,6 +124,7 @@ describe("parseHostedExecutionEvent", () => {
           },
           phoneLookupKey: "hbidx:phone:v1:sender",
           routeAuthority: {
+            accountLookupKey: "hbidx:phone:v1:account",
             channel: "linq",
             containerMemberId: "member_container_123",
             threadId: "chat_123",
@@ -135,6 +136,7 @@ describe("parseHostedExecutionEvent", () => {
     ).toMatchObject({
       message: {
         routeAuthority: {
+          accountLookupKey: "hbidx:phone:v1:account",
           channel: "linq",
           containerMemberId: "member_container_123",
           threadId: "chat_123",

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -324,7 +324,7 @@ export const assistantDeliverySourceSchema = z.discriminatedUnion('kind', [
 
 export const assistantExternalThreadRouteAuthoritySchema = z
   .object({
-    accountLookupKey: z.string().min(1),
+    accountLookupKey: z.string().min(1).nullable().optional(),
     channel: z.enum(['email', 'linq', 'telegram']),
     containerMemberId: z.string().min(1),
     threadId: z.string().min(1),


### PR DESCRIPTION
## Why this PR exists

Hosted Linq thread routing and reply-egress were anchored on a line-coupled key (`thread_lookup_key = hash(recipientLine + channel + chatId)`) instead of the stable chat id. That coupling produced silent failures when the audience/line shape drifted: a group message could be dropped at ingestion as `thread-route-authority-mismatch`, and the same coupling was the root of the `ASSISTANT_SESSION_ROUTING_CONFLICT` egress class patched in #388. `hosted_thread_route` already keys its PRIMARY KEY on the stable `(channel, threadIdentityLookupKey)` = `(channel, chatId)`, so the line-coupled key was redundant.

## User goal / user-visible behavior

A group/thread keeps routing to its container by the stable chat id, regardless of which line delivers the message — no silent drops when the audience shape drifts. One `chatId → container` lookup, end to end.

## What changed

- Route existing-thread lookup AND egress authorization on the stable chat-id key (`threadIdentityLookupKey`); deleted the line-coupled reader (~165 lines) and the silent `thread-route-authority-mismatch` ingestion drop.
- New route authorities omit `accountLookupKey`; it is now optional in the authority contracts/parsers so already-persisted sessions/outbox rows still parse and authorize by `(channel, threadId, containerMemberId)` — no data migration.

## Invariants the PR must preserve

- Billing/access gates (`hasActiveHostedThreadContainerAccess`) and membership/home-line provisioning gates are unchanged — this PR does NOT alter who has access, only how an existing route is located. (Verified: no changes to `member-access.ts`/`entitlement.ts`.)
- A `(channel, chatId)` route is unique (table PK), so routing on it introduces no ambiguity; the ambiguity/channel guards are preserved.
- Cross-audience isolation is preserved: replies still validate `containerMemberId` + access before delivery.
- Backward-compat: legacy authorities carrying a stale `accountLookupKey` still authorize.

## Deployment skew / compatibility

`@murphai/hosted-execution` + `assistant-cli-contracts` consume the authority in both web (Vercel) and the Cloudflare runner. Deploy order is safe both ways: old runner emits authority-with-`accountLookupKey` → new web ignores it and validates by chat id; new web emits accountless authority → old runner still reads its own fields. No `container_rollout=immediate` needed. Post-deploy check: routed Linq group replies append to the container mailbox with no `thread-route-authority-mismatch` drops.

## Scope note

This is the routing/egress-authority collapse only. It does NOT change the group billing/owner-access model (a separate, in-progress design about whether a group should die with one owner's billing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785946879&installation_id=127572939&pr_number=393&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F393&signature=0089a63806080aaf6d2a772b2d21421e67dc1f11f0567a1dfdde77d4cf381b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->