### PR TITLE
group container membership roster + any-active-member access

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-06-2026-07-06-group-tool-owner-access.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-2026-07-06-group-tool-owner-access.md
@@ -1,0 +1,67 @@
+# Group tool owner access gates
+
+Status: completed
+Created: 2026-07-06
+Updated: 2026-07-06
+
+## Goal
+
+- Fix hosted group-tool access so owner-authority/admin actions require the
+  group owner's active access, while participant-aware group reply/read paths
+  remain available when an active participant keeps the container alive.
+
+## Success criteria
+
+- `create_join_link` denies inactive-owner/active-participant containers and
+  still allows active-owner containers.
+- `share_contact_card` and any other owner-authored group-tool writes are
+  audited and classified owner-only.
+- `read_chat_participants` remains participant-aware.
+- Focused hosted group-tool tests, `pnpm --dir apps/web typecheck`, and
+  `git diff --check` pass.
+- The final handoff reports the per-action access classification.
+
+## Scope
+
+- In scope: `apps/web/src/lib/hosted-groups/group-tool.ts` and focused
+  hosted group-tool tests.
+- Out of scope: changing reply/runtime participant-aware access, group-store
+  persistence shape, provider APIs, schema, or user-facing copy.
+
+## Constraints
+
+- Technical constraints: keep suspension fail-closed; use the existing hosted
+  member access resolver; do not add a parallel access authority.
+- Product/process constraints: preserve the user-critical reply path and keep
+  the implementation narrow.
+
+## Risks and mitigations
+
+1. Risk: tightening the wrong gate could block legitimate group replies.
+   Mitigation: classify actions explicitly and keep read/reply paths on the
+   participant-aware container gate.
+2. Risk: contact-card sharing could retain a participant-aware authority path.
+   Mitigation: audit `group-tool.ts` for owner-authored writes and add focused
+   tests for owner-only actions.
+
+## Tasks
+
+1. Inspect group-tool actions, access helpers, and existing tests.
+2. Add the smallest owner-only gate for owner-authority actions.
+3. Add focused inactive-owner/active-participant regressions.
+4. Run required verification and local final review.
+5. Close the plan through the scoped commit path.
+
+## Decisions
+
+- Owner-authority group-tool actions should check the container owner's active
+  hosted access directly, not the participant-aware runtime access predicate.
+
+## Verification
+
+- Commands to run:
+  - `pnpm --dir apps/web test -- hosted-group-tool`
+  - `pnpm --dir apps/web typecheck`
+  - `git diff --check`
+- Expected outcomes: all commands pass.
+Completed: 2026-07-06

--- a/agent-docs/exec-plans/completed/2026-07-06-group-container-roster-access.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-group-container-roster-access.md
@@ -1,0 +1,45 @@
+# Group Container Roster Access
+
+Status: completed
+Updated: 2026-07-06
+
+## Why
+
+Hosted group containers currently inherit access only from the container owner.
+That makes a group unavailable when the owner lapses even if another current
+participant has active Murph access.
+
+## Scope
+
+Add a persisted projection of resolved hosted thread-container participants,
+reconcile it off the inbound/delivery hot path from the existing Linq roster
+read path, and grant group-container access when the owner has active access or
+any non-removed participant has active access.
+
+## Constraints
+
+- No synchronous Linq roster fetch on webhook ingestion or egress delivery.
+- Do not change provisioning owner selection, home-line gates, routing keys, or
+  billing grace semantics.
+- Suspended containers still hard-block access regardless of participant access.
+- Store only participants that resolve to hosted members; soft-remove departed
+  participants on successful roster reconciliation.
+- Keep the owner as the data/budget anchor.
+
+## Implementation Notes
+
+- Add `HostedThreadContainerParticipant` plus an additive migration.
+- Add `reconcileHostedThreadContainerParticipants` as a best-effort helper that
+  accepts pre-fetched handles so `read_chat_participants` does not fetch twice.
+- Add `hasAnyActiveHostedThreadContainerParticipant` and use it only as an
+  additive fallback at the ingestion inactive-container gate and egress
+  authority check.
+
+## Verification Plan
+
+- `pnpm --dir apps/web prisma:generate`
+- Focused hosted-web tests covering reconcile, ingestion access, and egress
+  authority.
+- `pnpm --dir apps/web typecheck`
+
+Completed: 2026-07-06

--- a/agent-docs/exec-plans/completed/2026-07-06-group-membership-roster-round1.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-group-membership-roster-round1.md
@@ -1,0 +1,38 @@
+# Group Membership Roster Round 1 Fixes
+
+## Goal
+
+Apply the PR 398 round 1 fixes:
+
+- Use one canonical participant-aware thread-container access resolver for route admission, egress, usage allowance, and runtime access.
+- Bound foreground group roster reconciliation work with a hard cap and update coverage.
+
+## Constraints
+
+- Keep the owner-active path short-circuited so healthy owner-authorized containers do not query participants.
+- Suspended containers remain a hard block.
+- Usage ownership and budgets stay anchored to the container member.
+- Reconcile must not scan or upsert beyond the cap.
+
+## State
+
+Implementation complete; ready for scoped commit.
+
+## Verification
+
+Planned:
+
+- Focused hosted web tests touching access and group roster behavior.
+- `pnpm --dir apps/web prisma:generate`
+- `pnpm --dir apps/web typecheck`
+
+Completed:
+
+- `pnpm --dir apps/web prisma:generate`
+- `pnpm --dir apps/web typecheck`
+- `pnpm --dir apps/web test -- hosted-onboarding-entitlement.test.ts runtime-access.test.ts hosted-execution-usage-allowance.test.ts hosted-thread-route-store.test.ts hosted-group-tool.test.ts hosted-onboarding-linq-thread-route.test.ts hosted-orchestration-signal-runtime.test.ts hosted-runtime-internal-routes.test.ts`
+- `pnpm --dir apps/web lint` (warnings only in unrelated existing files)
+- `git diff --check`
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/agent-docs/exec-plans/completed/2026-07-06-group-roster-reconcile.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-group-roster-reconcile.md
@@ -1,0 +1,54 @@
+# Group Roster Reconcile
+
+Status: completed
+Created: 2026-07-06
+Updated: 2026-07-06
+
+## Goal
+
+- Newly provisioned hosted Linq group containers get one best-effort participant roster reconcile immediately after route creation, so access gates can recognize active participants from message one.
+
+## Success criteria
+
+- `planHostedLinqGroupChatWebhook` records a post-commit reconcile request only after `ensureHostedThreadContainerRouteTx` has confirmed a newly created route.
+- The reconcile uses a fresh `getPrisma()` client outside any transaction-owned `input.prisma` path and never performs the Linq roster fetch inside an open DB transaction.
+- Roster reconcile failure does not break group route provisioning, mailbox append, or delivery.
+- Focused tests prove new-group reconcile writes rows and reconcile failure remains best-effort.
+
+## Scope
+
+- In scope: hosted Linq group provisioning planner and focused hosted web tests.
+- Out of scope: routing keys, billing/access predicates, provisioning gates, and the existing `read_chat_participants` trigger.
+
+## Constraints
+
+- Technical constraints: keep the change minimal; no new persisted state; no external Linq fetch inside an open Prisma transaction.
+- Product/process constraints: preserve current delivery behavior and commit through the active-plan workflow.
+
+## Risks and mitigations
+
+1. Risk: running roster fetch inside the webhook transaction extends locks and violates provider-call boundaries.
+   Mitigation: trace the transaction boundary and call the reconcile only from a post-transaction hook with a fresh root Prisma client.
+2. Risk: roster fetch failure blocks provisioning.
+   Mitigation: rely on the helper's swallowed errors and keep the call in the post-transaction side-effect lane.
+
+## Tasks
+
+1. Trace `planHostedLinqGroupChatWebhook`, `ensureHostedThreadContainerRouteTx`, and webhook-service transaction handling.
+2. Patch the group provisioning planner to enqueue a best-effort post-commit roster reconcile on newly created routes.
+3. Add focused hosted web tests for success and failure.
+4. Run required verification and final local review.
+5. Commit with `scripts/finish-task`.
+
+## Decisions
+
+- Treat this as a post-transaction side effect, not a transaction-internal planner step, because the reconcile performs external Linq HTTP.
+- Drain the reconcile in `handleHostedOnboardingLinqWebhook` after `runHostedOnboardingWebhookTransaction` returns, using `getPrisma()` instead of the transaction client passed into the planner.
+
+## Verification
+
+- Passed: `pnpm --dir apps/web prisma:generate`.
+- Passed: `pnpm --dir apps/web typecheck`.
+- Passed: `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts apps/web/test/hosted-onboarding-linq-thread-route.test.ts`.
+- Passed: `bash scripts/workspace-verify.sh test:diff apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts apps/web/src/lib/hosted-onboarding/webhook-provider-linq-types.ts apps/web/src/lib/hosted-onboarding/webhook-service.ts apps/web/test/hosted-onboarding-linq-thread-route.test.ts apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts`.
+Completed: 2026-07-06

--- a/agent-docs/exec-plans/completed/2026-07-06-thread-container-member-access.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-thread-container-member-access.md
@@ -1,0 +1,37 @@
+# Thread Container Member Access
+
+Status: completed
+Updated: 2026-07-06
+
+## Why
+
+Participant-authorized hosted group threads must be able to wake, restore,
+decrypt, and reply even when the thread-container owner is inactive. Existing
+fixes routed several gates through participant-aware access, but other hot-path
+gates still resolved thread-container access as owner-only.
+
+## Scope
+
+- Centralize participant-aware thread-container access in
+  `readActiveHostedMemberAccess`.
+- Keep usage and budget ownership anchored to the owner member.
+- Preserve owner-active short-circuit behavior and suspension fail-closed
+  behavior.
+- Fix roster reconciliation so an over-cap provider roster never soft-removes
+  still-active participants beyond the cap.
+- Add focused tests for Temporal reconciliation facts, runtime crypto-context
+  authorization, and over-cap participant reconciliation.
+
+## Non-Goals
+
+- No real-time departure machinery for stale participant rows.
+- No new persisted access state.
+- No change to billing/usage ownership semantics.
+
+## Verification
+
+- Focused web tests for access gates and roster cap behavior.
+- `pnpm --dir apps/web prisma:generate`.
+- `pnpm --dir apps/web typecheck`.
+- Additional package checks only if touched files require them.
+Completed: 2026-07-06

--- a/apps/web/prisma/migrations/20260706120000_hosted_thread_container_participant/migration.sql
+++ b/apps/web/prisma/migrations/20260706120000_hosted_thread_container_participant/migration.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "hosted_thread_container_participant" (
+    "container_member_id" TEXT NOT NULL,
+    "participant_member_id" TEXT NOT NULL,
+    "handle_lookup_key" TEXT NOT NULL,
+    "first_seen_at" TIMESTAMP(3) NOT NULL,
+    "last_seen_at" TIMESTAMP(3) NOT NULL,
+    "removed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "hosted_thread_container_participant_pkey" PRIMARY KEY ("container_member_id", "participant_member_id")
+);
+
+CREATE INDEX "hosted_thread_container_participant_container_member_id_idx" ON "hosted_thread_container_participant"("container_member_id");
+
+ALTER TABLE "hosted_thread_container_participant" ADD CONSTRAINT "hosted_thread_container_participant_container_member_id_fkey" FOREIGN KEY ("container_member_id") REFERENCES "hosted_thread_container"("member_id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "hosted_thread_container_participant" ADD CONSTRAINT "hosted_thread_container_participant_participant_member_id_fkey" FOREIGN KEY ("participant_member_id") REFERENCES "hosted_member"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -377,6 +377,7 @@ model HostedMember {
   sensitiveActionChallenges      HostedSensitiveActionChallenge[]
   threadContainer                HostedThreadContainer?          @relation("HostedThreadContainerMember")
   ownedThreadContainers          HostedThreadContainer[]         @relation("HostedThreadContainerOwner")
+  threadContainerParticipations  HostedThreadContainerParticipant[] @relation("HostedThreadContainerParticipantMember")
 
   @@index([billingStatus])
   @@map("hosted_member")
@@ -1092,10 +1093,28 @@ model HostedThreadContainer {
   createdAt                  DateTime            @default(now()) @map("created_at")
   member                     HostedMember        @relation("HostedThreadContainerMember", fields: [memberId], references: [id], onDelete: Cascade)
   owner                      HostedMember        @relation("HostedThreadContainerOwner", fields: [ownerMemberId], references: [id], onDelete: Restrict)
+  participants               HostedThreadContainerParticipant[]
   routes                     HostedThreadRoute[]
 
   @@index([ownerMemberId])
   @@map("hosted_thread_container")
+}
+
+model HostedThreadContainerParticipant {
+  containerMemberId   String                @map("container_member_id")
+  participantMemberId String                @map("participant_member_id")
+  handleLookupKey     String                @map("handle_lookup_key")
+  firstSeenAt         DateTime              @map("first_seen_at")
+  lastSeenAt          DateTime              @map("last_seen_at")
+  removedAt           DateTime?             @map("removed_at")
+  createdAt           DateTime              @default(now()) @map("created_at")
+  updatedAt           DateTime              @updatedAt @map("updated_at")
+  container           HostedThreadContainer @relation(fields: [containerMemberId], references: [memberId], onDelete: Cascade)
+  participant         HostedMember          @relation("HostedThreadContainerParticipantMember", fields: [participantMemberId], references: [id], onDelete: Cascade)
+
+  @@id([containerMemberId, participantMemberId])
+  @@index([containerMemberId])
+  @@map("hosted_thread_container_participant")
 }
 
 model HostedThreadRoute {

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -37,7 +37,7 @@ import {
   readHostedFamilyAccessForMember,
 } from "../hosted-onboarding/family-plan";
 import {
-  hasActiveHostedMemberAccess,
+  hasActiveHostedThreadContainerAccessWithParticipants,
   type HostedMemberPersonAccessState,
   hostedMemberPersonAccessSelect,
 } from "../hosted-onboarding/member-access";
@@ -286,6 +286,28 @@ async function readHostedFamilySponsoredBillingRefForMember(input: {
 interface HostedAiUsageAllowanceThreadContainerRef {
   monthlyUsageLimitUsdMicros: bigint;
   owner: HostedMemberPersonAccessState;
+}
+
+async function hasHostedAiUsageThreadContainerAccess(input: {
+  container: { suspendedAt: Date | null };
+  containerMemberId: string;
+  threadContainer: HostedAiUsageAllowanceThreadContainerRef | null;
+  tx: Prisma.TransactionClient;
+}): Promise<boolean | null> {
+  if (!input.threadContainer) {
+    return null;
+  }
+
+  if (input.container.suspendedAt !== null) {
+    return false;
+  }
+
+  return await hasActiveHostedThreadContainerAccessWithParticipants({
+    container: input.container,
+    containerMemberId: input.containerMemberId,
+    owner: input.threadContainer.owner,
+    prisma: input.tx,
+  });
 }
 
 const HOSTED_AI_USAGE_ALLOWANCE_PRICING_VERSION = "openai-api-pricing-2026-05-05-standard";
@@ -575,12 +597,19 @@ export async function accountHostedAiUsageForAllowanceTx(input: {
         billingRef: memberState.billingRef,
         familyAccessActive: false,
       };
+  const threadContainerAccessActive = await hasHostedAiUsageThreadContainerAccess({
+    container: memberState,
+    containerMemberId: input.memberId,
+    threadContainer: memberState.threadContainer,
+    tx: input.tx,
+  });
   const period = await ensureHostedAiUsageAllowancePeriodTx({
     at,
     billingRef: allowanceAccess.billingRef,
     memberId: input.memberId,
     now,
     threadContainer: memberState.threadContainer,
+    threadContainerAccessActive,
     tx: input.tx,
   });
   if (period.kind === "denied") {
@@ -718,11 +747,17 @@ export async function resolveHostedAiUsageGate(input: {
         };
     const allowanceBillingRef = allowanceAccess.billingRef;
     const familyAccessActive = allowanceAccess.familyAccessActive;
+    const threadContainerAccessActive = await hasHostedAiUsageThreadContainerAccess({
+      container: memberState,
+      containerMemberId: input.memberId,
+      threadContainer: memberState.threadContainer,
+      tx,
+    });
 
     // Thread-container members are synthetic (`not_started` own billing):
-    // their access is the owner's, decided by the container branch of the
-    // allowance-period resolver below. Only non-container members are denied
-    // on their own billing here; suspension always fails closed.
+    // their access is decided by the container branch of the allowance-period
+    // resolver below. Only non-container members are denied on their own
+    // billing here; suspension always fails closed.
     if (
       memberState.suspendedAt !== null ||
       (
@@ -736,6 +771,7 @@ export async function resolveHostedAiUsageGate(input: {
         billingRef: allowanceBillingRef,
         memberId: input.memberId,
         threadContainer: memberState.threadContainer,
+        threadContainerAccessActive,
       });
     }
 
@@ -745,6 +781,7 @@ export async function resolveHostedAiUsageGate(input: {
       memberId: input.memberId,
       now,
       threadContainer: memberState.threadContainer,
+      threadContainerAccessActive,
       tx,
     });
     if (period.kind === "denied") {
@@ -819,11 +856,17 @@ export async function readHostedAiUsageGate(input: {
         };
     const allowanceBillingRef = allowanceAccess.billingRef;
     const familyAccessActive = allowanceAccess.familyAccessActive;
+    const threadContainerAccessActive = await hasHostedAiUsageThreadContainerAccess({
+      container: memberState,
+      containerMemberId: input.memberId,
+      threadContainer: memberState.threadContainer,
+      tx,
+    });
 
     // Thread-container members are synthetic (`not_started` own billing):
-    // their access is the owner's, decided by the container branch of the
-    // allowance-period resolver below. Only non-container members are denied
-    // on their own billing here; suspension always fails closed.
+    // their access is decided by the container branch of the allowance-period
+    // resolver below. Only non-container members are denied on their own
+    // billing here; suspension always fails closed.
     if (
       memberState.suspendedAt !== null ||
       (
@@ -837,6 +880,7 @@ export async function readHostedAiUsageGate(input: {
         billingRef: allowanceBillingRef,
         memberId: input.memberId,
         threadContainer: memberState.threadContainer,
+        threadContainerAccessActive,
       });
     }
 
@@ -845,6 +889,7 @@ export async function readHostedAiUsageGate(input: {
       billingRef: allowanceBillingRef,
       memberId: input.memberId,
       threadContainer: memberState.threadContainer,
+      threadContainerAccessActive,
       tx,
     });
 
@@ -955,12 +1000,14 @@ function resolveHostedAiUsageInactiveGateDecision(input: {
   billingRef: HostedAiUsageAllowanceBillingRef | null;
   memberId: string;
   threadContainer?: HostedAiUsageAllowanceThreadContainerRef | null;
+  threadContainerAccessActive?: boolean | null;
 }): HostedAiUsageGateDecision {
   const resolved = resolveHostedAiUsageAllowancePeriod({
     at: input.at,
     billingRef: input.billingRef,
     memberId: input.memberId,
     threadContainer: input.threadContainer ?? null,
+    threadContainerAccessActive: input.threadContainerAccessActive ?? null,
   });
   const period = resolved.kind === "denied"
     ? resolved
@@ -1054,6 +1101,7 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
   memberId: string;
   now: Date;
   threadContainer?: HostedAiUsageAllowanceThreadContainerRef | null;
+  threadContainerAccessActive?: boolean | null;
   tx: Prisma.TransactionClient;
 }): Promise<HostedAiUsageAllowancePeriodResult> {
   const resolved = resolveHostedAiUsageAllowancePeriod({
@@ -1061,6 +1109,7 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
     billingRef: input.billingRef,
     memberId: input.memberId,
     threadContainer: input.threadContainer ?? null,
+    threadContainerAccessActive: input.threadContainerAccessActive ?? null,
   });
   if (resolved.kind === "denied") {
     return {
@@ -1207,6 +1256,7 @@ async function readHostedAiUsageAllowancePeriodTx(input: {
   billingRef: HostedAiUsageAllowanceBillingRef | null;
   memberId: string;
   threadContainer?: HostedAiUsageAllowanceThreadContainerRef | null;
+  threadContainerAccessActive?: boolean | null;
   tx: Prisma.TransactionClient;
 }): Promise<HostedAiUsageAllowancePeriodResult> {
   const resolved = resolveHostedAiUsageAllowancePeriod({
@@ -1214,6 +1264,7 @@ async function readHostedAiUsageAllowancePeriodTx(input: {
     billingRef: input.billingRef,
     memberId: input.memberId,
     threadContainer: input.threadContainer ?? null,
+    threadContainerAccessActive: input.threadContainerAccessActive ?? null,
   });
   if (resolved.kind === "denied") {
     return {
@@ -1312,6 +1363,7 @@ function resolveHostedAiUsageAllowancePeriod(input: {
   billingRef: HostedAiUsageAllowanceBillingRef | null;
   memberId: string;
   threadContainer?: HostedAiUsageAllowanceThreadContainerRef | null;
+  threadContainerAccessActive?: boolean | null;
 }): HostedAiUsageAllowancePeriodResolution {
   const billingPlanCode =
     parseHostedBillingPlanCode(input.billingRef?.currentBillingPlanCode)
@@ -1329,7 +1381,7 @@ function resolveHostedAiUsageAllowancePeriod(input: {
 
     if (
       threadContainerLimitUsdMicros === null
-      || !hasActiveHostedMemberAccess(input.threadContainer.owner)
+      || input.threadContainerAccessActive !== true
     ) {
       return {
         billingPlanCode,

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -37,9 +37,9 @@ import {
   readHostedFamilyAccessForMember,
 } from "../hosted-onboarding/family-plan";
 import {
-  hasActiveHostedThreadContainerAccessWithParticipants,
   type HostedMemberPersonAccessState,
   hostedMemberPersonAccessSelect,
+  readActiveHostedMemberAccess,
 } from "../hosted-onboarding/member-access";
 import { getPrisma } from "../prisma";
 import { sha256Hex } from "../primitives";
@@ -298,14 +298,8 @@ async function hasHostedAiUsageThreadContainerAccess(input: {
     return null;
   }
 
-  if (input.container.suspendedAt !== null) {
-    return false;
-  }
-
-  return await hasActiveHostedThreadContainerAccessWithParticipants({
-    container: input.container,
-    containerMemberId: input.containerMemberId,
-    owner: input.threadContainer.owner,
+  return await readActiveHostedMemberAccess({
+    memberId: input.containerMemberId,
     prisma: input.tx,
   });
 }

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -53,6 +53,9 @@ import {
   readHostedGroupByRuntimeMemberId,
 } from "./group-store";
 
+export const HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX =
+  HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX;
+
 export async function handleHostedRuntimeGroupTool(input: {
   memberId: string;
   request: HostedRuntimeGroupToolRequest;
@@ -231,13 +234,15 @@ async function handleHostedRuntimeGroupReadChatParticipants(input: {
   }
 
   const prisma = getPrisma();
+  const participantHandles = selectHostedThreadContainerParticipantHandles({
+    chatId: authorized.chatId,
+    containerMemberId: input.memberId,
+    handles,
+  });
   const participants: HostedRuntimeGroupChatParticipant[] = [];
   const resolvedParticipants: HostedThreadContainerResolvedParticipant[] = [];
   try {
-    for (const handle of handles) {
-      if (!isCurrentHostedLinqParticipantHandle(handle)) {
-        continue;
-      }
+    for (const handle of participantHandles) {
       const lookup = await lookupParticipantMemberByHandle({
         handle: handle.handle,
         prisma,
@@ -249,7 +254,7 @@ async function handleHostedRuntimeGroupReadChatParticipants(input: {
           participantMemberId,
         });
       }
-      if (participants.length < HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX) {
+      if (participants.length < HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX) {
         participants.push({
           handle: handle.handle,
           hasOwnMurph: participantMemberId !== null
@@ -269,7 +274,7 @@ async function handleHostedRuntimeGroupReadChatParticipants(input: {
   await reconcileHostedThreadContainerParticipants({
     chatId: authorized.chatId,
     containerMemberId: input.memberId,
-    handles,
+    handles: participantHandles,
     prisma,
     resolvedParticipants,
   });
@@ -303,11 +308,17 @@ export async function reconcileHostedThreadContainerParticipants(input: {
       return;
     }
 
-    const resolvedParticipants = input.resolvedParticipants
+    const participantHandles = selectHostedThreadContainerParticipantHandles({
+      chatId: input.chatId,
+      containerMemberId: input.containerMemberId,
+      handles,
+    });
+    const boundedHandleValues = new Set(participantHandles.map((handle) => handle.handle));
+    const resolvedParticipants = (input.resolvedParticipants
       ?? await resolveHostedThreadContainerParticipants({
-        handles,
+        handles: participantHandles,
         prisma: input.prisma,
-      });
+      })).filter((participant) => boundedHandleValues.has(participant.handle));
     const now = new Date();
     const seenByMemberId = new Map<string, {
       handleLookupKey: string;
@@ -423,6 +434,24 @@ function isCurrentHostedLinqParticipantHandle(handle: HostedLinqChatHandleSummar
     && (!handle.status || handle.status.trim().toLowerCase() === "active");
 }
 
+function selectHostedThreadContainerParticipantHandles(input: {
+  chatId: string;
+  containerMemberId: string;
+  handles: readonly HostedLinqChatHandleSummary[];
+}): HostedLinqChatHandleSummary[] {
+  const currentHandles = input.handles.filter(isCurrentHostedLinqParticipantHandle);
+  if (currentHandles.length > HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX) {
+    logHostedThreadContainerParticipantReconcileCapped({
+      cap: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+      chatId: input.chatId,
+      containerMemberId: input.containerMemberId,
+      rosterSize: currentHandles.length,
+    });
+  }
+
+  return currentHandles.slice(0, HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX);
+}
+
 function createHostedThreadContainerParticipantHandleLookupKey(handle: string): string | null {
   if (handle.includes("@")) {
     return createHostedLinqParticipantContactLookupKey({
@@ -452,6 +481,23 @@ function logHostedThreadContainerParticipantReconcileSkipped(input: {
       containerMemberIdSuffix: toHostedOnboardingLogIdSuffix(input.containerMemberId),
       errorName: input.errorName,
       reason: input.reason,
+    }),
+  });
+}
+
+function logHostedThreadContainerParticipantReconcileCapped(input: {
+  cap: number;
+  chatId: string;
+  containerMemberId: string;
+  rosterSize: number;
+}): void {
+  console.warn("Hosted thread-container participant reconcile capped.", {
+    ...sanitizeHostedOnboardingStructuredLogDetails({
+      cap: input.cap,
+      chatIdSuffix: toHostedOnboardingLogIdSuffix(input.chatId),
+      containerMemberIdSuffix: toHostedOnboardingLogIdSuffix(input.containerMemberId),
+      reason: "roster_exceeds_cap",
+      rosterSize: input.rosterSize,
     }),
   });
 }

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -10,13 +10,12 @@ import {
 } from "@murphai/hosted-execution/runtime-control";
 
 import { hasHostedRuntimeActiveAccess } from "../hosted-mailbox/runtime-access";
-import {
-} from "../hosted-onboarding/entitlement";
 import { readActiveHostedMemberAccess } from "../hosted-onboarding/member-access";
 import { lookupHostedMemberIdentityByPhoneNumber } from "../hosted-onboarding/hosted-member-identity-store";
 import { lookupHostedMemberByVerifiedEmailAddress } from "../hosted-onboarding/hosted-member-store";
 import {
   getHostedLinqChatHandles,
+  type HostedLinqChatHandleSummary,
   isHostedLinqAttachmentSendPrepareFailure,
   sendHostedLinqAttachmentMessage,
 } from "../hosted-onboarding/linq-client";
@@ -31,8 +30,17 @@ import {
   releaseHostedLinqContactCardShareAttempt,
   reserveHostedLinqContactCardShareAttempt,
 } from "../hosted-onboarding/linq-contact-card-share";
+import { createHostedLinqParticipantContactLookupKey } from "../hosted-onboarding/linq-participant-contact";
+import {
+  deriveHostedOnboardingTimingErrorName,
+  sanitizeHostedOnboardingStructuredLogDetails,
+  toHostedOnboardingLogIdSuffix,
+} from "../hosted-onboarding/logging";
 import { normalizePhoneNumber } from "../hosted-onboarding/phone";
-import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from "../hosted-onboarding/shared";
+import {
+  HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+  type HostedOnboardingReadClient,
+} from "../hosted-onboarding/shared";
 import {
   signalHostedRuntimeMaintenanceRuntime,
 } from "../hosted-orchestration/signal-runtime";
@@ -224,24 +232,33 @@ async function handleHostedRuntimeGroupReadChatParticipants(input: {
 
   const prisma = getPrisma();
   const participants: HostedRuntimeGroupChatParticipant[] = [];
+  const resolvedParticipants: HostedThreadContainerResolvedParticipant[] = [];
   try {
     for (const handle of handles) {
-      if (handle.isMe) {
+      if (!isCurrentHostedLinqParticipantHandle(handle)) {
         continue;
       }
-      if (handle.status && handle.status.trim().toLowerCase() !== "active") {
-        continue;
-      }
-      if (participants.length >= HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX) {
-        break;
-      }
-      participants.push({
+      const lookup = await lookupParticipantMemberByHandle({
         handle: handle.handle,
-        hasOwnMurph: await hasParticipantOwnMurphMembership({
-          handle: handle.handle,
-          prisma,
-        }),
+        prisma,
       });
+      const participantMemberId = lookup?.core.id ?? null;
+      if (participantMemberId) {
+        resolvedParticipants.push({
+          handle: handle.handle,
+          participantMemberId,
+        });
+      }
+      if (participants.length < HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX) {
+        participants.push({
+          handle: handle.handle,
+          hasOwnMurph: participantMemberId !== null
+            && await readActiveHostedMemberAccess({
+              memberId: participantMemberId,
+              prisma,
+            }),
+        });
+      }
     }
   } catch {
     // A failed identity lookup must not degrade into a guessed hasOwnMurph
@@ -249,28 +266,141 @@ async function handleHostedRuntimeGroupReadChatParticipants(input: {
     return unavailable("membership_lookup_unavailable");
   }
 
+  await reconcileHostedThreadContainerParticipants({
+    chatId: authorized.chatId,
+    containerMemberId: input.memberId,
+    handles,
+    prisma,
+    resolvedParticipants,
+  });
+
   return {
     action: "read_chat_participants",
     result: { participants, status: "ok" },
   };
 }
 
-async function hasParticipantOwnMurphMembership(input: {
+export type HostedThreadContainerResolvedParticipant = {
   handle: string;
-  prisma: ReturnType<typeof getPrisma>;
-}): Promise<boolean> {
-  const lookup = await lookupParticipantMemberByHandle(input);
-  const member = lookup?.core ?? null;
-  return member !== null
-    && await readActiveHostedMemberAccess({
-      memberId: member.id,
+  participantMemberId: string;
+};
+
+export async function reconcileHostedThreadContainerParticipants(input: {
+  chatId: string;
+  containerMemberId: string;
+  handles?: readonly HostedLinqChatHandleSummary[];
+  prisma: HostedOnboardingReadClient;
+  resolvedParticipants?: readonly HostedThreadContainerResolvedParticipant[];
+}): Promise<void> {
+  try {
+    const handles = input.handles ?? await getHostedLinqChatHandles({ chatId: input.chatId });
+    if (handles.length === 0) {
+      logHostedThreadContainerParticipantReconcileSkipped({
+        chatId: input.chatId,
+        containerMemberId: input.containerMemberId,
+        reason: "empty_roster",
+      });
+      return;
+    }
+
+    const resolvedParticipants = input.resolvedParticipants
+      ?? await resolveHostedThreadContainerParticipants({
+        handles,
+        prisma: input.prisma,
+      });
+    const now = new Date();
+    const seenByMemberId = new Map<string, {
+      handleLookupKey: string;
+      participantMemberId: string;
+    }>();
+
+    for (const participant of resolvedParticipants) {
+      const handleLookupKey = createHostedThreadContainerParticipantHandleLookupKey(
+        participant.handle,
+      );
+      if (!handleLookupKey || seenByMemberId.has(participant.participantMemberId)) {
+        continue;
+      }
+      seenByMemberId.set(participant.participantMemberId, {
+        handleLookupKey,
+        participantMemberId: participant.participantMemberId,
+      });
+    }
+
+    const seenParticipantMemberIds = [...seenByMemberId.keys()];
+    for (const participant of seenByMemberId.values()) {
+      await input.prisma.hostedThreadContainerParticipant.upsert({
+        create: {
+          containerMemberId: input.containerMemberId,
+          firstSeenAt: now,
+          handleLookupKey: participant.handleLookupKey,
+          lastSeenAt: now,
+          participantMemberId: participant.participantMemberId,
+          removedAt: null,
+        },
+        update: {
+          handleLookupKey: participant.handleLookupKey,
+          lastSeenAt: now,
+          removedAt: null,
+        },
+        where: {
+          containerMemberId_participantMemberId: {
+            containerMemberId: input.containerMemberId,
+            participantMemberId: participant.participantMemberId,
+          },
+        },
+      });
+    }
+
+    await input.prisma.hostedThreadContainerParticipant.updateMany({
+      data: {
+        removedAt: now,
+      },
+      where: {
+        containerMemberId: input.containerMemberId,
+        ...(seenParticipantMemberIds.length > 0
+          ? { participantMemberId: { notIn: seenParticipantMemberIds } }
+          : {}),
+        removedAt: null,
+      },
+    });
+  } catch (error) {
+    logHostedThreadContainerParticipantReconcileSkipped({
+      chatId: input.chatId,
+      containerMemberId: input.containerMemberId,
+      errorName: deriveHostedOnboardingTimingErrorName(error),
+      reason: "reconcile_failed",
+    });
+  }
+}
+
+async function resolveHostedThreadContainerParticipants(input: {
+  handles: readonly HostedLinqChatHandleSummary[];
+  prisma: HostedOnboardingReadClient;
+}): Promise<HostedThreadContainerResolvedParticipant[]> {
+  const resolvedParticipants: HostedThreadContainerResolvedParticipant[] = [];
+  for (const handle of input.handles) {
+    if (!isCurrentHostedLinqParticipantHandle(handle)) {
+      continue;
+    }
+    const lookup = await lookupParticipantMemberByHandle({
+      handle: handle.handle,
       prisma: input.prisma,
     });
+    const participantMemberId = lookup?.core.id ?? null;
+    if (participantMemberId) {
+      resolvedParticipants.push({
+        handle: handle.handle,
+        participantMemberId,
+      });
+    }
+  }
+  return resolvedParticipants;
 }
 
 async function lookupParticipantMemberByHandle(input: {
   handle: string;
-  prisma: ReturnType<typeof getPrisma>;
+  prisma: HostedOnboardingReadClient;
 }) {
   if (input.handle.includes("@")) {
     return await lookupHostedMemberByVerifiedEmailAddress({
@@ -285,6 +415,44 @@ async function lookupParticipantMemberByHandle(input: {
   return await lookupHostedMemberIdentityByPhoneNumber({
     phoneNumber,
     prisma: input.prisma,
+  });
+}
+
+function isCurrentHostedLinqParticipantHandle(handle: HostedLinqChatHandleSummary): boolean {
+  return !handle.isMe
+    && (!handle.status || handle.status.trim().toLowerCase() === "active");
+}
+
+function createHostedThreadContainerParticipantHandleLookupKey(handle: string): string | null {
+  if (handle.includes("@")) {
+    return createHostedLinqParticipantContactLookupKey({
+      kind: "email",
+      value: handle,
+    });
+  }
+
+  const phoneNumber = normalizePhoneNumber(handle);
+  return phoneNumber
+    ? createHostedLinqParticipantContactLookupKey({
+        kind: "phone",
+        value: phoneNumber,
+      })
+    : null;
+}
+
+function logHostedThreadContainerParticipantReconcileSkipped(input: {
+  chatId: string;
+  containerMemberId: string;
+  errorName?: string;
+  reason: string;
+}): void {
+  console.warn("Hosted thread-container participant reconcile skipped.", {
+    ...sanitizeHostedOnboardingStructuredLogDetails({
+      chatIdSuffix: toHostedOnboardingLogIdSuffix(input.chatId),
+      containerMemberIdSuffix: toHostedOnboardingLogIdSuffix(input.containerMemberId),
+      errorName: input.errorName,
+      reason: input.reason,
+    }),
   });
 }
 

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -4,6 +4,7 @@ import {
   HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX,
   type HostedRuntimeGroupChatParticipant,
   type HostedRuntimeGroupCreateJoinLinkRequest,
+  type HostedRuntimeGroupToolAction,
   type HostedRuntimeGroupToolLinqThreadContext,
   type HostedRuntimeGroupToolRequest,
   type HostedRuntimeGroupToolResponse,
@@ -56,6 +57,20 @@ import {
 export const HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX =
   HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX;
 
+export type HostedRuntimeGroupToolAccessClassification =
+  | "owner_active"
+  | "participant_aware";
+
+export const HOSTED_RUNTIME_GROUP_TOOL_ACCESS_CLASSIFICATION = {
+  create_join_link: "owner_active",
+  read_chat_participants: "participant_aware",
+  read_current: "participant_aware",
+  share_contact_card: "owner_active",
+} as const satisfies Record<
+  HostedRuntimeGroupToolAction,
+  HostedRuntimeGroupToolAccessClassification
+>;
+
 export async function handleHostedRuntimeGroupTool(input: {
   memberId: string;
   request: HostedRuntimeGroupToolRequest;
@@ -104,6 +119,45 @@ export async function handleHostedRuntimeGroupTool(input: {
   };
 }
 
+type HostedRuntimeGroupOwnerActiveAccess =
+  | { status: "ok"; ownerMemberId: string }
+  | {
+      status: "unavailable";
+      unavailableReason:
+        | "not_group_runtime"
+        | "owner_unavailable"
+        | "runtime_inactive";
+    };
+
+async function readHostedRuntimeGroupOwnerActiveAccess(input: {
+  memberId: string;
+  prisma: HostedOnboardingReadClient;
+}): Promise<HostedRuntimeGroupOwnerActiveAccess> {
+  const container = await input.prisma.hostedThreadContainer.findUnique({
+    where: { memberId: input.memberId },
+    select: {
+      member: {
+        select: { suspendedAt: true },
+      },
+      ownerMemberId: true,
+    },
+  });
+  if (!container) {
+    return { status: "unavailable", unavailableReason: "not_group_runtime" };
+  }
+  if (container.member.suspendedAt) {
+    return { status: "unavailable", unavailableReason: "runtime_inactive" };
+  }
+  if (!await readActiveHostedMemberAccess({
+    memberId: container.ownerMemberId,
+    prisma: input.prisma,
+  })) {
+    return { status: "unavailable", unavailableReason: "owner_unavailable" };
+  }
+
+  return { status: "ok", ownerMemberId: container.ownerMemberId };
+}
+
 async function handleHostedRuntimeGroupCreateJoinLink(input: {
   joinLink: HostedRuntimeGroupCreateJoinLinkRequest | null;
   memberId: string;
@@ -113,9 +167,6 @@ async function handleHostedRuntimeGroupCreateJoinLink(input: {
     result: { group: null, status: "unavailable", unavailableReason },
   });
 
-  if (!await hasHostedRuntimeActiveAccess(input.memberId)) {
-    return unavailable("runtime_inactive");
-  }
   const publicBaseUrl = resolveHostedPublicBaseUrl();
   if (!publicBaseUrl) {
     return unavailable("join_links_unavailable");
@@ -124,22 +175,15 @@ async function handleHostedRuntimeGroupCreateJoinLink(input: {
   const prisma = getPrisma();
   const now = new Date();
   const created = await prisma.$transaction(async (tx) => {
-    const container = await tx.hostedThreadContainer.findUnique({
-      where: { memberId: input.memberId },
-      select: { ownerMemberId: true },
+    const ownerAccess = await readHostedRuntimeGroupOwnerActiveAccess({
+      memberId: input.memberId,
+      prisma: tx,
     });
-    if (!container) {
-      return { kind: "not_group_runtime" as const };
-    }
-    const owner = await tx.hostedMember.findUnique({
-      where: { id: container.ownerMemberId },
-      select: { suspendedAt: true },
-    });
-    if (!owner || owner.suspendedAt) {
-      return { kind: "owner_unavailable" as const };
+    if (ownerAccess.status !== "ok") {
+      return { kind: ownerAccess.unavailableReason };
     }
     const result = await createHostedGroupJoinLinkForOwnedThreadContainerTx({
-      actorMemberId: container.ownerMemberId,
+      actorMemberId: ownerAccess.ownerMemberId,
       containerMemberId: input.memberId,
       displayName: input.joinLink?.displayName ?? null,
       kind: input.joinLink?.kind ?? null,
@@ -148,7 +192,7 @@ async function handleHostedRuntimeGroupCreateJoinLink(input: {
         input.joinLink?.requestedVaultShareProjectionKinds ?? [],
       tx,
     });
-    return { kind: "ok" as const, ownerMemberId: container.ownerMemberId, ...result };
+    return { kind: "ok" as const, ownerMemberId: ownerAccess.ownerMemberId, ...result };
   }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
 
   if (created.kind !== "ok") {
@@ -527,6 +571,15 @@ async function handleHostedRuntimeGroupShareContactCard(input: {
     return unavailable(authorized.unavailableReason);
   }
 
+  const prisma = getPrisma();
+  const ownerAccess = await readHostedRuntimeGroupOwnerActiveAccess({
+    memberId: input.memberId,
+    prisma,
+  });
+  if (ownerAccess.status !== "ok") {
+    return unavailable(ownerAccess.unavailableReason);
+  }
+
   let linePhoneNumber: string | null = null;
   let rosterPresent = false;
   try {
@@ -545,7 +598,6 @@ async function handleHostedRuntimeGroupShareContactCard(input: {
     return unavailable("line_unresolved");
   }
 
-  const prisma = getPrisma();
   const reservation = await reserveHostedLinqContactCardShareAttempt({
     chatId: authorized.chatId,
     memberId: input.memberId,

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -274,7 +274,7 @@ async function handleHostedRuntimeGroupReadChatParticipants(input: {
   await reconcileHostedThreadContainerParticipants({
     chatId: authorized.chatId,
     containerMemberId: input.memberId,
-    handles: participantHandles,
+    handles,
     prisma,
     resolvedParticipants,
   });
@@ -308,6 +308,8 @@ export async function reconcileHostedThreadContainerParticipants(input: {
       return;
     }
 
+    const hasCompleteRoster =
+      handles.length <= HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX;
     const participantHandles = selectHostedThreadContainerParticipantHandles({
       chatId: input.chatId,
       containerMemberId: input.containerMemberId,
@@ -361,6 +363,15 @@ export async function reconcileHostedThreadContainerParticipants(input: {
           },
         },
       });
+    }
+
+    if (!hasCompleteRoster) {
+      logHostedThreadContainerParticipantReconcileSkipped({
+        chatId: input.chatId,
+        containerMemberId: input.containerMemberId,
+        reason: "roster_exceeds_cap",
+      });
+      return;
     }
 
     await input.prisma.hostedThreadContainerParticipant.updateMany({

--- a/apps/web/src/lib/hosted-mailbox/runtime-access.ts
+++ b/apps/web/src/lib/hosted-mailbox/runtime-access.ts
@@ -5,6 +5,7 @@ import type {
 
 import {
   hasActiveHostedMemberAccess,
+  hasActiveHostedThreadContainerAccessWithParticipants,
   hostedMemberAccessSelect,
 } from "../hosted-onboarding/member-access";
 import {
@@ -36,8 +37,18 @@ export async function requireHostedRuntimeActiveAccess(
     select: hostedMemberAccessSelect,
   });
 
-  if (member && hasActiveHostedMemberAccess(member)) {
-    return;
+  if (member) {
+    const active = member.threadContainer
+      ? await hasActiveHostedThreadContainerAccessWithParticipants({
+          container: member,
+          containerMemberId: userId,
+          owner: member.threadContainer.owner,
+          prisma,
+        })
+      : hasActiveHostedMemberAccess(member);
+    if (active) {
+      return;
+    }
   }
 
   throw hostedOnboardingError({

--- a/apps/web/src/lib/hosted-mailbox/runtime-access.ts
+++ b/apps/web/src/lib/hosted-mailbox/runtime-access.ts
@@ -3,11 +3,7 @@ import type {
   PrismaClient,
 } from "@prisma/client";
 
-import {
-  hasActiveHostedMemberAccess,
-  hasActiveHostedThreadContainerAccessWithParticipants,
-  hostedMemberAccessSelect,
-} from "../hosted-onboarding/member-access";
+import { readActiveHostedMemberAccess } from "../hosted-onboarding/member-access";
 import {
   hostedOnboardingError,
   isHostedOnboardingError,
@@ -23,32 +19,18 @@ interface HostedRuntimeActiveAccessOptions {
 }
 
 // Shared fail-closed gate for runtime surfaces: only members with active hosted
-// access and, for thread containers, active owner authority may wake or touch
-// runtime state.
+// access and, for thread containers, active owner or participant authority may
+// wake or touch runtime state.
 export async function requireHostedRuntimeActiveAccess(
   userId: string,
   options: HostedRuntimeActiveAccessOptions = {},
 ): Promise<void> {
   const prisma = options.prisma ?? getPrisma();
-  const member = await prisma.hostedMember.findUnique({
-    where: {
-      id: userId,
-    },
-    select: hostedMemberAccessSelect,
-  });
-
-  if (member) {
-    const active = member.threadContainer
-      ? await hasActiveHostedThreadContainerAccessWithParticipants({
-          container: member,
-          containerMemberId: userId,
-          owner: member.threadContainer.owner,
-          prisma,
-        })
-      : hasActiveHostedMemberAccess(member);
-    if (active) {
-      return;
-    }
+  if (await readActiveHostedMemberAccess({
+    memberId: userId,
+    prisma,
+  })) {
+    return;
   }
 
   throw hostedOnboardingError({

--- a/apps/web/src/lib/hosted-onboarding/member-access.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-access.ts
@@ -171,6 +171,25 @@ export async function readActiveHostedMemberAccess(input: {
   return member !== null && hasActiveHostedMemberAccess(member);
 }
 
+export async function hasAnyActiveHostedThreadContainerParticipant(input: {
+  containerMemberId: string;
+  prisma?: HostedOnboardingReadClient;
+}): Promise<boolean> {
+  const prisma = input.prisma ?? getPrisma();
+  const participant = await prisma.hostedThreadContainerParticipant.findFirst({
+    select: {
+      participantMemberId: true,
+    },
+    where: {
+      containerMemberId: input.containerMemberId,
+      participant: activeHostedMemberAccessWhere(),
+      removedAt: null,
+    },
+  });
+
+  return participant !== null;
+}
+
 export async function assertActiveHostedMemberAccessAllowed(input: {
   memberId: string;
   prisma?: HostedOnboardingReadClient;

--- a/apps/web/src/lib/hosted-onboarding/member-access.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-access.ts
@@ -23,7 +23,8 @@ import type { HostedOnboardingReadClient } from "./shared";
  * that already exist in the data model:
  *
  * - an active membership in an active, unsuspended account group (family), or
- * - for synthetic thread-container members, the container owner's access.
+ * - for synthetic thread-container members, the container owner's access, or
+ *   an active current participant through the async thread-container resolver.
  *
  * Owners cannot themselves be containers, so the derivation depth is at most
  * two and a single query loads everything `hasActiveHostedMemberAccess` needs.
@@ -97,7 +98,8 @@ export function hasActiveHostedMemberAccess(member: HostedMemberAccessState): bo
   }
 
   // A thread-container member is synthetic: its own billing status is not an
-  // access source. The container lives and dies with its owner.
+  // access source. Participant-aware container gates use the async resolver
+  // below; this pure member resolver stays owner-only for legacy callers.
   if (member.threadContainer) {
     return hasActiveHostedPersonAccess(member.threadContainer.owner);
   }
@@ -111,6 +113,29 @@ export function hasActiveHostedThreadContainerAccess(input: {
 }): boolean {
   return !isHostedMemberSuspended(input.container.suspendedAt)
     && hasActiveHostedPersonAccess(input.owner);
+}
+
+export async function hasActiveHostedThreadContainerAccessWithParticipants(input: {
+  container: Pick<HostedMemberPersonAccessState, "suspendedAt">;
+  containerMemberId: string;
+  owner: HostedMemberPersonAccessState;
+  prisma?: HostedOnboardingReadClient;
+}): Promise<boolean> {
+  if (hasActiveHostedThreadContainerAccess({
+    container: input.container,
+    owner: input.owner,
+  })) {
+    return true;
+  }
+
+  if (isHostedMemberSuspended(input.container.suspendedAt)) {
+    return false;
+  }
+
+  return await hasAnyActiveHostedThreadContainerParticipant({
+    containerMemberId: input.containerMemberId,
+    prisma: input.prisma,
+  });
 }
 
 /**

--- a/apps/web/src/lib/hosted-onboarding/member-access.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-access.ts
@@ -24,10 +24,10 @@ import type { HostedOnboardingReadClient } from "./shared";
  *
  * - an active membership in an active, unsuspended account group (family), or
  * - for synthetic thread-container members, the container owner's access, or
- *   an active current participant through the async thread-container resolver.
+ *   an active current participant through `readActiveHostedMemberAccess`.
  *
  * Owners cannot themselves be containers, so the derivation depth is at most
- * two and a single query loads everything `hasActiveHostedMemberAccess` needs.
+ * two and a single query loads everything the owner branch needs.
  * Every runtime, webhook, page, and egress gate must use this module; the
  * own-billing predicates in `entitlement.ts` are for billing surfaces that
  * genuinely mean "this member's own subscription".
@@ -98,8 +98,8 @@ export function hasActiveHostedMemberAccess(member: HostedMemberAccessState): bo
   }
 
   // A thread-container member is synthetic: its own billing status is not an
-  // access source. Participant-aware container gates use the async resolver
-  // below; this pure member resolver stays owner-only for legacy callers.
+  // access source. Async gates must use `readActiveHostedMemberAccess`, which
+  // adds participant-aware access after this owner-only pure shortcut.
   if (member.threadContainer) {
     return hasActiveHostedPersonAccess(member.threadContainer.owner);
   }
@@ -139,10 +139,10 @@ export async function hasActiveHostedThreadContainerAccessWithParticipants(input
 }
 
 /**
- * Set-based projection of `hasActiveHostedMemberAccess` for queries that must
- * select access-holding members in the database (pagination, counts, sweeps).
- * Keep it semantically identical to the pure derivation above; the raw-SQL
- * due-reconcile sweep in device-sync mirrors the person branch of this shape.
+ * Set-based projection of the pure access branch for queries that must select
+ * access-holding members in the database (pagination, counts, sweeps). It
+ * intentionally cannot recurse into thread-container participant rosters; use
+ * `readActiveHostedMemberAccess` for user-visible async gates.
  */
 export function activeHostedMemberAccessWhere(): Prisma.HostedMemberWhereInput {
   const personAccess: Prisma.HostedMemberWhereInput["OR"] = [
@@ -193,7 +193,20 @@ export async function readActiveHostedMemberAccess(input: {
     },
   });
 
-  return member !== null && hasActiveHostedMemberAccess(member);
+  if (!member) {
+    return false;
+  }
+
+  if (member.threadContainer) {
+    return await hasActiveHostedThreadContainerAccessWithParticipants({
+      container: member,
+      containerMemberId: input.memberId,
+      owner: member.threadContainer.owner,
+      prisma,
+    });
+  }
+
+  return hasActiveHostedMemberAccess(member);
 }
 
 export async function hasAnyActiveHostedThreadContainerParticipant(input: {
@@ -201,6 +214,9 @@ export async function hasAnyActiveHostedThreadContainerParticipant(input: {
   prisma?: HostedOnboardingReadClient;
 }): Promise<boolean> {
   const prisma = input.prisma ?? getPrisma();
+  // Participant rows are a provider-roster projection. A departed member can
+  // remain active until the next successful complete roster reconcile; that
+  // stale-open window is accepted because false removal would drop live groups.
   const participant = await prisma.hostedThreadContainerParticipant.findFirst({
     select: {
       participantMemberId: true,

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq-types.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq-types.ts
@@ -12,9 +12,15 @@ export type HostedOnboardingLinqWebhookResponse = {
   reason?: string;
 };
 
+export type HostedOnboardingLinqGroupRosterReconcile = {
+  chatId: string;
+  containerMemberId: string;
+};
+
 export type HostedOnboardingLinqDirectPlan =
   HostedWebhookPlan<HostedOnboardingLinqWebhookResponse, HostedLinqMessageSideEffect>
   & {
     firstContactAdmissionParticipantContact?: HostedLinqParticipantContact;
     firstContactAdmissionRequest?: HostedLinqFirstContactAdmissionRequest;
+    postCommitGroupRosterReconciles?: readonly HostedOnboardingLinqGroupRosterReconcile[];
   };

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -1344,8 +1344,9 @@ async function planHostedLinqGroupChatWebhook(input: {
     return ignored("group-chat-not-home-line");
   }
 
+  let createdContainerMemberId: string | null = null;
   try {
-    await ensureHostedThreadContainerRouteTx({
+    const ensureResult = await ensureHostedThreadContainerRouteTx({
       accountLookupKey,
       accountLookupKeys: input.threadRouteAccountLookupKeys,
       channel: "linq",
@@ -1354,6 +1355,9 @@ async function planHostedLinqGroupChatWebhook(input: {
       prisma: input.prisma,
       threadId: summary.chatId,
     });
+    createdContainerMemberId = ensureResult.created
+      ? ensureResult.containerMemberId
+      : null;
   } catch (error) {
     if (
       !isHostedOnboardingError(error)
@@ -1377,12 +1381,26 @@ async function planHostedLinqGroupChatWebhook(input: {
     return ignored("group-chat-provision-unavailable");
   }
 
-  return planHostedLinqExplicitThreadRouteWebhook({
+  const plan = await planHostedLinqExplicitThreadRouteWebhook({
     context: input.context,
     event: input.event,
     prisma: input.prisma,
     route,
   });
+  if (createdContainerMemberId && route.containerMemberId === createdContainerMemberId) {
+    return {
+      ...plan,
+      postCommitGroupRosterReconciles: [
+        ...(plan.postCommitGroupRosterReconciles ?? []),
+        {
+          chatId: summary.chatId,
+          containerMemberId: route.containerMemberId,
+        },
+      ],
+    };
+  }
+
+  return plan;
 }
 
 async function planHostedLinqInboundAdmissionDenied(input: {

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -10,8 +10,7 @@ import {
   isHostedMemberSuspended,
 } from "./entitlement";
 import {
-  hasAnyActiveHostedThreadContainerParticipant,
-  hasActiveHostedThreadContainerAccess,
+  hasActiveHostedThreadContainerAccessWithParticipants,
   readActiveHostedMemberAccess,
 } from "./member-access";
 import {
@@ -1025,19 +1024,14 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
     summary,
   } = input.context;
 
-  const ownerOrSponsorActive = hasActiveHostedThreadContainerAccess({
+  const containerAccessActive = await hasActiveHostedThreadContainerAccessWithParticipants({
     container: input.route.container,
+    containerMemberId: input.route.containerMemberId,
     owner: input.route.owner,
+    prisma: input.prisma,
   });
-  const participantActive = ownerOrSponsorActive
-    ? false
-    : !isHostedMemberSuspended(input.route.container.suspendedAt)
-      && await hasAnyActiveHostedThreadContainerParticipant({
-        containerMemberId: input.route.containerMemberId,
-        prisma: input.prisma,
-      });
 
-  if (!ownerOrSponsorActive && !participantActive) {
+  if (!containerAccessActive) {
     return logHostedLinqWebhookPlannerDecisionAndReturn(
       buildIgnoredLinqWebhookPlan("thread-container-inactive"),
       buildHostedLinqWebhookPlannerDetails(input.event, input.context, {

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -10,6 +10,7 @@ import {
   isHostedMemberSuspended,
 } from "./entitlement";
 import {
+  hasAnyActiveHostedThreadContainerParticipant,
   hasActiveHostedThreadContainerAccess,
   readActiveHostedMemberAccess,
 } from "./member-access";
@@ -1024,12 +1025,19 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
     summary,
   } = input.context;
 
-  if (
-    !hasActiveHostedThreadContainerAccess({
-      container: input.route.container,
-      owner: input.route.owner,
-    })
-  ) {
+  const ownerOrSponsorActive = hasActiveHostedThreadContainerAccess({
+    container: input.route.container,
+    owner: input.route.owner,
+  });
+  const participantActive = ownerOrSponsorActive
+    ? false
+    : !isHostedMemberSuspended(input.route.container.suspendedAt)
+      && await hasAnyActiveHostedThreadContainerParticipant({
+        containerMemberId: input.route.containerMemberId,
+        prisma: input.prisma,
+      });
+
+  if (!ownerOrSponsorActive && !participantActive) {
     return logHostedLinqWebhookPlannerDecisionAndReturn(
       buildIgnoredLinqWebhookPlan("thread-container-inactive"),
       buildHostedLinqWebhookPlannerDetails(input.event, input.context, {

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -9,10 +9,7 @@ import { issueHostedInviteTx } from "./invite-service";
 import {
   isHostedMemberSuspended,
 } from "./entitlement";
-import {
-  hasActiveHostedThreadContainerAccessWithParticipants,
-  readActiveHostedMemberAccess,
-} from "./member-access";
+import { readActiveHostedMemberAccess } from "./member-access";
 import {
   isHostedOnboardingError,
 } from "./errors";
@@ -1024,10 +1021,8 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
     summary,
   } = input.context;
 
-  const containerAccessActive = await hasActiveHostedThreadContainerAccessWithParticipants({
-    container: input.route.container,
-    containerMemberId: input.route.containerMemberId,
-    owner: input.route.owner,
+  const containerAccessActive = await readActiveHostedMemberAccess({
+    memberId: input.route.containerMemberId,
     prisma: input.prisma,
   });
 

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -78,6 +78,12 @@ import {
 import type {
   HostedWebhookWakeHandoff,
 } from "./webhook-service-types";
+import {
+  reconcileHostedThreadContainerParticipants,
+} from "../hosted-groups/group-tool";
+import type {
+  HostedOnboardingLinqGroupRosterReconcile,
+} from "./webhook-provider-linq-types";
 
 export {
   handleHostedStripeWebhook,
@@ -319,6 +325,11 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       wakeUserPresent: Boolean(plan.wakeHandoffs?.some((handoff) => handoff.userId)),
     });
 
+    await reconcileHostedLinqGroupRostersAfterCommitBestEffort({
+      reconciles: plan.postCommitGroupRosterReconciles ?? [],
+      scheduleAfterResponse: input.scheduleAfterResponse,
+    });
+
     if (plan.desiredSideEffects.length > 0) {
       await drainHostedLinqSideEffectsDirect({
         currentInboundReply,
@@ -482,6 +493,40 @@ async function maybeSendHostedLinqIngressReadReceipt(input: {
 function normalizeHostedLinqReadReceiptChatId(value: string | null | undefined): string | null {
   const normalized = value?.trim() ?? "";
   return normalized.length > 0 ? normalized : null;
+}
+
+async function reconcileHostedLinqGroupRostersAfterCommitBestEffort(input: {
+  reconciles: readonly HostedOnboardingLinqGroupRosterReconcile[];
+  scheduleAfterResponse?: HostedWebhookPostResponseScheduler;
+}): Promise<void> {
+  if (input.reconciles.length === 0) {
+    return;
+  }
+
+  const run = async () => {
+    for (const reconcile of input.reconciles) {
+      try {
+        await reconcileHostedThreadContainerParticipants({
+          chatId: reconcile.chatId,
+          containerMemberId: reconcile.containerMemberId,
+          prisma: getPrisma(),
+        });
+      } catch (error) {
+        console.warn("Hosted Linq group roster post-commit reconcile failed.", {
+          errorName: deriveHostedOnboardingTimingErrorName(error),
+          chatIdSuffix: toHostedOnboardingLogIdSuffix(reconcile.chatId),
+          containerMemberIdSuffix: toHostedOnboardingLogIdSuffix(reconcile.containerMemberId),
+        });
+      }
+    }
+  };
+
+  if (input.scheduleAfterResponse) {
+    input.scheduleAfterResponse(run);
+    return;
+  }
+
+  await run();
 }
 
 function buildHostedLinqCurrentInboundReplyProof(

--- a/apps/web/src/lib/hosted-routing/thread-route-store.ts
+++ b/apps/web/src/lib/hosted-routing/thread-route-store.ts
@@ -12,9 +12,9 @@ import {
   isHostedExternalThreadChannel,
 } from "../hosted-onboarding/contact-privacy";
 import {
-  hasActiveHostedThreadContainerAccessWithParticipants,
   type HostedMemberPersonAccessState,
   hostedMemberPersonAccessSelect,
+  readActiveHostedMemberAccess,
 } from "../hosted-onboarding/member-access";
 import {
   hostedOnboardingError,
@@ -257,10 +257,8 @@ export async function assertHostedThreadRouteEgressAuthority(input: {
   });
 
   if (route && route.containerMemberId === input.authority.containerMemberId) {
-    if (await hasActiveHostedThreadContainerAccessWithParticipants({
-      container: route.container,
-      containerMemberId: route.containerMemberId,
-      owner: route.owner,
+    if (await readActiveHostedMemberAccess({
+      memberId: route.containerMemberId,
       prisma: input.prisma,
     })) {
       return route;

--- a/apps/web/src/lib/hosted-routing/thread-route-store.ts
+++ b/apps/web/src/lib/hosted-routing/thread-route-store.ts
@@ -11,7 +11,9 @@ import {
   createHostedExternalThreadLookupKeyReadCandidates,
   isHostedExternalThreadChannel,
 } from "../hosted-onboarding/contact-privacy";
+import { isHostedMemberSuspended } from "../hosted-onboarding/entitlement";
 import {
+  hasAnyActiveHostedThreadContainerParticipant,
   hasActiveHostedThreadContainerAccess,
   type HostedMemberPersonAccessState,
   hostedMemberPersonAccessSelect,
@@ -256,15 +258,23 @@ export async function assertHostedThreadRouteEgressAuthority(input: {
     threadId: input.authority.threadId,
   });
 
-  if (
-    route
-    && route.containerMemberId === input.authority.containerMemberId
-    && hasActiveHostedThreadContainerAccess({
+  if (route && route.containerMemberId === input.authority.containerMemberId) {
+    if (hasActiveHostedThreadContainerAccess({
       container: route.container,
       owner: route.owner,
-    })
-  ) {
-    return route;
+    })) {
+      return route;
+    }
+
+    if (
+      !isHostedMemberSuspended(route.container.suspendedAt)
+      && await hasAnyActiveHostedThreadContainerParticipant({
+        containerMemberId: route.containerMemberId,
+        prisma: input.prisma,
+      })
+    ) {
+      return route;
+    }
   }
 
   throw buildHostedThreadRouteEgressUnauthorizedError();

--- a/apps/web/src/lib/hosted-routing/thread-route-store.ts
+++ b/apps/web/src/lib/hosted-routing/thread-route-store.ts
@@ -11,10 +11,8 @@ import {
   createHostedExternalThreadLookupKeyReadCandidates,
   isHostedExternalThreadChannel,
 } from "../hosted-onboarding/contact-privacy";
-import { isHostedMemberSuspended } from "../hosted-onboarding/entitlement";
 import {
-  hasAnyActiveHostedThreadContainerParticipant,
-  hasActiveHostedThreadContainerAccess,
+  hasActiveHostedThreadContainerAccessWithParticipants,
   type HostedMemberPersonAccessState,
   hostedMemberPersonAccessSelect,
 } from "../hosted-onboarding/member-access";
@@ -259,20 +257,12 @@ export async function assertHostedThreadRouteEgressAuthority(input: {
   });
 
   if (route && route.containerMemberId === input.authority.containerMemberId) {
-    if (hasActiveHostedThreadContainerAccess({
+    if (await hasActiveHostedThreadContainerAccessWithParticipants({
       container: route.container,
+      containerMemberId: route.containerMemberId,
       owner: route.owner,
+      prisma: input.prisma,
     })) {
-      return route;
-    }
-
-    if (
-      !isHostedMemberSuspended(route.container.suspendedAt)
-      && await hasAnyActiveHostedThreadContainerParticipant({
-        containerMemberId: route.containerMemberId,
-        prisma: input.prisma,
-      })
-    ) {
       return route;
     }
   }

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -1849,6 +1849,37 @@ describe("readHostedAiUsageGate", () => {
     expect(prisma.hostedAiUsagePeriod.update).not.toHaveBeenCalled();
   });
 
+  it("allows thread-container usage when an active participant has access", async () => {
+    const prisma = createGatePrisma({
+      billingStatus: HostedBillingStatus.not_started,
+      spentUsdMicros: 1_000_000n,
+      threadContainerLimitUsdMicros: 4_500_000n,
+      threadContainerOwnerBillingStatus: HostedBillingStatus.paused,
+      threadContainerParticipantActive: true,
+    });
+
+    await expect(readHostedAiUsageGate({
+      memberId: "member_123",
+      now: "2026-03-29T12:00:00.000Z",
+      prisma: prisma as never,
+    })).resolves.toMatchObject({
+      allowed: true,
+      limitUsdMicros: 4_500_000n,
+      remainingUsdMicros: 3_500_000n,
+      spentUsdMicros: 1_000_000n,
+    });
+
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_123",
+        removedAt: null,
+      }),
+    });
+  });
+
   it("uses usage-period spend for billing periods before allowing", async () => {
     const aggregate = vi.fn(async () => ({
       _max: {
@@ -2268,6 +2299,7 @@ function createGatePrisma(input: {
   threadContainerOwnerBillingStatus?: HostedBillingStatus;
   threadContainerOwnerFamilySponsored?: boolean;
   threadContainerOwnerSuspendedAt?: Date | null;
+  threadContainerParticipantActive?: boolean;
   trialEndsAt?: Date | null;
   trialStartedAt?: Date | null;
   suspendedAt?: Date | null;
@@ -2423,6 +2455,11 @@ function createGatePrisma(input: {
           suspendedAt: input.suspendedAt ?? null,
           threadContainer,
         }),
+    },
+    hostedThreadContainerParticipant: {
+      findFirst: vi.fn(async () => input.threadContainerParticipantActive
+        ? { participantMemberId: "member_participant" }
+        : null),
     },
   };
 }

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -2005,7 +2005,9 @@ describe("checkHostedAiUsageGate", () => {
         scheduledBillingPlanCode: null,
       },
       billingStatus: HostedBillingStatus.active,
+      id: "member_123",
       suspendedAt: null,
+      threadContainer: null,
     }));
 
     await expect(checkHostedAiUsageGate({
@@ -2051,7 +2053,9 @@ describe("checkHostedAiUsageGate", () => {
         scheduledBillingPlanCode: null,
       },
       billingStatus: HostedBillingStatus.active,
+      id: "member_123",
       suspendedAt: null,
+      threadContainer: null,
     }));
     await expect(checkHostedAiUsageGate({
       memberId: "member_123",
@@ -2417,44 +2421,25 @@ function createGatePrisma(input: {
         : null),
     },
     hostedMember: {
-      findUnique: vi.fn()
-        .mockResolvedValueOnce({
-          billingRef: {
-            currentBillingPhase: input.billingPhase ?? null,
-            currentBillingPlanCode: input.billingPlanCode ?? "launch_monthly",
-            currentCheckoutOffer: input.checkoutOffer ?? null,
-            currentPeriodEnd: periodEnd,
-            currentPeriodStart: periodStart,
-            currentTrialEndsAt: input.trialEndsAt ?? null,
-            currentTrialStartedAt: input.trialStartedAt ?? null,
-            pulseTrialPolicyVersion: input.pulseTrialPolicyVersion ?? null,
-            pulseTrialRedeemedAt: input.pulseTrialRedeemedAt ?? null,
-            scheduledBillingEffectiveAt: input.scheduledBillingEffectiveAt ?? null,
-            scheduledBillingPlanCode: input.scheduledBillingPlanCode ?? null,
-          },
-          billingStatus: input.billingStatus ?? HostedBillingStatus.active,
-          suspendedAt: input.suspendedAt ?? null,
-          threadContainer,
-        })
-        .mockResolvedValueOnce({
-          billingRef: {
-            currentBillingPhase: input.billingPhase ?? null,
-            currentBillingPlanCode: input.billingPlanCode ?? "launch_monthly",
-            currentCheckoutOffer: input.checkoutOffer ?? null,
-            currentPeriodEnd: periodEnd,
-            currentPeriodStart: periodStart,
-            currentTrialEndsAt: input.trialEndsAt ?? null,
-            currentTrialStartedAt: input.trialStartedAt ?? null,
-            pulseTrialPolicyVersion: input.pulseTrialPolicyVersion ?? null,
-            pulseTrialRedeemedAt: input.pulseTrialRedeemedAt ?? null,
-            scheduledBillingEffectiveAt: input.scheduledBillingEffectiveAt ?? null,
-            scheduledBillingPlanCode: input.scheduledBillingPlanCode ?? null,
-          },
-          billingStatus: input.billingStatus ?? HostedBillingStatus.active,
-          id: "member_123",
-          suspendedAt: input.suspendedAt ?? null,
-          threadContainer,
-        }),
+      findUnique: vi.fn(async () => ({
+        billingRef: {
+          currentBillingPhase: input.billingPhase ?? null,
+          currentBillingPlanCode: input.billingPlanCode ?? "launch_monthly",
+          currentCheckoutOffer: input.checkoutOffer ?? null,
+          currentPeriodEnd: periodEnd,
+          currentPeriodStart: periodStart,
+          currentTrialEndsAt: input.trialEndsAt ?? null,
+          currentTrialStartedAt: input.trialStartedAt ?? null,
+          pulseTrialPolicyVersion: input.pulseTrialPolicyVersion ?? null,
+          pulseTrialRedeemedAt: input.pulseTrialRedeemedAt ?? null,
+          scheduledBillingEffectiveAt: input.scheduledBillingEffectiveAt ?? null,
+          scheduledBillingPlanCode: input.scheduledBillingPlanCode ?? null,
+        },
+        billingStatus: input.billingStatus ?? HostedBillingStatus.active,
+        id: "member_123",
+        suspendedAt: input.suspendedAt ?? null,
+        threadContainer,
+      })),
     },
     hostedThreadContainerParticipant: {
       findFirst: vi.fn(async () => input.threadContainerParticipantActive

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   getHostedLinqChatHandles: vi.fn(),
   hasHostedRuntimeActiveAccess: vi.fn(),
   hostedMemberFindUnique: vi.fn(),
+  hostedThreadContainerParticipantUpdateMany: vi.fn(),
+  hostedThreadContainerParticipantUpsert: vi.fn(),
   hostedThreadContainerFindUnique: vi.fn(),
   isHostedMemberSuspended: vi.fn(),
   lookupHostedMemberByVerifiedEmailAddress: vi.fn(),
@@ -84,14 +86,28 @@ const fakeTx = {
   hostedMember: { findUnique: mocks.hostedMemberFindUnique },
   hostedThreadContainer: { findUnique: mocks.hostedThreadContainerFindUnique },
 };
+const fakePrisma = {
+  ...fakeTx,
+  hostedThreadContainerParticipant: {
+    updateMany: mocks.hostedThreadContainerParticipantUpdateMany,
+    upsert: mocks.hostedThreadContainerParticipantUpsert,
+  },
+};
 
 vi.mock("@/src/lib/prisma", () => ({
   getPrisma: () => ({
+    ...fakePrisma,
     $transaction: (run: (tx: typeof fakeTx) => Promise<unknown>) => run(fakeTx),
   }),
 }));
 
-import { handleHostedRuntimeGroupTool } from "@/src/lib/hosted-groups/group-tool";
+import {
+  handleHostedRuntimeGroupTool,
+  reconcileHostedThreadContainerParticipants,
+} from "@/src/lib/hosted-groups/group-tool";
+import {
+  HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX,
+} from "@murphai/hosted-execution/runtime-control";
 import { HOSTED_VAULT_SHARE_SELECTABLE_PROJECTION_KINDS } from "@murphai/hosted-execution/vault-share";
 import {
   mergeHostedGroupJoinPolicy,
@@ -118,6 +134,8 @@ describe("handleHostedRuntimeGroupTool", () => {
       ownerMemberId: "member_owner",
     });
     mocks.hostedMemberFindUnique.mockResolvedValue({ suspendedAt: null });
+    mocks.hostedThreadContainerParticipantUpdateMany.mockResolvedValue({ count: 0 });
+    mocks.hostedThreadContainerParticipantUpsert.mockResolvedValue({});
     mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx.mockResolvedValue({
       group: GROUP_SUMMARY,
       joinCode: "abc123",
@@ -454,6 +472,77 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     expect(mocks.lookupHostedMemberByVerifiedEmailAddress).toHaveBeenCalledWith(
       expect.objectContaining({ address: "person@example.com" }),
     );
+    expect(mocks.hostedThreadContainerParticipantUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          containerMemberId: "member_container",
+          handleLookupKey: expect.stringMatching(/^hbidx:phone:/),
+          participantMemberId: "member_participant",
+          removedAt: null,
+        }),
+        update: expect.objectContaining({
+          handleLookupKey: expect.stringMatching(/^hbidx:phone:/),
+          removedAt: null,
+        }),
+        where: {
+          containerMemberId_participantMemberId: {
+            containerMemberId: "member_container",
+            participantMemberId: "member_participant",
+          },
+        },
+      }),
+    );
+    expect(mocks.hostedThreadContainerParticipantUpdateMany).toHaveBeenCalledWith({
+      data: {
+        removedAt: expect.any(Date),
+      },
+      where: {
+        containerMemberId: "member_container",
+        participantMemberId: { notIn: ["member_participant"] },
+        removedAt: null,
+      },
+    });
+  });
+
+  it("reconciles every resolved member even when the returned participant list is capped", async () => {
+    const activeHandles = Array.from(
+      { length: HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX + 1 },
+      (_, index) => ({
+        handle: `+1555001${index.toString().padStart(4, "0")}`,
+        isMe: false,
+        status: "active",
+      }),
+    );
+    mocks.getHostedLinqChatHandles.mockResolvedValue([
+      { handle: "+15557770000", isMe: true, status: "active" },
+      ...activeHandles,
+    ]);
+    mocks.lookupHostedMemberIdentityByPhoneNumber.mockImplementation(async ({ phoneNumber }) => ({
+      core: { id: `member_${phoneNumber.slice(-4)}`, suspendedAt: null },
+    }));
+
+    const response = await handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants", linqThread: LINQ_THREAD },
+    });
+
+    expect(response).toMatchObject({
+      action: "read_chat_participants",
+      result: { status: "ok" },
+    });
+    if (response.action !== "read_chat_participants" || response.result.status !== "ok") {
+      throw new Error("Expected ok participants response.");
+    }
+    expect(response.result.participants).toHaveLength(
+      HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX,
+    );
+    expect(mocks.hostedThreadContainerParticipantUpsert).toHaveBeenCalledTimes(
+      HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX + 1,
+    );
+    const updateWhere = mocks.hostedThreadContainerParticipantUpdateMany.mock.calls[0]?.[0]?.where;
+    expect(updateWhere?.participantMemberId?.notIn).toHaveLength(
+      HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX + 1,
+    );
   });
 
   it("treats an unrecognized empty roster as provider trouble, not an empty room", async () => {
@@ -486,6 +575,50 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
         unavailableReason: "provider_unavailable",
       },
     });
+  });
+
+  it("soft-removes prior roster members when a successful roster pass sees none", async () => {
+    await reconcileHostedThreadContainerParticipants({
+      chatId: "chat_group_1",
+      containerMemberId: "member_container",
+      handles: [
+        { handle: "+15550000001", isMe: false, status: "left" },
+      ],
+      prisma: fakePrisma as never,
+      resolvedParticipants: [],
+    });
+
+    expect(mocks.hostedThreadContainerParticipantUpsert).not.toHaveBeenCalled();
+    expect(mocks.hostedThreadContainerParticipantUpdateMany).toHaveBeenCalledWith({
+      data: {
+        removedAt: expect.any(Date),
+      },
+      where: {
+        containerMemberId: "member_container",
+        removedAt: null,
+      },
+    });
+  });
+
+  it("keeps the existing roster projection when the provider fetch fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.getHostedLinqChatHandles.mockRejectedValueOnce(new Error("linq unavailable"));
+
+    await reconcileHostedThreadContainerParticipants({
+      chatId: "chat_group_1",
+      containerMemberId: "member_container",
+      prisma: fakePrisma as never,
+    });
+
+    expect(mocks.hostedThreadContainerParticipantUpsert).not.toHaveBeenCalled();
+    expect(mocks.hostedThreadContainerParticipantUpdateMany).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted thread-container participant reconcile skipped.",
+      expect.objectContaining({
+        reason: "reconcile_failed",
+      }),
+    );
+    warn.mockRestore();
   });
 
   it("sends the contact card vcf into the chat using the line's own handle", async () => {

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -102,6 +102,7 @@ vi.mock("@/src/lib/prisma", () => ({
 }));
 
 import {
+  HOSTED_RUNTIME_GROUP_TOOL_ACCESS_CLASSIFICATION,
   HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
   handleHostedRuntimeGroupTool,
   reconcileHostedThreadContainerParticipants,
@@ -126,9 +127,11 @@ describe("handleHostedRuntimeGroupTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(true);
+    mocks.readActiveHostedMemberAccess.mockResolvedValue(true);
     mocks.readHostedGroupByRuntimeMemberId.mockResolvedValue(GROUP_SUMMARY);
     mocks.resolveHostedPublicBaseUrl.mockReturnValue("https://www.withmurph.ai");
     mocks.hostedThreadContainerFindUnique.mockResolvedValue({
+      member: { suspendedAt: null },
       ownerMemberId: "member_owner",
     });
     mocks.hostedMemberFindUnique.mockResolvedValue({ suspendedAt: null });
@@ -137,6 +140,15 @@ describe("handleHostedRuntimeGroupTool", () => {
     mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx.mockResolvedValue({
       group: GROUP_SUMMARY,
       joinCode: "abc123",
+    });
+  });
+
+  it("classifies group-tool actions by access authority", () => {
+    expect(HOSTED_RUNTIME_GROUP_TOOL_ACCESS_CLASSIFICATION).toEqual({
+      create_join_link: "owner_active",
+      read_chat_participants: "participant_aware",
+      read_current: "participant_aware",
+      share_contact_card: "owner_active",
     });
   });
 
@@ -212,7 +224,16 @@ describe("handleHostedRuntimeGroupTool", () => {
 
     expect(mocks.hostedThreadContainerFindUnique).toHaveBeenCalledWith({
       where: { memberId: "member_group_runtime" },
-      select: { ownerMemberId: true },
+      select: {
+        member: {
+          select: { suspendedAt: true },
+        },
+        ownerMemberId: true,
+      },
+    });
+    expect(mocks.readActiveHostedMemberAccess).toHaveBeenCalledWith({
+      memberId: "member_owner",
+      prisma: fakeTx,
     });
     expect(mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -225,8 +246,31 @@ describe("handleHostedRuntimeGroupTool", () => {
     );
   });
 
-  it("does not mint a join link when runtime access is inactive", async () => {
-    mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(false);
+  it("does not mint a join link when the owner lacks active access even if participant-aware access is active", async () => {
+    mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(true);
+    mocks.readActiveHostedMemberAccess.mockResolvedValue(false);
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_group_runtime",
+      request: { action: "create_join_link" },
+    })).resolves.toEqual({
+      action: "create_join_link",
+      result: {
+        group: null,
+        status: "unavailable",
+        unavailableReason: "owner_unavailable",
+      },
+    });
+
+    expect(mocks.hasHostedRuntimeActiveAccess).not.toHaveBeenCalled();
+    expect(mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx).not.toHaveBeenCalled();
+  });
+
+  it("does not mint a join link when the synthetic group runtime member is suspended", async () => {
+    mocks.hostedThreadContainerFindUnique.mockResolvedValue({
+      member: { suspendedAt: new Date("2026-07-06T12:00:00Z") },
+      ownerMemberId: "member_owner",
+    });
 
     await expect(handleHostedRuntimeGroupTool({
       memberId: "member_group_runtime",
@@ -240,6 +284,7 @@ describe("handleHostedRuntimeGroupTool", () => {
       },
     });
 
+    expect(mocks.readActiveHostedMemberAccess).not.toHaveBeenCalled();
     expect(mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx).not.toHaveBeenCalled();
   });
 
@@ -273,24 +318,6 @@ describe("handleHostedRuntimeGroupTool", () => {
         group: null,
         status: "unavailable",
         unavailableReason: "not_group_runtime",
-      },
-    });
-
-    expect(mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx).not.toHaveBeenCalled();
-  });
-
-  it("rejects join-link creation when the container owner is suspended", async () => {
-    mocks.hostedMemberFindUnique.mockResolvedValue({ suspendedAt: new Date() });
-
-    await expect(handleHostedRuntimeGroupTool({
-      memberId: "member_group_runtime",
-      request: { action: "create_join_link" },
-    })).resolves.toEqual({
-      action: "create_join_link",
-      result: {
-        group: null,
-        status: "unavailable",
-        unavailableReason: "owner_unavailable",
       },
     });
 
@@ -379,6 +406,10 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       { handle: "person@example.com", isMe: false, status: null },
       { handle: "+15550000002", isMe: false, status: "left" },
     ]);
+    mocks.hostedThreadContainerFindUnique.mockResolvedValue({
+      member: { suspendedAt: null },
+      ownerMemberId: "member_owner",
+    });
     mocks.isHostedMemberSuspended.mockReturnValue(false);
     mocks.lookupHostedMemberIdentityByPhoneNumber.mockResolvedValue({
       core: { id: "member_participant", suspendedAt: null },
@@ -446,6 +477,23 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     });
 
     expect(mocks.getHostedLinqChatHandles).not.toHaveBeenCalled();
+  });
+
+  it("keeps read_chat_participants participant-aware when the generic runtime gate is inactive", async () => {
+    mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(false);
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "read_chat_participants", linqThread: LINQ_THREAD },
+    })).resolves.toMatchObject({
+      action: "read_chat_participants",
+      result: {
+        status: "ok",
+      },
+    });
+
+    expect(mocks.hasHostedRuntimeActiveAccess).not.toHaveBeenCalled();
+    expect(mocks.hostedThreadContainerFindUnique).not.toHaveBeenCalled();
   });
 
   it("classifies chat participants by Murph membership and skips the line and departed handles", async () => {
@@ -722,6 +770,26 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
         memberId: "member_container",
       }),
     );
+  });
+
+  it("does not share the contact card when the owner lacks active access even if participant-aware access is active", async () => {
+    mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(true);
+    mocks.readActiveHostedMemberAccess.mockResolvedValue(false);
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: { action: "share_contact_card", linqThread: LINQ_THREAD },
+    })).resolves.toEqual({
+      action: "share_contact_card",
+      result: {
+        status: "unavailable",
+        unavailableReason: "owner_unavailable",
+      },
+    });
+
+    expect(mocks.hasHostedRuntimeActiveAccess).not.toHaveBeenCalled();
+    expect(mocks.reserveHostedLinqContactCardShareAttempt).not.toHaveBeenCalled();
+    expect(mocks.sendHostedLinqAttachmentMessage).not.toHaveBeenCalled();
   });
 
   it("reports already_shared when the per-chat throttle is active", async () => {

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -544,16 +544,19 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     expect(mocks.hostedThreadContainerParticipantUpsert).toHaveBeenCalledTimes(
       HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
     );
-    const updateWhere = mocks.hostedThreadContainerParticipantUpdateMany.mock.calls[0]?.[0]?.where;
-    expect(updateWhere?.participantMemberId?.notIn).toHaveLength(
-      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
-    );
+    expect(mocks.hostedThreadContainerParticipantUpdateMany).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(
       "Hosted thread-container participant reconcile capped.",
       expect.objectContaining({
         cap: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
         reason: "roster_exceeds_cap",
         rosterSize: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX + 1,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted thread-container participant reconcile skipped.",
+      expect.objectContaining({
+        reason: "roster_exceeds_cap",
       }),
     );
     warn.mockRestore();
@@ -592,16 +595,19 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     expect(mocks.hostedThreadContainerParticipantUpsert).toHaveBeenCalledTimes(
       HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
     );
-    const updateWhere = mocks.hostedThreadContainerParticipantUpdateMany.mock.calls[0]?.[0]?.where;
-    expect(updateWhere?.participantMemberId?.notIn).toHaveLength(
-      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
-    );
+    expect(mocks.hostedThreadContainerParticipantUpdateMany).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(
       "Hosted thread-container participant reconcile capped.",
       expect.objectContaining({
         cap: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
         reason: "roster_exceeds_cap",
         rosterSize: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX + 1,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted thread-container participant reconcile skipped.",
+      expect.objectContaining({
+        reason: "roster_exceeds_cap",
       }),
     );
     warn.mockRestore();

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -102,12 +102,10 @@ vi.mock("@/src/lib/prisma", () => ({
 }));
 
 import {
+  HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
   handleHostedRuntimeGroupTool,
   reconcileHostedThreadContainerParticipants,
 } from "@/src/lib/hosted-groups/group-tool";
-import {
-  HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX,
-} from "@murphai/hosted-execution/runtime-control";
 import { HOSTED_VAULT_SHARE_SELECTABLE_PROJECTION_KINDS } from "@murphai/hosted-execution/vault-share";
 import {
   mergeHostedGroupJoinPolicy,
@@ -504,9 +502,10 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     });
   });
 
-  it("reconciles every resolved member even when the returned participant list is capped", async () => {
+  it("bounds read_chat_participants lookups and reconcile writes to the roster cap", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const activeHandles = Array.from(
-      { length: HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX + 1 },
+      { length: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX + 1 },
       (_, index) => ({
         handle: `+1555001${index.toString().padStart(4, "0")}`,
         isMe: false,
@@ -534,15 +533,78 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       throw new Error("Expected ok participants response.");
     }
     expect(response.result.participants).toHaveLength(
-      HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX,
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+    );
+    expect(mocks.lookupHostedMemberIdentityByPhoneNumber).toHaveBeenCalledTimes(
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+    );
+    expect(mocks.readActiveHostedMemberAccess).toHaveBeenCalledTimes(
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
     );
     expect(mocks.hostedThreadContainerParticipantUpsert).toHaveBeenCalledTimes(
-      HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX + 1,
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
     );
     const updateWhere = mocks.hostedThreadContainerParticipantUpdateMany.mock.calls[0]?.[0]?.where;
     expect(updateWhere?.participantMemberId?.notIn).toHaveLength(
-      HOSTED_RUNTIME_GROUP_CHAT_PARTICIPANTS_MAX + 1,
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
     );
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted thread-container participant reconcile capped.",
+      expect.objectContaining({
+        cap: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+        reason: "roster_exceeds_cap",
+        rosterSize: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX + 1,
+      }),
+    );
+    warn.mockRestore();
+  });
+
+  it("bounds at-creation reconcile lookups and upserts to the roster cap", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const activeHandles = Array.from(
+      { length: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX + 1 },
+      (_, index) => ({
+        handle: `+1555011${index.toString().padStart(4, "0")}`,
+        isMe: false,
+        status: "active",
+      }),
+    );
+    mocks.getHostedLinqChatHandles.mockResolvedValue([
+      { handle: "+15557770000", isMe: true, status: "active" },
+      ...activeHandles,
+    ]);
+    mocks.lookupHostedMemberIdentityByPhoneNumber.mockImplementation(async ({ phoneNumber }) => ({
+      core: { id: `member_${phoneNumber.slice(-4)}`, suspendedAt: null },
+    }));
+
+    await reconcileHostedThreadContainerParticipants({
+      chatId: "chat_group_1",
+      containerMemberId: "member_container",
+      prisma: fakePrisma as never,
+    });
+
+    expect(mocks.getHostedLinqChatHandles).toHaveBeenCalledWith({
+      chatId: "chat_group_1",
+    });
+    expect(mocks.lookupHostedMemberIdentityByPhoneNumber).toHaveBeenCalledTimes(
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+    );
+    expect(mocks.hostedThreadContainerParticipantUpsert).toHaveBeenCalledTimes(
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+    );
+    const updateWhere = mocks.hostedThreadContainerParticipantUpdateMany.mock.calls[0]?.[0]?.where;
+    expect(updateWhere?.participantMemberId?.notIn).toHaveLength(
+      HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted thread-container participant reconcile capped.",
+      expect.objectContaining({
+        cap: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX,
+        reason: "roster_exceeds_cap",
+        rosterSize: HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX + 1,
+      }),
+    );
+    warn.mockRestore();
   });
 
   it("treats an unrecognized empty roster as provider trouble, not an empty room", async () => {

--- a/apps/web/test/hosted-onboarding-entitlement.test.ts
+++ b/apps/web/test/hosted-onboarding-entitlement.test.ts
@@ -10,6 +10,7 @@ import {
   hasActiveHostedMemberAccess,
   hasActiveHostedThreadContainerAccess,
   hasActiveHostedThreadContainerAccessWithParticipants,
+  readActiveHostedMemberAccess,
 } from "@/src/lib/hosted-onboarding/member-access";
 
 const SUSPENDED_AT = new Date("2026-04-06T10:00:00.000Z");
@@ -258,6 +259,41 @@ describe("hosted member access (single resolver)", () => {
       prisma: prisma as never,
     })).resolves.toBe(true);
 
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_container",
+        removedAt: null,
+      }),
+    });
+  });
+
+  it("makes readActiveHostedMemberAccess the participant-aware thread-container gate", async () => {
+    const prisma = {
+      hostedMember: {
+        findUnique: vi.fn(async () => ({
+          ...person({ billingStatus: HostedBillingStatus.not_started }),
+          threadContainer: {
+            owner: person({ billingStatus: HostedBillingStatus.paused }),
+          },
+        })),
+      },
+      hostedThreadContainerParticipant: {
+        findFirst: vi.fn(async () => ({ participantMemberId: "member_participant" })),
+      },
+    };
+
+    await expect(readActiveHostedMemberAccess({
+      memberId: "member_container",
+      prisma: prisma as never,
+    })).resolves.toBe(true);
+
+    expect(prisma.hostedMember.findUnique).toHaveBeenCalledWith({
+      select: expect.any(Object),
+      where: { id: "member_container" },
+    });
     expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
       select: {
         participantMemberId: true,

--- a/apps/web/test/hosted-onboarding-entitlement.test.ts
+++ b/apps/web/test/hosted-onboarding-entitlement.test.ts
@@ -1,5 +1,5 @@
 import { HostedBillingStatus } from "@prisma/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   assertHostedMemberOwnActiveBillingAllowed,
@@ -9,6 +9,7 @@ import {
 import {
   hasActiveHostedMemberAccess,
   hasActiveHostedThreadContainerAccess,
+  hasActiveHostedThreadContainerAccessWithParticipants,
 } from "@/src/lib/hosted-onboarding/member-access";
 
 const SUSPENDED_AT = new Date("2026-04-06T10:00:00.000Z");
@@ -207,5 +208,64 @@ describe("hosted member access (single resolver)", () => {
         memberships: [{ group: { billingStatus: HostedBillingStatus.active } }],
       }),
     })).toBe(true);
+  });
+
+  it("short-circuits participant lookup when the owner has active access", async () => {
+    const prisma = {
+      hostedThreadContainerParticipant: {
+        findFirst: vi.fn(),
+      },
+    };
+
+    await expect(hasActiveHostedThreadContainerAccessWithParticipants({
+      container: { suspendedAt: null },
+      containerMemberId: "member_container",
+      owner: person({ billingStatus: HostedBillingStatus.active }),
+      prisma: prisma as never,
+    })).resolves.toBe(true);
+
+    expect(prisma.hostedThreadContainerParticipant.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("hard-blocks suspended containers before participant lookup", async () => {
+    const prisma = {
+      hostedThreadContainerParticipant: {
+        findFirst: vi.fn(async () => ({ participantMemberId: "member_participant" })),
+      },
+    };
+
+    await expect(hasActiveHostedThreadContainerAccessWithParticipants({
+      container: { suspendedAt: SUSPENDED_AT },
+      containerMemberId: "member_container",
+      owner: person({ billingStatus: HostedBillingStatus.paused }),
+      prisma: prisma as never,
+    })).resolves.toBe(false);
+
+    expect(prisma.hostedThreadContainerParticipant.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("grants non-suspended container access through any active participant", async () => {
+    const prisma = {
+      hostedThreadContainerParticipant: {
+        findFirst: vi.fn(async () => ({ participantMemberId: "member_participant" })),
+      },
+    };
+
+    await expect(hasActiveHostedThreadContainerAccessWithParticipants({
+      container: { suspendedAt: null },
+      containerMemberId: "member_container",
+      owner: person({ billingStatus: HostedBillingStatus.paused }),
+      prisma: prisma as never,
+    })).resolves.toBe(true);
+
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_container",
+        removedAt: null,
+      }),
+    });
   });
 });

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -1725,6 +1725,22 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     if (!routeLookupKey) {
       throw new Error("Expected test route lookup key.");
     }
+    const threadContainerAccessRecord = {
+      accountGroupMemberships: [],
+      billingStatus: HostedBillingStatus.active,
+      createdAt: new Date("2026-03-26T00:00:00.000Z"),
+      id: "member_thread_container_123",
+      suspendedAt: null,
+      updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+    };
+    const ownerAccessRecord = {
+      accountGroupMemberships: [],
+      billingStatus: HostedBillingStatus.active,
+      createdAt: new Date("2026-03-26T00:00:00.000Z"),
+      id: "member_owner_123",
+      suspendedAt: null,
+      updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+    };
     const prisma = asPrismaTransactionClient({
       hostedThreadRoute: {
         findMany: vi.fn()
@@ -1739,19 +1755,24 @@ describe("handleHostedOnboardingLinqWebhook", () => {
                   suspendedAt: null,
                   updatedAt: new Date("2026-03-26T00:00:00.000Z"),
                 },
-                owner: {
-                  billingStatus: HostedBillingStatus.active,
-                  createdAt: new Date("2026-03-26T00:00:00.000Z"),
-                  id: "member_owner_123",
-                  suspendedAt: null,
-                  updatedAt: new Date("2026-03-26T00:00:00.000Z"),
-                },
+                owner: ownerAccessRecord,
               },
               containerMemberId: "member_thread_container_123",
               threadLookupKey: routeLookupKey,
             },
           ])
           .mockResolvedValue([]),
+      },
+      hostedMember: {
+        findUnique: vi.fn().mockResolvedValue({
+          ...threadContainerAccessRecord,
+          threadContainer: {
+            owner: ownerAccessRecord,
+          },
+        }),
+      },
+      hostedThreadContainerParticipant: {
+        findFirst: vi.fn().mockResolvedValue(null),
       },
       hostedWebhookReceipt: {
         create: vi.fn().mockResolvedValue({}),

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -17,6 +17,9 @@ import {
 import {
   planHostedOnboardingLinqWebhook,
 } from "../src/lib/hosted-onboarding/webhook-provider-linq";
+import {
+  handleHostedOnboardingLinqWebhook,
+} from "../src/lib/hosted-onboarding/webhook-service";
 
 vi.mock("../src/lib/hosted-mailbox/store", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/lib/hosted-mailbox/store")>();
@@ -82,6 +85,48 @@ vi.mock("../src/lib/hosted-onboarding/hosted-member-routing-store", async (impor
   };
 });
 
+vi.mock("../src/lib/prisma", () => ({
+  getPrisma: vi.fn(),
+}));
+
+vi.mock("../src/lib/hosted-onboarding/linq", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/hosted-onboarding/linq")>();
+  return {
+    ...actual,
+    sendHostedLinqReadReceipt: vi.fn().mockResolvedValue({ ok: true, status: 200 }),
+    verifyAndParseHostedLinqWebhookRequest: vi.fn(),
+  };
+});
+
+vi.mock("../src/lib/hosted-onboarding/linq-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/hosted-onboarding/linq-client")>();
+  return {
+    ...actual,
+    getHostedLinqChatHandles: vi.fn(),
+  };
+});
+
+vi.mock("../src/lib/hosted-orchestration/signal-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/hosted-orchestration/signal-runtime")>();
+  return {
+    ...actual,
+    signalHostedMailboxAppendRuntime: vi.fn().mockResolvedValue({
+      signalAccepted: true,
+      workflowId: "workflow_group_123",
+    }),
+    signalHostedRuntimeMaintenanceRuntime: vi.fn(),
+  };
+});
+
+vi.mock("../src/lib/hosted-runtime-latency/store", () => ({
+  recordHostedIngressAcceptedFromMailboxItem: vi.fn().mockResolvedValue(undefined),
+  recordHostedIngressTemporalSignalAccepted: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/lib/hosted-execution/control", () => ({
+  readHostedExecutionControlClientIfConfigured: vi.fn(() => null),
+}));
+
 const mailboxStore = await import("../src/lib/hosted-mailbox/store");
 const memberIdentityStore = await import("../src/lib/hosted-onboarding/hosted-member-identity-store");
 const memberRoutingStore = await import("../src/lib/hosted-onboarding/hosted-member-routing-store");
@@ -89,6 +134,10 @@ const usageAllowance = await import("../src/lib/hosted-execution/usage-allowance
 const linqDailyState = await import("../src/lib/hosted-onboarding/linq-daily-state");
 const domainRootStore = await import("../src/lib/hosted-crypto/domain-root-store");
 const hostedMemberStore = await import("../src/lib/hosted-onboarding/hosted-member-store");
+const prismaModule = await import("../src/lib/prisma");
+const linqModule = await import("../src/lib/hosted-onboarding/linq");
+const linqClient = await import("../src/lib/hosted-onboarding/linq-client");
+const signalRuntime = await import("../src/lib/hosted-orchestration/signal-runtime");
 
 const TEST_KEYRING_ENTRIES = {
   v1: "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
@@ -97,6 +146,17 @@ const TEST_KEYRING_ENTRIES = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(prismaModule.getPrisma).mockReset();
+  vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest).mockReset();
+  vi.mocked(linqClient.getHostedLinqChatHandles).mockReset();
+  vi.mocked(linqModule.sendHostedLinqReadReceipt).mockResolvedValue({
+    ok: true,
+    status: 200,
+  });
+  vi.mocked(signalRuntime.signalHostedMailboxAppendRuntime).mockResolvedValue({
+    signalAccepted: true,
+    workflowId: "workflow_group_123",
+  });
 });
 
 function buildLinqMessageReceivedEvent(input: {
@@ -440,12 +500,18 @@ function createStatefulThreadRoutePrisma() {
     upsert: vi.fn().mockResolvedValue({}),
   };
   const executeRaw = vi.fn().mockResolvedValue(undefined);
-
-  return {
+  const hostedThreadContainerParticipant = {
+    findFirst: vi.fn().mockResolvedValue(null),
+    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    upsert: vi.fn().mockResolvedValue({}),
+  };
+  const prisma = {
     $executeRaw: executeRaw,
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(prisma)),
     hostedMember,
     hostedMemberRouting,
     hostedThreadContainer,
+    hostedThreadContainerParticipant,
     hostedThreadRoute,
     hostedWorkspace,
     seedThreadRoute(input: {
@@ -476,6 +542,7 @@ function createStatefulThreadRoutePrisma() {
       });
     },
   };
+  return prisma;
 }
 
 function buildHostedMailboxItem(input: {
@@ -1396,6 +1463,57 @@ describe("Linq group chat auto-provision", () => {
     );
   }
 
+  function mockSuccessfulGroupProvision(input: {
+    prisma: ReturnType<typeof createStatefulThreadRoutePrisma>;
+    senderCore: typeof senderCore;
+  }): void {
+    input.prisma.hostedMember.findUnique.mockImplementation(async () => ({
+      accountGroupMemberships: [],
+      billingStatus: HostedBillingStatus.active,
+      suspendedAt: null,
+      threadContainer: null,
+    }));
+    mockHomeLinqRoute("+15550000000");
+    vi.mocked(hostedMemberStore.readHostedMemberCoreState).mockResolvedValue(input.senderCore);
+    vi.mocked(hostedMemberStore.createHostedMember).mockImplementation(async (createInput) => ({
+      ...input.senderCore,
+      id: createInput.memberId,
+    }));
+    vi.mocked(domainRootStore.provisionHostedCryptoDomainRootsForUserTx)
+      .mockResolvedValue(undefined);
+    vi.mocked(mailboxStore.readHostedMailboxItemByDedupeKey).mockResolvedValue(null);
+    vi.mocked(mailboxStore.appendHostedMailboxEnvelopeTx).mockImplementation(
+      async ({ envelope }) => ({
+        dedupeConflict: false,
+        duplicate: false,
+        inserted: true,
+        item: buildHostedMailboxItem({
+          id: envelope.kind === "member.activated"
+            ? "mailbox_activation_123"
+            : "mailbox_group_123",
+          userId: envelope.userId,
+        }),
+      }),
+    );
+    vi.mocked(linqDailyState.incrementHostedLinqInboundDailyState).mockResolvedValue({
+      dayUtc: new Date("2026-06-24T00:00:00.000Z"),
+      inboundCount: 1,
+      memberId: "member_thread_container_123",
+      outboundCount: 0,
+      quotaReplySentAt: null,
+    } as Awaited<ReturnType<typeof linqDailyState.incrementHostedLinqInboundDailyState>>);
+    vi.mocked(usageAllowance.checkHostedAiUsageGate).mockResolvedValue({
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: 4_500_000n,
+      memberId: "member_thread_container_123",
+      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+      periodStart: new Date("2026-06-01T00:00:00.000Z"),
+      remainingUsdMicros: 4_500_000n,
+      spentUsdMicros: 0n,
+    });
+  }
+
   it.each([
     {
       kind: "direct-paid",
@@ -1495,6 +1613,10 @@ describe("Linq group chat auto-provision", () => {
       source: "linq",
       userId: containerCreate.data.memberId,
     });
+    expect(plan.postCommitGroupRosterReconciles).toEqual([{
+      chatId: "chat_group_123",
+      containerMemberId: containerCreate.data.memberId,
+    }]);
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(2);
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenNthCalledWith(1, {
       envelope: expect.objectContaining({
@@ -1518,6 +1640,166 @@ describe("Linq group chat auto-provision", () => {
       }),
       tx: prisma,
     });
+  });
+
+  it("reconciles a new group roster after the provisioning transaction commits", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    let transactionOpen = false;
+    prisma.$transaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+      transactionOpen = true;
+      try {
+        return await callback(prisma);
+      } finally {
+        transactionOpen = false;
+      }
+    });
+    vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
+    vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
+      .mockReturnValue(buildLinqMessageReceivedEvent({}) as never);
+    vi.mocked(memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber)
+      .mockImplementation(async ({ phoneNumber }) => {
+        if (phoneNumber === "+15551112222") {
+          return {
+            core: senderCore,
+            identity: {},
+            matchedBy: "phoneNumber",
+          } as Awaited<
+            ReturnType<typeof memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber>
+          >;
+        }
+        if (phoneNumber === "+15552223333") {
+          return {
+            core: {
+              ...senderCore,
+              id: "member_participant_123",
+            },
+            identity: {},
+            matchedBy: "phoneNumber",
+          } as Awaited<
+            ReturnType<typeof memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber>
+          >;
+        }
+        return null;
+      });
+    mockSuccessfulGroupProvision({ prisma, senderCore });
+    vi.mocked(linqClient.getHostedLinqChatHandles).mockImplementation(async () => {
+      expect(transactionOpen).toBe(false);
+      return [
+        { handle: "+15550000000", isMe: true, status: "active" },
+        { handle: "+15551112222", isMe: false, status: "active" },
+        { handle: "+15552223333", isMe: false, status: "active" },
+      ];
+    });
+
+    const response = await handleHostedOnboardingLinqWebhook({
+      rawBody: "{}",
+      signature: null,
+      timestamp: null,
+    });
+
+    const containerCreate = prisma.hostedThreadContainer.create.mock.calls[0]![0] as {
+      data: { memberId: string };
+    };
+    expect(response).toMatchObject({
+      ignored: false,
+      ok: true,
+      reason: "wake-appended-thread-route",
+    });
+    expect(prismaModule.getPrisma).toHaveBeenCalledTimes(2);
+    expect(linqClient.getHostedLinqChatHandles).toHaveBeenCalledWith({
+      chatId: "chat_group_123",
+    });
+    expect(prisma.hostedThreadContainerParticipant.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          containerMemberId: containerCreate.data.memberId,
+          participantMemberId: "member_participant_123",
+          removedAt: null,
+        }),
+        where: {
+          containerMemberId_participantMemberId: {
+            containerMemberId: containerCreate.data.memberId,
+            participantMemberId: "member_participant_123",
+          },
+        },
+      }),
+    );
+    expect(prisma.hostedThreadContainerParticipant.updateMany).toHaveBeenCalledWith({
+      data: {
+        removedAt: expect.any(Date),
+      },
+      where: {
+        containerMemberId: containerCreate.data.memberId,
+        participantMemberId: {
+          notIn: ["member_owner_123", "member_participant_123"],
+        },
+        removedAt: null,
+      },
+    });
+    expect(signalRuntime.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      expectedUserId: containerCreate.data.memberId,
+      knownCheckpoint: {
+        lane: "conversation",
+        laneSeq: "1",
+        userId: containerCreate.data.memberId,
+      },
+      mailboxItemId: "mailbox_group_123",
+    });
+  });
+
+  it("still provisions and hands off the first group message when roster fetch fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const prisma = createStatefulThreadRoutePrisma();
+    let transactionOpen = false;
+    prisma.$transaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+      transactionOpen = true;
+      try {
+        return await callback(prisma);
+      } finally {
+        transactionOpen = false;
+      }
+    });
+    vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
+    vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
+      .mockReturnValue(buildLinqMessageReceivedEvent({}) as never);
+    mockSenderLookup(senderCore);
+    mockSuccessfulGroupProvision({ prisma, senderCore });
+    vi.mocked(linqClient.getHostedLinqChatHandles).mockImplementation(async () => {
+      expect(transactionOpen).toBe(false);
+      throw new Error("linq unavailable");
+    });
+
+    try {
+      const response = await handleHostedOnboardingLinqWebhook({
+        rawBody: "{}",
+        signature: null,
+        timestamp: null,
+      });
+      const containerCreate = prisma.hostedThreadContainer.create.mock.calls[0]![0] as {
+        data: { memberId: string };
+      };
+
+      expect(response).toMatchObject({
+        ignored: false,
+        ok: true,
+        reason: "wake-appended-thread-route",
+      });
+      expect(prisma.hostedThreadContainerParticipant.upsert).not.toHaveBeenCalled();
+      expect(signalRuntime.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expectedUserId: containerCreate.data.memberId,
+          mailboxItemId: "mailbox_group_123",
+        }),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        "Hosted thread-container participant reconcile skipped.",
+        expect.objectContaining({
+          reason: "reconcile_failed",
+        }),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("does not auto-provision group threads from a pending (uncommitted) route", async () => {

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -1357,6 +1357,10 @@ describe("Linq explicit external-thread routing", () => {
         removedAt: null,
       }),
     });
+    expect(usageAllowance.checkHostedAiUsageGate).toHaveBeenCalledWith({
+      memberId: "member_thread_container_123",
+      prisma,
+    });
     expect(readSingleWakeHandoff(plan)).toMatchObject({
       eventId: "evt_group_123",
       mailboxItemId: "mailbox_active_participant_123",

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -307,7 +307,45 @@ function createPrisma(input: {
     updateMany: vi.fn(),
   };
   const hostedMember = {
-    findUnique: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+      if (routeContainerMemberId && where.id === routeContainerMemberId) {
+        return {
+          accountGroupMemberships: [],
+          billingStatus: HostedBillingStatus.not_started,
+          suspendedAt: routeContainerActive
+            ? null
+            : new Date("2026-06-24T00:00:00.000Z"),
+          threadContainer: {
+            owner: {
+              accountGroupMemberships: routeOwnerSponsored
+                ? [
+                    {
+                      group: {
+                        billingStatus: HostedBillingStatus.active,
+                        suspendedAt: null,
+                      },
+                      status: "active",
+                    },
+                  ]
+                : [],
+              billingStatus: routeOwnerSponsored
+                ? HostedBillingStatus.not_started
+                : routeOwnerActive
+                  ? HostedBillingStatus.active
+                  : HostedBillingStatus.paused,
+              suspendedAt: null,
+            },
+          },
+        };
+      }
+
+      return {
+        accountGroupMemberships: [],
+        billingStatus: HostedBillingStatus.active,
+        suspendedAt: null,
+        threadContainer: null,
+      };
+    }),
   };
   const hostedThreadContainerParticipant = {
     findFirst: vi.fn().mockImplementation(async ({ where }: { where: Record<string, unknown> }) =>

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -161,6 +161,7 @@ function createPrisma(input: {
   routeContainerActive?: boolean;
   routeOwnerActive?: boolean;
   routeOwnerSponsored?: boolean;
+  routeParticipantActive?: boolean;
 } = {}) {
   const routeAccountLookupKey = createHostedPhoneLookupKey(
     input.routeAccountPhone ?? "+15550000000",
@@ -169,6 +170,7 @@ function createPrisma(input: {
   const routeContainerActive = input.routeContainerActive ?? true;
   const routeOwnerActive = input.routeOwnerActive ?? true;
   const routeOwnerSponsored = input.routeOwnerSponsored ?? false;
+  const routeParticipantActive = input.routeParticipantActive ?? false;
   const hostedThreadRoute = {
     findMany: vi.fn().mockImplementation(async ({ where }: { where: Record<string, unknown> }) => {
       if (!routeContainerMemberId) {
@@ -247,12 +249,22 @@ function createPrisma(input: {
   const hostedMember = {
     findUnique: vi.fn().mockResolvedValue(null),
   };
+  const hostedThreadContainerParticipant = {
+    findFirst: vi.fn().mockImplementation(async ({ where }: { where: Record<string, unknown> }) =>
+      routeParticipantActive
+      && where.containerMemberId === routeContainerMemberId
+      && where.removedAt === null
+        ? { participantMemberId: "member_active_participant_123" }
+        : null
+    ),
+  };
   const hostedWorkspace = {
     upsert: vi.fn().mockResolvedValue({}),
   };
   return {
     hostedMember,
     hostedMemberRouting,
+    hostedThreadContainerParticipant,
     hostedThreadRoute,
     hostedWorkspace,
   };
@@ -1189,6 +1201,7 @@ describe("Linq explicit external-thread routing", () => {
     const prisma = createPrisma({
       routeContainerActive: false,
       routeContainerMemberId: "member_thread_container_123",
+      routeParticipantActive: true,
     });
 
     const plan = await planHostedOnboardingLinqWebhook({
@@ -1202,6 +1215,7 @@ describe("Linq explicit external-thread routing", () => {
       reason: "thread-container-inactive",
     });
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(prisma.hostedThreadContainerParticipant.findFirst).not.toHaveBeenCalled();
   });
 
   it("ignores routed thread traffic when the route owner is inactive", async () => {
@@ -1221,6 +1235,74 @@ describe("Linq explicit external-thread routing", () => {
       reason: "thread-container-inactive",
     });
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+  });
+
+  it("routes a bound group thread when any current participant has active access", async () => {
+    const prisma = createPrisma({
+      routeContainerMemberId: "member_thread_container_123",
+      routeOwnerActive: false,
+      routeParticipantActive: true,
+    });
+    vi.mocked(mailboxStore.readHostedMailboxItemByDedupeKey).mockResolvedValueOnce(null);
+    vi.mocked(linqDailyState.incrementHostedLinqInboundDailyState).mockResolvedValueOnce({
+      dayUtc: new Date("2026-06-24T00:00:00.000Z"),
+      inboundCount: 1,
+      memberId: "member_thread_container_123",
+      outboundCount: 0,
+      quotaReplySentAt: null,
+    } as Awaited<ReturnType<typeof linqDailyState.incrementHostedLinqInboundDailyState>>);
+    vi.mocked(usageAllowance.checkHostedAiUsageGate).mockResolvedValueOnce({
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: 4_500_000n,
+      memberId: "member_thread_container_123",
+      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+      periodStart: new Date("2026-06-01T00:00:00.000Z"),
+      remainingUsdMicros: 4_500_000n,
+      spentUsdMicros: 0n,
+    });
+    vi.mocked(mailboxStore.appendHostedMailboxEnvelopeTx).mockResolvedValueOnce({
+      dedupeConflict: false,
+      duplicate: false,
+      inserted: true,
+      item: buildHostedMailboxItem({
+        id: "mailbox_active_participant_123",
+        userId: "member_thread_container_123",
+      }),
+    });
+
+    const plan = await planHostedOnboardingLinqWebhook({
+      event: buildLinqMessageReceivedEvent({}),
+      prisma: prisma as never,
+    });
+
+    expect(plan.response).toMatchObject({
+      ignored: false,
+      ok: true,
+      reason: "wake-appended-thread-route",
+    });
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_thread_container_123",
+        removedAt: null,
+      }),
+    });
+    expect(readSingleWakeHandoff(plan)).toMatchObject({
+      eventId: "evt_group_123",
+      mailboxItemId: "mailbox_active_participant_123",
+      source: "linq",
+      userId: "member_thread_container_123",
+    });
+    expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: expect.objectContaining({
+        kind: "conversation.message",
+        userId: "member_thread_container_123",
+      }),
+      tx: prisma,
+    });
   });
 
   it("fails closed for an inactive routed direct thread instead of normal Linq routing", async () => {

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -1392,6 +1392,10 @@ function buildAuthorizedLinqRouteFixture(input: {
     suspendedAt: null,
     updatedAt: new Date("2026-03-26T00:00:00.000Z"),
   };
+  const memberAccessState = {
+    ...memberState,
+    accountGroupMemberships: [],
+  };
 
   return {
     authority: {
@@ -1407,13 +1411,24 @@ function buildAuthorizedLinqRouteFixture(input: {
             channel: "linq",
             container: {
               member: memberState,
-              owner: memberState,
+              owner: memberAccessState,
             },
             containerMemberId: input.memberId,
             lastInboundAt: new Date("2026-03-26T11:59:00.000Z"),
             threadLookupKey,
           },
         ]),
+      },
+      hostedMember: {
+        findUnique: vi.fn().mockResolvedValue({
+          ...memberAccessState,
+          threadContainer: {
+            owner: memberAccessState,
+          },
+        }),
+      },
+      hostedThreadContainerParticipant: {
+        findFirst: vi.fn().mockResolvedValue(null),
       },
     },
   };

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -49,6 +49,7 @@ const HOSTED_MEMBER_SCHEMA_GUARD = {
     'signupNotificationEmailAttemptedAt DateTime? @map("signup_notification_email_attempted_at")',
     'signupWelcomeEmailAttemptedAt DateTime? @map("signup_welcome_email_attempted_at")',
     'suspendedAt DateTime? @map("suspended_at")',
+    'threadContainerParticipations HostedThreadContainerParticipant[] @relation("HostedThreadContainerParticipantMember")',
     'createdAt DateTime @default(now()) @map("created_at")',
     'updatedAt DateTime @updatedAt @map("updated_at")',
   ],
@@ -502,6 +503,13 @@ describe("hosted Prisma baseline migration", () => {
       ),
       "utf8",
     );
+    const hostedThreadContainerParticipantMigrationSql = readFileSync(
+      new URL(
+        "../prisma/migrations/20260706120000_hosted_thread_container_participant/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     expect(migrationEntries).toEqual([
       "2026040600_init",
       "20260425000000_drop_legacy_linq_control_plane",
@@ -581,6 +589,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260701153000_hosted_vault_share_active_indexes",
       "20260703160000_device_oauth_session_consumed_at",
       "20260705120000_hosted_mailbox_item_consumed_at",
+      "20260706120000_hosted_thread_container_participant",
       "migration_lock.toml",
     ]);
     expect(hostedThreadRoutesMigrationSql).toContain('CREATE TABLE "hosted_thread_container"');
@@ -610,6 +619,25 @@ describe("hosted Prisma baseline migration", () => {
     expect(hostedThreadRoutesMigrationSql).not.toContain("thread_id_encrypted");
     expect(hostedThreadRoutesMigrationSql).not.toContain('"source"');
     expect(hostedThreadRoutesMigrationSql).not.toContain('"status"');
+    expect(hostedThreadContainerParticipantMigrationSql).toContain(
+      'CREATE TABLE "hosted_thread_container_participant"',
+    );
+    expect(hostedThreadContainerParticipantMigrationSql).toContain(
+      '"handle_lookup_key" TEXT NOT NULL',
+    );
+    expect(hostedThreadContainerParticipantMigrationSql).toContain(
+      'PRIMARY KEY ("container_member_id", "participant_member_id")',
+    );
+    expect(hostedThreadContainerParticipantMigrationSql).toContain(
+      'REFERENCES "hosted_thread_container"("member_id") ON DELETE CASCADE',
+    );
+    expect(hostedThreadContainerParticipantMigrationSql).toContain(
+      'REFERENCES "hosted_member"("id") ON DELETE CASCADE',
+    );
+    expect(hostedThreadContainerParticipantMigrationSql).not.toContain('"handle" TEXT');
+    expect(hostedThreadContainerParticipantMigrationSql).not.toMatch(
+      /"(?:raw_)?(?:message|body|payload)[^"]*"/iu,
+    );
     expect(schema).not.toContain('profileKey                 String                         @map("profile_key")');
     expect(schema).not.toContain("@@index([memberId, profileKey, updatedAt])");
     expect(singleMemberComputerProfileMigrationSql).toContain(

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   drainHostedLinqSideEffectsDirect: vi.fn(),
   fetch: vi.fn(),
   getPrisma: vi.fn(),
+  hostedThreadContainerParticipantFindFirst: vi.fn(),
   hostedMemberFindUnique: vi.fn(),
   readHostedMailboxConsumedSeqByLane: vi.fn(),
   readHostedMailboxFirstPendingConversationItem: vi.fn(),
@@ -103,6 +104,7 @@ describe("hosted orchestration reconciliation facts", () => {
     mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue(MEMBER_ID);
     mocks.readHostedMemberCoreState.mockResolvedValue(buildActiveMemberRecord());
     mocks.hostedMemberFindUnique.mockResolvedValue(buildMemberAccessRecord());
+    mocks.hostedThreadContainerParticipantFindFirst.mockResolvedValue(null);
     mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord());
     mocks.readHostedMailboxMaxSeqByLane.mockResolvedValue(noMailboxBacklog());
     mocks.readHostedMailboxConsumedSeqByLane.mockResolvedValue([
@@ -921,6 +923,40 @@ describe("hosted orchestration reconciliation facts", () => {
     expect(mocks.resolveHostedRuntimeAiUsageGate).not.toHaveBeenCalled();
   });
 
+  it("does not block thread-container runtime facts when an active participant keeps an inactive-owner group alive", async () => {
+    mocks.hostedMemberFindUnique.mockResolvedValue(buildMemberAccessRecord({
+      billingStatus: "not_started",
+      threadContainer: {
+        owner: {
+          accountGroupMemberships: [],
+          billingStatus: "paused",
+          suspendedAt: null,
+        },
+      },
+    }));
+    mocks.hostedThreadContainerParticipantFindFirst.mockResolvedValue({
+      participantMemberId: "member_active_participant",
+    });
+
+    const response = await reconciliationRoute.GET(
+      requestForFacts(),
+      routeContext(),
+    );
+    const facts = parseHostedRuntimeReconciliationFacts(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(facts.blocked).toBeNull();
+    expect(mocks.hostedThreadContainerParticipantFindFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: MEMBER_ID,
+        removedAt: null,
+      }),
+    });
+  });
+
   it("gates due model-capable workspace wakes", async () => {
     mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
       nextWakeAt: "2026-05-20T11:59:59.000Z",
@@ -1137,6 +1173,9 @@ function createPrismaClientStub() {
     },
     hostedMember: {
       findUnique: mocks.hostedMemberFindUnique,
+    },
+    hostedThreadContainerParticipant: {
+      findFirst: mocks.hostedThreadContainerParticipantFindFirst,
     },
     kind: "prisma",
   };

--- a/apps/web/test/hosted-orchestration-signal-runtime.test.ts
+++ b/apps/web/test/hosted-orchestration-signal-runtime.test.ts
@@ -13,18 +13,23 @@ import {
 
 const mocks = vi.hoisted(() => {
   const hostedMemberFindUnique = vi.fn();
+  const hostedThreadContainerParticipantFindFirst = vi.fn();
 
   return {
     appendHostedMailboxEnvelopeTx: vi.fn(),
     ensureHostedWorkspace: vi.fn(),
     getPrisma: vi.fn(),
     hostedMemberFindUnique,
+    hostedThreadContainerParticipantFindFirst,
     prisma: {
       $transaction: vi.fn(async (callback: (tx: unknown) => unknown) =>
         await callback({ kind: "tx" })
       ),
       hostedMember: {
         findUnique: hostedMemberFindUnique,
+      },
+      hostedThreadContainerParticipant: {
+        findFirst: hostedThreadContainerParticipantFindFirst,
       },
       hostedAccountGroupMembership: {
         count: vi.fn(async () => 0),
@@ -85,6 +90,7 @@ describe("hosted runtime Temporal signaling", () => {
     mocks.getPrisma.mockReturnValue(mocks.prisma);
     mocks.ensureHostedWorkspace.mockResolvedValue(buildHostedWorkspaceRecord());
     mocks.hostedMemberFindUnique.mockResolvedValue(buildActiveMemberRecord());
+    mocks.hostedThreadContainerParticipantFindFirst.mockResolvedValue(null);
     mocks.resolveHostedRuntimeAiUsageGate.mockResolvedValue({
       status: "allowed",
     });

--- a/apps/web/test/hosted-runtime-crypto-context-route.test.ts
+++ b/apps/web/test/hosted-runtime-crypto-context-route.test.ts
@@ -104,6 +104,46 @@ describe("hosted runtime crypto-context route", () => {
     });
   });
 
+  it("allows thread-container runtime context when an active participant keeps an inactive-owner group alive", async () => {
+    const prisma = createPrisma({
+      member: {
+        accountGroupMemberships: [],
+        billingStatus: "not_started",
+        suspendedAt: null,
+        threadContainer: {
+          owner: {
+            accountGroupMemberships: [],
+            billingStatus: "paused",
+            suspendedAt: null,
+          },
+        },
+      },
+      participantActive: true,
+      workspace: { userId: "member_crypto_1" },
+    });
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    const response = await route.POST(new Request("https://join.example.test/api/internal/hosted-runtime/crypto-context", {
+      method: "POST",
+    }));
+
+    expect(response.status).toBe(200);
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_crypto_1",
+        removedAt: null,
+      }),
+    });
+    expect(mocks.readHostedRuntimeCryptoContextForWorker).toHaveBeenCalledWith({
+      prisma,
+      userId: "member_crypto_1",
+    });
+  });
+
+
   it("rejects missing, inactive, or suspended hosted members before reading crypto roots", async () => {
     for (const member of [
       null,
@@ -172,11 +212,17 @@ type HostedMemberAccessFixture = {
 
 function createPrisma(input: {
   member: HostedMemberAccessFixture | null;
+  participantActive?: boolean;
   workspace: { userId: string } | null;
 }) {
   return {
     hostedMember: {
       findUnique: vi.fn().mockResolvedValue(input.member),
+    },
+    hostedThreadContainerParticipant: {
+      findFirst: vi.fn(async () => input.participantActive
+        ? { participantMemberId: "member_active_participant" }
+        : null),
     },
     hostedWorkspace: {
       findUnique: vi.fn().mockResolvedValue(input.workspace),

--- a/apps/web/test/hosted-runtime-crypto-root-route.test.ts
+++ b/apps/web/test/hosted-runtime-crypto-root-route.test.ts
@@ -41,21 +41,17 @@ describe("hosted runtime crypto root route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue("member_123");
-    mocks.getPrisma.mockReturnValue({
-      hostedMember: {
-        findUnique: vi.fn().mockResolvedValue({
-          accountGroupMemberships: [],
-          billingStatus: "active",
-          suspendedAt: null,
-          threadContainer: null,
-        }),
+    mocks.getPrisma.mockReturnValue(createPrisma({
+      member: {
+        accountGroupMemberships: [],
+        billingStatus: "active",
+        suspendedAt: null,
+        threadContainer: null,
       },
-      hostedWorkspace: {
-        findUnique: vi.fn().mockResolvedValue({
-          userId: "member_123",
-        }),
+      workspace: {
+        userId: "member_123",
       },
-    });
+    }));
     mocks.readHostedDomainRootEnvelopeByRootKeyIdOrThrow.mockResolvedValue({
       domain: "runtime",
       rootKeyId: "udrk:runtime:test-root",
@@ -95,4 +91,78 @@ describe("hosted runtime crypto root route", () => {
       },
     });
   });
+
+  it("allows crypto root reads when an active participant keeps an inactive-owner group alive", async () => {
+    const prisma = createPrisma({
+      member: {
+        accountGroupMemberships: [],
+        billingStatus: "not_started",
+        suspendedAt: null,
+        threadContainer: {
+          owner: {
+            accountGroupMemberships: [],
+            billingStatus: "paused",
+            suspendedAt: null,
+          },
+        },
+      },
+      participantActive: true,
+      workspace: {
+        userId: "member_123",
+      },
+    });
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    const response = await hostedRuntimeCryptoRootRoute.POST(
+      new Request("https://join.example.test/api/internal/hosted-runtime/crypto-context/root", {
+        body: JSON.stringify({
+          domain: "runtime",
+          rootKeyId: "udrk:runtime:test-root",
+        }),
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_123",
+        removedAt: null,
+      }),
+    });
+    expect(mocks.readHostedDomainRootEnvelopeByRootKeyIdOrThrow).toHaveBeenCalledWith({
+      domain: "runtime",
+      prisma,
+      rootKeyId: "udrk:runtime:test-root",
+      userId: "member_123",
+    });
+  });
 });
+
+function createPrisma(input: {
+  member: {
+    accountGroupMemberships: unknown[];
+    billingStatus: string;
+    suspendedAt: Date | null;
+    threadContainer: null | { owner: unknown };
+  } | null;
+  participantActive?: boolean;
+  workspace: { userId: string } | null;
+}) {
+  return {
+    hostedMember: {
+      findUnique: vi.fn().mockResolvedValue(input.member),
+    },
+    hostedThreadContainerParticipant: {
+      findFirst: vi.fn(async () => input.participantActive
+        ? { participantMemberId: "member_active_participant" }
+        : null),
+    },
+    hostedWorkspace: {
+      findUnique: vi.fn().mockResolvedValue(input.workspace),
+    },
+  };
+}

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   fetchHostedMailboxItemsAfterLaneCursors: vi.fn(),
   fetchHostedMailboxPayload: vi.fn(),
   hostedRuntimeMailboxMemberFindUnique: vi.fn(),
+  hostedThreadContainerParticipantFindFirst: vi.fn(),
   getPrisma: vi.fn(),
   listHostedRuntimeLogs: vi.fn(),
   publishLegacySourceHashBrowserVaultReplicaRef: vi.fn(),
@@ -149,6 +150,7 @@ describe("hosted runtime internal web routes", () => {
     mocks.hostedRuntimeMailboxMemberFindUnique.mockResolvedValue(
       buildRuntimeMailboxAccessRecord(),
     );
+    mocks.hostedThreadContainerParticipantFindFirst.mockResolvedValue(null);
     mocks.getPrisma.mockReturnValue(createPrismaClientStub());
     mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue("member_routes_1");
     mocks.readHostedMailboxConsumedSeqByLane.mockImplementation((input: {
@@ -2609,6 +2611,9 @@ function createPrismaClientStub() {
   return {
     hostedMember: {
       findUnique: mocks.hostedRuntimeMailboxMemberFindUnique,
+    },
+    hostedThreadContainerParticipant: {
+      findFirst: mocks.hostedThreadContainerParticipantFindFirst,
     },
     hostedAccountGroupMembership: {
       count: vi.fn(async () => 0),

--- a/apps/web/test/hosted-thread-route-store.test.ts
+++ b/apps/web/test/hosted-thread-route-store.test.ts
@@ -27,14 +27,19 @@ function createPrismaMock() {
   const hostedThreadRoute = {
     findMany: vi.fn(),
   };
+  const hostedThreadContainerParticipant = {
+    findFirst: vi.fn(),
+  };
 
   return {
     hostedMember,
     hostedMemberRouting,
+    hostedThreadContainerParticipant,
     hostedThreadRoute,
   } as unknown as Prisma.TransactionClient & {
     hostedMember: typeof hostedMember;
     hostedMemberRouting: typeof hostedMemberRouting;
+    hostedThreadContainerParticipant: typeof hostedThreadContainerParticipant;
     hostedThreadRoute: typeof hostedThreadRoute;
   };
 }
@@ -313,6 +318,173 @@ describe("hosted thread route store", () => {
     );
     expect(prisma.hostedMember.findUnique).not.toHaveBeenCalled();
     expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
+    expect(prisma.hostedThreadContainerParticipant.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("authorizes egress when an active participant keeps an inactive-owner group alive", async () => {
+    const prisma = createPrismaMock();
+    const threadLookupKey = createHostedExternalThreadLookupKey({
+      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+      channel: "linq",
+      threadId: "chat_group_abc",
+    });
+    if (!threadLookupKey) {
+      throw new Error("Expected test thread lookup key.");
+    }
+    prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
+      {
+        channel: "linq",
+        container: {
+          member: {
+            billingStatus: "not_started",
+            createdAt: new Date("2026-06-24T00:00:00.000Z"),
+            id: "member_container_123",
+            suspendedAt: null,
+            updatedAt: new Date("2026-06-24T00:00:00.000Z"),
+          },
+          owner: {
+            accountGroupMemberships: [],
+            billingStatus: "paused",
+            createdAt: new Date("2026-06-24T00:00:00.000Z"),
+            id: "member_owner_123",
+            suspendedAt: null,
+            updatedAt: new Date("2026-06-24T00:00:00.000Z"),
+          },
+        },
+        containerMemberId: "member_container_123",
+        threadLookupKey,
+      },
+    ]);
+    prisma.hostedThreadContainerParticipant.findFirst.mockResolvedValueOnce({
+      participantMemberId: "member_active_participant_123",
+    });
+
+    await expect(assertHostedLinqRouteEgressAuthority({
+      authority: {
+        accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+        channel: "linq",
+        containerMemberId: "member_container_123",
+        threadId: "chat_group_abc",
+      },
+      prisma,
+    })).resolves.toMatchObject({
+      channel: "linq",
+      containerMemberId: "member_container_123",
+    });
+
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_container_123",
+        removedAt: null,
+      }),
+    });
+  });
+
+  it("does not authorize egress when owner and projected participants are inactive", async () => {
+    const prisma = createPrismaMock();
+    const threadLookupKey = createHostedExternalThreadLookupKey({
+      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+      channel: "linq",
+      threadId: "chat_group_abc",
+    });
+    if (!threadLookupKey) {
+      throw new Error("Expected test thread lookup key.");
+    }
+    prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
+      {
+        channel: "linq",
+        container: {
+          member: {
+            billingStatus: "not_started",
+            createdAt: new Date("2026-06-24T00:00:00.000Z"),
+            id: "member_container_123",
+            suspendedAt: null,
+            updatedAt: new Date("2026-06-24T00:00:00.000Z"),
+          },
+          owner: {
+            accountGroupMemberships: [],
+            billingStatus: "paused",
+            createdAt: new Date("2026-06-24T00:00:00.000Z"),
+            id: "member_owner_123",
+            suspendedAt: null,
+            updatedAt: new Date("2026-06-24T00:00:00.000Z"),
+          },
+        },
+        containerMemberId: "member_container_123",
+        threadLookupKey,
+      },
+    ]);
+    prisma.hostedThreadContainerParticipant.findFirst.mockResolvedValueOnce(null);
+
+    await expect(assertHostedLinqRouteEgressAuthority({
+      authority: {
+        accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+        channel: "linq",
+        containerMemberId: "member_container_123",
+        threadId: "chat_group_abc",
+      },
+      prisma,
+    })).rejects.toMatchObject({
+      code: "HOSTED_THREAD_ROUTE_EGRESS_UNAUTHORIZED",
+    });
+
+    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not authorize egress for a suspended container even with an active participant", async () => {
+    const prisma = createPrismaMock();
+    const threadLookupKey = createHostedExternalThreadLookupKey({
+      accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+      channel: "linq",
+      threadId: "chat_group_abc",
+    });
+    if (!threadLookupKey) {
+      throw new Error("Expected test thread lookup key.");
+    }
+    prisma.hostedThreadRoute.findMany.mockResolvedValueOnce([
+      {
+        channel: "linq",
+        container: {
+          member: {
+            billingStatus: "not_started",
+            createdAt: new Date("2026-06-24T00:00:00.000Z"),
+            id: "member_container_123",
+            suspendedAt: new Date("2026-06-24T00:00:00.000Z"),
+            updatedAt: new Date("2026-06-24T00:00:00.000Z"),
+          },
+          owner: {
+            accountGroupMemberships: [],
+            billingStatus: "paused",
+            createdAt: new Date("2026-06-24T00:00:00.000Z"),
+            id: "member_owner_123",
+            suspendedAt: null,
+            updatedAt: new Date("2026-06-24T00:00:00.000Z"),
+          },
+        },
+        containerMemberId: "member_container_123",
+        threadLookupKey,
+      },
+    ]);
+    prisma.hostedThreadContainerParticipant.findFirst.mockResolvedValueOnce({
+      participantMemberId: "member_active_participant_123",
+    });
+
+    await expect(assertHostedLinqRouteEgressAuthority({
+      authority: {
+        accountLookupKey: LINQ_ACCOUNT_LOOKUP_KEY,
+        channel: "linq",
+        containerMemberId: "member_container_123",
+        threadId: "chat_group_abc",
+      },
+      prisma,
+    })).rejects.toMatchObject({
+      code: "HOSTED_THREAD_ROUTE_EGRESS_UNAUTHORIZED",
+    });
+
+    expect(prisma.hostedThreadContainerParticipant.findFirst).not.toHaveBeenCalled();
   });
 
   it("fails closed when lookup candidates match multiple containers", async () => {

--- a/apps/web/test/hosted-thread-route-store.test.ts
+++ b/apps/web/test/hosted-thread-route-store.test.ts
@@ -44,6 +44,25 @@ function createPrismaMock() {
   };
 }
 
+function buildThreadContainerAccessRecord(input: {
+  containerSuspendedAt?: Date | null;
+  ownerBillingStatus?: string;
+  ownerSuspendedAt?: Date | null;
+}) {
+  return {
+    accountGroupMemberships: [],
+    billingStatus: "not_started",
+    suspendedAt: input.containerSuspendedAt ?? null,
+    threadContainer: {
+      owner: {
+        accountGroupMemberships: [],
+        billingStatus: input.ownerBillingStatus ?? "paused",
+        suspendedAt: input.ownerSuspendedAt ?? null,
+      },
+    },
+  };
+}
+
 describe("hosted thread route store", () => {
   it("reads a routed external thread without exposing raw thread ids", async () => {
     const prisma = createPrismaMock();
@@ -355,6 +374,9 @@ describe("hosted thread route store", () => {
         threadLookupKey,
       },
     ]);
+    prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({
+      ownerBillingStatus: "paused",
+    }));
     prisma.hostedThreadContainerParticipant.findFirst.mockResolvedValueOnce({
       participantMemberId: "member_active_participant_123",
     });
@@ -417,6 +439,9 @@ describe("hosted thread route store", () => {
         threadLookupKey,
       },
     ]);
+    prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({
+      ownerBillingStatus: "paused",
+    }));
     prisma.hostedThreadContainerParticipant.findFirst.mockResolvedValueOnce(null);
 
     await expect(assertHostedLinqRouteEgressAuthority({
@@ -468,6 +493,10 @@ describe("hosted thread route store", () => {
         threadLookupKey,
       },
     ]);
+    prisma.hostedMember.findUnique.mockResolvedValueOnce(buildThreadContainerAccessRecord({
+      containerSuspendedAt: new Date("2026-06-24T00:00:00.000Z"),
+      ownerBillingStatus: "paused",
+    }));
     prisma.hostedThreadContainerParticipant.findFirst.mockResolvedValueOnce({
       participantMemberId: "member_active_participant_123",
     });

--- a/apps/web/test/runtime-access.test.ts
+++ b/apps/web/test/runtime-access.test.ts
@@ -1,14 +1,26 @@
-import type { Prisma } from "@prisma/client";
+import {
+  HostedBillingStatus,
+  type Prisma,
+} from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { requireHostedRuntimeActiveAccessForUpdateTx } from "@/src/lib/hosted-mailbox/runtime-access";
 
-function buildRuntimeAccessTx(ownerReads: Array<string | null>): {
+function buildRuntimeAccessTx(
+  ownerReads: Array<string | null>,
+  input: {
+    ownerBillingStatus?: HostedBillingStatus;
+    participantActive?: boolean;
+  } = {},
+): {
   lockOrder: string[];
   tx: Prisma.TransactionClient & {
     $queryRaw: ReturnType<typeof vi.fn>;
     hostedMember: {
       findUnique: ReturnType<typeof vi.fn>;
+    };
+    hostedThreadContainerParticipant: {
+      findFirst: ReturnType<typeof vi.fn>;
     };
   };
 } {
@@ -36,11 +48,16 @@ function buildRuntimeAccessTx(ownerReads: Array<string | null>): {
         threadContainer: {
           owner: {
             accountGroupMemberships: [],
-            billingStatus: "active",
+            billingStatus: input.ownerBillingStatus ?? HostedBillingStatus.active,
             suspendedAt: null,
           },
         },
       })),
+    },
+    hostedThreadContainerParticipant: {
+      findFirst: vi.fn(async () => input.participantActive
+        ? { participantMemberId: "member_participant" }
+        : null),
     },
   };
 
@@ -50,6 +67,9 @@ function buildRuntimeAccessTx(ownerReads: Array<string | null>): {
       $queryRaw: ReturnType<typeof vi.fn>;
       hostedMember: {
         findUnique: ReturnType<typeof vi.fn>;
+      };
+      hostedThreadContainerParticipant: {
+        findFirst: ReturnType<typeof vi.fn>;
       };
     },
   };
@@ -74,6 +94,27 @@ describe("requireHostedRuntimeActiveAccessForUpdateTx", () => {
       "container-lock",
     ]);
     expect(tx.hostedMember.findUnique).toHaveBeenCalled();
+  });
+
+  it("allows a thread-container runtime through an active participant", async () => {
+    const { tx } = buildRuntimeAccessTx(["member_owner", "member_owner"], {
+      ownerBillingStatus: HostedBillingStatus.paused,
+      participantActive: true,
+    });
+
+    await expect(requireHostedRuntimeActiveAccessForUpdateTx("member_group_runtime", {
+      prisma: tx,
+    })).resolves.toBeUndefined();
+
+    expect(tx.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
+      select: {
+        participantMemberId: true,
+      },
+      where: expect.objectContaining({
+        containerMemberId: "member_group_runtime",
+        removedAt: null,
+      }),
+    });
   });
 
   it("fails closed when thread-container authority changes while locking", async () => {


### PR DESCRIPTION
## Why this PR exists

A hosted group chat currently gets Murph access ONLY from its single `owner_member_id` ("the container lives and dies with its owner"). So a group with several paying members silently loses Murph the moment the **owner's** billing lapses — every member's inbound message is dropped as `thread-container-inactive`. A group full of paying members shouldn't die because one person's card failed.

## User goal / user-visible behavior

A group's Murph stays alive as long as the owner **or any current participant** has active Murph. The owner becomes just the data/budget anchor, not a single point of failure. To evaluate this cheaply and off the hot path, the group's participant roster is maintained as a projection.

## What changed

- **`hosted_thread_container_participant`** projection (new table + migration): the container's participants that resolve to Murph members, with soft-remove.
- **Reconciled off the hot path** from the Linq roster we already fetch — as a best-effort side effect of the assistant's `read_chat_participants`, and once at container creation (post-commit, outside any DB transaction, via a fresh client). No synchronous provider fetch on the inbound/delivery path.
- **Access gate** at both ingestion (`planHostedLinqExplicitThreadRouteWebhook`) and egress (`assertHostedThreadRouteEgressAuthority`): grant when the owner is active **OR** any non-removed participant has active Murph. Owner-active short-circuits (no extra query for healthy groups).

## Invariants the PR must preserve

- **Suspension still hard-blocks**: a suspended container has no access regardless of participants (checked explicitly before the participant fallback).
- Egress still binds `route.containerMemberId === authority.containerMemberId` and requires the DB route.
- Reconcile is best-effort: a Linq fetch failure never breaks the participant read, provisioning, or delivery, and leaves the prior projection intact.
- Billing **grace** semantics (`past_due`) are unchanged — deliberately out of scope for this PR.
- Provisioning owner selection, home-line gates, and routing keys are unchanged.

## Deployment skew / compatibility

Additive: a new table + migration (auto-applies on merge) and an additive access fallback. No change to existing payloads or cross-service contracts, so web/Cloudflare can deploy in any order. The projection starts empty and fills from the two reconcile triggers; a brand-new group is covered by the at-creation reconcile.

## Coordination note

Overlaps with PR #393 (routing collapse) in `webhook-provider-linq.ts` and `thread-route-store.ts`; a rebase will be needed at merge — the changes are semantically independent (this adds an access fallback; #393 changes the route lookup key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deliberately deferred (intentional scope, not missed)

- **Existing-group roster bootstrap (sender-seed):** the roster fills from two triggers — the assistant's `read_chat_participants` and a fetch at container **creation**. A group that already existed *before* this ships, whose owner later lapses with an empty projection, will not self-heal (its messages are dropped before any reconcile runs). Skipped intentionally: there are no such groups in production, and every new group self-seeds at creation. Follow-up (if ever needed): seed the current sender's row on the inactive-owner ingestion path (no extra Linq fetch).
- **Billing grace (`past_due`):** treating Stripe dunning/grace as retaining access is a separate billing-policy decision, out of scope here.

## Review

Two ReviewGPT rounds + a full-context Codex deep-review. Access enforcement was centralized into `readActiveHostedMemberAccess` (owner-active short-circuit; suspension hard-block; else any active non-removed participant) after the reviews found owner-only gates in the usage/runtime/Temporal-facts/crypto-context paths; the roster reconcile is bounded and fails safe (never soft-removes when the roster exceeds the cap).

## Access-boundary note (reviewed, intentional)

Centralizing container access makes **container-scoped capabilities follow container liveness**: a participant-kept-alive group's runtime can use its own tools, including connected-apps (verified scoped to the container's `memberId` — never the owner's personal accounts). **Owner-authority actions** (`create_join_link`, `share_contact_card`) remain pinned to owner-active via the explicit group-tool classification.
