### PR TITLE
fix(hosted-family): accept phone invites via Messages, gate Telegram to bound invites

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-06-family-invite-imessage-accept.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-family-invite-imessage-accept.md
@@ -1,0 +1,73 @@
+# Family invite iMessage/SMS accept + accept-page redesign
+
+## Why
+
+A family-plan invitee reachable only by phone/iMessage (no Telegram) landed on
+the web accept page and was shown only "Continue in Telegram", pushing them into
+an app they do not have and a Telegram verification they cannot pass. Root cause:
+the accept page offered Telegram whenever a bot username was configured in env,
+independent of how the invitee was actually reachable, and offered no
+iMessage/SMS path even though the LinQ accept-by-phone webhook already exists.
+The page was also a bare one-off, not built on the shared invite shell.
+
+Utmost priority: clean, simple, long term maintainable and composable
+architecture with minimal complexity.
+
+## User-visible goal
+
+- A phone-bound invitee accepts by texting Murph the family token from the phone
+  they already use ("Continue in Messages"), with no Telegram and no separate
+  verification step.
+- Telegram is offered only when the invite is actually Telegram-bound.
+- Email-bound invites keep the web sign-in path; authenticated invitees keep the
+  one-tap web accept.
+- The accept page is rebuilt on the shared branded invite shell.
+
+## Approach (minimal, reuses existing paths)
+
+1. `readHostedFamilyInviteAcceptanceView` (`family-plan.ts`):
+   - Select `targetTelegramUsernameLookupKey`; add `isTelegramBound`; gate
+     `telegramInviteUrl` on it (env bot username alone is not enough).
+   - Add `messagesRecipientPhone`: for a phone-bound pending invite, resolve the
+     existing member's home line via `lookupHostedMemberIdentityByPhoneLookupKey`
+     + `readHostedMemberRoutingState` (null for brand-new invitees).
+   - Add pure `buildHostedFamilyInviteMessagesHref` (sms deep link whose body is
+     exactly the `family_<code>` token the webhook parses). No backend/webhook
+     change: `acceptHostedFamilyInviteFromPhoneTx` via `webhook-provider-linq.ts`
+     already accepts it.
+2. Accept page (`app/family/accept/[inviteCode]/page.tsx`): rebuild on
+   `JoinInviteCenteredShell` + `PageHeader` + `Card` + `JoinInviteEyebrow`; CTA
+   precedence = authenticated web accept -> Messages (phone-bound, web sign-in as
+   compact secondary) -> web sign-in (email-bound) -> Telegram (telegram-bound) ->
+   channel-neutral fallback. Fall back to a configured Murph line when no member
+   home line resolves.
+3. `FamilyInviteSignInButton`: add a compact `link` variant for the secondary
+   web option in the Messages case.
+
+## Invariants to preserve
+
+- Product-Critical Flow Preservation: every invite variant keeps a working accept
+  CTA (phone -> Messages, email -> web, telegram -> Telegram, else -> guidance).
+- Durable Authority: the invite token in the sms body is a client-supplied
+  request; the webhook re-asserts authority by matching the sender phone.
+- No new ingress/auth surface: the sms link only feeds the existing, documented
+  accept-by-phone webhook.
+
+## Verification
+
+- `apps/web` typecheck + lint clean.
+- Unit: `family-accept-page`, `hosted-family-owner-snapshot`,
+  `hosted-family-invite-messages` (incl. an assertion that the prefilled sms body
+  round-trips through `parseHostedFamilyInviteStartToken`), plus regression run of
+  `family-invite-accept-route`, `hosted-family-plan`,
+  `settings-hosted-family-manager`, `hosted-onboarding-member-channel-sync`.
+- Browser visual pass on the Vercel preview (desktop + mobile) recommended before
+  merge; the page reuses the established `/join` invite shell primitives.
+
+## Notes
+
+- Avoid the active `Hosted ingress wake repair` lane (webhook-provider files); this
+  change does not touch them.
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/agent-docs/exec-plans/completed/2026-07-06-family-unbound-invite-claims.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-family-unbound-invite-claims.md
@@ -1,0 +1,51 @@
+# Family unbound invite claims
+
+## Why
+
+Family invite binding is optional targeting, not mandatory verification. A
+label-only invite should be claimable by the first verified identity that
+explicitly presents the family token or taps accept after web sign-in, while
+phone, email, and Telegram-bound invites keep enforcing their binding.
+
+Utmost priority: clean, simple, long term maintainable and composable
+architecture with minimal complexity.
+
+## User-visible goal
+
+- A label-only invite can be accepted through Messages, Telegram, or web sign-in.
+- Bound invites still offer and accept only through their bound identity.
+- The prefilled Messages body is human-readable while keeping the embedded
+  `family_<code>` token as the explicit consent marker.
+- The plan owner is notified when an unbound invite is claimed.
+- The owner invite form puts phone first and uses the shared hosted phone input.
+
+## Approach
+
+1. Extend the existing family token parser and Messages href helper.
+2. Adjust the existing invite acceptance authority checks so fully unbound
+   invites bind to the accepting verified phone, email, or Telegram identity.
+3. Reuse `appendHostedFamilyChatNotificationTx` and route resolution for owner
+   announcements on unbound claims only.
+4. Update the accept page CTAs and settings invite form in place, following the
+   current component patterns.
+5. Update tests and product/security docs for the final rule.
+
+## Invariants
+
+- No implicit acceptance: messaging paths still require a `family_<code>` token.
+- Bound invite matching stays fail-closed for mismatched phone, email, or
+  Telegram identities.
+- Double-claim remains single-winner through the existing pending-row claim.
+- No new tables, queues, or notification machinery.
+- Do not commit in this task; the supervisor reviews and commits.
+
+## Verification
+
+- Requested hosted family Vitest batch.
+- Any LinQ/webhook acceptance suites found by search.
+- ESLint on touched `apps/web` files.
+- `pnpm --dir apps/web typecheck`.
+
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/agent-docs/product-specs/hosted-family-plan.md
+++ b/agent-docs/product-specs/hosted-family-plan.md
@@ -155,6 +155,11 @@ Telegram `from.username`.
 
 The simplest acceptance path should be chat-first.
 
+The web accept page (`/family/accept/<code>`) selects the accept channel from how
+the invite is actually bound (phone, Telegram, or email). A configured Telegram
+bot is never a fallback for a non-Telegram invite: an invitee with only a phone
+number must not be routed into Telegram.
+
 ### Telegram
 
 Telegram invites use a deep link such as:
@@ -178,6 +183,17 @@ the invited phone number and the WhatsApp messaging consent path has been
 completed. For the MVP, the inbound family invite token is the WhatsApp
 consent-writing command for that phone-bound acceptance. The accepted member
 still gets their own `HostedMember` and routing rows.
+
+### iMessage / SMS
+
+A phone pre-bound invite opened on the web accept page leads with a "Continue in
+Messages" action: an `sms:` deep link to Murph prefilled with the family invite
+token (`family_<code>`). Sending it reuses the same inbound phone-bound
+acceptance path, so the invitee joins from the thread they already use with no
+separate web sign-in or verification step. Prefer the Murph line an existing
+member already messages on so acceptance lands in their current thread instead
+of being redirected to their home line; fall back to a configured line for a
+brand-new invitee, whom the webhook assigns a home line on first contact.
 
 ### Web Fallback
 

--- a/agent-docs/product-specs/hosted-family-plan.md
+++ b/agent-docs/product-specs/hosted-family-plan.md
@@ -155,10 +155,20 @@ Telegram `from.username`.
 
 The simplest acceptance path should be chat-first.
 
-The web accept page (`/family/accept/<code>`) selects the accept channel from how
-the invite is actually bound (phone, Telegram, or email). A configured Telegram
-bot is never a fallback for a non-Telegram invite: an invitee with only a phone
-number must not be routed into Telegram.
+Binding is optional targeting, not mandatory verification. A phone-, email-, or
+Telegram-bound invite can only be claimed by that matching identity. A fully
+unbound label-only invite is claimable by the first verified identity that
+presents the invite reference through an explicit act: sending the
+`family_<code>` message by text, opening the Telegram bot deep link, or tapping
+Accept after web sign-in. Acceptance must never happen as a side effect of an
+unrelated message, and the `family_<code>` token remains the messaging consent
+marker.
+
+The web accept page (`/family/accept/<code>`) selects the accept channels from
+the invite binding. Bound invites never offer channels other than their
+binding; unbound invites offer all configured claim channels. When an unbound
+invite is claimed, notify the plan owner that the label, or "Someone" when no
+label exists, joined the family plan.
 
 ### Telegram
 
@@ -181,16 +191,18 @@ missing or ambiguous, fail closed rather than guessing.
 Phone pre-bound invites may be accepted in chat when the response arrives from
 the invited phone number and the WhatsApp messaging consent path has been
 completed. For the MVP, the inbound family invite token is the WhatsApp
-consent-writing command for that phone-bound acceptance. The accepted member
-still gets their own `HostedMember` and routing rows.
+consent-writing command for that phone-bound acceptance. Fully unbound invites
+may also be claimed from phone messaging when the sender explicitly sends the
+family invite token; the sender's verified phone identity becomes the claimant.
+The accepted member still gets their own `HostedMember` and routing rows.
 
 ### iMessage / SMS
 
 A phone pre-bound invite opened on the web accept page leads with a "Continue in
 Messages" action: an `sms:` deep link to Murph prefilled with the family invite
-token (`family_<code>`). Sending it reuses the same inbound phone-bound
-acceptance path, so the invitee joins from the thread they already use with no
-separate web sign-in or verification step. Prefer the Murph line an existing
+token embedded in a human-readable sentence. Sending it reuses the same inbound
+phone-bound acceptance path, so the invitee joins from the thread they already
+use with no separate web sign-in or verification step. Prefer the Murph line an existing
 member already messages on so acceptance lands in their current thread instead
 of being redirected to their home line; fall back to a configured line for a
 brand-new invitee, whom the webhook assigns a home line on first contact.
@@ -199,8 +211,10 @@ brand-new invitee, whom the webhook assigns a home line on first contact.
 
 Web remains a fallback for unsupported verification, settings, wearable
 connection, export, deletion, and other account management tasks. The family
-MVP should not require a web visit for a straightforward Telegram or WhatsApp
-invite acceptance.
+MVP should not require a web visit for a straightforward Telegram, WhatsApp, or
+Messages invite acceptance. For unbound invites, a signed-in hosted member may
+tap Accept on the web page, and their verified phone or email identity becomes
+the claimant.
 
 ## Acceptance Copy
 

--- a/apps/web/app/api/family/invites/[inviteCode]/accept/route.ts
+++ b/apps/web/app/api/family/invites/[inviteCode]/accept/route.ts
@@ -45,7 +45,7 @@ export const POST = withJsonError(async (
         message: "This family plan isn't active right now. Ask the plan owner to finish setting it up.",
       });
     }
-    if (!view.isPhoneBound && !view.isEmailBound) {
+    if (!view.isPhoneBound && !view.isEmailBound && view.isTelegramBound) {
       throw hostedOnboardingError({
         code: "HOSTED_FAMILY_WEB_ACCEPT_REQUIRES_CONTACT",
         httpStatus: 409,

--- a/apps/web/app/api/settings/billing/family/invite/route.ts
+++ b/apps/web/app/api/settings/billing/family/invite/route.ts
@@ -104,7 +104,7 @@ export const POST = withJsonError(async (request: Request) => {
       targetPhoneHint: invite.targetPhoneHint,
       telegramInviteUrl: resolveHostedFamilyTelegramInviteUrl({
         inviteCode: invite.inviteCode,
-        isTelegramBound: targetTelegramUsername !== null,
+        isTelegramBound: invite.targetTelegramUsername !== null,
         telegramBotUsername,
       }),
     },

--- a/apps/web/app/api/settings/billing/family/invite/route.ts
+++ b/apps/web/app/api/settings/billing/family/invite/route.ts
@@ -3,11 +3,11 @@ import { assertHostedMemberNotSuspended } from "@/src/lib/hosted-onboarding/enti
 import { readHostedOnboardingEnvironment } from "@/src/lib/hosted-onboarding/env";
 import {
   buildHostedFamilyInviteAcceptUrl,
-  buildHostedFamilyTelegramInviteUrl,
   ensureHostedAccountGroupForOwnerTx,
   hostedFamilyInviteHasReusableTarget,
   issueHostedFamilyInviteTx,
   readHostedFamilyOwnerSnapshotForMember,
+  resolveHostedFamilyTelegramInviteUrl,
   updateHostedFamilySeatCount,
   waitForHostedFamilyBilledSeatCount,
 } from "@/src/lib/hosted-onboarding/family-plan";
@@ -102,12 +102,11 @@ export const POST = withJsonError(async (request: Request) => {
       status: invite.status,
       targetLabel: invite.targetLabel,
       targetPhoneHint: invite.targetPhoneHint,
-      telegramInviteUrl: telegramBotUsername
-        ? buildHostedFamilyTelegramInviteUrl({
-            botUsername: telegramBotUsername,
-            inviteCode: invite.inviteCode,
-          })
-        : null,
+      telegramInviteUrl: resolveHostedFamilyTelegramInviteUrl({
+        inviteCode: invite.inviteCode,
+        isTelegramBound: targetTelegramUsername !== null,
+        telegramBotUsername,
+      }),
     },
   });
 });

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -17,6 +17,7 @@ import { HealthDomainCard } from "@/src/components/overview/health-domain-card";
 import { ActiveExperimentBanner } from "@/src/components/overview/active-experiment-banner";
 import { ProfileStats } from "@/src/components/overview/profile-stats";
 import { HostedAuthFinishingNotice } from "@/src/components/hosted-onboarding/hosted-auth-shared";
+import { HOSTED_PHONE_COUNTRY_OPTIONS } from "@/src/components/hosted-onboarding/hosted-phone-country-options";
 import { ContactSupportAction } from "@/src/components/support/contact-support-action";
 import { AuthButton } from "@/src/components/ui/auth-button";
 import { MurphPulseLoader } from "@/src/components/ui/murph-pulse-loader";
@@ -29,6 +30,7 @@ import { Separator } from "@/src/components/ui/separator";
 import { Input } from "@/src/components/ui/input";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/src/components/ui/input-otp";
 import { Label } from "@/src/components/ui/label";
+import { PhoneNumberInput } from "@/src/components/ui/phone-number-input";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { Avatar, AvatarFallback } from "@/src/components/ui/avatar";
 import { Alert, AlertTitle, AlertDescription } from "@/src/components/ui/alert";
@@ -80,6 +82,17 @@ function DialogPreviewFrame({ label, children }: { label: string; children: Reac
   );
 }
 
+function resolveDesignPhoneCountryOption(value: string) {
+  const option =
+    HOSTED_PHONE_COUNTRY_OPTIONS.find((candidate) => candidate.code === value)
+    ?? HOSTED_PHONE_COUNTRY_OPTIONS.find((candidate) => candidate.code === "US")
+    ?? HOSTED_PHONE_COUNTRY_OPTIONS[0];
+  if (!option) {
+    throw new Error("Phone country options are empty.");
+  }
+  return option;
+}
+
 
 const EXPERIMENT_START_CHANNEL_OPTIONS: ExperimentStartContactOption[] = [
   {
@@ -115,6 +128,9 @@ export function ComponentsContent() {
   const [addedContactAvatar, setAddedContactAvatar] =
     useState<MurphContactAvatarOption | null>(null);
   const [inlineContactAvatarId, setInlineContactAvatarId] = useState("hooded");
+  const [phoneInputCountryCode, setPhoneInputCountryCode] = useState("US");
+  const [phoneInputValue, setPhoneInputValue] = useState("");
+  const selectedPhoneInputCountry = resolveDesignPhoneCountryOption(phoneInputCountryCode);
 
   return (
     <TooltipProvider>
@@ -184,6 +200,17 @@ export function ComponentsContent() {
             <div className="grid gap-2">
               <Label htmlFor="disabled-ds">Disabled</Label>
               <Input id="disabled-ds" placeholder="Can't edit this" disabled />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="phone-number-ds">Phone number</Label>
+              <PhoneNumberInput
+                id="phone-number-ds"
+                options={HOSTED_PHONE_COUNTRY_OPTIONS}
+                selectedCountry={selectedPhoneInputCountry}
+                value={phoneInputValue}
+                onCountryChange={setPhoneInputCountryCode}
+                onPhoneNumberChange={setPhoneInputValue}
+              />
             </div>
           </div>
         </Section>

--- a/apps/web/app/family/accept/[inviteCode]/page.tsx
+++ b/apps/web/app/family/accept/[inviteCode]/page.tsx
@@ -1,12 +1,25 @@
+import { Check as CheckIcon } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import type { ReactNode } from "react";
 
 import {
   FamilyInviteSignInButton,
   FamilyInviteWebAcceptButton,
 } from "@/src/components/family/family-invite-accept-client";
+import {
+  JoinInviteEyebrow,
+  type JoinInviteEyebrowTone,
+} from "@/src/components/hosted-onboarding/join-invite-eyebrow";
+import { JoinInviteCenteredShell } from "@/src/components/hosted-onboarding/join-invite-shell";
 import { Button } from "@/src/components/ui/button";
-import { readHostedFamilyInviteAcceptanceView } from "@/src/lib/hosted-onboarding/family-plan";
+import { Card, CardContent } from "@/src/components/ui/card";
+import { PageHeader } from "@/src/components/ui/page-header";
+import { readConfiguredMurphPhoneNumbers } from "@/src/lib/device-sync/messaging-return-destination";
+import {
+  buildHostedFamilyInviteMessagesHref,
+  readHostedFamilyInviteAcceptanceView,
+} from "@/src/lib/hosted-onboarding/family-plan";
 import { getHostedPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
 import { createMurphPageMetadata } from "@/src/lib/site-metadata";
 
@@ -17,6 +30,8 @@ export const metadata: Metadata = {
   }),
   robots: { follow: false, index: false },
 };
+
+type FamilyInviteView = Awaited<ReturnType<typeof readHostedFamilyInviteAcceptanceView>>;
 
 export default async function FamilyAcceptPage({
   params,
@@ -30,21 +45,48 @@ export default async function FamilyAcceptPage({
   ]);
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center gap-6 px-6 py-16">
-      {renderInvite({ authenticated: auth.authenticated, view })}
-    </main>
+    <JoinInviteCenteredShell>
+      <div className="flex w-full flex-col gap-6">
+        {renderInvite({
+          authenticated: auth.authenticated,
+          messagesAcceptHref: resolveMessagesAcceptHref(view),
+          view,
+        })}
+      </div>
+    </JoinInviteCenteredShell>
   );
+}
+
+// The invitee accepts by texting Murph the family token. Prefer the line an
+// existing member already messages on; fall back to a configured line for a
+// brand-new invitee (the webhook assigns them a home line on first contact).
+function resolveMessagesAcceptHref(view: FamilyInviteView): string | null {
+  if (!view || !view.isPhoneBound) {
+    return null;
+  }
+  const murphPhoneNumber =
+    view.messagesRecipientPhone ?? readConfiguredMurphPhoneNumbers()[0] ?? null;
+  if (!murphPhoneNumber) {
+    return null;
+  }
+  return buildHostedFamilyInviteMessagesHref({
+    inviteCode: view.inviteCode,
+    murphPhoneNumber,
+  });
 }
 
 function renderInvite(input: {
   authenticated: boolean;
-  view: Awaited<ReturnType<typeof readHostedFamilyInviteAcceptanceView>>;
-}) {
+  messagesAcceptHref: string | null;
+  view: FamilyInviteView;
+}): ReactNode {
   const { view } = input;
 
   if (!view) {
     return (
       <InviteMessage
+        eyebrow="Link no longer works"
+        tone="danger"
         title="This invite isn't valid"
         body="This family invite is no longer available. Ask the person who invited you to send a new one."
       />
@@ -54,6 +96,8 @@ function renderInvite(input: {
   if (view.status === "expired") {
     return (
       <InviteMessage
+        eyebrow="Link no longer works"
+        tone="danger"
         title="This invite has expired"
         body="Ask the plan owner to send you a fresh family invite."
       />
@@ -61,12 +105,20 @@ function renderInvite(input: {
   }
 
   if (view.status === "revoked") {
-    return <InviteMessage title="This invite was canceled" body="Ask the plan owner for a new invite." />;
+    return (
+      <InviteMessage
+        eyebrow="Link no longer works"
+        tone="danger"
+        title="This invite was canceled"
+        body="Ask the plan owner for a new invite."
+      />
+    );
   }
 
   if (view.status === "accepted") {
     return (
       <InviteMessage
+        eyebrow="Murph Family"
         title="This invite was already used"
         body="If that was you, open Murph to continue."
         action={
@@ -81,6 +133,7 @@ function renderInvite(input: {
   if (!view.groupActive) {
     return (
       <InviteMessage
+        eyebrow="Almost ready"
         title="This family plan isn't active yet"
         body="Ask the plan owner to finish setting up billing, then open this invite again."
       />
@@ -90,6 +143,7 @@ function renderInvite(input: {
   if (!view.seatAvailable) {
     return (
       <InviteMessage
+        eyebrow="Family is full"
         title="This family plan is full"
         body="The plan has no open paid seats. Ask the owner to add a Family seat."
       />
@@ -97,62 +151,139 @@ function renderInvite(input: {
   }
 
   const inviter = view.groupDisplayName ?? "Your family plan owner";
-  const webBindingLabel = view.isEmailBound && view.isPhoneBound
-    ? "phone number or email address"
-    : view.isEmailBound
-      ? "email address"
-      : "phone number";
+  const webBindingLabel =
+    view.isEmailBound && view.isPhoneBound
+      ? "phone number or email address"
+      : view.isEmailBound
+        ? "email address"
+        : "phone number";
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-3">
-        <h1 className="font-serif text-3xl font-semibold tracking-tight text-balance text-foreground">
-          {inviter} invited you to Murph Family
-        </h1>
-        <ul className="flex flex-col gap-1.5 text-sm text-pretty text-muted-foreground">
-          <li>They pay for your Murph access.</li>
-          <li>You get your own private Murph account.</li>
-          <li>{"They can't see your messages, health data, or vault."}</li>
-        </ul>
-      </div>
+    <>
+      <PageHeader
+        eyebrow={<JoinInviteEyebrow label="Murph Family" tone="default" />}
+        title={`${inviter} invited you to Murph Family`}
+        description="Join to get your own private Murph account, paid for by your family plan."
+      />
 
-      {view.webAcceptable ? (
-        input.authenticated ? (
-          <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />
-        ) : (
-          <div className="flex flex-col gap-2">
-            <FamilyInviteSignInButton bindingLabel={webBindingLabel} />
-            <p className="text-xs leading-5 text-muted-foreground">
-              {`Sign in with the ${webBindingLabel} this invite was sent to, and we'll bring you back here.`}
-            </p>
-          </div>
-        )
-      ) : view.telegramInviteUrl ? (
-        <div className="flex flex-col gap-2">
-          <Button render={<a href={view.telegramInviteUrl} />} nativeButton={false} size="xl">
-            Continue in Telegram
-          </Button>
-          <p className="text-xs leading-5 text-muted-foreground">
-            {"Open this in Telegram to join — that's how Murph confirms it's you."}
-          </p>
-        </div>
-      ) : (
-        <p className="text-sm text-pretty text-muted-foreground">
-          Open this invite from the Telegram or WhatsApp chat where you received it to join.
-        </p>
-      )}
-    </div>
+      <Card size="sm">
+        <CardContent>
+          <ul className="flex flex-col gap-2.5 text-sm text-muted-foreground">
+            <FeatureRow>They pay for your Murph access.</FeatureRow>
+            <FeatureRow>You get your own private Murph account.</FeatureRow>
+            <FeatureRow>
+              {"They can't see your messages, health data, or vault."}
+            </FeatureRow>
+          </ul>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-2">
+        {renderAcceptCta({
+          authenticated: input.authenticated,
+          messagesAcceptHref: input.messagesAcceptHref,
+          view,
+          webBindingLabel,
+        })}
+      </div>
+    </>
   );
 }
 
-function InviteMessage(props: { action?: React.ReactNode; body: string; title: string }) {
+function renderAcceptCta(input: {
+  authenticated: boolean;
+  messagesAcceptHref: string | null;
+  view: NonNullable<FamilyInviteView>;
+  webBindingLabel: string;
+}): ReactNode {
+  const { view } = input;
+
+  // Already signed in as an invite-bound identity: one tap, no re-verification.
+  if (input.authenticated && view.webAcceptable) {
+    return <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />;
+  }
+
+  // Phone-bound: accept in the channel they already use. Texting the token to
+  // Murph proves it's them by matching their phone, so there's no separate
+  // verification step or web sign-in required.
+  if (input.messagesAcceptHref) {
+    return (
+      <>
+        <Button
+          render={<a href={input.messagesAcceptHref} />}
+          nativeButton={false}
+          size="xl"
+        >
+          Continue in Messages
+        </Button>
+        <p className="text-xs leading-5 text-muted-foreground">
+          This opens a text to Murph so you can join right from your phone.
+        </p>
+        {view.webAcceptable ? (
+          <FamilyInviteSignInButton bindingLabel={input.webBindingLabel} variant="link" />
+        ) : null}
+      </>
+    );
+  }
+
+  // Email-bound (or a phone invite with no reachable Murph line): sign in on the
+  // web with the identity the invite was sent to.
+  if (view.webAcceptable) {
+    return (
+      <>
+        <FamilyInviteSignInButton bindingLabel={input.webBindingLabel} />
+        <p className="text-xs leading-5 text-muted-foreground">
+          {`Sign in with the ${input.webBindingLabel} this invite was sent to, and we'll bring you back here.`}
+        </p>
+      </>
+    );
+  }
+
+  // Telegram-bound invites only: continue in Telegram.
+  if (view.telegramInviteUrl) {
+    return (
+      <>
+        <Button render={<a href={view.telegramInviteUrl} />} nativeButton={false} size="xl">
+          Continue in Telegram
+        </Button>
+        <p className="text-xs leading-5 text-muted-foreground">
+          Open this in Telegram to join, so Murph can confirm it&apos;s you.
+        </p>
+      </>
+    );
+  }
+
   return (
-    <div className="flex flex-col gap-3">
-      <h1 className="font-serif text-3xl font-semibold tracking-tight text-balance text-foreground">
-        {props.title}
-      </h1>
-      <p className="text-sm text-pretty text-muted-foreground">{props.body}</p>
-      {props.action ?? null}
-    </div>
+    <p className="text-sm text-pretty text-muted-foreground">
+      Open this invite from the chat where you received it to join.
+    </p>
+  );
+}
+
+function FeatureRow({ children }: { children: ReactNode }) {
+  return (
+    <li className="flex items-start gap-2.5">
+      <CheckIcon className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden="true" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function InviteMessage(props: {
+  action?: ReactNode;
+  body: string;
+  eyebrow: string;
+  title: string;
+  tone?: JoinInviteEyebrowTone;
+}) {
+  return (
+    <>
+      <PageHeader
+        eyebrow={<JoinInviteEyebrow label={props.eyebrow} tone={props.tone ?? "default"} />}
+        title={props.title}
+        description={props.body}
+      />
+      {props.action ? <div className="flex flex-col gap-2">{props.action}</div> : null}
+    </>
   );
 }

--- a/apps/web/app/family/accept/[inviteCode]/page.tsx
+++ b/apps/web/app/family/accept/[inviteCode]/page.tsx
@@ -200,6 +200,25 @@ function renderAcceptCta(input: {
 
   // Already signed in as an invite-bound identity: one tap, no re-verification.
   if (input.authenticated && view.webAcceptable) {
+    if (input.messagesAcceptHref) {
+      return (
+        <>
+          <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />
+          <Button
+            render={<a href={input.messagesAcceptHref} />}
+            nativeButton={false}
+            size="xl"
+            variant="secondary"
+          >
+            Continue in Messages
+          </Button>
+          <p className="text-xs leading-5 text-muted-foreground">
+            Joining by text works from the phone this invite was sent to.
+          </p>
+        </>
+      );
+    }
+
     return <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />;
   }
 

--- a/apps/web/app/family/accept/[inviteCode]/page.tsx
+++ b/apps/web/app/family/accept/[inviteCode]/page.tsx
@@ -57,11 +57,16 @@ export default async function FamilyAcceptPage({
   );
 }
 
-// The invitee accepts by texting Murph the family token. Prefer the line an
-// existing member already messages on; fall back to a configured line for a
-// brand-new invitee (the webhook assigns them a home line on first contact).
+// The invitee accepts by texting Murph the family token. Phone-bound invites
+// prefer the line an existing member already messages on; unbound invites fall
+// back to a configured line and the webhook assigns a home line on first
+// contact.
 function resolveMessagesAcceptHref(view: FamilyInviteView): string | null {
-  if (!view || !view.isPhoneBound) {
+  if (!view) {
+    return null;
+  }
+  const isFullyUnbound = !view.isPhoneBound && !view.isEmailBound && !view.isTelegramBound;
+  if (!view.isPhoneBound && !isFullyUnbound) {
     return null;
   }
   const murphPhoneNumber =
@@ -151,12 +156,15 @@ function renderInvite(input: {
   }
 
   const inviter = view.groupDisplayName ?? "Your family plan owner";
+  const isFullyUnbound = !view.isPhoneBound && !view.isEmailBound && !view.isTelegramBound;
   const webBindingLabel =
-    view.isEmailBound && view.isPhoneBound
-      ? "phone number or email address"
-      : view.isEmailBound
-        ? "email address"
-        : "phone number";
+    isFullyUnbound
+      ? "your phone number or email address"
+      : view.isEmailBound && view.isPhoneBound
+        ? "phone number or email address"
+        : view.isEmailBound
+          ? "email address"
+          : "phone number";
 
   return (
     <>
@@ -184,6 +192,9 @@ function renderInvite(input: {
           messagesAcceptHref: input.messagesAcceptHref,
           view,
           webBindingLabel,
+          webSignInDescription: isFullyUnbound
+            ? "Sign in with your own phone number or email address. We'll bring you back here."
+            : undefined,
         })}
       </div>
     </>
@@ -195,10 +206,15 @@ function renderAcceptCta(input: {
   messagesAcceptHref: string | null;
   view: NonNullable<FamilyInviteView>;
   webBindingLabel: string;
+  webSignInDescription?: string;
 }): ReactNode {
   const { view } = input;
+  const isFullyUnbound = !view.isPhoneBound && !view.isEmailBound && !view.isTelegramBound;
+  const webSignInDescriptionProps = input.webSignInDescription
+    ? { description: input.webSignInDescription }
+    : {};
 
-  // Already signed in as an invite-bound identity: one tap, no re-verification.
+  // Already signed in with an acceptable identity: one tap, no re-verification.
   if (input.authenticated && view.webAcceptable) {
     if (input.messagesAcceptHref) {
       return (
@@ -213,7 +229,9 @@ function renderAcceptCta(input: {
             Continue in Messages
           </Button>
           <p className="text-xs leading-5 text-muted-foreground">
-            Joining by text works from the phone this invite was sent to.
+            {isFullyUnbound
+              ? "Joining by text works from the phone you use to send the message."
+              : "Joining by text works from the phone this invite was sent to."}
           </p>
         </>
       );
@@ -222,9 +240,7 @@ function renderAcceptCta(input: {
     return <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />;
   }
 
-  // Phone-bound: accept in the channel they already use. Texting the token to
-  // Murph proves it's them by matching their phone, so there's no separate
-  // verification step or web sign-in required.
+  // Phone-bound or unbound-by-text: accept in Messages by sending the token.
   if (input.messagesAcceptHref) {
     return (
       <>
@@ -239,7 +255,22 @@ function renderAcceptCta(input: {
           This opens a text to Murph so you can join right from your phone.
         </p>
         {view.webAcceptable ? (
-          <FamilyInviteSignInButton bindingLabel={input.webBindingLabel} variant="link" />
+          <FamilyInviteSignInButton
+            bindingLabel={input.webBindingLabel}
+            variant="link"
+            {...webSignInDescriptionProps}
+          />
+        ) : null}
+        {isFullyUnbound && view.telegramInviteUrl ? (
+          <Button
+            render={<a href={view.telegramInviteUrl} />}
+            nativeButton={false}
+            size="sm"
+            variant="link"
+            className="h-auto w-fit p-0 text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            Continue in Telegram
+          </Button>
         ) : null}
       </>
     );
@@ -250,9 +281,13 @@ function renderAcceptCta(input: {
   if (view.webAcceptable) {
     return (
       <>
-        <FamilyInviteSignInButton bindingLabel={input.webBindingLabel} />
+        <FamilyInviteSignInButton
+          bindingLabel={input.webBindingLabel}
+          {...webSignInDescriptionProps}
+        />
         <p className="text-xs leading-5 text-muted-foreground">
-          {`Sign in with the ${input.webBindingLabel} this invite was sent to, and we'll bring you back here.`}
+          {input.webSignInDescription ??
+            `Sign in with the ${input.webBindingLabel} this invite was sent to, and we'll bring you back here.`}
         </p>
       </>
     );

--- a/apps/web/app/family/accept/[inviteCode]/page.tsx
+++ b/apps/web/app/family/accept/[inviteCode]/page.tsx
@@ -213,6 +213,17 @@ function renderAcceptCta(input: {
   const webSignInDescriptionProps = input.webSignInDescription
     ? { description: input.webSignInDescription }
     : {};
+  const unboundTelegramInviteLink = isFullyUnbound && view.telegramInviteUrl ? (
+    <Button
+      render={<a href={view.telegramInviteUrl} />}
+      nativeButton={false}
+      size="sm"
+      variant="link"
+      className="h-auto w-fit p-0 text-sm font-medium text-muted-foreground hover:text-foreground"
+    >
+      Continue in Telegram
+    </Button>
+  ) : null;
 
   // Already signed in with an acceptable identity: one tap, no re-verification.
   if (input.authenticated && view.webAcceptable) {
@@ -261,17 +272,7 @@ function renderAcceptCta(input: {
             {...webSignInDescriptionProps}
           />
         ) : null}
-        {isFullyUnbound && view.telegramInviteUrl ? (
-          <Button
-            render={<a href={view.telegramInviteUrl} />}
-            nativeButton={false}
-            size="sm"
-            variant="link"
-            className="h-auto w-fit p-0 text-sm font-medium text-muted-foreground hover:text-foreground"
-          >
-            Continue in Telegram
-          </Button>
-        ) : null}
+        {unboundTelegramInviteLink}
       </>
     );
   }
@@ -289,6 +290,7 @@ function renderAcceptCta(input: {
           {input.webSignInDescription ??
             `Sign in with the ${input.webBindingLabel} this invite was sent to, and we'll bring you back here.`}
         </p>
+        {unboundTelegramInviteLink}
       </>
     );
   }

--- a/apps/web/app/family/accept/[inviteCode]/page.tsx
+++ b/apps/web/app/family/accept/[inviteCode]/page.tsx
@@ -244,11 +244,19 @@ function renderAcceptCta(input: {
               ? "Joining by text works from the phone you use to send the message."
               : "Joining by text works from the phone this invite was sent to."}
           </p>
+          {unboundTelegramInviteLink}
         </>
       );
     }
 
-    return <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />;
+    return unboundTelegramInviteLink ? (
+      <>
+        <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />
+        {unboundTelegramInviteLink}
+      </>
+    ) : (
+      <FamilyInviteWebAcceptButton inviteCode={view.inviteCode} />
+    );
   }
 
   // Phone-bound or unbound-by-text: accept in Messages by sending the token.

--- a/apps/web/src/components/family/family-invite-accept-client.tsx
+++ b/apps/web/src/components/family/family-invite-accept-client.tsx
@@ -60,7 +60,10 @@ export function FamilyInviteWebAcceptButton(props: { inviteCode: string }) {
   );
 }
 
-export function FamilyInviteSignInButton(props: { bindingLabel: string }) {
+export function FamilyInviteSignInButton(props: {
+  bindingLabel: string;
+  variant?: "link" | "primary";
+}) {
   const [open, setOpen] = useState(false);
 
   function handleCompleted(_payload: HostedPrivyCompletionPayload) {
@@ -69,9 +72,21 @@ export function FamilyInviteSignInButton(props: { bindingLabel: string }) {
 
   return (
     <>
-      <Button type="button" size="xl" onClick={() => setOpen(true)}>
-        Sign in to join
-      </Button>
+      {props.variant === "link" ? (
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto w-fit p-0 text-sm font-medium text-muted-foreground hover:text-foreground"
+          onClick={() => setOpen(true)}
+        >
+          Sign in on the web instead
+        </Button>
+      ) : (
+        <Button type="button" size="xl" onClick={() => setOpen(true)}>
+          Sign in to join
+        </Button>
+      )}
       <AuthDialog
         open={open}
         onCompleted={handleCompleted}

--- a/apps/web/src/components/family/family-invite-accept-client.tsx
+++ b/apps/web/src/components/family/family-invite-accept-client.tsx
@@ -8,7 +8,6 @@ import { navigateHostedAuthRedirect } from "@/src/components/hosted-onboarding/h
 import { requestHostedOnboardingJson } from "@/src/components/hosted-onboarding/client-api";
 import { toErrorMessage } from "@/src/components/settings/hosted-settings-sync-helpers";
 import { Button } from "@/src/components/ui/button";
-import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
 
 export function FamilyInviteWebAcceptButton(props: { inviteCode: string }) {
   const router = useRouter();
@@ -62,11 +61,12 @@ export function FamilyInviteWebAcceptButton(props: { inviteCode: string }) {
 
 export function FamilyInviteSignInButton(props: {
   bindingLabel: string;
+  description?: string;
   variant?: "link" | "primary";
 }) {
   const [open, setOpen] = useState(false);
 
-  function handleCompleted(_payload: HostedPrivyCompletionPayload) {
+  function handleCompleted() {
     navigateHostedAuthRedirect(readCurrentFamilyInvitePath());
   }
 
@@ -93,7 +93,7 @@ export function FamilyInviteSignInButton(props: {
         onOpenChange={setOpen}
         requireLaunchConsentOnCompletion
         title="Sign in to join Murph Family"
-        description={`Use the same ${props.bindingLabel} this invite was sent to.`}
+        description={props.description ?? `Use the same ${props.bindingLabel} this invite was sent to.`}
       />
     </>
   );

--- a/apps/web/src/components/hosted-onboarding/hosted-phone-auth-step-views.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-phone-auth-step-views.tsx
@@ -1,26 +1,10 @@
 "use client";
 
-import { useId, useState, type FormEvent } from "react";
-import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { useId, type FormEvent } from "react";
 
-import { Button, buttonVariants } from "@/src/components/ui/button";
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxTrigger,
-} from "@/src/components/ui/combobox";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTrigger,
-} from "@/src/components/ui/drawer";
-import { Input } from "@/src/components/ui/input";
+import { Button } from "@/src/components/ui/button";
 import { Label } from "@/src/components/ui/label";
-import { useIsMobile } from "@/src/hooks/use-mobile";
-import { cn } from "@/src/lib/utils";
+import { PhoneNumberInput } from "@/src/components/ui/phone-number-input";
 
 import { HostedUseDifferentNumberButton } from "./hosted-phone-auth-use-different-number-button";
 import { HostedVerificationCodeStep } from "./hosted-verification-code-step";
@@ -124,25 +108,15 @@ export function HostedPhoneEntryStep({
           {phoneFieldLabel ??
             (intent === "link" ? "Phone number" : "Your phone")}
         </Label>
-        <div className="flex gap-3">
-          <CountryCodePicker
-            options={phoneCountryOptions}
-            selectedCountry={selectedPhoneCountry}
-            onCountryChange={onPhoneCountryChange}
-          />
-          <Input
-            id={phoneInputId}
-            autoFocus={phoneInputAutoFocus}
-            autoComplete="tel-national"
-            inputMode="tel"
-            name="phone-number"
-            placeholder={selectedPhoneCountry.placeholder}
-            inputSize="xl"
-            value={phoneNumber}
-            onChange={(event) => onPhoneNumberChange(event.currentTarget.value)}
-            className="flex-1"
-          />
-        </div>
+        <PhoneNumberInput
+          id={phoneInputId}
+          autoFocus={phoneInputAutoFocus}
+          options={phoneCountryOptions}
+          selectedCountry={selectedPhoneCountry}
+          value={phoneNumber}
+          onCountryChange={onPhoneCountryChange}
+          onPhoneNumberChange={onPhoneNumberChange}
+        />
         {phoneFieldDescription ? (
           <p className="text-sm text-muted-foreground">{phoneFieldDescription}</p>
         ) : null}
@@ -248,158 +222,4 @@ function resolveHostedPhoneCodeEntryDescription({
   }
 
   return `We texted the latest code to ${verificationPhoneNumberHint}.`;
-}
-
-const COUNTRY_TRIGGER_CLASS = cn(
-  buttonVariants({ variant: "outline", size: "lg" }),
-  "h-14 w-auto shrink-0 justify-between rounded-2xl px-5 text-left text-base font-medium md:text-base sm:min-w-28",
-);
-
-function CountryCodePicker({
-  options,
-  selectedCountry,
-  onCountryChange,
-}: {
-  options: HostedPhoneCountryOption[];
-  selectedCountry: HostedPhoneCountryOption;
-  onCountryChange: (code: string) => void;
-}) {
-  const isMobile = useIsMobile();
-
-  if (isMobile) {
-    return (
-      <CountryCodeDrawer
-        options={options}
-        selectedCountry={selectedCountry}
-        onCountryChange={onCountryChange}
-      />
-    );
-  }
-
-  return (
-    <Combobox
-      items={options}
-      value={selectedCountry}
-      itemToStringValue={(option) =>
-        `${option.label} ${option.dialCode} ${option.dialCode.replace("+", "")}`
-      }
-      onValueChange={(option) => {
-        if (option) {
-          onCountryChange(option.code);
-        }
-      }}
-    >
-      <ComboboxTrigger
-        aria-label={`Country or region, ${selectedCountry.label} ${selectedCountry.dialCode}`}
-        className={COUNTRY_TRIGGER_CLASS}
-      >
-        {selectedCountry.dialCode}
-      </ComboboxTrigger>
-      <ComboboxContent className="w-64">
-        <ComboboxInput placeholder="Search countries..." />
-        <ComboboxList>
-          {(option) => (
-            <ComboboxItem key={option.code} value={option}>
-              <span className="flex min-w-0 items-center justify-between gap-3">
-                <span>{option.label}</span>
-                <span className="text-xs text-muted-foreground">
-                  {option.dialCode}
-                </span>
-              </span>
-            </ComboboxItem>
-          )}
-        </ComboboxList>
-      </ComboboxContent>
-    </Combobox>
-  );
-}
-
-function CountryCodeDrawer({
-  options,
-  selectedCountry,
-  onCountryChange,
-}: {
-  options: HostedPhoneCountryOption[];
-  selectedCountry: HostedPhoneCountryOption;
-  onCountryChange: (code: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-
-  const digits = search.replace(/[^0-9]/g, "");
-  const normalizedSearch = search.toLowerCase();
-  const filtered = search
-    ? options.filter(
-        (o) =>
-          o.label.toLowerCase().includes(normalizedSearch) ||
-          (digits.length > 0 && o.dialCode.replace("+", "").startsWith(digits)),
-      )
-    : options;
-
-  return (
-    <Drawer
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) setSearch("");
-      }}
-    >
-      <DrawerTrigger asChild>
-        <button
-          type="button"
-          aria-label={`Country or region, ${selectedCountry.label} ${selectedCountry.dialCode}`}
-          className={COUNTRY_TRIGGER_CLASS}
-        >
-          {selectedCountry.dialCode}
-          <ChevronDownIcon className="pointer-events-none size-4 text-stone-500" />
-        </button>
-      </DrawerTrigger>
-      <DrawerContent>
-        <div className="flex flex-col pb-12">
-          <div className="sticky top-0 border-b border-border bg-popover px-4 py-3">
-            <input
-              autoFocus
-              type="text"
-              placeholder="Search countries..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="w-full rounded-xl border border-border bg-muted px-4 py-2.5 text-sm outline-none placeholder:text-muted-foreground"
-            />
-          </div>
-          <div className="overflow-y-auto overscroll-contain">
-            {filtered.map((option) => (
-              <button
-                key={option.code}
-                type="button"
-                className={cn(
-                  "flex w-full items-center gap-3 px-5 py-3.5 text-left text-base transition-colors active:bg-muted",
-                  option.code === selectedCountry.code
-                    ? "font-medium text-foreground"
-                    : "text-muted-foreground",
-                )}
-                onClick={() => {
-                  onCountryChange(option.code);
-                  setOpen(false);
-                  setSearch("");
-                }}
-              >
-                <span className="flex-1">{option.label}</span>
-                <span className="text-xs text-muted-foreground">
-                  {option.dialCode}
-                </span>
-                {option.code === selectedCountry.code && (
-                  <CheckIcon className="size-4 shrink-0 text-foreground" />
-                )}
-              </button>
-            ))}
-            {filtered.length === 0 && (
-              <p className="px-5 py-8 text-center text-sm text-muted-foreground">
-                No countries found
-              </p>
-            )}
-          </div>
-        </div>
-      </DrawerContent>
-    </Drawer>
-  );
 }

--- a/apps/web/src/components/settings/hosted-family-settings-actions.tsx
+++ b/apps/web/src/components/settings/hosted-family-settings-actions.tsx
@@ -2,12 +2,14 @@
 
 import { Check, Copy, Loader2, Minus } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import {
   HostedOnboardingApiError,
   requestHostedOnboardingJson,
 } from "@/src/components/hosted-onboarding/client-api";
+import { HOSTED_PHONE_COUNTRY_OPTIONS } from "@/src/components/hosted-onboarding/hosted-phone-country-options";
+import { usePhoneCountryCode } from "@/src/components/hosted-onboarding/phone-country-code-client-provider";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -19,6 +21,8 @@ import {
 } from "@/src/components/ui/dialog";
 import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
+import { PhoneNumberInput } from "@/src/components/ui/phone-number-input";
+import { normalizePhoneNumberForCountry } from "@/src/lib/hosted-onboarding/shared";
 import { cn } from "@/src/lib/utils";
 
 import { toErrorMessage } from "./hosted-settings-sync-helpers";
@@ -80,6 +84,23 @@ type PendingAction =
 
 const DIALOG_CLASS =
   "max-w-md gap-6 border border-[#c4a882]/25 bg-[#fffcf6] p-6 text-[#2d3436] ring-[#c4a882]/25 md:p-7";
+const DEFAULT_INVITE_PHONE_COUNTRY_CODE = "US";
+
+function resolveInvitePhoneCountryOption(value: string | null | undefined) {
+  const normalized = value?.trim().toUpperCase() ?? null;
+  const option =
+    (normalized
+      ? HOSTED_PHONE_COUNTRY_OPTIONS.find((candidate) => candidate.code === normalized)
+      : null)
+    ?? HOSTED_PHONE_COUNTRY_OPTIONS.find(
+      (candidate) => candidate.code === DEFAULT_INVITE_PHONE_COUNTRY_CODE,
+    )
+    ?? HOSTED_PHONE_COUNTRY_OPTIONS[0];
+  if (!option) {
+    throw new Error("Phone country options are empty.");
+  }
+  return option;
+}
 
 export function HostedFamilyStartButton(props: {
   block?: boolean;
@@ -152,6 +173,10 @@ export function HostedFamilyManager(props: {
 }) {
   const router = useRouter();
   const [inviteOpen, setInviteOpen] = useState(false);
+  const phoneCountryCodeHint = usePhoneCountryCode();
+  const [phoneCountryCode, setPhoneCountryCode] = useState(() =>
+    resolveInvitePhoneCountryOption(phoneCountryCodeHint).code
+  );
   const [label, setLabel] = useState("");
   const [phone, setPhone] = useState("");
   const [telegram, setTelegram] = useState("");
@@ -168,10 +193,18 @@ export function HostedFamilyManager(props: {
   const [seatError, setSeatError] = useState<string | null>(null);
 
   const seatsFull = props.seats.remaining <= 0;
+  const selectedPhoneCountry = useMemo(
+    () => resolveInvitePhoneCountryOption(phoneCountryCode),
+    [phoneCountryCode],
+  );
+  const normalizedPhone = useMemo(
+    () => normalizePhoneNumberForCountry(phone, selectedPhoneCountry.dialCode),
+    [phone, selectedPhoneCountry.dialCode],
+  );
   const planCanGrow = props.billingActive && seatsFull && props.seats.billed < props.seats.max;
   // A seat is only auto-added for invites the server can dedup on retry, so the
   // paid CTA (and the addSeatIfNeeded flag) require a phone, email, or Telegram.
-  const hasStableTarget = Boolean(phone.trim() || email.trim() || telegram.trim());
+  const hasStableTarget = Boolean(normalizedPhone || email.trim() || telegram.trim());
   const inviteWillAddSeat = planCanGrow && hasStableTarget;
   const inviteNeedsStableTargetForSeat = planCanGrow && !hasStableTarget;
   const inviteSubmitDisabled = isInviting || inviteNeedsStableTargetForSeat;
@@ -196,6 +229,10 @@ export function HostedFamilyManager(props: {
       setInviteError("Add a phone number, email, Telegram username, or name.");
       return;
     }
+    if (phone.trim() && !normalizedPhone) {
+      setInviteError(`Enter a valid phone number for ${selectedPhoneCountry.label}.`);
+      return;
+    }
     setInviteError(null);
     setCreatedInvite(null);
     setCreatedInviteCopied(false);
@@ -211,7 +248,7 @@ export function HostedFamilyManager(props: {
           addSeatIfNeeded: inviteWillAddSeat,
           targetEmail: email.trim() || undefined,
           targetLabel: label.trim() || undefined,
-          targetPhoneNumber: phone.trim() || undefined,
+          targetPhoneNumber: normalizedPhone ?? undefined,
           targetTelegramUsername: telegram.trim() || undefined,
         },
         url: "/api/settings/billing/family/invite",
@@ -516,7 +553,7 @@ export function HostedFamilyManager(props: {
                       Send this invite to {createdInvite.targetLabel ?? createdInvite.targetPhoneHint ?? "your family member"}.
                     </p>
                     <p className="mt-1 text-xs leading-5 text-[#736a58]">
-                      The contact info you added just makes sure the right person can accept it. Murph hasn&apos;t sent them anything.
+                      With a contact, only that person can use it. With no contact, whoever has the link can join. Murph hasn&apos;t sent them anything.
                     </p>
                   </div>
                 </div>
@@ -546,24 +583,16 @@ export function HostedFamilyManager(props: {
             <>
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="family-invite-label">Name (optional)</Label>
-                  <Input
-                    id="family-invite-label"
-                    value={label}
-                    onChange={(event) => setLabel(event.target.value)}
-                    placeholder="Mom"
-                    autoComplete="off"
-                  />
-                </div>
-                <div className="flex flex-col gap-1.5">
                   <Label htmlFor="family-invite-phone">Phone number (optional)</Label>
-                  <Input
+                  <PhoneNumberInput
                     id="family-invite-phone"
-                    value={phone}
-                    onChange={(event) => setPhone(event.target.value)}
-                    placeholder="+1 555 000 1234"
-                    inputMode="tel"
                     autoComplete="off"
+                    inputName="family-invite-phone"
+                    options={HOSTED_PHONE_COUNTRY_OPTIONS}
+                    selectedCountry={selectedPhoneCountry}
+                    value={phone}
+                    onCountryChange={setPhoneCountryCode}
+                    onPhoneNumberChange={setPhone}
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
@@ -588,8 +617,18 @@ export function HostedFamilyManager(props: {
                     autoComplete="off"
                   />
                 </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="family-invite-label">Name (optional)</Label>
+                  <Input
+                    id="family-invite-label"
+                    value={label}
+                    onChange={(event) => setLabel(event.target.value)}
+                    placeholder="Mom"
+                    autoComplete="off"
+                  />
+                </div>
                 <p className="text-xs leading-5 text-[#736a58]">
-                  This info just makes sure the right person can accept the invite. You&apos;ll send the link yourself.
+                  With a contact, only that person can use the invite. With no contact, anyone who has the link can join. You&apos;ll send the link yourself.
                 </p>
                 {inviteWillAddSeat ? (
                   <p

--- a/apps/web/src/components/ui/phone-number-input.tsx
+++ b/apps/web/src/components/ui/phone-number-input.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState, type ComponentProps } from "react";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
+import { buttonVariants } from "@/src/components/ui/button";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+} from "@/src/components/ui/combobox";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTrigger,
+} from "@/src/components/ui/drawer";
+import { Input } from "@/src/components/ui/input";
+import { useIsMobile } from "@/src/hooks/use-mobile";
+import { cn } from "@/src/lib/utils";
+
+export interface PhoneNumberCountryOption {
+  code: string;
+  dialCode: string;
+  label: string;
+  placeholder: string;
+}
+
+export function PhoneNumberInput({
+  autoComplete = "tel-national",
+  autoFocus = false,
+  className,
+  id,
+  inputClassName,
+  inputMode = "tel",
+  inputName = "phone-number",
+  inputSize = "xl",
+  options,
+  selectedCountry,
+  value,
+  onCountryChange,
+  onPhoneNumberChange,
+}: {
+  autoComplete?: string;
+  autoFocus?: boolean;
+  className?: string;
+  id: string;
+  inputClassName?: string;
+  inputMode?: "decimal" | "email" | "numeric" | "search" | "tel" | "text" | "url";
+  inputName?: string;
+  inputSize?: ComponentProps<typeof Input>["inputSize"];
+  options: PhoneNumberCountryOption[];
+  selectedCountry: PhoneNumberCountryOption;
+  value: string;
+  onCountryChange: (code: string) => void;
+  onPhoneNumberChange: (value: string) => void;
+}) {
+  return (
+    <div className={cn("flex gap-3", className)}>
+      <CountryCodePicker
+        options={options}
+        selectedCountry={selectedCountry}
+        onCountryChange={onCountryChange}
+      />
+      <Input
+        id={id}
+        autoFocus={autoFocus}
+        autoComplete={autoComplete}
+        inputMode={inputMode}
+        name={inputName}
+        placeholder={selectedCountry.placeholder}
+        inputSize={inputSize}
+        value={value}
+        onChange={(event) => onPhoneNumberChange(event.currentTarget.value)}
+        className={cn("flex-1", inputClassName)}
+      />
+    </div>
+  );
+}
+
+const COUNTRY_TRIGGER_CLASS = cn(
+  buttonVariants({ variant: "outline", size: "lg" }),
+  "h-14 w-auto shrink-0 justify-between rounded-2xl px-5 text-left text-base font-medium md:text-base sm:min-w-28",
+);
+
+function CountryCodePicker({
+  options,
+  selectedCountry,
+  onCountryChange,
+}: {
+  options: PhoneNumberCountryOption[];
+  selectedCountry: PhoneNumberCountryOption;
+  onCountryChange: (code: string) => void;
+}) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <CountryCodeDrawer
+        options={options}
+        selectedCountry={selectedCountry}
+        onCountryChange={onCountryChange}
+      />
+    );
+  }
+
+  return (
+    <Combobox
+      items={options}
+      value={selectedCountry}
+      itemToStringValue={(option) =>
+        `${option.label} ${option.dialCode} ${option.dialCode.replace("+", "")}`
+      }
+      onValueChange={(option) => {
+        if (option) {
+          onCountryChange(option.code);
+        }
+      }}
+    >
+      <ComboboxTrigger
+        aria-label={`Country or region, ${selectedCountry.label} ${selectedCountry.dialCode}`}
+        className={COUNTRY_TRIGGER_CLASS}
+      >
+        {selectedCountry.dialCode}
+      </ComboboxTrigger>
+      <ComboboxContent className="w-64">
+        <ComboboxInput placeholder="Search countries..." />
+        <ComboboxList>
+          {(option) => (
+            <ComboboxItem key={option.code} value={option}>
+              <span className="flex min-w-0 items-center justify-between gap-3">
+                <span>{option.label}</span>
+                <span className="text-xs text-muted-foreground">
+                  {option.dialCode}
+                </span>
+              </span>
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+function CountryCodeDrawer({
+  options,
+  selectedCountry,
+  onCountryChange,
+}: {
+  options: PhoneNumberCountryOption[];
+  selectedCountry: PhoneNumberCountryOption;
+  onCountryChange: (code: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const digits = search.replace(/[^0-9]/g, "");
+  const normalizedSearch = search.toLowerCase();
+  const filtered = search
+    ? options.filter(
+        (option) =>
+          option.label.toLowerCase().includes(normalizedSearch) ||
+          (digits.length > 0 && option.dialCode.replace("+", "").startsWith(digits)),
+      )
+    : options;
+
+  return (
+    <Drawer
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setSearch("");
+      }}
+    >
+      <DrawerTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Country or region, ${selectedCountry.label} ${selectedCountry.dialCode}`}
+          className={COUNTRY_TRIGGER_CLASS}
+        >
+          {selectedCountry.dialCode}
+          <ChevronDownIcon className="pointer-events-none size-4 text-stone-500" />
+        </button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <div className="flex flex-col pb-12">
+          <div className="sticky top-0 border-b border-border bg-popover px-4 py-3">
+            <input
+              autoFocus
+              type="text"
+              placeholder="Search countries..."
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="w-full rounded-xl border border-border bg-muted px-4 py-2.5 text-sm outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+          <div className="overflow-y-auto overscroll-contain">
+            {filtered.map((option) => (
+              <button
+                key={option.code}
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-3 px-5 py-3.5 text-left text-base transition-colors active:bg-muted",
+                  option.code === selectedCountry.code
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground",
+                )}
+                onClick={() => {
+                  onCountryChange(option.code);
+                  setOpen(false);
+                  setSearch("");
+                }}
+              >
+                <span className="flex-1">{option.label}</span>
+                <span className="text-xs text-muted-foreground">
+                  {option.dialCode}
+                </span>
+                {option.code === selectedCountry.code && (
+                  <CheckIcon className="size-4 shrink-0 text-foreground" />
+                )}
+              </button>
+            ))}
+            {filtered.length === 0 && (
+              <p className="px-5 py-8 text-center text-sm text-muted-foreground">
+                No countries found
+              </p>
+            )}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -9,7 +9,7 @@ import {
   type HostedExecutionAssistantNotificationRoute,
 } from "@murphai/hosted-execution";
 
-import { normalizeMurphTelegramUsername } from "../murph-contact-routing";
+import { buildMurphSmsHref, normalizeMurphTelegramUsername } from "../murph-contact-routing";
 import { appendHostedMailboxEnvelopeTx } from "../hosted-mailbox/store";
 import { getPrisma } from "../prisma";
 import {
@@ -82,7 +82,10 @@ import {
 } from "./member-activation";
 import { createHostedMember } from "./hosted-member-store";
 import { readHostedMemberStripeBillingRef } from "./hosted-member-billing-store";
-import { readHostedMemberIdentity } from "./hosted-member-identity-store";
+import {
+  lookupHostedMemberIdentityByPhoneLookupKey,
+  readHostedMemberIdentity,
+} from "./hosted-member-identity-store";
 import {
   readHostedMemberRoutingState,
   resolveHostedMemberRoutingByTelegramUserId,
@@ -330,6 +333,14 @@ export interface HostedFamilyInviteAcceptanceView {
   inviteCode: string;
   isEmailBound: boolean;
   isPhoneBound: boolean;
+  isTelegramBound: boolean;
+  /**
+   * The Murph line a phone-bound invitee already messages Murph on, when they
+   * are an existing member. The accept page prefers this so accepting by text
+   * lands in their existing thread instead of being redirected to their home
+   * line. Null for brand-new invitees (the page falls back to a configured line).
+   */
+  messagesRecipientPhone: string | null;
   seatAvailable: boolean;
   status: HostedAccountGroupInviteStatus;
   targetLabel: string | null;
@@ -597,6 +608,7 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
       targetEmailLookupKey: true,
       targetLabel: true,
       targetPhoneLookupKey: true,
+      targetTelegramUsernameLookupKey: true,
     },
     where: {
       inviteCode: input.inviteCode,
@@ -646,7 +658,19 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
   });
   const isPhoneBound = invite.targetPhoneLookupKey !== null;
   const isEmailBound = invite.targetEmailLookupKey !== null;
+  const isTelegramBound = invite.targetTelegramUsernameLookupKey !== null;
   const telegramBotUsername = readHostedOnboardingEnvironment().telegramBotUsername;
+
+  // A phone-bound invitee accepts by texting the family token to Murph; the
+  // LinQ webhook matches it against their phone. Resolve the line they already
+  // message Murph on (when they are an existing member) so acceptance lands in
+  // their existing thread rather than being redirected to their home line.
+  const messagesRecipientPhone = isPhoneBound && isPending
+    ? await resolveHostedFamilyInviteExistingHomeLinePhone({
+        phoneLookupKey: invite.targetPhoneLookupKey,
+        prisma,
+      })
+    : null;
 
   return {
     groupActive,
@@ -654,11 +678,16 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
     inviteCode: invite.inviteCode,
     isEmailBound,
     isPhoneBound,
+    isTelegramBound,
+    messagesRecipientPhone,
     seatAvailable,
     status,
     targetLabel: invite.targetLabel,
+    // Only route to Telegram when the invite is actually bound to a Telegram
+    // username. A bot username being configured does not mean the invitee uses
+    // Telegram, so it must never be the fallback channel.
     telegramInviteUrl:
-      telegramBotUsername && isPending
+      telegramBotUsername && isPending && isTelegramBound
         ? buildHostedFamilyTelegramInviteUrl({
             botUsername: telegramBotUsername,
             inviteCode: invite.inviteCode,
@@ -666,6 +695,33 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
         : null,
     webAcceptable: isPending && seatAvailable && groupActive && (isPhoneBound || isEmailBound),
   };
+}
+
+/**
+ * Resolves the Murph LinQ line a phone-bound invitee already messages on, when
+ * they are an existing member. Returns null for brand-new invitees, letting the
+ * accept page fall back to a configured line (the webhook assigns a home line
+ * on first contact for those).
+ */
+async function resolveHostedFamilyInviteExistingHomeLinePhone(input: {
+  phoneLookupKey: string | null;
+  prisma: HostedOnboardingReadClient;
+}): Promise<string | null> {
+  if (!input.phoneLookupKey) {
+    return null;
+  }
+  const identity = await lookupHostedMemberIdentityByPhoneLookupKey({
+    phoneLookupKey: input.phoneLookupKey,
+    prisma: input.prisma,
+  });
+  if (!identity) {
+    return null;
+  }
+  const routing = await readHostedMemberRoutingState({
+    memberId: identity.core.id,
+    prisma: input.prisma,
+  });
+  return normalizePhoneNumber(routing?.linqRecipientPhone ?? null);
 }
 
 export async function readHostedAccountGroupStripeBillingRef(input: {
@@ -3029,6 +3085,22 @@ export function buildHostedFamilyTelegramInviteUrl(input: {
   }
 
   return `https://t.me/${botUsername}?start=${encodeURIComponent(`family_${input.inviteCode}`)}`;
+}
+
+/**
+ * Builds the `sms:` deep link a phone-bound invitee taps to accept by text. The
+ * prefilled body is exactly the `family_<code>` token the LinQ webhook parses
+ * via {@link parseHostedFamilyInviteStartToken}, so the message the invitee
+ * sends is recognized and matched against their phone.
+ */
+export function buildHostedFamilyInviteMessagesHref(input: {
+  inviteCode: string;
+  murphPhoneNumber: string;
+}): string {
+  return buildMurphSmsHref({
+    body: `family_${input.inviteCode}`,
+    murphPhoneNumber: input.murphPhoneNumber,
+  });
 }
 
 export function buildHostedFamilyInviteAcceptUrl(input: {

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -2913,9 +2913,29 @@ export async function acceptHostedFamilyInviteTx(input: {
     });
   }
 
-  if (
+  const phoneBindingMatches = Boolean(
     invite.targetPhoneLookupKey &&
-    !hostedPhoneLookupKeyMatchesValue(input.phoneNumber, invite.targetPhoneLookupKey)
+    hostedPhoneLookupKeyMatchesValue(input.phoneNumber, invite.targetPhoneLookupKey),
+  );
+  const emailBindingMatches = Boolean(
+    invite.targetEmailLookupKey &&
+    hostedEmailLookupKeyMatchesValue(input.email, invite.targetEmailLookupKey),
+  );
+  const telegramUsernameWasPresented =
+    Object.prototype.hasOwnProperty.call(input, "telegramUsername");
+  const telegramBindingMatches = Boolean(
+    telegramUsernameWasPresented &&
+    invite.targetTelegramUsernameLookupKey &&
+    hostedTelegramUsernameLookupKeyMatchesValue(
+      input.telegramUsername,
+      invite.targetTelegramUsernameLookupKey,
+    ),
+  );
+
+  if (
+    normalizeNullableString(input.phoneNumber) &&
+    invite.targetPhoneLookupKey &&
+    !phoneBindingMatches
   ) {
     throw hostedOnboardingError({
       code: "HOSTED_FAMILY_INVITE_PHONE_MISMATCH",
@@ -2925,8 +2945,9 @@ export async function acceptHostedFamilyInviteTx(input: {
   }
 
   if (
+    normalizeNullableString(input.email) &&
     invite.targetEmailLookupKey &&
-    !hostedEmailLookupKeyMatchesValue(input.email, invite.targetEmailLookupKey)
+    !emailBindingMatches
   ) {
     throw hostedOnboardingError({
       code: "HOSTED_FAMILY_INVITE_EMAIL_MISMATCH",
@@ -2936,13 +2957,37 @@ export async function acceptHostedFamilyInviteTx(input: {
   }
 
   if (
-    Object.prototype.hasOwnProperty.call(input, "telegramUsername") &&
+    telegramUsernameWasPresented &&
     invite.targetTelegramUsernameLookupKey &&
-    !hostedTelegramUsernameLookupKeyMatchesValue(
-      input.telegramUsername,
-      invite.targetTelegramUsernameLookupKey,
-    )
+    !telegramBindingMatches
   ) {
+    throw hostedOnboardingError({
+      code: "HOSTED_FAMILY_INVITE_TELEGRAM_MISMATCH",
+      httpStatus: 403,
+      message: "This family invite was sent to a different Telegram username.",
+    });
+  }
+
+  if (
+    !isFullyUnbound &&
+    !phoneBindingMatches &&
+    !emailBindingMatches &&
+    !telegramBindingMatches
+  ) {
+    if (invite.targetPhoneLookupKey) {
+      throw hostedOnboardingError({
+        code: "HOSTED_FAMILY_INVITE_PHONE_MISMATCH",
+        httpStatus: 403,
+        message: "This family invite was sent to a different phone number.",
+      });
+    }
+    if (invite.targetEmailLookupKey) {
+      throw hostedOnboardingError({
+        code: "HOSTED_FAMILY_INVITE_EMAIL_MISMATCH",
+        httpStatus: 403,
+        message: "This family invite was sent to a different email address.",
+      });
+    }
     throw hostedOnboardingError({
       code: "HOSTED_FAMILY_INVITE_TELEGRAM_MISMATCH",
       httpStatus: 403,

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -83,7 +83,7 @@ import {
 import { createHostedMember } from "./hosted-member-store";
 import { readHostedMemberStripeBillingRef } from "./hosted-member-billing-store";
 import {
-  lookupHostedMemberIdentityByPhoneLookupKey,
+  lookupHostedMemberIdentityByPhoneNumber,
   readHostedMemberIdentity,
 } from "./hosted-member-identity-store";
 import {
@@ -545,12 +545,11 @@ export async function readHostedFamilyOwnerSnapshotForMember(input: {
         targetLabel: invite.targetLabel,
         targetPhoneHint: projected.targetPhoneHint,
         targetTelegramUsername: projected.targetTelegramUsername,
-        telegramInviteUrl: telegramBotUsername
-          ? buildHostedFamilyTelegramInviteUrl({
-              botUsername: telegramBotUsername,
-              inviteCode: invite.inviteCode,
-            })
-          : null,
+        telegramInviteUrl: resolveHostedFamilyTelegramInviteUrl({
+          inviteCode: invite.inviteCode,
+          isTelegramBound: projected.targetTelegramUsername !== null,
+          telegramBotUsername,
+        }),
       };
     }),
   );
@@ -608,6 +607,7 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
       targetEmailLookupKey: true,
       targetLabel: true,
       targetPhoneLookupKey: true,
+      targetPhoneNumberEncrypted: true,
       targetTelegramUsernameLookupKey: true,
     },
     where: {
@@ -667,8 +667,9 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
   // their existing thread rather than being redirected to their home line.
   const messagesRecipientPhone = isPhoneBound && isPending
     ? await resolveHostedFamilyInviteExistingHomeLinePhone({
-        phoneLookupKey: invite.targetPhoneLookupKey,
+        ownerMemberId: invite.group.ownerMemberId,
         prisma,
+        targetPhoneNumberEncrypted: invite.targetPhoneNumberEncrypted,
       })
     : null;
 
@@ -683,45 +684,61 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
     seatAvailable,
     status,
     targetLabel: invite.targetLabel,
-    // Only route to Telegram when the invite is actually bound to a Telegram
-    // username. A bot username being configured does not mean the invitee uses
-    // Telegram, so it must never be the fallback channel.
-    telegramInviteUrl:
-      telegramBotUsername && isPending && isTelegramBound
-        ? buildHostedFamilyTelegramInviteUrl({
-            botUsername: telegramBotUsername,
-            inviteCode: invite.inviteCode,
-          })
-        : null,
+    telegramInviteUrl: isPending
+      ? resolveHostedFamilyTelegramInviteUrl({
+          inviteCode: invite.inviteCode,
+          isTelegramBound,
+          telegramBotUsername,
+        })
+      : null,
     webAcceptable: isPending && seatAvailable && groupActive && (isPhoneBound || isEmailBound),
   };
 }
 
 /**
  * Resolves the Murph LinQ line a phone-bound invitee already messages on, when
- * they are an existing member. Returns null for brand-new invitees, letting the
- * accept page fall back to a configured line (the webhook assigns a home line
- * on first contact for those).
+ * they are an existing member, so accepting by text lands in their existing
+ * thread instead of being redirected to their home line. Returns null for
+ * brand-new invitees (the accept page falls back to a configured line and the
+ * webhook assigns a home line on first contact).
+ *
+ * It resolves the member by the decrypted phone via version-tolerant read
+ * candidates, the same authority `acceptHostedFamilyInviteFromPhoneTx` uses.
+ * Matching on the invite's single stored lookup key would miss an existing
+ * member after a contact key-version rotation and silently point them at the
+ * wrong line. Best-effort: any failure falls back to null so a resolution error
+ * degrades to a configured line rather than failing the accept page.
  */
 async function resolveHostedFamilyInviteExistingHomeLinePhone(input: {
-  phoneLookupKey: string | null;
+  ownerMemberId: string;
   prisma: HostedOnboardingReadClient;
+  targetPhoneNumberEncrypted: string | null;
 }): Promise<string | null> {
-  if (!input.phoneLookupKey) {
+  try {
+    const phoneNumber = await decryptHostedWebNullableString({
+      field: HOSTED_ACCOUNT_GROUP_INVITE_TARGET_PHONE_FIELD,
+      memberId: input.ownerMemberId,
+      prisma: input.prisma,
+      value: input.targetPhoneNumberEncrypted,
+    });
+    if (!phoneNumber) {
+      return null;
+    }
+    const identity = await lookupHostedMemberIdentityByPhoneNumber({
+      phoneNumber,
+      prisma: input.prisma,
+    });
+    if (!identity) {
+      return null;
+    }
+    const routing = await readHostedMemberRoutingState({
+      memberId: identity.core.id,
+      prisma: input.prisma,
+    });
+    return normalizePhoneNumber(routing?.linqRecipientPhone ?? null);
+  } catch {
     return null;
   }
-  const identity = await lookupHostedMemberIdentityByPhoneLookupKey({
-    phoneLookupKey: input.phoneLookupKey,
-    prisma: input.prisma,
-  });
-  if (!identity) {
-    return null;
-  }
-  const routing = await readHostedMemberRoutingState({
-    memberId: identity.core.id,
-    prisma: input.prisma,
-  });
-  return normalizePhoneNumber(routing?.linqRecipientPhone ?? null);
 }
 
 export async function readHostedAccountGroupStripeBillingRef(input: {
@@ -3085,6 +3102,28 @@ export function buildHostedFamilyTelegramInviteUrl(input: {
   }
 
   return `https://t.me/${botUsername}?start=${encodeURIComponent(`family_${input.inviteCode}`)}`;
+}
+
+/**
+ * A family invite routes to Telegram only when it is actually bound to a
+ * Telegram username. A configured bot username alone must never turn a phone-
+ * or email-only invite into a Telegram link on any surface (accept page, owner
+ * snapshot, invite API response, assistant tool). This is the single gate every
+ * projection uses so the "Telegram only when Telegram-bound" rule stays
+ * consistent across surfaces.
+ */
+export function resolveHostedFamilyTelegramInviteUrl(input: {
+  inviteCode: string;
+  isTelegramBound: boolean;
+  telegramBotUsername: string | null | undefined;
+}): string | null {
+  if (!input.telegramBotUsername || !input.isTelegramBound) {
+    return null;
+  }
+  return buildHostedFamilyTelegramInviteUrl({
+    botUsername: input.telegramBotUsername,
+    inviteCode: input.inviteCode,
+  });
 }
 
 /**

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -348,6 +348,16 @@ export interface HostedFamilyInviteAcceptanceView {
   webAcceptable: boolean;
 }
 
+function hostedFamilyInviteIsFullyUnbound(input: {
+  targetEmailLookupKey: string | null;
+  targetPhoneLookupKey: string | null;
+  targetTelegramUsernameLookupKey: string | null;
+}): boolean {
+  return !input.targetEmailLookupKey &&
+    !input.targetPhoneLookupKey &&
+    !input.targetTelegramUsernameLookupKey;
+}
+
 type HostedFamilyBillingCheckoutInput =
   | {
       alreadyActive: true;
@@ -659,6 +669,7 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
   const isPhoneBound = invite.targetPhoneLookupKey !== null;
   const isEmailBound = invite.targetEmailLookupKey !== null;
   const isTelegramBound = invite.targetTelegramUsernameLookupKey !== null;
+  const isFullyUnbound = hostedFamilyInviteIsFullyUnbound(invite);
   const telegramBotUsername = readHostedOnboardingEnvironment().telegramBotUsername;
 
   // A phone-bound invitee accepts by texting the family token to Murph; the
@@ -687,11 +698,14 @@ export async function readHostedFamilyInviteAcceptanceView(input: {
     telegramInviteUrl: isPending
       ? resolveHostedFamilyTelegramInviteUrl({
           inviteCode: invite.inviteCode,
-          isTelegramBound,
+          isTelegramBound: isTelegramBound || isFullyUnbound,
           telegramBotUsername,
         })
       : null,
-    webAcceptable: isPending && seatAvailable && groupActive && (isPhoneBound || isEmailBound),
+    webAcceptable: isPending &&
+      seatAvailable &&
+      groupActive &&
+      (isPhoneBound || isEmailBound || isFullyUnbound),
   };
 }
 
@@ -2570,9 +2584,31 @@ export function parseHostedFamilyInviteStartToken(text: string | null | undefine
 
   const token = normalized.match(/^\/?start\s+(family_[A-Za-z0-9_-]+)$/u)?.[1]
     ?? normalized.match(/^(family_[A-Za-z0-9_-]+)$/u)?.[1]
+    ?? normalized.match(/(?:^|[^A-Za-z0-9_-])(family_[A-Za-z0-9_-]+)(?=$|[^A-Za-z0-9_-])/u)?.[1]
     ?? null;
 
   return token ? token.slice("family_".length) : null;
+}
+
+export async function resolveHostedFamilyInviteTokenForInbound(input: {
+  prisma: HostedOnboardingReadClient;
+  text: string | null | undefined;
+}): Promise<string | null> {
+  const inviteCode = parseHostedFamilyInviteStartToken(input.text);
+  if (!inviteCode) {
+    return null;
+  }
+
+  const invite = await input.prisma.hostedAccountGroupInvite.findUnique({
+    select: {
+      id: true,
+    },
+    where: {
+      inviteCode,
+    },
+  });
+
+  return invite ? inviteCode : null;
 }
 
 export async function acceptHostedFamilyInviteFromTelegramTx(input: {
@@ -2761,7 +2797,9 @@ export async function acceptHostedFamilyInviteFromPhoneTx(input: {
     select: {
       expiresAt: true,
       status: true,
+      targetEmailLookupKey: true,
       targetPhoneLookupKey: true,
+      targetTelegramUsernameLookupKey: true,
     },
     where: {
       inviteCode,
@@ -2770,7 +2808,8 @@ export async function acceptHostedFamilyInviteFromPhoneTx(input: {
   if (!invite) {
     return null;
   }
-  if (!invite.targetPhoneLookupKey) {
+  const isFullyUnbound = hostedFamilyInviteIsFullyUnbound(invite);
+  if (!invite.targetPhoneLookupKey && !isFullyUnbound) {
     return null;
   }
   if (
@@ -2779,7 +2818,10 @@ export async function acceptHostedFamilyInviteFromPhoneTx(input: {
   ) {
     return null;
   }
-  if (!hostedPhoneLookupKeyMatchesValue(input.phoneNumber, invite.targetPhoneLookupKey)) {
+  if (
+    invite.targetPhoneLookupKey &&
+    !hostedPhoneLookupKeyMatchesValue(input.phoneNumber, invite.targetPhoneLookupKey)
+  ) {
     throw hostedOnboardingError({
       code: "HOSTED_FAMILY_INVITE_PHONE_MISMATCH",
       httpStatus: 403,
@@ -2799,7 +2841,7 @@ export async function acceptHostedFamilyInviteFromPhoneTx(input: {
     now,
     onAcceptedMemberValidated: input.onAcceptedMemberValidated,
     phoneNumber: input.phoneNumber,
-    requirePhoneBinding: true,
+    requirePhoneBinding: !isFullyUnbound,
     tx: input.tx,
   });
 }
@@ -2835,8 +2877,11 @@ export async function acceptHostedFamilyInviteTx(input: {
     });
   }
 
+  const isFullyUnbound = hostedFamilyInviteIsFullyUnbound(invite);
+
   if (
     input.requireWebBinding &&
+    invite.targetTelegramUsernameLookupKey &&
     !invite.targetPhoneLookupKey &&
     !invite.targetEmailLookupKey
   ) {
@@ -2844,6 +2889,19 @@ export async function acceptHostedFamilyInviteTx(input: {
       code: "HOSTED_FAMILY_WEB_ACCEPT_REQUIRES_CONTACT",
       httpStatus: 409,
       message: "Open this invite from Telegram or WhatsApp to join.",
+    });
+  }
+
+  if (
+    input.requireWebBinding &&
+    isFullyUnbound &&
+    !normalizePhoneNumber(input.phoneNumber) &&
+    !normalizeHostedEmailAddress(input.email)
+  ) {
+    throw hostedOnboardingError({
+      code: "HOSTED_FAMILY_WEB_ACCEPT_REQUIRES_CONTACT",
+      httpStatus: 409,
+      message: "Sign in with a verified phone number or email address to join.",
     });
   }
 
@@ -3003,7 +3061,36 @@ export async function acceptHostedFamilyInviteTx(input: {
     });
   }
 
+  if (isFullyUnbound) {
+    await notifyHostedFamilyOwnerOfUnboundInviteClaimTx({
+      acceptedMemberId: input.acceptedMemberId,
+      invite,
+      now,
+      tx: input.tx,
+    });
+  }
+
   return membership;
+}
+
+async function notifyHostedFamilyOwnerOfUnboundInviteClaimTx(input: {
+  acceptedMemberId: string;
+  invite: HostedAccountGroupInviteSnapshot;
+  now: Date;
+  tx: Prisma.TransactionClient;
+}): Promise<void> {
+  const route = await resolveHostedFamilyChatNotificationRouteTx({
+    memberId: input.invite.group.ownerMemberId,
+    tx: input.tx,
+  });
+  await appendHostedFamilyChatNotificationTx({
+    memberId: input.invite.group.ownerMemberId,
+    message: `${input.invite.targetLabel ?? "Someone"} just joined your family plan.`,
+    occurredAt: input.now.toISOString(),
+    route,
+    sourceEventId: `family-invite-claim:${input.invite.id}:${input.acceptedMemberId}`,
+    tx: input.tx,
+  });
 }
 
 export async function removeHostedFamilyMemberTx(input: {
@@ -3105,12 +3192,9 @@ export function buildHostedFamilyTelegramInviteUrl(input: {
 }
 
 /**
- * A family invite routes to Telegram only when it is actually bound to a
- * Telegram username. A configured bot username alone must never turn a phone-
- * or email-only invite into a Telegram link on any surface (accept page, owner
- * snapshot, invite API response, assistant tool). This is the single gate every
- * projection uses so the "Telegram only when Telegram-bound" rule stays
- * consistent across surfaces.
+ * Resolves a Telegram claim URL for surfaces that are allowed to offer
+ * Telegram. Owner snapshot/API projections pass true only for Telegram-bound
+ * invites; the public accept view may also pass true for fully unbound invites.
  */
 export function resolveHostedFamilyTelegramInviteUrl(input: {
   inviteCode: string;
@@ -3127,17 +3211,16 @@ export function resolveHostedFamilyTelegramInviteUrl(input: {
 }
 
 /**
- * Builds the `sms:` deep link a phone-bound invitee taps to accept by text. The
- * prefilled body is exactly the `family_<code>` token the LinQ webhook parses
- * via {@link parseHostedFamilyInviteStartToken}, so the message the invitee
- * sends is recognized and matched against their phone.
+ * Builds the `sms:` deep link a phone-bound or unbound invitee taps to accept
+ * by text. The prefilled body contains the `family_<code>` token the LinQ
+ * webhook parses via {@link parseHostedFamilyInviteStartToken}.
  */
 export function buildHostedFamilyInviteMessagesHref(input: {
   inviteCode: string;
   murphPhoneNumber: string;
 }): string {
   return buildMurphSmsHref({
-    body: `family_${input.inviteCode}`,
+    body: `Hi Murph, joining the family plan (code family_${input.inviteCode})`,
     murphPhoneNumber: input.murphPhoneNumber,
   });
 }
@@ -3207,7 +3290,16 @@ export function buildHostedFamilyInviteReplyText(input: {
       })}`,
     );
   } else if (input.invite.targetLabel) {
-    lines.push(`Telegram invite token: ${inviteToken}`);
+    const acceptUrl = buildHostedFamilyInviteAcceptUrl({
+      inviteCode: input.invite.inviteCode,
+      publicBaseUrl: input.publicBaseUrl ?? null,
+    });
+    if (acceptUrl) {
+      lines.push(`Forward this Family invite link to ${targetLabel}: ${acceptUrl}`);
+      lines.push("Whoever opens it can join, so it is best sent directly to them.");
+    } else {
+      lines.push(`Family invite token: ${inviteToken}`);
+    }
   }
 
   lines.push(

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -3155,7 +3155,12 @@ export function buildHostedFamilyInviteAcceptUrl(input: {
 
 export function buildHostedFamilyInviteReplyText(input: {
   invite: Pick<HostedAccountGroupInvitePrivateSnapshot,
-    "inviteCode" | "targetEmail" | "targetLabel" | "targetPhoneHint" | "targetPhoneNumber"
+    | "inviteCode"
+    | "targetEmail"
+    | "targetLabel"
+    | "targetPhoneHint"
+    | "targetPhoneNumber"
+    | "targetTelegramUsername"
   >;
   publicBaseUrl?: string | null;
   telegramBotUsername?: string | null;
@@ -3168,12 +3173,21 @@ export function buildHostedFamilyInviteReplyText(input: {
   const telegramBotUsername = normalizeMurphTelegramUsername(input.telegramBotUsername);
 
   if (input.invite.targetPhoneNumber) {
-    lines.push(
-      `Invite token for ${input.invite.targetPhoneHint ?? "their phone"}: ${inviteToken}`,
-    );
-    lines.push(
-      "They need to send this token to Murph from that phone number, for example on WhatsApp.",
-    );
+    const acceptUrl = buildHostedFamilyInviteAcceptUrl({
+      inviteCode: input.invite.inviteCode,
+      publicBaseUrl: input.publicBaseUrl ?? null,
+    });
+    if (acceptUrl) {
+      lines.push(`Forward this Family invite link to ${targetLabel}: ${acceptUrl}`);
+      lines.push("When they open it they can join by text right from their phone.");
+    } else {
+      lines.push(
+        `Invite token for ${input.invite.targetPhoneHint ?? "their phone"}: ${inviteToken}`,
+      );
+      lines.push(
+        "They need to send this token to Murph from that phone number, for example on WhatsApp.",
+      );
+    }
   } else if (input.invite.targetEmail) {
     const acceptUrl = buildHostedFamilyInviteAcceptUrl({
       inviteCode: input.invite.inviteCode,
@@ -3185,7 +3199,7 @@ export function buildHostedFamilyInviteReplyText(input: {
     } else {
       lines.push(`Family invite code for ${input.invite.targetEmail}: ${inviteToken}`);
     }
-  } else if (telegramBotUsername) {
+  } else if (telegramBotUsername && input.invite.targetTelegramUsername !== null) {
     lines.push(
       `Forward this Telegram invite link to ${targetLabel}: ${buildHostedFamilyTelegramInviteUrl({
         botUsername: telegramBotUsername,

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -19,7 +19,7 @@ import {
 import {
   acceptHostedFamilyInviteFromPhoneTx,
   buildHostedFamilyInviteAcceptedReplyText,
-  parseHostedFamilyInviteStartToken,
+  resolveHostedFamilyInviteTokenForInbound,
 } from "./family-plan";
 import {
   ensureHostedMemberForPendingLinqParticipantContactTx,
@@ -438,7 +438,10 @@ export async function planHostedOnboardingLinqWebhook(input: {
     );
   };
 
-  const familyInviteTokenPresent = parseHostedFamilyInviteStartToken(summary.text) !== null;
+  const familyInviteTokenPresent = await resolveHostedFamilyInviteTokenForInbound({
+    prisma: input.prisma,
+    text: summary.text,
+  }) !== null;
   let familyAcceptance: Awaited<ReturnType<typeof acceptHostedFamilyInviteFromPhoneTx>> = null;
   let familyHomeLineAssignedAt: Date | null = null;
   let familyHomeRecipientPhone: string | null = recipientPhoneNumber;

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-telegram.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-telegram.ts
@@ -12,7 +12,7 @@ import {
   appendHostedFamilyChatNotificationTx,
   buildHostedFamilyInviteAcceptedReplyText,
   acceptHostedFamilyInviteFromTelegramTx,
-  parseHostedFamilyInviteStartToken,
+  resolveHostedFamilyInviteTokenForInbound,
   resolveHostedFamilyChatNotificationRouteTx,
 } from "./family-plan";
 import { readActiveHostedMemberAccess } from "./member-access";
@@ -61,9 +61,10 @@ export async function planHostedOnboardingTelegramWebhook(input: {
   }
 
   const telegramMessage = buildHostedTelegramMessagePayload(input.update);
-  const familyInviteTokenPresent = parseHostedFamilyInviteStartToken(
-    telegramMessage?.text ?? null,
-  ) !== null;
+  const familyInviteTokenPresent = await resolveHostedFamilyInviteTokenForInbound({
+    prisma: input.prisma,
+    text: telegramMessage?.text ?? null,
+  }) !== null;
   let familyInviteNotAccepted = false;
   let familyAcceptance: Awaited<ReturnType<typeof acceptHostedFamilyInviteFromTelegramTx>> = null;
   try {

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-whatsapp.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-whatsapp.ts
@@ -26,7 +26,7 @@ import {
   appendHostedFamilyChatNotificationTx,
   buildHostedFamilyInviteAcceptedReplyText,
   acceptHostedFamilyInviteFromPhoneTx,
-  parseHostedFamilyInviteStartToken,
+  resolveHostedFamilyInviteTokenForInbound,
 } from "./family-plan";
 import { readActiveHostedMemberAccess } from "./member-access";
 import { normalizePhoneNumber } from "./phone";
@@ -155,7 +155,10 @@ async function planHostedOnboardingWhatsAppInboundText(input: {
     return buildWhatsAppInboundTextNoWakePlan("invalid-whatsapp-sender");
   }
 
-  const familyInviteTokenPresent = parseHostedFamilyInviteStartToken(input.inboundText.text) !== null;
+  const familyInviteTokenPresent = await resolveHostedFamilyInviteTokenForInbound({
+    prisma: input.prisma,
+    text: input.inboundText.text,
+  }) !== null;
   let familyAcceptance: Awaited<ReturnType<typeof acceptHostedFamilyInviteFromPhoneTx>> = null;
   try {
     familyAcceptance = await acceptHostedFamilyInviteFromPhoneTx({

--- a/apps/web/test/family-accept-page.test.ts
+++ b/apps/web/test/family-accept-page.test.ts
@@ -117,6 +117,24 @@ test("renders the web accept path for authenticated email-bound invites", async 
   expect(markup).not.toContain("Continue in Messages");
 });
 
+test("keeps Telegram available for authenticated unbound invites without Messages", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue({
+    ...BASE_VIEW,
+    inviteCode: "CODETGWEB",
+    telegramInviteUrl: "https://t.me/withmurph_bot?start=family_CODETGWEB",
+    webAcceptable: true,
+  });
+  mocks.getHostedPageAuthSnapshot.mockResolvedValueOnce({ authenticated: true });
+
+  const markup = await renderFamilyAcceptPage("CODETGWEB");
+
+  expect(mocks.webAcceptButtonProps).toEqual({ inviteCode: "CODETGWEB" });
+  expect(markup).toContain("Accept invite");
+  expect(markup).toContain("Continue in Telegram");
+  expect(markup).toContain("https://t.me/withmurph_bot?start=family_CODETGWEB");
+  expect(markup).not.toContain("Continue in Messages");
+});
+
 test("leads phone-bound invites with the Messages accept path, not Telegram", async () => {
   mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue(PHONE_BOUND_VIEW);
 

--- a/apps/web/test/family-accept-page.test.ts
+++ b/apps/web/test/family-accept-page.test.ts
@@ -4,17 +4,22 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getHostedPageAuthSnapshot: vi.fn(),
+  readConfiguredMurphPhoneNumbers: vi.fn<() => string[]>(),
   readHostedFamilyInviteAcceptanceView: vi.fn(),
-  signInButtonProps: null as { bindingLabel: string } | null,
+  signInButtonProps: null as { bindingLabel: string; variant?: string } | null,
   signInButtonRendered: false,
   webAcceptButtonProps: null as { inviteCode: string } | null,
 }));
 
 vi.mock("@/src/components/family/family-invite-accept-client", () => ({
-  FamilyInviteSignInButton(props: { bindingLabel: string }) {
+  FamilyInviteSignInButton(props: { bindingLabel: string; variant?: string }) {
     mocks.signInButtonProps = props;
     mocks.signInButtonRendered = true;
-    return createElement("button", { "data-family-sign-in": "true" }, "Sign in to join");
+    return createElement(
+      "button",
+      { "data-family-sign-in": props.variant ?? "primary" },
+      props.variant === "link" ? "Sign in on the web instead" : "Sign in to join",
+    );
   },
   FamilyInviteWebAcceptButton(props: { inviteCode: string }) {
     mocks.webAcceptButtonProps = props;
@@ -27,6 +32,10 @@ vi.mock("@/src/components/family/family-invite-accept-client", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/family-plan", () => ({
+  buildHostedFamilyInviteMessagesHref: (input: {
+    inviteCode: string;
+    murphPhoneNumber: string;
+  }) => `sms:${input.murphPhoneNumber}?body=family_${input.inviteCode}`,
   readHostedFamilyInviteAcceptanceView: mocks.readHostedFamilyInviteAcceptanceView,
 }));
 
@@ -34,16 +43,37 @@ vi.mock("@/src/lib/hosted-onboarding/page-auth", () => ({
   getHostedPageAuthSnapshot: mocks.getHostedPageAuthSnapshot,
 }));
 
-const EMAIL_BOUND_VIEW = {
+vi.mock("@/src/lib/device-sync/messaging-return-destination", () => ({
+  readConfiguredMurphPhoneNumbers: mocks.readConfiguredMurphPhoneNumbers,
+}));
+
+const BASE_VIEW = {
   groupActive: true,
   groupDisplayName: "Kim Family",
-  inviteCode: "CODEMAIL",
-  isEmailBound: true,
+  inviteCode: "CODE",
+  isEmailBound: false,
   isPhoneBound: false,
+  isTelegramBound: false,
+  messagesRecipientPhone: null,
   seatAvailable: true,
   status: "pending",
   targetLabel: "Pat",
-  telegramInviteUrl: "https://t.me/withmurph_bot?start=family_CODEMAIL",
+  telegramInviteUrl: null,
+  webAcceptable: false,
+};
+
+const EMAIL_BOUND_VIEW = {
+  ...BASE_VIEW,
+  inviteCode: "CODEMAIL",
+  isEmailBound: true,
+  webAcceptable: true,
+};
+
+const PHONE_BOUND_VIEW = {
+  ...BASE_VIEW,
+  inviteCode: "CODEPHONE",
+  isPhoneBound: true,
+  messagesRecipientPhone: "+15551230000",
   webAcceptable: true,
 };
 
@@ -52,38 +82,109 @@ beforeEach(() => {
   mocks.signInButtonProps = null;
   mocks.signInButtonRendered = false;
   mocks.webAcceptButtonProps = null;
+  mocks.readConfiguredMurphPhoneNumbers.mockReturnValue([]);
   mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue(EMAIL_BOUND_VIEW);
   mocks.getHostedPageAuthSnapshot.mockResolvedValue({ authenticated: false });
 });
 
 test("renders the web sign-in path for unauthenticated email-bound invites", async () => {
-  const markup = await renderFamilyAcceptPage();
+  const markup = await renderFamilyAcceptPage("CODEMAIL");
 
   expect(mocks.signInButtonRendered).toBe(true);
   expect(mocks.signInButtonProps).toEqual({ bindingLabel: "email address" });
   expect(markup).toContain("Sign in to join");
   expect(markup).toContain("Sign in with the email address this invite was sent to");
   expect(markup).not.toContain("Continue in Telegram");
-  expect(markup).not.toContain("Open this in Telegram");
+  expect(markup).not.toContain("Continue in Messages");
 });
 
 test("renders the web accept path for authenticated email-bound invites", async () => {
   mocks.getHostedPageAuthSnapshot.mockResolvedValueOnce({ authenticated: true });
 
-  const markup = await renderFamilyAcceptPage();
+  const markup = await renderFamilyAcceptPage("CODEMAIL");
 
   expect(mocks.webAcceptButtonProps).toEqual({ inviteCode: "CODEMAIL" });
   expect(markup).toContain("Accept invite");
   expect(markup).not.toContain("Continue in Telegram");
-  expect(markup).not.toContain("Open this in Telegram");
+  expect(markup).not.toContain("Continue in Messages");
 });
 
-async function renderFamilyAcceptPage(): Promise<string> {
+test("leads phone-bound invites with the Messages accept path, not Telegram", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue(PHONE_BOUND_VIEW);
+
+  const markup = await renderFamilyAcceptPage("CODEPHONE");
+
+  expect(markup).toContain("Continue in Messages");
+  expect(markup).toContain("sms:+15551230000?body=family_CODEPHONE");
+  expect(markup).toContain("This opens a text to Murph");
+  // The web sign-in is offered only as a compact secondary option.
+  expect(mocks.signInButtonProps).toEqual({
+    bindingLabel: "phone number",
+    variant: "link",
+  });
+  expect(markup).not.toContain("Continue in Telegram");
+});
+
+test("falls back to a configured Murph line for a brand-new phone invitee", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue({
+    ...PHONE_BOUND_VIEW,
+    messagesRecipientPhone: null,
+  });
+  mocks.readConfiguredMurphPhoneNumbers.mockReturnValue(["+15559990000"]);
+
+  const markup = await renderFamilyAcceptPage("CODEPHONE");
+
+  expect(markup).toContain("sms:+15559990000?body=family_CODEPHONE");
+  expect(markup).toContain("Continue in Messages");
+});
+
+test("uses the one-tap web accept path for authenticated phone-bound invites", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue(PHONE_BOUND_VIEW);
+  mocks.getHostedPageAuthSnapshot.mockResolvedValueOnce({ authenticated: true });
+
+  const markup = await renderFamilyAcceptPage("CODEPHONE");
+
+  expect(mocks.webAcceptButtonProps).toEqual({ inviteCode: "CODEPHONE" });
+  expect(markup).toContain("Accept invite");
+  expect(markup).not.toContain("Continue in Messages");
+});
+
+test("continues in Telegram only for Telegram-bound invites", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue({
+    ...BASE_VIEW,
+    inviteCode: "CODETG",
+    isTelegramBound: true,
+    telegramInviteUrl: "https://t.me/withmurph_bot?start=family_CODETG",
+  });
+
+  const markup = await renderFamilyAcceptPage("CODETG");
+
+  expect(markup).toContain("Continue in Telegram");
+  expect(markup).toContain("https://t.me/withmurph_bot?start=family_CODETG");
+  expect(markup).not.toContain("Continue in Messages");
+  expect(mocks.signInButtonRendered).toBe(false);
+});
+
+test("shows a channel-neutral fallback for a label-only invite", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue({
+    ...BASE_VIEW,
+    inviteCode: "CODELABEL",
+  });
+
+  const markup = await renderFamilyAcceptPage("CODELABEL");
+
+  expect(markup).toContain("Open this invite from the chat where you received it");
+  expect(markup).not.toContain("Continue in Telegram");
+  expect(markup).not.toContain("Continue in Messages");
+  expect(mocks.signInButtonRendered).toBe(false);
+});
+
+async function renderFamilyAcceptPage(inviteCode: string): Promise<string> {
   const { default: FamilyAcceptPage } = await import("../app/family/accept/[inviteCode]/page");
 
   return renderToStaticMarkup(
     await FamilyAcceptPage({
-      params: Promise.resolve({ inviteCode: "CODEMAIL" }),
+      params: Promise.resolve({ inviteCode }),
     }),
   );
 }

--- a/apps/web/test/family-accept-page.test.ts
+++ b/apps/web/test/family-accept-page.test.ts
@@ -209,6 +209,26 @@ test("shows Messages, web sign-in, and Telegram options for a label-only invite"
   expect(markup).not.toContain("Open this invite from the chat where you received it");
 });
 
+test("shows web sign-in and Telegram for an unbound invite without a Messages line", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue({
+    ...BASE_VIEW,
+    inviteCode: "CODEUNBOUND",
+    telegramInviteUrl: "https://t.me/withmurph_bot?start=family_CODEUNBOUND",
+    webAcceptable: true,
+  });
+
+  const markup = await renderFamilyAcceptPage("CODEUNBOUND");
+
+  expect(markup).toContain("Sign in to join");
+  expect(markup).toContain("Continue in Telegram");
+  expect(markup).toContain("https://t.me/withmurph_bot?start=family_CODEUNBOUND");
+  expect(markup).not.toContain("Continue in Messages");
+  expect(mocks.signInButtonProps).toEqual({
+    bindingLabel: "your phone number or email address",
+    description: "Sign in with your own phone number or email address. We'll bring you back here.",
+  });
+});
+
 async function renderFamilyAcceptPage(inviteCode: string): Promise<string> {
   const { default: FamilyAcceptPage } = await import("../app/family/accept/[inviteCode]/page");
 

--- a/apps/web/test/family-accept-page.test.ts
+++ b/apps/web/test/family-accept-page.test.ts
@@ -146,7 +146,11 @@ test("uses the one-tap web accept path for authenticated phone-bound invites", a
 
   expect(mocks.webAcceptButtonProps).toEqual({ inviteCode: "CODEPHONE" });
   expect(markup).toContain("Accept invite");
-  expect(markup).not.toContain("Continue in Messages");
+  expect(markup).toContain("Continue in Messages");
+  expect(markup).toContain("sms:+15551230000?body=family_CODEPHONE");
+  expect(markup).toContain(
+    "Joining by text works from the phone this invite was sent to.",
+  );
 });
 
 test("continues in Telegram only for Telegram-bound invites", async () => {

--- a/apps/web/test/family-accept-page.test.ts
+++ b/apps/web/test/family-accept-page.test.ts
@@ -6,13 +6,21 @@ const mocks = vi.hoisted(() => ({
   getHostedPageAuthSnapshot: vi.fn(),
   readConfiguredMurphPhoneNumbers: vi.fn<() => string[]>(),
   readHostedFamilyInviteAcceptanceView: vi.fn(),
-  signInButtonProps: null as { bindingLabel: string; variant?: string } | null,
+  signInButtonProps: null as {
+    bindingLabel: string;
+    description?: string;
+    variant?: string;
+  } | null,
   signInButtonRendered: false,
   webAcceptButtonProps: null as { inviteCode: string } | null,
 }));
 
 vi.mock("@/src/components/family/family-invite-accept-client", () => ({
-  FamilyInviteSignInButton(props: { bindingLabel: string; variant?: string }) {
+  FamilyInviteSignInButton(props: {
+    bindingLabel: string;
+    description?: string;
+    variant?: string;
+  }) {
     mocks.signInButtonProps = props;
     mocks.signInButtonRendered = true;
     return createElement(
@@ -35,7 +43,7 @@ vi.mock("@/src/lib/hosted-onboarding/family-plan", () => ({
   buildHostedFamilyInviteMessagesHref: (input: {
     inviteCode: string;
     murphPhoneNumber: string;
-  }) => `sms:${input.murphPhoneNumber}?body=family_${input.inviteCode}`,
+  }) => `sms:${input.murphPhoneNumber}?body=Hi%20Murph%2C%20joining%20the%20family%20plan%20(code%20family_${input.inviteCode})`,
   readHostedFamilyInviteAcceptanceView: mocks.readHostedFamilyInviteAcceptanceView,
 }));
 
@@ -115,7 +123,9 @@ test("leads phone-bound invites with the Messages accept path, not Telegram", as
   const markup = await renderFamilyAcceptPage("CODEPHONE");
 
   expect(markup).toContain("Continue in Messages");
-  expect(markup).toContain("sms:+15551230000?body=family_CODEPHONE");
+  expect(markup).toContain(
+    "sms:+15551230000?body=Hi%20Murph%2C%20joining%20the%20family%20plan%20(code%20family_CODEPHONE)",
+  );
   expect(markup).toContain("This opens a text to Murph");
   // The web sign-in is offered only as a compact secondary option.
   expect(mocks.signInButtonProps).toEqual({
@@ -134,7 +144,9 @@ test("falls back to a configured Murph line for a brand-new phone invitee", asyn
 
   const markup = await renderFamilyAcceptPage("CODEPHONE");
 
-  expect(markup).toContain("sms:+15559990000?body=family_CODEPHONE");
+  expect(markup).toContain(
+    "sms:+15559990000?body=Hi%20Murph%2C%20joining%20the%20family%20plan%20(code%20family_CODEPHONE)",
+  );
   expect(markup).toContain("Continue in Messages");
 });
 
@@ -147,7 +159,9 @@ test("uses the one-tap web accept path for authenticated phone-bound invites", a
   expect(mocks.webAcceptButtonProps).toEqual({ inviteCode: "CODEPHONE" });
   expect(markup).toContain("Accept invite");
   expect(markup).toContain("Continue in Messages");
-  expect(markup).toContain("sms:+15551230000?body=family_CODEPHONE");
+  expect(markup).toContain(
+    "sms:+15551230000?body=Hi%20Murph%2C%20joining%20the%20family%20plan%20(code%20family_CODEPHONE)",
+  );
   expect(markup).toContain(
     "Joining by text works from the phone this invite was sent to.",
   );
@@ -169,18 +183,30 @@ test("continues in Telegram only for Telegram-bound invites", async () => {
   expect(mocks.signInButtonRendered).toBe(false);
 });
 
-test("shows a channel-neutral fallback for a label-only invite", async () => {
+test("shows Messages, web sign-in, and Telegram options for a label-only invite", async () => {
   mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValue({
     ...BASE_VIEW,
     inviteCode: "CODELABEL",
+    telegramInviteUrl: "https://t.me/withmurph_bot?start=family_CODELABEL",
+    webAcceptable: true,
   });
+  mocks.readConfiguredMurphPhoneNumbers.mockReturnValue(["+15559990000"]);
 
   const markup = await renderFamilyAcceptPage("CODELABEL");
 
-  expect(markup).toContain("Open this invite from the chat where you received it");
-  expect(markup).not.toContain("Continue in Telegram");
-  expect(markup).not.toContain("Continue in Messages");
-  expect(mocks.signInButtonRendered).toBe(false);
+  expect(markup).toContain("Continue in Messages");
+  expect(markup).toContain(
+    "sms:+15559990000?body=Hi%20Murph%2C%20joining%20the%20family%20plan%20(code%20family_CODELABEL)",
+  );
+  expect(markup).toContain("Sign in on the web instead");
+  expect(markup).toContain("Continue in Telegram");
+  expect(markup).toContain("https://t.me/withmurph_bot?start=family_CODELABEL");
+  expect(mocks.signInButtonProps).toEqual({
+    bindingLabel: "your phone number or email address",
+    description: "Sign in with your own phone number or email address. We'll bring you back here.",
+    variant: "link",
+  });
+  expect(markup).not.toContain("Open this invite from the chat where you received it");
 });
 
 async function renderFamilyAcceptPage(inviteCode: string): Promise<string> {

--- a/apps/web/test/family-invite-accept-route.test.ts
+++ b/apps/web/test/family-invite-accept-route.test.ts
@@ -36,6 +36,7 @@ const ACTIVE_PHONE_BOUND = {
   inviteCode: "CODEDAD",
   isEmailBound: false,
   isPhoneBound: true,
+  isTelegramBound: false,
   seatAvailable: true,
   status: "pending",
   targetLabel: "Dad",
@@ -114,11 +115,35 @@ test("passes a null email when the member's email is not verified", async () => 
   );
 });
 
-test("rejects web acceptance of a Telegram/label-only invite (no phone or email)", async () => {
+test("accepts web acceptance of an unbound label-only invite", async () => {
   mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValueOnce({
     ...ACTIVE_PHONE_BOUND,
     isEmailBound: false,
     isPhoneBound: false,
+    isTelegramBound: false,
+    telegramInviteUrl: "https://t.me/withmurph_bot?start=family_CODEDAD",
+    webAcceptable: true,
+  });
+
+  const response = await acceptRoute.POST(postRequest(), params);
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ accepted: true });
+  expect(mocks.acceptHostedFamilyInvite).toHaveBeenCalledWith(
+    expect.objectContaining({
+      acceptedMemberId: "member_mom",
+      inviteCode: "CODEDAD",
+      requireWebBinding: true,
+    }),
+  );
+});
+
+test("rejects web acceptance of a Telegram-only invite", async () => {
+  mocks.readHostedFamilyInviteAcceptanceView.mockResolvedValueOnce({
+    ...ACTIVE_PHONE_BOUND,
+    isEmailBound: false,
+    isPhoneBound: false,
+    isTelegramBound: true,
     telegramInviteUrl: "https://t.me/withmurph_bot?start=family_CODEDAD",
     webAcceptable: false,
   });

--- a/apps/web/test/hosted-family-invite-messages.test.ts
+++ b/apps/web/test/hosted-family-invite-messages.test.ts
@@ -1,0 +1,132 @@
+import { HostedBillingStatus } from "@prisma/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+const storeMocks = vi.hoisted(() => ({
+  lookupHostedMemberIdentityByPhoneLookupKey: vi.fn(),
+  readHostedMemberRoutingState: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-identity-store", async (importActual) => ({
+  ...(await importActual<object>()),
+  lookupHostedMemberIdentityByPhoneLookupKey:
+    storeMocks.lookupHostedMemberIdentityByPhoneLookupKey,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-routing-store", async (importActual) => ({
+  ...(await importActual<object>()),
+  readHostedMemberRoutingState: storeMocks.readHostedMemberRoutingState,
+}));
+
+import {
+  buildHostedFamilyInviteMessagesHref,
+  parseHostedFamilyInviteStartToken,
+  readHostedFamilyInviteAcceptanceView,
+} from "@/src/lib/hosted-onboarding/family-plan";
+
+const NOW = new Date("2026-06-24T00:00:00.000Z");
+const FUTURE = new Date("2026-07-01T00:00:00.000Z");
+const previousPublicBaseUrl = process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL;
+
+const GROUP = {
+  billingStatus: HostedBillingStatus.active,
+  displayName: "Kim Family",
+  id: "hbag_1",
+  ownerMemberId: "m_owner",
+  suspendedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL = "https://app.murph.test";
+});
+
+afterEach(() => {
+  if (previousPublicBaseUrl === undefined) {
+    delete process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL;
+  } else {
+    process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL = previousPublicBaseUrl;
+  }
+});
+
+function phoneBoundPrisma() {
+  return {
+    hostedAccountGroupInvite: {
+      count: vi.fn().mockResolvedValue(1),
+      findUnique: vi.fn().mockResolvedValue({
+        expiresAt: FUTURE,
+        group: GROUP,
+        inviteCode: "CODEDAD",
+        status: "pending",
+        targetEmailLookupKey: null,
+        targetLabel: "Dad",
+        targetPhoneLookupKey: "lookup_dad",
+        targetTelegramUsernameLookupKey: null,
+      }),
+    },
+    hostedAccountGroupMembership: {
+      count: vi.fn().mockResolvedValue(2),
+    },
+    hostedAccountGroupBillingRef: {
+      findUnique: vi.fn().mockResolvedValue({ billedSeatCount: 4 }),
+    },
+  };
+}
+
+test("prefers an existing member's home line for the Messages accept target", async () => {
+  storeMocks.lookupHostedMemberIdentityByPhoneLookupKey.mockResolvedValue({
+    core: { id: "m_dad" },
+  });
+  storeMocks.readHostedMemberRoutingState.mockResolvedValue({
+    linqRecipientPhone: "+15551112222",
+  });
+
+  const view = await readHostedFamilyInviteAcceptanceView({
+    // @ts-expect-error: focused prisma double exposes only the methods under test
+    prisma: phoneBoundPrisma(),
+    inviteCode: "CODEDAD",
+    now: NOW,
+  });
+
+  expect(view?.messagesRecipientPhone).toBe("+15551112222");
+  expect(storeMocks.lookupHostedMemberIdentityByPhoneLookupKey).toHaveBeenCalledWith(
+    expect.objectContaining({ phoneLookupKey: "lookup_dad" }),
+  );
+  expect(storeMocks.readHostedMemberRoutingState).toHaveBeenCalledWith(
+    expect.objectContaining({ memberId: "m_dad" }),
+  );
+});
+
+test("returns no Messages target when the phone matches no existing member", async () => {
+  storeMocks.lookupHostedMemberIdentityByPhoneLookupKey.mockResolvedValue(null);
+
+  const view = await readHostedFamilyInviteAcceptanceView({
+    // @ts-expect-error: focused prisma double
+    prisma: phoneBoundPrisma(),
+    inviteCode: "CODEDAD",
+    now: NOW,
+  });
+
+  expect(view?.messagesRecipientPhone).toBeNull();
+  expect(storeMocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+});
+
+test("builds an sms deep link carrying the webhook-parseable family token", () => {
+  expect(
+    buildHostedFamilyInviteMessagesHref({
+      inviteCode: "CODEDAD",
+      murphPhoneNumber: "+15550000000",
+    }),
+  ).toBe("sms:+15550000000?body=family_CODEDAD");
+});
+
+test("the prefilled sms body is exactly what the accept-by-phone webhook parses", () => {
+  const href = buildHostedFamilyInviteMessagesHref({
+    inviteCode: "CODEDAD",
+    murphPhoneNumber: "+15550000000",
+  });
+  const body = decodeURIComponent(href.split("?body=")[1] ?? "");
+
+  // The invitee sends this body to Murph; the LinQ webhook must recover the
+  // invite code from it, or accept-by-text silently fails.
+  expect(parseHostedFamilyInviteStartToken(body)).toBe("CODEDAD");
+});

--- a/apps/web/test/hosted-family-invite-messages.test.ts
+++ b/apps/web/test/hosted-family-invite-messages.test.ts
@@ -147,17 +147,18 @@ test("builds an sms deep link carrying the webhook-parseable family token", () =
       inviteCode: "CODEDAD",
       murphPhoneNumber: "+15550000000",
     }),
-  ).toBe("sms:+15550000000?body=family_CODEDAD");
+  ).toBe(
+    "sms:+15550000000?body=Hi%20Murph%2C%20joining%20the%20family%20plan%20(code%20family_CODEDAD)",
+  );
 });
 
-test("the prefilled sms body is exactly what the accept-by-phone webhook parses", () => {
+test("the prefilled sms body is still what the accept-by-phone webhook parses", () => {
   const href = buildHostedFamilyInviteMessagesHref({
     inviteCode: "CODEDAD",
     murphPhoneNumber: "+15550000000",
   });
   const body = decodeURIComponent(href.split("?body=")[1] ?? "");
 
-  // The invitee sends this body to Murph; the LinQ webhook must recover the
-  // invite code from it, or accept-by-text silently fails.
+  expect(body).toBe("Hi Murph, joining the family plan (code family_CODEDAD)");
   expect(parseHostedFamilyInviteStartToken(body)).toBe("CODEDAD");
 });

--- a/apps/web/test/hosted-family-invite-messages.test.ts
+++ b/apps/web/test/hosted-family-invite-messages.test.ts
@@ -1,15 +1,24 @@
 import { HostedBillingStatus } from "@prisma/client";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
+const encryptionMocks = vi.hoisted(() => ({
+  decryptHostedWebNullableString: vi.fn(),
+}));
+
 const storeMocks = vi.hoisted(() => ({
-  lookupHostedMemberIdentityByPhoneLookupKey: vi.fn(),
+  lookupHostedMemberIdentityByPhoneNumber: vi.fn(),
   readHostedMemberRoutingState: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-web/encryption", async (importActual) => ({
+  ...(await importActual<object>()),
+  decryptHostedWebNullableString: encryptionMocks.decryptHostedWebNullableString,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-member-identity-store", async (importActual) => ({
   ...(await importActual<object>()),
-  lookupHostedMemberIdentityByPhoneLookupKey:
-    storeMocks.lookupHostedMemberIdentityByPhoneLookupKey,
+  lookupHostedMemberIdentityByPhoneNumber:
+    storeMocks.lookupHostedMemberIdentityByPhoneNumber,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-member-routing-store", async (importActual) => ({
@@ -25,6 +34,7 @@ import {
 
 const NOW = new Date("2026-06-24T00:00:00.000Z");
 const FUTURE = new Date("2026-07-01T00:00:00.000Z");
+const INVITED_PHONE = "+15550001111";
 const previousPublicBaseUrl = process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL;
 
 const GROUP = {
@@ -38,6 +48,8 @@ const GROUP = {
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL = "https://app.murph.test";
+  // The invitee's phone is resolved from the encrypted invite field.
+  encryptionMocks.decryptHostedWebNullableString.mockResolvedValue(INVITED_PHONE);
 });
 
 afterEach(() => {
@@ -60,6 +72,7 @@ function phoneBoundPrisma() {
         targetEmailLookupKey: null,
         targetLabel: "Dad",
         targetPhoneLookupKey: "lookup_dad",
+        targetPhoneNumberEncrypted: "enc:dad-phone",
         targetTelegramUsernameLookupKey: null,
       }),
     },
@@ -72,8 +85,8 @@ function phoneBoundPrisma() {
   };
 }
 
-test("prefers an existing member's home line for the Messages accept target", async () => {
-  storeMocks.lookupHostedMemberIdentityByPhoneLookupKey.mockResolvedValue({
+test("prefers an existing member's home line, resolved by the decrypted phone", async () => {
+  storeMocks.lookupHostedMemberIdentityByPhoneNumber.mockResolvedValue({
     core: { id: "m_dad" },
   });
   storeMocks.readHostedMemberRoutingState.mockResolvedValue({
@@ -88,8 +101,10 @@ test("prefers an existing member's home line for the Messages accept target", as
   });
 
   expect(view?.messagesRecipientPhone).toBe("+15551112222");
-  expect(storeMocks.lookupHostedMemberIdentityByPhoneLookupKey).toHaveBeenCalledWith(
-    expect.objectContaining({ phoneLookupKey: "lookup_dad" }),
+  // Version-tolerant authority: it resolves the member by the raw phone (the
+  // same path the accept-by-phone webhook uses), not the invite's stored key.
+  expect(storeMocks.lookupHostedMemberIdentityByPhoneNumber).toHaveBeenCalledWith(
+    expect.objectContaining({ phoneNumber: INVITED_PHONE }),
   );
   expect(storeMocks.readHostedMemberRoutingState).toHaveBeenCalledWith(
     expect.objectContaining({ memberId: "m_dad" }),
@@ -97,7 +112,7 @@ test("prefers an existing member's home line for the Messages accept target", as
 });
 
 test("returns no Messages target when the phone matches no existing member", async () => {
-  storeMocks.lookupHostedMemberIdentityByPhoneLookupKey.mockResolvedValue(null);
+  storeMocks.lookupHostedMemberIdentityByPhoneNumber.mockResolvedValue(null);
 
   const view = await readHostedFamilyInviteAcceptanceView({
     // @ts-expect-error: focused prisma double
@@ -108,6 +123,22 @@ test("returns no Messages target when the phone matches no existing member", asy
 
   expect(view?.messagesRecipientPhone).toBeNull();
   expect(storeMocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+});
+
+test("degrades to no home-line target (not a page error) when resolution throws", async () => {
+  storeMocks.lookupHostedMemberIdentityByPhoneNumber.mockRejectedValue(
+    new Error("ambiguous phone lookup"),
+  );
+
+  const view = await readHostedFamilyInviteAcceptanceView({
+    // @ts-expect-error: focused prisma double
+    prisma: phoneBoundPrisma(),
+    inviteCode: "CODEDAD",
+    now: NOW,
+  });
+
+  expect(view?.messagesRecipientPhone).toBeNull();
+  expect(view?.isPhoneBound).toBe(true);
 });
 
 test("builds an sms deep link carrying the webhook-parseable family token", () => {

--- a/apps/web/test/hosted-family-owner-snapshot.test.ts
+++ b/apps/web/test/hosted-family-owner-snapshot.test.ts
@@ -349,7 +349,7 @@ test("Telegram-bound invite exposes the Telegram link and is not web-acceptable"
   expect(view?.telegramInviteUrl).toBe("https://t.me/withmurph_bot?start=family_CODEDAD");
 });
 
-test("label-only invite offers no channel link (Telegram is not a fallback)", async () => {
+test("label-only acceptance view offers unbound claim channels", async () => {
   const prisma = acceptanceViewPrisma({
     activeMemberships: 2,
     expiresAt: FUTURE,
@@ -367,10 +367,8 @@ test("label-only invite offers no channel link (Telegram is not a fallback)", as
 
   expect(view?.isPhoneBound).toBe(false);
   expect(view?.isTelegramBound).toBe(false);
-  expect(view?.webAcceptable).toBe(false);
-  // A configured Telegram bot must never turn a non-Telegram invite into a
-  // Telegram redirect.
-  expect(view?.telegramInviteUrl).toBeNull();
+  expect(view?.webAcceptable).toBe(true);
+  expect(view?.telegramInviteUrl).toBe("https://t.me/withmurph_bot?start=family_CODEDAD");
   expect(view?.messagesRecipientPhone).toBeNull();
 });
 

--- a/apps/web/test/hosted-family-owner-snapshot.test.ts
+++ b/apps/web/test/hosted-family-owner-snapshot.test.ts
@@ -192,6 +192,7 @@ function acceptanceViewPrisma(input: {
   status: string;
   targetEmailLookupKey?: string | null;
   targetPhoneLookupKey: string | null;
+  targetTelegramUsernameLookupKey?: string | null;
 }) {
   return {
     hostedAccountGroupInvite: {
@@ -204,6 +205,7 @@ function acceptanceViewPrisma(input: {
         targetEmailLookupKey: input.targetEmailLookupKey ?? null,
         targetLabel: "Dad",
         targetPhoneLookupKey: input.targetPhoneLookupKey,
+        targetTelegramUsernameLookupKey: input.targetTelegramUsernameLookupKey ?? null,
       }),
     },
     hostedAccountGroupMembership: {
@@ -211,6 +213,11 @@ function acceptanceViewPrisma(input: {
     },
     hostedAccountGroupBillingRef: {
       findUnique: vi.fn().mockResolvedValue({ billedSeatCount: 4 }),
+    },
+    // No existing member matches the invited phone by default, so the accept
+    // page falls back to a configured Murph line.
+    hostedMemberIdentity: {
+      findUnique: vi.fn().mockResolvedValue(null),
     },
   };
 }
@@ -234,6 +241,9 @@ test("phone-bound invite to an active group is web-acceptable", async () => {
   expect(view).toMatchObject({
     groupActive: true,
     isPhoneBound: true,
+    isTelegramBound: false,
+    // No existing member matches, so the page falls back to a configured line.
+    messagesRecipientPhone: null,
     seatAvailable: true,
     status: "pending",
     webAcceptable: true,
@@ -266,7 +276,30 @@ test("email-bound invite to an active group is web-acceptable", async () => {
   });
 });
 
-test("Telegram/label-only invite is NOT web-acceptable (must use the chat link)", async () => {
+test("Telegram-bound invite exposes the Telegram link and is not web-acceptable", async () => {
+  const prisma = acceptanceViewPrisma({
+    activeMemberships: 2,
+    expiresAt: FUTURE,
+    pendingInvites: 1,
+    status: "pending",
+    targetPhoneLookupKey: null,
+    targetTelegramUsernameLookupKey: "lookup_telegram_dad",
+  });
+
+  const view = await readHostedFamilyInviteAcceptanceView({
+    // @ts-expect-error: focused prisma double
+    prisma,
+    inviteCode: "CODEDAD",
+    now: NOW,
+  });
+
+  expect(view?.isPhoneBound).toBe(false);
+  expect(view?.isTelegramBound).toBe(true);
+  expect(view?.webAcceptable).toBe(false);
+  expect(view?.telegramInviteUrl).toBe("https://t.me/withmurph_bot?start=family_CODEDAD");
+});
+
+test("label-only invite offers no channel link (Telegram is not a fallback)", async () => {
   const prisma = acceptanceViewPrisma({
     activeMemberships: 2,
     expiresAt: FUTURE,
@@ -283,8 +316,12 @@ test("Telegram/label-only invite is NOT web-acceptable (must use the chat link)"
   });
 
   expect(view?.isPhoneBound).toBe(false);
+  expect(view?.isTelegramBound).toBe(false);
   expect(view?.webAcceptable).toBe(false);
-  expect(view?.telegramInviteUrl).toBe("https://t.me/withmurph_bot?start=family_CODEDAD");
+  // A configured Telegram bot must never turn a non-Telegram invite into a
+  // Telegram redirect.
+  expect(view?.telegramInviteUrl).toBeNull();
+  expect(view?.messagesRecipientPhone).toBeNull();
 });
 
 test("invite to an inactive (canceled) group is not web-acceptable", async () => {

--- a/apps/web/test/hosted-family-owner-snapshot.test.ts
+++ b/apps/web/test/hosted-family-owner-snapshot.test.ts
@@ -33,7 +33,11 @@ beforeEach(() => {
   process.env.HOSTED_ONBOARDING_PUBLIC_BASE_URL = "https://app.murph.test";
   process.env.HOSTED_CONTACT_PRIVACY_KEYS = "v1:MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=";
   process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = "v1";
-  encryptionMocks.decryptHostedWebNullableString.mockResolvedValue(RAW_PHONE);
+  // Value-aware so a null encrypted field decrypts to null: a phone-only invite
+  // has no Telegram username, so it must not read as Telegram-bound.
+  encryptionMocks.decryptHostedWebNullableString.mockImplementation(
+    async (input: { value: string | null }) => (input.value ? RAW_PHONE : null),
+  );
 });
 
 afterEach(() => {
@@ -118,8 +122,52 @@ test("owner snapshot maps seats, member labels, masked phone, and share links", 
   expect(invite?.targetLabel).toBe("Dad");
   expect(invite?.targetPhoneHint).toBeTruthy();
   expect(invite?.targetPhoneHint).not.toBe(RAW_PHONE);
-  expect(invite?.telegramInviteUrl).toBe("https://t.me/withmurph_bot?start=family_CODEDAD");
+  // Dad is a phone-bound invite: no Telegram link, even though a bot is configured.
+  expect(invite?.telegramInviteUrl).toBeNull();
   expect(invite?.acceptUrl).toBe("https://app.murph.test/family/accept/CODEDAD");
+});
+
+test("owner snapshot exposes a Telegram link only for a Telegram-bound invite", async () => {
+  const prisma = {
+    hostedAccountGroup: { findUnique: vi.fn().mockResolvedValue(GROUP) },
+    hostedAccountGroupBillingRef: {
+      findUnique: vi.fn().mockResolvedValue({ billedSeatCount: 4 }),
+    },
+    hostedAccountGroupInvite: {
+      findMany: vi.fn(({ where }: { where: { status: string } }) =>
+        where.status === "accepted"
+          ? Promise.resolve([])
+          : Promise.resolve([
+              {
+                channel: "family",
+                expiresAt: FUTURE,
+                group: GROUP,
+                id: "inv_uncle",
+                inviteCode: "CODETG",
+                status: "pending",
+                targetLabel: "Uncle",
+                targetTelegramUsernameEncrypted: "enc:uncle",
+              },
+            ]),
+      ),
+    },
+    hostedAccountGroupMembership: {
+      findMany: vi.fn().mockResolvedValue([
+        { joinedAt: NOW, memberId: "m_owner", role: "owner", status: "active" },
+      ]),
+    },
+  };
+
+  const snapshot = await readHostedFamilyOwnerSnapshotForMember({
+    // @ts-expect-error: focused prisma double exposes only the methods under test
+    prisma,
+    memberId: "m_owner",
+    now: NOW,
+  });
+
+  expect(snapshot?.invites[0]?.telegramInviteUrl).toBe(
+    "https://t.me/withmurph_bot?start=family_CODETG",
+  );
 });
 
 test("active member identity falls back to the invited email when there is no label", async () => {
@@ -205,6 +253,7 @@ function acceptanceViewPrisma(input: {
         targetEmailLookupKey: input.targetEmailLookupKey ?? null,
         targetLabel: "Dad",
         targetPhoneLookupKey: input.targetPhoneLookupKey,
+        targetPhoneNumberEncrypted: input.targetPhoneLookupKey ? "enc:dad-phone" : null,
         targetTelegramUsernameLookupKey: input.targetTelegramUsernameLookupKey ?? null,
       }),
     },
@@ -214,10 +263,11 @@ function acceptanceViewPrisma(input: {
     hostedAccountGroupBillingRef: {
       findUnique: vi.fn().mockResolvedValue({ billedSeatCount: 4 }),
     },
-    // No existing member matches the invited phone by default, so the accept
-    // page falls back to a configured Murph line.
+    // No existing member matches the invited phone by default (findMany is the
+    // version-tolerant read the resolver uses), so the accept page falls back to
+    // a configured Murph line.
     hostedMemberIdentity: {
-      findUnique: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
     },
   };
 }

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -799,6 +799,106 @@ describe("hosted Family plan", () => {
     });
   });
 
+  it("accepts a phone plus Telegram invite from the matching Telegram username", async () => {
+    const tx = createTxMock();
+    const invite = createPendingInvite({
+      targetPhoneLookupKey: createHostedPhoneLookupKey("+48600000000"),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    });
+    tx.hostedAccountGroupInvite.findUnique
+      .mockResolvedValueOnce(invite)
+      .mockResolvedValueOnce(invite);
+
+    await expect(acceptHostedFamilyInviteFromTelegramTx({
+      telegramThreadId: "123",
+      telegramUserId: "456",
+      telegramUsername: "mom_user",
+      text: "/start family_invite_phone",
+      tx,
+    })).resolves.toMatchObject({
+      groupId: "hbag_family",
+      status: "active",
+    });
+
+    expect(tx.hostedMember.create).toHaveBeenCalled();
+    expect(tx.hostedMemberRouting.upsert).toHaveBeenCalled();
+    expect(tx.hostedAccountGroupMembership.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      create: expect.objectContaining({
+        memberId: expect.stringMatching(/^hbm_/u),
+      }),
+    }));
+  });
+
+  it("accepts a phone plus Telegram invite from the matching phone webhook sender", async () => {
+    const now = new Date("2026-06-18T12:30:00.000Z");
+    const tx = createTxMock();
+    const invite = createPendingInvite({
+      targetPhoneLookupKey: createHostedPhoneLookupKey("+48600000000"),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    });
+    tx.hostedAccountGroupInvite.findUnique
+      .mockResolvedValueOnce(invite)
+      .mockResolvedValueOnce(invite);
+
+    await expect(acceptHostedFamilyInviteFromPhoneTx({
+      now,
+      phoneNumber: "+48 600 000 000",
+      text: "family_invite_phone",
+      tx,
+    })).resolves.toMatchObject({
+      memberId: "member_mom",
+      status: "active",
+    });
+
+    expect(identityMocks.ensureHostedMemberForPhoneTx).toHaveBeenCalledWith({
+      phoneNumber: "+48 600 000 000",
+      phoneNumberVerifiedAt: now,
+      prisma: tx,
+    });
+  });
+
+  it("rejects a phone plus Telegram invite from the wrong Telegram username", async () => {
+    const tx = createTxMock();
+    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(createPendingInvite({
+      targetPhoneLookupKey: createHostedPhoneLookupKey("+48600000000"),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    }));
+
+    await expect(acceptHostedFamilyInviteFromTelegramTx({
+      now: new Date("2026-06-18T12:00:00.000Z"),
+      telegramThreadId: "123",
+      telegramUserId: "456",
+      telegramUsername: "other_user",
+      text: "/start family_invite_phone",
+      tx,
+    })).rejects.toMatchObject({
+      code: "HOSTED_FAMILY_INVITE_TELEGRAM_MISMATCH",
+    });
+
+    expect(tx.hostedMember.create).not.toHaveBeenCalled();
+    expect(tx.hostedMemberRouting.upsert).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroupMembership.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a phone plus Telegram invite from the wrong phone webhook sender", async () => {
+    const tx = createTxMock();
+    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(createPendingInvite({
+      targetPhoneLookupKey: createHostedPhoneLookupKey("+48600000000"),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    }));
+
+    await expect(acceptHostedFamilyInviteFromPhoneTx({
+      phoneNumber: "+48 700 000 000",
+      text: "family_invite_phone",
+      tx,
+    })).rejects.toMatchObject({
+      code: "HOSTED_FAMILY_INVITE_PHONE_MISMATCH",
+    });
+
+    expect(identityMocks.ensureHostedMemberForPhoneTx).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroupMembership.upsert).not.toHaveBeenCalled();
+  });
+
   it("accepts email-bound invites only from the invited email address", async () => {
     const tx = createTxMock();
 
@@ -831,6 +931,75 @@ describe("hosted Family plan", () => {
       memberId: "member_mom",
       status: "active",
     });
+  });
+
+  it("accepts an email plus Telegram invite from the matching web email", async () => {
+    const tx = createTxMock();
+    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(createPendingInvite({
+      targetEmailLookupKey: createHostedEmailLookupKey("mom@example.com"),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    }));
+
+    await expect(acceptHostedFamilyInviteTx({
+      acceptedMemberId: "member_mom",
+      email: "MOM@example.com",
+      inviteCode: "invite_phone",
+      requireWebBinding: true,
+      tx,
+    })).resolves.toMatchObject({
+      groupId: "hbag_family",
+      memberId: "member_mom",
+      status: "active",
+    });
+  });
+
+  it("accepts an email plus Telegram invite from the matching Telegram username", async () => {
+    const tx = createTxMock();
+    const invite = createPendingInvite({
+      targetEmailLookupKey: createHostedEmailLookupKey("mom@example.com"),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    });
+    tx.hostedAccountGroupInvite.findUnique
+      .mockResolvedValueOnce(invite)
+      .mockResolvedValueOnce(invite);
+
+    await expect(acceptHostedFamilyInviteFromTelegramTx({
+      telegramThreadId: "123",
+      telegramUserId: "456",
+      telegramUsername: "mom_user",
+      text: "/start family_invite_phone",
+      tx,
+    })).resolves.toMatchObject({
+      groupId: "hbag_family",
+      status: "active",
+    });
+    expect(tx.hostedAccountGroupMembership.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      create: expect.objectContaining({
+        memberId: expect.stringMatching(/^hbm_/u),
+      }),
+    }));
+  });
+
+  it("rejects an email plus Telegram invite on web when no session identity matches", async () => {
+    const tx = createTxMock();
+    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(createPendingInvite({
+      targetEmailLookupKey: createHostedEmailLookupKey("mom@example.com"),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    }));
+
+    await expect(acceptHostedFamilyInviteTx({
+      acceptedMemberId: "member_mom",
+      email: "someone-else@example.com",
+      inviteCode: "invite_phone",
+      phoneNumber: "+48 600 000 000",
+      requireWebBinding: true,
+      tx,
+    })).rejects.toMatchObject({
+      code: "HOSTED_FAMILY_INVITE_EMAIL_MISMATCH",
+    });
+
+    expect(tx.hostedAccountGroupMembership.upsert).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroupInvite.updateMany).not.toHaveBeenCalled();
   });
 
   it("accepts an unbound invite via web with any signed-in member identity", async () => {

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -280,9 +280,50 @@ describe("hosted Family plan", () => {
         targetLabel: "Dad",
         targetPhoneHint: null,
         targetPhoneNumber: null,
+        targetTelegramUsername: "dad_username",
       },
       telegramBotUsername: "@withmurph_bot",
     })).toContain("Forward this Telegram invite link to Dad: https://t.me/withmurph_bot?start=family_invite_123");
+  });
+
+  it("does not build a Telegram deep link for label-only family invite replies", () => {
+    const replyText = buildHostedFamilyInviteReplyText({
+      invite: {
+        inviteCode: "invite_label",
+        targetEmail: null,
+        targetLabel: "Dad",
+        targetPhoneHint: null,
+        targetPhoneNumber: null,
+        targetTelegramUsername: null,
+      },
+      telegramBotUsername: "@withmurph_bot",
+    });
+
+    expect(replyText).not.toContain("https://t.me/");
+    expect(replyText).toContain("Telegram invite token: family_invite_label");
+  });
+
+  it("uses the web accept link for phone-bound family invite replies", () => {
+    const replyText = buildHostedFamilyInviteReplyText({
+      invite: {
+        inviteCode: "invite_phone",
+        targetEmail: null,
+        targetLabel: "Dad",
+        targetPhoneHint: "+48 6** *** ***",
+        targetPhoneNumber: "+48600000000",
+        targetTelegramUsername: null,
+      },
+      publicBaseUrl: "https://local.withmurph.ai:3443",
+      telegramBotUsername: "@withmurph_bot",
+    });
+
+    expect(replyText).toContain(
+      "Forward this Family invite link to Dad: https://local.withmurph.ai:3443/family/accept/invite_phone",
+    );
+    expect(replyText).toContain(
+      "When they open it they can join by text right from their phone.",
+    );
+    expect(replyText).not.toContain("for example on WhatsApp");
   });
 
   it("uses the web accept link for email-bound family invite replies", () => {
@@ -293,6 +334,7 @@ describe("hosted Family plan", () => {
         targetLabel: "Dad",
         targetPhoneHint: null,
         targetPhoneNumber: null,
+        targetTelegramUsername: null,
       },
       publicBaseUrl: "https://local.withmurph.ai:3443",
       telegramBotUsername: "@withmurph_bot",
@@ -365,7 +407,12 @@ describe("hosted Family plan", () => {
       },
     });
     expect(result.replyText).not.toContain("Forward this Telegram invite link");
-    expect(result.replyText).toContain("They need to send this token to Murph from that phone number");
+    expect(result.replyText).toContain(
+      "Forward this Family invite link to dad: https://local.withmurph.ai:3443/family/accept/",
+    );
+    expect(result.replyText).toContain(
+      "When they open it they can join by text right from their phone.",
+    );
     expect(result.replyText).toContain("you cannot see their private Murph conversations");
   });
 

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -18,6 +18,9 @@ const cryptoRootMocks = vi.hoisted(() => ({
 const identityMocks = vi.hoisted(() => ({
   ensureHostedMemberForPhoneTx: vi.fn(),
 }));
+const mailboxMocks = vi.hoisted(() => ({
+  appendHostedMailboxEnvelopeTx: vi.fn(),
+}));
 const runtimeMocks = vi.hoisted(() => ({
   requireHostedOnboardingPublicBaseUrl: vi.fn(),
   requireHostedStripeApi: vi.fn(),
@@ -40,6 +43,9 @@ vi.mock("@/src/lib/hosted-crypto/domain-root-store", () => ({
 }));
 vi.mock("@/src/lib/hosted-onboarding/member-identity-service", () => ({
   ensureHostedMemberForPhoneTx: identityMocks.ensureHostedMemberForPhoneTx,
+}));
+vi.mock("@/src/lib/hosted-mailbox/store", () => ({
+  appendHostedMailboxEnvelopeTx: mailboxMocks.appendHostedMailboxEnvelopeTx,
 }));
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   requireHostedOnboardingPublicBaseUrl: runtimeMocks.requireHostedOnboardingPublicBaseUrl,
@@ -72,6 +78,7 @@ import {
   writeHostedAccountGroupStripeBillingTx,
   parseHostedFamilyInviteStartToken,
   readHostedFamilyAccessForMember,
+  resolveHostedFamilyInviteTokenForInbound,
   removeHostedFamilyMemberTx,
   updateHostedFamilySeatCount,
 } from "@/src/lib/hosted-onboarding/family-plan";
@@ -110,6 +117,9 @@ type FamilyPlanTxMock = Prisma.TransactionClient & {
     create: MockFn;
     findUnique: MockFn;
     update: MockFn;
+  };
+  hostedMemberIdentity: Prisma.TransactionClient["hostedMemberIdentity"] & {
+    findUnique: MockFn;
   };
   hostedMemberBillingRef: Prisma.TransactionClient["hostedMemberBillingRef"] & {
     findUnique: MockFn;
@@ -167,6 +177,9 @@ describe("hosted Family plan", () => {
       hostedExecutionEventId: "member.activated:family",
       memberId,
     }));
+    mailboxMocks.appendHostedMailboxEnvelopeTx.mockResolvedValue({
+      item: { id: "mailbox_item_owner_notification" },
+    });
     runtimeMocks.requireHostedStripeApi.mockReturnValue({
       subscriptionItems: {
         update: vi.fn().mockResolvedValue({
@@ -252,7 +265,56 @@ describe("hosted Family plan", () => {
     })).toBe("https://t.me/withmurph_bot?start=family_invite_123");
     expect(parseHostedFamilyInviteStartToken("/start family_invite_123")).toBe("invite_123");
     expect(parseHostedFamilyInviteStartToken("family_invite_123")).toBe("invite_123");
+    expect(
+      parseHostedFamilyInviteStartToken(
+        "Hi Murph, joining the family plan (code family_invite_123)",
+      ),
+    ).toBe("invite_123");
+    expect(parseHostedFamilyInviteStartToken("code family_invite_123.")).toBe("invite_123");
+    expect(parseHostedFamilyInviteStartToken("hello")).toBeNull();
+    expect(parseHostedFamilyInviteStartToken("prefamily_invite_123")).toBeNull();
+    expect(parseHostedFamilyInviteStartToken("family_invite_123_extra")).toBe(
+      "invite_123_extra",
+    );
     expect(parseHostedFamilyInviteStartToken("@dad_username")).toBeNull();
+  });
+
+  it("resolves inbound family invite tokens only when the invite row exists", async () => {
+    const tx = createTxMock();
+
+    await expect(resolveHostedFamilyInviteTokenForInbound({
+      prisma: tx,
+      text: "Hi Murph, joining the family plan (code family_invite_123)",
+    })).resolves.toBe("invite_123");
+    expect(tx.hostedAccountGroupInvite.findUnique).toHaveBeenLastCalledWith({
+      select: {
+        id: true,
+      },
+      where: {
+        inviteCode: "invite_123",
+      },
+    });
+
+    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(null);
+
+    await expect(resolveHostedFamilyInviteTokenForInbound({
+      prisma: tx,
+      text: "sending the family_photos album now",
+    })).resolves.toBeNull();
+    expect(tx.hostedAccountGroupInvite.findUnique).toHaveBeenLastCalledWith({
+      select: {
+        id: true,
+      },
+      where: {
+        inviteCode: "photos",
+      },
+    });
+
+    await expect(resolveHostedFamilyInviteTokenForInbound({
+      prisma: tx,
+      text: "hello",
+    })).resolves.toBeNull();
+    expect(tx.hostedAccountGroupInvite.findUnique).toHaveBeenCalledTimes(2);
   });
 
   it("builds short hosted Family checkout links from Stripe checkout URLs", () => {
@@ -286,7 +348,7 @@ describe("hosted Family plan", () => {
     })).toContain("Forward this Telegram invite link to Dad: https://t.me/withmurph_bot?start=family_invite_123");
   });
 
-  it("does not build a Telegram deep link for label-only family invite replies", () => {
+  it("uses the web accept link for label-only family invite replies", () => {
     const replyText = buildHostedFamilyInviteReplyText({
       invite: {
         inviteCode: "invite_label",
@@ -296,11 +358,35 @@ describe("hosted Family plan", () => {
         targetPhoneNumber: null,
         targetTelegramUsername: null,
       },
+      publicBaseUrl: "https://local.withmurph.ai:3443",
       telegramBotUsername: "@withmurph_bot",
     });
 
     expect(replyText).not.toContain("https://t.me/");
-    expect(replyText).toContain("Telegram invite token: family_invite_label");
+    expect(replyText).toContain(
+      "Forward this Family invite link to Dad: https://local.withmurph.ai:3443/family/accept/invite_label",
+    );
+    expect(replyText).toContain(
+      "Whoever opens it can join, so it is best sent directly to them.",
+    );
+  });
+
+  it("falls back to a token for label-only family invite replies without a public base URL", () => {
+    const replyText = buildHostedFamilyInviteReplyText({
+      invite: {
+        inviteCode: "invite_label",
+        targetEmail: null,
+        targetLabel: "Dad",
+        targetPhoneHint: null,
+        targetPhoneNumber: null,
+        targetTelegramUsername: null,
+      },
+      publicBaseUrl: null,
+      telegramBotUsername: "@withmurph_bot",
+    });
+
+    expect(replyText).not.toContain("https://t.me/");
+    expect(replyText).toContain("Family invite token: family_invite_label");
   });
 
   it("uses the web accept link for phone-bound family invite replies", () => {
@@ -747,23 +833,128 @@ describe("hosted Family plan", () => {
     });
   });
 
-  it("blocks web acceptance of an invite with no phone or email binding", async () => {
+  it("accepts an unbound invite via web with any signed-in member identity", async () => {
     const tx = createTxMock();
 
-    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce({
-      ...createPendingInvite(),
-      targetEmailLookupKey: null,
-      targetPhoneLookupKey: null,
+    await expect(acceptHostedFamilyInviteTx({
+      acceptedMemberId: "member_mom",
+      inviteCode: "invite_phone",
+      phoneNumber: "+48 600 000 000",
+      requireWebBinding: true,
+      tx,
+    })).resolves.toMatchObject({
+      groupId: "hbag_family",
+      memberId: "member_mom",
+      role: "member",
+      status: "active",
+    });
+  });
+
+  it("notifies the owner when an unbound invite is claimed", async () => {
+    const tx = createTxMock();
+    tx.hostedMemberIdentity.findUnique.mockResolvedValueOnce({
+      maskedPhoneNumberHint: "+1 *** *** 1111",
+      memberId: "member_owner",
+      phoneLookupKey: createHostedPhoneLookupKey("+15550001111"),
+      phoneNumberEncrypted: "encrypted:+15550001111",
+      phoneNumberVerifiedAt: new Date("2026-06-18T12:00:00.000Z"),
+      privyUserIdEncrypted: null,
+      privyUserLookupKey: null,
+      signupPhoneCodeSendAttemptId: null,
+      signupPhoneCodeSendAttemptStartedAt: null,
+      signupPhoneCodeSentAt: null,
+      signupPhoneNumberEncrypted: null,
+      walletAddressEncrypted: null,
+      walletChainType: null,
+      walletCreatedAt: null,
+      walletProvider: null,
+    });
+    tx.hostedMemberRouting.findUnique.mockResolvedValueOnce({
+      linqChatIdEncrypted: null,
+      linqChatLookupKey: null,
+      linqHomeLineAssignedAt: new Date("2026-06-18T12:00:00.000Z"),
+      linqRecipientPhoneEncrypted: "encrypted:+15559990000",
+      linqRecipientPhoneLookupKey: createHostedPhoneLookupKey("+15559990000"),
+      memberId: "member_owner",
+      pendingLinqChatIdEncrypted: null,
+      pendingLinqChatLookupKey: null,
+      pendingLinqLastInboundAt: null,
+      pendingLinqParticipantContactEncrypted: null,
+      pendingLinqParticipantContactKind: null,
+      pendingLinqParticipantContactLookupKey: null,
+      pendingLinqParticipantContactObservedAt: null,
+      pendingLinqRecipientPhoneEncrypted: null,
+      pendingLinqRecipientPhoneLookupKey: null,
+      replyAliasLookupKey: null,
+      telegramUserIdEncrypted: null,
+      telegramUserLookupKey: null,
     });
 
     await expect(acceptHostedFamilyInviteTx({
       acceptedMemberId: "member_mom",
       inviteCode: "invite_phone",
+      phoneNumber: "+48 600 000 000",
+      tx,
+    })).resolves.toMatchObject({
+      memberId: "member_mom",
+      status: "active",
+    });
+
+    expect(mailboxMocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
+    const appendInput = mailboxMocks.appendHostedMailboxEnvelopeTx.mock.calls[0]?.[0];
+    expect(appendInput).toEqual(expect.objectContaining({ tx }));
+    expect(JSON.stringify(appendInput?.envelope)).toContain(
+      "Mom just joined your family plan.",
+    );
+    expect(JSON.stringify(appendInput?.envelope)).toContain("member_owner");
+  });
+
+  it("rejects web acceptance of a Telegram-only invite", async () => {
+    const tx = createTxMock();
+
+    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce({
+      ...createPendingInvite(),
+      targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@Mom_User"),
+    });
+
+    await expect(acceptHostedFamilyInviteTx({
+      acceptedMemberId: "member_mom",
+      inviteCode: "invite_phone",
+      phoneNumber: "+48 600 000 000",
       requireWebBinding: true,
       tx,
     })).rejects.toMatchObject({
       code: "HOSTED_FAMILY_WEB_ACCEPT_REQUIRES_CONTACT",
     });
+  });
+
+  it("accepts an unbound invite from a new phone and binds the sender phone", async () => {
+    const now = new Date("2026-06-18T12:30:00.000Z");
+    const tx = createTxMock();
+    const unboundInvite = createPendingInvite({
+      targetEmailLookupKey: null,
+      targetPhoneLookupKey: null,
+      targetTelegramUsernameLookupKey: null,
+    });
+    tx.hostedAccountGroupInvite.findUnique
+      .mockResolvedValueOnce(unboundInvite)
+      .mockResolvedValueOnce(unboundInvite);
+
+    await expect(acceptHostedFamilyInviteFromPhoneTx({
+      now,
+      phoneNumber: "+48 600 000 000",
+      text: "family_invite_phone",
+      tx,
+    })).resolves.toMatchObject({
+      memberId: "member_mom",
+    });
+
+    expect(identityMocks.ensureHostedMemberForPhoneTx).toHaveBeenCalledWith({
+      phoneNumber: "+48 600 000 000",
+      phoneNumberVerifiedAt: now,
+      prisma: tx,
+    });
+    expect(tx.hostedAccountGroupMembership.upsert).toHaveBeenCalled();
   });
 
   it("marks WhatsApp family invite phone acceptance as provider-verified", async () => {
@@ -848,6 +1039,24 @@ describe("hosted Family plan", () => {
     tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(createPendingInvite({
       targetPhoneLookupKey: null,
       targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@alice"),
+    }));
+
+    await expect(acceptHostedFamilyInviteFromPhoneTx({
+      phoneNumber: "+48 600 000 000",
+      text: "family_invite_phone",
+      tx,
+    })).resolves.toBeNull();
+
+    expect(identityMocks.ensureHostedMemberForPhoneTx).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroupMembership.upsert).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroupInvite.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("does not let WhatsApp claim an email-bound invite", async () => {
+    const tx = createTxMock();
+    tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(createPendingInvite({
+      targetEmailLookupKey: createHostedEmailLookupKey("mom@example.com"),
+      targetPhoneLookupKey: null,
     }));
 
     await expect(acceptHostedFamilyInviteFromPhoneTx({
@@ -954,7 +1163,7 @@ describe("hosted Family plan", () => {
     expect(tx.hostedAccountGroupInvite.update).not.toHaveBeenCalled();
   });
 
-  it("does not create membership when another accept already claimed the invite", async () => {
+  it("keeps unbound double-claim single-winner when another accept already claimed it", async () => {
     const tx = createTxMock();
     tx.hostedAccountGroupInvite.findUnique.mockResolvedValueOnce(createPendingInvite());
     tx.hostedAccountGroupInvite.updateMany.mockResolvedValueOnce({ count: 0 });
@@ -2608,6 +2817,9 @@ function createTxMock(input: {
         id: "member_owner",
         suspendedAt: null,
       }),
+    },
+    hostedMemberIdentity: {
+      findUnique: vi.fn().mockResolvedValue(null),
     },
     hostedMemberBillingRef: {
       findUnique: vi.fn().mockResolvedValue(null),

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -192,6 +192,7 @@ const mocks = vi.hoisted(() => {
     }),
     acceptHostedFamilyInviteFromPhoneTx: vi.fn(),
     buildHostedFamilyInviteAcceptedReplyText: vi.fn(() => "Welcome to Murph Family."),
+    resolveHostedFamilyInviteTokenForInbound: vi.fn(),
   };
 
   return state;
@@ -328,11 +329,15 @@ vi.mock("@/src/lib/hosted-onboarding/family-plan", async () => {
   const actual = await vi.importActual<typeof import("@/src/lib/hosted-onboarding/family-plan")>(
     "@/src/lib/hosted-onboarding/family-plan",
   );
+  mocks.resolveHostedFamilyInviteTokenForInbound.mockImplementation(async (input: {
+    text: string | null | undefined;
+  }) => actual.parseHostedFamilyInviteStartToken(input.text));
 
   return {
     ...actual,
     acceptHostedFamilyInviteFromPhoneTx: mocks.acceptHostedFamilyInviteFromPhoneTx,
     buildHostedFamilyInviteAcceptedReplyText: mocks.buildHostedFamilyInviteAcceptedReplyText,
+    resolveHostedFamilyInviteTokenForInbound: mocks.resolveHostedFamilyInviteTokenForInbound,
   };
 });
 
@@ -1173,6 +1178,79 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expectHostedLinqReadReceiptSent();
     expect(mocks.nudgeHostedRunnerUserBestEffortResult).not.toHaveBeenCalled();
     expectHostedLinqPointerSignalAccepted();
+  });
+
+  it("routes an active Linq member's unknown token-shaped text as a normal message", async () => {
+    mocks.resolveHostedFamilyInviteTokenForInbound.mockResolvedValueOnce(null);
+    const prisma = asPrismaTransactionClient({
+      $queryRaw: vi.fn().mockResolvedValue([]),
+      hostedWebhookReceipt: {
+        create: vi.fn().mockResolvedValue({}),
+        findUnique: vi.fn().mockResolvedValue({
+          payloadJson: {
+            eventType: "message.received",
+            receiptAttemptCount: 1,
+            receiptStatus: "processing",
+          },
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      hostedMember: {
+        findUnique: vi.fn().mockResolvedValue({
+          accountGroupMemberships: [],
+          billingStatus: HostedBillingStatus.active,
+          id: "member_123",
+          invites: [],
+          linqChatId: "chat_123",
+          phoneLookupKey: "+15551234567",
+        }),
+      },
+    });
+
+    await expect(handleHostedOnboardingLinqWebhook({
+      prisma,
+      rawBody: buildHostedLinqWebhookBody({
+        data: {
+          parts: [
+            {
+              type: "text",
+              value: "sending the family_photos album now",
+            },
+          ],
+        },
+        eventId: "evt_unknown_family_shape_linq",
+        service: "iMessage",
+      }),
+      signature: null,
+      timestamp: null,
+    })).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+
+    expect(mocks.resolveHostedFamilyInviteTokenForInbound).toHaveBeenCalledWith({
+      prisma,
+      text: "sending the family_photos album now",
+    });
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: expect.objectContaining({
+        eventId: "evt_unknown_family_shape_linq",
+        kind: "conversation.message",
+        message: expect.objectContaining({
+          linqMessage: expect.objectContaining({
+            parts: expect.arrayContaining([
+              expect.objectContaining({
+                type: "text",
+                value: "sending the family_photos album now",
+              }),
+            ]),
+          }),
+        }),
+      }),
+      tx: prisma,
+    });
+    expectHostedLinqPointerSignalAccepted("evt_unknown_family_shape_linq");
+    expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
   });
 
   it("prioritizes active-member Linq text when attachment descriptors arrive first", async () => {

--- a/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
@@ -403,6 +403,88 @@ describe("handleHostedOnboardingTelegramWebhook", () => {
     );
   });
 
+  it("routes unknown token-shaped Telegram text to the assistant", async () => {
+    mocks.runtimeEnv.telegramWebhookSecret = "telegram-secret";
+    const hostedMemberRoutingFindUnique = vi.fn(async (args?: { where?: { memberId?: string } }) => {
+      if (args?.where?.memberId) {
+        return null;
+      }
+
+      return {
+        member: {
+          billingStatus: HostedBillingStatus.active,
+          id: "member_telegram_123",
+          suspendedAt: null,
+        },
+        memberId: "member_telegram_123",
+      };
+    });
+    const hostedAccountGroupInviteFindUnique = vi.fn().mockResolvedValue(null);
+    const prisma = withPrismaTransaction({
+      hostedAccountGroupInvite: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: hostedAccountGroupInviteFindUnique,
+      },
+      hostedMemberIdentity: {
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+      hostedMemberRouting: {
+        findUnique: hostedMemberRoutingFindUnique,
+      },
+    });
+
+    await expect(handleHostedOnboardingTelegramWebhook({
+      prisma,
+      rawBody: JSON.stringify({
+        message: {
+          chat: {
+            id: 123,
+            type: "private",
+          },
+          date: 1_774_522_600,
+          from: {
+            first_name: "Alice",
+            id: 456,
+            username: "alice_user",
+          },
+          message_id: 6,
+          text: "sending the family_photos album now",
+        },
+        update_id: 326,
+      }),
+      secretToken: "telegram-secret",
+    })).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+
+    expect(hostedAccountGroupInviteFindUnique).toHaveBeenCalledWith({
+      select: {
+        id: true,
+      },
+      where: {
+        inviteCode: "photos",
+      },
+    });
+    expect(mocks.enqueueHostedExecutionOutbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envelope: expect.objectContaining({
+          eventId: "telegram:update:326",
+          kind: "conversation.message",
+          message: expect.objectContaining({
+            telegramMessage: expect.objectContaining({
+              text: "sending the family_photos album now",
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      expectedUserId: "member_telegram_123",
+      mailboxItemId: "mailbox_telegram:update:326",
+    });
+  });
+
   it("ignores Telegram family invite tokens that are not acceptable for the sender", async () => {
     mocks.runtimeEnv.telegramWebhookSecret = "telegram-secret";
     const hostedAccountGroupInviteFindUnique = vi.fn().mockResolvedValue({

--- a/apps/web/test/hosted-onboarding-whatsapp-service.test.ts
+++ b/apps/web/test/hosted-onboarding-whatsapp-service.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     void _input;
     return null;
   }),
+  resolveHostedFamilyInviteTokenForInbound: vi.fn(),
   appendHostedMailboxEnvelopeTx: vi.fn(async (input: {
     envelope?: { eventId?: string };
   }) => ({
@@ -89,10 +90,14 @@ vi.mock("@/src/lib/hosted-onboarding/family-plan", async () => {
   const actual = await vi.importActual<typeof import("@/src/lib/hosted-onboarding/family-plan")>(
     "@/src/lib/hosted-onboarding/family-plan",
   );
+  mocks.resolveHostedFamilyInviteTokenForInbound.mockImplementation(async (input: {
+    text: string | null | undefined;
+  }) => actual.parseHostedFamilyInviteStartToken(input.text));
 
   return {
     ...actual,
     acceptHostedFamilyInviteFromPhoneTx: mocks.acceptHostedFamilyInviteFromPhoneTx,
+    resolveHostedFamilyInviteTokenForInbound: mocks.resolveHostedFamilyInviteTokenForInbound,
   };
 });
 
@@ -611,6 +616,45 @@ describe("handleHostedOnboardingWhatsAppWebhook", () => {
         message: expect.objectContaining({
           whatsappMessage: expect.objectContaining({
             text: "wiesz cos o family planie?",
+          }),
+        }),
+      }),
+      tx: prisma,
+    });
+  });
+
+  it("routes unknown token-shaped WhatsApp text to the assistant", async () => {
+    mocks.resolveHostedFamilyInviteTokenForInbound.mockResolvedValueOnce(null);
+    const prisma = createWhatsAppPrismaHarness({
+      consentGranted: true,
+      memberId: "member_whatsapp_123",
+    });
+    const rawBody = buildWhatsAppInboundTextBody("sending the family_photos album now");
+
+    await expect(handleHostedOnboardingWhatsAppWebhook({
+      prisma,
+      rawBody,
+      signature: signWhatsAppBody(rawBody),
+    })).resolves.toEqual({
+      commandHandledCount: 0,
+      ignored: false,
+      inboundTextCount: 1,
+      ok: true,
+      reason: "wake-appended-active-member",
+      routedTextCount: 1,
+    });
+
+    expect(mocks.resolveHostedFamilyInviteTokenForInbound).toHaveBeenCalledWith({
+      prisma,
+      text: "sending the family_photos album now",
+    });
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: expect.objectContaining({
+        eventId: "whatsapp:message:wamid.test-message-1",
+        kind: "conversation.message",
+        message: expect.objectContaining({
+          whatsappMessage: expect.objectContaining({
+            text: "sending the family_photos album now",
           }),
         }),
       }),

--- a/apps/web/test/settings-billing-family-management-routes.test.ts
+++ b/apps/web/test/settings-billing-family-management-routes.test.ts
@@ -85,6 +85,7 @@ beforeEach(async () => {
     status: "pending",
     targetLabel: "Mom",
     targetPhoneHint: "+48 6** *** ***",
+    targetTelegramUsername: null,
   });
   mocks.buildHostedFamilyInviteAcceptUrl.mockReturnValue(
     "https://app.murph.test/family/accept/NEWCODE",
@@ -161,6 +162,17 @@ test("issues a family invite and returns safe share links", async () => {
 });
 
 test("returns a Telegram share link only for a Telegram-bound invite", async () => {
+  mocks.issueHostedFamilyInviteTx.mockResolvedValueOnce({
+    channel: "family",
+    expiresAt: new Date("2026-07-01T00:00:00.000Z"),
+    id: "inv_new",
+    inviteCode: "NEWCODE",
+    status: "pending",
+    targetLabel: "Uncle",
+    targetPhoneHint: null,
+    targetTelegramUsername: "uncle",
+  });
+
   const response = await inviteRoute.POST(
     inviteRequest({ targetLabel: "Uncle", targetTelegramUsername: "@uncle" }),
   );
@@ -170,6 +182,36 @@ test("returns a Telegram share link only for a Telegram-bound invite", async () 
   expect(payload.invite.telegramInviteUrl).toBe(
     "https://t.me/withmurph_bot?start=family_NEWCODE",
   );
+});
+
+test("does not return a Telegram share link when the stored invite is not Telegram-bound", async () => {
+  mocks.issueHostedFamilyInviteTx.mockResolvedValueOnce({
+    channel: "family",
+    expiresAt: new Date("2026-07-01T00:00:00.000Z"),
+    id: "inv_new",
+    inviteCode: "NEWCODE",
+    status: "pending",
+    targetLabel: "Uncle",
+    targetPhoneHint: "+48 6** *** ***",
+    targetTelegramUsername: null,
+  });
+
+  const response = await inviteRoute.POST(
+    inviteRequest({
+      targetLabel: "Uncle",
+      targetPhoneNumber: "+48600000000",
+      targetTelegramUsername: " ",
+    }),
+  );
+
+  expect(response.status).toBe(200);
+  const payload = (await response.json()) as { invite: { telegramInviteUrl: string | null } };
+  expect(payload.invite.telegramInviteUrl).toBeNull();
+  expect(mocks.resolveHostedFamilyTelegramInviteUrl).toHaveBeenCalledWith({
+    inviteCode: "NEWCODE",
+    isTelegramBound: false,
+    telegramBotUsername: "withmurph_bot",
+  });
 });
 
 test("adds one paid seat and retries when the plan is full", async () => {
@@ -191,6 +233,7 @@ test("adds one paid seat and retries when the plan is full", async () => {
       status: "pending",
       targetLabel: "Dad",
       targetPhoneHint: "+48 6** *** ***",
+      targetTelegramUsername: null,
     });
 
   const response = await inviteRoute.POST(
@@ -224,6 +267,7 @@ test("reuses a concurrently-created invite on the pre-buy re-check (no purchase)
       status: "pending",
       targetLabel: "Dad",
       targetPhoneHint: "+48 6** *** ***",
+      targetTelegramUsername: null,
     });
 
   const response = await inviteRoute.POST(
@@ -255,6 +299,7 @@ test("uses a seat freed before the purchase instead of buying another", async ()
       status: "pending",
       targetLabel: "Dad",
       targetPhoneHint: "+48 6** *** ***",
+      targetTelegramUsername: null,
     });
   mocks.readHostedFamilyOwnerSnapshotForMember.mockResolvedValueOnce({
     billingActive: true,

--- a/apps/web/test/settings-billing-family-management-routes.test.ts
+++ b/apps/web/test/settings-billing-family-management-routes.test.ts
@@ -5,7 +5,7 @@ import { hostedOnboardingError } from "../src/lib/hosted-onboarding/errors";
 const mocks = vi.hoisted(() => ({
   assertHostedOnboardingMutationOrigin: vi.fn(),
   buildHostedFamilyInviteAcceptUrl: vi.fn(),
-  buildHostedFamilyTelegramInviteUrl: vi.fn(),
+  resolveHostedFamilyTelegramInviteUrl: vi.fn(),
   ensureHostedAccountGroupForOwnerTx: vi.fn(),
   getPrisma: vi.fn(),
   hostedFamilyInviteHasReusableTarget: vi.fn(),
@@ -34,7 +34,7 @@ vi.mock("@/src/lib/hosted-onboarding/env", () => ({
 }));
 vi.mock("@/src/lib/hosted-onboarding/family-plan", () => ({
   buildHostedFamilyInviteAcceptUrl: mocks.buildHostedFamilyInviteAcceptUrl,
-  buildHostedFamilyTelegramInviteUrl: mocks.buildHostedFamilyTelegramInviteUrl,
+  resolveHostedFamilyTelegramInviteUrl: mocks.resolveHostedFamilyTelegramInviteUrl,
   ensureHostedAccountGroupForOwnerTx: mocks.ensureHostedAccountGroupForOwnerTx,
   hostedFamilyInviteHasReusableTarget: mocks.hostedFamilyInviteHasReusableTarget,
   issueHostedFamilyInviteTx: mocks.issueHostedFamilyInviteTx,
@@ -89,8 +89,12 @@ beforeEach(async () => {
   mocks.buildHostedFamilyInviteAcceptUrl.mockReturnValue(
     "https://app.murph.test/family/accept/NEWCODE",
   );
-  mocks.buildHostedFamilyTelegramInviteUrl.mockReturnValue(
-    "https://t.me/withmurph_bot?start=family_NEWCODE",
+  // Mirror the real gate: a Telegram link only for a Telegram-bound invite.
+  mocks.resolveHostedFamilyTelegramInviteUrl.mockImplementation(
+    (input: { inviteCode: string; isTelegramBound: boolean }) =>
+      input.isTelegramBound
+        ? `https://t.me/withmurph_bot?start=family_${input.inviteCode}`
+        : null,
   );
   mocks.revokeHostedFamilyInviteTx.mockResolvedValue(true);
   mocks.removeHostedFamilyMemberTx.mockResolvedValue(true);
@@ -142,7 +146,8 @@ test("issues a family invite and returns safe share links", async () => {
       status: "pending",
       targetLabel: "Mom",
       targetPhoneHint: "+48 6** *** ***",
-      telegramInviteUrl: "https://t.me/withmurph_bot?start=family_NEWCODE",
+      // Phone-bound invite: no Telegram link even though a bot is configured.
+      telegramInviteUrl: null,
     },
   });
   expect(mocks.issueHostedFamilyInviteTx).toHaveBeenCalledWith(
@@ -152,6 +157,18 @@ test("issues a family invite and returns safe share links", async () => {
       targetLabel: "Mom",
       targetPhoneNumber: "+48600000000",
     }),
+  );
+});
+
+test("returns a Telegram share link only for a Telegram-bound invite", async () => {
+  const response = await inviteRoute.POST(
+    inviteRequest({ targetLabel: "Uncle", targetTelegramUsername: "@uncle" }),
+  );
+
+  expect(response.status).toBe(200);
+  const payload = (await response.json()) as { invite: { telegramInviteUrl: string | null } };
+  expect(payload.invite.telegramInviteUrl).toBe(
+    "https://t.me/withmurph_bot?start=family_NEWCODE",
   );
 });
 

--- a/apps/web/test/settings-hosted-family-manager.test.tsx
+++ b/apps/web/test/settings-hosted-family-manager.test.tsx
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   act,
   createElement,
+  type ChangeEvent,
   type HTMLAttributes,
   type InputHTMLAttributes,
   type ReactNode,
@@ -62,6 +63,30 @@ vi.mock("@/src/components/ui/input", () => ({
     }),
 }));
 
+vi.mock("@/src/components/ui/phone-number-input", () => ({
+  PhoneNumberInput: ({
+    id,
+    value,
+    onPhoneNumberChange,
+  }: {
+    id: string;
+    value: string;
+    onPhoneNumberChange: (value: string) => void;
+  }) =>
+    createElement("input", {
+      id,
+      value,
+      onChange: (event: ChangeEvent<HTMLInputElement>) =>
+        onPhoneNumberChange(event.currentTarget.value),
+      onInput: (event: ChangeEvent<HTMLInputElement>) =>
+        onPhoneNumberChange(event.currentTarget.value),
+    }),
+}));
+
+vi.mock("@/src/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.requestHostedOnboardingJson.mockResolvedValue({
@@ -92,6 +117,7 @@ test("HostedFamilyManager keeps the created invite visible for manual sharing", 
     try {
       await clickButton(container, window, "Invite member");
       assert.match(container.textContent ?? "", /Murph won't message them/);
+      assertInviteFieldOrder(container);
 
       await act(async () => {
         setInputValue(window, inputById(container, "family-invite-phone"), "+48600000000");
@@ -283,4 +309,17 @@ function setInputValue(
   descriptor?.set?.call(input, value);
   input.dispatchEvent(new window.Event("input", { bubbles: true }));
   input.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+function assertInviteFieldOrder(container: HTMLElement) {
+  const text = container.textContent ?? "";
+  const phoneIndex = text.indexOf("Phone number (optional)");
+  const emailIndex = text.indexOf("Email (optional)");
+  const telegramIndex = text.indexOf("Telegram username (optional)");
+  const nameIndex = text.indexOf("Name (optional)");
+
+  assert.ok(phoneIndex >= 0, "Expected phone field");
+  assert.ok(emailIndex > phoneIndex, "Expected email after phone");
+  assert.ok(telegramIndex > emailIndex, "Expected Telegram after email");
+  assert.ok(nameIndex > telegramIndex, "Expected name after Telegram");
 }


### PR DESCRIPTION
## Why this PR exists

A family-plan invitee reachable only by phone/iMessage (no Telegram) opened the web invite-accept page and was shown only "Continue in Telegram", forcing her into an app she does not have and a Telegram verification she cannot pass. Root causes: the accept view offered Telegram whenever a bot username was configured in env regardless of the invitee's channel; the page had no iMessage/SMS path even though the accept-by-phone LinQ webhook already existed; and the settings form made contact-less (label-only) invites the path of least resistance, a class that then had no working accept path at all.

## User-visible goal / intent contract

**Binding is optional targeting, not mandatory verification** (owner-decided product rule, codified in `agent-docs/product-specs/hosted-family-plan.md`):

- Stored bindings are alternative claim identities: an invite bound to a phone, email, and/or Telegram username can be claimed through any one matching bound identity. A presented identity that contradicts its stored binding always fails closed. Bound invites never offer channels outside their bindings.
- A fully unbound (label-only) invite is claimable by the first verified identity that presents the invite reference through an EXPLICIT act: sending the prefilled join text, opening the Telegram deep link, or tapping Accept after web sign-in. Acceptance never happens as a side effect of an unrelated message. Unbound invites offer all configured claim channels, including the Telegram fallback when no Murph Messages line is configured.
- Unauthenticated phone-bound invitees lead with "Continue in Messages": an `sms:` deep link prefilled with a human sentence carrying the join code (`Hi Murph, joining the family plan (code family_X)`), reusing the existing accept-by-phone webhook with no separate verification step. An existing member's link targets the Murph line they already message. Signed-in sessions get one-tap web accept with Messages as the visible secondary action.
- Unbound claims notify the plan owner ("<label or Someone> just joined your family plan") via the existing family chat notification path.
- The invite form leads with a shared PhoneNumberInput (extracted from phone auth, submits normalized E.164) and states the binding tradeoff honestly.
- The accept page is rebuilt on the shared invite-shell primitives.

## Invariants the PR must preserve

- Every invite variant keeps a working accept path (Product-Critical Flow Preservation): phone → Messages (+ web), email → web, telegram → Telegram, multi-bound → any bound channel, unbound → Messages/web/Telegram.
- Bound-invite enforcement: at least one presented identity must match a stored binding; presented-identity contradictions throw per-channel mismatch errors; telegram-only invites still fail closed on web/phone claims; the invite-create API and owner surfaces gate the Telegram share link on the STORED invite binding, never the raw request or env.
- No silent message drops: a token-shaped string that matches no invite row must not divert an inbound chat message in any webhook provider (LinQ, WhatsApp, Telegram).
- The `sms:` prefill body must round-trip through `parseHostedFamilyInviteStartToken` (pinned by test).
- Unbound web claims still require a verified phone or email identity from sign-in; double-claims stay single-winner/idempotent.
- No new persisted state, queues, or notification machinery: unbound-claim announcements reuse the pre-existing family chat notification primitives with an idempotent source event id.

## Deployment

Single-plane (`apps/web`) change, no schema changes, no `apps/cloudflare` involvement: no deploy-skew concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)