### PR TITLE
build(hosted-runner): ratchet entry-chunk bundle budget to its measured baseline

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -30,12 +30,25 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // surface fails the assembly instead of silently regressing cold start.
 // Baselines measured from the real assembled bundle on 2026-07-06: total
 // 8,201,281B across 34 chunks, entry container-entrypoint.js 2,288,516B.
-// The entry budget is baseline + ~25% headroom (it gates cold-start parse).
-// The total ceiling is held at its prior 9,300,000B value: this change shrank
-// the bundle, so there is no reason to loosen the regression guard.
-// Investigate the listed largest inputs before raising either.
+//
+// The entry chunk gates cold-start parse, so it is ratcheted, not given
+// headroom: the guard holds it to the measured baseline plus a tight noise
+// band. Any growth past baseline + tolerance fails the assembly, so weight
+// can only land on the boot path as a reviewed edit to the baseline constant
+// below. When an increase is intentional, set the baseline to the measured
+// value the failure prints and say why in the same change.
+//
+// The total ceiling stays a fixed backstop at its prior 9,300,000B value (not
+// ratcheted): #397 shrank the bundle, so there is no reason to loosen it, and
+// dynamic (non-boot) chunk jitter should not force a baseline bump. Ratchet it
+// too if total creep becomes the concern. Investigate the listed largest
+// inputs before raising either.
 const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_300_000;
-const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BYTES_BUDGET = 2_900_000;
+const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 2_288_516;
+// Noise band above the baseline before the ratchet trips (~2%): absorbs
+// content-hash and minifier jitter without letting real boot-path weight land
+// silently. Keep it tight; it is a tolerance for noise, not feature headroom.
+const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;
 const RUNNER_ENTRYPOINT_FORBIDDEN_BOOT_INPUT_MARKERS = [
   "node_modules/grammy/",
   "node_modules/node-fetch/",
@@ -78,9 +91,25 @@ export async function bundleRunnerContainerEntrypoint(
     buildResult.metafile,
   );
   console.log(
-    `runner entrypoint bundle size: total ${bundleBytes.totalBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET}B budget, entry ${bundleBytes.entryBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BYTES_BUDGET}B budget`,
+    `runner entrypoint bundle size: entry ${bundleBytes.entryBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES}B tolerance), total ${bundleBytes.totalBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET}B budget`,
   );
   assertRunnerEntrypointBundleBoots({ bundleDir, bundleOutDir });
+}
+
+// Single source of truth for the production budgets: the entry chunk is the
+// ratcheted baseline plus its noise tolerance, the total is the fixed ceiling.
+// Exported so a unit test can lock these values (the assembly path calls
+// assertRunnerEntrypointBundleWithinBudgets with this as the default).
+export function resolveRunnerEntrypointBundleBudgets(): {
+  entryBytes: number;
+  totalBytes: number;
+} {
+  return {
+    entryBytes:
+      RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES
+      + RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES,
+    totalBytes: RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET,
+  };
 }
 
 function assertRunnerEntrypointBundleInputsStayExternal(
@@ -101,10 +130,8 @@ function assertRunnerEntrypointBundleInputsStayExternal(
 // call site always uses the default budgets above.
 export function assertRunnerEntrypointBundleWithinBudgets(
   metafile: Metafile,
-  budgets: { entryBytes: number; totalBytes: number } = {
-    entryBytes: RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BYTES_BUDGET,
-    totalBytes: RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET,
-  },
+  budgets: { entryBytes: number; totalBytes: number }
+    = resolveRunnerEntrypointBundleBudgets(),
 ): { entryBytes: number; totalBytes: number } {
   const outputs = Object.entries(metafile.outputs);
   const totalBytes = outputs.reduce((sum, [, output]) => sum + output.bytes, 0);
@@ -148,7 +175,7 @@ export function assertRunnerEntrypointBundleWithinBudgets(
   throw new Error(
     [
       `runner entrypoint bundle exceeded its byte budget: ${violations.join("; ")}.`,
-      "Investigate the largest metafile inputs below before raising the budget (see baseline comment on the budget constants):",
+      "Investigate the largest metafile inputs below. If the growth is intended, update the matching baseline/budget constant to the measured value in the same change (see the baseline comment on the budget constants):",
       ...largestInputs,
     ].join("\n"),
   );

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -8,8 +8,27 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   assertRunnerEntrypointBundleWithinBudgets,
   bundleRunnerContainerEntrypoint,
+  resolveRunnerEntrypointBundleBudgets,
   RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME,
 } from "../scripts/runner-bundle/bundle-entrypoint.js";
+
+// A metafile with a single container-entrypoint.js output sized to `entryBytes`
+// and no other chunks, so the total equals the entry size. Used to prove the
+// production budgets gate the entry chunk at the ratchet boundary.
+function entryOnlyMetafile(entryBytes: number): Metafile {
+  return {
+    inputs: { "dist/container-entrypoint.js": { bytes: 10, imports: [] } },
+    outputs: {
+      "dist-bundled/container-entrypoint.js": {
+        bytes: entryBytes,
+        entryPoint: "dist/container-entrypoint.js",
+        exports: [],
+        imports: [],
+        inputs: {},
+      },
+    },
+  };
+}
 
 const temporaryDirectories: string[] = [];
 
@@ -213,6 +232,37 @@ describe("runner bundle container-entrypoint esbuild step", () => {
         totalBytes: 10_000,
       }),
     ).toEqual({ entryBytes: 2_000, totalBytes: 6_000 });
+  });
+
+  it("resolves the production budgets as the ratcheted entry baseline plus tolerance", () => {
+    const budgets = resolveRunnerEntrypointBundleBudgets();
+
+    // Entry = measured baseline (2,288,516B on 2026-07-06) + 48,000B noise
+    // band. Locking the exact value makes any silent change to the ratchet a
+    // failing, reviewed diff.
+    expect(budgets).toEqual({
+      entryBytes: 2_288_516 + 48_000,
+      totalBytes: 9_300_000,
+    });
+    // The ratchet is meaningfully tighter than the prior loose 2.9MB ceiling
+    // it replaced, so real boot-path creep can no longer hide in headroom.
+    expect(budgets.entryBytes).toBeLessThan(2_900_000);
+  });
+
+  it("gates the entry chunk at the production ratchet boundary", () => {
+    const { entryBytes } = resolveRunnerEntrypointBundleBudgets();
+
+    // At the boundary the default (production) budgets accept the bundle.
+    expect(
+      assertRunnerEntrypointBundleWithinBudgets(entryOnlyMetafile(entryBytes)),
+    ).toEqual({ entryBytes, totalBytes: entryBytes });
+
+    // One byte over the baseline + tolerance trips the assembly.
+    expect(() =>
+      assertRunnerEntrypointBundleWithinBudgets(
+        entryOnlyMetafile(entryBytes + 1),
+      ),
+    ).toThrow(/entry chunk .* exceeds budget/);
   });
 
   it("rejects metafiles without a container-entrypoint.js entry output", () => {


### PR DESCRIPTION
## Why

PR #397 shrank the hosted-runner cold-boot entry chunk (3.43MB → 2.29MB) and added a byte-budget guard. But that guard is a **loose ceiling**: the entry budget was set to 2.9MB, ~25% above the measured 2,288,516B entry chunk. That headroom means ~600KB of cold-start boot-path weight can creep back in silently before the guard ever trips. A fixed ceiling catches a sudden jump (grammy sneaking back onto boot), not slow drift back up.

This is the follow-up asked for after #397: a guard that keeps us from quietly re-inflating the bundle.

## User-visible goal

Keep hosted cold-start fast over time. `nodeStartupMs` spans process start → HTTP listen, so every byte the entry chunk gains is paid on every cold start. This change makes any regression of that byte count a build failure that must be consciously accepted, so the cold-start win from #397 doesn't erode PR by PR.

## What changed

Turn the entry-chunk ceiling into a **ratchet** (the total stays a fixed backstop):

- Hold the entry chunk to its **measured baseline** (2,288,516B) plus a tight **48KB noise band** (~2%, absorbs content-hash / minifier jitter). Growth past baseline + tolerance fails the assembly.
- Because the guard is now pinned to the measured size, a legitimate increase can only land as a **reviewed edit to the baseline constant** in the same PR. Every added boot-path byte becomes a visible, signed-off diff line instead of silent slack.
- Derive the production budgets through one exported `resolveRunnerEntrypointBundleBudgets()` so they're a single source of truth and unit-testable.
- Failure message now points at updating the baseline, not "raising the budget."
- Two tests lock the resolved budgets (baseline + tolerance, tighter than the old 2.9MB) and prove the entry gate fires one byte over the boundary.

No new committed baseline file and no refresh script: the baseline is a documented constant, so bumping it is an ordinary reviewed code change. The total bundle stays a fixed 9.3MB ceiling (not ratcheted) so dynamic non-boot chunk jitter doesn't force baseline churn; it can be ratcheted later if total creep becomes the concern.

## Invariants to preserve

- The guard must still **allow** provider connectors behind dynamic imports and **reject** them in the static boot closure (unchanged; existing tests cover it).
- The ratchet must not false-positive on the current bundle: measured entry 2,288,516B < budget 2,336,516B (48KB headroom).

## Verification

- `runner-bundle-entrypoint-bundle` vitest: **9 passed** (7 existing + 2 new).
- `apps/cloudflare` typecheck: pass.
- The real assembly (`runner:bundle`) runs on this PR via the hosted-e2e workflows, exercising the ratchet against the actually-assembled bundle.

## Deploy

Build-time guard only. No runtime, web, or Cloudflare tandem-deploy concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785959444&installation_id=127572939&pr_number=402&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F402&signature=ead183ca2d2bd5795f355486986226737dc3e160d53833221a9144e03b266ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->