### PR TITLE
build(hosted-runner): boot probe also evaluates lazy bundle chunks

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-06-runner-boot-probe-lazy-chunks.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-runner-boot-probe-lazy-chunks.md
@@ -1,0 +1,41 @@
+# Runner Boot Probe Lazy Chunks
+
+## Goal
+
+Extend the runner entrypoint bundle boot probe so the assembled artifact also
+evaluates lazy chunks reached through dynamic imports, and prove the chunk
+collection behavior with a focused test.
+
+## Constraints
+
+- Keep the existing boot-probe primitive and one subprocess.
+- Reuse the current metafile traversal shape instead of duplicating graph
+  walking.
+- Do not add scripts, config, or new machinery.
+- Preserve the entrypoint guard protection by keeping probe paths out of argv.
+- Stop if lazy chunk module scope performs IO or network work.
+
+## Plan
+
+1. Refactor the existing output traversal into a shared helper used by the
+   static boot-closure check and the new lazy-chunk collector.
+2. Pass lazy chunk file URLs to the existing probe subprocess through env and
+   import them after the entry import succeeds.
+3. Add one synthetic-metafile unit test for lazy chunk collection.
+4. Verify with runner bundle assembly, a local corruption sanity check, focused
+   runner-bundle tests, and Cloudflare typecheck.
+
+## Verification
+
+- Passed: `pnpm --dir apps/cloudflare runner:bundle`
+  - Entry chunk 2,291,540B within baseline 2,288,516B + 48,000B tolerance.
+  - Total output 8,210,004B within 9,300,000B budget.
+- Passed: local post-build lazy chunk corruption sanity check
+  - Temporarily corrupted `conversation-W4C22JD5.js`; probe failed with status
+    4 and named the chunk, then restored the file and verified the hash.
+- Passed: `pnpm --dir apps/cloudflare exec vitest run --config vitest.node.workspace.ts --no-coverage test/runner-bundle-cli-bundle.test.ts test/runner-bundle-contract.test.ts test/runner-bundle-dependency-install.test.ts test/runner-bundle-entrypoint-bundle.test.ts test/runner-bundle-helpers.test.ts test/runner-bundle-process.test.ts test/runner-bundle-runtime-shape.test.ts test/runner-bundle-workspace-artifacts.test.ts test/sync-smoke-runner-bundle.test.ts`
+  - 9 files, 72 tests.
+- Passed: `pnpm --dir apps/cloudflare typecheck`
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -87,13 +87,23 @@ export async function bundleRunnerContainerEntrypoint(
   assertRunnerEntrypointBundleInputsStayExternal(
     Object.keys(buildResult.metafile.inputs),
   );
+  const entryOutputPath = findRunnerEntrypointBundleEntryOutputPath(
+    buildResult.metafile,
+  );
   const bundleBytes = assertRunnerEntrypointBundleWithinBudgets(
     buildResult.metafile,
   );
   console.log(
     `runner entrypoint bundle size: entry ${bundleBytes.entryBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES}B tolerance), total ${bundleBytes.totalBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET}B budget`,
   );
-  assertRunnerEntrypointBundleBoots({ bundleDir, bundleOutDir });
+  assertRunnerEntrypointBundleBoots({
+    bundleDir,
+    bundleOutDir,
+    lazyChunkOutputPaths: [...collectLazyRunnerEntrypointOutputPaths(
+      buildResult.metafile,
+      entryOutputPath,
+    )],
+  });
 }
 
 // Single source of truth for the production budgets: the entry chunk is the
@@ -136,20 +146,13 @@ export function assertRunnerEntrypointBundleWithinBudgets(
   const outputs = Object.entries(metafile.outputs);
   const totalBytes = outputs.reduce((sum, [, output]) => sum + output.bytes, 0);
 
-  // With code splitting, esbuild stamps `entryPoint` on dynamic-import
-  // chunks too; the real entry output keeps the entry file's plain name
-  // while shared and dynamic chunks carry content-hash suffixes.
-  const entryOutput = outputs.find(
-    ([outputPath, output]) =>
-      output.entryPoint !== undefined
-      && path.basename(outputPath) === "container-entrypoint.js",
-  );
-  if (!entryOutput) {
+  const entryPath = findRunnerEntrypointBundleEntryOutputPath(metafile);
+  const entryBytes = metafile.outputs[entryPath]?.bytes;
+  if (entryBytes === undefined) {
     throw new Error(
-      "runner entrypoint bundle metafile has no container-entrypoint.js entry-point output; cannot enforce the entry-chunk byte budget.",
+      `runner entrypoint bundle metafile is missing output ${entryPath}; cannot enforce the entry-chunk byte budget.`,
     );
   }
-  const [entryPath, { bytes: entryBytes }] = entryOutput;
   assertRunnerEntrypointBundleBootInputsAllowed(metafile, entryPath);
 
   const violations: string[] = [];
@@ -179,6 +182,23 @@ export function assertRunnerEntrypointBundleWithinBudgets(
       ...largestInputs,
     ].join("\n"),
   );
+}
+
+function findRunnerEntrypointBundleEntryOutputPath(metafile: Metafile): string {
+  // With code splitting, esbuild stamps `entryPoint` on dynamic-import
+  // chunks too; the real entry output keeps the entry file's plain name
+  // while shared and dynamic chunks carry content-hash suffixes.
+  const entryOutput = Object.entries(metafile.outputs).find(
+    ([outputPath, output]) =>
+      output.entryPoint !== undefined
+      && path.basename(outputPath) === "container-entrypoint.js",
+  );
+  if (!entryOutput) {
+    throw new Error(
+      "runner entrypoint bundle metafile has no container-entrypoint.js entry-point output; cannot enforce the entry-chunk byte budget.",
+    );
+  }
+  return entryOutput[0];
 }
 
 function assertRunnerEntrypointBundleBootInputsAllowed(
@@ -216,9 +236,44 @@ function assertRunnerEntrypointBundleBootInputsAllowed(
   }
 }
 
+type MetafileOutputImport = Metafile["outputs"][string]["imports"][number];
+
 function collectStaticRunnerEntrypointOutputPaths(
   metafile: Metafile,
   entryPath: string,
+): Set<string> {
+  return collectRunnerEntrypointOutputPaths(
+    metafile,
+    entryPath,
+    (imported) => imported.kind !== "dynamic-import",
+  );
+}
+
+export function collectLazyRunnerEntrypointOutputPaths(
+  metafile: Metafile,
+  entryPath: string,
+): Set<string> {
+  const staticOutputPaths = collectStaticRunnerEntrypointOutputPaths(
+    metafile,
+    entryPath,
+  );
+  const outputPaths = collectRunnerEntrypointOutputPaths(
+    metafile,
+    entryPath,
+    () => true,
+  );
+
+  for (const outputPath of staticOutputPaths) {
+    outputPaths.delete(outputPath);
+  }
+
+  return outputPaths;
+}
+
+function collectRunnerEntrypointOutputPaths(
+  metafile: Metafile,
+  entryPath: string,
+  shouldFollowImport: (imported: MetafileOutputImport) => boolean,
 ): Set<string> {
   const outputPaths = new Set<string>();
   const pending = [normalizeMetafilePath(entryPath)];
@@ -235,7 +290,7 @@ function collectStaticRunnerEntrypointOutputPaths(
       continue;
     }
     for (const imported of output.imports) {
-      if (imported.kind === "dynamic-import") {
+      if (!shouldFollowImport(imported)) {
         continue;
       }
       const importedOutputPath = resolveMetafileOutputImportPath(
@@ -276,19 +331,41 @@ function normalizeMetafilePath(inputPath: string): string {
 function assertRunnerEntrypointBundleBoots(input: {
   bundleDir: string;
   bundleOutDir: string;
+  lazyChunkOutputPaths: string[];
 }): void {
   const bundledEntryPath = path.join(
     input.bundleOutDir,
     "container-entrypoint.js",
   );
+  const lazyChunks = input.lazyChunkOutputPaths.map((outputPath) => {
+    const filePath = path.resolve(outputPath.split("/").join(path.sep));
+    const relativePath = path.relative(input.bundleOutDir, filePath);
+    return {
+      path: relativePath.startsWith("..") || path.isAbsolute(relativePath)
+        ? normalizeMetafilePath(outputPath)
+        : normalizeMetafilePath(relativePath),
+      url: pathToFileURL(filePath).href,
+    };
+  });
   // The entry path travels via env, not argv: with it in argv[1] the module's
   // own main-entrypoint guard would match during the probe import and start
-  // the container HTTP server on the assembling machine.
+  // the container HTTP server on the assembling machine. Lazy chunk paths use
+  // the same env channel so the probe still has no bundle target in argv.
   const probeSource = [
     "const entry = await import(process.env.RUNNER_ENTRYPOINT_BUNDLE_PROBE_PATH);",
     "if (typeof entry.startHostedContainerEntrypoint !== 'function') {",
     "  console.error('bundled container entrypoint is missing startHostedContainerEntrypoint');",
     "  process.exit(3);",
+    "}",
+    "const lazyChunks = JSON.parse(process.env.RUNNER_ENTRYPOINT_BUNDLE_PROBE_LAZY_CHUNKS ?? '[]');",
+    "for (const chunk of lazyChunks) {",
+    "  try {",
+    "    await import(chunk.url);",
+    "  } catch (error) {",
+    "    console.error(`bundled lazy chunk failed to evaluate: ${chunk.path}`);",
+    "    console.error(error instanceof Error ? `${error.name}: ${error.message}` : String(error));",
+    "    process.exit(4);",
+    "  }",
     "}",
     "process.exit(0);",
   ].join("\n");
@@ -301,6 +378,7 @@ function assertRunnerEntrypointBundleBoots(input: {
       env: {
         ...process.env,
         RUNNER_ENTRYPOINT_BUNDLE_PROBE_PATH: pathToFileURL(bundledEntryPath).href,
+        RUNNER_ENTRYPOINT_BUNDLE_PROBE_LAZY_CHUNKS: JSON.stringify(lazyChunks),
       },
       timeout: 60_000,
     },

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   assertRunnerEntrypointBundleWithinBudgets,
   bundleRunnerContainerEntrypoint,
+  collectLazyRunnerEntrypointOutputPaths,
   resolveRunnerEntrypointBundleBudgets,
   RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME,
 } from "../scripts/runner-bundle/bundle-entrypoint.js";
@@ -232,6 +233,74 @@ describe("runner bundle container-entrypoint esbuild step", () => {
         totalBytes: 10_000,
       }),
     ).toEqual({ entryBytes: 2_000, totalBytes: 6_000 });
+  });
+
+  it("collects output chunks reachable only through dynamic imports", () => {
+    const metafile: Metafile = {
+      inputs: {
+        "dist/container-entrypoint.js": { bytes: 10, imports: [] },
+        "dist/static.js": { bytes: 10, imports: [] },
+        "dist/lazy.js": { bytes: 10, imports: [] },
+      },
+      outputs: {
+        "dist-bundled/container-entrypoint.js": {
+          bytes: 100,
+          entryPoint: "dist/container-entrypoint.js",
+          exports: [],
+          imports: [
+            { kind: "import-statement", path: "./static-STATIC.js" },
+            { kind: "dynamic-import", path: "./lazy-LAZY.js" },
+          ],
+          inputs: {
+            "dist/container-entrypoint.js": { bytesInOutput: 10 },
+          },
+        },
+        "dist-bundled/static-STATIC.js": {
+          bytes: 100,
+          entryPoint: undefined,
+          exports: [],
+          imports: [
+            { kind: "import-statement", path: "./static-shared-STATIC.js" },
+          ],
+          inputs: {
+            "dist/static.js": { bytesInOutput: 10 },
+          },
+        },
+        "dist-bundled/static-shared-STATIC.js": {
+          bytes: 100,
+          entryPoint: undefined,
+          exports: [],
+          imports: [],
+          inputs: {},
+        },
+        "dist-bundled/lazy-LAZY.js": {
+          bytes: 100,
+          entryPoint: "dist/lazy.js",
+          exports: [],
+          imports: [
+            { kind: "import-statement", path: "./lazy-shared-LAZY.js" },
+          ],
+          inputs: {
+            "dist/lazy.js": { bytesInOutput: 10 },
+          },
+        },
+        "dist-bundled/lazy-shared-LAZY.js": {
+          bytes: 100,
+          entryPoint: undefined,
+          exports: [],
+          imports: [],
+          inputs: {},
+        },
+      },
+    };
+
+    expect([...collectLazyRunnerEntrypointOutputPaths(
+      metafile,
+      "dist-bundled/container-entrypoint.js",
+    )].sort()).toEqual([
+      "dist-bundled/lazy-LAZY.js",
+      "dist-bundled/lazy-shared-LAZY.js",
+    ]);
   });
 
   it("resolves the production budgets as the ratcheted entry baseline plus tolerance", () => {


### PR DESCRIPTION
## Why

The runner bundle's boot probe only imported the bundled entry, so a lazy-chunk-only module-scope crash (bad transform, unresolved external, future regression) would pass assembly and surface at a user's first conversation turn instead of failing the build. Flagged as the one residual test gap by the post-merge cold audit of #397, which moved the conversation projection graph into a dynamic-import chunk.

## What

- The existing probe subprocess now also `await import()`s every chunk reachable from the entry **only** via dynamic-import edges (generic — computed from the esbuild metafile, no hardcoded chunk names), and names the failing chunk in the assembly error.
- The chunk traversal is refactored into one parameterized walker; static closure (used by the #397 forbidden-input guard) and lazy set are now complements of the same primitive. Entry-output lookup deduplicated.
- Focused unit test for the lazy-set collection (includes transitive static deps of lazy chunks; excludes the static closure).

## Verification

- `runner:bundle` assembly green (entry 2,291,540B within #402's ratchet; total 8,210,004B).
- **Corruption sanity check**: corrupted the real `conversation-*.js` chunk post-build → probe failed status 4 naming the chunk → restored (hash-checked). Proves the probe catches exactly the audited failure mode.
- Runner-bundle tests: 9 files, 72 tests green; apps/cloudflare typecheck green.

Module-scope evaluation of lazy chunks in the probe is the same evaluation production performs at first conversation turn; no import-time IO was found in the lazy graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785961737&installation_id=127572939&pr_number=405&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F405&signature=016710c798db00726c011c47853cdab6ddc9109606eae7f9869e1f5f0f020d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->