### PR TITLE
fix(hosted-runner): harden boot-guard markers + distinct conversation module-load failure reason

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -49,11 +49,15 @@ const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 2_288_516;
 // content-hash and minifier jitter without letting real boot-path weight land
 // silently. Keep it tight; it is a tolerance for noise, not feature headroom.
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;
+// The inboxd markers are path suffixes, not node_modules-anchored: workspace
+// package inputs appear as `node_modules/@murphai/inboxd/dist/...` in the
+// staged production assembly but as `packages/inboxd/dist/...` when bundling
+// straight from the repo checkout, and the guard must bite in both shapes.
 const RUNNER_ENTRYPOINT_FORBIDDEN_BOOT_INPUT_MARKERS = [
   "node_modules/grammy/",
   "node_modules/node-fetch/",
-  "node_modules/@murphai/inboxd/dist/connectors/hosted-conversation.js",
-  "node_modules/@murphai/inboxd/dist/connectors/telegram/connector.js",
+  "/inboxd/dist/connectors/hosted-conversation.js",
+  "/inboxd/dist/connectors/telegram/connector.js",
 ] as const;
 
 export async function bundleRunnerContainerEntrypoint(

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -30,6 +30,35 @@ function entryOnlyMetafile(entryBytes: number): Metafile {
   };
 }
 
+function staticBootClosureMetafile(inputPath: string): Metafile {
+  return {
+    inputs: {
+      "dist/container-entrypoint.js": { bytes: 600, imports: [] },
+      [inputPath]: { bytes: 5_000, imports: [] },
+    },
+    outputs: {
+      "dist-bundled/container-entrypoint.js": {
+        bytes: 2_000,
+        entryPoint: "dist/container-entrypoint.js",
+        exports: [],
+        imports: [{ kind: "import-statement", path: "./chunk-STATIC.js" }],
+        inputs: {
+          "dist/container-entrypoint.js": { bytesInOutput: 600 },
+        },
+      },
+      "dist-bundled/chunk-STATIC.js": {
+        bytes: 4_000,
+        entryPoint: undefined,
+        exports: [],
+        imports: [],
+        inputs: {
+          [inputPath]: { bytesInOutput: 4_000 },
+        },
+      },
+    },
+  };
+}
+
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
@@ -163,32 +192,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
   });
 
   it("rejects provider connector inputs from the static boot closure", () => {
-    const metafile: Metafile = {
-      inputs: {
-        "dist/container-entrypoint.js": { bytes: 600, imports: [] },
-        "node_modules/grammy/out/mod.js": { bytes: 5_000, imports: [] },
-      },
-      outputs: {
-        "dist-bundled/container-entrypoint.js": {
-          bytes: 2_000,
-          entryPoint: "dist/container-entrypoint.js",
-          exports: [],
-          imports: [{ kind: "import-statement", path: "./chunk-STATIC.js" }],
-          inputs: {
-            "dist/container-entrypoint.js": { bytesInOutput: 600 },
-          },
-        },
-        "dist-bundled/chunk-STATIC.js": {
-          bytes: 4_000,
-          entryPoint: undefined,
-          exports: [],
-          imports: [],
-          inputs: {
-            "node_modules/grammy/out/mod.js": { bytesInOutput: 4_000 },
-          },
-        },
-      },
-    };
+    const metafile = staticBootClosureMetafile("node_modules/grammy/out/mod.js");
 
     expect(() =>
       assertRunnerEntrypointBundleWithinBudgets(metafile, {
@@ -196,6 +200,36 @@ describe("runner bundle container-entrypoint esbuild step", () => {
         totalBytes: 10_000,
       }),
     ).toThrow(/provider connector inputs in the static boot closure[\s\S]*node_modules\/grammy\/out\/mod\.js/);
+  });
+
+  it("rejects staged @murphai/inboxd connector inputs from the static boot closure", () => {
+    const inputPath =
+      ".deploy/runner-bundle/node_modules/@murphai/inboxd/dist/connectors/hosted-conversation.js";
+    const metafile = staticBootClosureMetafile(inputPath);
+
+    expect(() =>
+      assertRunnerEntrypointBundleWithinBudgets(metafile, {
+        entryBytes: 10_000,
+        totalBytes: 10_000,
+      }),
+    ).toThrow(
+      /provider connector inputs in the static boot closure[\s\S]*\.deploy\/runner-bundle\/node_modules\/@murphai\/inboxd\/dist\/connectors\/hosted-conversation\.js/,
+    );
+  });
+
+  it("rejects workspace @murphai/inboxd connector inputs from the static boot closure", () => {
+    const metafile = staticBootClosureMetafile(
+      "packages/inboxd/dist/connectors/hosted-conversation.js",
+    );
+
+    expect(() =>
+      assertRunnerEntrypointBundleWithinBudgets(metafile, {
+        entryBytes: 10_000,
+        totalBytes: 10_000,
+      }),
+    ).toThrow(
+      /provider connector inputs in the static boot closure[\s\S]*packages\/inboxd\/dist\/connectors\/hosted-conversation\.js/,
+    );
   });
 
   it("allows provider connector inputs behind dynamic imports", () => {

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -67,6 +67,8 @@ import {
 
 const CONVERSATION_PROJECTION_FAILED_REASON =
   "conversation-import.projection-failed";
+const CONVERSATION_MODULE_LOAD_FAILED_REASON =
+  "conversation-import.module-load-failed";
 const CONVERSATION_ATTACHMENT_EVIDENCE_FAILED_REASON =
   "conversation-import.attachment-evidence-failed";
 const CONVERSATION_PROJECTION_UPDATE_FAILED_REASON =
@@ -83,11 +85,22 @@ const ATTACHMENT_EVIDENCE_PARTIAL_REASON =
   "attachment.evidence_partial";
 const ASSISTANT_INPUT_SOURCE_METADATA_TEXT_MAX_LENGTH = 512;
 const RUNTIME_WAKE_NOTIFY_STALE_SKEW_TOLERANCE_MS = 5_000;
+const CONVERSATION_MODULE_LOAD_FAILED_CODE =
+  "conversation-module-load-failed";
 
 type HostedConversationEventsModule = typeof import("./events/conversation.ts");
 
 let hostedConversationEventsModulePromise:
   Promise<HostedConversationEventsModule> | null = null;
+
+class HostedConversationEventsModuleLoadError extends Error {
+  readonly code = CONVERSATION_MODULE_LOAD_FAILED_CODE;
+
+  constructor(cause: unknown) {
+    super("Failed to load hosted conversation events module.", { cause });
+    this.name = "HostedConversationEventsModuleLoadError";
+  }
+}
 
 export type HostedConversationMailboxPayloadDecodeResult =
   | {
@@ -723,7 +736,7 @@ function loadHostedConversationEventsModule(): Promise<HostedConversationEventsM
       if (hostedConversationEventsModulePromise === modulePromise) {
         hostedConversationEventsModulePromise = null;
       }
-      throw error;
+      throw new HostedConversationEventsModuleLoadError(error);
     });
     hostedConversationEventsModulePromise = modulePromise;
   }
@@ -839,6 +852,9 @@ function readHostedConversationProjectionFailureReason(
   }
 
   const errorCode = readHostedConversationFailureCode(error);
+  if (errorCode === CONVERSATION_MODULE_LOAD_FAILED_CODE) {
+    return CONVERSATION_MODULE_LOAD_FAILED_REASON;
+  }
   if (errorCode === "inbox-not-initialized") {
     return CONVERSATION_INBOX_RUNTIME_UNAVAILABLE_REASON;
   }
@@ -857,6 +873,9 @@ function readHostedConversationAttachmentEvidenceFailureReason(
   }
 
   const errorCode = readHostedConversationFailureCode(error);
+  if (errorCode === CONVERSATION_MODULE_LOAD_FAILED_CODE) {
+    return CONVERSATION_MODULE_LOAD_FAILED_REASON;
+  }
   if (errorCode === "inbox-not-initialized") {
     return CONVERSATION_INBOX_RUNTIME_UNAVAILABLE_REASON;
   }

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-loader.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-loader.test.ts
@@ -26,6 +26,13 @@ type MailboxConversationImportInput = Parameters<
   MailboxConversationImportModule["importHostedConversationMailboxItem"]
 >[0];
 
+class HostedConversationInboxProjectionError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "HostedConversationInboxProjectionError";
+  }
+}
+
 afterEach(() => {
   vi.doUnmock(CONVERSATION_MODULE_PATH);
   vi.resetModules();
@@ -53,12 +60,6 @@ test("lazy conversation events import retries after rejection while preserving p
         },
       }),
     );
-  class HostedConversationInboxProjectionError extends Error {
-    constructor(message: string, options?: { cause?: unknown }) {
-      super(message, options);
-      this.name = "HostedConversationInboxProjectionError";
-    }
-  }
 
   vi.doMock(CONVERSATION_MODULE_PATH, async () => {
     const moduleLoad = moduleLoads[moduleLoadCount];
@@ -79,7 +80,8 @@ test("lazy conversation events import retries after rejection while preserving p
 
   const firstOutcome = await firstImport;
   assert.equal(firstOutcome.status, "imported");
-  assert.equal(firstOutcome.reasonCode, "conversation-import.projection-failed");
+  assert.equal(firstOutcome.reasonCode, "conversation-import.module-load-failed");
+  assert.notEqual(firstOutcome.reasonCode, "conversation-import.projection-failed");
   assert.equal(importHostedConversationMessageWakeIntoLocalInbox.mock.calls.length, 0);
 
   const secondImport = importHostedConversationMailboxItem(
@@ -115,6 +117,38 @@ test("lazy conversation events import retries after rejection while preserving p
   assert.equal(memoizedOutcome.reasonCode ?? null, null);
   assert.equal(moduleLoadCount, 2);
   assert.equal(importHostedConversationMessageWakeIntoLocalInbox.mock.calls.length, 3);
+});
+
+test("successfully loaded conversation projection failures stay projection failures", async () => {
+  vi.resetModules();
+  let moduleLoadCount = 0;
+  const importHostedConversationMessageWakeIntoLocalInbox =
+    vi.fn<ConversationEventsModule["importHostedConversationMessageWakeIntoLocalInbox"]>(
+      async () => {
+        throw new HostedConversationInboxProjectionError(
+          "synthetic projection failure after module load",
+        );
+      },
+    );
+
+  vi.doMock(CONVERSATION_MODULE_PATH, () => {
+    moduleLoadCount += 1;
+    return {
+      HostedConversationInboxProjectionError,
+      importHostedConversationMessageWakeIntoLocalInbox,
+    };
+  });
+
+  const { importHostedConversationMailboxItem } =
+    await import("../src/hosted-runtime/mailbox-conversation-import.ts");
+  const outcome = await importHostedConversationMailboxItem(
+    createImportInput("005"),
+  );
+
+  assert.equal(outcome.status, "imported");
+  assert.equal(outcome.reasonCode, "conversation-import.projection-failed");
+  assert.equal(moduleLoadCount, 1);
+  assert.equal(importHostedConversationMessageWakeIntoLocalInbox.mock.calls.length, 1);
 });
 
 function createImportInput(


### PR DESCRIPTION
## Why

A post-merge deep review of #397 found two proven Low defects in the landed code. Both are tightening fixes; runtime behavior of the happy path is unchanged.

## What changed

**1. Boot-guard markers hardened to path suffixes.** The static-boot-closure guard's two inboxd markers were anchored on `node_modules/@murphai/inboxd/dist/...`. The staged production assembly does record that shape (verified against the real assembled metafile: `.deploy/runner-bundle/node_modules/@murphai/inboxd/dist/connectors/hosted-conversation.js`), but bundling straight from the repo checkout records `packages/inboxd/dist/...`, where the markers silently never match. The markers are now path suffixes (`/inboxd/dist/connectors/...`) that bite in both shapes, with tests pinning both.

**2. Distinct reason for conversation module-load failures.** A rejected lazy `import()` of `events/conversation.ts` (missing/corrupt chunk in a deployed image) was swallowed into the generic `conversation-import.projection-failed` reason. Operators could not tell "the conversation chunk cannot load at all" (infrastructure, affects every item) from a per-item projection failure. Loader rejections are now wrapped in a typed error and mapped to `conversation-import.module-load-failed`. Everything else is preserved: the loader still resets its cache on rejection so the next call retries, and item disposition is unchanged.

## Compatibility with #402

The entry ratchet is untouched. Real assembly passes: entry 2,292,259B (baseline 2,288,516B + 48KB tolerance), total 8,210,723B of 9.3MB.

## Verification

- `runner-bundle-entrypoint-bundle` vitest: 11 passed (new: forbidden input rejected in BOTH the staged `node_modules` shape and the workspace `packages/...` shape; dynamic-allowed unchanged)
- assistant-runtime loader + conversation-event vitest: 18 passed (new: module-load rejection → `module-load-failed`; post-load projection error still → `projection-failed`; retry-after-failure still proven)
- `pnpm --dir apps/cloudflare typecheck`, `pnpm --dir packages/assistant-runtime typecheck` — pass
- `pnpm --dir apps/cloudflare runner:bundle` — pass (guard + ratchet green against the real assembly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785962214&installation_id=127572939&pr_number=406&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F406&signature=53f190ab98a8aa7058c050a760af65d5fe8fd8826b08d625f67e27c2d0570583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->