### PR TITLE
docs(product-specs): lock Call Circle spec (friend-call matchmaking for groups)

### DIFF
--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -55,6 +55,7 @@ It intentionally lists live architecture, product, verification, and package-bou
 | `agent-docs/product-specs/query-metric-universality.md` | Universal metric queryability invariant: every metric-bearing canonical event yields a query metric point through the generic extraction rule. | Query metric product spec | High | 2026-06-12 |
 | `agent-docs/product-specs/companion-app-mvp.md` | Two-screen companion app MVP build spec: Privy login, Connect Apple Health, sign-in token endpoint. | Companion app build plan | High | 2026-06-10 |
 | `agent-docs/product-specs/murph-contact-card-picker.md` | Post-signup add-Murph-to-contacts step with member-chosen contact-card avatar. | Contact-card picker spec | Medium | 2026-07-03 |
+| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: private availability, matching automation, group-to-member notification primitive, phased Retell connector bridge. | Call Circle spec | Medium | 2026-07-06 |
 | `agent-docs/phone-calls/retell-phone-agent.md` | Retell hosted phone agent prompt, authority, transfer, and call-brief handling rules. | Hosted phone-call provider setup | Medium | 2026-06-25 |
 | `agent-docs/phone-calls/retell-analysis-fields.md` | Retell post-call analysis field contract and transcript-retention boundary. | Hosted phone-call provider setup | Medium | 2026-06-25 |
 | `agent-docs/feature-user-story-audit/README.md` | Feature user-story audit overview and artifact inventory. | Point-in-time feature audit | Low | 2026-06-21 |

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -55,7 +55,7 @@ It intentionally lists live architecture, product, verification, and package-bou
 | `agent-docs/product-specs/query-metric-universality.md` | Universal metric queryability invariant: every metric-bearing canonical event yields a query metric point through the generic extraction rule. | Query metric product spec | High | 2026-06-12 |
 | `agent-docs/product-specs/companion-app-mvp.md` | Two-screen companion app MVP build spec: Privy login, Connect Apple Health, sign-in token endpoint. | Companion app build plan | High | 2026-06-10 |
 | `agent-docs/product-specs/murph-contact-card-picker.md` | Post-signup add-Murph-to-contacts step with member-chosen contact-card avatar. | Contact-card picker spec | Medium | 2026-07-03 |
-| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: in-chat enrollment, notification-rail availability, calendar-aware confirms, Retell connector bridge. | Call Circle spec | Medium | 2026-07-06 |
+| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: web-owned coordinator, in-chat enrollment, calendar-aware confirms, Retell connector bridge. | Call Circle spec | Medium | 2026-07-06 |
 | `agent-docs/phone-calls/retell-phone-agent.md` | Retell hosted phone agent prompt, authority, transfer, and call-brief handling rules. | Hosted phone-call provider setup | Medium | 2026-06-25 |
 | `agent-docs/phone-calls/retell-analysis-fields.md` | Retell post-call analysis field contract and transcript-retention boundary. | Hosted phone-call provider setup | Medium | 2026-06-25 |
 | `agent-docs/feature-user-story-audit/README.md` | Feature user-story audit overview and artifact inventory. | Point-in-time feature audit | Low | 2026-06-21 |

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -55,7 +55,7 @@ It intentionally lists live architecture, product, verification, and package-bou
 | `agent-docs/product-specs/query-metric-universality.md` | Universal metric queryability invariant: every metric-bearing canonical event yields a query metric point through the generic extraction rule. | Query metric product spec | High | 2026-06-12 |
 | `agent-docs/product-specs/companion-app-mvp.md` | Two-screen companion app MVP build spec: Privy login, Connect Apple Health, sign-in token endpoint. | Companion app build plan | High | 2026-06-10 |
 | `agent-docs/product-specs/murph-contact-card-picker.md` | Post-signup add-Murph-to-contacts step with member-chosen contact-card avatar. | Contact-card picker spec | Medium | 2026-07-03 |
-| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: private availability, matching automation, group-to-member notification primitive, phased Retell connector bridge. | Call Circle spec | Medium | 2026-07-06 |
+| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: in-chat enrollment, notification-rail availability, calendar-aware confirms, Retell connector bridge. | Call Circle spec | Medium | 2026-07-06 |
 | `agent-docs/phone-calls/retell-phone-agent.md` | Retell hosted phone agent prompt, authority, transfer, and call-brief handling rules. | Hosted phone-call provider setup | Medium | 2026-06-25 |
 | `agent-docs/phone-calls/retell-analysis-fields.md` | Retell post-call analysis field contract and transcript-retention boundary. | Hosted phone-call provider setup | Medium | 2026-06-25 |
 | `agent-docs/feature-user-story-audit/README.md` | Feature user-story audit overview and artifact inventory. | Point-in-time feature audit | Low | 2026-06-21 |

--- a/agent-docs/product-specs/call-circle.md
+++ b/agent-docs/product-specs/call-circle.md
@@ -2,17 +2,17 @@
 
 Last verified: 2026-07-06
 
-Status: decisions locked 2026-07-06; not yet implemented. Phase 1 is the next
-buildable unit.
+Status: decisions locked 2026-07-06 (revised same day after founder review);
+not yet implemented. Ships as one release including the connector bridge.
 
 ## Purpose
 
 Call Circle helps an existing Murph group actually talk on the phone. Friends
 want to call each other more, but nobody knows anyone's schedule and
 coordination costs kill the intent. Murph acts as the neutral third party:
-members privately tell their own Murph when they are usually free, a group
-automation matches pairs, Murph double-confirms with each person privately,
-and at the agreed time the call happens.
+members privately tell their own Murph when they like to talk, a group
+automation matches pairs weekly, Murph confirms both sides privately with
+calendar awareness, and at the agreed time Murph connects the call.
 
 This is a health feature. Social connection is one of the strongest
 wellbeing levers, and the product constitution asks for more participation
@@ -23,52 +23,63 @@ member's relationships instead of their metrics.
 
 - Any active group member can ask the group's Murph to set up Call Circle in
   the group chat. Setup is per group.
-- Availability is private. Each member tells their own Murph preferred days
-  and rough time windows in their own 1:1 conversation, or connects a
-  calendar there. Only coarse windows ever reach the group container, via a
-  dedicated vault-share projection kind. Raw calendars, exact events, phone
-  numbers, and private conversation content never enter the group vault.
-- A recurring group automation proposes at most one match per member per
-  cycle (default cadence: weekly per member, tunable per group). Matching
-  rotates pairs so the same two people are not matched twice in a row and no
-  member is starved.
-- Matches are confirmed privately with each member by their own Murph, in
-  their existing 1:1 thread:
-  - Morning-of soft confirm, answerable in one word.
-  - Short final confirm near the call time.
-  - Both must say yes before any call step happens.
-- Mystery framing is per-group and honest. Murph may withhold who the match
-  is until both confirm, but must never imply a specific person asked for
-  the call. Say "I matched you with someone from the group", not "one of
-  your buddies wants to talk to you".
-- Non-response is a graceful no. One confirm message per step, no chasing.
-  A dead match is dropped silently and the pair is eligible again in a later
-  cycle. Declining or ignoring never produces guilt copy.
-- Every member has an instant off-ramp: "pause calls" or equivalent in their
-  own thread pauses their participation per group without leaving the group.
-- Consent moment: the first Call Circle DM a member receives from their own
-  Murph is the enrollment ask ("Your group asked me to help you all talk
-  more. Want in? yes/no"). A yes records a feature consent grant; a no
-  records opt-out and stops all Call Circle DMs for that group. Joining a
-  group is not by itself consent to Call Circle.
+- Enrollment happens in the group chat. Members who reply "I'm in" (or
+  equivalent) are enrolled by matching the message's sender handle to the
+  group roster. The first private DM is not a consent question; it is a
+  transparent start with an instant off-ramp: Murph introduces Call Circle
+  for that group, asks for preferences, and says pausing is one word away.
+  Chat participants without their own Murph cannot enroll; the group's
+  Murph points them at the join link.
+- Availability preferences are private and stated conversationally: "weekday
+  lunches", "Sunday mornings", time zone aware. They live at full fidelity
+  in the member's own vault (time zone from vault metadata). No availability
+  projection is shared into the group vault.
+- A recurring group automation (default: one proposal per member per week,
+  tunable per group) matches pairs. Before proposing, it queries enrolled
+  members' stated preferences through the notification rail's silent-query
+  mode; responses carry coarse windows in absolute time. Matching rotates
+  pairs so the same two people are not matched twice in a row and no member
+  is starved.
+- Matches are named, not mystery, by default: the morning-of ask is "Free at
+  5 for a call with Mike? yes/no". A per-group mystery mode may withhold the
+  name until both confirm, but Murph must never imply a specific person
+  asked for the call.
+- Confirms are calendar-aware before asking. When web files a match-confirm
+  request for a member with a connected calendar, it checks free/busy for
+  the proposed window server-side (web already owns the Composio account
+  binding) and attaches the verdict to the request payload. Busy windows
+  bounce back to the matcher without disturbing the member; no calendar
+  detail beyond the free/busy verdict for the proposed window is read or
+  stored. Members without a connected calendar get plain asks.
+- Rescheduling is capped at one counter-proposal per side per match. If no
+  fit after that, the match is dropped quietly and the pair is eligible
+  again in a later cycle.
+- Both members must confirm (morning-of soft confirm plus a short final
+  confirm near call time) before any call step happens. Non-response is a
+  graceful no: one message per confirm step, no chasing, no guilt copy.
+- No phone call is ever placed to a member who has not interacted with Call
+  Circle in their own thread at least once (automatic, since matching
+  requires stated preferences).
+- Every member can say "pause" in their own thread to pause participation
+  per group without leaving the group.
 
-## Call Mechanics By Phase
+## Call Mechanics
 
-- Phase 1 (no telephony): when both members confirm, Murph tells each of
-  them who they are matched with and that the other is ready now, and one of
-  them dials directly. Murph never places a call.
-- Phase 2 (Retell connector bridge): at the agreed time Murph places one
-  outbound call to member A from a dedicated connector agent whose entire
-  script is one line ("This is Murph. Connecting you with a friend from your
-  group, one moment."), then transfers the call to member B's verified
-  phone. The AI is an operator for one sentence, never a call participant.
-  A "Murph Calls" contact card ships with enrollment so the incoming call is
-  named. If the transfer fails or B does not answer, the agent tells A it
-  will find another time, and both members get a low-key follow-up message.
-  Phase 2 does not start until transfer-failure behavior has been prototyped
-  and feels acceptable.
-- Phase 2 uses the existing phone-call disclosure posture: the connector
-  identifies itself as Murph in its single line.
+- At the agreed time Murph places one outbound call to member A from a
+  dedicated Retell connector agent whose entire script is one line ("This is
+  Murph. Connecting you with a friend from your group, one moment."), then
+  transfers the call to member B's verified phone. The AI is an operator for
+  one sentence, never a call participant. It identifies itself as Murph in
+  that single line, consistent with the existing phone-call disclosure
+  posture.
+- A "Murph Calls" contact card ships with enrollment so the incoming call is
+  named.
+- Fallback, not a phase: if the bridge fails, B does not answer, or line
+  health blocks calling, the connector tells A it will find another time and
+  both members get a low-key message with the other's confirmed readiness so
+  they can dial directly.
+- Transfer-failure behavior (what A hears when B does not pick up) must be
+  prototyped on Retell in week one of the build; it is on the critical path.
 
 ## Non-Goals
 
@@ -77,45 +88,30 @@ member's relationships instead of their metrics.
   it up.
 - No matching across groups, and no matching people who have not both
   enrolled.
-- No conference calls of three or more people in v1/v2.
+- No conference calls of three or more people.
 - No free-form outbound copy authored by the group container for private
   DMs (see security invariants).
-- No real-time calendar sync into the group vault.
+- No calendar data in the group vault, and no calendar reads beyond
+  free/busy for a concretely proposed window.
+- No new VaultShare projection kind; availability flows only through the
+  notification rail.
 
 ## Architecture
 
-Roughly 70% of Call Circle rides existing rails. Two primitives are new.
+Most of Call Circle rides existing rails: group containers and roster
+(`apps/web/src/lib/hosted-groups/`, roster handles landed in PR #398),
+canonical automations in the group vault for the weekly cadence
+(`packages/core/src/automation.ts`; the 60-minute stale-notification guard
+applies to scheduled steps), notification wakes with event-id dedupe and the
+notification-decision turn (phone-call result path in
+`apps/web/src/lib/phone-calls/result.ts` is the template), consent feature
+scopes (`apps/web/src/lib/legal/consent.ts`), Composio calendar accounts
+(`apps/web/src/lib/connected-apps/`), vCard generation, and the Retell stack
+(`apps/web/src/lib/phone-calls/`).
 
-### Reused
+Two primitives are new.
 
-- Group containers, provisioning, roster, and the group-chat skill
-  (`apps/web/src/lib/hosted-routing/thread-container-service.ts`,
-  `apps/web/src/lib/hosted-groups/`,
-  `packages/assistant-engine/skills/group-chat/SKILL.md`).
-- Canonical automations in the group vault for the matching cadence and
-  one-shot morning-of / near-time steps (`packages/core/src/automation.ts`,
-  cron execution in `packages/assistant-engine/src/assistant/cron/`). The
-  60-minute stale-notification guard applies to scheduled steps.
-- VaultShare closed projection registry for availability
-  (`packages/hosted-execution/src/vault-share.ts`): new kind
-  `call-circle-availability.v0`, current-state, coarse windows plus a
-  last-connected recency bucket. Follows the existing add-a-kind path:
-  schema parser, member-side projector, join-policy selectability, reader.
-- Per-member calendar via Composio connected apps (Google/Outlook) inside
-  the member's own container; the member's Murph derives coarse windows
-  from it. Calendar data itself never leaves the member container.
-- Consent feature scopes with grant/revoke
-  (`apps/web/src/lib/legal/consent.ts`; WhatsApp START/STOP is the
-  precedent), plus per-member per-group pause state.
-- Notification-wake delivery: `assistant.notification.requested` wakes with
-  event-id dedupe, queue-only dispatch, server-resolved route, consumed by
-  the notification-decision turn (phone-call result path in
-  `apps/web/src/lib/phone-calls/result.ts` is the template).
-- Phase 2 reuses the Retell stack (`apps/web/src/lib/phone-calls/`):
-  rows, signed webhooks, idempotency, and the `transfer_number` dynamic
-  variable.
-
-### New Primitive 1: Group-To-Member Private Notification (the linchpin)
+### New Primitive 1: Group-To-Member Private Notification Rail (the linchpin)
 
 A group container must never gain send authority into private threads. It
 may only file a request with web, and the member's own Murph decides and
@@ -130,20 +126,28 @@ Flow:
    definition, Cloudflare port, web handler in
    `apps/web/src/lib/hosted-groups/group-tool.ts`.
 2. Group runtime supplies: target `memberId` (roster id only), a `purpose`
-   from a closed enum (`call-circle.enroll`,
-   `call-circle.availability-request`, `call-circle.match-confirm`,
-   `call-circle.match-outcome`), a purpose-typed zod-validated structured
-   payload, and a `dedupeKey`.
+   from a closed enum, a purpose-typed zod-validated structured payload, and
+   a `dedupeKey`. Call Circle purposes: `call-circle.enroll-start`,
+   `call-circle.availability-query`, `call-circle.match-confirm`,
+   `call-circle.match-outcome`.
 3. Web validates: signed Cloudflare callback bound to the group runtime,
    thread-route authority re-read, target is an active member of that exact
-   group, feature consent granted (except `call-circle.enroll`, which is the
-   consent ask itself), not paused, rate limit per (group, member, purpose).
-4. Web persists a `HostedGroupMemberNotification` row and appends a
-   notification wake to the target member's own runtime with event id
-   `group-member-notify:<groupId>:<dedupeKey>` and an `expiresAt`.
-5. The member's Murph renders the ask in its own voice in the existing 1:1
-   thread. Skip is allowed (no `require_send`); the member's assistant keeps
-   editorial control over quiet hours and timing.
+   group, feature enrollment recorded (except `enroll-start`), not paused,
+   rate limit per (group, member, purpose).
+4. Purposes have a mode. Interactive purposes append a notification wake to
+   the member's own runtime (event id
+   `group-member-notify:<groupId>:<dedupeKey>`, `expiresAt` set); the
+   member's Murph renders the ask in its own voice and may skip (no
+   `require_send`). Silent purposes (`availability-query`) run the same wake
+   path, but the member's Murph answers from vault data and returns skip; the
+   member sees nothing. Notification turns have vault access but no
+   connected-app tools, which is sufficient for stated preferences and keeps
+   the unattended-turn trust boundary unchanged.
+5. For `match-confirm` targeting a member with a connected calendar, web
+   enriches the request payload with a free/busy verdict for the proposed
+   window before appending the wake (server-side Composio read, scoped to
+   that window). A busy verdict is returned to the matcher as a bounce
+   without appending any member-facing wake.
 6. The member's structured response returns through a member-side tool
    action keyed by notification id; web validates the notification targets
    that member and is pending, records the response, and appends a response
@@ -156,15 +160,21 @@ Security invariants:
 - Purpose-typed payloads, never free-form outbound copy. The group runtime
   reads untrusted group-chat text; free-form copy would let any group
   member prompt-inject someone's private DMs.
-- Web is the sole authority for membership, consent, pause, rate, and
+- Web is the sole authority for membership, enrollment, pause, rate, and
   dedupe.
-- Confirmation state lives in `HostedGroupMemberNotification` rows
-  (requested -> delivered/skipped -> responded/expired), never in runtime
-  memory.
-- The group vault learns only the structured response, never the private
-  conversation.
+- Match and confirmation state lives in `HostedGroupMemberNotification` rows
+  (requested -> delivered/skipped -> responded/expired) plus match rows,
+  never in runtime memory.
+- The group vault learns only structured responses, never private
+  conversations or calendar contents.
+- Unattended (notification/cron) container turns gain no new tool access;
+  the only calendar touch is web-side free/busy for a proposed window.
+- In-chat enrollment is recorded as attested by the group runtime (sender
+  handle matched to roster). The transparency DM and the
+  interact-before-any-call rule are the compensating controls; a member who
+  never engages privately can never be called.
 
-### New Primitive 2: Server-Initiated Connector Call (Phase 2 only)
+### New Primitive 2: Server-Initiated Connector Call
 
 - A separate minimal Retell "connector" agent (own agent id): one opening
   line, then immediate `transfer_call`. No health content, no conversation.
@@ -172,29 +182,15 @@ Security invariants:
   never by a model tool call. Containers never supply phone numbers.
 - A dedicated resolver returns member B's verified phone only when the match
   row is in `both_confirmed` state and the current time is inside the
-  confirmed window. This extends the existing invariant that the Retell
-  layer forwards whatever the server supplies, so the binding guarantee
-  must live in the resolver (`apps/web/src/lib/phone-calls/transfer.ts` is
-  the pattern).
+  confirmed window. The Retell layer forwards whatever the server supplies,
+  so the binding guarantee lives in the resolver
+  (`apps/web/src/lib/phone-calls/transfer.ts` is the pattern).
 - Bridge sessions get their own rows keyed by match id; do not overload
   `HostedPhoneCall` semantics that assume a member-initiated agent call.
 
-## Phasing
-
-1. Phase 1: availability projection kind, `call-circle` skill (group
-   workflow plus member-side enrollment/availability sections), matching
-   automation, the group-to-member notification primitive, consent/pause,
-   and the "you are both ready, call now" handoff. No telephony.
-2. Phase 2: connector-agent Retell bridge, "Murph Calls" vCard, transfer
-   failure handling. Gated on a transfer-failure prototype.
-3. Later, only if minutes cost or transfer UX demands it: a silent
-   Twilio-class conference bridge.
-
 ## Open Questions
 
-- Exact coarseness of availability windows (day-of-week plus broad
-  daypart vs. hour ranges) and whether time zones display per member.
-- Whether the group chat gets any ambient signal that Call Circle is active
-  (recommended: only what members say themselves, plus the setup
-  confirmation).
-- Retell transfer failure semantics (prototype before Phase 2 commit).
+- Which Composio free/busy tool slug is available under the current session
+  policy (verify during build; fall back to plain asks if reads prove
+  unreliable).
+- Retell transfer-failure semantics (week-one prototype gates the bridge).

--- a/agent-docs/product-specs/call-circle.md
+++ b/agent-docs/product-specs/call-circle.md
@@ -2,191 +2,199 @@
 
 Last verified: 2026-07-06
 
-Status: decisions locked 2026-07-06 (revised same day after founder review);
-not yet implemented. Ships as one release including the connector bridge.
+Status: decisions locked 2026-07-06 (revised twice same day: founder review,
+then a three-lens Codex stress test against the codebase); not yet
+implemented. Ships as one release including the connector bridge.
 
 ## Purpose
 
 Call Circle helps an existing Murph group actually talk on the phone. Friends
 want to call each other more, but nobody knows anyone's schedule and
 coordination costs kill the intent. Murph acts as the neutral third party:
-members privately tell their own Murph when they like to talk, a group
-automation matches pairs weekly, Murph confirms both sides privately with
-calendar awareness, and at the agreed time Murph connects the call.
+members privately tell their own Murph when they like to talk, web matches
+pairs weekly, Murph confirms both sides privately with calendar awareness,
+and at the agreed time Murph connects the call.
 
 This is a health feature. Social connection is one of the strongest
 wellbeing levers, and the product constitution asks for more participation
-in life and less inward fixation. Call Circle spends product effort on the
-member's relationships instead of their metrics.
+in life and less inward fixation.
+
+## Coordination Model (stress-test outcome)
+
+Call Circle is a web-owned feature, like Family plan or billing, that speaks
+to members through their own Murphs. Web owns all coordination truth
+(enrollment, preferences, matches, confirmations, call authorization) in
+ordinary DB rows with conditional-update transitions, and owns all stage
+timing with web-side scheduling. Containers only converse: the group's Murph
+captures enrollment in the group chat; each member's Murph gathers
+preferences and renders confirm asks in its own voice.
+
+This placement follows from three hard constraints found in the codebase:
+notification turns cannot carry structured responses out of a container
+(no `hostedToolContext`: `packages/assistant-engine/src/assistant/notification-turn.ts`,
+`codex-turn/planning.ts`); assistant cron one-shots expire late wakes after
+60 minutes, which would silently kill time-sensitive confirms
+(`packages/assistant-engine/src/assistant/cron/execution.ts`); and matching
+caps must be deterministic server code, not model behavior, because the
+group runtime reads untrusted group-chat text. It also satisfies the
+persisted-state placement gate: a server-placed phone call must be
+authorized by state web can check atomically, which vault or runtime state
+cannot provide.
 
 ## Product Contract
 
 - Any active group member can ask the group's Murph to set up Call Circle in
   the group chat. Setup is per group.
 - Enrollment happens in the group chat. Members who reply "I'm in" (or
-  equivalent) are enrolled by matching the message's sender handle to the
-  group roster. The first private DM is not a consent question; it is a
+  equivalent) are enrolled; attribution resolves the sender to a `memberId`
+  through the existing participant-contact lookup (not raw handle string
+  comparison). The first private DM is not a consent question; it is a
   transparent start with an instant off-ramp: Murph introduces Call Circle
-  for that group, asks for preferences, and says pausing is one word away.
-  Chat participants without their own Murph cannot enroll; the group's
-  Murph points them at the join link.
-- Availability preferences are private and stated conversationally: "weekday
-  lunches", "Sunday mornings", time zone aware. They live at full fidelity
-  in the member's own vault (time zone from vault metadata). No availability
-  projection is shared into the group vault.
-- A recurring group automation (default: one proposal per member per week,
-  tunable per group) matches pairs. Before proposing, it queries enrolled
-  members' stated preferences through the notification rail's silent-query
-  mode; responses carry coarse windows in absolute time. Matching rotates
-  pairs so the same two people are not matched twice in a row and no member
-  is starved.
-- Matches are named, not mystery, by default: the morning-of ask is "Free at
-  5 for a call with Mike? yes/no". A per-group mystery mode may withhold the
-  name until both confirm, but Murph must never imply a specific person
-  asked for the call.
-- Confirms are calendar-aware before asking. When web files a match-confirm
-  request for a member with a connected calendar, it checks free/busy for
-  the proposed window server-side (web already owns the Composio account
-  binding) and attaches the verdict to the request payload. Busy windows
-  bounce back to the matcher without disturbing the member; no calendar
-  detail beyond the free/busy verdict for the proposed window is read or
-  stored. Members without a connected calendar get plain asks.
-- Rescheduling is capped at one counter-proposal per side per match. If no
-  fit after that, the match is dropped quietly and the pair is eligible
-  again in a later cycle.
-- Both members must confirm (morning-of soft confirm plus a short final
-  confirm near call time) before any call step happens. Non-response is a
-  graceful no: one message per confirm step, no chasing, no guilt copy.
+  for that group and asks what days and times usually work. Chat
+  participants without their own Murph cannot enroll; the group's Murph
+  points them at the join link.
+- Availability preferences are stated conversationally to the member's own
+  Murph ("weekday lunches", "Sunday mornings"). The member's Murph submits
+  them as coarse structured windows to web, where they are stored on the
+  member's participant row. Full-fidelity context stays in the member's
+  vault; web holds only the coarse windows the member chose to give the
+  coordinator. Members update preferences the same way, any time.
+- Web matches pairs weekly (fixed cadence in v1) under deterministic,
+  DB-enforced caps: at most one proposal per member per week, no repeat
+  pair back to back, rotation so no member is starved. Members are skipped
+  for a cycle when the 28-day recipient-reply egress guard would block
+  their confirm DM (preflighted web-side, never bypassed).
+- Matches are named: "Free at 5 for a call with Mike? yes/no". (A mystery
+  mode was considered and deferred; nothing in v1 may imply a specific
+  person asked for the call.)
+- Confirms are calendar-aware before asking. For a member with a connected
+  calendar, web calls a stateless free/busy helper for the proposed window
+  (`{free|busy|unknown}`, nothing persisted, no calendar detail read beyond
+  the verdict). Busy windows are rescheduled or dropped without disturbing
+  the member. Members without a calendar get plain asks.
+- Confirm asks are morning-of plus a short final confirm near call time,
+  scheduled web-side, clamped to recipient-local daytime hours and gated on
+  line health. A late or blocked send is recorded as a match outcome
+  (expired/skipped), never silently consumed.
+- Rescheduling is capped at one counter-proposal per side per match,
+  enforced on the match row. If no fit, the match is dropped quietly and
+  the pair is eligible again in a later cycle.
+- Non-response is a graceful no: one message per confirm step, no chasing,
+  no guilt copy.
 - No phone call is ever placed to a member who has not interacted with Call
-  Circle in their own thread at least once (automatic, since matching
-  requires stated preferences).
-- Every member can say "pause" in their own thread to pause participation
-  per group without leaving the group.
+  Circle in their own thread at least once (automatic: matching requires
+  submitted preferences).
+- Every member can say "pause" in their own thread; their Murph submits it
+  and web stops matching them for that group. Pause, leaving the group, or
+  losing access mid-match invalidates pending asks at the next transition:
+  every response, confirm, and call-start transition predicate-checks
+  active enrollment, membership, and access.
 
 ## Call Mechanics
 
-- At the agreed time Murph places one outbound call to member A from a
-  dedicated Retell connector agent whose entire script is one line ("This is
-  Murph. Connecting you with a friend from your group, one moment."), then
-  transfers the call to member B's verified phone. The AI is an operator for
-  one sentence, never a call participant. It identifies itself as Murph in
-  that single line, consistent with the existing phone-call disclosure
-  posture.
-- A "Murph Calls" contact card ships with enrollment so the incoming call is
-  named.
+- At the agreed time web places one outbound call to member A via the
+  existing Retell stack, using a dedicated connector agent (own agent id)
+  whose entire script is one line ("This is Murph. Connecting you with a
+  friend from your group, one moment."), then `transfer_call` to member B's
+  verified phone. The AI is an operator for one sentence, never a call
+  participant, and identifies itself as Murph consistent with the existing
+  disclosure posture.
+- The connector call reuses `HostedPhoneCall` (member A scoped, request key
+  derived from match id and attempt) with a connector brief variant; no new
+  call table. Authorization lives one level up: a single conditional update
+  claims the match row (`both_confirmed`, not canceled or expired, inside
+  the stored absolute window, both members still active) before any call is
+  created, and member B's verified phone is resolved server-side only at
+  claim time. Containers never supply phone numbers.
+- A "Murph Calls" contact card ships with enrollment so the incoming call
+  is named.
 - Fallback, not a phase: if the bridge fails, B does not answer, or line
-  health blocks calling, the connector tells A it will find another time and
-  both members get a low-key message with the other's confirmed readiness so
-  they can dial directly.
+  health blocks calling, the connector tells A it will find another time
+  and both members get a low-key message with the other's confirmed
+  readiness so they can dial directly.
 - Transfer-failure behavior (what A hears when B does not pick up) must be
-  prototyped on Retell in week one of the build; it is on the critical path.
+  prototyped on Retell in week one of the build; it is on the critical
+  path.
 
 ## Non-Goals
 
-- No group-visible scoreboard of who called whom, call counts, or streaks.
-  The group chat may celebrate a completed call only if a participant brings
-  it up.
-- No matching across groups, and no matching people who have not both
-  enrolled.
-- No conference calls of three or more people.
+- No generic group-to-member notification rail, no purpose enum, no
+  notification state table. Web appends ordinary notification wakes
+  (family-plan private notifications are the template) and correlates
+  responses to match rows.
+- No widening of `murph.group` into a cross-thread dispatch surface; it
+  gains exactly one narrow action (enrollment capture).
+- No silent container turns acting on members' behalf; every ask is
+  visible to the member it targets.
+- No new VaultShare projection kind and no calendar data in the group
+  vault; the group container never holds availability.
+- No group-visible scoreboard, call counts, or streaks. The group chat may
+  celebrate a completed call only if a participant brings it up.
+- No matching across groups, no conference calls, no mystery mode, no
+  per-group cadence tuning, and no dedicated assistant skill in v1
+  (prompt-local instructions on the wakes carry the behavior until proven
+  insufficient).
 - No free-form outbound copy authored by the group container for private
-  DMs (see security invariants).
-- No calendar data in the group vault, and no calendar reads beyond
-  free/busy for a concretely proposed window.
-- No new VaultShare projection kind; availability flows only through the
-  notification rail.
+  DMs.
 
-## Architecture
+## Net-New Surface (complete list)
 
-Most of Call Circle rides existing rails: group containers and roster
-(`apps/web/src/lib/hosted-groups/`, roster handles landed in PR #398),
-canonical automations in the group vault for the weekly cadence
-(`packages/core/src/automation.ts`; the 60-minute stale-notification guard
-applies to scheduled steps), notification wakes with event-id dedupe and the
-notification-decision turn (phone-call result path in
-`apps/web/src/lib/phone-calls/result.ts` is the template), consent feature
-scopes (`apps/web/src/lib/legal/consent.ts`), Composio calendar accounts
-(`apps/web/src/lib/connected-apps/`), vCard generation, and the Retell stack
-(`apps/web/src/lib/phone-calls/`).
+1. Two tables: `call_circle_participant` (group, member, enrollment
+   provenance, pause state, coarse windows, last-matched-at) and
+   `call_circle_match` (pair, proposed window as absolute time, per-side
+   ask/confirm/counter state, outcome, claimed phone-call id). Match
+   transitions are single conditional updates.
+2. One group-tool action: enrollment capture from the group chat (sender
+   resolved to memberId server-side).
+3. One member-side runtime action: submit a structured Call Circle response
+   (preferences, confirm yes/no, counter-proposal, pause), validated
+   against a pending ask or active participation for that member. This is
+   the only new container-to-web write, and it is member-scoped by design.
+4. A web cron that runs the deterministic matcher and stage scheduler
+   (morning-of and near-time asks, expiry outcomes).
+5. A stateless web free/busy helper reading one proposed window from the
+   member's connected calendar account.
+6. A Retell connector agent config plus a connector brief variant on the
+   existing phone-call path.
 
-Two primitives are new.
+Everything else is existing rails: group containers and roster, mailbox
+notification wakes with event-id dedupe, the notification-decision turn,
+participant-contact lookup, LinQ egress guards, Composio accounts, vCard
+generation, `HostedPhoneCall` and Retell webhooks.
 
-### New Primitive 1: Group-To-Member Private Notification Rail (the linchpin)
+## Security Invariants
 
-A group container must never gain send authority into private threads. It
-may only file a request with web, and the member's own Murph decides and
-speaks. This primitive is intentionally general; the group health
-newsletter's private nudges and future group features use the same rail.
+- Only member ids cross the group/member boundary. Phones, routes, and
+  calendar verdicts resolve web-side only.
+- Web is the sole authority for enrollment, pause, matching caps, stage
+  timing, dedupe, and call authorization. Models summarize and converse;
+  they never choose unconstrained targets, times, or recipients.
+- All deliverability guards (28-day reply guard, quiet hours, line health)
+  are enforced web-side as hard gates for these server-initiated sends;
+  prompt guidance is not the control.
+- The member response action only accepts writes for the authenticated
+  member's own pending asks; it cannot touch other members or other groups.
+- No failure path may leak member B's phone, a calendar verdict, or
+  private-thread content into the group vault, group chat, or logs.
+- In-chat enrollment is attested by the group runtime from untrusted chat
+  text; the transparency DM and the interact-before-any-call rule are the
+  compensating controls.
 
-Flow:
+## Rejected Alternatives (stress-test record, 2026-07-06)
 
-1. New `murph.group` action `request_member_notification`, wired like
-   `create_join_link`: shared contract in
-   `packages/hosted-execution/src/runtime-control.ts`, dynamic tool
-   definition, Cloudflare port, web handler in
-   `apps/web/src/lib/hosted-groups/group-tool.ts`.
-2. Group runtime supplies: target `memberId` (roster id only), a `purpose`
-   from a closed enum, a purpose-typed zod-validated structured payload, and
-   a `dedupeKey`. Call Circle purposes: `call-circle.enroll-start`,
-   `call-circle.availability-query`, `call-circle.match-confirm`,
-   `call-circle.match-outcome`.
-3. Web validates: signed Cloudflare callback bound to the group runtime,
-   thread-route authority re-read, target is an active member of that exact
-   group, feature enrollment recorded (except `enroll-start`), not paused,
-   rate limit per (group, member, purpose).
-4. Purposes have a mode. Interactive purposes append a notification wake to
-   the member's own runtime (event id
-   `group-member-notify:<groupId>:<dedupeKey>`, `expiresAt` set); the
-   member's Murph renders the ask in its own voice and may skip (no
-   `require_send`). Silent purposes (`availability-query`) run the same wake
-   path, but the member's Murph answers from vault data and returns skip; the
-   member sees nothing. Notification turns have vault access but no
-   connected-app tools, which is sufficient for stated preferences and keeps
-   the unattended-turn trust boundary unchanged.
-5. For `match-confirm` targeting a member with a connected calendar, web
-   enriches the request payload with a free/busy verdict for the proposed
-   window before appending the wake (server-side Composio read, scoped to
-   that window). A busy verdict is returned to the matcher as a bounce
-   without appending any member-facing wake.
-6. The member's structured response returns through a member-side tool
-   action keyed by notification id; web validates the notification targets
-   that member and is pending, records the response, and appends a response
-   wake to the group runtime so the automation continues event-driven.
-
-Security invariants:
-
-- Only member ids cross the group/member boundary. Phones, handles, and
-  thread identities resolve web-side only.
-- Purpose-typed payloads, never free-form outbound copy. The group runtime
-  reads untrusted group-chat text; free-form copy would let any group
-  member prompt-inject someone's private DMs.
-- Web is the sole authority for membership, enrollment, pause, rate, and
-  dedupe.
-- Match and confirmation state lives in `HostedGroupMemberNotification` rows
-  (requested -> delivered/skipped -> responded/expired) plus match rows,
-  never in runtime memory.
-- The group vault learns only structured responses, never private
-  conversations or calendar contents.
-- Unattended (notification/cron) container turns gain no new tool access;
-  the only calendar touch is web-side free/busy for a proposed window.
-- In-chat enrollment is recorded as attested by the group runtime (sender
-  handle matched to roster). The transparency DM and the
-  interact-before-any-call rule are the compensating controls; a member who
-  never engages privately can never be called.
-
-### New Primitive 2: Server-Initiated Connector Call
-
-- A separate minimal Retell "connector" agent (own agent id): one opening
-  line, then immediate `transfer_call`. No health content, no conversation.
-- Calls are created by the web-side match state machine after both confirms,
-  never by a model tool call. Containers never supply phone numbers.
-- A dedicated resolver returns member B's verified phone only when the match
-  row is in `both_confirmed` state and the current time is inside the
-  confirmed window. The Retell layer forwards whatever the server supplies,
-  so the binding guarantee lives in the resolver
-  (`apps/web/src/lib/phone-calls/transfer.ts` is the pattern).
-- Bridge sessions get their own rows keyed by match id; do not overload
-  `HostedPhoneCall` semantics that assume a member-initiated agent call.
+- Group-container-driven orchestration with a generic notification rail and
+  silent availability queries: rejected. Silent-query responses have no
+  carrier (notification turns cannot post structured data), member 1:1
+  replies cannot use group-thread authority, and a hidden query mode would
+  be an implicit VaultShare bypass.
+- Vault records as match/confirmation state: rejected; a server-placed
+  phone call needs atomically checkable server truth, and the persisted-
+  state placement gate forbids product truth starting in runtime state.
+- A separate bridge-session table: rejected; the match-row conditional
+  claim plus `HostedPhoneCall` covers idempotency and lifecycle.
+- A new consent table or scope in v1: rejected; the participant row records
+  enrollment provenance, and document-backed consent can be added if legal
+  posture requires it.
 
 ## Open Questions
 
@@ -194,3 +202,6 @@ Security invariants:
   policy (verify during build; fall back to plain asks if reads prove
   unreliable).
 - Retell transfer-failure semantics (week-one prototype gates the bridge).
+- Recipient-local quiet-hour clamps use the signup timezone on
+  `HostedMember`; acceptable staleness for v1, revisit if wrong-timezone
+  sends appear.

--- a/agent-docs/product-specs/call-circle.md
+++ b/agent-docs/product-specs/call-circle.md
@@ -1,0 +1,200 @@
+# Call Circle
+
+Last verified: 2026-07-06
+
+Status: decisions locked 2026-07-06; not yet implemented. Phase 1 is the next
+buildable unit.
+
+## Purpose
+
+Call Circle helps an existing Murph group actually talk on the phone. Friends
+want to call each other more, but nobody knows anyone's schedule and
+coordination costs kill the intent. Murph acts as the neutral third party:
+members privately tell their own Murph when they are usually free, a group
+automation matches pairs, Murph double-confirms with each person privately,
+and at the agreed time the call happens.
+
+This is a health feature. Social connection is one of the strongest
+wellbeing levers, and the product constitution asks for more participation
+in life and less inward fixation. Call Circle spends product effort on the
+member's relationships instead of their metrics.
+
+## Product Contract
+
+- Any active group member can ask the group's Murph to set up Call Circle in
+  the group chat. Setup is per group.
+- Availability is private. Each member tells their own Murph preferred days
+  and rough time windows in their own 1:1 conversation, or connects a
+  calendar there. Only coarse windows ever reach the group container, via a
+  dedicated vault-share projection kind. Raw calendars, exact events, phone
+  numbers, and private conversation content never enter the group vault.
+- A recurring group automation proposes at most one match per member per
+  cycle (default cadence: weekly per member, tunable per group). Matching
+  rotates pairs so the same two people are not matched twice in a row and no
+  member is starved.
+- Matches are confirmed privately with each member by their own Murph, in
+  their existing 1:1 thread:
+  - Morning-of soft confirm, answerable in one word.
+  - Short final confirm near the call time.
+  - Both must say yes before any call step happens.
+- Mystery framing is per-group and honest. Murph may withhold who the match
+  is until both confirm, but must never imply a specific person asked for
+  the call. Say "I matched you with someone from the group", not "one of
+  your buddies wants to talk to you".
+- Non-response is a graceful no. One confirm message per step, no chasing.
+  A dead match is dropped silently and the pair is eligible again in a later
+  cycle. Declining or ignoring never produces guilt copy.
+- Every member has an instant off-ramp: "pause calls" or equivalent in their
+  own thread pauses their participation per group without leaving the group.
+- Consent moment: the first Call Circle DM a member receives from their own
+  Murph is the enrollment ask ("Your group asked me to help you all talk
+  more. Want in? yes/no"). A yes records a feature consent grant; a no
+  records opt-out and stops all Call Circle DMs for that group. Joining a
+  group is not by itself consent to Call Circle.
+
+## Call Mechanics By Phase
+
+- Phase 1 (no telephony): when both members confirm, Murph tells each of
+  them who they are matched with and that the other is ready now, and one of
+  them dials directly. Murph never places a call.
+- Phase 2 (Retell connector bridge): at the agreed time Murph places one
+  outbound call to member A from a dedicated connector agent whose entire
+  script is one line ("This is Murph. Connecting you with a friend from your
+  group, one moment."), then transfers the call to member B's verified
+  phone. The AI is an operator for one sentence, never a call participant.
+  A "Murph Calls" contact card ships with enrollment so the incoming call is
+  named. If the transfer fails or B does not answer, the agent tells A it
+  will find another time, and both members get a low-key follow-up message.
+  Phase 2 does not start until transfer-failure behavior has been prototyped
+  and feels acceptable.
+- Phase 2 uses the existing phone-call disclosure posture: the connector
+  identifies itself as Murph in its single line.
+
+## Non-Goals
+
+- No group-visible scoreboard of who called whom, call counts, or streaks.
+  The group chat may celebrate a completed call only if a participant brings
+  it up.
+- No matching across groups, and no matching people who have not both
+  enrolled.
+- No conference calls of three or more people in v1/v2.
+- No free-form outbound copy authored by the group container for private
+  DMs (see security invariants).
+- No real-time calendar sync into the group vault.
+
+## Architecture
+
+Roughly 70% of Call Circle rides existing rails. Two primitives are new.
+
+### Reused
+
+- Group containers, provisioning, roster, and the group-chat skill
+  (`apps/web/src/lib/hosted-routing/thread-container-service.ts`,
+  `apps/web/src/lib/hosted-groups/`,
+  `packages/assistant-engine/skills/group-chat/SKILL.md`).
+- Canonical automations in the group vault for the matching cadence and
+  one-shot morning-of / near-time steps (`packages/core/src/automation.ts`,
+  cron execution in `packages/assistant-engine/src/assistant/cron/`). The
+  60-minute stale-notification guard applies to scheduled steps.
+- VaultShare closed projection registry for availability
+  (`packages/hosted-execution/src/vault-share.ts`): new kind
+  `call-circle-availability.v0`, current-state, coarse windows plus a
+  last-connected recency bucket. Follows the existing add-a-kind path:
+  schema parser, member-side projector, join-policy selectability, reader.
+- Per-member calendar via Composio connected apps (Google/Outlook) inside
+  the member's own container; the member's Murph derives coarse windows
+  from it. Calendar data itself never leaves the member container.
+- Consent feature scopes with grant/revoke
+  (`apps/web/src/lib/legal/consent.ts`; WhatsApp START/STOP is the
+  precedent), plus per-member per-group pause state.
+- Notification-wake delivery: `assistant.notification.requested` wakes with
+  event-id dedupe, queue-only dispatch, server-resolved route, consumed by
+  the notification-decision turn (phone-call result path in
+  `apps/web/src/lib/phone-calls/result.ts` is the template).
+- Phase 2 reuses the Retell stack (`apps/web/src/lib/phone-calls/`):
+  rows, signed webhooks, idempotency, and the `transfer_number` dynamic
+  variable.
+
+### New Primitive 1: Group-To-Member Private Notification (the linchpin)
+
+A group container must never gain send authority into private threads. It
+may only file a request with web, and the member's own Murph decides and
+speaks. This primitive is intentionally general; the group health
+newsletter's private nudges and future group features use the same rail.
+
+Flow:
+
+1. New `murph.group` action `request_member_notification`, wired like
+   `create_join_link`: shared contract in
+   `packages/hosted-execution/src/runtime-control.ts`, dynamic tool
+   definition, Cloudflare port, web handler in
+   `apps/web/src/lib/hosted-groups/group-tool.ts`.
+2. Group runtime supplies: target `memberId` (roster id only), a `purpose`
+   from a closed enum (`call-circle.enroll`,
+   `call-circle.availability-request`, `call-circle.match-confirm`,
+   `call-circle.match-outcome`), a purpose-typed zod-validated structured
+   payload, and a `dedupeKey`.
+3. Web validates: signed Cloudflare callback bound to the group runtime,
+   thread-route authority re-read, target is an active member of that exact
+   group, feature consent granted (except `call-circle.enroll`, which is the
+   consent ask itself), not paused, rate limit per (group, member, purpose).
+4. Web persists a `HostedGroupMemberNotification` row and appends a
+   notification wake to the target member's own runtime with event id
+   `group-member-notify:<groupId>:<dedupeKey>` and an `expiresAt`.
+5. The member's Murph renders the ask in its own voice in the existing 1:1
+   thread. Skip is allowed (no `require_send`); the member's assistant keeps
+   editorial control over quiet hours and timing.
+6. The member's structured response returns through a member-side tool
+   action keyed by notification id; web validates the notification targets
+   that member and is pending, records the response, and appends a response
+   wake to the group runtime so the automation continues event-driven.
+
+Security invariants:
+
+- Only member ids cross the group/member boundary. Phones, handles, and
+  thread identities resolve web-side only.
+- Purpose-typed payloads, never free-form outbound copy. The group runtime
+  reads untrusted group-chat text; free-form copy would let any group
+  member prompt-inject someone's private DMs.
+- Web is the sole authority for membership, consent, pause, rate, and
+  dedupe.
+- Confirmation state lives in `HostedGroupMemberNotification` rows
+  (requested -> delivered/skipped -> responded/expired), never in runtime
+  memory.
+- The group vault learns only the structured response, never the private
+  conversation.
+
+### New Primitive 2: Server-Initiated Connector Call (Phase 2 only)
+
+- A separate minimal Retell "connector" agent (own agent id): one opening
+  line, then immediate `transfer_call`. No health content, no conversation.
+- Calls are created by the web-side match state machine after both confirms,
+  never by a model tool call. Containers never supply phone numbers.
+- A dedicated resolver returns member B's verified phone only when the match
+  row is in `both_confirmed` state and the current time is inside the
+  confirmed window. This extends the existing invariant that the Retell
+  layer forwards whatever the server supplies, so the binding guarantee
+  must live in the resolver (`apps/web/src/lib/phone-calls/transfer.ts` is
+  the pattern).
+- Bridge sessions get their own rows keyed by match id; do not overload
+  `HostedPhoneCall` semantics that assume a member-initiated agent call.
+
+## Phasing
+
+1. Phase 1: availability projection kind, `call-circle` skill (group
+   workflow plus member-side enrollment/availability sections), matching
+   automation, the group-to-member notification primitive, consent/pause,
+   and the "you are both ready, call now" handoff. No telephony.
+2. Phase 2: connector-agent Retell bridge, "Murph Calls" vCard, transfer
+   failure handling. Gated on a transfer-failure prototype.
+3. Later, only if minutes cost or transfer UX demands it: a silent
+   Twilio-class conference bridge.
+
+## Open Questions
+
+- Exact coarseness of availability windows (day-of-week plus broad
+  daypart vs. hour ranges) and whether time zones display per member.
+- Whether the group chat gets any ambient signal that Call Circle is active
+  (recommended: only what members say themselves, plus the setup
+  confirmation).
+- Retell transfer failure semantics (prototype before Phase 2 commit).

--- a/agent-docs/product-specs/index.md
+++ b/agent-docs/product-specs/index.md
@@ -19,7 +19,7 @@ Last verified: 2026-06-21
 | `agent-docs/product-specs/query-metric-universality.md` | Invariant that every metric-bearing canonical event yields a query metric point through one generic rule; summary pipeline becomes presentation + precedence, never a gatekeeper. | Specified |
 | `agent-docs/product-specs/companion-app-mvp.md` | Two-screen MVP build spec: Privy phone/email login, Connect Apple Health, Junction sign-in token endpoint. | Planned |
 | `agent-docs/product-specs/murph-contact-card-picker.md` | Post-signup add-Murph-to-contacts step where the member picks the avatar on Murph's vCard; picker components live on `/design`. | Planned |
-| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: in-chat enrollment, private availability via the group-to-member notification rail, calendar-aware confirms, and a Retell connector bridge. | Planned |
+| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: web-owned coordinator, in-chat enrollment, calendar-aware confirms, and a Retell connector bridge over existing rails. | Planned |
 
 ## Rule
 

--- a/agent-docs/product-specs/index.md
+++ b/agent-docs/product-specs/index.md
@@ -19,6 +19,7 @@ Last verified: 2026-06-21
 | `agent-docs/product-specs/query-metric-universality.md` | Invariant that every metric-bearing canonical event yields a query metric point through one generic rule; summary pipeline becomes presentation + precedence, never a gatekeeper. | Specified |
 | `agent-docs/product-specs/companion-app-mvp.md` | Two-screen MVP build spec: Privy phone/email login, Connect Apple Health, Junction sign-in token endpoint. | Planned |
 | `agent-docs/product-specs/murph-contact-card-picker.md` | Post-signup add-Murph-to-contacts step where the member picks the avatar on Murph's vCard; picker components live on `/design`. | Planned |
+| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: private availability projection, group matching automation, group-to-member private notification primitive, and phased call mechanics ending in a Retell connector bridge. | Planned |
 
 ## Rule
 

--- a/agent-docs/product-specs/index.md
+++ b/agent-docs/product-specs/index.md
@@ -19,7 +19,7 @@ Last verified: 2026-06-21
 | `agent-docs/product-specs/query-metric-universality.md` | Invariant that every metric-bearing canonical event yields a query metric point through one generic rule; summary pipeline becomes presentation + precedence, never a gatekeeper. | Specified |
 | `agent-docs/product-specs/companion-app-mvp.md` | Two-screen MVP build spec: Privy phone/email login, Connect Apple Health, Junction sign-in token endpoint. | Planned |
 | `agent-docs/product-specs/murph-contact-card-picker.md` | Post-signup add-Murph-to-contacts step where the member picks the avatar on Murph's vCard; picker components live on `/design`. | Planned |
-| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: private availability projection, group matching automation, group-to-member private notification primitive, and phased call mechanics ending in a Retell connector bridge. | Planned |
+| `agent-docs/product-specs/call-circle.md` | Friend-call matchmaking for groups: in-chat enrollment, private availability via the group-to-member notification rail, calendar-aware confirms, and a Retell connector bridge. | Planned |
 
 ## Rule
 


### PR DESCRIPTION
## Why

Friends want to call each other more but scheduling coordination kills the intent. Call Circle makes Murph the neutral third party: private availability, a group matching automation, private double-confirms, then the call. Decisions were locked 2026-07-06 after a code-grounded exploration of the group-container, vault-share, automation, notification-wake, and Retell seams.

## User-visible goal

A group member asks the group's Murph to help everyone stay in touch; members privately opt in and share coarse availability with their own Murph; Murph matches pairs, confirms both sides in their own 1:1 threads, and (phase 1) tells both to call now, later (phase 2) places a one-line connector call that transfers to the friend. This PR ships the spec only; no runtime behavior changes.

## Invariants to preserve

- Group containers never gain send authority into private threads; the new notification primitive only files purpose-typed requests with web, which validates membership, consent, pause, rate, and dedupe.
- Only member ids cross the group/member boundary; phones, handles, and calendars stay web-side or in the member container.
- VaultShare stays a closed projection registry; availability enters the group vault only as a new coarse fixed-schema kind.
- Phase 2 transfer destination binding lives in a server-side resolver gated on a both-confirmed match row; containers never supply phone numbers.
- No AI as a phone-call participant; the connector agent speaks one disclosure line and transfers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785962895&installation_id=127572939&pr_number=408&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F408&signature=96bdb7c2eaef44005b8b26841db27ef0dabf2a31e96826cb750b6a53bda447aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->