### PR TITLE
feat(hosted-ops): founder-gated Linq home-line rehome primitive

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-06-linq-line-rehome.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-linq-line-rehome.md
@@ -1,0 +1,86 @@
+# Ops primitive to rehome hosted member Linq home line
+
+Status: completed
+Created: 2026-07-06
+Updated: 2026-07-06
+
+## Goal
+
+- Ship a founder-gated hosted ops primitive that can move one active hosted member's Linq home-line authority to an explicitly selected assignable home line.
+- Preserve the existing bare-authority semantics: clear bound chat and pending route state, reset `linqLastInboundAt`, and require the member to text the new line before Murph-initiated sends resume.
+
+## Success criteria
+
+- `GET /api/ops/linq-rehome?memberId=...` returns only member routing summary, line hints, lookup keys, and capacity counts; it never returns decrypted phone numbers.
+- `POST /api/ops/linq-rehome` rejects unauthorized operators, unknown/suspended members, non-assignable targets, already-targeted members, and capacity-exhausted targets with typed hosted onboarding errors.
+- Successful rehome is one database transaction guarded by the existing Linq home assignment lock and writes through `upsertHostedMemberHomeLinqRecipientPhoneTx` with `clearPending: true`.
+- Tests cover the requested success, pending-clear, none-authority, target rejection, already-target, capacity, member validation, auth/body validation, and raw-number exposure cases.
+
+## Scope
+
+- In scope:
+  - `apps/web/src/lib/hosted-ops/linq-line-rehome.ts`
+  - `apps/web/app/api/ops/linq-rehome/route.ts`
+  - Focused hosted-web tests for the new primitive and route
+  - Exporting or sharing `startOfUtcDay` only if that is the simplest way to keep one source of truth
+- Out of scope:
+  - Automatic health-triggered failover, cron, watchers, or bulk/multi-member moves
+  - Ops UI
+  - Schema changes
+  - Changes to webhook, egress, routing policy, or the existing rehome write primitive
+  - Thread-route cleanup for stale old 1:1 chats
+
+## Constraints
+
+- Technical constraints:
+  - Raw phone numbers must not be returned by the ops route or committed fixtures/docs.
+  - The mutation must fail closed for degraded/unconfigured/disabled target lines by relying on `listHostedLinqAssignableHomeLines`.
+  - Already-on-target detection must compare against lookup-key read candidates for the target phone, not only strict lookup-key equality.
+  - Capacity checks must reuse `chooseHostedLinqHomeLine` with the target as the only candidate and exclude the member's current binding from active counts.
+- Product/process constraints:
+  - Keep the primitive explicit and founder-gated; no automatic trigger.
+  - Preserve anti-cold-contact behavior by not carrying last-inbound across lines.
+  - Leave the working tree uncommitted for supervisor review.
+
+## Risks and mitigations
+
+1. Risk: exposing decrypted phone numbers through the ops overview or mutation result.
+   Mitigation: use phone hints and lookup keys only in response types and tests.
+2. Risk: rehoming onto an unhealthy or disabled line.
+   Mitigation: target must be present in `listHostedLinqAssignableHomeLines`.
+3. Risk: bypassing assignment capacity/pacing invariants.
+   Mitigation: acquire the assignment lock and reuse the existing chooser/counts with the target as the only candidate.
+4. Risk: stale `hosted_thread_route` rows for the old 1:1 chat can allow an in-flight runner session with old route authority to egress on the old thread until sessions roll over.
+   Mitigation: document as accepted residual for this manual healthy-line migration; thread-route cleanup is out of scope and belongs to future banned-line failover work.
+
+## Tasks
+
+1. Inspect the existing hosted ops, Linq line-store, routing, and test harness patterns.
+2. Implement the read-only overview and transactional rehome service.
+3. Add the ops API route with existing ops auth and JSON-body validation helpers.
+4. Add focused hosted-web tests for library behavior, route auth/body handling, and no raw-number responses.
+5. Run required verification and completion audits (`security-privacy-review`, `coverage-write`, and local final review).
+
+## Decisions
+
+- Use the existing `upsertHostedMemberHomeLinqRecipientPhoneTx` primitive unchanged.
+- Keep post-rehome authority bare by design; the member must text the new line to bind the new chat and satisfy the recent-reply egress guard.
+- No durable docs update is needed beyond this active plan because this change adds an ops primitive, not a new durable architecture rule or automatic failover behavior.
+
+## Verification
+
+- Setup completed:
+  - `pnpm install`
+  - `pnpm --dir apps/web prisma:generate`
+- Required checks completed:
+  - `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-ops-linq-line-rehome.test.ts` passed.
+  - `pnpm typecheck` passed after generating ignored local package build artifacts required by unrelated workspace package entrypoints.
+  - `pnpm test:diff apps/web/src/lib/hosted-ops/linq-line-rehome.ts apps/web/app/api/ops/linq-rehome/route.ts apps/web/src/lib/hosted-onboarding/linq-home-routing.ts apps/web/test/hosted-ops-linq-line-rehome.test.ts` passed.
+- Audit passes completed:
+  - `security-privacy-review`: no medium-or-higher findings. Residual assumptions: ops allowlist is the intended authority, and stale old thread-route cleanup remains out of scope for this primitive.
+  - `coverage-write`: added test proof that already-on-target detection works against lookup-key read candidates across contact-privacy key rotation; focused test passed.
+  - Parent local final review: no unresolved implementation findings.
+- Notes:
+  - The owner verifier still emits pre-existing apps/web lint warnings and a Turbopack NFT warning unrelated to this diff; the command exits successfully.
+  - The working tree is intentionally uncommitted for supervisor review.
+Completed: 2026-07-06

--- a/apps/web/app/api/ops/linq-rehome/route.ts
+++ b/apps/web/app/api/ops/linq-rehome/route.ts
@@ -30,7 +30,7 @@ export const GET = withJsonError(async (request: Request) => {
 });
 
 export const POST = withJsonError(async (request: Request) => {
-  await requireHostedOpsRequestAccess(request, {
+  const session = await requireHostedOpsRequestAccess(request, {
     requireMutationOrigin: true,
   });
   const body = await readHostedOnboardingJsonObject(request, {
@@ -38,19 +38,30 @@ export const POST = withJsonError(async (request: Request) => {
     tooLargeErrorCode: "HOSTED_LINQ_REHOME_REQUEST_TOO_LARGE",
     tooLargeErrorMessage: "Hosted Linq rehome request body is too large.",
   });
+  const memberId = readRequiredString(
+    body.memberId,
+    "HOSTED_LINQ_REHOME_MEMBER_ID_REQUIRED",
+    "Hosted Linq rehome requires a memberId.",
+  );
+  const targetLineLookupKey = readRequiredString(
+    body.targetLineLookupKey,
+    "HOSTED_LINQ_REHOME_TARGET_LOOKUP_KEY_REQUIRED",
+    "Hosted Linq rehome requires a targetLineLookupKey.",
+  );
 
-  return jsonOk(await rehomeHostedMemberLinqHomeLine({
-    memberId: readRequiredString(
-      body.memberId,
-      "HOSTED_LINQ_REHOME_MEMBER_ID_REQUIRED",
-      "Hosted Linq rehome requires a memberId.",
-    ),
-    targetLineLookupKey: readRequiredString(
-      body.targetLineLookupKey,
-      "HOSTED_LINQ_REHOME_TARGET_LOOKUP_KEY_REQUIRED",
-      "Hosted Linq rehome requires a targetLineLookupKey.",
-    ),
-  }));
+  const result = await rehomeHostedMemberLinqHomeLine({
+    memberId,
+    targetLineLookupKey,
+  });
+  console.info("Hosted ops Linq rehome completed.", {
+    fromLineHint: result.fromLineHint,
+    operatorMemberId: session.member.id,
+    targetMemberId: memberId,
+    timestamp: new Date().toISOString(),
+    toLineHint: result.toLineHint,
+  });
+
+  return jsonOk(result);
 });
 
 function readRequiredString(

--- a/apps/web/app/api/ops/linq-rehome/route.ts
+++ b/apps/web/app/api/ops/linq-rehome/route.ts
@@ -1,0 +1,71 @@
+import {
+  readHostedLinqLineRehomeOverview,
+  rehomeHostedMemberLinqHomeLine,
+} from "@/src/lib/hosted-ops/linq-line-rehome";
+import { requireHostedOpsRequestAccess } from "@/src/lib/hosted-ops/access";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import {
+  jsonOk,
+  readHostedOnboardingJsonObject,
+  withJsonError,
+} from "@/src/lib/hosted-onboarding/http";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const revalidate = 0;
+
+const HOSTED_LINQ_REHOME_BODY_LIMIT_BYTES = 4 * 1024;
+
+export const GET = withJsonError(async (request: Request) => {
+  await requireHostedOpsRequestAccess(request);
+  const url = new URL(request.url);
+
+  return jsonOk(await readHostedLinqLineRehomeOverview({
+    memberId: readRequiredString(
+      url.searchParams.get("memberId"),
+      "HOSTED_LINQ_REHOME_MEMBER_ID_REQUIRED",
+      "Hosted Linq rehome overview requires a memberId query parameter.",
+    ),
+  }));
+});
+
+export const POST = withJsonError(async (request: Request) => {
+  await requireHostedOpsRequestAccess(request, {
+    requireMutationOrigin: true,
+  });
+  const body = await readHostedOnboardingJsonObject(request, {
+    limitBytes: HOSTED_LINQ_REHOME_BODY_LIMIT_BYTES,
+    tooLargeErrorCode: "HOSTED_LINQ_REHOME_REQUEST_TOO_LARGE",
+    tooLargeErrorMessage: "Hosted Linq rehome request body is too large.",
+  });
+
+  return jsonOk(await rehomeHostedMemberLinqHomeLine({
+    memberId: readRequiredString(
+      body.memberId,
+      "HOSTED_LINQ_REHOME_MEMBER_ID_REQUIRED",
+      "Hosted Linq rehome requires a memberId.",
+    ),
+    targetLineLookupKey: readRequiredString(
+      body.targetLineLookupKey,
+      "HOSTED_LINQ_REHOME_TARGET_LOOKUP_KEY_REQUIRED",
+      "Hosted Linq rehome requires a targetLineLookupKey.",
+    ),
+  }));
+});
+
+function readRequiredString(
+  value: unknown,
+  code: string,
+  message: string,
+): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw hostedOnboardingError({
+      code,
+      httpStatus: 400,
+      message,
+      retryable: false,
+    });
+  }
+
+  return value.trim();
+}

--- a/apps/web/src/lib/hosted-onboarding/linq-home-routing.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-home-routing.ts
@@ -599,7 +599,7 @@ function hostedLinqRouteBindingAuthorityMatchesCurrentRoute(input: {
   return input.routing?.pendingLinqParticipantContact?.lookupKey === input.authority.contact.lookupKey;
 }
 
-function startOfUtcDay(value: Date): Date {
+export function startOfUtcDay(value: Date): Date {
   return new Date(Date.UTC(
     value.getUTCFullYear(),
     value.getUTCMonth(),

--- a/apps/web/src/lib/hosted-ops/linq-line-rehome.ts
+++ b/apps/web/src/lib/hosted-ops/linq-line-rehome.ts
@@ -1,0 +1,329 @@
+import "server-only";
+
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+import {
+  createHostedPhoneLookupKeyReadCandidates,
+  readHostedPhoneHint,
+} from "../hosted-onboarding/contact-privacy";
+import { hostedOnboardingError } from "../hosted-onboarding/errors";
+import {
+  acquireHostedMemberHomeLinqRecipientAssignmentLockTx,
+  countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince,
+  countHostedMemberHomeLinqBindingsByRecipientPhone,
+  readHostedMemberRoutingState,
+  type HostedMemberRoutingStateSnapshot,
+  upsertHostedMemberHomeLinqRecipientPhoneTx,
+} from "../hosted-onboarding/hosted-member-routing-store";
+import {
+  readHostedLinqHomeLineAuthority,
+  startOfUtcDay,
+} from "../hosted-onboarding/linq-home-routing";
+import {
+  listHostedLinqAssignableHomeLines,
+  type HostedLinqAssignableHomeLine,
+} from "../hosted-onboarding/linq-line-store";
+import { chooseHostedLinqHomeLine } from "../hosted-onboarding/linq-routing-policy";
+import { getPrisma } from "../prisma";
+
+type HostedLinqRehomeClient = PrismaClient | Prisma.TransactionClient;
+
+export interface HostedLinqLineRehomeOverview {
+  assignableTargetLines: HostedLinqLineRehomeTargetLine[];
+  currentRouting: HostedLinqLineRehomeRoutingSummary;
+  generatedAt: string;
+  member: {
+    id: string;
+    suspendedAt: string | null;
+  };
+}
+
+export interface HostedLinqLineRehomeTargetLine {
+  activeMemberCount: number;
+  activeMemberLimit: number | null;
+  maxNewConversationsPerDay: number | null;
+  phoneNumberHint: string;
+  phoneNumberLookupKey: string;
+}
+
+export interface HostedLinqLineRehomeRoutingSummary {
+  authorityKind: "bare" | "home" | "none" | "pending";
+  currentLinePhoneHint: string | null;
+  homeChatBound: boolean;
+  linqHomeLineAssignedAt: string | null;
+  linqLastInboundAt: string | null;
+  linqRecipientPhoneLookupKey: string | null;
+}
+
+export interface HostedLinqLineRehomeResult {
+  clearedHomeChat: boolean;
+  clearedPendingRoute: boolean;
+  fromLineHint: string | null;
+  toLineHint: string;
+}
+
+export async function readHostedLinqLineRehomeOverview(input: {
+  memberId: string;
+  prisma?: PrismaClient;
+}): Promise<HostedLinqLineRehomeOverview> {
+  const memberId = normalizeHostedLinqRehomeRequiredString(
+    input.memberId,
+    "HOSTED_LINQ_REHOME_MEMBER_ID_REQUIRED",
+    "Hosted Linq rehome requires a member id.",
+  );
+  const prisma = input.prisma ?? getPrisma();
+  const now = new Date();
+  const member = await readHostedLinqRehomeMemberOrThrow({
+    memberId,
+    prisma,
+    rejectSuspended: false,
+  });
+  const [routingRead, targetLines] = await Promise.all([
+    readHostedLinqRehomeRoutingState({
+      memberId,
+      prisma,
+    }),
+    listHostedLinqAssignableHomeLines({ prisma }),
+  ]);
+  const activeMembersByRecipientPhone =
+    await countHostedMemberHomeLinqBindingsByRecipientPhone({
+      now,
+      prisma,
+      recipientPhones: targetLines.map((line) => line.phoneNumber),
+    });
+
+  return {
+    assignableTargetLines: targetLines.map((line) => ({
+      activeMemberCount: activeMembersByRecipientPhone.get(line.phoneNumber) ?? 0,
+      activeMemberLimit: line.activeMemberLimit,
+      maxNewConversationsPerDay: line.maxNewConversationsPerDay,
+      phoneNumberHint: line.phoneNumberHint,
+      phoneNumberLookupKey: line.phoneNumberLookupKey,
+    })),
+    currentRouting: summarizeHostedLinqRehomeRouting(routingRead),
+    generatedAt: now.toISOString(),
+    member: {
+      id: member.id,
+      suspendedAt: member.suspendedAt?.toISOString() ?? null,
+    },
+  };
+}
+
+export async function rehomeHostedMemberLinqHomeLine(input: {
+  memberId: string;
+  prisma?: PrismaClient;
+  targetLineLookupKey: string;
+}): Promise<HostedLinqLineRehomeResult> {
+  const memberId = normalizeHostedLinqRehomeRequiredString(
+    input.memberId,
+    "HOSTED_LINQ_REHOME_MEMBER_ID_REQUIRED",
+    "Hosted Linq rehome requires a member id.",
+  );
+  const targetLineLookupKey = normalizeHostedLinqRehomeRequiredString(
+    input.targetLineLookupKey,
+    "HOSTED_LINQ_REHOME_TARGET_LOOKUP_KEY_REQUIRED",
+    "Hosted Linq rehome requires a target line lookup key.",
+  );
+  const prisma = input.prisma ?? getPrisma();
+
+  return prisma.$transaction(async (tx) => {
+    await readHostedLinqRehomeMemberOrThrow({
+      memberId,
+      prisma: tx,
+      rejectSuspended: true,
+    });
+    await acquireHostedMemberHomeLinqRecipientAssignmentLockTx({
+      prisma: tx,
+    });
+
+    const target = (await listHostedLinqAssignableHomeLines({ prisma: tx }))
+      .find((line) => line.phoneNumberLookupKey === targetLineLookupKey);
+    if (!target) {
+      throw hostedOnboardingError({
+        code: "HOSTED_LINQ_REHOME_TARGET_NOT_ASSIGNABLE",
+        httpStatus: 400,
+        message: "Hosted Linq rehome target line is not assignable.",
+        retryable: false,
+      });
+    }
+
+    const routing = await readHostedMemberRoutingState({
+      memberId,
+      prisma: tx,
+    });
+    if (hostedLinqRoutingAlreadyTargetsLine({ routing, target })) {
+      throw hostedOnboardingError({
+        code: "HOSTED_LINQ_REHOME_ALREADY_ON_TARGET",
+        httpStatus: 409,
+        message: "Hosted member is already homed on the requested Linq line.",
+        retryable: false,
+      });
+    }
+
+    const now = new Date();
+    const activeMembersByRecipientPhone =
+      await countHostedMemberHomeLinqBindingsByRecipientPhone({
+        excludedMemberId: memberId,
+        now,
+        prisma: tx,
+        recipientPhones: [target.phoneNumber],
+      });
+    const newAssignmentsByRecipientPhone =
+      await countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince({
+        prisma: tx,
+        recipientPhones: [target.phoneNumber],
+        since: startOfUtcDay(now),
+      });
+    const chosen = chooseHostedLinqHomeLine({
+      activeMembersByRecipientPhone,
+      lines: [target],
+      newAssignmentsByRecipientPhone,
+      preferredRecipientPhone: target.phoneNumber,
+    });
+    if (!chosen) {
+      throw hostedOnboardingError({
+        code: "HOSTED_LINQ_REHOME_TARGET_AT_CAPACITY",
+        httpStatus: 409,
+        message: "Hosted Linq rehome target line is at assignment capacity.",
+        retryable: false,
+      });
+    }
+
+    await upsertHostedMemberHomeLinqRecipientPhoneTx({
+      clearPending: true,
+      homeLineAssignedAt: now,
+      memberId,
+      prisma: tx,
+      recipientPhone: target.phoneNumber,
+    });
+
+    return {
+      clearedHomeChat: Boolean(routing?.linqChatId),
+      clearedPendingRoute: routing?.hasPendingLinqRouteState === true,
+      fromLineHint: readHostedLinqRehomeAuthorityPhoneHint(routing),
+      toLineHint: target.phoneNumberHint,
+    };
+  });
+}
+
+async function readHostedLinqRehomeMemberOrThrow(input: {
+  memberId: string;
+  prisma: HostedLinqRehomeClient;
+  rejectSuspended: boolean;
+}): Promise<{ id: string; suspendedAt: Date | null }> {
+  const member = await input.prisma.hostedMember.findUnique({
+    where: {
+      id: input.memberId,
+    },
+    select: {
+      id: true,
+      suspendedAt: true,
+    },
+  });
+
+  if (!member) {
+    throw hostedOnboardingError({
+      code: "HOSTED_LINQ_REHOME_MEMBER_NOT_FOUND",
+      httpStatus: 404,
+      message: "Hosted Linq rehome member was not found.",
+      retryable: false,
+    });
+  }
+
+  if (input.rejectSuspended && member.suspendedAt) {
+    throw hostedOnboardingError({
+      code: "HOSTED_LINQ_REHOME_MEMBER_SUSPENDED",
+      httpStatus: 409,
+      message: "Hosted Linq rehome cannot run for a suspended member.",
+      retryable: false,
+    });
+  }
+
+  return member;
+}
+
+async function readHostedLinqRehomeRoutingState(input: {
+  memberId: string;
+  prisma: HostedLinqRehomeClient;
+}): Promise<{
+  linqLastInboundAt: Date | null;
+  routing: HostedMemberRoutingStateSnapshot | null;
+}> {
+  const [routing, inbound] = await Promise.all([
+    readHostedMemberRoutingState({
+      memberId: input.memberId,
+      prisma: input.prisma,
+    }),
+    input.prisma.hostedMemberRouting.findUnique({
+      where: {
+        memberId: input.memberId,
+      },
+      select: {
+        linqLastInboundAt: true,
+      },
+    }),
+  ]);
+
+  return {
+    linqLastInboundAt: inbound?.linqLastInboundAt ?? null,
+    routing,
+  };
+}
+
+function summarizeHostedLinqRehomeRouting(input: {
+  linqLastInboundAt: Date | null;
+  routing: HostedMemberRoutingStateSnapshot | null;
+}): HostedLinqLineRehomeRoutingSummary {
+  const authority = readHostedLinqHomeLineAuthority(input.routing);
+
+  return {
+    authorityKind: authority.kind,
+    currentLinePhoneHint: authority.kind === "none"
+      ? null
+      : readHostedPhoneHint(authority.recipientPhone),
+    homeChatBound: Boolean(input.routing?.linqChatId),
+    linqHomeLineAssignedAt:
+      input.routing?.linqHomeLineAssignedAt?.toISOString() ?? null,
+    linqLastInboundAt: input.linqLastInboundAt?.toISOString() ?? null,
+    linqRecipientPhoneLookupKey:
+      input.routing?.linqRecipientPhoneLookupKey ?? null,
+  };
+}
+
+function hostedLinqRoutingAlreadyTargetsLine(input: {
+  routing: HostedMemberRoutingStateSnapshot | null;
+  target: HostedLinqAssignableHomeLine;
+}): boolean {
+  const currentLookupKey = input.routing?.linqRecipientPhoneLookupKey;
+  if (!currentLookupKey) {
+    return false;
+  }
+
+  return createHostedPhoneLookupKeyReadCandidates(input.target.phoneNumber)
+    .includes(currentLookupKey);
+}
+
+function readHostedLinqRehomeAuthorityPhoneHint(
+  routing: HostedMemberRoutingStateSnapshot | null,
+): string | null {
+  const authority = readHostedLinqHomeLineAuthority(routing);
+  return authority.kind === "none" ? null : readHostedPhoneHint(authority.recipientPhone);
+}
+
+function normalizeHostedLinqRehomeRequiredString(
+  value: string,
+  code: string,
+  message: string,
+): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw hostedOnboardingError({
+      code,
+      httpStatus: 400,
+      message,
+      retryable: false,
+    });
+  }
+
+  return normalized;
+}

--- a/apps/web/src/lib/hosted-ops/linq-line-rehome.ts
+++ b/apps/web/src/lib/hosted-ops/linq-line-rehome.ts
@@ -24,6 +24,7 @@ import {
   type HostedLinqAssignableHomeLine,
 } from "../hosted-onboarding/linq-line-store";
 import { chooseHostedLinqHomeLine } from "../hosted-onboarding/linq-routing-policy";
+import { normalizePhoneNumber } from "../hosted-onboarding/phone";
 import { getPrisma } from "../prisma";
 
 type HostedLinqRehomeClient = PrismaClient | Prisma.TransactionClient;
@@ -131,6 +132,10 @@ export async function rehomeHostedMemberLinqHomeLine(input: {
       memberId,
       prisma: tx,
       rejectSuspended: true,
+    });
+    await assertHostedLinqRehomeMemberHasPhoneIdentity({
+      memberId,
+      prisma: tx,
     });
     await acquireHostedMemberHomeLinqRecipientAssignmentLockTx({
       prisma: tx,
@@ -242,6 +247,33 @@ async function readHostedLinqRehomeMemberOrThrow(input: {
   return member;
 }
 
+async function assertHostedLinqRehomeMemberHasPhoneIdentity(input: {
+  memberId: string;
+  prisma: HostedLinqRehomeClient;
+}): Promise<void> {
+  const identity = await input.prisma.hostedMemberIdentity.findUnique({
+    where: {
+      memberId: input.memberId,
+    },
+    select: {
+      phoneLookupKey: true,
+    },
+  });
+
+  if (identity?.phoneLookupKey) {
+    return;
+  }
+
+  // Linq rediscovers fresh chats by member phone identity; activation already
+  // requires one, so rehome cannot clear old chat bindings for phone-less members.
+  throw hostedOnboardingError({
+    code: "HOSTED_LINQ_REHOME_MEMBER_PHONE_REQUIRED",
+    httpStatus: 409,
+    message: "Hosted Linq rehome requires a verified member phone identity.",
+    retryable: false,
+  });
+}
+
 async function readHostedLinqRehomeRoutingState(input: {
   memberId: string;
   prisma: HostedLinqRehomeClient;
@@ -294,6 +326,10 @@ function hostedLinqRoutingAlreadyTargetsLine(input: {
   routing: HostedMemberRoutingStateSnapshot | null;
   target: HostedLinqAssignableHomeLine;
 }): boolean {
+  if (normalizePhoneNumber(input.routing?.linqRecipientPhone) === input.target.phoneNumber) {
+    return true;
+  }
+
   const currentLookupKey = input.routing?.linqRecipientPhoneLookupKey;
   if (!currentLookupKey) {
     return false;

--- a/apps/web/test/hosted-ops-linq-line-rehome.test.ts
+++ b/apps/web/test/hosted-ops-linq-line-rehome.test.ts
@@ -1,0 +1,580 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  acquireHostedMemberHomeLinqRecipientAssignmentLockTx: vi.fn(),
+  assertHostedOnboardingMutationOrigin: vi.fn(),
+  countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince: vi.fn(),
+  countHostedMemberHomeLinqBindingsByRecipientPhone: vi.fn(),
+  getPrisma: vi.fn(),
+  hostedMember: {
+    findUnique: vi.fn(),
+  },
+  hostedMemberRouting: {
+    findUnique: vi.fn(),
+  },
+  listHostedLinqAssignableHomeLines: vi.fn(),
+  readHostedMemberRoutingState: vi.fn(),
+  requireActiveHostedAppSessionFromRequest: vi.fn(),
+  upsertHostedMemberHomeLinqRecipientPhoneTx: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
+  requireActiveHostedAppSessionFromRequest:
+    mocks.requireActiveHostedAppSessionFromRequest,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/csrf", () => ({
+  assertHostedOnboardingMutationOrigin: mocks.assertHostedOnboardingMutationOrigin,
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: mocks.getPrisma,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-routing-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/hosted-member-routing-store")
+  >("@/src/lib/hosted-onboarding/hosted-member-routing-store");
+  return {
+    ...actual,
+    acquireHostedMemberHomeLinqRecipientAssignmentLockTx:
+      mocks.acquireHostedMemberHomeLinqRecipientAssignmentLockTx,
+    countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince:
+      mocks.countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince,
+    countHostedMemberHomeLinqBindingsByRecipientPhone:
+      mocks.countHostedMemberHomeLinqBindingsByRecipientPhone,
+    readHostedMemberRoutingState: mocks.readHostedMemberRoutingState,
+    upsertHostedMemberHomeLinqRecipientPhoneTx:
+      mocks.upsertHostedMemberHomeLinqRecipientPhoneTx,
+  };
+});
+
+vi.mock("@/src/lib/hosted-onboarding/linq-line-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/linq-line-store")
+  >("@/src/lib/hosted-onboarding/linq-line-store");
+  return {
+    ...actual,
+    listHostedLinqAssignableHomeLines: mocks.listHostedLinqAssignableHomeLines,
+  };
+});
+
+import {
+  createHostedPhoneLookupKey,
+  createHostedPhoneLookupKeyReadCandidates,
+} from "@/src/lib/hosted-onboarding/contact-privacy";
+import type { HostedMemberRoutingStateSnapshot } from "@/src/lib/hosted-onboarding/hosted-member-routing-store";
+import type { HostedLinqAssignableHomeLine } from "@/src/lib/hosted-onboarding/linq-line-store";
+
+type LinqRehomeRouteModule = typeof import("../app/api/ops/linq-rehome/route");
+type LinqRehomeServiceModule = typeof import("../src/lib/hosted-ops/linq-line-rehome");
+
+let route: LinqRehomeRouteModule;
+let service: LinqRehomeServiceModule;
+
+const originalHostedOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
+const NOW = new Date("2026-07-06T15:45:30.000Z");
+const MEMBER_ID = "member_123";
+const LINE_A = buildLine("+15550100001");
+const LINE_B = buildLine("+15550100002");
+
+const transactionClient = {
+  hostedMember: mocks.hostedMember,
+  hostedMemberRouting: mocks.hostedMemberRouting,
+};
+
+const prisma = {
+  $transaction: vi.fn(async (
+    callback: (tx: typeof transactionClient) => Promise<unknown>,
+  ) => callback(transactionClient)),
+  hostedMember: mocks.hostedMember,
+  hostedMemberRouting: mocks.hostedMemberRouting,
+};
+
+describe("hosted Linq line rehome ops", () => {
+  beforeAll(async () => {
+    route = await import("../app/api/ops/linq-rehome/route");
+    service = await import("../src/lib/hosted-ops/linq-line-rehome");
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+    process.env.HOSTED_OPS_MEMBER_IDS = "member_ops";
+    prisma.$transaction.mockImplementation(async (
+      callback: (tx: typeof transactionClient) => Promise<unknown>,
+    ) => callback(transactionClient));
+    mocks.assertHostedOnboardingMutationOrigin.mockImplementation(() => {});
+    mocks.getPrisma.mockReturnValue(prisma);
+    mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
+      member: { id: "member_ops" },
+    });
+    mocks.hostedMember.findUnique.mockResolvedValue({
+      id: MEMBER_ID,
+      suspendedAt: null,
+    });
+    mocks.hostedMemberRouting.findUnique.mockResolvedValue({
+      linqLastInboundAt: new Date("2026-07-01T12:00:00.000Z"),
+    });
+    mocks.readHostedMemberRoutingState.mockResolvedValue(buildRouting({
+      linqChatId: "chat_home_a",
+      linqHomeLineAssignedAt: new Date("2026-07-01T11:00:00.000Z"),
+      linqRecipientPhone: LINE_A.phoneNumber,
+      linqRecipientPhoneLookupKey: LINE_A.phoneNumberLookupKey,
+    }));
+    mocks.listHostedLinqAssignableHomeLines.mockResolvedValue([LINE_A, LINE_B]);
+    mocks.countHostedMemberHomeLinqBindingsByRecipientPhone.mockResolvedValue(new Map());
+    mocks.countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince.mockResolvedValue(new Map());
+    mocks.upsertHostedMemberHomeLinqRecipientPhoneTx.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalHostedOpsMemberIds === undefined) {
+      delete process.env.HOSTED_OPS_MEMBER_IDS;
+    } else {
+      process.env.HOSTED_OPS_MEMBER_IDS = originalHostedOpsMemberIds;
+    }
+  });
+
+  it("reads an overview with authority, line hints, lookup keys, and active counts only", async () => {
+    mocks.countHostedMemberHomeLinqBindingsByRecipientPhone.mockResolvedValue(
+      new Map([
+        [LINE_A.phoneNumber, 7],
+        [LINE_B.phoneNumber, 2],
+      ]),
+    );
+
+    const overview = await service.readHostedLinqLineRehomeOverview({
+      memberId: MEMBER_ID,
+    });
+
+    expect(overview).toMatchObject({
+      assignableTargetLines: [
+        {
+          activeMemberCount: 7,
+          phoneNumberHint: "*** 0001",
+          phoneNumberLookupKey: LINE_A.phoneNumberLookupKey,
+        },
+        {
+          activeMemberCount: 2,
+          phoneNumberHint: "*** 0002",
+          phoneNumberLookupKey: LINE_B.phoneNumberLookupKey,
+        },
+      ],
+      currentRouting: {
+        authorityKind: "home",
+        currentLinePhoneHint: "*** 0001",
+        homeChatBound: true,
+        linqHomeLineAssignedAt: "2026-07-01T11:00:00.000Z",
+        linqLastInboundAt: "2026-07-01T12:00:00.000Z",
+        linqRecipientPhoneLookupKey: LINE_A.phoneNumberLookupKey,
+      },
+      member: {
+        id: MEMBER_ID,
+        suspendedAt: null,
+      },
+    });
+    expect(mocks.countHostedMemberHomeLinqBindingsByRecipientPhone).toHaveBeenCalledWith({
+      now: NOW,
+      prisma,
+      recipientPhones: [LINE_A.phoneNumber, LINE_B.phoneNumber],
+    });
+    expect(JSON.stringify(overview)).not.toContain(LINE_A.phoneNumber);
+    expect(JSON.stringify(overview)).not.toContain(LINE_B.phoneNumber);
+  });
+
+  it("rehomes a bound home chat to a bare target line through the existing write primitive", async () => {
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).resolves.toEqual({
+      clearedHomeChat: true,
+      clearedPendingRoute: false,
+      fromLineHint: "*** 0001",
+      toLineHint: "*** 0002",
+    });
+
+    expect(mocks.acquireHostedMemberHomeLinqRecipientAssignmentLockTx)
+      .toHaveBeenCalledWith({ prisma: transactionClient });
+    expect(mocks.countHostedMemberHomeLinqBindingsByRecipientPhone).toHaveBeenCalledWith({
+      excludedMemberId: MEMBER_ID,
+      now: NOW,
+      prisma: transactionClient,
+      recipientPhones: [LINE_B.phoneNumber],
+    });
+    expect(mocks.countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince).toHaveBeenCalledWith({
+      prisma: transactionClient,
+      recipientPhones: [LINE_B.phoneNumber],
+      since: new Date("2026-07-06T00:00:00.000Z"),
+    });
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).toHaveBeenCalledWith({
+      clearPending: true,
+      homeLineAssignedAt: NOW,
+      memberId: MEMBER_ID,
+      prisma: transactionClient,
+      recipientPhone: LINE_B.phoneNumber,
+    });
+  });
+
+  it("clears pending Linq route state when rehoming", async () => {
+    mocks.readHostedMemberRoutingState.mockResolvedValue(buildRouting({
+      hasPendingLinqRouteState: true,
+      linqHomeLineAssignedAt: new Date("2026-07-01T11:00:00.000Z"),
+      linqRecipientPhone: LINE_A.phoneNumber,
+      linqRecipientPhoneLookupKey: LINE_A.phoneNumberLookupKey,
+      pendingLinqChatId: "chat_pending",
+      pendingLinqRecipientPhone: LINE_A.phoneNumber,
+    }));
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).resolves.toMatchObject({
+      clearedHomeChat: false,
+      clearedPendingRoute: true,
+      fromLineHint: "*** 0001",
+      toLineHint: "*** 0002",
+    });
+
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clearPending: true,
+        recipientPhone: LINE_B.phoneNumber,
+      }),
+    );
+  });
+
+  it("allows members with no existing Linq route to become bare on the target", async () => {
+    mocks.readHostedMemberRoutingState.mockResolvedValue(null);
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).resolves.toEqual({
+      clearedHomeChat: false,
+      clearedPendingRoute: false,
+      fromLineHint: null,
+      toLineHint: "*** 0002",
+    });
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clearPending: true,
+        recipientPhone: LINE_B.phoneNumber,
+      }),
+    );
+  });
+
+  it("rejects a target that is not in the assignable line pool", async () => {
+    mocks.listHostedLinqAssignableHomeLines.mockResolvedValue([LINE_A]);
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_LINQ_REHOME_TARGET_NOT_ASSIGNABLE",
+      httpStatus: 400,
+    });
+
+    expect(mocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+  });
+
+  it("rejects already-on-target routes using target phone lookup-key candidates", async () => {
+    const previousKeys = process.env.HOSTED_CONTACT_PRIVACY_KEYS;
+    const previousCurrentVersion = process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION;
+    process.env.HOSTED_CONTACT_PRIVACY_KEYS = [
+      `v1:${Buffer.alloc(32, 0).toString("base64")}`,
+      `v2:${Buffer.alloc(32, 1).toString("base64")}`,
+    ].join(",");
+    process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = "v2";
+
+    try {
+      const rotatedLineB = buildLine(LINE_B.phoneNumber);
+      const [currentLookupKey, legacyLookupKey] =
+        createHostedPhoneLookupKeyReadCandidates(rotatedLineB.phoneNumber);
+
+      if (!currentLookupKey || !legacyLookupKey) {
+        throw new Error("Expected current and legacy lookup keys for rotated test keyring.");
+      }
+
+      expect(rotatedLineB.phoneNumberLookupKey).toBe(currentLookupKey);
+      mocks.listHostedLinqAssignableHomeLines.mockResolvedValue([rotatedLineB]);
+      mocks.readHostedMemberRoutingState.mockResolvedValue(buildRouting({
+        linqRecipientPhone: LINE_B.phoneNumber,
+        linqRecipientPhoneLookupKey: legacyLookupKey,
+      }));
+
+      await expect(
+        service.rehomeHostedMemberLinqHomeLine({
+          memberId: MEMBER_ID,
+          targetLineLookupKey: rotatedLineB.phoneNumberLookupKey,
+        }),
+      ).rejects.toMatchObject({
+        code: "HOSTED_LINQ_REHOME_ALREADY_ON_TARGET",
+        httpStatus: 409,
+      });
+
+      expect(mocks.countHostedMemberHomeLinqBindingsByRecipientPhone).not.toHaveBeenCalled();
+      expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+    } finally {
+      restoreEnvValue("HOSTED_CONTACT_PRIVACY_KEYS", previousKeys);
+      restoreEnvValue(
+        "HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION",
+        previousCurrentVersion,
+      );
+    }
+  });
+
+  it("rejects a target at active-member capacity", async () => {
+    const cappedLine = buildLine("+15550100003", {
+      activeMemberLimit: 1,
+    });
+    mocks.listHostedLinqAssignableHomeLines.mockResolvedValue([cappedLine]);
+    mocks.countHostedMemberHomeLinqBindingsByRecipientPhone.mockResolvedValue(
+      new Map([[cappedLine.phoneNumber, 1]]),
+    );
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: cappedLine.phoneNumberLookupKey,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_LINQ_REHOME_TARGET_AT_CAPACITY",
+      httpStatus: 409,
+    });
+
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+  });
+
+  it("rejects a target at daily new-conversation capacity", async () => {
+    const cappedLine = buildLine("+15550100004", {
+      maxNewConversationsPerDay: 1,
+    });
+    mocks.listHostedLinqAssignableHomeLines.mockResolvedValue([cappedLine]);
+    mocks.countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince.mockResolvedValue(
+      new Map([[cappedLine.phoneNumber, 1]]),
+    );
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: cappedLine.phoneNumberLookupKey,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_LINQ_REHOME_TARGET_AT_CAPACITY",
+      httpStatus: 409,
+    });
+
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown and suspended members before route writes", async () => {
+    mocks.hostedMember.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: "member_missing",
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_LINQ_REHOME_MEMBER_NOT_FOUND",
+      httpStatus: 404,
+    });
+
+    mocks.hostedMember.findUnique.mockResolvedValueOnce({
+      id: MEMBER_ID,
+      suspendedAt: new Date("2026-07-01T00:00:00.000Z"),
+    });
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_LINQ_REHOME_MEMBER_SUSPENDED",
+      httpStatus: 409,
+    });
+
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+  });
+
+  it("gates GET and POST through hosted ops access with 404 semantics", async () => {
+    mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
+      member: { id: "member_other" },
+    });
+
+    const getResponse = await route.GET(
+      new Request(`https://join.example.test/api/ops/linq-rehome?memberId=${MEMBER_ID}`),
+    );
+    const postResponse = await route.POST(
+      new Request("https://join.example.test/api/ops/linq-rehome", {
+        body: JSON.stringify({
+          memberId: MEMBER_ID,
+          targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(getResponse.status).toBe(404);
+    expect(postResponse.status).toBe(404);
+    expect(mocks.hostedMember.findUnique).not.toHaveBeenCalled();
+    await expect(getResponse.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_OPS_ACCESS_DENIED",
+      },
+    });
+    await expect(postResponse.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_OPS_ACCESS_DENIED",
+      },
+    });
+  });
+
+  it("rejects missing memberId and targetLineLookupKey request fields before mutation", async () => {
+    const missingMember = await route.GET(
+      new Request("https://join.example.test/api/ops/linq-rehome"),
+    );
+    expect(missingMember.status).toBe(400);
+    await expect(missingMember.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_LINQ_REHOME_MEMBER_ID_REQUIRED",
+      },
+    });
+
+    const missingTarget = await route.POST(
+      new Request("https://join.example.test/api/ops/linq-rehome", {
+        body: JSON.stringify({
+          memberId: MEMBER_ID,
+          targetLineLookupKey: " ",
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(missingTarget.status).toBe(400);
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+    await expect(missingTarget.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_LINQ_REHOME_TARGET_LOOKUP_KEY_REQUIRED",
+      },
+    });
+  });
+
+  it("returns route payloads with hints and lookup keys but no raw phone numbers", async () => {
+    const getResponse = await route.GET(
+      new Request(`https://join.example.test/api/ops/linq-rehome?memberId=${MEMBER_ID}`),
+    );
+    const postResponse = await route.POST(
+      new Request("https://join.example.test/api/ops/linq-rehome", {
+        body: JSON.stringify({
+          memberId: MEMBER_ID,
+          targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(getResponse.status).toBe(200);
+    expect(postResponse.status).toBe(200);
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    const getPayload = await getResponse.json();
+    const postPayload = await postResponse.json();
+    expect(getPayload.assignableTargetLines[1]).toMatchObject({
+      phoneNumberHint: "*** 0002",
+      phoneNumberLookupKey: LINE_B.phoneNumberLookupKey,
+    });
+    expect(postPayload).toEqual({
+      clearedHomeChat: true,
+      clearedPendingRoute: false,
+      fromLineHint: "*** 0001",
+      toLineHint: "*** 0002",
+    });
+    const serialized = JSON.stringify({ getPayload, postPayload });
+    expect(serialized).not.toContain(LINE_A.phoneNumber);
+    expect(serialized).not.toContain(LINE_B.phoneNumber);
+  });
+});
+
+function buildLine(
+  phoneNumber: string,
+  overrides: Partial<{
+    activeMemberLimit: number | null;
+    assignmentWeight: number;
+    maxNewConversationsPerDay: number | null;
+  }> = {},
+): HostedLinqAssignableHomeLine {
+  const phoneNumberLookupKey = createHostedPhoneLookupKey(phoneNumber);
+  if (!phoneNumberLookupKey) {
+    throw new Error("Expected hosted phone lookup key for test line.");
+  }
+
+  return {
+    activeMemberLimit: overrides.activeMemberLimit ?? null,
+    assignmentWeight: overrides.assignmentWeight ?? 100,
+    maxNewConversationsPerDay: overrides.maxNewConversationsPerDay ?? null,
+    phoneNumber,
+    phoneNumberHint: `*** ${phoneNumber.slice(-4)}`,
+    phoneNumberLookupKey,
+  };
+}
+
+function buildRouting(
+  overrides: Partial<HostedMemberRoutingStateSnapshot> = {},
+): HostedMemberRoutingStateSnapshot {
+  return {
+    hasPendingLinqRouteState: false,
+    linqChatId: null,
+    linqChatLookupKey: null,
+    linqHomeLineAssignedAt: null,
+    linqRecipientPhone: null,
+    linqRecipientPhoneLookupKey: null,
+    memberId: MEMBER_ID,
+    pendingLinqChatId: null,
+    pendingLinqParticipantContact: null,
+    pendingLinqRecipientPhone: null,
+    replyAliasLookupKey: null,
+    telegramThreadId: null,
+    telegramUserId: null,
+    telegramUserLookupKey: null,
+    ...overrides,
+  };
+}
+
+function restoreEnvValue(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/apps/web/test/hosted-ops-linq-line-rehome.test.ts
+++ b/apps/web/test/hosted-ops-linq-line-rehome.test.ts
@@ -11,6 +11,9 @@ const mocks = vi.hoisted(() => ({
   hostedMember: {
     findUnique: vi.fn(),
   },
+  hostedMemberIdentity: {
+    findUnique: vi.fn(),
+  },
   hostedMemberRouting: {
     findUnique: vi.fn(),
   },
@@ -77,11 +80,17 @@ let service: LinqRehomeServiceModule;
 const originalHostedOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
 const NOW = new Date("2026-07-06T15:45:30.000Z");
 const MEMBER_ID = "member_123";
+const MEMBER_PHONE_LOOKUP_KEY = createHostedPhoneLookupKey("+15550109999");
 const LINE_A = buildLine("+15550100001");
 const LINE_B = buildLine("+15550100002");
 
+if (!MEMBER_PHONE_LOOKUP_KEY) {
+  throw new Error("Expected hosted phone lookup key for test member.");
+}
+
 const transactionClient = {
   hostedMember: mocks.hostedMember,
+  hostedMemberIdentity: mocks.hostedMemberIdentity,
   hostedMemberRouting: mocks.hostedMemberRouting,
 };
 
@@ -90,7 +99,15 @@ const prisma = {
     callback: (tx: typeof transactionClient) => Promise<unknown>,
   ) => callback(transactionClient)),
   hostedMember: mocks.hostedMember,
+  hostedMemberIdentity: mocks.hostedMemberIdentity,
   hostedMemberRouting: mocks.hostedMemberRouting,
+};
+
+let consoleInfoSpy: {
+  mock: {
+    calls: unknown[][];
+  };
+  mockRestore(): void;
 };
 
 describe("hosted Linq line rehome ops", () => {
@@ -112,6 +129,9 @@ describe("hosted Linq line rehome ops", () => {
     mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
       member: { id: "member_ops" },
     });
+    mocks.hostedMemberIdentity.findUnique.mockResolvedValue({
+      phoneLookupKey: MEMBER_PHONE_LOOKUP_KEY,
+    });
     mocks.hostedMember.findUnique.mockResolvedValue({
       id: MEMBER_ID,
       suspendedAt: null,
@@ -129,9 +149,11 @@ describe("hosted Linq line rehome ops", () => {
     mocks.countHostedMemberHomeLinqBindingsByRecipientPhone.mockResolvedValue(new Map());
     mocks.countHostedMemberHomeLinqAssignmentsByRecipientPhoneSince.mockResolvedValue(new Map());
     mocks.upsertHostedMemberHomeLinqRecipientPhoneTx.mockResolvedValue(undefined);
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    consoleInfoSpy.mockRestore();
     vi.useRealTimers();
     if (originalHostedOpsMemberIds === undefined) {
       delete process.env.HOSTED_OPS_MEMBER_IDS;
@@ -202,6 +224,14 @@ describe("hosted Linq line rehome ops", () => {
 
     expect(mocks.acquireHostedMemberHomeLinqRecipientAssignmentLockTx)
       .toHaveBeenCalledWith({ prisma: transactionClient });
+    expect(mocks.hostedMemberIdentity.findUnique).toHaveBeenCalledWith({
+      where: {
+        memberId: MEMBER_ID,
+      },
+      select: {
+        phoneLookupKey: true,
+      },
+    });
     expect(mocks.countHostedMemberHomeLinqBindingsByRecipientPhone).toHaveBeenCalledWith({
       excludedMemberId: MEMBER_ID,
       now: NOW,
@@ -220,6 +250,48 @@ describe("hosted Linq line rehome ops", () => {
       prisma: transactionClient,
       recipientPhone: LINE_B.phoneNumber,
     });
+  });
+
+  it("rejects members without a phone identity before locking or routing writes", async () => {
+    mocks.hostedMemberIdentity.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_LINQ_REHOME_MEMBER_PHONE_REQUIRED",
+      httpStatus: 409,
+      retryable: false,
+    });
+
+    expect(mocks.acquireHostedMemberHomeLinqRecipientAssignmentLockTx).not.toHaveBeenCalled();
+    expect(mocks.listHostedLinqAssignableHomeLines).not.toHaveBeenCalled();
+    expect(mocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+  });
+
+  it("rejects members with null phone lookup identity before locking or routing writes", async () => {
+    mocks.hostedMemberIdentity.findUnique.mockResolvedValueOnce({
+      phoneLookupKey: null,
+    });
+
+    await expect(
+      service.rehomeHostedMemberLinqHomeLine({
+        memberId: MEMBER_ID,
+        targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_LINQ_REHOME_MEMBER_PHONE_REQUIRED",
+      httpStatus: 409,
+      retryable: false,
+    });
+
+    expect(mocks.acquireHostedMemberHomeLinqRecipientAssignmentLockTx).not.toHaveBeenCalled();
+    expect(mocks.listHostedLinqAssignableHomeLines).not.toHaveBeenCalled();
+    expect(mocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+    expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
   });
 
   it("clears pending Linq route state when rehoming", async () => {
@@ -336,6 +408,31 @@ describe("hosted Linq line rehome ops", () => {
       );
     }
   });
+
+  for (const [label, linqRecipientPhoneLookupKey] of [
+    ["null lookup key", null],
+    ["stale lookup key", LINE_A.phoneNumberLookupKey],
+  ] as const) {
+    it(`rejects already-on-target routes by normalized phone with ${label}`, async () => {
+      mocks.readHostedMemberRoutingState.mockResolvedValue(buildRouting({
+        linqRecipientPhone: "1 (555) 010-0002",
+        linqRecipientPhoneLookupKey,
+      }));
+
+      await expect(
+        service.rehomeHostedMemberLinqHomeLine({
+          memberId: MEMBER_ID,
+          targetLineLookupKey: LINE_B.phoneNumberLookupKey,
+        }),
+      ).rejects.toMatchObject({
+        code: "HOSTED_LINQ_REHOME_ALREADY_ON_TARGET",
+        httpStatus: 409,
+      });
+
+      expect(mocks.countHostedMemberHomeLinqBindingsByRecipientPhone).not.toHaveBeenCalled();
+      expect(mocks.upsertHostedMemberHomeLinqRecipientPhoneTx).not.toHaveBeenCalled();
+    });
+  }
 
   it("rejects a target at active-member capacity", async () => {
     const cappedLine = buildLine("+15550100003", {
@@ -519,9 +616,21 @@ describe("hosted Linq line rehome ops", () => {
       fromLineHint: "*** 0001",
       toLineHint: "*** 0002",
     });
+    expect(consoleInfoSpy).toHaveBeenCalledWith("Hosted ops Linq rehome completed.", {
+      fromLineHint: "*** 0001",
+      operatorMemberId: "member_ops",
+      targetMemberId: MEMBER_ID,
+      timestamp: NOW.toISOString(),
+      toLineHint: "*** 0002",
+    });
     const serialized = JSON.stringify({ getPayload, postPayload });
     expect(serialized).not.toContain(LINE_A.phoneNumber);
     expect(serialized).not.toContain(LINE_B.phoneNumber);
+    const serializedLog = JSON.stringify(consoleInfoSpy.mock.calls);
+    expect(serializedLog).not.toContain(LINE_A.phoneNumber);
+    expect(serializedLog).not.toContain(LINE_B.phoneNumber);
+    expect(serializedLog).not.toContain(LINE_A.phoneNumberLookupKey);
+    expect(serializedLog).not.toContain(LINE_B.phoneNumberLookupKey);
   });
 });
 


### PR DESCRIPTION
## Why

We now run two configured Linq lines and need to migrate a member (starting with the founder) from one line to another — and, longer term, fold members off a degraded or banned line automatically. The prod DB role is read-only and routing phone columns are encrypted app-side, so line migration must be a deployed, ops-gated action. This PR ships the minimal reusable rehome primitive that a future health-driven failover loop can call.

## User-visible goal

A founder-gated ops action (GET/POST `/api/ops/linq-rehome`) that moves one hosted member's Linq home line onto an explicitly selected assignable line. After rehome the member's next text to the new line binds the new home chat; texting the old line gets the existing redirect-to-home reply. Murph-initiated sends stay fail-closed until the member texts the new line (last-inbound intentionally resets), preserving the anti-cold-contact posture.

## Invariants preserved

- Rehome target must be in the assignable pool (configured, enabled, healthy) and under active-member / daily-assignment capacity — checked via the existing `chooseHostedLinqHomeLine` under the existing assignment advisory lock.
- Single write path: `upsertHostedMemberHomeLinqRecipientPhoneTx({ clearPending: true })`; no new routing write logic, no webhook/egress/routing-policy changes, no schema change.
- 28-day recipient-reply egress guard is not weakened: last-inbound is not carried across lines.
- Ops responses expose phone hints and lookup keys only, never decrypted numbers.
- Known accepted residual (documented in the plan doc): stale `hosted_thread_route` rows for the old 1:1 chat may let an in-flight session egress on the old thread until sessions roll over; thread-route cleanup belongs to future banned-line failover work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785965976&installation_id=127572939&pr_number=413&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F413&signature=142467319df0e2dd422317327c0892af5067902c271075c861a21d3d972b7758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->