### PR TITLE
perf(hosted): ack direct ensure before runtime wake + widen keep-alive window

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-06-hosted-ensure-ack-early.md
+++ b/agent-docs/exec-plans/completed/2026-07-06-hosted-ensure-ack-early.md
@@ -1,0 +1,104 @@
+# Hosted Ensure Ack-Early
+
+## Goal
+
+Make the web direct `ensure-processing` wake acknowledge immediately after auth
+and request parsing, while keeping Temporal callback-signed ensure requests
+synchronous and response-compatible.
+
+Success criteria:
+
+- Vercel OIDC direct wake receives `202 { accepted: true }`.
+- The existing Durable Object `ensureRuntimeProcessingForUser` call still runs
+  identically for the direct wake, but under Worker `ctx.waitUntil`.
+- Callback-signed Temporal ensure requests return the existing full result
+  synchronously.
+- The hosted-control client tolerates both old full-result responses and the new
+  direct-wake ack, and still emits timing callbacks.
+- Web direct-control keep-alive windows are widened to cover the observed
+  1-5 minute conversation gaps without adding new state or routing.
+
+## Context
+
+Measured post-PR-404 traces showed reused direct-ensure connection arrivals at
+12-255 ms versus roughly 600-850 ms after the current 60 second undici idle
+window expires. The long tail was on the response leg because the Worker route
+awaited Durable Object wake/reconstruction before returning even though the web
+caller is fire-and-forget and ignores the response body.
+
+Cloudflare Worker `ctx.waitUntil` is the minimal platform primitive for this:
+it keeps post-response work alive after the response or client disconnect, with
+the documented post-response extension window covering the observed worst case.
+
+## Constraints
+
+- No new headers, flags, environment variables, routes, durable state, or
+  production harness bypasses.
+- Dispatch only on the existing presented auth kind:
+  `vercel-oidc` versus `web-callback-signature`.
+- Do not touch `ensureRuntimeProcessingForUser` or its diagnostics payload.
+- WaitUntil-path failures must use the existing structured logging helper and
+  must not become unhandled promise rejections.
+- Temporal backstop behavior and callback-signed response shape stay unchanged.
+
+## Semantic Note
+
+After this change, the web direct wake RTT metric recorded by the hosted-control
+client for Vercel OIDC direct wake measures request arrival plus auth/parse/ack,
+not Durable Object wake completion. The client remains response-shape tolerant
+for deploy skew: old Cloudflare returns the full result, new Cloudflare returns
+the ack.
+
+## Verification Plan
+
+- Verify the Vercel OIDC caller matrix before code changes:
+  web direct wake path, Temporal callback-signed path, and local harness/smoke
+  credentials/body assertions.
+- Add Cloudflare route tests for Vercel OIDC ack + captured waitUntil, callback
+  signature full synchronous result, and waitUntil rejection logging.
+- Add hosted-control client tests for `202` ack acceptance, timing callback, and
+  old full-result compatibility.
+- Run focused typechecks for `apps/cloudflare`, `apps/web`, and
+  `packages/cloudflare-hosted-control`.
+- Run focused touched-owner test suites for the route, client, and webhook wake.
+
+## State
+
+Done:
+
+- Verified the Vercel OIDC ensure caller is the web direct wake path through
+  `apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts` and
+  `packages/cloudflare-hosted-control/src/client.ts`; it is best-effort and
+  does not use the response body for correctness.
+- Verified the Temporal worker uses the callback-signature HTTP client path and
+  still parses the full synchronous ensure result.
+- Verified `apps/cloudflare/test/helpers/hosted-local-wake.ts` uses callback
+  signatures and parses the full result, so harness synchronous behavior stays
+  on that credential path.
+- Threaded the Worker execution context through the Worker fetch entrypoints
+  into `WorkerRouteContext`.
+- Vercel OIDC direct ensure now returns `202 { accepted: true }` after auth and
+  parse, while scheduling the existing Durable Object ensure call under
+  `ctx.waitUntil` with structured failure logging.
+- Callback-signature ensure requests retain the old synchronous response path.
+- The hosted-control client accepts both the old full result and the new ack
+  shape while still emitting timing.
+- Web direct-control keep-alive windows are now 300s/600s with the measured
+  direct-wake RTT rationale in code.
+- Verification passed:
+  - `pnpm --dir apps/cloudflare typecheck`
+  - `pnpm --dir apps/web typecheck`
+  - `pnpm --dir packages/cloudflare-hosted-control typecheck`
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/index.test.ts`
+  - `pnpm exec vitest run --config vitest.config.ts --no-coverage test/client.test.ts` from `packages/cloudflare-hosted-control`
+  - `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts`
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/helpers/hosted-local-wake.test.ts`
+
+Now: final diff inspection and scoped commit.
+
+Next: no runner bundle rebuild; hand off with deployment note that web and
+Cloudflare can deploy in either order because the request shape is unchanged
+and the new web client accepts both response shapes.
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/apps/cloudflare/src/hosted-local-test-index.ts
+++ b/apps/cloudflare/src/hosted-local-test-index.ts
@@ -13,6 +13,7 @@ import {
   handleHostedEmailIngress,
 } from "./hosted-email/worker-ingress.ts";
 import type {
+  WorkerExecutionContext,
   WorkerEnvironmentSource,
 } from "./worker-routes/shared.ts";
 import {
@@ -37,9 +38,10 @@ export default {
   async fetch(
     request: Request,
     env: WorkerEnvironmentSource,
+    ctx?: WorkerExecutionContext,
   ): Promise<Response> {
     try {
-      return await handleHostedLocalTestWorkerFetch(request, env);
+      return await handleHostedLocalTestWorkerFetch(request, env, ctx);
     } catch (error) {
       return mapWorkerRouteError(request, error);
     }

--- a/apps/cloudflare/src/worker-routes/shared.ts
+++ b/apps/cloudflare/src/worker-routes/shared.ts
@@ -66,9 +66,14 @@ export interface WorkerEnvironmentSource
   RUNNER_CONTAINER_SMOKE: HostedExecutionContainerNamespaceLike;
 }
 
+export interface WorkerExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
 export interface WorkerRouteContext {
   env: WorkerEnvironmentSource;
   environment: ReturnType<typeof readHostedExecutionEnvironment>;
+  executionCtx?: WorkerExecutionContext;
   request: Request;
   requestText?: Promise<string>;
   runtimeControlAuthTiming?: {

--- a/apps/cloudflare/src/worker/fetch-handler.ts
+++ b/apps/cloudflare/src/worker/fetch-handler.ts
@@ -9,6 +9,7 @@ import {
 } from "../worker-contracts.ts";
 import type {
   WorkerRouteContext,
+  WorkerExecutionContext,
   WorkerEnvironmentSource,
 } from "../worker-routes/shared.ts";
 import type {
@@ -29,6 +30,7 @@ export function createWorkerFetchHandler(input: {
   return async function handleWorkerFetch(
     request: Request,
     env: WorkerEnvironmentSource,
+    executionCtx?: WorkerExecutionContext,
   ): Promise<Response> {
     const url = new URL(request.url);
     const publicResponse = await handleDeclarativeRoute(input.publicRoutes, { env, request, url });
@@ -42,6 +44,7 @@ export function createWorkerFetchHandler(input: {
       await handleDeclarativeRoute(input.internalRoutes, {
         env,
         environment,
+        ...(executionCtx ? { executionCtx } : {}),
         request,
         url,
       })

--- a/apps/cloudflare/src/worker/index.ts
+++ b/apps/cloudflare/src/worker/index.ts
@@ -2,6 +2,7 @@ import {
   handleHostedEmailIngress,
 } from "../hosted-email/worker-ingress.ts";
 import type {
+  WorkerExecutionContext,
   WorkerEnvironmentSource,
 } from "../worker-routes/shared.ts";
 import {
@@ -26,9 +27,10 @@ export default {
   async fetch(
     request: Request,
     env: WorkerEnvironmentSource,
+    ctx?: WorkerExecutionContext,
   ): Promise<Response> {
     try {
-      return await handleWorkerFetch(request, env);
+      return await handleWorkerFetch(request, env, ctx);
     } catch (error) {
       return mapWorkerRouteError(request, error);
     }

--- a/apps/cloudflare/src/worker/route-handlers/runtime-control.ts
+++ b/apps/cloudflare/src/worker/route-handlers/runtime-control.ts
@@ -3,6 +3,7 @@ import {
 } from "@murphai/hosted-execution";
 import type {
   HostedRuntimeEnsureProcessingRequest,
+  HostedRuntimeEnsureProcessingResponse,
 } from "@murphai/hosted-execution/orchestration-control";
 import type {
   HostedRuntimeLatencyPhaseBreakdown,
@@ -143,14 +144,45 @@ export async function handleRuntimeEnsureProcessingRoute(
       requireJsonObject(payload.trim() ? JSON.parse(payload) : {}),
     );
     commandTimeoutMs = readRuntimeEnsureProcessingCommandTimeoutMs(context.request.headers);
+    const authorizationKind = readPresentedWorkerRouteAuthorization(context.request);
     orchestration = readRuntimeEnsureProcessingOrchestrationDiagnostics(
       context.request.headers,
       cloudflareRouteReceivedAtEpochMs,
       context.runtimeControlAuthTiming ?? null,
       // Derived from the credential that authorized this request, never from
       // caller-supplied body fields.
-      readPresentedWorkerRouteAuthorization(context.request) === "vercel-oidc",
+      authorizationKind === "vercel-oidc",
     );
+    if (authorizationKind === "vercel-oidc") {
+      const executionCtx = context.executionCtx;
+      if (!executionCtx) {
+        throw new Error("Worker execution context is required for direct runtime ensure-processing.");
+      }
+
+      executionCtx.waitUntil(
+        runRuntimeEnsureProcessingForUser({
+          commandTimeoutMs,
+          context,
+          ensureRequest,
+          orchestration,
+          userId,
+        }).catch((error: unknown) => {
+          emitHostedExecutionStructuredLog({
+            component: "worker",
+            details: buildWorkerRouteLogDetails({
+              reason: "runtime-ensure-processing-waituntil-failed",
+              routeName: "runtime-ensure-processing",
+            }, context.request, userId),
+            error,
+            level: "error",
+            message: "Hosted worker runtime ensure-processing waitUntil task failed.",
+            phase: "failed",
+            userId,
+          });
+        }),
+      );
+      return json({ accepted: true }, 202);
+    }
   } catch (error) {
     emitHostedExecutionStructuredLog({
       component: "worker",
@@ -171,13 +203,29 @@ export async function handleRuntimeEnsureProcessingRoute(
     }, classified.status);
   }
 
-  const stub = context.env.USER_RUNNER.getByName(userId);
-  return json(await stub.ensureRuntimeProcessingForUser({
-    ...ensureRequest,
-    ...(commandTimeoutMs === null ? {} : { commandTimeoutMs }),
+  return json(await runRuntimeEnsureProcessingForUser({
+    commandTimeoutMs,
+    context,
+    ensureRequest,
     orchestration,
     userId,
   }));
+}
+
+function runRuntimeEnsureProcessingForUser(input: {
+  commandTimeoutMs: number | null;
+  context: WorkerRouteContext;
+  ensureRequest: HostedRuntimeEnsureProcessingRequest;
+  orchestration: NonNullable<HostedRuntimeLatencyPhaseBreakdown["orchestration"]>;
+  userId: string;
+}): Promise<HostedRuntimeEnsureProcessingResponse> {
+  const stub = input.context.env.USER_RUNNER.getByName(input.userId);
+  return stub.ensureRuntimeProcessingForUser({
+    ...input.ensureRequest,
+    ...(input.commandTimeoutMs === null ? {} : { commandTimeoutMs: input.commandTimeoutMs }),
+    orchestration: input.orchestration,
+    userId: input.userId,
+  });
 }
 
 export function readRuntimeEnsureProcessingCommandTimeoutMs(headers: Headers): number | null {

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -56,6 +56,7 @@ import {
 } from "../src/storage-paths.ts";
 import type {
   UserRunnerDurableObjectStubLike,
+  WorkerExecutionContext,
   WorkerEnvironmentSource,
 } from "../src/worker-routes/shared.ts";
 import { handleRunnerOutboundRequest } from "../src/runner-outbound.ts";
@@ -1990,16 +1991,26 @@ describe("cloudflare worker routes", () => {
       });
     });
 
-    it("accepts web-plane OIDC runtime ensure-processing requests and stamps the direct-wake trigger", async () => {
+    it("acks web-plane OIDC runtime ensure-processing requests early and schedules the Durable Object call", async () => {
+      let resolveEnsure!: (value: {
+        action: "woken";
+        kind: "runtime_processing_accepted";
+        recommendedRecheckAt: string;
+        runtimeAttemptId: string;
+      }) => void;
+      const ensurePromise = new Promise<{
+        action: "woken";
+        kind: "runtime_processing_accepted";
+        recommendedRecheckAt: string;
+        runtimeAttemptId: string;
+      }>((resolve) => {
+        resolveEnsure = resolve;
+      });
       const stub = createUserRunnerStub({
-        ensureRuntimeProcessingForUser: vi.fn(async () => ({
-          action: "woken" as const,
-          kind: "runtime_processing_accepted" as const,
-          recommendedRecheckAt: "2026-04-27T00:03:00.000Z",
-          runtimeAttemptId: "runtime-attempt-test",
-        })),
+        ensureRuntimeProcessingForUser: vi.fn(() => ensurePromise),
       });
       const env = createWorkerEnv(stub);
+      const execution = createWorkerExecutionContextForTest();
 
       const response = await worker.fetch(
         await signControlRequest(
@@ -2020,15 +2031,15 @@ describe("cloudflare worker routes", () => {
           }),
         ),
         env,
+        execution.ctx,
       );
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(202);
       await expect(response.json()).resolves.toEqual({
-        action: "woken",
-        kind: "runtime_processing_accepted",
-        recommendedRecheckAt: "2026-04-27T00:03:00.000Z",
-        runtimeAttemptId: "runtime-attempt-test",
+        accepted: true,
       });
+      expect(execution.waitUntil).toHaveBeenCalledTimes(1);
+      expect(execution.waitUntilPromises).toHaveLength(1);
       expect(stub.ensureRuntimeProcessingForUser).toHaveBeenCalledWith({
         orchestrationAttemptId: "web-ingress-attempt-test",
         orchestration: {
@@ -2042,6 +2053,60 @@ describe("cloudflare worker routes", () => {
         },
         userId: "test-user",
       });
+      resolveEnsure({
+        action: "woken",
+        kind: "runtime_processing_accepted",
+        recommendedRecheckAt: "2026-04-27T00:03:00.000Z",
+        runtimeAttemptId: "runtime-attempt-test",
+      });
+      await expect(execution.waitUntilPromises[0]).resolves.toEqual({
+        action: "woken",
+        kind: "runtime_processing_accepted",
+        recommendedRecheckAt: "2026-04-27T00:03:00.000Z",
+        runtimeAttemptId: "runtime-attempt-test",
+      });
+    });
+
+    it("logs web-plane OIDC waitUntil ensure-processing failures without rethrowing", async () => {
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.stubEnv("MURPH_HOSTED_EXECUTION_STDIO_LOGS", "1");
+      const stub = createUserRunnerStub({
+        ensureRuntimeProcessingForUser: vi.fn(async () => {
+          throw new Error("direct ensure failed");
+        }),
+      });
+      const env = createWorkerEnv(stub);
+      const execution = createWorkerExecutionContextForTest();
+
+      const response = await worker.fetch(
+        await signControlRequest(
+          new Request("https://runner.example.test/internal/users/test-user/runtime/ensure-processing", {
+            body: JSON.stringify({
+              orchestrationAttemptId: "web-ingress-attempt-test",
+            }),
+            headers: {
+              "content-type": "application/json; charset=utf-8",
+            },
+            method: "POST",
+          }),
+        ),
+        env,
+        execution.ctx,
+      );
+
+      expect(response.status).toBe(202);
+      await expect(response.json()).resolves.toEqual({
+        accepted: true,
+      });
+      expect(execution.waitUntilPromises).toHaveLength(1);
+      await expect(execution.waitUntilPromises[0]).resolves.toBeUndefined();
+      expect(errorLog).toHaveBeenCalledTimes(1);
+      const serializedErrorLogs = errorLog.mock.calls
+        .map(([payload]) => String(payload))
+        .join("\n");
+      expect(serializedErrorLogs).toContain("runtime-ensure-processing-waituntil-failed");
+      expect(serializedErrorLogs).toContain("/internal/users/<REDACTED_USER>/runtime/ensure-processing");
+      expect(serializedErrorLogs).toContain("direct ensure failed");
     });
 
     it("rejects runtime ensure-processing requests whose only credential is an invalid OIDC bearer", async () => {
@@ -3336,6 +3401,22 @@ type WorkerTestUserRunnerStub = UserRunnerDurableObjectStubLike & {
     userId: string;
   }): Promise<HostedRunnerStuckInvocationTestResult>;
 };
+
+function createWorkerExecutionContextForTest(): {
+  ctx: WorkerExecutionContext;
+  waitUntil: ReturnType<typeof vi.fn>;
+  waitUntilPromises: Promise<unknown>[];
+} {
+  const waitUntilPromises: Promise<unknown>[] = [];
+  const waitUntil = vi.fn((promise: Promise<unknown>) => {
+    waitUntilPromises.push(promise);
+  });
+  return {
+    ctx: { waitUntil },
+    waitUntil,
+    waitUntilPromises,
+  };
+}
 
 function createUserRunnerStub(overrides: Record<string, unknown> = {}) {
   return {

--- a/apps/web/src/lib/hosted-execution/control.ts
+++ b/apps/web/src/lib/hosted-execution/control.ts
@@ -11,8 +11,12 @@ import {
 } from "./environment";
 
 const hostedExecutionControlKeepAliveAgent = new Agent({
-  keepAliveMaxTimeout: 120_000,
-  keepAliveTimeout: 60_000,
+  // Reused direct-ensure arrivals measured 12-255ms vs ~600-850ms after the
+  // old 60s window expired; 300s covers common 1-5 minute conversation gaps
+  // while staying below Cloudflare's ~400s idle edge window. Stale-socket
+  // ECONNRESET remains tolerated by this best-effort direct wake plus Temporal.
+  keepAliveMaxTimeout: 600_000,
+  keepAliveTimeout: 300_000,
 });
 
 export function readHostedExecutionControlClientIfConfigured(

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
@@ -189,11 +189,19 @@ function startHostedDirectEnsureWakeBestEffort(wake: {
         userId: wake.userId,
       })
       .then((ensureResult) => {
-        console.info("Hosted direct ensure wake completed.", {
-          kind: ensureResult.kind,
-          ...(ensureResult.kind === "runtime_processing_accepted"
-            ? { action: ensureResult.action }
-            : {}),
+        if ("kind" in ensureResult) {
+          console.info("Hosted direct ensure wake completed.", {
+            kind: ensureResult.kind,
+            ...(ensureResult.kind === "runtime_processing_accepted"
+              ? { action: ensureResult.action }
+              : {}),
+            source: wakeSource,
+          });
+          return;
+        }
+
+        console.info("Hosted direct ensure wake accepted.", {
+          accepted: ensureResult.accepted,
           source: wakeSource,
         });
       })

--- a/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
@@ -158,6 +158,57 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     });
   });
 
+  it("accepts an early direct ensure ack and still records timing", async () => {
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const afterResponseTasks: Array<() => Promise<void>> = [];
+    mocks.ensureRuntimeProcessing.mockImplementationOnce(async (input: DirectEnsureInput) => {
+      input.onTiming({
+        tokenAcquireStartedAtEpochMs: 1_777_000_000_000,
+        tokenAcquiredAtEpochMs: 1_777_000_000_010,
+        directEnsureRequestStartedAtEpochMs: 1_777_000_000_012,
+        directEnsureResponseReceivedAtEpochMs: 1_777_000_000_025,
+      });
+      return {
+        accepted: true,
+      };
+    });
+
+    await expect(maybeHandoffHostedExecutionWebhookWake({
+      response,
+      scheduleAfterResponse: (task) => {
+        afterResponseTasks.push(task);
+      },
+      wakeHandoff: buildWakeHandoff(),
+    })).resolves.toMatchObject({
+      reason: "temporal-signaled",
+      signalAccepted: true,
+    });
+
+    await Promise.all(afterResponseTasks.map((task) => task()));
+    expect(consoleInfo).toHaveBeenCalledWith(
+      "Hosted direct ensure wake accepted.",
+      {
+        accepted: true,
+        source: "linq",
+      },
+    );
+    expect(mocks.recordHostedIngressDirectEnsureTiming).toHaveBeenCalledWith({
+      expectedUserId: "member_123",
+      mailboxItemId: "mailbox_123",
+      phaseBreakdown: {
+        schemaVersion: 1,
+        orchestration: {
+          tokenAcquireStartedAtEpochMs: 1_777_000_000_000,
+          tokenAcquiredAtEpochMs: 1_777_000_000_010,
+          directEnsureRequestStartedAtEpochMs: 1_777_000_000_012,
+          directEnsureResponseReceivedAtEpochMs: 1_777_000_000_025,
+        },
+      },
+      source: "linq",
+    });
+    consoleInfo.mockRestore();
+  });
+
   it("keeps the Temporal signal and handoff result intact when the direct ensure fails", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mocks.ensureRuntimeProcessing.mockRejectedValue(new Error("cloudflare unreachable"));

--- a/packages/cloudflare-hosted-control/src/client.ts
+++ b/packages/cloudflare-hosted-control/src/client.ts
@@ -82,9 +82,17 @@ export interface CloudflareHostedControlClient {
     onTiming?: (timing: CloudflareHostedControlRuntimeEnsureProcessingTiming) => void;
     orchestrationAttemptId: string;
     userId: string;
-  }): Promise<HostedRuntimeEnsureProcessingResponse>;
+  }): Promise<CloudflareHostedControlRuntimeEnsureProcessingResponse>;
   getRunnerStatus(userId: string): Promise<HostedRunnerStatusResponse>;
 }
+
+export interface CloudflareHostedControlRuntimeEnsureProcessingAcceptedAck {
+  accepted: true;
+}
+
+export type CloudflareHostedControlRuntimeEnsureProcessingResponse =
+  | HostedRuntimeEnsureProcessingResponse
+  | CloudflareHostedControlRuntimeEnsureProcessingAcceptedAck;
 
 export interface CloudflareHostedControlRuntimeEnsureProcessingTiming {
   directEnsureRequestStartedAtEpochMs: number;
@@ -197,7 +205,7 @@ export function createCloudflareHostedControlClient(
         getAuthorizationHeader,
         label: "runtime ensure-processing",
         onRuntimeEnsureProcessingTiming: input.onTiming,
-        parse: parseHostedRuntimeEnsureProcessingResponse,
+        parse: parseCloudflareHostedControlRuntimeEnsureProcessingResponse,
         path: buildCloudflareHostedControlRuntimeEnsureProcessingPath(userId),
         request: {
           body: JSON.stringify({
@@ -504,6 +512,19 @@ function parseHostedRunnerStatusForExpectedUser(
   }
 
   return status;
+}
+
+function parseCloudflareHostedControlRuntimeEnsureProcessingResponse(
+  value: unknown,
+): CloudflareHostedControlRuntimeEnsureProcessingResponse {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if (record.accepted === true) {
+      return { accepted: true };
+    }
+  }
+
+  return parseHostedRuntimeEnsureProcessingResponse(value);
 }
 
 function assertHostedBrowserVaultReplicaRefMatches(

--- a/packages/cloudflare-hosted-control/test/client.test.ts
+++ b/packages/cloudflare-hosted-control/test/client.test.ts
@@ -93,6 +93,44 @@ describe("createCloudflareHostedControlClient", () => {
     });
   });
 
+  it("accepts an early runtime ensure-processing ack and still reports timing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-06T12:00:00.000Z"));
+    const fetchImpl = vi.fn(async () => {
+      vi.setSystemTime(new Date("2026-07-06T12:00:00.025Z"));
+      return createJsonResponse({ accepted: true }, { status: 202 });
+    }) as typeof fetch;
+    const client = createCloudflareHostedControlClient({
+      baseUrl: "https://runner.example.test",
+      fetchImpl,
+      getBearerToken: async () => {
+        vi.setSystemTime(new Date("2026-07-06T12:00:00.010Z"));
+        return "token-123";
+      },
+    });
+    const onTiming = vi.fn();
+
+    try {
+      await expect(client.ensureRuntimeProcessing({
+        onTiming,
+        orchestrationAttemptId: "web-ingress-attempt-test",
+        userId: "user_123",
+      })).resolves.toEqual({
+        accepted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(onTiming).toHaveBeenCalledWith({
+      directEnsureRequestStartedAtEpochMs: Date.parse("2026-07-06T12:00:00.010Z"),
+      directEnsureResponseReceivedAtEpochMs: Date.parse("2026-07-06T12:00:00.025Z"),
+      tokenAcquiredAtEpochMs: Date.parse("2026-07-06T12:00:00.010Z"),
+      tokenAcquireStartedAtEpochMs: Date.parse("2026-07-06T12:00:00.000Z"),
+    });
+  });
+
   it("rejects blank user identifiers for runtime ensure-processing before issuing requests", () => {
     const fetchImpl = vi.fn() as unknown as typeof fetch;
     const client = createCloudflareHostedControlClient({


### PR DESCRIPTION
## Why

Post-#404 instrumentation (15 prod traces) split the direct-ensure hop into two costs with different owners:
- **Response leg 0.1–10s**: the ensure route awaits the user-runner DO before responding. Idle DOs are evicted after 70–140s (CF docs), so a post-lull ensure pays DO reconstruction + container wake while the fire-and-forget caller holds the connection. Worse: observed 10.4s RTTs flirt with the web client's AbortSignal.timeout, and per CF docs a client disconnect can **cancel in-flight work not held by `ctx.waitUntil`** — i.e. a slow cold ensure's DO wake can be killed mid-flight today.
- **Arrival leg**: 12–255ms on a reused connection vs ~600–850ms expired; reuse tracked the 60s undici window exactly, and real conversation gaps (76s, 3m47s) missed it.

## What

1. **Ack-early on `runtime-ensure-processing`**, scoped by the existing auth-kind discriminator (no new headers/flags/state): `vercel-oidc` callers (the web fire-and-forget direct wake — verified the only production caller on this credential, ignores the body) get `202 {accepted:true}` after auth+parse, with the identical DO ensure running in `ctx.waitUntil` (30s budget vs 10s observed worst case; rejections logged via the existing structured-log helper). `web-callback-signature` callers (the Temporal worker activity, which parses the synchronous result; the hosted-local harness likewise) keep today's behavior byte-identical.
2. **Keep-alive window 60s→300s** (max 600s): converts the ~700ms expired-connection arrivals for lull-length gaps; stays under Cloudflare's ~400s edge idle timeout with margin. Stale-socket reuse races remain tolerated by best-effort + Temporal backstop.

## Invariants

- Direct wake stays best-effort; Temporal backstop untouched (its activity path never sees the ack).
- Deploy order free: request shape unchanged; new web client accepts both the old full-result and the new ack; old web client during skew logs a benign parse warn while the wake still executes (waitUntil runs regardless).
- The waitUntil path makes the DO wake **survive client timeouts** — strictly fewer lost direct wakes than today.

## Verification

- Typechecks: apps/cloudflare, apps/web, cloudflare-hosted-control — green.
- CF route tests (87, incl. new: oidc→202-ack with DO still invoked via captured waitUntil; callback-signature unchanged; waitUntil rejection logged), client tests (30, incl. ack + old-shape + timing), webhook wake tests (10), hosted-local wake helper tests (4) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785976226&installation_id=127572939&pr_number=417&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F417&signature=f21139158a54914310f18cb6795d9357cd0768c610677d45fac4003487361c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->