### PR TITLE
build(hosted-runner): ratchet the static boot closure + fix guard traversal blind spot

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -29,9 +29,9 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // Byte budgets over the esbuild metafile so import-graph creep in the boot
 // surface fails the assembly instead of silently regressing cold start.
 // Latest measured from the real assembled bundle on 2026-07-07: total
-// 7,882,321B across 40 chunks, entry container-entrypoint.js 1,270,041B.
-// The entry ratchet baseline remains 1,267,937B because the latest entry did
-// not beat the prior baseline.
+// 7,884,530B across 40 chunks, entry container-entrypoint.js 1,270,050B,
+// static boot closure 6,382,690B across 30 chunks. The entry ratchet baseline
+// remains 1,267,937B because the latest entry did not beat the prior baseline.
 //
 // The entry chunk gates cold-start parse, so it is ratcheted, not given
 // headroom: the guard holds it to the measured baseline plus a tight noise
@@ -40,6 +40,14 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // below. When an increase is intentional, set the baseline to the measured
 // value the failure prints and say why in the same change.
 //
+// Node parses the entry chunk plus every statically reachable chunk before
+// HTTP listen, so the static boot closure is ratcheted with the same reviewed
+// baseline discipline as the entry chunk. Its tolerance is wider than the
+// entry tolerance because the closure spans ~5x more bytes and many more
+// chunks, so path comments, content hashes, and platform-specific emit jitter
+// have more surface. CI Linux has measured slightly smaller than local macOS;
+// since this ratchet fails only on growth, the local baseline remains safe.
+//
 // The total ceiling stays a fixed backstop at its prior 9,300,000B value (not
 // ratcheted): #397 shrank the bundle, so there is no reason to loosen it, and
 // dynamic (non-boot) chunk jitter should not force a baseline bump. Ratchet it
@@ -47,10 +55,12 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // inputs before raising either.
 const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_300_000;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_267_937;
+const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 6_382_690;
 // Noise band above the baseline before the ratchet trips (~2%): absorbs
 // content-hash and minifier jitter without letting real boot-path weight land
 // silently. Keep it tight; it is a tolerance for noise, not feature headroom.
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;
+const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES = 96_000;
 // The @murphai package markers are path suffixes, not node_modules-anchored:
 // workspace package inputs appear as `node_modules/@murphai/*/dist/...` in
 // the staged production assembly but as `packages/*/dist/...` when bundling
@@ -109,7 +119,7 @@ export async function bundleRunnerContainerEntrypoint(
     buildResult.metafile,
   );
   console.log(
-    `runner entrypoint bundle size: entry ${bundleBytes.entryBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES}B tolerance), total ${bundleBytes.totalBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET}B budget`,
+    `runner entrypoint bundle size: entry ${bundleBytes.entryBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES}B tolerance), static boot closure ${bundleBytes.staticClosureBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES}B tolerance), total ${bundleBytes.totalBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET}B budget`,
   );
   assertRunnerEntrypointBundleBoots({
     bundleDir,
@@ -127,12 +137,16 @@ export async function bundleRunnerContainerEntrypoint(
 // assertRunnerEntrypointBundleWithinBudgets with this as the default).
 export function resolveRunnerEntrypointBundleBudgets(): {
   entryBytes: number;
+  staticClosureBytes: number;
   totalBytes: number;
 } {
   return {
     entryBytes:
       RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES
       + RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES,
+    staticClosureBytes:
+      RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES
+      + RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES,
     totalBytes: RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET,
   };
 }
@@ -155,9 +169,9 @@ function assertRunnerEntrypointBundleInputsStayExternal(
 // call site always uses the default budgets above.
 export function assertRunnerEntrypointBundleWithinBudgets(
   metafile: Metafile,
-  budgets: { entryBytes: number; totalBytes: number }
+  budgets: { entryBytes: number; staticClosureBytes: number; totalBytes: number }
     = resolveRunnerEntrypointBundleBudgets(),
-): { entryBytes: number; totalBytes: number } {
+): { entryBytes: number; staticClosureBytes: number; totalBytes: number } {
   const outputs = Object.entries(metafile.outputs);
   const totalBytes = outputs.reduce((sum, [, output]) => sum + output.bytes, 0);
 
@@ -168,7 +182,18 @@ export function assertRunnerEntrypointBundleWithinBudgets(
       `runner entrypoint bundle metafile is missing output ${entryPath}; cannot enforce the entry-chunk byte budget.`,
     );
   }
-  assertRunnerEntrypointBundleBootInputsAllowed(metafile, entryPath);
+  const staticBootOutputPaths = collectStaticRunnerEntrypointOutputPaths(
+    metafile,
+    entryPath,
+  );
+  const staticClosureBytes = [...staticBootOutputPaths].reduce(
+    (sum, outputPath) => sum + (metafile.outputs[outputPath]?.bytes ?? 0),
+    0,
+  );
+  assertRunnerEntrypointBundleBootInputsAllowed(
+    metafile,
+    staticBootOutputPaths,
+  );
 
   const violations: string[] = [];
   if (totalBytes > budgets.totalBytes) {
@@ -181,8 +206,13 @@ export function assertRunnerEntrypointBundleWithinBudgets(
       `entry chunk ${entryPath} ${entryBytes}B exceeds budget ${budgets.entryBytes}B`,
     );
   }
+  if (staticClosureBytes > budgets.staticClosureBytes) {
+    violations.push(
+      `static boot closure ${staticClosureBytes}B exceeds budget ${budgets.staticClosureBytes}B`,
+    );
+  }
   if (violations.length === 0) {
-    return { entryBytes, totalBytes };
+    return { entryBytes, staticClosureBytes, totalBytes };
   }
 
   const largestInputs = Object.entries(metafile.inputs)
@@ -218,9 +248,8 @@ function findRunnerEntrypointBundleEntryOutputPath(metafile: Metafile): string {
 
 function assertRunnerEntrypointBundleBootInputsAllowed(
   metafile: Metafile,
-  entryPath: string,
+  bootOutputPaths: Set<string>,
 ): void {
-  const bootOutputPaths = collectStaticRunnerEntrypointOutputPaths(metafile, entryPath);
   const forbiddenInputs = new Set<string>();
 
   for (const outputPath of bootOutputPaths) {
@@ -308,10 +337,11 @@ function collectRunnerEntrypointOutputPaths(
       if (!shouldFollowImport(imported)) {
         continue;
       }
-      const importedOutputPath = resolveMetafileOutputImportPath(
-        outputPath,
-        imported.path,
-      );
+      const importedOutputPath = resolveMetafileOutputImportPath({
+        importedPath: imported.path,
+        importerOutputPath: outputPath,
+        outputPaths: metafile.outputs,
+      });
       if (importedOutputPath in metafile.outputs) {
         pending.push(importedOutputPath);
       }
@@ -321,11 +351,16 @@ function collectRunnerEntrypointOutputPaths(
   return outputPaths;
 }
 
-function resolveMetafileOutputImportPath(
-  importerOutputPath: string,
-  importedPath: string,
-): string {
+function resolveMetafileOutputImportPath(input: {
+  importedPath: string;
+  importerOutputPath: string;
+  outputPaths: Metafile["outputs"];
+}): string {
+  const { importedPath, importerOutputPath, outputPaths } = input;
   const normalizedImportedPath = normalizeMetafilePath(importedPath);
+  if (normalizedImportedPath in outputPaths) {
+    return normalizedImportedPath;
+  }
   if (!normalizedImportedPath.startsWith(".")) {
     return normalizedImportedPath;
   }

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -31,6 +31,43 @@ function entryOnlyMetafile(entryBytes: number): Metafile {
   };
 }
 
+function staticBootClosureBytesMetafile(staticClosureBytes: number): Metafile {
+  const entryBytes = 1_000;
+  const staticChunkBytes = staticClosureBytes - entryBytes;
+  if (staticChunkBytes < 0) {
+    throw new Error("static closure bytes must include the entry chunk");
+  }
+
+  return {
+    inputs: {
+      "dist/container-entrypoint.js": { bytes: 100, imports: [] },
+      "dist/static-heavy.js": { bytes: staticChunkBytes, imports: [] },
+    },
+    outputs: {
+      "dist-bundled/container-entrypoint.js": {
+        bytes: entryBytes,
+        entryPoint: "dist/container-entrypoint.js",
+        exports: [],
+        imports: [
+          { kind: "import-statement", path: "dist-bundled/static-heavy.js" },
+        ],
+        inputs: {
+          "dist/container-entrypoint.js": { bytesInOutput: 100 },
+        },
+      },
+      "dist-bundled/static-heavy.js": {
+        bytes: staticChunkBytes,
+        entryPoint: undefined,
+        exports: [],
+        imports: [],
+        inputs: {
+          "dist/static-heavy.js": { bytesInOutput: staticChunkBytes },
+        },
+      },
+    },
+  };
+}
+
 function staticBootClosureMetafile(inputPath: string): Metafile {
   return {
     inputs: {
@@ -54,6 +91,35 @@ function staticBootClosureMetafile(inputPath: string): Metafile {
         imports: [],
         inputs: {
           [inputPath]: { bytesInOutput: 4_000 },
+        },
+      },
+    },
+  };
+}
+
+function dynamicOnlyChunkMetafile(dynamicChunkBytes: number): Metafile {
+  return {
+    inputs: {
+      "dist/container-entrypoint.js": { bytes: 100, imports: [] },
+      "dist/lazy-heavy.js": { bytes: dynamicChunkBytes, imports: [] },
+    },
+    outputs: {
+      "dist-bundled/container-entrypoint.js": {
+        bytes: 1_000,
+        entryPoint: "dist/container-entrypoint.js",
+        exports: [],
+        imports: [{ kind: "dynamic-import", path: "./lazy-heavy.js" }],
+        inputs: {
+          "dist/container-entrypoint.js": { bytesInOutput: 100 },
+        },
+      },
+      "dist-bundled/lazy-heavy.js": {
+        bytes: dynamicChunkBytes,
+        entryPoint: "dist/lazy-heavy.js",
+        exports: [],
+        imports: [],
+        inputs: {
+          "dist/lazy-heavy.js": { bytesInOutput: dynamicChunkBytes },
         },
       },
     },
@@ -90,6 +156,11 @@ function dynamicImportMetafile(inputPath: string): Metafile {
 }
 
 const temporaryDirectories: string[] = [];
+const ROOMY_TEST_BUDGETS = {
+  entryBytes: 10_000,
+  staticClosureBytes: 10_000,
+  totalBytes: 10_000,
+};
 
 afterEach(async () => {
   await Promise.all(
@@ -207,6 +278,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(() =>
       assertRunnerEntrypointBundleWithinBudgets(metafile, {
         entryBytes: 1_000,
+        staticClosureBytes: 10_000,
         totalBytes: 3_000,
       }),
     ).toThrow(
@@ -214,21 +286,19 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     );
 
     expect(
-      assertRunnerEntrypointBundleWithinBudgets(metafile, {
-        entryBytes: 10_000,
-        totalBytes: 10_000,
-      }),
-    ).toEqual({ entryBytes: 2_000, totalBytes: 6_000 });
+      assertRunnerEntrypointBundleWithinBudgets(metafile, ROOMY_TEST_BUDGETS),
+    ).toEqual({
+      entryBytes: 2_000,
+      staticClosureBytes: 2_000,
+      totalBytes: 6_000,
+    });
   });
 
   it("rejects provider connector inputs from the static boot closure", () => {
     const metafile = staticBootClosureMetafile("node_modules/grammy/out/mod.js");
 
     expect(() =>
-      assertRunnerEntrypointBundleWithinBudgets(metafile, {
-        entryBytes: 10_000,
-        totalBytes: 10_000,
-      }),
+      assertRunnerEntrypointBundleWithinBudgets(metafile, ROOMY_TEST_BUDGETS),
     ).toThrow(/forbidden inputs in the static boot closure[\s\S]*node_modules\/grammy\/out\/mod\.js/);
   });
 
@@ -238,10 +308,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     const metafile = staticBootClosureMetafile(inputPath);
 
     expect(() =>
-      assertRunnerEntrypointBundleWithinBudgets(metafile, {
-        entryBytes: 10_000,
-        totalBytes: 10_000,
-      }),
+      assertRunnerEntrypointBundleWithinBudgets(metafile, ROOMY_TEST_BUDGETS),
     ).toThrow(
       /forbidden inputs in the static boot closure[\s\S]*\.deploy\/runner-bundle\/node_modules\/@murphai\/inboxd\/dist\/connectors\/hosted-conversation\.js/,
     );
@@ -253,10 +320,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     );
 
     expect(() =>
-      assertRunnerEntrypointBundleWithinBudgets(metafile, {
-        entryBytes: 10_000,
-        totalBytes: 10_000,
-      }),
+      assertRunnerEntrypointBundleWithinBudgets(metafile, ROOMY_TEST_BUDGETS),
     ).toThrow(
       /forbidden inputs in the static boot closure[\s\S]*packages\/inboxd\/dist\/connectors\/hosted-conversation\.js/,
     );
@@ -317,10 +381,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     const metafile = staticBootClosureMetafile(inputPath);
 
     expect(() =>
-      assertRunnerEntrypointBundleWithinBudgets(metafile, {
-        entryBytes: 10_000,
-        totalBytes: 10_000,
-      }),
+      assertRunnerEntrypointBundleWithinBudgets(metafile, ROOMY_TEST_BUDGETS),
     ).toThrow(expected);
   });
 
@@ -353,11 +414,12 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     };
 
     expect(
-      assertRunnerEntrypointBundleWithinBudgets(metafile, {
-        entryBytes: 10_000,
-        totalBytes: 10_000,
-      }),
-    ).toEqual({ entryBytes: 2_000, totalBytes: 6_000 });
+      assertRunnerEntrypointBundleWithinBudgets(metafile, ROOMY_TEST_BUDGETS),
+    ).toEqual({
+      entryBytes: 2_000,
+      staticClosureBytes: 2_000,
+      totalBytes: 6_000,
+    });
   });
 
   it.each([
@@ -366,11 +428,15 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     ".deploy/runner-bundle/node_modules/@junction-api/sdk/index.js",
   ])("allows %s behind dynamic imports", (inputPath) => {
     expect(
-      assertRunnerEntrypointBundleWithinBudgets(dynamicImportMetafile(inputPath), {
-        entryBytes: 10_000,
-        totalBytes: 10_000,
-      }),
-    ).toEqual({ entryBytes: 2_000, totalBytes: 6_000 });
+      assertRunnerEntrypointBundleWithinBudgets(
+        dynamicImportMetafile(inputPath),
+        ROOMY_TEST_BUDGETS,
+      ),
+    ).toEqual({
+      entryBytes: 2_000,
+      staticClosureBytes: 2_000,
+      totalBytes: 6_000,
+    });
   });
 
   it("collects output chunks reachable only through dynamic imports", () => {
@@ -441,19 +507,22 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     ]);
   });
 
-  it("resolves the production budgets as the ratcheted entry baseline plus tolerance", () => {
+  it("resolves the production budgets as the ratcheted baselines plus tolerance", () => {
     const budgets = resolveRunnerEntrypointBundleBudgets();
 
     // Entry = measured baseline (1,267,937B on 2026-07-06) + 48,000B noise
-    // band. Locking the exact value makes any silent change to the ratchet a
-    // failing, reviewed diff.
+    // band. Static closure = measured baseline (6,382,690B on 2026-07-07) +
+    // 96,000B noise band. Locking exact values makes any silent change to a
+    // ratchet a failing, reviewed diff.
     expect(budgets).toEqual({
       entryBytes: 1_267_937 + 48_000,
+      staticClosureBytes: 6_382_690 + 96_000,
       totalBytes: 9_300_000,
     });
     // The ratchet is meaningfully tighter than the prior loose 2.9MB ceiling
     // it replaced, so real boot-path creep can no longer hide in headroom.
     expect(budgets.entryBytes).toBeLessThan(2_900_000);
+    expect(budgets.staticClosureBytes).toBeLessThan(6_600_000);
   });
 
   it("gates the entry chunk at the production ratchet boundary", () => {
@@ -462,7 +531,11 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     // At the boundary the default (production) budgets accept the bundle.
     expect(
       assertRunnerEntrypointBundleWithinBudgets(entryOnlyMetafile(entryBytes)),
-    ).toEqual({ entryBytes, totalBytes: entryBytes });
+    ).toEqual({
+      entryBytes,
+      staticClosureBytes: entryBytes,
+      totalBytes: entryBytes,
+    });
 
     // One byte over the baseline + tolerance trips the assembly.
     expect(() =>
@@ -470,6 +543,42 @@ describe("runner bundle container-entrypoint esbuild step", () => {
         entryOnlyMetafile(entryBytes + 1),
       ),
     ).toThrow(/entry chunk .* exceeds budget/);
+  });
+
+  it("gates the static boot closure at the production ratchet boundary", () => {
+    const { staticClosureBytes } = resolveRunnerEntrypointBundleBudgets();
+
+    expect(
+      assertRunnerEntrypointBundleWithinBudgets(
+        staticBootClosureBytesMetafile(staticClosureBytes),
+      ),
+    ).toEqual({
+      entryBytes: 1_000,
+      staticClosureBytes,
+      totalBytes: staticClosureBytes,
+    });
+
+    expect(() =>
+      assertRunnerEntrypointBundleWithinBudgets(
+        staticBootClosureBytesMetafile(staticClosureBytes + 1),
+      ),
+    ).toThrow(/static boot closure .* exceeds budget/);
+  });
+
+  it("does not count dynamic-only chunks toward the static boot closure budget", () => {
+    const { staticClosureBytes, totalBytes } = resolveRunnerEntrypointBundleBudgets();
+    const dynamicChunkBytes = staticClosureBytes + 500_000;
+    expect(dynamicChunkBytes + 1_000).toBeLessThan(totalBytes);
+
+    expect(
+      assertRunnerEntrypointBundleWithinBudgets(
+        dynamicOnlyChunkMetafile(dynamicChunkBytes),
+      ),
+    ).toEqual({
+      entryBytes: 1_000,
+      staticClosureBytes: 1_000,
+      totalBytes: dynamicChunkBytes + 1_000,
+    });
   });
 
   it("rejects metafiles without a container-entrypoint.js entry output", () => {

--- a/packages/device-syncd/src/provider-label.ts
+++ b/packages/device-syncd/src/provider-label.ts
@@ -1,12 +1,11 @@
-import { resolveDeviceProviderDescriptor } from "@murphai/importers/device-providers/provider-descriptors";
-
+import { resolveDeviceConnectSourceById } from "./config/connect-routes.ts";
 import { resolveJunctionConnectSourceLabel } from "./config/junction-connect-sources.ts";
 
 export function formatDeviceSyncProviderLabel(provider: string): string {
-  const descriptor = resolveDeviceProviderDescriptor(provider);
+  const directConnectSourceLabel = resolveDeviceConnectSourceById(provider)?.label;
 
-  if (descriptor?.displayName) {
-    return descriptor.displayName;
+  if (directConnectSourceLabel) {
+    return directConnectSourceLabel;
   }
 
   const junctionLabel = resolveJunctionConnectSourceLabel(provider);

--- a/packages/device-syncd/test/provider-label.test.ts
+++ b/packages/device-syncd/test/provider-label.test.ts
@@ -7,7 +7,7 @@ import {
   formatDeviceSyncProviderLabel,
 } from "../src/provider-label.ts";
 
-test("formatDeviceSyncProviderLabel prefers the registered descriptor display name", () => {
+test("formatDeviceSyncProviderLabel prefers the configured source label", () => {
   assert.equal(formatDeviceSyncProviderLabel("whoop"), "WHOOP");
 });
 


### PR DESCRIPTION
## Why

Node parses the entry chunk **plus every statically reachable chunk** before HTTP listen — the static boot closure (~6.4MB across 30 chunks) is the real cold-start surface. The entry ratchet alone can't see weight landing in shared static chunks: #418 removed 344KB from the closure and moved the entry chunk by 30 bytes. A new static import in a shared chunk was an invisible regression.

## What changed

- **Static-closure ratchet**, mirroring the #402 entry-ratchet shape: measured baseline 6,382,690B + 96KB tolerance (wider than entry's 48KB — ~5x the bytes across many more chunks; CI Linux measures slightly smaller than local macOS and the ratchet fails only on growth). Budgets flow through the existing `resolveRunnerEntrypointBundleBudgets()` resolver; the assembly log prints the closure number every build. The closure sum reuses the existing static traversal — computed once, shared with the forbidden-marker guard.
- **Guard traversal blind-spot fix (found in the process)**: the traversal mis-resolved esbuild output-import paths whose recorded form is already an exact metafile output key, so parts of the static closure were never visited — the forbidden-marker guard has been partially blind since #397. Exact output-key matches now resolve first, with relative resolution as the fallback.
- **Real forbidden edge removed**: the corrected guard immediately caught `device-syncd/provider-label.ts` statically importing `@murphai/importers` provider descriptors (forbidden since #411, hidden by the blind spot) just to read a display name. The label now comes from device-syncd's own connect-route config — the right dependency direction anyway — dropping the last static importers edge from the boot closure.

## Result

Every assembly now enforces three honest numbers:

```
entry 1270050B (baseline 1267937B + 48000B tolerance)
static boot closure 6382690B (baseline 6382690B + 96000B tolerance)
total 7884530B of 9300000B budget
```

## Verification

- Fresh `pnpm --dir apps/cloudflare runner:bundle` — green with the new gate active
- Runner-bundle vitest: 27 passed (resolver lock extended, closure boundary proven at +tolerance pass / +1 fail, dynamic-only chunks excluded from the sum)
- device-syncd provider-label tests + typecheck; cloudflare typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785981209&installation_id=127572939&pr_number=424&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F424&signature=18e85b94c7dad826c2cfe8551acde35c122361d00e399cc8a7befee49e5215ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->