### PR TITLE
fix(cloudflare): precise retry reasons for fence preserve and budget exhaustion

### DIFF
--- a/apps/cloudflare/src/user-runner/diagnostics.ts
+++ b/apps/cloudflare/src/user-runner/diagnostics.ts
@@ -18,7 +18,9 @@ export type RuntimeProcessingRetryReason =
   | "container_busy"
   | "container_rpc_error"
   | "container_rpc_timeout"
+  | "command_budget_exhausted"
   | "missing_container_binding"
+  | "starting_fence_preserved"
   | "stale_fence_replacement_race";
 
 export type RuntimeProcessingStartFailureRetryReason = Extract<

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -371,7 +371,7 @@ export class RuntimeProcessingController {
     ) {
       await this.syncRunnerAlarm(record);
       return createRuntimeProcessingRetryLater({
-        reason: "container_rpc_timeout",
+        reason: "starting_fence_preserved",
         userId: input.input.userId,
       });
     }
@@ -391,7 +391,7 @@ export class RuntimeProcessingController {
     }
     if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
       return createRuntimeProcessingRetryLater({
-        reason: "container_rpc_timeout",
+        reason: "command_budget_exhausted",
         userId: input.input.userId,
       });
     }

--- a/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
@@ -17,8 +17,10 @@ export function computeRuntimeProcessingRetryAt(
   reason: RuntimeProcessingRetryReason,
 ): string {
   const delayMs =
+    reason === "starting_fence_preserved" ? 3_000 :
     reason === "stale_fence_replacement_race" ? 5_000 :
     reason === "container_busy" ? 5_000 :
+    reason === "command_budget_exhausted" ? 10_000 :
     reason === "container_rpc_timeout" ? 10_000 :
     reason === "container_rpc_error" ? 30_000 :
     reason === "missing_container_binding" ? 60_000 :

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -2419,7 +2419,7 @@ describe("cloudflare worker routes", () => {
 
       expect(response).toEqual({
         kind: "retry_later",
-        retryAt: "2026-04-27T00:00:10.000Z",
+        retryAt: "2026-04-27T00:00:03.000Z",
       });
       expect(ensureProcessing).toHaveBeenCalledOnce();
       expect(ensureProcessing).toHaveBeenCalledWith({

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2451,7 +2451,7 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     })).resolves.toEqual({
       kind: "retry_later",
-      retryAt: "2026-04-27T00:00:10.000Z",
+      retryAt: "2026-04-27T00:00:03.000Z",
     });
 
     expect(ensureProcessing).toHaveBeenCalledOnce();
@@ -2462,6 +2462,14 @@ describe("HostedUserRunner execution coordination", () => {
       backoff_until: null,
       wake_at: null,
     });
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          runtimeProcessingRetryReason: "starting_fence_preserved",
+        }),
+        message: "Hosted runner runtime processing could not be accepted yet.",
+      }),
+    );
   });
 
   it("replaces a non-wakeable write fence after startup grace elapses", async () => {
@@ -2610,6 +2618,14 @@ describe("HostedUserRunner execution coordination", () => {
       active_attempt_id: null,
       wake_at: null,
     });
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          runtimeProcessingRetryReason: "command_budget_exhausted",
+        }),
+        message: "Hosted runner runtime processing could not be accepted yet.",
+      }),
+    );
   });
 
   it("returns retry_later when active child wake cannot be confirmed", async () => {


### PR DESCRIPTION
Two non-RPC outcomes in `replaceInactiveRuntimeFence` were labeled `container_rpc_timeout`: preserving a young startup write fence after an explicit absent-child wake result (~:368), and command-budget exhaustion after a fence clear (~:394). During this week's E2E flake investigation the mislabel sent the root-cause hunt down a wrong trail (same family as the `STALE_INVOCATION_AUTHORITY` mislabel from June).

- `starting_fence_preserved`: retry after **3s** (container registration lands in ms-to-seconds; 10s was dead air inside the 30s startup grace)
- `command_budget_exhausted`: keeps 10s
- Temporal workflow consumers branch only on `retry_later`/`retryAt`, never the reason string — verified, so accept/reject semantics are unchanged. Labels + one retry delay only.

Verification: focused user-runner tests, typecheck, and `test:diff` (93 files / 1,658 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785983310&installation_id=127572939&pr_number=425&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F425&signature=be902b00a5ef51bac8fff296ebaf333fe4f3cd4a3e62a7a1ed8d78661e54f672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->