### PR TITLE
fix(hosted): Linq egress guard denies only on affirmative staleness

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-07-linq-egress-null-inbound.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-linq-egress-null-inbound.md
@@ -1,0 +1,63 @@
+# Linq egress guard: stop failing closed on null last-inbound
+
+Date: 2026-07-07
+Owner: Claude (Fable supervises, Codex implements)
+Branch: `fix/linq-egress-null-inbound` (worktree `.claude/worktrees/linq-egress-null-inbound`)
+
+## Why
+
+Production incident (2026-07-06): members whose `hosted_member_routing.linq_last_inbound_at`
+was never recorded (a chat-lookup-key bind/write drift; see follow-up work below) had every
+server-initiated Linq/iMessage send silently skipped by the 28-day recent-reply egress guard
+with `skip_reason last_inbound_at=null`, while cron automations kept running and burned their
+entire trial AI allowance on messages that were discarded at egress. 8 members affected; users
+were deaf to Murph for a week with no signal.
+
+Founder decision: a null `last_inbound_at` on an established member route is a bookkeeping-bug
+state, not evidence of a cold contact. The guard must only deny on affirmative staleness
+(a recorded inbound older than the 28-day window), never on missing bookkeeping.
+
+## Behavior change
+
+In `apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts`:
+
+1. `decideHostedLinqRecentInbound`: `lastInboundAt === null` → `{ allowed: true, lastInboundAt: null }`.
+   Keep the future-skew denial and the >28d `stale_inbound` denial unchanged.
+2. Preserve the targeting constraint: when the send target cannot be associated with the member
+   at all (no routing row, or no chat/phone lookup-key match), keep denying (`missing_inbound`).
+   `readHostedMemberLinqRouteLastInboundAt` must therefore distinguish "matched a route key but
+   timestamp is null" (→ allow) from "no route association" (→ deny). Same for the
+   `!memberId` branch in `readHostedLinqSideEffectRecentInboundDecision` (keep deny).
+3. Thread-route path (`route.lastInboundAt` from a validated route authority): null → allow
+   (route existence + membership already authority-checked).
+4. Update tests in `apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts` (and any
+   webhook-transport tests asserting the old missing→deny behavior); add coverage for
+   matched-route-null → allowed and no-association → denied.
+5. Update durable docs that document the guard as failing closed on missing inbound
+   (grep `RECIPIENT_RECENT_REPLY_REQUIRED`, `28-day`, `missing_inbound` under `agent-docs/`
+   and `docs/`).
+
+## Invariants to preserve
+
+- First-contact authority path (`engagementKind: "first_contact"`) unchanged.
+- Participant-target identity matching unchanged.
+- Route-authority validation unchanged.
+- Skip bookkeeping (`markHostedLinqDeliverySkippedTx`) unchanged for remaining denials.
+- No new tables, queues, or state.
+
+## Verification
+
+- `pnpm test:diff` over touched files (or the apps/web scoped coverage command).
+- Typecheck.
+- Required audits: security-privacy-review (egress trust boundary loosened deliberately),
+  coverage-write; parent local final review; PR-lane Codex deep-review loop after push.
+
+## Follow-ups (separate tasks, not this branch)
+
+- Root fix: chat-lookup-key bind/write drift so `linq_last_inbound_at` records correctly
+  (engagement write should share the read path's phone-key fallback; self-heal stale keys on inbound).
+- Pre-check delivery viability before model-capable cron wakes spend AI allowance.
+- Proactive AI-usage limit notice for blocked automation wakes (reuse `limitNoticeSentAt` claim).
+Status: completed
+Updated: 2026-07-06
+Completed: 2026-07-06

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -37,6 +37,14 @@ import { normalizePhoneNumber } from "./phone";
 
 type HostedLinqEngagementClient = PrismaClient | Prisma.TransactionClient;
 type HostedLinqEgressEngagementKind = "first_contact" | "requires_recent_inbound";
+type HostedMemberLinqRouteLastInboundResult =
+  | {
+      lastInboundAt: Date | null;
+      matched: true;
+    }
+  | {
+      matched: false;
+    };
 
 export const HOSTED_LINQ_RECENT_INBOUND_WINDOW_DAYS = 28;
 const HOSTED_LINQ_RECENT_INBOUND_WINDOW_MS =
@@ -70,8 +78,8 @@ export function decideHostedLinqRecentInbound(input: {
 }): HostedLinqRecentInboundDecision {
   const now = input.now ?? new Date();
   const lastInboundAt = input.lastInboundAt;
-  if (!lastInboundAt) {
-    return { allowed: false, lastInboundAt: null, reason: "missing_inbound" };
+  if (lastInboundAt === null) {
+    return { allowed: true, lastInboundAt: null };
   }
   if (lastInboundAt.getTime() > now.getTime() + HOSTED_LINQ_FUTURE_INBOUND_SKEW_MS) {
     return { allowed: false, lastInboundAt, reason: "stale_inbound" };
@@ -202,15 +210,20 @@ export async function readHostedLinqSideEffectRecentInboundDecision(input: {
   }
 
   if (!memberId) {
-    return decideHostedLinqRecentInbound({ lastInboundAt: null, now });
+    return { allowed: false, lastInboundAt: null, reason: "missing_inbound" };
+  }
+
+  const routeLastInbound = await readHostedMemberLinqRouteLastInboundAt({
+    chatId: input.payload.chatId,
+    memberId,
+    prisma: input.prisma,
+  });
+  if (!routeLastInbound.matched) {
+    return { allowed: false, lastInboundAt: null, reason: "missing_inbound" };
   }
 
   return decideHostedLinqRecentInbound({
-    lastInboundAt: await readHostedMemberLinqRouteLastInboundAt({
-      chatId: input.payload.chatId,
-      memberId,
-      prisma: input.prisma,
-    }),
+    lastInboundAt: routeLastInbound.lastInboundAt,
     now,
   });
 }
@@ -302,20 +315,28 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
     });
     fallbackRecipientPhone = input.fromPhoneNumber ?? null;
   }
-  const decision = route
-    ? decideHostedLinqRecentInbound({
+  let decision: HostedLinqRecentInboundDecision;
+  if (route) {
+    decision = decideHostedLinqRecentInbound({
       lastInboundAt: route.lastInboundAt,
       now,
-    })
-    : decideHostedLinqRecentInbound({
-      lastInboundAt: await readHostedMemberLinqRouteLastInboundAt({
-        chatId: fallbackChatId,
-        memberId: input.memberId,
-        prisma: input.prisma,
-        recipientPhone: fallbackRecipientPhone,
-      }),
-      now,
     });
+  } else {
+    const routeLastInbound = await readHostedMemberLinqRouteLastInboundAt({
+      chatId: fallbackChatId,
+      memberId: input.memberId,
+      prisma: input.prisma,
+      recipientPhone: fallbackRecipientPhone,
+    });
+    if (routeLastInbound.matched) {
+      decision = decideHostedLinqRecentInbound({
+        lastInboundAt: routeLastInbound.lastInboundAt,
+        now,
+      });
+    } else {
+      decision = { allowed: false, lastInboundAt: null, reason: "missing_inbound" };
+    }
+  }
 
   if (decision.allowed) {
     return;
@@ -726,7 +747,7 @@ async function readHostedMemberLinqRouteLastInboundAt(input: {
   memberId: string;
   prisma: HostedLinqEngagementClient;
   recipientPhone?: string | null;
-}): Promise<Date | null> {
+}): Promise<HostedMemberLinqRouteLastInboundResult> {
   const chatLookupKeys = createHostedLinqChatLookupKeyReadCandidates(input.chatId);
   const recipientPhoneLookupKeys = createHostedPhoneLookupKeyReadCandidates(input.recipientPhone);
   const routing = await input.prisma.hostedMemberRouting.findUnique({
@@ -742,33 +763,33 @@ async function readHostedMemberLinqRouteLastInboundAt(input: {
   });
 
   if (!routing) {
-    return null;
+    return { matched: false };
   }
 
   if (
     routing.linqChatLookupKey
     && chatLookupKeys.includes(routing.linqChatLookupKey)
   ) {
-    return routing.linqLastInboundAt;
+    return { lastInboundAt: routing.linqLastInboundAt, matched: true };
   }
   if (
     routing.pendingLinqChatLookupKey
     && chatLookupKeys.includes(routing.pendingLinqChatLookupKey)
   ) {
-    return routing.pendingLinqLastInboundAt;
+    return { lastInboundAt: routing.pendingLinqLastInboundAt, matched: true };
   }
   if (
     routing.linqRecipientPhoneLookupKey
     && recipientPhoneLookupKeys.includes(routing.linqRecipientPhoneLookupKey)
   ) {
-    return routing.linqLastInboundAt;
+    return { lastInboundAt: routing.linqLastInboundAt, matched: true };
   }
   if (
     routing.pendingLinqRecipientPhoneLookupKey
     && recipientPhoneLookupKeys.includes(routing.pendingLinqRecipientPhoneLookupKey)
   ) {
-    return routing.pendingLinqLastInboundAt;
+    return { lastInboundAt: routing.pendingLinqLastInboundAt, matched: true };
   }
 
-  return null;
+  return { matched: false };
 }

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@/src/lib/hosted-onboarding/linq-egress-engagement";
 
 describe("hosted Linq egress engagement", () => {
-  it("allows recent inbound and blocks missing or stale inbound proof", () => {
+  it("allows recent or missing-bookkeeping inbound proof and blocks stale inbound proof", () => {
     const now = new Date("2026-06-25T12:00:00.000Z");
 
     expect(decideHostedLinqRecentInbound({
@@ -27,9 +27,8 @@ describe("hosted Linq egress engagement", () => {
       lastInboundAt: null,
       now,
     })).toMatchObject({
-      allowed: false,
+      allowed: true,
       lastInboundAt: null,
-      reason: "missing_inbound",
     });
     expect(decideHostedLinqRecentInbound({
       lastInboundAt: new Date("2026-05-01T12:00:00.000Z"),
@@ -299,6 +298,24 @@ describe("hosted Linq egress engagement", () => {
     });
   });
 
+  it("denies side-effect egress when no member can be resolved", async () => {
+    await expect(readHostedLinqSideEffectRecentInboundDecision({
+      payload: {
+        chatId: "chat-1",
+        message: "joined",
+        occurredAt: "2026-06-25T12:00:00.000Z",
+        replyToMessageId: "message-1",
+        sourceEventId: "event-1",
+        template: "group_join_offer_accepted",
+      },
+      prisma: {} as never,
+    })).resolves.toEqual({
+      allowed: false,
+      lastInboundAt: null,
+      reason: "missing_inbound",
+    });
+  });
+
   it("projects real inbound Linq messages onto active and pending member routes", async () => {
     const prisma = {
       hostedMemberRouting: {
@@ -406,7 +423,7 @@ describe("hosted Linq egress engagement", () => {
       .not.toHaveProperty("threadLookupKey");
   });
 
-  it("records skipped runtime sends when no recent inbound exists", async () => {
+  it("records skipped runtime sends when recorded inbound is stale", async () => {
     const chatLookupKey = createHostedLinqChatLookupKey("chat-1");
     if (!chatLookupKey) {
       throw new Error("Expected test Linq chat lookup key.");
@@ -452,6 +469,10 @@ describe("hosted Linq egress engagement", () => {
       targetKind: "thread",
     })).rejects.toMatchObject({
       code: "HOSTED_LINQ_RECIPIENT_RECENT_REPLY_REQUIRED",
+      details: {
+        lastInboundAt: "2026-05-01T12:00:00.000Z",
+        reason: "stale_inbound",
+      },
       httpStatus: 403,
     });
 
@@ -461,6 +482,7 @@ describe("hosted Linq egress engagement", () => {
         data: expect.objectContaining({
           idempotencyKey: expect.stringMatching(/^hbid:linq\.delivery-idempotency:/u),
           skippedAt: new Date("2026-06-25T12:00:00.000Z"),
+          skipReason: `last_inbound_at=2026-05-01T12:00:00.000Z; window_days=28`,
           sourceRef: expect.stringMatching(/^hbid:linq\.delivery-source-ref:/u),
           source: "hosted_runtime_linq_egress_guard",
           status: "skipped",
@@ -469,7 +491,7 @@ describe("hosted Linq egress engagement", () => {
     );
   });
 
-  it("records skipped runtime sends when inbound proof is missing", async () => {
+  it("allows runtime sends when a matched member route has null inbound bookkeeping", async () => {
     const chatLookupKey = createHostedLinqChatLookupKey("chat-1");
     if (!chatLookupKey) {
       throw new Error("Expected test Linq chat lookup key.");
@@ -495,6 +517,56 @@ describe("hosted Linq egress engagement", () => {
       hostedMemberRouting: {
         findUnique: vi.fn().mockResolvedValue({
           linqChatLookupKey: chatLookupKey,
+          linqLastInboundAt: null,
+          linqRecipientPhoneLookupKey: null,
+          pendingLinqChatLookupKey: null,
+          pendingLinqLastInboundAt: null,
+          pendingLinqRecipientPhoneLookupKey: null,
+        }),
+      },
+    };
+
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      fromPhoneNumber: "+15550100001",
+      idempotencyKey: "delivery-key-1",
+      intentId: "intent-1",
+      memberId: "member-1",
+      now: new Date("2026-06-25T12:00:00.000Z"),
+      prisma: prisma as never,
+      target: "chat-1",
+      targetKind: "thread",
+    })).resolves.toBeUndefined();
+
+    expect(prisma.hostedLinqLine.upsert).not.toHaveBeenCalled();
+    expect(prisma.hostedLinqDelivery.create).not.toHaveBeenCalled();
+  });
+
+  it("records skipped runtime sends when no member route matches the target", async () => {
+    const otherChatLookupKey = createHostedLinqChatLookupKey("other-chat");
+    if (!otherChatLookupKey) {
+      throw new Error("Expected test Linq chat lookup key.");
+    }
+    const prisma = {
+      $executeRaw: vi.fn().mockResolvedValue([]),
+      hostedLinqDelivery: {
+        create: vi.fn().mockResolvedValue({ id: "hld_skip" }),
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+      hostedLinqLine: {
+        findMany: vi.fn().mockResolvedValue([]),
+        upsert: vi.fn().mockImplementation((input: { create: { phoneNumberLookupKey: string } }) =>
+          Promise.resolve({
+            phoneNumberLookupKey: input.create.phoneNumberLookupKey,
+          })),
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn().mockImplementation((input: { where?: { phoneNumberLookupKey?: string } }) =>
+          Promise.resolve({
+            phoneNumberLookupKey: input.where?.phoneNumberLookupKey ?? "hbidx:phone:updated",
+          })),
+      },
+      hostedMemberRouting: {
+        findUnique: vi.fn().mockResolvedValue({
+          linqChatLookupKey: otherChatLookupKey,
           linqLastInboundAt: null,
           linqRecipientPhoneLookupKey: null,
           pendingLinqChatLookupKey: null,


### PR DESCRIPTION
## Why

Production incident (2026-07-06): 8 active members had `hosted_member_routing.linq_last_inbound_at` stuck at NULL because the inbound engagement stamp is written by a chat-lookup-key-matched `updateMany` that silently no-ops when the stored key was bound from a different chat-id representation than the webhook sends (root-cause fix tracked separately). When the 28-day recent-reply egress guard reached prod enforcement (~Jul 1), it fail-closed on that NULL: every server-initiated Linq/iMessage send was silently skipped (`skip_reason last_inbound_at=null; window_days=28`) while cron automations kept running and burned the members' full trial AI allowance on messages discarded at egress. Users were deaf to Murph for a week with no signal.

## User-visible goal

Server-initiated messages (reminders, weekly summaries, automation nudges) deliver again for active members whose last-inbound bookkeeping is missing. The guard denies only on affirmative evidence of staleness — a recorded inbound older than 28 days (or an impossible future timestamp) — never on missing bookkeeping.

## What changed

- `decideHostedLinqRecentInbound`: `lastInboundAt === null` → allowed. Stale (>28d) and future-skew denials unchanged.
- Targeting constraint preserved: sends whose target has **no** member route association (no routing row, no chat/phone lookup-key match, or unresolvable side-effect member) still deny with `missing_inbound` and still record the delivery skip. `readHostedMemberLinqRouteLastInboundAt` now returns a discriminated matched/no-match result so callers can tell "matched route, null timestamp" (allow) from "no association" (deny).

## Invariants preserved

- First-contact authority path and invite templates unchanged.
- Participant-target identity matching unchanged.
- Route-authority validation unchanged.
- Skip bookkeeping (`markHostedLinqDeliverySkippedTx`) unchanged for remaining denials.
- Engagement recording functions untouched; no new tables/state.

## Verification

- Focused suite `hosted-onboarding-linq-egress-engagement.test.ts`: 17/17 green (new cases: null-on-matched-route allows without skip; no-association still throws + records skip; stale still denies; unresolvable side-effect member still denies).
- Full apps/web vitest: 3809 passed | 9 skipped; `pnpm --dir apps/web typecheck` green; next build green.

## Deployment

Decision logic lives entirely in apps/web (runtime calls the engagement API route) — Vercel deploy on merge is sufficient; no Cloudflare hosted rollout needed.

## Follow-ups (separate PRs)

1. Root fix: record the engagement stamp reliably (chat-key bind/write drift; write-side fallback symmetry with the read path).
2. Pre-check delivery viability before model-capable cron wakes spend AI allowance.
3. Proactive AI-usage limit notice for blocked automation wakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785986624&installation_id=127572939&pr_number=427&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F427&signature=6b3a65f294c7c229ea44955910ac153131884191fb7e50c100f5c6174c1c009b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->