### PR TITLE
fix(web): keep nav text/logo visible over dark heroes

### DIFF
--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -1281,6 +1281,7 @@ export default async function ChangelogPage() {
       <main className="min-h-dvh bg-[#f5f0e8] text-[#2d3436] antialiased">
         <StickyNav
           authenticated={authenticated}
+          darkTop
           githubStarCount={githubStarCount}
         />
         <section className="bg-[#1f241c] px-6 pt-24 pb-12 text-[#f5f0e8] sm:px-10 sm:pt-28 sm:pb-14 lg:px-16 lg:pt-32 lg:pb-16">

--- a/apps/web/app/security/page.tsx
+++ b/apps/web/app/security/page.tsx
@@ -47,7 +47,7 @@ export default async function SecurityPage() {
   return (
     <>
       <main className="isolate min-h-dvh bg-[#f5f0e8] antialiased">
-        <StickyNav authenticated={authenticated} githubStarCount={githubStarCount} />
+        <StickyNav authenticated={authenticated} darkTop githubStarCount={githubStarCount} />
         <HeroSection />
         <PromisesSection />
         <HostedOverviewSection />

--- a/apps/web/app/sticky-nav.tsx
+++ b/apps/web/app/sticky-nav.tsx
@@ -27,11 +27,18 @@ const MOBILE_MENU_ROW =
 
 export function StickyNav({
   authenticated,
+  darkTop = false,
   githubStarCount = null,
   preloadAuthPanel = false,
   splitUnauthenticatedAuth = true,
 }: {
   authenticated: boolean;
+  /**
+   * Set when the page's hero sits directly under the nav on a dark surface, so
+   * the unscrolled nav uses light text and the dark-background logo instead of
+   * the default light-hero (dark text) treatment.
+   */
+  darkTop?: boolean;
   githubStarCount?: number | null;
   preloadAuthPanel?: boolean;
   splitUnauthenticatedAuth?: boolean;
@@ -64,6 +71,11 @@ export function StickyNav({
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
+  // The nav sits on a dark surface either once scrolled (dark backdrop appears)
+  // or when the page declares its top hero is dark. Text, logo, and auth
+  // controls key off this; only the nav's own background keys off `scrolled`.
+  const onDark = scrolled || darkTop;
+
   return (
     <nav
       className={`fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-5 py-4 transition-[background-color,backdrop-filter] duration-300 sm:px-10 lg:px-16 ${
@@ -85,7 +97,7 @@ export function StickyNav({
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={scrolled ? "/logo-dark.svg" : "/logo.svg"}
+          src={onDark ? "/logo-dark.svg" : "/logo.svg"}
           alt="Murph"
           width={107}
           height={24}
@@ -98,7 +110,7 @@ export function StickyNav({
             key={href}
             href={href}
             className={`hidden text-sm transition-colors md:block ${
-              scrolled
+              onDark
                 ? "text-white/75 hover:text-white"
                 : "text-[#2d3436]/80 hover:text-[#2d3436]"
             }`}
@@ -116,7 +128,7 @@ export function StickyNav({
               : "Star Murph on GitHub"
           }
           className={`hidden items-center gap-1.5 text-sm transition-colors md:inline-flex ${
-            scrolled
+            onDark
               ? "text-white/75 hover:text-white"
               : "text-[#2d3436]/80 hover:text-[#2d3436]"
           }`}
@@ -136,7 +148,7 @@ export function StickyNav({
           authLabel="Dashboard"
           authenticated={authenticated}
           context="nav"
-          {...(scrolled ? { onDarkSurface: true } : {})}
+          {...(onDark ? { onDarkSurface: true } : {})}
           {...(preloadAuthPanel ? { preloadAuthPanel: true } : {})}
           splitUnauthenticated={splitUnauthenticatedAuth}
         />
@@ -144,7 +156,7 @@ export function StickyNav({
           <DrawerTrigger
             aria-label="Open menu"
             className={`inline-flex size-9 items-center justify-center rounded-lg transition-colors md:hidden ${
-              scrolled
+              onDark
                 ? "text-white/85 hover:bg-white/10"
                 : "text-[#2d3436]/85 hover:bg-[#2d3436]/[0.06]"
             }`}


### PR DESCRIPTION
## Problem
The security page nav rendered its `murph` wordmark and links dark-on-dark and nearly invisible (reported with a screenshot). `StickyNav` chose text/logo colors purely from scroll state, with the unscrolled branch hardcoded for a **light** hero (dark text + dark-ink `logo.svg`). The security page hero directly under the nav is dark (`#2a2520`), so the assumption broke. The changelog page has the identical dark hero (`#1f241c`) and the same latent bug.

## Fix
Decouple the nav's surface treatment from its scrolled backdrop:
- Derive `onDark = scrolled || darkTop` and key text, logo, GitHub link, auth controls (`onDarkSurface`), and the mobile menu trigger off it.
- Keep the nav's own background/blur keyed on `scrolled` only.
- Add a `darkTop` prop (default `false`, so every light-hero page — including the homepage — is unchanged) and set it on the two dark-hero pages (security, changelog).

Because `scrolled` engages at 100px and both dark heroes are far taller, the nav already has its dark backdrop before you scroll into the light sections below, so white text never lands on a light surface.

## Verification
- `eslint` clean on all three changed files.
- Purely presentational change; light-hero pages are untouched by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785993773&installation_id=127572939&pr_number=432&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F432&signature=4722c39a68a413a49e099cbceb433084add07dcb771043968792d9511593bc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->