### PR TITLE
fix(settings): steer Murph contact refresh to delete-then-save-fresh

### DIFF
--- a/apps/web/src/components/settings/hosted-account-settings-cards.tsx
+++ b/apps/web/src/components/settings/hosted-account-settings-cards.tsx
@@ -65,7 +65,7 @@ export function HostedAccountSettingsCards({
           <SettingsRow
             icon={<ContactRound className="size-[18px] shrink-0 text-muted-foreground" strokeWidth={1.6} aria-hidden="true" />}
             label="Murph contact"
-            value="Pick a look and save the updated card."
+            value="Pick a new look for Murph in your contacts."
             action={
               <Button
                 onClick={() => setContactPickerOpen(true)}
@@ -132,10 +132,11 @@ export function HostedAccountSettingsCards({
       {contactPickerOpen ? (
         <MurphContactCardPicker
           copy={{
-            description: "Pick a look and save the updated card.",
-            primaryAction: "Save updated card",
+            description:
+              "iPhone only applies the photo when the card is saved as a new contact. Delete your current Murph contact first, then save this one fresh.",
+            primaryAction: "Save new card",
             secondaryAction: "Close",
-            title: "Customize Murph contact",
+            title: "Pick a new look",
           }}
           onAddToContacts={() => setContactPickerOpen(false)}
           onOpenChange={setContactPickerOpen}

--- a/apps/web/test/hosted-account-settings-cards.test.tsx
+++ b/apps/web/test/hosted-account-settings-cards.test.tsx
@@ -35,7 +35,7 @@ describe("HostedAccountSettingsCards", () => {
     );
 
     expect(markup).not.toContain("Murph contact");
-    expect(markup).not.toContain("Pick a look and save the updated card.");
+    expect(markup).not.toContain("Pick a new look for Murph in your contacts.");
   });
 
   test("shows Murph contact customization with an assigned Murph text line", () => {
@@ -47,7 +47,7 @@ describe("HostedAccountSettingsCards", () => {
     );
 
     expect(markup).toContain("Murph contact");
-    expect(markup).toContain("Pick a look and save the updated card.");
+    expect(markup).toContain("Pick a new look for Murph in your contacts.");
     expect(markup).toContain("Customize");
   });
 
@@ -60,7 +60,7 @@ describe("HostedAccountSettingsCards", () => {
     );
 
     expect(markup).toContain("Murph contact");
-    expect(markup).toContain("Pick a look and save the updated card.");
+    expect(markup).toContain("Pick a new look for Murph in your contacts.");
     expect(markup).toContain("Customize");
   });
 


### PR DESCRIPTION
## Why this PR exists

Live iPhone testing plus documentation research confirmed iOS cannot update an existing contact from a web-delivered vCard: Add to Existing Contact ignores the incoming photo and duplicates phone numbers. The settings picker copy shipped in #422 implied the card updates in place.

## User goal / user-visible behavior

The settings Murph contact picker now tells the user the honest, working recipe: delete the current Murph contact first, then save the downloaded card as a new contact so the chosen photo applies.

## Invariants to preserve

Copy-only: no layout, behavior, gating, or route changes. Onboarding picker copy (new-contact case) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785993904&installation_id=127572939&pr_number=433&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F433&signature=bea5cfa83dbe2eb3cf8a1d6357f99e84b05119cf37c58b8cbf0b29886517eca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->