### PR TITLE
Fix red main: assert onDarkSurface on SecurityPage dark-hero nav test

### DIFF
--- a/apps/web/test/page.test.ts
+++ b/apps/web/test/page.test.ts
@@ -228,6 +228,7 @@ test("SecurityPage splits the shared sticky nav into Log in + Signup when logged
       context: "nav",
       authLabel: "Dashboard",
       splitUnauthenticated: true,
+      onDarkSurface: true,
     },
     undefined
   );


### PR DESCRIPTION
## Why

`main` is currently red on one test. PR #432 (`fix(web): keep nav text/logo visible over dark heroes`) changed `StickyNav` to key its auth controls off `onDark = scrolled || darkTop` and set `darkTop` on the security and changelog pages. As a result `LandingAuthActions` now receives `onDarkSurface: true` at the top of the security page's dark hero — but `apps/web/test/page.test.ts` was never updated, so its `toHaveBeenNthCalledWith` assertion still expects the prop to be absent and fails.

This is blocking every open PR whose CI merges with current `main` (including #434).

## Change

One-line test-only fix: add `onDarkSurface: true` to the expected `LandingAuthActions` props in the "SecurityPage splits the shared sticky nav" test, so it tracks the intended #432 behavior.

## Verification

`pnpm exec vitest run apps/web/test/page.test.ts --config apps/web/vitest.config.ts` — 4 passed (was 1 failed / 3 passed on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785995558&installation_id=127572939&pr_number=435&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F435&signature=457fcaf81695990f6a518ded99a808fc96c519342544e83536d45709ad3a0a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->