### PR TITLE
feat(assistant): add music-generation skill for generate_song prompts

### DIFF
--- a/packages/assistant-engine/skills/music-generation/SKILL.md
+++ b/packages/assistant-engine/skills/music-generation/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: music-generation
+description: |
+  How Murph writes the prompt for the generate_song tool so ElevenLabs
+  Eleven Music returns the track you intended. Read before every
+  generate_song call: reminder songs, group-challenge hype tracks,
+  jingles, celebration anthems, and any generated song or instrumental.
+  Owns music prompt craft (genre, instrumentation, tempo, key, vocals,
+  lyrics, structure, instrumental-only, and duration) plus the
+  copyright-safe style rules and the reggae house-style default.
+  behavior-followthrough and groupchat-comedy decide WHEN to send a
+  song; this skill decides WHAT prompt to send.
+---
+
+# Music generation
+
+This skill governs the `prompt` you hand to the `generate_song` tool. The tool
+takes only three inputs, and the `prompt` string carries every musical
+decision. Writing that prompt well is the whole job.
+
+## The tool
+
+`generate_song` (murph namespace) generates one original track with ElevenLabs
+Eleven Music and attaches it to your final response as a native voice memo.
+
+- `prompt` (string, 1-4100 chars, required): all musical direction — style,
+  mood, instrumentation, tempo, key, vocals, and the exact lyrics.
+- `durationSeconds` (integer, 3-300, default 30): track length. Reminder songs
+  sit at 15-30s.
+- `instrumental` (boolean, default false): `true` produces no vocals.
+
+Constraints to plan around:
+
+- It does not send on its own — it attaches the song to the reply you compose.
+- It cannot share a turn with any other response media (an image, another voice
+  memo). A song is the whole message.
+- It is available only on a deliverable iMessage/Linq or Telegram reply. If the
+  user asked for only the song, attach it and leave the reply text empty.
+- Generation can take up to a few minutes.
+- Generated audio cannot be re-sent later. If a song may be replayed (a repeat
+  challenge dispatch), save the full lyrics and prompt in your durable notes so
+  you can regenerate it.
+
+## The prompt is the whole instrument
+
+The model reads only the `prompt` string, plus the length and the instrumental
+flag. There are no separate genre, tempo, or lyrics fields — layer all of it
+into one natural sentence or two. Cover:
+
+- **Genre / style** — be specific. "Warm 70s roots-reggae groove with offbeat
+  guitar skank and a round bassline" beats "reggae." "Energetic 1980s synth-pop
+  with a driving drum-machine beat" beats "upbeat song."
+- **Mood / energy** — mood words land well: warm, playful, triumphant, mellow,
+  gentle, hype, wistful.
+- **Instrumentation** — name the instruments. Prefix a single instrument with
+  **solo** ("solo acoustic guitar").
+- **Tempo and key** — the model follows both. Give a BPM ("90 BPM"), and a key
+  when it matters ("in A major").
+- **Vocals** — describe the voice ("warm, casual male lead vocal"; "two singers
+  harmonizing in C"). Prefix an unaccompanied vocal with **a cappella**.
+- **Structure** — for anything longer than a hook, sketch the sections (intro,
+  verse, chorus, outro) and timing cues ("lyrics begin around 4 seconds,"
+  "instrumental for the first bar"). Keep structure proportional to length; do
+  not ask for four verses in 20 seconds.
+
+## Lyrics
+
+Songs include vocals unless you say otherwise. When the words have to land — a
+reminder, a callback, a chant — write the lyrics yourself and quote them inside
+the prompt rather than describing a topic and hoping. The action has to be
+unmistakable. For example, the `prompt` value:
+
+> Upbeat roots-reggae, ~20s, warm male lead vocal. Lyrics: "Lace 'em up, Sam,
+> two easy miles / your knees move better the more that you move."
+
+Keep lyrics short: a 20-second track holds a couplet or two, not a full
+verse-chorus. For reminder songs specifically, name the action to do now, say
+why it matters to this person, fold in at most two non-sensitive personal
+details, and keep it encouraging, never shaming.
+
+## Instrumental tracks
+
+Set `instrumental: true` (or add "instrumental only" to the prompt) for a
+focus, background, or celebration bed with no words. Everything else — genre,
+instruments, tempo, key, mood — still belongs in the prompt.
+
+## Duration
+
+`durationSeconds` is 3-300. Reminder songs are 15-30s. Shorter tracks are
+tighter and land faster; match the lyric and structure to the length you ask
+for.
+
+## House style and preferences
+
+When the user has no known music preference and nothing else clearly fits
+better, default to a light, upbeat reggae groove — Murph's house style. An
+explicit or learned preference (a genre they love, a vibe they asked for)
+always overrides the default.
+
+## Copyright and safety (hard limits)
+
+- Never name a real artist, band, or song, and never paste copyrighted lyrics.
+  These trip Eleven Music's `bad_prompt` guard and fail the generation.
+  Describe the *style* generically instead ("90s boom-bap hip-hop beat," not "a
+  Beatles-style track").
+- Never put sensitive or potentially embarrassing personal information in the
+  lyrics — assume the audio could be overheard on a speaker. Do not invent
+  personal details.
+
+## Write tight, pick one lane
+
+A longer prompt is not a better prompt. A focused, evocative direction
+("rainy-day jazz cafe, mellow, brushed drums, ~20s") beats a paragraph of
+competing instructions. If two moods fight, choose one.
+
+## When it fails or would delay
+
+If generation fails, or a time-sensitive reminder cannot wait for it, send the
+plain-text version immediately — a song is a delight, never a blocker. Pair a
+reminder song with a one-line text version of the same reminder. And a richer
+modality never fixes a plan the user keeps ignoring: if reminders are not
+landing, revisit the action's size, timing, or relevance rather than dressing
+up the same cue.
+
+## Worked examples
+
+Each of these is a complete `prompt` value.
+
+Reminder song, `durationSeconds: 20`, vocal:
+
+> Upbeat, warm roots-reggae groove around 75 BPM, offbeat guitar skank, round
+> bassline, light percussion, easygoing male lead vocal. Lyrics: "Morning,
+> Priya, sun's up too / ten quiet minutes, just you and the mat / stretch it
+> out and the back feels new."
+
+Focus bed, `durationSeconds: 45`, `instrumental: true`:
+
+> Calm lo-fi study beat, soft Rhodes chords, mellow boom-bap drums around 80
+> BPM, warm vinyl texture, no vocals. Steady and unintrusive for focused work.
+
+Group-challenge hype track, `durationSeconds: 25`, vocal:
+
+> Triumphant brass-forward funk, ~110 BPM, punchy horns, slap bass, tight drums,
+> big gang-vocal chant. Celebratory and a little cocky. Lyrics: "Step-count
+> champions, take a bow / the leaderboard belongs to you now."

--- a/packages/assistant-engine/src/assistant-skill-assets.ts
+++ b/packages/assistant-engine/src/assistant-skill-assets.ts
@@ -133,6 +133,12 @@ export const ASSISTANT_SKILLS = [
     triggerHint:
       'Read whenever a group chat starts, runs, scores, or closes a challenge, and on every scheduled challenge dispatch. Owns the challenge lifecycle: kickoff (metric negotiation, consent, introductions and photos, baselines, stakes), the durable challenge page that survives context resets, daily standings dispatches, rulings, confounders, and close-out. Use group-chat for room etiquette and groupchat-comedy for the referee voice.',
   },
+  {
+    slug: 'music-generation',
+    name: 'music-generation',
+    triggerHint:
+      'Read before calling the generate_song tool or writing any music prompt, including reminder songs, group-challenge hype tracks, jingles, celebration anthems, and any generated song or instrumental. Owns how to write the ElevenLabs music prompt (genre, instrumentation, tempo, key, vocals, lyrics, structure, instrumental-only, and duration), the copyright-safe style rules, and the reggae house-style default. Use behavior-followthrough and groupchat-comedy to decide when to send a song; use this to decide what prompt to send.',
+  },
 ] as const
 
 export type AssistantSkillSlug = typeof ASSISTANT_SKILLS[number]['slug']


### PR DESCRIPTION
## Why

Murph can generate songs via the `generate_song` tool (ElevenLabs Eleven Music), and the system prompt already covers *when* to reach for a reminder song and the reggae house style. But nothing owned *how to write the music prompt itself*, so the model was improvising the single most important input. This adds a dedicated skill so Murph knows what prompt to send to the music model.

## User-visible goal

Better, more reliable generated songs (reminder nudges, group-challenge dispatches, celebration tracks): the assistant learns to write ElevenLabs music prompts that actually produce the intended genre, mood, instrumentation, tempo, vocals, and lyrics, and to avoid prompts that fail.

## What changed

- New `packages/assistant-engine/skills/music-generation/SKILL.md`. It teaches prompt craft for the `generate_song` tool's `prompt` arg: genre specificity, instrumentation (`solo`), tempo/key, vocal direction (`a cappella`), embedding lyrics inline, structure/timing cues, instrumental-only, and duration bounds (3-300s; 15-30s for reminders). It codifies the hard limits (no real artist/band/song names or copyrighted lyrics, which trip Eleven Music's `bad_prompt` guard; no sensitive/embarrassing lyric content), the reggae house-style default, and includes worked prompt examples. It cross-references `behavior-followthrough` and `groupchat-comedy` for the *when* decision.
- Registered the skill in `ASSISTANT_SKILLS` so it surfaces in the system-prompt skill catalog with a trigger hint that routes to it before any `generate_song` call.

## Invariants preserved

- Skill-assets contract (valid SKILL.md YAML frontmatter, unique kebab-case slug/name, trigger hint and description under parser limits) — verified by `test/assistant-skill-assets.test.ts` (15 tests green, including the full system-prompt build).
- Prompt-primary only: no tool, engine, persisted-state, or runtime behavior changes.

## Verification

- `pnpm exec vitest run --config vitest.config.ts --no-coverage test/assistant-skill-assets.test.ts` in `packages/assistant-engine` → 15 passed.
- Pre-existing unrelated `tsc` error in `assistant-codex/dynamic-tools.ts:2529` (group join-offer type) is present on the base branch with this change stashed; not caused by or related to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785997667&installation_id=127572939&pr_number=440&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F440&signature=e925b06936d2e6337f8fabcfebbd7be420c3ffd83cf7cc6d50195426f374c5c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->