### PR TITLE
Reduce hosted Codex stream idle stalls

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-07-2026-07-07-hosted-codex-stream-timeout.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-2026-07-07-hosted-codex-stream-timeout.md
@@ -1,0 +1,99 @@
+# Hosted Codex stream timeout and observability
+
+Status: completed
+Created: 2026-07-07
+Updated: 2026-07-07
+
+## Goal
+
+- Reduce the hosted Codex provider stream idle stall window that caused a
+  foreground reply to wait about five minutes, while surfacing metadata-only
+  transport retry/timeout evidence for future hosted runtime triage.
+
+## Success criteria
+
+- Hosted Codex config writes a shorter Codex-native `stream_idle_timeout_ms`
+  for production hosted OpenAI/Codex provider turns without disabling
+  WebSockets or adding a Murph-side scheduler/supervisor.
+- Runtime diagnostics/logging expose the configured timeout and Codex stream
+  retry/error/fallback events in a redacted, metadata-only way.
+- Focused tests prove the generated config and observability behavior.
+- Required verification passes, the scoped commit, PR creation, and PR-lane
+  deep-review loop complete.
+
+## Scope
+
+- In scope:
+  - `packages/assistant-runtime` hosted runtime phase diagnostics.
+  - `packages/assistant-runtime` hosted Codex config generation and tests.
+  - Narrow `packages/assistant-engine` Codex event diagnostics if needed to
+    expose stream retry/fallback events already emitted by Codex.
+- Out of scope:
+  - Replacing Codex transport retry/fallback logic.
+  - Adding a Murph-side active-turn watchdog, new queue, or scheduler.
+  - Changing Cloudflare provider egress credential authority.
+
+## Constraints
+
+- Technical constraints:
+  - Prefer Codex-native provider config over bespoke Murph supervision.
+  - Keep observability fire-and-forget/metadata-only; do not log prompts,
+    transcripts, provider payloads, secrets, raw paths, or personal identifiers.
+  - Preserve hosted foreground reply priority and Codex App Server warm reuse.
+- Product/process constraints:
+  - Use the isolated worktree/PR lane.
+  - Close the active plan with `scripts/finish-task` after verification.
+  - Run the PR deep-review loop to zero accepted findings after opening the PR.
+
+## Risks and mitigations
+
+1. Risk: A shorter timeout increases retries for genuinely slow but healthy
+   streams.
+   Mitigation: Keep the first change to Codex's stream-idle knob, not a hard
+   total-turn cap, and choose a conservative foreground value rather than a
+   very aggressive one.
+2. Risk: Observability leaks sensitive user/provider data.
+   Mitigation: Log only event type, timing, retry/fallback status, and bounded
+   error categories/messages through existing redaction paths.
+
+## Tasks
+
+1. Inspect hosted Codex config generation, assistant-engine Codex event
+   handling, and focused test surfaces.
+2. Add the configured hosted stream idle timeout and prove it in config tests.
+3. Surface Codex stream retry/fallback/error events with metadata-only logs or
+   diagnostics; add focused tests.
+4. Run targeted verification, typecheck/test:diff as required, and local final
+   diff review.
+5. Commit through `scripts/finish-task`, push, open a PR, and run the PR
+   deep-review loop.
+
+## Decisions
+
+- Use Codex-native `stream_idle_timeout_ms` rather than a Murph-side live-turn
+  timeout as the first fix. This preserves the existing Codex transport owner
+  and targets the observed 300s idle boundary directly.
+- Keep WebSockets enabled. Existing Codex behavior retries stream errors and
+  falls back to HTTPS transport after the retry budget, so this change shortens
+  the silent-stream detection window and adds metadata-only evidence around
+  retries/fallbacks.
+
+## Verification
+
+- Commands to run:
+  - Focused tests for touched config/runtime/diagnostic surfaces.
+  - `pnpm typecheck`
+  - `pnpm test:diff <touched paths>`
+  - PR-lane deep-review loop after PR creation.
+- Completed before commit:
+  - `pnpm exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-workspace-entrypoint.test.ts test/hosted-runtime-codex-config.test.ts test/hosted-runtime-events.test.ts`
+  - `pnpm exec vitest run --config vitest.config.ts --no-coverage test/assistant-codex-runtime.test.ts`
+  - `pnpm typecheck`
+  - `pnpm test:diff packages/assistant-engine/src/assistant-codex.ts packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/src/hosted-runtime/codex-config.ts packages/assistant-runtime/src/hosted-runtime/events/provider-trace-log.ts packages/assistant-engine/test/assistant-codex-runtime.test.ts packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts packages/assistant-runtime/test/hosted-runtime-events.test.ts packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts`
+- Expected outcomes:
+  - Generated hosted Codex config contains the shorter stream idle timeout for
+    hosted OpenAI production config and keeps WebSockets enabled.
+  - Stream retry/fallback/timeout observability is metadata-only.
+  - Hosted runtime phase logs expose configured Codex transport metadata.
+  - All required checks pass or any unrelated blocker is documented with proof.
+Completed: 2026-07-07

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -167,6 +167,10 @@ const CODEX_APP_SERVER_TIMING_TRACE_SCHEMA =
   'murph.assistant-codex-app-server-timing.v1'
 const CODEX_APP_SERVER_TIMING_TRACE_TYPE =
   'assistant.codex.app_server_timing'
+const CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA =
+  'murph.assistant-codex-transport-diagnostics.v1'
+const CODEX_TRANSPORT_DIAGNOSTICS_TRACE_TYPE =
+  'assistant.codex.transport_diagnostics'
 const CODEX_APP_SERVER_STARTUP_STDERR_MAX_LENGTH = 16_384
 // Bound on distinct subagent threads whose token usage is tracked per parent
 // turn. Far above any sane spawn fan-out; threads past the cap are counted
@@ -2075,6 +2079,175 @@ function isCodexTurnCompletedMethod(method: string | null): boolean {
   return method === 'turn/completed' || method === 'turn.completed'
 }
 
+type CodexTransportDiagnosticSource = {
+  additionalDetails: string | null
+  message: string
+  sourceMethod: 'error' | 'warning'
+  threadIdPresent: boolean
+  turnIdPresent: boolean
+  willRetry: boolean | null
+}
+
+function buildCodexTransportDiagnosticsTraceEvent(input: {
+  codexThreadId: string | null
+  message: CodexRpcMessage
+  method: string | null
+  providerActionCount: number
+  turnId: string | null
+}): Record<string, unknown> | null {
+  const source = readCodexTransportDiagnosticSource(input.message, input.method)
+  if (!source) {
+    return null
+  }
+
+  const diagnosticText = [source.message, source.additionalDetails]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n')
+    .slice(0, 4096)
+  const normalizedText = diagnosticText.toLowerCase()
+  const retryProgress = readCodexTransportRetryProgress(diagnosticText)
+  const fallbackActivated =
+    normalizedText.includes('falling back from websockets to https transport')
+  const idleTimeout =
+    normalizedText.includes('idle timeout waiting for websocket') ||
+    normalizedText.includes('idle timeout waiting for sse')
+  const streamDisconnected =
+    normalizedText.includes('stream disconnected') ||
+    normalizedText.includes('response stream disconnected')
+
+  if (!fallbackActivated && !idleTimeout && !streamDisconnected && !retryProgress) {
+    return null
+  }
+
+  const transport = normalizedText.includes('websocket')
+    ? 'websocket'
+    : normalizedText.includes('https') ||
+        normalizedText.includes('http') ||
+        normalizedText.includes('sse')
+      ? 'http'
+      : 'unknown'
+  const eventKind = fallbackActivated
+    ? 'transport-fallback'
+    : idleTimeout
+      ? 'stream-idle-timeout'
+      : retryProgress
+        ? 'stream-retry'
+        : 'stream-disconnected'
+
+  return {
+    schema: CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA,
+    type: CODEX_TRANSPORT_DIAGNOSTICS_TRACE_TYPE,
+    codexTransportAdditionalDetailsPresent: source.additionalDetails !== null,
+    codexTransportErrorMessageLength: diagnosticText.length,
+    codexTransportErrorMessagePresent: source.message.length > 0,
+    codexTransportEventKind: eventKind,
+    codexTransportFallbackActivated: fallbackActivated,
+    codexTransportIdleTimeout: idleTimeout,
+    codexTransportProviderActionCount: input.providerActionCount,
+    codexTransportRetryCount: retryProgress?.retryCount ?? null,
+    codexTransportRetryMax: retryProgress?.retryMax ?? null,
+    codexTransportSourceMethod: source.sourceMethod,
+    codexTransportStreamDisconnected: streamDisconnected,
+    codexTransportThreadIdPresent:
+      source.threadIdPresent || input.codexThreadId !== null,
+    codexTransportTransport: transport,
+    codexTransportTurnIdPresent: source.turnIdPresent || input.turnId !== null,
+    codexTransportWillRetry: source.willRetry,
+  }
+}
+
+function readCodexTransportDiagnosticSource(
+  message: CodexRpcMessage,
+  method: string | null,
+): CodexTransportDiagnosticSource | null {
+  const params = readCodexRecordField(message, 'params')
+  if (method === 'warning') {
+    const warningMessage = readCodexStringField(params, 'message')
+    if (!warningMessage) {
+      return null
+    }
+    return {
+      additionalDetails: null,
+      message: warningMessage,
+      sourceMethod: 'warning',
+      threadIdPresent: readCodexStringField(params, 'threadId') !== null,
+      turnIdPresent: false,
+      willRetry: null,
+    }
+  }
+
+  if (method !== 'error') {
+    return null
+  }
+
+  const error = readCodexRecordField(params, 'error')
+  const errorMessage = readCodexStringField(error, 'message')
+  if (!errorMessage) {
+    return null
+  }
+
+  return {
+    additionalDetails: readCodexStringField(error, 'additionalDetails'),
+    message: errorMessage,
+    sourceMethod: 'error',
+    threadIdPresent: readCodexStringField(params, 'threadId') !== null,
+    turnIdPresent: readCodexStringField(params, 'turnId') !== null,
+    willRetry: readCodexBooleanField(params, 'willRetry'),
+  }
+}
+
+function readCodexTransportRetryProgress(
+  value: string,
+): { retryCount: number; retryMax: number } | null {
+  const match = /\bReconnecting\.\.\.\s+(\d+)\/(\d+)\b/iu.exec(value)
+  if (!match) {
+    return null
+  }
+
+  const retryCount = Number(match[1])
+  const retryMax = Number(match[2])
+  return Number.isSafeInteger(retryCount) &&
+    retryCount >= 0 &&
+    Number.isSafeInteger(retryMax) &&
+    retryMax >= 0
+    ? { retryCount, retryMax }
+    : null
+}
+
+function readCodexRecordField(
+  value: unknown,
+  key: string,
+): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const fieldValue = (value as Record<string, unknown>)[key]
+  return fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)
+    ? fieldValue as Record<string, unknown>
+    : null
+}
+
+function readCodexStringField(
+  value: Record<string, unknown> | null,
+  key: string,
+): string | null {
+  const fieldValue = value?.[key]
+  if (typeof fieldValue !== 'string') {
+    return null
+  }
+
+  const normalized = fieldValue.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function readCodexBooleanField(
+  value: Record<string, unknown> | null,
+  key: string,
+): boolean | null {
+  const fieldValue = value?.[key]
+  return typeof fieldValue === 'boolean' ? fieldValue : null
+}
+
 async function runCodexAppServerTurnOnProcess(
   codexProcess: CodexAppServerProcess,
   input: CodexAppServerPreparedTurnInput,
@@ -3081,6 +3254,26 @@ async function runCodexAppServerTurnOnProcess(
       normalizedEvent,
       rawEvent: message,
     })
+    const transportDiagnosticsTraceEvent = input.onTraceEvent
+      ? buildCodexTransportDiagnosticsTraceEvent({
+          codexThreadId,
+          message,
+          method,
+          providerActionCount,
+          turnId,
+        })
+      : null
+    if (transportDiagnosticsTraceEvent) {
+      try {
+        input.onTraceEvent?.({
+          codexThreadId: null,
+          rawEvent: transportDiagnosticsTraceEvent,
+          updates: [],
+        })
+      } catch {
+        // Transport diagnostics are metadata-only and must not block turns.
+      }
+    }
     const providerActionKey = extractCodexProviderActionKey(normalizedEvent)
     if (providerActionKey && !providerActionItemIds.has(providerActionKey)) {
       providerActionItemIds.add(providerActionKey)

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -99,6 +99,8 @@ const MURPH_DYNAMIC_TOOLS_WITH_COMPUTER_WITHOUT_PROGRESS = resolveMurphDynamicTo
   computerToolsAvailable: true,
   progressUpdatesAvailable: false,
 })
+const CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA =
+  'murph.assistant-codex-transport-diagnostics.v1'
 
 const tempRoots: string[] = []
 
@@ -5743,6 +5745,160 @@ describe('assistant codex runtime', () => {
     expect(JSON.stringify(diagnosticEvent?.rawEvent)).not.toContain('secretPath')
     expect(JSON.stringify(diagnosticEvent?.rawEvent)).not.toContain('thread-diagnostics')
     expect(JSON.stringify(diagnosticEvent?.rawEvent)).not.toContain('turn-diagnostics')
+  })
+
+  it('emits metadata-only Codex transport diagnostics for stream retry and fallback', async () => {
+    const workingDirectory = await createTempDir('assistant-codex-transport-diagnostics-')
+    const onTraceEvent = vi.fn()
+
+    codexMocks.spawn.mockImplementation(() => {
+      const child = new MockChildProcess()
+
+      queueMicrotask(() => {
+        void (async () => {
+          await waitForRpcMethod(child, 'initialize')
+          child.stdout.write(jsonLine({ id: 1, result: {} }))
+          await waitForRpcMethod(child, 'thread/start')
+          child.stdout.write(
+            jsonLine({
+              id: 2,
+              result: {
+                thread: {
+                  id: 'thread-transport',
+                },
+              },
+            }),
+          )
+          await waitForRpcMethod(child, 'turn/start')
+          child.stdout.write(
+            jsonLine({
+              id: 3,
+              result: {
+                turn: {
+                  id: 'turn-transport',
+                },
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'turn/started',
+              params: {
+                turn: {
+                  id: 'turn-transport',
+                },
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'error',
+              params: {
+                error: {
+                  message: 'Reconnecting... 2/5',
+                  codexErrorInfo: {
+                    responseStreamDisconnected: {
+                      httpStatusCode: null,
+                    },
+                  },
+                  additionalDetails:
+                    'stream disconnected before completion: idle timeout waiting for websocket at https://api.openai.com/v1/responses',
+                },
+                threadId: 'thread-transport',
+                turnId: 'turn-transport',
+                willRetry: true,
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'warning',
+              params: {
+                threadId: 'thread-transport',
+                message:
+                  'Falling back from WebSockets to HTTPS transport. raw endpoint https://api.openai.com/v1/responses',
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'assistant-transport',
+                  type: 'assistant_message',
+                  message: 'Recovered.',
+                },
+              },
+            }),
+          )
+          child.stdout.write(
+            jsonLine({
+              method: 'turn/completed',
+              params: {
+                turn: {
+                  id: 'turn-transport',
+                  status: 'completed',
+                },
+              },
+            }),
+          )
+        })()
+      })
+
+      return child
+    })
+
+    await expect(
+      executeCodexAppServerTurn({
+        onTraceEvent,
+        prompt: 'diagnose transport',
+        workingDirectory,
+      }),
+    ).resolves.toMatchObject({
+      finalMessage: 'Recovered.',
+      sessionId: 'thread-transport',
+      turnId: 'turn-transport',
+    })
+
+    const diagnosticEvents = onTraceEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => {
+        const rawEvent = asRecord(event.rawEvent)
+        return rawEvent.schema === CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA
+      })
+    expect(diagnosticEvents).toHaveLength(2)
+
+    const retryDiagnostic = asRecord(diagnosticEvents[0]?.rawEvent)
+    expect(retryDiagnostic).toMatchObject({
+      schema: CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA,
+      type: 'assistant.codex.transport_diagnostics',
+      codexTransportAdditionalDetailsPresent: true,
+      codexTransportEventKind: 'stream-idle-timeout',
+      codexTransportFallbackActivated: false,
+      codexTransportIdleTimeout: true,
+      codexTransportRetryCount: 2,
+      codexTransportRetryMax: 5,
+      codexTransportSourceMethod: 'error',
+      codexTransportStreamDisconnected: true,
+      codexTransportThreadIdPresent: true,
+      codexTransportTransport: 'websocket',
+      codexTransportTurnIdPresent: true,
+      codexTransportWillRetry: true,
+    })
+
+    const fallbackDiagnostic = asRecord(diagnosticEvents[1]?.rawEvent)
+    expect(fallbackDiagnostic).toMatchObject({
+      schema: CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA,
+      type: 'assistant.codex.transport_diagnostics',
+      codexTransportEventKind: 'transport-fallback',
+      codexTransportFallbackActivated: true,
+      codexTransportSourceMethod: 'warning',
+      codexTransportTransport: 'websocket',
+      codexTransportWillRetry: null,
+    })
+
+    expect(JSON.stringify(diagnosticEvents)).not.toContain('api.openai.com')
   })
 
   it('keeps Codex action diagnostics scoped and deduped per active turn', () => {

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -50,6 +50,7 @@ import {
 } from "./hosted-runtime/environment.ts";
 import {
   HOSTED_CODEX_OPERATOR_MEMORY_DIAGNOSTICS,
+  HOSTED_CODEX_PROVIDER_TRANSPORT_DIAGNOSTICS,
   prepareHostedCodexRuntimeEnvironment,
 } from "./hosted-runtime/codex-config.ts";
 import {
@@ -1113,6 +1114,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         codexEffectiveModelProviderId:
           hostedCodexRuntime.runtimeEnv[HOSTED_CODEX_EFFECTIVE_MODEL_PROVIDER_ID_ENV] ?? null,
         ...HOSTED_CODEX_OPERATOR_MEMORY_DIAGNOSTICS,
+        ...HOSTED_CODEX_PROVIDER_TRANSPORT_DIAGNOSTICS,
         runtimeEnvKeyCount: Object.keys(hostedCodexRuntime.runtimeEnv).length,
         voiceMemoElevenLabsApiKeyConfigured:
           hasHostedRuntimeEnvValue(hostedCodexRuntime.runtimeEnv, "ELEVENLABS_API_KEY"),

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -72,6 +72,7 @@ const DEFAULT_HOSTED_CODEX_AUTO_COMPACT_TOKEN_LIMIT = 100_000;
 const DEFAULT_HOSTED_CODEX_LOG_DIR = "/tmp/murph-codex-log";
 const HOSTED_CODEX_PROVIDER_REQUEST_MAX_RETRIES = 4;
 const HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES = 5;
+const HOSTED_CODEX_PROVIDER_STREAM_IDLE_TIMEOUT_MS = 90_000;
 const HOSTED_CODEX_OPERATOR_MEMORY_CONFIG = {
   disableOnExternalContext: false,
   featureEnabled: true,
@@ -106,6 +107,13 @@ export const HOSTED_CODEX_OPERATOR_MEMORY_DIAGNOSTICS = {
   codexOperatorMemoryMode: "codex-native-operator-context",
   codexOperatorMemoryUseMemories:
     HOSTED_CODEX_OPERATOR_MEMORY_CONFIG.useMemories,
+} as const;
+export const HOSTED_CODEX_PROVIDER_TRANSPORT_DIAGNOSTICS = {
+  codexProviderRequestMaxRetries: HOSTED_CODEX_PROVIDER_REQUEST_MAX_RETRIES,
+  codexProviderStreamIdleTimeoutMs:
+    HOSTED_CODEX_PROVIDER_STREAM_IDLE_TIMEOUT_MS,
+  codexProviderStreamMaxRetries: HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES,
+  codexProviderTransportMode: "codex-native-provider-transport",
 } as const;
 const HOSTED_CODEX_REJECTED_SEED_ENV_KEYS = [
   HOSTED_ASSISTANT_API_KEY_ENV,
@@ -521,6 +529,7 @@ export function buildHostedCodexConfigToml(input: {
     ...(input.provider.supportsWebSockets
       ? ["supports_websockets = true"]
       : []),
+    `stream_idle_timeout_ms = ${HOSTED_CODEX_PROVIDER_STREAM_IDLE_TIMEOUT_MS}`,
     "requires_openai_auth = false",
     ...(input.writeProviderRetryDefaults
       ? [

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -49,10 +49,10 @@ import {
 const HOSTED_CODEX_CONFIG_DIR_NAME = ".codex-hosted";
 const HOSTED_CODEX_CONFIG_FILE_NAME = "config.toml";
 const HOSTED_CODEX_AUTH_FILE_NAME = "auth.json";
-// Codex's built-in OpenAI provider id. With hosted-local subscription auth in
-// CODEX_HOME, Codex routes this provider to the ChatGPT subscription backend
-// itself; configuring a base_url would misroute subscription bearer tokens.
-const HOSTED_CODEX_CHATGPT_MODEL_PROVIDER_ID = "openai";
+// Custom provider id for ChatGPT-auth OpenAI. The provider intentionally omits
+// base_url/env_key: Codex routes auth-backed providers with no base_url to the
+// ChatGPT backend while still honoring provider-level transport settings.
+const HOSTED_CODEX_CHATGPT_MODEL_PROVIDER_ID = "hosted-chatgpt-openai";
 const DEFAULT_HOSTED_CODEX_REASONING_EFFORT = "low";
 const DEFAULT_HOSTED_CODEX_APPROVAL_POLICY = "never";
 const DEFAULT_HOSTED_CODEX_SANDBOX = "danger-full-access";
@@ -71,7 +71,7 @@ const DEFAULT_HOSTED_CODEX_SANDBOX = "danger-full-access";
 const DEFAULT_HOSTED_CODEX_AUTO_COMPACT_TOKEN_LIMIT = 100_000;
 const DEFAULT_HOSTED_CODEX_LOG_DIR = "/tmp/murph-codex-log";
 const HOSTED_CODEX_PROVIDER_REQUEST_MAX_RETRIES = 4;
-const HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES = 5;
+const HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES = 0;
 const HOSTED_CODEX_PROVIDER_STREAM_IDLE_TIMEOUT_MS = 90_000;
 const HOSTED_CODEX_OPERATOR_MEMORY_CONFIG = {
   disableOnExternalContext: false,
@@ -168,10 +168,6 @@ export async function prepareHostedCodexRuntimeEnvironment(
     provider: normalizeHostedCodexEnvString(input.runtimeEnv.HOSTED_ASSISTANT_PROVIDER),
     runtimeEnv: input.runtimeEnv,
   });
-  const usesTestProviderBaseUrlOverride =
-    normalizeHostedCodexEnvString(
-      input.runtimeEnv[HOSTED_RUNTIME_CODEX_MODEL_PROVIDER_BASE_URL_ENV],
-    ) !== null;
   const codexHome = path.join(input.operatorHomeRoot, HOSTED_CODEX_CONFIG_DIR_NAME);
   const codexConfigPath = path.join(codexHome, HOSTED_CODEX_CONFIG_FILE_NAME);
   const codexAuthPath = path.join(codexHome, HOSTED_CODEX_AUTH_FILE_NAME);
@@ -237,7 +233,6 @@ export async function prepareHostedCodexRuntimeEnvironment(
     codexConfigPath,
     buildHostedCodexConfigToml({
       chatGptAuth,
-      writeProviderRetryDefaults: usesTestProviderBaseUrlOverride,
       model: normalizeHostedCodexEnvString(runtimeEnv.HOSTED_ASSISTANT_MODEL),
       provider: providerConfig,
       reasoningEffort: runtimeEnv.HOSTED_ASSISTANT_REASONING_EFFORT,
@@ -512,36 +507,32 @@ function normalizeHostedCodexUrlHostname(hostname: string): string {
 
 export function buildHostedCodexConfigToml(input: {
   chatGptAuth?: boolean;
-  writeProviderRetryDefaults?: boolean;
   model: string | null;
   provider: AssistantCodexModelProviderConfig;
   reasoningEffort: string;
 }): string {
-  // ChatGPT-subscription auth uses Codex's built-in provider so Codex itself
-  // selects the subscription backend; a custom provider entry with base_url or
-  // env_key would bypass that routing.
-  const providerConfigLines = input.chatGptAuth ? [] : [
-    `[model_providers.${tomlQuotedKey(input.provider.id)}]`,
+  const modelProviderId = input.chatGptAuth
+    ? HOSTED_CODEX_CHATGPT_MODEL_PROVIDER_ID
+    : input.provider.id;
+  const providerConfigLines = [
+    `[model_providers.${tomlQuotedKey(modelProviderId)}]`,
     `name = ${tomlString(input.provider.name)}`,
-    `base_url = ${tomlString(input.provider.baseUrl)}`,
-    `env_key = ${tomlString(input.provider.envKey)}`,
+    ...(input.chatGptAuth
+      ? []
+      : [
+          `base_url = ${tomlString(input.provider.baseUrl)}`,
+          `env_key = ${tomlString(input.provider.envKey)}`,
+        ]),
     `wire_api = ${tomlString(input.provider.wireApi)}`,
     ...(input.provider.supportsWebSockets
       ? ["supports_websockets = true"]
       : []),
     `stream_idle_timeout_ms = ${HOSTED_CODEX_PROVIDER_STREAM_IDLE_TIMEOUT_MS}`,
-    "requires_openai_auth = false",
-    ...(input.writeProviderRetryDefaults
-      ? [
-          `request_max_retries = ${HOSTED_CODEX_PROVIDER_REQUEST_MAX_RETRIES}`,
-          `stream_max_retries = ${HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES}`,
-        ]
-      : []),
+    `requires_openai_auth = ${input.chatGptAuth ? "true" : "false"}`,
+    `request_max_retries = ${HOSTED_CODEX_PROVIDER_REQUEST_MAX_RETRIES}`,
+    `stream_max_retries = ${HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES}`,
     "",
   ];
-  const modelProviderId = input.chatGptAuth
-    ? HOSTED_CODEX_CHATGPT_MODEL_PROVIDER_ID
-    : input.provider.id;
 
   return [
     ...(input.model ? [`model = ${tomlString(input.model)}`] : []),

--- a/packages/assistant-runtime/src/hosted-runtime/events/provider-trace-log.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/provider-trace-log.ts
@@ -31,6 +31,10 @@ const ASSISTANT_CODEX_APP_SERVER_TIMING_TRACE_SCHEMA =
   "murph.assistant-codex-app-server-timing.v1";
 const ASSISTANT_CODEX_APP_SERVER_TIMING_TRACE_TYPE =
   "assistant.codex.app_server_timing";
+const ASSISTANT_CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA =
+  "murph.assistant-codex-transport-diagnostics.v1";
+const ASSISTANT_CODEX_TRANSPORT_DIAGNOSTICS_TRACE_TYPE =
+  "assistant.codex.transport_diagnostics";
 const ASSISTANT_CODEX_ACTION_DIAGNOSTICS_TRACE_SCHEMA =
   "murph.assistant-codex-action-diagnostics.v1";
 const ASSISTANT_CODEX_ACTION_DIAGNOSTICS_TRACE_TYPE =
@@ -150,6 +154,21 @@ const HOSTED_ASSISTANT_CODEX_APP_SERVER_TIMING_STAGE_VALUES = new Set([
   "warm-abort-poisoned",
   "warm-idle",
   "warm-reused",
+]);
+const HOSTED_ASSISTANT_CODEX_TRANSPORT_EVENT_KIND_VALUES = new Set([
+  "stream-disconnected",
+  "stream-idle-timeout",
+  "stream-retry",
+  "transport-fallback",
+]);
+const HOSTED_ASSISTANT_CODEX_TRANSPORT_METHOD_VALUES = new Set([
+  "error",
+  "warning",
+]);
+const HOSTED_ASSISTANT_CODEX_TRANSPORT_VALUES = new Set([
+  "http",
+  "unknown",
+  "websocket",
 ]);
 const HOSTED_ASSISTANT_CODEX_ACTION_KIND_VALUES = new Set([
   "command.execution",
@@ -272,6 +291,22 @@ const HOSTED_ASSISTANT_CODEX_RESUME_FAILURE_NUMBER_ARRAY_KEYS = [
 const HOSTED_ASSISTANT_CODEX_ACTION_DIAGNOSTIC_BOOLEAN_KEYS = [
   "codexActionThreadIdPresent",
   "codexActionTurnIdPresent",
+] as const;
+const HOSTED_ASSISTANT_CODEX_TRANSPORT_DIAGNOSTIC_BOOLEAN_KEYS = [
+  "codexTransportAdditionalDetailsPresent",
+  "codexTransportErrorMessagePresent",
+  "codexTransportFallbackActivated",
+  "codexTransportIdleTimeout",
+  "codexTransportStreamDisconnected",
+  "codexTransportThreadIdPresent",
+  "codexTransportTurnIdPresent",
+  "codexTransportWillRetry",
+] as const;
+const HOSTED_ASSISTANT_CODEX_TRANSPORT_DIAGNOSTIC_NUMBER_KEYS = [
+  "codexTransportErrorMessageLength",
+  "codexTransportProviderActionCount",
+  "codexTransportRetryCount",
+  "codexTransportRetryMax",
 ] as const;
 const HOSTED_ASSISTANT_CODEX_ACTION_DIAGNOSTIC_NUMBER_KEYS = [
   "codexActionCachedInputUnitMax",
@@ -408,6 +443,15 @@ function readHostedAssistantProviderDiagnosticTrace(
     return {
       details: appServerTimingDiagnostic,
       message: "Hosted assistant Codex app-server timing captured.",
+    };
+  }
+
+  const transportDiagnostic =
+    readHostedAssistantCodexTransportDiagnosticTrace(event);
+  if (transportDiagnostic) {
+    return {
+      details: transportDiagnostic,
+      message: "Hosted assistant Codex transport diagnostics captured.",
     };
   }
 
@@ -994,6 +1038,68 @@ function readHostedAssistantCodexAppServerTimingTrace(
   return details;
 }
 
+function readHostedAssistantCodexTransportDiagnosticTrace(
+  event: unknown,
+): HostedExecutionStructuredLogDetails | null {
+  const record = readHostedAssistantProviderRawTraceRecord(event);
+  if (!record) {
+    return null;
+  }
+
+  const schema = readHostedAssistantProviderPlanString(record, "schema");
+  const type = readHostedAssistantProviderPlanString(record, "type");
+  if (
+    schema !== ASSISTANT_CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA
+    || type !== ASSISTANT_CODEX_TRANSPORT_DIAGNOSTICS_TRACE_TYPE
+  ) {
+    return null;
+  }
+
+  const eventKind = readHostedAssistantProviderDiagnosticAllowedString(
+    record,
+    "codexTransportEventKind",
+    HOSTED_ASSISTANT_CODEX_TRANSPORT_EVENT_KIND_VALUES,
+  );
+  const sourceMethod = readHostedAssistantProviderDiagnosticAllowedString(
+    record,
+    "codexTransportSourceMethod",
+    HOSTED_ASSISTANT_CODEX_TRANSPORT_METHOD_VALUES,
+  );
+  const transport = readHostedAssistantProviderDiagnosticAllowedString(
+    record,
+    "codexTransportTransport",
+    HOSTED_ASSISTANT_CODEX_TRANSPORT_VALUES,
+  );
+  if (!eventKind || !sourceMethod || !transport) {
+    return null;
+  }
+
+  const details: HostedExecutionStructuredLogDetails = {
+    codexTransportEventKind: eventKind,
+    codexTransportSourceMethod: sourceMethod,
+    codexTransportTraceType: "transport-diagnostics",
+    codexTransportTransport: transport,
+    providerTraceKind: "codex.transport_diagnostics",
+    schema: ASSISTANT_CODEX_TRANSPORT_DIAGNOSTICS_TRACE_SCHEMA,
+  };
+
+  for (const key of HOSTED_ASSISTANT_CODEX_TRANSPORT_DIAGNOSTIC_BOOLEAN_KEYS) {
+    maybeSetHostedAssistantProviderDiagnosticDetail(
+      details,
+      key,
+      readHostedAssistantProviderDiagnosticBoolean(record, key),
+    );
+  }
+  for (const key of HOSTED_ASSISTANT_CODEX_TRANSPORT_DIAGNOSTIC_NUMBER_KEYS) {
+    maybeSetHostedAssistantProviderDiagnosticDetail(
+      details,
+      key,
+      readHostedAssistantProviderDiagnosticNonnegativeNumber(record, key),
+    );
+  }
+  return details;
+}
+
 function readHostedAssistantCodexActionDiagnosticTrace(
   event: unknown,
 ): HostedExecutionStructuredLogDetails | null {
@@ -1388,4 +1494,3 @@ function readHostedAssistantProviderDiagnosticNumberArray(
   );
   return output.length > 0 ? output : undefined;
 }
-

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -85,7 +85,7 @@ test("hosted Codex provider transport diagnostics expose only safe config metada
   assert.deepEqual(HOSTED_CODEX_PROVIDER_TRANSPORT_DIAGNOSTICS, {
     codexProviderRequestMaxRetries: 4,
     codexProviderStreamIdleTimeoutMs: 90_000,
-    codexProviderStreamMaxRetries: 5,
+    codexProviderStreamMaxRetries: 0,
     codexProviderTransportMode: "codex-native-provider-transport",
   });
 });
@@ -173,6 +173,8 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
   assert.match(config, /^supports_websockets = true$/mu);
   assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
   assert.match(config, /^requires_openai_auth = false$/mu);
+  assert.match(config, /^request_max_retries = 4$/mu);
+  assert.match(config, /^stream_max_retries = 0$/mu);
   assert.doesNotMatch(config, /^requires_openai_auth = true$/mu);
   assert.match(config, /\[features\]\nplugins = false\nmulti_agent_v2 = true\nmemories = true/u);
   assert.doesNotMatch(config, /root_agent_usage_hint_text/u);
@@ -399,7 +401,7 @@ test("hosted Codex runtime config accepts a local test-only model provider base 
   assert.doesNotMatch(config, /^supports_websockets = true$/mu);
   assert.match(config, /stream_idle_timeout_ms = 90000/u);
   assert.match(config, /request_max_retries = 4/u);
-  assert.match(config, /stream_max_retries = 5/u);
+  assert.match(config, /stream_max_retries = 0/u);
   assert.doesNotMatch(config, /https:\/\/api\.openai\.com\/v1/u);
 });
 
@@ -434,10 +436,9 @@ test("hosted Codex runtime config uses ChatGPT subscription auth in local dev", 
     },
   });
 
-  // The built-in provider id routes Codex to the ChatGPT backend via auth.json.
   assert.equal(
     result.runtimeEnv[HOSTED_CODEX_EFFECTIVE_MODEL_PROVIDER_ID_ENV],
-    "openai",
+    "hosted-chatgpt-openai",
   );
   // Token material must not linger in the runtime env; image-gen keeps the key.
   assert.equal(result.runtimeEnv[HOSTED_RUNTIME_CODEX_CHATGPT_AUTH_JSON_ENV], undefined);
@@ -450,11 +451,15 @@ test("hosted Codex runtime config uses ChatGPT subscription auth in local dev", 
 
   const config = await readFile(result.codexConfigPath, "utf8");
   assert.match(config, /^cli_auth_credentials_store = "file"$/mu);
-  assert.match(config, /^model_provider = "openai"$/mu);
-  assert.doesNotMatch(config, /\[model_providers\./u);
+  assert.match(config, /^model_provider = "hosted-chatgpt-openai"$/mu);
+  assert.match(config, /\[model_providers\."hosted-chatgpt-openai"\]/u);
   assert.doesNotMatch(config, /base_url/u);
   assert.doesNotMatch(config, /env_key/u);
-  assert.doesNotMatch(config, /requires_openai_auth/u);
+  assert.match(config, /^supports_websockets = true$/mu);
+  assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
+  assert.match(config, /^requires_openai_auth = true$/mu);
+  assert.match(config, /^request_max_retries = 4$/mu);
+  assert.match(config, /^stream_max_retries = 0$/mu);
   assert.doesNotMatch(config, /chatgpt-access-token/u);
   assert.match(config, /model_reasoning_effort = "low"/u);
   assert.match(config, /\[history\]\npersistence = "none"/u);
@@ -620,13 +625,20 @@ test("hosted Codex runtime config preserves managed ChatGPT auth", async () => {
   assert.equal(result.runtimeEnv.OPENAI_API_KEY, undefined);
   assert.equal(
     result.runtimeEnv[HOSTED_CODEX_EFFECTIVE_MODEL_PROVIDER_ID_ENV],
-    "openai",
+    "hosted-chatgpt-openai",
   );
 
   const config = await readFile(result.codexConfigPath, "utf8");
   assert.match(config, /^cli_auth_credentials_store = "file"$/mu);
-  assert.match(config, /^model_provider = "openai"$/mu);
-  assert.doesNotMatch(config, /\[model_providers\./u);
+  assert.match(config, /^model_provider = "hosted-chatgpt-openai"$/mu);
+  assert.match(config, /\[model_providers\."hosted-chatgpt-openai"\]/u);
+  assert.doesNotMatch(config, /base_url/u);
+  assert.doesNotMatch(config, /env_key/u);
+  assert.match(config, /^supports_websockets = true$/mu);
+  assert.match(config, /^requires_openai_auth = true$/mu);
+  assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
+  assert.match(config, /^request_max_retries = 4$/mu);
+  assert.match(config, /^stream_max_retries = 0$/mu);
   assert.doesNotMatch(config, /chatgpt-refresh-token/u);
   assertHostedCodexConfigDisablesLoginShellAtTopLevel(config);
   assertHostedCodexAutoCompactTokenLimit(config);
@@ -1288,6 +1300,8 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
       'wire_api = "responses"',
       "stream_idle_timeout_ms = 90000",
       "requires_openai_auth = false",
+      "request_max_retries = 4",
+      "stream_max_retries = 0",
       "",
       "# Hosted runs should not perform Codex plugin marketplace or remote plugin",
       "# sync work on cold wake; Murph owns the hosted runtime tool surface.",

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -44,6 +44,7 @@ import {
 import {
   buildHostedCodexConfigToml,
   HOSTED_CODEX_OPERATOR_MEMORY_DIAGNOSTICS,
+  HOSTED_CODEX_PROVIDER_TRANSPORT_DIAGNOSTICS,
   prepareHostedCodexRuntimeEnvironment,
 } from "../src/hosted-runtime/codex-config.ts";
 import {
@@ -77,6 +78,15 @@ test("hosted Codex memory diagnostics expose only safe config metadata", () => {
     codexOperatorMemoryMinRolloutIdleHours: 1,
     codexOperatorMemoryMode: "codex-native-operator-context",
     codexOperatorMemoryUseMemories: true,
+  });
+});
+
+test("hosted Codex provider transport diagnostics expose only safe config metadata", () => {
+  assert.deepEqual(HOSTED_CODEX_PROVIDER_TRANSPORT_DIAGNOSTICS, {
+    codexProviderRequestMaxRetries: 4,
+    codexProviderStreamIdleTimeoutMs: 90_000,
+    codexProviderStreamMaxRetries: 5,
+    codexProviderTransportMode: "codex-native-provider-transport",
   });
 });
 
@@ -161,6 +171,7 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
   assert.match(config, /env_key = "OPENAI_API_KEY"/u);
   assert.match(config, /wire_api = "responses"/u);
   assert.match(config, /^supports_websockets = true$/mu);
+  assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
   assert.match(config, /^requires_openai_auth = false$/mu);
   assert.doesNotMatch(config, /^requires_openai_auth = true$/mu);
   assert.match(config, /\[features\]\nplugins = false\nmulti_agent_v2 = true\nmemories = true/u);
@@ -386,6 +397,7 @@ test("hosted Codex runtime config accepts a local test-only model provider base 
   assert.match(config, /env_key = "OPENAI_API_KEY"/u);
   assert.match(config, /requires_openai_auth = false/u);
   assert.doesNotMatch(config, /^supports_websockets = true$/mu);
+  assert.match(config, /stream_idle_timeout_ms = 90000/u);
   assert.match(config, /request_max_retries = 4/u);
   assert.match(config, /stream_max_retries = 5/u);
   assert.doesNotMatch(config, /https:\/\/api\.openai\.com\/v1/u);
@@ -1274,6 +1286,7 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
       'base_url = "https://api.openai.com/v1"',
       'env_key = "OPENAI_API_KEY"',
       'wire_api = "responses"',
+      "stream_idle_timeout_ms = 90000",
       "requires_openai_auth = false",
       "",
       "# Hosted runs should not perform Codex plugin marketplace or remote plugin",

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -680,6 +680,95 @@ describe("executeHostedMailboxEvent", () => {
     expect(JSON.stringify(entry?.redacted)).not.toContain("/tmp/raw-path");
   });
 
+  it("captures hosted Codex transport diagnostics without raw payloads", () => {
+    const wake = buildHostedExecutionAssistantNotificationRequestedWake({
+      eventId: "evt_codex_transport_diagnostics",
+      memberId: "member_123",
+      notification: {
+        instructions: "Reply in chat.",
+        route: {
+          actorId: "actor_codex_transport",
+          channel: "linq",
+          delivery: {
+            kind: "thread",
+            target: "thread_123",
+          },
+          identityId: "hbidx:phone:v1:test",
+          threadId: "thread_123",
+          threadIsDirect: true,
+        },
+      },
+      occurredAt: "2026-04-08T00:00:00.000Z",
+    });
+
+    const entry = emitHostedAssistantProviderTraceLog({
+      details: {
+        requestId: "req_123",
+      },
+      event: {
+        codexThreadId: "raw-provider-session-id",
+        rawEvent: {
+          schema: "murph.assistant-codex-transport-diagnostics.v1",
+          type: "assistant.codex.transport_diagnostics",
+          codexTransportAdditionalDetailsPresent: true,
+          codexTransportErrorMessage: "raw provider message must not appear",
+          codexTransportErrorMessageLength: 144,
+          codexTransportErrorMessagePresent: true,
+          codexTransportEventKind: "stream-idle-timeout",
+          codexTransportFallbackActivated: false,
+          codexTransportIdleTimeout: true,
+          codexTransportProviderActionCount: 0,
+          codexTransportRetryCount: 2,
+          codexTransportRetryMax: 5,
+          codexTransportSourceMethod: "error",
+          codexTransportStreamDisconnected: true,
+          codexTransportThreadId: "raw-thread-id",
+          codexTransportThreadIdPresent: true,
+          codexTransportTransport: "websocket",
+          codexTransportTurnId: "raw-turn-id",
+          codexTransportTurnIdPresent: true,
+          codexTransportUrl: "https://api.openai.com/v1/responses",
+          codexTransportWillRetry: true,
+        },
+      },
+      wake,
+    });
+
+    expect(entry).toEqual({
+      component: "runtime.provider",
+      eventId: "evt_codex_transport_diagnostics",
+      level: "info",
+      message: "Hosted assistant Codex transport diagnostics captured.",
+      phase: "wake.running",
+      redacted: expect.objectContaining({
+        codexTransportAdditionalDetailsPresent: true,
+        codexTransportErrorMessageLength: 144,
+        codexTransportErrorMessagePresent: true,
+        codexTransportEventKind: "stream-idle-timeout",
+        codexTransportFallbackActivated: false,
+        codexTransportIdleTimeout: true,
+        codexTransportProviderActionCount: 0,
+        codexTransportRetryCount: 2,
+        codexTransportRetryMax: 5,
+        codexTransportSourceMethod: "error",
+        codexTransportStreamDisconnected: true,
+        codexTransportThreadIdPresent: true,
+        codexTransportTraceType: "transport-diagnostics",
+        codexTransportTransport: "websocket",
+        codexTransportTurnIdPresent: true,
+        codexTransportWillRetry: true,
+        providerTraceKind: "codex.transport_diagnostics",
+        requestId: "req_123",
+        schema: "murph.assistant-codex-transport-diagnostics.v1",
+      }),
+    });
+    expect(JSON.stringify(entry?.redacted)).not.toContain("raw-provider-session-id");
+    expect(JSON.stringify(entry?.redacted)).not.toContain("raw provider message");
+    expect(JSON.stringify(entry?.redacted)).not.toContain("raw-thread-id");
+    expect(JSON.stringify(entry?.redacted)).not.toContain("raw-turn-id");
+    expect(JSON.stringify(entry?.redacted)).not.toContain("api.openai.com");
+  });
+
   it("captures hosted Codex warm app-server timing traces", () => {
     for (const stage of ["warm-reused", "warm-idle", "warm-abort-poisoned"]) {
       const eventId = `evt_codex_${stage.replaceAll("-", "_")}_timing`;

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -448,7 +448,7 @@ describe("hosted workspace runtime entrypoint", () => {
       expect(codexPrepareDoneLog?.details).toEqual(expect.objectContaining({
         codexProviderRequestMaxRetries: 4,
         codexProviderStreamIdleTimeoutMs: 90_000,
-        codexProviderStreamMaxRetries: 5,
+        codexProviderStreamMaxRetries: 0,
         codexProviderTransportMode: "codex-native-provider-transport",
       }));
       expect(phaseLogs.every((entry) =>

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -445,6 +445,12 @@ describe("hosted workspace runtime entrypoint", () => {
         codexPrepareDoneLog?.details.codexEffectiveModelProviderId,
         "hosted-openai",
       );
+      expect(codexPrepareDoneLog?.details).toEqual(expect.objectContaining({
+        codexProviderRequestMaxRetries: 4,
+        codexProviderStreamIdleTimeoutMs: 90_000,
+        codexProviderStreamMaxRetries: 5,
+        codexProviderTransportMode: "codex-native-provider-transport",
+      }));
       expect(phaseLogs.every((entry) =>
         typeof entry.details.runtimeElapsedMs === "number"
       )).toBe(true);


### PR DESCRIPTION
## Why

A production hosted foreground reply waited about five minutes before recovering. The upstream Codex default stream idle timeout is 300 seconds, and Codex can fall back from WebSockets to HTTPS only after its stream retry budget is exhausted. This PR targets that idle/fallback boundary directly instead of adding a Murph-side watchdog.

## User-visible goal

Hosted replies should recover materially faster from a silent Codex stream while keeping the existing Codex-native WebSocket transport path enabled by default. Future incidents should also leave metadata-only evidence showing whether Codex saw a stream retry, idle timeout, disconnect, or WebSocket-to-HTTPS fallback.

## Changes

- Sets the hosted OpenAI/Codex provider `stream_idle_timeout_ms` to 90 seconds in generated Codex config.
- Sets hosted `stream_max_retries = 0`, so Codex tries WebSockets first and then activates HTTPS fallback after one failed or idle stream window instead of spending multiple additional WebSocket retry windows.
- Writes a custom ChatGPT-auth OpenAI provider id without `base_url` or `env_key`, so managed/seeded ChatGPT auth also receives the hosted timeout and fallback settings while Codex still routes auth-backed traffic to the ChatGPT backend.
- Adds hosted runtime phase diagnostics for the effective Codex retry/timeout transport settings.
- Emits redacted Codex transport diagnostic trace events for retry, idle-timeout, disconnect, and WebSocket-to-HTTPS fallback notifications.
- Allows hosted provider trace logging to persist only allowlisted metadata from those diagnostics.

## Invariants preserved

- WebSockets remain enabled by default for hosted OpenAI provider paths.
- No prompts, transcripts, provider payloads, raw provider messages, URLs, secrets, raw paths, thread IDs, turn IDs, or direct personal identifiers are logged through the new diagnostics.
- Codex remains the transport retry/fallback owner; Murph does not add a parallel scheduler, watchdog, or live-turn supervisor.

## Verification

- `pnpm exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-workspace-entrypoint.test.ts test/hosted-runtime-codex-config.test.ts test/hosted-runtime-events.test.ts`
- `pnpm exec vitest run --config vitest.config.ts --no-coverage test/assistant-codex-runtime.test.ts`
- `pnpm typecheck`
- `pnpm test:diff packages/assistant-engine/src/assistant-codex.ts packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/src/hosted-runtime/codex-config.ts packages/assistant-runtime/src/hosted-runtime/events/provider-trace-log.ts packages/assistant-engine/test/assistant-codex-runtime.test.ts packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts packages/assistant-runtime/test/hosted-runtime-events.test.ts packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts`
