### PR TITLE
docs(invariants): deterministic multi-recipient sends must use the seeded variant bank

### DIFF
--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -135,6 +135,7 @@ rationale, not a live mechanism.
 ## User-Facing Message Sends
 
 - Do not hard-code messages that automatically send to users, except for the AI usage gate, signup link delivery, first welcome, Linq daily text quota, Linq home-thread redirect, and billing cancellation feedback email. The Linq quota and home-thread redirects are narrowly scoped policy responses that preserve admission/routing invariants before assistant generation runs. All other automatic outbound user messages must come from the normal AI-gated assistant path, an explicit user/operator-authored message, or another reviewed product-copy surface that is not sent automatically.
+- Any deterministic message that can send identically to more than one recipient renders from the seeded variant bank in `apps/web/src/lib/hosted-messages/user-facing-messages.ts`: at least 20 structurally distinct variants per class, selected by a stable per-recipient seed, never a single fixed string. Sending identical copy to many recipients is an iMessage spam signal (`agent-docs/operations/imessage-deliverability.md`), so the variant floor is enforced at module import and in the corpus test. This binds the allowed hard-coded classes above and any transactional onboarding, family, or group reply that would otherwise send fixed text. Managed automations satisfy it by composing each send through the AI-gated path instead of a fixed script, which is why they carry instructions rather than message text.
 
 ## Hosted Foreground Priority
 


### PR DESCRIPTION
## Why

Following the pattern established in #428 (family welcome moved into the seeded variant bank), we want a durable rule that prevents deterministic outbound copy from being sent identically to many people. iMessage's spam engine flags identical text sent to many recipients (`agent-docs/operations/imessage-deliverability.md`: "20 identical messages to 20 different people is a spam signal").

The `## User-Facing Message Sends` invariant already governed *which* messages may be hard-coded and auto-sent, but it never stated the anti-spam *variance* requirement on the ones it allows. The enforcement mechanism already exists in code (`user-facing-messages.ts` enforces a >=20-variant floor at module import and in the corpus test); this change just writes the rule down where reviewers and agents will hit it, so new deterministic-copy surfaces are steered into the bank instead of shipping a fixed string.

## User-visible goal

Users never receive the exact same deterministic system message as many other people, keeping Murph's lines out of iMessage spam scoring. No runtime behavior changes in this PR; it is a documentation invariant that governs future work.

## What changed

- `docs/contracts/00-invariants.md`, `## User-Facing Message Sends`: one added bullet requiring any deterministic message that can send identically to more than one recipient to render from the seeded variant bank (>=20 structurally distinct variants, stable per-recipient seed), never a single fixed string. It also records why managed automations are exempt (they compose each send through the AI-gated path and carry instructions, not message text).

## Invariants to preserve

- The bank's >=20-variant floor and deterministic per-recipient seed selection stay enforced at module import and in the corpus test.
- Managed/scheduled automations remain LLM-composed (instructions, not fixed message text); this invariant must not be read as licensing a fixed-script automation.

## Note for reviewers

The map that motivated this turned up several deterministic multi-recipient sends that do **not** yet go through the bank and are not in the exception list above (group join offer/accepted/consent replies, family invite reply, family "joined" notice). This PR intentionally scopes to the invariant only; bringing those sends into compliance (bank them, per the #428 precedent) is a tracked follow-up, not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786027988&installation_id=127572939&pr_number=443&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F443&signature=866afcd7171dd57539ce7096eaacfc48b7b3edd88f546c226af08d67bd411a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->