### PR TITLE
Simplify hosted Linq egress guard

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-07-linq-egress-guard-simplification.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-linq-egress-guard-simplification.md
@@ -57,6 +57,38 @@ Success criteria:
 This spans web and hosted runtime bundle behavior. Web must tolerate old runtime
 calls during rollout; runtime-side deletion of the old assertion call should
 deploy after the web route accepts the simplified authority contract.
+
+Safe deploy order:
+
+1. Deploy web with the simplified engagement route and the stale-column drop.
+2. Deploy Cloudflare/runner bundles that stop sending the deleted delivery
+   engagement assertion.
+
+Gradual rollout behavior:
+
+- Warm old runner bundles can still call the web engagement route with either
+  `routeAuthority` or legacy `currentInbound`; the web route keeps both inputs
+  accepted during this rollout.
+- `container_rollout=immediate` is not required. Immediate rollout is acceptable
+  if operationally convenient, but not required for correctness.
+
+Schema-drop proof:
+
+- The dropped `hosted_member_routing` and `hosted_thread_route` recency columns
+  are not referenced by application source on the base branch; the remaining
+  references are Prisma schema, migration DDL, and migration tests.
+- Base-branch application reads of the affected tables use explicit Prisma
+  `select` shapes, so a warm old web process or code rollback does not
+  implicitly select the dropped scalar fields.
+- Runtime recency decisions are already owned by reconciliation facts and
+  `hosted_linq_daily_state`, not by these columns.
+
+Rollback floor:
+
+- Web and Cloudflare can roll back to the base branch for this PR because the
+  base application source does not read or write the dropped columns.
+- Rolling back to any older revision that explicitly names these recency columns
+  outside schema/migration/test code requires restoring the columns first.
 Status: completed
 Updated: 2026-07-07
 Completed: 2026-07-07

--- a/agent-docs/exec-plans/completed/2026-07-07-linq-egress-guard-simplification.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-linq-egress-guard-simplification.md
@@ -1,0 +1,62 @@
+# Linq Egress Guard Simplification
+
+## Goal
+
+Remove stale hosted Linq egress guard complexity that can block valid hosted
+automation delivery after message generation, while preserving concrete
+authority checks for signup welcome, routed thread/group sends, and typing
+pacing.
+
+Success criteria:
+
+- Hosted automation engagement remains owned by reconciliation facts and
+  `hosted_linq_daily_state`, not delivery egress.
+- Participant-target Linq sends remain limited to signup welcome first contact.
+- Route authority no longer shadows normal delivery with a stale thread-route
+  assertion.
+- Typing uses direct cadence/session/cooldown controls instead of a web DB
+  egress authority assertion.
+- Post-send delivery outcome recording does not fail solely because a routed
+  thread proof is stale.
+- Obsolete member/thread recency columns are removed from Prisma schema,
+  migrations, tests, and seeds.
+
+## Constraints
+
+- Preserve wrong-user and wrong-target fail-closed checks.
+- Do not weaken phone-number deliverability policy: signup welcome remains the
+  only first-contact participant send.
+- Do not remove `routeAuthority` as group/thread context until all runtime
+  group/thread consumers have another source.
+- Keep provider payloads, secrets, phone numbers, message bodies, and direct
+  identifiers out of diagnostics, docs, and tests.
+- Avoid new state or new schedulers; prefer deletion and direct predicates.
+
+## Working Set
+
+- `apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts`
+- `apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts`
+- `packages/assistant-runtime/src/hosted-runtime/channel-activity.ts`
+- `packages/assistant-runtime/src/hosted-runtime/callbacks.ts`
+- `apps/cloudflare/src/runtime-platform/effects-port.ts`
+- `apps/cloudflare/test/runner-*.test.ts`
+- `agent-docs/operations/imessage-deliverability.md`
+- `apps/web/prisma/schema.prisma`
+- `apps/web/prisma/migrations/**`
+- Focused hosted Linq/runtime tests and seed helpers
+
+## Verification Plan
+
+- Focused unit tests for Linq egress authority, delivery outcome recording,
+  typing activity, and schema-related hosted onboarding fixtures.
+- `pnpm test:diff` over the touched paths if it remains a truthful scoped lane.
+- `pnpm typecheck` or report any unrelated pre-existing blocker.
+
+## Deployment Notes
+
+This spans web and hosted runtime bundle behavior. Web must tolerate old runtime
+calls during rollout; runtime-side deletion of the old assertion call should
+deploy after the web route accepts the simplified authority contract.
+Status: completed
+Updated: 2026-07-07
+Completed: 2026-07-07

--- a/agent-docs/operations/imessage-deliverability.md
+++ b/agent-docs/operations/imessage-deliverability.md
@@ -82,7 +82,14 @@ If the answer is unknown, do not assume the path is safe. Add the missing guard,
 
 ## Murph Hosted Automation Engagement
 
-Murph pauses model-capable automation wakes for Linq members with no inbound day in the last 28 days, using `hosted_linq_daily_state` as the source of truth. Conversational replies are never gated by this pause because fresh conversation mailbox lag bypasses it. First-contact, participant identity, and route-authority checks remain separate authority checks and still fail closed.
+Murph pauses model-capable automation wakes for Linq members with no inbound day in the last 28 days, using `hosted_linq_daily_state` as the source of truth. Conversational replies are never gated by this pause because fresh conversation mailbox lag bypasses it.
+
+Linq egress should stay small and obvious:
+
+- Participant-target sends are signup-welcome only, tied to `signup-welcome:<memberId>`, the member's verified phone, and the assigned home line.
+- Thread sends use same-user route authority as target context when it matches the requested thread, otherwise they fall back to the member's durable home or pending Linq route.
+- Egress no longer owns a separate "recent inbound" recency check; hosted automation recency belongs to reconciliation/wake selection.
+- Typing indicators do not call web-owned egress assertions. They are locally throttled to one session per chat, capped at five minutes, with a restart cooldown after a max-length session.
 
 ## Prompt and copy guidance
 

--- a/apps/cloudflare/src/runtime-platform/effects-port.ts
+++ b/apps/cloudflare/src/runtime-platform/effects-port.ts
@@ -129,10 +129,10 @@ export function createCloudflareEffectsPort(input: {
             await fetchHostedWebControlPlaneJson({
               body: request,
               boundUserId: input.boundUserId,
-              description: "Hosted Linq recent inbound engagement assertion",
+              description: "Hosted Linq egress authority assertion",
               fetchImpl: input.fetchImpl,
               headers: await requireHostedEffectsRuntimeWriteFenceHeaders({
-                description: "Hosted Linq recent inbound engagement assertion",
+                description: "Hosted Linq egress authority assertion",
                 workspaceCheckpointBridge: input.workspaceCheckpointBridge ?? null,
               }),
               path: HOSTED_RUNTIME_LINQ_EGRESS_ENGAGEMENT_PATH,

--- a/apps/cloudflare/test/hosted-local-runner-warm-auth-recovery-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-runner-warm-auth-recovery-e2e.test.ts
@@ -168,7 +168,7 @@ describe("hosted local runner warm reuse e2e", () => {
     expect(finalStatus.mailboxLag.every((lane) => lane.lag === "0")).toBe(true);
   }, 600_000);
 
-  it("sends typing before replying from pending Linq input restored without initial delivery context", async () => {
+  it("replies from pending Linq input restored without initial delivery context without typing", async () => {
     const memberPhone = buildLinqRecipientPhoneNumber(pendingUserId);
     const homePhone = buildLinqHomePhoneNumber(pendingUserId);
     const replyPath = `/chats/${encodeURIComponent(pendingChatId)}/messages`;
@@ -214,13 +214,10 @@ describe("hosted local runner warm reuse e2e", () => {
     const typingStarts = requestsAfterInvocation.filter((request) =>
       request.method === "POST" && request.url === typingPath
     );
-    expect(typingStarts.length).toBeGreaterThanOrEqual(1);
+    expect(typingStarts).toHaveLength(0);
 
     const replySendIndex = requestsAfterInvocation.indexOf(reply);
-    const typingStartIndex = requestsAfterInvocation.indexOf(typingStarts[0]!);
     expect(replySendIndex).toBeGreaterThanOrEqual(0);
-    expect(typingStartIndex).toBeGreaterThanOrEqual(0);
-    expect(replySendIndex).toBeGreaterThan(typingStartIndex);
 
     const providerRequests = requireScenario().assistantProviderRequests
       .filter((request) => request.url === "/v1/responses");

--- a/apps/cloudflare/test/runner-outbound.test.ts
+++ b/apps/cloudflare/test/runner-outbound.test.ts
@@ -226,11 +226,10 @@ const ALLOWLISTED_WEB_CONTROL_CASES = [
   },
   {
     body: {
-      engagementKind: "requires_recent_inbound",
       target: "chat_123",
       targetKind: "thread",
     },
-    name: "hosted Linq egress engagement",
+    name: "hosted Linq egress authority",
     path: HOSTED_RUNTIME_LINQ_EGRESS_ENGAGEMENT_PATH,
   },
   {
@@ -806,7 +805,7 @@ describe("handleRunnerOutboundRequest", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects Linq egress engagement assertions without the active runtime fence", async () => {
+  it("rejects Linq egress authority assertions without the active runtime fence", async () => {
     const validateRuntimeWriteFence = vi.fn(async () => true);
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -814,7 +813,6 @@ describe("handleRunnerOutboundRequest", () => {
     const response = await handleRunnerOutboundRequest(
       new Request(`http://web-control.worker${HOSTED_RUNTIME_LINQ_EGRESS_ENGAGEMENT_PATH}`, {
         body: JSON.stringify({
-          engagementKind: "requires_recent_inbound",
           target: "chat_123",
           targetKind: "thread",
         }),

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -3850,7 +3850,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
   });
 
-  it("write-fences Linq engagement assertions through direct web-control", async () => {
+  it("write-fences Linq egress authority assertions through direct web-control", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const request = input instanceof Request ? input : new Request(input, init);
       expect(new URL(request.url).pathname).toBe(HOSTED_RUNTIME_LINQ_EGRESS_ENGAGEMENT_PATH);
@@ -3872,17 +3872,16 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     const assertLinqRecentInboundEngagement =
       platform.effectsPort.assertLinqRecentInboundEngagement;
     if (!assertLinqRecentInboundEngagement) {
-      throw new Error("Expected hosted Linq engagement assertion effect.");
+      throw new Error("Expected hosted Linq egress authority assertion effect.");
     }
 
     await assertLinqRecentInboundEngagement({
-      engagementKind: "requires_recent_inbound",
       target: "chat_123",
       targetKind: "thread",
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const request = requireFetchRequest(fetchMock.mock.calls[0], "direct Linq engagement request");
+    const request = requireFetchRequest(fetchMock.mock.calls[0], "direct Linq egress authority request");
     expect(request.url).toBe(`https://web.example.test${HOSTED_RUNTIME_LINQ_EGRESS_ENGAGEMENT_PATH}`);
     expectDefaultRuntimeWriteFenceHeaders(request);
     expect(request.headers.get("x-hosted-execution-user-id")).toBe("member_123");

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
@@ -24,9 +24,6 @@ import {
   jsonOk,
   withJsonError,
 } from "@/src/lib/hosted-onboarding/http";
-import {
-  assertHostedThreadRouteEgressAuthority,
-} from "@/src/lib/hosted-routing/thread-route-store";
 import { readOptionalJsonObject } from "@/src/lib/http";
 import { getPrisma } from "@/src/lib/prisma";
 
@@ -94,7 +91,6 @@ export const POST = withJsonError(async (request: Request) => {
   if (validatedRouteAuthority) {
     routeLineLookupKey = await readHostedLinqDeliveryRouteLineLookupKey({
       memberId: userId,
-      prisma,
       routeAuthority: validatedRouteAuthority,
     });
   } else if (!fromPhoneNumber) {
@@ -132,7 +128,6 @@ export const POST = withJsonError(async (request: Request) => {
 
 async function readHostedLinqDeliveryRouteLineLookupKey(input: {
   memberId: string;
-  prisma: ReturnType<typeof getPrisma>;
   routeAuthority: HostedExecutionLinqExternalThreadRouteAuthority;
 }): Promise<string | null> {
   if (input.routeAuthority.containerMemberId !== input.memberId) {
@@ -144,19 +139,12 @@ async function readHostedLinqDeliveryRouteLineLookupKey(input: {
     });
   }
 
-  await assertHostedThreadRouteEgressAuthority({
-    authority: input.routeAuthority,
-    prisma: input.prisma,
-  });
   // This is a post-send delivery-OUTCOME callback (Cloudflare-runner
-  // authenticated), not a routing decision. Authorization is already bound to
-  // the DB route by channel + chatId + containerMemberId above; the returned
-  // line key is used only to attribute the recorded outcome to a Linq line's
-  // stats. Since a chat-id route is intentionally no longer line-pinned, the DB
-  // route carries no authoritative send line — the runner that performed the
-  // send is the source of truth for which line it used, so we read it from the
-  // (already authority-validated) request. A missing key is benign: the outcome
-  // still records without line attribution.
+  // authenticated), not a routing decision. The cheap channel/chat/member
+  // consistency check already ran before this helper; the returned line key is
+  // used only to attribute the recorded outcome to a Linq line's stats. A stale
+  // route row cannot prevent a send that already happened, so it must not make
+  // outcome recording fail or trigger retries.
   return input.routeAuthority.accountLookupKey?.trim() || null;
 }
 

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
@@ -33,7 +33,6 @@ export const POST = withJsonError(async (request: Request) => {
   await assertHostedLinqRecentInboundEngagementForRuntime({
     currentInbound: parseHostedLinqLegacyCurrentInboundProof(body.currentInbound),
     directRecipientPhoneNumber: readOptionalBodyString(body.directRecipientPhoneNumber),
-    engagementKind: parseHostedLinqEgressEngagementKind(body.engagementKind),
     fromPhoneNumber: readOptionalBodyString(body.fromPhoneNumber),
     idempotencyKey: readOptionalBodyString(body.idempotencyKey),
     memberId: userId,
@@ -105,23 +104,6 @@ function throwHostedLinqCurrentInboundInvalid(): never {
   });
 }
 
-function parseHostedLinqEgressEngagementKind(
-  value: unknown,
-): "first_contact" | "requires_recent_inbound" | null {
-  if (value === undefined || value === null) {
-    return null;
-  }
-  if (value === "first_contact" || value === "requires_recent_inbound") {
-    return value;
-  }
-  throw hostedOnboardingError({
-    code: "HOSTED_LINQ_EGRESS_ENGAGEMENT_KIND_INVALID",
-    httpStatus: 400,
-    message: "Hosted Linq egress engagement kind is invalid.",
-    retryable: false,
-  });
-}
-
 function parseHostedLinqEgressRouteAuthority(
   value: unknown,
 ): HostedExecutionLinqExternalThreadRouteAuthority | null {
@@ -130,7 +112,7 @@ function parseHostedLinqEgressRouteAuthority(
   }
   const authority = parseHostedExecutionExternalThreadRouteAuthority(
     value,
-    "Hosted Linq egress engagement request route authority",
+    "Hosted Linq egress authority request route authority",
   );
   if (authority.channel !== "linq") {
     throw hostedOnboardingError({

--- a/apps/web/prisma/migrations/20260707170000_drop_stale_linq_recency_columns/migration.sql
+++ b/apps/web/prisma/migrations/20260707170000_drop_stale_linq_recency_columns/migration.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS "hosted_member_routing_linq_last_inbound_at_idx";
+DROP INDEX IF EXISTS "hosted_member_routing_pending_linq_last_inbound_at_idx";
+DROP INDEX IF EXISTS "hosted_thread_route_channel_last_inbound_at_idx";
+
+ALTER TABLE "hosted_member_routing"
+  DROP COLUMN IF EXISTS "linq_last_inbound_at",
+  DROP COLUMN IF EXISTS "pending_linq_last_inbound_at";
+
+ALTER TABLE "hosted_thread_route"
+  DROP COLUMN IF EXISTS "last_inbound_at";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -598,13 +598,11 @@ model HostedMemberRouting {
   linqRecipientPhoneLookupKey        String?      @map("linq_recipient_phone_lookup_key")
   linqRecipientPhoneEncrypted        String?      @map("linq_recipient_phone_encrypted")
   linqHomeLineAssignedAt             DateTime?    @map("linq_home_line_assigned_at")
-  linqLastInboundAt                  DateTime?    @map("linq_last_inbound_at")
   /// Pre-activation Linq acquisition/referral thread before a home line is chosen.
   pendingLinqChatLookupKey           String?      @unique @map("pending_linq_chat_lookup_key")
   pendingLinqChatIdEncrypted         String?      @map("pending_linq_chat_id_encrypted")
   pendingLinqRecipientPhoneLookupKey String?      @map("pending_linq_recipient_phone_lookup_key")
   pendingLinqRecipientPhoneEncrypted String?      @map("pending_linq_recipient_phone_encrypted")
-  pendingLinqLastInboundAt           DateTime?    @map("pending_linq_last_inbound_at")
   pendingLinqParticipantContactKind       String?   @map("pending_linq_participant_contact_kind")
   pendingLinqParticipantContactLookupKey  String?   @unique @map("pending_linq_participant_contact_lookup_key")
   pendingLinqParticipantContactEncrypted  String?   @map("pending_linq_participant_contact_encrypted")
@@ -619,8 +617,6 @@ model HostedMemberRouting {
   @@index([linqRecipientPhoneLookupKey])
   @@index([linqRecipientPhoneLookupKey, linqHomeLineAssignedAt])
   @@index([pendingLinqRecipientPhoneLookupKey])
-  @@index([linqLastInboundAt])
-  @@index([pendingLinqLastInboundAt])
   @@map("hosted_member_routing")
 }
 
@@ -1152,7 +1148,6 @@ model HostedThreadRoute {
   threadLookupKey         String                @map("thread_lookup_key")
   threadIdentityLookupKey String                @map("thread_identity_lookup_key")
   containerMemberId       String                @map("container_member_id")
-  lastInboundAt           DateTime?             @map("last_inbound_at")
   createdAt               DateTime              @default(now()) @map("created_at")
   updatedAt               DateTime              @default(now()) @updatedAt @map("updated_at")
   container               HostedThreadContainer @relation(fields: [containerMemberId], references: [memberId], onDelete: Cascade)
@@ -1160,7 +1155,6 @@ model HostedThreadRoute {
   @@id([channel, threadIdentityLookupKey])
   @@index([channel, threadLookupKey])
   @@index([containerMemberId])
-  @@index([channel, lastInboundAt])
   @@map("hosted_thread_route")
 }
 

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -13,12 +13,8 @@ import {
   hostedOnboardingError,
 } from "./errors";
 import { normalizePhoneNumber } from "./phone";
-import {
-  assertHostedThreadRouteEgressAuthority,
-} from "../hosted-routing/thread-route-store";
 
 type HostedLinqEngagementClient = PrismaClient | Prisma.TransactionClient;
-type HostedLinqEgressEngagementKind = "first_contact" | "requires_recent_inbound";
 type HostedLinqLegacyCurrentInboundProof = {
   dedupeKey: string;
   eventId: string;
@@ -62,7 +58,6 @@ export function assertHostedLinqRouteAuthorityMatchesTarget(input: {
 export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
   currentInbound?: HostedLinqLegacyCurrentInboundProof | null;
   directRecipientPhoneNumber?: string | null;
-  engagementKind?: HostedLinqEgressEngagementKind | null;
   fromPhoneNumber?: string | null;
   idempotencyKey?: string | null;
   memberId: string;
@@ -81,12 +76,13 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
     throw hostedOnboardingError({
       code: "HOSTED_LINQ_EGRESS_BOUND_USER_MISMATCH",
       httpStatus: 403,
-      message: "Linq egress engagement authority does not match the runtime user.",
+      message: "Linq egress authority does not match the runtime user.",
       retryable: false,
     });
   }
-  if ((input.engagementKind ?? "requires_recent_inbound") === "first_contact") {
-    await assertHostedLinqFirstContactEgressAuthority({
+
+  if (normalizeNullable(input.targetKind) === "participant") {
+    await assertHostedLinqSignupWelcomeParticipantEgressAuthority({
       directRecipientPhoneNumber: input.directRecipientPhoneNumber,
       fromPhoneNumber: input.fromPhoneNumber,
       idempotencyKey: input.idempotencyKey,
@@ -99,24 +95,6 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
   }
 
   if (routeAuthority) {
-    await assertHostedThreadRouteEgressAuthority({
-      authority: routeAuthority,
-      prisma: input.prisma,
-    });
-    return;
-  }
-
-  if (normalizeNullable(input.targetKind) === "participant") {
-    await assertHostedLinqParticipantTargetMatchesMemberIdentity({
-      memberId: input.memberId,
-      participantPhone: input.target ?? input.directRecipientPhoneNumber ?? null,
-      prisma: input.prisma,
-    });
-    await assertHostedMemberLinqRouteMatchesEgressTarget({
-      memberId: input.memberId,
-      prisma: input.prisma,
-      recipientPhone: input.fromPhoneNumber ?? null,
-    });
     return;
   }
 
@@ -126,7 +104,7 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
   })) {
     // Temporary CF-rollout follow-up compatibility: old warm runner bundles
     // sent currentInbound before external thread routeAuthority existed. Delete
-    // this with the engagement assertion route after that rollout window is gone.
+    // this with the egress authority callback route after that rollout window is gone.
     return;
   }
 
@@ -134,39 +112,6 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
     chatId: input.target,
     memberId: input.memberId,
     prisma: input.prisma,
-  });
-}
-
-async function assertHostedLinqParticipantTargetMatchesMemberIdentity(input: {
-  memberId: string;
-  participantPhone?: string | null;
-  prisma: HostedLinqEngagementClient;
-}): Promise<void> {
-  const participantPhone = normalizePhoneNumber(input.participantPhone);
-  const participantPhoneLookupKeys = createHostedPhoneLookupKeyReadCandidates(participantPhone);
-  if (!participantPhone || participantPhoneLookupKeys.length === 0) {
-    throwHostedLinqParticipantEgressAuthorityMismatch();
-  }
-
-  const identity = await input.prisma.hostedMemberIdentity.findUnique({
-    where: { memberId: input.memberId },
-    select: { phoneLookupKey: true },
-  });
-
-  if (
-    !identity?.phoneLookupKey
-    || !participantPhoneLookupKeys.includes(identity.phoneLookupKey)
-  ) {
-    throwHostedLinqParticipantEgressAuthorityMismatch();
-  }
-}
-
-function throwHostedLinqParticipantEgressAuthorityMismatch(): never {
-  throw hostedOnboardingError({
-    code: "HOSTED_LINQ_PARTICIPANT_AUTHORITY_MISMATCH",
-    httpStatus: 403,
-    message: "Linq participant egress requires the participant target to match the runtime user.",
-    retryable: false,
   });
 }
 
@@ -245,7 +190,7 @@ function throwHostedLinqRouteAuthorityMismatch(): never {
   });
 }
 
-async function assertHostedLinqFirstContactEgressAuthority(input: {
+async function assertHostedLinqSignupWelcomeParticipantEgressAuthority(input: {
   directRecipientPhoneNumber?: string | null;
   fromPhoneNumber?: string | null;
   idempotencyKey?: string | null;
@@ -255,7 +200,7 @@ async function assertHostedLinqFirstContactEgressAuthority(input: {
   targetKind?: string | null;
 }): Promise<void> {
   if (!isHostedLinqSignupWelcomeFirstContact(input)) {
-    throwHostedLinqFirstContactEgressAuthorityMismatch();
+    throwHostedLinqParticipantEgressAuthorityMismatch();
   }
 
   const targetKind = normalizeNullable(input.targetKind);
@@ -266,13 +211,13 @@ async function assertHostedLinqFirstContactEgressAuthority(input: {
   );
   const fromPhoneNumber = normalizePhoneNumber(input.fromPhoneNumber);
   if (targetKind !== "participant" || !recipientPhone || !fromPhoneNumber) {
-    throwHostedLinqFirstContactEgressAuthorityMismatch();
+    throwHostedLinqParticipantEgressAuthorityMismatch();
   }
 
   const recipientPhoneLookupKeys = createHostedPhoneLookupKeyReadCandidates(recipientPhone);
   const fromPhoneLookupKeys = createHostedPhoneLookupKeyReadCandidates(fromPhoneNumber);
   if (recipientPhoneLookupKeys.length === 0 || fromPhoneLookupKeys.length === 0) {
-    throwHostedLinqFirstContactEgressAuthorityMismatch();
+    throwHostedLinqParticipantEgressAuthorityMismatch();
   }
 
   const [identity, routing] = await Promise.all([
@@ -292,15 +237,15 @@ async function assertHostedLinqFirstContactEgressAuthority(input: {
     || !routing?.linqRecipientPhoneLookupKey
     || !fromPhoneLookupKeys.includes(routing.linqRecipientPhoneLookupKey)
   ) {
-    throwHostedLinqFirstContactEgressAuthorityMismatch();
+    throwHostedLinqParticipantEgressAuthorityMismatch();
   }
 }
 
-function throwHostedLinqFirstContactEgressAuthorityMismatch(): never {
+function throwHostedLinqParticipantEgressAuthorityMismatch(): never {
   throw hostedOnboardingError({
-    code: "HOSTED_LINQ_FIRST_CONTACT_AUTHORITY_MISMATCH",
+    code: "HOSTED_LINQ_PARTICIPANT_AUTHORITY_MISMATCH",
     httpStatus: 403,
-    message: "Linq first-contact egress requires signup welcome authority for the runtime user.",
+    message: "Linq participant egress requires signup welcome authority for the runtime user.",
     retryable: false,
   });
 }
@@ -341,20 +286,10 @@ function normalizeHostedLinqRouteAuthorityForEgress(input: {
     return linqAuthority;
   }
   if (targetKind !== "thread" && targetKind !== "explicit") {
-    throw hostedOnboardingError({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
-      httpStatus: 403,
-      message: "Linq egress route authority can only authorize thread delivery.",
-      retryable: false,
-    });
+    return null;
   }
   if (!target || target !== linqAuthority.threadId) {
-    throw hostedOnboardingError({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
-      httpStatus: 403,
-      message: "Linq egress route authority does not match the requested thread.",
-      retryable: false,
-    });
+    return null;
   }
 
   return linqAuthority;

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -12,6 +12,9 @@ import {
 import {
   hostedOnboardingError,
 } from "./errors";
+import {
+  readActiveHostedMemberAccess,
+} from "./member-access";
 import { normalizePhoneNumber } from "./phone";
 
 type HostedLinqEngagementClient = PrismaClient | Prisma.TransactionClient;
@@ -95,6 +98,10 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
   }
 
   if (routeAuthority) {
+    await assertHostedLinqRouteAuthorityActiveAccess({
+      memberId: input.memberId,
+      prisma: input.prisma,
+    });
     return;
   }
 
@@ -186,6 +193,25 @@ function throwHostedLinqRouteAuthorityMismatch(): never {
     code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
     httpStatus: 403,
     message: "Linq egress target does not match the runtime user's Linq route.",
+    retryable: false,
+  });
+}
+
+async function assertHostedLinqRouteAuthorityActiveAccess(input: {
+  memberId: string;
+  prisma: HostedLinqEngagementClient;
+}): Promise<void> {
+  if (await readActiveHostedMemberAccess({
+    memberId: input.memberId,
+    prisma: input.prisma,
+  })) {
+    return;
+  }
+
+  throw hostedOnboardingError({
+    code: "HOSTED_LINQ_EGRESS_ACCESS_REQUIRED",
+    httpStatus: 403,
+    message: "Linq route-authority egress requires active hosted member access.",
     retryable: false,
   });
 }

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -1051,7 +1051,6 @@ describe("hosted Family plan", () => {
       memberId: "member_owner",
       pendingLinqChatIdEncrypted: null,
       pendingLinqChatLookupKey: null,
-      pendingLinqLastInboundAt: null,
       pendingLinqParticipantContactEncrypted: null,
       pendingLinqParticipantContactKind: null,
       pendingLinqParticipantContactLookupKey: null,

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -162,6 +162,7 @@ describe("hosted Linq egress authority", () => {
 
     expect(prisma.hostedThreadRoute.findMany).not.toHaveBeenCalled();
     expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
+    expect(prisma.hostedMember.findUnique).toHaveBeenCalled();
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       memberId: "member-1",
@@ -178,6 +179,32 @@ describe("hosted Linq egress authority", () => {
       code: "HOSTED_LINQ_EGRESS_BOUND_USER_MISMATCH",
       httpStatus: 403,
     });
+  });
+
+  it("rejects same-user route authority when hosted member access is inactive", async () => {
+    const prisma = createPrismaStub({
+      activeMemberAccess: false,
+    });
+
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      memberId: "member-1",
+      prisma: asRuntimeEngagementPrisma(prisma),
+      routeAuthority: {
+        accountLookupKey: "hbidx:phone:v1:line-1",
+        channel: "linq",
+        containerMemberId: "member-1",
+        threadId: "chat-authorized",
+      },
+      target: "chat-authorized",
+      targetKind: "thread",
+    })).rejects.toMatchObject({
+      code: "HOSTED_LINQ_EGRESS_ACCESS_REQUIRED",
+      httpStatus: 403,
+    });
+
+    expect(prisma.hostedThreadRoute.findMany).not.toHaveBeenCalled();
+    expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
+    expect(prisma.hostedMember.findUnique).toHaveBeenCalled();
   });
 
   it("falls back to the durable home route when same-user route authority is stale", async () => {
@@ -273,12 +300,23 @@ describe("hosted Linq egress authority", () => {
 });
 
 function createPrismaStub(input: {
+  activeMemberAccess?: boolean;
   homeChatId?: string;
   homeLinePhone?: string;
   identityPhone?: string;
   pendingChatId?: string;
 }) {
   return {
+    hostedMember: {
+      findUnique: vi.fn().mockResolvedValue(input.activeMemberAccess === false
+        ? null
+        : {
+            accountGroupMemberships: [],
+            billingStatus: "active",
+            suspendedAt: null,
+            threadContainer: null,
+          }),
+    },
     hostedMemberIdentity: {
       findUnique: vi.fn().mockResolvedValue({
         phoneLookupKey: createRequiredPhoneLookupKey(input.identityPhone),

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
-  readActiveHostedMemberAccess: vi.fn(),
   requireHostedCloudflareCallbackRequest: vi.fn(),
 }));
 
@@ -10,17 +9,6 @@ vi.mock("@/src/lib/hosted-execution/cloudflare-callback-auth", () => ({
   requireHostedCloudflareCallbackRequest:
     mocks.requireHostedCloudflareCallbackRequest,
 }));
-
-vi.mock("@/src/lib/hosted-onboarding/member-access", async (importOriginal) => {
-  const original = await importOriginal<
-    typeof import("@/src/lib/hosted-onboarding/member-access")
-  >();
-
-  return {
-    ...original,
-    readActiveHostedMemberAccess: mocks.readActiveHostedMemberAccess,
-  };
-});
 
 vi.mock("@/src/lib/prisma", () => ({
   getPrisma: mocks.getPrisma,
@@ -36,10 +24,9 @@ import {
 } from "@/src/lib/hosted-onboarding/linq-egress-engagement";
 import { POST as postHostedLinqEgressEngagement } from "../app/api/internal/hosted-runtime/linq-egress/engagement/route";
 
-describe("hosted Linq egress engagement", () => {
+describe("hosted Linq egress authority", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.readActiveHostedMemberAccess.mockResolvedValue(true);
     mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue("member-1");
   });
 
@@ -50,7 +37,6 @@ describe("hosted Linq egress engagement", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      engagementKind: "first_contact",
       fromPhoneNumber: "+15550100099",
       idempotencyKey: "signup-welcome:member-1",
       memberId: "member-1",
@@ -72,7 +58,6 @@ describe("hosted Linq egress engagement", () => {
 
   it("rejects first contact without signup-welcome authority", async () => {
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      engagementKind: "first_contact",
       fromPhoneNumber: "+15550100099",
       idempotencyKey: "signup-welcome:member-2",
       memberId: "member-1",
@@ -83,12 +68,12 @@ describe("hosted Linq egress engagement", () => {
       target: "+15550100001",
       targetKind: "participant",
     })).rejects.toMatchObject({
-      code: "HOSTED_LINQ_FIRST_CONTACT_AUTHORITY_MISMATCH",
+      code: "HOSTED_LINQ_PARTICIPANT_AUTHORITY_MISMATCH",
       httpStatus: 403,
     });
   });
 
-  it("allows participant replies only when participant identity and source line match", async () => {
+  it("rejects participant sends without signup-welcome idempotency even when identity and source line match", async () => {
     const prisma = createPrismaStub({
       identityPhone: "+15550100001",
       homeLinePhone: "+15550100099",
@@ -100,7 +85,10 @@ describe("hosted Linq egress engagement", () => {
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "+15550100001",
       targetKind: "participant",
-    })).resolves.toBeUndefined();
+    })).rejects.toMatchObject({
+      code: "HOSTED_LINQ_PARTICIPANT_AUTHORITY_MISMATCH",
+      httpStatus: 403,
+    });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       fromPhoneNumber: "+15550100100",
@@ -109,7 +97,7 @@ describe("hosted Linq egress engagement", () => {
       target: "+15550100001",
       targetKind: "participant",
     })).rejects.toMatchObject({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
+      code: "HOSTED_LINQ_PARTICIPANT_AUTHORITY_MISMATCH",
       httpStatus: 403,
     });
 
@@ -156,11 +144,8 @@ describe("hosted Linq egress engagement", () => {
     });
   });
 
-  it("preserves route-authority validation for bound external threads", async () => {
-    const prisma = createPrismaStub({
-      routeThreadId: "chat-authorized",
-      routeContainerMemberId: "member-1",
-    });
+  it("allows same-user route authority without a DB route assertion", async () => {
+    const prisma = createPrismaStub({});
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       memberId: "member-1",
@@ -175,17 +160,8 @@ describe("hosted Linq egress engagement", () => {
       targetKind: "thread",
     })).resolves.toBeUndefined();
 
-    expect(prisma.hostedThreadRoute.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          channel: "linq",
-        }),
-      }),
-    );
-    expect(mocks.readActiveHostedMemberAccess).toHaveBeenCalledWith({
-      memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-    });
+    expect(prisma.hostedThreadRoute.findMany).not.toHaveBeenCalled();
+    expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       memberId: "member-1",
@@ -201,6 +177,36 @@ describe("hosted Linq egress engagement", () => {
     })).rejects.toMatchObject({
       code: "HOSTED_LINQ_EGRESS_BOUND_USER_MISMATCH",
       httpStatus: 403,
+    });
+  });
+
+  it("falls back to the durable home route when same-user route authority is stale", async () => {
+    const prisma = createPrismaStub({
+      homeChatId: "chat-home",
+    });
+
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      memberId: "member-1",
+      prisma: asRuntimeEngagementPrisma(prisma),
+      routeAuthority: {
+        accountLookupKey: "hbidx:phone:v1:line-1",
+        channel: "linq",
+        containerMemberId: "member-1",
+        threadId: "chat-stale",
+      },
+      target: "chat-home",
+      targetKind: "thread",
+    })).resolves.toBeUndefined();
+
+    expect(prisma.hostedThreadRoute.findMany).not.toHaveBeenCalled();
+    expect(prisma.hostedMemberRouting.findUnique).toHaveBeenCalledWith({
+      select: {
+        linqChatLookupKey: true,
+        linqRecipientPhoneLookupKey: true,
+        pendingLinqChatLookupKey: true,
+        pendingLinqRecipientPhoneLookupKey: true,
+      },
+      where: { memberId: "member-1" },
     });
   });
 
@@ -232,7 +238,7 @@ describe("hosted Linq egress engagement", () => {
     })).toThrow(/Linq egress route authority/u);
   });
 
-  it("accepts old-runner currentInbound payloads for external thread engagement assertions", async () => {
+  it("accepts old-runner currentInbound payloads for external thread egress authority", async () => {
     const prisma = createPrismaStub({
       homeChatId: "chat-home",
     });
@@ -249,7 +255,6 @@ describe("hosted Linq egress engagement", () => {
             replyToMessageId: "message_external",
             target: "chat-external",
           },
-          engagementKind: "requires_recent_inbound",
           target: "chat-external",
           targetKind: "thread",
         }),
@@ -272,8 +277,6 @@ function createPrismaStub(input: {
   homeLinePhone?: string;
   identityPhone?: string;
   pendingChatId?: string;
-  routeContainerMemberId?: string;
-  routeThreadId?: string;
 }) {
   return {
     hostedMemberIdentity: {
@@ -290,11 +293,7 @@ function createPrismaStub(input: {
       }),
     },
     hostedThreadRoute: {
-      findMany: vi.fn().mockResolvedValue(input.routeThreadId
-        ? [buildThreadRouteRow({
-            containerMemberId: input.routeContainerMemberId ?? "member-1",
-          })]
-        : []),
+      findMany: vi.fn().mockResolvedValue([]),
     },
   };
 }
@@ -325,29 +324,4 @@ function createRequiredLinqChatLookupKey(value: string | undefined): string | nu
     throw new Error("Expected Linq chat lookup key.");
   }
   return lookupKey;
-}
-
-function buildThreadRouteRow(input: {
-  containerMemberId: string;
-}) {
-  return {
-    channel: "linq",
-    container: {
-      member: buildMemberAccessRecord(input.containerMemberId),
-      owner: buildMemberAccessRecord("owner-1"),
-    },
-    containerMemberId: input.containerMemberId,
-  };
-}
-
-function buildMemberAccessRecord(id: string) {
-  return {
-    accountGroupMemberships: [],
-    billingStatus: "active",
-    createdAt: new Date("2026-06-01T12:00:00.000Z"),
-    id,
-    suspendedAt: null,
-    threadContainer: null,
-    updatedAt: new Date("2026-06-01T12:00:00.000Z"),
-  };
 }

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -1328,7 +1328,6 @@ function buildAuthorizedLinqRouteFixture(input: {
               owner: memberAccessState,
             },
             containerMemberId: input.memberId,
-            lastInboundAt: new Date("2026-03-26T11:59:00.000Z"),
             threadLookupKey,
           },
         ]),

--- a/apps/web/test/hosted-onboarding-member-store.test.ts
+++ b/apps/web/test/hosted-onboarding-member-store.test.ts
@@ -1179,7 +1179,7 @@ describe("hosted-member-store", () => {
     });
   });
 
-  it("does not promote pending Linq inbound freshness when pending chat binding becomes home", async () => {
+  it("clears pending Linq route state when pending chat binding becomes home", async () => {
     const executeRaw = vi.fn().mockResolvedValue(0);
     const updateMany = vi.fn().mockResolvedValue({ count: 0 });
     const pendingLinqChatLookupKey = createHostedLinqChatLookupKeyReadCandidates("chat_123")[0];
@@ -1214,12 +1214,10 @@ describe("hosted-member-store", () => {
       pendingLinqChatIdEncrypted: null,
       pendingLinqChatLookupKey: null,
     }));
-    expect(upsertUpdate).not.toHaveProperty("linqLastInboundAt");
-    expect(upsertUpdate).not.toHaveProperty("pendingLinqLastInboundAt");
     expect(updateMany).toHaveBeenCalledTimes(2);
   });
 
-  it("does not write Linq inbound freshness when a different pending chat becomes home", async () => {
+  it("clears pending Linq route state when a different pending chat becomes home", async () => {
     const executeRaw = vi.fn().mockResolvedValue(0);
     const updateMany = vi.fn().mockResolvedValue({ count: 0 });
     const findUnique = vi.fn().mockResolvedValue({
@@ -1252,13 +1250,11 @@ describe("hosted-member-store", () => {
       linqChatLookupKey: createHostedLinqChatLookupKeyReadCandidates("chat_c")[0],
       pendingLinqChatLookupKey: null,
     }));
-    expect(upsertUpdate).not.toHaveProperty("linqLastInboundAt");
-    expect(upsertUpdate).not.toHaveProperty("pendingLinqLastInboundAt");
     expect(findUnique).not.toHaveBeenCalled();
     expect(updateMany).toHaveBeenCalledTimes(2);
   });
 
-  it("does not write pending Linq inbound freshness when pending chat binding is rewritten", async () => {
+  it("rewrites pending Linq chat binding without reading prior route state", async () => {
     const executeRaw = vi.fn().mockResolvedValue(0);
     const updateMany = vi.fn().mockResolvedValue({ count: 0 });
     const findUnique = vi.fn().mockResolvedValue({
@@ -1287,7 +1283,6 @@ describe("hosted-member-store", () => {
         pendingLinqChatLookupKey: createHostedLinqChatLookupKeyReadCandidates("chat_new")[0],
       }),
     }));
-    expect(upsert.mock.calls[0]?.[0]?.update).not.toHaveProperty("pendingLinqLastInboundAt");
     expect(findUnique).not.toHaveBeenCalled();
   });
 
@@ -1575,8 +1570,6 @@ describe("hosted-member-store", () => {
       pendingLinqChatLookupKey: null,
       pendingLinqRecipientPhoneLookupKey: null,
     }));
-    expect(upsertUpdate).not.toHaveProperty("linqLastInboundAt");
-    expect(upsertUpdate).not.toHaveProperty("pendingLinqLastInboundAt");
     expect(findUnique).not.toHaveBeenCalled();
     expect(updateMany).not.toHaveBeenCalled();
   });

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -80,7 +80,6 @@ const HOSTED_MEMBER_SCHEMA_GUARD = {
     'linqRecipientPhoneLookupKey String? @map("linq_recipient_phone_lookup_key")',
     'linqRecipientPhoneEncrypted String? @map("linq_recipient_phone_encrypted")',
     'linqHomeLineAssignedAt DateTime? @map("linq_home_line_assigned_at")',
-    'linqLastInboundAt DateTime? @map("linq_last_inbound_at")',
     'pendingLinqChatLookupKey String? @unique @map("pending_linq_chat_lookup_key")',
     'pendingLinqChatIdEncrypted String? @map("pending_linq_chat_id_encrypted")',
     'pendingLinqParticipantContactKind String? @map("pending_linq_participant_contact_kind")',
@@ -89,7 +88,6 @@ const HOSTED_MEMBER_SCHEMA_GUARD = {
     'pendingLinqParticipantContactObservedAt DateTime? @map("pending_linq_participant_contact_observed_at")',
     'pendingLinqRecipientPhoneLookupKey String? @map("pending_linq_recipient_phone_lookup_key")',
     'pendingLinqRecipientPhoneEncrypted String? @map("pending_linq_recipient_phone_encrypted")',
-    'pendingLinqLastInboundAt DateTime? @map("pending_linq_last_inbound_at")',
     'replyAliasLookupKey String? @unique @map("reply_alias_lookup_key")',
     'telegramUserLookupKey String? @unique @map("telegram_user_lookup_key")',
     'telegramUserIdEncrypted String? @map("telegram_user_id_encrypted")',
@@ -524,6 +522,13 @@ describe("hosted Prisma baseline migration", () => {
       ),
       "utf8",
     );
+    const staleLinqRecencyDropMigrationSql = readFileSync(
+      new URL(
+        "../prisma/migrations/20260707170000_drop_stale_linq_recency_columns/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     expect(migrationEntries).toEqual([
       "2026040600_init",
       "20260425000000_drop_legacy_linq_control_plane",
@@ -606,6 +611,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260706120000_hosted_thread_container_participant",
       "20260706130000_hosted_group_join_offer",
       "20260706130000_hosted_growth_daily_snapshot",
+      "20260707170000_drop_stale_linq_recency_columns",
       "migration_lock.toml",
     ]);
     expect(hostedThreadRoutesMigrationSql).toContain('CREATE TABLE "hosted_thread_container"');
@@ -751,6 +757,24 @@ describe("hosted Prisma baseline migration", () => {
     );
     expect(hostedLinqEgressEngagementMigrationSql).not.toContain(
       'SET "last_inbound_at" = CURRENT_TIMESTAMP',
+    );
+    expect(staleLinqRecencyDropMigrationSql).toContain(
+      'DROP INDEX IF EXISTS "hosted_member_routing_linq_last_inbound_at_idx"',
+    );
+    expect(staleLinqRecencyDropMigrationSql).toContain(
+      'DROP INDEX IF EXISTS "hosted_member_routing_pending_linq_last_inbound_at_idx"',
+    );
+    expect(staleLinqRecencyDropMigrationSql).toContain(
+      'DROP INDEX IF EXISTS "hosted_thread_route_channel_last_inbound_at_idx"',
+    );
+    expect(staleLinqRecencyDropMigrationSql).toContain(
+      'DROP COLUMN IF EXISTS "linq_last_inbound_at"',
+    );
+    expect(staleLinqRecencyDropMigrationSql).toContain(
+      'DROP COLUMN IF EXISTS "pending_linq_last_inbound_at"',
+    );
+    expect(staleLinqRecencyDropMigrationSql).toContain(
+      'DROP COLUMN IF EXISTS "last_inbound_at"',
     );
     expect(hostedLinqObservabilityMigrationSql).toContain('"skipped_at" TIMESTAMP(3)');
     expect(hostedLinqObservabilityMigrationSql).toContain('"skip_reason" TEXT');

--- a/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
@@ -498,7 +498,6 @@ describe("handleHostedOnboardingTelegramWebhook", () => {
             memberId: acceptedMemberId,
             pendingLinqChatIdEncrypted: null,
             pendingLinqChatLookupKey: null,
-            pendingLinqLastInboundAt: null,
             pendingLinqParticipantContactEncrypted: null,
             pendingLinqParticipantContactKind: null,
             pendingLinqParticipantContactLookupKey: null,

--- a/apps/web/test/hosted-runtime-linq-delivery-route.test.ts
+++ b/apps/web/test/hosted-runtime-linq-delivery-route.test.ts
@@ -5,7 +5,6 @@ import {
 } from "@/src/lib/hosted-onboarding/contact-privacy";
 
 const mocks = vi.hoisted(() => ({
-  assertHostedThreadRouteEgressAuthority: vi.fn(),
   getPrisma: vi.fn(),
   recordHostedLinqRuntimeDeliveryOutcomeTx: vi.fn(),
   requireHostedCloudflareCallbackRequest: vi.fn(),
@@ -17,10 +16,6 @@ vi.mock("@/src/lib/hosted-execution/cloudflare-callback-auth", () => ({
 
 vi.mock("@/src/lib/hosted-onboarding/linq-delivery-store", () => ({
   recordHostedLinqRuntimeDeliveryOutcomeTx: mocks.recordHostedLinqRuntimeDeliveryOutcomeTx,
-}));
-
-vi.mock("@/src/lib/hosted-routing/thread-route-store", () => ({
-  assertHostedThreadRouteEgressAuthority: mocks.assertHostedThreadRouteEgressAuthority,
 }));
 
 vi.mock("@/src/lib/prisma", () => ({
@@ -169,14 +164,13 @@ describe("hosted runtime Linq delivery route", () => {
     );
   });
 
-  it("uses route authority for routed sends and rejects authority for a different user", async () => {
+  it("uses route authority line attribution and rejects authority for a different user", async () => {
     const routeAuthority = {
       accountLookupKey: "hbidx:phone:v1:account",
       channel: "linq",
       containerMemberId: "member_123",
       threadId: "linq_chat_123",
     };
-    mocks.assertHostedThreadRouteEgressAuthority.mockResolvedValueOnce({});
 
     const response = await route.POST(buildDeliveryRequest({
       acceptedAt: "2026-04-26T00:00:04.000Z",
@@ -191,10 +185,7 @@ describe("hosted runtime Linq delivery route", () => {
     }));
 
     expect(response.status).toBe(200);
-    expect(mocks.assertHostedThreadRouteEgressAuthority).toHaveBeenCalledWith({
-      authority: routeAuthority,
-      prisma,
-    });
+    expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
     expect(mocks.recordHostedLinqRuntimeDeliveryOutcomeTx).toHaveBeenCalledWith(
       expect.objectContaining({
         phoneNumber: null,
@@ -238,7 +229,6 @@ describe("hosted runtime Linq delivery route", () => {
       containerMemberId: "member_123",
       threadId: "linq_chat_123",
     };
-    mocks.assertHostedThreadRouteEgressAuthority.mockResolvedValueOnce({});
 
     const response = await route.POST(buildDeliveryRequest({
       acceptedAt: "2026-04-26T00:00:04.000Z",
@@ -252,10 +242,7 @@ describe("hosted runtime Linq delivery route", () => {
     }));
 
     expect(response.status).toBe(200);
-    expect(mocks.assertHostedThreadRouteEgressAuthority).toHaveBeenCalledWith({
-      authority: routeAuthority,
-      prisma,
-    });
+    expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
     expect(mocks.recordHostedLinqRuntimeDeliveryOutcomeTx).toHaveBeenCalledWith(
       expect.objectContaining({
         phoneNumber: null,

--- a/apps/web/test/support/hosted-member-seeds.ts
+++ b/apps/web/test/support/hosted-member-seeds.ts
@@ -35,6 +35,10 @@ const hostedLinqLineStoreModuleSpecifier = new URL(
   "../../src/lib/hosted-onboarding/linq-line-store.ts",
   import.meta.url,
 ).href;
+const hostedLinqDailyStateModuleSpecifier = new URL(
+  "../../src/lib/hosted-onboarding/linq-daily-state.ts",
+  import.meta.url,
+).href;
 const hostedCryptoDomainRootStoreModuleSpecifier = new URL(
   "../../src/lib/hosted-crypto/domain-root-store.ts",
   import.meta.url,
@@ -135,15 +139,6 @@ interface HostedMemberSeedPrismaClient {
   $transaction<T>(callback: (tx: unknown) => Promise<T>): Promise<T>;
 }
 
-interface HostedMemberSeedRoutingTx {
-  hostedMemberRouting: {
-    updateMany(input: {
-      data: { linqLastInboundAt: Date };
-      where: { memberId: string };
-    }): Promise<unknown>;
-  };
-}
-
 interface HostedMemberSeedPrismaModule {
   createPrismaClient(input: {
     databaseUrl: string;
@@ -235,6 +230,14 @@ interface HostedLinqLineStoreModule {
   }): Promise<unknown>;
 }
 
+interface HostedLinqDailyStateModule {
+  incrementHostedLinqInboundDailyState(input: {
+    memberId: string;
+    occurredAt: Date | string;
+    prisma: unknown;
+  }): Promise<unknown>;
+}
+
 interface HostedDeviceSyncControlPlaneStore {
   upsertConnection(input: {
     connectedAt: string;
@@ -295,6 +298,8 @@ interface HostedMemberSeedModules {
   upsertHostedMemberTelegramRoutingBindingTx:
     HostedMemberRoutingStoreModule["upsertHostedMemberTelegramRoutingBindingTx"];
   upsertHostedMemberIdentity: HostedMemberIdentityStoreModule["upsertHostedMemberIdentity"];
+  incrementHostedLinqInboundDailyState:
+    HostedLinqDailyStateModule["incrementHostedLinqInboundDailyState"];
   upsertHostedLinqLineForPhoneTx:
     HostedLinqLineStoreModule["upsertHostedLinqLineForPhoneTx"];
   writeHostedMemberStripeBillingRefTx:
@@ -422,8 +427,9 @@ export async function seedHostedActiveLinqMember(
           ? null
           : normalizeHostedMemberSeedDate(input.recentInboundAt);
         if (recentInboundAt) {
-          await updateHostedMemberSeedLinqLastInboundAtTx({
+          await seedHostedMemberLinqRecentInboundAtTx({
             memberId: input.memberId,
+            modules,
             tx,
             value: recentInboundAt,
           });
@@ -435,38 +441,17 @@ export async function seedHostedActiveLinqMember(
   });
 }
 
-async function updateHostedMemberSeedLinqLastInboundAtTx(input: {
+async function seedHostedMemberLinqRecentInboundAtTx(input: {
   memberId: string;
+  modules: HostedMemberSeedModules;
   tx: unknown;
   value: Date;
 }): Promise<void> {
-  const prisma = requireHostedMemberSeedRoutingTx(input.tx);
-  await prisma.hostedMemberRouting.updateMany({
-    where: {
-      memberId: input.memberId,
-    },
-    data: {
-      linqLastInboundAt: input.value,
-    },
+  await input.modules.incrementHostedLinqInboundDailyState({
+    memberId: input.memberId,
+    occurredAt: input.value,
+    prisma: input.tx,
   });
-}
-
-function requireHostedMemberSeedRoutingTx(value: unknown): HostedMemberSeedRoutingTx {
-  if (isHostedMemberSeedRoutingTx(value)) {
-    return value;
-  }
-
-  throw new Error("Hosted member Linq seed requires Prisma hostedMemberRouting access.");
-}
-
-function isHostedMemberSeedRoutingTx(value: unknown): value is HostedMemberSeedRoutingTx {
-  return typeof value === "object"
-    && value !== null
-    && "hostedMemberRouting" in value
-    && typeof value.hostedMemberRouting === "object"
-    && value.hostedMemberRouting !== null
-    && "updateMany" in value.hostedMemberRouting
-    && typeof value.hostedMemberRouting.updateMany === "function";
 }
 
 function normalizeHostedMemberSeedDate(value: Date | string | null | undefined): Date | null {
@@ -513,8 +498,9 @@ export async function bindHostedActiveLinqHomeChat(input: {
           ? null
           : normalizeHostedMemberSeedDate(input.recentInboundAt);
         if (recentInboundAt) {
-          await updateHostedMemberSeedLinqLastInboundAtTx({
+          await seedHostedMemberLinqRecentInboundAtTx({
             memberId: input.memberId,
+            modules,
             tx,
             value: recentInboundAt,
           });
@@ -790,6 +776,7 @@ async function loadHostedMemberSeedModules(
     hostedMemberRoutingStoreModule,
     hostedMemberStoreModule,
     hostedMemberBillingStoreModule,
+    hostedLinqDailyStateModule,
     hostedLinqLineStoreModule,
   ] = await Promise.all([
     import(prismaModuleSpecifier),
@@ -799,6 +786,7 @@ async function loadHostedMemberSeedModules(
     import(hostedMemberRoutingStoreModuleSpecifier),
     import(hostedMemberStoreModuleSpecifier),
     import(hostedMemberBillingStoreModuleSpecifier),
+    import(hostedLinqDailyStateModuleSpecifier),
     import(hostedLinqLineStoreModuleSpecifier),
   ]);
 
@@ -817,6 +805,8 @@ async function loadHostedMemberSeedModules(
   const typedHostedMemberStoreModule = hostedMemberStoreModule as HostedMemberStoreModule;
   const typedHostedMemberBillingStoreModule =
     hostedMemberBillingStoreModule as HostedMemberBillingStoreModule;
+  const typedHostedLinqDailyStateModule =
+    hostedLinqDailyStateModule as HostedLinqDailyStateModule;
   const typedHostedLinqLineStoreModule =
     hostedLinqLineStoreModule as HostedLinqLineStoreModule;
 
@@ -834,6 +824,8 @@ async function loadHostedMemberSeedModules(
     upsertHostedMemberTelegramRoutingBindingTx:
       typedHostedMemberRoutingStoreModule.upsertHostedMemberTelegramRoutingBindingTx,
     upsertHostedMemberIdentity: typedHostedMemberIdentityStoreModule.upsertHostedMemberIdentity,
+    incrementHostedLinqInboundDailyState:
+      typedHostedLinqDailyStateModule.incrementHostedLinqInboundDailyState,
     upsertHostedLinqLineForPhoneTx:
       typedHostedLinqLineStoreModule.upsertHostedLinqLineForPhoneTx,
     writeHostedMemberStripeBillingRefTx:

--- a/packages/assistant-runtime/src/hosted-runtime-contracts.ts
+++ b/packages/assistant-runtime/src/hosted-runtime-contracts.ts
@@ -26,7 +26,6 @@ export type {
   HostedRuntimeIssueRecordResponse,
   HostedRuntimeLinqChatActionRequest,
   HostedRuntimeLinqDeleteMessagesRequest,
-  HostedRuntimeLinqEngagementKind,
   HostedRuntimeLinqMarkReadRequest,
   HostedRuntimeLinqSendRequest,
   HostedRuntimeLinqSendResponse,

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -73,7 +73,6 @@ import type {
   HostedRuntimeActionApprovalPort,
   HostedRuntimeEffectsPort,
   HostedRuntimeLinqDeliveryOutcomeRequest,
-  HostedRuntimeLinqEngagementKind,
   HostedRuntimeLinqSendResponse,
   HostedRuntimePlatform,
   HostedRuntimeProviderTargetKind,
@@ -2853,7 +2852,7 @@ async function assertHostedAssistantLinqRecentInboundEngagementForDelivery(input
   if (!assertRecentInbound) {
     throw new VaultCliError(
       "ASSISTANT_LINQ_ENGAGEMENT_ASSERT_UNAVAILABLE",
-      "Hosted Linq delivery requires recent-recipient-engagement assertion before provider dispatch.",
+      "Hosted Linq delivery requires an egress authority assertion before provider dispatch.",
       { retryable: true },
     );
   }
@@ -2863,10 +2862,6 @@ async function assertHostedAssistantLinqRecentInboundEngagementForDelivery(input
   await assertRecentInbound({
     ...(currentInbound ? { currentInbound } : {}),
     directRecipientPhoneNumber: input.directRecipientPhoneNumber,
-    engagementKind: readHostedAssistantLinqEngagementKind({
-      idempotencyKey: input.idempotencyKey,
-      targetKind,
-    }),
     fromPhoneNumber: input.fromPhoneNumber,
     idempotencyKey: input.idempotencyKey,
     intentId: input.intentId,
@@ -2922,16 +2917,6 @@ function normalizeHostedAssistantLinqTargetKind(
   return targetKind === "explicit" || targetKind === "participant" || targetKind === "thread"
     ? targetKind
     : null;
-}
-
-function readHostedAssistantLinqEngagementKind(input: {
-  idempotencyKey: string | null,
-  targetKind: HostedRuntimeProviderTargetKind | null,
-}): HostedRuntimeLinqEngagementKind {
-  return input.targetKind === "participant"
-    && isHostedSignupWelcomeDeliveryIdempotencyKey(input.idempotencyKey)
-    ? "first_contact"
-    : "requires_recent_inbound";
 }
 
 function normalizeHostedLinqDirectRecipient(value: string | null | undefined): string | null {

--- a/packages/assistant-runtime/src/hosted-runtime/channel-activity.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/channel-activity.ts
@@ -12,9 +12,6 @@ import {
 import {
   requireHostedProviderFetchDependencies,
 } from "./provider-fetch.ts";
-import type {
-  HostedRuntimeEffectsPort,
-} from "./platform.ts";
 import {
   resolveHostedAssistantLinqDeliveryContextFromCandidatesForRequest,
   type HostedAssistantLinqDeliveryContext,
@@ -31,6 +28,18 @@ const HOSTED_WHATSAPP_CHANNEL_ENV_KEYS = [
   "WHATSAPP_GRAPH_VERSION",
   "WHATSAPP_PHONE_NUMBER_ID",
 ] as const;
+
+const HOSTED_LINQ_TYPING_MAX_SESSION_MS = 5 * 60_000;
+const HOSTED_LINQ_TYPING_REFRESH_MS = 45_000;
+const HOSTED_LINQ_TYPING_RESTART_COOLDOWN_MS = 10 * 60_000;
+
+type HostedLinqTypingTargetState = {
+  activeUntilMs: number;
+  cooldownUntilMs: number;
+};
+
+const hostedLinqTypingTargets = new Map<string, HostedLinqTypingTargetState>();
+
 export function buildHostedLinqChannelEnv(input: {
   forwardedEnv: Readonly<Record<string, string>>;
   userEnv: Readonly<Record<string, string>>;
@@ -97,7 +106,6 @@ export function buildHostedWhatsAppChannelEnv(input: {
 }
 
 export function createHostedAssistantChannelTypingDependencies(input: {
-  effectsPort?: Pick<HostedRuntimeEffectsPort, "assertLinqRecentInboundEngagement"> | null;
   forwardedEnv: Readonly<Record<string, string>>;
   linqDeliveryContexts?: readonly HostedAssistantLinqDeliveryContext[] | null;
   platformEnv?: Readonly<Record<string, string>>;
@@ -120,27 +128,9 @@ export function createHostedAssistantChannelTypingDependencies(input: {
       if (!input.providerFetch) {
         return undefined;
       }
-      const assertRecentInbound = input.effectsPort?.assertLinqRecentInboundEngagement;
-      if (!assertRecentInbound) {
-        return undefined;
-      }
       const target = deliveryContext?.target ?? request.target;
-      const currentInbound = deliveryContext?.currentInbound ?? null;
-      try {
-        await assertRecentInbound({
-          ...(currentInbound ? { currentInbound } : {}),
-          directRecipientPhoneNumber: deliveryContext?.directRecipientPhoneNumber ?? null,
-          engagementKind: "requires_recent_inbound",
-          fromPhoneNumber: deliveryContext?.fromPhoneNumber ?? null,
-          idempotencyKey: null,
-          intentId: null,
-          routeAuthority: deliveryContext?.routeAuthority ?? null,
-          target,
-          targetKind: "thread",
-        }, {
-          signal: input.signal ?? null,
-        });
-      } catch {
+      const typingTarget = claimHostedLinqTypingTarget(target);
+      if (!typingTarget) {
         return undefined;
       }
 
@@ -152,9 +142,30 @@ export function createHostedAssistantChannelTypingDependencies(input: {
         fetchImplementation: input.providerFetch,
         signal: input.signal,
       }, "Hosted Linq typing indicator");
-      return startLinqTypingIndicator({
-        target,
-      }, dependencies);
+      try {
+        const handle = await startLinqTypingIndicator({
+          target,
+        }, {
+          ...dependencies,
+          maxSessionMs: HOSTED_LINQ_TYPING_MAX_SESSION_MS,
+          refreshMs: HOSTED_LINQ_TYPING_REFRESH_MS,
+        });
+        if (!handle) {
+          releaseHostedLinqTypingTarget(typingTarget, {
+            completedMaxSession: false,
+          });
+          return undefined;
+        }
+        return wrapHostedLinqTypingHandle({
+          handle,
+          target: typingTarget,
+        });
+      } catch (error) {
+        releaseHostedLinqTypingTarget(typingTarget, {
+          completedMaxSession: false,
+        });
+        throw error;
+      }
     },
     startTelegramTyping: async (request) => {
       const dependencies = requireHostedProviderFetchDependencies({
@@ -168,6 +179,66 @@ export function createHostedAssistantChannelTypingDependencies(input: {
       return startTelegramTypingIndicator(request, dependencies);
     },
   };
+}
+
+function claimHostedLinqTypingTarget(target: string): string | null {
+  const normalized = target.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const now = Date.now();
+  for (const [key, state] of hostedLinqTypingTargets) {
+    if (state.activeUntilMs <= now && state.cooldownUntilMs <= now) {
+      hostedLinqTypingTargets.delete(key);
+    }
+  }
+
+  const existing = hostedLinqTypingTargets.get(normalized);
+  if (existing && (existing.activeUntilMs > now || existing.cooldownUntilMs > now)) {
+    return null;
+  }
+
+  hostedLinqTypingTargets.set(normalized, {
+    activeUntilMs: now + HOSTED_LINQ_TYPING_MAX_SESSION_MS,
+    cooldownUntilMs: now + HOSTED_LINQ_TYPING_MAX_SESSION_MS
+      + HOSTED_LINQ_TYPING_RESTART_COOLDOWN_MS,
+  });
+  return normalized;
+}
+
+function wrapHostedLinqTypingHandle(input: {
+  handle: NonNullable<Awaited<ReturnType<typeof startLinqTypingIndicator>>>;
+  target: string;
+}): NonNullable<Awaited<ReturnType<typeof startLinqTypingIndicator>>> {
+  return {
+    ...input.handle,
+    stop: async (options) => {
+      const state = hostedLinqTypingTargets.get(input.target);
+      const completedMaxSession = Boolean(state && Date.now() >= state.activeUntilMs);
+      try {
+        await input.handle.stop(options);
+      } finally {
+        releaseHostedLinqTypingTarget(input.target, {
+          completedMaxSession,
+        });
+      }
+    },
+  };
+}
+
+function releaseHostedLinqTypingTarget(input: string, options: {
+  completedMaxSession: boolean;
+}): void {
+  if (!options.completedMaxSession) {
+    hostedLinqTypingTargets.delete(input);
+    return;
+  }
+
+  hostedLinqTypingTargets.set(input, {
+    activeUntilMs: Date.now(),
+    cooldownUntilMs: Date.now() + HOSTED_LINQ_TYPING_RESTART_COOLDOWN_MS,
+  });
 }
 
 function pickHostedChannelEnv(

--- a/packages/assistant-runtime/src/hosted-runtime/channel-activity.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/channel-activity.ts
@@ -122,13 +122,16 @@ export function createHostedAssistantChannelTypingDependencies(input: {
         target: request.target,
         targetKind: "thread",
       });
-      if (!deliveryContext && linqDeliveryContexts.length > 0) {
+      if (!deliveryContext) {
         return undefined;
       }
       if (!input.providerFetch) {
         return undefined;
       }
-      const target = deliveryContext?.target ?? request.target;
+      const target = deliveryContext.target?.trim() ?? "";
+      if (!target) {
+        return undefined;
+      }
       const typingTarget = claimHostedLinqTypingTarget(target);
       if (!typingTarget) {
         return undefined;

--- a/packages/assistant-runtime/src/hosted-runtime/platform.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/platform.ts
@@ -190,10 +190,6 @@ export interface HostedRuntimeLinqSendResponse {
   targetKind?: HostedRuntimeProviderTargetKind | null;
 }
 
-export type HostedRuntimeLinqEngagementKind =
-  | "first_contact"
-  | "requires_recent_inbound";
-
 export interface HostedRuntimeLinqCurrentInboundProof {
   dedupeKey: string;
   eventId: string;
@@ -206,7 +202,6 @@ export interface HostedRuntimeLinqCurrentInboundProof {
 export interface HostedRuntimeLinqRecentInboundEngagementRequest {
   currentInbound?: HostedRuntimeLinqCurrentInboundProof | null;
   directRecipientPhoneNumber?: string | null;
-  engagementKind?: HostedRuntimeLinqEngagementKind | null;
   fromPhoneNumber?: string | null;
   idempotencyKey?: string | null;
   intentId?: string | null;

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -389,7 +389,6 @@ function buildHostedSystemMailboxExecutionContext(input: {
   return {
     hosted: {
       channelTypingDependencies: createHostedAssistantChannelTypingDependencies({
-        effectsPort: input.runtime.platform.effectsPort,
         forwardedEnv: input.runtime.forwardedEnv,
         platformEnv: input.runtime.platformEnv,
         providerFetch: input.runtime.platform.providerFetch ?? null,

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -536,7 +536,6 @@ export async function runHostedWorkspaceAssistantPhase(
           wake,
         }),
         channelTypingDependencies: createHostedAssistantChannelTypingDependencies({
-          effectsPort: input.runtime.platform.effectsPort,
           forwardedEnv: input.runtime.forwardedEnv,
           linqDeliveryContexts: initialLinqDeliveryContexts,
           platformEnv: input.runtime.platformEnv,

--- a/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
@@ -5661,7 +5661,7 @@ describe("hosted runtime callbacks", () => {
         targetMessageId: "linq_message_1",
       });
 
-      throw new Error("unreachable after engagement assertion failure");
+      throw new Error("unreachable after egress authority failure");
     });
 
     await expect(drainHostedPreparedAssistantDeliveries({
@@ -5685,7 +5685,7 @@ describe("hosted runtime callbacks", () => {
     expect(mocks.setLinqMessageReaction).not.toHaveBeenCalled();
   });
 
-  it("blocks Linq reactions when recent inbound engagement is missing", async () => {
+  it("blocks Linq reactions when egress authority is rejected", async () => {
     const effect = createEffect({
       channel: "linq",
       bindingDeliveryTarget: "linq_chat_123",
@@ -5703,7 +5703,7 @@ describe("hosted runtime callbacks", () => {
         targetMessageId: "linq_message_1",
       });
 
-      throw new Error("unreachable after engagement assertion failure");
+      throw new Error("unreachable after egress authority failure");
     });
 
     await expect(drainHostedPreparedAssistantDeliveries({
@@ -5722,7 +5722,6 @@ describe("hosted runtime callbacks", () => {
 
     expect(assertRecentInbound).toHaveBeenCalledWith(
       expect.objectContaining({
-        engagementKind: "requires_recent_inbound",
         idempotencyKey: "assistant-outbox:intent_123",
         intentId: "intent_123",
         target: "linq_chat_123",
@@ -5735,7 +5734,7 @@ describe("hosted runtime callbacks", () => {
     expect(mocks.setLinqMessageReaction).not.toHaveBeenCalled();
   });
 
-  it("marks signup welcome Linq sends as first-contact engagement", async () => {
+  it("sends signup welcome Linq egress authority with participant context", async () => {
     const effect = createEffect({
       actorId: "ain_blinded_member_phone",
       answeredMailboxItemIds: ["mailbox_item_answered_1", "mailbox_item_answered_2"],
@@ -5796,7 +5795,6 @@ describe("hosted runtime callbacks", () => {
     expect(assertRecentInbound).toHaveBeenCalledWith(
       expect.objectContaining({
         directRecipientPhoneNumber: null,
-        engagementKind: "first_contact",
         fromPhoneNumber: "+15550100099",
         idempotencyKey: "signup-welcome:member_123",
         target: "+15550100001",
@@ -6307,7 +6305,7 @@ describe("hosted runtime callbacks", () => {
     expect(recordedOutcome).not.toContain("private reply text");
   });
 
-  it("requires recent inbound proof for signup welcome Linq sends into existing threads", async () => {
+  it("checks egress authority for signup welcome Linq sends into existing threads", async () => {
     const effect = createEffect({
       actorId: "ain_blinded_member_phone",
       bindingDeliveryTarget: "linq_chat_123",
@@ -6364,7 +6362,6 @@ describe("hosted runtime callbacks", () => {
     expect(assertRecentInbound).toHaveBeenCalledWith(
       expect.objectContaining({
         directRecipientPhoneNumber: null,
-        engagementKind: "requires_recent_inbound",
         fromPhoneNumber: "+15550100099",
         idempotencyKey: "signup-welcome:member_123",
         target: "linq_chat_123",
@@ -6460,7 +6457,6 @@ describe("hosted runtime callbacks", () => {
 
     expect(assertRecentInbound).toHaveBeenCalledWith({
       directRecipientPhoneNumber: null,
-      engagementKind: "requires_recent_inbound",
       fromPhoneNumber: null,
       idempotencyKey: "assistant-outbox:intent_123",
       intentId: "intent_123",
@@ -6952,7 +6948,6 @@ describe("hosted runtime callbacks", () => {
 
     expect(assertRecentInbound).toHaveBeenCalledWith({
       directRecipientPhoneNumber: "+15550001",
-      engagementKind: "requires_recent_inbound",
       fromPhoneNumber: null,
       idempotencyKey: "assistant-outbox:intent_hashed_target",
       intentId: "intent_123",
@@ -7176,7 +7171,6 @@ describe("hosted runtime callbacks", () => {
         target: "linq_chat_a",
       },
       directRecipientPhoneNumber: "+15550000001",
-      engagementKind: "requires_recent_inbound",
       fromPhoneNumber: "+15559990000",
       idempotencyKey: "assistant-outbox:intent_hashed_target",
       intentId: "intent_123",
@@ -7279,7 +7273,6 @@ describe("hosted runtime callbacks", () => {
 
     expect(assertRecentInbound).toHaveBeenCalledWith({
       directRecipientPhoneNumber: null,
-      engagementKind: "requires_recent_inbound",
       fromPhoneNumber: null,
       idempotencyKey: "assistant-outbox:intent_hashed_target",
       intentId: "intent_123",
@@ -7374,7 +7367,6 @@ describe("hosted runtime callbacks", () => {
 
     expect(assertRecentInbound).toHaveBeenCalledWith({
       directRecipientPhoneNumber: "+15550001",
-      engagementKind: "requires_recent_inbound",
       fromPhoneNumber: null,
       idempotencyKey: "assistant-outbox:intent_hashed_target",
       intentId: "intent_123",
@@ -7454,7 +7446,7 @@ describe("hosted runtime callbacks", () => {
         targetKind: "thread",
       });
 
-      throw new Error("unreachable after engagement assertion failure");
+      throw new Error("unreachable after egress authority failure");
     });
 
     await expect(drainHostedPreparedAssistantDeliveries({
@@ -7542,7 +7534,7 @@ describe("hosted runtime callbacks", () => {
         targetKind: "thread",
       });
 
-      throw new Error("unreachable after engagement assertion failure");
+      throw new Error("unreachable after egress authority failure");
     });
 
     await expect(drainHostedPreparedAssistantDeliveries({
@@ -8247,7 +8239,7 @@ describe("hosted runtime callbacks", () => {
     ]);
   });
 
-  it("uses recent-inbound engagement for route-scoped Linq timer retries without prepared authority", async () => {
+  it("checks egress authority for route-scoped Linq timer retries without prepared authority", async () => {
     const effect = buildHostedAssistantDeliveryEffect({
       dedupeKey: "dedupe_123",
       deliveryPhase: "background_retry",
@@ -8313,7 +8305,6 @@ describe("hosted runtime callbacks", () => {
 
     expect(assertRecentInbound).toHaveBeenCalledWith({
       directRecipientPhoneNumber: null,
-      engagementKind: "requires_recent_inbound",
       fromPhoneNumber: null,
       idempotencyKey: "assistant-outbox:intent_123",
       intentId: "intent_123",

--- a/packages/assistant-runtime/test/hosted-runtime-channel-activity.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-channel-activity.test.ts
@@ -38,6 +38,7 @@ import {
 } from "../src/hosted-runtime/channel-activity.ts";
 
 beforeEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
   mocks.sendEmail.mockResolvedValue({
     providerMessageId: "email-message",
@@ -63,7 +64,7 @@ function buildLinqRouteAuthority(threadId: string) {
   };
 }
 
-test("hosted Linq typing uses the hosted env after recent inbound assertion", async () => {
+test("hosted Linq typing uses the hosted env after target context validation", async () => {
   const forwardedEnv = {
     LINQ_API_BASE_URL: "https://api.linq.example",
     LINQ_API_TOKEN: "platform-linq-token",
@@ -83,11 +84,7 @@ test("hosted Linq typing uses the hosted env after recent inbound assertion", as
   });
 
   const routeAuthority = buildLinqRouteAuthority("chat_123");
-  const assertRecentInbound = vi.fn(async () => undefined);
   const typing = createHostedAssistantChannelTypingDependencies({
-    effectsPort: {
-      assertLinqRecentInboundEngagement: assertRecentInbound,
-    },
     forwardedEnv,
     linqDeliveryContexts: [
       {
@@ -114,27 +111,13 @@ test("hosted Linq typing uses the hosted env after recent inbound assertion", as
   assert.deepEqual(mocks.startLinqTypingIndicator.mock.calls[0]?.[0], {
     target: "chat_123",
   });
-  expect(assertRecentInbound).toHaveBeenCalledWith({
-    directRecipientPhoneNumber: "+15551234567",
-    engagementKind: "requires_recent_inbound",
-    fromPhoneNumber: null,
-    idempotencyKey: null,
-    intentId: null,
-    routeAuthority,
-    target: "chat_123",
-    targetKind: "thread",
-  }, {
-    signal: null,
-  });
   assert.deepEqual(mocks.startLinqTypingIndicator.mock.calls[0]?.[1]?.env, linqEnv);
+  assert.equal(mocks.startLinqTypingIndicator.mock.calls[0]?.[1]?.maxSessionMs, 5 * 60_000);
+  assert.equal(mocks.startLinqTypingIndicator.mock.calls[0]?.[1]?.refreshMs, 45_000);
 });
 
-test("hosted Linq typing can use recent inbound engagement without route authority", async () => {
-  const assertRecentInbound = vi.fn(async () => undefined);
+test("hosted Linq typing starts without route authority when the target context matches", async () => {
   const typing = createHostedAssistantChannelTypingDependencies({
-    effectsPort: {
-      assertLinqRecentInboundEngagement: assertRecentInbound,
-    },
     forwardedEnv: {
       LINQ_API_TOKEN: "linq-token",
     },
@@ -158,16 +141,6 @@ test("hosted Linq typing can use recent inbound engagement without route authori
     target: "chat_123",
   })).resolves.toBeUndefined();
 
-  expect(assertRecentInbound).toHaveBeenCalledWith(
-    expect.objectContaining({
-      routeAuthority: null,
-      target: "chat_123",
-      targetKind: "thread",
-    }),
-    {
-      signal: null,
-    },
-  );
   expect(mocks.startLinqTypingIndicator).toHaveBeenCalledWith(
     {
       target: "chat_123",
@@ -176,12 +149,8 @@ test("hosted Linq typing can use recent inbound engagement without route authori
   );
 });
 
-test("hosted Linq typing falls back to target recent inbound when initial context is unavailable", async () => {
-  const assertRecentInbound = vi.fn(async () => undefined);
+test("hosted Linq typing falls back to the requested target when no context is present", async () => {
   const typing = createHostedAssistantChannelTypingDependencies({
-    effectsPort: {
-      assertLinqRecentInboundEngagement: assertRecentInbound,
-    },
     forwardedEnv: {
       LINQ_API_TOKEN: "linq-token",
     },
@@ -195,18 +164,6 @@ test("hosted Linq typing falls back to target recent inbound when initial contex
     target: "chat_123",
   })).resolves.toBeUndefined();
 
-  expect(assertRecentInbound).toHaveBeenCalledWith({
-    directRecipientPhoneNumber: null,
-    engagementKind: "requires_recent_inbound",
-    fromPhoneNumber: null,
-    idempotencyKey: null,
-    intentId: null,
-    routeAuthority: null,
-    target: "chat_123",
-    targetKind: "thread",
-  }, {
-    signal: null,
-  });
   expect(mocks.startLinqTypingIndicator).toHaveBeenCalledWith(
     {
       target: "chat_123",
@@ -215,15 +172,12 @@ test("hosted Linq typing falls back to target recent inbound when initial contex
   );
 });
 
-test("hosted Linq typing no-ops when recent inbound engagement is rejected", async () => {
-  const routeAuthority = buildLinqRouteAuthority("chat_123");
-  const assertRecentInbound = vi.fn(async () => {
-    throw new Error("recent inbound required");
+test("hosted Linq typing allows only one active session per target", async () => {
+  const stop = vi.fn(async () => undefined);
+  mocks.startLinqTypingIndicator.mockResolvedValue({
+    stop,
   });
   const typing = createHostedAssistantChannelTypingDependencies({
-    effectsPort: {
-      assertLinqRecentInboundEngagement: assertRecentInbound,
-    },
     forwardedEnv: {
       LINQ_API_TOKEN: "linq-token",
     },
@@ -232,7 +186,7 @@ test("hosted Linq typing no-ops when recent inbound engagement is rejected", asy
         directRecipientPhoneNumber: "+15551234567",
         fromPhoneNumber: null,
         replyToMessageId: "msg_123",
-        routeAuthority,
+        routeAuthority: buildLinqRouteAuthority("chat_123"),
         service: null,
         target: "chat_123",
         threadIsDirect: null,
@@ -243,24 +197,30 @@ test("hosted Linq typing no-ops when recent inbound engagement is rejected", asy
     userEnv: {},
   });
 
+  const handle = await typing.startLinqTyping?.({
+    target: "chat_123",
+  });
   await expect(typing.startLinqTyping?.({
     target: "chat_123",
   })).resolves.toBeUndefined();
 
-  expect(assertRecentInbound).toHaveBeenCalledWith(
-    expect.objectContaining({
-      routeAuthority,
-      target: "chat_123",
-      targetKind: "thread",
-    }),
-    {
-      signal: null,
-    },
-  );
-  expect(mocks.startLinqTypingIndicator).not.toHaveBeenCalled();
+  expect(mocks.startLinqTypingIndicator).toHaveBeenCalledTimes(1);
+  await handle?.stop();
+  const restartedHandle = await typing.startLinqTyping?.({
+    target: "chat_123",
+  });
+  expect(restartedHandle).toBeDefined();
+  expect(mocks.startLinqTypingIndicator).toHaveBeenCalledTimes(2);
+  await restartedHandle?.stop();
 });
 
-test("hosted Linq typing no-ops when recent inbound assertion is unavailable", async () => {
+test("hosted Linq typing suppresses restarts after a max-length session", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-07T12:00:00.000Z"));
+  const stop = vi.fn(async () => undefined);
+  mocks.startLinqTypingIndicator.mockResolvedValue({
+    stop,
+  });
   const typing = createHostedAssistantChannelTypingDependencies({
     forwardedEnv: {
       LINQ_API_TOKEN: "linq-token",
@@ -281,11 +241,24 @@ test("hosted Linq typing no-ops when recent inbound assertion is unavailable", a
     userEnv: {},
   });
 
+  const handle = await typing.startLinqTyping?.({
+    target: "chat_123",
+  });
+  vi.setSystemTime(new Date("2026-07-07T12:05:01.000Z"));
+  await handle?.stop();
+
   await expect(typing.startLinqTyping?.({
     target: "chat_123",
   })).resolves.toBeUndefined();
+  expect(mocks.startLinqTypingIndicator).toHaveBeenCalledTimes(1);
 
-  expect(mocks.startLinqTypingIndicator).not.toHaveBeenCalled();
+  vi.setSystemTime(new Date("2026-07-07T12:15:02.000Z"));
+  const restartedHandle = await typing.startLinqTyping?.({
+    target: "chat_123",
+  });
+  expect(restartedHandle).toBeDefined();
+  expect(mocks.startLinqTypingIndicator).toHaveBeenCalledTimes(2);
+  await restartedHandle?.stop();
 });
 
 test("hosted Linq channel env does not mix a forwarded token with a user base URL", () => {
@@ -366,9 +339,6 @@ test("hosted channel activity uses provider fetch instead of effects-port provid
   const providerFetch = vi.fn<typeof fetch>();
   const routeAuthority = buildLinqRouteAuthority("linq_chat_123");
   const typing = createHostedAssistantChannelTypingDependencies({
-    effectsPort: {
-      async assertLinqRecentInboundEngagement() {},
-    },
     forwardedEnv: {},
     linqDeliveryContexts: [
       {
@@ -426,11 +396,7 @@ test("hosted Linq typing no-ops when the target is not the current inbound conte
 });
 
 test("hosted Linq typing does not use target fallback when another context is present", async () => {
-  const assertRecentInbound = vi.fn(async () => undefined);
   const typing = createHostedAssistantChannelTypingDependencies({
-    effectsPort: {
-      assertLinqRecentInboundEngagement: assertRecentInbound,
-    },
     forwardedEnv: {
       LINQ_API_TOKEN: "linq-token",
     },
@@ -454,7 +420,6 @@ test("hosted Linq typing does not use target fallback when another context is pr
     target: "different_linq_chat",
   })).resolves.toBeUndefined();
 
-  expect(assertRecentInbound).not.toHaveBeenCalled();
   expect(mocks.startLinqTypingIndicator).not.toHaveBeenCalled();
 });
 
@@ -763,7 +728,7 @@ test("hosted progress Linq delivery sends recovered same-wake chat when request 
   });
 });
 
-test("hosted progress Linq delivery recovers redacted routed same-wake chat through engagement assertion", async () => {
+test("hosted progress Linq delivery recovers redacted routed same-wake chat through egress authority", async () => {
   const routeAuthority = buildLinqRouteAuthority("linq_chat_current");
   const wake = buildHostedExecutionLinqConversationMessageWake({
     eventId: "evt_linq_progress_blinded_routed_target",

--- a/packages/assistant-runtime/test/hosted-runtime-channel-activity.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-channel-activity.test.ts
@@ -149,7 +149,7 @@ test("hosted Linq typing starts without route authority when the target context 
   );
 });
 
-test("hosted Linq typing falls back to the requested target when no context is present", async () => {
+test("hosted Linq typing no-ops when no delivery context is present", async () => {
   const typing = createHostedAssistantChannelTypingDependencies({
     forwardedEnv: {
       LINQ_API_TOKEN: "linq-token",
@@ -164,12 +164,7 @@ test("hosted Linq typing falls back to the requested target when no context is p
     target: "chat_123",
   })).resolves.toBeUndefined();
 
-  expect(mocks.startLinqTypingIndicator).toHaveBeenCalledWith(
-    {
-      target: "chat_123",
-    },
-    expect.any(Object),
-  );
+  expect(mocks.startLinqTypingIndicator).not.toHaveBeenCalled();
 });
 
 test("hosted Linq typing allows only one active session per target", async () => {


### PR DESCRIPTION
## Why
The hosted Linq egress guard was doing stale recency and thread-route proof work at delivery time. That made valid hosted automation fragile: generation could succeed, then the outbox could fail because a redundant egress check could not prove recent engagement or stale route state.

## User-visible goal
Hosted Linq automation should deliver the already-generated message when the runtime is sending to the member's valid Linq route, instead of retrying into required-send failures caused by stale egress guard state.

## What changed
- Participant-target Linq sends are signup-welcome only and tied to the member phone plus assigned home line.
- Thread sends use same-user route authority as target context when it matches and the hosted member still has active access; otherwise they fall back to the durable home or pending Linq route.
- Typing no longer calls the web egress guard and only starts when the runtime has a resolved delivery context; restored pending inputs without delivery context still reply, but skip typing.
- Typing keeps one active session per chat, a 45s refresh, a 5m cap, and a cooldown after max-length sessions.
- Delivery outcome recording no longer re-checks stale DB route authority after provider acceptance.
- Removed obsolete Linq recency columns from routing/thread-route schema and moved test seeding to hosted_linq_daily_state.

## Invariants to preserve
- Wrong-user, wrong-target, and inactive-access Linq sends must still fail closed before provider dispatch.
- Signup welcome remains the only participant-target Linq send.
- Hosted automation recency remains owned by reconciliation/wake selection using hosted_linq_daily_state.
- Delivery outcome callbacks must record accepted/failure state without raw provider payloads or private message bodies.
- Linq typing is non-critical provider egress and must not fall back to request.target without delivery authority.

## Validation
- pnpm --dir apps/web prisma:generate
- Focused hosted web Linq/schema tests passed.
- Focused assistant-runtime callback/typing tests passed.
- Focused Cloudflare runner platform/outbound tests passed.
- pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-channel-activity.test.ts
- pnpm --dir apps/cloudflare test:node -- hosted-local-runner-warm-auth-recovery-e2e.test.ts
- pnpm typecheck
- git diff --check
- ReviewGPT round 1 findings were accepted and addressed.
- ReviewGPT round 2 finding was accepted and addressed.
- ReviewGPT final blocker pass at 16960a1f: no blocking or high-severity findings remain.
- Earlier pnpm test:diff expanded to the full assistant-runtime package suite and hit unrelated hosted-runtime-maintenance shared temp-dir/package-suite failures; rerunning that maintenance file alone passed.

## Deployment
Safe order:
1. Deploy web with the simplified engagement route and stale-column drop.
2. Deploy Cloudflare/runner bundles that stop sending the deleted delivery engagement assertion.

Gradual rollout behavior:
- Warm old runner bundles can still call the web engagement route with either routeAuthority or legacy currentInbound; the web route accepts both during this rollout.
- container_rollout=immediate is not required.

Schema-drop proof:
- The dropped hosted_member_routing and hosted_thread_route recency columns are not referenced by application source on the base branch; remaining references are Prisma schema, migration DDL, and migration tests.
- Base-branch application reads of the affected tables use explicit Prisma select shapes, so warm old web code or a code rollback does not implicitly select the dropped scalar fields.
- Runtime recency decisions are owned by reconciliation facts and hosted_linq_daily_state, not these columns.

Rollback floor:
- Web and Cloudflare can roll back to the base branch for this PR because the base application source does not read or write the dropped columns.
- Rolling back to any older revision that explicitly names these recency columns outside schema/migration/test code requires restoring the columns first.