### PR TITLE
fix(web): escape changelog apostrophes for lint

### DIFF
--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -60,8 +60,8 @@ const VISUALS: Record<string, ReactNode> = {
       body={
         <div className="space-y-1.5">
           <p>Dana logged 6 workouts, a season high.</p>
-          <p>Everyone's sleep held above 7 hours except Fridays.</p>
-          <p>Nobody's touched the step goal yet, so that's the dare for next week.</p>
+          <p>Everyone&apos;s sleep held above 7 hours except Fridays.</p>
+          <p>Nobody&apos;s touched the step goal yet, so that&apos;s the dare for next week.</p>
         </div>
       }
     />


### PR DESCRIPTION
## Why this PR exists

The July 7 changelog edition (7febc75974, pushed directly to main) added JSX text with unescaped apostrophes in apps/web/app/changelog/page.tsx, failing react/no-unescaped-entities and turning main's Release app verification lint red. Every open PR inherits the failure through its merge-commit CI.

## User goal / user-visible behavior

Identical rendered changelog copy; main and downstream PR CI go green again.

## Invariants to preserve

- Copy-only change: three apostrophes escaped as &apos;, no layout/behavior/content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786043302&installation_id=127572939&pr_number=448&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F448&signature=56b4431cc3e3043d083962d16bfae4636b21ffb2f102761d45164c69a0c762bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->