### PR TITLE
Show Apple Health on device connect page

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-07-apple-health-connect-visibility.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-apple-health-connect-visibility.md
@@ -1,0 +1,34 @@
+# Apple Health Connect Visibility
+
+## Goal
+
+Make Apple Health connections created through the iOS companion visible on the
+hosted web `/connect` device page once the backend has confirmed a Junction
+`apple_health` or `apple_health_kit` source.
+
+## Success Criteria
+
+- A connected Apple Health Junction source maps to the visible Apple Health
+  card on `/connect`.
+- Apple Health is labeled as `Apple Health` in hosted device-sync summaries.
+- The web page does not offer a hosted OAuth/Junction Link start action for
+  Apple Health; it remains an iOS-app-managed source.
+- Focused tests cover the connected-state mapping and label behavior.
+
+## Constraints
+
+- Keep the companion app as the Apple Health connection flow.
+- Do not add new persisted state.
+- Do not expose health payload values; this is metadata/status presentation
+  only.
+- Preserve existing direct/Junction Link behavior for other sources.
+
+## Working Set
+
+- `packages/device-syncd/src/config/connect-routes.ts`
+- `apps/web/src/lib/device-sync/provider-label.ts`
+- `apps/web/app/(dashboard)/connect/page.tsx`
+- Focused tests under `apps/web/test/**` and/or `packages/device-syncd/test/**`
+Status: completed
+Updated: 2026-07-07
+Completed: 2026-07-07

--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -282,7 +282,7 @@ export function ConnectSourcesGrid({
     } catch (error) {
       const message = error instanceof Error
         ? error.message
-        : source.disconnectFailureMessage ?? `We could not disconnect ${source.name} right now.`;
+        : resolveDisconnectFailureMessage(source);
       setActionError({
         message,
         sourceId: source.id,
@@ -409,5 +409,13 @@ export function ConnectSourcesGrid({
 }
 
 function resolveDisconnectSuccessMessage(source: ConnectSource): string {
-  return source.disconnectSuccessMessage ?? `Disconnected ${source.name}. Your history is still saved.`;
+  return source.disconnectScope === "junction_account"
+    ? "Disconnected this Junction account. Your history is still saved."
+    : `Disconnected ${source.name}. Your history is still saved.`;
+}
+
+function resolveDisconnectFailureMessage(source: ConnectSource): string {
+  return source.disconnectScope === "junction_account"
+    ? "We could not disconnect this Junction account right now."
+    : `We could not disconnect ${source.name} right now.`;
 }

--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -276,11 +276,13 @@ export function ConnectSourcesGrid({
         kind: result.warning?.message ? "warning" : "success",
         title: "Source disconnected",
         message: result.warning?.message
-          ? `Disconnected ${source.name}. Your history is still saved. The provider did not fully confirm, so check that account if you want access removed there too.`
-          : `Disconnected ${source.name}. Your history is still saved.`,
+          ? `${resolveDisconnectSuccessMessage(source)} The provider did not fully confirm, so check that account if you want access removed there too.`
+          : resolveDisconnectSuccessMessage(source),
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : `We could not disconnect ${source.name} right now.`;
+      const message = error instanceof Error
+        ? error.message
+        : source.disconnectFailureMessage ?? `We could not disconnect ${source.name} right now.`;
       setActionError({
         message,
         sourceId: source.id,
@@ -404,4 +406,8 @@ export function ConnectSourcesGrid({
 
     </section>
   );
+}
+
+function resolveDisconnectSuccessMessage(source: ConnectSource): string {
+  return source.disconnectSuccessMessage ?? `Disconnected ${source.name}. Your history is still saved.`;
 }

--- a/apps/web/app/(dashboard)/connect/connect-page-dialogs.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-dialogs.tsx
@@ -71,10 +71,11 @@ export function ConnectDisconnectDialog({
       <DialogContent className="max-w-md gap-6 p-6 md:p-7">
         <DialogHeader className="pr-10">
           <DialogTitle className="text-xl font-bold tracking-tight text-foreground">
-            Disconnect {source?.name ?? "source"}?
+            {source?.disconnectDialogTitle ?? `Disconnect ${source?.name ?? "source"}?`}
           </DialogTitle>
           <DialogDescription>
-            Murph will stop syncing new data from this connection. Your history is kept.
+            {source?.disconnectDialogDescription
+              ?? "Murph will stop syncing new data from this connection. Your history is kept."}
           </DialogDescription>
         </DialogHeader>
         {errorMessage ? (

--- a/apps/web/app/(dashboard)/connect/connect-page-dialogs.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-dialogs.tsx
@@ -71,11 +71,10 @@ export function ConnectDisconnectDialog({
       <DialogContent className="max-w-md gap-6 p-6 md:p-7">
         <DialogHeader className="pr-10">
           <DialogTitle className="text-xl font-bold tracking-tight text-foreground">
-            {source?.disconnectDialogTitle ?? `Disconnect ${source?.name ?? "source"}?`}
+            {resolveDisconnectDialogTitle(source)}
           </DialogTitle>
           <DialogDescription>
-            {source?.disconnectDialogDescription
-              ?? "Murph will stop syncing new data from this connection. Your history is kept."}
+            {resolveDisconnectDialogDescription(source)}
           </DialogDescription>
         </DialogHeader>
         {errorMessage ? (
@@ -111,6 +110,22 @@ export function ConnectDisconnectDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+function resolveDisconnectDialogTitle(source: ConnectSource | null): string {
+  if (source?.disconnectScope === "junction_account") {
+    return "Disconnect Junction account?";
+  }
+
+  return `Disconnect ${source?.name ?? "source"}?`;
+}
+
+function resolveDisconnectDialogDescription(source: ConnectSource | null): string {
+  if (source?.disconnectScope === "junction_account") {
+    return "Murph will stop syncing new data from every source in this Junction connection. Your history is kept.";
+  }
+
+  return "Murph will stop syncing new data from this connection. Your history is kept.";
 }
 
 export function ConnectRedirectDialog({ sourceName }: { sourceName: string | null }) {

--- a/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
@@ -89,12 +89,22 @@ export function markLocallyDisconnectedSources(
       return source;
     }
 
+    const {
+      connected,
+      connectProvider,
+      disconnectConnectionId,
+      disconnectScope,
+      requiresReconnect,
+      ...locallyDisconnectedSource
+    } = source;
+    void connected;
+    void connectProvider;
+    void disconnectConnectionId;
+    void disconnectScope;
+    void requiresReconnect;
+
     return {
-      description: source.description,
-      id: source.id,
-      logo: source.logo,
-      name: source.name,
-      ...(source.connectTarget ? { connectTarget: source.connectTarget } : {}),
+      ...locallyDisconnectedSource,
     };
   });
 }

--- a/apps/web/app/(dashboard)/connect/connect-page-types.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-types.ts
@@ -9,12 +9,19 @@ export type ConnectSource = {
   connectProvider?: string;
   connectTarget?: string;
   connected?: boolean;
+  disconnectActionLabel?: string;
+  disconnectAriaLabel?: string;
   description: string;
+  disconnectDialogDescription?: string;
+  disconnectDialogTitle?: string;
   disconnectConnectionId?: string;
+  disconnectFailureMessage?: string;
+  disconnectSuccessMessage?: string;
   id: string;
   logo: LogoAsset;
   name: string;
   requiresReconnect?: boolean;
+  unavailableActionLabel?: string;
   unavailableMessage?: string;
 };
 

--- a/apps/web/app/(dashboard)/connect/connect-page-types.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-types.ts
@@ -15,6 +15,7 @@ export type ConnectSource = {
   logo: LogoAsset;
   name: string;
   requiresReconnect?: boolean;
+  unavailableMessage?: string;
 };
 
 export type ConnectPageInitialLoadError = {

--- a/apps/web/app/(dashboard)/connect/connect-page-types.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-types.ts
@@ -9,14 +9,9 @@ export type ConnectSource = {
   connectProvider?: string;
   connectTarget?: string;
   connected?: boolean;
-  disconnectActionLabel?: string;
-  disconnectAriaLabel?: string;
   description: string;
-  disconnectDialogDescription?: string;
-  disconnectDialogTitle?: string;
   disconnectConnectionId?: string;
-  disconnectFailureMessage?: string;
-  disconnectSuccessMessage?: string;
+  disconnectScope?: "junction_account";
   id: string;
   logo: LogoAsset;
   name: string;

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -26,6 +26,7 @@ export function SourceCard({
   const canStart = authenticated && isAvailable;
   const canDisconnect = authenticated && Boolean(source.disconnectConnectionId);
   const actionLabel = source.requiresReconnect ? "Reconnect" : "Connect";
+  const reconnectUnavailable = source.requiresReconnect && !isAvailable;
 
   return (
     <div className="relative box-border flex min-w-0 w-full max-w-full flex-col justify-between overflow-hidden rounded-xl border border-border/50 bg-[rgba(255,252,246,0.9)] p-4 sm:p-5">
@@ -74,14 +75,16 @@ export function SourceCard({
           <div className="flex shrink-0 flex-col items-start gap-2 sm:mt-auto sm:shrink">
             {source.requiresReconnect ? (
               <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
-                Please reconnect {source.name} to resume syncing.
+                {reconnectUnavailable
+                  ? `${source.name} needs attention from the connected app before Murph can keep syncing it.`
+                  : `Please reconnect ${source.name} to resume syncing.`}
               </p>
             ) : null}
             {!authenticated ? (
               <AuthButton aria-label={`Sign in to connect ${source.name}`}>
                 Sign in
               </AuthButton>
-            ) : (
+            ) : reconnectUnavailable ? null : (
               <Button
                 type="button"
                 disabled={!canStart || pending}
@@ -93,6 +96,17 @@ export function SourceCard({
                 {pending ? "Opening..." : isAvailable ? actionLabel : "Not available"}
               </Button>
             )}
+            {reconnectUnavailable && canDisconnect ? (
+              <button
+                type="button"
+                aria-label={`Disconnect ${source.name}`}
+                disabled={pendingDisconnect}
+                onClick={() => onDisconnectTargetChange(source)}
+                className="relative self-start text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-['']"
+              >
+                {pendingDisconnect ? "Disconnecting..." : "Disconnect"}
+              </button>
+            ) : null}
             {errorMessage ? (
               <p role="alert" className="text-xs leading-snug text-destructive">
                 {errorMessage}

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -26,6 +26,8 @@ export function SourceCard({
   const canStart = authenticated && isAvailable;
   const canDisconnect = authenticated && Boolean(source.disconnectConnectionId);
   const actionLabel = source.requiresReconnect ? "Reconnect" : "Connect";
+  const disconnectActionLabel = source.disconnectActionLabel ?? "Disconnect";
+  const disconnectAriaLabel = source.disconnectAriaLabel ?? `Disconnect ${source.name}`;
   const reconnectUnavailable = source.requiresReconnect && !isAvailable;
   const unavailableMessage = !source.requiresReconnect && !isAvailable
     ? source.unavailableMessage
@@ -60,12 +62,12 @@ export function SourceCard({
             {canDisconnect ? (
               <button
                 type="button"
-                aria-label={`Disconnect ${source.name}`}
+                aria-label={disconnectAriaLabel}
                 disabled={pendingDisconnect}
                 onClick={() => onDisconnectTargetChange(source)}
                 className="relative self-start text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-['']"
               >
-                {pendingDisconnect ? "Disconnecting..." : "Disconnect"}
+                {pendingDisconnect ? "Disconnecting..." : disconnectActionLabel}
               </button>
             ) : null}
             {errorMessage ? (
@@ -92,6 +94,14 @@ export function SourceCard({
               <AuthButton aria-label={`Sign in to connect ${source.name}`}>
                 Sign in
               </AuthButton>
+            ) : unavailableMessage && source.unavailableActionLabel ? (
+              <Button
+                type="button"
+                disabled
+                aria-label={`${source.name} web setup is not available yet`}
+              >
+                {source.unavailableActionLabel}
+              </Button>
             ) : reconnectUnavailable || unavailableMessage ? null : (
               <Button
                 type="button"
@@ -107,12 +117,12 @@ export function SourceCard({
             {reconnectUnavailable && canDisconnect ? (
               <button
                 type="button"
-                aria-label={`Disconnect ${source.name}`}
+                aria-label={disconnectAriaLabel}
                 disabled={pendingDisconnect}
                 onClick={() => onDisconnectTargetChange(source)}
                 className="relative self-start text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-['']"
               >
-                {pendingDisconnect ? "Disconnecting..." : "Disconnect"}
+                {pendingDisconnect ? "Disconnecting..." : disconnectActionLabel}
               </button>
             ) : null}
             {errorMessage ? (

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -26,8 +26,8 @@ export function SourceCard({
   const canStart = authenticated && isAvailable;
   const canDisconnect = authenticated && Boolean(source.disconnectConnectionId);
   const actionLabel = source.requiresReconnect ? "Reconnect" : "Connect";
-  const disconnectActionLabel = source.disconnectActionLabel ?? "Disconnect";
-  const disconnectAriaLabel = source.disconnectAriaLabel ?? `Disconnect ${source.name}`;
+  const disconnectActionLabel = resolveDisconnectActionLabel(source);
+  const disconnectAriaLabel = resolveDisconnectAriaLabel(source);
   const reconnectUnavailable = source.requiresReconnect && !isAvailable;
   const unavailableMessage = !source.requiresReconnect && !isAvailable
     ? source.unavailableMessage
@@ -135,6 +135,18 @@ export function SourceCard({
       </div>
     </div>
   );
+}
+
+function resolveDisconnectActionLabel(source: ConnectSource): string {
+  return source.disconnectScope === "junction_account"
+    ? "Disconnect Junction account"
+    : "Disconnect";
+}
+
+function resolveDisconnectAriaLabel(source: ConnectSource): string {
+  return source.disconnectScope === "junction_account"
+    ? "Disconnect Junction account"
+    : `Disconnect ${source.name}`;
 }
 
 function SourceStatusDot({

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -29,6 +29,8 @@ export function SourceCard({
   const disconnectActionLabel = resolveDisconnectActionLabel(source);
   const disconnectAriaLabel = resolveDisconnectAriaLabel(source);
   const reconnectUnavailable = source.requiresReconnect && !isAvailable;
+  const showReconnectStateDisconnect = canDisconnect
+    && (reconnectUnavailable || source.disconnectScope === "junction_account");
   const unavailableMessage = !source.requiresReconnect && !isAvailable
     ? source.unavailableMessage
     : undefined;
@@ -114,7 +116,7 @@ export function SourceCard({
                 {pending ? "Opening..." : isAvailable ? actionLabel : "Not available"}
               </Button>
             )}
-            {reconnectUnavailable && canDisconnect ? (
+            {showReconnectStateDisconnect ? (
               <button
                 type="button"
                 aria-label={disconnectAriaLabel}

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -27,6 +27,9 @@ export function SourceCard({
   const canDisconnect = authenticated && Boolean(source.disconnectConnectionId);
   const actionLabel = source.requiresReconnect ? "Reconnect" : "Connect";
   const reconnectUnavailable = source.requiresReconnect && !isAvailable;
+  const unavailableMessage = !source.requiresReconnect && !isAvailable
+    ? source.unavailableMessage
+    : undefined;
 
   return (
     <div className="relative box-border flex min-w-0 w-full max-w-full flex-col justify-between overflow-hidden rounded-xl border border-border/50 bg-[rgba(255,252,246,0.9)] p-4 sm:p-5">
@@ -80,11 +83,16 @@ export function SourceCard({
                   : `Please reconnect ${source.name} to resume syncing.`}
               </p>
             ) : null}
+            {unavailableMessage ? (
+              <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-muted-foreground">
+                {unavailableMessage}
+              </p>
+            ) : null}
             {!authenticated ? (
               <AuthButton aria-label={`Sign in to connect ${source.name}`}>
                 Sign in
               </AuthButton>
-            ) : reconnectUnavailable ? null : (
+            ) : reconnectUnavailable || unavailableMessage ? null : (
               <Button
                 type="button"
                 disabled={!canStart || pending}

--- a/apps/web/app/(dashboard)/connect/connect-source-order.ts
+++ b/apps/web/app/(dashboard)/connect/connect-source-order.ts
@@ -5,6 +5,7 @@ type OrderedConnectSource = {
 };
 
 const CONNECT_SOURCE_POPULARITY_ORDER = [
+  "apple-health",
   "samsung-health",
   "garmin",
   "fitbit",

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -560,11 +560,7 @@ function resolveConnectSourceDisconnect(
     return { connectionId, scope: null };
   }
 
-  const affectedUpstreamSourceCount = isReauthorizationRequiredConnectSourceState(source.state)
-    ? source.upstreamSources.length
-    : countLiveJunctionUpstreamSources(source.upstreamSources);
-
-  if (affectedUpstreamSourceCount <= 1) {
+  if (countDisconnectableJunctionUpstreamSources(source.upstreamSources) <= 1) {
     return { connectionId, scope: null };
   }
 
@@ -580,12 +576,24 @@ function countLiveJunctionUpstreamSources(
   return upstreamSources.filter(isLiveJunctionUpstreamSource).length;
 }
 
+function countDisconnectableJunctionUpstreamSources(
+  upstreamSources: ConnectSettingsSourceMatch["upstreamSources"],
+): number {
+  return upstreamSources.filter(isDisconnectableJunctionUpstreamSource).length;
+}
+
 function isLiveJunctionUpstreamSource(
   source: ConnectSettingsSourceMatch["upstreamSources"][number],
 ): boolean {
   return source.status === "connected"
     || source.status === "error"
     || source.requiresReconnect === true;
+}
+
+function isDisconnectableJunctionUpstreamSource(
+  source: ConnectSettingsSourceMatch["upstreamSources"][number],
+): boolean {
+  return source.status !== "disconnected" || source.requiresReconnect === true;
 }
 
 function upsertConnectSourceConnection(

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -59,6 +59,7 @@ const CONNECT_SOURCE_UI = {
     description: "iPhone and Apple Watch activity, sleep, vitals, and workouts.",
     logo: logoAsset("apple-health.png"),
     name: "Apple Health",
+    unavailableMessage: "Apple Health connects through the Murph iOS app and appears here after the first sync.",
   },
   whoop: {
     description: "Recovery, strain, sleep, and heart rate.",
@@ -317,6 +318,7 @@ export function listVisibleConnectSources(): ConnectSource[] {
             id: source.connectSourceId,
             logo: ui.logo,
             name: ui.name,
+            ...(ui.unavailableMessage ? { unavailableMessage: ui.unavailableMessage } : {}),
           },
         ]
       : [];

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -33,7 +33,6 @@ export const metadata: Metadata = createMurphPageMetadata({
 type ConnectPageSearchParams = Record<string, string | string[] | undefined>;
 
 type ConnectSourceUi = Omit<ConnectSource, "id">;
-type DeviceConnectRoute = (typeof DEVICE_CONNECT_SOURCES)[number]["routes"][number];
 type ConnectSettingsSourceMatch = Pick<
   HostedDeviceSyncSettingsSource,
   "connectSourceId" | "connectTarget" | "provider" | "state" | "upstreamSources"
@@ -50,7 +49,17 @@ type ConnectSourceConnectionState = {
   state: "active" | "reauthorization_required";
 };
 
+const DISPLAY_ONLY_CONNECT_SOURCE_IDS = new Set<string>(["apple-health"]);
+const SOURCE_ID_BY_JUNCTION_UPSTREAM_ALIAS = new Map<string, string>([
+  ["apple_health", "apple-health"],
+]);
+
 const CONNECT_SOURCE_UI = {
+  "apple-health": {
+    description: "iPhone and Apple Watch activity, sleep, vitals, and workouts.",
+    logo: logoAsset("apple-health.png"),
+    name: "Apple Health",
+  },
   whoop: {
     description: "Recovery, strain, sleep, and heart rate.",
     logo: logoAsset("whoop.svg", "h-auto max-h-7 w-auto max-w-[8rem] object-contain", 96, 15),
@@ -296,7 +305,7 @@ export default async function ConnectPage({
 
 export function listVisibleConnectSources(): ConnectSource[] {
   return DEVICE_CONNECT_SOURCES.flatMap((source) => {
-    if (!hasHostedConnectRoute(source.routes)) {
+    if (!isVisibleConnectSource(source)) {
       return [];
     }
 
@@ -330,8 +339,9 @@ async function resolveDeviceConnectRecoveryContactAction(authenticated: boolean)
   }
 }
 
-function hasHostedConnectRoute(routes: readonly DeviceConnectRoute[]): boolean {
-  return routes.some((route) => route.kind === "direct" || route.kind === "junction_link");
+function isVisibleConnectSource(source: (typeof DEVICE_CONNECT_SOURCES)[number]): boolean {
+  return DISPLAY_ONLY_CONNECT_SOURCE_IDS.has(source.connectSourceId)
+    || source.routes.some((route) => route.kind === "direct" || route.kind === "junction_link");
 }
 
 export function resolveConfiguredConnectSources(
@@ -442,11 +452,12 @@ function resolveConnectSourceConnectionMatches(
     const connectTarget = typeof source.connectTarget === "string" && source.connectTarget.trim()
       ? source.connectTarget
       : null;
+    const disconnectConnectionId = resolveSourceScopedDisconnectConnectionId(source, connectionId);
 
     const configuredSourceId = normalizeDeviceConnectSourceId(source.connectSourceId ?? null);
     if (sourceState && configuredSourceId && visibleSourceIds.has(configuredSourceId)) {
       upsertConnectSourceConnection(connectedConnections, {
-        connectionId,
+        connectionId: disconnectConnectionId,
         connectProvider: provider,
         connectTarget,
         requiresReconnect,
@@ -459,7 +470,7 @@ function resolveConnectSourceConnectionMatches(
       const sourceId = sourceIdByDirectProvider.get(provider);
       if (sourceId) {
         upsertConnectSourceConnection(connectedConnections, {
-          connectionId,
+          connectionId: disconnectConnectionId,
           connectProvider: provider,
           connectTarget,
           requiresReconnect,
@@ -495,10 +506,11 @@ function resolveConnectSourceConnectionMatches(
       const sourceProviderSlug = normalizeDeviceSyncConnectTargetKey(upstreamSource.sourceProviderSlug);
       const sourceId = sourceProviderSlug
         ? sourceIdByJunctionTarget.get(sourceProviderSlug)
+          ?? SOURCE_ID_BY_JUNCTION_UPSTREAM_ALIAS.get(sourceProviderSlug)
         : null;
       if (sourceId) {
         upsertConnectSourceConnection(connectedConnections, {
-          connectionId,
+          connectionId: disconnectConnectionId,
           connectProvider: upstreamRequiresReconnect ? upstreamConnectProvider : provider,
           connectTarget: upstreamRequiresReconnect ? upstreamConnectTarget : null,
           requiresReconnect: upstreamRequiresReconnect,
@@ -510,6 +522,32 @@ function resolveConnectSourceConnectionMatches(
   }
 
   return [...connectedConnections.values()];
+}
+
+function resolveSourceScopedDisconnectConnectionId(
+  source: ConnectSettingsSourceMatch,
+  connectionId: string | null,
+): string | null {
+  if (!connectionId) {
+    return null;
+  }
+
+  const provider = normalizeDeviceSyncConnectTargetKey(source.provider);
+  if (provider !== "junction") {
+    return connectionId;
+  }
+
+  return countLiveJunctionUpstreamSources(source.upstreamSources) <= 1 ? connectionId : null;
+}
+
+function countLiveJunctionUpstreamSources(
+  upstreamSources: ConnectSettingsSourceMatch["upstreamSources"],
+): number {
+  return upstreamSources.filter((source) =>
+    source.status === "connected"
+    || source.status === "error"
+    || source.requiresReconnect === true
+  ).length;
 }
 
 function upsertConnectSourceConnection(

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -44,20 +44,12 @@ type ConnectSourceConnectionState = {
   connectionId: string | null;
   connectProvider: string | null;
   connectTarget: string | null;
-  disconnectPresentation?: ConnectSourceDisconnectPresentation;
+  disconnectScope?: ConnectSourceDisconnectScope;
   requiresReconnect: boolean;
   sourceId: string;
   state: "active" | "reauthorization_required";
 };
-type ConnectSourceDisconnectPresentation = Pick<
-  ConnectSource,
-  | "disconnectActionLabel"
-  | "disconnectAriaLabel"
-  | "disconnectDialogDescription"
-  | "disconnectDialogTitle"
-  | "disconnectFailureMessage"
-  | "disconnectSuccessMessage"
->;
+type ConnectSourceDisconnectScope = NonNullable<ConnectSource["disconnectScope"]>;
 
 const DISPLAY_ONLY_CONNECT_SOURCE_IDS = new Set<string>(["apple-health"]);
 const SOURCE_ID_BY_JUNCTION_UPSTREAM_ALIAS = new Map<string, string>([
@@ -248,7 +240,7 @@ export default async function ConnectPage({
   const reconnectProviderBySourceId = new Map<string, string>();
   const reconnectTargetBySourceId = new Map<string, string>();
   const disconnectConnectionIdBySourceId = new Map<string, string>();
-  const disconnectPresentationBySourceId = new Map<string, ConnectSourceDisconnectPresentation>();
+  const disconnectScopeBySourceId = new Map<string, ConnectSourceDisconnectScope>();
   let initialLoadError: ConnectPageInitialLoadError | null = null;
   const recoveryContactAction = await resolveDeviceConnectRecoveryContactAction(
     Boolean(auth.authenticatedMember),
@@ -269,8 +261,8 @@ export default async function ConnectPage({
         if (connection.connectionId) {
           disconnectConnectionIdBySourceId.set(sourceId, connection.connectionId);
         }
-        if (connection.disconnectPresentation) {
-          disconnectPresentationBySourceId.set(sourceId, connection.disconnectPresentation);
+        if (connection.disconnectScope) {
+          disconnectScopeBySourceId.set(sourceId, connection.disconnectScope);
         }
         if (connection.requiresReconnect) {
           if (connection.connectProvider) {
@@ -295,7 +287,7 @@ export default async function ConnectPage({
   const sources = resolveConfiguredConnectSources(CONNECT_SOURCES, {
     connectedSourceIds,
     disconnectConnectionIdBySourceId,
-    disconnectPresentationBySourceId,
+    disconnectScopeBySourceId,
     reconnectProviderBySourceId,
     reconnectSourceIds,
     reconnectTargetBySourceId,
@@ -368,7 +360,7 @@ export function resolveConfiguredConnectSources(
   options: {
     connectedSourceIds?: ReadonlySet<string>;
     disconnectConnectionIdBySourceId?: ReadonlyMap<string, string>;
-    disconnectPresentationBySourceId?: ReadonlyMap<string, ConnectSourceDisconnectPresentation>;
+    disconnectScopeBySourceId?: ReadonlyMap<string, ConnectSourceDisconnectScope>;
     reconnectProviderBySourceId?: ReadonlyMap<string, string>;
     reconnectSourceIds?: ReadonlySet<string>;
     reconnectTargetBySourceId?: ReadonlyMap<string, string>;
@@ -386,7 +378,7 @@ export function resolveConfiguredConnectSources(
       const connected = options.connectedSourceIds?.has(source.id) === true;
       const requiresReconnect = !connected && options.reconnectSourceIds?.has(source.id) === true;
       const disconnectConnectionId = options.disconnectConnectionIdBySourceId?.get(source.id);
-      const disconnectPresentation = options.disconnectPresentationBySourceId?.get(source.id);
+      const disconnectScope = options.disconnectScopeBySourceId?.get(source.id);
       const reconnectProvider = options.reconnectProviderBySourceId?.get(source.id);
       const reconnectTarget = options.reconnectTargetBySourceId?.get(source.id);
       const resolvedConnectTarget = reconnectTarget ?? connectTarget;
@@ -396,7 +388,7 @@ export function resolveConfiguredConnectSources(
         ...(reconnectProvider ? { connectProvider: reconnectProvider } : {}),
         ...(resolvedConnectTarget ? { connectTarget: resolvedConnectTarget } : {}),
         ...(disconnectConnectionId ? { disconnectConnectionId } : {}),
-        ...(disconnectPresentation ?? {}),
+        ...(disconnectScope ? { disconnectScope } : {}),
         ...(requiresReconnect ? { requiresReconnect } : {}),
         ...(connected ? { connected } : {}),
       };
@@ -488,7 +480,7 @@ function resolveConnectSourceConnectionMatches(
         connectionId: disconnect.connectionId,
         connectProvider: provider,
         connectTarget,
-        ...(disconnect.presentation ? { disconnectPresentation: disconnect.presentation } : {}),
+        ...(disconnect.scope ? { disconnectScope: disconnect.scope } : {}),
         requiresReconnect,
         sourceId: configuredSourceId,
         state: sourceState,
@@ -502,7 +494,7 @@ function resolveConnectSourceConnectionMatches(
           connectionId: disconnect.connectionId,
           connectProvider: provider,
           connectTarget,
-          ...(disconnect.presentation ? { disconnectPresentation: disconnect.presentation } : {}),
+          ...(disconnect.scope ? { disconnectScope: disconnect.scope } : {}),
           requiresReconnect,
           sourceId,
           state: sourceState,
@@ -543,7 +535,7 @@ function resolveConnectSourceConnectionMatches(
           connectionId: disconnect.connectionId,
           connectProvider: upstreamRequiresReconnect ? upstreamConnectProvider : provider,
           connectTarget: upstreamRequiresReconnect ? upstreamConnectTarget : null,
-          ...(disconnect.presentation ? { disconnectPresentation: disconnect.presentation } : {}),
+          ...(disconnect.scope ? { disconnectScope: disconnect.scope } : {}),
           requiresReconnect: upstreamRequiresReconnect,
           sourceId,
           state: sourceState,
@@ -558,31 +550,23 @@ function resolveConnectSourceConnectionMatches(
 function resolveConnectSourceDisconnect(
   source: ConnectSettingsSourceMatch,
   connectionId: string | null,
-): { connectionId: string | null; presentation: ConnectSourceDisconnectPresentation | null } {
+): { connectionId: string | null; scope: ConnectSourceDisconnectScope | null } {
   if (!connectionId) {
-    return { connectionId: null, presentation: null };
+    return { connectionId: null, scope: null };
   }
 
   const provider = normalizeDeviceSyncConnectTargetKey(source.provider);
   if (provider !== "junction") {
-    return { connectionId, presentation: null };
+    return { connectionId, scope: null };
   }
 
   if (countLiveJunctionUpstreamSources(source.upstreamSources) <= 1) {
-    return { connectionId, presentation: null };
+    return { connectionId, scope: null };
   }
 
   return {
     connectionId,
-    presentation: {
-      disconnectActionLabel: "Disconnect Junction account",
-      disconnectAriaLabel: "Disconnect Junction account",
-      disconnectDialogDescription:
-        "Murph will stop syncing new data from every source in this Junction connection. Your history is kept.",
-      disconnectDialogTitle: "Disconnect Junction account?",
-      disconnectFailureMessage: "We could not disconnect this Junction account right now.",
-      disconnectSuccessMessage: "Disconnected this Junction account. Your history is still saved.",
-    },
+    scope: "junction_account",
   };
 }
 

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -502,6 +502,10 @@ function resolveConnectSourceConnectionMatches(
     }
 
     for (const upstreamSource of source.upstreamSources) {
+      if (!isDisconnectableJunctionUpstreamSource(upstreamSource)) {
+        continue;
+      }
+
       const upstreamOwnRequiresReconnect = upstreamSource.requiresReconnect === true;
       const upstreamInheritsSourceReconnect =
         sourceRequiresReconnect

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -560,7 +560,11 @@ function resolveConnectSourceDisconnect(
     return { connectionId, scope: null };
   }
 
-  if (countLiveJunctionUpstreamSources(source.upstreamSources) <= 1) {
+  const affectedUpstreamSourceCount = isReauthorizationRequiredConnectSourceState(source.state)
+    ? source.upstreamSources.length
+    : countLiveJunctionUpstreamSources(source.upstreamSources);
+
+  if (affectedUpstreamSourceCount <= 1) {
     return { connectionId, scope: null };
   }
 

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -44,10 +44,20 @@ type ConnectSourceConnectionState = {
   connectionId: string | null;
   connectProvider: string | null;
   connectTarget: string | null;
+  disconnectPresentation?: ConnectSourceDisconnectPresentation;
   requiresReconnect: boolean;
   sourceId: string;
   state: "active" | "reauthorization_required";
 };
+type ConnectSourceDisconnectPresentation = Pick<
+  ConnectSource,
+  | "disconnectActionLabel"
+  | "disconnectAriaLabel"
+  | "disconnectDialogDescription"
+  | "disconnectDialogTitle"
+  | "disconnectFailureMessage"
+  | "disconnectSuccessMessage"
+>;
 
 const DISPLAY_ONLY_CONNECT_SOURCE_IDS = new Set<string>(["apple-health"]);
 const SOURCE_ID_BY_JUNCTION_UPSTREAM_ALIAS = new Map<string, string>([
@@ -59,7 +69,8 @@ const CONNECT_SOURCE_UI = {
     description: "iPhone and Apple Watch activity, sleep, vitals, and workouts.",
     logo: logoAsset("apple-health.png"),
     name: "Apple Health",
-    unavailableMessage: "Apple Health connects through the Murph iOS app and appears here after the first sync.",
+    unavailableActionLabel: "Coming soon",
+    unavailableMessage: "Apple Health web setup is coming soon. Connect from the Murph iOS app for now.",
   },
   whoop: {
     description: "Recovery, strain, sleep, and heart rate.",
@@ -237,6 +248,7 @@ export default async function ConnectPage({
   const reconnectProviderBySourceId = new Map<string, string>();
   const reconnectTargetBySourceId = new Map<string, string>();
   const disconnectConnectionIdBySourceId = new Map<string, string>();
+  const disconnectPresentationBySourceId = new Map<string, ConnectSourceDisconnectPresentation>();
   let initialLoadError: ConnectPageInitialLoadError | null = null;
   const recoveryContactAction = await resolveDeviceConnectRecoveryContactAction(
     Boolean(auth.authenticatedMember),
@@ -256,6 +268,9 @@ export default async function ConnectPage({
         }
         if (connection.connectionId) {
           disconnectConnectionIdBySourceId.set(sourceId, connection.connectionId);
+        }
+        if (connection.disconnectPresentation) {
+          disconnectPresentationBySourceId.set(sourceId, connection.disconnectPresentation);
         }
         if (connection.requiresReconnect) {
           if (connection.connectProvider) {
@@ -280,6 +295,7 @@ export default async function ConnectPage({
   const sources = resolveConfiguredConnectSources(CONNECT_SOURCES, {
     connectedSourceIds,
     disconnectConnectionIdBySourceId,
+    disconnectPresentationBySourceId,
     reconnectProviderBySourceId,
     reconnectSourceIds,
     reconnectTargetBySourceId,
@@ -318,6 +334,7 @@ export function listVisibleConnectSources(): ConnectSource[] {
             id: source.connectSourceId,
             logo: ui.logo,
             name: ui.name,
+            ...(ui.unavailableActionLabel ? { unavailableActionLabel: ui.unavailableActionLabel } : {}),
             ...(ui.unavailableMessage ? { unavailableMessage: ui.unavailableMessage } : {}),
           },
         ]
@@ -351,6 +368,7 @@ export function resolveConfiguredConnectSources(
   options: {
     connectedSourceIds?: ReadonlySet<string>;
     disconnectConnectionIdBySourceId?: ReadonlyMap<string, string>;
+    disconnectPresentationBySourceId?: ReadonlyMap<string, ConnectSourceDisconnectPresentation>;
     reconnectProviderBySourceId?: ReadonlyMap<string, string>;
     reconnectSourceIds?: ReadonlySet<string>;
     reconnectTargetBySourceId?: ReadonlyMap<string, string>;
@@ -368,6 +386,7 @@ export function resolveConfiguredConnectSources(
       const connected = options.connectedSourceIds?.has(source.id) === true;
       const requiresReconnect = !connected && options.reconnectSourceIds?.has(source.id) === true;
       const disconnectConnectionId = options.disconnectConnectionIdBySourceId?.get(source.id);
+      const disconnectPresentation = options.disconnectPresentationBySourceId?.get(source.id);
       const reconnectProvider = options.reconnectProviderBySourceId?.get(source.id);
       const reconnectTarget = options.reconnectTargetBySourceId?.get(source.id);
       const resolvedConnectTarget = reconnectTarget ?? connectTarget;
@@ -377,6 +396,7 @@ export function resolveConfiguredConnectSources(
         ...(reconnectProvider ? { connectProvider: reconnectProvider } : {}),
         ...(resolvedConnectTarget ? { connectTarget: resolvedConnectTarget } : {}),
         ...(disconnectConnectionId ? { disconnectConnectionId } : {}),
+        ...(disconnectPresentation ?? {}),
         ...(requiresReconnect ? { requiresReconnect } : {}),
         ...(connected ? { connected } : {}),
       };
@@ -454,14 +474,21 @@ function resolveConnectSourceConnectionMatches(
     const connectTarget = typeof source.connectTarget === "string" && source.connectTarget.trim()
       ? source.connectTarget
       : null;
-    const disconnectConnectionId = resolveSourceScopedDisconnectConnectionId(source, connectionId);
+    const disconnect = resolveConnectSourceDisconnect(source, connectionId);
+    const hasJunctionUpstreamSources = provider === "junction" && source.upstreamSources.length > 0;
 
     const configuredSourceId = normalizeDeviceConnectSourceId(source.connectSourceId ?? null);
-    if (sourceState && configuredSourceId && visibleSourceIds.has(configuredSourceId)) {
+    if (
+      sourceState
+      && configuredSourceId
+      && visibleSourceIds.has(configuredSourceId)
+      && !hasJunctionUpstreamSources
+    ) {
       upsertConnectSourceConnection(connectedConnections, {
-        connectionId: disconnectConnectionId,
+        connectionId: disconnect.connectionId,
         connectProvider: provider,
         connectTarget,
+        ...(disconnect.presentation ? { disconnectPresentation: disconnect.presentation } : {}),
         requiresReconnect,
         sourceId: configuredSourceId,
         state: sourceState,
@@ -472,9 +499,10 @@ function resolveConnectSourceConnectionMatches(
       const sourceId = sourceIdByDirectProvider.get(provider);
       if (sourceId) {
         upsertConnectSourceConnection(connectedConnections, {
-          connectionId: disconnectConnectionId,
+          connectionId: disconnect.connectionId,
           connectProvider: provider,
           connectTarget,
+          ...(disconnect.presentation ? { disconnectPresentation: disconnect.presentation } : {}),
           requiresReconnect,
           sourceId,
           state: sourceState,
@@ -495,7 +523,7 @@ function resolveConnectSourceConnectionMatches(
       const upstreamConnectTarget =
         typeof upstreamSource.connectTarget === "string" && upstreamSource.connectTarget.trim()
           ? upstreamSource.connectTarget
-          : connectTarget;
+          : null;
 
       if (
         sourceState === "active"
@@ -512,9 +540,10 @@ function resolveConnectSourceConnectionMatches(
         : null;
       if (sourceId) {
         upsertConnectSourceConnection(connectedConnections, {
-          connectionId: disconnectConnectionId,
+          connectionId: disconnect.connectionId,
           connectProvider: upstreamRequiresReconnect ? upstreamConnectProvider : provider,
           connectTarget: upstreamRequiresReconnect ? upstreamConnectTarget : null,
+          ...(disconnect.presentation ? { disconnectPresentation: disconnect.presentation } : {}),
           requiresReconnect: upstreamRequiresReconnect,
           sourceId,
           state: sourceState,
@@ -526,20 +555,35 @@ function resolveConnectSourceConnectionMatches(
   return [...connectedConnections.values()];
 }
 
-function resolveSourceScopedDisconnectConnectionId(
+function resolveConnectSourceDisconnect(
   source: ConnectSettingsSourceMatch,
   connectionId: string | null,
-): string | null {
+): { connectionId: string | null; presentation: ConnectSourceDisconnectPresentation | null } {
   if (!connectionId) {
-    return null;
+    return { connectionId: null, presentation: null };
   }
 
   const provider = normalizeDeviceSyncConnectTargetKey(source.provider);
   if (provider !== "junction") {
-    return connectionId;
+    return { connectionId, presentation: null };
   }
 
-  return countLiveJunctionUpstreamSources(source.upstreamSources) <= 1 ? connectionId : null;
+  if (countLiveJunctionUpstreamSources(source.upstreamSources) <= 1) {
+    return { connectionId, presentation: null };
+  }
+
+  return {
+    connectionId,
+    presentation: {
+      disconnectActionLabel: "Disconnect Junction account",
+      disconnectAriaLabel: "Disconnect Junction account",
+      disconnectDialogDescription:
+        "Murph will stop syncing new data from every source in this Junction connection. Your history is kept.",
+      disconnectDialogTitle: "Disconnect Junction account?",
+      disconnectFailureMessage: "We could not disconnect this Junction account right now.",
+      disconnectSuccessMessage: "Disconnected this Junction account. Your history is still saved.",
+    },
+  };
 }
 
 function countLiveJunctionUpstreamSources(

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -459,7 +459,8 @@ function resolveConnectSourceConnectionMatches(
       ? source.state
       : null;
     const parentRequiresReconnect = isReauthorizationRequiredConnectSourceState(source.state);
-    const requiresReconnect = source.primaryAction?.kind === "reconnect" || parentRequiresReconnect;
+    const sourceRequiresReconnect = source.primaryAction?.kind === "reconnect";
+    const requiresReconnect = sourceRequiresReconnect || parentRequiresReconnect;
     const connectionId = typeof source.connectionId === "string" && source.connectionId.trim()
       ? source.connectionId
       : null;
@@ -468,6 +469,9 @@ function resolveConnectSourceConnectionMatches(
       : null;
     const disconnect = resolveConnectSourceDisconnect(source, connectionId);
     const hasJunctionUpstreamSources = provider === "junction" && source.upstreamSources.length > 0;
+    const unambiguousJunctionReconnectUpstreamCount = hasJunctionUpstreamSources && sourceRequiresReconnect
+      ? countLiveJunctionUpstreamSources(source.upstreamSources)
+      : 0;
 
     const configuredSourceId = normalizeDeviceConnectSourceId(source.connectSourceId ?? null);
     if (
@@ -507,8 +511,14 @@ function resolveConnectSourceConnectionMatches(
     }
 
     for (const upstreamSource of source.upstreamSources) {
+      const upstreamOwnRequiresReconnect = upstreamSource.requiresReconnect === true;
+      const upstreamInheritsSourceReconnect =
+        sourceRequiresReconnect
+        && unambiguousJunctionReconnectUpstreamCount === 1
+        && isLiveJunctionUpstreamSource(upstreamSource);
       const upstreamRequiresReconnect = parentRequiresReconnect
-        || upstreamSource.requiresReconnect === true;
+        || upstreamOwnRequiresReconnect
+        || upstreamInheritsSourceReconnect;
       const upstreamConnectProvider = upstreamSource.connectProvider
         ? normalizeDeviceSyncConnectTargetKey(upstreamSource.connectProvider)
         : provider;
@@ -573,11 +583,15 @@ function resolveConnectSourceDisconnect(
 function countLiveJunctionUpstreamSources(
   upstreamSources: ConnectSettingsSourceMatch["upstreamSources"],
 ): number {
-  return upstreamSources.filter((source) =>
-    source.status === "connected"
+  return upstreamSources.filter(isLiveJunctionUpstreamSource).length;
+}
+
+function isLiveJunctionUpstreamSource(
+  source: ConnectSettingsSourceMatch["upstreamSources"][number],
+): boolean {
+  return source.status === "connected"
     || source.status === "error"
-    || source.requiresReconnect === true
-  ).length;
+    || source.requiresReconnect === true;
 }
 
 function upsertConnectSourceConnection(

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -5,7 +5,7 @@ import {
   normalizeDeviceConnectSourceId,
   normalizeDeviceSyncConnectTargetKey,
   readConfiguredDeviceSyncConnectTargetConfigs,
-  resolveJunctionConnectTargetForSourceId,
+  resolveDeviceConnectSourceIdForJunctionProviderSlug,
 } from "@murphai/device-syncd/connect-config";
 
 import { PageHeader } from "@/src/components/ui/page-header";
@@ -52,9 +52,6 @@ type ConnectSourceConnectionState = {
 type ConnectSourceDisconnectScope = NonNullable<ConnectSource["disconnectScope"]>;
 
 const DISPLAY_ONLY_CONNECT_SOURCE_IDS = new Set<string>(["apple-health"]);
-const SOURCE_ID_BY_JUNCTION_UPSTREAM_ALIAS = new Map<string, string>([
-  ["apple_health", "apple-health"],
-]);
 
 const CONNECT_SOURCE_UI = {
   "apple-health": {
@@ -436,17 +433,11 @@ function resolveConnectSourceConnectionMatches(
   const connectedConnections = new Map<string, ConnectSourceConnectionState>();
   const visibleSourceIds = new Set(sources.map((source) => source.id));
   const sourceIdByDirectProvider = new Map<string, string>();
-  const sourceIdByJunctionTarget = new Map<string, string>();
 
   for (const source of sources) {
     const directProvider = normalizeDeviceSyncConnectTargetKey(source.id);
     if (directProvider) {
       sourceIdByDirectProvider.set(directProvider, source.id);
-    }
-
-    const junctionTarget = resolveJunctionConnectTargetForSourceId(source.id);
-    if (junctionTarget) {
-      sourceIdByJunctionTarget.set(junctionTarget, source.id);
     }
   }
 
@@ -537,10 +528,9 @@ function resolveConnectSourceConnectionMatches(
 
       const sourceProviderSlug = normalizeDeviceSyncConnectTargetKey(upstreamSource.sourceProviderSlug);
       const sourceId = sourceProviderSlug
-        ? sourceIdByJunctionTarget.get(sourceProviderSlug)
-          ?? SOURCE_ID_BY_JUNCTION_UPSTREAM_ALIAS.get(sourceProviderSlug)
+        ? resolveDeviceConnectSourceIdForJunctionProviderSlug(sourceProviderSlug)
         : null;
-      if (sourceId) {
+      if (sourceId && visibleSourceIds.has(sourceId)) {
         upsertConnectSourceConnection(connectedConnections, {
           connectionId: disconnect.connectionId,
           connectProvider: upstreamRequiresReconnect ? upstreamConnectProvider : provider,

--- a/apps/web/src/lib/device-sync/provider-label.ts
+++ b/apps/web/src/lib/device-sync/provider-label.ts
@@ -28,6 +28,10 @@ export function formatHostedDeviceSyncSourceLabel(sourceProviderSlug: string): s
   const normalized = sourceProviderSlug.trim().toLowerCase().replace(/_/gu, "-");
 
   switch (normalized) {
+    case "apple-health":
+    case "apple-health-kit":
+    case "apple-healthkit":
+      return "Apple Health";
     case "whoop":
       return formatDeviceSyncProviderLabel("whoop");
     default:

--- a/apps/web/src/lib/device-sync/provider-label.ts
+++ b/apps/web/src/lib/device-sync/provider-label.ts
@@ -28,10 +28,6 @@ export function formatHostedDeviceSyncSourceLabel(sourceProviderSlug: string): s
   const normalized = sourceProviderSlug.trim().toLowerCase().replace(/_/gu, "-");
 
   switch (normalized) {
-    case "apple-health":
-    case "apple-health-kit":
-    case "apple-healthkit":
-      return "Apple Health";
     case "whoop":
       return formatDeviceSyncProviderLabel("whoop");
     default:

--- a/apps/web/src/lib/device-sync/settings-surface.ts
+++ b/apps/web/src/lib/device-sync/settings-surface.ts
@@ -230,8 +230,11 @@ function buildConnectedSource(input: {
   const connectedAgeMs = ageInMilliseconds(connection.connectedAt, now);
   const setupPhase = connection.setupPhase ?? null;
   const reconnectSource = findReconnectRequiredUpstreamSource(input.upstreamSources);
+  const sourceReconnectTarget = reconnectSource
+    ? resolveUpstreamSourceReconnectTarget(reconnectSource)
+    : null;
   const sourceReconnectAction = reconnectSource
-    ? buildReconnectAction(input.connectTarget)
+    ? buildReconnectAction(sourceReconnectTarget)
     : null;
 
   if (connection.status === "disconnected") {
@@ -343,8 +346,8 @@ function buildConnectedSource(input: {
     return {
       connectionId: connection.id,
       connectedAt: connection.connectedAt,
-      connectSourceId: input.connectTarget?.connectSourceId ?? null,
-      connectTarget: input.connectTarget?.connectTarget ?? null,
+      connectSourceId: sourceReconnectTarget?.connectSourceId ?? null,
+      connectTarget: sourceReconnectTarget?.connectTarget ?? null,
       detail: `${reconnectSource.providerLabel} needs to be reconnected before Murph can keep syncing it.`,
       displayName,
       guidance: sourceReconnectAction
@@ -516,6 +519,32 @@ function buildReconnectAction(
   return {
     kind: "reconnect",
     label: "Reconnect",
+  };
+}
+
+function resolveUpstreamSourceReconnectTarget(
+  source: HostedDeviceSyncSettingsUpstreamSource,
+): HostedDeviceSyncSettingsConnectTarget | null {
+  const connectTarget = source.connectTarget?.trim();
+  if (!connectTarget) {
+    return null;
+  }
+
+  const connectSourceId = source.connectSourceId?.trim();
+  if (!connectSourceId) {
+    return null;
+  }
+
+  const provider = source.connectProvider ?? null;
+  if (!provider) {
+    return null;
+  }
+
+  return {
+    connectSourceId,
+    connectTarget,
+    provider,
+    sourceProviderSlug: source.sourceProviderSlug,
   };
 }
 

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -832,6 +832,54 @@ test("ConnectPage keeps account disconnects visible for parent-level Junction re
   assert.equal(markup.match(/aria-label="Disconnect Junction account"/gu)?.length, 2);
 });
 
+test("ConnectPage does not apply parent Junction reauthorization to disconnected upstream projections", async () => {
+  vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+  vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+  vi.stubEnv("JUNCTION_ENV", "sandbox");
+  vi.stubEnv("JUNCTION_PROVIDER_FILTER", "garmin");
+  vi.stubEnv("JUNCTION_REGION", "us");
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_multi",
+        provider: "junction",
+        state: "reauthorization_required",
+        upstreamSources: [
+          {
+            connectProvider: "junction",
+            connectTarget: "garmin",
+            providerLabel: "Garmin",
+            resourceCount: 2,
+            sourceProviderSlug: "garmin",
+            status: "unavailable",
+          },
+          {
+            providerLabel: "Apple Health",
+            resourceCount: 4,
+            sourceProviderSlug: "apple_health_kit",
+            status: "disconnected",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Garmin needs reconnect/u);
+  assert.match(markup, /aria-label="Reconnect Garmin"/u);
+  assert.match(markup, /Apple Health not connected/u);
+  assert.match(markup, /Apple Health web setup is coming soon\. Connect from the Murph iOS app for now\./u);
+  assert.match(markup, /aria-label="Apple Health web setup is not available yet"/u);
+  assert.doesNotMatch(markup, /Apple Health needs reconnect/u);
+  assert.doesNotMatch(markup, /aria-label="Reconnect Apple Health"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Apple Health"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Junction account"/u);
+});
+
 test("ConnectPage shows mobile-managed guidance for Apple Health reconnect states without web target", async () => {
   mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
     generatedAt: "2026-05-01T00:00:00.000Z",

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -132,13 +132,18 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
   assert.match(markup, /Live Well/);
   assert.match(markup, /placeholder="Search sources"/);
   assert.match(markup, /aria-label="Search sources"/);
-  assert.match(markup, />27 of 27 sources</);
+  assert.match(markup, />28 of 28 sources</);
   assert.match(markup, /lg:grid-cols-2 xl:grid-cols-4/);
   assert.doesNotMatch(markup, /data-priority list/);
   assert.doesNotMatch(markup, /Priority/u);
   assert.doesNotMatch(markup, /Health data source from the Just Cobuild priority catalog/u);
 
   const sources = [
+    {
+      assetPath: "/brand-logos/connect/apple-health.png",
+      description: "iPhone and Apple Watch activity, sleep, vitals, and workouts.",
+      name: "Apple Health",
+    },
     {
       assetPath: "/brand-logos/connect/whoop.svg",
       description: "Recovery, strain, sleep, heart rate, and daily readiness from Whoop.",
@@ -276,16 +281,17 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
     },
   ];
 
-  assert.equal(sources.length, 27);
+  assert.equal(sources.length, 28);
   assert.equal(markup.match(/data-connection-state="idle"/gu)?.length, sources.length);
   assert.equal(markup.match(/>Not available<\/button>/gu)?.length, sources.length);
   assert.match(markup, /disabled=""/);
+  assert.match(markup, /aria-label="Apple Health connection is not available yet"/);
   assert.match(markup, /aria-label="Oura connection is not available yet"/);
+  assert.match(markup, /Apple Health not connected/);
   assert.match(markup, /Oura not connected/);
   assert.doesNotMatch(markup, /Coming soon/u);
   assert.doesNotMatch(markup, /Not connected/u);
   assert.doesNotMatch(markup, />Connected</u);
-  assert.doesNotMatch(markup, />Apple Health</u);
   assert.doesNotMatch(markup, />Health Connect</u);
   assert.doesNotMatch(markup, />Samsung Health</u);
   assert.doesNotMatch(markup, />Freestyle Libre BLE</u);
@@ -294,6 +300,7 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
   assert.doesNotMatch(markup, />OneTouch</u);
   assert.doesNotMatch(markup, />Manual</u);
   assert.doesNotMatch(markup, /Whoop V2/u);
+  assert.ok(sourceHeadingIndex(markup, "Apple Health") < sourceHeadingIndex(markup, "Garmin"));
   assert.ok(sourceHeadingIndex(markup, "Garmin") < sourceHeadingIndex(markup, "Fitbit"));
   assert.ok(sourceHeadingIndex(markup, "Fitbit") < sourceHeadingIndex(markup, "Google Fit"));
   assert.ok(sourceHeadingIndex(markup, "Google Fit") < sourceHeadingIndex(markup, "Strava"));
@@ -489,7 +496,8 @@ test("ConnectPage enables every Link source exposed by the shared Junction defau
   const markup = renderToStaticMarkup(await ConnectPage());
 
   assert.equal(markup.match(/>Connect<\/button>/gu)?.length, JUNCTION_DEFAULT_PROVIDER_FILTER.length);
-  assert.equal(markup.match(/>Not available<\/button>/gu)?.length ?? 0, 0);
+  assert.equal(markup.match(/>Not available<\/button>/gu)?.length ?? 0, 1);
+  assert.match(markup, /aria-label="Apple Health connection is not available yet"/u);
   assert.doesNotMatch(markup, />Accu-Chek</u);
   assert.doesNotMatch(markup, />Samsung Health</u);
 
@@ -670,6 +678,110 @@ test("ConnectPage marks direct and Junction upstream sources connected from host
   assert.doesNotMatch(markup, /aria-label="Connect Whoop"/u);
 });
 
+test("ConnectPage marks iOS Apple Health Junction SDK source connected from hosted state", async () => {
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_apple_health",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Apple Health",
+            resourceCount: 4,
+            sourceProviderSlug: "apple_health_kit",
+            status: "connected",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Apple Health connected/u);
+  assert.match(markup, /aria-label="Disconnect Apple Health"/u);
+  assert.doesNotMatch(markup, /aria-label="Connect Apple Health"/u);
+  assert.equal(markup.match(/data-connection-state="connected"/gu)?.length, 1);
+  assert.ok(sourceHeadingIndex(markup, "Apple Health") < sourceHeadingIndex(markup, "Garmin"));
+});
+
+test("ConnectPage avoids source-specific disconnects for multi-source Junction accounts", async () => {
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_multi_source",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Apple Health",
+            resourceCount: 4,
+            sourceProviderSlug: "apple_health_kit",
+            status: "connected",
+          },
+          {
+            providerLabel: "WHOOP",
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "connected",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Apple Health connected/u);
+  assert.match(markup, /Whoop connected/u);
+  assert.equal(markup.match(/data-connection-state="connected"/gu)?.length, 2);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Apple Health"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Whoop"/u);
+});
+
+test("ConnectPage shows mobile-managed guidance for Apple Health reconnect states without web target", async () => {
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_apple_health",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Apple Health",
+            requiresReconnect: true,
+            resourceCount: 4,
+            sourceProviderSlug: "apple_health_kit",
+            status: "error",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Apple Health needs reconnect/u);
+  assert.match(
+    markup,
+    /Apple Health needs attention from the connected app before Murph can keep syncing it\./u,
+  );
+  assert.match(markup, /aria-label="Disconnect Apple Health"/u);
+  assert.match(markup, /data-connection-state="needs-access"/u);
+  assert.doesNotMatch(markup, /aria-label="Apple Health connection is not available yet"/u);
+  assert.doesNotMatch(markup, /Please reconnect Apple Health to resume syncing\./u);
+});
+
 test("ConnectPage ignores disconnected Junction upstream projections on active connections", async () => {
   vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
   vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
@@ -840,6 +952,84 @@ test("ConnectPage lets active state win when duplicate rows mention the same sou
   );
 });
 
+test("ConnectPage maps Apple Health Junction upstream slugs to the visible source", async () => {
+  const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
+
+  for (const sourceProviderSlug of ["apple_health_kit", "apple_health"]) {
+    assert.deepEqual(
+      resolveConnectSourceConnectionStates([{ id: "apple-health" }], [
+        {
+          connectionId: "dsc_junction_apple_health",
+          provider: "junction",
+          state: "active",
+          upstreamSources: [
+            {
+              providerLabel: "Apple Health",
+              resourceCount: 4,
+              sourceProviderSlug,
+              status: "connected",
+            },
+          ],
+        },
+      ]),
+      [{
+        connectionId: "dsc_junction_apple_health",
+        connectProvider: "junction",
+        connectTarget: null,
+        requiresReconnect: false,
+        sourceId: "apple-health",
+        state: "active",
+      }],
+    );
+  }
+});
+
+test("ConnectPage withholds Junction connection ids from multi-source upstream projections", async () => {
+  const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
+
+  assert.deepEqual(
+    resolveConnectSourceConnectionStates([{ id: "apple-health" }, { id: "whoop" }], [
+      {
+        connectionId: "dsc_junction_multi_source",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Apple Health",
+            resourceCount: 4,
+            sourceProviderSlug: "apple_health_kit",
+            status: "connected",
+          },
+          {
+            providerLabel: "WHOOP",
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "connected",
+          },
+        ],
+      },
+    ]),
+    [
+      {
+        connectionId: null,
+        connectProvider: "junction",
+        connectTarget: null,
+        requiresReconnect: false,
+        sourceId: "apple-health",
+        state: "active",
+      },
+      {
+        connectionId: null,
+        connectProvider: "junction",
+        connectTarget: null,
+        requiresReconnect: false,
+        sourceId: "whoop",
+        state: "active",
+      },
+    ],
+  );
+});
+
 test("ConnectPage preserves reconnect action on active source matches", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 
@@ -941,7 +1131,7 @@ test("ConnectPage keeps healthy Junction child sources connected when another ch
     ]),
     [
       {
-        connectionId: "dsc_junction_multi",
+        connectionId: null,
         connectProvider: "junction",
         connectTarget: "whoop",
         requiresReconnect: true,
@@ -949,7 +1139,7 @@ test("ConnectPage keeps healthy Junction child sources connected when another ch
         state: "active",
       },
       {
-        connectionId: "dsc_junction_multi",
+        connectionId: null,
         connectProvider: "junction",
         connectTarget: null,
         requiresReconnect: false,
@@ -1001,7 +1191,7 @@ test("ConnectPage gives each reconnect-required Junction child its own target", 
     ]),
     [
       {
-        connectionId: "dsc_junction_multi",
+        connectionId: null,
         connectProvider: "junction",
         connectTarget: "whoop",
         requiresReconnect: true,
@@ -1009,7 +1199,7 @@ test("ConnectPage gives each reconnect-required Junction child its own target", 
         state: "active",
       },
       {
-        connectionId: "dsc_junction_multi",
+        connectionId: null,
         connectProvider: "junction",
         connectTarget: "garmin",
         requiresReconnect: true,

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -70,6 +70,16 @@ const mocks = vi.hoisted(() => ({
   resolveHostedMurphContactOption: vi.fn(),
 }));
 
+const JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION = {
+  disconnectActionLabel: "Disconnect Junction account",
+  disconnectAriaLabel: "Disconnect Junction account",
+  disconnectDialogDescription:
+    "Murph will stop syncing new data from every source in this Junction connection. Your history is kept.",
+  disconnectDialogTitle: "Disconnect Junction account?",
+  disconnectFailureMessage: "We could not disconnect this Junction account right now.",
+  disconnectSuccessMessage: "Disconnected this Junction account. Your history is still saved.",
+};
+
 vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
   AuthDialog(props: { open?: boolean }) {
     mocks.authDialogProps = props;
@@ -285,12 +295,12 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
   assert.equal(markup.match(/data-connection-state="idle"/gu)?.length, sources.length);
   assert.equal(markup.match(/>Not available<\/button>/gu)?.length, sources.length - 1);
   assert.match(markup, /disabled=""/);
-  assert.match(markup, /Apple Health connects through the Murph iOS app and appears here after the first sync\./);
-  assert.doesNotMatch(markup, /aria-label="Apple Health connection is not available yet"/);
+  assert.match(markup, /Apple Health web setup is coming soon\. Connect from the Murph iOS app for now\./);
+  assert.match(markup, /aria-label="Apple Health web setup is not available yet"/);
   assert.match(markup, /aria-label="Oura connection is not available yet"/);
   assert.match(markup, /Apple Health not connected/);
   assert.match(markup, /Oura not connected/);
-  assert.doesNotMatch(markup, /Coming soon/u);
+  assert.match(markup, />Coming soon<\/button>/u);
   assert.doesNotMatch(markup, /Not connected/u);
   assert.doesNotMatch(markup, />Connected</u);
   assert.doesNotMatch(markup, />Health Connect</u);
@@ -498,8 +508,8 @@ test("ConnectPage enables every Link source exposed by the shared Junction defau
 
   assert.equal(markup.match(/>Connect<\/button>/gu)?.length, JUNCTION_DEFAULT_PROVIDER_FILTER.length);
   assert.equal(markup.match(/>Not available<\/button>/gu)?.length ?? 0, 0);
-  assert.match(markup, /Apple Health connects through the Murph iOS app and appears here after the first sync\./u);
-  assert.doesNotMatch(markup, /aria-label="Apple Health connection is not available yet"/u);
+  assert.match(markup, /Apple Health web setup is coming soon\. Connect from the Murph iOS app for now\./u);
+  assert.match(markup, /aria-label="Apple Health web setup is not available yet"/u);
   assert.doesNotMatch(markup, />Accu-Chek</u);
   assert.doesNotMatch(markup, />Samsung Health</u);
 
@@ -711,7 +721,7 @@ test("ConnectPage marks iOS Apple Health Junction SDK source connected from host
   assert.ok(sourceHeadingIndex(markup, "Apple Health") < sourceHeadingIndex(markup, "Garmin"));
 });
 
-test("ConnectPage avoids source-specific disconnects for multi-source Junction accounts", async () => {
+test("ConnectPage shows account-scoped disconnects for multi-source Junction accounts", async () => {
   mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
     generatedAt: "2026-05-01T00:00:00.000Z",
     ok: true,
@@ -746,6 +756,7 @@ test("ConnectPage avoids source-specific disconnects for multi-source Junction a
   assert.equal(markup.match(/data-connection-state="connected"/gu)?.length, 2);
   assert.doesNotMatch(markup, /aria-label="Disconnect Apple Health"/u);
   assert.doesNotMatch(markup, /aria-label="Disconnect Whoop"/u);
+  assert.equal(markup.match(/aria-label="Disconnect Junction account"/gu)?.length, 2);
 });
 
 test("ConnectPage shows mobile-managed guidance for Apple Health reconnect states without web target", async () => {
@@ -986,7 +997,7 @@ test("ConnectPage maps Apple Health Junction upstream slugs to the visible sourc
   }
 });
 
-test("ConnectPage withholds Junction connection ids from multi-source upstream projections", async () => {
+test("ConnectPage carries account-scoped disconnect ids for multi-source upstream projections", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 
   assert.deepEqual(
@@ -1013,17 +1024,19 @@ test("ConnectPage withholds Junction connection ids from multi-source upstream p
     ]),
     [
       {
-        connectionId: null,
+        connectionId: "dsc_junction_multi_source",
         connectProvider: "junction",
         connectTarget: null,
+        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
         requiresReconnect: false,
         sourceId: "apple-health",
         state: "active",
       },
       {
-        connectionId: null,
+        connectionId: "dsc_junction_multi_source",
         connectProvider: "junction",
         connectTarget: null,
+        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
         requiresReconnect: false,
         sourceId: "whoop",
         state: "active",
@@ -1133,19 +1146,21 @@ test("ConnectPage keeps healthy Junction child sources connected when another ch
     ]),
     [
       {
-        connectionId: null,
+        connectionId: "dsc_junction_multi",
         connectProvider: "junction",
-        connectTarget: "whoop",
-        requiresReconnect: true,
-        sourceId: "whoop",
+        connectTarget: null,
+        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        requiresReconnect: false,
+        sourceId: "garmin",
         state: "active",
       },
       {
-        connectionId: null,
+        connectionId: "dsc_junction_multi",
         connectProvider: "junction",
         connectTarget: null,
-        requiresReconnect: false,
-        sourceId: "garmin",
+        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        requiresReconnect: true,
+        sourceId: "whoop",
         state: "active",
       },
     ],
@@ -1193,19 +1208,21 @@ test("ConnectPage gives each reconnect-required Junction child its own target", 
     ]),
     [
       {
-        connectionId: null,
+        connectionId: "dsc_junction_multi",
         connectProvider: "junction",
-        connectTarget: "whoop",
+        connectTarget: "garmin",
+        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
         requiresReconnect: true,
-        sourceId: "whoop",
+        sourceId: "garmin",
         state: "active",
       },
       {
-        connectionId: null,
+        connectionId: "dsc_junction_multi",
         connectProvider: "junction",
-        connectTarget: "garmin",
+        connectTarget: "whoop",
+        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
         requiresReconnect: true,
-        sourceId: "garmin",
+        sourceId: "whoop",
         state: "active",
       },
     ],

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -1257,6 +1257,59 @@ test("ConnectPage gives each reconnect-required Junction child its own target", 
   );
 });
 
+test("ConnectPage keeps account disconnects visible when all Junction children need reconnect", async () => {
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_multi",
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        primaryAction: {
+          kind: "reconnect",
+          label: "Reconnect",
+        },
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            connectProvider: "junction",
+            connectSourceId: "garmin",
+            connectTarget: "garmin",
+            providerLabel: "Garmin",
+            requiresReconnect: true,
+            resourceCount: 2,
+            sourceProviderSlug: "garmin",
+            status: "error",
+          },
+          {
+            connectProvider: "junction",
+            connectSourceId: "whoop",
+            connectTarget: "whoop",
+            providerLabel: "WHOOP",
+            requiresReconnect: true,
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "error",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Garmin needs reconnect/u);
+  assert.match(markup, /Whoop needs reconnect/u);
+  assert.match(markup, /aria-label="Reconnect Garmin"/u);
+  assert.match(markup, /aria-label="Reconnect Whoop"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Garmin"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Whoop"/u);
+  assert.equal(markup.match(/aria-label="Disconnect Junction account"/gu)?.length, 2);
+});
+
 test("ConnectPage lets active reconnect rows win over stale reconnectable rows", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -70,16 +70,6 @@ const mocks = vi.hoisted(() => ({
   resolveHostedMurphContactOption: vi.fn(),
 }));
 
-const JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION = {
-  disconnectActionLabel: "Disconnect Junction account",
-  disconnectAriaLabel: "Disconnect Junction account",
-  disconnectDialogDescription:
-    "Murph will stop syncing new data from every source in this Junction connection. Your history is kept.",
-  disconnectDialogTitle: "Disconnect Junction account?",
-  disconnectFailureMessage: "We could not disconnect this Junction account right now.",
-  disconnectSuccessMessage: "Disconnected this Junction account. Your history is still saved.",
-};
-
 vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
   AuthDialog(props: { open?: boolean }) {
     mocks.authDialogProps = props;
@@ -1027,7 +1017,7 @@ test("ConnectPage carries account-scoped disconnect ids for multi-source upstrea
         connectionId: "dsc_junction_multi_source",
         connectProvider: "junction",
         connectTarget: null,
-        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        disconnectScope: "junction_account",
         requiresReconnect: false,
         sourceId: "apple-health",
         state: "active",
@@ -1036,7 +1026,7 @@ test("ConnectPage carries account-scoped disconnect ids for multi-source upstrea
         connectionId: "dsc_junction_multi_source",
         connectProvider: "junction",
         connectTarget: null,
-        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        disconnectScope: "junction_account",
         requiresReconnect: false,
         sourceId: "whoop",
         state: "active",
@@ -1149,7 +1139,7 @@ test("ConnectPage keeps healthy Junction child sources connected when another ch
         connectionId: "dsc_junction_multi",
         connectProvider: "junction",
         connectTarget: null,
-        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        disconnectScope: "junction_account",
         requiresReconnect: false,
         sourceId: "garmin",
         state: "active",
@@ -1158,7 +1148,7 @@ test("ConnectPage keeps healthy Junction child sources connected when another ch
         connectionId: "dsc_junction_multi",
         connectProvider: "junction",
         connectTarget: null,
-        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        disconnectScope: "junction_account",
         requiresReconnect: true,
         sourceId: "whoop",
         state: "active",
@@ -1211,7 +1201,7 @@ test("ConnectPage gives each reconnect-required Junction child its own target", 
         connectionId: "dsc_junction_multi",
         connectProvider: "junction",
         connectTarget: "garmin",
-        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        disconnectScope: "junction_account",
         requiresReconnect: true,
         sourceId: "garmin",
         state: "active",
@@ -1220,7 +1210,7 @@ test("ConnectPage gives each reconnect-required Junction child its own target", 
         connectionId: "dsc_junction_multi",
         connectProvider: "junction",
         connectTarget: "whoop",
-        disconnectPresentation: JUNCTION_ACCOUNT_DISCONNECT_PRESENTATION,
+        disconnectScope: "junction_account",
         requiresReconnect: true,
         sourceId: "whoop",
         state: "active",
@@ -2046,6 +2036,129 @@ test("ConnectSourcesGrid disconnects a connected source after confirmation", asy
   });
   assert.match(rendered.container.textContent ?? "", /Whoop not connected/);
   assert.equal(rendered.container.querySelector("button[aria-label='Connect Whoop']")?.textContent, "Connect");
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid keeps Apple Health mobile guidance after local disconnect", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({});
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connected: true,
+        description: "iPhone and Apple Watch activity, sleep, vitals, and workouts.",
+        disconnectConnectionId: "dsc_apple_health_123",
+        id: "apple-health",
+        logo: {
+          className: "h-9 w-auto object-contain",
+          height: 48,
+          src: "/brand-logos/connect/apple-health.png",
+          width: 48,
+        },
+        name: "Apple Health",
+        unavailableActionLabel: "Coming soon",
+        unavailableMessage: "Apple Health web setup is coming soon. Connect from the Murph iOS app for now.",
+      },
+    ],
+  }));
+
+  const disconnectButton = rendered.container.querySelector("button[aria-label='Disconnect Apple Health']");
+  assert.ok(disconnectButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    disconnectButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  const confirmButton = [...rendered.container.querySelectorAll("button")]
+    .filter((button) => button.textContent === "Disconnect")
+    .at(-1);
+  assert.ok(confirmButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    confirmButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(rendered.container.textContent ?? "", /Disconnected Apple Health\. Your history is still saved\./);
+  });
+
+  assert.equal(fetch.mock.calls[0]?.[0], "/api/settings/device-sync/connections/dsc_apple_health_123/disconnect");
+  assert.match(rendered.container.textContent ?? "", /Apple Health not connected/);
+  assert.match(rendered.container.textContent ?? "", /Apple Health web setup is coming soon\. Connect from the Murph iOS app for now\./);
+  assert.equal(rendered.container.querySelector("button[aria-label='Apple Health web setup is not available yet']")?.textContent, "Coming soon");
+  assert.doesNotMatch(rendered.container.textContent ?? "", /Not available/u);
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid uses account-scoped Junction disconnect copy", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({});
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connected: true,
+        description: "Recovery, strain, sleep, and heart rate.",
+        disconnectConnectionId: "dsc_junction_multi",
+        disconnectScope: "junction_account",
+        id: "whoop",
+        logo: {
+          className: "h-auto max-h-7 w-auto max-w-[8rem] object-contain",
+          height: 15,
+          src: "/brand-logos/connect/whoop.svg",
+          width: 96,
+        },
+        name: "Whoop",
+      },
+    ],
+  }));
+
+  const disconnectButton = rendered.container.querySelector("button[aria-label='Disconnect Junction account']");
+  assert.ok(disconnectButton instanceof rendered.window.HTMLButtonElement);
+  assert.equal(disconnectButton.textContent, "Disconnect Junction account");
+
+  await act(async () => {
+    disconnectButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  assert.match(rendered.container.textContent ?? "", /Disconnect Junction account\?/);
+  assert.match(
+    rendered.container.textContent ?? "",
+    /Murph will stop syncing new data from every source in this Junction connection\. Your history is kept\./,
+  );
+
+  const confirmButton = [...rendered.container.querySelectorAll("button")]
+    .filter((button) => button.textContent === "Disconnect")
+    .at(-1);
+  assert.ok(confirmButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    confirmButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(rendered.container.textContent ?? "", /Disconnected this Junction account\. Your history is still saved\./);
+  });
+  assert.equal(fetch.mock.calls[0]?.[0], "/api/settings/device-sync/connections/dsc_junction_multi/disconnect");
 
   await rendered.cleanup();
 });

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -920,6 +920,44 @@ test("ConnectPage surfaces active sources with reconnect action as reconnectable
   assert.doesNotMatch(markup, /aria-label="Connect Whoop"/u);
 });
 
+test("ConnectPage preserves unambiguous Junction source reconnects with upstream projections", async () => {
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_whoop",
+        primaryAction: {
+          kind: "reconnect",
+          label: "Reconnect",
+        },
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            connectProvider: "junction",
+            connectSourceId: "whoop",
+            connectTarget: "whoop",
+            providerLabel: "WHOOP",
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "connected",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Whoop needs reconnect/u);
+  assert.match(markup, /Please reconnect Whoop to resume syncing\./u);
+  assert.match(markup, /aria-label="Reconnect Whoop"/u);
+  assert.match(markup, /data-connection-state="needs-access"/u);
+  assert.doesNotMatch(markup, /Whoop connected/u);
+});
+
 test("ConnectPage lets active state win when duplicate rows mention the same source", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -749,6 +749,43 @@ test("ConnectPage shows account-scoped disconnects for multi-source Junction acc
   assert.equal(markup.match(/aria-label="Disconnect Junction account"/gu)?.length, 2);
 });
 
+test("ConnectPage scopes disconnects by every non-disconnected Junction upstream", async () => {
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_multi_source",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Garmin",
+            resourceCount: 2,
+            sourceProviderSlug: "garmin",
+            status: "connected",
+          },
+          {
+            providerLabel: "Apple Health",
+            resourceCount: 4,
+            sourceProviderSlug: "apple_health_kit",
+            status: "unavailable",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Garmin connected/u);
+  assert.doesNotMatch(markup, /Apple Health connected/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Garmin"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Apple Health"/u);
+  assert.equal(markup.match(/aria-label="Disconnect Junction account"/gu)?.length, 1);
+});
+
 test("ConnectPage keeps account disconnects visible for parent-level Junction reauthorization", async () => {
   vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
   vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -749,6 +749,52 @@ test("ConnectPage shows account-scoped disconnects for multi-source Junction acc
   assert.equal(markup.match(/aria-label="Disconnect Junction account"/gu)?.length, 2);
 });
 
+test("ConnectPage keeps account disconnects visible for parent-level Junction reauthorization", async () => {
+  vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+  vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+  vi.stubEnv("JUNCTION_ENV", "sandbox");
+  vi.stubEnv("JUNCTION_PROVIDER_FILTER", "garmin");
+  vi.stubEnv("JUNCTION_REGION", "us");
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_multi",
+        provider: "junction",
+        state: "reauthorization_required",
+        upstreamSources: [
+          {
+            connectProvider: "junction",
+            connectTarget: "garmin",
+            providerLabel: "Garmin",
+            resourceCount: 2,
+            sourceProviderSlug: "garmin",
+            status: "unavailable",
+          },
+          {
+            providerLabel: "Apple Health",
+            resourceCount: 4,
+            sourceProviderSlug: "apple_health_kit",
+            status: "unavailable",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Apple Health needs reconnect/u);
+  assert.match(markup, /Garmin needs reconnect/u);
+  assert.match(markup, /aria-label="Reconnect Garmin"/u);
+  assert.doesNotMatch(markup, /aria-label="Reconnect Apple Health"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Apple Health"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect Garmin"/u);
+  assert.equal(markup.match(/aria-label="Disconnect Junction account"/gu)?.length, 2);
+});
+
 test("ConnectPage shows mobile-managed guidance for Apple Health reconnect states without web target", async () => {
   mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
     generatedAt: "2026-05-01T00:00:00.000Z",

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -283,9 +283,10 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
 
   assert.equal(sources.length, 28);
   assert.equal(markup.match(/data-connection-state="idle"/gu)?.length, sources.length);
-  assert.equal(markup.match(/>Not available<\/button>/gu)?.length, sources.length);
+  assert.equal(markup.match(/>Not available<\/button>/gu)?.length, sources.length - 1);
   assert.match(markup, /disabled=""/);
-  assert.match(markup, /aria-label="Apple Health connection is not available yet"/);
+  assert.match(markup, /Apple Health connects through the Murph iOS app and appears here after the first sync\./);
+  assert.doesNotMatch(markup, /aria-label="Apple Health connection is not available yet"/);
   assert.match(markup, /aria-label="Oura connection is not available yet"/);
   assert.match(markup, /Apple Health not connected/);
   assert.match(markup, /Oura not connected/);
@@ -496,8 +497,9 @@ test("ConnectPage enables every Link source exposed by the shared Junction defau
   const markup = renderToStaticMarkup(await ConnectPage());
 
   assert.equal(markup.match(/>Connect<\/button>/gu)?.length, JUNCTION_DEFAULT_PROVIDER_FILTER.length);
-  assert.equal(markup.match(/>Not available<\/button>/gu)?.length ?? 0, 1);
-  assert.match(markup, /aria-label="Apple Health connection is not available yet"/u);
+  assert.equal(markup.match(/>Not available<\/button>/gu)?.length ?? 0, 0);
+  assert.match(markup, /Apple Health connects through the Murph iOS app and appears here after the first sync\./u);
+  assert.doesNotMatch(markup, /aria-label="Apple Health connection is not available yet"/u);
   assert.doesNotMatch(markup, />Accu-Chek</u);
   assert.doesNotMatch(markup, />Samsung Health</u);
 

--- a/apps/web/test/connect-source-and-experiment-card-routes.test.tsx
+++ b/apps/web/test/connect-source-and-experiment-card-routes.test.tsx
@@ -59,7 +59,8 @@ test("listVisibleConnectSources covers every hosted-visible device source with U
 
   const expectedVisibleSourceIds = DEVICE_CONNECT_SOURCES
     .filter((source) =>
-      source.routes.some((route) => route.kind === "direct" || route.kind === "junction_link"),
+      source.connectSourceId === "apple-health"
+      || source.routes.some((route) => route.kind === "direct" || route.kind === "junction_link"),
     )
     .map((source) => source.connectSourceId)
     .sort();

--- a/apps/web/test/device-sync-provider-label.test.ts
+++ b/apps/web/test/device-sync-provider-label.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+import {
+  formatHostedDeviceSyncSourceLabel,
+  resolveHostedDeviceSyncBrowserProviderLabel,
+} from "@/src/lib/device-sync/provider-label";
+
+test("hosted device sync labels Apple Health upstream source slugs", () => {
+  assert.equal(formatHostedDeviceSyncSourceLabel("apple_health_kit"), "Apple Health");
+  assert.equal(formatHostedDeviceSyncSourceLabel("apple_health"), "Apple Health");
+  assert.equal(formatHostedDeviceSyncSourceLabel("apple-healthkit"), "Apple Health");
+});
+
+test("hosted device sync browser label uses Apple Health when it is the only source", () => {
+  assert.equal(
+    resolveHostedDeviceSyncBrowserProviderLabel({
+      provider: "junction",
+      upstreamSources: [
+        {
+          sourceProviderSlug: "apple_health_kit",
+          status: "connected",
+        },
+      ],
+    }),
+    "Apple Health",
+  );
+});

--- a/apps/web/test/device-sync-settings-surface.test.ts
+++ b/apps/web/test/device-sync-settings-surface.test.ts
@@ -457,6 +457,58 @@ describe("buildHostedDeviceSyncSettingsSources", () => {
     ]);
   });
 
+  it("does not borrow another Junction child source's target for Apple Health reconnect", () => {
+    const [source] = buildHostedDeviceSyncSettingsSources({
+      connectionSources: [
+        {
+          connectionId: "dspc_junction_multi",
+          firstSeenAt: "2026-04-01T08:00:00.000Z",
+          lastSeenAt: "2026-06-09T08:30:00.000Z",
+          resourceCount: 2,
+          sourceProviderSlug: "garmin",
+          status: "connected",
+        },
+        {
+          connectionId: "dspc_junction_multi",
+          firstSeenAt: "2026-04-01T08:00:00.000Z",
+          lastSeenAt: "2026-06-09T08:50:48.000Z",
+          requiresReconnect: true,
+          resourceCount: 3,
+          sourceProviderSlug: "apple_health_kit",
+          status: "error",
+        },
+      ],
+      connectTargets: [{
+        connectSourceId: "garmin",
+        connectTarget: "garmin",
+        provider: "junction",
+        sourceProviderSlug: "garmin",
+      }],
+      connections: [buildConnection({
+        id: "dspc_junction_multi",
+        lastSyncCompletedAt: "2026-06-09T07:00:00.000Z",
+        provider: "junction",
+        status: "active",
+        updatedAt: "2026-06-09T08:50:48.000Z",
+      })],
+      now: new Date("2026-06-09T12:00:00.000Z"),
+      providers: [JUNCTION_PROVIDER],
+    });
+
+    expect(source).toMatchObject({
+      connectSourceId: null,
+      connectTarget: null,
+      detail: "Apple Health needs to be reconnected before Murph can keep syncing it.",
+      guidance: "Disconnect this source if you no longer need it.",
+      primaryAction: null,
+      provider: "junction",
+      providerLabel: "Apple Health",
+      secondaryAction: { kind: "disconnect", label: "Disconnect" },
+      statusLabel: "Needs access",
+      tone: "attention",
+    });
+  });
+
   it("keeps pending external-link setup separate from the active lifecycle state", () => {
     const [source] = buildHostedDeviceSyncSettingsSources({
       connections: [buildConnection({

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -320,6 +320,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(prReviewGptLoop).toContain('Eragon managed browser profile')
     expect(prReviewGptLoop).toContain('zero accepted findings')
     expect(prReviewGptLoop).toContain('`review-gpt-pr-context/pr.diff`')
+    expect(prReviewGptLoop).toContain('It does **not** run the local Codex')
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-full.config.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.data.config.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'research-run.mjs'))).toBe(false)

--- a/packages/device-syncd/src/config/connect-routes.ts
+++ b/packages/device-syncd/src/config/connect-routes.ts
@@ -12,12 +12,14 @@ export interface DeviceConnectJunctionLinkRoute {
   readonly kind: "junction_link";
   readonly connectTarget: string;
   readonly sourceProviderSlug: string;
+  readonly sourceProviderSlugAliases?: readonly string[];
   readonly defaultEnabled: boolean;
 }
 
 export interface DeviceConnectJunctionSdkRoute {
   readonly kind: "junction_sdk";
   readonly sourceProviderSlug: string;
+  readonly sourceProviderSlugAliases?: readonly string[];
 }
 
 export interface DeviceConnectDirectRoute {
@@ -207,7 +209,7 @@ export const DEVICE_CONNECT_SOURCES = Object.freeze([
   {
     connectSourceId: "apple-health",
     label: "Apple Health",
-    routes: [junctionSdkRoute("apple_health_kit")],
+    routes: [junctionSdkRoute("apple_health_kit", { aliases: ["apple_health", "apple_healthkit"] })],
   },
   {
     connectSourceId: "health-connect",
@@ -224,9 +226,7 @@ const DIRECT_ROUTE_ENTRY_BY_PROVIDER = new Map(
   listDirectDeviceConnectRouteEntries().map((entry) => [entry.route.provider, entry] as const),
 );
 
-const JUNCTION_ROUTE_ENTRY_BY_PROVIDER_SLUG = new Map(
-  listJunctionDeviceConnectRouteEntries().map((entry) => [entry.route.sourceProviderSlug, entry] as const),
-);
+const JUNCTION_ROUTE_ENTRY_BY_PROVIDER_SLUG = buildJunctionDeviceConnectRouteEntryMap();
 
 const JUNCTION_LINK_ROUTE_ENTRY_BY_PROVIDER_SLUG = new Map(
   listJunctionLinkDeviceConnectRouteEntries().map((entry) => [entry.route.sourceProviderSlug, entry] as const),
@@ -354,6 +354,10 @@ export function resolveJunctionDeviceConnectRouteByProviderSlug(
   return normalized ? JUNCTION_ROUTE_ENTRY_BY_PROVIDER_SLUG.get(normalized) ?? null : null;
 }
 
+export function resolveDeviceConnectSourceIdForJunctionProviderSlug(providerSlug: string): string | null {
+  return resolveJunctionDeviceConnectRouteByProviderSlug(providerSlug)?.source.connectSourceId ?? null;
+}
+
 export function resolveJunctionLinkDeviceConnectRouteByProviderSlug(
   providerSlug: string,
 ): DeviceConnectRouteEntry<DeviceConnectJunctionLinkRoute> | null {
@@ -363,7 +367,7 @@ export function resolveJunctionLinkDeviceConnectRouteByProviderSlug(
 
 function junctionLinkRoute(
   sourceProviderSlug: string,
-  options: { connectTarget?: string; defaultEnabled?: boolean } = {},
+  options: { aliases?: readonly string[]; connectTarget?: string; defaultEnabled?: boolean } = {},
 ): DeviceConnectJunctionLinkRoute {
   const normalizedProviderSlug = normalizeJunctionProviderSlug(sourceProviderSlug);
   const normalizedConnectTarget = normalizeJunctionProviderSlug(options.connectTarget ?? sourceProviderSlug);
@@ -376,17 +380,25 @@ function junctionLinkRoute(
     kind: "junction_link",
     connectTarget: normalizedConnectTarget,
     sourceProviderSlug: normalizedProviderSlug,
+    ...normalizeJunctionProviderSlugAliases(options.aliases),
     defaultEnabled: options.defaultEnabled ?? true,
   };
 }
 
-function junctionSdkRoute(sourceProviderSlug: string): DeviceConnectJunctionSdkRoute {
+function junctionSdkRoute(
+  sourceProviderSlug: string,
+  options: { aliases?: readonly string[] } = {},
+): DeviceConnectJunctionSdkRoute {
   const normalizedProviderSlug = normalizeJunctionProviderSlug(sourceProviderSlug);
   if (!normalizedProviderSlug) {
     throw new TypeError("Junction SDK routes require normalized provider slugs.");
   }
 
-  return { kind: "junction_sdk", sourceProviderSlug: normalizedProviderSlug };
+  return {
+    kind: "junction_sdk",
+    sourceProviderSlug: normalizedProviderSlug,
+    ...normalizeJunctionProviderSlugAliases(options.aliases),
+  };
 }
 
 function directRoute(
@@ -408,4 +420,49 @@ function directRoute(
 
 function unavailableRoute(reason: string): DeviceConnectUnavailableRoute {
   return { kind: "unavailable", reason };
+}
+
+function buildJunctionDeviceConnectRouteEntryMap(): ReadonlyMap<
+  string,
+  DeviceConnectRouteEntry<DeviceConnectJunctionLinkRoute | DeviceConnectJunctionSdkRoute>
+> {
+  const entries = new Map<
+    string,
+    DeviceConnectRouteEntry<DeviceConnectJunctionLinkRoute | DeviceConnectJunctionSdkRoute>
+  >();
+
+  for (const entry of listJunctionDeviceConnectRouteEntries()) {
+    for (const providerSlug of [
+      entry.route.sourceProviderSlug,
+      ...(entry.route.sourceProviderSlugAliases ?? []),
+    ]) {
+      const existing = entries.get(providerSlug);
+      if (existing && existing.source.connectSourceId !== entry.source.connectSourceId) {
+        throw new TypeError(
+          `Junction provider slug ${providerSlug} is mapped to multiple device connect sources.`,
+        );
+      }
+      entries.set(providerSlug, entry);
+    }
+  }
+
+  return entries;
+}
+
+function normalizeJunctionProviderSlugAliases(
+  aliases: readonly string[] | undefined,
+): { sourceProviderSlugAliases?: readonly string[] } {
+  if (!aliases || aliases.length === 0) {
+    return {};
+  }
+
+  const normalizedAliases = [...new Set(
+    aliases
+      .map((alias) => normalizeJunctionProviderSlug(alias))
+      .filter((alias): alias is string => Boolean(alias)),
+  )];
+
+  return normalizedAliases.length > 0
+    ? { sourceProviderSlugAliases: Object.freeze(normalizedAliases) }
+    : {};
 }

--- a/packages/device-syncd/src/config/connect-routes.ts
+++ b/packages/device-syncd/src/config/connect-routes.ts
@@ -207,7 +207,7 @@ export const DEVICE_CONNECT_SOURCES = Object.freeze([
   {
     connectSourceId: "apple-health",
     label: "Apple Health",
-    routes: [unavailableRoute("Apple Health is a mobile/local device flow, not hosted Junction Link.")],
+    routes: [junctionSdkRoute("apple_health_kit")],
   },
   {
     connectSourceId: "health-connect",

--- a/packages/device-syncd/src/connect-config.ts
+++ b/packages/device-syncd/src/connect-config.ts
@@ -37,6 +37,7 @@ export {
   normalizeDeviceConnectSourceId,
   normalizeJunctionLinkProviderFilter,
   normalizeJunctionProviderSlug,
+  resolveDeviceConnectSourceIdForJunctionProviderSlug,
   resolveDeviceConnectSourceById,
   resolveDirectDeviceConnectRouteByProvider,
   resolveJunctionDeviceConnectRouteByProviderSlug,

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -614,7 +614,7 @@ export function createJunctionDeviceSyncProvider(
     const providerSlugs = [
       ...new Set(
         providers
-          .filter((provider) => mapJunctionSourceStatus(provider.status) === "connected")
+          .filter((provider) => mapJunctionSourceStatus(provider.status) !== "disconnected")
           .map((provider) =>
             normalizeProviderSlug(provider.origin.sourceProviderSlug)
             ?? normalizeProviderSlug(provider.slug)
@@ -638,7 +638,7 @@ export function createJunctionDeviceSyncProvider(
     if (failedProviderSlugs.length > 0) {
       throw deviceSyncError({
         code: "JUNCTION_PROVIDER_DEREGISTER_FAILED",
-        message: "Junction provider deregistration failed for one or more connected sources.",
+        message: "Junction provider deregistration failed for one or more sources.",
         retryable: true,
         httpStatus: 503,
         details: {

--- a/packages/device-syncd/test/config.test.ts
+++ b/packages/device-syncd/test/config.test.ts
@@ -242,7 +242,7 @@ test("Junction default provider filter excludes non-Link connect routes", () => 
     "accuchek_ble",
     "contour_ble",
     "onetouch_ble",
-    "apple_health",
+    "apple_health_kit",
     "health_connect",
     "samsung_health",
   ]) {

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -540,7 +540,7 @@ test("Junction provider exposes primitive handlers without OAuth compatibility m
 });
 
 test("Junction default provider filter covers hosted Link connect routes", () => {
-  assert.equal(JUNCTION_CONNECT_SOURCE_TARGETS.length, 32);
+  assert.equal(JUNCTION_CONNECT_SOURCE_TARGETS.length, 33);
 
   assert.deepEqual(
     JUNCTION_LINK_PROVIDER_SLUGS,
@@ -558,6 +558,7 @@ test("Junction default provider filter covers hosted Link connect routes", () =>
     "accuchek_ble",
     "contour_ble",
     "onetouch_ble",
+    "apple_health_kit",
   ]) {
     assert.equal(JUNCTION_DEFAULT_PROVIDER_FILTER.includes(providerSlug), false);
   }
@@ -567,13 +568,16 @@ test("Junction default provider filter covers hosted Link connect routes", () =>
   assert.equal(resolveJunctionTarget("accuchek_ble")?.connectMode, "junction_sdk");
   assert.equal(resolveJunctionTarget("contour_ble")?.connectMode, "junction_sdk");
   assert.equal(resolveJunctionTarget("onetouch_ble")?.connectMode, "junction_sdk");
+  assert.equal(resolveJunctionTarget("apple_health_kit")?.connectMode, "junction_sdk");
 
   assert.equal(resolveJunctionConnectTargetForSourceId("dexcom-g6-and-older"), "dexcom");
   assert.equal(resolveJunctionConnectTargetForSourceId("dexcom"), "dexcom_v3");
   assert.equal(resolveJunctionConnectTargetForSourceId("mapmyfitness"), "map_my_fitness");
   assert.equal(resolveJunctionConnectTargetForSourceId("accuchek"), "accuchek_ble");
   assert.equal(resolveJunctionConnectTargetForSourceId("onetouch"), "onetouch_ble");
+  assert.equal(resolveJunctionConnectTargetForSourceId("apple-health"), "apple_health_kit");
   assert.equal(resolveJunctionConnectSourceLabel("accuchek_ble"), "Accu-Chek");
+  assert.equal(resolveJunctionConnectSourceLabel("apple_health_kit"), "Apple Health");
 });
 
 test("Junction empty historical backfill records progress and stores the retry wake in metadata", async () => {

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -20,6 +20,7 @@ import {
   resolveJunctionConnectSourceLabel,
   resolveJunctionConnectTargetForSourceId,
 } from "../src/config/junction-connect-sources.ts";
+import { resolveDeviceConnectSourceIdForJunctionProviderSlug } from "../src/config/connect-routes.ts";
 import {
   isAllowedJunctionLinkHost,
   JUNCTION_DEFAULT_ALLOWED_LINK_HOSTS,
@@ -577,7 +578,10 @@ test("Junction default provider filter covers hosted Link connect routes", () =>
   assert.equal(resolveJunctionConnectTargetForSourceId("onetouch"), "onetouch_ble");
   assert.equal(resolveJunctionConnectTargetForSourceId("apple-health"), "apple_health_kit");
   assert.equal(resolveJunctionConnectSourceLabel("accuchek_ble"), "Accu-Chek");
-  assert.equal(resolveJunctionConnectSourceLabel("apple_health_kit"), "Apple Health");
+  for (const providerSlug of ["apple_health_kit", "apple_health", "apple-healthkit"]) {
+    assert.equal(resolveDeviceConnectSourceIdForJunctionProviderSlug(providerSlug), "apple-health");
+    assert.equal(resolveJunctionConnectSourceLabel(providerSlug), "Apple Health");
+  }
 });
 
 test("Junction empty historical backfill records progress and stores the retry wake in metadata", async () => {

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -2830,7 +2830,7 @@ test("Junction provider source keys are stable provider-level opaque ids", () =>
   assert.doesNotMatch(garminKey ?? "", /acct|junction|garmin/u);
 });
 
-test("Junction provider revokes connected remote provider slugs", async () => {
+test("Junction provider revokes remote provider slugs unless Junction already reports them disconnected", async () => {
   const requests: Array<{ method: string; url: string }> = [];
   const provider = createJunctionProvider(async (input, init) => {
     const request = {
@@ -2844,6 +2844,7 @@ test("Junction provider revokes connected remote provider slugs", async () => {
         data: [
           { slug: "garmin", status: "connected" },
           { slug: "Garmin", status: "active" },
+          { slug: "apple_health_kit", status: "error" },
           { slug: "fitbit", status: "revoked" },
           { provider: "Oura", status: "unknown" },
         ],
@@ -2868,6 +2869,14 @@ test("Junction provider revokes connected remote provider slugs", async () => {
     {
       method: "DELETE",
       url: "https://api.sandbox.us.junction.com/v2/user/junction-user-1/garmin",
+    },
+    {
+      method: "DELETE",
+      url: "https://api.sandbox.us.junction.com/v2/user/junction-user-1/apple_health_kit",
+    },
+    {
+      method: "DELETE",
+      url: "https://api.sandbox.us.junction.com/v2/user/junction-user-1/oura",
     },
   ]);
 });


### PR DESCRIPTION
## Why

The iOS app can connect Apple Health through the mobile Junction SDK, but the hosted `/connect` page previously only represented web-startable device connections. That made Apple Health invisible or misleading on web even when backend settings state already confirmed it was connected.

## User-visible behavior

- `/connect` now includes an Apple Health card.
- If hosted device-sync settings report an Apple Health Junction upstream source, Apple Health shows as connected or needing reconnect from that real backend state.
- If Apple Health is not connected, web setup stays disabled with `Coming soon` and guidance to connect from the Murph iOS app.
- Apple Health never gets a hosted web OAuth/Junction Link start button.
- Junction accounts with multiple upstream sources use account-scoped disconnect copy so the web does not imply that disconnecting one card only removes one child source.
- When a single Junction upstream needs reconnect, the reconnect action uses that upstream source's own target.
- When all children of a multi-source Junction account need reconnect, each child keeps its own reconnect action and the account-scoped Junction disconnect remains visible.
- When a parent Junction account requires reauthorization and child upstream rows are stale, account-scoped disconnect still remains visible for the affected non-disconnected child cards.
- Disconnected Junction child projections stay inactive even if the parent account requires reauthorization, so a stale Apple Health row cannot expose reconnect or disconnect actions for the shared account.
- Disconnecting a Junction account attempts remote deregistration for every returned provider unless Junction already reports it disconnected/revoked/inactive, so error-status Apple Health providers are not silently left remote-connected.
- `/connect` labels Junction disconnects as account-scoped whenever the same connection has more than one non-disconnected upstream projection, matching the backend revoke scope even if only one child card renders connected.
- After a local disconnect of Apple Health, the card returns to the mobile-managed `Coming soon` guidance instead of a generic unavailable state.

## Invariants

- Apple Health web connect remains display-only until a real hosted web flow exists.
- No new persisted state, schema, token storage, or web-side HealthKit/Junction SDK flow is introduced.
- Junction upstream identity is owned by the shared device-sync connect config, including Apple Health slug aliases.
- Hosted reconnect targets are source-owned; the page does not borrow a parent or sibling target for Apple Health or other upstreams.
- Parent-level Junction reauthorization applies only to non-disconnected upstream projections; disconnected child rows cannot inherit the shared connection id as actionable source authority.
- Multi-source Junction disconnects are presented as account-scoped because the connection id belongs to the shared Junction account.
- User-facing disconnect must attempt provider-side Junction deregistration for connected, errored, and unknown provider rows; only already-disconnected remote rows are skipped.
- Web disconnect copy must match that same non-disconnected upstream scope.

## Verification

- `pnpm --dir . exec vitest run --config apps/web/vitest.workspace.ts --no-coverage --project hosted-web-store-config apps/web/test/connect-page.test.ts apps/web/test/device-sync-provider-label.test.ts`
- `pnpm --dir . exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/device-sync-provider-label.test.ts`
- `pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/junction-provider.test.ts`
- `pnpm --dir . exec vitest run --config apps/web/vitest.workspace.ts --no-coverage --project hosted-web-store-config apps/web/test/connect-page.test.ts apps/web/test/connect-source-and-experiment-card-routes.test.tsx`
- `pnpm --dir . exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/device-sync-settings-surface.test.ts`
- `pnpm --dir . exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts`
- `pnpm --dir . exec vitest run --config apps/web/vitest.workspace.ts --no-coverage --project hosted-web-store-config apps/web/test/connect-page.test.ts`
- `pnpm --dir apps/web typecheck`
- `pnpm --dir packages/device-syncd typecheck`
- `git diff --check`
- `pnpm --filter @murphai/cloudflare-runner... build` (prerequisite for hosted-local-harness snapshot tests)
- `pnpm test:diff apps/web/app/'(dashboard)'/connect/connect-source-card.tsx apps/web/app/'(dashboard)'/connect/page.tsx apps/web/src/lib/device-sync/provider-label.ts apps/web/test/connect-page.test.ts packages/device-syncd/src/config/connect-routes.ts packages/device-syncd/src/connect-config.ts packages/device-syncd/test/junction-provider.test.ts`
- `pnpm test:diff apps/web/app/'(dashboard)'/connect/page.tsx apps/web/test/connect-page.test.ts`
- `pnpm test:diff packages/device-syncd/src/providers/junction.ts packages/device-syncd/test/junction-provider.test.ts`

Notes: the first broad `test:diff` attempt failed in hosted-local-harness because the local Cloudflare snapshot prerequisites were missing workspace `dist` artifacts. After building the Cloudflare dependency closure, the same `test:diff` command passed. Web verify still prints existing lint warnings in unrelated files and the existing Turbopack NFT trace warning.
