### PR TITLE
fix(hosted): deliver vault-file attachments over Linq and surface terminal send failures

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-07-2026-07-07-vault-file-linq-delivery-fixes.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-2026-07-07-vault-file-linq-delivery-fixes.md
@@ -1,0 +1,86 @@
+# Vault file Linq delivery failure feedback fixes
+
+Status: completed
+Created: 2026-07-07
+Updated: 2026-07-07
+
+## Goal
+
+- Fix hosted vault-file delivery over Linq/iMessage so presigned attachment uploads use public fetch, terminal non-retryable delivery failures become model-visible pending input, and the send-vault-file tool wording does not imply confirmed delivery before transport completion.
+
+## Success criteria
+
+- Vault-file Linq attachment delivery performs the provider `POST /attachments` with provider fetch and the presigned storage `PUT` with `publicInternetFetch` in hosted runtime.
+- Generated voice memo and vault-file attachment uploads share one operator-config helper with local/unhosted fallback semantics.
+- A terminal non-retryable outbox failure stages exactly one assistant-facing pending input event per intent and wakes the hosted assistant without duplicating on re-observation.
+- `send_vault_file` approved tool and prompt wording says approval succeeded and delivery is queued, not confirmed delivered.
+- Hosted Linq send failure rows include a sanitized `failure_reason` for trusted `VaultCliError` messages.
+- Focused tests and required typecheck/scoped package verification pass or any unrelated blocker is documented.
+
+## Scope
+
+- In scope:
+  - `packages/operator-config` Linq upload helper and tests.
+  - `packages/assistant-engine` voice memo/vault-file media upload wiring, tool wording, prompt wording, and focused tests.
+  - `packages/assistant-runtime` hosted Linq dependency plumbing, terminal failure pending-input staging, sanitized failure reason, and focused tests.
+- Out of scope:
+  - New retry queues, delivery polling, approval un-consumption, Telegram/WhatsApp media behavior, or broad outbox refactors.
+
+## Constraints
+
+- Technical constraints:
+  - Preserve existing atomic send behavior for multi-file messages.
+  - Do not add persisted state classes; reuse assistant input and pending-input primitives.
+  - Keep public fetch unrestricted only for the presigned storage upload; do not carry internal authority headers.
+  - Avoid `as any` and cross-package internal imports.
+- Product/process constraints:
+  - Do not commit; supervising agent handles commits, audits, and PR.
+  - Keep failure notes assistant-facing only, secret-safe, and not outbound copy.
+  - Preserve iMessage delivery safety; retryable failures must not stage user-visible recovery pressure.
+
+## Risks and mitigations
+
+1. Risk: Public fetch is accidentally used for Linq provider API calls.
+   Mitigation: Keep helper split explicit and test provider fetch for POST vs public fetch for PUT.
+2. Risk: Terminal failure observations duplicate pending input across drain re-entry.
+   Mitigation: Derive a deterministic assistant input id from the outbox intent id and upsert before enqueue.
+3. Risk: Failure feedback leaks sensitive transport details.
+   Mitigation: Include only channel kind, failure code, and attachment filenames; no URLs, headers, phone numbers, or raw payloads.
+
+## Tasks
+
+1. Inspect existing Linq upload helpers, voice memo upload path, vault-file media preparation path, hosted send dependency plumbing, and outbox drain failure handling.
+2. Add `uploadLinqAttachment` in `packages/operator-config` and switch voice memo plus vault-file callers to it.
+3. Thread `publicInternetFetch` through hosted Linq send dependencies to `prepareLinqMessageMedia`.
+4. Stage deterministic pending assistant input for terminal non-retryable outbox failures using the existing hosted mailbox assistant-input pattern.
+5. Reword `send_vault_file` approved result and matching system prompt contract.
+6. Populate sanitized `failure_reason` from trusted `VaultCliError` messages.
+7. Add/extend focused tests and run required verification.
+
+## Decisions
+
+- Use the generated plan filename with the repeated date segment rather than renaming it, to avoid unnecessary workflow churn.
+
+## Verification
+
+- Commands to run:
+  - `pnpm typecheck`
+  - `pnpm test:diff <touched paths>` if truthful, otherwise package-level coverage commands for `packages/operator-config`, `packages/assistant-engine`, and `packages/assistant-runtime`.
+  - Focused tests for Linq attachment fetch split, vault-file public fetch plumbing, and terminal failed intent pending-input dedupe/wake behavior.
+- Expected outcomes:
+  - Typecheck passes.
+  - Focused package tests cover the incident and edge cases listed in the task.
+
+## Verification results
+
+- `pnpm --dir packages/operator-config test http-linq-device-runtime.test.ts`: passed.
+- `pnpm --dir packages/assistant-engine test assistant-channels-runtime.test.ts assistant-codex-generate-voice-memo-tool.test.ts assistant-vault-file-send.test.ts model-behavior.test.ts`: passed.
+- `pnpm --dir packages/assistant-runtime test hosted-runtime-callbacks.test.ts hosted-runtime-workspace-assistant-phase.test.ts`: passed.
+- `pnpm --dir packages/assistant-runtime typecheck`: passed.
+- `pnpm typecheck`: passed after rebuilding missing local dist artifacts for `packages/operator-config`, `packages/exercise-library`, `packages/assistant-engine`, `packages/setup-cli`, and `packages/assistant-runtime`.
+- `pnpm --dir packages/assistant-runtime test hosted-runtime-workspace-entrypoint.test.ts -t "reports mailbox budget exhaustion only after deferring an overflow item"`: passed after the diff run surfaced a suite-level fake-timer/temp-dir failure in that test.
+- `pnpm --dir packages/assistant-runtime test`: passed.
+- `pnpm --dir packages/hosted-local-harness test`: passed after building `packages/assistant-runtime/dist`.
+- `pnpm test:diff <touched paths>`: run multiple times; blocked by the same unrelated `packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts` fake-timer/temp-dir failure (`reports mailbox budget exhaustion only after deferring an overflow item`) before later packages completed. The failing test passed isolated and the full assistant-runtime suite passed separately.
+- `git diff --check`: passed.
+Completed: 2026-07-07

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -435,7 +435,7 @@ export const MURPH_SEND_VAULT_FILE_TOOL = {
   namespace: 'murph',
   name: 'send_vault_file',
   description:
-    "Securely prepare one existing file from the user's vault for the current iMessage conversation. Use a normalized vault-relative file path. When approval is pending, include the returned approval link in your normal reply. When approval is approved, this attaches the exact approved file to your normal reply. It does not reveal file bytes to the model, does not queue a separate delivery, and does not support arbitrary recipients.",
+    "Securely prepare one existing file from the user's vault for the current iMessage conversation. Use a normalized vault-relative file path. When approval is pending, include the returned approval link in your normal reply. When approval is approved, the file is queued to deliver with your normal reply but delivery is not yet confirmed. It does not reveal file bytes to the model and does not support arbitrary recipients.",
   inputSchema: {
     type: 'object',
     additionalProperties: false,
@@ -1671,7 +1671,10 @@ export async function executeMurphDynamicToolRequest(input: {
               ...toolTextResult(
                 true,
                 JSON.stringify({
+                  deliveryStatus: 'queued_with_reply',
                   filename: result.filename,
+                  note:
+                    'Approval succeeded. The file is queued to deliver with your normal reply; delivery is not confirmed yet.',
                   status: result.status,
                 }),
               ),

--- a/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
+++ b/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
@@ -395,6 +395,7 @@ function createStringFetchAdapter(fetchImpl: typeof fetch) {
       body?: string | Blob
       headers?: Record<string, string>
       method: string
+      redirect?: RequestRedirect
       signal?: AbortSignal
     },
   ) => fetchImpl(input, init)

--- a/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
+++ b/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
@@ -14,9 +14,8 @@ import {
   resolveElevenLabsVoiceId,
 } from '@murphai/operator-config/elevenlabs-runtime'
 import {
-  createLinqAttachmentUpload,
   resolveLinqApiToken,
-  uploadLinqAttachmentBytes,
+  uploadLinqAttachment,
 } from '@murphai/operator-config/linq-runtime'
 import {
   normalizeHostedAiUsageAllowanceElevenLabsTtsModelId,
@@ -346,26 +345,16 @@ export function createVoiceMemoToolRuntimeFromEnv(input: {
       }
 
       const linqFilename = `${request.filenameBase}.${audio.filenameExtension}`
-      const upload = await createLinqAttachmentUpload(
+      const upload = await uploadLinqAttachment(
         {
+          bytes: audio.bytes,
           contentType: audio.contentType,
           filename: linqFilename,
-          sizeBytes: audio.bytes.byteLength,
         },
         {
           env: input.env,
           fetchImplementation,
-          signal: request.signal ?? undefined,
-        },
-      )
-      await uploadLinqAttachmentBytes(
-        {
-          bytes: audio.bytes,
-          requiredHeaders: upload.requiredHeaders,
-          uploadUrl: upload.uploadUrl,
-        },
-        {
-          fetchImplementation: uploadFetchImplementation,
+          publicFetchImplementation: uploadFetchImplementation,
           signal: request.signal ?? undefined,
         },
       )
@@ -425,4 +414,3 @@ function describeVoiceMemoGeneration(
       return { label: 'song', transcript: null }
   }
 }
-

--- a/packages/assistant-engine/src/assistant/channels/runtime.ts
+++ b/packages/assistant-engine/src/assistant/channels/runtime.ts
@@ -9,7 +9,6 @@ import {
   resolveAgentmailBaseUrl,
 } from '@murphai/operator-config/agentmail-runtime'
 import {
-  createLinqAttachmentUpload,
   createLinqChat,
   resolveLinqApiToken,
   sendLinqChatMessage,
@@ -17,7 +16,7 @@ import {
   sendLinqVoiceMemo,
   startLinqChatTypingIndicator,
   stopLinqChatTypingIndicator,
-  uploadLinqAttachmentBytes,
+  uploadLinqAttachment,
 } from '@murphai/operator-config/linq-runtime'
 import {
   generateElevenLabsVoiceMemoAudio,
@@ -566,26 +565,16 @@ async function prepareLinqMessageMedia(
     }
 
     const bytes = await dependencies.loadVaultFile(item)
-    const upload = await createLinqAttachmentUpload(
+    const upload = await uploadLinqAttachment(
       {
+        bytes,
         contentType: item.contentType,
         filename: item.filename,
-        sizeBytes: item.sizeBytes,
       },
       {
         env: dependencies.env,
         fetchImplementation: dependencies.fetchImplementation,
-        ...(dependencies.signal ? { signal: dependencies.signal } : {}),
-      },
-    )
-    await uploadLinqAttachmentBytes(
-      {
-        bytes,
-        requiredHeaders: upload.requiredHeaders,
-        uploadUrl: upload.uploadUrl,
-      },
-      {
-        fetchImplementation: dependencies.fetchImplementation,
+        publicFetchImplementation: dependencies.publicFetchImplementation,
         ...(dependencies.signal ? { signal: dependencies.signal } : {}),
       },
     )

--- a/packages/assistant-engine/src/assistant/channels/types.ts
+++ b/packages/assistant-engine/src/assistant/channels/types.ts
@@ -45,6 +45,7 @@ export interface EmailRuntimeDependencies {
 export interface LinqRuntimeDependencies {
   env?: NodeJS.ProcessEnv
   fetchImplementation?: LinqFetch
+  publicFetchImplementation?: LinqFetch
   loadVaultFile?: (
     media: AssistantVaultFileResponseMedia,
   ) => Promise<Uint8Array>

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -884,7 +884,7 @@ function buildAssistantVaultFileSendGuidanceText(): string {
   return [
     "Vault file sends:",
     "- When `murph.send_vault_file` returns `status: \"pending\"` with an `approvalUrl`, send a normal text reply with the raw approval URL, preferably as the final line in messaging channels. The file is not attached yet. Do not omit the URL, summarize around it without the URL, or rely on a separate automated message.",
-    "- When `murph.send_vault_file` returns `status: \"approved\"`, the approved file is attached to your normal reply. Send a concise normal reply; do not call `finish_without_reply` for the file send.",
+    "- When `murph.send_vault_file` returns `status: \"approved\"`, approval succeeded and the file is queued to deliver with your normal reply; delivery is not confirmed yet. Send a concise normal reply; do not call `finish_without_reply` for the file send.",
   ].join("\n");
 }
 

--- a/packages/assistant-engine/test/assistant-channels-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-channels-runtime.test.ts
@@ -9,13 +9,12 @@ import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 
 const runtimeMocks = vi.hoisted(() => ({
   createAgentmailApiClient: vi.fn(),
-  createLinqAttachmentUpload: vi.fn(),
   createLinqChat: vi.fn(),
   probeLinqApi: vi.fn(),
   sendLinqChatMessage: vi.fn(),
   startLinqChatTypingIndicator: vi.fn(),
   stopLinqChatTypingIndicator: vi.fn(),
-  uploadLinqAttachmentBytes: vi.fn(),
+  uploadLinqAttachment: vi.fn(),
 }))
 
 const mp3Bytes = new Uint8Array([0xff, 0xfb, 0x90, 0x64])
@@ -34,13 +33,12 @@ vi.mock('@murphai/operator-config/linq-runtime', async (importOriginal) => {
     await importOriginal<typeof import('@murphai/operator-config/linq-runtime')>()
   return {
     ...actual,
-    createLinqAttachmentUpload: runtimeMocks.createLinqAttachmentUpload,
     createLinqChat: runtimeMocks.createLinqChat,
     probeLinqApi: runtimeMocks.probeLinqApi,
     sendLinqChatMessage: runtimeMocks.sendLinqChatMessage,
     startLinqChatTypingIndicator: runtimeMocks.startLinqChatTypingIndicator,
     stopLinqChatTypingIndicator: runtimeMocks.stopLinqChatTypingIndicator,
-    uploadLinqAttachmentBytes: runtimeMocks.uploadLinqAttachmentBytes,
+    uploadLinqAttachment: runtimeMocks.uploadLinqAttachment,
   }
 })
 
@@ -67,13 +65,12 @@ beforeEach(() => {
   vi.useRealTimers()
   vi.restoreAllMocks()
   runtimeMocks.createAgentmailApiClient.mockReset()
-  runtimeMocks.createLinqAttachmentUpload.mockReset()
   runtimeMocks.createLinqChat.mockReset()
   runtimeMocks.probeLinqApi.mockReset()
   runtimeMocks.sendLinqChatMessage.mockReset()
   runtimeMocks.startLinqChatTypingIndicator.mockReset()
   runtimeMocks.stopLinqChatTypingIndicator.mockReset()
-  runtimeMocks.uploadLinqAttachmentBytes.mockReset()
+  runtimeMocks.uploadLinqAttachment.mockReset()
 })
 
 afterEach(() => {
@@ -1135,16 +1132,11 @@ describe('assistant channels runtime seam', () => {
   it('uploads trusted vault-file bytes and sends the resulting Linq attachment id', async () => {
     const bytes = new Uint8Array([1, 2, 3, 4])
     const loadVaultFile = vi.fn().mockResolvedValue(bytes)
-    runtimeMocks.createLinqAttachmentUpload.mockResolvedValue({
+    const providerFetch = vi.fn()
+    const publicFetch = vi.fn()
+    runtimeMocks.uploadLinqAttachment.mockResolvedValue({
       attachmentId: 'attachment_123',
-      downloadUrl: null,
-      expiresAt: '2026-06-24T12:15:00.000Z',
-      requiredHeaders: {
-        'content-type': 'application/pdf',
-      },
-      uploadUrl: 'https://upload.linq.test/attachment_123',
     })
-    runtimeMocks.uploadLinqAttachmentBytes.mockResolvedValue(undefined)
     runtimeMocks.sendLinqChatMessage.mockResolvedValue({
       message: { id: 'message_123' },
     })
@@ -1165,25 +1157,24 @@ describe('assistant channels runtime seam', () => {
       target: 'chat_123',
     }, {
       env: { LINQ_API_TOKEN: 'linq-token' },
+      fetchImplementation: providerFetch,
       loadVaultFile,
+      publicFetchImplementation: publicFetch,
     })).resolves.toMatchObject({
       providerMessageId: 'message_123',
       target: 'chat_123',
     })
 
     expect(loadVaultFile).toHaveBeenCalledTimes(1)
-    expect(runtimeMocks.createLinqAttachmentUpload).toHaveBeenCalledWith({
+    expect(runtimeMocks.uploadLinqAttachment).toHaveBeenCalledWith({
+      bytes,
       contentType: 'application/pdf',
       filename: 'report.pdf',
-      sizeBytes: bytes.byteLength,
     }, expect.objectContaining({
       env: { LINQ_API_TOKEN: 'linq-token' },
+      fetchImplementation: providerFetch,
+      publicFetchImplementation: publicFetch,
     }))
-    expect(runtimeMocks.uploadLinqAttachmentBytes).toHaveBeenCalledWith({
-      bytes,
-      requiredHeaders: { 'content-type': 'application/pdf' },
-      uploadUrl: 'https://upload.linq.test/attachment_123',
-    }, expect.any(Object))
     expect(runtimeMocks.sendLinqChatMessage).toHaveBeenCalledWith({
       chatId: 'chat_123',
       idempotencyKey: 'delivery_123',
@@ -1192,8 +1183,54 @@ describe('assistant channels runtime seam', () => {
       replyToMessageId: null,
     }, expect.any(Object))
     expect(loadVaultFile.mock.invocationCallOrder[0]).toBeLessThan(
-      runtimeMocks.createLinqAttachmentUpload.mock.invocationCallOrder[0]!,
+      runtimeMocks.uploadLinqAttachment.mock.invocationCallOrder[0]!,
     )
+  })
+
+  it('fails Linq delivery atomically when a later vault-file upload fails', async () => {
+    const firstBytes = new Uint8Array([1, 2, 3, 4])
+    const secondBytes = new Uint8Array([5, 6, 7, 8])
+    const loadVaultFile = vi.fn()
+      .mockResolvedValueOnce(firstBytes)
+      .mockResolvedValueOnce(secondBytes)
+    runtimeMocks.uploadLinqAttachment
+      .mockResolvedValueOnce({ attachmentId: 'attachment_first' })
+      .mockRejectedValueOnce(new Error('presigned upload failed'))
+
+    await expect(sendLinqMessage({
+      idempotencyKey: 'delivery_two_files',
+      media: [
+        {
+          approvalGeneration: null,
+          approvalId: null,
+          contentType: 'application/pdf',
+          filename: 'first.pdf',
+          kind: 'vault_file',
+          ref: 'documents/first.pdf',
+          sha256: 'a'.repeat(64),
+          sizeBytes: firstBytes.byteLength,
+        },
+        {
+          approvalGeneration: null,
+          approvalId: null,
+          contentType: 'application/pdf',
+          filename: 'second.pdf',
+          kind: 'vault_file',
+          ref: 'documents/second.pdf',
+          sha256: 'b'.repeat(64),
+          sizeBytes: secondBytes.byteLength,
+        },
+      ],
+      message: 'Attached files',
+      target: 'chat_123',
+    }, {
+      env: { LINQ_API_TOKEN: 'linq-token' },
+      loadVaultFile,
+    })).rejects.toThrow('presigned upload failed')
+
+    expect(loadVaultFile).toHaveBeenCalledTimes(2)
+    expect(runtimeMocks.uploadLinqAttachment).toHaveBeenCalledTimes(2)
+    expect(runtimeMocks.sendLinqChatMessage).not.toHaveBeenCalled()
   })
 
   it('passes the dependency abort signal to Linq typing and removes the listener after stop', async () => {

--- a/packages/assistant-engine/test/assistant-vault-file-send.test.ts
+++ b/packages/assistant-engine/test/assistant-vault-file-send.test.ts
@@ -414,7 +414,10 @@ describe('assistant vault-file send', () => {
     })
     expect(result.rpcResult).toMatchObject({ success: true })
     expect(result.rpcResult.contentItems[0]?.text).toBe(JSON.stringify({
+      deliveryStatus: 'queued_with_reply',
       filename: 'report.pdf',
+      note:
+        'Approval succeeded. The file is queued to deliver with your normal reply; delivery is not confirmed yet.',
       status: 'approved',
     }))
   })

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -125,6 +125,9 @@ describe('assistant execution prompt contract', () => {
     expect(prompt).toContain(
       'When `murph.send_vault_file` returns `status: "approved"`',
     )
+    expect(prompt).toContain(
+      'approval succeeded and the file is queued to deliver with your normal reply; delivery is not confirmed yet.',
+    )
   })
 
   it('routes accepted habit plans through canonical health surfaces', () => {

--- a/packages/assistant-runtime/src/hosted-provider-effects.ts
+++ b/packages/assistant-runtime/src/hosted-provider-effects.ts
@@ -47,6 +47,7 @@ export interface HostedProviderEffectDependencies {
   loadVaultFile?: (media: AssistantVaultFileResponseMedia) => Promise<Uint8Array>;
   env: NodeJS.ProcessEnv;
   fetchImplementation: typeof fetch | null;
+  publicFetchImplementation?: typeof fetch | null;
   onProviderDispatchEntered?: (() => void) | null;
   signal?: AbortSignal;
 }
@@ -55,6 +56,7 @@ interface HostedProviderEffectContext {
   loadVaultFile?: (media: AssistantVaultFileResponseMedia) => Promise<Uint8Array>;
   env: NodeJS.ProcessEnv;
   fetchImplementation: typeof fetch;
+  publicFetchImplementation?: typeof fetch;
   signal?: AbortSignal;
 }
 
@@ -309,6 +311,9 @@ async function sendHostedProviderLinqMessageDirect(
     env: context.env,
     fetchImplementation: context.fetchImplementation,
     signal: context.signal,
+    ...(context.publicFetchImplementation
+      ? { publicFetchImplementation: context.publicFetchImplementation }
+      : {}),
     ...(context.loadVaultFile ? { loadVaultFile: context.loadVaultFile } : {}),
   });
 }
@@ -317,8 +322,12 @@ function createHostedProviderEffectContext(
   dependencies: HostedProviderEffectDependencies,
   operation: string,
 ): HostedProviderEffectContext {
+  const { publicFetchImplementation, ...providerDependencies } = dependencies;
   return {
-    ...requireHostedProviderFetchDependencies(dependencies, operation),
+    ...requireHostedProviderFetchDependencies(providerDependencies, operation),
+    ...(publicFetchImplementation
+      ? { publicFetchImplementation }
+      : {}),
     ...(dependencies.loadVaultFile
       ? { loadVaultFile: dependencies.loadVaultFile }
       : {}),

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -1128,6 +1128,7 @@ export function createHostedAssistantProgressDeliveryDependencies(input: {
   linqEgressLatencyTrace?: HostedAssistantLinqEgressLatencyTrace | null;
   platformEnv?: Readonly<Record<string, string>>;
   providerFetch?: typeof fetch | null;
+  publicInternetFetch?: typeof fetch | null;
   signal?: AbortSignal | null;
   userEnv?: Readonly<Record<string, string>>;
   wake?: HostedRuntimeEvent | null;
@@ -1164,6 +1165,7 @@ export function createHostedAssistantProgressDeliveryDependencies(input: {
       linqDeliveryContexts,
       linqEgressLatencyTrace: input.linqEgressLatencyTrace ?? null,
       providerFetch: input.providerFetch ?? null,
+      publicInternetFetch: input.publicInternetFetch ?? null,
       signal: input.signal ?? null,
     }),
     sendLinqVoiceMemo: createHostedAssistantLinqVoiceMemoSendDependency({
@@ -1267,6 +1269,7 @@ export async function drainHostedPreparedAssistantDeliveries(input: {
   platformEnv?: Readonly<Record<string, string>>;
   preparedDispatches?: readonly HostedAssistantDeliveryPreparedDispatch[] | null;
   providerFetch?: typeof fetch | null;
+  publicInternetFetch?: typeof fetch | null;
   shouldYieldBackgroundDelivery?: (() => boolean) | null;
   signal?: AbortSignal | null;
   userEnv?: Readonly<Record<string, string>>;
@@ -1378,6 +1381,7 @@ export async function drainHostedPreparedAssistantDeliveries(input: {
           telegramVoiceMemoEnv,
           whatsAppEnv,
           providerFetch: input.providerFetch ?? null,
+          publicInternetFetch: input.publicInternetFetch ?? null,
           userId: input.wake.userId,
           vaultRoot: input.vaultRoot,
           onTerminalLinqTypingStopFailure: (terminalOutcome) => {
@@ -1800,6 +1804,7 @@ async function deliverHostedPreparedAssistantDelivery(input: {
   telegramVoiceMemoEnv: NodeJS.ProcessEnv;
   whatsAppEnv: NodeJS.ProcessEnv;
   providerFetch: typeof fetch | null;
+  publicInternetFetch: typeof fetch | null;
   userId: string;
   vaultRoot: string;
   onTerminalLinqTypingStopFailure?: (
@@ -1955,6 +1960,7 @@ async function deliverHostedPreparedAssistantDelivery(input: {
             providerDispatchEntered = true;
           },
           providerFetch: input.providerFetch,
+          publicInternetFetch: input.publicInternetFetch,
           signal: input.signal,
           vaultRoot: input.vaultRoot,
         }),
@@ -2277,6 +2283,7 @@ function createHostedAssistantLinqSendDependency(input: {
   linqEnv: NodeJS.ProcessEnv;
   onProviderDispatchEntered?: () => void;
   providerFetch: typeof fetch | null;
+  publicInternetFetch?: typeof fetch | null;
   shouldYieldBackgroundDelivery?: (() => boolean) | null;
   signal: AbortSignal | null;
   threadIsDirect?: boolean | null;
@@ -2339,6 +2346,9 @@ function createHostedAssistantLinqSendDependency(input: {
         targetKind: request.targetKind ?? null,
       }, {
         ...dependencies,
+        ...(input.publicInternetFetch
+          ? { publicFetchImplementation: input.publicInternetFetch }
+          : {}),
         ...(verifiedVaultFiles.size > 0
           ? {
               loadVaultFile: async (media) => {
@@ -2365,7 +2375,7 @@ function createHostedAssistantLinqSendDependency(input: {
           deliveryContext,
           failedAt: new Date(),
           failureCode: readHostedAssistantLinqDeliveryFailureCode(error),
-          failureReason: null,
+          failureReason: readTrustedHostedAssistantLinqDeliveryFailureReason(error),
           fromPhoneNumber,
           idempotencyKey: request.idempotencyKey ?? null,
           intentId: input.intentId ?? null,
@@ -2834,6 +2844,16 @@ function readHostedAssistantLinqDeliveryFailureCode(error: unknown): string {
   return error instanceof Error && error.name !== "Error"
     ? error.name
     : "HOSTED_LINQ_PROVIDER_SEND_FAILED";
+}
+
+function readTrustedHostedAssistantLinqDeliveryFailureReason(
+  error: unknown,
+): string | null {
+  if (!(error instanceof VaultCliError)) {
+    return null;
+  }
+  const message = error.message.replace(/\s+/gu, " ").trim();
+  return message ? message.slice(0, 500) : null;
 }
 
 async function assertHostedAssistantLinqRecentInboundEngagementForDelivery(input: {

--- a/packages/assistant-runtime/src/hosted-runtime/direct-assistant-session-route.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/direct-assistant-session-route.ts
@@ -1,0 +1,61 @@
+import {
+  listAssistantSessions,
+  type AssistantInputEventRecord,
+} from "@murphai/assistant-engine";
+import type {
+  AssistantSession,
+} from "@murphai/operator-config/assistant-cli-contracts";
+import {
+  normalizeAssistantRouteString,
+} from "@murphai/operator-config/assistant/current-delivery-route";
+
+const DELIVERY_CHANNELS: readonly string[] = ["linq", "telegram"];
+
+export async function readCurrentDirectAssistantSessionRoute(
+  vaultRoot: string,
+): Promise<Pick<AssistantInputEventRecord, "conversation" | "replyTarget"> | null> {
+  const sessions = await listAssistantSessions(vaultRoot);
+  for (const session of sessions) {
+    const route = readDirectAssistantSessionRoute(session);
+    if (route) {
+      return route;
+    }
+  }
+
+  return null;
+}
+
+function readDirectAssistantSessionRoute(
+  session: Pick<AssistantSession, "binding">,
+): Pick<AssistantInputEventRecord, "conversation" | "replyTarget"> | null {
+  const binding = session.binding;
+  if (binding.threadIsDirect !== true) {
+    return null;
+  }
+
+  const channel = normalizeAssistantRouteString(binding.channel);
+  if (!channel || !DELIVERY_CHANNELS.includes(channel)) {
+    return null;
+  }
+
+  const deliveryTarget = normalizeAssistantRouteString(binding.delivery?.target);
+  if (!deliveryTarget) {
+    return null;
+  }
+
+  return {
+    conversation: {
+      accountId: normalizeAssistantRouteString(binding.identityId),
+      actorId: normalizeAssistantRouteString(binding.actorId),
+      actorIsSelf: false,
+      source: channel,
+      threadId: normalizeAssistantRouteString(binding.threadId),
+      threadIsDirect: true,
+    },
+    replyTarget: {
+      channel,
+      messageId: null,
+      threadId: deliveryTarget,
+    },
+  };
+}

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-group-newsletter-email-needed.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-group-newsletter-email-needed.ts
@@ -4,23 +4,19 @@ import type {
   HostedExecutionGroupNewsletterEmailNeededWake,
 } from "@murphai/hosted-execution/contracts";
 import {
-  listAssistantSessions,
   recordHostedMailboxAssistantInputItem,
   upsertAssistantInputEvent,
   type AssistantInputEventRecord,
   type UpsertAssistantInputEventInput,
 } from "@murphai/assistant-engine";
-import {
-  type AssistantSession,
-} from "@murphai/operator-config/assistant-cli-contracts";
-import {
-  normalizeAssistantRouteString,
-} from "@murphai/operator-config/assistant/current-delivery-route";
 
 import type {
   HostedMailboxItemImportOutcome,
   HostedMailboxResolvedImportItem,
 } from "./mailbox-import.ts";
+import {
+  readCurrentDirectAssistantSessionRoute,
+} from "./direct-assistant-session-route.ts";
 import {
   enqueueHostedPendingAssistantInputId,
 } from "./pending-input-index.ts";
@@ -31,7 +27,6 @@ const GROUP_NEWSLETTER_EMAIL_NEEDED_NO_ROUTE_REASON =
   "group-newsletter.email-needed.no-direct-route";
 const ASSISTANT_INPUT_EVENT_SAFE_TOKEN_PATTERN =
   /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,191}$/u;
-const DELIVERY_CHANNELS: readonly string[] = ["linq", "telegram"];
 
 export async function importHostedGroupNewsletterEmailNeededMailboxItem(input: {
   item: HostedMailboxResolvedImportItem;
@@ -93,55 +88,6 @@ export async function importHostedGroupNewsletterEmailNeededMailboxItem(input: {
     ...(input.item.durablyConsumed === true ? {} : { assistantInputId: event.inputId }),
     reasonCode: GROUP_NEWSLETTER_EMAIL_NEEDED_STAGED_REASON,
     status: "imported",
-  };
-}
-
-async function readCurrentDirectAssistantSessionRoute(
-  vaultRoot: string,
-): Promise<Pick<AssistantInputEventRecord, "conversation" | "replyTarget"> | null> {
-  const sessions = await listAssistantSessions(vaultRoot);
-  for (const session of sessions) {
-    const route = readDirectAssistantSessionRoute(session);
-    if (route) {
-      return route;
-    }
-  }
-
-  return null;
-}
-
-function readDirectAssistantSessionRoute(
-  session: Pick<AssistantSession, "binding">,
-): Pick<AssistantInputEventRecord, "conversation" | "replyTarget"> | null {
-  const binding = session.binding;
-  if (binding.threadIsDirect !== true) {
-    return null;
-  }
-
-  const channel = normalizeAssistantRouteString(binding.channel);
-  if (!channel || !DELIVERY_CHANNELS.includes(channel)) {
-    return null;
-  }
-
-  const deliveryTarget = normalizeAssistantRouteString(binding.delivery?.target);
-  if (!deliveryTarget) {
-    return null;
-  }
-
-  return {
-    conversation: {
-      accountId: normalizeAssistantRouteString(binding.identityId),
-      actorId: normalizeAssistantRouteString(binding.actorId),
-      actorIsSelf: false,
-      source: channel,
-      threadId: normalizeAssistantRouteString(binding.threadId),
-      threadIsDirect: true,
-    },
-    replyTarget: {
-      channel,
-      messageId: null,
-      threadId: deliveryTarget,
-    },
   };
 }
 

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -4233,6 +4233,16 @@ function buildHostedTerminalOutboxFailureRouteFromIntent(
     return null;
   }
 
+  if (
+    intent?.answeredMailboxItemIds.some((mailboxItemId) =>
+      mailboxItemId.startsWith(`${OUTBOX_DELIVERY_FAILED_INPUT_PREFIX}:`)
+    ) === true
+  ) {
+    // Failure notes use outbox-delivery-failed:<intentId>; answering one must
+    // not create another failure-note obligation.
+    return null;
+  }
+
   if (intent?.threadIsDirect !== true) {
     return null;
   }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -43,6 +43,9 @@ import {
   findAssistantAutoReplyDeliveryIntentIds,
 } from "@murphai/assistant-engine/assistant-automation";
 import {
+  resolveDeliveryCandidates,
+} from "@murphai/assistant-engine/assistant-channel-adapters";
+import {
   listConfiguredDeviceSyncConnectTargets,
   listConfiguredDeviceSyncReconnectTargets,
 } from "@murphai/device-syncd/connect-config";
@@ -4237,10 +4240,15 @@ function buildHostedTerminalOutboxFailureRouteFromIntent(
     return null;
   }
 
-  const replyTargetThreadId =
-    normalizeAssistantRouteString(intent.bindingDelivery?.target)
-    ?? normalizeAssistantRouteString(intent.explicitTarget)
-    ?? normalizeAssistantRouteString(intent.threadId);
+  const candidate = resolveDeliveryCandidates({
+    bindingDelivery: intent.bindingDelivery,
+    explicitTarget: intent.explicitTarget,
+  })[0] ?? null;
+  if (!candidate || candidate.kind === "participant") {
+    return null;
+  }
+
+  const replyTargetThreadId = normalizeAssistantRouteString(candidate.target);
   if (!replyTargetThreadId) {
     return null;
   }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -33,6 +33,7 @@ import {
   upsertAssistantInputEvent,
   type AssistantCronStatusOptions,
   type AssistantExecutionContext,
+  type AssistantInputEventRecord,
   type HostedAssistantTurnTimingStage,
 } from "@murphai/assistant-engine";
 import type {
@@ -45,8 +46,9 @@ import {
   listConfiguredDeviceSyncConnectTargets,
   listConfiguredDeviceSyncReconnectTargets,
 } from "@murphai/device-syncd/connect-config";
-import type {
-  AssistantCurrentDeliveryRoute,
+import {
+  type AssistantCurrentDeliveryRoute,
+  normalizeAssistantRouteString,
 } from "@murphai/operator-config/assistant/current-delivery-route";
 
 import {
@@ -74,9 +76,6 @@ import {
   readHostedAssistantInputCurrentDeliveryRoute,
   resolveUnambiguousCurrentDeliveryRoute,
 } from "./current-delivery-route.ts";
-import {
-  readCurrentDirectAssistantSessionRoute,
-} from "./direct-assistant-session-route.ts";
 import {
   runHostedAssistantAutomationLane,
 } from "./maintenance.ts";
@@ -4127,6 +4126,18 @@ function isHostedAssistantDeliveryOutcomeTerminalized(
     && outcome.deliveryStatus !== "sending";
 }
 
+const HOSTED_TERMINAL_OUTBOX_FAILURE_DIRECT_REPLY_CHANNELS = new Set([
+  "linq",
+  "telegram",
+]);
+
+type HostedTerminalOutboxFailureIntent =
+  NonNullable<Awaited<ReturnType<typeof readAssistantOutboxIntent>>>;
+type HostedTerminalOutboxFailureRoute = Pick<
+  AssistantInputEventRecord,
+  "conversation" | "replyTarget"
+>;
+
 async function stageHostedTerminalOutboxFailureInputs(input: {
   deliveryEffects: HostedAssistantDeliveryEffects;
   outcomes: readonly HostedAssistantDeliveryOutcome[];
@@ -4138,21 +4149,19 @@ async function stageHostedTerminalOutboxFailureInputs(input: {
   if (terminalFailures.length === 0) {
     return 0;
   }
-  const route = await readCurrentDirectAssistantSessionRoute(input.vaultRoot);
-  if (!route) {
-    return 0;
-  }
   const effectsById = new Map(
     input.deliveryEffects.map((effect) => [effect.effectId, effect]),
   );
   let staged = 0;
 
   for (const outcome of terminalFailures) {
-    const occurredAt = await readHostedTerminalOutboxFailureInputOccurredAt({
-      effectId: outcome.effectId,
-      vaultRoot: input.vaultRoot,
-    });
+    const intent = await readAssistantOutboxIntent(input.vaultRoot, outcome.effectId);
+    const occurredAt = readHostedTerminalOutboxFailureInputOccurredAt(intent);
     if (!occurredAt) {
+      continue;
+    }
+    const route = buildHostedTerminalOutboxFailureRouteFromIntent(intent);
+    if (!route) {
       continue;
     }
     const identity = safeHostedAssistantInputTokenOrHash(
@@ -4205,15 +4214,52 @@ async function stageHostedTerminalOutboxFailureInputs(input: {
   return staged;
 }
 
-async function readHostedTerminalOutboxFailureInputOccurredAt(input: {
-  effectId: string;
-  vaultRoot: string;
-}): Promise<string | null> {
-  const intent = await readAssistantOutboxIntent(input.vaultRoot, input.effectId);
+function readHostedTerminalOutboxFailureInputOccurredAt(
+  intent: HostedTerminalOutboxFailureIntent | null,
+): string | null {
   const createdAt = intent?.createdAt ?? null;
   return typeof createdAt === "string" && Number.isFinite(Date.parse(createdAt))
     ? createdAt
     : null;
+}
+
+function buildHostedTerminalOutboxFailureRouteFromIntent(
+  intent: HostedTerminalOutboxFailureIntent | null,
+): HostedTerminalOutboxFailureRoute | null {
+  if (intent?.threadIsDirect !== true) {
+    return null;
+  }
+
+  const channel = normalizeHostedTerminalOutboxFailureDirectReplyChannel(
+    intent.channel,
+  );
+  if (!channel) {
+    return null;
+  }
+
+  const replyTargetThreadId =
+    normalizeAssistantRouteString(intent.bindingDelivery?.target)
+    ?? normalizeAssistantRouteString(intent.explicitTarget)
+    ?? normalizeAssistantRouteString(intent.threadId);
+  if (!replyTargetThreadId) {
+    return null;
+  }
+
+  return {
+    conversation: {
+      accountId: normalizeAssistantRouteString(intent.identityId),
+      actorId: normalizeAssistantRouteString(intent.actorId),
+      actorIsSelf: false,
+      source: channel,
+      threadId: normalizeAssistantRouteString(intent.threadId),
+      threadIsDirect: true,
+    },
+    replyTarget: {
+      channel,
+      messageId: null,
+      threadId: replyTargetThreadId,
+    },
+  };
 }
 
 function shouldStageHostedTerminalOutboxFailureInput(
@@ -4222,14 +4268,18 @@ function shouldStageHostedTerminalOutboxFailureInput(
   if (outcome.deliveryStatus !== "failed" || outcome.retryable === true) {
     return false;
   }
-  return isHostedMemberFacingDeliveryChannel(outcome.deliveryChannel);
+  return normalizeHostedTerminalOutboxFailureDirectReplyChannel(
+    outcome.deliveryChannel,
+  ) !== null;
 }
 
-function isHostedMemberFacingDeliveryChannel(channel: string | null): boolean {
-  return channel === "email"
-    || channel === "linq"
-    || channel === "telegram"
-    || channel === "whatsapp";
+function normalizeHostedTerminalOutboxFailureDirectReplyChannel(
+  value: string | null | undefined,
+): string | null {
+  const channel = normalizeAssistantRouteString(value);
+  return channel && HOSTED_TERMINAL_OUTBOX_FAILURE_DIRECT_REPLY_CHANNELS.has(channel)
+    ? channel
+    : null;
 }
 
 function renderHostedTerminalOutboxFailureSystemNote(input: {

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -75,6 +75,9 @@ import {
   resolveUnambiguousCurrentDeliveryRoute,
 } from "./current-delivery-route.ts";
 import {
+  readCurrentDirectAssistantSessionRoute,
+} from "./direct-assistant-session-route.ts";
+import {
   runHostedAssistantAutomationLane,
 } from "./maintenance.ts";
 import {
@@ -3925,7 +3928,6 @@ async function drainHostedPostCheckpointDelivery(input: {
   const stagedTerminalFailureInputCount =
     await stageHostedTerminalOutboxFailureInputs({
       deliveryEffects: input.assistantDeliveryEffects,
-      now: new Date(resolveHostedAssistantPhaseNowMs(input.input)).toISOString(),
       outcomes,
       vaultRoot: input.input.restored.vaultRoot,
     });
@@ -4128,16 +4130,29 @@ function isHostedAssistantDeliveryOutcomeTerminalized(
 async function stageHostedTerminalOutboxFailureInputs(input: {
   deliveryEffects: HostedAssistantDeliveryEffects;
   outcomes: readonly HostedAssistantDeliveryOutcome[];
-  now: string;
   vaultRoot: string;
 }): Promise<number> {
+  const terminalFailures = input.outcomes.filter((outcome) =>
+    shouldStageHostedTerminalOutboxFailureInput(outcome)
+  );
+  if (terminalFailures.length === 0) {
+    return 0;
+  }
+  const route = await readCurrentDirectAssistantSessionRoute(input.vaultRoot);
+  if (!route) {
+    return 0;
+  }
   const effectsById = new Map(
     input.deliveryEffects.map((effect) => [effect.effectId, effect]),
   );
   let staged = 0;
 
-  for (const outcome of input.outcomes) {
-    if (!shouldStageHostedTerminalOutboxFailureInput(outcome)) {
+  for (const outcome of terminalFailures) {
+    const occurredAt = await readHostedTerminalOutboxFailureInputOccurredAt({
+      effectId: outcome.effectId,
+      vaultRoot: input.vaultRoot,
+    });
+    if (!occurredAt) {
       continue;
     }
     const identity = safeHostedAssistantInputTokenOrHash(
@@ -4155,10 +4170,10 @@ async function stageHostedTerminalOutboxFailureInputs(input: {
           transcriptText: text,
           userMessageContent: [{ text, type: "text" }],
         },
-        conversation: null,
-        occurredAt: input.now,
-        receivedAt: input.now,
-        replyTarget: null,
+        conversation: route.conversation,
+        occurredAt,
+        receivedAt: occurredAt,
+        replyTarget: route.replyTarget,
         sourceMetadata: null,
         sourceRef: {
           dedupeKey: identity,
@@ -4188,6 +4203,17 @@ async function stageHostedTerminalOutboxFailureInputs(input: {
   }
 
   return staged;
+}
+
+async function readHostedTerminalOutboxFailureInputOccurredAt(input: {
+  effectId: string;
+  vaultRoot: string;
+}): Promise<string | null> {
+  const intent = await readAssistantOutboxIntent(input.vaultRoot, input.effectId);
+  const createdAt = intent?.createdAt ?? null;
+  return typeof createdAt === "string" && Number.isFinite(Date.parse(createdAt))
+    ? createdAt
+    : null;
 }
 
 function shouldStageHostedTerminalOutboxFailureInput(

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -4247,13 +4247,15 @@ function buildHostedTerminalOutboxFailureRouteFromIntent(
     return null;
   }
 
+  const answeredMailboxItemIds = intent?.answeredMailboxItemIds ?? [];
   if (
-    intent?.answeredMailboxItemIds.some((mailboxItemId) =>
+    answeredMailboxItemIds.length > 0
+    && answeredMailboxItemIds.every((mailboxItemId) =>
       mailboxItemId.startsWith(`${OUTBOX_DELIVERY_FAILED_INPUT_PREFIX}:`)
-    ) === true
+    )
   ) {
-    // Failure notes use outbox-delivery-failed:<intentId>; answering one must
-    // not create another failure-note obligation.
+    // Failure-note-only replies are terminal evidence. Mixed replies may still
+    // owe a real user a failure signal, so they continue staging.
     return null;
   }
 

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -4229,6 +4229,10 @@ function readHostedTerminalOutboxFailureInputOccurredAt(
 function buildHostedTerminalOutboxFailureRouteFromIntent(
   intent: HostedTerminalOutboxFailureIntent | null,
 ): HostedTerminalOutboxFailureRoute | null {
+  if (intent?.operation) {
+    return null;
+  }
+
   if (intent?.threadIsDirect !== true) {
     return null;
   }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -3915,8 +3915,15 @@ async function drainHostedPostCheckpointDelivery(input: {
       outcomes,
       vaultRoot: input.input.restored.vaultRoot,
     });
+    const stagedTerminalFailureInputCount =
+      await stageHostedTerminalOutboxFailureInputs({
+        deliveryEffects: input.assistantDeliveryEffects,
+        outcomes,
+        vaultRoot: input.input.restored.vaultRoot,
+      });
     return await yieldHostedBackgroundPostCheckpointDrain(input, {
       resetPreparedDelivery: false,
+      stagedTerminalFailureInputCount,
       yieldedDeliveryCount: backgroundDeliveryDrainYieldedCount,
     });
   }
@@ -4029,6 +4036,7 @@ async function yieldHostedBackgroundPostCheckpointDrain(
   input: Parameters<typeof drainHostedPostCheckpointDelivery>[0],
   options?: {
     resetPreparedDelivery?: boolean;
+    stagedTerminalFailureInputCount?: number;
     yieldedDeliveryCount?: number;
   },
 ): Promise<HostedWorkspaceRunnerAssistantPhasePostCheckpoint> {
@@ -4061,6 +4069,12 @@ async function yieldHostedBackgroundPostCheckpointDrain(
       ...(input.redactedStatus ?? {}),
       hostedOutboxDeliveryYielded:
         options?.yieldedDeliveryCount ?? input.assistantDeliveryEffects.length,
+      ...(typeof options?.stagedTerminalFailureInputCount === "number"
+        ? {
+            hostedOutboxTerminalFailureInputsStaged:
+              options.stagedTerminalFailureInputCount,
+          }
+        : {}),
       hostedAssistantNextWakeAt: nextWake.at,
       nextWakeAt: nextWake.at,
     },

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   buildHostedExecutionSafeErrorDiagnostics,
   buildHostedExecutionRuntimeTimerWake,
@@ -23,10 +25,12 @@ import {
   HOSTED_ASSISTANT_TURN_TIMING_TYPE,
   applyMurphManagedAutomations,
   getAssistantCronStatus,
+  recordHostedMailboxAssistantInputItem,
   readAssistantOutboxIntent,
   readAssistantInputEvent,
   refreshAssistantContextSnapshotBestEffort,
   scheduleDeviceActivityTriggeredAutomations,
+  upsertAssistantInputEvent,
   type AssistantCronStatusOptions,
   type AssistantExecutionContext,
   type HostedAssistantTurnTimingStage,
@@ -88,6 +92,9 @@ import {
   resolveHostedPendingAssistantInputWakeAt,
 } from "./pending-assistant-input.ts";
 import {
+  enqueueHostedPendingAssistantInputId,
+} from "./pending-input-index.ts";
+import {
   drainHostedProviderCleanupAfterCommit,
   recordHostedProviderCleanupAfterDelivery,
   resolveHostedProviderCleanupScheduledWakeAt,
@@ -145,6 +152,13 @@ import {
 
 const HOSTED_DEVICE_SYNC_DIRTY_ACK_FAILURE_RETRY_DELAY_MS = 60_000;
 const HOSTED_OUTBOX_DELIVERY_ERROR_LOG_LIMIT = 16;
+const OUTBOX_DELIVERY_FAILED_INPUT_PREFIX = "outbox-delivery-failed";
+const OUTBOX_DELIVERY_FAILED_PAYLOAD_SCHEMA =
+  "murph.outbox-delivery-failed.v1";
+const OUTBOX_DELIVERY_FAILED_WAKE_SCHEMA =
+  "murph.hosted-runtime-outbox-delivery.v1";
+const ASSISTANT_INPUT_EVENT_SAFE_TOKEN_PATTERN =
+  /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,191}$/u;
 
 const HOSTED_RUNTIME_REDACTED_TEXT_MAX_LENGTH = 2048;
 const HOSTED_RUNTIME_BLOCKED_LOG_KEY_PARTS = [
@@ -531,6 +545,7 @@ export async function runHostedWorkspaceAssistantPhase(
           linqEgressLatencyTrace,
           platformEnv: input.runtime.platformEnv,
           providerFetch: input.runtime.platform.providerFetch ?? null,
+          publicInternetFetch: input.runtime.platform.publicInternetFetch ?? null,
           signal: channelAbortController.signal,
           userEnv: input.runtime.userEnv,
           wake,
@@ -3880,6 +3895,7 @@ async function drainHostedPostCheckpointDelivery(input: {
         platformEnv: input.input.runtime.platformEnv,
         preparedDispatches: input.assistantDeliveryPreparation?.preparedDispatches ?? null,
         providerFetch: input.input.runtime.platform.providerFetch ?? null,
+        publicInternetFetch: input.input.runtime.platform.publicInternetFetch ?? null,
         shouldYieldBackgroundDelivery: input.shouldYieldBackgroundDrain ?? null,
         signal: input.input.signal ?? null,
         userEnv: input.input.runtime.userEnv,
@@ -3906,6 +3922,16 @@ async function drainHostedPostCheckpointDelivery(input: {
     shouldYieldBackgroundDrain: input.shouldYieldBackgroundDrain ?? null,
     wake: input.wake,
   });
+  const stagedTerminalFailureInputCount =
+    await stageHostedTerminalOutboxFailureInputs({
+      deliveryEffects: input.assistantDeliveryEffects,
+      now: new Date(resolveHostedAssistantPhaseNowMs(input.input)).toISOString(),
+      outcomes,
+      vaultRoot: input.input.restored.vaultRoot,
+    });
+  const postFailurePendingAssistantInputWakeAt = stagedTerminalFailureInputCount > 0
+    ? await resolvePendingAssistantInputWakeAt(input.input)
+    : null;
   const postOutboxWakeAt = await resolveHostedAssistantOutboxNextWakeAt({
     vaultRoot: input.input.restored.vaultRoot,
   });
@@ -3948,6 +3974,10 @@ async function drainHostedPostCheckpointDelivery(input: {
     postAssistantCronWakeCandidate,
     createHostedRuntimeWakeCandidate(postOutboxWakeAt, "assistant"),
     createHostedRuntimeWakeCandidate(postSystemMailboxWakeAt, "assistant"),
+    createHostedRuntimeWakeCandidate(
+      postFailurePendingAssistantInputWakeAt,
+      "assistant",
+    ),
     providerCleanup.wake,
   ]);
   const postNextWakeAt = postNextWake.at;
@@ -3972,6 +4002,7 @@ async function drainHostedPostCheckpointDelivery(input: {
           hostedOutboxDeliverySent: sentCount,
           hostedOutboxPendingDeliveryEffects: 0,
           hostedOutboxTerminalizedSending: terminalizedSendingCount,
+          hostedOutboxTerminalFailureInputsStaged: stagedTerminalFailureInputCount,
         }
       : {};
 
@@ -4092,6 +4123,176 @@ function isHostedAssistantDeliveryOutcomeTerminalized(
     && outcome.deliveryStatus !== "pending"
     && outcome.deliveryStatus !== "retryable"
     && outcome.deliveryStatus !== "sending";
+}
+
+async function stageHostedTerminalOutboxFailureInputs(input: {
+  deliveryEffects: HostedAssistantDeliveryEffects;
+  outcomes: readonly HostedAssistantDeliveryOutcome[];
+  now: string;
+  vaultRoot: string;
+}): Promise<number> {
+  const effectsById = new Map(
+    input.deliveryEffects.map((effect) => [effect.effectId, effect]),
+  );
+  let staged = 0;
+
+  for (const outcome of input.outcomes) {
+    if (!shouldStageHostedTerminalOutboxFailureInput(outcome)) {
+      continue;
+    }
+    const identity = safeHostedAssistantInputTokenOrHash(
+      `${OUTBOX_DELIVERY_FAILED_INPUT_PREFIX}:${outcome.effectId}`,
+    );
+    const text = renderHostedTerminalOutboxFailureSystemNote({
+      effect: effectsById.get(outcome.effectId) ?? null,
+      outcome,
+    });
+    const event = await upsertAssistantInputEvent({
+      event: {
+        content: {
+          attachmentDescriptors: [],
+          text,
+          transcriptText: text,
+          userMessageContent: [{ text, type: "text" }],
+        },
+        conversation: null,
+        occurredAt: input.now,
+        receivedAt: input.now,
+        replyTarget: null,
+        sourceMetadata: null,
+        sourceRef: {
+          dedupeKey: identity,
+          eventId: identity,
+          itemId: identity,
+          kind: "hosted-mailbox",
+          lane: "system",
+          laneSeq: identity,
+          payloadSchema: OUTBOX_DELIVERY_FAILED_PAYLOAD_SCHEMA,
+          payloadSource: "inline",
+          source: "hosted-mailbox",
+          wakeSchema: OUTBOX_DELIVERY_FAILED_WAKE_SCHEMA,
+        },
+      },
+      vault: input.vaultRoot,
+    });
+    await recordHostedMailboxAssistantInputItem({
+      inputId: event.inputId,
+      mailboxItemId: identity,
+      vault: input.vaultRoot,
+    });
+    await enqueueHostedPendingAssistantInputId({
+      inputId: event.inputId,
+      vaultRoot: input.vaultRoot,
+    });
+    staged += 1;
+  }
+
+  return staged;
+}
+
+function shouldStageHostedTerminalOutboxFailureInput(
+  outcome: HostedAssistantDeliveryOutcome,
+): boolean {
+  if (outcome.deliveryStatus !== "failed" || outcome.retryable === true) {
+    return false;
+  }
+  return isHostedMemberFacingDeliveryChannel(outcome.deliveryChannel);
+}
+
+function isHostedMemberFacingDeliveryChannel(channel: string | null): boolean {
+  return channel === "email"
+    || channel === "linq"
+    || channel === "telegram"
+    || channel === "whatsapp";
+}
+
+function renderHostedTerminalOutboxFailureSystemNote(input: {
+  effect: HostedAssistantDeliveryEffects[number] | null;
+  outcome: HostedAssistantDeliveryOutcome;
+}): string {
+  const channel = normalizeHostedFailureNoteToken(
+    input.outcome.deliveryChannel ?? input.effect?.payload.channel,
+    "unknown",
+  );
+  const failureCode = normalizeHostedFailureNoteToken(
+    input.outcome.deliveryErrorCode,
+    "unknown",
+  );
+  const mediaDescription = renderHostedFailureNoteMedia(input.effect);
+  const hasVaultFile = input.effect?.payload.media.some((item) =>
+    item.kind === "vault_file"
+  ) === true;
+
+  const lines = [
+    "System note: The assistant's outgoing message failed to send and was NOT delivered to the user.",
+    `channel: ${channel}.`,
+    `failure code: ${failureCode}.`,
+    `attached media: ${mediaDescription}.`,
+  ];
+  if (hasVaultFile) {
+    lines.push(
+      "Any consumed vault-file approval must be re-requested before retrying.",
+    );
+  }
+  lines.push("Do not claim the failed message or file was sent.");
+  return lines.join(" ");
+}
+
+function renderHostedFailureNoteMedia(
+  effect: HostedAssistantDeliveryEffects[number] | null,
+): string {
+  const media = effect?.payload.media ?? [];
+  if (media.length === 0) {
+    return "none";
+  }
+
+  return media.map((item) => {
+    if (item.kind === "vault_file") {
+      return `vault file "${normalizeHostedFailureNoteFilename(item.filename)}"`;
+    }
+    if (item.kind === "voice_memo") {
+      return "voice memo";
+    }
+    return "image";
+  }).join(", ");
+}
+
+function normalizeHostedFailureNoteFilename(filename: string): string {
+  const normalized = filename.replace(/[\u0000-\u001F\u007F\\/]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return (normalized || "attached file").slice(0, 120);
+}
+
+function normalizeHostedFailureNoteToken(
+  value: string | null | undefined,
+  fallback: string,
+): string {
+  const normalized = value?.trim() ?? "";
+  return /^[A-Za-z0-9_.:-]{1,80}$/u.test(normalized)
+    ? normalized
+    : fallback;
+}
+
+function safeHostedAssistantInputTokenOrHash(value: string): string {
+  const normalized = value.trim();
+  if (
+    normalized.length > 0
+    && normalized.length <= 192
+    && ASSISTANT_INPUT_EVENT_SAFE_TOKEN_PATTERN.test(normalized)
+    && !isUnsafeHostedAssistantInputToken(normalized)
+  ) {
+    return normalized;
+  }
+
+  return `tok_${createHash("sha256").update(normalized || "empty").digest("hex").slice(0, 32)}`;
+}
+
+function isUnsafeHostedAssistantInputToken(value: string): boolean {
+  return value.includes("://")
+    || value.includes("@")
+    || value.includes("/")
+    || value.toLowerCase().includes("authorization");
 }
 
 async function flushHostedMemberChannelUpdatesBeforeAutoReplyDelivery(

--- a/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
@@ -7617,6 +7617,12 @@ describe("hosted runtime callbacks", () => {
       target: "chat_123",
       targetKind: "thread",
     });
+    const providerFetch = vi.fn<typeof fetch>(
+      async () => new Response(null, { status: 204 }),
+    );
+    const publicInternetFetch = vi.fn<typeof fetch>(
+      async () => new Response(null, { status: 204 }),
+    );
     mocks.dispatchAssistantOutboxIntent.mockImplementationOnce(async ({ dependencies }) => {
       const delivery = await dependencies.sendLinq({
         idempotencyKey: "assistant-outbox:intent_123",
@@ -7643,9 +7649,8 @@ describe("hosted runtime callbacks", () => {
       actionApprovalPort,
       assistantDeliveryEffects: [effect],
       effectsPort: createHostedRuntimeEffectsPortStub(),
-      providerFetch: vi.fn<typeof fetch>(
-        async () => new Response(null, { status: 204 }),
-      ),
+      providerFetch,
+      publicInternetFetch,
       vaultRoot: HOSTED_WAKE.vaultRoot,
       wake: HOSTED_WAKE.wake,
     });
@@ -7667,6 +7672,8 @@ describe("hosted runtime callbacks", () => {
       }),
       expect.objectContaining({
         loadVaultFile: expect.any(Function),
+        fetchImplementation: providerFetch,
+        publicFetchImplementation: publicInternetFetch,
       }),
     );
     expect(outcomes).toEqual([

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -6009,6 +6009,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
           channel: "linq",
           createdAt: intentCreatedAt,
           effectId: deliveryEffect.effectId,
+          explicitTarget: null,
           identityId: "identity_linq_a",
           replyToMessageId: "linq_message_a",
           threadId: "thread_linq_a",
@@ -6071,6 +6072,115 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }
   });
 
+  it("routes terminal delivery failure pending input to the explicit target when it overrides binding delivery", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-explicit-target-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      await seedDirectLinqAssistantInputRoute({
+        actorId: "actor_linq_a",
+        deliveryTarget: "linq_chat_a",
+        enabledAt: intentCreatedAt,
+        identityId: "identity_linq_a",
+        sessionId: "asst_linq_a",
+        threadId: "thread_linq_a",
+        vaultRoot,
+      });
+      await seedDirectLinqAssistantInputRoute({
+        actorId: "actor_linq_b",
+        deliveryTarget: "linq_chat_b",
+        enabledAt: "2026-05-08T16:00:05.000Z",
+        identityId: "identity_linq_b",
+        sessionId: "asst_linq_b",
+        threadId: "thread_linq_b",
+        vaultRoot,
+      });
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      const baseEffect = createDeliveryEffect();
+      const deliveryEffect = {
+        ...baseEffect,
+        effectId: "intent_terminal_failure_explicit_target",
+        fingerprint: "fingerprint_terminal_failure_explicit_target",
+        payload: {
+          ...baseEffect.payload,
+          channel: "linq" as const,
+          idempotencyKey: "assistant-outbox:intent_terminal_failure_explicit_target",
+        },
+      };
+      const terminalFailure = {
+        ...createFailedDeliveryOutcome({
+          deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+          effectId: deliveryEffect.effectId,
+        }),
+        deliveryStatus: "failed" as const,
+        effectFingerprint: deliveryEffect.fingerprint,
+        retryable: false,
+      };
+      mocks.readAssistantOutboxIntent.mockImplementation(async (
+        _vaultRoot: string,
+        intentId: string,
+      ) => intentId === deliveryEffect.effectId
+        ? createTerminalFailureOutboxIntent({
+          actorId: "actor_linq_b",
+          bindingDelivery: { kind: "thread", target: "linq_chat_a" },
+          channel: "linq",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          explicitTarget: "linq_chat_b",
+          identityId: "identity_linq_b",
+          replyToMessageId: "linq_message_b",
+          threadId: "thread_linq_b",
+          threadIsDirect: true,
+        })
+        : null);
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        terminalFailure,
+      ]);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        checkpointReason: "outbox_receipt",
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 1,
+          hostedOutboxTerminalizedSending: 1,
+        }),
+      }));
+      const pendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(pendingInputIds).toHaveLength(1);
+      const event = await actualAssistantAutomation.readAssistantInputEvent({
+        inputId: pendingInputIds[0]!,
+        vault: vaultRoot,
+      });
+      expect(event?.replyTarget?.threadId).toBe("linq_chat_b");
+      expect(event?.replyTarget?.threadId).not.toBe("linq_chat_a");
+      expect(event?.conversation?.threadId).toBe("thread_linq_b");
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("keeps terminal delivery failure input idempotent after the current session changes", async () => {
     const vaultRoot = await mkdtemp(path.join(
       tmpdir(),
@@ -6123,6 +6233,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
           channel: "linq",
           createdAt: intentCreatedAt,
           effectId: deliveryEffect.effectId,
+          explicitTarget: null,
           identityId: "identity_linq_a",
           replyToMessageId: "linq_message_a",
           threadId: "thread_linq_a",
@@ -6257,8 +6368,10 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         intentId: string,
       ) => intentId === deliveryEffect.effectId
         ? createTerminalFailureOutboxIntent({
+          bindingDeliveryTarget: "linq_chat_direct",
           createdAt: intentCreatedAt,
           effectId: deliveryEffect.effectId,
+          explicitTarget: null,
         })
         : null);
       mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
@@ -6416,6 +6529,85 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
           explicitTarget: null,
           threadId: null,
           threadIsDirect: null,
+        }),
+      );
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        {
+          ...createFailedDeliveryOutcome({
+            deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+            effectId: deliveryEffect.effectId,
+          }),
+          deliveryStatus: "failed" as const,
+          effectFingerprint: deliveryEffect.fingerprint,
+          retryable: false,
+        },
+      ]);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 0,
+        }),
+      }));
+      await expect(readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      })).resolves.toEqual([]);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not stage pending assistant input for participant terminal failure delivery candidates", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-participant-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      await saveAssistantAutomationState(vaultRoot, {
+        autoReply: [{
+          channel: "linq",
+          eligibleAfter: null,
+          enabledAt: intentCreatedAt,
+        }],
+        updatedAt: intentCreatedAt,
+        version: 1,
+      });
+      const deliveryEffect = {
+        ...createDeliveryEffect(),
+        effectId: "intent_vault_file_terminal_failure_participant",
+        fingerprint: "fingerprint_vault_file_terminal_failure_participant",
+        payload: {
+          ...createDeliveryEffect().payload,
+          channel: "linq" as const,
+          idempotencyKey:
+            "assistant-outbox:intent_vault_file_terminal_failure_participant",
+        },
+      };
+      mocks.readAssistantOutboxIntent.mockResolvedValue(
+        createTerminalFailureOutboxIntent({
+          bindingDelivery: { kind: "participant", target: "+15550000001" },
+          channel: "linq",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          explicitTarget: null,
+          threadId: "thread_linq_direct",
+          threadIsDirect: true,
         }),
       );
       mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
@@ -11354,6 +11546,7 @@ async function seedDirectLinqAssistantInputRoute(input: {
 
 function createTerminalFailureOutboxIntent(input: {
   actorId?: string | null;
+  bindingDelivery?: { kind: "participant" | "thread"; target: string } | null;
   bindingDeliveryTarget?: string | null;
   channel?: string | null;
   createdAt: string;
@@ -11367,6 +11560,11 @@ function createTerminalFailureOutboxIntent(input: {
   const bindingDeliveryTarget = "bindingDeliveryTarget" in input
     ? input.bindingDeliveryTarget
     : "linq_chat_direct";
+  const bindingDelivery = "bindingDelivery" in input
+    ? input.bindingDelivery ?? null
+    : bindingDeliveryTarget
+      ? { kind: "thread" as const, target: bindingDeliveryTarget }
+      : null;
   const channel = "channel" in input ? input.channel : "linq";
   const actorId = "actorId" in input ? input.actorId : "actor_linq_direct";
   const identityId = "identityId" in input
@@ -11382,9 +11580,7 @@ function createTerminalFailureOutboxIntent(input: {
   return {
     actorId,
     answeredMailboxItemIds: [],
-    bindingDelivery: bindingDeliveryTarget
-      ? { kind: "thread", target: bindingDeliveryTarget }
-      : null,
+    bindingDelivery,
     channel,
     createdAt: input.createdAt,
     dedupeKey: `dedupe_${input.effectId}`,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -6632,6 +6632,108 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }
   });
 
+  it("stages terminal delivery failure input when a mixed reply answered a failure note and a user message", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-mixed-one-hop-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      const deliveryEffect = {
+        ...createDeliveryEffect(),
+        effectId: "intent_terminal_failure_mixed_recovery_reply",
+        fingerprint: "fingerprint_terminal_failure_mixed_recovery_reply",
+        payload: {
+          ...createDeliveryEffect().payload,
+          channel: "linq" as const,
+          idempotencyKey:
+            "assistant-outbox:intent_terminal_failure_mixed_recovery_reply",
+        },
+      };
+      mocks.readAssistantOutboxIntent.mockResolvedValue(
+        createTerminalFailureOutboxIntent({
+          actorId: "actor_linq_direct",
+          answeredMailboxItemIds: [
+            "outbox-delivery-failed:intent_original_terminal_failure",
+            "hosted-mailbox-item-user-b",
+          ],
+          bindingDeliveryTarget: "linq_chat_direct",
+          channel: "linq",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          explicitTarget: null,
+          identityId: "identity_linq_direct",
+          replyToMessageId: "linq_message_direct",
+          threadId: "thread_linq_direct",
+          threadIsDirect: true,
+        }),
+      );
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        {
+          ...createFailedDeliveryOutcome({
+            deliveryChannel: "linq",
+            deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+            effectId: deliveryEffect.effectId,
+          }),
+          deliveryStatus: "failed" as const,
+          effectFingerprint: deliveryEffect.fingerprint,
+          retryable: false,
+        },
+      ]);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        checkpointReason: "outbox_receipt",
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 1,
+          hostedOutboxTerminalizedSending: 1,
+        }),
+      }));
+      const pendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(pendingInputIds).toHaveLength(1);
+      const event = await actualAssistantAutomation.readAssistantInputEvent({
+        inputId: pendingInputIds[0]!,
+        vault: vaultRoot,
+      });
+      expect(event?.sourceRef.kind).toBe("hosted-mailbox");
+      if (event?.sourceRef.kind !== "hosted-mailbox") {
+        throw new Error("Expected hosted-mailbox terminal failure input.");
+      }
+      expect(event.sourceRef.eventId).toBe(
+        "outbox-delivery-failed:intent_terminal_failure_mixed_recovery_reply",
+      );
+      expect(event?.replyTarget).toEqual({
+        channel: "linq",
+        messageId: null,
+        threadId: "linq_chat_direct",
+      });
+      expect(event?.conversation?.threadId).toBe("thread_linq_direct");
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("does not stage pending assistant input when a terminal failure was itself replying to a failure note", async () => {
     const vaultRoot = await mkdtemp(path.join(
       tmpdir(),

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -72,13 +72,18 @@ const mocks = vi.hoisted(() => ({
   scheduleDeviceActivityTriggeredAutomations: vi.fn(),
 }));
 
-vi.mock("@murphai/assistant-engine/assistant-automation", () => ({
-  findAssistantAutoReplyDeliveryIntentIds:
-    mocks.findAssistantAutoReplyDeliveryIntentIds,
-  listPendingAssistantAutoReplyLinqCleanupEvidence:
-    mocks.listPendingAssistantAutoReplyLinqCleanupEvidence,
-  markAssistantAutoReplyLinqCleanupQueued: mocks.markAssistantAutoReplyLinqCleanupQueued,
-}));
+vi.mock("@murphai/assistant-engine/assistant-automation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@murphai/assistant-engine/assistant-automation")>();
+  return {
+    ...actual,
+    findAssistantAutoReplyDeliveryIntentIds:
+      mocks.findAssistantAutoReplyDeliveryIntentIds,
+    listPendingAssistantAutoReplyLinqCleanupEvidence:
+      mocks.listPendingAssistantAutoReplyLinqCleanupEvidence,
+    markAssistantAutoReplyLinqCleanupQueued: mocks.markAssistantAutoReplyLinqCleanupQueued,
+  };
+});
 
 vi.mock("@murphai/assistant-engine/assistant-store", () => ({
   readAssistantAutomationState: mocks.readAssistantAutomationState,
@@ -93,6 +98,11 @@ vi.mock("@murphai/assistant-engine", async (importOriginal) => {
   return {
     ...actual,
     applyMurphManagedAutomations: mocks.applyMurphManagedAutomations,
+    compareAssistantInputCursors: automation.compareAssistantInputCursors,
+    createStoreBackedAssistantInputSource:
+      automation.createStoreBackedAssistantInputSource,
+    DEFAULT_ASSISTANT_AUTOMATION_SCAN_LIMIT:
+      automation.DEFAULT_ASSISTANT_AUTOMATION_SCAN_LIMIT,
     getAssistantCronStatus: mocks.getAssistantCronStatus,
     readAssistantInputEvent: mocks.readAssistantInputEvent,
     readAssistantOutboxIntent: mocks.readAssistantOutboxIntent,
@@ -181,7 +191,12 @@ import {
 import {
   markAssistantContextSnapshotDirty,
   readAssistantContextSnapshotState,
+  saveAssistantAutomationState,
+  saveAssistantSession,
 } from "@murphai/assistant-engine";
+import {
+  parseAssistantSessionRecord,
+} from "@murphai/operator-config/assistant-cli-contracts";
 import {
   runHostedWorkspaceAssistantPhase,
   type HostedWorkspaceRuntimeAssistantPhaseInput,
@@ -216,6 +231,8 @@ type RuntimeUsageRecordPort = NonNullable<
 type RuntimeDeviceSyncConnectLinkRequest = Parameters<
   RuntimeDeviceSyncPort["createConnectLink"]
 >[0];
+type HostedPendingAssistantInputModule =
+  typeof import("../src/hosted-runtime/pending-assistant-input.ts");
 
 function withoutAssistantTurnTimingLogs(
   logRequests: HostedRuntimeLogRequest[],
@@ -271,6 +288,17 @@ function createNoDirtyRuntimeDeviceSyncPortMethods(): Pick<
       };
     },
   };
+}
+
+async function resolveHostedPendingAssistantInputWakeAtWithRealImplementation(
+  input: Parameters<
+    HostedPendingAssistantInputModule["resolveHostedPendingAssistantInputWakeAt"]
+  >[0],
+): Promise<string | null> {
+  const actual = await vi.importActual<HostedPendingAssistantInputModule>(
+    "../src/hosted-runtime/pending-assistant-input.ts",
+  );
+  return actual.resolveHostedPendingAssistantInputWakeAt(input);
 }
 
 async function runHostedWorkspaceDurableCheckpointEffects(
@@ -5921,13 +5949,29 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
   });
 
-  it("stages one pending assistant input when terminal member-facing delivery fails", async () => {
+  it("keeps terminal member-facing delivery failure pending input replyable and idempotent", async () => {
     const vaultRoot = await mkdtemp(path.join(
       tmpdir(),
       "murph-outbox-terminal-failure-",
     ));
     try {
       const now = "2026-05-08T16:00:08.000Z";
+      const laterNow = "2026-05-08T16:05:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      await seedDirectLinqAssistantInputRoute({
+        enabledAt: intentCreatedAt,
+        vaultRoot,
+      });
+      mocks.resolveHostedPendingAssistantInputWakeAt.mockImplementation(
+        resolveHostedPendingAssistantInputWakeAtWithRealImplementation,
+      );
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      mocks.readAssistantInputEvent.mockImplementation(
+        actualAssistantAutomation.readAssistantInputEvent,
+      );
       const baseEffect = createDeliveryEffect();
       const deliveryEffect = {
         ...baseEffect,
@@ -5958,25 +6002,23 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         effectFingerprint: deliveryEffect.fingerprint,
         retryable: false,
       };
+      mocks.readAssistantOutboxIntent.mockImplementation(async (
+        _vaultRoot: string,
+        intentId: string,
+      ) => intentId === deliveryEffect.effectId
+        ? createTerminalFailureOutboxIntent({
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+        })
+        : null);
       mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
         deliveryEffect,
       ]);
       mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
         preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
       });
-      let deliveryDrained = false;
       mocks.drainHostedPreparedAssistantDeliveries.mockImplementation(async () => {
-        deliveryDrained = true;
         return [terminalFailure];
-      });
-      mocks.resolveHostedPendingAssistantInputWakeAt.mockImplementation(async (input) => {
-        if (!deliveryDrained) {
-          return null;
-        }
-        const inputIds = await readExistingHostedPendingAssistantInputIds({
-          vaultRoot,
-        });
-        return inputIds.length > 0 ? input.now?.() ?? now : null;
       });
 
       const firstResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
@@ -6001,14 +6043,26 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         vaultRoot,
       });
       expect(pendingInputIds).toHaveLength(1);
-      const actualAssistantAutomation =
-        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
-          "@murphai/assistant-engine/assistant-automation",
-        );
+      await expect(resolveHostedPendingAssistantInputWakeAtWithRealImplementation({
+        now: () => now,
+        vaultRoot,
+      })).resolves.toBe(now);
+      pendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(pendingInputIds).toHaveLength(1);
       const event = await actualAssistantAutomation.readAssistantInputEvent({
         inputId: pendingInputIds[0]!,
         vault: vaultRoot,
       });
+      expect(event?.conversation?.source).toBe("linq");
+      expect(event?.replyTarget).toEqual({
+        channel: "linq",
+        messageId: null,
+        threadId: "linq_chat_direct",
+      });
+      expect(event?.occurredAt).toBe(intentCreatedAt);
+      expect(event?.receivedAt).toBe(intentCreatedAt);
       expect(event?.content.text).toContain(
         "outgoing message failed to send and was NOT delivered",
       );
@@ -6021,28 +6075,133 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
       expect(event?.content.text).not.toContain("documents/lab-results.pdf");
       expect(event?.content.text).not.toContain("presigned");
 
-      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
-        deliveryEffect,
-      ]);
-      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
-        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      const noteTextsSeenByAssistantPass: string[] = [];
+      mocks.runHostedAssistantAutomationLane.mockImplementationOnce(async (laneInput) => {
+        expect(laneInput.freshAssistantInputIds).toEqual([event?.inputId]);
+        for (const inputId of laneInput.freshAssistantInputIds) {
+          const actualEvent = await actualAssistantAutomation.readAssistantInputEvent({
+            inputId,
+            vault: vaultRoot,
+          });
+          if (actualEvent?.content.text) {
+            noteTextsSeenByAssistantPass.push(actualEvent.content.text);
+          }
+        }
+        return {
+          assistantAutomationCurrentTurnDeliveryIntentIds: [],
+          assistantAutomationProgressed: true,
+          nextWakeAt: null,
+          redactedLogEntries: [],
+        };
       });
-      deliveryDrained = false;
 
       const secondResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
-        now: () => now,
+        assistantInputIds: [event!.inputId],
+        importedCount: 1,
+        now: () => laterNow,
         vaultRoot,
         workspace: createDueAssistantWorkspace(),
       }));
-      if (secondResult.afterCheckpoint) {
-        await secondResult.afterCheckpoint();
-      }
+
+      expect(secondResult).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 1,
+        }),
+      }));
+      expect(noteTextsSeenByAssistantPass).toHaveLength(1);
+      expect(noteTextsSeenByAssistantPass[0]).toContain(
+        "outgoing message failed to send and was NOT delivered",
+      );
 
       pendingInputIds = await readExistingHostedPendingAssistantInputIds({
         vaultRoot,
       });
       expect(pendingInputIds).toHaveLength(1);
       expect(pendingInputIds[0]).toBe(event?.inputId);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not stage pending assistant input for terminal failures without a direct route", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-no-route-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      await saveAssistantAutomationState(vaultRoot, {
+        autoReply: [{
+          channel: "linq",
+          eligibleAfter: null,
+          enabledAt: intentCreatedAt,
+        }],
+        updatedAt: intentCreatedAt,
+        version: 1,
+      });
+      mocks.resolveHostedPendingAssistantInputWakeAt.mockImplementation(
+        resolveHostedPendingAssistantInputWakeAtWithRealImplementation,
+      );
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      mocks.readAssistantInputEvent.mockImplementation(
+        actualAssistantAutomation.readAssistantInputEvent,
+      );
+      const deliveryEffect = {
+        ...createDeliveryEffect(),
+        effectId: "intent_vault_file_terminal_failure_no_route",
+        fingerprint: "fingerprint_vault_file_terminal_failure_no_route",
+        payload: {
+          ...createDeliveryEffect().payload,
+          channel: "linq" as const,
+          idempotencyKey:
+            "assistant-outbox:intent_vault_file_terminal_failure_no_route",
+        },
+      };
+      mocks.readAssistantOutboxIntent.mockResolvedValue(
+        createTerminalFailureOutboxIntent({
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+        }),
+      );
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        {
+          ...createFailedDeliveryOutcome({
+            deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+            effectId: deliveryEffect.effectId,
+          }),
+          deliveryStatus: "failed" as const,
+          effectFingerprint: deliveryEffect.fingerprint,
+          retryable: false,
+        },
+      ]);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 0,
+        }),
+      }));
+      await expect(readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      })).resolves.toEqual([]);
     } finally {
       await rm(vaultRoot, { force: true, recursive: true });
     }
@@ -10811,6 +10970,92 @@ function createDeliveryEffect(): HostedAssistantDeliverySideEffect {
       transportIdempotent: true,
       turnId: "turn_synthetic",
     },
+  };
+}
+
+async function seedDirectLinqAssistantInputRoute(input: {
+  enabledAt: string;
+  vaultRoot: string;
+}): Promise<void> {
+  await saveAssistantSession(input.vaultRoot, parseAssistantSessionRecord({
+    alias: null,
+    binding: {
+      actorId: "actor_linq_direct",
+      channel: "linq",
+      conversationKey: null,
+      delivery: {
+        kind: "thread",
+        target: "linq_chat_direct",
+      },
+      identityId: "identity_linq_direct",
+      threadId: "thread_linq_direct",
+      threadIsDirect: true,
+    },
+    createdAt: input.enabledAt,
+    lastTurnAt: null,
+    resumeState: null,
+    schema: "murph.assistant-session.v1",
+    sessionId: "asst_linq_direct",
+    target: {
+      adapter: "codex-cli",
+      approvalPolicy: "never",
+      codexCommand: null,
+      codexHome: null,
+      model: "gpt-5.5",
+      modelProvider: "vercel-ai-gateway",
+      oss: false,
+      profile: null,
+      reasoningEffort: "medium",
+      sandbox: "danger-full-access",
+    },
+    turnCount: 0,
+    updatedAt: input.enabledAt,
+  }));
+  await saveAssistantAutomationState(input.vaultRoot, {
+    autoReply: [{
+      channel: "linq",
+      eligibleAfter: null,
+      enabledAt: input.enabledAt,
+    }],
+    updatedAt: input.enabledAt,
+    version: 1,
+  });
+}
+
+function createTerminalFailureOutboxIntent(input: {
+  createdAt: string;
+  effectId: string;
+}) {
+  return {
+    actorId: "actor_linq_direct",
+    answeredMailboxItemIds: [],
+    bindingDelivery: { kind: "thread", target: "linq_chat_direct" },
+    channel: "linq",
+    createdAt: input.createdAt,
+    dedupeKey: `dedupe_${input.effectId}`,
+    delivery: null,
+    deliveryConfirmationPending: false,
+    deliveryIdempotencyKey: `assistant-outbox:${input.effectId}`,
+    deliveryTransportIdempotent: true,
+    explicitTarget: null,
+    identityId: "identity_linq_direct",
+    intentId: input.effectId,
+    lastAttemptAt: null,
+    lastError: null,
+    media: [],
+    message: "Synthetic delivery",
+    nextAttemptAt: null,
+    operation: null,
+    replyToMessageId: "linq_message_direct",
+    sentAt: null,
+    sessionId: "asst_linq_direct",
+    status: "failed",
+    subject: null,
+    targetFingerprint: `target_${input.effectId}`,
+    threadId: "thread_linq_direct",
+    threadIsDirect: true,
+    turnId: "turn_synthetic",
+    updatedAt: input.createdAt,
   };
 }
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -8,6 +8,9 @@ import type {
   HostedRuntimeLatencyTraceRequest,
   HostedRuntimeLogRequest,
 } from "@murphai/hosted-execution/runtime-control";
+import type {
+  AssistantOutboxIntent,
+} from "@murphai/operator-config/assistant-cli-contracts";
 import {
   ASSISTANT_USAGE_SCHEMA,
   type AssistantUsageRecord,
@@ -6571,6 +6574,85 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }
   });
 
+  it("does not stage pending assistant input for terminal reaction operation failures", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-reaction-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      const deliveryEffect = {
+        ...createDeliveryEffect(),
+        effectId: "intent_telegram_reaction_terminal_failure",
+        fingerprint: "fingerprint_telegram_reaction_terminal_failure",
+        payload: {
+          ...createDeliveryEffect().payload,
+          channel: "telegram" as const,
+          idempotencyKey:
+            "assistant-outbox:intent_telegram_reaction_terminal_failure",
+        },
+      };
+      mocks.readAssistantOutboxIntent.mockResolvedValue(
+        createTerminalFailureOutboxIntent({
+          actorId: "actor_telegram_direct",
+          bindingDeliveryTarget: "telegram_chat_direct",
+          channel: "telegram",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          explicitTarget: null,
+          identityId: "identity_telegram_direct",
+          operation: {
+            kind: "message-reaction",
+            reaction: "heart",
+          },
+          replyToMessageId: "telegram_message_direct",
+          threadId: "thread_telegram_direct",
+          threadIsDirect: true,
+        }),
+      );
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        {
+          ...createFailedDeliveryOutcome({
+            deliveryChannel: "telegram",
+            deliveryErrorCode: "TELEGRAM_REACTION_DELIVERY_FAILED",
+            effectId: deliveryEffect.effectId,
+          }),
+          deliveryStatus: "failed" as const,
+          effectFingerprint: deliveryEffect.fingerprint,
+          retryable: false,
+        },
+      ]);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 0,
+          hostedOutboxTerminalizedSending: 1,
+        }),
+      }));
+      await expect(readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      })).resolves.toEqual([]);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("does not stage pending assistant input for participant terminal failure delivery candidates", async () => {
     const vaultRoot = await mkdtemp(path.join(
       tmpdir(),
@@ -11556,6 +11638,7 @@ function createTerminalFailureOutboxIntent(input: {
   replyToMessageId?: string | null;
   threadId?: string | null;
   threadIsDirect?: boolean | null;
+  operation?: AssistantOutboxIntent["operation"];
 }) {
   const bindingDeliveryTarget = "bindingDeliveryTarget" in input
     ? input.bindingDeliveryTarget
@@ -11596,7 +11679,7 @@ function createTerminalFailureOutboxIntent(input: {
     media: [],
     message: "Synthetic delivery",
     nextAttemptAt: null,
-    operation: null,
+    operation: input.operation ?? null,
     replyToMessageId,
     sentAt: null,
     sessionId: "asst_linq_direct",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -86,14 +86,21 @@ vi.mock("@murphai/assistant-engine/assistant-store", () => ({
 
 vi.mock("@murphai/assistant-engine", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@murphai/assistant-engine")>();
+  const automation =
+    await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+      "@murphai/assistant-engine/assistant-automation",
+    );
   return {
     ...actual,
     applyMurphManagedAutomations: mocks.applyMurphManagedAutomations,
     getAssistantCronStatus: mocks.getAssistantCronStatus,
     readAssistantInputEvent: mocks.readAssistantInputEvent,
     readAssistantOutboxIntent: mocks.readAssistantOutboxIntent,
+    recordHostedMailboxAssistantInputItem:
+      automation.recordHostedMailboxAssistantInputItem,
     scheduleDeviceActivityTriggeredAutomations:
       mocks.scheduleDeviceActivityTriggeredAutomations,
+    upsertAssistantInputEvent: automation.upsertAssistantInputEvent,
   };
 });
 
@@ -179,6 +186,9 @@ import {
   runHostedWorkspaceAssistantPhase,
   type HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import {
+  readExistingHostedPendingAssistantInputIds,
+} from "../src/hosted-runtime/pending-input-index.ts";
 import {
   isHostedDeviceSyncMaintenanceModuleLoadError,
   loadHostedDeviceSyncMaintenanceModule,
@@ -5909,6 +5919,175 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         nextWakeAt: consumedWakeAt,
       }),
     }));
+  });
+
+  it("stages one pending assistant input when terminal member-facing delivery fails", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const baseEffect = createDeliveryEffect();
+      const deliveryEffect = {
+        ...baseEffect,
+        effectId: "intent_vault_file_terminal_failure",
+        fingerprint: "fingerprint_vault_file_terminal_failure",
+        payload: {
+          ...baseEffect.payload,
+          channel: "linq" as const,
+          idempotencyKey: "assistant-outbox:intent_vault_file_terminal_failure",
+          media: [{
+            approvalGeneration: "b".repeat(64),
+            approvalId: "approval_vault_file_terminal_failure",
+            contentType: "application/pdf",
+            filename: "lab-results.pdf",
+            kind: "vault_file" as const,
+            ref: "documents/lab-results.pdf",
+            sha256: "a".repeat(64),
+            sizeBytes: 1234,
+          }],
+        },
+      };
+      const terminalFailure = {
+        ...createFailedDeliveryOutcome({
+          deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+          effectId: deliveryEffect.effectId,
+        }),
+        deliveryStatus: "failed" as const,
+        effectFingerprint: deliveryEffect.fingerprint,
+        retryable: false,
+      };
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      let deliveryDrained = false;
+      mocks.drainHostedPreparedAssistantDeliveries.mockImplementation(async () => {
+        deliveryDrained = true;
+        return [terminalFailure];
+      });
+      mocks.resolveHostedPendingAssistantInputWakeAt.mockImplementation(async (input) => {
+        if (!deliveryDrained) {
+          return null;
+        }
+        const inputIds = await readExistingHostedPendingAssistantInputIds({
+          vaultRoot,
+        });
+        return inputIds.length > 0 ? input.now?.() ?? now : null;
+      });
+
+      const firstResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const firstPostCheckpoint = firstResult.afterCheckpoint
+        ? await firstResult.afterCheckpoint()
+        : firstResult;
+
+      expect(firstPostCheckpoint).toEqual(expect.objectContaining({
+        checkpointReason: "outbox_receipt",
+        nextWakeAt: now,
+        nextWakeReason: "assistant",
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 1,
+          hostedOutboxTerminalizedSending: 1,
+        }),
+      }));
+      let pendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(pendingInputIds).toHaveLength(1);
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      const event = await actualAssistantAutomation.readAssistantInputEvent({
+        inputId: pendingInputIds[0]!,
+        vault: vaultRoot,
+      });
+      expect(event?.content.text).toContain(
+        "outgoing message failed to send and was NOT delivered",
+      );
+      expect(event?.content.text).toContain("channel: linq");
+      expect(event?.content.text).toContain("failure code: LINQ_API_REQUEST_FAILED");
+      expect(event?.content.text).toContain('vault file "lab-results.pdf"');
+      expect(event?.content.text).toContain(
+        "Any consumed vault-file approval must be re-requested before retrying",
+      );
+      expect(event?.content.text).not.toContain("documents/lab-results.pdf");
+      expect(event?.content.text).not.toContain("presigned");
+
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      deliveryDrained = false;
+
+      const secondResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      if (secondResult.afterCheckpoint) {
+        await secondResult.afterCheckpoint();
+      }
+
+      pendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(pendingInputIds).toHaveLength(1);
+      expect(pendingInputIds[0]).toBe(event?.inputId);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not stage pending assistant input for retryable delivery failures", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-retryable-failure-",
+    ));
+    try {
+      const deliveryEffect = createDeliveryEffect();
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        createFailedDeliveryOutcome({
+          deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+          effectId: deliveryEffect.effectId,
+        }),
+      ]);
+      mocks.resolveHostedPendingAssistantInputWakeAt.mockResolvedValue(null);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 0,
+        }),
+      }));
+      await expect(readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      })).resolves.toEqual([]);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
   });
 
   it("fast-dispatches idempotent active nudge delivery before the runner checkpoint", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -6485,6 +6485,84 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }
   });
 
+  it("does not stage pending assistant input when a terminal failure was itself replying to a failure note", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-one-hop-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      const deliveryEffect = {
+        ...createDeliveryEffect(),
+        effectId: "intent_terminal_failure_recovery_reply",
+        fingerprint: "fingerprint_terminal_failure_recovery_reply",
+        payload: {
+          ...createDeliveryEffect().payload,
+          channel: "telegram" as const,
+          idempotencyKey:
+            "assistant-outbox:intent_terminal_failure_recovery_reply",
+        },
+      };
+      mocks.readAssistantOutboxIntent.mockResolvedValue(
+        createTerminalFailureOutboxIntent({
+          actorId: "actor_telegram_direct",
+          answeredMailboxItemIds: [
+            "outbox-delivery-failed:intent_original_terminal_failure",
+          ],
+          bindingDeliveryTarget: "telegram_chat_direct",
+          channel: "telegram",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          explicitTarget: null,
+          identityId: "identity_telegram_direct",
+          replyToMessageId: "telegram_message_direct",
+          threadId: "thread_telegram_direct",
+          threadIsDirect: true,
+        }),
+      );
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        {
+          ...createFailedDeliveryOutcome({
+            deliveryChannel: "telegram",
+            deliveryErrorCode: "TELEGRAM_SEND_FAILED",
+            effectId: deliveryEffect.effectId,
+          }),
+          deliveryStatus: "failed" as const,
+          effectFingerprint: deliveryEffect.fingerprint,
+          retryable: false,
+        },
+      ]);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 0,
+          hostedOutboxTerminalizedSending: 1,
+        }),
+      }));
+      await expect(readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      })).resolves.toEqual([]);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("does not stage pending assistant input for terminal failures without a durable direct route on the intent", async () => {
     const vaultRoot = await mkdtemp(path.join(
       tmpdir(),
@@ -11628,6 +11706,7 @@ async function seedDirectLinqAssistantInputRoute(input: {
 
 function createTerminalFailureOutboxIntent(input: {
   actorId?: string | null;
+  answeredMailboxItemIds?: readonly string[];
   bindingDelivery?: { kind: "participant" | "thread"; target: string } | null;
   bindingDeliveryTarget?: string | null;
   channel?: string | null;
@@ -11662,7 +11741,7 @@ function createTerminalFailureOutboxIntent(input: {
     : true;
   return {
     actorId,
-    answeredMailboxItemIds: [],
+    answeredMailboxItemIds: input.answeredMailboxItemIds ?? [],
     bindingDelivery,
     channel,
     createdAt: input.createdAt,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -5949,10 +5949,260 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
   });
 
-  it("keeps terminal member-facing delivery failure pending input replyable and idempotent", async () => {
+  it("routes terminal delivery failure pending input to the failed intent thread, not the current session", async () => {
     const vaultRoot = await mkdtemp(path.join(
       tmpdir(),
-      "murph-outbox-terminal-failure-",
+      "murph-outbox-terminal-failure-route-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      await seedDirectLinqAssistantInputRoute({
+        actorId: "actor_linq_a",
+        deliveryTarget: "linq_chat_a",
+        enabledAt: intentCreatedAt,
+        identityId: "identity_linq_a",
+        sessionId: "asst_linq_a",
+        threadId: "thread_linq_a",
+        vaultRoot,
+      });
+      await seedDirectLinqAssistantInputRoute({
+        actorId: "actor_linq_b",
+        deliveryTarget: "linq_chat_b",
+        enabledAt: "2026-05-08T16:00:05.000Z",
+        identityId: "identity_linq_b",
+        sessionId: "asst_linq_b",
+        threadId: "thread_linq_b",
+        vaultRoot,
+      });
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      const baseEffect = createDeliveryEffect();
+      const deliveryEffect = {
+        ...baseEffect,
+        effectId: "intent_terminal_failure_thread_a",
+        fingerprint: "fingerprint_terminal_failure_thread_a",
+        payload: {
+          ...baseEffect.payload,
+          channel: "linq" as const,
+          idempotencyKey: "assistant-outbox:intent_terminal_failure_thread_a",
+        },
+      };
+      const terminalFailure = {
+        ...createFailedDeliveryOutcome({
+          deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+          effectId: deliveryEffect.effectId,
+        }),
+        deliveryStatus: "failed" as const,
+        effectFingerprint: deliveryEffect.fingerprint,
+        retryable: false,
+      };
+      mocks.readAssistantOutboxIntent.mockImplementation(async (
+        _vaultRoot: string,
+        intentId: string,
+      ) => intentId === deliveryEffect.effectId
+        ? createTerminalFailureOutboxIntent({
+          actorId: "actor_linq_a",
+          bindingDeliveryTarget: "linq_chat_a",
+          channel: "linq",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          identityId: "identity_linq_a",
+          replyToMessageId: "linq_message_a",
+          threadId: "thread_linq_a",
+          threadIsDirect: true,
+        })
+        : null);
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockImplementation(async () => {
+        return [terminalFailure];
+      });
+
+      const firstResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const firstPostCheckpoint = firstResult.afterCheckpoint
+        ? await firstResult.afterCheckpoint()
+        : firstResult;
+
+      expect(firstPostCheckpoint).toEqual(expect.objectContaining({
+        checkpointReason: "outbox_receipt",
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 1,
+          hostedOutboxTerminalizedSending: 1,
+        }),
+      }));
+      const pendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(pendingInputIds).toHaveLength(1);
+      const event = await actualAssistantAutomation.readAssistantInputEvent({
+        inputId: pendingInputIds[0]!,
+        vault: vaultRoot,
+      });
+      expect(event?.conversation).toEqual({
+        accountId: "identity_linq_a",
+        actorId: "actor_linq_a",
+        actorIsSelf: false,
+        source: "linq",
+        threadId: "thread_linq_a",
+        threadIsDirect: true,
+      });
+      expect(event?.replyTarget).toEqual({
+        channel: "linq",
+        messageId: null,
+        threadId: "linq_chat_a",
+      });
+      expect(event?.conversation?.threadId).not.toBe("thread_linq_b");
+      expect(event?.replyTarget?.threadId).not.toBe("linq_chat_b");
+      expect(event?.occurredAt).toBe(intentCreatedAt);
+      expect(event?.receivedAt).toBe(intentCreatedAt);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps terminal delivery failure input idempotent after the current session changes", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-idempotent-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const laterNow = "2026-05-08T16:05:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      await seedDirectLinqAssistantInputRoute({
+        actorId: "actor_linq_a",
+        deliveryTarget: "linq_chat_a",
+        enabledAt: intentCreatedAt,
+        identityId: "identity_linq_a",
+        sessionId: "asst_linq_a",
+        threadId: "thread_linq_a",
+        vaultRoot,
+      });
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      const baseEffect = createDeliveryEffect();
+      const deliveryEffect = {
+        ...baseEffect,
+        effectId: "intent_terminal_failure_idempotent",
+        fingerprint: "fingerprint_terminal_failure_idempotent",
+        payload: {
+          ...baseEffect.payload,
+          channel: "linq" as const,
+          idempotencyKey: "assistant-outbox:intent_terminal_failure_idempotent",
+        },
+      };
+      const terminalFailure = {
+        ...createFailedDeliveryOutcome({
+          deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+          effectId: deliveryEffect.effectId,
+        }),
+        deliveryStatus: "failed" as const,
+        effectFingerprint: deliveryEffect.fingerprint,
+        retryable: false,
+      };
+      mocks.readAssistantOutboxIntent.mockImplementation(async (
+        _vaultRoot: string,
+        intentId: string,
+      ) => intentId === deliveryEffect.effectId
+        ? createTerminalFailureOutboxIntent({
+          actorId: "actor_linq_a",
+          bindingDeliveryTarget: "linq_chat_a",
+          channel: "linq",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          identityId: "identity_linq_a",
+          replyToMessageId: "linq_message_a",
+          threadId: "thread_linq_a",
+          threadIsDirect: true,
+        })
+        : null);
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        terminalFailure,
+      ]);
+
+      const firstResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const firstPostCheckpoint = firstResult.afterCheckpoint
+        ? await firstResult.afterCheckpoint()
+        : firstResult;
+      expect(firstPostCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 1,
+        }),
+      }));
+      const firstPendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(firstPendingInputIds).toHaveLength(1);
+      const firstEvent = await actualAssistantAutomation.readAssistantInputEvent({
+        inputId: firstPendingInputIds[0]!,
+        vault: vaultRoot,
+      });
+      expect(firstEvent?.replyTarget?.threadId).toBe("linq_chat_a");
+
+      await seedDirectLinqAssistantInputRoute({
+        actorId: "actor_linq_b",
+        deliveryTarget: "linq_chat_b",
+        enabledAt: laterNow,
+        identityId: "identity_linq_b",
+        sessionId: "asst_linq_b",
+        threadId: "thread_linq_b",
+        vaultRoot,
+      });
+      const secondResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => laterNow,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const secondPostCheckpoint = secondResult.afterCheckpoint
+        ? await secondResult.afterCheckpoint()
+        : secondResult;
+      expect(secondPostCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 1,
+        }),
+      }));
+      const secondPendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(secondPendingInputIds).toEqual(firstPendingInputIds);
+      const secondEvent = await actualAssistantAutomation.readAssistantInputEvent({
+        inputId: secondPendingInputIds[0]!,
+        vault: vaultRoot,
+      });
+      expect(secondEvent?.replyTarget?.threadId).toBe("linq_chat_a");
+      expect(secondEvent?.conversation?.threadId).toBe("thread_linq_a");
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps terminal member-facing delivery failure pending input replyable through compaction and the next assistant pass", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-compaction-",
     ));
     try {
       const now = "2026-05-08T16:00:08.000Z";
@@ -6017,9 +6267,9 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
       mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
         preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
       });
-      mocks.drainHostedPreparedAssistantDeliveries.mockImplementation(async () => {
-        return [terminalFailure];
-      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        terminalFailure,
+      ]);
 
       const firstResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
         now: () => now,
@@ -6075,6 +6325,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
       expect(event?.content.text).not.toContain("documents/lab-results.pdf");
       expect(event?.content.text).not.toContain("presigned");
 
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([]);
       const noteTextsSeenByAssistantPass: string[] = [];
       mocks.runHostedAssistantAutomationLane.mockImplementationOnce(async (laneInput) => {
         expect(laneInput.freshAssistantInputIds).toEqual([event?.inputId]);
@@ -6095,7 +6346,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         };
       });
 
-      const secondResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      await runHostedWorkspaceAssistantPhase(createPhaseInput({
         assistantInputIds: [event!.inputId],
         importedCount: 1,
         now: () => laterNow,
@@ -6103,11 +6354,6 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         workspace: createDueAssistantWorkspace(),
       }));
 
-      expect(secondResult).toEqual(expect.objectContaining({
-        redactedStatus: expect.objectContaining({
-          hostedOutboxTerminalFailureInputsStaged: 1,
-        }),
-      }));
       expect(noteTextsSeenByAssistantPass).toHaveLength(1);
       expect(noteTextsSeenByAssistantPass[0]).toContain(
         "outgoing message failed to send and was NOT delivered",
@@ -6123,7 +6369,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }
   });
 
-  it("does not stage pending assistant input for terminal failures without a direct route", async () => {
+  it("does not stage pending assistant input for terminal failures without a durable direct route on the intent", async () => {
     const vaultRoot = await mkdtemp(path.join(
       tmpdir(),
       "murph-outbox-terminal-failure-no-route-",
@@ -6163,8 +6409,13 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
       };
       mocks.readAssistantOutboxIntent.mockResolvedValue(
         createTerminalFailureOutboxIntent({
+          bindingDeliveryTarget: null,
+          channel: null,
           createdAt: intentCreatedAt,
           effectId: deliveryEffect.effectId,
+          explicitTarget: null,
+          threadId: null,
+          threadIsDirect: null,
         }),
       );
       mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
@@ -6177,6 +6428,75 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         {
           ...createFailedDeliveryOutcome({
             deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+            effectId: deliveryEffect.effectId,
+          }),
+          deliveryStatus: "failed" as const,
+          effectFingerprint: deliveryEffect.fingerprint,
+          retryable: false,
+        },
+      ]);
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = result.afterCheckpoint
+        ? await result.afterCheckpoint()
+        : result;
+
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        redactedStatus: expect.objectContaining({
+          hostedOutboxTerminalFailureInputsStaged: 0,
+        }),
+      }));
+      await expect(readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      })).resolves.toEqual([]);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not stage terminal failure input for email because it has no supported direct reply route here", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-email-terminal-failure-",
+    ));
+    try {
+      const now = "2026-05-08T16:00:08.000Z";
+      const intentCreatedAt = "2026-05-08T16:00:00.000Z";
+      const deliveryEffect = {
+        ...createDeliveryEffect(),
+        effectId: "intent_email_terminal_failure",
+        fingerprint: "fingerprint_email_terminal_failure",
+        payload: {
+          ...createDeliveryEffect().payload,
+          idempotencyKey: "assistant-outbox:intent_email_terminal_failure",
+        },
+      };
+      mocks.readAssistantOutboxIntent.mockResolvedValue(
+        createTerminalFailureOutboxIntent({
+          bindingDeliveryTarget: "email_thread_direct",
+          channel: "email",
+          createdAt: intentCreatedAt,
+          effectId: deliveryEffect.effectId,
+          explicitTarget: "email_thread_direct",
+          threadId: "email_thread_direct",
+          threadIsDirect: true,
+        }),
+      );
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValue([
+        deliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValue({
+        preparedDispatches: createPreparedDispatchesForDeliveryEffect(deliveryEffect),
+      });
+      mocks.drainHostedPreparedAssistantDeliveries.mockResolvedValue([
+        {
+          ...createFailedDeliveryOutcome({
+            deliveryChannel: "email",
+            deliveryErrorCode: "EMAIL_SEND_FAILED",
             effectId: deliveryEffect.effectId,
           }),
           deliveryStatus: "failed" as const,
@@ -10974,28 +11294,38 @@ function createDeliveryEffect(): HostedAssistantDeliverySideEffect {
 }
 
 async function seedDirectLinqAssistantInputRoute(input: {
+  actorId?: string;
+  deliveryTarget?: string;
   enabledAt: string;
+  identityId?: string;
+  sessionId?: string;
+  threadId?: string;
   vaultRoot: string;
 }): Promise<void> {
+  const sessionId = input.sessionId ?? "asst_linq_direct";
+  const actorId = input.actorId ?? "actor_linq_direct";
+  const deliveryTarget = input.deliveryTarget ?? "linq_chat_direct";
+  const identityId = input.identityId ?? "identity_linq_direct";
+  const threadId = input.threadId ?? "thread_linq_direct";
   await saveAssistantSession(input.vaultRoot, parseAssistantSessionRecord({
     alias: null,
     binding: {
-      actorId: "actor_linq_direct",
+      actorId,
       channel: "linq",
       conversationKey: null,
       delivery: {
         kind: "thread",
-        target: "linq_chat_direct",
+        target: deliveryTarget,
       },
-      identityId: "identity_linq_direct",
-      threadId: "thread_linq_direct",
+      identityId,
+      threadId,
       threadIsDirect: true,
     },
     createdAt: input.enabledAt,
     lastTurnAt: null,
     resumeState: null,
     schema: "murph.assistant-session.v1",
-    sessionId: "asst_linq_direct",
+    sessionId,
     target: {
       adapter: "codex-cli",
       approvalPolicy: "never",
@@ -11023,22 +11353,47 @@ async function seedDirectLinqAssistantInputRoute(input: {
 }
 
 function createTerminalFailureOutboxIntent(input: {
+  actorId?: string | null;
+  bindingDeliveryTarget?: string | null;
+  channel?: string | null;
   createdAt: string;
   effectId: string;
+  explicitTarget?: string | null;
+  identityId?: string | null;
+  replyToMessageId?: string | null;
+  threadId?: string | null;
+  threadIsDirect?: boolean | null;
 }) {
+  const bindingDeliveryTarget = "bindingDeliveryTarget" in input
+    ? input.bindingDeliveryTarget
+    : "linq_chat_direct";
+  const channel = "channel" in input ? input.channel : "linq";
+  const actorId = "actorId" in input ? input.actorId : "actor_linq_direct";
+  const identityId = "identityId" in input
+    ? input.identityId
+    : "identity_linq_direct";
+  const replyToMessageId = "replyToMessageId" in input
+    ? input.replyToMessageId
+    : "linq_message_direct";
+  const threadId = "threadId" in input ? input.threadId : "thread_linq_direct";
+  const threadIsDirect = "threadIsDirect" in input
+    ? input.threadIsDirect
+    : true;
   return {
-    actorId: "actor_linq_direct",
+    actorId,
     answeredMailboxItemIds: [],
-    bindingDelivery: { kind: "thread", target: "linq_chat_direct" },
-    channel: "linq",
+    bindingDelivery: bindingDeliveryTarget
+      ? { kind: "thread", target: bindingDeliveryTarget }
+      : null,
+    channel,
     createdAt: input.createdAt,
     dedupeKey: `dedupe_${input.effectId}`,
     delivery: null,
     deliveryConfirmationPending: false,
     deliveryIdempotencyKey: `assistant-outbox:${input.effectId}`,
     deliveryTransportIdempotent: true,
-    explicitTarget: null,
-    identityId: "identity_linq_direct",
+    explicitTarget: input.explicitTarget ?? null,
+    identityId,
     intentId: input.effectId,
     lastAttemptAt: null,
     lastError: null,
@@ -11046,14 +11401,14 @@ function createTerminalFailureOutboxIntent(input: {
     message: "Synthetic delivery",
     nextAttemptAt: null,
     operation: null,
-    replyToMessageId: "linq_message_direct",
+    replyToMessageId,
     sentAt: null,
     sessionId: "asst_linq_direct",
     status: "failed",
     subject: null,
     targetFingerprint: `target_${input.effectId}`,
-    threadId: "thread_linq_direct",
-    threadIsDirect: true,
+    threadId,
+    threadIsDirect,
     turnId: "turn_synthetic",
     updatedAt: input.createdAt,
   };

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -5622,6 +5622,153 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
   });
 
+  it("stages terminal delivery failure input before yielding prepared background outbox delivery", async () => {
+    const vaultRoot = await mkdtemp(path.join(
+      tmpdir(),
+      "murph-outbox-terminal-failure-yield-",
+    ));
+    try {
+      const now = "2026-04-27T00:00:00.000Z";
+      const intentCreatedAt = "2026-04-26T23:59:50.000Z";
+      await seedDirectLinqAssistantInputRoute({
+        enabledAt: intentCreatedAt,
+        vaultRoot,
+      });
+      const actualAssistantAutomation =
+        await vi.importActual<typeof import("@murphai/assistant-engine/assistant-automation")>(
+          "@murphai/assistant-engine/assistant-automation",
+        );
+      const baseEffect = createDeliveryEffect();
+      const firstDeliveryEffect = {
+        ...baseEffect,
+        deliveryPhase: "background_retry" as const,
+        effectId: "intent_terminal_failure_late_yield_first",
+        fingerprint: "fingerprint_terminal_failure_late_yield_first",
+        payload: {
+          ...baseEffect.payload,
+          channel: "linq" as const,
+          idempotencyKey:
+            "assistant-outbox:intent_terminal_failure_late_yield_first",
+          media: [{
+            approvalGeneration: "b".repeat(64),
+            approvalId: "approval_terminal_failure_late_yield",
+            contentType: "application/pdf",
+            filename: "lab-results.pdf",
+            kind: "vault_file" as const,
+            ref: "documents/lab-results.pdf",
+            sha256: "a".repeat(64),
+            sizeBytes: 1234,
+          }],
+        },
+      };
+      const secondDeliveryEffect = {
+        ...createDeliveryEffect(),
+        deliveryPhase: "background_retry" as const,
+        effectId: "intent_terminal_failure_late_yield_second",
+        fingerprint: "fingerprint_terminal_failure_late_yield_second",
+        payload: {
+          ...createDeliveryEffect().payload,
+          channel: "linq" as const,
+          idempotencyKey:
+            "assistant-outbox:intent_terminal_failure_late_yield_second",
+        },
+      };
+      const preparedDispatches = [
+        ...createPreparedDispatchesForDeliveryEffect(firstDeliveryEffect),
+        ...createPreparedDispatchesForDeliveryEffect(secondDeliveryEffect),
+      ];
+      const terminalFailure = {
+        ...createFailedDeliveryOutcome({
+          deliveryErrorCode: "LINQ_API_REQUEST_FAILED",
+          effectId: firstDeliveryEffect.effectId,
+        }),
+        deliveryStatus: "failed" as const,
+        effectFingerprint: firstDeliveryEffect.fingerprint,
+        retryable: false,
+      };
+      let shouldYield = false;
+      mocks.readAssistantOutboxIntent.mockImplementation(async (
+        _vaultRoot: string,
+        intentId: string,
+      ) => intentId === firstDeliveryEffect.effectId
+        ? createTerminalFailureOutboxIntent({
+          bindingDeliveryTarget: "linq_chat_direct",
+          channel: "linq",
+          createdAt: intentCreatedAt,
+          effectId: firstDeliveryEffect.effectId,
+          explicitTarget: null,
+        })
+        : null);
+      mocks.collectHostedAssistantDeliverySideEffects.mockResolvedValueOnce([
+        firstDeliveryEffect,
+        secondDeliveryEffect,
+      ]);
+      mocks.prepareHostedAssistantDeliveryEffectsForDispatch.mockResolvedValueOnce({
+        preparedDispatches,
+      });
+      mocks.resolveHostedAssistantOutboxNextWakeAt.mockResolvedValueOnce(
+        "2026-04-27T00:00:30.000Z",
+      );
+      mocks.drainHostedPreparedAssistantDeliveries.mockImplementationOnce(async (input) => {
+        expect(input.shouldYieldBackgroundDelivery?.()).toBe(false);
+        const outcomes = [terminalFailure];
+        shouldYield = true;
+        expect(input.shouldYieldBackgroundDelivery?.()).toBe(true);
+        input.onBackgroundDeliveryYield?.({ yieldedEffectCount: 1 });
+        return outcomes;
+      });
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        now: () => now,
+        shouldYieldBackgroundMaintenance: () => shouldYield,
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+      const postCheckpoint = await result.afterCheckpoint?.();
+
+      expect(mocks.drainHostedProviderCleanupAfterCommit).not.toHaveBeenCalled();
+      expect(mocks.resetHostedPreparedAssistantDeliveryEffects).not.toHaveBeenCalled();
+      expect(postCheckpoint).toEqual(expect.objectContaining({
+        checkpointReason: "assistant_runtime_commit",
+        nextWakeAt: now,
+        nextWakeReason: "assistant",
+        redactedStatus: expect.objectContaining({
+          hostedAssistantNextWakeAt: now,
+          hostedOutboxDeliveryYielded: 1,
+          hostedOutboxTerminalFailureInputsStaged: 1,
+          nextWakeAt: now,
+        }),
+      }));
+      const pendingInputIds = await readExistingHostedPendingAssistantInputIds({
+        vaultRoot,
+      });
+      expect(pendingInputIds).toHaveLength(1);
+      const event = await actualAssistantAutomation.readAssistantInputEvent({
+        inputId: pendingInputIds[0]!,
+        vault: vaultRoot,
+      });
+      expect(event?.sourceRef.kind).toBe("hosted-mailbox");
+      if (event?.sourceRef.kind !== "hosted-mailbox") {
+        throw new Error("Expected hosted-mailbox terminal failure input.");
+      }
+      expect(event.sourceRef.eventId).toBe(
+        `outbox-delivery-failed:${firstDeliveryEffect.effectId}`,
+      );
+      expect(event?.replyTarget).toEqual({
+        channel: "linq",
+        messageId: null,
+        threadId: "linq_chat_direct",
+      });
+      expect(event?.occurredAt).toBe(intentCreatedAt);
+      expect(event?.content.text).toContain(
+        "outgoing message failed to send and was NOT delivered",
+      );
+      expect(event?.content.text).toContain('vault file "lab-results.pdf"');
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("does not carry device-sync next-wake reasons from the assistant automation lane", async () => {
     const nextWakeAt = new Date(Date.now() + 60_000).toISOString();
     mocks.runHostedAssistantAutomationLane.mockResolvedValueOnce({

--- a/packages/operator-config/src/linq-runtime.ts
+++ b/packages/operator-config/src/linq-runtime.ts
@@ -378,7 +378,7 @@ export async function sendLinqChatMessage(
   })
 }
 
-export async function createLinqAttachmentUpload(
+async function createLinqAttachmentUpload(
   input: {
     contentType: string
     filename: string
@@ -417,7 +417,7 @@ export async function createLinqAttachmentUpload(
   return parseLinqAttachmentUploadResponse(response)
 }
 
-export async function uploadLinqAttachmentBytes(
+async function uploadLinqAttachmentBytes(
   input: {
     bytes: Uint8Array
     requiredHeaders: Record<string, string>
@@ -498,6 +498,49 @@ export async function uploadLinqAttachmentBytes(
       false,
     )
   }
+}
+
+export async function uploadLinqAttachment(
+  input: {
+    bytes: Uint8Array
+    contentType: string
+    filename: string
+  },
+  dependencies: {
+    env?: NodeJS.ProcessEnv
+    fetchImplementation?: LinqFetch
+    publicFetchImplementation?: LinqFetch
+    signal?: AbortSignal
+  } = {},
+): Promise<{ attachmentId: string }> {
+  const bytes = normalizeLinqAttachmentBytes(input.bytes)
+  const upload = await createLinqAttachmentUpload(
+    {
+      contentType: input.contentType,
+      filename: input.filename,
+      sizeBytes: bytes.byteLength,
+    },
+    {
+      env: dependencies.env,
+      fetchImplementation: dependencies.fetchImplementation,
+      ...(dependencies.signal ? { signal: dependencies.signal } : {}),
+    },
+  )
+  await uploadLinqAttachmentBytes(
+    {
+      bytes,
+      requiredHeaders: upload.requiredHeaders,
+      uploadUrl: upload.uploadUrl,
+    },
+    {
+      fetchImplementation:
+        dependencies.publicFetchImplementation
+        ?? dependencies.fetchImplementation,
+      ...(dependencies.signal ? { signal: dependencies.signal } : {}),
+    },
+  )
+
+  return { attachmentId: upload.attachmentId }
 }
 
 export async function sendLinqVoiceMemo(

--- a/packages/operator-config/src/linq-runtime.ts
+++ b/packages/operator-config/src/linq-runtime.ts
@@ -229,6 +229,7 @@ export type LinqFetch = (
     body?: string | Blob
     headers?: Record<string, string>
     method: string
+    redirect?: RequestRedirect
     signal?: AbortSignal
   },
 ) => Promise<LinqFetchResponse>
@@ -459,6 +460,7 @@ async function uploadLinqAttachmentBytes(
       }),
       headers,
       method: 'PUT',
+      redirect: 'error',
       signal: timeout.signal,
     })
   } catch (error) {

--- a/packages/operator-config/test/http-linq-device-runtime.test.ts
+++ b/packages/operator-config/test/http-linq-device-runtime.test.ts
@@ -685,6 +685,7 @@ test('linq runtime uploads attachment bytes with public fetch for the presigned 
   const publicFetch = vi.fn(async (url: string, init) => {
     assert.equal(url, 'https://uploads.example.test/upload/report')
     assert.equal(init.method, 'PUT')
+    assert.equal(init.redirect, 'error')
     assert.deepEqual(init.headers, {
       'content-type': 'application/pdf',
       'x-upload-token': 'upload-token',
@@ -706,6 +707,65 @@ test('linq runtime uploads attachment bytes with public fetch for the presigned 
       },
     ),
   ).resolves.toEqual({ attachmentId: 'attachment_pdf_1' })
+
+  expect(providerFetch).toHaveBeenCalledTimes(1)
+  expect(publicFetch).toHaveBeenCalledTimes(1)
+})
+
+test('linq runtime fails closed when a presigned attachment PUT redirects', async () => {
+  const env = {
+    LINQ_API_BASE_URL: 'https://linq.example.test/custom/',
+    LINQ_API_TOKEN: 'linq-token',
+  } satisfies NodeJS.ProcessEnv
+  const bytes = new Uint8Array([1, 2, 3, 4])
+  const providerFetch = vi.fn(async (url: string, init) => {
+    assert.equal(init.method, 'POST')
+    assert.ok(url.endsWith('/attachments'))
+    return createJsonResponse({
+      attachment_id: 'attachment_pdf_1',
+      download_url: 'https://cdn.example.test/report.pdf',
+      expires_at: '2026-04-08T00:05:00.000Z',
+      http_method: 'PUT',
+      required_headers: {
+        'content-type': 'application/pdf',
+        'x-upload-token': 'upload-token',
+      },
+      upload_url: 'https://uploads.example.test/upload/report',
+    })
+  })
+  const publicFetch = vi.fn(async (url: string, init) => {
+    assert.equal(url, 'https://uploads.example.test/upload/report')
+    assert.equal(init.method, 'PUT')
+    assert.equal(init.redirect, 'error')
+    throw new TypeError('fetch failed: redirected')
+  })
+
+  await assert.rejects(
+    () =>
+      uploadLinqAttachment(
+        {
+          bytes,
+          contentType: 'application/pdf',
+          filename: 'report.pdf',
+        },
+        {
+          env,
+          fetchImplementation: providerFetch,
+          publicFetchImplementation: publicFetch,
+        },
+      ),
+    (error) =>
+      error instanceof VaultCliError &&
+      error.code === 'LINQ_API_REQUEST_FAILED' &&
+      error.context?.operation === 'create_attachment_upload' &&
+      error.context?.provider === 'linq' &&
+      error.context?.failureStage === 'transport' &&
+      error.context?.method === 'PUT' &&
+      error.context?.path === '[presigned-upload]' &&
+      error.context?.requestOrigin === 'https://uploads.example.test' &&
+      error.context?.retryable === false &&
+      error.context?.timedOut === false,
+  )
 
   expect(providerFetch).toHaveBeenCalledTimes(1)
   expect(publicFetch).toHaveBeenCalledTimes(1)

--- a/packages/operator-config/test/http-linq-device-runtime.test.ts
+++ b/packages/operator-config/test/http-linq-device-runtime.test.ts
@@ -17,7 +17,6 @@ import {
 import { resolveExternalUrlBrowserCommands } from '../src/device-sync-browser-opener.ts'
 import { createDeviceSyncClient } from '../src/device-sync-client.ts'
 import {
-  createLinqAttachmentUpload,
   createLinqChat,
   createLinqWebhookSubscription,
   deleteLinqMessage,
@@ -27,7 +26,7 @@ import {
   sendLinqVoiceMemo,
   startLinqChatTypingIndicator,
   stopLinqChatTypingIndicator,
-  uploadLinqAttachmentBytes,
+  uploadLinqAttachment,
 } from '../src/linq-runtime.ts'
 import { VaultCliError } from '../src/vault-cli-errors.ts'
 
@@ -584,36 +583,17 @@ test('linq runtime creates, uploads, and sends voice memo attachments without re
   })
 
   await expect(
-    createLinqAttachmentUpload(
+    uploadLinqAttachment(
       {
+        bytes: audioBytes,
         contentType: 'audio/mpeg',
         filename: ' voice-memo.mp3 ',
-        sizeBytes: audioBytes.byteLength,
       },
       { env, fetchImplementation },
     ),
   ).resolves.toEqual({
     attachmentId: 'attachment_voice_1',
-    downloadUrl: 'https://cdn.example.test/voice-memo.mp3',
-    expiresAt: '2026-04-08T00:05:00.000Z',
-    requiredHeaders: {
-      'content-type': 'audio/mpeg',
-      'x-upload-token': 'upload-token',
-    },
-    uploadUrl: 'https://uploads.example.test/upload/voice-memo',
   })
-
-  await uploadLinqAttachmentBytes(
-    {
-      bytes: audioBytes,
-      requiredHeaders: {
-        'content-type': 'audio/mpeg',
-        'x-upload-token': 'upload-token',
-      },
-      uploadUrl: ' https://uploads.example.test/upload/voice-memo ',
-    },
-    { fetchImplementation },
-  )
 
   await expect(
     sendLinqVoiceMemo(
@@ -676,6 +656,110 @@ test('linq runtime creates, uploads, and sends voice memo attachments without re
   }
 })
 
+test('linq runtime uploads attachment bytes with public fetch for the presigned PUT', async () => {
+  const env = {
+    LINQ_API_BASE_URL: 'https://linq.example.test/custom/',
+    LINQ_API_TOKEN: 'linq-token',
+  } satisfies NodeJS.ProcessEnv
+  const bytes = new Uint8Array([1, 2, 3, 4])
+  const providerFetch = vi.fn(async (url: string, init) => {
+    assert.equal(init.method, 'POST')
+    assert.ok(url.endsWith('/attachments'))
+    assert.deepEqual(parseJsonRequestBody(init.body), {
+      content_type: 'application/pdf',
+      filename: 'report.pdf',
+      size_bytes: bytes.byteLength,
+    })
+    return createJsonResponse({
+      attachment_id: 'attachment_pdf_1',
+      download_url: 'https://cdn.example.test/report.pdf',
+      expires_at: '2026-04-08T00:05:00.000Z',
+      http_method: 'PUT',
+      required_headers: {
+        'content-type': 'application/pdf',
+        'x-upload-token': 'upload-token',
+      },
+      upload_url: 'https://uploads.example.test/upload/report',
+    })
+  })
+  const publicFetch = vi.fn(async (url: string, init) => {
+    assert.equal(url, 'https://uploads.example.test/upload/report')
+    assert.equal(init.method, 'PUT')
+    assert.deepEqual(init.headers, {
+      'content-type': 'application/pdf',
+      'x-upload-token': 'upload-token',
+    })
+    return new Response(null, { status: 204 })
+  })
+
+  await expect(
+    uploadLinqAttachment(
+      {
+        bytes,
+        contentType: 'application/pdf',
+        filename: 'report.pdf',
+      },
+      {
+        env,
+        fetchImplementation: providerFetch,
+        publicFetchImplementation: publicFetch,
+      },
+    ),
+  ).resolves.toEqual({ attachmentId: 'attachment_pdf_1' })
+
+  expect(providerFetch).toHaveBeenCalledTimes(1)
+  expect(publicFetch).toHaveBeenCalledTimes(1)
+})
+
+test('linq runtime falls back to provider fetch for attachment PUT when public fetch is absent', async () => {
+  const env = {
+    LINQ_API_BASE_URL: 'https://linq.example.test/custom/',
+    LINQ_API_TOKEN: 'linq-token',
+  } satisfies NodeJS.ProcessEnv
+  const seenRequests: Array<{ method: string; url: string }> = []
+  const fetchImplementation = vi.fn(async (url: string, init) => {
+    seenRequests.push({ method: init.method, url })
+    if (url.endsWith('/attachments')) {
+      return createJsonResponse({
+        attachment_id: 'attachment_pdf_1',
+        download_url: 'https://cdn.example.test/report.pdf',
+        expires_at: '2026-04-08T00:05:00.000Z',
+        http_method: 'PUT',
+        required_headers: {
+          'content-type': 'application/pdf',
+        },
+        upload_url: 'https://uploads.example.test/upload/report',
+      })
+    }
+    if (url === 'https://uploads.example.test/upload/report') {
+      return new Response(null, { status: 204 })
+    }
+    throw new Error(`Unexpected request: ${init.method} ${url}`)
+  })
+
+  await expect(
+    uploadLinqAttachment(
+      {
+        bytes: new Uint8Array([1, 2, 3, 4]),
+        contentType: 'application/pdf',
+        filename: 'report.pdf',
+      },
+      { env, fetchImplementation },
+    ),
+  ).resolves.toEqual({ attachmentId: 'attachment_pdf_1' })
+
+  expect(seenRequests).toEqual([
+    {
+      method: 'POST',
+      url: 'https://linq.example.test/custom/attachments',
+    },
+    {
+      method: 'PUT',
+      url: 'https://uploads.example.test/upload/report',
+    },
+  ])
+})
+
 test('linq runtime rejects unsafe attachment upload URLs before uploading bytes', async () => {
   const env = {
     LINQ_API_BASE_URL: ' https://linq.example.test/custom/ ',
@@ -700,11 +784,11 @@ test('linq runtime rejects unsafe attachment upload URLs before uploading bytes'
 
   await assert.rejects(
     () =>
-      createLinqAttachmentUpload(
+      uploadLinqAttachment(
         {
+          bytes: new Uint8Array([1, 2, 3, 4]),
           contentType: 'audio/mpeg',
           filename: 'voice-memo.mp3',
-          sizeBytes: 4,
         },
         { env, fetchImplementation: createFetch },
       ),
@@ -716,17 +800,35 @@ test('linq runtime rejects unsafe attachment upload URLs before uploading bytes'
   expect(createFetch).toHaveBeenCalledTimes(1)
 
   const uploadFetch = vi.fn()
+  const unsafeUploadFetch = vi.fn(async (url: string, init) => {
+    if (url.endsWith('/attachments') && init.method === 'POST') {
+      return createJsonResponse({
+        attachment_id: 'attachment_voice_1',
+        download_url: 'https://cdn.example.test/voice-memo.mp3',
+        expires_at: '2026-04-08T00:05:00.000Z',
+        http_method: 'PUT',
+        required_headers: {
+          'content-type': 'audio/mpeg',
+        },
+        upload_url: 'https://127.0.0.1/upload/voice-memo',
+      })
+    }
+
+    throw new Error(`Unexpected request: ${init.method} ${url}`)
+  })
   await assert.rejects(
     () =>
-      uploadLinqAttachmentBytes(
+      uploadLinqAttachment(
         {
           bytes: new Uint8Array([1, 2, 3, 4]),
-          requiredHeaders: {
-            'content-type': 'audio/mpeg',
-          },
-          uploadUrl: 'https://127.0.0.1/upload/voice-memo',
+          contentType: 'audio/mpeg',
+          filename: 'voice-memo.mp3',
         },
-        { fetchImplementation: uploadFetch },
+        {
+          env,
+          fetchImplementation: unsafeUploadFetch,
+          publicFetchImplementation: uploadFetch,
+        },
       ),
     (error) =>
       error instanceof VaultCliError &&

--- a/scripts/send-linq-voice-memo.ts
+++ b/scripts/send-linq-voice-memo.ts
@@ -4,9 +4,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
-  createLinqAttachmentUpload,
   sendLinqVoiceMemo,
-  uploadLinqAttachmentBytes,
+  uploadLinqAttachment,
   type LinqFetch,
 } from "@murphai/operator-config/linq-runtime";
 
@@ -39,9 +38,6 @@ export interface LinqVoiceMemoSendReport {
   fingerprintScope: "env-secret" | "ephemeral";
   upload: {
     attachment: RedactedIdentifier;
-    downloadUrlPresent: boolean;
-    expiresAtPresent: boolean;
-    requiredHeaderCount: number;
   };
   voiceMemo: {
     providerMessage: RedactedIdentifier;
@@ -139,25 +135,14 @@ export async function runLinqVoiceMemoSend(
   } catch {
     throw new Error("Voice memo file bytes could not be read.");
   }
-  const upload = await createLinqAttachmentUpload(
+  const upload = await uploadLinqAttachment(
     {
+      bytes,
       contentType,
       filename: uploadFilename,
-      sizeBytes: bytes.byteLength,
     },
     {
       env: requestEnv,
-      fetchImplementation: dependencies.fetchImplementation,
-    },
-  );
-
-  await uploadLinqAttachmentBytes(
-    {
-      bytes,
-      requiredHeaders: upload.requiredHeaders,
-      uploadUrl: upload.uploadUrl,
-    },
-    {
       fetchImplementation: dependencies.fetchImplementation,
     },
   );
@@ -188,9 +173,6 @@ export async function runLinqVoiceMemoSend(
     fingerprintScope: context.scope,
     upload: {
       attachment: redactIdentifier(upload.attachmentId, context),
-      downloadUrlPresent: upload.downloadUrl !== null,
-      expiresAtPresent: upload.expiresAt.length > 0,
-      requiredHeaderCount: Object.keys(upload.requiredHeaders).length,
     },
     voiceMemo: {
       providerMessage: redactIdentifier(voiceMemo.providerMessageId, context),


### PR DESCRIPTION
## Why this PR exists

A hosted member asked Murph to send a vault PDF over iMessage. The `send_vault_file` approval flow worked, but the attachment never arrived and Murph told the user it had sent. Root cause: sending a Linq attachment is two calls from the hosted container — `POST /attachments` (returns a presigned storage-upload URL) then a `PUT` of the bytes to that URL. The vault-file path reused one fetch (`providerFetch`) for both, and `providerFetch` hard-asserts the destination hostname against a six-entry provider allowlist, so the presigned `PUT` to the storage host threw before any network call. This path had never worked in hosted runtime; voice memos worked only because they thread a separate public fetch for that one `PUT`. On top of that, the terminal, non-retryable delivery failure was invisible to the model on the next turn, so it claimed success.

## User goal / user-visible behavior

- A member can ask Murph to send an approved vault file over iMessage and actually receive it.
- When a message send fails terminally, Murph learns it was not delivered and tells the user the truth (and that a consumed approval must be re-requested) instead of claiming success.

## What changed

- **Delivery fix:** new `uploadLinqAttachment` seam in `operator-config` owns the two-call rule — provider fetch for `POST /attachments`, public fetch for the presigned `PUT`, falling back to provider fetch when no public fetch is supplied (local/unhosted dev). Voice-memo and vault-file callers both switch to it; the two lower-level functions are no longer exported.
- **Wiring:** hosted `publicInternetFetch` is threaded through the Linq send dependency to `prepareLinqMessageMedia`, mirroring the existing `providerFetch` plumbing.
- **Failure feedback:** a terminal non-retryable **message** send failure on a direct member-facing Linq/Telegram channel stages exactly one deterministic, deduped pending assistant-input note and schedules an immediate wake, reusing the existing hosted mailbox assistant-input pattern (no new state class). The note routes from the failed outbox intent's own durable route (via the same `resolveDeliveryCandidates` dispatch uses), so it lands on the exact thread that failed. Non-message operations (reactions/typing), participant/non-direct routes, retryable failures, and ambiguous outcomes are excluded.
- **Honest status:** `send_vault_file` approved tool result and the matching system-prompt line now say approval succeeded and delivery is queued, not confirmed.
- **Observability:** Linq send failures now record a sanitized `failure_reason` from trusted `VaultCliError` messages.

## Invariants to preserve

- The presigned `PUT` uses an unrestricted fetch **only** for the storage upload and must not carry internal authority headers (public fetch already strips them); Linq provider API calls still go through the asserted provider egress boundary.
- Multi-file sends stay atomic — a failure on any attachment fails the whole message.
- Failure notes are assistant-facing, secret-safe (channel kind, failure code, attachment filename only — no URLs, headers, phone numbers, or raw payloads), and staged only for unambiguous non-retryable **message** failures with a durable direct route; reactions/operations, participant/non-direct routes, and retryable failures stage nothing.
- Terminal-failure staging dedupes per intent (stable identity from the durable intent) and does not resurface or conflict on drain re-entry.

## Deliberately deferred (follow-up)

The failure-feedback note is staged during the post-checkpoint delivery drain, including on the background-drain yield path. One narrow residual window remains: a process crash/redeploy landing between the durable `failed` write and the staging call within the same drain tick could skip the note. This is **at parity with current production behavior** (terminal failures are silent today), so it is not a regression, but it does not yet fully satisfy crash-survival for the note. A follow-up will close it with a no-new-state recovery scan for durably-failed direct message intents missing the deterministic `outbox-delivery-failed:<intentId>` input. Both the normal completion and foreground-preemption (yield) paths surface the failure today.

## Deployment concerns

`publicInternetFetch` already exists on the hosted platform, so this is a runner-bundle change with no Worker/web contract change. Deploy order is not sensitive: web and Cloudflare can deploy independently. Warm containers on the old bundle keep the pre-fix behavior (failed vault-file sends) until they cycle to the new bundle; no compatibility window is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786048240&installation_id=127572939&pr_number=451&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F451&signature=780220026e5bb47d9bbab92046ef06408cb891080f9eea8f1a849a9661d126ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
