### PR TITLE
Update Temporal SDK advisory dependencies

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-07-temporal.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-temporal.md
@@ -1,0 +1,81 @@
+# Temporal SDK advisory
+
+Status: completed
+Created: 2026-07-07
+Updated: 2026-07-07
+
+## Goal
+
+- Remove Murph's exposure to the Temporal TypeScript SDK workflow-context advisory by moving the hosted Temporal worker and hosted web signal client off affected `@temporalio/*` patch releases.
+
+## Success criteria
+
+- Official advisory links are verified as legitimate enough to act on.
+- All repo `@temporalio/*` dependencies resolve to a fixed patch release on the selected minor branch.
+- Temporal package specs are no longer exact affected patch pins.
+- Existing dependency guard, audit, and Temporal/package verification pass or any unrelated blockers are documented.
+- A scoped PR is opened from an isolated task branch.
+
+## Scope
+
+- In scope:
+  - `apps/web/package.json`
+  - `packages/hosted-orchestrator-temporal/package.json`
+  - `pnpm-workspace.yaml`
+  - `pnpm-lock.yaml`
+- Out of scope:
+  - Temporal workflow command-order changes.
+  - Runtime behavior changes outside dependency resolution.
+  - Webpack pinning unless the fixed SDK cannot be used.
+
+## Constraints
+
+- Technical constraints:
+  - Keep all `@temporalio/*` package versions aligned.
+  - Keep pnpm supply-chain controls enabled and lockfile committed with manifest edits.
+  - Do not print secrets or environment values.
+- Product/process constraints:
+  - Preserve hosted Temporal hard-cut architecture and pointer-only workflow state.
+  - Use the PR lane and close this plan through `scripts/finish-task`.
+
+## Risks and mitigations
+
+1. Risk: The upgrade could pull Webpack or native SDK transitive dependencies in unexpected ways.
+   Mitigation: inspect the lockfile, run dependency guard/audit, and build the Temporal workflow bundle through the package verification lane.
+2. Risk: Temporal SDK package versions drift apart.
+   Mitigation: update all direct `@temporalio/*` packages together and verify the lockfile has one resolved patch version.
+
+## Tasks
+
+1. Verify advisory authenticity from official Temporal/GitHub sources.
+2. Inspect manifests, lockfile, Webpack version, and Temporal worker startup options.
+3. Update Temporal package specs and pnpm overrides to fixed patch ranges.
+4. Refresh the lockfile.
+5. Run required verification and dependency checks.
+6. Commit with `scripts/finish-task`, push, open draft PR, and run PR review gate as required.
+
+## Decisions
+
+- Use the fixed `1.16.3` branch instead of jumping to the latest minor, minimizing SDK/runtime change surface while applying Temporal's backported patch.
+- Use `~1.16.3` ranges for Temporal packages so future patch releases in the same minor are not blocked by exact pins.
+
+## Verification
+
+- Completed:
+  - `pnpm install --lockfile-only` passed after adding exact Temporal `1.16.3` minimum-release-age excludes.
+  - `pnpm install` passed with the repo's ignored-build protection intact.
+  - Temporal advisory and release links were verified against the official `temporalio/sdk-typescript` GitHub repo.
+  - npm metadata for resolved `@temporalio/*@1.16.3` packages has registry integrity and one registry signature per package.
+  - npm tarball comparison from `1.16.2` to `1.16.3` showed no added or removed files and no new package scripts or bin entrypoints; `@temporalio/worker` changed only the bundler source/map/package metadata.
+  - `rg` confirmed no manifest/lockfile `@temporalio/*` `1.16.2` references remain and Webpack remains `5.106.2`.
+  - `pnpm deps:guard` passed.
+  - `pnpm deps:ignored-builds` passed and listed the expected ignored build-script packages.
+  - `pnpm build:test-runtime:prepared` passed.
+  - `pnpm typecheck` passed after preparing local workspace artifacts in the fresh worktree.
+  - `pnpm --dir packages/hosted-orchestrator-temporal build` passed and built the workflow bundle with Webpack `5.106.2`.
+  - `pnpm --dir packages/hosted-orchestrator-temporal test:coverage` passed: 12 files, 78 tests.
+  - Focused rerun of `packages/hosted-local-harness` `starts Cloudflare through the prepared app-owned dev entrypoint` passed after building `packages/assistant-runtime`.
+- Recorded caveats:
+  - `pnpm deps:audit` still fails on unrelated existing advisories in `ws`, `form-data`, `vite`, `undici`, and `repomix`. The `protobufjs` high advisory on the Temporal/gRPC path was removed by the override to `7.6.5`.
+  - `pnpm test:diff apps/web/package.json packages/hosted-orchestrator-temporal/package.json pnpm-workspace.yaml pnpm-lock.yaml` ran the global-root diff lane and passed through CLI Vitest plus many affected package tests, then failed in `packages/hosted-local-harness` local-dev stack tests. The dominant failure was missing `@murphai/assistant-runtime/dist` in the fresh worktree; a focused rerun of one affected harness case passed after building that prerequisite. A remaining local-only class depends on Linux Docker bridge host alias discovery in this environment and is unrelated to the Temporal dependency update.
+Completed: 2026-07-07

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,7 +49,7 @@
     "@privy-io/node": "^0.18.0",
     "@privy-io/react-auth": "^3.24.0",
     "@radix-ui/react-dialog": "^1.1.15",
-    "@temporalio/client": "1.16.2",
+    "@temporalio/client": "~1.16.3",
     "@vercel/analytics": "2.0.1",
     "@vercel/oidc": "^3.4.1",
     "@vercel/speed-insights": "2.0.0",

--- a/packages/hosted-orchestrator-temporal/package.json
+++ b/packages/hosted-orchestrator-temporal/package.json
@@ -60,11 +60,11 @@
   },
   "dependencies": {
     "@murphai/hosted-execution": "workspace:*",
-    "@temporalio/activity": "1.16.2",
-    "@temporalio/client": "1.16.2",
-    "@temporalio/common": "1.16.2",
-    "@temporalio/worker": "1.16.2",
-    "@temporalio/workflow": "1.16.2"
+    "@temporalio/activity": "~1.16.3",
+    "@temporalio/client": "~1.16.3",
+    "@temporalio/common": "~1.16.3",
+    "@temporalio/worker": "~1.16.3",
+    "@temporalio/workflow": "~1.16.3"
   },
   "engines": {
     "node": ">=24.14.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,9 @@ overrides:
   '@privy-io/js-sdk-core@0.62.0>js-cookie': 3.0.8
   '@privy-io/react-auth@3.24.0>js-cookie': 3.0.8
   '@solana/rpc-subscriptions-channel-websocket@5.5.1>ws': 8.21.0
-  '@temporalio/client@1.16.2>@grpc/grpc-js': 1.14.4
-  '@temporalio/core-bridge@1.16.2>@grpc/grpc-js': 1.14.4
-  '@temporalio/worker@1.16.2>@grpc/grpc-js': 1.14.4
+  '@temporalio/client@1.16.3>@grpc/grpc-js': 1.14.4
+  '@temporalio/core-bridge@1.16.3>@grpc/grpc-js': 1.14.4
+  '@temporalio/worker@1.16.3>@grpc/grpc-js': 1.14.4
   '@workflow/builders@4.0.5>esbuild': 0.28.1
   '@workflow/cli@4.2.4>esbuild': 0.28.1
   axios-retry@4.5.0>axios: 1.17.0
@@ -37,6 +37,7 @@ overrides:
   miniflare@4.20260507.1>ws: 8.21.0
   next@16.2.6>postcss: 8.5.15
   porto@0.2.35>hono: 4.12.25
+  protobufjs: 7.6.5
   terser-webpack-plugin@5.6.0>esbuild: 0.28.1
   tsx@4.21.0>esbuild: 0.28.1
   viem@2.23.2>ws: 8.21.0
@@ -212,8 +213,8 @@ importers:
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@temporalio/client':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: ~1.16.3
+        version: 1.16.3
       '@vercel/analytics':
         specifier: 2.0.1
         version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -712,20 +713,20 @@ importers:
         specifier: workspace:*
         version: link:../hosted-execution
       '@temporalio/activity':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: ~1.16.3
+        version: 1.16.3
       '@temporalio/client':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: ~1.16.3
+        version: 1.16.3
       '@temporalio/common':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: ~1.16.3
+        version: 1.16.3
       '@temporalio/worker':
-        specifier: 1.16.2
-        version: 1.16.2(@swc/helpers@0.5.21)(esbuild@0.28.1)(tslib@2.8.1)
+        specifier: ~1.16.3
+        version: 1.16.3(@swc/helpers@0.5.21)(esbuild@0.28.1)(tslib@2.8.1)
       '@temporalio/workflow':
-        specifier: 1.16.2
-        version: 1.16.2
+        specifier: ~1.16.3
+        version: 1.16.3
 
   packages/importers:
     dependencies:
@@ -2686,17 +2687,14 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
   '@protobufjs/fetch@1.1.1':
     resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -3921,36 +3919,36 @@ packages:
   '@tanstack/virtual-core@3.14.0':
     resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
-  '@temporalio/activity@1.16.2':
-    resolution: {integrity: sha512-fhemoI7xBO6rR1wOedaQPJEKE5KuYdRX5tEQt4SMp9XqdoOyC4oYzljoXQ+/Q62d4skK3/fNSK86HTKHF2ngDQ==}
+  '@temporalio/activity@1.16.3':
+    resolution: {integrity: sha512-yrfEn0WXMGWouceXaCRG81d9jh9CNQu8eZpNv37mAaRuHrDcvkTiSw+gYT5YrNbYrrBfMZqTFDJ62F3Yxw1N1w==}
     engines: {node: '>= 20.0.0'}
 
-  '@temporalio/client@1.16.2':
-    resolution: {integrity: sha512-SvuFpikonwOSLjedesueh71010h304ub436OA16mHeunQgUfldqtI9ZrHqP9L5jzBxWOxRIKZL52clMjaebSxQ==}
+  '@temporalio/client@1.16.3':
+    resolution: {integrity: sha512-LAE+JLiefzkiK7GmDSh/rytL6085YVN6rXPtK2IjzEwaeeEUOsE/Fn8UiXuYKlmoWs/fXchmeg+2KLLOCmAmuQ==}
     engines: {node: '>= 20.0.0'}
 
-  '@temporalio/common@1.16.2':
-    resolution: {integrity: sha512-Yu62OW85wU3/XDt/xXDxw1lB3bce0xCrrgfd7aJJ5lp7FGzPgIgcC7bu2iIcSZnnCJGF86pnLJb+emo0mwINVg==}
+  '@temporalio/common@1.16.3':
+    resolution: {integrity: sha512-Rd5/nJ8zCDyFkvix3LQfbYRO3YLyMaN761EJzuIc1YvqAduI+T9jP+HTFUxh4XpYDmPsJTE+5sPTx43EOlTqxA==}
     engines: {node: '>= 20.0.0'}
 
-  '@temporalio/core-bridge@1.16.2':
-    resolution: {integrity: sha512-KJ301Lh7xzjprWVM9GqwRj3PnLHaxycQQv83QKeo59rqHh0AmR+wmWDKkDEHLG9CITNx4X/XtJdG1McjpFc3WA==}
+  '@temporalio/core-bridge@1.16.3':
+    resolution: {integrity: sha512-nMTkWscmaNRoQGsG4W2B2GYOIO6sSXzjCdoqXrWKSMHLxSqyn/HHUP+LFrp1nI7W0mrUz+Wsc3n/ymI/nVe9/Q==}
     engines: {node: '>= 20.0.0'}
 
-  '@temporalio/nexus@1.16.2':
-    resolution: {integrity: sha512-IVcyztAUEWUC2ae/7maQiRwnE9pXz4SYfypI6sBdxpCHe3OxV21sMCqHku3Lot/IuFV9kyHYnL3Srn0WAZWQwA==}
+  '@temporalio/nexus@1.16.3':
+    resolution: {integrity: sha512-hbBiWXoJjgT6ExHNsqffvJ3DrgMXvicpwmd6LeLwBZ1yci2iT9+Rp2Rfd1XA74ql8TPec6U+ZPer3b7UMu/mIQ==}
     engines: {node: '>= 20.0.0'}
 
-  '@temporalio/proto@1.16.2':
-    resolution: {integrity: sha512-KIBlGV38W3HiHsDFSEs33TsXl7I2KcApbuLlBcCKtjHVdl5pzEt1nQpD5szi+y6saIENaXBifmVTELtYh2w7Rw==}
+  '@temporalio/proto@1.16.3':
+    resolution: {integrity: sha512-dCgil6TwdcJ+2HC7Th8VIj+XqH6vIph8xjhG27hC7U3mLTF0ZyweCcTXnX0GE+iWz2CapLjjSZr8tUMA9Wx0vA==}
     engines: {node: '>= 20.0.0'}
 
-  '@temporalio/worker@1.16.2':
-    resolution: {integrity: sha512-kdLwWOn/vEDgaUV7OBqjq6ZIMFDJqGOGHmSzZ8j7PLrGrKJ521yai29/2VeqAL6JKQBxCllRNNhocdQBQfZDtg==}
+  '@temporalio/worker@1.16.3':
+    resolution: {integrity: sha512-p4jSDgf6FeVFrVTg4skgQsrZvzMeLM+JbOt8A8RqcI7g3825P9Ykco5eCyqN6G5BEu//16lcX2XAbFBx5iEbIw==}
     engines: {node: '>= 20.0.0'}
 
-  '@temporalio/workflow@1.16.2':
-    resolution: {integrity: sha512-EESJV9CsRSpLgebrzMY9FOMrDD1BHrXvaDB+++69eYNvH5nWNS94zfVzpPZpUoRRRLfNvSJd3jSXV/pH1HwLiQ==}
+  '@temporalio/workflow@1.16.3':
+    resolution: {integrity: sha512-Vi7agsYwTBddWEf6RD5+LGxgnRqzEUMZdKMhhyfgE+KpDYdEmSp6W89IJRnVNb0sLS/QEubqBcOvs+6uxgdwmw==}
     engines: {node: '>= 20.0.0'}
 
   '@tokenizer/inflate@0.4.1':
@@ -8083,8 +8081,8 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.6.0:
-    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   protocols@2.0.2:
@@ -10756,7 +10754,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.0
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@hcaptcha/loader@2.3.0': {}
@@ -11984,15 +11982,13 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -13742,64 +13738,64 @@ snapshots:
 
   '@tanstack/virtual-core@3.14.0': {}
 
-  '@temporalio/activity@1.16.2':
+  '@temporalio/activity@1.16.3':
     dependencies:
-      '@temporalio/client': 1.16.2
-      '@temporalio/common': 1.16.2
+      '@temporalio/client': 1.16.3
+      '@temporalio/common': 1.16.3
       abort-controller: 3.0.0
 
-  '@temporalio/client@1.16.2':
+  '@temporalio/client@1.16.3':
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@temporalio/common': 1.16.2
-      '@temporalio/proto': 1.16.2
+      '@temporalio/common': 1.16.3
+      '@temporalio/proto': 1.16.3
       abort-controller: 3.0.0
       long: 5.3.2
       uuid: 11.1.1
 
-  '@temporalio/common@1.16.2':
+  '@temporalio/common@1.16.3':
     dependencies:
-      '@temporalio/proto': 1.16.2
+      '@temporalio/proto': 1.16.3
       long: 5.3.2
       ms: 3.0.0-canary.1
       nexus-rpc: 0.0.2
       proto3-json-serializer: 2.0.2
 
-  '@temporalio/core-bridge@1.16.2':
+  '@temporalio/core-bridge@1.16.3':
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@temporalio/common': 1.16.2
+      '@temporalio/common': 1.16.3
 
-  '@temporalio/nexus@1.16.2':
+  '@temporalio/nexus@1.16.3':
     dependencies:
-      '@temporalio/client': 1.16.2
-      '@temporalio/common': 1.16.2
-      '@temporalio/proto': 1.16.2
+      '@temporalio/client': 1.16.3
+      '@temporalio/common': 1.16.3
+      '@temporalio/proto': 1.16.3
       long: 5.3.2
       nexus-rpc: 0.0.2
 
-  '@temporalio/proto@1.16.2':
+  '@temporalio/proto@1.16.3':
     dependencies:
       long: 5.3.2
-      protobufjs: 7.6.0
+      protobufjs: 7.6.5
 
-  '@temporalio/worker@1.16.2(@swc/helpers@0.5.21)(esbuild@0.28.1)(tslib@2.8.1)':
+  '@temporalio/worker@1.16.3(@swc/helpers@0.5.21)(esbuild@0.28.1)(tslib@2.8.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@temporalio/activity': 1.16.2
-      '@temporalio/client': 1.16.2
-      '@temporalio/common': 1.16.2
-      '@temporalio/core-bridge': 1.16.2
-      '@temporalio/nexus': 1.16.2
-      '@temporalio/proto': 1.16.2
-      '@temporalio/workflow': 1.16.2
+      '@temporalio/activity': 1.16.3
+      '@temporalio/client': 1.16.3
+      '@temporalio/common': 1.16.3
+      '@temporalio/core-bridge': 1.16.3
+      '@temporalio/nexus': 1.16.3
+      '@temporalio/proto': 1.16.3
+      '@temporalio/workflow': 1.16.3
       abort-controller: 3.0.0
       heap-js: 2.7.1
       memfs: 4.57.2(tslib@2.8.1)
       nexus-rpc: 0.0.2
       proto3-json-serializer: 2.0.2
-      protobufjs: 7.6.0
+      protobufjs: 7.6.5
       rxjs: 7.8.2
       source-map: 0.7.6
       source-map-loader: 4.0.2(webpack@5.106.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(esbuild@0.28.1))
@@ -13823,10 +13819,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@temporalio/workflow@1.16.2':
+  '@temporalio/workflow@1.16.3':
     dependencies:
-      '@temporalio/common': 1.16.2
-      '@temporalio/proto': 1.16.2
+      '@temporalio/common': 1.16.3
+      '@temporalio/proto': 1.16.3
       nexus-rpc: 0.0.2
 
   '@tokenizer/inflate@0.4.1':
@@ -19270,17 +19266,16 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.6.0
+      protobufjs: 7.6.5
 
-  protobufjs@7.6.0:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,9 +26,9 @@ overrides:
   '@privy-io/js-sdk-core@0.62.0>js-cookie': 3.0.8
   '@privy-io/react-auth@3.24.0>js-cookie': 3.0.8
   '@solana/rpc-subscriptions-channel-websocket@5.5.1>ws': 8.21.0
-  '@temporalio/client@1.16.2>@grpc/grpc-js': 1.14.4
-  '@temporalio/core-bridge@1.16.2>@grpc/grpc-js': 1.14.4
-  '@temporalio/worker@1.16.2>@grpc/grpc-js': 1.14.4
+  '@temporalio/client@1.16.3>@grpc/grpc-js': 1.14.4
+  '@temporalio/core-bridge@1.16.3>@grpc/grpc-js': 1.14.4
+  '@temporalio/worker@1.16.3>@grpc/grpc-js': 1.14.4
   '@workflow/builders@4.0.5>esbuild': 0.28.1
   '@workflow/cli@4.2.4>esbuild': 0.28.1
   axios-retry@4.5.0>axios: 1.17.0
@@ -45,6 +45,7 @@ overrides:
   miniflare@4.20260507.1>ws: 8.21.0
   next@16.2.6>postcss: 8.5.15
   porto@0.2.35>hono: 4.12.25
+  protobufjs: 7.6.5
   terser-webpack-plugin@5.6.0>esbuild: 0.28.1
   tsx@4.21.0>esbuild: 0.28.1
   viem@2.23.2>ws: 8.21.0
@@ -65,6 +66,14 @@ minimumReleaseAgeExclude:
   - incur@0.4.4
   - '@cobuild/review-gpt@0.5.95'
   - '@openai/codex@0.143.0||0.143.0-darwin-arm64||0.143.0-darwin-x64||0.143.0-linux-arm64||0.143.0-linux-x64||0.143.0-win32-arm64||0.143.0-win32-x64'
+  - '@temporalio/activity@1.16.3'
+  - '@temporalio/client@1.16.3'
+  - '@temporalio/common@1.16.3'
+  - '@temporalio/core-bridge@1.16.3'
+  - '@temporalio/nexus@1.16.3'
+  - '@temporalio/proto@1.16.3'
+  - '@temporalio/worker@1.16.3'
+  - '@temporalio/workflow@1.16.3'
   - fast-uri@3.1.2
   - fast-xml-builder@1.2.0
 nodeVersion: 24.14.1


### PR DESCRIPTION
## Why

Temporal published an official TypeScript SDK advisory for a workflow-context isolation bug when `reuseV8Context: true` is combined with workflow bundles built by Webpack `>= 5.108.0` on affected SDK releases.

This repo had exact `@temporalio/*` `1.16.2` pins in the hosted Temporal worker/client path. Our lockfile was still on Webpack `5.106.2`, but the exact affected SDK pins and future lockfile refresh risk made this worth fixing now.

References:
- Advisory: https://github.com/temporalio/sdk-typescript/issues/2170
- Fixed release: https://github.com/temporalio/sdk-typescript/releases/tag/v1.16.3
- Fix PR: https://github.com/temporalio/sdk-typescript/pull/2169

## User-visible goal

Hosted Temporal orchestration should run on Temporal's fixed `1.16.3` patch line without changing workflow command ordering, workflow state shape, task queues, or hosted runtime behavior.

## What changed

- Updated direct Temporal deps in `apps/web` and `packages/hosted-orchestrator-temporal` from exact `1.16.2` to `~1.16.3`.
- Refreshed `pnpm-lock.yaml` so all resolved `@temporalio/*` packages are aligned on `1.16.3`.
- Moved the existing Temporal gRPC overrides to the `1.16.3` package keys.
- Added exact `minimumReleaseAgeExclude` entries for the Temporal `1.16.3` backport packages, matching the advisory's cooldown guidance.
- Added a `protobufjs: 7.6.5` override to remove the high audit finding on the Temporal/protobuf path.

## Security checks

- Verified the advisory, release, and fix PR on the official `temporalio/sdk-typescript` GitHub repo.
- Checked npm metadata for resolved `@temporalio/*@1.16.3`: every package has registry integrity and one registry signature.
- Compared npm tarballs from `1.16.2` to `1.16.3`: no added/removed files, no new package scripts, no new bin entrypoints; `@temporalio/worker` changed only the bundler source/map/package metadata.
- Confirmed Webpack remains `5.106.2` in the lockfile.

## Invariants to preserve

- Keep all `@temporalio/*` packages on the same patch version.
- Do not alter Temporal workflow code, command ordering, history semantics, task queue names, or pointer-only hosted workflow state.
- Keep pnpm supply-chain exceptions narrow and version-specific.
- Keep Webpack below the known-bad threshold unless the patched SDK path is in place.

## Verification

Passed:
- `pnpm install --lockfile-only`
- `pnpm install`
- `pnpm deps:guard`
- `pnpm deps:ignored-builds`
- `pnpm build:test-runtime:prepared`
- `pnpm typecheck`
- `pnpm --dir packages/hosted-orchestrator-temporal build`
- `pnpm --dir packages/hosted-orchestrator-temporal test:coverage` (12 files, 78 tests)
- Focused hosted-local-harness rerun for the missing-dist failure case after building `packages/assistant-runtime`

Known unrelated caveats:
- `pnpm deps:audit` still fails on existing non-Temporal advisories in `ws`, `form-data`, `vite`, `undici`, and `repomix`. The prior Temporal/protobuf-path high finding is removed by this PR.
- `pnpm test:diff apps/web/package.json packages/hosted-orchestrator-temporal/package.json pnpm-workspace.yaml pnpm-lock.yaml` ran the broad global-root lane and passed many affected typechecks/tests, then failed in `packages/hosted-local-harness` local-dev stack tests due fresh-worktree `@murphai/assistant-runtime/dist` setup and local Docker bridge host discovery in this environment. The focused missing-dist case passed after building that prerequisite.

## Deployment concerns

This is an SDK patch-level dependency change only. It does not change workflow type names, signal/query/activity arguments, command ordering, task queue names, workflow state schema, Cloudflare Worker code, or hosted runtime protocol.

Safe deploy order: the web app Temporal client and hosted Temporal worker may roll in either order. New web with old worker and old web with new worker remain wire-compatible because the Temporal API contract used by this PR is unchanged.

Gradual rollout: warm old worker containers continue running the old SDK until restarted or replaced; new worker containers load `@temporalio/*@1.16.3`. Mixed old/new worker containers should remain behavior-compatible, but only restarted/redeployed workers get the advisory fix.

Cloudflare `container_rollout=immediate`: not applicable or required for this change. A normal hosted Temporal worker restart/redeploy is sufficient to pick up the fixed SDK.

Rollback floor: rollback to the previous commit is wire-compatible but reintroduces the Temporal SDK advisory exposure, so it should only be used for an operational regression and followed by a fixed redeploy.

Post-deploy checks: confirm hosted Temporal worker startup, workflow bundle load, activity polling, and a hosted `signalWithStart`/query smoke path from the web app.
