### PR TITLE
Fix hosted Codex auth guard request count

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-07-2026-07-08-codex-auth-e2e.md
+++ b/agent-docs/exec-plans/completed/2026-07-07-2026-07-08-codex-auth-e2e.md
@@ -1,0 +1,121 @@
+# Fix hosted Codex auth e2e for Codex CLI 0.143
+
+Status: completed
+Created: 2026-07-07
+Updated: 2026-07-07
+
+## Goal
+
+- Restore the hosted Cloudflare deploy guard on current `main` by fixing the
+  hosted Codex auth regression check for Codex CLI 0.143.0 while preserving the
+  invariant that hosted OpenAI config uses Murph's worker-owned credential
+  boundary and does not leak secret values.
+
+## Success criteria
+
+- Reproduce or directly prove the failing `hosted-runtime-codex-config` test
+  condition from GitHub Actions.
+- Patch the smallest durable surface in `packages/assistant-runtime` test or
+  runtime config needed for the changed Codex CLI behavior.
+- Run focused hosted Codex auth E2E verification with the pinned Codex CLI
+  version from `Dockerfile.cloudflare-hosted-runner-base`.
+- Run required package verification and typecheck for the touched owner.
+- Commit through `scripts/finish-task`.
+
+## Scope
+
+- In scope:
+  - `packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts`
+  - Hosted Codex runtime config code only if the trace proves runtime behavior
+    is wrong rather than the guard assertion being stale.
+  - The deploy workflow only if its command no longer matches the intended
+    guard.
+- Out of scope:
+  - Changing the Codex CLI version again.
+  - Broad hosted runner, Cloudflare deploy, or provider-egress refactors.
+  - Any provider secret handling outside this auth regression guard.
+
+## Constraints
+
+- Technical constraints:
+  - Keep OpenAI credentials env-only and out of logs, fixtures, docs, and
+    committed artifacts.
+  - Preserve hosted `model_provider = "hosted-openai"` plus
+    `requires_openai_auth = false` behavior.
+  - Do not weaken the legacy built-in OpenAI failure proof unless replaced with
+    an equivalent current-behavior proof.
+- Product/process constraints:
+  - Use current `origin/main` in an isolated worktree because the primary
+    checkout is on another branch.
+  - Keep the diff narrow and avoid unrelated active-plan files.
+
+## Risks and mitigations
+
+1. Risk: Treating an upstream Codex CLI request-shape change as a Murph runtime
+   fix and weakening the auth boundary.
+   Mitigation: Inspect the exact stubbed requests and config files before
+   editing production code.
+2. Risk: CI-only guard depends on an installed CLI version not present locally.
+   Mitigation: Install the pinned `@openai/codex` version into a temporary npm
+   prefix for reproduction, matching the workflow.
+
+## Tasks
+
+1. Reproduce the failing hosted Codex auth test with
+   `MURPH_RUN_HOSTED_CODEX_AUTH_E2E=1`.
+2. Inspect the request/authorization sequence under Codex CLI 0.143.0.
+3. Apply the smallest test/runtime patch that reflects the intended auth
+   contract.
+4. Run focused E2E, package verification, and typecheck.
+5. Run required review path, close the plan, commit, and prepare handoff.
+
+## Decisions
+
+- Use a fresh worktree from current `origin/main`; do not modify the primary
+  checkout's unrelated branch.
+- The auth regression test should assert the credential invariant, not an exact
+  Codex provider request count. Codex CLI 0.143.0 can issue more than one
+  request on CI/Linux before the final answer, and every hosted-config request
+  must still carry the expected hosted bearer credential.
+
+## Verification
+
+- Commands to run:
+  - `MURPH_RUN_HOSTED_CODEX_AUTH_E2E=1 pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/hosted-runtime-codex-config.test.ts`
+  - `pnpm typecheck`
+  - `pnpm test:diff packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts`
+- Expected outcomes:
+  - Focused hosted Codex auth guard passes locally with Codex CLI 0.143.0.
+  - Typecheck and diff-aware package verification pass, or any unrelated
+    failures are named with evidence.
+
+## Progress
+
+- GitHub Actions failure identified: `Hosted Codex auth deploy guard` failed on
+  `test/hosted-runtime-codex-config.test.ts` because `requests.length` was `2`
+  where the test expected `1`.
+- Current `origin/main` focused guard passed locally before the patch on macOS,
+  but the exact-count assertion was not the auth invariant and matched the CI
+  failure mode.
+- Patched the test to:
+  - capture the hosted-config request count after the fixed turn,
+  - require at least one fixed request,
+  - require every fixed request to use the expected Authorization header,
+  - require at least one fixed request to contain the user prompt, and
+  - require the later legacy built-in OpenAI attempt to send at least one
+    non-matching Authorization header and fail.
+- Verification run:
+  - `MURPH_RUN_HOSTED_CODEX_AUTH_E2E=1 pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/hosted-runtime-codex-config.test.ts` passed with Codex CLI 0.143.0.
+  - `CI=true GITHUB_ACTIONS=true MURPH_RUN_HOSTED_CODEX_AUTH_E2E=1 pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/hosted-runtime-codex-config.test.ts --testNamePattern "legacy built-in OpenAI config fails"` passed.
+  - First `pnpm typecheck` failed in the fresh worktree before this change's
+    surface because runtime package `dist` entrypoints were not materialized.
+    `pnpm build:test-runtime:prepared` passed, and the rerun `pnpm typecheck`
+    passed.
+  - `bash scripts/workspace-verify.sh test:diff packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts` passed the changed owner
+    (`packages/assistant-runtime` typecheck and 70-file Vitest suite) but failed
+    in reverse-dependent `apps/cloudflare verify` on
+    `apps/cloudflare/test/run-hosted-local-e2e-runner.test.ts`; that failure is
+    unrelated to this test-only assistant-runtime diff.
+  - `pnpm --dir packages/assistant-runtime test:coverage` passed.
+  - `pnpm test:smoke` passed.
+Completed: 2026-07-07

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -801,10 +801,19 @@ testHostedCodexAuthE2e(
         workingDirectory: operatorHomeRoot,
       });
 
-      assert.equal(requests.length, 1);
+      const fixedRequestCount = requests.length;
+      assert.ok(fixedRequestCount >= 1);
       assert.equal(fixedResult.finalMessage, "auth regression ok");
-      assert.equal(authorizationHeaders[0], expectedAuthorization);
-      assert.match(requests[0]!, /hello hosted auth regression/u);
+      assert.ok(
+        authorizationHeaders
+          .slice(0, fixedRequestCount)
+          .every((header) => header === expectedAuthorization),
+      );
+      assert.ok(
+        requests
+          .slice(0, fixedRequestCount)
+          .some((request) => /hello hosted auth regression/u.test(request)),
+      );
 
       const legacyCodexHome = await prepareLegacyBuiltInOpenAiCodexHome({
         baseUrl: `${readServerBaseUrl(server)}/v1`,
@@ -830,7 +839,11 @@ testHostedCodexAuthE2e(
         legacyError = error;
       }
 
-      assert.notEqual(authorizationHeaders[1], expectedAuthorization);
+      const legacyAuthorizationHeaders = authorizationHeaders.slice(fixedRequestCount);
+      assert.ok(legacyAuthorizationHeaders.length >= 1);
+      assert.ok(
+        legacyAuthorizationHeaders.some((header) => header !== expectedAuthorization),
+      );
       assert(legacyError instanceof Error);
     } finally {
       await closeHttpServer(server);


### PR DESCRIPTION
## Why this PR exists

The manual Cloudflare hosted deploy guard failed after the Codex CLI 0.143.0 bump because the hosted Codex auth regression test asserted an exact provider request count. CI observed two requests before the final answer, but the real security invariant is that hosted-config requests use the expected hosted OpenAI bearer credential and the legacy built-in OpenAI config does not.

## User goal / user-visible behavior

A protected hosted Cloudflare deploy can run the Codex auth guard without being blocked by a non-contractual request-count change, while still proving Murph's hosted OpenAI credential boundary.

## Invariants the PR must preserve

- Hosted Codex config stays on `model_provider = "hosted-openai"` with `requires_openai_auth = false`.
- Every fixed hosted-config provider request in the regression test must use the expected Authorization header.
- The legacy built-in OpenAI config path must still fail and must not use that expected hosted Authorization header.
- No provider secret values are written into committed fixtures, docs, or logs.

## Verification

- Passed: `MURPH_RUN_HOSTED_CODEX_AUTH_E2E=1 pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/hosted-runtime-codex-config.test.ts` with Codex CLI 0.143.0.
- Passed: `CI=true GITHUB_ACTIONS=true MURPH_RUN_HOSTED_CODEX_AUTH_E2E=1 pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/hosted-runtime-codex-config.test.ts --testNamePattern "legacy built-in OpenAI config fails"`.
- Passed after preparing fresh-worktree runtime artifacts: `pnpm typecheck`.
- Passed: `pnpm --dir packages/assistant-runtime test:coverage`.
- Passed: `pnpm test:smoke`.
- Partial: `bash scripts/workspace-verify.sh test:diff packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts` passed `packages/assistant-runtime` typecheck and tests, then failed in reverse-dependent `apps/cloudflare verify` on `apps/cloudflare/test/run-hosted-local-e2e-runner.test.ts` with a spawn mock receiving 0 calls and an unrelated hosted-local harness `.once` error. This PR does not touch Cloudflare or hosted-local harness files.

## Deployment skew / compatibility

No runtime deploy-skew concern: this is a test-only change to the deploy guard. It does not change web, Worker, container, runner bundle, provider credentials, or persisted state behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786072660&installation_id=127572939&pr_number=468&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F468&signature=05514a60b29ddc888cca8f17c73a1d81b160284393f7c8ef70f808a309b449fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->