### PR TITLE
Fix Junction sleep zero selection

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-08-junction-sleep-zero-selection.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-junction-sleep-zero-selection.md
@@ -1,0 +1,46 @@
+Goal (incl. success criteria):
+- Fix Junction sleep normalization so Apple HealthKit sleep summaries with impossible zero asleep metrics cannot beat valid direct WHOOP sleep data.
+- Success means same-window direct WHOOP Junction sleep remains selected for total/stages/efficiency when Apple HealthKit has a zeroed summary, while Apple generic asleep intervals can still contribute non-stage total sleep when no better direct source exists.
+
+Constraints/Assumptions:
+- Keep provider-specific behavior in the Junction importer and sleep query selection path.
+- Do not invent Apple REM/deep/light stages from generic HealthKit `Asleep` intervals.
+- Preserve sleep windows and awake minutes from Apple HealthKit when they are valid.
+- Preserve unrelated active ledger rows and current checkout edits.
+
+Key decisions:
+- Treat Junction Apple HealthKit `sleep_cycle.stage_type = -1` as asleep-unspecified for total-sleep derivation only.
+- Suppress zeroed Apple HealthKit summary total/efficiency/asleep-stage facts when a real window and awake intervals exist.
+- Add read-side filtering so already-imported bad Apple zero observations and projected summaries cannot continue winning selection.
+
+State:
+- Complete; ready for scoped commit.
+
+Done:
+- Confirmed raw Junction Apple HealthKit summary contains zero total/efficiency/asleep stages despite a real sleep window and awake intervals.
+- Confirmed Apple Health app samples shown by the user are WHOOP-sourced HealthKit sleep intervals, not independent Apple Watch detailed stages.
+- Implemented Junction importer handling for generic `-1` asleep intervals and zeroed Apple HealthKit summary suppression.
+- Implemented sleep query selection safeguards for existing zeroed Apple HealthKit candidates and duplicate HealthKit sleep windows.
+- Added focused importer, raw-query, trend, and stored-projection regression coverage.
+- Verified `@murphai/importers` focused tests and typecheck, `@murphai/query` focused sleep/projection tests, and `git diff --check`.
+
+Now:
+- Commit scoped fix and archive this plan.
+
+Next:
+- Backfill/rebuild the affected vault projection after this fix lands.
+
+Open questions (UNCONFIRMED if needed):
+- Junction does not publicly document `stage_type = -1`; mapping is inferred from raw Apple HealthKit-via-Junction payloads and user-provided Health sample screenshots.
+- `pnpm --filter @murphai/query typecheck` remains blocked by unrelated Murph Age type/module errors outside this task.
+
+Working set (files/ids/commands):
+- packages/importers/src/device-providers/junction.ts
+- packages/importers/src/device-providers/junction-resources.ts
+- packages/importers/test/device-providers-junction.test.ts
+- packages/query/src/wearables.ts
+- packages/query/test/wearable-summary-stored-codec.test.ts
+- packages/query/test/wearables-sleep-session-anchor.test.ts
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round1.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round1.md
@@ -1,0 +1,48 @@
+# PR 471 ReviewGPT Round 1
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-1 findings for PR 471 without broadening the Junction sleep architecture.
+- Success means near-identical duplicate HealthKit windows cannot anchor zeroed Apple sleep over WHOOP, and cycle-derived total sleep includes all non-awake intervals while preserving explicit stage semantics.
+
+Constraints/Assumptions:
+- Keep fixes scoped to Junction importer/query sleep owners and focused tests.
+- Do not infer deep, REM, or light from generic HealthKit `Asleep` intervals.
+- Preserve valid Apple HealthKit windows and awake minutes.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Accept both round-1 findings as real correctness gaps.
+- Use existing session-minute tolerance for duplicate sleep-window time deltas.
+- Make sleep-cycle fallback total own every non-awake interval while stage aggregates remain detailed-stage only.
+
+State:
+- Complete; ready for scoped commit.
+
+Done:
+- ReviewGPT round 1 completed with `REVIEW_COMPLETE`.
+- Triage accepted two High findings:
+  - exact duplicate-window matching missed provider timestamp precision differences;
+  - mixed generic/detailed sleep-cycle intervals emitted partial direct total sleep.
+- Fixed duplicate sleep-window matching to use session-minute timestamp and duration tolerance.
+- Fixed cycle-derived total sleep to include all non-awake intervals in windows that contain generic asleep intervals.
+- Added focused importer and query regressions for both findings.
+- Verified focused importer/query tests, stored projection test, importer typecheck, and `git diff --check`.
+
+Now:
+- Commit and push round-1 fixes.
+
+Next:
+- Rerun ReviewGPT on the new PR head.
+
+Open questions (UNCONFIRMED if needed):
+- `pnpm --filter @murphai/query typecheck` remains blocked by unrelated Murph Age type/module errors; after the fix, it reports no task-owned `wearables.ts` errors.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables.ts
+- packages/query/test/wearables-sleep-session-anchor.test.ts
+- packages/importers/src/device-providers/junction.ts
+- packages/importers/test/device-providers-junction.test.ts
+- audit-packages/pr-471-round-1.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round2.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round2.md
@@ -1,0 +1,60 @@
+# PR 471 ReviewGPT Round 2
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-2 findings for PR 471 without adding broad repair machinery.
+- Success means zeroed Apple HealthKit sleep repairs are scoped to the bad sleep window, provider-filtered stale projections cannot keep old zero summaries fresh, and focused tests cover both cases.
+
+Constraints/Assumptions:
+- Keep read-side repair in the wearable sleep query owner.
+- Prefer projection invalidation over compatibility shims for stale stored summaries.
+- Preserve valid zero stages from other Apple sleep windows.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Replace date/provider invalid-zero detection with invalid Apple window detection.
+- Associate zero candidates with invalid windows through resource-window matching or candidate time within the sleep window.
+- Bump query projection SQLite version so v14 wearable summaries rebuild under the new resolver.
+
+State:
+- Verification complete; ready to commit and push.
+
+Done:
+- ReviewGPT round 2 completed with `REVIEW_COMPLETE`.
+- Accepted two High findings:
+  - provider/date-wide invalid-zero filtering can miss one Apple zeroed sleep or suppress another valid Apple sleep;
+  - provider-filtered stored projections can return stale v14 zero summaries without rebuild.
+- Replaced provider/date-wide invalid-zero detection with invalid Apple sleep-window detection.
+- Added timestamp-window association for sleep stage metrics whose stage resource id does not match the parent sleep session id.
+- Added a short-window sleep-selection penalty so a same-day nap does not outrank a full main sleep window.
+- Bumped `QUERY_PROJECTION_SQLITE_VERSION` from 14 to 15.
+- Added regressions for window-scoped Apple zero repair, WHOOP duplicate-window fallback, and v14 projection rebuild.
+- Verification:
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/wearables-sleep-session-anchor.test.ts` passed.
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/wearable-summary-stored-codec.test.ts` passed.
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/query.test.ts -t "rebuilds v14 wearable-summary projections|creates the compact metric point schema"` passed.
+  - `pnpm --filter @murphai/importers test -- --run packages/importers/test/device-providers-junction.test.ts` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `git diff --check` passed.
+  - Privacy grep over touched files passed.
+  - `pnpm --filter @murphai/query typecheck` still fails on pre-existing Murph Age type/module errors outside the touched files.
+
+Now:
+- Commit and push the round-2 follow-up.
+
+Next:
+- Rerun the ReviewGPT PR loop against the pushed head.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables.ts
+- packages/query/src/wearables/selection.ts
+- packages/query/test/wearables-sleep-session-anchor.test.ts
+- packages/query/src/projection/schema.ts
+- packages/query/test/query.test.ts
+- packages/query/test/wearable-summary-stored-codec.test.ts
+- audit-packages/pr-471-round-2.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round3.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round3.md
@@ -1,0 +1,57 @@
+# PR 471 ReviewGPT Round 3
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-3 findings for PR 471 without broad repair machinery.
+- Success means stale exact Apple zero rows cannot hide a newly derived generic Apple sleep total, and numeric Junction `-1` sleep-stage inference is Apple HealthKit-specific.
+
+Constraints/Assumptions:
+- Keep sleep candidate repair in the query wearable selector.
+- Keep provider-specific Junction enum assumptions out of provider-neutral normalization.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Filter invalid zero sleep candidates before selected-window narrowing so valid fallback candidates remain reachable.
+- Detect invalid Apple zero windows by any zero total plus awake and no positive stage/efficiency evidence, not first metric order.
+- Interpret numeric `-1` / `"-1"` as generic asleep only when the Junction source provider is Apple HealthKit.
+
+State:
+- Verification complete; ready to commit and push.
+
+Done:
+- ReviewGPT round 3 completed with `REVIEW_COMPLETE`.
+- Accepted two High findings:
+  - stale exact Apple zero rows can mask the new generic Apple total after re-sync;
+  - numeric `stage_type=-1` inference was global instead of Apple HealthKit-specific.
+- Query now filters invalid zero sleep candidates before selected-window narrowing, so valid generic totals remain reachable.
+- Invalid Apple zero-window detection now keys off any zero total with awake and no positive stage/efficiency evidence, instead of first metric order.
+- Junction sleep-stage normalization is provider-neutral again; numeric `-1` / `"-1"` maps to generic asleep only through the Apple HealthKit source-aware sleep-cycle path.
+- Added regressions for repaired Apple generic total replacing a legacy exact zero and non-Apple `stage_type=-1` not creating `sleep-total-minutes`.
+- Verification:
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/wearables-sleep-session-anchor.test.ts` passed.
+  - `pnpm --filter @murphai/importers test -- --run packages/importers/test/device-providers-junction.test.ts` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/wearable-summary-stored-codec.test.ts` passed.
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/query.test.ts -t "rebuilds v14 wearable-summary projections|creates the compact metric point schema"` passed.
+  - `git diff --check` passed.
+  - Privacy grep over touched files passed.
+  - `pnpm --filter @murphai/query typecheck` still fails on pre-existing Murph Age type/module errors outside the touched files.
+
+Now:
+- Commit and push the round-3 follow-up.
+
+Next:
+- Rerun the ReviewGPT PR loop against the pushed head.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables.ts
+- packages/query/test/wearables-sleep-session-anchor.test.ts
+- packages/importers/src/device-providers/junction-resources.ts
+- packages/importers/src/device-providers/junction.ts
+- packages/importers/test/device-providers-junction.test.ts
+- audit-packages/pr-471-round-3.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round4.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round4.md
@@ -1,0 +1,57 @@
+# PR 471 ReviewGPT Round 4
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-4 findings for PR 471 without broad repair machinery.
+- Success means stale Apple zero totals cannot suppress valid stage-derived totals, and Apple HealthKit `stage_type=-1` stays inside source-aware parent/direct-interval gates.
+
+Constraints/Assumptions:
+- Keep read-side repair scoped to invalid Apple sleep summary zeros.
+- Keep parentless direct Junction sleep stage fragments raw-only unless a stable parent/session identity exists.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Classify Apple impossible-zero sleep windows from zero total + positive awake + real duration gap, independent of positive replacement stage evidence.
+- Keep Junction sleep-cycle parent/direct-interval checks source-aware anywhere `stage_type=-1` could be interpreted as Apple generic asleep.
+
+State:
+- Verification complete; ready to commit and push.
+
+Done:
+- ReviewGPT round 4 completed with `REVIEW_COMPLETE`.
+- Accepted two High findings:
+  - positive Apple stage evidence can currently rescue a stale impossible Apple zero summary;
+  - Apple HealthKit `stage_type=-1` is source-aware in interval parsing but source-blind in parent/direct-interval gates.
+- Query invalid-zero detection no longer lets positive replacement stage evidence validate a stale Apple zero total.
+- Junction sleep-cycle parent identity and nested direct-interval splitting now use the source-aware sleep stage classifier.
+- Added regressions for:
+  - stale Apple exact zero plus positive Apple stage facts deriving total sleep from stages;
+  - parentless Apple `stage_type=-1` direct fragments staying raw-only;
+  - parented Apple generic asleep envelope still emitting `sleep-total-minutes`.
+- Verification:
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/wearables-sleep-session-anchor.test.ts` passed.
+  - `pnpm --filter @murphai/importers test -- --run packages/importers/test/device-providers-junction.test.ts` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/wearable-summary-stored-codec.test.ts` passed.
+  - `pnpm --filter @murphai/query test -- --run packages/query/test/query.test.ts -t "rebuilds v14 wearable-summary projections|creates the compact metric point schema"` passed.
+  - `git diff --check` passed.
+  - Privacy grep over touched files passed.
+  - `pnpm --filter @murphai/query typecheck` still fails on pre-existing Murph Age type/module errors outside the touched files.
+
+Now:
+- Commit and push the round-4 follow-up.
+
+Next:
+- Rerun the ReviewGPT PR loop against the pushed head.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables.ts
+- packages/query/test/wearables-sleep-session-anchor.test.ts
+- packages/importers/src/device-providers/junction.ts
+- packages/importers/test/device-providers-junction.test.ts
+- audit-packages/pr-471-round-4.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round5.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round5.md
@@ -1,0 +1,45 @@
+# PR 471 ReviewGPT Round 5
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-5 finding for PR 471 without broad stage-mapping changes.
+- Success means Apple HealthKit string `"-1"` maps only through the Apple source-aware generic-asleep path, and non-Apple string `"-1"` maps to no canonical sleep stage.
+
+Constraints/Assumptions:
+- Keep provider-neutral sleep stage normalization limited to documented names and unsigned stage codes.
+- Keep Apple `-1` inference source-aware in the Junction importer wrapper.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Keep provider-neutral normalization from accepting signed numeric strings; Apple source-aware wrapper remains the only owner of `-1` / `"-1"` generic-asleep inference.
+
+State:
+- Verification complete; ready to commit and push.
+
+Done:
+- ReviewGPT round 5 completed with `REVIEW_COMPLETE`.
+- Accepted one High finding:
+  - provider-neutral string normalization can strip `"-1"` to `"1"` and import Apple generic asleep as deep sleep.
+- Provider-neutral sleep-stage normalization now rejects signed integer strings before punctuation normalization.
+- Added regressions for Apple string `"-1"` deriving only generic total/awake and non-Apple string `"-1"` creating neither generic total nor detailed stage facts.
+- Verification:
+  - `pnpm --filter @murphai/importers test -- --run packages/importers/test/device-providers-junction.test.ts` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `git diff --check` passed.
+  - Privacy grep over touched files passed.
+
+Now:
+- Commit and push the round-5 follow-up.
+
+Next:
+- Rerun the ReviewGPT PR loop against the pushed head.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/importers/src/device-providers/junction-resources.ts
+- packages/importers/test/device-providers-junction.test.ts
+- audit-packages/pr-471-round-5.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round6.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round6.md
@@ -1,0 +1,50 @@
+# PR 471 ReviewGPT Round 6
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-6 finding for PR 471 without changing public wearable summary provenance.
+- Success means invalid Apple HealthKit zero sleep observations are excluded from decision-grade metric points as well as wearable sleep summaries.
+
+Constraints/Assumptions:
+- Keep invalid Apple zero rows non-selectable and out of public selected evidence.
+- Reuse existing metric-point suppression evidence instead of adding a parallel projection filter.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Reuse the existing metric projection suppression path instead of adding a second raw-point filter.
+- Build invalid Apple HealthKit zero sleep suppression evidence from the same wearable dataset used for summary selection, keyed by canonical metric point ids.
+- Keep invalid Apple zero rows out of public selected evidence; they are internal suppression evidence only.
+
+State:
+- Implementation and verification complete; ready to commit, push, and rerun ReviewGPT.
+
+Done:
+- ReviewGPT round 6 completed with `REVIEW_COMPLETE`.
+- Accepted one High finding:
+  - invalid Apple zero sleep observations are filtered from wearable summaries but can still leak into metric-point projections.
+- Added metric suppression evidence for invalid Apple HealthKit zero sleep total/efficiency/stage metrics.
+- Added projection regressions for invalid Apple zero sleep rows with and without a valid WHOOP sleep candidate.
+- Verification:
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/query.test.ts -t "listMetricPointsRuntime suppresses invalid Apple HealthKit zero" --reporter=dot` passed.
+  - `pnpm --filter @murphai/query test` passed.
+  - `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers-junction.test.ts --reporter=dot` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `pnpm --filter @murphai/query typecheck` failed on pre-existing Murph Age module/type errors outside this change.
+  - `git diff --check` passed.
+
+Now:
+- Commit and push the round-6 fix.
+
+Next:
+- Run PR preflight and ReviewGPT round 7.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables.ts
+- packages/query/src/metrics/projection.ts
+- packages/query/test/*
+- audit-packages/pr-471-round-6.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round7.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round7.md
@@ -1,0 +1,50 @@
+# PR 471 ReviewGPT Round 7
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-7 finding for PR 471.
+- Success means stale Apple HealthKit zero summary candidates are suppressed without hiding valid same-window cycle fallback zero stage facts such as REM=0.
+
+Constraints/Assumptions:
+- Keep read-side repair for already-imported bad Apple zero summary rows.
+- Do not add provider-specific broad special cases when candidate ownership can solve the issue.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Invalid Apple zero repair now tracks exact metric candidate ids instead of treating every zero inside an invalid window as bad.
+- Summary-owned rows are identified by same sleep summary resource or `junction-sleep-stage-summary.v1`; `junction-sleep-stage-cycle-fallback.v1` rows are explicitly preserved.
+- Legacy unversioned stale rows are only suppressed as companions when they share the same provider/source origin and `recordedAt` batch as the invalid zero total summary candidate.
+
+State:
+- Implementation and verification complete; ready to commit, push, and rerun ReviewGPT.
+
+Done:
+- ReviewGPT round 7 completed with `REVIEW_COMPLETE`.
+- Accepted one High finding:
+  - window-wide invalid-zero suppression can hide valid same-window zero sleep stage facts from Apple cycle fallback records.
+- Replaced window-wide invalid-zero suppression with candidate-id suppression evidence.
+- Added a runtime projection regression proving valid Apple cycle fallback REM=0 remains visible while stale summary zero rows are suppressed.
+- Verification:
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/query.test.ts -t "Apple HealthKit" --reporter=dot` passed.
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/wearables-sleep-session-anchor.test.ts --reporter=dot` passed.
+  - `pnpm --filter @murphai/query test` passed.
+  - `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers-junction.test.ts --reporter=dot` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `pnpm --filter @murphai/query typecheck` failed on pre-existing Murph Age module/type errors outside this change.
+  - `git diff --check` passed.
+
+Now:
+- Commit and push the round-7 fix.
+
+Next:
+- Run PR preflight and ReviewGPT round 8.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables.ts
+- packages/query/test/query.test.ts
+- audit-packages/pr-471-round-7.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round8.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round8.md
@@ -1,0 +1,54 @@
+# PR 471 ReviewGPT Round 8
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-8 finding for PR 471.
+- Success means stale summary-owned Apple zero stage records and valid cycle-fallback zero stage records cannot merge before invalid-zero ownership is classified.
+
+Constraints/Assumptions:
+- Keep canonical vault records append-only.
+- Prefer one candidate truth for summary and projection over another downstream special case.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- Preserve `dataOrigin.normalizerVersion` in exact metric candidate dedupe identity when present.
+- Keep broad candidate ids unchanged; invalid Apple zero repair now tracks record ids internally so same-window summary and cycle-fallback candidates with shared candidate ids do not suppress each other.
+- Use a canonical read-model regression with stale-first and cycle-first insertion orders to cover summary selection and metric projection together.
+
+State:
+- Implementation and verification complete; ready to commit, push, and rerun ReviewGPT.
+
+Done:
+- ReviewGPT round 8 completed with `REVIEW_COMPLETE`.
+- Accepted one High finding:
+  - exact candidate dedupe can merge stale Apple summary zero rows with valid cycle-fallback zero rows because the dedupe identity omits `dataOrigin.normalizerVersion`.
+- Added normalizer-aware exact candidate dedupe identity.
+- Switched invalid Apple zero summary suppression from candidate-id sets to record-id sets.
+- Converted the cycle-fallback zero regression to a canonical read-model fixture and asserted stale-first/cycle-first order invariance.
+- Verification:
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/query.test.ts -t "Apple HealthKit" --reporter=dot` passed.
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/wearables-sleep-session-anchor.test.ts --reporter=dot` passed.
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/wearables-coverage-branches.test.ts -t "dedupe, selection" --reporter=dot` passed.
+  - `pnpm --filter @murphai/query test` passed.
+  - `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers-junction.test.ts --reporter=dot` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `pnpm --filter @murphai/query typecheck` failed on pre-existing Murph Age module/type errors outside this change.
+  - `git diff --check` passed.
+
+Now:
+- Commit and push the round-8 fix.
+
+Next:
+- Run PR preflight and ReviewGPT round 9.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables/dedupe.ts
+- packages/query/src/wearables/origin.ts
+- packages/query/src/wearables.ts
+- packages/query/test/query.test.ts
+- audit-packages/pr-471-round-8.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round9.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-pr471-reviewgpt-round9.md
@@ -1,0 +1,64 @@
+# PR 471 ReviewGPT Round 9
+
+Goal (incl. success criteria):
+- Resolve accepted ReviewGPT round-9 complexity-collapse finding for PR 471.
+- Success means legacy Apple HealthKit zero-summary validity is classified once at wearable candidate construction, with valid candidates exposed to summaries/projection and suppressed record IDs carried for raw metric-point suppression.
+
+Constraints/Assumptions:
+- Keep importer fail-closed for new bad Apple zero summaries.
+- Keep raw canonical vault records append-only; read-side sanitizer is for legacy rows only.
+- Preserve valid WHOOP/direct sleep selection, Apple generic asleep totals, and valid cycle-fallback zero stages.
+- Keep ReviewGPT artifacts under `audit-packages/` uncommitted.
+
+Key decisions:
+- The legacy Apple HealthKit zero-sleep summary repair is owned by `collectWearableDataset`.
+- Downstream sleep summaries resolve only sanitized metric candidates and still prefer direct device evidence over Apple HealthKit mirroring for same-window metrics.
+- Metric projection consumes `dataset.metricSuppressionEvidence` instead of reclassifying invalid rows.
+
+State:
+- Implementation complete; verification complete except for the pre-existing `@murphai/query` Murph Age typecheck failure.
+
+Done:
+- ReviewGPT round 9 completed with `REVIEW_COMPLETE`.
+- Accepted one complexity-collapse finding:
+  - invalid Apple zero summary is currently reclassified in summary selection and metric projection instead of owned once.
+- Added dataset-level metric suppression evidence for raw Apple zero rows.
+- Moved sleep association helpers to `packages/query/src/wearables/sleep-association.ts`.
+- Deleted duplicate invalid-zero discovery from `packages/query/src/wearables.ts`.
+- Updated metric projection to consume dataset suppression evidence directly.
+- Verification:
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/query.test.ts -t "Apple HealthKit" --reporter=dot` passed.
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/wearable-summary-stored-codec.test.ts --reporter=dot` passed.
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/wearables-sleep-session-anchor.test.ts --reporter=dot` passed.
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/wearables-coverage-branches.test.ts --reporter=dot` passed.
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/query.test.ts --reporter=dot` passed.
+  - `pnpm --filter @murphai/query test` passed.
+  - `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers-junction.test.ts --reporter=dot` passed.
+  - `pnpm --filter @murphai/importers typecheck` passed.
+  - `git diff --check` passed.
+  - Privacy scan of touched files for local identifiers passed.
+- `pnpm --filter @murphai/query typecheck` remains blocked by unrelated Murph Age module/type errors.
+
+Now:
+- Commit, push, and rerun ReviewGPT.
+
+Next:
+- Resolve any accepted ReviewGPT follow-up findings.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/query/src/wearables/candidates.ts
+- packages/query/src/wearables/types.ts
+- packages/query/src/wearables/sleep-association.ts
+- packages/query/src/wearables.ts
+- packages/query/src/metrics/projection.ts
+- packages/query/src/projection/wearable-summary-compose.ts
+- packages/query/src/projection/wearable-summary-projector.ts
+- packages/query/test/wearable-summary-stored-codec.test.ts
+- packages/query/test/wearables-source-health-final.test.ts
+- audit-packages/pr-471-round-9.md (local artifact, uncommitted)
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/packages/importers/src/device-providers/junction-resources.ts
+++ b/packages/importers/src/device-providers/junction-resources.ts
@@ -345,10 +345,12 @@ export const JUNCTION_SLEEP_STAGE_VALUE_PATHS = Object.freeze([
   "type",
   "value",
 ] as const);
-export type JunctionSleepStageValue = "awake" | "light" | "deep" | "rem";
+export type JunctionSleepStageValue = "awake" | "light" | "deep" | "rem" | "asleep_unspecified";
 export function normalizeJunctionSleepStageValue(value: unknown): JunctionSleepStageValue | null {
   if (typeof value === "number" && Number.isInteger(value)) {
     switch (value) {
+      case -1:
+        return "asleep_unspecified";
       case 1:
         return "deep";
       case 2:
@@ -366,6 +368,10 @@ export function normalizeJunctionSleepStageValue(value: unknown): JunctionSleepS
     return null;
   }
 
+  if (value.trim() === "-1") {
+    return "asleep_unspecified";
+  }
+
   const normalized = value
     .trim()
     .toLowerCase()
@@ -373,6 +379,11 @@ export function normalizeJunctionSleepStageValue(value: unknown): JunctionSleepS
     .replace(/^_+|_+$/gu, "");
 
   switch (normalized) {
+    case "asleep":
+    case "asleep_unspecified":
+    case "sleep":
+    case "sleeping":
+      return "asleep_unspecified";
     case "1":
       return "deep";
     case "2":

--- a/packages/importers/src/device-providers/junction-resources.ts
+++ b/packages/importers/src/device-providers/junction-resources.ts
@@ -366,8 +366,12 @@ export function normalizeJunctionSleepStageValue(value: unknown): JunctionSleepS
     return null;
   }
 
-  const normalized = value
-    .trim()
+  const trimmed = value.trim();
+  if (/^[+-]\d+$/u.test(trimmed)) {
+    return null;
+  }
+
+  const normalized = trimmed
     .toLowerCase()
     .replace(/[^a-z0-9]+/gu, "_")
     .replace(/^_+|_+$/gu, "");

--- a/packages/importers/src/device-providers/junction-resources.ts
+++ b/packages/importers/src/device-providers/junction-resources.ts
@@ -349,8 +349,6 @@ export type JunctionSleepStageValue = "awake" | "light" | "deep" | "rem" | "asle
 export function normalizeJunctionSleepStageValue(value: unknown): JunctionSleepStageValue | null {
   if (typeof value === "number" && Number.isInteger(value)) {
     switch (value) {
-      case -1:
-        return "asleep_unspecified";
       case 1:
         return "deep";
       case 2:
@@ -366,10 +364,6 @@ export function normalizeJunctionSleepStageValue(value: unknown): JunctionSleepS
 
   if (typeof value !== "string") {
     return null;
-  }
-
-  if (value.trim() === "-1") {
-    return "asleep_unspecified";
   }
 
   const normalized = value

--- a/packages/importers/src/device-providers/junction.ts
+++ b/packages/importers/src/device-providers/junction.ts
@@ -267,6 +267,9 @@ const SLEEP_STAGE_METRIC_NAMES = new Set([
 ]);
 const SLEEP_STAGE_METRICS = SLEEP_METRICS.filter((metric) => SLEEP_STAGE_METRIC_NAMES.has(metric.metric));
 const SLEEP_NON_STAGE_METRICS = SLEEP_METRICS.filter((metric) => !SLEEP_STAGE_METRIC_NAMES.has(metric.metric));
+const SLEEP_SUMMARY_OWNER_METRICS = SLEEP_METRICS.filter((metric) =>
+  metric.metric === "sleep-total-minutes" || SLEEP_STAGE_METRIC_NAMES.has(metric.metric)
+);
 
 type WorkoutSessionMetrics = NonNullable<WorkoutSession["metrics"]>;
 type WorkoutHeartRateZone = NonNullable<WorkoutSession["heartRateZones"]>[number];
@@ -698,10 +701,24 @@ const JUNCTION_SLEEP_COVERAGE_END_TIMESTAMP_PATHS = [
 ] as const;
 const SLEEP_STAGE_COVERAGE_TOLERANCE_MS = 1000;
 const JUNCTION_SLEEP_STAGES: readonly JunctionSleepStage[] = ["awake", "light", "deep", "rem"];
+const APPLE_HEALTH_KIT_SOURCE_PROVIDER_SLUG = "apple-health-kit";
+const SLEEP_ZEROED_SUMMARY_SUPPRESSED_METRIC_NAMES = new Set([
+  "sleep-total-minutes",
+  "sleep-efficiency",
+  "sleep-light-minutes",
+  "sleep-deep-minutes",
+  "sleep-rem-minutes",
+]);
+const SLEEP_ASLEEP_STAGE_METRIC_NAMES = new Set([
+  "sleep-light-minutes",
+  "sleep-deep-minutes",
+  "sleep-rem-minutes",
+]);
 const JUNCTION_SLEEP_STAGE_SUMMARY_NORMALIZER_VERSION = "junction-sleep-stage-summary.v1";
 const JUNCTION_SLEEP_STAGE_CYCLE_FALLBACK_NORMALIZER_VERSION = "junction-sleep-stage-cycle-fallback.v1";
+const JUNCTION_SLEEP_UNSPECIFIED_TOTAL_NORMALIZER_VERSION = "junction-sleep-unspecified-total.v1";
 
-type JunctionSleepStage = JunctionSleepStageValue;
+type JunctionSleepStage = Exclude<JunctionSleepStageValue, "asleep_unspecified">;
 
 interface JunctionDailyTimeseriesAggregate {
   dayKey: string;
@@ -735,13 +752,27 @@ interface JunctionSleepStageAggregate {
   timeZone?: string;
 }
 
+interface JunctionSleepTotalAggregate {
+  coverageEndAt: string;
+  coverageStartAt: string;
+  dataOriginEntry: PlainObject;
+  durationMinutes: number;
+  endAt: string;
+  parentResourceId: string;
+  recordedAt?: string;
+  resourceContext: ResourceContext;
+  startAt: string;
+  timestamp: ReturnType<typeof resolveRecordTimestamp>;
+  timeZone?: string;
+}
+
 interface JunctionSleepStageInterval {
   dataOriginEntry: PlainObject;
   durationMinutes: number;
   endAt: string;
   intervalEntry: PlainObject;
   recordedAt?: string;
-  stage: JunctionSleepStage;
+  stage: JunctionSleepStageValue;
   startAt: string;
   timestamp: ReturnType<typeof resolveRecordTimestamp>;
   timeZone?: string;
@@ -855,7 +886,7 @@ function normalizeSummaries(
   context: NormalizationContext,
 ): void {
   const summaryEntries = allowedResourceEntries(summaries, SUMMARY_RESOURCE_ALLOWLIST);
-  const sleepSummaryStageMetricOwners = collectJunctionSleepSummaryStageMetricOwners(summaryEntries, context);
+  const sleepSummaryMetricOwners = collectJunctionSleepSummaryMetricOwners(summaryEntries, context);
 
   for (const [resource, payload] of summaryEntries) {
     const entries = resourceEntries(payload, resource);
@@ -900,7 +931,7 @@ function normalizeSummaries(
     });
 
     if (resource === "sleep_cycle") {
-      pushSleepCycleEntries(resolvedEntries, context, sleepSummaryStageMetricOwners);
+      pushSleepCycleEntries(resolvedEntries, context, sleepSummaryMetricOwners);
       continue;
     }
 
@@ -935,7 +966,7 @@ function normalizeSummaries(
   }
 }
 
-function collectJunctionSleepSummaryStageMetricOwners(
+function collectJunctionSleepSummaryMetricOwners(
   summaryEntries: readonly [string, unknown][],
   context: NormalizationContext,
 ): JunctionSleepSummaryStageMetricOwner[] {
@@ -975,8 +1006,13 @@ function collectJunctionSleepSummaryStageMetricOwners(
     if (!startAt || !endAt) {
       return;
     }
+    const durationMinutes = resolveSleepSummaryDurationMinutes(entry, startAt, endAt);
+    const zeroedSummary = isZeroedAppleHealthKitSleepSummary(entry, resourceContext, durationMinutes);
 
-    for (const metric of SLEEP_STAGE_METRICS) {
+    for (const metric of SLEEP_SUMMARY_OWNER_METRICS) {
+      if (zeroedSummary && SLEEP_ZEROED_SUMMARY_SUPPRESSED_METRIC_NAMES.has(metric.metric)) {
+        continue;
+      }
       if (!resolveMetricDescriptorValue(entry, metric)) {
         continue;
       }
@@ -1875,20 +1911,11 @@ function pushSleepSummary(
     firstValueFromPaths(entry, JUNCTION_SLEEP_END_TIMESTAMP_PATHS),
     resourceContext.sourceProviderSlug,
   );
-  const durationMinutes =
-    normalizePositiveIntegerMinutes(
-      firstNumberFromPaths(entry, JUNCTION_SLEEP_DURATION_MINUTE_PATHS),
-    ) ??
-    normalizePositiveIntegerMinutes(
-      secondsToMinutes(firstNumberFromPaths(entry, JUNCTION_SLEEP_DURATION_SECOND_PATHS)),
-    ) ??
-    normalizePositiveIntegerMinutes(
-      millisecondsToMinutes(firstNumberFromPaths(entry, JUNCTION_SLEEP_DURATION_MILLISECOND_PATHS)),
-    ) ??
-    normalizePositiveIntegerMinutes(minutesBetween(startAt, endAt));
+  const durationMinutes = resolveSleepSummaryDurationMinutes(entry, startAt, endAt);
   const sleepTimestamp = withTimestampOverride(timestamp, {
     occurredAt: endAt ?? startAt ?? timestamp.occurredAt,
   });
+  const zeroedSummary = isZeroedAppleHealthKitSleepSummary(entry, resourceContext, durationMinutes);
 
   if (startAt && endAt && durationMinutes !== undefined) {
     const occurredAt = sleepTimestamp.occurredAt ?? startAt;
@@ -1911,9 +1938,72 @@ function pushSleepSummary(
     }));
   }
 
-  pushObservationMetrics(entry, resourceContext, context, SLEEP_NON_STAGE_METRICS, sleepTimestamp);
-  pushSleepSummaryStageMetrics(entry, resourceContext, context, sleepTimestamp, startAt, endAt);
+  pushObservationMetrics(
+    entry,
+    resourceContext,
+    context,
+    zeroedSummary
+      ? SLEEP_NON_STAGE_METRICS.filter((metric) => !SLEEP_ZEROED_SUMMARY_SUPPRESSED_METRIC_NAMES.has(metric.metric))
+      : SLEEP_NON_STAGE_METRICS,
+    sleepTimestamp,
+  );
+  pushSleepSummaryStageMetrics(entry, resourceContext, context, sleepTimestamp, startAt, endAt, zeroedSummary);
   pushJunctionRecoveryReadinessScore(entry, resourceContext, context, sleepTimestamp);
+}
+
+function resolveSleepSummaryDurationMinutes(
+  entry: PlainObject,
+  startAt: string | undefined,
+  endAt: string | undefined,
+): number | undefined {
+  return normalizePositiveIntegerMinutes(
+    firstNumberFromPaths(entry, JUNCTION_SLEEP_DURATION_MINUTE_PATHS),
+  ) ??
+    normalizePositiveIntegerMinutes(
+      secondsToMinutes(firstNumberFromPaths(entry, JUNCTION_SLEEP_DURATION_SECOND_PATHS)),
+    ) ??
+    normalizePositiveIntegerMinutes(
+      millisecondsToMinutes(firstNumberFromPaths(entry, JUNCTION_SLEEP_DURATION_MILLISECOND_PATHS)),
+    ) ??
+    normalizePositiveIntegerMinutes(minutesBetween(startAt, endAt));
+}
+
+function isZeroedAppleHealthKitSleepSummary(
+  entry: PlainObject,
+  resourceContext: ResourceContext,
+  durationMinutes: number | undefined,
+): boolean {
+  if (normalizeJunctionSourceProviderSlug(resourceContext.sourceProviderSlug) !== APPLE_HEALTH_KIT_SOURCE_PROVIDER_SLUG) {
+    return false;
+  }
+
+  const totalMinutes = resolveSleepSummaryMetricValue(entry, "sleep-total-minutes");
+  const awakeMinutes = resolveSleepSummaryMetricValue(entry, "sleep-awake-minutes");
+  if (
+    durationMinutes === undefined ||
+    totalMinutes !== 0 ||
+    awakeMinutes === undefined ||
+    awakeMinutes <= 0 ||
+    awakeMinutes >= durationMinutes - 1
+  ) {
+    return false;
+  }
+
+  return isSleepSummaryMetricMissingOrZero(entry, "sleep-efficiency") &&
+    isSleepSummaryMetricMissingOrZero(entry, "sleep-light-minutes") &&
+    isSleepSummaryMetricMissingOrZero(entry, "sleep-deep-minutes") &&
+    isSleepSummaryMetricMissingOrZero(entry, "sleep-rem-minutes");
+}
+
+function isSleepSummaryMetricMissingOrZero(entry: PlainObject, metricName: string): boolean {
+  const value = resolveSleepSummaryMetricValue(entry, metricName);
+  return value === undefined || value === 0;
+}
+
+function resolveSleepSummaryMetricValue(entry: PlainObject, metricName: string): number | undefined {
+  const metric = SLEEP_METRICS.find((candidate) => candidate.metric === metricName);
+  const resolved = metric ? resolveMetricDescriptorValue(entry, metric) : null;
+  return resolved?.value;
 }
 
 function pushSleepSummaryStageMetrics(
@@ -1923,6 +2013,7 @@ function pushSleepSummaryStageMetrics(
   timestamp: ReturnType<typeof resolveRecordTimestamp>,
   startAt: string | undefined,
   endAt: string | undefined,
+  zeroedSummary = false,
 ): void {
   const occurredAt = timestamp.occurredAt;
   if (!occurredAt) {
@@ -1934,6 +2025,9 @@ function pushSleepSummaryStageMetrics(
     ? resolveSleepStageAnchorDayKey(endAt, timeZone, timestamp)
     : timestamp.dayKey ?? extractIsoDatePrefix(occurredAt) ?? undefined;
   for (const metric of SLEEP_STAGE_METRICS) {
+    if (zeroedSummary && SLEEP_ASLEEP_STAGE_METRIC_NAMES.has(metric.metric)) {
+      continue;
+    }
     const resolved = resolveMetricDescriptorValue(entry, metric);
     if (!resolved) {
       continue;
@@ -2008,14 +2102,46 @@ function pushSleepCycleEntries(
   sleepSummaryStageMetricOwners: readonly JunctionSleepSummaryStageMetricOwner[],
 ): void {
   const aggregates = new Map<string, JunctionSleepStageAggregate>();
+  const totalAggregates = new Map<string, JunctionSleepTotalAggregate>();
 
   for (const { entry, resourceContext } of entries) {
-    collectJunctionSleepStageAggregates(entry, resourceContext, context, aggregates);
+    collectJunctionSleepStageAggregates(entry, resourceContext, context, aggregates, totalAggregates);
+  }
+
+  for (const aggregate of totalAggregates.values()) {
+    if (isSleepMetricOwnedBySleepSummary(aggregate, "sleep-total-minutes", sleepSummaryStageMetricOwners)) {
+      continue;
+    }
+
+    context.events.push(stripUndefined({
+      kind: "observation",
+      occurredAt: aggregate.endAt,
+      recordedAt: aggregate.recordedAt,
+      dayKey: aggregate.timestamp.dayKey,
+      timeZone: aggregate.timeZone,
+      source: "device",
+      title: "Junction total sleep",
+      evidenceRoles: aggregate.resourceContext.evidenceRoles,
+      externalRef: makeJunctionSleepAggregateExternalRef(
+        aggregate.resourceContext,
+        aggregate,
+        "sleep-total-minutes",
+      ),
+      dataOrigin: buildDataOrigin(aggregate.dataOriginEntry, aggregate.resourceContext, aggregate.timestamp, {
+        normalizerVersion: JUNCTION_SLEEP_UNSPECIFIED_TOTAL_NORMALIZER_VERSION,
+      }),
+      fields: {
+        metric: "sleep-total-minutes",
+        observationGrain: "summary",
+        value: Number(aggregate.durationMinutes.toFixed(4)),
+        unit: "minutes",
+      },
+    }));
   }
 
   for (const aggregate of aggregates.values()) {
     const metric = sleepStageMetricDescriptor(aggregate.stage);
-    if (isSleepStageMetricOwnedBySleepSummary(aggregate, metric.metric, sleepSummaryStageMetricOwners)) {
+    if (isSleepMetricOwnedBySleepSummary(aggregate, metric.metric, sleepSummaryStageMetricOwners)) {
       continue;
     }
 
@@ -2028,7 +2154,7 @@ function pushSleepCycleEntries(
       source: "device",
       title: metric.title,
       evidenceRoles: aggregate.resourceContext.evidenceRoles,
-      externalRef: makeJunctionSleepStageAggregateExternalRef(
+      externalRef: makeJunctionSleepAggregateExternalRef(
         aggregate.resourceContext,
         aggregate,
         metric.metric,
@@ -2046,8 +2172,8 @@ function pushSleepCycleEntries(
   }
 }
 
-function isSleepStageMetricOwnedBySleepSummary(
-  aggregate: JunctionSleepStageAggregate,
+function isSleepMetricOwnedBySleepSummary(
+  aggregate: JunctionSleepStageAggregate | JunctionSleepTotalAggregate,
   metric: string,
   sleepSummaryStageMetricOwners: readonly JunctionSleepSummaryStageMetricOwner[],
 ): boolean {
@@ -2060,7 +2186,7 @@ function isSleepStageMetricOwnedBySleepSummary(
 
 function sleepStageOwnerSourceMatchesAggregate(
   owner: JunctionSleepSummaryStageMetricOwner,
-  aggregate: JunctionSleepStageAggregate,
+  aggregate: JunctionSleepStageAggregate | JunctionSleepTotalAggregate,
 ): boolean {
   if (owner.sourceProviderSlug !== aggregate.resourceContext.sourceProviderSlug) {
     return false;
@@ -2077,7 +2203,7 @@ function sleepStageOwnerSourceMatchesAggregate(
 
 function sleepStageOwnerWindowMatchesAggregate(
   owner: JunctionSleepSummaryStageMetricOwner,
-  aggregate: JunctionSleepStageAggregate,
+  aggregate: JunctionSleepStageAggregate | JunctionSleepTotalAggregate,
 ): boolean {
   return owner.startAt === aggregate.coverageStartAt &&
     owner.endAt === aggregate.coverageEndAt;
@@ -2088,6 +2214,7 @@ function collectJunctionSleepStageAggregates(
   resourceContext: ResourceContext,
   context: NormalizationContext,
   aggregates: Map<string, JunctionSleepStageAggregate>,
+  totalAggregates: Map<string, JunctionSleepTotalAggregate>,
 ): void {
   const parentTimestamp = resolveRecordTimestamp(entry, context, resourceContext.sourceProviderSlug);
   const intervals = collectJunctionSleepStageIntervals(entry, resourceContext, context, parentTimestamp);
@@ -2099,6 +2226,8 @@ function collectJunctionSleepStageAggregates(
 
   const buckets = new Map<string, JunctionSleepStageAggregateBucket>();
   const entryAggregates = new Map<string, JunctionSleepStageAggregate>();
+  const entryTotalAggregates = new Map<string, JunctionSleepTotalAggregate>();
+  const hasDetailedAsleepStage = covered.intervals.some((interval) => isDetailedAsleepStage(interval.stage));
   for (const interval of covered.intervals) {
     const stageTimestamp = withTimestampOverride(interval.timestamp, {
       occurredAt: covered.coverageWindow.endAt,
@@ -2114,52 +2243,36 @@ function collectJunctionSleepStageAggregates(
       covered.coverageWindow.startAt,
       covered.coverageWindow.endAt,
     );
+    const totalAggregateKey = sleepTotalAggregateKey(
+      resourceContext,
+      covered.coverageWindow.startAt,
+      covered.coverageWindow.endAt,
+    );
+    if (interval.stage === "asleep_unspecified") {
+      addSleepTotalAggregateDuration(entryTotalAggregates, totalAggregateKey, {
+        coverageEndAt: covered.coverageWindow.endAt,
+        coverageStartAt: covered.coverageWindow.startAt,
+        dataOriginEntry: interval.dataOriginEntry,
+        durationMinutes: interval.durationMinutes,
+        endAt: covered.coverageWindow.endAt,
+        parentResourceId,
+        recordedAt: stageTimestamp.recordedAt,
+        resourceContext,
+        startAt: covered.coverageWindow.startAt,
+        timestamp: stageTimestamp,
+        timeZone: interval.timeZone,
+      });
+      continue;
+    }
+
     const aggregateKey = sleepStageAggregateKey(
       resourceContext,
       interval.stage,
       covered.coverageWindow.startAt,
       covered.coverageWindow.endAt,
     );
-    const existingBucket = buckets.get(bucketKey);
-    if (existingBucket) {
-      existingBucket.recordedAt = laterOptionalIsoTimestamp(existingBucket.recordedAt, stageTimestamp.recordedAt);
-      const preferredBucket = compareSleepStageBucketPreference(
-        {
-          coverageEndAt: covered.coverageWindow.endAt,
-          coverageStartAt: covered.coverageWindow.startAt,
-          dataOriginEntry: interval.dataOriginEntry,
-          endAt: covered.coverageWindow.endAt,
-          parentResourceId,
-          recordedAt: stageTimestamp.recordedAt,
-          resourceContext,
-          startAt: covered.coverageWindow.startAt,
-          timestamp: stageTimestamp,
-          timeZone: interval.timeZone,
-        },
-        existingBucket,
-      ) > 0
-        ? {
-          coverageEndAt: covered.coverageWindow.endAt,
-          coverageStartAt: covered.coverageWindow.startAt,
-          dataOriginEntry: interval.dataOriginEntry,
-          endAt: covered.coverageWindow.endAt,
-          parentResourceId,
-          recordedAt: existingBucket.recordedAt,
-          resourceContext,
-          startAt: covered.coverageWindow.startAt,
-          timestamp: stageTimestamp,
-          timeZone: interval.timeZone,
-        }
-        : existingBucket;
-      buckets.set(bucketKey, {
-        ...preferredBucket,
-        recordedAt: existingBucket.recordedAt,
-        timestamp: withTimestampOverride(preferredBucket.timestamp, {
-          recordedAt: existingBucket.recordedAt,
-        }),
-      });
-    } else {
-      buckets.set(bucketKey, {
+    if (hasDetailedAsleepStage) {
+      const bucketCandidate = {
         coverageEndAt: covered.coverageWindow.endAt,
         coverageStartAt: covered.coverageWindow.startAt,
         dataOriginEntry: interval.dataOriginEntry,
@@ -2170,7 +2283,23 @@ function collectJunctionSleepStageAggregates(
         startAt: covered.coverageWindow.startAt,
         timestamp: stageTimestamp,
         timeZone: interval.timeZone,
-      });
+      };
+      const existingBucket = buckets.get(bucketKey);
+      if (existingBucket) {
+        existingBucket.recordedAt = laterOptionalIsoTimestamp(existingBucket.recordedAt, stageTimestamp.recordedAt);
+        const preferredBucket = compareSleepStageBucketPreference(bucketCandidate, existingBucket) > 0
+          ? { ...bucketCandidate, recordedAt: existingBucket.recordedAt }
+          : existingBucket;
+        buckets.set(bucketKey, {
+          ...preferredBucket,
+          recordedAt: existingBucket.recordedAt,
+          timestamp: withTimestampOverride(preferredBucket.timestamp, {
+            recordedAt: existingBucket.recordedAt,
+          }),
+        });
+      } else {
+        buckets.set(bucketKey, bucketCandidate);
+      }
     }
 
     addSleepStageAggregateDuration(entryAggregates, aggregateKey, {
@@ -2221,6 +2350,9 @@ function collectJunctionSleepStageAggregates(
   for (const aggregate of entryAggregates.values()) {
     mergeSleepStageAggregateCandidate(aggregates, aggregate);
   }
+  for (const aggregate of entryTotalAggregates.values()) {
+    mergeSleepTotalAggregateCandidate(totalAggregates, aggregate);
+  }
 }
 
 function sleepStageBucketKey(
@@ -2255,6 +2387,22 @@ function sleepStageAggregateKey(
   ].join("|");
 }
 
+function sleepTotalAggregateKey(
+  resourceContext: ResourceContext,
+  coverageStartAt: string,
+  coverageEndAt: string,
+): string {
+  return [
+    resourceContext.externalRefResourceType,
+    resourceContext.sourceProviderSlug,
+    resourceContext.origin.sourceType,
+    resourceContext.origin.sourceInstanceId,
+    coverageStartAt,
+    coverageEndAt,
+    "sleep-total-minutes",
+  ].join("|");
+}
+
 function addSleepStageAggregateDuration(
   aggregates: Map<string, JunctionSleepStageAggregate>,
   aggregateKey: string,
@@ -2268,6 +2416,27 @@ function addSleepStageAggregateDuration(
 
   const recordedAt = laterOptionalIsoTimestamp(existing.recordedAt, candidate.recordedAt);
   const preferred = compareSleepStageAggregatePreference(candidate, existing) > 0 ? candidate : existing;
+  aggregates.set(aggregateKey, {
+    ...preferred,
+    durationMinutes: existing.durationMinutes + candidate.durationMinutes,
+    recordedAt,
+    timestamp: withTimestampOverride(preferred.timestamp, { recordedAt }),
+  });
+}
+
+function addSleepTotalAggregateDuration(
+  aggregates: Map<string, JunctionSleepTotalAggregate>,
+  aggregateKey: string,
+  candidate: JunctionSleepTotalAggregate,
+): void {
+  const existing = aggregates.get(aggregateKey);
+  if (!existing) {
+    aggregates.set(aggregateKey, candidate);
+    return;
+  }
+
+  const recordedAt = laterOptionalIsoTimestamp(existing.recordedAt, candidate.recordedAt);
+  const preferred = compareSleepAggregatePreference(candidate, existing) > 0 ? candidate : existing;
   aggregates.set(aggregateKey, {
     ...preferred,
     durationMinutes: existing.durationMinutes + candidate.durationMinutes,
@@ -2301,6 +2470,30 @@ function mergeSleepStageAggregateCandidate(
   });
 }
 
+function mergeSleepTotalAggregateCandidate(
+  aggregates: Map<string, JunctionSleepTotalAggregate>,
+  candidate: JunctionSleepTotalAggregate,
+): void {
+  const aggregateKey = sleepTotalAggregateKey(
+    candidate.resourceContext,
+    candidate.coverageStartAt,
+    candidate.coverageEndAt,
+  );
+  const existing = aggregates.get(aggregateKey);
+  if (!existing) {
+    aggregates.set(aggregateKey, candidate);
+    return;
+  }
+
+  const recordedAt = laterOptionalIsoTimestamp(existing.recordedAt, candidate.recordedAt);
+  const preferred = compareSleepAggregatePreference(candidate, existing) > 0 ? candidate : existing;
+  aggregates.set(aggregateKey, {
+    ...preferred,
+    recordedAt,
+    timestamp: withTimestampOverride(preferred.timestamp, { recordedAt }),
+  });
+}
+
 function compareSleepStageBucketPreference(
   left: JunctionSleepStageAggregateBucket,
   right: JunctionSleepStageAggregateBucket,
@@ -2322,6 +2515,13 @@ function compareSleepStageBucketPreference(
 function compareSleepStageAggregatePreference(
   left: JunctionSleepStageAggregate,
   right: JunctionSleepStageAggregate,
+): number {
+  return compareSleepAggregatePreference(left, right);
+}
+
+function compareSleepAggregatePreference(
+  left: JunctionSleepStageAggregate | JunctionSleepTotalAggregate,
+  right: JunctionSleepStageAggregate | JunctionSleepTotalAggregate,
 ): number {
   const durationPreference = Number(left.durationMinutes > 0) - Number(right.durationMinutes > 0);
   if (durationPreference !== 0) {
@@ -2363,6 +2563,10 @@ function compareSleepStageDisplayPreference(
   }
 
   return compareOptionalSleepStageDisplayValue(left.parentResourceId, right.parentResourceId);
+}
+
+function isDetailedAsleepStage(stage: JunctionSleepStageValue): stage is Exclude<JunctionSleepStage, "awake"> {
+  return stage === "light" || stage === "deep" || stage === "rem";
 }
 
 function sleepStageTimeZonePreference(timeZone: string | undefined): number {
@@ -2635,9 +2839,9 @@ function hasSleepCycleCompactParentIdentity(entry: PlainObject): boolean {
     );
 }
 
-function makeJunctionSleepStageAggregateExternalRef(
+function makeJunctionSleepAggregateExternalRef(
   resourceContext: ResourceContext,
-  aggregate: JunctionSleepStageAggregate,
+  aggregate: JunctionSleepStageAggregate | JunctionSleepTotalAggregate,
   metric: string,
 ): DeviceExternalRefPayload {
   return makeJunctionCanonicalSleepStageExternalRef(resourceContext, {
@@ -4570,7 +4774,10 @@ function listAllowedResourceKeys(
   return allowedResourceEntries(resources, allowlist).map(([resource]) => resource);
 }
 
-function firstSleepStageFromPaths(source: PlainObject | undefined, paths: readonly string[]): JunctionSleepStage | undefined {
+function firstSleepStageFromPaths(
+  source: PlainObject | undefined,
+  paths: readonly string[],
+): JunctionSleepStageValue | undefined {
   for (const path of paths) {
     const stage = normalizeJunctionSleepStageValue(readPath(source, path));
     if (stage) {

--- a/packages/importers/src/device-providers/junction.ts
+++ b/packages/importers/src/device-providers/junction.ts
@@ -2227,6 +2227,7 @@ function collectJunctionSleepStageAggregates(
   const buckets = new Map<string, JunctionSleepStageAggregateBucket>();
   const entryAggregates = new Map<string, JunctionSleepStageAggregate>();
   const entryTotalAggregates = new Map<string, JunctionSleepTotalAggregate>();
+  const hasGenericAsleepStage = covered.intervals.some((interval) => interval.stage === "asleep_unspecified");
   const hasDetailedAsleepStage = covered.intervals.some((interval) => isDetailedAsleepStage(interval.stage));
   for (const interval of covered.intervals) {
     const stageTimestamp = withTimestampOverride(interval.timestamp, {
@@ -2248,7 +2249,7 @@ function collectJunctionSleepStageAggregates(
       covered.coverageWindow.startAt,
       covered.coverageWindow.endAt,
     );
-    if (interval.stage === "asleep_unspecified") {
+    if (hasGenericAsleepStage && isSleepTotalStage(interval.stage)) {
       addSleepTotalAggregateDuration(entryTotalAggregates, totalAggregateKey, {
         coverageEndAt: covered.coverageWindow.endAt,
         coverageStartAt: covered.coverageWindow.startAt,
@@ -2262,6 +2263,9 @@ function collectJunctionSleepStageAggregates(
         timestamp: stageTimestamp,
         timeZone: interval.timeZone,
       });
+    }
+
+    if (interval.stage === "asleep_unspecified") {
       continue;
     }
 
@@ -2567,6 +2571,10 @@ function compareSleepStageDisplayPreference(
 
 function isDetailedAsleepStage(stage: JunctionSleepStageValue): stage is Exclude<JunctionSleepStage, "awake"> {
   return stage === "light" || stage === "deep" || stage === "rem";
+}
+
+function isSleepTotalStage(stage: JunctionSleepStageValue): boolean {
+  return stage !== "awake";
 }
 
 function sleepStageTimeZonePreference(timeZone: string | undefined): number {

--- a/packages/importers/src/device-providers/junction.ts
+++ b/packages/importers/src/device-providers/junction.ts
@@ -2633,8 +2633,8 @@ function collectSleepStageCoverageIntervals(
   entry: PlainObject,
   sourceProviderSlug: string,
 ): Array<Pick<JunctionSleepStageInterval, "endAt" | "startAt">> {
-  return sleepStageIntervalEntries(entry).flatMap((intervalEntry) => {
-    const stage = firstSleepStageFromPaths(intervalEntry, JUNCTION_SLEEP_STAGE_VALUE_PATHS);
+  return sleepStageIntervalEntries(entry, sourceProviderSlug).flatMap((intervalEntry) => {
+    const stage = firstSleepStageFromPaths(intervalEntry, JUNCTION_SLEEP_STAGE_VALUE_PATHS, sourceProviderSlug);
     if (!stage) {
       return [];
     }
@@ -2773,8 +2773,12 @@ function collectJunctionSleepStageIntervals(
 ): JunctionSleepStageInterval[] {
   const intervals: JunctionSleepStageInterval[] = [];
 
-  for (const intervalEntry of sleepStageIntervalEntries(entry)) {
-    const stage = firstSleepStageFromPaths(intervalEntry, JUNCTION_SLEEP_STAGE_VALUE_PATHS);
+  for (const intervalEntry of sleepStageIntervalEntries(entry, resourceContext.sourceProviderSlug)) {
+    const stage = firstSleepStageFromPaths(
+      intervalEntry,
+      JUNCTION_SLEEP_STAGE_VALUE_PATHS,
+      resourceContext.sourceProviderSlug,
+    );
     if (!stage) {
       continue;
     }
@@ -4630,18 +4634,25 @@ function groupedTimeseriesResourceEntries(payload: unknown): JunctionResourceEnt
   );
 }
 
-function sleepStageIntervalEntries(entry: PlainObject): PlainObject[] {
+function sleepStageIntervalEntries(
+  entry: PlainObject,
+  sourceProviderSlug: string | undefined,
+): PlainObject[] {
   const seen = new Set<PlainObject>();
 
   return [
-    ...collectSleepStageIntervalEntries(entry, seen),
-    ...parallelSleepStageIntervalEntries(entry),
+    ...collectSleepStageIntervalEntries(entry, seen, sourceProviderSlug),
+    ...parallelSleepStageIntervalEntries(entry, sourceProviderSlug),
   ];
 }
 
-function collectSleepStageIntervalEntries(value: unknown, seen: Set<PlainObject>): PlainObject[] {
+function collectSleepStageIntervalEntries(
+  value: unknown,
+  seen: Set<PlainObject>,
+  sourceProviderSlug: string | undefined,
+): PlainObject[] {
   if (Array.isArray(value)) {
-    return value.flatMap((entry) => collectSleepStageIntervalEntries(entry, seen));
+    return value.flatMap((entry) => collectSleepStageIntervalEntries(entry, seen, sourceProviderSlug));
   }
 
   const entry = asPlainObject(value);
@@ -4653,7 +4664,7 @@ function collectSleepStageIntervalEntries(value: unknown, seen: Set<PlainObject>
   }
   seen.add(entry);
 
-  if (firstSleepStageFromPaths(entry, JUNCTION_SLEEP_STAGE_VALUE_PATHS)) {
+  if (firstSleepStageFromPaths(entry, JUNCTION_SLEEP_STAGE_VALUE_PATHS, sourceProviderSlug)) {
     return [entry];
   }
 
@@ -4663,11 +4674,14 @@ function collectSleepStageIntervalEntries(value: unknown, seen: Set<PlainObject>
       return [];
     }
 
-    return collectSleepStageIntervalEntries(nested, seen);
+    return collectSleepStageIntervalEntries(nested, seen, sourceProviderSlug);
   });
 }
 
-function parallelSleepStageIntervalEntries(entry: PlainObject): PlainObject[] {
+function parallelSleepStageIntervalEntries(
+  entry: PlainObject,
+  sourceProviderSlug: string | undefined,
+): PlainObject[] {
   const sessionStartRaw = firstValueFromPaths(entry, [
     "sessionStart",
     "session_start",
@@ -4688,7 +4702,7 @@ function parallelSleepStageIntervalEntries(entry: PlainObject): PlainObject[] {
   const timeZone = firstStringFromPaths(entry, ["timeZone", "timezone", "time_zone"]);
 
   return stageValues.flatMap((stageValue, index) => {
-    const stage = normalizeJunctionSleepStageValue(stageValue);
+    const stage = normalizeJunctionSleepStageValueForSource(stageValue, sourceProviderSlug);
     const startOffsetSeconds = startOffsets[index];
     const endOffsetSeconds = endOffsets[index];
     if (!stage || startOffsetSeconds === undefined || endOffsetSeconds === undefined) {
@@ -4785,15 +4799,38 @@ function listAllowedResourceKeys(
 function firstSleepStageFromPaths(
   source: PlainObject | undefined,
   paths: readonly string[],
+  sourceProviderSlug?: string,
 ): JunctionSleepStageValue | undefined {
   for (const path of paths) {
-    const stage = normalizeJunctionSleepStageValue(readPath(source, path));
+    const stage = normalizeJunctionSleepStageValueForSource(readPath(source, path), sourceProviderSlug);
     if (stage) {
       return stage;
     }
   }
 
   return undefined;
+}
+
+function normalizeJunctionSleepStageValueForSource(
+  value: unknown,
+  sourceProviderSlug: string | undefined,
+): JunctionSleepStageValue | null {
+  const normalized = normalizeJunctionSleepStageValue(value);
+  if (normalized) {
+    return normalized;
+  }
+
+  return isAppleHealthKitSourceProvider(sourceProviderSlug) && isJunctionAppleGenericAsleepStageValue(value)
+    ? "asleep_unspecified"
+    : null;
+}
+
+function isAppleHealthKitSourceProvider(sourceProviderSlug: string | undefined): boolean {
+  return normalizeJunctionSourceProviderSlug(sourceProviderSlug) === APPLE_HEALTH_KIT_SOURCE_PROVIDER_SLUG;
+}
+
+function isJunctionAppleGenericAsleepStageValue(value: unknown): boolean {
+  return value === -1 || (typeof value === "string" && value.trim() === "-1");
 }
 
 function normalizeTimestamp(value: unknown): string | undefined {

--- a/packages/importers/src/device-providers/junction.ts
+++ b/packages/importers/src/device-providers/junction.ts
@@ -867,7 +867,7 @@ export function canNormalizeJunctionSleepCycleRecordToCompactStages(
 ): boolean {
   const entries = resourceEntries(record, "sleep_cycle");
   return entries.length > 0 && entries.every(({ entry }) => {
-    if (!hasSleepCycleCompactParentIdentity(entry)) {
+    if (!hasSleepCycleCompactParentIdentity(entry, sourceProviderSlug)) {
       return false;
     }
 
@@ -2836,15 +2836,18 @@ function resolveSleepCycleParentResourceId(
   parentTimestamp: ReturnType<typeof resolveRecordTimestamp>,
 ): string | undefined {
   const explicitParentId = firstStringFromPaths(entry, JUNCTION_GENERIC_SUMMARY_ID_PATHS);
-  if ((parentTimestamp.observedAtRaw || explicitParentId) && !isDirectSleepStageIntervalEntry(entry)) {
+  if (
+    (parentTimestamp.observedAtRaw || explicitParentId) &&
+    !isDirectSleepStageIntervalEntry(entry, resourceContext.sourceProviderSlug)
+  ) {
     return buildStableResourceId(resourceContext, entry, parentTimestamp);
   }
 
   return undefined;
 }
 
-function hasSleepCycleCompactParentIdentity(entry: PlainObject): boolean {
-  return !isDirectSleepStageIntervalEntry(entry) &&
+function hasSleepCycleCompactParentIdentity(entry: PlainObject, sourceProviderSlug: string | undefined): boolean {
+  return !isDirectSleepStageIntervalEntry(entry, sourceProviderSlug) &&
     Boolean(
       firstStringFromPaths(entry, JUNCTION_GENERIC_SUMMARY_ID_PATHS) ||
         firstStringFromPaths(entry, JUNCTION_RECORD_TIMESTAMP_PATHS),
@@ -4745,6 +4748,10 @@ function expandResourceEntry(value: unknown, resource?: string): JunctionResourc
 }
 
 function readNestedResourceEntries(envelope: PlainObject, resource?: string): PlainObject[] | null {
+  const sourceProviderSlug = resource === "sleep_cycle"
+    ? readJunctionSourceProviderSlug(envelope, undefined)
+    : undefined;
+
   for (const key of nestedResourceEntryKeys(resource)) {
     const directEntry = asPlainObject(envelope[key]);
     const entries = directEntry
@@ -4754,7 +4761,15 @@ function readNestedResourceEntries(envelope: PlainObject, resource?: string): Pl
           return normalized ? [normalized] : [];
         });
     if (entries.length > 0) {
-      if (resource === "sleep_cycle" && entries.some(isDirectSleepStageIntervalEntry)) {
+      if (
+        resource === "sleep_cycle" &&
+        entries.some((entry) =>
+          isDirectSleepStageIntervalEntry(
+            entry,
+            readJunctionSourceProviderSlug(entry, envelope) ?? sourceProviderSlug,
+          )
+        )
+      ) {
         return null;
       }
 
@@ -4765,8 +4780,11 @@ function readNestedResourceEntries(envelope: PlainObject, resource?: string): Pl
   return null;
 }
 
-function isDirectSleepStageIntervalEntry(entry: PlainObject): boolean {
-  return firstSleepStageFromPaths(entry, JUNCTION_SLEEP_STAGE_VALUE_PATHS) !== undefined;
+function isDirectSleepStageIntervalEntry(
+  entry: PlainObject,
+  sourceProviderSlug: string | undefined,
+): boolean {
+  return firstSleepStageFromPaths(entry, JUNCTION_SLEEP_STAGE_VALUE_PATHS, sourceProviderSlug) !== undefined;
 }
 
 function nestedResourceEntryKeys(resource: string | undefined): readonly string[] {

--- a/packages/importers/test/device-providers-junction.test.ts
+++ b/packages/importers/test/device-providers-junction.test.ts
@@ -4857,6 +4857,46 @@ test("Junction Apple HealthKit zeroed sleep summary preserves awake and derives 
   );
 });
 
+test("Junction sleep_cycle generic asleep total includes explicit detailed asleep intervals", () => {
+  const payload = normalizeJunctionSnapshot(
+    {
+      importedAt: "2026-07-08T12:00:00.000Z",
+      summaries: {
+        sleep_cycle: [{
+          id: "apple-healthkit-mixed-generic-detailed-cycle",
+          sourceProviderSlug: "apple_health_kit",
+          sourceType: "unknown",
+          session_start: "2026-07-08T00:00:00+00:00",
+          session_end: "2026-07-08T08:00:00+00:00",
+          stage_start_offset_second: [0, 7200, 10800, 25200],
+          stage_end_offset_second: [7200, 10800, 25200, 28800],
+          stage_type: [-1, 1, 2, 4],
+          time_zone: "UTC",
+          created_at: "2026-07-08T12:00:00+00:00",
+        }],
+      },
+    },
+    { defaultTimeZone: "UTC" },
+  );
+
+  const observations = payload.events?.filter((event) => event.kind === "observation") ?? [];
+  const metricValues = (metric: string) =>
+    observations.filter((event) => event.fields?.metric === metric).map((event) => event.fields?.value);
+  const positiveMetricValues = (metric: string) =>
+    metricValues(metric).filter((value) => typeof value === "number" && value > 0);
+
+  assert.deepEqual(metricValues("sleep-total-minutes"), [420]);
+  assert.deepEqual(positiveMetricValues("sleep-deep-minutes"), [60]);
+  assert.deepEqual(positiveMetricValues("sleep-light-minutes"), [240]);
+  assert.deepEqual(positiveMetricValues("sleep-awake-minutes"), [60]);
+  assert.deepEqual(positiveMetricValues("sleep-rem-minutes"), []);
+  assert.ok(
+    observations
+      .filter((event) => event.fields?.metric === "sleep-total-minutes")
+      .every((event) => event.dataOrigin?.normalizerVersion === "junction-sleep-unspecified-total.v1"),
+  );
+});
+
 test("Junction sleep_cycle direct intervals use timezone for local sleep-stage day", () => {
   const payload = normalizeJunctionSnapshot(
     {

--- a/packages/importers/test/device-providers-junction.test.ts
+++ b/packages/importers/test/device-providers-junction.test.ts
@@ -4753,6 +4753,110 @@ test("Junction sleep_cycle normalizer vectorizes parallel offset stage arrays", 
   ]);
 });
 
+test("Junction Apple HealthKit zeroed sleep summary preserves awake and derives generic asleep total", () => {
+  const payload = normalizeJunctionSnapshot(
+    {
+      importedAt: "2026-07-07T18:53:32.000Z",
+      summaries: {
+        sleep: [{
+          id: "apple-healthkit-zeroed-sleep",
+          sourceProviderSlug: "apple_health_kit",
+          sourceType: "unknown",
+          bedtime_start: "2026-07-07T08:17:04+00:00",
+          bedtime_stop: "2026-07-07T14:02:56+00:00",
+          duration: 20752,
+          total: 0,
+          deep: 0,
+          rem: 0,
+          light: 0,
+          awake: 1110,
+          efficiency: 0,
+          created_at: "2026-07-07T18:53:32+00:00",
+        }],
+        sleep_cycle: [{
+          id: "apple-healthkit-generic-asleep-cycle",
+          sleep_id: "apple-healthkit-zeroed-sleep",
+          sourceProviderSlug: "apple_health_kit",
+          sourceType: "unknown",
+          session_start: "2026-07-07T08:17:04+00:00",
+          session_end: "2026-07-07T14:02:56+00:00",
+          stage_start_offset_second: [
+            0,
+            5148,
+            5358,
+            6259,
+            6319,
+            6439,
+            6529,
+            9230,
+            9320,
+            9890,
+            10100,
+            14061,
+            14091,
+            14421,
+            14451,
+            16161,
+            16221,
+            16401,
+            16431,
+            19552,
+            19792,
+            19912,
+            19972,
+          ],
+          stage_end_offset_second: [
+            5148,
+            5358,
+            6259,
+            6319,
+            6439,
+            6529,
+            9230,
+            9320,
+            9890,
+            10100,
+            14061,
+            14091,
+            14421,
+            14451,
+            16161,
+            16221,
+            16401,
+            16431,
+            19552,
+            19792,
+            19912,
+            19972,
+            20752,
+          ],
+          stage_type: [-1, 4, -1, 4, -1, 4, -1, 4, -1, 4, -1, 4, -1, 4, -1, 4, -1, 4, -1, 4, -1, 4, -1],
+          created_at: "2026-07-07T18:53:32+00:00",
+        }],
+      },
+    },
+    { defaultTimeZone: "America/New_York" },
+  );
+
+  const observations = payload.events?.filter((event) => event.kind === "observation") ?? [];
+  const metricValues = (metric: string) =>
+    observations.filter((event) => event.fields?.metric === metric).map((event) => event.fields?.value);
+  const metrics = observations.map((event) => event.fields?.metric);
+
+  assert.equal(payload.events?.some((event) => event.kind === "sleep_session"), true);
+  assert.deepEqual(metricValues("sleep-total-minutes"), [327.3667]);
+  assert.deepEqual(metricValues("sleep-awake-minutes"), [18.5]);
+  assert.equal(metrics.includes("sleep-efficiency"), false);
+  assert.equal(metrics.includes("sleep-deep-minutes"), false);
+  assert.equal(metrics.includes("sleep-rem-minutes"), false);
+  assert.equal(metrics.includes("sleep-light-minutes"), false);
+  assert.ok(
+    observations
+      .filter((event) => event.fields?.metric === "sleep-total-minutes")
+      .every((event) => event.dataOrigin?.normalizerVersion === "junction-sleep-unspecified-total.v1"),
+  );
+});
+
 test("Junction sleep_cycle direct intervals use timezone for local sleep-stage day", () => {
   const payload = normalizeJunctionSnapshot(
     {

--- a/packages/importers/test/device-providers-junction.test.ts
+++ b/packages/importers/test/device-providers-junction.test.ts
@@ -4857,6 +4857,62 @@ test("Junction Apple HealthKit zeroed sleep summary preserves awake and derives 
   );
 });
 
+test("Junction Apple HealthKit string negative-one stages derive generic asleep total", () => {
+  const payload = normalizeJunctionSnapshot(
+    {
+      importedAt: "2026-07-08T12:00:00.000Z",
+      summaries: {
+        sleep: [{
+          id: "apple-healthkit-zeroed-string-stage-sleep",
+          sourceProviderSlug: "apple_health_kit",
+          sourceType: "unknown",
+          bedtime_start: "2026-07-08T00:00:00+00:00",
+          bedtime_stop: "2026-07-08T02:00:00+00:00",
+          duration: 7200,
+          total: 0,
+          deep: 0,
+          rem: 0,
+          light: 0,
+          awake: 900,
+          efficiency: 0,
+          created_at: "2026-07-08T12:00:00+00:00",
+        }],
+        sleep_cycle: [{
+          id: "apple-healthkit-string-generic-asleep-cycle",
+          sleep_id: "apple-healthkit-zeroed-string-stage-sleep",
+          sourceProviderSlug: "apple_health_kit",
+          sourceType: "unknown",
+          session_start: "2026-07-08T00:00:00+00:00",
+          session_end: "2026-07-08T02:00:00+00:00",
+          stage_start_offset_second: [0, 3600, 4500],
+          stage_end_offset_second: [3600, 4500, 7200],
+          stage_type: ["-1", "4", "-1"],
+          time_zone: "UTC",
+          created_at: "2026-07-08T12:00:00+00:00",
+        }],
+      },
+    },
+    { defaultTimeZone: "UTC" },
+  );
+
+  const observations = payload.events?.filter((event) => event.kind === "observation") ?? [];
+  const metricValues = (metric: string) =>
+    observations.filter((event) => event.fields?.metric === metric).map((event) => event.fields?.value);
+  const metrics = observations.map((event) => event.fields?.metric);
+
+  assert.deepEqual(metricValues("sleep-total-minutes"), [105]);
+  assert.deepEqual(metricValues("sleep-awake-minutes"), [15]);
+  assert.equal(metrics.includes("sleep-efficiency"), false);
+  assert.equal(metrics.includes("sleep-deep-minutes"), false);
+  assert.equal(metrics.includes("sleep-rem-minutes"), false);
+  assert.equal(metrics.includes("sleep-light-minutes"), false);
+  assert.ok(
+    observations
+      .filter((event) => event.fields?.metric === "sleep-total-minutes")
+      .every((event) => event.dataOrigin?.normalizerVersion === "junction-sleep-unspecified-total.v1"),
+  );
+});
+
 test("Junction sleep_cycle generic asleep total includes explicit detailed asleep intervals", () => {
   const payload = normalizeJunctionSnapshot(
     {
@@ -4911,6 +4967,37 @@ test("Junction sleep_cycle numeric unknown stage does not create generic total f
           stage_start_offset_second: [0, 3600],
           stage_end_offset_second: [3600, 7200],
           stage_type: [-1, 4],
+          time_zone: "UTC",
+          created_at: "2026-07-08T12:00:00+00:00",
+        }],
+      },
+    },
+    { defaultTimeZone: "UTC" },
+  );
+
+  const observations = payload.events?.filter((event) => event.kind === "observation") ?? [];
+  const metrics = observations.map((event) => event.fields?.metric);
+
+  assert.equal(metrics.includes("sleep-total-minutes"), false);
+  assert.equal(metrics.includes("sleep-deep-minutes"), false);
+  assert.equal(metrics.includes("sleep-light-minutes"), false);
+  assert.equal(metrics.includes("sleep-rem-minutes"), false);
+});
+
+test("Junction sleep_cycle string negative-one stage does not create stage facts for non-Apple sources", () => {
+  const payload = normalizeJunctionSnapshot(
+    {
+      importedAt: "2026-07-08T12:00:00.000Z",
+      summaries: {
+        sleep_cycle: [{
+          id: "garmin-string-unknown-stage-cycle",
+          sourceProviderSlug: "garmin",
+          sourceType: "unknown",
+          session_start: "2026-07-08T00:00:00+00:00",
+          session_end: "2026-07-08T02:00:00+00:00",
+          stage_start_offset_second: [0, 3600],
+          stage_end_offset_second: [3600, 7200],
+          stage_type: ["-1", "4"],
           time_zone: "UTC",
           created_at: "2026-07-08T12:00:00+00:00",
         }],

--- a/packages/importers/test/device-providers-junction.test.ts
+++ b/packages/importers/test/device-providers-junction.test.ts
@@ -4928,6 +4928,75 @@ test("Junction sleep_cycle numeric unknown stage does not create generic total f
   assert.equal(metrics.includes("sleep-rem-minutes"), false);
 });
 
+test("Junction Apple sleep_cycle parentless generic asleep fragments stay raw-only", () => {
+  const payload = normalizeJunctionSnapshot(
+    {
+      importedAt: "2026-07-08T12:00:00.000Z",
+      summaries: {
+        sleep_cycle: [{
+          source_provider: "apple_health_kit",
+          source_type: "unknown",
+          time_zone: "UTC",
+          data: [{
+            start: "2026-07-08T00:00:00.000Z",
+            end: "2026-07-08T01:00:00.000Z",
+            stage_type: -1,
+          }],
+        }],
+      },
+    },
+    { defaultTimeZone: "UTC" },
+  );
+  const observations = payload.events?.filter((event) => event.kind === "observation") ?? [];
+  const metrics = observations.map((event) => event.fields?.metric);
+
+  assert.equal(payload.samples?.length ?? 0, 0);
+  assert.equal(
+    payload.evidenceParts?.some((artifact) => artifact.role === "junction-summary-sleep-cycle"),
+    true,
+  );
+  assert.equal(metrics.includes("sleep-total-minutes"), false);
+  assert.equal(metrics.includes("sleep-awake-minutes"), false);
+  assert.equal(metrics.includes("sleep-light-minutes"), false);
+  assert.equal(metrics.includes("sleep-deep-minutes"), false);
+  assert.equal(metrics.includes("sleep-rem-minutes"), false);
+});
+
+test("Junction Apple sleep_cycle parented generic asleep envelope emits total", () => {
+  const payload = normalizeJunctionSnapshot(
+    {
+      importedAt: "2026-07-08T12:00:00.000Z",
+      summaries: {
+        sleep_cycle: [{
+          id: "apple-healthkit-parented-generic-cycle",
+          source_provider: "apple_health_kit",
+          source_type: "unknown",
+          start: "2026-07-08T00:00:00.000Z",
+          end: "2026-07-08T01:00:00.000Z",
+          time_zone: "UTC",
+          data: [{
+            start: "2026-07-08T00:00:00.000Z",
+            end: "2026-07-08T01:00:00.000Z",
+            stage_type: -1,
+          }],
+        }],
+      },
+    },
+    { defaultTimeZone: "UTC" },
+  );
+  const observations = payload.events?.filter((event) => event.kind === "observation") ?? [];
+  const totalObservations = observations.filter((event) => event.fields?.metric === "sleep-total-minutes");
+
+  assert.equal(payload.samples?.length ?? 0, 0);
+  assert.equal(totalObservations.length, 1);
+  assert.equal(totalObservations[0]?.fields?.value, 60);
+  assert.equal(totalObservations[0]?.dataOrigin?.sourceProviderSlug, "apple-health-kit");
+  assert.equal(
+    totalObservations[0]?.dataOrigin?.normalizerVersion,
+    "junction-sleep-unspecified-total.v1",
+  );
+});
+
 test("Junction sleep_cycle direct intervals use timezone for local sleep-stage day", () => {
   const payload = normalizeJunctionSnapshot(
     {

--- a/packages/importers/test/device-providers-junction.test.ts
+++ b/packages/importers/test/device-providers-junction.test.ts
@@ -4897,6 +4897,37 @@ test("Junction sleep_cycle generic asleep total includes explicit detailed aslee
   );
 });
 
+test("Junction sleep_cycle numeric unknown stage does not create generic total for non-Apple sources", () => {
+  const payload = normalizeJunctionSnapshot(
+    {
+      importedAt: "2026-07-08T12:00:00.000Z",
+      summaries: {
+        sleep_cycle: [{
+          id: "garmin-unknown-stage-cycle",
+          sourceProviderSlug: "garmin",
+          sourceType: "unknown",
+          session_start: "2026-07-08T00:00:00+00:00",
+          session_end: "2026-07-08T02:00:00+00:00",
+          stage_start_offset_second: [0, 3600],
+          stage_end_offset_second: [3600, 7200],
+          stage_type: [-1, 4],
+          time_zone: "UTC",
+          created_at: "2026-07-08T12:00:00+00:00",
+        }],
+      },
+    },
+    { defaultTimeZone: "UTC" },
+  );
+
+  const observations = payload.events?.filter((event) => event.kind === "observation") ?? [];
+  const metrics = observations.map((event) => event.fields?.metric);
+
+  assert.equal(metrics.includes("sleep-total-minutes"), false);
+  assert.equal(metrics.includes("sleep-deep-minutes"), false);
+  assert.equal(metrics.includes("sleep-light-minutes"), false);
+  assert.equal(metrics.includes("sleep-rem-minutes"), false);
+});
+
 test("Junction sleep_cycle direct intervals use timezone for local sleep-stage day", () => {
   const payload = normalizeJunctionSnapshot(
     {

--- a/packages/query/src/metrics/projection.ts
+++ b/packages/query/src/metrics/projection.ts
@@ -5,6 +5,7 @@ import { summarizeDailySamples, type DailySampleSummary } from "../summaries.ts"
 import {
   buildWearableSummaryBundle,
   buildWearableSummaryBundleFromDataset,
+  collectWearableSleepMetricSuppressionEvidenceFromDataset,
   summarizeWearableActivityFromBundle,
   summarizeWearableBodyStateFromBundle,
   summarizeWearableRecoveryFromBundle,
@@ -17,6 +18,7 @@ import {
   type WearableSleepSummary,
   type WearableSummaryBundle,
 } from "../wearables.ts";
+import { collectWearableDataset } from "../wearables/candidates.ts";
 import type { WearableDataset } from "../wearables/types.ts";
 import { formatProviderName } from "../wearables/provider-policy.ts";
 import {
@@ -85,15 +87,17 @@ function resolveWearableMetricProjectionEvidence(
   vault: VaultReadModel,
   options: BuildMetricProjectionOptions,
 ): WearableMetricProjectionEvidence {
-  if (options.wearableDataset) {
-    return buildWearableMetricProjectionEvidenceFromBundle(
-      buildWearableSummaryBundleFromDataset(options.wearableDataset),
-    );
-  }
-  return buildWearableMetricProjectionEvidenceFromBundle(buildWearableSummaryBundle(vault));
+  const dataset = options.wearableDataset ?? collectWearableDataset(vault, {});
+  return buildWearableMetricProjectionEvidenceFromBundle(
+    buildWearableSummaryBundleFromDataset(dataset),
+    collectWearableSleepMetricSuppressionEvidenceFromDataset(dataset),
+  );
 }
 
-function buildWearableMetricProjectionEvidenceFromBundle(bundle: WearableSummaryBundle): WearableMetricProjectionEvidence {
+function buildWearableMetricProjectionEvidenceFromBundle(
+  bundle: WearableSummaryBundle,
+  additionalSuppressionEvidence: readonly WearableMetricSuppressionEvidence[] = [],
+): WearableMetricProjectionEvidence {
   const sleepSummaries = summarizeWearableSleepFromBundle(bundle, { limit: METRIC_PROJECTION_LIMIT });
   const recoverySummaries = summarizeWearableRecoveryFromBundle(bundle, { limit: METRIC_PROJECTION_LIMIT });
   const activitySummaries = summarizeWearableActivityFromBundle(bundle, { limit: METRIC_PROJECTION_LIMIT });
@@ -111,7 +115,10 @@ function buildWearableMetricProjectionEvidenceFromBundle(bundle: WearableSummary
 
   return {
     rows: evidence.map((entry) => entry.row),
-    suppressionEvidence: evidence.map((entry) => entry.suppressionEvidence),
+    suppressionEvidence: [
+      ...evidence.map((entry) => entry.suppressionEvidence),
+      ...additionalSuppressionEvidence,
+    ],
   };
 }
 

--- a/packages/query/src/metrics/projection.ts
+++ b/packages/query/src/metrics/projection.ts
@@ -5,7 +5,6 @@ import { summarizeDailySamples, type DailySampleSummary } from "../summaries.ts"
 import {
   buildWearableSummaryBundle,
   buildWearableSummaryBundleFromDataset,
-  collectWearableSleepMetricSuppressionEvidenceFromDataset,
   summarizeWearableActivityFromBundle,
   summarizeWearableBodyStateFromBundle,
   summarizeWearableRecoveryFromBundle,
@@ -19,7 +18,7 @@ import {
   type WearableSummaryBundle,
 } from "../wearables.ts";
 import { collectWearableDataset } from "../wearables/candidates.ts";
-import type { WearableDataset } from "../wearables/types.ts";
+import type { WearableDataset, WearableMetricSuppressionEvidence } from "../wearables/types.ts";
 import { formatProviderName } from "../wearables/provider-policy.ts";
 import {
   extractMetricPoints,
@@ -43,12 +42,6 @@ export interface BuildMetricProjectionOptions {
 interface WearableMetricProjectionEvidence {
   rows: MetricRowEvidence[];
   suppressionEvidence: WearableMetricSuppressionEvidence[];
-}
-
-interface WearableMetricSuppressionEvidence {
-  date: string;
-  metricKey: string;
-  recordIds: readonly string[];
 }
 
 interface WearableMetricEvidenceResult {
@@ -90,7 +83,7 @@ function resolveWearableMetricProjectionEvidence(
   const dataset = options.wearableDataset ?? collectWearableDataset(vault, {});
   return buildWearableMetricProjectionEvidenceFromBundle(
     buildWearableSummaryBundleFromDataset(dataset),
-    collectWearableSleepMetricSuppressionEvidenceFromDataset(dataset),
+    dataset.metricSuppressionEvidence,
   );
 }
 

--- a/packages/query/src/projection/schema.ts
+++ b/packages/query/src/projection/schema.ts
@@ -13,8 +13,8 @@ export type DatabaseSync = import("node:sqlite").DatabaseSync;
 export type SqliteRow = Record<string, unknown>;
 
 export const QUERY_PROJECTION_SCHEMA_ID = "murph.query-projection";
-// 14: challenge share metric rows for workout count and heart-rate zone minutes.
-export const QUERY_PROJECTION_SQLITE_VERSION = 14;
+// 15: Junction Apple HealthKit zero sleep summary repair.
+export const QUERY_PROJECTION_SQLITE_VERSION = 15;
 
 export interface QueryProjectionLocation {
   absolutePath: string;

--- a/packages/query/src/projection/wearable-summary-compose.ts
+++ b/packages/query/src/projection/wearable-summary-compose.ts
@@ -570,6 +570,7 @@ function wearableDatasetFromProjectedBundle(bundle: ProjectedWearableSummaryBund
 
   return {
     activitySessionAggregates,
+    metricSuppressionEvidence: [],
     metricCandidates,
     provenanceDiagnostics: [],
     rawMetricCandidates: metricCandidates,

--- a/packages/query/src/projection/wearable-summary-projector.ts
+++ b/packages/query/src/projection/wearable-summary-projector.ts
@@ -41,6 +41,7 @@ export function buildWearableSummaryProjectionFromDataset(dataset: WearableDatas
 
 type MutableWearableDataset = {
   activitySessionAggregates: WearableActivitySessionAggregate[];
+  metricSuppressionEvidence: WearableDataset["metricSuppressionEvidence"][number][];
   metricCandidates: WearableMetricCandidate[];
   provenanceDiagnostics: WearableDataset["provenanceDiagnostics"][number][];
   rawMetricCandidates: WearableMetricCandidate[];
@@ -91,6 +92,7 @@ function groupWearableDatasetByPublicProvider(dataset: WearableDataset): Map<str
 function emptyWearableDataset(): MutableWearableDataset {
   return {
     activitySessionAggregates: [],
+    metricSuppressionEvidence: [],
     metricCandidates: [],
     provenanceDiagnostics: [],
     rawMetricCandidates: [],

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -28,7 +28,13 @@ import {
 } from "./wearables/provider-policy.ts";
 import { buildWearableSourceHealth } from "./wearables/source-health.ts";
 import { resolveWearablePublicSourceProvider, wearableDataOriginKey } from "./wearables/origin.ts";
-import { buildCandidateId, collectLatestDate, collectSortedDatesDesc, latestIsoTimestamp, uniqueStrings } from "./wearables/shared.ts";
+import {
+  buildCandidateId,
+  collectLatestDate,
+  collectSortedDatesDesc,
+  latestIsoTimestamp,
+  uniqueStrings,
+} from "./wearables/shared.ts";
 import {
   resolveMetric,
   resolveSleepWindowSelection,
@@ -296,6 +302,14 @@ const ASLEEP_STAGE_TOTAL_METRICS: readonly WearableMetricKey[] = [
   "lightMinutes",
   "remMinutes",
 ];
+const APPLE_HEALTH_KIT_PROVIDER = "apple-health-kit";
+const INVALID_ZERO_SLEEP_METRICS = new Set<string>([
+  "totalSleepMinutes",
+  "sleepEfficiency",
+  "deepMinutes",
+  "lightMinutes",
+  "remMinutes",
+]);
 
 function buildDerivedTotalSleepCandidates(
   date: string,
@@ -389,6 +403,132 @@ function selectSleepMetricCandidates(
   return selectSleepWindowMetricCandidates(selectMetricCandidates(candidates, metric), selectedWindow, sleepWindows);
 }
 
+function selectValidSleepMetricCandidates(
+  candidates: readonly WearableMetricCandidate[],
+  metric: WearableMetricKey,
+  selectedWindow: WearableSleepWindowCandidate | null,
+  sleepWindows: readonly WearableSleepWindowCandidate[],
+  invalidZeroProviders: ReadonlySet<string>,
+): WearableMetricCandidate[] {
+  const selectedCandidates = selectSleepMetricCandidates(candidates, metric, selectedWindow, sleepWindows)
+    .filter((candidate) => !isInvalidZeroSleepMetricCandidate(candidate, metric, invalidZeroProviders));
+  return preferDirectSleepMetricCandidates(selectedCandidates);
+}
+
+function isInvalidZeroSleepMetricCandidate(
+  candidate: WearableMetricCandidate,
+  metric: string,
+  invalidZeroProviders: ReadonlySet<string>,
+): boolean {
+  return INVALID_ZERO_SLEEP_METRICS.has(metric) &&
+    candidate.value === 0 &&
+    invalidZeroProviders.has(resolveSleepCandidateProvider(candidate));
+}
+
+function preferDirectSleepMetricCandidates(
+  candidates: readonly WearableMetricCandidate[],
+): WearableMetricCandidate[] {
+  if (!candidates.some(isAppleHealthKitSleepCandidate)) {
+    return [...candidates];
+  }
+
+  const directCandidates = candidates.filter((candidate) => !isAppleHealthKitSleepCandidate(candidate));
+  return directCandidates.length > 0 ? directCandidates : [...candidates];
+}
+
+function preferDirectSleepWindows(
+  sleepWindows: readonly WearableSleepWindowCandidate[],
+): WearableSleepWindowCandidate[] {
+  const directWindows = sleepWindows.filter((window) => !isAppleHealthKitSleepCandidate(window));
+  if (directWindows.length === 0) {
+    return [...sleepWindows];
+  }
+
+  return sleepWindows.filter((window) =>
+    !isAppleHealthKitSleepCandidate(window) ||
+    !directWindows.some((directWindow) => sleepWindowsRepresentSameWindow(window, directWindow))
+  );
+}
+
+function sleepWindowsRepresentSameWindow(
+  left: WearableSleepWindowCandidate,
+  right: WearableSleepWindowCandidate,
+): boolean {
+  return left.startAt === right.startAt &&
+    left.endAt === right.endAt &&
+    Math.abs(left.durationMinutes - right.durationMinutes) <= resolveMetricTolerance("sessionMinutes");
+}
+
+function collectInvalidZeroSleepSummaryProviders(
+  candidates: readonly WearableMetricCandidate[],
+  sleepWindows: readonly WearableSleepWindowCandidate[],
+): Set<string> {
+  const providers = new Set<string>();
+  const appleProviders = uniqueStrings(
+    candidates
+      .map(resolveSleepCandidateProvider)
+      .filter((provider) => provider === APPLE_HEALTH_KIT_PROVIDER),
+  );
+
+  for (const provider of appleProviders) {
+    const providerCandidates = candidates.filter((candidate) => resolveSleepCandidateProvider(candidate) === provider);
+    const awakeMinutes = firstMetricValue(providerCandidates, "awakeMinutes");
+    if (
+      firstMetricValue(providerCandidates, "totalSleepMinutes") !== 0 ||
+      awakeMinutes === null ||
+      awakeMinutes <= 0 ||
+      !isMissingOrZeroMetric(providerCandidates, "sleepEfficiency") ||
+      !isMissingOrZeroMetric(providerCandidates, "deepMinutes") ||
+      !isMissingOrZeroMetric(providerCandidates, "lightMinutes") ||
+      !isMissingOrZeroMetric(providerCandidates, "remMinutes")
+    ) {
+      continue;
+    }
+
+    const hasRealSleepWindow = sleepWindows
+      .filter((window) => resolveSleepCandidateProvider(window) === provider)
+      .some((window) => window.durationMinutes > awakeMinutes + 1);
+    if (hasRealSleepWindow) {
+      providers.add(provider);
+    }
+  }
+
+  return providers;
+}
+
+function firstMetricValue(
+  candidates: readonly WearableMetricCandidate[],
+  metric: WearableMetricKey,
+): number | null {
+  return candidates.find((candidate) => candidate.metric === metric)?.value ?? null;
+}
+
+function isMissingOrZeroMetric(
+  candidates: readonly WearableMetricCandidate[],
+  metric: WearableMetricKey,
+): boolean {
+  const value = firstMetricValue(candidates, metric);
+  return value === null || value === 0;
+}
+
+function isAppleHealthKitSleepCandidate(
+  candidate: Pick<WearableMetricCandidate | WearableSleepWindowCandidate, "dataOrigin" | "externalRef" | "provider">,
+): boolean {
+  return resolveSleepCandidateProvider(candidate) === APPLE_HEALTH_KIT_PROVIDER;
+}
+
+function resolveSleepCandidateProvider(
+  candidate: Pick<WearableMetricCandidate | WearableSleepWindowCandidate, "dataOrigin" | "externalRef" | "provider">,
+): string {
+  return resolveWearablePublicSourceProvider({
+    dataOrigin: candidate.dataOrigin,
+    externalRef: candidate.externalRef,
+    provider: candidate.provider,
+  }, {
+    suppressJunctionSourceInstanceFallback: true,
+  });
+}
+
 function buildDerivedTotalSleepCandidatesForWindow(
   date: string,
   candidates: readonly WearableMetricCandidate[],
@@ -479,13 +619,15 @@ function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableS
 
   return dates.map((date) => {
     const dateCandidates = metricCandidatesByDate.get(date) ?? [];
-    const sleepWindows = sleepWindowsByDate.get(date) ?? [];
+    const rawSleepWindows = sleepWindowsByDate.get(date) ?? [];
+    const sleepWindows = preferDirectSleepWindows(rawSleepWindows);
     const windowSelection = resolveSleepWindowSelection(sleepWindows);
     const selectedWindow = windowSelection.selection;
+    const invalidZeroSleepProviders = collectInvalidZeroSleepSummaryProviders(dateCandidates, rawSleepWindows);
     const sessionMinutes = resolveSessionMinutesForSleepWindows(selectedWindow, sleepWindows);
     const directTotalSleepMinutes = resolveMetric(
       "totalSleepMinutes",
-      selectSleepMetricCandidates(dateCandidates, "totalSleepMinutes", selectedWindow, sleepWindows),
+      selectValidSleepMetricCandidates(dateCandidates, "totalSleepMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders),
       {
         metricFamily: "sleep",
       },
@@ -493,29 +635,36 @@ function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableS
     const totalSleepMinutes =
       directTotalSleepMinutes.selection.value !== null
         ? directTotalSleepMinutes
-        : resolveMetric("totalSleepMinutes", buildDerivedTotalSleepCandidatesForWindow(date, dateCandidates, selectedWindow, sleepWindows), {
+        : resolveMetric("totalSleepMinutes", buildDerivedTotalSleepCandidatesForWindow(
+            date,
+            dateCandidates.filter((candidate) =>
+              !isInvalidZeroSleepMetricCandidate(candidate, candidate.metric, invalidZeroSleepProviders)
+            ),
+            selectedWindow,
+            sleepWindows,
+          ), {
             metricFamily: "sleep",
           });
     const timeInBedMinutes = withMetricFallback(
-      resolveMetric("timeInBedMinutes", selectSleepMetricCandidates(dateCandidates, "timeInBedMinutes", selectedWindow, sleepWindows), {
+      resolveMetric("timeInBedMinutes", selectValidSleepMetricCandidates(dateCandidates, "timeInBedMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
         metricFamily: "sleep",
       }),
       sessionMinutes,
       "Used the selected sleep session duration because no explicit time-in-bed metric was available.",
     );
-    const sleepEfficiency = resolveMetric("sleepEfficiency", selectSleepMetricCandidates(dateCandidates, "sleepEfficiency", selectedWindow, sleepWindows), {
+    const sleepEfficiency = resolveMetric("sleepEfficiency", selectValidSleepMetricCandidates(dateCandidates, "sleepEfficiency", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
       metricFamily: "sleep",
     });
-    const awakeMinutes = resolveMetric("awakeMinutes", selectSleepMetricCandidates(dateCandidates, "awakeMinutes", selectedWindow, sleepWindows), {
+    const awakeMinutes = resolveMetric("awakeMinutes", selectValidSleepMetricCandidates(dateCandidates, "awakeMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
       metricFamily: "sleep",
     });
-    const lightMinutes = resolveMetric("lightMinutes", selectSleepMetricCandidates(dateCandidates, "lightMinutes", selectedWindow, sleepWindows), {
+    const lightMinutes = resolveMetric("lightMinutes", selectValidSleepMetricCandidates(dateCandidates, "lightMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
       metricFamily: "sleep",
     });
-    const deepMinutes = resolveMetric("deepMinutes", selectSleepMetricCandidates(dateCandidates, "deepMinutes", selectedWindow, sleepWindows), {
+    const deepMinutes = resolveMetric("deepMinutes", selectValidSleepMetricCandidates(dateCandidates, "deepMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
       metricFamily: "sleep",
     });
-    const remMinutes = resolveMetric("remMinutes", selectSleepMetricCandidates(dateCandidates, "remMinutes", selectedWindow, sleepWindows), {
+    const remMinutes = resolveMetric("remMinutes", selectValidSleepMetricCandidates(dateCandidates, "remMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
       metricFamily: "sleep",
     });
     const sleepScore = resolveMetric("sleepScore", selectSleepMetricCandidates(dateCandidates, "sleepScore", selectedWindow, sleepWindows), {

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -454,9 +454,28 @@ function sleepWindowsRepresentSameWindow(
   left: WearableSleepWindowCandidate,
   right: WearableSleepWindowCandidate,
 ): boolean {
-  return left.startAt === right.startAt &&
-    left.endAt === right.endAt &&
-    Math.abs(left.durationMinutes - right.durationMinutes) <= resolveMetricTolerance("sessionMinutes");
+  const toleranceMinutes = resolveMetricTolerance("sessionMinutes");
+  return timestampsWithinMinutes(left.startAt, right.startAt, toleranceMinutes) &&
+    timestampsWithinMinutes(left.endAt, right.endAt, toleranceMinutes) &&
+    Math.abs(left.durationMinutes - right.durationMinutes) <= toleranceMinutes;
+}
+
+function timestampsWithinMinutes(
+  left: string | null | undefined,
+  right: string | null | undefined,
+  toleranceMinutes: number,
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(leftMs) || !Number.isFinite(rightMs)) {
+    return left === right;
+  }
+
+  return Math.abs(leftMs - rightMs) / 60000 <= toleranceMinutes;
 }
 
 function collectInvalidZeroSleepSummaryProviders(

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -311,6 +311,10 @@ const INVALID_ZERO_SLEEP_METRICS = new Set<string>([
   "remMinutes",
 ]);
 
+interface InvalidZeroSleepWindow {
+  window: WearableSleepWindowCandidate;
+}
+
 function buildDerivedTotalSleepCandidates(
   date: string,
   candidates: readonly WearableMetricCandidate[],
@@ -387,6 +391,11 @@ function selectSleepWindowMetricCandidates(
     return anchored;
   }
 
+  const timeAnchored = candidates.filter((candidate) => sleepMetricAssociatedWithWindow(candidate, selectedWindow));
+  if (timeAnchored.length > 0) {
+    return timeAnchored;
+  }
+
   const nonSelectedWindowCandidates = candidates.filter((candidate) =>
     !sleepMetricMatchesNonSelectedWindow(candidate, selectedWindow, sleepWindows)
   );
@@ -408,21 +417,21 @@ function selectValidSleepMetricCandidates(
   metric: WearableMetricKey,
   selectedWindow: WearableSleepWindowCandidate | null,
   sleepWindows: readonly WearableSleepWindowCandidate[],
-  invalidZeroProviders: ReadonlySet<string>,
+  invalidZeroWindows: readonly InvalidZeroSleepWindow[],
 ): WearableMetricCandidate[] {
   const selectedCandidates = selectSleepMetricCandidates(candidates, metric, selectedWindow, sleepWindows)
-    .filter((candidate) => !isInvalidZeroSleepMetricCandidate(candidate, metric, invalidZeroProviders));
+    .filter((candidate) => !isInvalidZeroSleepMetricCandidate(candidate, metric, invalidZeroWindows));
   return preferDirectSleepMetricCandidates(selectedCandidates);
 }
 
 function isInvalidZeroSleepMetricCandidate(
   candidate: WearableMetricCandidate,
   metric: string,
-  invalidZeroProviders: ReadonlySet<string>,
+  invalidZeroWindows: readonly InvalidZeroSleepWindow[],
 ): boolean {
   return INVALID_ZERO_SLEEP_METRICS.has(metric) &&
     candidate.value === 0 &&
-    invalidZeroProviders.has(resolveSleepCandidateProvider(candidate));
+    invalidZeroWindows.some((entry) => sleepMetricAssociatedWithWindow(candidate, entry.window));
 }
 
 function preferDirectSleepMetricCandidates(
@@ -478,41 +487,63 @@ function timestampsWithinMinutes(
   return Math.abs(leftMs - rightMs) / 60000 <= toleranceMinutes;
 }
 
-function collectInvalidZeroSleepSummaryProviders(
+function collectInvalidZeroSleepSummaryWindows(
   candidates: readonly WearableMetricCandidate[],
   sleepWindows: readonly WearableSleepWindowCandidate[],
-): Set<string> {
-  const providers = new Set<string>();
-  const appleProviders = uniqueStrings(
-    candidates
-      .map(resolveSleepCandidateProvider)
-      .filter((provider) => provider === APPLE_HEALTH_KIT_PROVIDER),
-  );
+): InvalidZeroSleepWindow[] {
+  const invalidWindows: InvalidZeroSleepWindow[] = [];
 
-  for (const provider of appleProviders) {
-    const providerCandidates = candidates.filter((candidate) => resolveSleepCandidateProvider(candidate) === provider);
-    const awakeMinutes = firstMetricValue(providerCandidates, "awakeMinutes");
+  for (const window of sleepWindows) {
+    const provider = resolveSleepCandidateProvider(window);
+    if (provider !== APPLE_HEALTH_KIT_PROVIDER) {
+      continue;
+    }
+
+    const windowCandidates = candidates.filter((candidate) => sleepMetricAssociatedWithWindow(candidate, window));
+    const awakeMinutes = firstMetricValue(windowCandidates, "awakeMinutes");
     if (
-      firstMetricValue(providerCandidates, "totalSleepMinutes") !== 0 ||
+      firstMetricValue(windowCandidates, "totalSleepMinutes") !== 0 ||
       awakeMinutes === null ||
       awakeMinutes <= 0 ||
-      !isMissingOrZeroMetric(providerCandidates, "sleepEfficiency") ||
-      !isMissingOrZeroMetric(providerCandidates, "deepMinutes") ||
-      !isMissingOrZeroMetric(providerCandidates, "lightMinutes") ||
-      !isMissingOrZeroMetric(providerCandidates, "remMinutes")
+      window.durationMinutes <= awakeMinutes + 1 ||
+      !isMissingOrZeroMetric(windowCandidates, "sleepEfficiency") ||
+      !isMissingOrZeroMetric(windowCandidates, "deepMinutes") ||
+      !isMissingOrZeroMetric(windowCandidates, "lightMinutes") ||
+      !isMissingOrZeroMetric(windowCandidates, "remMinutes")
     ) {
       continue;
     }
 
-    const hasRealSleepWindow = sleepWindows
-      .filter((window) => resolveSleepCandidateProvider(window) === provider)
-      .some((window) => window.durationMinutes > awakeMinutes + 1);
-    if (hasRealSleepWindow) {
-      providers.add(provider);
-    }
+    invalidWindows.push({ window });
   }
 
-  return providers;
+  return invalidWindows;
+}
+
+function sleepMetricAssociatedWithWindow(
+  candidate: WearableMetricCandidate,
+  window: WearableSleepWindowCandidate,
+): boolean {
+  if (resolveSleepCandidateProvider(candidate) !== resolveSleepCandidateProvider(window)) {
+    return false;
+  }
+
+  return sleepMetricMatchesWindow(candidate, window) || sleepMetricOccursInsideWindow(candidate, window);
+}
+
+function sleepMetricOccursInsideWindow(
+  candidate: WearableMetricCandidate,
+  window: WearableSleepWindowCandidate,
+): boolean {
+  const occurredAtMs = Date.parse(candidate.occurredAt ?? "");
+  const startAtMs = Date.parse(window.startAt ?? "");
+  const endAtMs = Date.parse(window.endAt ?? "");
+  if (!Number.isFinite(occurredAtMs) || !Number.isFinite(startAtMs) || !Number.isFinite(endAtMs)) {
+    return false;
+  }
+
+  const toleranceMs = resolveMetricTolerance("sessionMinutes") * 60000;
+  return occurredAtMs >= startAtMs - toleranceMs && occurredAtMs <= endAtMs + toleranceMs;
 }
 
 function firstMetricValue(
@@ -603,7 +634,7 @@ function sleepMetricMatchesNonSelectedWindow(
   sleepWindows: readonly WearableSleepWindowCandidate[],
 ): boolean {
   return sleepWindows.some((window) =>
-    window.candidateId !== selectedWindow.candidateId && sleepMetricMatchesWindow(candidate, window)
+    window.candidateId !== selectedWindow.candidateId && sleepMetricAssociatedWithWindow(candidate, window)
   );
 }
 
@@ -642,11 +673,11 @@ function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableS
     const sleepWindows = preferDirectSleepWindows(rawSleepWindows);
     const windowSelection = resolveSleepWindowSelection(sleepWindows);
     const selectedWindow = windowSelection.selection;
-    const invalidZeroSleepProviders = collectInvalidZeroSleepSummaryProviders(dateCandidates, rawSleepWindows);
+    const invalidZeroSleepWindows = collectInvalidZeroSleepSummaryWindows(dateCandidates, rawSleepWindows);
     const sessionMinutes = resolveSessionMinutesForSleepWindows(selectedWindow, sleepWindows);
     const directTotalSleepMinutes = resolveMetric(
       "totalSleepMinutes",
-      selectValidSleepMetricCandidates(dateCandidates, "totalSleepMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders),
+      selectValidSleepMetricCandidates(dateCandidates, "totalSleepMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows),
       {
         metricFamily: "sleep",
       },
@@ -657,7 +688,7 @@ function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableS
         : resolveMetric("totalSleepMinutes", buildDerivedTotalSleepCandidatesForWindow(
             date,
             dateCandidates.filter((candidate) =>
-              !isInvalidZeroSleepMetricCandidate(candidate, candidate.metric, invalidZeroSleepProviders)
+              !isInvalidZeroSleepMetricCandidate(candidate, candidate.metric, invalidZeroSleepWindows)
             ),
             selectedWindow,
             sleepWindows,
@@ -665,25 +696,25 @@ function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableS
             metricFamily: "sleep",
           });
     const timeInBedMinutes = withMetricFallback(
-      resolveMetric("timeInBedMinutes", selectValidSleepMetricCandidates(dateCandidates, "timeInBedMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
+      resolveMetric("timeInBedMinutes", selectValidSleepMetricCandidates(dateCandidates, "timeInBedMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
         metricFamily: "sleep",
       }),
       sessionMinutes,
       "Used the selected sleep session duration because no explicit time-in-bed metric was available.",
     );
-    const sleepEfficiency = resolveMetric("sleepEfficiency", selectValidSleepMetricCandidates(dateCandidates, "sleepEfficiency", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
+    const sleepEfficiency = resolveMetric("sleepEfficiency", selectValidSleepMetricCandidates(dateCandidates, "sleepEfficiency", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
       metricFamily: "sleep",
     });
-    const awakeMinutes = resolveMetric("awakeMinutes", selectValidSleepMetricCandidates(dateCandidates, "awakeMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
+    const awakeMinutes = resolveMetric("awakeMinutes", selectValidSleepMetricCandidates(dateCandidates, "awakeMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
       metricFamily: "sleep",
     });
-    const lightMinutes = resolveMetric("lightMinutes", selectValidSleepMetricCandidates(dateCandidates, "lightMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
+    const lightMinutes = resolveMetric("lightMinutes", selectValidSleepMetricCandidates(dateCandidates, "lightMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
       metricFamily: "sleep",
     });
-    const deepMinutes = resolveMetric("deepMinutes", selectValidSleepMetricCandidates(dateCandidates, "deepMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
+    const deepMinutes = resolveMetric("deepMinutes", selectValidSleepMetricCandidates(dateCandidates, "deepMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
       metricFamily: "sleep",
     });
-    const remMinutes = resolveMetric("remMinutes", selectValidSleepMetricCandidates(dateCandidates, "remMinutes", selectedWindow, sleepWindows, invalidZeroSleepProviders), {
+    const remMinutes = resolveMetric("remMinutes", selectValidSleepMetricCandidates(dateCandidates, "remMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
       metricFamily: "sleep",
     });
     const sleepScore = resolveMetric("sleepScore", selectSleepMetricCandidates(dateCandidates, "sleepScore", selectedWindow, sleepWindows), {

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -303,16 +303,57 @@ const ASLEEP_STAGE_TOTAL_METRICS: readonly WearableMetricKey[] = [
   "remMinutes",
 ];
 const APPLE_HEALTH_KIT_PROVIDER = "apple-health-kit";
-const INVALID_ZERO_SLEEP_METRICS = new Set<string>([
-  "totalSleepMinutes",
-  "sleepEfficiency",
-  "deepMinutes",
-  "lightMinutes",
-  "remMinutes",
+const INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS = new Map<WearableMetricKey, string>([
+  ["totalSleepMinutes", "total-sleep-minutes"],
+  ["sleepEfficiency", "sleep-efficiency"],
+  ["deepMinutes", "deep-sleep-minutes"],
+  ["lightMinutes", "sleep-light-minutes"],
+  ["remMinutes", "rem-sleep-minutes"],
 ]);
+const INVALID_ZERO_SLEEP_METRICS = new Set<string>(INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.keys());
 
 interface InvalidZeroSleepWindow {
   window: WearableSleepWindowCandidate;
+}
+
+export interface WearableMetricRecordSuppressionEvidence {
+  date: string;
+  metricKey: string;
+  recordIds: readonly string[];
+}
+
+export function collectWearableSleepMetricSuppressionEvidenceFromDataset(
+  dataset: WearableDataset,
+): WearableMetricRecordSuppressionEvidence[] {
+  const metricCandidatesByDate = groupMetricCandidatesByDate(
+    dataset.metricCandidates.filter((candidate) => metricSetHas(SLEEP_METRIC_KEYS, candidate.metric)),
+  );
+  const sleepWindowsByDate = groupSleepWindowsByDate(dataset.sleepWindows);
+  const dates = collectSortedDatesDesc([
+    ...metricCandidatesByDate.keys(),
+    ...sleepWindowsByDate.keys(),
+  ]);
+
+  return dates.flatMap((date) => {
+    const dateCandidates = metricCandidatesByDate.get(date) ?? [];
+    const invalidZeroSleepWindows = collectInvalidZeroSleepSummaryWindows(
+      dateCandidates,
+      sleepWindowsByDate.get(date) ?? [],
+    );
+    if (invalidZeroSleepWindows.length === 0) {
+      return [];
+    }
+
+    return [...INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.entries()].flatMap(([metric, metricKey]) => {
+      const recordIds = uniqueStrings(
+        selectMetricCandidates(dateCandidates, metric)
+          .filter((candidate) => isInvalidZeroSleepMetricCandidate(candidate, metric, invalidZeroSleepWindows))
+          .flatMap((candidate) => candidate.recordIds),
+      );
+
+      return recordIds.length > 0 ? [{ date, metricKey, recordIds }] : [];
+    });
+  });
 }
 
 function buildDerivedTotalSleepCandidates(

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -505,11 +505,7 @@ function collectInvalidZeroSleepSummaryWindows(
     if (
       !hasZeroMetricValue(windowCandidates, "totalSleepMinutes") ||
       awakeMinutes === null ||
-      window.durationMinutes <= awakeMinutes + 1 ||
-      !isMissingOrZeroMetric(windowCandidates, "sleepEfficiency") ||
-      !isMissingOrZeroMetric(windowCandidates, "deepMinutes") ||
-      !isMissingOrZeroMetric(windowCandidates, "lightMinutes") ||
-      !isMissingOrZeroMetric(windowCandidates, "remMinutes")
+      window.durationMinutes <= awakeMinutes + 1
     ) {
       continue;
     }
@@ -558,13 +554,6 @@ function hasZeroMetricValue(
   metric: WearableMetricKey,
 ): boolean {
   return candidates.some((candidate) => candidate.metric === metric && candidate.value === 0);
-}
-
-function isMissingOrZeroMetric(
-  candidates: readonly WearableMetricCandidate[],
-  metric: WearableMetricKey,
-): boolean {
-  return !candidates.some((candidate) => candidate.metric === metric && candidate.value > 0);
 }
 
 function isAppleHealthKitSleepCandidate(

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -315,7 +315,7 @@ const INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS = new Map<WearableMetricKey, st
 const INVALID_ZERO_SLEEP_METRICS = new Set<string>(INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.keys());
 
 interface InvalidZeroSleepWindow {
-  candidateIds: ReadonlySet<string>;
+  recordIds: ReadonlySet<string>;
   window: WearableSleepWindowCandidate;
 }
 
@@ -476,7 +476,7 @@ function isInvalidZeroSleepMetricCandidate(
 ): boolean {
   return INVALID_ZERO_SLEEP_METRICS.has(metric) &&
     candidate.value === 0 &&
-    invalidZeroWindows.some((entry) => entry.candidateIds.has(candidate.candidateId));
+    invalidZeroWindows.some((entry) => candidate.recordIds.some((recordId) => entry.recordIds.has(recordId)));
 }
 
 function preferDirectSleepMetricCandidates(
@@ -561,7 +561,7 @@ function collectInvalidZeroSleepSummaryWindows(
     }
 
     invalidWindows.push({
-      candidateIds: new Set(invalidZeroCandidates.map((candidate) => candidate.candidateId)),
+      recordIds: new Set(invalidZeroCandidates.flatMap((candidate) => candidate.recordIds)),
       window,
     });
   }

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -303,6 +303,8 @@ const ASLEEP_STAGE_TOTAL_METRICS: readonly WearableMetricKey[] = [
   "remMinutes",
 ];
 const APPLE_HEALTH_KIT_PROVIDER = "apple-health-kit";
+const JUNCTION_SLEEP_STAGE_SUMMARY_NORMALIZER_VERSION = "junction-sleep-stage-summary.v1";
+const JUNCTION_SLEEP_STAGE_CYCLE_FALLBACK_NORMALIZER_VERSION = "junction-sleep-stage-cycle-fallback.v1";
 const INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS = new Map<WearableMetricKey, string>([
   ["totalSleepMinutes", "total-sleep-minutes"],
   ["sleepEfficiency", "sleep-efficiency"],
@@ -313,6 +315,7 @@ const INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS = new Map<WearableMetricKey, st
 const INVALID_ZERO_SLEEP_METRICS = new Set<string>(INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.keys());
 
 interface InvalidZeroSleepWindow {
+  candidateIds: ReadonlySet<string>;
   window: WearableSleepWindowCandidate;
 }
 
@@ -473,7 +476,7 @@ function isInvalidZeroSleepMetricCandidate(
 ): boolean {
   return INVALID_ZERO_SLEEP_METRICS.has(metric) &&
     candidate.value === 0 &&
-    invalidZeroWindows.some((entry) => sleepMetricAssociatedWithWindow(candidate, entry.window));
+    invalidZeroWindows.some((entry) => entry.candidateIds.has(candidate.candidateId));
 }
 
 function preferDirectSleepMetricCandidates(
@@ -543,18 +546,81 @@ function collectInvalidZeroSleepSummaryWindows(
 
     const windowCandidates = candidates.filter((candidate) => sleepMetricAssociatedWithWindow(candidate, window));
     const awakeMinutes = firstPositiveMetricValue(windowCandidates, "awakeMinutes");
+    const invalidZeroTotalCandidates = collectInvalidZeroSleepTotalCandidates(windowCandidates, window);
+    const invalidZeroCandidates = collectInvalidZeroSleepMetricCandidates(
+      windowCandidates,
+      window,
+      invalidZeroTotalCandidates,
+    );
     if (
-      !hasZeroMetricValue(windowCandidates, "totalSleepMinutes") ||
+      invalidZeroTotalCandidates.length === 0 ||
       awakeMinutes === null ||
       window.durationMinutes <= awakeMinutes + 1
     ) {
       continue;
     }
 
-    invalidWindows.push({ window });
+    invalidWindows.push({
+      candidateIds: new Set(invalidZeroCandidates.map((candidate) => candidate.candidateId)),
+      window,
+    });
   }
 
   return invalidWindows;
+}
+
+function collectInvalidZeroSleepTotalCandidates(
+  candidates: readonly WearableMetricCandidate[],
+  window: WearableSleepWindowCandidate,
+): WearableMetricCandidate[] {
+  return candidates.filter((candidate) =>
+    candidate.metric === "totalSleepMinutes" &&
+    candidate.value === 0 &&
+    isInvalidZeroSleepSummaryOwnedCandidate(candidate, window)
+  );
+}
+
+function collectInvalidZeroSleepMetricCandidates(
+  candidates: readonly WearableMetricCandidate[],
+  window: WearableSleepWindowCandidate,
+  invalidZeroTotalCandidates: readonly WearableMetricCandidate[],
+): WearableMetricCandidate[] {
+  return candidates.filter((candidate) =>
+    INVALID_ZERO_SLEEP_METRICS.has(candidate.metric) &&
+    candidate.value === 0 &&
+    (
+      isInvalidZeroSleepSummaryOwnedCandidate(candidate, window) ||
+      isLegacyInvalidZeroSleepSummaryCompanion(candidate, invalidZeroTotalCandidates)
+    )
+  );
+}
+
+function isInvalidZeroSleepSummaryOwnedCandidate(
+  candidate: WearableMetricCandidate,
+  window: WearableSleepWindowCandidate,
+): boolean {
+  const normalizerVersion = normalizeResourceToken(candidate.dataOrigin?.normalizerVersion);
+  if (normalizerVersion === JUNCTION_SLEEP_STAGE_CYCLE_FALLBACK_NORMALIZER_VERSION) {
+    return false;
+  }
+
+  return sleepMetricMatchesWindow(candidate, window) ||
+    normalizerVersion === JUNCTION_SLEEP_STAGE_SUMMARY_NORMALIZER_VERSION;
+}
+
+function isLegacyInvalidZeroSleepSummaryCompanion(
+  candidate: WearableMetricCandidate,
+  invalidZeroTotalCandidates: readonly WearableMetricCandidate[],
+): boolean {
+  if (normalizeResourceToken(candidate.dataOrigin?.normalizerVersion)) {
+    return false;
+  }
+
+  return invalidZeroTotalCandidates.some((totalCandidate) =>
+    candidate.provider === totalCandidate.provider &&
+    wearableDataOriginKey(candidate.dataOrigin) === wearableDataOriginKey(totalCandidate.dataOrigin) &&
+    candidate.recordedAt === totalCandidate.recordedAt
+  );
 }
 
 function sleepMetricAssociatedWithWindow(
@@ -588,13 +654,6 @@ function firstPositiveMetricValue(
   metric: WearableMetricKey,
 ): number | null {
   return candidates.find((candidate) => candidate.metric === metric && candidate.value > 0)?.value ?? null;
-}
-
-function hasZeroMetricValue(
-  candidates: readonly WearableMetricCandidate[],
-  metric: WearableMetricKey,
-): boolean {
-  return candidates.some((candidate) => candidate.metric === metric && candidate.value === 0);
 }
 
 function isAppleHealthKitSleepCandidate(

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -419,8 +419,9 @@ function selectValidSleepMetricCandidates(
   sleepWindows: readonly WearableSleepWindowCandidate[],
   invalidZeroWindows: readonly InvalidZeroSleepWindow[],
 ): WearableMetricCandidate[] {
-  const selectedCandidates = selectSleepMetricCandidates(candidates, metric, selectedWindow, sleepWindows)
+  const validMetricCandidates = selectMetricCandidates(candidates, metric)
     .filter((candidate) => !isInvalidZeroSleepMetricCandidate(candidate, metric, invalidZeroWindows));
+  const selectedCandidates = selectSleepWindowMetricCandidates(validMetricCandidates, selectedWindow, sleepWindows);
   return preferDirectSleepMetricCandidates(selectedCandidates);
 }
 
@@ -500,11 +501,10 @@ function collectInvalidZeroSleepSummaryWindows(
     }
 
     const windowCandidates = candidates.filter((candidate) => sleepMetricAssociatedWithWindow(candidate, window));
-    const awakeMinutes = firstMetricValue(windowCandidates, "awakeMinutes");
+    const awakeMinutes = firstPositiveMetricValue(windowCandidates, "awakeMinutes");
     if (
-      firstMetricValue(windowCandidates, "totalSleepMinutes") !== 0 ||
+      !hasZeroMetricValue(windowCandidates, "totalSleepMinutes") ||
       awakeMinutes === null ||
-      awakeMinutes <= 0 ||
       window.durationMinutes <= awakeMinutes + 1 ||
       !isMissingOrZeroMetric(windowCandidates, "sleepEfficiency") ||
       !isMissingOrZeroMetric(windowCandidates, "deepMinutes") ||
@@ -546,19 +546,25 @@ function sleepMetricOccursInsideWindow(
   return occurredAtMs >= startAtMs - toleranceMs && occurredAtMs <= endAtMs + toleranceMs;
 }
 
-function firstMetricValue(
+function firstPositiveMetricValue(
   candidates: readonly WearableMetricCandidate[],
   metric: WearableMetricKey,
 ): number | null {
-  return candidates.find((candidate) => candidate.metric === metric)?.value ?? null;
+  return candidates.find((candidate) => candidate.metric === metric && candidate.value > 0)?.value ?? null;
+}
+
+function hasZeroMetricValue(
+  candidates: readonly WearableMetricCandidate[],
+  metric: WearableMetricKey,
+): boolean {
+  return candidates.some((candidate) => candidate.metric === metric && candidate.value === 0);
 }
 
 function isMissingOrZeroMetric(
   candidates: readonly WearableMetricCandidate[],
   metric: WearableMetricKey,
 ): boolean {
-  const value = firstMetricValue(candidates, metric);
-  return value === null || value === 0;
+  return !candidates.some((candidate) => candidate.metric === metric && candidate.value > 0);
 }
 
 function isAppleHealthKitSleepCandidate(

--- a/packages/query/src/wearables.ts
+++ b/packages/query/src/wearables.ts
@@ -29,6 +29,13 @@ import {
 import { buildWearableSourceHealth } from "./wearables/source-health.ts";
 import { resolveWearablePublicSourceProvider, wearableDataOriginKey } from "./wearables/origin.ts";
 import {
+  isAppleHealthKitSleepCandidate,
+  sleepMetricAssociatedWithWindow,
+  sleepMetricMatchesNonSelectedWindow,
+  sleepMetricMatchesWindow,
+  sleepWindowsRepresentSameWindow,
+} from "./wearables/sleep-association.ts";
+import {
   buildCandidateId,
   collectLatestDate,
   collectSortedDatesDesc,
@@ -302,62 +309,6 @@ const ASLEEP_STAGE_TOTAL_METRICS: readonly WearableMetricKey[] = [
   "lightMinutes",
   "remMinutes",
 ];
-const APPLE_HEALTH_KIT_PROVIDER = "apple-health-kit";
-const JUNCTION_SLEEP_STAGE_SUMMARY_NORMALIZER_VERSION = "junction-sleep-stage-summary.v1";
-const JUNCTION_SLEEP_STAGE_CYCLE_FALLBACK_NORMALIZER_VERSION = "junction-sleep-stage-cycle-fallback.v1";
-const INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS = new Map<WearableMetricKey, string>([
-  ["totalSleepMinutes", "total-sleep-minutes"],
-  ["sleepEfficiency", "sleep-efficiency"],
-  ["deepMinutes", "deep-sleep-minutes"],
-  ["lightMinutes", "sleep-light-minutes"],
-  ["remMinutes", "rem-sleep-minutes"],
-]);
-const INVALID_ZERO_SLEEP_METRICS = new Set<string>(INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.keys());
-
-interface InvalidZeroSleepWindow {
-  recordIds: ReadonlySet<string>;
-  window: WearableSleepWindowCandidate;
-}
-
-export interface WearableMetricRecordSuppressionEvidence {
-  date: string;
-  metricKey: string;
-  recordIds: readonly string[];
-}
-
-export function collectWearableSleepMetricSuppressionEvidenceFromDataset(
-  dataset: WearableDataset,
-): WearableMetricRecordSuppressionEvidence[] {
-  const metricCandidatesByDate = groupMetricCandidatesByDate(
-    dataset.metricCandidates.filter((candidate) => metricSetHas(SLEEP_METRIC_KEYS, candidate.metric)),
-  );
-  const sleepWindowsByDate = groupSleepWindowsByDate(dataset.sleepWindows);
-  const dates = collectSortedDatesDesc([
-    ...metricCandidatesByDate.keys(),
-    ...sleepWindowsByDate.keys(),
-  ]);
-
-  return dates.flatMap((date) => {
-    const dateCandidates = metricCandidatesByDate.get(date) ?? [];
-    const invalidZeroSleepWindows = collectInvalidZeroSleepSummaryWindows(
-      dateCandidates,
-      sleepWindowsByDate.get(date) ?? [],
-    );
-    if (invalidZeroSleepWindows.length === 0) {
-      return [];
-    }
-
-    return [...INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.entries()].flatMap(([metric, metricKey]) => {
-      const recordIds = uniqueStrings(
-        selectMetricCandidates(dateCandidates, metric)
-          .filter((candidate) => isInvalidZeroSleepMetricCandidate(candidate, metric, invalidZeroSleepWindows))
-          .flatMap((candidate) => candidate.recordIds),
-      );
-
-      return recordIds.length > 0 ? [{ date, metricKey, recordIds }] : [];
-    });
-  });
-}
 
 function buildDerivedTotalSleepCandidates(
   date: string,
@@ -456,27 +407,15 @@ function selectSleepMetricCandidates(
   return selectSleepWindowMetricCandidates(selectMetricCandidates(candidates, metric), selectedWindow, sleepWindows);
 }
 
-function selectValidSleepMetricCandidates(
+function selectPreferredSleepMetricCandidates(
   candidates: readonly WearableMetricCandidate[],
   metric: WearableMetricKey,
   selectedWindow: WearableSleepWindowCandidate | null,
   sleepWindows: readonly WearableSleepWindowCandidate[],
-  invalidZeroWindows: readonly InvalidZeroSleepWindow[],
 ): WearableMetricCandidate[] {
-  const validMetricCandidates = selectMetricCandidates(candidates, metric)
-    .filter((candidate) => !isInvalidZeroSleepMetricCandidate(candidate, metric, invalidZeroWindows));
-  const selectedCandidates = selectSleepWindowMetricCandidates(validMetricCandidates, selectedWindow, sleepWindows);
-  return preferDirectSleepMetricCandidates(selectedCandidates);
-}
-
-function isInvalidZeroSleepMetricCandidate(
-  candidate: WearableMetricCandidate,
-  metric: string,
-  invalidZeroWindows: readonly InvalidZeroSleepWindow[],
-): boolean {
-  return INVALID_ZERO_SLEEP_METRICS.has(metric) &&
-    candidate.value === 0 &&
-    invalidZeroWindows.some((entry) => candidate.recordIds.some((recordId) => entry.recordIds.has(recordId)));
+  return preferDirectSleepMetricCandidates(
+    selectSleepMetricCandidates(candidates, metric, selectedWindow, sleepWindows),
+  );
 }
 
 function preferDirectSleepMetricCandidates(
@@ -504,176 +443,6 @@ function preferDirectSleepWindows(
   );
 }
 
-function sleepWindowsRepresentSameWindow(
-  left: WearableSleepWindowCandidate,
-  right: WearableSleepWindowCandidate,
-): boolean {
-  const toleranceMinutes = resolveMetricTolerance("sessionMinutes");
-  return timestampsWithinMinutes(left.startAt, right.startAt, toleranceMinutes) &&
-    timestampsWithinMinutes(left.endAt, right.endAt, toleranceMinutes) &&
-    Math.abs(left.durationMinutes - right.durationMinutes) <= toleranceMinutes;
-}
-
-function timestampsWithinMinutes(
-  left: string | null | undefined,
-  right: string | null | undefined,
-  toleranceMinutes: number,
-): boolean {
-  if (!left || !right) {
-    return left === right;
-  }
-
-  const leftMs = Date.parse(left);
-  const rightMs = Date.parse(right);
-  if (!Number.isFinite(leftMs) || !Number.isFinite(rightMs)) {
-    return left === right;
-  }
-
-  return Math.abs(leftMs - rightMs) / 60000 <= toleranceMinutes;
-}
-
-function collectInvalidZeroSleepSummaryWindows(
-  candidates: readonly WearableMetricCandidate[],
-  sleepWindows: readonly WearableSleepWindowCandidate[],
-): InvalidZeroSleepWindow[] {
-  const invalidWindows: InvalidZeroSleepWindow[] = [];
-
-  for (const window of sleepWindows) {
-    const provider = resolveSleepCandidateProvider(window);
-    if (provider !== APPLE_HEALTH_KIT_PROVIDER) {
-      continue;
-    }
-
-    const windowCandidates = candidates.filter((candidate) => sleepMetricAssociatedWithWindow(candidate, window));
-    const awakeMinutes = firstPositiveMetricValue(windowCandidates, "awakeMinutes");
-    const invalidZeroTotalCandidates = collectInvalidZeroSleepTotalCandidates(windowCandidates, window);
-    const invalidZeroCandidates = collectInvalidZeroSleepMetricCandidates(
-      windowCandidates,
-      window,
-      invalidZeroTotalCandidates,
-    );
-    if (
-      invalidZeroTotalCandidates.length === 0 ||
-      awakeMinutes === null ||
-      window.durationMinutes <= awakeMinutes + 1
-    ) {
-      continue;
-    }
-
-    invalidWindows.push({
-      recordIds: new Set(invalidZeroCandidates.flatMap((candidate) => candidate.recordIds)),
-      window,
-    });
-  }
-
-  return invalidWindows;
-}
-
-function collectInvalidZeroSleepTotalCandidates(
-  candidates: readonly WearableMetricCandidate[],
-  window: WearableSleepWindowCandidate,
-): WearableMetricCandidate[] {
-  return candidates.filter((candidate) =>
-    candidate.metric === "totalSleepMinutes" &&
-    candidate.value === 0 &&
-    isInvalidZeroSleepSummaryOwnedCandidate(candidate, window)
-  );
-}
-
-function collectInvalidZeroSleepMetricCandidates(
-  candidates: readonly WearableMetricCandidate[],
-  window: WearableSleepWindowCandidate,
-  invalidZeroTotalCandidates: readonly WearableMetricCandidate[],
-): WearableMetricCandidate[] {
-  return candidates.filter((candidate) =>
-    INVALID_ZERO_SLEEP_METRICS.has(candidate.metric) &&
-    candidate.value === 0 &&
-    (
-      isInvalidZeroSleepSummaryOwnedCandidate(candidate, window) ||
-      isLegacyInvalidZeroSleepSummaryCompanion(candidate, invalidZeroTotalCandidates)
-    )
-  );
-}
-
-function isInvalidZeroSleepSummaryOwnedCandidate(
-  candidate: WearableMetricCandidate,
-  window: WearableSleepWindowCandidate,
-): boolean {
-  const normalizerVersion = normalizeResourceToken(candidate.dataOrigin?.normalizerVersion);
-  if (normalizerVersion === JUNCTION_SLEEP_STAGE_CYCLE_FALLBACK_NORMALIZER_VERSION) {
-    return false;
-  }
-
-  return sleepMetricMatchesWindow(candidate, window) ||
-    normalizerVersion === JUNCTION_SLEEP_STAGE_SUMMARY_NORMALIZER_VERSION;
-}
-
-function isLegacyInvalidZeroSleepSummaryCompanion(
-  candidate: WearableMetricCandidate,
-  invalidZeroTotalCandidates: readonly WearableMetricCandidate[],
-): boolean {
-  if (normalizeResourceToken(candidate.dataOrigin?.normalizerVersion)) {
-    return false;
-  }
-
-  return invalidZeroTotalCandidates.some((totalCandidate) =>
-    candidate.provider === totalCandidate.provider &&
-    wearableDataOriginKey(candidate.dataOrigin) === wearableDataOriginKey(totalCandidate.dataOrigin) &&
-    candidate.recordedAt === totalCandidate.recordedAt
-  );
-}
-
-function sleepMetricAssociatedWithWindow(
-  candidate: WearableMetricCandidate,
-  window: WearableSleepWindowCandidate,
-): boolean {
-  if (resolveSleepCandidateProvider(candidate) !== resolveSleepCandidateProvider(window)) {
-    return false;
-  }
-
-  return sleepMetricMatchesWindow(candidate, window) || sleepMetricOccursInsideWindow(candidate, window);
-}
-
-function sleepMetricOccursInsideWindow(
-  candidate: WearableMetricCandidate,
-  window: WearableSleepWindowCandidate,
-): boolean {
-  const occurredAtMs = Date.parse(candidate.occurredAt ?? "");
-  const startAtMs = Date.parse(window.startAt ?? "");
-  const endAtMs = Date.parse(window.endAt ?? "");
-  if (!Number.isFinite(occurredAtMs) || !Number.isFinite(startAtMs) || !Number.isFinite(endAtMs)) {
-    return false;
-  }
-
-  const toleranceMs = resolveMetricTolerance("sessionMinutes") * 60000;
-  return occurredAtMs >= startAtMs - toleranceMs && occurredAtMs <= endAtMs + toleranceMs;
-}
-
-function firstPositiveMetricValue(
-  candidates: readonly WearableMetricCandidate[],
-  metric: WearableMetricKey,
-): number | null {
-  return candidates.find((candidate) => candidate.metric === metric && candidate.value > 0)?.value ?? null;
-}
-
-function isAppleHealthKitSleepCandidate(
-  candidate: Pick<WearableMetricCandidate | WearableSleepWindowCandidate, "dataOrigin" | "externalRef" | "provider">,
-): boolean {
-  return resolveSleepCandidateProvider(candidate) === APPLE_HEALTH_KIT_PROVIDER;
-}
-
-function resolveSleepCandidateProvider(
-  candidate: Pick<WearableMetricCandidate | WearableSleepWindowCandidate, "dataOrigin" | "externalRef" | "provider">,
-): string {
-  return resolveWearablePublicSourceProvider({
-    dataOrigin: candidate.dataOrigin,
-    externalRef: candidate.externalRef,
-    provider: candidate.provider,
-  }, {
-    suppressJunctionSourceInstanceFallback: true,
-  });
-}
-
 function buildDerivedTotalSleepCandidatesForWindow(
   date: string,
   candidates: readonly WearableMetricCandidate[],
@@ -697,61 +466,6 @@ function buildDerivedTotalSleepCandidatesForWindow(
       );
 }
 
-function sleepMetricMatchesWindow(
-  candidate: WearableMetricCandidate,
-  selectedWindow: WearableSleepWindowCandidate,
-): boolean {
-  const candidateRef = candidate.externalRef;
-  const windowRef = selectedWindow.externalRef;
-  const candidateResourceId = normalizeResourceToken(candidateRef?.resourceId);
-  const windowResourceId = normalizeResourceToken(windowRef?.resourceId);
-
-  if (!candidateResourceId || !windowResourceId || candidateResourceId !== windowResourceId) {
-    return false;
-  }
-
-  if (candidate.provider !== selectedWindow.provider) {
-    return false;
-  }
-
-  const candidateSystem = normalizeResourceToken(candidateRef?.system);
-  const windowSystem = normalizeResourceToken(windowRef?.system);
-  if (candidateSystem && windowSystem && candidateSystem !== windowSystem) {
-    return false;
-  }
-
-  return sleepResourceTypesCompatible(candidateRef?.resourceType, windowRef?.resourceType);
-}
-
-function sleepMetricMatchesNonSelectedWindow(
-  candidate: WearableMetricCandidate,
-  selectedWindow: WearableSleepWindowCandidate,
-  sleepWindows: readonly WearableSleepWindowCandidate[],
-): boolean {
-  return sleepWindows.some((window) =>
-    window.candidateId !== selectedWindow.candidateId && sleepMetricAssociatedWithWindow(candidate, window)
-  );
-}
-
-function sleepResourceTypesCompatible(
-  candidateResourceType: string | null | undefined,
-  windowResourceType: string | null | undefined,
-): boolean {
-  const candidateType = normalizeResourceToken(candidateResourceType);
-  const windowType = normalizeResourceToken(windowResourceType);
-
-  if (!candidateType || !windowType) {
-    return true;
-  }
-
-  return candidateType === windowType || (candidateType.includes("sleep") && windowType.includes("sleep"));
-}
-
-function normalizeResourceToken(value: string | null | undefined): string | null {
-  const trimmed = value?.trim().toLowerCase() ?? "";
-  return trimmed.length > 0 ? trimmed : null;
-}
-
 function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableSleepNight[] {
   const metricCandidatesByDate = groupMetricCandidatesByDate(
     dataset.metricCandidates.filter((candidate) => metricSetHas(SLEEP_METRIC_KEYS, candidate.metric)),
@@ -768,11 +482,10 @@ function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableS
     const sleepWindows = preferDirectSleepWindows(rawSleepWindows);
     const windowSelection = resolveSleepWindowSelection(sleepWindows);
     const selectedWindow = windowSelection.selection;
-    const invalidZeroSleepWindows = collectInvalidZeroSleepSummaryWindows(dateCandidates, rawSleepWindows);
     const sessionMinutes = resolveSessionMinutesForSleepWindows(selectedWindow, sleepWindows);
     const directTotalSleepMinutes = resolveMetric(
       "totalSleepMinutes",
-      selectValidSleepMetricCandidates(dateCandidates, "totalSleepMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows),
+      selectPreferredSleepMetricCandidates(dateCandidates, "totalSleepMinutes", selectedWindow, sleepWindows),
       {
         metricFamily: "sleep",
       },
@@ -782,34 +495,32 @@ function listWearableSleepNightsFromDataset(dataset: WearableDataset): WearableS
         ? directTotalSleepMinutes
         : resolveMetric("totalSleepMinutes", buildDerivedTotalSleepCandidatesForWindow(
             date,
-            dateCandidates.filter((candidate) =>
-              !isInvalidZeroSleepMetricCandidate(candidate, candidate.metric, invalidZeroSleepWindows)
-            ),
+            dateCandidates,
             selectedWindow,
             sleepWindows,
           ), {
             metricFamily: "sleep",
           });
     const timeInBedMinutes = withMetricFallback(
-      resolveMetric("timeInBedMinutes", selectValidSleepMetricCandidates(dateCandidates, "timeInBedMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
+      resolveMetric("timeInBedMinutes", selectPreferredSleepMetricCandidates(dateCandidates, "timeInBedMinutes", selectedWindow, sleepWindows), {
         metricFamily: "sleep",
       }),
       sessionMinutes,
       "Used the selected sleep session duration because no explicit time-in-bed metric was available.",
     );
-    const sleepEfficiency = resolveMetric("sleepEfficiency", selectValidSleepMetricCandidates(dateCandidates, "sleepEfficiency", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
+    const sleepEfficiency = resolveMetric("sleepEfficiency", selectPreferredSleepMetricCandidates(dateCandidates, "sleepEfficiency", selectedWindow, sleepWindows), {
       metricFamily: "sleep",
     });
-    const awakeMinutes = resolveMetric("awakeMinutes", selectValidSleepMetricCandidates(dateCandidates, "awakeMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
+    const awakeMinutes = resolveMetric("awakeMinutes", selectPreferredSleepMetricCandidates(dateCandidates, "awakeMinutes", selectedWindow, sleepWindows), {
       metricFamily: "sleep",
     });
-    const lightMinutes = resolveMetric("lightMinutes", selectValidSleepMetricCandidates(dateCandidates, "lightMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
+    const lightMinutes = resolveMetric("lightMinutes", selectPreferredSleepMetricCandidates(dateCandidates, "lightMinutes", selectedWindow, sleepWindows), {
       metricFamily: "sleep",
     });
-    const deepMinutes = resolveMetric("deepMinutes", selectValidSleepMetricCandidates(dateCandidates, "deepMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
+    const deepMinutes = resolveMetric("deepMinutes", selectPreferredSleepMetricCandidates(dateCandidates, "deepMinutes", selectedWindow, sleepWindows), {
       metricFamily: "sleep",
     });
-    const remMinutes = resolveMetric("remMinutes", selectValidSleepMetricCandidates(dateCandidates, "remMinutes", selectedWindow, sleepWindows, invalidZeroSleepWindows), {
+    const remMinutes = resolveMetric("remMinutes", selectPreferredSleepMetricCandidates(dateCandidates, "remMinutes", selectedWindow, sleepWindows), {
       metricFamily: "sleep",
     });
     const sleepScore = resolveMetric("sleepScore", selectSleepMetricCandidates(dateCandidates, "sleepScore", selectedWindow, sleepWindows), {

--- a/packages/query/src/wearables/candidates.ts
+++ b/packages/query/src/wearables/candidates.ts
@@ -20,6 +20,12 @@ import {
 } from "./origin.ts";
 import { formatProviderName } from "./provider-policy.ts";
 import {
+  normalizeResourceToken,
+  resolveSleepCandidateProvider,
+  sleepMetricAssociatedWithWindow,
+  sleepMetricMatchesWindow,
+} from "./sleep-association.ts";
+import {
   buildCandidateId,
   collectSortedDatesDesc,
   latestIsoTimestamp,
@@ -39,12 +45,25 @@ import type {
   WearableHeartRateZoneAggregate,
   WearableMetricCandidate,
   WearableMetricKey,
+  WearableMetricSuppressionEvidence,
   WearableMetricSelection,
   WearableProvenanceDiagnostic,
   WearableSleepWindowCandidate,
 } from "./types.ts";
 
 import { compareMetricCandidateByDateDesc, compareSleepWindowByDateDesc } from "./selection.ts";
+
+const APPLE_HEALTH_KIT_PROVIDER = "apple-health-kit";
+const JUNCTION_SLEEP_STAGE_SUMMARY_NORMALIZER_VERSION = "junction-sleep-stage-summary.v1";
+const JUNCTION_SLEEP_STAGE_CYCLE_FALLBACK_NORMALIZER_VERSION = "junction-sleep-stage-cycle-fallback.v1";
+const INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS = new Map<WearableMetricKey, string>([
+  ["totalSleepMinutes", "total-sleep-minutes"],
+  ["sleepEfficiency", "sleep-efficiency"],
+  ["deepMinutes", "deep-sleep-minutes"],
+  ["lightMinutes", "sleep-light-minutes"],
+  ["remMinutes", "rem-sleep-minutes"],
+]);
+const INVALID_ZERO_SLEEP_METRICS = new Set<string>(INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.keys());
 
 export function collectWearableDataset(
   vault: VaultReadModel,
@@ -165,18 +184,143 @@ export function collectWearableDataset(
   const filteredSleepWindows = dedupedSleepWindows.filter((candidate) => matchesDateFilters(candidate.date, filters));
   const sleepStageAggregates = buildSleepStageAggregateCandidates(sleepStageCandidates, dedupedSleepWindows)
     .filter((candidate) => matchesDateFilters(candidate.date, filters));
+  const sanitizedMetricCandidates = sanitizeWearableMetricCandidates(rawMetricCandidates, dedupedSleepWindows);
   const metricCandidates = [
-    ...dedupeExactMetricCandidates(rawMetricCandidates).candidates,
+    ...dedupeExactMetricCandidates(sanitizedMetricCandidates.candidates).candidates,
     ...dedupeExactMetricCandidates(sleepStageAggregates).candidates,
   ].sort(compareMetricCandidateByDateDesc);
 
   return {
     activitySessionAggregates: buildActivitySessionAggregates(activitySessions),
+    metricSuppressionEvidence: sanitizedMetricCandidates.suppressionEvidence,
     metricCandidates,
     provenanceDiagnostics: [...provenanceDiagnostics.values()].sort(compareWearableProvenanceDiagnostics),
     rawMetricCandidates,
     sleepWindows: filteredSleepWindows,
   };
+}
+
+function sanitizeWearableMetricCandidates(
+  candidates: readonly WearableMetricCandidate[],
+  sleepWindows: readonly WearableSleepWindowCandidate[],
+): {
+  candidates: WearableMetricCandidate[];
+  suppressionEvidence: WearableMetricSuppressionEvidence[];
+} {
+  const invalidCandidates = collectInvalidAppleZeroSleepMetricCandidates(candidates, sleepWindows);
+  const invalidRecordIds = new Set(invalidCandidates.flatMap((candidate) => candidate.recordIds));
+
+  return {
+    candidates: candidates.filter((candidate) => !candidate.recordIds.some((recordId) => invalidRecordIds.has(recordId))),
+    suppressionEvidence: buildMetricSuppressionEvidence(invalidCandidates),
+  };
+}
+
+function collectInvalidAppleZeroSleepMetricCandidates(
+  candidates: readonly WearableMetricCandidate[],
+  sleepWindows: readonly WearableSleepWindowCandidate[],
+): WearableMetricCandidate[] {
+  const invalidCandidates: WearableMetricCandidate[] = [];
+
+  for (const window of sleepWindows) {
+    if (resolveSleepCandidateProvider(window) !== APPLE_HEALTH_KIT_PROVIDER) {
+      continue;
+    }
+
+    const windowCandidates = candidates.filter((candidate) => sleepMetricAssociatedWithWindow(candidate, window));
+    const awakeMinutes = firstPositiveMetricValue(windowCandidates, "awakeMinutes");
+    const invalidZeroTotalCandidates = windowCandidates.filter((candidate) =>
+      candidate.metric === "totalSleepMinutes" &&
+      candidate.value === 0 &&
+      isInvalidZeroSleepSummaryOwnedCandidate(candidate, window)
+    );
+    if (
+      invalidZeroTotalCandidates.length === 0 ||
+      awakeMinutes === null ||
+      window.durationMinutes <= awakeMinutes + 1
+    ) {
+      continue;
+    }
+
+    invalidCandidates.push(
+      ...windowCandidates.filter((candidate) =>
+        INVALID_ZERO_SLEEP_METRICS.has(candidate.metric) &&
+        candidate.value === 0 &&
+        (
+          isInvalidZeroSleepSummaryOwnedCandidate(candidate, window) ||
+          isLegacyInvalidZeroSleepSummaryCompanion(candidate, invalidZeroTotalCandidates)
+        )
+      ),
+    );
+  }
+
+  const invalidRecordIds = new Set<string>();
+  return invalidCandidates.filter((candidate) => {
+    const unseenRecordIds = candidate.recordIds.filter((recordId) => !invalidRecordIds.has(recordId));
+    for (const recordId of unseenRecordIds) {
+      invalidRecordIds.add(recordId);
+    }
+    return unseenRecordIds.length > 0;
+  });
+}
+
+function buildMetricSuppressionEvidence(
+  invalidCandidates: readonly WearableMetricCandidate[],
+): WearableMetricSuppressionEvidence[] {
+  const evidence = new Map<string, { date: string; metricKey: string; recordIds: string[] }>();
+
+  for (const candidate of invalidCandidates) {
+    const metricKey = INVALID_ZERO_SLEEP_METRIC_SUPPRESSION_KEYS.get(candidate.metric as WearableMetricKey);
+    if (!metricKey) {
+      continue;
+    }
+
+    const key = `${candidate.date}\0${metricKey}`;
+    const existing = evidence.get(key) ?? {
+      date: candidate.date,
+      metricKey,
+      recordIds: [],
+    };
+    existing.recordIds = uniqueStrings([...existing.recordIds, ...candidate.recordIds]);
+    evidence.set(key, existing);
+  }
+
+  return [...evidence.values()];
+}
+
+function isInvalidZeroSleepSummaryOwnedCandidate(
+  candidate: WearableMetricCandidate,
+  window: WearableSleepWindowCandidate,
+): boolean {
+  const normalizerVersion = normalizeResourceToken(candidate.dataOrigin?.normalizerVersion);
+  if (normalizerVersion === JUNCTION_SLEEP_STAGE_CYCLE_FALLBACK_NORMALIZER_VERSION) {
+    return false;
+  }
+
+  return sleepMetricMatchesWindow(candidate, window) ||
+    normalizerVersion === JUNCTION_SLEEP_STAGE_SUMMARY_NORMALIZER_VERSION;
+}
+
+function isLegacyInvalidZeroSleepSummaryCompanion(
+  candidate: WearableMetricCandidate,
+  invalidZeroTotalCandidates: readonly WearableMetricCandidate[],
+): boolean {
+  if (normalizeResourceToken(candidate.dataOrigin?.normalizerVersion)) {
+    return false;
+  }
+
+  return invalidZeroTotalCandidates.some((totalCandidate) =>
+    candidate.provider === totalCandidate.provider &&
+    wearableDataOriginKey(candidate.dataOrigin) === wearableDataOriginKey(totalCandidate.dataOrigin) &&
+    candidate.recordedAt === totalCandidate.recordedAt
+  );
+}
+
+function firstPositiveMetricValue(
+  candidates: readonly WearableMetricCandidate[],
+  metric: WearableMetricKey,
+): number | null {
+  return candidates.find((candidate) => candidate.metric === metric && candidate.value > 0)?.value ?? null;
 }
 
 export function buildActivitySessionAggregates(

--- a/packages/query/src/wearables/dedupe.ts
+++ b/packages/query/src/wearables/dedupe.ts
@@ -2,7 +2,7 @@ import type {
   WearableMetricCandidate,
   WearableSleepWindowCandidate,
 } from "./types.ts";
-import { latestIsoTimestamp, uniqueStrings } from "./shared.ts";
+import { latestIsoTimestamp, normalizeLowercaseString, uniqueStrings } from "./shared.ts";
 import { wearableDataOriginKey } from "./origin.ts";
 
 export function dedupeExactMetricCandidates(
@@ -72,10 +72,12 @@ export function dedupeSleepWindowCandidates(
 
 export function buildCandidateExactKey(candidate: WearableMetricCandidate): string {
   const originKey = wearableDataOriginKey(candidate.dataOrigin);
+  const normalizerVersion = normalizeLowercaseString(candidate.dataOrigin?.normalizerVersion) ?? "";
 
   return [
     candidate.provider,
     ...(originKey ? [originKey] : []),
+    ...(normalizerVersion ? [`normalizer:${normalizerVersion}`] : []),
     candidate.date,
     candidate.metric,
     candidate.unit ?? "",

--- a/packages/query/src/wearables/selection.ts
+++ b/packages/query/src/wearables/selection.ts
@@ -335,6 +335,7 @@ function rankSleepWindows(
     candidates.map((candidate) => candidate.recordedAt ?? candidate.endAt ?? candidate.startAt),
   );
   const durationScores = buildNumberRankScores(candidates.map((candidate) => candidate.durationMinutes));
+  const maxDurationMinutes = Math.max(0, ...candidates.map((candidate) => candidate.durationMinutes));
   const scorecards = new Map<string, WearableSleepWindowScorecard>();
 
   for (const candidate of candidates) {
@@ -343,7 +344,7 @@ function rankSleepWindows(
     const recencyScore = recencyScores.get(candidate.recordedAt ?? candidate.endAt ?? candidate.startAt ?? "") ?? 0;
     const durationScore = durationScores.get(candidate.durationMinutes) ?? 0;
     const agreementScore = scoreSleepWindowAgreement(candidate, candidates);
-    const napPenalty = candidate.nap ? -6 : 0;
+    const napPenalty = candidate.nap || isShortWindowBesideMainSleep(candidate, maxDurationMinutes) ? -6 : 0;
 
     scorecards.set(candidate.candidateId, {
       agreementScore,
@@ -382,6 +383,13 @@ function rankSleepWindows(
     scorecards,
     sortedCandidates,
   };
+}
+
+function isShortWindowBesideMainSleep(
+  candidate: WearableSleepWindowCandidate,
+  maxDurationMinutes: number,
+): boolean {
+  return maxDurationMinutes >= 180 && candidate.durationMinutes < maxDurationMinutes / 2;
 }
 
 function buildProviderRankScores(

--- a/packages/query/src/wearables/sleep-association.ts
+++ b/packages/query/src/wearables/sleep-association.ts
@@ -1,0 +1,130 @@
+import type { WearableMetricCandidate, WearableSleepWindowCandidate } from "./types.ts";
+import { resolveWearablePublicSourceProvider } from "./origin.ts";
+import { resolveMetricTolerance } from "./provider-policy.ts";
+
+export function isAppleHealthKitSleepCandidate(
+  candidate: Pick<WearableMetricCandidate | WearableSleepWindowCandidate, "dataOrigin" | "externalRef" | "provider">,
+): boolean {
+  return resolveSleepCandidateProvider(candidate) === "apple-health-kit";
+}
+
+export function sleepWindowsRepresentSameWindow(
+  left: WearableSleepWindowCandidate,
+  right: WearableSleepWindowCandidate,
+): boolean {
+  const toleranceMinutes = resolveMetricTolerance("sessionMinutes");
+  return timestampsWithinMinutes(left.startAt, right.startAt, toleranceMinutes) &&
+    timestampsWithinMinutes(left.endAt, right.endAt, toleranceMinutes) &&
+    Math.abs(left.durationMinutes - right.durationMinutes) <= toleranceMinutes;
+}
+
+export function sleepMetricAssociatedWithWindow(
+  candidate: WearableMetricCandidate,
+  window: WearableSleepWindowCandidate,
+): boolean {
+  if (resolveSleepCandidateProvider(candidate) !== resolveSleepCandidateProvider(window)) {
+    return false;
+  }
+
+  return sleepMetricMatchesWindow(candidate, window) || sleepMetricOccursInsideWindow(candidate, window);
+}
+
+export function sleepMetricMatchesWindow(
+  candidate: WearableMetricCandidate,
+  selectedWindow: WearableSleepWindowCandidate,
+): boolean {
+  const candidateRef = candidate.externalRef;
+  const windowRef = selectedWindow.externalRef;
+  const candidateResourceId = normalizeResourceToken(candidateRef?.resourceId);
+  const windowResourceId = normalizeResourceToken(windowRef?.resourceId);
+
+  if (!candidateResourceId || !windowResourceId || candidateResourceId !== windowResourceId) {
+    return false;
+  }
+
+  if (candidate.provider !== selectedWindow.provider) {
+    return false;
+  }
+
+  const candidateSystem = normalizeResourceToken(candidateRef?.system);
+  const windowSystem = normalizeResourceToken(windowRef?.system);
+  if (candidateSystem && windowSystem && candidateSystem !== windowSystem) {
+    return false;
+  }
+
+  return sleepResourceTypesCompatible(candidateRef?.resourceType, windowRef?.resourceType);
+}
+
+export function sleepMetricMatchesNonSelectedWindow(
+  candidate: WearableMetricCandidate,
+  selectedWindow: WearableSleepWindowCandidate,
+  sleepWindows: readonly WearableSleepWindowCandidate[],
+): boolean {
+  return sleepWindows.some((window) =>
+    window.candidateId !== selectedWindow.candidateId && sleepMetricAssociatedWithWindow(candidate, window)
+  );
+}
+
+export function normalizeResourceToken(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().toLowerCase() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function resolveSleepCandidateProvider(
+  candidate: Pick<WearableMetricCandidate | WearableSleepWindowCandidate, "dataOrigin" | "externalRef" | "provider">,
+): string {
+  return resolveWearablePublicSourceProvider({
+    dataOrigin: candidate.dataOrigin,
+    externalRef: candidate.externalRef,
+    provider: candidate.provider,
+  }, {
+    suppressJunctionSourceInstanceFallback: true,
+  });
+}
+
+function sleepMetricOccursInsideWindow(
+  candidate: WearableMetricCandidate,
+  window: WearableSleepWindowCandidate,
+): boolean {
+  const occurredAtMs = Date.parse(candidate.occurredAt ?? "");
+  const startAtMs = Date.parse(window.startAt ?? "");
+  const endAtMs = Date.parse(window.endAt ?? "");
+  if (!Number.isFinite(occurredAtMs) || !Number.isFinite(startAtMs) || !Number.isFinite(endAtMs)) {
+    return false;
+  }
+
+  const toleranceMs = resolveMetricTolerance("sessionMinutes") * 60000;
+  return occurredAtMs >= startAtMs - toleranceMs && occurredAtMs <= endAtMs + toleranceMs;
+}
+
+function sleepResourceTypesCompatible(
+  candidateResourceType: string | null | undefined,
+  windowResourceType: string | null | undefined,
+): boolean {
+  const candidateType = normalizeResourceToken(candidateResourceType);
+  const windowType = normalizeResourceToken(windowResourceType);
+
+  if (!candidateType || !windowType) {
+    return true;
+  }
+
+  return candidateType === windowType || (candidateType.includes("sleep") && windowType.includes("sleep"));
+}
+
+function timestampsWithinMinutes(
+  left: string | null | undefined,
+  right: string | null | undefined,
+  toleranceMinutes: number,
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(leftMs) || !Number.isFinite(rightMs)) {
+    return left === right;
+  }
+
+  return Math.abs(leftMs - rightMs) / 60000 <= toleranceMinutes;
+}

--- a/packages/query/src/wearables/types.ts
+++ b/packages/query/src/wearables/types.ts
@@ -406,10 +406,17 @@ export interface WearableActivitySessionAggregate {
 
 export interface WearableDataset {
   activitySessionAggregates: readonly WearableActivitySessionAggregate[];
+  metricSuppressionEvidence: readonly WearableMetricSuppressionEvidence[];
   metricCandidates: readonly WearableMetricCandidate[];
   provenanceDiagnostics: readonly WearableProvenanceDiagnostic[];
   rawMetricCandidates: readonly WearableMetricCandidate[];
   sleepWindows: readonly WearableSleepWindowCandidate[];
+}
+
+export interface WearableMetricSuppressionEvidence {
+  date: string;
+  metricKey: string;
+  recordIds: readonly string[];
 }
 
 export interface WearableProvenanceDiagnostic {

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -4532,7 +4532,7 @@ test("rebuildQueryProjection creates the compact metric point schema", async () 
       // Pin the literal version: a revert of the latest bump would keep every
       // constant-relative assertion green while legacy stores still carried old
       // projected metric point identities.
-      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 14);
+      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 15);
       assert.equal(readSqliteRuntimeUserVersion(database), QUERY_PROJECTION_SQLITE_VERSION);
 
       const columnRows = database
@@ -5240,7 +5240,7 @@ test("importer sleep keys, canonical day keys, and losing providers all resolve 
   }
 });
 
-test("listMetricPointsRuntime rebuilds v13 metric-content projections before serving metric points", async () => {
+test("listMetricPointsRuntime rebuilds v14 wearable-summary projections before serving metric points", async () => {
   const vaultRoot = await createMetricObservationVault([
     {
       id: "evt_metric_observation_caffeine_rebuild_01",
@@ -5260,7 +5260,7 @@ test("listMetricPointsRuntime rebuilds v13 metric-content projections before ser
     const staleDatabase = openSqliteRuntimeDatabase(runtimeDatabasePath, { create: false });
     try {
       staleDatabase.exec(`
-        PRAGMA user_version = 13;
+        PRAGMA user_version = 14;
         DELETE FROM query_metric_points;
       `);
     } finally {

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -5276,6 +5276,7 @@ test("listMetricPointsRuntime suppresses invalid Apple HealthKit zero sleep tota
   const appleOrigin = {
     version: 1,
     aggregatorProvider: "junction",
+    normalizerVersion: "junction-sleep-stage-summary.v1",
     sourceProviderSlug: "apple-health-kit",
     sourceType: "unknown",
   };
@@ -5407,6 +5408,9 @@ test("listMetricPointsRuntime suppresses invalid Apple HealthKit zero totals bes
   const origin = (sourceProviderSlug: string) => ({
     version: 1,
     aggregatorProvider: "junction",
+    normalizerVersion: sourceProviderSlug === "apple-health-kit"
+      ? "junction-sleep-stage-summary.v1"
+      : undefined,
     sourceProviderSlug,
     sourceType: "unknown",
   });
@@ -5545,6 +5549,193 @@ test("listMetricPointsRuntime suppresses invalid Apple HealthKit zero totals bes
     assert.equal(
       totalSleep.some((point) => point.source.recordId === "evt_apple_projection_duplicate_zero_total"),
       false,
+    );
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("listMetricPointsRuntime preserves valid Apple HealthKit cycle fallback zero stages beside stale zero summaries", async () => {
+  const date = "2026-07-07";
+  const startAt = "2026-07-07T08:17:04.000Z";
+  const endAt = "2026-07-07T14:02:56.000Z";
+  const appleOrigin = (normalizerVersion?: string) => ({
+    version: 1,
+    aggregatorProvider: "junction",
+    normalizerVersion,
+    sourceProviderSlug: "apple-health-kit",
+    sourceType: "unknown",
+  });
+  const appleRef = (resourceId: string, facet?: string) => ({
+    facet,
+    resourceId,
+    resourceType: "junction-apple-health-kit-sleep",
+    system: "junction",
+  });
+  const appleMetric = (input: {
+    id: string;
+    metric: string;
+    normalizerVersion?: string;
+    resourceId: string;
+    unit: string;
+    value: number;
+  }) => ({
+    id: input.id,
+    kind: "observation",
+    occurredAt: endAt,
+    recordedAt: input.normalizerVersion === "junction-sleep-stage-cycle-fallback.v1"
+      ? "2026-07-07T18:54:32.000Z"
+      : "2026-07-07T18:53:32.000Z",
+    dayKey: date,
+    source: "device",
+    title: `Apple ${input.metric}`,
+    metric: input.metric,
+    value: input.value,
+    unit: input.unit,
+    dataOrigin: appleOrigin(input.normalizerVersion),
+    externalRef: appleRef(input.resourceId, input.metric),
+  });
+  const staleSummaryRecordIds = [
+    "evt_apple_cycle_stale_zero_total",
+    "evt_apple_cycle_stale_zero_efficiency",
+    "evt_apple_cycle_stale_zero_deep",
+    "evt_apple_cycle_stale_zero_rem",
+    "evt_apple_cycle_stale_zero_light",
+  ];
+  const staleSummaryNormalizer = "junction-sleep-stage-summary.v1";
+  const cycleFallbackNormalizer = "junction-sleep-stage-cycle-fallback.v1";
+  const vaultRoot = await createEventLedgerVault([
+    {
+      id: "evt_apple_cycle_sleep_window",
+      kind: "sleep_session",
+      occurredAt: endAt,
+      recordedAt: "2026-07-07T18:53:32.000Z",
+      dayKey: date,
+      source: "device",
+      title: "Apple overnight sleep",
+      startAt,
+      endAt,
+      durationMinutes: 346,
+      dataOrigin: appleOrigin(),
+      externalRef: appleRef("sleep-apple-cycle-window"),
+    },
+    appleMetric({
+      id: "evt_apple_cycle_stale_zero_total",
+      metric: "sleep-total-minutes",
+      normalizerVersion: staleSummaryNormalizer,
+      resourceId: "sleep-apple-cycle-window",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_stale_zero_efficiency",
+      metric: "sleep-efficiency",
+      normalizerVersion: staleSummaryNormalizer,
+      resourceId: "sleep-apple-cycle-window",
+      unit: "%",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_stale_zero_deep",
+      metric: "sleep-deep-minutes",
+      normalizerVersion: staleSummaryNormalizer,
+      resourceId: "sleep-stage-apple-cycle",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_stale_zero_rem",
+      metric: "sleep-rem-minutes",
+      normalizerVersion: staleSummaryNormalizer,
+      resourceId: "sleep-stage-apple-cycle",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_stale_zero_light",
+      metric: "sleep-light-minutes",
+      normalizerVersion: staleSummaryNormalizer,
+      resourceId: "sleep-stage-apple-cycle",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_awake",
+      metric: "sleep-awake-minutes",
+      normalizerVersion: staleSummaryNormalizer,
+      resourceId: "sleep-stage-apple-cycle",
+      unit: "minutes",
+      value: 18.5,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_deep",
+      metric: "sleep-deep-minutes",
+      normalizerVersion: cycleFallbackNormalizer,
+      resourceId: "sleep-stage-apple-cycle",
+      unit: "minutes",
+      value: 120,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_rem_zero",
+      metric: "sleep-rem-minutes",
+      normalizerVersion: cycleFallbackNormalizer,
+      resourceId: "sleep-stage-apple-cycle",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_cycle_light",
+      metric: "sleep-light-minutes",
+      normalizerVersion: cycleFallbackNormalizer,
+      resourceId: "sleep-stage-apple-cycle",
+      unit: "minutes",
+      value: 300,
+    }),
+  ]);
+
+  try {
+    await rebuildQueryProjection(vaultRoot);
+
+    const sleep = await summarizeWearableSleepRuntime(vaultRoot, {
+      from: date,
+      to: date,
+    });
+    const night = sleep.find((candidate) => candidate.date === date);
+    const totalSleep = await listMetricPointsRuntime(vaultRoot, {
+      from: date,
+      limit: null,
+      metricKey: "total-sleep-minutes",
+      to: date,
+    });
+    const remSleep = await listMetricPointsRuntime(vaultRoot, {
+      from: date,
+      limit: null,
+      metricKey: "rem-sleep-minutes",
+      to: date,
+    });
+    const allDayPoints = await listMetricPointsRuntime(vaultRoot, {
+      from: date,
+      limit: null,
+      to: date,
+    });
+
+    assert.equal(night?.remMinutes.selection.value, 0);
+    assert.equal(night?.totalSleepMinutes.selection.value, 420);
+    assert.equal(night?.totalSleepMinutes.selection.sourceFamily, "derived");
+    assert.equal(night?.totalSleepMinutes.selection.sourceKind, "sleep-stage-total");
+    assert.equal(totalSleep.length, 1);
+    assert.equal(totalSleep[0]?.value, 420);
+    assert.equal(
+      remSleep.some((point) => point.source.recordId === "evt_apple_cycle_rem_zero" && point.value === 0),
+      true,
+    );
+    assert.equal(
+      allDayPoints.some((point) => staleSummaryRecordIds.includes(point.source.recordId)),
+      false,
+    );
+    assert.equal(
+      allDayPoints.some((point) => point.source.recordId === "evt_apple_cycle_rem_zero"),
+      true,
     );
   } finally {
     await rm(vaultRoot, { recursive: true, force: true });

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   ID_FAMILY_REGISTRY,
   buildWearableMetricEvidence,
+  buildMetricProjection,
   buildOverviewMetrics,
   buildOverviewWeeklyStats,
   buildExportPack,
@@ -5555,7 +5556,7 @@ test("listMetricPointsRuntime suppresses invalid Apple HealthKit zero totals bes
   }
 });
 
-test("listMetricPointsRuntime preserves valid Apple HealthKit cycle fallback zero stages beside stale zero summaries", async () => {
+test("wearable projection preserves valid Apple HealthKit cycle fallback zero stages beside stale zero summaries", () => {
   const date = "2026-07-07";
   const startAt = "2026-07-07T08:17:04.000Z";
   const endAt = "2026-07-07T14:02:56.000Z";
@@ -5572,6 +5573,33 @@ test("listMetricPointsRuntime preserves valid Apple HealthKit cycle fallback zer
     resourceType: "junction-apple-health-kit-sleep",
     system: "junction",
   });
+  const eventEntity = (input: {
+    attributes: Record<string, unknown>;
+    id: string;
+    kind: string;
+    occurredAt: string;
+    title: string;
+  }): CanonicalEntity => ({
+    attributes: input.attributes,
+    body: null,
+    date,
+    entityId: input.id,
+    experimentSlug: null,
+    family: "event",
+    frontmatter: null,
+    kind: input.kind,
+    links: [],
+    lookupIds: [input.id],
+    occurredAt: input.occurredAt,
+    path: `ledger/events/${input.id}.jsonl`,
+    primaryLookupId: input.id,
+    recordClass: "ledger",
+    relatedIds: [],
+    status: null,
+    stream: null,
+    tags: [],
+    title: input.title,
+  });
   const appleMetric = (input: {
     id: string;
     metric: string;
@@ -5579,21 +5607,22 @@ test("listMetricPointsRuntime preserves valid Apple HealthKit cycle fallback zer
     resourceId: string;
     unit: string;
     value: number;
-  }) => ({
+  }): CanonicalEntity => eventEntity({
+    attributes: {
+      dayKey: date,
+      dataOrigin: appleOrigin(input.normalizerVersion),
+      externalRef: appleRef(input.resourceId, input.metric),
+      metric: input.metric,
+      recordedAt: input.normalizerVersion === "junction-sleep-stage-cycle-fallback.v1"
+        ? "2026-07-07T18:54:32.000Z"
+        : "2026-07-07T18:53:32.000Z",
+      unit: input.unit,
+      value: input.value,
+    },
     id: input.id,
     kind: "observation",
     occurredAt: endAt,
-    recordedAt: input.normalizerVersion === "junction-sleep-stage-cycle-fallback.v1"
-      ? "2026-07-07T18:54:32.000Z"
-      : "2026-07-07T18:53:32.000Z",
-    dayKey: date,
-    source: "device",
     title: `Apple ${input.metric}`,
-    metric: input.metric,
-    value: input.value,
-    unit: input.unit,
-    dataOrigin: appleOrigin(input.normalizerVersion),
-    externalRef: appleRef(input.resourceId, input.metric),
   });
   const staleSummaryRecordIds = [
     "evt_apple_cycle_stale_zero_total",
@@ -5604,21 +5633,22 @@ test("listMetricPointsRuntime preserves valid Apple HealthKit cycle fallback zer
   ];
   const staleSummaryNormalizer = "junction-sleep-stage-summary.v1";
   const cycleFallbackNormalizer = "junction-sleep-stage-cycle-fallback.v1";
-  const vaultRoot = await createEventLedgerVault([
-    {
-      id: "evt_apple_cycle_sleep_window",
-      kind: "sleep_session",
-      occurredAt: endAt,
-      recordedAt: "2026-07-07T18:53:32.000Z",
-      dayKey: date,
-      source: "device",
-      title: "Apple overnight sleep",
-      startAt,
-      endAt,
-      durationMinutes: 346,
+  const sleepWindow = eventEntity({
+    attributes: {
       dataOrigin: appleOrigin(),
+      dayKey: date,
+      durationMinutes: 346,
+      endAt,
       externalRef: appleRef("sleep-apple-cycle-window"),
+      recordedAt: "2026-07-07T18:53:32.000Z",
+      startAt,
     },
+    id: "evt_apple_cycle_sleep_window",
+    kind: "sleep_session",
+    occurredAt: endAt,
+    title: "Apple overnight sleep",
+  });
+  const staleSummaryEvents = [
     appleMetric({
       id: "evt_apple_cycle_stale_zero_total",
       metric: "sleep-total-minutes",
@@ -5667,6 +5697,8 @@ test("listMetricPointsRuntime preserves valid Apple HealthKit cycle fallback zer
       unit: "minutes",
       value: 18.5,
     }),
+  ];
+  const cycleFallbackEvents = [
     appleMetric({
       id: "evt_apple_cycle_deep",
       metric: "sleep-deep-minutes",
@@ -5691,54 +5723,50 @@ test("listMetricPointsRuntime preserves valid Apple HealthKit cycle fallback zer
       unit: "minutes",
       value: 300,
     }),
-  ]);
+  ];
 
-  try {
-    await rebuildQueryProjection(vaultRoot);
+  for (const eventOrder of ["stale-first", "cycle-first"] as const) {
+    const vault = createVaultReadModel({
+      entities: [
+        sleepWindow,
+        ...(eventOrder === "stale-first"
+          ? [...staleSummaryEvents, ...cycleFallbackEvents]
+          : [...cycleFallbackEvents, ...staleSummaryEvents]),
+      ],
+      metadata: null,
+      vaultRoot: "/tmp/wearables-junction-apple-cycle-fallback",
+    });
+    const [night] = summarizeWearableSleep(vault, { date });
+    const projection = buildMetricProjection(vault);
+    const totalSleep = projection.metricPoints.filter((point) =>
+      point.effectiveDate === date && point.metricKey === "total-sleep-minutes"
+    );
+    const remSleep = projection.metricPoints.filter((point) =>
+      point.effectiveDate === date && point.metricKey === "rem-sleep-minutes"
+    );
+    const allDayPoints = projection.metricPoints.filter((point) => point.effectiveDate === date);
 
-    const sleep = await summarizeWearableSleepRuntime(vaultRoot, {
-      from: date,
-      to: date,
-    });
-    const night = sleep.find((candidate) => candidate.date === date);
-    const totalSleep = await listMetricPointsRuntime(vaultRoot, {
-      from: date,
-      limit: null,
-      metricKey: "total-sleep-minutes",
-      to: date,
-    });
-    const remSleep = await listMetricPointsRuntime(vaultRoot, {
-      from: date,
-      limit: null,
-      metricKey: "rem-sleep-minutes",
-      to: date,
-    });
-    const allDayPoints = await listMetricPointsRuntime(vaultRoot, {
-      from: date,
-      limit: null,
-      to: date,
-    });
-
-    assert.equal(night?.remMinutes.selection.value, 0);
-    assert.equal(night?.totalSleepMinutes.selection.value, 420);
-    assert.equal(night?.totalSleepMinutes.selection.sourceFamily, "derived");
-    assert.equal(night?.totalSleepMinutes.selection.sourceKind, "sleep-stage-total");
-    assert.equal(totalSleep.length, 1);
-    assert.equal(totalSleep[0]?.value, 420);
+    assert.equal(night?.remMinutes.selection.value, 0, eventOrder);
+    assert.equal(night?.totalSleepMinutes.selection.value, 420, eventOrder);
+    assert.equal(night?.totalSleepMinutes.selection.sourceFamily, "derived", eventOrder);
+    assert.equal(night?.totalSleepMinutes.selection.sourceKind, "sleep-stage-total", eventOrder);
+    assert.equal(totalSleep.length, 1, eventOrder);
+    assert.equal(totalSleep[0]?.value, 420, eventOrder);
     assert.equal(
       remSleep.some((point) => point.source.recordId === "evt_apple_cycle_rem_zero" && point.value === 0),
       true,
+      eventOrder,
     );
     assert.equal(
       allDayPoints.some((point) => staleSummaryRecordIds.includes(point.source.recordId)),
       false,
+      eventOrder,
     );
     assert.equal(
       allDayPoints.some((point) => point.source.recordId === "evt_apple_cycle_rem_zero"),
       true,
+      eventOrder,
     );
-  } finally {
-    await rm(vaultRoot, { recursive: true, force: true });
   }
 });
 

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -3591,6 +3591,35 @@ async function createMetricObservationVault(
   return vaultRoot;
 }
 
+async function createEventLedgerVault(events: readonly Record<string, unknown>[]): Promise<string> {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-query-event-ledger-"));
+
+  await mkdir(path.join(vaultRoot, "ledger/events/2026"), { recursive: true });
+  await writeFile(
+    path.join(vaultRoot, "vault.json"),
+    `${JSON.stringify({
+      formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+      vaultId: "vault_01JNV40W8VFYQ2H7CMJY5A9R4K",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      title: "Event ledger vault",
+      timezone: "UTC",
+    })}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(vaultRoot, "ledger/events/2026/2026-07.jsonl"),
+    `${events.map((event) =>
+      JSON.stringify({
+        schemaVersion: "murph.event.v1",
+        ...event,
+      })
+    ).join("\n")}\n`,
+    "utf8",
+  );
+
+  return vaultRoot;
+}
+
 interface MetricSampleInput {
   id: string;
   metric: string;
@@ -5235,6 +5264,288 @@ test("importer sleep keys, canonical day keys, and losing providers all resolve 
     assert.equal(spo2Evidence.recordIds.includes(selectedRecordId), true);
     assert.equal(spo2Evidence.recordIds.includes(losingRecordId), false);
     assert.equal(Object.prototype.hasOwnProperty.call(spo2Evidence, "suppressionRecordIds"), false);
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("listMetricPointsRuntime suppresses invalid Apple HealthKit zero sleep totals without a direct provider", async () => {
+  const date = "2026-07-07";
+  const startAt = "2026-07-07T08:17:04.000Z";
+  const endAt = "2026-07-07T14:02:56.000Z";
+  const appleOrigin = {
+    version: 1,
+    aggregatorProvider: "junction",
+    sourceProviderSlug: "apple-health-kit",
+    sourceType: "unknown",
+  };
+  const appleRef = (resourceId: string, facet?: string) => ({
+    facet,
+    resourceId,
+    resourceType: "junction-apple-health-kit-sleep",
+    system: "junction",
+  });
+  const appleMetric = (input: {
+    id: string;
+    metric: string;
+    resourceId: string;
+    unit: string;
+    value: number;
+  }) => ({
+    id: input.id,
+    kind: "observation",
+    occurredAt: endAt,
+    recordedAt: "2026-07-07T18:53:32.000Z",
+    dayKey: date,
+    source: "device",
+    title: `Apple ${input.metric}`,
+    metric: input.metric,
+    value: input.value,
+    unit: input.unit,
+    dataOrigin: appleOrigin,
+    externalRef: appleRef(input.resourceId, input.metric),
+  });
+  const zeroRecordIds = [
+    "evt_apple_projection_zero_total",
+    "evt_apple_projection_zero_efficiency",
+    "evt_apple_projection_zero_deep",
+    "evt_apple_projection_zero_rem",
+    "evt_apple_projection_zero_light",
+  ];
+  const vaultRoot = await createEventLedgerVault([
+    {
+      id: "evt_apple_projection_sleep_window",
+      kind: "sleep_session",
+      occurredAt: endAt,
+      recordedAt: "2026-07-07T18:53:32.000Z",
+      dayKey: date,
+      source: "device",
+      title: "Apple overnight sleep",
+      startAt,
+      endAt,
+      durationMinutes: 346,
+      dataOrigin: appleOrigin,
+      externalRef: appleRef("sleep-apple-projection-zero"),
+    },
+    appleMetric({
+      id: "evt_apple_projection_zero_total",
+      metric: "sleep-total-minutes",
+      resourceId: "sleep-apple-projection-zero",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_projection_zero_efficiency",
+      metric: "sleep-efficiency",
+      resourceId: "sleep-apple-projection-zero",
+      unit: "%",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_projection_zero_deep",
+      metric: "sleep-deep-minutes",
+      resourceId: "sleep-stage-apple-projection-zero",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_projection_zero_rem",
+      metric: "sleep-rem-minutes",
+      resourceId: "sleep-stage-apple-projection-zero",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_projection_zero_light",
+      metric: "sleep-light-minutes",
+      resourceId: "sleep-stage-apple-projection-zero",
+      unit: "minutes",
+      value: 0,
+    }),
+    appleMetric({
+      id: "evt_apple_projection_awake",
+      metric: "sleep-awake-minutes",
+      resourceId: "sleep-stage-apple-projection-zero",
+      unit: "minutes",
+      value: 18.5,
+    }),
+  ]);
+
+  try {
+    await rebuildQueryProjection(vaultRoot);
+
+    const totalSleep = await listMetricPointsRuntime(vaultRoot, {
+      from: date,
+      limit: null,
+      metricKey: "total-sleep-minutes",
+      to: date,
+    });
+    const allDayPoints = await listMetricPointsRuntime(vaultRoot, {
+      from: date,
+      limit: null,
+      to: date,
+    });
+
+    assert.equal(totalSleep.length, 0);
+    assert.equal(
+      allDayPoints.some((point) => zeroRecordIds.includes(point.source.recordId)),
+      false,
+    );
+    assert.equal(
+      allDayPoints.some((point) => point.source.recordId === "evt_apple_projection_awake"),
+      true,
+    );
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("listMetricPointsRuntime suppresses invalid Apple HealthKit zero totals beside WHOOP sleep", async () => {
+  const date = "2026-07-07";
+  const startAt = "2026-07-07T08:17:04.000Z";
+  const endAt = "2026-07-07T14:02:56.000Z";
+  const origin = (sourceProviderSlug: string) => ({
+    version: 1,
+    aggregatorProvider: "junction",
+    sourceProviderSlug,
+    sourceType: "unknown",
+  });
+  const externalRef = (sourceProviderSlug: string, resourceId: string, facet?: string) => ({
+    facet,
+    resourceId,
+    resourceType: `junction-${sourceProviderSlug}-sleep`,
+    system: "junction",
+  });
+  const sleepWindow = (input: {
+    id: string;
+    resourceId: string;
+    sourceProviderSlug: string;
+  }) => ({
+    id: input.id,
+    kind: "sleep_session",
+    occurredAt: endAt,
+    recordedAt: input.sourceProviderSlug === "whoop-v2"
+      ? "2026-07-07T14:24:36.000Z"
+      : "2026-07-07T18:53:32.000Z",
+    dayKey: date,
+    source: "device",
+    title: `${input.sourceProviderSlug} overnight sleep`,
+    startAt,
+    endAt,
+    durationMinutes: 346,
+    dataOrigin: origin(input.sourceProviderSlug),
+    externalRef: externalRef(input.sourceProviderSlug, input.resourceId),
+  });
+  const sleepMetric = (input: {
+    id: string;
+    metric: string;
+    resourceId: string;
+    sourceProviderSlug: string;
+    unit: string;
+    value: number;
+  }) => ({
+    id: input.id,
+    kind: "observation",
+    occurredAt: endAt,
+    recordedAt: input.sourceProviderSlug === "whoop-v2"
+      ? "2026-07-07T14:24:36.000Z"
+      : "2026-07-07T18:53:32.000Z",
+    dayKey: date,
+    source: "device",
+    title: `${input.sourceProviderSlug} ${input.metric}`,
+    metric: input.metric,
+    value: input.value,
+    unit: input.unit,
+    dataOrigin: origin(input.sourceProviderSlug),
+    externalRef: externalRef(input.sourceProviderSlug, input.resourceId, input.metric),
+  });
+  const vaultRoot = await createEventLedgerVault([
+    sleepWindow({
+      id: "evt_whoop_projection_sleep_window",
+      resourceId: "sleep-whoop-projection-valid",
+      sourceProviderSlug: "whoop-v2",
+    }),
+    sleepWindow({
+      id: "evt_apple_projection_duplicate_sleep_window",
+      resourceId: "sleep-apple-projection-duplicate-zero",
+      sourceProviderSlug: "apple-health-kit",
+    }),
+    sleepMetric({
+      id: "evt_whoop_projection_total",
+      metric: "sleep-total-minutes",
+      resourceId: "sleep-whoop-projection-valid",
+      sourceProviderSlug: "whoop-v2",
+      unit: "minutes",
+      value: 327.3667,
+    }),
+    sleepMetric({
+      id: "evt_apple_projection_duplicate_zero_total",
+      metric: "sleep-total-minutes",
+      resourceId: "sleep-apple-projection-duplicate-zero",
+      sourceProviderSlug: "apple-health-kit",
+      unit: "minutes",
+      value: 0,
+    }),
+    sleepMetric({
+      id: "evt_apple_projection_duplicate_zero_efficiency",
+      metric: "sleep-efficiency",
+      resourceId: "sleep-apple-projection-duplicate-zero",
+      sourceProviderSlug: "apple-health-kit",
+      unit: "%",
+      value: 0,
+    }),
+    sleepMetric({
+      id: "evt_apple_projection_duplicate_zero_deep",
+      metric: "sleep-deep-minutes",
+      resourceId: "sleep-stage-apple-projection-duplicate-zero",
+      sourceProviderSlug: "apple-health-kit",
+      unit: "minutes",
+      value: 0,
+    }),
+    sleepMetric({
+      id: "evt_apple_projection_duplicate_zero_rem",
+      metric: "sleep-rem-minutes",
+      resourceId: "sleep-stage-apple-projection-duplicate-zero",
+      sourceProviderSlug: "apple-health-kit",
+      unit: "minutes",
+      value: 0,
+    }),
+    sleepMetric({
+      id: "evt_apple_projection_duplicate_zero_light",
+      metric: "sleep-light-minutes",
+      resourceId: "sleep-stage-apple-projection-duplicate-zero",
+      sourceProviderSlug: "apple-health-kit",
+      unit: "minutes",
+      value: 0,
+    }),
+    sleepMetric({
+      id: "evt_apple_projection_duplicate_awake",
+      metric: "sleep-awake-minutes",
+      resourceId: "sleep-stage-apple-projection-duplicate-zero",
+      sourceProviderSlug: "apple-health-kit",
+      unit: "minutes",
+      value: 18.5,
+    }),
+  ]);
+
+  try {
+    await rebuildQueryProjection(vaultRoot);
+
+    const totalSleep = await listMetricPointsRuntime(vaultRoot, {
+      from: date,
+      limit: null,
+      metricKey: "total-sleep-minutes",
+      to: date,
+    });
+
+    assert.equal(totalSleep.length, 1);
+    assert.equal(totalSleep[0]?.value, 327.3667);
+    assert.equal(totalSleep[0]?.source.family, "derived");
+    assert.notEqual(totalSleep[0]?.source.kind, "observation");
+    assert.equal(
+      totalSleep.some((point) => point.source.recordId === "evt_apple_projection_duplicate_zero_total"),
+      false,
+    );
   } finally {
     await rm(vaultRoot, { recursive: true, force: true });
   }

--- a/packages/query/test/wearable-summary-stored-codec.test.ts
+++ b/packages/query/test/wearable-summary-stored-codec.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 
 import { test } from "vitest";
 
-import { buildWearableSummaryBundleFromDataset } from "../src/wearables.ts";
+import { buildWearableSummaryBundleFromDataset, summarizeWearableMetricTrendFromBundle } from "../src/wearables.ts";
 import type {
   WearableActivitySessionAggregate,
   WearableDataset,
@@ -318,6 +318,62 @@ test("compose preserves stored activity aggregate-owned types and heart-rate zon
     label: "Zone 2",
     zone: 2,
   }]);
+});
+
+test("compose rebuilt stored sleep rows drops zeroed Apple HealthKit summary in favor of WHOOP", () => {
+  const date = "2026-07-07";
+  const startAt = "2026-07-07T08:17:04.000Z";
+  const endAt = "2026-07-07T14:02:56.000Z";
+  const dataset: WearableDataset = {
+    activitySessionAggregates: [],
+    metricCandidates: [
+      candidate({ date, facet: "whoop-asleep", metric: "totalSleepMinutes", provider: "whoop", unit: "minutes", value: 327.3667 }),
+      candidate({ date, facet: "whoop-efficiency", metric: "sleepEfficiency", provider: "whoop", unit: "%", value: 94.6511 }),
+      candidate({ date, facet: "whoop-deep", metric: "deepMinutes", provider: "whoop", unit: "minutes", value: 141.6167 }),
+      candidate({ date, facet: "whoop-rem", metric: "remMinutes", provider: "whoop", unit: "minutes", value: 91 }),
+      candidate({ date, facet: "whoop-light", metric: "lightMinutes", provider: "whoop", unit: "minutes", value: 94.75 }),
+      candidate({ date, facet: "whoop-awake", metric: "awakeMinutes", provider: "whoop", unit: "minutes", value: 18.5 }),
+      candidate({ date, facet: "apple-asleep-zero", metric: "totalSleepMinutes", provider: "apple-health-kit", unit: "minutes", value: 0 }),
+      candidate({ date, facet: "apple-efficiency-zero", metric: "sleepEfficiency", provider: "apple-health-kit", unit: "%", value: 0 }),
+      candidate({ date, facet: "apple-deep-zero", metric: "deepMinutes", provider: "apple-health-kit", unit: "minutes", value: 0 }),
+      candidate({ date, facet: "apple-rem-zero", metric: "remMinutes", provider: "apple-health-kit", unit: "minutes", value: 0 }),
+      candidate({ date, facet: "apple-light-zero", metric: "lightMinutes", provider: "apple-health-kit", unit: "minutes", value: 0 }),
+      candidate({ date, facet: "apple-awake", metric: "awakeMinutes", provider: "apple-health-kit", unit: "minutes", value: 18.5 }),
+    ],
+    provenanceDiagnostics: [],
+    rawMetricCandidates: [],
+    sleepWindows: [
+      sleepWindow("whoop", date, {
+        durationMinutes: 346,
+        endAt,
+        startAt,
+      }),
+      sleepWindow("apple-health-kit", date, {
+        durationMinutes: 346,
+        endAt,
+        startAt,
+      }),
+    ],
+  };
+  const rows = buildWearableSummaryProjectionFromDataset(dataset);
+  const composed = composePublicWearableSummaryBundleFromStoredRows({
+    providerFilterWasProvided: false,
+    providers: [],
+    rows,
+  }, {});
+  const sleep = composed.sleepNights.find((summary) => summary.date === date);
+  const trend = summarizeWearableMetricTrendFromBundle(composed, "totalSleepMinutes", { windowDays: 1 });
+
+  assert.ok(sleep);
+  assert.equal(sleep.sleepWindowProvider, "whoop");
+  assert.equal(sleep.totalSleepMinutes.selection.provider, "whoop");
+  assert.equal(sleep.totalSleepMinutes.selection.value, 327.3667);
+  assert.equal(sleep.sleepEfficiency.selection.provider, "whoop");
+  assert.equal(sleep.deepMinutes.selection.provider, "whoop");
+  assert.equal(sleep.remMinutes.selection.provider, "whoop");
+  assert.equal(sleep.lightMinutes.selection.provider, "whoop");
+  assert.equal(trend?.provider, "whoop");
+  assert.equal(trend?.points[0]?.value, 327.3667);
 });
 
 test("compose preserves non-selected provider same-public conflict evidence", () => {

--- a/packages/query/test/wearable-summary-stored-codec.test.ts
+++ b/packages/query/test/wearable-summary-stored-codec.test.ts
@@ -151,6 +151,7 @@ function buildFixtureDataset(providers: readonly string[]): WearableDataset {
 
   return {
     activitySessionAggregates: [],
+    metricSuppressionEvidence: [],
     metricCandidates,
     provenanceDiagnostics: [],
     rawMetricCandidates: metricCandidates,
@@ -209,6 +210,7 @@ test("compose preserves stored same-public provider conflict evidence", () => {
   const date = "2026-05-03";
   const dataset: WearableDataset = {
     activitySessionAggregates: [],
+    metricSuppressionEvidence: [],
     metricCandidates: [
       candidate({
         date,
@@ -296,6 +298,7 @@ test("compose preserves stored activity aggregate-owned types and heart-rate zon
         provider: "garmin",
       }),
     ],
+    metricSuppressionEvidence: [],
     metricCandidates: [],
     provenanceDiagnostics: [],
     rawMetricCandidates: [],
@@ -326,6 +329,7 @@ test("compose rebuilt stored sleep rows drops zeroed Apple HealthKit summary in 
   const endAt = "2026-07-07T14:02:56.000Z";
   const dataset: WearableDataset = {
     activitySessionAggregates: [],
+    metricSuppressionEvidence: [],
     metricCandidates: [
       candidate({ date, facet: "whoop-asleep", metric: "totalSleepMinutes", provider: "whoop", unit: "minutes", value: 327.3667 }),
       candidate({ date, facet: "whoop-efficiency", metric: "sleepEfficiency", provider: "whoop", unit: "%", value: 94.6511 }),
@@ -380,6 +384,7 @@ test("compose preserves non-selected provider same-public conflict evidence", ()
   const date = "2026-05-03";
   const dataset: WearableDataset = {
     activitySessionAggregates: [],
+    metricSuppressionEvidence: [],
     metricCandidates: [
       candidate({
         date,
@@ -447,6 +452,7 @@ test("compose recomputes source health and summary notes after stored conflicts 
   const date = "2026-05-03";
   const dataset: WearableDataset = {
     activitySessionAggregates: [],
+    metricSuppressionEvidence: [],
     metricCandidates: [
       candidate({
         date,
@@ -523,6 +529,7 @@ test("compose preserves stored same-public sleep-window conflict evidence", () =
   const date = "2026-05-04";
   const dataset: WearableDataset = {
     activitySessionAggregates: [],
+    metricSuppressionEvidence: [],
     metricCandidates: [],
     provenanceDiagnostics: [],
     rawMetricCandidates: [],

--- a/packages/query/test/wearables-sleep-session-anchor.test.ts
+++ b/packages/query/test/wearables-sleep-session-anchor.test.ts
@@ -231,6 +231,8 @@ test("daily sleep summary prefers direct WHOOP over zeroed Apple HealthKit dupli
   const date = "2026-07-07";
   const startAt = "2026-07-07T08:17:04.000Z";
   const endAt = "2026-07-07T14:02:56.000Z";
+  const appleStartAt = "2026-07-07T08:17:05.000Z";
+  const appleEndAt = "2026-07-07T14:02:57.000Z";
   const whoopSleepResourceId = "sleep-direct-whoop";
   const appleSleepResourceId = "sleep-healthkit-copy";
   const whoopStageResourceId = "sleep-stage-direct-whoop";
@@ -272,12 +274,12 @@ test("daily sleep summary prefers direct WHOOP over zeroed Apple HealthKit dupli
       makeJunctionSleepSession({
         date,
         durationMinutes: 346,
-        endAt,
+        endAt: appleEndAt,
         entityId: "evt_apple_sleep_window",
         recordedAt: "2026-07-07T18:53:32.000Z",
         resourceId: appleSleepResourceId,
         sourceProviderSlug: "apple-health-kit",
-        startAt,
+        startAt: appleStartAt,
       }),
       whoopMetric("sleep-total-minutes", 327.3667),
       whoopMetric("sleep-efficiency", 94.6511),
@@ -302,6 +304,8 @@ test("daily sleep summary prefers direct WHOOP over zeroed Apple HealthKit dupli
 
   assert.equal(night?.provider, "whoop");
   assert.equal(night?.sleepWindowProvider, "whoop");
+  assert.equal(night?.sleepStartAt, startAt);
+  assert.equal(night?.sleepEndAt, endAt);
   assert.equal(night?.totalSleepMinutes.selection.provider, "whoop");
   assert.equal(night?.totalSleepMinutes.selection.value, 327.3667);
   assert.equal(night?.sleepEfficiency.selection.provider, "whoop");

--- a/packages/query/test/wearables-sleep-session-anchor.test.ts
+++ b/packages/query/test/wearables-sleep-session-anchor.test.ts
@@ -418,6 +418,278 @@ test("daily sleep summary treats zeroed Apple HealthKit asleep metrics as missin
   assert.equal(night?.awakeMinutes.selection.value, 18.5);
 });
 
+test("daily sleep summary scopes zeroed Apple HealthKit repair to the invalid sleep window", () => {
+  const date = "2026-07-07";
+  const napStartAt = "2026-07-07T18:00:00.000Z";
+  const napEndAt = "2026-07-07T18:30:00.000Z";
+  const overnightStartAt = "2026-07-07T08:17:04.000Z";
+  const overnightEndAt = "2026-07-07T14:02:56.000Z";
+  const appleMetric = (input: {
+    entityId: string;
+    metric: string;
+    occurredAt: string;
+    resourceId: string;
+    value: number;
+  }) =>
+    makeJunctionSleepMetric({
+      date,
+      entityId: input.entityId,
+      metric: input.metric,
+      occurredAt: input.occurredAt,
+      recordedAt: "2026-07-07T18:53:32.000Z",
+      resourceId: input.resourceId,
+      sourceProviderSlug: "apple-health-kit",
+      value: input.value,
+    });
+  const vault = createVaultReadModel({
+    entities: [
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 30,
+        endAt: napEndAt,
+        entityId: "evt_apple_a_nap_window",
+        recordedAt: "2026-07-07T18:40:00.000Z",
+        resourceId: "sleep-apple-a-nap",
+        sourceProviderSlug: "apple-health-kit",
+        startAt: napStartAt,
+      }),
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt: overnightEndAt,
+        entityId: "evt_apple_z_overnight_window",
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-apple-z-overnight",
+        sourceProviderSlug: "apple-health-kit",
+        startAt: overnightStartAt,
+      }),
+      appleMetric({
+        entityId: "evt_apple_a_nap_total",
+        metric: "sleep-total-minutes",
+        occurredAt: napEndAt,
+        resourceId: "sleep-apple-a-nap",
+        value: 25,
+      }),
+      appleMetric({
+        entityId: "evt_apple_a_nap_awake",
+        metric: "sleep-awake-minutes",
+        occurredAt: napEndAt,
+        resourceId: "sleep-stage-apple-a-nap",
+        value: 5,
+      }),
+      appleMetric({
+        entityId: "evt_apple_z_overnight_total",
+        metric: "sleep-total-minutes",
+        occurredAt: overnightEndAt,
+        resourceId: "sleep-apple-z-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_z_overnight_efficiency",
+        metric: "sleep-efficiency",
+        occurredAt: overnightEndAt,
+        resourceId: "sleep-apple-z-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_z_overnight_deep",
+        metric: "sleep-deep-minutes",
+        occurredAt: overnightEndAt,
+        resourceId: "sleep-stage-apple-z-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_z_overnight_rem",
+        metric: "sleep-rem-minutes",
+        occurredAt: overnightEndAt,
+        resourceId: "sleep-stage-apple-z-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_z_overnight_light",
+        metric: "sleep-light-minutes",
+        occurredAt: overnightEndAt,
+        resourceId: "sleep-stage-apple-z-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_z_overnight_awake",
+        metric: "sleep-awake-minutes",
+        occurredAt: overnightEndAt,
+        resourceId: "sleep-stage-apple-z-overnight",
+        value: 18.5,
+      }),
+    ],
+    metadata: null,
+    vaultRoot: "/virtual/wearables-junction-apple-zero-with-nap",
+  });
+
+  const [night] = summarizeWearableSleep(vault, { date });
+
+  assert.equal(night?.sleepStartAt, overnightStartAt);
+  assert.equal(night?.sessionMinutes.selection.value, 346);
+  assert.equal(night?.totalSleepMinutes.selection.value, null);
+  assert.equal(night?.sleepEfficiency.selection.value, null);
+  assert.equal(night?.deepMinutes.selection.value, null);
+  assert.equal(night?.remMinutes.selection.value, null);
+  assert.equal(night?.lightMinutes.selection.value, null);
+  assert.equal(night?.awakeMinutes.selection.value, 18.5);
+});
+
+test("daily sleep summary does not fill missing WHOOP duplicate metrics from zeroed Apple HealthKit sleep", () => {
+  const date = "2026-07-07";
+  const napStartAt = "2026-07-07T18:00:00.000Z";
+  const napEndAt = "2026-07-07T18:30:00.000Z";
+  const overnightStartAt = "2026-07-07T08:17:04.000Z";
+  const overnightEndAt = "2026-07-07T14:02:56.000Z";
+  const junctionMetric = (input: {
+    entityId: string;
+    metric: string;
+    occurredAt: string;
+    provider: string;
+    resourceId: string;
+    value: number;
+  }) =>
+    makeJunctionSleepMetric({
+      date,
+      entityId: input.entityId,
+      metric: input.metric,
+      occurredAt: input.occurredAt,
+      recordedAt: input.provider === "whoop-v2" ? "2026-07-07T14:24:36.000Z" : "2026-07-07T18:53:32.000Z",
+      resourceId: input.resourceId,
+      sourceProviderSlug: input.provider,
+      value: input.value,
+    });
+  const vault = createVaultReadModel({
+    entities: [
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt: overnightEndAt,
+        entityId: "evt_whoop_missing_metric_window",
+        recordedAt: "2026-07-07T14:24:36.000Z",
+        resourceId: "sleep-whoop-overnight",
+        sourceProviderSlug: "whoop-v2",
+        startAt: overnightStartAt,
+      }),
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 30,
+        endAt: napEndAt,
+        entityId: "evt_apple_valid_nap_window",
+        recordedAt: "2026-07-07T18:40:00.000Z",
+        resourceId: "sleep-apple-valid-nap",
+        sourceProviderSlug: "apple-health-kit",
+        startAt: napStartAt,
+      }),
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt: overnightEndAt,
+        entityId: "evt_apple_zero_duplicate_window",
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-apple-zero-duplicate",
+        sourceProviderSlug: "apple-health-kit",
+        startAt: overnightStartAt,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_valid_nap_total",
+        metric: "sleep-total-minutes",
+        occurredAt: napEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-apple-valid-nap",
+        value: 25,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_valid_nap_awake",
+        metric: "sleep-awake-minutes",
+        occurredAt: napEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-stage-apple-valid-nap",
+        value: 5,
+      }),
+      junctionMetric({
+        entityId: "evt_whoop_missing_metric_total",
+        metric: "sleep-total-minutes",
+        occurredAt: overnightEndAt,
+        provider: "whoop-v2",
+        resourceId: "sleep-whoop-overnight",
+        value: 327.3667,
+      }),
+      junctionMetric({
+        entityId: "evt_whoop_missing_metric_awake",
+        metric: "sleep-awake-minutes",
+        occurredAt: overnightEndAt,
+        provider: "whoop-v2",
+        resourceId: "sleep-stage-whoop-overnight",
+        value: 18.5,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_zero_duplicate_total",
+        metric: "sleep-total-minutes",
+        occurredAt: overnightEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-apple-zero-duplicate",
+        value: 0,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_zero_duplicate_efficiency",
+        metric: "sleep-efficiency",
+        occurredAt: overnightEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-apple-zero-duplicate",
+        value: 0,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_zero_duplicate_deep",
+        metric: "sleep-deep-minutes",
+        occurredAt: overnightEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-stage-apple-zero-duplicate",
+        value: 0,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_zero_duplicate_rem",
+        metric: "sleep-rem-minutes",
+        occurredAt: overnightEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-stage-apple-zero-duplicate",
+        value: 0,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_zero_duplicate_light",
+        metric: "sleep-light-minutes",
+        occurredAt: overnightEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-stage-apple-zero-duplicate",
+        value: 0,
+      }),
+      junctionMetric({
+        entityId: "evt_apple_zero_duplicate_awake",
+        metric: "sleep-awake-minutes",
+        occurredAt: overnightEndAt,
+        provider: "apple-health-kit",
+        resourceId: "sleep-stage-apple-zero-duplicate",
+        value: 18.5,
+      }),
+    ],
+    metadata: null,
+    vaultRoot: "/virtual/wearables-junction-whoop-missing-apple-zero-fill",
+  });
+
+  const [night] = summarizeWearableSleep(vault, { date });
+
+  assert.equal(night?.sleepWindowProvider, "whoop");
+  assert.equal(night?.totalSleepMinutes.selection.provider, "whoop");
+  assert.equal(night?.totalSleepMinutes.selection.value, 327.3667);
+  assert.equal(night?.sleepEfficiency.selection.value, null);
+  assert.equal(night?.deepMinutes.selection.value, null);
+  assert.equal(night?.remMinutes.selection.value, null);
+  assert.equal(night?.lightMinutes.selection.value, null);
+  assert.equal(night?.awakeMinutes.selection.provider, "whoop");
+  assert.equal(night?.awakeMinutes.selection.value, 18.5);
+});
+
 test("daily sleep summary anchors metrics to the selected overnight sleep session instead of same-day nap", () => {
   const longSleepResourceId = "z-overnight-sleep";
   const napResourceId = "a-afternoon-nap";

--- a/packages/query/test/wearables-sleep-session-anchor.test.ts
+++ b/packages/query/test/wearables-sleep-session-anchor.test.ts
@@ -4,7 +4,7 @@ import { test } from "vitest";
 
 import type { CanonicalEntity } from "../src/canonical-entities.ts";
 import { createVaultReadModel } from "../src/model.ts";
-import { summarizeWearableDay, summarizeWearableSleep } from "../src/wearables.ts";
+import { summarizeWearableDay, summarizeWearableMetricTrend, summarizeWearableSleep } from "../src/wearables.ts";
 
 type ExternalRefInput = {
   facet?: string;
@@ -116,6 +116,85 @@ function makeSleepMetric(input: {
   });
 }
 
+function makeJunctionSleepSession(input: {
+  date: string;
+  durationMinutes: number;
+  endAt: string;
+  entityId: string;
+  recordedAt: string;
+  resourceId: string;
+  sourceProviderSlug: string;
+  startAt: string;
+}): CanonicalEntity {
+  const sourceProviderSlug = input.sourceProviderSlug.replace(/_/gu, "-");
+  return makeEntity({
+    attributes: {
+      dataOrigin: {
+        version: 1,
+        aggregatorProvider: "junction",
+        sourceProviderSlug,
+        sourceType: "unknown",
+      },
+      dayKey: input.date,
+      durationMinutes: input.durationMinutes,
+      endAt: input.endAt,
+      externalRef: makeExternalRef({
+        resourceId: input.resourceId,
+        resourceType: `junction-${sourceProviderSlug}-sleep`,
+        system: "junction",
+      }),
+      recordedAt: input.recordedAt,
+      startAt: input.startAt,
+    },
+    entityId: input.entityId,
+    family: "event",
+    kind: "sleep_session",
+    occurredAt: input.endAt,
+    recordClass: "ledger",
+    title: `${sourceProviderSlug} sleep`,
+  });
+}
+
+function makeJunctionSleepMetric(input: {
+  date: string;
+  entityId: string;
+  metric: string;
+  occurredAt: string;
+  recordedAt: string;
+  resourceId: string;
+  sourceProviderSlug: string;
+  value: number;
+}): CanonicalEntity {
+  const sourceProviderSlug = input.sourceProviderSlug.replace(/_/gu, "-");
+  return makeEntity({
+    attributes: {
+      dataOrigin: {
+        version: 1,
+        aggregatorProvider: "junction",
+        sourceProviderSlug,
+        sourceType: "unknown",
+      },
+      dayKey: input.date,
+      externalRef: makeExternalRef({
+        facet: input.metric,
+        resourceId: input.resourceId,
+        resourceType: `junction-${sourceProviderSlug}-sleep`,
+        system: "junction",
+      }),
+      metric: input.metric,
+      recordedAt: input.recordedAt,
+      unit: input.metric === "sleep-efficiency" ? "%" : "minutes",
+      value: input.value,
+    },
+    entityId: input.entityId,
+    family: "event",
+    kind: "observation",
+    occurredAt: input.occurredAt,
+    recordClass: "ledger",
+    title: `${sourceProviderSlug} ${input.metric}`,
+  });
+}
+
 function makeSleepStageSample(input: {
   dayKey?: string;
   durationMinutes: number;
@@ -147,6 +226,193 @@ function makeSleepStageSample(input: {
     title: `Oura ${input.stage} sleep`,
   });
 }
+
+test("daily sleep summary prefers direct WHOOP over zeroed Apple HealthKit duplicate sleep", () => {
+  const date = "2026-07-07";
+  const startAt = "2026-07-07T08:17:04.000Z";
+  const endAt = "2026-07-07T14:02:56.000Z";
+  const whoopSleepResourceId = "sleep-direct-whoop";
+  const appleSleepResourceId = "sleep-healthkit-copy";
+  const whoopStageResourceId = "sleep-stage-direct-whoop";
+  const appleStageResourceId = "sleep-stage-healthkit-copy";
+  const whoopMetric = (metric: string, value: number, resourceId = whoopSleepResourceId) =>
+    makeJunctionSleepMetric({
+      date,
+      entityId: `evt_whoop_${metric}`,
+      metric,
+      occurredAt: endAt,
+      recordedAt: "2026-07-07T14:24:36.000Z",
+      resourceId,
+      sourceProviderSlug: "whoop-v2",
+      value,
+    });
+  const appleMetric = (metric: string, value: number, resourceId = appleSleepResourceId) =>
+    makeJunctionSleepMetric({
+      date,
+      entityId: `evt_apple_${metric}`,
+      metric,
+      occurredAt: endAt,
+      recordedAt: "2026-07-07T18:53:32.000Z",
+      resourceId,
+      sourceProviderSlug: "apple-health-kit",
+      value,
+    });
+  const vault = createVaultReadModel({
+    entities: [
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt,
+        entityId: "evt_whoop_sleep_window",
+        recordedAt: "2026-07-07T14:24:36.000Z",
+        resourceId: whoopSleepResourceId,
+        sourceProviderSlug: "whoop-v2",
+        startAt,
+      }),
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt,
+        entityId: "evt_apple_sleep_window",
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: appleSleepResourceId,
+        sourceProviderSlug: "apple-health-kit",
+        startAt,
+      }),
+      whoopMetric("sleep-total-minutes", 327.3667),
+      whoopMetric("sleep-efficiency", 94.6511),
+      whoopMetric("sleep-deep-minutes", 141.6167, whoopStageResourceId),
+      whoopMetric("sleep-rem-minutes", 91, whoopStageResourceId),
+      whoopMetric("sleep-light-minutes", 94.75, whoopStageResourceId),
+      whoopMetric("sleep-awake-minutes", 18.5, whoopStageResourceId),
+      appleMetric("sleep-total-minutes", 0),
+      appleMetric("sleep-efficiency", 0),
+      appleMetric("sleep-deep-minutes", 0, appleStageResourceId),
+      appleMetric("sleep-rem-minutes", 0, appleStageResourceId),
+      appleMetric("sleep-light-minutes", 0, appleStageResourceId),
+      appleMetric("sleep-awake-minutes", 18.5, appleStageResourceId),
+    ],
+    metadata: null,
+    vaultRoot: "/virtual/wearables-junction-apple-zero-sleep",
+  });
+
+  const [night] = summarizeWearableSleep(vault, { date });
+  const day = summarizeWearableDay(vault, date);
+  const trend = summarizeWearableMetricTrend(vault, "totalSleepMinutes", { windowDays: 1 });
+
+  assert.equal(night?.provider, "whoop");
+  assert.equal(night?.sleepWindowProvider, "whoop");
+  assert.equal(night?.totalSleepMinutes.selection.provider, "whoop");
+  assert.equal(night?.totalSleepMinutes.selection.value, 327.3667);
+  assert.equal(night?.sleepEfficiency.selection.provider, "whoop");
+  assert.equal(night?.sleepEfficiency.selection.value, 94.6511);
+  assert.equal(night?.deepMinutes.selection.provider, "whoop");
+  assert.equal(night?.deepMinutes.selection.value, 141.6167);
+  assert.equal(night?.remMinutes.selection.provider, "whoop");
+  assert.equal(night?.remMinutes.selection.value, 91);
+  assert.equal(night?.lightMinutes.selection.provider, "whoop");
+  assert.equal(night?.lightMinutes.selection.value, 94.75);
+  assert.equal(night?.awakeMinutes.selection.provider, "whoop");
+  assert.equal(night?.awakeMinutes.selection.value, 18.5);
+  assert.equal(day?.sleep?.provider, "whoop");
+  assert.equal(day?.sleep?.totalSleepMinutes.selection.value, 327.3667);
+  assert.equal(trend?.provider, "whoop");
+  assert.equal(trend?.value, 327.3667);
+  assert.equal(trend?.points[0]?.provider, "whoop");
+});
+
+test("daily sleep summary treats zeroed Apple HealthKit asleep metrics as missing without a direct provider", () => {
+  const date = "2026-07-07";
+  const startAt = "2026-07-07T08:17:04.000Z";
+  const endAt = "2026-07-07T14:02:56.000Z";
+  const vault = createVaultReadModel({
+    entities: [
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt,
+        entityId: "evt_apple_only_sleep_window",
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-healthkit-only",
+        sourceProviderSlug: "apple-health-kit",
+        startAt,
+      }),
+      makeJunctionSleepMetric({
+        date,
+        entityId: "evt_apple_only_total",
+        metric: "sleep-total-minutes",
+        occurredAt: endAt,
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-healthkit-only",
+        sourceProviderSlug: "apple-health-kit",
+        value: 0,
+      }),
+      makeJunctionSleepMetric({
+        date,
+        entityId: "evt_apple_only_efficiency",
+        metric: "sleep-efficiency",
+        occurredAt: endAt,
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-healthkit-only",
+        sourceProviderSlug: "apple-health-kit",
+        value: 0,
+      }),
+      makeJunctionSleepMetric({
+        date,
+        entityId: "evt_apple_only_deep",
+        metric: "sleep-deep-minutes",
+        occurredAt: endAt,
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-stage-healthkit-only",
+        sourceProviderSlug: "apple-health-kit",
+        value: 0,
+      }),
+      makeJunctionSleepMetric({
+        date,
+        entityId: "evt_apple_only_rem",
+        metric: "sleep-rem-minutes",
+        occurredAt: endAt,
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-stage-healthkit-only",
+        sourceProviderSlug: "apple-health-kit",
+        value: 0,
+      }),
+      makeJunctionSleepMetric({
+        date,
+        entityId: "evt_apple_only_light",
+        metric: "sleep-light-minutes",
+        occurredAt: endAt,
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-stage-healthkit-only",
+        sourceProviderSlug: "apple-health-kit",
+        value: 0,
+      }),
+      makeJunctionSleepMetric({
+        date,
+        entityId: "evt_apple_only_awake",
+        metric: "sleep-awake-minutes",
+        occurredAt: endAt,
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-stage-healthkit-only",
+        sourceProviderSlug: "apple-health-kit",
+        value: 18.5,
+      }),
+    ],
+    metadata: null,
+    vaultRoot: "/virtual/wearables-junction-apple-zero-only",
+  });
+
+  const [night] = summarizeWearableSleep(vault, { date });
+
+  assert.equal(night?.provider, "apple-health-kit");
+  assert.equal(night?.sessionMinutes.selection.value, 346);
+  assert.equal(night?.totalSleepMinutes.selection.value, null);
+  assert.equal(night?.sleepEfficiency.selection.value, null);
+  assert.equal(night?.deepMinutes.selection.value, null);
+  assert.equal(night?.remMinutes.selection.value, null);
+  assert.equal(night?.lightMinutes.selection.value, null);
+  assert.equal(night?.awakeMinutes.selection.value, 18.5);
+});
 
 test("daily sleep summary anchors metrics to the selected overnight sleep session instead of same-day nap", () => {
   const longSleepResourceId = "z-overnight-sleep";

--- a/packages/query/test/wearables-sleep-session-anchor.test.ts
+++ b/packages/query/test/wearables-sleep-session-anchor.test.ts
@@ -536,6 +536,97 @@ test("daily sleep summary scopes zeroed Apple HealthKit repair to the invalid sl
   assert.equal(night?.awakeMinutes.selection.value, 18.5);
 });
 
+test("daily sleep summary lets repaired Apple generic total replace legacy exact zero", () => {
+  const date = "2026-07-07";
+  const overnightStartAt = "2026-07-07T08:17:04.000Z";
+  const overnightEndAt = "2026-07-07T14:02:56.000Z";
+  const appleMetric = (input: {
+    entityId: string;
+    metric: string;
+    resourceId: string;
+    value: number;
+  }) =>
+    makeJunctionSleepMetric({
+      date,
+      entityId: input.entityId,
+      metric: input.metric,
+      occurredAt: overnightEndAt,
+      recordedAt: "2026-07-07T18:53:32.000Z",
+      resourceId: input.resourceId,
+      sourceProviderSlug: "apple-health-kit",
+      value: input.value,
+    });
+  const vault = createVaultReadModel({
+    entities: [
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt: overnightEndAt,
+        entityId: "evt_apple_repaired_overnight_window",
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-apple-repaired-overnight",
+        sourceProviderSlug: "apple-health-kit",
+        startAt: overnightStartAt,
+      }),
+      appleMetric({
+        entityId: "evt_apple_repaired_generic_total",
+        metric: "sleep-total-minutes",
+        resourceId: "sleep-cycle-apple-repaired-generic-total",
+        value: 327.3667,
+      }),
+      appleMetric({
+        entityId: "evt_apple_repaired_legacy_zero_total",
+        metric: "sleep-total-minutes",
+        resourceId: "sleep-apple-repaired-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_repaired_legacy_zero_efficiency",
+        metric: "sleep-efficiency",
+        resourceId: "sleep-apple-repaired-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_repaired_legacy_zero_deep",
+        metric: "sleep-deep-minutes",
+        resourceId: "sleep-stage-apple-repaired-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_repaired_legacy_zero_rem",
+        metric: "sleep-rem-minutes",
+        resourceId: "sleep-stage-apple-repaired-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_repaired_legacy_zero_light",
+        metric: "sleep-light-minutes",
+        resourceId: "sleep-stage-apple-repaired-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_repaired_awake",
+        metric: "sleep-awake-minutes",
+        resourceId: "sleep-stage-apple-repaired-overnight",
+        value: 18.5,
+      }),
+    ],
+    metadata: null,
+    vaultRoot: "/virtual/wearables-junction-apple-repaired-generic-total",
+  });
+
+  const [night] = summarizeWearableSleep(vault, { date });
+
+  assert.equal(night?.sleepStartAt, overnightStartAt);
+  assert.equal(night?.sessionMinutes.selection.value, 346);
+  assert.equal(night?.totalSleepMinutes.selection.value, 327.3667);
+  assert.equal(night?.sleepEfficiency.selection.value, null);
+  assert.equal(night?.deepMinutes.selection.value, null);
+  assert.equal(night?.remMinutes.selection.value, null);
+  assert.equal(night?.lightMinutes.selection.value, null);
+  assert.equal(night?.awakeMinutes.selection.value, 18.5);
+});
+
 test("daily sleep summary does not fill missing WHOOP duplicate metrics from zeroed Apple HealthKit sleep", () => {
   const date = "2026-07-07";
   const napStartAt = "2026-07-07T18:00:00.000Z";

--- a/packages/query/test/wearables-sleep-session-anchor.test.ts
+++ b/packages/query/test/wearables-sleep-session-anchor.test.ts
@@ -627,6 +627,92 @@ test("daily sleep summary lets repaired Apple generic total replace legacy exact
   assert.equal(night?.awakeMinutes.selection.value, 18.5);
 });
 
+test("daily sleep summary derives Apple total from positive stages despite stale exact zero", () => {
+  const date = "2026-07-07";
+  const overnightStartAt = "2026-07-07T08:17:04.000Z";
+  const overnightEndAt = "2026-07-07T14:02:56.000Z";
+  const appleMetric = (input: {
+    entityId: string;
+    metric: string;
+    resourceId: string;
+    value: number;
+  }) =>
+    makeJunctionSleepMetric({
+      date,
+      entityId: input.entityId,
+      metric: input.metric,
+      occurredAt: overnightEndAt,
+      recordedAt: "2026-07-07T18:53:32.000Z",
+      resourceId: input.resourceId,
+      sourceProviderSlug: "apple-health-kit",
+      value: input.value,
+    });
+  const vault = createVaultReadModel({
+    entities: [
+      makeJunctionSleepSession({
+        date,
+        durationMinutes: 346,
+        endAt: overnightEndAt,
+        entityId: "evt_apple_stage_repair_overnight_window",
+        recordedAt: "2026-07-07T18:53:32.000Z",
+        resourceId: "sleep-apple-stage-repair-overnight",
+        sourceProviderSlug: "apple-health-kit",
+        startAt: overnightStartAt,
+      }),
+      appleMetric({
+        entityId: "evt_apple_stage_repair_legacy_zero_total",
+        metric: "sleep-total-minutes",
+        resourceId: "sleep-apple-stage-repair-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_stage_repair_legacy_zero_efficiency",
+        metric: "sleep-efficiency",
+        resourceId: "sleep-apple-stage-repair-overnight",
+        value: 0,
+      }),
+      appleMetric({
+        entityId: "evt_apple_stage_repair_light",
+        metric: "sleep-light-minutes",
+        resourceId: "sleep-cycle-apple-stage-repair",
+        value: 94.75,
+      }),
+      appleMetric({
+        entityId: "evt_apple_stage_repair_deep",
+        metric: "sleep-deep-minutes",
+        resourceId: "sleep-cycle-apple-stage-repair",
+        value: 141.6167,
+      }),
+      appleMetric({
+        entityId: "evt_apple_stage_repair_rem",
+        metric: "sleep-rem-minutes",
+        resourceId: "sleep-cycle-apple-stage-repair",
+        value: 91,
+      }),
+      appleMetric({
+        entityId: "evt_apple_stage_repair_awake",
+        metric: "sleep-awake-minutes",
+        resourceId: "sleep-stage-apple-stage-repair",
+        value: 18.5,
+      }),
+    ],
+    metadata: null,
+    vaultRoot: "/virtual/wearables-junction-apple-stage-repaired-total",
+  });
+
+  const [night] = summarizeWearableSleep(vault, { date });
+
+  assert.equal(night?.sleepStartAt, overnightStartAt);
+  assert.equal(night?.sessionMinutes.selection.value, 346);
+  assert.equal(night?.totalSleepMinutes.selection.value, 327.3667);
+  assert.equal(night?.totalSleepMinutes.selection.sourceKind, "sleep-stage-total");
+  assert.equal(night?.sleepEfficiency.selection.value, null);
+  assert.equal(night?.deepMinutes.selection.value, 141.6167);
+  assert.equal(night?.remMinutes.selection.value, 91);
+  assert.equal(night?.lightMinutes.selection.value, 94.75);
+  assert.equal(night?.awakeMinutes.selection.value, 18.5);
+});
+
 test("daily sleep summary does not fill missing WHOOP duplicate metrics from zeroed Apple HealthKit sleep", () => {
   const date = "2026-07-07";
   const napStartAt = "2026-07-07T18:00:00.000Z";

--- a/packages/query/test/wearables-source-health-final.test.ts
+++ b/packages/query/test/wearables-source-health-final.test.ts
@@ -131,6 +131,7 @@ function makeSleepWindowCandidate(
 function makeDataset(overrides: Partial<WearableDataset>): WearableDataset {
   return {
     activitySessionAggregates: overrides.activitySessionAggregates ?? [],
+    metricSuppressionEvidence: overrides.metricSuppressionEvidence ?? [],
     metricCandidates: overrides.metricCandidates ?? [],
     provenanceDiagnostics: overrides.provenanceDiagnostics ?? [],
     rawMetricCandidates: overrides.rawMetricCandidates ?? [],


### PR DESCRIPTION
## Why
Junction Apple HealthKit can emit sleep summaries with a real window and awake minutes but zero total sleep, zero efficiency, and zero asleep-stage metrics for HealthKit-copied WHOOP generic asleep samples. Those zero candidates could tie and win over direct WHOOP data for the same night.

## User-visible goal
WHOOP-via-Junction nights with duplicate Apple HealthKit zero summaries should select WHOOP for total sleep, sleep stages, and sleep efficiency. Apple HealthKit generic asleep intervals may contribute total sleep only when no better direct source exists, and impossible Apple zero asleep metrics are treated as missing.

## Invariants
- Do not infer deep, REM, or light sleep from generic HealthKit Asleep intervals.
- Preserve valid HealthKit sleep windows and awake minutes.
- Keep provider-specific handling bounded to Junction import/query sleep selection.

## Verification
- pnpm --filter @murphai/importers test -- --run packages/importers/test/device-providers-junction.test.ts
- pnpm --filter @murphai/importers typecheck
- pnpm --filter @murphai/query test -- --run packages/query/test/wearables-sleep-session-anchor.test.ts
- pnpm --filter @murphai/query test -- --run packages/query/test/wearable-summary-stored-codec.test.ts
- git diff --check

Note: pnpm --filter @murphai/query typecheck is still blocked by unrelated Murph Age type/module errors outside this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786082508&installation_id=127572939&pr_number=471&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F471&signature=e2dfdaecb5e972dad7aee247e80fe917bc11fc168d5e18b33ce69e93bcee3298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->