### PR TITLE
Fix hosted web contract migration dispatch

### DIFF
--- a/.github/workflows/hosted-web-contract-migrations.yml
+++ b/.github/workflows/hosted-web-contract-migrations.yml
@@ -2,6 +2,12 @@ name: Hosted Web Contract Migrations
 
 on:
   deployment_status:
+  workflow_dispatch:
+    inputs:
+      deployed_sha:
+        description: Current Vercel production commit SHA to prove before applying contract migrations.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -9,14 +15,14 @@ permissions:
 jobs:
   production-contract-migrations:
     name: Run post-deploy contract migrations
-    if: ${{ github.event.deployment_status.state == 'success' && contains(fromJSON('["Production","production"]'), github.event.deployment.environment) && (github.event.deployment_status.creator.login == 'vercel[bot]' || github.event.deployment.creator.login == 'vercel[bot]') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.deployment_status.state == 'success' && github.event.deployment_status.description == 'Deployment has completed' && contains(fromJSON('["Production","production"]'), github.event.deployment.environment) && (github.event.deployment_status.creator.login == 'vercel[bot]' || github.event.deployment.creator.login == 'vercel[bot]')) }}
     runs-on: ubuntu-24.04
     environment: production
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.deployment.sha }}
+          ref: ${{ github.event.deployment.sha || inputs.deployed_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -24,7 +30,7 @@ jobs:
         id: production-branch
         shell: bash
         env:
-          DEPLOYED_SHA: ${{ github.event.deployment.sha }}
+          DEPLOYED_SHA: ${{ github.event.deployment.sha || inputs.deployed_sha }}
         run: |
           set -euo pipefail
 
@@ -58,7 +64,7 @@ jobs:
         if: ${{ steps.production-branch.outputs.should_run == 'true' }}
         shell: bash
         env:
-          DEPLOYED_SHA: ${{ github.event.deployment.sha }}
+          DEPLOYED_SHA: ${{ github.event.deployment.sha || inputs.deployed_sha }}
           HOSTED_WEB_PRODUCTION_BASE_URL: ${{ vars.HOSTED_WEB_PRODUCTION_BASE_URL }}
           HOSTED_WEB_VERCEL_PROJECT_ID: ${{ vars.HOSTED_WEB_VERCEL_PROJECT_ID }}
           HOSTED_WEB_VERCEL_TEAM_ID: ${{ vars.HOSTED_WEB_VERCEL_TEAM_ID }}
@@ -113,7 +119,7 @@ jobs:
         if: ${{ steps.production-branch.outputs.should_run == 'true' && steps.current-production.outputs.should_apply == 'true' }}
         shell: bash
         env:
-          DEPLOYED_SHA: ${{ github.event.deployment.sha }}
+          DEPLOYED_SHA: ${{ github.event.deployment.sha || inputs.deployed_sha }}
           HOSTED_WEB_PRODUCTION_BASE_URL: ${{ vars.HOSTED_WEB_PRODUCTION_BASE_URL }}
           HOSTED_WEB_VERCEL_PROJECT_ID: ${{ vars.HOSTED_WEB_VERCEL_PROJECT_ID }}
           HOSTED_WEB_VERCEL_TEAM_ID: ${{ vars.HOSTED_WEB_VERCEL_TEAM_ID }}

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -81,21 +81,24 @@ Last verified: 2026-07-06
   expand/backfill/switch/final-cleanup sequencing; only final cleanup belongs in
   `apps/web/prisma/contract-migrations`. Destructive hosted web contract cleanup
   is applied by `.github/workflows/hosted-web-contract-migrations.yml` after a
-  successful Vercel-originated production deployment status; that workflow
-  checks out the deployed SHA, verifies it is reachable from `origin/main`,
-  waits `HOSTED_WEB_CONTRACT_MIGRATION_DRAIN_SECONDS` seconds for prior
-  production function executions to drain, rechecks that the configured Vercel
-  production alias still points at that SHA before exposing the database secret,
-  does not use GitHub Actions concurrency for this lane so stale events cannot
-  replace valid pending runs, and requires GitHub Actions values for
+  successful Vercel-originated completed production deployment status; that
+  workflow checks out the deployed SHA, verifies it is reachable from
+  `origin/main`, waits `HOSTED_WEB_CONTRACT_MIGRATION_DRAIN_SECONDS` seconds for
+  prior production function executions to drain, rechecks that the configured
+  Vercel production alias still points at that SHA before exposing the database
+  secret, supports manual dispatch with `deployed_sha` for the same current-alias
+  proof path, does not use GitHub Actions concurrency for this lane so stale
+  events cannot replace valid pending runs, and requires GitHub Actions values for
   `HOSTED_WEB_VERCEL_TOKEN`,
   `HOSTED_WEB_VERCEL_PROJECT_ID`, `HOSTED_WEB_PRODUCTION_BASE_URL`, and
-  `HOSTED_WEB_DIRECT_DATABASE_URL`. After contract cleanup applies, the rollback
-  floor is the first deployed Vercel commit that no longer reads or writes the
-  dropped schema shape; rollback below that floor requires DB restore/re-expand
-  or a forward deploy. Cloudflare `container_rollout=immediate` is not
-  applicable to this Vercel-only lane; the bounded drain wait and final alias
-  check own the old-function window.
+  `HOSTED_WEB_DIRECT_DATABASE_URL`. The shared production migration URL resolver
+  removes Prisma-style `sslcert=system`, `sslkey=system`, and
+  `sslrootcert=system` markers before handing Postgres URLs to raw `pg` clients.
+  After contract cleanup applies, the rollback floor is the first deployed Vercel
+  commit that no longer reads or writes the dropped schema shape; rollback below
+  that floor requires DB restore/re-expand or a forward deploy. Cloudflare
+  `container_rollout=immediate` is not applicable to this Vercel-only lane; the
+  bounded drain wait and final alias check own the old-function window.
 
 ## Current Gaps
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -582,11 +582,14 @@ Destructive contract cleanup belongs under
 `apps/web/prisma/contract-migrations` and runs through the
 `Hosted Web Contract Migrations` GitHub workflow after Vercel reports a
 successful production deployment. That workflow only accepts Vercel-originated
-deployment statuses, checks out the exact deployed commit, verifies it is
-reachable from `origin/main`, waits `HOSTED_WEB_CONTRACT_MIGRATION_DRAIN_SECONDS`
-seconds for prior production function executions to drain, then verifies the
-configured Vercel production alias still points at that commit before exposing
-the database secret. It requires
+completed production deployment statuses, checks out the exact deployed commit,
+verifies it is reachable from `origin/main`, waits
+`HOSTED_WEB_CONTRACT_MIGRATION_DRAIN_SECONDS` seconds for prior production
+function executions to drain, then verifies the configured Vercel production
+alias still points at that commit before exposing the database secret. It can
+also be manually dispatched with `deployed_sha` set to the current Vercel
+production commit; the same drain and alias proof still apply before SQL runs.
+It requires
 `HOSTED_WEB_VERCEL_TOKEN`, `HOSTED_WEB_VERCEL_PROJECT_ID`,
 `HOSTED_WEB_PRODUCTION_BASE_URL`, and `HOSTED_WEB_DIRECT_DATABASE_URL` in
 GitHub Actions; `HOSTED_WEB_CONTRACT_MIGRATION_DRAIN_SECONDS` defaults to
@@ -595,6 +598,9 @@ does not use GitHub Actions concurrency for this lane; the final alias check and
 the contract migration advisory lock make stale or duplicate runs skip safely
 without letting stale events replace valid pending runs. After those gates, it calls
 `pnpm --dir apps/web release:production:contract-migrate` with explicit opt-in.
+The shared production migration URL resolver strips Prisma-style
+`sslcert=system`, `sslkey=system`, and `sslrootcert=system` markers before
+handing Postgres URLs to raw `pg` clients, while preserving real SSL file paths.
 Rollback floor: after contract cleanup drops an old schema shape, the oldest
 safe Vercel rollback target is the first deployed commit that no longer reads or
 writes that dropped shape. Rolling back below that floor requires restoring or

--- a/apps/web/scripts/run-prisma-migrate-deploy.ts
+++ b/apps/web/scripts/run-prisma-migrate-deploy.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const CONFIG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const HOSTED_WEB_PRISMA_MIGRATIONS_DIR = path.join(CONFIG_DIR, "prisma", "migrations");
 const KNOWN_POOLER_PORTS = new Set(["6432", "6543"]);
+const SYSTEM_SSL_FILE_PARAMETERS = ["sslcert", "sslkey", "sslrootcert"] as const;
 
 export const hostedWebPrismaPredeployDestructiveMigrationBaseline =
   "20260707170000_drop_stale_linq_recency_columns";
@@ -154,8 +155,13 @@ export function resolveHostedWebMigrationDatabaseUrl(
   const directDatabaseUrl = nonEmptyEnv(environment.DIRECT_DATABASE_URL);
 
   if (directDatabaseUrl !== undefined) {
-    assertDirectMigrationDatabaseUrl(directDatabaseUrl, "DIRECT_DATABASE_URL");
-    return { source: "DIRECT_DATABASE_URL", url: directDatabaseUrl };
+    const normalizedDirectDatabaseUrl =
+      normalizeHostedWebMigrationDatabaseUrl(directDatabaseUrl);
+    assertDirectMigrationDatabaseUrl(
+      normalizedDirectDatabaseUrl,
+      "DIRECT_DATABASE_URL",
+    );
+    return { source: "DIRECT_DATABASE_URL", url: normalizedDirectDatabaseUrl };
   }
 
   if (shouldRequireDirectDatabaseUrl(environment)) {
@@ -170,7 +176,32 @@ export function resolveHostedWebMigrationDatabaseUrl(
   }
 
   assertDirectMigrationDatabaseUrl(databaseUrl, "DATABASE_URL");
-  return { source: "DATABASE_URL", url: databaseUrl };
+  return {
+    source: "DATABASE_URL",
+    url: normalizeHostedWebMigrationDatabaseUrl(databaseUrl),
+  };
+}
+
+export function normalizeHostedWebMigrationDatabaseUrl(databaseUrl: string): string {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    return databaseUrl;
+  }
+
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    return databaseUrl;
+  }
+
+  for (const key of SYSTEM_SSL_FILE_PARAMETERS) {
+    if (parsed.searchParams.get(key) === "system") {
+      parsed.searchParams.delete(key);
+    }
+  }
+
+  return parsed.toString();
 }
 
 export function assertDirectMigrationDatabaseUrl(
@@ -206,14 +237,19 @@ export async function runHostedWebPrismaMigrateDeploy(
 
   const migrationDatabaseUrl = resolveHostedWebMigrationDatabaseUrl(environment);
   console.log(`Applying hosted web Prisma migrations with ${migrationDatabaseUrl.source}.`);
+  const childEnvironment: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...environment,
+    DATABASE_URL: migrationDatabaseUrl.url,
+  };
+  if (migrationDatabaseUrl.source === "DIRECT_DATABASE_URL") {
+    childEnvironment.DIRECT_DATABASE_URL = migrationDatabaseUrl.url;
+  }
+
   await runCommand(
     hostedWebPrismaMigrateDeployCommand.command,
     hostedWebPrismaMigrateDeployCommand.args,
-    {
-      ...process.env,
-      ...environment,
-      DATABASE_URL: migrationDatabaseUrl.url,
-    },
+    childEnvironment,
   );
 }
 

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -30,6 +30,7 @@ import {
   findHostedWebPrismaPredeployDestructiveMigrations,
   hostedWebPrismaMigrateDeployCommand,
   hostedWebPrismaPredeployDestructiveMigrationBaseline,
+  normalizeHostedWebMigrationDatabaseUrl,
   runHostedWebPrismaMigrateDeploy,
   resolveHostedWebMigrationDatabaseUrl,
 } from "../scripts/run-prisma-migrate-deploy";
@@ -342,6 +343,34 @@ describe("hosted web production migration guard", () => {
     );
   });
 
+  test("normalizes Prisma system SSL file markers for raw migration clients", () => {
+    assert.equal(
+      normalizeHostedWebMigrationDatabaseUrl(
+        "postgresql://direct.example.com:5432/app?sslmode=require&sslrootcert=system&sslcert=system&sslkey=system",
+      ),
+      "postgresql://direct.example.com:5432/app?sslmode=require",
+    );
+    assert.equal(
+      normalizeHostedWebMigrationDatabaseUrl(
+        "postgresql://direct.example.com:5432/app?sslrootcert=/etc/ssl/root.pem",
+      ),
+      "postgresql://direct.example.com:5432/app?sslrootcert=/etc/ssl/root.pem",
+    );
+  });
+
+  test("uses normalized DIRECT_DATABASE_URL for migration clients", () => {
+    assert.deepEqual(
+      resolveHostedWebMigrationDatabaseUrl({
+        DIRECT_DATABASE_URL:
+          "postgresql://direct.example.com:5432/app?sslmode=require&sslrootcert=system",
+      }),
+      {
+        source: "DIRECT_DATABASE_URL",
+        url: "postgresql://direct.example.com:5432/app?sslmode=require",
+      },
+    );
+  });
+
   test("requires DIRECT_DATABASE_URL for Vercel production migrations", () => {
     assert.throws(
       () =>
@@ -385,7 +414,8 @@ describe("hosted web production migration guard", () => {
     await runHostedWebPrismaMigrateDeploy(
       {
         DATABASE_URL: "postgresql://runtime.example.com:5432/app",
-        DIRECT_DATABASE_URL: "postgresql://direct.example.com:5432/app",
+        DIRECT_DATABASE_URL:
+          "postgresql://direct.example.com:5432/app?sslmode=require&sslrootcert=system",
       },
       async (command, args, environment) => {
         calls.push({
@@ -401,8 +431,8 @@ describe("hosted web production migration guard", () => {
       {
         command: hostedWebPrismaMigrateDeployCommand.command,
         args: hostedWebPrismaMigrateDeployCommand.args,
-        databaseUrl: "postgresql://direct.example.com:5432/app",
-        directDatabaseUrl: "postgresql://direct.example.com:5432/app",
+        databaseUrl: "postgresql://direct.example.com:5432/app?sslmode=require",
+        directDatabaseUrl: "postgresql://direct.example.com:5432/app?sslmode=require",
       },
     ]);
   });
@@ -667,7 +697,14 @@ describe("hosted web production migration guard", () => {
     );
 
     assert.match(workflow, /deployment_status/u);
+    assert.match(workflow, /workflow_dispatch/u);
+    assert.match(workflow, /deployed_sha/u);
+    assert.match(workflow, /github\.event_name == 'workflow_dispatch'/u);
     assert.match(workflow, /github\.event\.deployment_status\.state == 'success'/u);
+    assert.match(
+      workflow,
+      /github\.event\.deployment_status\.description == 'Deployment has completed'/u,
+    );
     assert.match(workflow, /deployment_status\.creator\.login == 'vercel\[bot\]'/u);
     assert.match(workflow, /deployment\.creator\.login == 'vercel\[bot\]'/u);
     assert.match(workflow, /environment: production/u);
@@ -675,7 +712,7 @@ describe("hosted web production migration guard", () => {
     assert.doesNotMatch(workflow, /concurrency:/u);
     assert.doesNotMatch(workflow, /cancel-in-progress/u);
     assert.doesNotMatch(workflow, /hosted-web-contract-migrations-production/u);
-    assert.match(workflow, /github\.event\.deployment\.sha/u);
+    assert.match(workflow, /github\.event\.deployment\.sha \|\| inputs\.deployed_sha/u);
     assert.match(workflow, /fetch-depth: 0/u);
     assert.match(workflow, /git merge-base --is-ancestor "\$\{DEPLOYED_SHA\}" origin\/main/u);
     assert.match(


### PR DESCRIPTION
## Why
The hosted web post-deploy contract migration workflow could succeed without applying SQL when the Vercel production alias moved during the drain window, and the raw `pg` migration client could fail on Prisma-style `sslrootcert=system` direct database URLs.

## User-visible goal
Keep production schema cleanup behind the current-production alias proof while giving operators a manual dispatch path for the exact current production SHA, so post-deploy contract migrations can be verified end to end without reintroducing deploy skew downtime.

## Invariants
- Database secrets are exposed only after the deployed/current production SHA proof.
- Stale deployment-status runs skip instead of applying SQL to the wrong production version.
- Contract migrations continue to require an origin/main-reachable commit and explicit opt-in.
- Raw `pg` migration clients do not receive Prisma `sslcert=system`, `sslkey=system`, or `sslrootcert=system` markers.

## Verification
- `pnpm --dir apps/web test:prepared production-migration-guard.test.ts`
- `pnpm --dir apps/web typecheck`
- `bash scripts/workspace-verify.sh test:diff .github/workflows/hosted-web-contract-migrations.yml apps/web/scripts/run-prisma-migrate-deploy.ts apps/web/test/production-migration-guard.test.ts apps/web/README.md agent-docs/references/testing-ci-map.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786082769&installation_id=127572939&pr_number=472&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F472&signature=55cb27629eddcf38120fe807fec59ad62f09fbd98d1633f84b62774d00411f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->