### PR TITLE
Bound CLI list output defaults

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-08-cli-output-budget-followup.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-cli-output-budget-followup.md
@@ -1,0 +1,41 @@
+# CLI Output Budget Follow-Up
+
+## Goal
+
+Close the remaining default CLI output-budget gaps found by measuring a private full vault, and add a durable regression guard so new agent-visible read surfaces do not grow without an explicit drilldown path.
+
+## Constraints
+
+- Treat the private vault as local measurement input only; commit no vault content, derived record text, paths, identifiers, or raw outputs.
+- Keep `--llms-full` and framework-owned discovery/schema surfaces unchanged.
+- Prefer default summary limits and compact status rows over new data stores or broad abstractions.
+- Preserve full operator access through detail commands, explicit limits, or internal persisted data.
+
+## Plan
+
+1. Patch the remaining over-budget default surfaces: assistant status, workout list, and wearable sleep list.
+2. Add focused regression coverage for default agent-visible output budgets and assistant status compaction.
+3. Document the bounded-output invariant for future CLI surfaces.
+4. Re-run focused verification and remeasure the private vault using aggregate character counts only.
+5. Commit and update the existing PR branch.
+
+## Verification
+
+- Focused assistant status tests.
+- Focused CLI output budget tests.
+- `pnpm typecheck`.
+- Private full-vault aggregate character-count smoke for representative default read commands.
+
+## State
+
+Implemented 2026-07-08.
+
+- `assistant status` now returns compact recent-turn summaries instead of full receipt timelines.
+- `workout list` defaults to 5 rows; wearable daily list commands default to 3 rows.
+- Added CLI output-budget regression coverage and assistant status timeline compaction coverage.
+- Added the default CLI output-budget invariant to the contracts.
+- Private full-vault aggregate smoke passed with all measured default reads under 15k chars; largest measured outputs were `assistant status` at 13,742 chars and `wearables sleep list` at 13,362 chars.
+- Focused assistant, CLI, and vault-usecases tests passed; repo-level `pnpm typecheck` passed.
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/agent-docs/exec-plans/completed/2026-07-08-cli-output-budget.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-cli-output-budget.md
@@ -1,0 +1,44 @@
+# CLI Output Budget
+
+## Goal
+
+Reduce high-volume `vault-cli` / `murph` outputs that exceeded roughly 20k characters in the July 8 CLI output audit, focusing on model-facing list/status/read surfaces that leak full records or unbounded history by default.
+
+## Constraints
+
+- Keep changes in the CLI/usecase/read-output layer; do not change canonical vault storage.
+- Prefer default limits, compact list rows, and explicit `--full-output` escape hatches over new abstractions.
+- Preserve operator access to detailed data through existing show/detail commands or explicit full-output modes.
+- Do not weaken Incur discovery semantics; leave large framework-owned `--schema` / `--llms-full` behavior alone unless there is a repo-owned bounded surface.
+- Use the prior count artifacts under `/tmp/murph-cli-output-audit` as measurement input, but do not commit vault data or raw command output.
+- Run CLI-focused verification and ReviewGPT PR rounds before handoff.
+
+## Plan
+
+1. Map every successful runtime command over 20k characters to its owning package/code path and classify whether it can be shrunk by default limits, compact rows, or explicit full-output gating.
+2. Implement the smallest bounded-output changes for high-value model-facing surfaces: assistant sessions, generic/entity lists, wearable summaries, audit/history, automation/regimen/experiment list rows, and onboarding resume context where reasonable.
+3. Add focused regression tests that prove default outputs stay compact while explicit full-output/detail paths remain available.
+4. Re-run output measurements against a synthetic oversized-record vault for the changed high-volume commands and record tradeoffs/product calls.
+5. Run required CLI verification, close this plan with `scripts/finish-task`, open a PR, and run PR ReviewGPT rounds to zero accepted findings.
+
+## Verification
+
+- `pnpm --dir packages/operator-config typecheck`
+- `pnpm --dir packages/vault-usecases typecheck`
+- `pnpm --dir packages/assistant-cli typecheck`
+- `pnpm --dir packages/cli typecheck`
+- `pnpm --dir packages/vault-usecases test`
+- `pnpm --dir packages/assistant-cli test`
+- `pnpm --dir packages/cli test:source`
+- `pnpm --dir packages/cli verify:package-shape`
+- Synthetic oversized-record byte smoke: `event list` 11,555 chars, root `list` 11,519 chars, `automation list` 7,852 chars, `scheduled-log list` 5,502 chars.
+- PR ReviewGPT loop to zero accepted findings.
+
+## State
+
+Implementation and local verification complete in `/tmp/murph-cli-output-budget`.
+
+Default model-facing list pages now return 10 rows, assistant session/onboarding defaults return 5 rows, wearable list defaults return 5 rows, audit tail returns 10 rows, and long/nested list payloads are compacted into scalar summaries. Detail commands still return full records. Incur discovery/schema outputs remain unchanged because they are explicit contract/discovery surfaces rather than default runtime reads.
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -126,6 +126,8 @@ rationale, not a live mechanism.
 
 - Agent-primary `add`, `save`, and `edit` commands expose their normal input shape through native Incur args and options so `--help`, `--schema`, `--llms`, MCP, and generated skills stay truthful. Batch or document-derived JSON payloads are explicitly named escape hatches such as `import-json`/`import-jsonl`, never hidden behind canonical typed command names.
 - Every agent-visible command that accepts a complex `--input @file|-` payload provides a paired Incur-discoverable shape path — a sibling `payload-schema` command with `scaffold` as a representative payload — sharing the runtime importer's normalization/schema path where practical. Agents must not have to infer payload shapes from source, tests, or stale docs.
+- Default agent-visible read/status/list/tail surfaces return bounded summaries suitable for a single model tool result. Growing fields such as markdown bodies, assistant timelines, raw provenance, manifest payloads, nested telemetry arrays, and long instruction text stay out of defaults unless the command is an explicit detail/export/schema surface.
+- Any new default CLI read surface that can grow with vault size needs a deterministic output-budget regression. The representative `--full-output --format json` default response should stay under roughly 15k characters on oversized fixtures; callers that need more data must use an explicit `show`, manifest/export/materialize command, or raised `--limit`.
 
 ## Assistant Boundary
 

--- a/docs/contracts/03-command-surface.md
+++ b/docs/contracts/03-command-surface.md
@@ -47,7 +47,7 @@ vault-cli assistant stop --vault <path> [--request-id <id>]
 vault-cli status --vault <path> [--session <id>] [--limit <n>] [--request-id <id>]
 vault-cli doctor --vault <path> [--repair] [--request-id <id>]
 vault-cli stop --vault <path> [--request-id <id>]
-vault-cli assistant session list --vault <path> [--limit <n>] [--request-id <id>]
+vault-cli assistant session list --vault <path> [--limit <n>] [--repair] [--request-id <id>]
 vault-cli assistant session show <sessionId> --vault <path> [--request-id <id>]
 vault-cli memory show [memoryId] --vault <path>
 vault-cli memory upsert <text> --vault <path> --section <section>

--- a/docs/contracts/03-command-surface.md
+++ b/docs/contracts/03-command-surface.md
@@ -47,7 +47,7 @@ vault-cli assistant stop --vault <path> [--request-id <id>]
 vault-cli status --vault <path> [--session <id>] [--limit <n>] [--request-id <id>]
 vault-cli doctor --vault <path> [--repair] [--request-id <id>]
 vault-cli stop --vault <path> [--request-id <id>]
-vault-cli assistant session list --vault <path> [--request-id <id>]
+vault-cli assistant session list --vault <path> [--limit <n>] [--request-id <id>]
 vault-cli assistant session show <sessionId> --vault <path> [--request-id <id>]
 vault-cli memory show [memoryId] --vault <path>
 vault-cli memory upsert <text> --vault <path> --section <section>
@@ -109,7 +109,7 @@ vault-cli event list --vault <path> [--kind <kind>] [--from <date>] [--to <date>
 vault-cli document import <file> --vault <path> [--title <title>] [--occurred-at <ts>] [--note "..."] [--source <source>] [--request-id <id>]
 vault-cli document edit <id> --vault <path> [--title <title>] [--note <text>] [--occurred-at <ts>] [--time-zone <zone>] [--day-key <YYYY-MM-DD>] [--source <source>] [--tag <tag> ...] [--clear-title] [--clear-note] [--clear-time-zone] [--clear-day-key] [--clear-source] [--clear-tags] [--day-key-policy keep|recompute] [--request-id <id>]
 vault-cli document show <id> --vault <path> [--request-id <id>]
-vault-cli document list --vault <path> [--from <date>] [--to <date>] [--request-id <id>]
+vault-cli document list --vault <path> [--from <date>] [--to <date>] [--limit <n>] [--request-id <id>]
 vault-cli document manifest <id> --vault <path> [--request-id <id>]
 vault-cli capture add --vault <path> [--media <path> ...] [--label <text>] [--body-site <text>] [--collection <text>] [--related-id <id> ...] [--note <text>] [--title <title>] [--occurred-at <ts>] [--source <source>] [--tag <tag> ...] [--request-id <id>]
 vault-cli capture import-json --vault <path> --input @file.json|- [--request-id <id>]

--- a/docs/contracts/03-command-surface.md
+++ b/docs/contracts/03-command-surface.md
@@ -342,6 +342,8 @@ Read surfaces intentionally separate summary from detail:
 - `show` returns the full canonical read entity, including `markdown` when that noun owns body text.
 - `list` returns summary rows, not many embedded `show` payloads.
 - List rows never include full `markdown`; when a family owns first-class body text, list rows may carry a compact `excerpt` instead.
+- Default read/status/list/tail pages are model-facing summaries and should fit under roughly 15k characters with `--full-output --format json` on representative oversized fixtures.
+- Assistant timelines, raw provenance, import manifests, full nested telemetry arrays, and long instruction/body text require an explicit detail/export/schema path or an explicitly raised `--limit`; `--full-output` is an envelope selector, not an uncompression switch.
 - Callers that need the full body must follow a list result with `show`.
 
 ## Shared Option Rules

--- a/docs/contracts/03-command-surface.md
+++ b/docs/contracts/03-command-surface.md
@@ -47,7 +47,7 @@ vault-cli assistant stop --vault <path> [--request-id <id>]
 vault-cli status --vault <path> [--session <id>] [--limit <n>] [--request-id <id>]
 vault-cli doctor --vault <path> [--repair] [--request-id <id>]
 vault-cli stop --vault <path> [--request-id <id>]
-vault-cli assistant session list --vault <path> [--limit <n>] [--repair] [--request-id <id>]
+vault-cli assistant session list --vault <path> [--limit <n>] [--request-id <id>]
 vault-cli assistant session show <sessionId> --vault <path> [--request-id <id>]
 vault-cli memory show [memoryId] --vault <path>
 vault-cli memory upsert <text> --vault <path> --section <section>

--- a/e2e/smoke/scenarios/assistant-session-list.json
+++ b/e2e/smoke/scenarios/assistant-session-list.json
@@ -1,6 +1,6 @@
 {
   "id": "assistant-session-list",
-  "command": "vault-cli assistant session list --vault <path> [--request-id <id>]",
+  "command": "vault-cli assistant session list --vault <path> [--limit <n>] [--request-id <id>]",
   "vaultFixture": "fixtures/minimal-vault",
   "inputs": [
     "fixtures/minimal-vault/CORE.md"

--- a/e2e/smoke/scenarios/document-list.json
+++ b/e2e/smoke/scenarios/document-list.json
@@ -1,6 +1,6 @@
 {
   "id": "document-list",
-  "command": "vault-cli document list --vault <path> [--from <date>] [--to <date>] [--request-id <id>]",
+  "command": "vault-cli document list --vault <path> [--from <date>] [--to <date>] [--limit <n>] [--request-id <id>]",
   "vaultFixture": "fixtures/minimal-vault",
   "inputs": [
     "fixtures/sample-imports/documents/visit-summary.md",

--- a/packages/assistant-cli/src/assistant-daemon-client.ts
+++ b/packages/assistant-cli/src/assistant-daemon-client.ts
@@ -9,7 +9,6 @@ import {
   assistantCronTargetSnapshotSchema,
   assistantOutboxIntentSchema,
   assistantRunResultSchema,
-  assistantSessionListResultSchema,
   assistantSessionShowResultSchema,
   assistantStatusResultSchema,
   type AssistantAskResult,
@@ -620,7 +619,7 @@ function parseAssistantSessionListPayload(payload: unknown): AssistantSession[] 
   if (!Array.isArray(payload)) {
     throw new Error('Assistant daemon returned an invalid session list payload.')
   }
-  return assistantSessionListResultSchema.shape.sessions.parse(payload)
+  return assistantSessionShowResultSchema.shape.session.array().parse(payload)
 }
 
 function parseAssistantSessionOutputPayload(payload: unknown): AssistantSession {

--- a/packages/assistant-cli/src/assistant/store.ts
+++ b/packages/assistant-cli/src/assistant/store.ts
@@ -4,6 +4,7 @@ import {
 } from '../assistant-daemon-client.js'
 import {
   getAssistantSessionLocal,
+  listAssistantSessions as listAssistantSessionsFromStore,
   listAssistantSessionsLocal,
 } from '@murphai/assistant-engine/assistant-store'
 import type { AssistantSession } from '@murphai/operator-config/assistant-cli-contracts'
@@ -13,7 +14,14 @@ export type { AssistantSession } from '@murphai/operator-config/assistant-cli-co
 
 export async function listAssistantSessions(
   vault: string,
+  options?: {
+    limit?: number
+  },
 ): Promise<AssistantSession[]> {
+  if (typeof options?.limit === 'number') {
+    return listAssistantSessionsFromStore(vault, options)
+  }
+
   const remote = await maybeListAssistantSessionsViaDaemon({ vault })
   if (remote !== null) {
     return remote

--- a/packages/assistant-cli/src/commands/assistant.ts
+++ b/packages/assistant-cli/src/commands/assistant.ts
@@ -45,7 +45,7 @@ import {
   readAssistantOnboardingState,
   reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath,
-  listAssistantSessions,
+  listRecentAssistantSessions,
   resolveAssistantStatePaths,
 } from '@murphai/assistant-engine/assistant-state'
 import {
@@ -1408,8 +1408,13 @@ export function registerAssistantCommands(
       async run(context) {
         await assertAssistantInitializedVaultRoot(context.options.vault)
         const limit = normalizeAssistantSessionListLimit(context.options.limit)
-        const sessions = (await listAssistantSessions(context.options.vault))
-          .slice(0, limit)
+        const sessions = await listRecentAssistantSessions(
+          context.options.vault,
+          {
+            limit,
+            repairMissingProjection: true,
+          },
+        )
         return assistantSessionListResultSchema.parse({
           ...buildAssistantStateResultPaths(context.options.vault),
           filters: { limit },

--- a/packages/assistant-cli/src/commands/assistant.ts
+++ b/packages/assistant-cli/src/commands/assistant.ts
@@ -43,6 +43,7 @@ import {
   redactAssistantDisplayPath,
   getAssistantSession,
   readAssistantOnboardingState,
+  repairAssistantSessionIndexes,
   reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath,
   listRecentAssistantSessions,
@@ -1403,15 +1404,26 @@ export function registerAssistantCommands(
           .max(50)
           .default(assistantSessionListDefaultLimit)
           .describe('Maximum number of recent assistant sessions to return. Defaults to 5.'),
+        repair: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            'Rebuild assistant session indexes from durable session files before listing. This is an explicit repair path for legacy or recovered vaults and may scan all assistant session records.',
+          ),
       }),
       output: assistantSessionListResultSchema,
       async run(context) {
         await assertAssistantInitializedVaultRoot(context.options.vault)
         const limit = normalizeAssistantSessionListLimit(context.options.limit)
+        if (context.options.repair) {
+          await repairAssistantSessionIndexes(context.options.vault)
+        }
         const sessions = await listRecentAssistantSessions(
           context.options.vault,
           {
             limit,
+            requireProjection: true,
           },
         )
         return assistantSessionListResultSchema.parse({

--- a/packages/assistant-cli/src/commands/assistant.ts
+++ b/packages/assistant-cli/src/commands/assistant.ts
@@ -22,6 +22,8 @@ import {
   assistantStopResultSchema,
   assistantStatusResultSchema,
   type AssistantOnboardingResumeContextResult,
+  type AssistantSession,
+  type AssistantSessionSummary,
 } from '@murphai/operator-config/assistant-cli-contracts'
 import { deliverAssistantMessage } from '@murphai/assistant-engine/outbound-channel'
 import type { ConversationRef } from '@murphai/assistant-engine/assistant-runtime'
@@ -35,7 +37,6 @@ import { runAssistantDoctor } from '../assistant/doctor.js'
 import { getAssistantStatus } from '../assistant/status.js'
 import {
   redactAssistantSessionForDisplay,
-  redactAssistantSessionsForDisplay,
 } from '@murphai/assistant-engine/assistant-runtime'
 import {
   completeAssistantOnboarding,
@@ -44,7 +45,7 @@ import {
   readAssistantOnboardingState,
   reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath,
-  listAssistantSessions,
+  listRecentAssistantSessions,
   resolveAssistantStatePaths,
 } from '@murphai/assistant-engine/assistant-state'
 import {
@@ -476,6 +477,42 @@ function buildAssistantOnboardingResult(vault: string, onboarding: unknown) {
   })
 }
 
+const assistantSessionListDefaultLimit = 5
+
+function normalizeAssistantSessionListLimit(limit: number | undefined): number {
+  if (typeof limit !== 'number' || !Number.isInteger(limit)) {
+    return assistantSessionListDefaultLimit
+  }
+
+  return Math.min(Math.max(limit, 1), 50)
+}
+
+function toAssistantSessionSummary(session: AssistantSession): AssistantSessionSummary {
+  const redacted = redactAssistantSessionForDisplay(session)
+  return {
+    schema: redacted.schema,
+    conversationId: redacted.conversationId,
+    sessionId: redacted.sessionId,
+    alias: redacted.alias,
+    binding: redacted.binding,
+    createdAt: redacted.createdAt,
+    updatedAt: redacted.updatedAt,
+    lastTurnAt: redacted.lastTurnAt,
+    turnCount: redacted.turnCount,
+    provider: redacted.provider,
+    model: redacted.providerOptions.model,
+    modelProvider: redacted.providerOptions.modelProvider ?? null,
+    reasoningEffort: redacted.providerOptions.reasoningEffort,
+    sandbox: redacted.providerOptions.sandbox,
+    approvalPolicy: redacted.providerOptions.approvalPolicy,
+    profile: redacted.providerOptions.profile,
+    oss: redacted.providerOptions.oss,
+    executionDriver: redacted.providerOptions.executionDriver,
+    resumeKind: redacted.providerOptions.resumeKind,
+    resumeThreadId: redacted.resumeState?.threadId ?? null,
+  }
+}
+
 type AssistantOnboardingResumeContextSurface =
   AssistantOnboardingResumeContextResult[
     | 'goals'
@@ -503,7 +540,7 @@ type AssistantOnboardingDeviceAccountServices = {
 type AssistantVaultServices = VaultServices &
   AssistantOnboardingDeviceAccountServices
 
-const assistantOnboardingResumeContextDefaultLimit = 10
+const assistantOnboardingResumeContextDefaultLimit = 3
 
 function normalizeAssistantOnboardingResumeContextLimit(limit: number): number {
   return Math.min(Math.max(limit, 1), 50)
@@ -1219,7 +1256,7 @@ export function registerAssistantCommands(
           .max(50)
           .default(assistantOnboardingResumeContextDefaultLimit)
           .describe(
-            'Maximum records to return per setup surface. Defaults to 10.',
+            'Maximum records to return per setup surface. Defaults to 3.',
           ),
       }),
       output: assistantOnboardingResumeContextResultSchema,
@@ -1358,14 +1395,28 @@ export function registerAssistantCommands(
     session.command('list', {
       args: emptyArgsSchema,
       description: 'List known assistant sessions for one vault.',
-      options: withBaseOptions(),
+      options: withBaseOptions({
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(50)
+          .default(assistantSessionListDefaultLimit)
+          .describe('Maximum number of recent assistant sessions to return. Defaults to 5.'),
+      }),
       output: assistantSessionListResultSchema,
       async run(context) {
         await assertAssistantInitializedVaultRoot(context.options.vault)
-        const sessions = await listAssistantSessions(context.options.vault)
+        const limit = normalizeAssistantSessionListLimit(context.options.limit)
+        const sessions = await listRecentAssistantSessions(
+          context.options.vault,
+          { limit },
+        )
         return assistantSessionListResultSchema.parse({
           ...buildAssistantStateResultPaths(context.options.vault),
-          sessions: redactAssistantSessionsForDisplay(sessions),
+          filters: { limit },
+          sessions: sessions.map(toAssistantSessionSummary),
+          count: sessions.length,
         })
       },
     })

--- a/packages/assistant-cli/src/commands/assistant.ts
+++ b/packages/assistant-cli/src/commands/assistant.ts
@@ -43,10 +43,9 @@ import {
   redactAssistantDisplayPath,
   getAssistantSession,
   readAssistantOnboardingState,
-  repairAssistantSessionIndexes,
   reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath,
-  listRecentAssistantSessions,
+  listAssistantSessions,
   resolveAssistantStatePaths,
 } from '@murphai/assistant-engine/assistant-state'
 import {
@@ -1404,28 +1403,13 @@ export function registerAssistantCommands(
           .max(50)
           .default(assistantSessionListDefaultLimit)
           .describe('Maximum number of recent assistant sessions to return. Defaults to 5.'),
-        repair: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe(
-            'Rebuild assistant session indexes from durable session files before listing. This is an explicit repair path for legacy or recovered vaults and may scan all assistant session records.',
-          ),
       }),
       output: assistantSessionListResultSchema,
       async run(context) {
         await assertAssistantInitializedVaultRoot(context.options.vault)
         const limit = normalizeAssistantSessionListLimit(context.options.limit)
-        if (context.options.repair) {
-          await repairAssistantSessionIndexes(context.options.vault)
-        }
-        const sessions = await listRecentAssistantSessions(
-          context.options.vault,
-          {
-            limit,
-            requireProjection: true,
-          },
-        )
+        const sessions = (await listAssistantSessions(context.options.vault))
+          .slice(0, limit)
         return assistantSessionListResultSchema.parse({
           ...buildAssistantStateResultPaths(context.options.vault),
           filters: { limit },

--- a/packages/assistant-cli/src/commands/assistant.ts
+++ b/packages/assistant-cli/src/commands/assistant.ts
@@ -1412,7 +1412,6 @@ export function registerAssistantCommands(
           context.options.vault,
           {
             limit,
-            repairMissingProjection: true,
           },
         )
         return assistantSessionListResultSchema.parse({

--- a/packages/assistant-cli/src/commands/assistant.ts
+++ b/packages/assistant-cli/src/commands/assistant.ts
@@ -1408,8 +1408,9 @@ export function registerAssistantCommands(
       async run(context) {
         await assertAssistantInitializedVaultRoot(context.options.vault)
         const limit = normalizeAssistantSessionListLimit(context.options.limit)
-        const sessions = (await listAssistantSessions(context.options.vault))
-          .slice(0, limit)
+        const sessions = await listAssistantSessions(context.options.vault, {
+          limit,
+        })
         return assistantSessionListResultSchema.parse({
           ...buildAssistantStateResultPaths(context.options.vault),
           filters: { limit },

--- a/packages/assistant-cli/src/commands/assistant.ts
+++ b/packages/assistant-cli/src/commands/assistant.ts
@@ -45,7 +45,7 @@ import {
   readAssistantOnboardingState,
   reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath,
-  listRecentAssistantSessions,
+  listAssistantSessions,
   resolveAssistantStatePaths,
 } from '@murphai/assistant-engine/assistant-state'
 import {
@@ -1408,10 +1408,8 @@ export function registerAssistantCommands(
       async run(context) {
         await assertAssistantInitializedVaultRoot(context.options.vault)
         const limit = normalizeAssistantSessionListLimit(context.options.limit)
-        const sessions = await listRecentAssistantSessions(
-          context.options.vault,
-          { limit },
-        )
+        const sessions = (await listAssistantSessions(context.options.vault))
+          .slice(0, limit)
         return assistantSessionListResultSchema.parse({
           ...buildAssistantStateResultPaths(context.options.vault),
           filters: { limit },

--- a/packages/assistant-cli/test/assistant-command-coverage.test.ts
+++ b/packages/assistant-cli/test/assistant-command-coverage.test.ts
@@ -32,10 +32,8 @@ const commandMocks = vi.hoisted(() => ({
   getAssistantSession: vi.fn(),
   getAssistantStatus: vi.fn(),
   listAssistantSelfDeliveryTargets: vi.fn(),
-  listRecentAssistantSessions: vi.fn(),
   listAssistantSessions: vi.fn(),
   readAssistantOnboardingState: vi.fn(),
-  repairAssistantSessionIndexes: vi.fn(),
   redactAssistantDisplayPath: vi.fn((value: string) => `redacted:${value}`),
   redactAssistantSessionForDisplay: vi.fn((value) => value),
   redactAssistantSessionsForDisplay: vi.fn((value) => value),
@@ -115,9 +113,7 @@ vi.mock('@murphai/assistant-engine/assistant-state', () => ({
   readAssistantOnboardingState: commandMocks.readAssistantOnboardingState,
   redactAssistantDisplayPath: commandMocks.redactAssistantDisplayPath,
   getAssistantSession: commandMocks.getAssistantSession,
-  listRecentAssistantSessions: commandMocks.listRecentAssistantSessions,
   listAssistantSessions: commandMocks.listAssistantSessions,
-  repairAssistantSessionIndexes: commandMocks.repairAssistantSessionIndexes,
   reopenAssistantOnboarding: commandMocks.reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath:
     commandMocks.resolveAssistantOnboardingStatePath,
@@ -1091,7 +1087,6 @@ test('assistant status and session commands reject uninitialized vault roots bef
 
   assert.equal(commandMocks.getAssistantStatus.mock.calls.length, 0)
   assert.equal(commandMocks.getAssistantSession.mock.calls.length, 0)
-  assert.equal(commandMocks.listRecentAssistantSessions.mock.calls.length, 0)
   assert.equal(commandMocks.listAssistantSessions.mock.calls.length, 0)
 })
 
@@ -1320,7 +1315,7 @@ test('session commands return redacted state paths and session payloads', async 
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
 
-  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
+  commandMocks.listAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
   commandMocks.getAssistantSession.mockResolvedValueOnce(TEST_SESSION)
   commandMocks.redactAssistantSessionForDisplay
     .mockReturnValueOnce({
@@ -1378,8 +1373,8 @@ test('session commands return redacted state paths and session payloads', async 
     stateRoot: 'redacted:/tmp/vault/.runtime/operations/assistant',
     vault: 'redacted:/tmp/vault',
   })
-  assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
-    ['/tmp/vault', { limit: 5, requireProjection: true }],
+  assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
+    ['/tmp/vault'],
   ])
   assert.deepEqual(showResult, {
     session: {
@@ -1391,12 +1386,18 @@ test('session commands return redacted state paths and session payloads', async 
   })
 })
 
-test('session list requests a bounded recent-session page', async () => {
+test('session list slices source-of-truth sessions to the bounded page', async () => {
   const commands = createAssistantCli()
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
 
-  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
+  commandMocks.listAssistantSessions.mockResolvedValueOnce([
+    TEST_SESSION,
+    {
+      ...TEST_SESSION,
+      sessionId: 'session-outside-limit',
+    },
+  ])
 
   const listResult = assistantSessionListResultSchema.parse(
     await readCommand(session.commands, 'list').run({
@@ -1410,34 +1411,7 @@ test('session list requests a bounded recent-session page', async () => {
   assert.equal(listResult.count, 1)
   assert.equal(listResult.filters.limit, 1)
   assert.equal(listResult.sessions[0]?.sessionId, TEST_SESSION.sessionId)
-  assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
-    ['/tmp/vault', { limit: 1, requireProjection: true }],
-  ])
-})
-
-test('session list repair explicitly rebuilds indexes before reading the bounded page', async () => {
-  const commands = createAssistantCli()
-  const assistant = readCommandGroup(commands, 'assistant')
-  const session = readCommandGroup(assistant.commands, 'session')
-
-  commandMocks.repairAssistantSessionIndexes.mockResolvedValueOnce(undefined)
-  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
-
-  const listResult = assistantSessionListResultSchema.parse(
-    await readCommand(session.commands, 'list').run({
-      options: {
-        vault: '/tmp/vault',
-        limit: 1,
-        repair: true,
-      },
-    }),
-  )
-
-  assert.equal(listResult.count, 1)
-  assert.deepEqual(commandMocks.repairAssistantSessionIndexes.mock.calls, [
+  assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
     ['/tmp/vault'],
-  ])
-  assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
-    ['/tmp/vault', { limit: 1, requireProjection: true }],
   ])
 })

--- a/packages/assistant-cli/test/assistant-command-coverage.test.ts
+++ b/packages/assistant-cli/test/assistant-command-coverage.test.ts
@@ -11,6 +11,7 @@ import {
   assistantOnboardingCompletionReasonValues,
   assistantOnboardingResultSchema,
   assistantOnboardingResumeContextResultSchema,
+  assistantSessionListResultSchema,
 } from '@murphai/operator-config/assistant-cli-contracts'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import type { InboxServices } from '@murphai/inbox-services'
@@ -31,7 +32,6 @@ const commandMocks = vi.hoisted(() => ({
   getAssistantSession: vi.fn(),
   getAssistantStatus: vi.fn(),
   listAssistantSelfDeliveryTargets: vi.fn(),
-  listRecentAssistantSessions: vi.fn(),
   listAssistantSessions: vi.fn(),
   readAssistantOnboardingState: vi.fn(),
   redactAssistantDisplayPath: vi.fn((value: string) => `redacted:${value}`),
@@ -113,7 +113,6 @@ vi.mock('@murphai/assistant-engine/assistant-state', () => ({
   readAssistantOnboardingState: commandMocks.readAssistantOnboardingState,
   redactAssistantDisplayPath: commandMocks.redactAssistantDisplayPath,
   getAssistantSession: commandMocks.getAssistantSession,
-  listRecentAssistantSessions: commandMocks.listRecentAssistantSessions,
   listAssistantSessions: commandMocks.listAssistantSessions,
   reopenAssistantOnboarding: commandMocks.reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath:
@@ -1088,7 +1087,6 @@ test('assistant status and session commands reject uninitialized vault roots bef
 
   assert.equal(commandMocks.getAssistantStatus.mock.calls.length, 0)
   assert.equal(commandMocks.getAssistantSession.mock.calls.length, 0)
-  assert.equal(commandMocks.listRecentAssistantSessions.mock.calls.length, 0)
   assert.equal(commandMocks.listAssistantSessions.mock.calls.length, 0)
 })
 
@@ -1317,7 +1315,7 @@ test('session commands return redacted state paths and session payloads', async 
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
 
-  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
+  commandMocks.listAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
   commandMocks.getAssistantSession.mockResolvedValueOnce(TEST_SESSION)
   commandMocks.redactAssistantSessionForDisplay
     .mockReturnValueOnce({
@@ -1375,6 +1373,9 @@ test('session commands return redacted state paths and session payloads', async 
     stateRoot: 'redacted:/tmp/vault/.runtime/operations/assistant',
     vault: 'redacted:/tmp/vault',
   })
+  assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
+    ['/tmp/vault'],
+  ])
   assert.deepEqual(showResult, {
     session: {
       ...TEST_SESSION,
@@ -1383,4 +1384,38 @@ test('session commands return redacted state paths and session payloads', async 
     stateRoot: 'redacted:/tmp/vault/.runtime/operations/assistant',
     vault: 'redacted:/tmp/vault',
   })
+})
+
+test('session list slices durable sessions by requested limit', async () => {
+  const commands = createAssistantCli()
+  const assistant = readCommandGroup(commands, 'assistant')
+  const session = readCommandGroup(assistant.commands, 'session')
+  const olderSession: AssistantSession = {
+    ...TEST_SESSION,
+    conversationId: 'older-session-command-coverage',
+    sessionId: 'older-session-command-coverage',
+    alias: 'chat:older',
+    updatedAt: '2026-03-27T00:00:00.000Z',
+  }
+
+  commandMocks.listAssistantSessions.mockResolvedValueOnce([
+    TEST_SESSION,
+    olderSession,
+  ])
+
+  const listResult = assistantSessionListResultSchema.parse(
+    await readCommand(session.commands, 'list').run({
+      options: {
+        vault: '/tmp/vault',
+        limit: 1,
+      },
+    }),
+  )
+
+  assert.equal(listResult.count, 1)
+  assert.equal(listResult.filters.limit, 1)
+  assert.equal(listResult.sessions[0]?.sessionId, TEST_SESSION.sessionId)
+  assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
+    ['/tmp/vault'],
+  ])
 })

--- a/packages/assistant-cli/test/assistant-command-coverage.test.ts
+++ b/packages/assistant-cli/test/assistant-command-coverage.test.ts
@@ -35,6 +35,7 @@ const commandMocks = vi.hoisted(() => ({
   listRecentAssistantSessions: vi.fn(),
   listAssistantSessions: vi.fn(),
   readAssistantOnboardingState: vi.fn(),
+  repairAssistantSessionIndexes: vi.fn(),
   redactAssistantDisplayPath: vi.fn((value: string) => `redacted:${value}`),
   redactAssistantSessionForDisplay: vi.fn((value) => value),
   redactAssistantSessionsForDisplay: vi.fn((value) => value),
@@ -116,6 +117,7 @@ vi.mock('@murphai/assistant-engine/assistant-state', () => ({
   getAssistantSession: commandMocks.getAssistantSession,
   listRecentAssistantSessions: commandMocks.listRecentAssistantSessions,
   listAssistantSessions: commandMocks.listAssistantSessions,
+  repairAssistantSessionIndexes: commandMocks.repairAssistantSessionIndexes,
   reopenAssistantOnboarding: commandMocks.reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath:
     commandMocks.resolveAssistantOnboardingStatePath,
@@ -1377,7 +1379,7 @@ test('session commands return redacted state paths and session payloads', async 
     vault: 'redacted:/tmp/vault',
   })
   assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
-    ['/tmp/vault', { limit: 5 }],
+    ['/tmp/vault', { limit: 5, requireProjection: true }],
   ])
   assert.deepEqual(showResult, {
     session: {
@@ -1409,6 +1411,33 @@ test('session list requests a bounded recent-session page', async () => {
   assert.equal(listResult.filters.limit, 1)
   assert.equal(listResult.sessions[0]?.sessionId, TEST_SESSION.sessionId)
   assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
-    ['/tmp/vault', { limit: 1 }],
+    ['/tmp/vault', { limit: 1, requireProjection: true }],
+  ])
+})
+
+test('session list repair explicitly rebuilds indexes before reading the bounded page', async () => {
+  const commands = createAssistantCli()
+  const assistant = readCommandGroup(commands, 'assistant')
+  const session = readCommandGroup(assistant.commands, 'session')
+
+  commandMocks.repairAssistantSessionIndexes.mockResolvedValueOnce(undefined)
+  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
+
+  const listResult = assistantSessionListResultSchema.parse(
+    await readCommand(session.commands, 'list').run({
+      options: {
+        vault: '/tmp/vault',
+        limit: 1,
+        repair: true,
+      },
+    }),
+  )
+
+  assert.equal(listResult.count, 1)
+  assert.deepEqual(commandMocks.repairAssistantSessionIndexes.mock.calls, [
+    ['/tmp/vault'],
+  ])
+  assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
+    ['/tmp/vault', { limit: 1, requireProjection: true }],
   ])
 })

--- a/packages/assistant-cli/test/assistant-command-coverage.test.ts
+++ b/packages/assistant-cli/test/assistant-command-coverage.test.ts
@@ -31,6 +31,7 @@ const commandMocks = vi.hoisted(() => ({
   getAssistantSession: vi.fn(),
   getAssistantStatus: vi.fn(),
   listAssistantSelfDeliveryTargets: vi.fn(),
+  listRecentAssistantSessions: vi.fn(),
   listAssistantSessions: vi.fn(),
   readAssistantOnboardingState: vi.fn(),
   redactAssistantDisplayPath: vi.fn((value: string) => `redacted:${value}`),
@@ -112,6 +113,7 @@ vi.mock('@murphai/assistant-engine/assistant-state', () => ({
   readAssistantOnboardingState: commandMocks.readAssistantOnboardingState,
   redactAssistantDisplayPath: commandMocks.redactAssistantDisplayPath,
   getAssistantSession: commandMocks.getAssistantSession,
+  listRecentAssistantSessions: commandMocks.listRecentAssistantSessions,
   listAssistantSessions: commandMocks.listAssistantSessions,
   reopenAssistantOnboarding: commandMocks.reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath:
@@ -1055,7 +1057,7 @@ test('assistant status and session commands reject uninitialized vault roots bef
     () =>
       readCommand(assistant.commands, 'status').run({
         options: {
-          limit: 5,
+          limit: 3,
           vault: '/tmp/not-vault',
         },
       }),
@@ -1086,6 +1088,7 @@ test('assistant status and session commands reject uninitialized vault roots bef
 
   assert.equal(commandMocks.getAssistantStatus.mock.calls.length, 0)
   assert.equal(commandMocks.getAssistantSession.mock.calls.length, 0)
+  assert.equal(commandMocks.listRecentAssistantSessions.mock.calls.length, 0)
   assert.equal(commandMocks.listAssistantSessions.mock.calls.length, 0)
 })
 
@@ -1314,18 +1317,17 @@ test('session commands return redacted state paths and session payloads', async 
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
 
-  commandMocks.listAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
+  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
   commandMocks.getAssistantSession.mockResolvedValueOnce(TEST_SESSION)
-  commandMocks.redactAssistantSessionsForDisplay.mockReturnValueOnce([
-    {
+  commandMocks.redactAssistantSessionForDisplay
+    .mockReturnValueOnce({
       ...TEST_SESSION,
       alias: 'redacted-alias',
-    },
-  ])
-  commandMocks.redactAssistantSessionForDisplay.mockReturnValueOnce({
-    ...TEST_SESSION,
-    alias: 'redacted-single',
-  })
+    })
+    .mockReturnValueOnce({
+      ...TEST_SESSION,
+      alias: 'redacted-single',
+    })
 
   const listResult = await readCommand(session.commands, 'list').run({
     options: {
@@ -1342,10 +1344,32 @@ test('session commands return redacted state paths and session payloads', async 
   })
 
   assert.deepEqual(listResult, {
+    filters: {
+      limit: 5,
+    },
+    count: 1,
     sessions: [
       {
-        ...TEST_SESSION,
+        schema: TEST_SESSION.schema,
+        conversationId: TEST_SESSION.conversationId,
+        sessionId: TEST_SESSION.sessionId,
         alias: 'redacted-alias',
+        binding: TEST_SESSION.binding,
+        createdAt: TEST_SESSION.createdAt,
+        updatedAt: TEST_SESSION.updatedAt,
+        lastTurnAt: TEST_SESSION.lastTurnAt,
+        turnCount: TEST_SESSION.turnCount,
+        provider: TEST_SESSION.provider,
+        model: null,
+        modelProvider: null,
+        reasoningEffort: null,
+        sandbox: null,
+        approvalPolicy: null,
+        profile: null,
+        oss: false,
+        executionDriver: 'codex-app-server',
+        resumeKind: 'codex-thread',
+        resumeThreadId: null,
       },
     ],
     stateRoot: 'redacted:/tmp/vault/.runtime/operations/assistant',

--- a/packages/assistant-cli/test/assistant-command-coverage.test.ts
+++ b/packages/assistant-cli/test/assistant-command-coverage.test.ts
@@ -32,6 +32,7 @@ const commandMocks = vi.hoisted(() => ({
   getAssistantSession: vi.fn(),
   getAssistantStatus: vi.fn(),
   listAssistantSelfDeliveryTargets: vi.fn(),
+  listRecentAssistantSessions: vi.fn(),
   listAssistantSessions: vi.fn(),
   readAssistantOnboardingState: vi.fn(),
   redactAssistantDisplayPath: vi.fn((value: string) => `redacted:${value}`),
@@ -113,6 +114,7 @@ vi.mock('@murphai/assistant-engine/assistant-state', () => ({
   readAssistantOnboardingState: commandMocks.readAssistantOnboardingState,
   redactAssistantDisplayPath: commandMocks.redactAssistantDisplayPath,
   getAssistantSession: commandMocks.getAssistantSession,
+  listRecentAssistantSessions: commandMocks.listRecentAssistantSessions,
   listAssistantSessions: commandMocks.listAssistantSessions,
   reopenAssistantOnboarding: commandMocks.reopenAssistantOnboarding,
   resolveAssistantOnboardingStatePath:
@@ -1087,6 +1089,7 @@ test('assistant status and session commands reject uninitialized vault roots bef
 
   assert.equal(commandMocks.getAssistantStatus.mock.calls.length, 0)
   assert.equal(commandMocks.getAssistantSession.mock.calls.length, 0)
+  assert.equal(commandMocks.listRecentAssistantSessions.mock.calls.length, 0)
   assert.equal(commandMocks.listAssistantSessions.mock.calls.length, 0)
 })
 
@@ -1315,7 +1318,7 @@ test('session commands return redacted state paths and session payloads', async 
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
 
-  commandMocks.listAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
+  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
   commandMocks.getAssistantSession.mockResolvedValueOnce(TEST_SESSION)
   commandMocks.redactAssistantSessionForDisplay
     .mockReturnValueOnce({
@@ -1373,8 +1376,8 @@ test('session commands return redacted state paths and session payloads', async 
     stateRoot: 'redacted:/tmp/vault/.runtime/operations/assistant',
     vault: 'redacted:/tmp/vault',
   })
-  assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
-    ['/tmp/vault'],
+  assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
+    ['/tmp/vault', { limit: 5, repairMissingProjection: true }],
   ])
   assert.deepEqual(showResult, {
     session: {
@@ -1386,22 +1389,12 @@ test('session commands return redacted state paths and session payloads', async 
   })
 })
 
-test('session list slices durable sessions by requested limit', async () => {
+test('session list requests a bounded repaired recent-session page', async () => {
   const commands = createAssistantCli()
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
-  const olderSession: AssistantSession = {
-    ...TEST_SESSION,
-    conversationId: 'older-session-command-coverage',
-    sessionId: 'older-session-command-coverage',
-    alias: 'chat:older',
-    updatedAt: '2026-03-27T00:00:00.000Z',
-  }
 
-  commandMocks.listAssistantSessions.mockResolvedValueOnce([
-    TEST_SESSION,
-    olderSession,
-  ])
+  commandMocks.listRecentAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
 
   const listResult = assistantSessionListResultSchema.parse(
     await readCommand(session.commands, 'list').run({
@@ -1415,7 +1408,7 @@ test('session list slices durable sessions by requested limit', async () => {
   assert.equal(listResult.count, 1)
   assert.equal(listResult.filters.limit, 1)
   assert.equal(listResult.sessions[0]?.sessionId, TEST_SESSION.sessionId)
-  assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
-    ['/tmp/vault'],
+  assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
+    ['/tmp/vault', { limit: 1, repairMissingProjection: true }],
   ])
 })

--- a/packages/assistant-cli/test/assistant-command-coverage.test.ts
+++ b/packages/assistant-cli/test/assistant-command-coverage.test.ts
@@ -1374,7 +1374,7 @@ test('session commands return redacted state paths and session payloads', async 
     vault: 'redacted:/tmp/vault',
   })
   assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
-    ['/tmp/vault'],
+    ['/tmp/vault', { limit: 5 }],
   ])
   assert.deepEqual(showResult, {
     session: {
@@ -1386,18 +1386,12 @@ test('session commands return redacted state paths and session payloads', async 
   })
 })
 
-test('session list slices source-of-truth sessions to the bounded page', async () => {
+test('session list requests a bounded source-of-truth page', async () => {
   const commands = createAssistantCli()
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
 
-  commandMocks.listAssistantSessions.mockResolvedValueOnce([
-    TEST_SESSION,
-    {
-      ...TEST_SESSION,
-      sessionId: 'session-outside-limit',
-    },
-  ])
+  commandMocks.listAssistantSessions.mockResolvedValueOnce([TEST_SESSION])
 
   const listResult = assistantSessionListResultSchema.parse(
     await readCommand(session.commands, 'list').run({
@@ -1412,6 +1406,6 @@ test('session list slices source-of-truth sessions to the bounded page', async (
   assert.equal(listResult.filters.limit, 1)
   assert.equal(listResult.sessions[0]?.sessionId, TEST_SESSION.sessionId)
   assert.deepEqual(commandMocks.listAssistantSessions.mock.calls, [
-    ['/tmp/vault'],
+    ['/tmp/vault', { limit: 1 }],
   ])
 })

--- a/packages/assistant-cli/test/assistant-command-coverage.test.ts
+++ b/packages/assistant-cli/test/assistant-command-coverage.test.ts
@@ -1377,7 +1377,7 @@ test('session commands return redacted state paths and session payloads', async 
     vault: 'redacted:/tmp/vault',
   })
   assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
-    ['/tmp/vault', { limit: 5, repairMissingProjection: true }],
+    ['/tmp/vault', { limit: 5 }],
   ])
   assert.deepEqual(showResult, {
     session: {
@@ -1389,7 +1389,7 @@ test('session commands return redacted state paths and session payloads', async 
   })
 })
 
-test('session list requests a bounded repaired recent-session page', async () => {
+test('session list requests a bounded recent-session page', async () => {
   const commands = createAssistantCli()
   const assistant = readCommandGroup(commands, 'assistant')
   const session = readCommandGroup(assistant.commands, 'session')
@@ -1409,6 +1409,6 @@ test('session list requests a bounded repaired recent-session page', async () =>
   assert.equal(listResult.filters.limit, 1)
   assert.equal(listResult.sessions[0]?.sessionId, TEST_SESSION.sessionId)
   assert.deepEqual(commandMocks.listRecentAssistantSessions.mock.calls, [
-    ['/tmp/vault', { limit: 1, repairMissingProjection: true }],
+    ['/tmp/vault', { limit: 1 }],
   ])
 })

--- a/packages/assistant-cli/test/assistant-doctor.test.ts
+++ b/packages/assistant-cli/test/assistant-doctor.test.ts
@@ -11,6 +11,7 @@ import type {
   AssistantOutboxIntent,
   AssistantSession,
   AssistantTurnReceipt,
+  AssistantTurnReceiptSummary,
 } from '@murphai/operator-config/assistant-cli-contracts'
 
 const test = baseTest.sequential
@@ -164,6 +165,26 @@ const BASE_RECEIPT: AssistantTurnReceipt = {
   completedAt: '2026-04-08T00:01:05.000Z',
   lastError: null,
   timeline: [],
+}
+
+const BASE_RECEIPT_SUMMARY: AssistantTurnReceiptSummary = {
+  schema: 'murph.assistant-turn-receipt-summary.v1',
+  turnId: BASE_RECEIPT.turnId,
+  sessionId: BASE_RECEIPT.sessionId,
+  provider: BASE_RECEIPT.provider,
+  providerModel: BASE_RECEIPT.providerModel,
+  promptPreview: BASE_RECEIPT.promptPreview,
+  responsePreview: BASE_RECEIPT.responsePreview,
+  status: BASE_RECEIPT.status,
+  deliveryRequested: BASE_RECEIPT.deliveryRequested,
+  deliveryDisposition: BASE_RECEIPT.deliveryDisposition,
+  deliveryIntentId: BASE_RECEIPT.deliveryIntentId,
+  startedAt: BASE_RECEIPT.startedAt,
+  updatedAt: BASE_RECEIPT.updatedAt,
+  completedAt: BASE_RECEIPT.completedAt,
+  lastError: BASE_RECEIPT.lastError,
+  timelineEventCount: BASE_RECEIPT.timeline.length,
+  latestTimelineEvent: null,
 }
 
 const BASE_OUTBOX_INTENT: AssistantOutboxIntent = {
@@ -427,7 +448,7 @@ test('runAssistantDoctor reports a clean assistant state as healthy', async () =
           notes: [],
         },
       },
-      recentTurns: [BASE_RECEIPT],
+      recentTurns: [BASE_RECEIPT_SUMMARY],
       warnings: [],
     },
   })

--- a/packages/assistant-engine/src/assistant/maintenance-evidence.ts
+++ b/packages/assistant-engine/src/assistant/maintenance-evidence.ts
@@ -6,6 +6,7 @@ import { compareAssistantTimestampsAscending } from './shared.js'
 import {
   listAssistantTranscriptTailEntries,
   listRecentAssistantSessions,
+  repairAssistantSessionIndexes,
 } from './store.js'
 
 export const ASSISTANT_MAINTENANCE_EVIDENCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
@@ -73,6 +74,21 @@ async function collectAssistantMaintenanceEvidenceMessages(input: {
 }): Promise<AssistantMaintenanceEvidenceMessage[]> {
   const sessions = await listRecentAssistantSessions(input.vault, {
     limit: ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS,
+    requireProjection: true,
+  }).catch(async (error: unknown) => {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED'
+    ) {
+      await repairAssistantSessionIndexes(input.vault)
+      return listRecentAssistantSessions(input.vault, {
+        limit: ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS,
+        requireProjection: true,
+      })
+    }
+    throw error
   })
   const messages: AssistantMaintenanceEvidenceMessage[] = []
 

--- a/packages/assistant-engine/src/assistant/maintenance-evidence.ts
+++ b/packages/assistant-engine/src/assistant/maintenance-evidence.ts
@@ -71,8 +71,9 @@ async function collectAssistantMaintenanceEvidenceMessages(input: {
   until: number
   vault: string
 }): Promise<AssistantMaintenanceEvidenceMessage[]> {
-  const sessions = (await listAssistantSessions(input.vault))
-    .slice(0, ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS)
+  const sessions = await listAssistantSessions(input.vault, {
+    limit: ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS,
+  })
   const messages: AssistantMaintenanceEvidenceMessage[] = []
 
   for (const session of sessions) {

--- a/packages/assistant-engine/src/assistant/maintenance-evidence.ts
+++ b/packages/assistant-engine/src/assistant/maintenance-evidence.ts
@@ -6,7 +6,6 @@ import { compareAssistantTimestampsAscending } from './shared.js'
 import {
   listAssistantTranscriptTailEntries,
   listRecentAssistantSessions,
-  repairAssistantSessionIndexes,
 } from './store.js'
 
 export const ASSISTANT_MAINTENANCE_EVIDENCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
@@ -74,21 +73,6 @@ async function collectAssistantMaintenanceEvidenceMessages(input: {
 }): Promise<AssistantMaintenanceEvidenceMessage[]> {
   const sessions = await listRecentAssistantSessions(input.vault, {
     limit: ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS,
-    requireProjection: true,
-  }).catch(async (error: unknown) => {
-    if (
-      error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error as { code?: unknown }).code === 'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED'
-    ) {
-      await repairAssistantSessionIndexes(input.vault)
-      return listRecentAssistantSessions(input.vault, {
-        limit: ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS,
-        requireProjection: true,
-      })
-    }
-    throw error
   })
   const messages: AssistantMaintenanceEvidenceMessage[] = []
 

--- a/packages/assistant-engine/src/assistant/maintenance-evidence.ts
+++ b/packages/assistant-engine/src/assistant/maintenance-evidence.ts
@@ -5,7 +5,7 @@ import {
 import { compareAssistantTimestampsAscending } from './shared.js'
 import {
   listAssistantTranscriptTailEntries,
-  listRecentAssistantSessions,
+  listAssistantSessions,
 } from './store.js'
 
 export const ASSISTANT_MAINTENANCE_EVIDENCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
@@ -71,9 +71,8 @@ async function collectAssistantMaintenanceEvidenceMessages(input: {
   until: number
   vault: string
 }): Promise<AssistantMaintenanceEvidenceMessage[]> {
-  const sessions = await listRecentAssistantSessions(input.vault, {
-    limit: ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS,
-  })
+  const sessions = (await listAssistantSessions(input.vault))
+    .slice(0, ASSISTANT_MAINTENANCE_EVIDENCE_MAX_SESSIONS)
   const messages: AssistantMaintenanceEvidenceMessage[] = []
 
   for (const session of sessions) {

--- a/packages/assistant-engine/src/assistant/status.ts
+++ b/packages/assistant-engine/src/assistant/status.ts
@@ -7,6 +7,7 @@ import {
   assistantStatusResultSchema,
   type AssistantStatusResult,
   type AssistantTurnReceipt,
+  type AssistantTurnReceiptSummary,
 } from '@murphai/operator-config/assistant-cli-contracts'
 import { buildAssistantOutboxSummary } from './outbox.js'
 import { readAssistantDiagnosticsSnapshot } from './diagnostics.js'
@@ -31,9 +32,11 @@ import {
   isMissingFileError,
   writeJsonFileAtomic,
 } from './shared.js'
+import { sanitizeAssistantPortableStateString } from './redaction.js'
 
 const ASSISTANT_STATUS_SNAPSHOT_SCHEMA = 'murph.assistant-status-snapshot.v1'
 const ASSISTANT_STATUS_SNAPSHOT_SCHEMA_VERSION = 1
+const ASSISTANT_STATUS_TIMELINE_DETAIL_MAX_LENGTH = 160
 
 export async function getAssistantStatus(
   input:
@@ -205,17 +208,53 @@ async function resolveRecentTurns(
         vault: string
       }
     | undefined,
-): Promise<AssistantTurnReceipt[]> {
+): Promise<AssistantTurnReceiptSummary[]> {
   const limit = normalizeTurnLimit(input?.limit)
   const sessionFilter = input?.sessionId?.trim() || null
-  if (sessionFilter) {
-    return await listRecentAssistantTurnReceiptsForSession(
-      vault,
-      sessionFilter,
-      limit,
-    )
+  const receipts = sessionFilter
+    ? await listRecentAssistantTurnReceiptsForSession(
+        vault,
+        sessionFilter,
+        limit,
+      )
+    : await listRecentAssistantTurnReceipts(vault, limit)
+  return receipts.map(toAssistantTurnReceiptSummary)
+}
+
+function toAssistantTurnReceiptSummary(
+  receipt: AssistantTurnReceipt,
+): AssistantTurnReceiptSummary {
+  const latestTimelineEvent = receipt.timeline.at(-1) ?? null
+  return {
+    schema: 'murph.assistant-turn-receipt-summary.v1',
+    turnId: receipt.turnId,
+    sessionId: receipt.sessionId,
+    provider: receipt.provider,
+    providerModel: receipt.providerModel,
+    promptPreview: receipt.promptPreview,
+    responsePreview: receipt.responsePreview,
+    status: receipt.status,
+    deliveryRequested: receipt.deliveryRequested,
+    deliveryDisposition: receipt.deliveryDisposition,
+    deliveryIntentId: receipt.deliveryIntentId,
+    startedAt: receipt.startedAt,
+    updatedAt: receipt.updatedAt,
+    completedAt: receipt.completedAt,
+    lastError: receipt.lastError,
+    timelineEventCount: receipt.timeline.length,
+    latestTimelineEvent: latestTimelineEvent
+      ? {
+          at: latestTimelineEvent.at,
+          kind: latestTimelineEvent.kind,
+          detail: latestTimelineEvent.detail
+            ? sanitizeAssistantPortableStateString(
+                latestTimelineEvent.detail,
+                ASSISTANT_STATUS_TIMELINE_DETAIL_MAX_LENGTH,
+              )
+            : null,
+        }
+      : null,
   }
-  return await listRecentAssistantTurnReceipts(vault, limit)
 }
 
 function normalizeTurnLimit(value?: number): number {

--- a/packages/assistant-engine/src/assistant/store.ts
+++ b/packages/assistant-engine/src/assistant/store.ts
@@ -352,23 +352,19 @@ export async function listAssistantSessionsLocal(
   })
 }
 
-// Bounded variant for recurring maintenance work: reads the bounded
-// recent-session projection from the assistant index store (maintained on
-// every session save, rebuilt from durable session records when missing) and
+// Bounded variant for recurring maintenance and compact CLI list work: reads
+// the bounded recent-session projection maintained on every session save, then
 // parses only the newest `limit` sessions by durable last-activity timestamp.
 export async function listRecentAssistantSessions(
   vault: string,
   options: {
     limit: number
-    repairMissingProjection?: boolean
   },
 ): Promise<AssistantSession[]> {
   return withAssistantRuntimeWriteLock(vault, async (paths) => {
     await ensureAssistantState(paths)
 
-    const recentSessions = await ensureAssistantRecentSessionsProjection(paths, {
-      repairMissingProjection: options.repairMissingProjection,
-    })
+    const recentSessions = await ensureAssistantRecentSessionsProjection(paths)
     return readAssistantSessionsSorted(
       paths,
       Object.entries(recentSessions)

--- a/packages/assistant-engine/src/assistant/store.ts
+++ b/packages/assistant-engine/src/assistant/store.ts
@@ -358,12 +358,17 @@ export async function listAssistantSessionsLocal(
 // parses only the newest `limit` sessions by durable last-activity timestamp.
 export async function listRecentAssistantSessions(
   vault: string,
-  options: { limit: number },
+  options: {
+    limit: number
+    repairMissingProjection?: boolean
+  },
 ): Promise<AssistantSession[]> {
   return withAssistantRuntimeWriteLock(vault, async (paths) => {
     await ensureAssistantState(paths)
 
-    const recentSessions = await ensureAssistantRecentSessionsProjection(paths)
+    const recentSessions = await ensureAssistantRecentSessionsProjection(paths, {
+      repairMissingProjection: options.repairMissingProjection,
+    })
     return readAssistantSessionsSorted(
       paths,
       Object.entries(recentSessions)

--- a/packages/assistant-engine/src/assistant/store.ts
+++ b/packages/assistant-engine/src/assistant/store.ts
@@ -32,6 +32,7 @@ import {
   appendTranscriptEntries,
   inspectAssistantSessionStorage,
   loadAndPersistResolvedSession,
+  readAssistantRecentSessionIds,
   readAssistantIndexStore,
   readAssistantSession,
   readAssistantTranscriptEntries,
@@ -324,8 +325,20 @@ function hasAssistantSessionProviderOverrideInput(
 
 export async function listAssistantSessions(
   vault: string,
+  options?: {
+    limit?: number
+  },
 ): Promise<AssistantSession[]> {
-  return listAssistantSessionsLocal(vault)
+  if (typeof options?.limit !== 'number') {
+    return listAssistantSessionsLocal(vault)
+  }
+
+  const limit = Math.max(0, Math.trunc(options.limit))
+  return withAssistantRuntimeWriteLock(vault, async (paths) => {
+    await ensureAssistantState(paths)
+    const sessionIds = await readAssistantRecentSessionIds(paths, { limit })
+    return (await readAssistantSessionsSorted(paths, sessionIds)).slice(0, limit)
+  })
 }
 
 // Maps a Codex thread back to the Murph assistant session that owns it (via

--- a/packages/assistant-engine/src/assistant/store.ts
+++ b/packages/assistant-engine/src/assistant/store.ts
@@ -36,9 +36,7 @@ import {
   readAssistantSession,
   readAssistantTranscriptEntries,
   readAssistantTranscriptTailEntries,
-  readAssistantRecentSessionsProjection,
   readAutomationState,
-  repairAssistantIndexStore,
   writeAutomationState,
   replaceTranscriptEntries,
   synchronizeAssistantIndexes,
@@ -350,50 +348,6 @@ export async function listAssistantSessionsLocal(
   return withAssistantRuntimeWriteLock(vault, async (paths) => {
     await ensureAssistantState(paths)
     return readAssistantSessionsSorted(paths, await listAssistantSessionFileIds(paths))
-  })
-}
-
-// Bounded variant for recurring maintenance and compact CLI list work: reads
-// the bounded recent-session projection maintained on every session save, then
-// parses only the newest `limit` sessions by durable last-activity timestamp.
-export async function listRecentAssistantSessions(
-  vault: string,
-  options: {
-    limit: number
-    requireProjection?: boolean
-  },
-): Promise<AssistantSession[]> {
-  return withAssistantRuntimeWriteLock(vault, async (paths) => {
-    await ensureAssistantState(paths)
-
-    const projection = await readAssistantRecentSessionsProjection(paths)
-    if (options.requireProjection === true && projection.state !== 'ready') {
-      throw new VaultCliError(
-        'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED',
-        'Assistant session list needs a recent-session index before it can return compact bounded results. Run `vault-cli assistant session list --repair` once for this vault, then retry.',
-        {
-          projectionState: projection.state,
-        },
-      )
-    }
-    return readAssistantSessionsSorted(
-      paths,
-      Object.entries(projection.recentSessions)
-        .sort(([, left], [, right]) =>
-          compareAssistantTimestampsAscending(right, left),
-        )
-        .slice(0, Math.max(0, options.limit))
-        .map(([sessionId]) => sessionId),
-    )
-  })
-}
-
-export async function repairAssistantSessionIndexes(
-  vault: string,
-): Promise<void> {
-  await withAssistantRuntimeWriteLock(vault, async (paths) => {
-    await ensureAssistantState(paths)
-    await repairAssistantIndexStore(paths)
   })
 }
 

--- a/packages/assistant-engine/src/assistant/store.ts
+++ b/packages/assistant-engine/src/assistant/store.ts
@@ -36,8 +36,9 @@ import {
   readAssistantSession,
   readAssistantTranscriptEntries,
   readAssistantTranscriptTailEntries,
+  readAssistantRecentSessionsProjection,
   readAutomationState,
-  ensureAssistantRecentSessionsProjection,
+  repairAssistantIndexStore,
   writeAutomationState,
   replaceTranscriptEntries,
   synchronizeAssistantIndexes,
@@ -359,21 +360,40 @@ export async function listRecentAssistantSessions(
   vault: string,
   options: {
     limit: number
+    requireProjection?: boolean
   },
 ): Promise<AssistantSession[]> {
   return withAssistantRuntimeWriteLock(vault, async (paths) => {
     await ensureAssistantState(paths)
 
-    const recentSessions = await ensureAssistantRecentSessionsProjection(paths)
+    const projection = await readAssistantRecentSessionsProjection(paths)
+    if (options.requireProjection === true && projection.state !== 'ready') {
+      throw new VaultCliError(
+        'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED',
+        'Assistant session list needs a recent-session index before it can return compact bounded results. Run `vault-cli assistant session list --repair` once for this vault, then retry.',
+        {
+          projectionState: projection.state,
+        },
+      )
+    }
     return readAssistantSessionsSorted(
       paths,
-      Object.entries(recentSessions)
+      Object.entries(projection.recentSessions)
         .sort(([, left], [, right]) =>
           compareAssistantTimestampsAscending(right, left),
         )
         .slice(0, Math.max(0, options.limit))
         .map(([sessionId]) => sessionId),
     )
+  })
+}
+
+export async function repairAssistantSessionIndexes(
+  vault: string,
+): Promise<void> {
+  await withAssistantRuntimeWriteLock(vault, async (paths) => {
+    await ensureAssistantState(paths)
+    await repairAssistantIndexStore(paths)
   })
 }
 

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -1,7 +1,6 @@
 import {
   access,
   open,
-  opendir,
   readdir,
   readFile,
   type FileHandle,
@@ -60,7 +59,6 @@ export const ASSISTANT_INDEX_STORE_VERSION = 1
 export const ASSISTANT_AUTOMATION_STATE_VERSION = 1
 export const ASSISTANT_TRANSCRIPT_AUDIT_RETENTION_LIMIT = 100
 const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 50
-const ASSISTANT_RECENT_SESSIONS_LEGACY_SCAN_LIMIT = 50
 
 const assistantAutomationStateCache = createAssistantBoundedRuntimeCache<string, AssistantAutomationState>({
   name: 'assistant.automation-state',
@@ -607,6 +605,17 @@ export async function readAssistantIndexStore(
 
   try {
     const parsed = assistantAliasStoreSchema.parse(JSON.parse(raw))
+    if (parsed.recentSessions === undefined) {
+      if (await hasDurableAssistantSessions(paths)) {
+        return rebuildAssistantIndexStore(paths)
+      }
+      const upgraded = assistantAliasStoreSchema.parse({
+        ...parsed,
+        recentSessions: {},
+      })
+      await writeJsonFileAtomic(paths.indexesPath, upgraded)
+      return upgraded
+    }
     return parsed
   } catch (error) {
     const quarantine = await quarantineAssistantStateFile({
@@ -657,14 +666,10 @@ export async function synchronizeAssistantIndexes(
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases,
     conversationKeys,
-    ...(store.recentSessions !== undefined
-      ? {
-          recentSessions: pruneAssistantRecentSessions({
-            ...store.recentSessions,
-            [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
-          }),
-        }
-      : {}),
+    recentSessions: pruneAssistantRecentSessions({
+      ...(store.recentSessions ?? {}),
+      [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
+    }),
   })
   await writeJsonFileAtomic(paths.indexesPath, updated)
 }
@@ -680,26 +685,8 @@ export async function readAssistantRecentSessionIds(
     return []
   }
 
-  let raw: string
-  try {
-    raw = await readFile(paths.indexesPath, 'utf8')
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      return readAssistantRecentSessionIdsFromDirectoryFallback(paths, limit)
-    }
-    throw error
-  }
-
-  try {
-    const store = assistantAliasStoreSchema.parse(JSON.parse(raw))
-    if (store.recentSessions) {
-      return sortRecentSessionIds(store.recentSessions).slice(0, limit)
-    }
-  } catch {
-    return readAssistantRecentSessionIdsFromDirectoryFallback(paths, limit)
-  }
-
-  return readAssistantRecentSessionIdsFromDirectoryFallback(paths, limit)
+  const store = await readAssistantIndexStore(paths, { fresh: true })
+  return sortRecentSessionIds(store.recentSessions ?? {}).slice(0, limit)
 }
 
 function sortRecentSessionIds(
@@ -722,42 +709,6 @@ function pruneAssistantRecentSessions(
       )
       .slice(0, ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT),
   )
-}
-
-async function readAssistantRecentSessionIdsFromDirectoryFallback(
-  paths: AssistantStatePaths,
-  limit: number,
-): Promise<string[]> {
-  const scanLimit = Math.min(
-    Math.max(limit, ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT),
-    ASSISTANT_RECENT_SESSIONS_LEGACY_SCAN_LIMIT,
-  )
-  let directory: Awaited<ReturnType<typeof opendir>>
-  try {
-    directory = await opendir(paths.sessionsDirectory)
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      return []
-    }
-    throw error
-  }
-
-  const sessionIds: string[] = []
-  try {
-    for (let checked = 0; checked < scanLimit; checked += 1) {
-      const entry = await directory.read()
-      if (!entry) {
-        break
-      }
-      if (entry.isFile() && entry.name.endsWith('.json')) {
-        sessionIds.push(entry.name.replace(/\.json$/u, ''))
-      }
-    }
-  } finally {
-    await directory.close()
-  }
-
-  return sessionIds
 }
 
 export async function writeAutomationState(

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -648,44 +648,28 @@ export async function synchronizeAssistantIndexes(
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases,
     conversationKeys,
-    // Foreground saves never rebuild the projection (that would scan every
-    // session file on the reply commit path). While the projection is absent
-    // it stays absent, so the idle maintenance read can tell "not built yet"
-    // from "partially built" and do the one-time rebuild off the hot path.
-    ...(store.recentSessions === undefined
-      ? {}
-      : {
-          recentSessions: pruneAssistantRecentSessions({
-            ...store.recentSessions,
-            [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
-          }),
-        }),
+    // Foreground saves own the bounded recent-session projection in O(1).
+    // Legacy indexes without the field start from the current save instead of
+    // rebuilding from every durable session on the reply commit path.
+    recentSessions: pruneAssistantRecentSessions({
+      ...(store.recentSessions ?? {}),
+      [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
+    }),
   })
   await writeJsonFileAtomic(paths.indexesPath, updated)
 }
 
 const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 50
 
-// Recurring-maintenance projection reader. Deliberately does NOT go through
-// readAssistantIndexStore by default: that reader's missing/corrupt fallbacks
+// Bounded projection reader. Deliberately does NOT go through
+// readAssistantIndexStore: that reader's missing/corrupt fallbacks
 // rebuild the index by scanning every session file, which is only acceptable on
-// explicit repair/routing paths. A parseable legacy index returns an in-memory
-// empty projection so bounded maintenance stays cheap while a later repair
-// owner can still distinguish "projection missing" from "projection built empty".
+// explicit routing/repair paths. A parseable legacy index returns an in-memory
+// empty projection so user-visible list and recurring maintenance reads stay
+// cheap until normal assistant saves warm the bounded projection.
 export async function ensureAssistantRecentSessionsProjection(
   paths: AssistantStatePaths,
-  options?: {
-    repairMissingProjection?: boolean
-  },
 ): Promise<Record<string, string>> {
-  if (options?.repairMissingProjection === true) {
-    const store = await readAssistantIndexStore(paths, { fresh: true })
-    if (store.recentSessions !== undefined) {
-      return store.recentSessions
-    }
-    return (await rebuildAssistantIndexStore(paths)).recentSessions ?? {}
-  }
-
   let raw: string
   try {
     raw = await readFile(paths.indexesPath, 'utf8')

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -661,21 +661,30 @@ export async function synchronizeAssistantIndexes(
 
 const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 50
 
+type AssistantRecentSessionsProjectionRead = {
+  recentSessions: Record<string, string>
+  state: 'ready' | 'missing' | 'unreadable'
+}
+
 // Bounded projection reader. Deliberately does NOT go through
 // readAssistantIndexStore: that reader's missing/corrupt fallbacks
 // rebuild the index by scanning every session file, which is only acceptable on
 // explicit routing/repair paths. A parseable legacy index returns an in-memory
-// empty projection so user-visible list and recurring maintenance reads stay
-// cheap until normal assistant saves warm the bounded projection.
-export async function ensureAssistantRecentSessionsProjection(
+// empty projection so recurring maintenance stays cheap until normal assistant
+// saves warm the bounded projection. User-visible compact list reads can reject
+// this state and point the operator at the explicit repair path instead.
+export async function readAssistantRecentSessionsProjection(
   paths: AssistantStatePaths,
-): Promise<Record<string, string>> {
+): Promise<AssistantRecentSessionsProjectionRead> {
   let raw: string
   try {
     raw = await readFile(paths.indexesPath, 'utf8')
   } catch (error) {
     if (isMissingFileError(error)) {
-      return {}
+      return {
+        recentSessions: {},
+        state: 'missing',
+      }
     }
     throw error
   }
@@ -685,14 +694,29 @@ export async function ensureAssistantRecentSessionsProjection(
     store = assistantAliasStoreSchema.parse(JSON.parse(raw))
   } catch {
     // Corrupt index: quarantine/rebuild belongs to the routing read path.
-    return {}
+    return {
+      recentSessions: {},
+      state: 'unreadable',
+    }
   }
 
   if (store.recentSessions !== undefined) {
-    return store.recentSessions
+    return {
+      recentSessions: store.recentSessions,
+      state: 'ready',
+    }
   }
 
-  return {}
+  return {
+    recentSessions: {},
+    state: 'missing',
+  }
+}
+
+export async function repairAssistantIndexStore(
+  paths: AssistantStatePaths,
+): Promise<AssistantAliasStore> {
+  return rebuildAssistantIndexStore(paths)
 }
 
 function pruneAssistantRecentSessions(

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -664,7 +664,7 @@ export async function synchronizeAssistantIndexes(
   await writeJsonFileAtomic(paths.indexesPath, updated)
 }
 
-const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 32
+const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 50
 
 // Recurring-maintenance projection reader. Deliberately does NOT go through
 // readAssistantIndexStore: that reader's missing/corrupt fallbacks rebuild
@@ -674,7 +674,18 @@ const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 32
 // it up, and a missing or corrupt index just yields no evidence this wake.
 export async function ensureAssistantRecentSessionsProjection(
   paths: AssistantStatePaths,
+  options?: {
+    repairMissingProjection?: boolean
+  },
 ): Promise<Record<string, string>> {
+  if (options?.repairMissingProjection === true) {
+    const store = await readAssistantIndexStore(paths, { fresh: true })
+    if (store.recentSessions !== undefined) {
+      return store.recentSessions
+    }
+    return (await rebuildAssistantIndexStore(paths)).recentSessions ?? {}
+  }
+
   let raw: string
   try {
     raw = await readFile(paths.indexesPath, 'utf8')

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -1,6 +1,7 @@
 import {
   access,
   open,
+  opendir,
   readdir,
   readFile,
   type FileHandle,
@@ -58,6 +59,8 @@ import type { ResolvedAssistantSession } from './types.js'
 export const ASSISTANT_INDEX_STORE_VERSION = 1
 export const ASSISTANT_AUTOMATION_STATE_VERSION = 1
 export const ASSISTANT_TRANSCRIPT_AUDIT_RETENTION_LIMIT = 100
+const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 50
+const ASSISTANT_RECENT_SESSIONS_LEGACY_SCAN_LIMIT = 50
 
 const assistantAutomationStateCache = createAssistantBoundedRuntimeCache<string, AssistantAutomationState>({
   name: 'assistant.automation-state',
@@ -654,8 +657,107 @@ export async function synchronizeAssistantIndexes(
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases,
     conversationKeys,
+    ...(store.recentSessions !== undefined
+      ? {
+          recentSessions: pruneAssistantRecentSessions({
+            ...store.recentSessions,
+            [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
+          }),
+        }
+      : {}),
   })
   await writeJsonFileAtomic(paths.indexesPath, updated)
+}
+
+export async function readAssistantRecentSessionIds(
+  paths: AssistantStatePaths,
+  options: {
+    limit: number
+  },
+): Promise<string[]> {
+  const limit = Math.max(0, Math.trunc(options.limit))
+  if (limit === 0) {
+    return []
+  }
+
+  let raw: string
+  try {
+    raw = await readFile(paths.indexesPath, 'utf8')
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return readAssistantRecentSessionIdsFromDirectoryFallback(paths, limit)
+    }
+    throw error
+  }
+
+  try {
+    const store = assistantAliasStoreSchema.parse(JSON.parse(raw))
+    if (store.recentSessions) {
+      return sortRecentSessionIds(store.recentSessions).slice(0, limit)
+    }
+  } catch {
+    return readAssistantRecentSessionIdsFromDirectoryFallback(paths, limit)
+  }
+
+  return readAssistantRecentSessionIdsFromDirectoryFallback(paths, limit)
+}
+
+function sortRecentSessionIds(
+  recentSessions: Record<string, string>,
+): string[] {
+  return Object.entries(recentSessions)
+    .sort(([, left], [, right]) =>
+      compareAssistantTimestampsAscending(right, left),
+    )
+    .map(([sessionId]) => sessionId)
+}
+
+function pruneAssistantRecentSessions(
+  recentSessions: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(recentSessions)
+      .sort(([, left], [, right]) =>
+        compareAssistantTimestampsAscending(right, left),
+      )
+      .slice(0, ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT),
+  )
+}
+
+async function readAssistantRecentSessionIdsFromDirectoryFallback(
+  paths: AssistantStatePaths,
+  limit: number,
+): Promise<string[]> {
+  const scanLimit = Math.min(
+    Math.max(limit, ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT),
+    ASSISTANT_RECENT_SESSIONS_LEGACY_SCAN_LIMIT,
+  )
+  let directory: Awaited<ReturnType<typeof opendir>>
+  try {
+    directory = await opendir(paths.sessionsDirectory)
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return []
+    }
+    throw error
+  }
+
+  const sessionIds: string[] = []
+  try {
+    for (let checked = 0; checked < scanLimit; checked += 1) {
+      const entry = await directory.read()
+      if (!entry) {
+        break
+      }
+      if (entry.isFile() && entry.name.endsWith('.json')) {
+        sessionIds.push(entry.name.replace(/\.json$/u, ''))
+      }
+    }
+  } finally {
+    await directory.close()
+  }
+
+  return sessionIds
 }
 
 export async function writeAutomationState(
@@ -730,6 +832,7 @@ function createInitialAssistantIndexStore(): AssistantAliasStore {
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases: {},
     conversationKeys: {},
+    recentSessions: {},
   })
 }
 
@@ -763,6 +866,7 @@ async function rebuildAssistantIndexStore(
 
   const aliases: Record<string, string> = {}
   const conversationKeys: Record<string, string> = {}
+  const recentSessions: Record<string, string> = {}
   for (const session of sortSessionsForIndexRebuild(sessions)) {
     if (session.alias) {
       aliases[session.alias] = session.sessionId
@@ -770,12 +874,14 @@ async function rebuildAssistantIndexStore(
     if (session.binding.conversationKey) {
       conversationKeys[session.binding.conversationKey] = session.sessionId
     }
+    recentSessions[session.sessionId] = resolveAssistantIndexRebuildTimestamp(session)
   }
 
   const rebuilt = assistantAliasStoreSchema.parse({
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases,
     conversationKeys,
+    recentSessions: pruneAssistantRecentSessions(recentSessions),
   })
   await writeJsonFileAtomic(paths.indexesPath, rebuilt)
   await appendAssistantRuntimeEventAtPaths(paths, {

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -1,7 +1,6 @@
 import {
   access,
   open,
-  opendir,
   readdir,
   readFile,
   type FileHandle,
@@ -651,181 +650,12 @@ export async function synchronizeAssistantIndexes(
     conversationKeys[session.binding.conversationKey] = session.sessionId
   }
 
-  const canUpdateRecentSessions =
-    store.recentSessions !== undefined ||
-    await assistantSessionDirectoryOnlyContains(paths, session.sessionId)
-
   const updated = assistantAliasStoreSchema.parse({
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases,
     conversationKeys,
-    // Foreground saves own the bounded recent-session projection in O(1).
-    // Legacy indexes without the field are updated only when the session
-    // directory is known to contain no older records; otherwise explicit
-    // repair owns the one-time full rebuild.
-    ...(canUpdateRecentSessions
-      ? {
-          recentSessions: pruneAssistantRecentSessions({
-            ...(store.recentSessions ?? {}),
-            [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
-          }),
-        }
-      : {}),
   })
   await writeJsonFileAtomic(paths.indexesPath, updated)
-}
-
-const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 50
-
-type AssistantRecentSessionsProjectionRead = {
-  recentSessions: Record<string, string>
-  state: 'ready' | 'missing' | 'unreadable'
-}
-
-// Bounded projection reader. Deliberately does NOT go through
-// readAssistantIndexStore: that reader's missing/corrupt fallbacks
-// rebuild the index by scanning every session file, which is only acceptable on
-// explicit routing/repair paths. A parseable legacy index returns an in-memory
-// empty projection so recurring maintenance stays cheap until normal assistant
-// saves warm the bounded projection. User-visible compact list reads can reject
-// this state and point the operator at the explicit repair path instead.
-export async function readAssistantRecentSessionsProjection(
-  paths: AssistantStatePaths,
-): Promise<AssistantRecentSessionsProjectionRead> {
-  let raw: string
-  try {
-    raw = await readFile(paths.indexesPath, 'utf8')
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      if (!(await assistantSessionDirectoryHasSessionFile(paths))) {
-        return {
-          recentSessions: {},
-          state: 'ready',
-        }
-      }
-      return {
-        recentSessions: {},
-        state: 'missing',
-      }
-    }
-    throw error
-  }
-
-  let store: AssistantAliasStore
-  try {
-    store = assistantAliasStoreSchema.parse(JSON.parse(raw))
-  } catch {
-    // Corrupt index: quarantine/rebuild belongs to the routing read path.
-    return {
-      recentSessions: {},
-      state: 'unreadable',
-    }
-  }
-
-  if (store.recentSessions !== undefined) {
-    return {
-      recentSessions: store.recentSessions,
-      state: 'ready',
-    }
-  }
-
-  if (
-    Object.keys(store.aliases).length === 0 &&
-    Object.keys(store.conversationKeys).length === 0 &&
-    !(await assistantSessionDirectoryHasSessionFile(paths))
-  ) {
-    return {
-      recentSessions: {},
-      state: 'ready',
-    }
-  }
-
-  return {
-    recentSessions: {},
-    state: 'missing',
-  }
-}
-
-export async function repairAssistantIndexStore(
-  paths: AssistantStatePaths,
-): Promise<AssistantAliasStore> {
-  return rebuildAssistantIndexStore(paths)
-}
-
-function pruneAssistantRecentSessions(
-  recentSessions: Record<string, string>,
-): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(recentSessions)
-      .sort(([, left], [, right]) =>
-        compareAssistantTimestampsAscending(right, left),
-      )
-      .slice(0, ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT),
-  )
-}
-
-async function assistantSessionDirectoryHasSessionFile(
-  paths: AssistantStatePaths,
-): Promise<boolean> {
-  let directory: Awaited<ReturnType<typeof opendir>>
-  try {
-    directory = await opendir(paths.sessionsDirectory)
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      return false
-    }
-    throw error
-  }
-
-  try {
-    for (let checked = 0; checked < 16; checked += 1) {
-      const entry = await directory.read()
-      if (!entry) {
-        return false
-      }
-      if (entry.isFile() && entry.name.endsWith('.json')) {
-        return true
-      }
-    }
-    return true
-  } finally {
-    await directory.close()
-  }
-}
-
-async function assistantSessionDirectoryOnlyContains(
-  paths: AssistantStatePaths,
-  sessionId: string,
-): Promise<boolean> {
-  let directory: Awaited<ReturnType<typeof opendir>>
-  try {
-    directory = await opendir(paths.sessionsDirectory)
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      return true
-    }
-    throw error
-  }
-
-  let matched = false
-  try {
-    for (let checked = 0; checked < 2; checked += 1) {
-      const entry = await directory.read()
-      if (!entry) {
-        return matched
-      }
-      if (!entry.isFile() || !entry.name.endsWith('.json')) {
-        return false
-      }
-      if (entry.name.replace(/\.json$/u, '') !== sessionId) {
-        return false
-      }
-      matched = true
-    }
-    return false
-  } finally {
-    await directory.close()
-  }
 }
 
 export async function writeAutomationState(
@@ -900,7 +730,6 @@ function createInitialAssistantIndexStore(): AssistantAliasStore {
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases: {},
     conversationKeys: {},
-    recentSessions: {},
   })
 }
 
@@ -934,7 +763,6 @@ async function rebuildAssistantIndexStore(
 
   const aliases: Record<string, string> = {}
   const conversationKeys: Record<string, string> = {}
-  const recentSessions: Record<string, string> = {}
   for (const session of sortSessionsForIndexRebuild(sessions)) {
     if (session.alias) {
       aliases[session.alias] = session.sessionId
@@ -942,14 +770,12 @@ async function rebuildAssistantIndexStore(
     if (session.binding.conversationKey) {
       conversationKeys[session.binding.conversationKey] = session.sessionId
     }
-    recentSessions[session.sessionId] = session.lastTurnAt ?? session.updatedAt
   }
 
   const rebuilt = assistantAliasStoreSchema.parse({
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases,
     conversationKeys,
-    recentSessions: pruneAssistantRecentSessions(recentSessions),
   })
   await writeJsonFileAtomic(paths.indexesPath, rebuilt)
   await appendAssistantRuntimeEventAtPaths(paths, {

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -667,11 +667,11 @@ export async function synchronizeAssistantIndexes(
 const ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT = 50
 
 // Recurring-maintenance projection reader. Deliberately does NOT go through
-// readAssistantIndexStore: that reader's missing/corrupt fallbacks rebuild
-// the index by scanning every session file, which is only acceptable on
-// explicit repair/routing paths. Here a parseable legacy index gets an
-// empty projection persisted once (O(1)) so bounded foreground saves warm
-// it up, and a missing or corrupt index just yields no evidence this wake.
+// readAssistantIndexStore by default: that reader's missing/corrupt fallbacks
+// rebuild the index by scanning every session file, which is only acceptable on
+// explicit repair/routing paths. A parseable legacy index returns an in-memory
+// empty projection so bounded maintenance stays cheap while a later repair
+// owner can still distinguish "projection missing" from "projection built empty".
 export async function ensureAssistantRecentSessionsProjection(
   paths: AssistantStatePaths,
   options?: {
@@ -708,13 +708,6 @@ export async function ensureAssistantRecentSessionsProjection(
     return store.recentSessions
   }
 
-  const updated = assistantAliasStoreSchema.parse({
-    version: ASSISTANT_INDEX_STORE_VERSION,
-    aliases: store.aliases,
-    conversationKeys: store.conversationKeys,
-    recentSessions: {},
-  })
-  await writeJsonFileAtomic(paths.indexesPath, updated)
   return {}
 }
 

--- a/packages/assistant-engine/src/assistant/store/persistence.ts
+++ b/packages/assistant-engine/src/assistant/store/persistence.ts
@@ -1,4 +1,11 @@
-import { access, open, readdir, readFile, type FileHandle } from 'node:fs/promises'
+import {
+  access,
+  open,
+  opendir,
+  readdir,
+  readFile,
+  type FileHandle,
+} from 'node:fs/promises'
 import path from 'node:path'
 import { z } from 'zod'
 import {
@@ -644,17 +651,26 @@ export async function synchronizeAssistantIndexes(
     conversationKeys[session.binding.conversationKey] = session.sessionId
   }
 
+  const canUpdateRecentSessions =
+    store.recentSessions !== undefined ||
+    await assistantSessionDirectoryOnlyContains(paths, session.sessionId)
+
   const updated = assistantAliasStoreSchema.parse({
     version: ASSISTANT_INDEX_STORE_VERSION,
     aliases,
     conversationKeys,
     // Foreground saves own the bounded recent-session projection in O(1).
-    // Legacy indexes without the field start from the current save instead of
-    // rebuilding from every durable session on the reply commit path.
-    recentSessions: pruneAssistantRecentSessions({
-      ...(store.recentSessions ?? {}),
-      [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
-    }),
+    // Legacy indexes without the field are updated only when the session
+    // directory is known to contain no older records; otherwise explicit
+    // repair owns the one-time full rebuild.
+    ...(canUpdateRecentSessions
+      ? {
+          recentSessions: pruneAssistantRecentSessions({
+            ...(store.recentSessions ?? {}),
+            [session.sessionId]: session.lastTurnAt ?? session.updatedAt,
+          }),
+        }
+      : {}),
   })
   await writeJsonFileAtomic(paths.indexesPath, updated)
 }
@@ -681,6 +697,12 @@ export async function readAssistantRecentSessionsProjection(
     raw = await readFile(paths.indexesPath, 'utf8')
   } catch (error) {
     if (isMissingFileError(error)) {
+      if (!(await assistantSessionDirectoryHasSessionFile(paths))) {
+        return {
+          recentSessions: {},
+          state: 'ready',
+        }
+      }
       return {
         recentSessions: {},
         state: 'missing',
@@ -707,6 +729,17 @@ export async function readAssistantRecentSessionsProjection(
     }
   }
 
+  if (
+    Object.keys(store.aliases).length === 0 &&
+    Object.keys(store.conversationKeys).length === 0 &&
+    !(await assistantSessionDirectoryHasSessionFile(paths))
+  ) {
+    return {
+      recentSessions: {},
+      state: 'ready',
+    }
+  }
+
   return {
     recentSessions: {},
     state: 'missing',
@@ -729,6 +762,70 @@ function pruneAssistantRecentSessions(
       )
       .slice(0, ASSISTANT_RECENT_SESSIONS_INDEX_LIMIT),
   )
+}
+
+async function assistantSessionDirectoryHasSessionFile(
+  paths: AssistantStatePaths,
+): Promise<boolean> {
+  let directory: Awaited<ReturnType<typeof opendir>>
+  try {
+    directory = await opendir(paths.sessionsDirectory)
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return false
+    }
+    throw error
+  }
+
+  try {
+    for (let checked = 0; checked < 16; checked += 1) {
+      const entry = await directory.read()
+      if (!entry) {
+        return false
+      }
+      if (entry.isFile() && entry.name.endsWith('.json')) {
+        return true
+      }
+    }
+    return true
+  } finally {
+    await directory.close()
+  }
+}
+
+async function assistantSessionDirectoryOnlyContains(
+  paths: AssistantStatePaths,
+  sessionId: string,
+): Promise<boolean> {
+  let directory: Awaited<ReturnType<typeof opendir>>
+  try {
+    directory = await opendir(paths.sessionsDirectory)
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return true
+    }
+    throw error
+  }
+
+  let matched = false
+  try {
+    for (let checked = 0; checked < 2; checked += 1) {
+      const entry = await directory.read()
+      if (!entry) {
+        return matched
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.json')) {
+        return false
+      }
+      if (entry.name.replace(/\.json$/u, '') !== sessionId) {
+        return false
+      }
+      matched = true
+    }
+    return false
+  } finally {
+    await directory.close()
+  }
 }
 
 export async function writeAutomationState(

--- a/packages/assistant-engine/test/assistant-status.test.ts
+++ b/packages/assistant-engine/test/assistant-status.test.ts
@@ -12,6 +12,7 @@ import {
   assistantStatusResultSchema,
   assistantStatusRunLockSchema,
   assistantTurnReceiptSchema,
+  assistantTurnReceiptSummarySchema,
   parseAssistantSessionRecord,
 } from '@murphai/operator-config/assistant-cli-contracts'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -293,7 +294,24 @@ describe('assistant status', () => {
         updatedAt: '2026-04-08T09:00:30.000Z',
         completedAt: '2026-04-08T09:00:30.000Z',
         lastError: null,
-        timeline: [],
+        timeline: [
+          {
+            at: '2026-04-08T09:00:01.000Z',
+            kind: 'turn.started',
+            detail: 'started',
+            metadata: {
+              retainedInReceiptOnly: 'yes',
+            },
+          },
+          {
+            at: '2026-04-08T09:00:30.000Z',
+            kind: 'turn.completed',
+            detail: `${'completed '.repeat(40)}done`,
+            metadata: {
+              omittedFromStatusSummary: 'large metadata stays in the receipt',
+            },
+          },
+        ],
       }),
     ])
 
@@ -315,6 +333,20 @@ describe('assistant status', () => {
     expect(status.generatedAt).toBe('2026-04-08T09:10:11.000Z')
     expect(status.warnings).toEqual(expectedWarnings)
     expect(status.recentTurns).toHaveLength(1)
+    expect(status.recentTurns[0]).toMatchObject({
+      schema: 'murph.assistant-turn-receipt-summary.v1',
+      turnId: 'turn-1',
+      sessionId: 'session-123',
+      status: 'completed',
+      timelineEventCount: 2,
+      latestTimelineEvent: {
+        at: '2026-04-08T09:00:30.000Z',
+        kind: 'turn.completed',
+      },
+    })
+    expect('timeline' in status.recentTurns[0]!).toBe(false)
+    expect(status.recentTurns[0]?.latestTimelineEvent?.detail?.length).toBeLessThanOrEqual(160)
+    expect(JSON.stringify(status.recentTurns[0])).not.toContain('omittedFromStatusSummary')
     expect(statusMocks.listRecentAssistantTurnReceiptsForSession).toHaveBeenCalledWith(
       vaultRoot,
       'session-123',
@@ -345,6 +377,55 @@ describe('assistant status', () => {
       10,
     )
     expect(statusMocks.listRecentAssistantTurnReceiptsForSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps recent turn status output bounded when receipt timelines are large', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T10:00:00.000Z'))
+
+    const { parentRoot, vaultRoot } = await createTempVaultContext('assistant-status-budget-')
+    tempRoots.push(parentRoot)
+    statusMocks.listRecentAssistantTurnReceipts.mockResolvedValue(
+      Array.from({ length: 5 }, (_unused, receiptIndex) =>
+        assistantTurnReceiptSchema.parse({
+          schema: 'murph.assistant-turn-receipt.v1',
+          turnId: `turn-${receiptIndex}`,
+          sessionId: `session-${receiptIndex}`,
+          provider: 'codex-cli',
+          providerModel: 'gpt-5.4',
+          promptPreview: `prompt ${receiptIndex}`,
+          responsePreview: `response ${receiptIndex}`,
+          status: 'completed',
+          deliveryRequested: false,
+          deliveryDisposition: 'not-requested',
+          deliveryIntentId: null,
+          startedAt: '2026-04-08T09:00:00.000Z',
+          updatedAt: '2026-04-08T09:00:30.000Z',
+          completedAt: '2026-04-08T09:00:30.000Z',
+          lastError: null,
+          timeline: Array.from({ length: 200 }, (_eventUnused, eventIndex) => ({
+            at: '2026-04-08T09:00:30.000Z',
+            kind: eventIndex === 199 ? 'turn.completed' : 'provider.attempt.started',
+            detail: `${'timeline detail '.repeat(80)}${receiptIndex}-${eventIndex}`,
+            metadata: {
+              largeMetadata: `${'metadata '.repeat(80)}${receiptIndex}-${eventIndex}`,
+            },
+          })),
+        }),
+      ),
+    )
+
+    const status = await getAssistantStatusLocal({
+      vault: vaultRoot,
+      limit: 5,
+    })
+    const encodedStatus = JSON.stringify(status)
+
+    expect(encodedStatus.length).toBeLessThanOrEqual(15_000)
+    expect(status.recentTurns).toHaveLength(5)
+    expect(status.recentTurns.every((turn) => turn.timelineEventCount === 200)).toBe(true)
+    expect(encodedStatus).not.toContain('largeMetadata')
+    expect(encodedStatus).not.toContain('provider.attempt.started')
   })
 
   it('refreshes the snapshot under the write lock and swallows runtime-event append failures', async () => {
@@ -635,8 +716,8 @@ function makeStatusSnapshot(paths: AssistantStatePaths) {
       },
     }),
     recentTurns: [
-      assistantTurnReceiptSchema.parse({
-        schema: 'murph.assistant-turn-receipt.v1',
+      assistantTurnReceiptSummarySchema.parse({
+        schema: 'murph.assistant-turn-receipt-summary.v1',
         turnId: 'turn-stored',
         sessionId: 'session-stored',
         provider: 'codex-cli',
@@ -651,7 +732,8 @@ function makeStatusSnapshot(paths: AssistantStatePaths) {
         updatedAt: '2026-04-08T06:00:01.000Z',
         completedAt: '2026-04-08T06:00:01.000Z',
         lastError: null,
-        timeline: [],
+        timelineEventCount: 0,
+        latestTimelineEvent: null,
       }),
     ],
     warnings: ['stored warning'],

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -15,6 +15,7 @@ import {
 import { listAssistantRuntimeEventsAtPath } from '../src/assistant/runtime-events.ts'
 import {
   appendAssistantTranscriptEntriesWithRefs,
+  listAssistantSessions,
   listAssistantSessionsLocal,
   updateAssistantAutomationState,
 } from '../src/assistant/store.ts'
@@ -427,6 +428,7 @@ describe('assistant store persistence seams', () => {
       version: 1,
       aliases: {},
       conversationKeys: {},
+      recentSessions: {},
     })
 
     const previous = createSession({
@@ -455,6 +457,9 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'telegram:user-1:thread-2': 'session-index-shared',
       },
+      recentSessions: {
+        'session-index-shared': '2026-04-08T00:06:00.000Z',
+      },
     })
     expect(JSON.parse(await readFile(paths.indexesPath, 'utf8'))).toEqual({
       version: 1,
@@ -463,6 +468,9 @@ describe('assistant store persistence seams', () => {
       },
       conversationKeys: {
         'telegram:user-1:thread-2': 'session-index-shared',
+      },
+      recentSessions: {
+        'session-index-shared': '2026-04-08T00:06:00.000Z',
       },
     })
   })
@@ -547,6 +555,9 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'telegram:user-1:thread-good': 'session-good',
       },
+      recentSessions: {
+        'session-good': '2026-04-08T00:05:00.000Z',
+      },
     })
 
     const quarantines = await listAssistantQuarantineEntriesAtPaths(paths)
@@ -611,6 +622,10 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'linq:user-1:thread-shared': 'session-newer',
       },
+      recentSessions: {
+        'session-newer': expect.any(String),
+        'session-older': expect.any(String),
+      },
     })
 
     const runtimeEvents = await listAssistantRuntimeEventsAtPath(paths.runtimeEventsPath)
@@ -662,7 +677,50 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'linq:user-1:thread-shared': 'session-newer',
       },
+      recentSessions: {
+        'session-newer': expect.any(String),
+        'session-older': expect.any(String),
+      },
     })
+  })
+
+  it('applies recent-session limits before reading durable session files', async () => {
+    const context = await createTempVaultContext('assistant-store-persistence-recent-bounded-')
+    tempRoots.push(context.parentRoot)
+    const paths = resolveAssistantStatePaths(context.vaultRoot)
+    await ensureAssistantState(paths)
+
+    const newest = createSession({
+      alias: 'newest-alias',
+      conversationKey: 'local:newest',
+      sessionId: 'session-newest',
+      updatedAt: '2026-04-08T00:03:00.000Z',
+    })
+    const olderSessionId = 'session-older-corrupt'
+    await writeAssistantSession(paths, newest)
+    await writeFile(
+      resolveAssistantSessionPath(paths, olderSessionId),
+      '{bad-json',
+      'utf8',
+    )
+    await writeFile(paths.indexesPath, JSON.stringify({
+      version: 1,
+      aliases: {},
+      conversationKeys: {},
+      recentSessions: {
+        'session-newest': '2026-04-08T00:03:00.000Z',
+        [olderSessionId]: '2026-04-08T00:01:00.000Z',
+      },
+    }), 'utf8')
+
+    await expect(listAssistantSessions(context.vaultRoot, {
+      limit: 1,
+    })).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-newest',
+      }),
+    ])
+    await expect(listAssistantQuarantineEntriesAtPaths(paths)).resolves.toEqual([])
   })
 
   it('treats corrupted session files as missing and ignores corrupted legacy sidecars for Codex sessions', async () => {

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -17,6 +17,7 @@ import {
   appendAssistantTranscriptEntriesWithRefs,
   listAssistantSessionsLocal,
   listRecentAssistantSessions,
+  repairAssistantSessionIndexes,
   updateAssistantAutomationState,
 } from '../src/assistant/store.ts'
 import {
@@ -677,6 +678,12 @@ describe('assistant store persistence seams', () => {
 
     await expect(listRecentAssistantSessions(context.vaultRoot, {
       limit: 1,
+      requireProjection: true,
+    })).rejects.toMatchObject({
+      code: 'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED',
+    })
+    await expect(listRecentAssistantSessions(context.vaultRoot, {
+      limit: 1,
     })).resolves.toEqual([])
     await expect(JSON.parse(await readFile(paths.indexesPath, 'utf8'))).toEqual({
       version: 1,
@@ -685,10 +692,38 @@ describe('assistant store persistence seams', () => {
     })
     await expect(listAssistantQuarantineEntriesAtPaths(paths)).resolves.toEqual([])
 
+    await repairAssistantSessionIndexes(context.vaultRoot)
+
+    await expect(listRecentAssistantSessions(context.vaultRoot, {
+      limit: 2,
+      requireProjection: true,
+    })).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-newer',
+      }),
+      expect.objectContaining({
+        sessionId: 'session-older',
+      }),
+    ])
+
+    const repaired = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
+      recentSessions?: Record<string, string>
+    }
+    expect(repaired.recentSessions).toEqual({
+      'session-newer': '2026-04-08T00:02:00.000Z',
+      'session-older': '2026-04-08T00:01:00.000Z',
+    })
+
+    await writeFile(paths.indexesPath, JSON.stringify({
+      version: 1,
+      aliases: {},
+      conversationKeys: {},
+    }), 'utf8')
     await synchronizeAssistantIndexes(paths, newer, null)
 
     await expect(listRecentAssistantSessions(context.vaultRoot, {
       limit: 1,
+      requireProjection: true,
     })).resolves.toEqual([
       expect.objectContaining({
         sessionId: 'session-newer',

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -16,6 +16,7 @@ import { listAssistantRuntimeEventsAtPath } from '../src/assistant/runtime-event
 import {
   appendAssistantTranscriptEntriesWithRefs,
   listAssistantSessionsLocal,
+  listRecentAssistantSessions,
   updateAssistantAutomationState,
 } from '../src/assistant/store.ts'
 import {
@@ -641,6 +642,90 @@ describe('assistant store persistence seams', () => {
         }),
       ]),
     )
+  })
+
+  it('repairs legacy recent-session projections for bounded user-facing reads', async () => {
+    const context = await createTempVaultContext('assistant-store-persistence-recent-repair-')
+    tempRoots.push(context.parentRoot)
+    const paths = resolveAssistantStatePaths(context.vaultRoot)
+    await ensureAssistantState(paths)
+
+    const older = createSession({
+      alias: 'older-alias',
+      conversationKey: 'local:older',
+      sessionId: 'session-older',
+      updatedAt: '2026-04-08T00:01:00.000Z',
+    })
+    const newer = createSession({
+      alias: 'newer-alias',
+      conversationKey: 'local:newer',
+      sessionId: 'session-newer',
+      updatedAt: '2026-04-08T00:02:00.000Z',
+    })
+    await writeAssistantSession(paths, older)
+    await writeAssistantSession(paths, newer)
+    await writeFile(paths.indexesPath, JSON.stringify({
+      version: 1,
+      aliases: {},
+      conversationKeys: {},
+    }), 'utf8')
+
+    await expect(listRecentAssistantSessions(context.vaultRoot, {
+      limit: 1,
+      repairMissingProjection: true,
+    })).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-newer',
+      }),
+    ])
+
+    const rebuilt = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
+      recentSessions?: Record<string, string>
+    }
+    expect(rebuilt.recentSessions).toEqual({
+      'session-newer': '2026-04-08T00:02:00.000Z',
+      'session-older': '2026-04-08T00:01:00.000Z',
+    })
+  })
+
+  it('applies recent-session limits before reading durable session files', async () => {
+    const context = await createTempVaultContext('assistant-store-persistence-recent-bounded-')
+    tempRoots.push(context.parentRoot)
+    const paths = resolveAssistantStatePaths(context.vaultRoot)
+    await ensureAssistantState(paths)
+
+    const newest = createSession({
+      alias: 'newest-alias',
+      conversationKey: 'local:newest',
+      sessionId: 'session-newest',
+      updatedAt: '2026-04-08T00:03:00.000Z',
+    })
+    const olderSessionId = 'session-older-corrupt'
+    await writeAssistantSession(paths, newest)
+    await writeFile(
+      resolveAssistantSessionPath(paths, olderSessionId),
+      '{bad-json',
+      'utf8',
+    )
+    await writeFile(paths.indexesPath, JSON.stringify({
+      version: 1,
+      aliases: {},
+      conversationKeys: {},
+      recentSessions: {
+        'session-newest': '2026-04-08T00:03:00.000Z',
+        [olderSessionId]: '2026-04-08T00:01:00.000Z',
+      },
+    }), 'utf8')
+
+    await expect(listRecentAssistantSessions(context.vaultRoot, {
+      limit: 1,
+      repairMissingProjection: true,
+    })).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-newest',
+      }),
+    ])
+    await expect(listAssistantQuarantineEntriesAtPaths(paths)).resolves.toEqual([])
   })
 
   it('orders sessions and duplicate index rebuilds by instant when offsets differ', async () => {

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -644,8 +644,8 @@ describe('assistant store persistence seams', () => {
     )
   })
 
-  it('repairs legacy recent-session projections for bounded user-facing reads', async () => {
-    const context = await createTempVaultContext('assistant-store-persistence-recent-repair-')
+  it('keeps legacy recent-session reads bounded and warms the projection on save', async () => {
+    const context = await createTempVaultContext('assistant-store-persistence-recent-legacy-')
     tempRoots.push(context.parentRoot)
     const paths = resolveAssistantStatePaths(context.vaultRoot)
     await ensureAssistantState(paths)
@@ -664,6 +664,11 @@ describe('assistant store persistence seams', () => {
     })
     await writeAssistantSession(paths, older)
     await writeAssistantSession(paths, newer)
+    await writeFile(
+      resolveAssistantSessionPath(paths, 'session-legacy-corrupt'),
+      '{bad-json',
+      'utf8',
+    )
     await writeFile(paths.indexesPath, JSON.stringify({
       version: 1,
       aliases: {},
@@ -678,10 +683,12 @@ describe('assistant store persistence seams', () => {
       aliases: {},
       conversationKeys: {},
     })
+    await expect(listAssistantQuarantineEntriesAtPaths(paths)).resolves.toEqual([])
+
+    await synchronizeAssistantIndexes(paths, newer, null)
 
     await expect(listRecentAssistantSessions(context.vaultRoot, {
       limit: 1,
-      repairMissingProjection: true,
     })).resolves.toEqual([
       expect.objectContaining({
         sessionId: 'session-newer',
@@ -693,7 +700,6 @@ describe('assistant store persistence seams', () => {
     }
     expect(rebuilt.recentSessions).toEqual({
       'session-newer': '2026-04-08T00:02:00.000Z',
-      'session-older': '2026-04-08T00:01:00.000Z',
     })
   })
 
@@ -728,7 +734,6 @@ describe('assistant store persistence seams', () => {
 
     await expect(listRecentAssistantSessions(context.vaultRoot, {
       limit: 1,
-      repairMissingProjection: true,
     })).resolves.toEqual([
       expect.objectContaining({
         sessionId: 'session-newest',

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -502,6 +502,9 @@ describe('assistant store persistence seams', () => {
         local: 'session-local',
       },
       conversationKeys: {},
+      recentSessions: {
+        'session-local': '2026-04-08T00:07:00.000Z',
+      },
     })
   })
 
@@ -528,6 +531,7 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'telegram:user-1:thread-external': 'session-external',
       },
+      recentSessions: {},
     })
   })
 
@@ -721,6 +725,43 @@ describe('assistant store persistence seams', () => {
       }),
     ])
     await expect(listAssistantQuarantineEntriesAtPaths(paths)).resolves.toEqual([])
+  })
+
+  it('rebuilds legacy recent-session indexes before bounded listing', async () => {
+    const context = await createTempVaultContext('assistant-store-persistence-recent-legacy-many-')
+    tempRoots.push(context.parentRoot)
+    const paths = resolveAssistantStatePaths(context.vaultRoot)
+    await ensureAssistantState(paths)
+
+    for (let index = 0; index < 60; index += 1) {
+      await writeAssistantSession(paths, createSession({
+        alias: `legacy-${index}`,
+        conversationKey: `local:legacy:${index}`,
+        sessionId: `session-legacy-${String(index).padStart(2, '0')}`,
+        updatedAt: `2026-04-08T00:${String(index).padStart(2, '0')}:00.000Z`,
+      }))
+    }
+    await writeFile(paths.indexesPath, JSON.stringify({
+      version: 1,
+      aliases: {},
+      conversationKeys: {},
+    }), 'utf8')
+
+    await expect(listAssistantSessions(context.vaultRoot, {
+      limit: 1,
+    })).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-legacy-59',
+      }),
+    ])
+
+    const rebuilt = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
+      recentSessions?: Record<string, string>
+    }
+    expect(Object.keys(rebuilt.recentSessions ?? {})).toHaveLength(50)
+    expect(rebuilt.recentSessions?.['session-legacy-59']).toBe(
+      '2026-04-08T00:59:00.000Z',
+    )
   })
 
   it('treats corrupted session files as missing and ignores corrupted legacy sidecars for Codex sessions', async () => {

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -16,8 +16,6 @@ import { listAssistantRuntimeEventsAtPath } from '../src/assistant/runtime-event
 import {
   appendAssistantTranscriptEntriesWithRefs,
   listAssistantSessionsLocal,
-  listRecentAssistantSessions,
-  repairAssistantSessionIndexes,
   updateAssistantAutomationState,
 } from '../src/assistant/store.ts'
 import {
@@ -429,7 +427,6 @@ describe('assistant store persistence seams', () => {
       version: 1,
       aliases: {},
       conversationKeys: {},
-      recentSessions: {},
     })
 
     const previous = createSession({
@@ -458,9 +455,6 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'telegram:user-1:thread-2': 'session-index-shared',
       },
-      recentSessions: {
-        'session-index-shared': '2026-04-08T00:06:00.000Z',
-      },
     })
     expect(JSON.parse(await readFile(paths.indexesPath, 'utf8'))).toEqual({
       version: 1,
@@ -469,9 +463,6 @@ describe('assistant store persistence seams', () => {
       },
       conversationKeys: {
         'telegram:user-1:thread-2': 'session-index-shared',
-      },
-      recentSessions: {
-        'session-index-shared': '2026-04-08T00:06:00.000Z',
       },
     })
   })
@@ -487,7 +478,6 @@ describe('assistant store persistence seams', () => {
         external: 'session-external',
       },
       conversationKeys: {},
-      recentSessions: {},
     }))
 
     await synchronizeAssistantIndexes(paths, createSession({
@@ -504,9 +494,6 @@ describe('assistant store persistence seams', () => {
         local: 'session-local',
       },
       conversationKeys: {},
-      recentSessions: {
-        'session-local': '2026-04-08T00:07:00.000Z',
-      },
     })
   })
 
@@ -523,7 +510,6 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'telegram:user-1:thread-external': 'session-external',
       },
-      recentSessions: {},
     }))
 
     await expect(readAssistantIndexStore(paths)).resolves.toEqual({
@@ -534,7 +520,6 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'telegram:user-1:thread-external': 'session-external',
       },
-      recentSessions: {},
     })
   })
 
@@ -561,9 +546,6 @@ describe('assistant store persistence seams', () => {
       },
       conversationKeys: {
         'telegram:user-1:thread-good': 'session-good',
-      },
-      recentSessions: {
-        'session-good': '2026-04-08T00:05:00.000Z',
       },
     })
 
@@ -629,10 +611,6 @@ describe('assistant store persistence seams', () => {
       conversationKeys: {
         'linq:user-1:thread-shared': 'session-newer',
       },
-      recentSessions: {
-        'session-newer': expect.any(String),
-        'session-older': expect.any(String),
-      },
     })
 
     const runtimeEvents = await listAssistantRuntimeEventsAtPath(paths.runtimeEventsPath)
@@ -643,146 +621,6 @@ describe('assistant store persistence seams', () => {
         }),
       ]),
     )
-  })
-
-  it('treats fresh empty recent-session projections as ready empty', async () => {
-    const context = await createTempVaultContext('assistant-store-persistence-recent-empty-')
-    tempRoots.push(context.parentRoot)
-    const paths = resolveAssistantStatePaths(context.vaultRoot)
-    await ensureAssistantState(paths)
-
-    await expect(listRecentAssistantSessions(context.vaultRoot, {
-      limit: 1,
-      requireProjection: true,
-    })).resolves.toEqual([])
-  })
-
-  it('keeps legacy recent-session reads bounded and repairable', async () => {
-    const context = await createTempVaultContext('assistant-store-persistence-recent-legacy-')
-    tempRoots.push(context.parentRoot)
-    const paths = resolveAssistantStatePaths(context.vaultRoot)
-    await ensureAssistantState(paths)
-
-    const older = createSession({
-      alias: 'older-alias',
-      conversationKey: 'local:older',
-      sessionId: 'session-older',
-      updatedAt: '2026-04-08T00:01:00.000Z',
-    })
-    const newer = createSession({
-      alias: 'newer-alias',
-      conversationKey: 'local:newer',
-      sessionId: 'session-newer',
-      updatedAt: '2026-04-08T00:02:00.000Z',
-    })
-    await writeAssistantSession(paths, older)
-    await writeAssistantSession(paths, newer)
-    await writeFile(
-      resolveAssistantSessionPath(paths, 'session-legacy-corrupt'),
-      '{bad-json',
-      'utf8',
-    )
-    await writeFile(paths.indexesPath, JSON.stringify({
-      version: 1,
-      aliases: {},
-      conversationKeys: {},
-    }), 'utf8')
-
-    await expect(listRecentAssistantSessions(context.vaultRoot, {
-      limit: 1,
-      requireProjection: true,
-    })).rejects.toMatchObject({
-      code: 'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED',
-    })
-    await expect(listRecentAssistantSessions(context.vaultRoot, {
-      limit: 1,
-    })).resolves.toEqual([])
-    await expect(JSON.parse(await readFile(paths.indexesPath, 'utf8'))).toEqual({
-      version: 1,
-      aliases: {},
-      conversationKeys: {},
-    })
-    await expect(listAssistantQuarantineEntriesAtPaths(paths)).resolves.toEqual([])
-
-    await repairAssistantSessionIndexes(context.vaultRoot)
-
-    await expect(listRecentAssistantSessions(context.vaultRoot, {
-      limit: 2,
-      requireProjection: true,
-    })).resolves.toEqual([
-      expect.objectContaining({
-        sessionId: 'session-newer',
-      }),
-      expect.objectContaining({
-        sessionId: 'session-older',
-      }),
-    ])
-
-    const repaired = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
-      recentSessions?: Record<string, string>
-    }
-    expect(repaired.recentSessions).toEqual({
-      'session-newer': '2026-04-08T00:02:00.000Z',
-      'session-older': '2026-04-08T00:01:00.000Z',
-    })
-
-    await writeFile(paths.indexesPath, JSON.stringify({
-      version: 1,
-      aliases: {},
-      conversationKeys: {},
-    }), 'utf8')
-    await synchronizeAssistantIndexes(paths, newer, null)
-
-    await expect(listRecentAssistantSessions(context.vaultRoot, {
-      limit: 1,
-      requireProjection: true,
-    })).rejects.toMatchObject({
-      code: 'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED',
-    })
-
-    const rebuilt = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
-      recentSessions?: Record<string, string>
-    }
-    expect(rebuilt.recentSessions).toBeUndefined()
-  })
-
-  it('applies recent-session limits before reading durable session files', async () => {
-    const context = await createTempVaultContext('assistant-store-persistence-recent-bounded-')
-    tempRoots.push(context.parentRoot)
-    const paths = resolveAssistantStatePaths(context.vaultRoot)
-    await ensureAssistantState(paths)
-
-    const newest = createSession({
-      alias: 'newest-alias',
-      conversationKey: 'local:newest',
-      sessionId: 'session-newest',
-      updatedAt: '2026-04-08T00:03:00.000Z',
-    })
-    const olderSessionId = 'session-older-corrupt'
-    await writeAssistantSession(paths, newest)
-    await writeFile(
-      resolveAssistantSessionPath(paths, olderSessionId),
-      '{bad-json',
-      'utf8',
-    )
-    await writeFile(paths.indexesPath, JSON.stringify({
-      version: 1,
-      aliases: {},
-      conversationKeys: {},
-      recentSessions: {
-        'session-newest': '2026-04-08T00:03:00.000Z',
-        [olderSessionId]: '2026-04-08T00:01:00.000Z',
-      },
-    }), 'utf8')
-
-    await expect(listRecentAssistantSessions(context.vaultRoot, {
-      limit: 1,
-    })).resolves.toEqual([
-      expect.objectContaining({
-        sessionId: 'session-newest',
-      }),
-    ])
-    await expect(listAssistantQuarantineEntriesAtPaths(paths)).resolves.toEqual([])
   })
 
   it('orders sessions and duplicate index rebuilds by instant when offsets differ', async () => {
@@ -823,10 +661,6 @@ describe('assistant store persistence seams', () => {
       },
       conversationKeys: {
         'linq:user-1:thread-shared': 'session-newer',
-      },
-      recentSessions: {
-        'session-newer': expect.any(String),
-        'session-older': expect.any(String),
       },
     })
   })

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -645,7 +645,19 @@ describe('assistant store persistence seams', () => {
     )
   })
 
-  it('keeps legacy recent-session reads bounded and warms the projection on save', async () => {
+  it('treats fresh empty recent-session projections as ready empty', async () => {
+    const context = await createTempVaultContext('assistant-store-persistence-recent-empty-')
+    tempRoots.push(context.parentRoot)
+    const paths = resolveAssistantStatePaths(context.vaultRoot)
+    await ensureAssistantState(paths)
+
+    await expect(listRecentAssistantSessions(context.vaultRoot, {
+      limit: 1,
+      requireProjection: true,
+    })).resolves.toEqual([])
+  })
+
+  it('keeps legacy recent-session reads bounded and repairable', async () => {
     const context = await createTempVaultContext('assistant-store-persistence-recent-legacy-')
     tempRoots.push(context.parentRoot)
     const paths = resolveAssistantStatePaths(context.vaultRoot)
@@ -724,18 +736,14 @@ describe('assistant store persistence seams', () => {
     await expect(listRecentAssistantSessions(context.vaultRoot, {
       limit: 1,
       requireProjection: true,
-    })).resolves.toEqual([
-      expect.objectContaining({
-        sessionId: 'session-newer',
-      }),
-    ])
+    })).rejects.toMatchObject({
+      code: 'ASSISTANT_SESSION_INDEX_REPAIR_REQUIRED',
+    })
 
     const rebuilt = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
       recentSessions?: Record<string, string>
     }
-    expect(rebuilt.recentSessions).toEqual({
-      'session-newer': '2026-04-08T00:02:00.000Z',
-    })
+    expect(rebuilt.recentSessions).toBeUndefined()
   })
 
   it('applies recent-session limits before reading durable session files', async () => {

--- a/packages/assistant-engine/test/assistant-store-persistence.test.ts
+++ b/packages/assistant-engine/test/assistant-store-persistence.test.ts
@@ -672,6 +672,15 @@ describe('assistant store persistence seams', () => {
 
     await expect(listRecentAssistantSessions(context.vaultRoot, {
       limit: 1,
+    })).resolves.toEqual([])
+    await expect(JSON.parse(await readFile(paths.indexesPath, 'utf8'))).toEqual({
+      version: 1,
+      aliases: {},
+      conversationKeys: {},
+    })
+
+    await expect(listRecentAssistantSessions(context.vaultRoot, {
+      limit: 1,
       repairMissingProjection: true,
     })).resolves.toEqual([
       expect.objectContaining({

--- a/packages/assistant-engine/test/maintenance-evidence.test.ts
+++ b/packages/assistant-engine/test/maintenance-evidence.test.ts
@@ -1,4 +1,4 @@
-import { rm, writeFile } from 'node:fs/promises'
+import { readFile, rm, writeFile } from 'node:fs/promises'
 import { afterEach, expect, test } from 'vitest'
 
 import {
@@ -135,7 +135,7 @@ test('builds bounded committed conversation evidence across recent sessions', as
   expect(evidence).not.toContain('internal status entry')
 })
 
-test('repairs legacy recent-session projections before building maintenance evidence', async () => {
+test('does not auto-repair legacy recent-session projections during maintenance evidence', async () => {
   const { parentRoot, vaultRoot } = await createTempVaultContext(
     'murph-maintenance-evidence-legacy-repair-',
   )
@@ -175,10 +175,12 @@ test('repairs legacy recent-session projections before building maintenance evid
     vault: vaultRoot,
   })
 
-  expect(evidence).toContain(
-    '- [2026-06-29T22:00:00.000Z] user: Legacy projection repair should still surface this message.',
-  )
-  expect(evidence).not.toContain('No committed user or assistant conversation messages')
+  expect(evidence).toContain('No committed user or assistant conversation messages')
+  expect(evidence).not.toContain('Legacy projection repair should still surface this message.')
+  const repaired = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
+    recentSessions?: Record<string, string>
+  }
+  expect(repaired.recentSessions).toBeUndefined()
 })
 
 test('bounds transcript evidence reads to the tail byte cap', async () => {

--- a/packages/assistant-engine/test/maintenance-evidence.test.ts
+++ b/packages/assistant-engine/test/maintenance-evidence.test.ts
@@ -14,6 +14,7 @@ import {
   appendAssistantTranscriptEntries,
   listAssistantTranscriptTailEntries,
   listRecentAssistantSessions,
+  repairAssistantSessionIndexes,
   saveAssistantSession,
 } from '../src/assistant/store.ts'
 import { resolveAssistantStatePaths } from '../src/assistant/store/paths.ts'
@@ -214,8 +215,8 @@ test('bounds session reads to the newest sessions by durable activity', async ()
 
   // Legacy index without the projection: the recurring path never rebuilds
   // from session files (that would scan all sessions under the runtime write
-  // lock). It returns an in-memory empty projection and warms up from normal
-  // bounded saves instead.
+  // lock). It returns an in-memory empty projection until explicit repair
+  // builds the bounded recent-session projection.
   const paths = resolveAssistantStatePaths(vaultRoot)
   await writeFile(
     paths.indexesPath,
@@ -224,6 +225,13 @@ test('bounds session reads to the newest sessions by durable activity', async ()
   )
   const initialized = await listRecentAssistantSessions(vaultRoot, { limit: 10 })
   expect(initialized).toEqual([])
+
+  await repairAssistantSessionIndexes(vaultRoot)
+  const repaired = await listRecentAssistantSessions(vaultRoot, { limit: 10 })
+  expect(repaired.map((session) => session.sessionId).sort()).toEqual([
+    'session-newer-activity',
+    'session-older-activity',
+  ])
 
   await saveAssistantSession(
     vaultRoot,
@@ -235,6 +243,8 @@ test('bounds session reads to the newest sessions by durable activity', async ()
   const warmed = await listRecentAssistantSessions(vaultRoot, { limit: 10 })
   expect(warmed.map((session) => session.sessionId)).toEqual([
     'session-post-deploy',
+    'session-newer-activity',
+    'session-older-activity',
   ])
 
   // Missing or corrupt index files must not trigger the repair-path rebuild

--- a/packages/assistant-engine/test/maintenance-evidence.test.ts
+++ b/packages/assistant-engine/test/maintenance-evidence.test.ts
@@ -214,7 +214,7 @@ test('bounds session reads to the newest sessions by durable activity', async ()
 
   // Legacy index without the projection: the recurring path never rebuilds
   // from session files (that would scan all sessions under the runtime write
-  // lock). It initializes an empty projection and warms up from normal
+  // lock). It returns an in-memory empty projection and warms up from normal
   // bounded saves instead.
   const paths = resolveAssistantStatePaths(vaultRoot)
   await writeFile(

--- a/packages/assistant-engine/test/maintenance-evidence.test.ts
+++ b/packages/assistant-engine/test/maintenance-evidence.test.ts
@@ -135,6 +135,52 @@ test('builds bounded committed conversation evidence across recent sessions', as
   expect(evidence).not.toContain('internal status entry')
 })
 
+test('repairs legacy recent-session projections before building maintenance evidence', async () => {
+  const { parentRoot, vaultRoot } = await createTempVaultContext(
+    'murph-maintenance-evidence-legacy-repair-',
+  )
+  cleanupPaths.push(parentRoot)
+
+  await saveAssistantSession(
+    vaultRoot,
+    createEvidenceTestSession({
+      lastTurnAt: '2026-06-29T22:00:00.000Z',
+      sessionId: 'session-legacy-newer',
+    }),
+  )
+  await saveAssistantSession(
+    vaultRoot,
+    createEvidenceTestSession({
+      lastTurnAt: '2026-06-29T21:00:00.000Z',
+      sessionId: 'session-legacy-older',
+    }),
+  )
+  await appendAssistantTranscriptEntries(vaultRoot, 'session-legacy-newer', [
+    {
+      createdAt: '2026-06-29T22:00:00.000Z',
+      kind: 'user',
+      text: 'Legacy projection repair should still surface this message.',
+    },
+  ])
+
+  const paths = resolveAssistantStatePaths(vaultRoot)
+  await writeFile(
+    paths.indexesPath,
+    JSON.stringify({ version: 1, aliases: {}, conversationKeys: {} }),
+    'utf8',
+  )
+
+  const evidence = await buildAssistantMaintenanceConversationEvidence({
+    now: new Date('2026-06-30T03:00:00.000Z'),
+    vault: vaultRoot,
+  })
+
+  expect(evidence).toContain(
+    '- [2026-06-29T22:00:00.000Z] user: Legacy projection repair should still surface this message.',
+  )
+  expect(evidence).not.toContain('No committed user or assistant conversation messages')
+})
+
 test('bounds transcript evidence reads to the tail byte cap', async () => {
   const { parentRoot, vaultRoot } = await createTempVaultContext(
     'murph-maintenance-evidence-tail-',

--- a/packages/assistant-engine/test/maintenance-evidence.test.ts
+++ b/packages/assistant-engine/test/maintenance-evidence.test.ts
@@ -1,4 +1,4 @@
-import { readFile, rm, writeFile } from 'node:fs/promises'
+import { rm, writeFile } from 'node:fs/promises'
 import { afterEach, expect, test } from 'vitest'
 
 import {
@@ -12,9 +12,8 @@ import {
 } from '../src/assistant/maintenance-evidence.ts'
 import {
   appendAssistantTranscriptEntries,
+  listAssistantSessions,
   listAssistantTranscriptTailEntries,
-  listRecentAssistantSessions,
-  repairAssistantSessionIndexes,
   saveAssistantSession,
 } from '../src/assistant/store.ts'
 import { resolveAssistantStatePaths } from '../src/assistant/store/paths.ts'
@@ -135,7 +134,7 @@ test('builds bounded committed conversation evidence across recent sessions', as
   expect(evidence).not.toContain('internal status entry')
 })
 
-test('does not auto-repair legacy recent-session projections during maintenance evidence', async () => {
+test('uses legacy assistant session files for maintenance evidence', async () => {
   const { parentRoot, vaultRoot } = await createTempVaultContext(
     'murph-maintenance-evidence-legacy-repair-',
   )
@@ -159,7 +158,7 @@ test('does not auto-repair legacy recent-session projections during maintenance 
     {
       createdAt: '2026-06-29T22:00:00.000Z',
       kind: 'user',
-      text: 'Legacy projection repair should still surface this message.',
+      text: 'Legacy assistant session files should still surface this message.',
     },
   ])
 
@@ -175,12 +174,10 @@ test('does not auto-repair legacy recent-session projections during maintenance 
     vault: vaultRoot,
   })
 
-  expect(evidence).toContain('No committed user or assistant conversation messages')
-  expect(evidence).not.toContain('Legacy projection repair should still surface this message.')
-  const repaired = JSON.parse(await readFile(paths.indexesPath, 'utf8')) as {
-    recentSessions?: Record<string, string>
-  }
-  expect(repaired.recentSessions).toBeUndefined()
+  expect(evidence).not.toContain('No committed user or assistant conversation messages')
+  expect(evidence).toContain(
+    '- [2026-06-29T22:00:00.000Z] user: Legacy assistant session files should still surface this message.',
+  )
 })
 
 test('bounds transcript evidence reads to the tail byte cap', async () => {
@@ -250,33 +247,25 @@ test('bounds session reads to the newest sessions by durable activity', async ()
     }),
   )
 
-  const limited = await listRecentAssistantSessions(vaultRoot, { limit: 1 })
+  const limited = (await listAssistantSessions(vaultRoot)).slice(0, 1)
   expect(limited.map((session) => session.sessionId)).toEqual([
     'session-newer-activity',
   ])
 
-  const unlimited = await listRecentAssistantSessions(vaultRoot, { limit: 10 })
+  const unlimited = await listAssistantSessions(vaultRoot)
   expect(unlimited.map((session) => session.sessionId).sort()).toEqual([
     'session-newer-activity',
     'session-older-activity',
   ])
 
-  // Legacy index without the projection: the recurring path never rebuilds
-  // from session files (that would scan all sessions under the runtime write
-  // lock). It returns an in-memory empty projection until explicit repair
-  // builds the bounded recent-session projection.
   const paths = resolveAssistantStatePaths(vaultRoot)
   await writeFile(
     paths.indexesPath,
     JSON.stringify({ version: 1, aliases: {}, conversationKeys: {} }),
     'utf8',
   )
-  const initialized = await listRecentAssistantSessions(vaultRoot, { limit: 10 })
-  expect(initialized).toEqual([])
-
-  await repairAssistantSessionIndexes(vaultRoot)
-  const repaired = await listRecentAssistantSessions(vaultRoot, { limit: 10 })
-  expect(repaired.map((session) => session.sessionId).sort()).toEqual([
+  const legacyIndexed = await listAssistantSessions(vaultRoot)
+  expect(legacyIndexed.map((session) => session.sessionId).sort()).toEqual([
     'session-newer-activity',
     'session-older-activity',
   ])
@@ -288,24 +277,12 @@ test('bounds session reads to the newest sessions by durable activity', async ()
       sessionId: 'session-post-deploy',
     }),
   )
-  const warmed = await listRecentAssistantSessions(vaultRoot, { limit: 10 })
+  const warmed = await listAssistantSessions(vaultRoot)
   expect(warmed.map((session) => session.sessionId)).toEqual([
     'session-post-deploy',
     'session-newer-activity',
     'session-older-activity',
   ])
-
-  // Missing or corrupt index files must not trigger the repair-path rebuild
-  // (an all-session scan) from this recurring read: the wake just sees no
-  // evidence and the routing path owns repair.
-  await rm(paths.indexesPath, { force: true })
-  await expect(
-    listRecentAssistantSessions(vaultRoot, { limit: 10 }),
-  ).resolves.toEqual([])
-  await writeFile(paths.indexesPath, '{corrupt-index', 'utf8')
-  await expect(
-    listRecentAssistantSessions(vaultRoot, { limit: 10 }),
-  ).resolves.toEqual([])
 })
 
 test('returns an explicit empty evidence section when the window has no messages', async () => {

--- a/packages/assistant-engine/test/maintenance-evidence.test.ts
+++ b/packages/assistant-engine/test/maintenance-evidence.test.ts
@@ -247,7 +247,7 @@ test('bounds session reads to the newest sessions by durable activity', async ()
     }),
   )
 
-  const limited = (await listAssistantSessions(vaultRoot)).slice(0, 1)
+  const limited = await listAssistantSessions(vaultRoot, { limit: 1 })
   expect(limited.map((session) => session.sessionId)).toEqual([
     'session-newer-activity',
   ])
@@ -264,7 +264,7 @@ test('bounds session reads to the newest sessions by durable activity', async ()
     JSON.stringify({ version: 1, aliases: {}, conversationKeys: {} }),
     'utf8',
   )
-  const legacyIndexed = await listAssistantSessions(vaultRoot)
+  const legacyIndexed = await listAssistantSessions(vaultRoot, { limit: 10 })
   expect(legacyIndexed.map((session) => session.sessionId).sort()).toEqual([
     'session-newer-activity',
     'session-older-activity',
@@ -277,7 +277,7 @@ test('bounds session reads to the newest sessions by durable activity', async ()
       sessionId: 'session-post-deploy',
     }),
   )
-  const warmed = await listAssistantSessions(vaultRoot)
+  const warmed = await listAssistantSessions(vaultRoot, { limit: 10 })
   expect(warmed.map((session) => session.sessionId)).toEqual([
     'session-post-deploy',
     'session-newer-activity',

--- a/packages/cli/config.schema.json
+++ b/packages/cli/config.schema.json
@@ -783,8 +783,8 @@
                                   "maxLength": 128
                                 },
                                 "limit": {
-                                  "default": 10,
-                                  "description": "Maximum records to return per setup surface. Defaults to 10.",
+                                  "default": 3,
+                                  "description": "Maximum records to return per setup surface. Defaults to 3.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 50
@@ -863,6 +863,13 @@
                                   "type": "string",
                                   "minLength": 1,
                                   "maxLength": 128
+                                },
+                                "limit": {
+                                  "default": 5,
+                                  "description": "Maximum number of recent assistant sessions to return. Defaults to 5.",
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 50
                                 }
                               }
                             }
@@ -1601,7 +1608,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200
@@ -2837,7 +2844,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200
@@ -3001,7 +3008,7 @@
                           ]
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of audit records to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -3026,7 +3033,7 @@
                           "maxLength": 128
                         },
                         "limit": {
-                          "default": 20,
+                          "default": 10,
                           "description": "Maximum number of recent audit records to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -3317,7 +3324,7 @@
                           }
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -3554,6 +3561,13 @@
                           "description": "Optional inclusive upper date bound in YYYY-MM-DD form.",
                           "type": "string",
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                        },
+                        "limit": {
+                          "default": 10,
+                          "description": "Maximum number of results to return.",
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 200
                         }
                       }
                     }
@@ -4711,7 +4725,7 @@
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -5331,7 +5345,7 @@
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -5709,8 +5723,8 @@
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         },
                         "limit": {
-                          "default": 50,
-                          "description": "Maximum number of results to return.",
+                          "default": 10,
+                          "description": "Maximum number of results to return. Defaults to 10.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200
@@ -6268,7 +6282,7 @@
                                   "maxLength": 128
                                 },
                                 "limit": {
-                                  "default": 50,
+                                  "default": 10,
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -6689,7 +6703,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -7009,7 +7023,7 @@
                           ]
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -7450,7 +7464,7 @@
                           ]
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -8149,7 +8163,7 @@
                           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -9696,7 +9710,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200
@@ -9760,7 +9774,7 @@
                                   "description": "Calendar date in YYYY-MM-DD form."
                                 },
                                 "limit": {
-                                  "default": 50,
+                                  "default": 10,
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10054,8 +10068,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 30,
-                                  "description": "Maximum number of daily summaries to return.",
+                                  "default": 5,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10114,8 +10128,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 30,
-                                  "description": "Maximum number of daily summaries to return.",
+                                  "default": 5,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10174,8 +10188,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 30,
-                                  "description": "Maximum number of daily summaries to return.",
+                                  "default": 5,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10234,8 +10248,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 30,
-                                  "description": "Maximum number of daily summaries to return.",
+                                  "default": 5,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10294,8 +10308,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 30,
-                                  "description": "Maximum number of daily summaries to return.",
+                                  "default": 5,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10697,7 +10711,7 @@
                           "maxLength": 128
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -11634,7 +11648,7 @@
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -11821,7 +11835,7 @@
                   }
                 },
                 "limit": {
-                  "default": 50,
+                  "default": 10,
                   "type": "integer",
                   "exclusiveMinimum": 0,
                   "maximum": 200
@@ -12033,7 +12047,7 @@
                   }
                 },
                 "limit": {
-                  "default": 20,
+                  "default": 10,
                   "description": "Maximum number of timeline entries to return.",
                   "type": "integer",
                   "exclusiveMinimum": 0,
@@ -12196,7 +12210,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 20,
+                          "default": 10,
                           "description": "Maximum number of knowledge pages to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -12300,7 +12314,7 @@
                                   "maxLength": 128
                                 },
                                 "limit": {
-                                  "default": 20,
+                                  "default": 10,
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -12449,7 +12463,7 @@
                                   "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
                                 },
                                 "limit": {
-                                  "default": 50,
+                                  "default": 10,
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -12612,7 +12626,7 @@
                           "description": "Calendar date in YYYY-MM-DD form."
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200
@@ -12747,7 +12761,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -12944,7 +12958,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -13140,7 +13154,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -13331,7 +13345,7 @@
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -13600,7 +13614,7 @@
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -13817,7 +13831,7 @@
                           "maxLength": 128
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -13976,7 +13990,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -14208,7 +14222,7 @@
                           "maxLength": 128
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "description": "Maximum number of results to return.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
@@ -14470,7 +14484,7 @@
                                   "maxLength": 128
                                 },
                                 "limit": {
-                                  "default": 50,
+                                  "default": 10,
                                   "description": "Maximum number of results to return.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
@@ -14562,7 +14576,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200
@@ -14861,7 +14875,7 @@
                           "minLength": 1
                         },
                         "limit": {
-                          "default": 50,
+                          "default": 10,
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200

--- a/packages/cli/config.schema.json
+++ b/packages/cli/config.schema.json
@@ -5723,8 +5723,8 @@
                           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         },
                         "limit": {
-                          "default": 10,
-                          "description": "Maximum number of results to return. Defaults to 10.",
+                          "default": 5,
+                          "description": "Maximum number of results to return. Defaults to 5.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 200
@@ -10068,8 +10068,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 5,
-                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
+                                  "default": 3,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 3.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10128,8 +10128,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 5,
-                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
+                                  "default": 3,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 3.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10188,8 +10188,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 5,
-                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
+                                  "default": 3,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 3.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10248,8 +10248,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 5,
-                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
+                                  "default": 3,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 3.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200
@@ -10308,8 +10308,8 @@
                                   }
                                 },
                                 "limit": {
-                                  "default": 5,
-                                  "description": "Maximum number of daily summaries to return. Defaults to 5.",
+                                  "default": 3,
+                                  "description": "Maximum number of daily summaries to return. Defaults to 3.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 200

--- a/packages/cli/config.schema.json
+++ b/packages/cli/config.schema.json
@@ -870,11 +870,6 @@
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 50
-                                },
-                                "repair": {
-                                  "default": false,
-                                  "description": "Rebuild assistant session indexes from durable session files before listing. This is an explicit repair path for legacy or recovered vaults and may scan all assistant session records.",
-                                  "type": "boolean"
                                 }
                               }
                             }

--- a/packages/cli/config.schema.json
+++ b/packages/cli/config.schema.json
@@ -870,6 +870,11 @@
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 50
+                                },
+                                "repair": {
+                                  "default": false,
+                                  "description": "Rebuild assistant session indexes from durable session files before listing. This is an explicit repair path for legacy or recovered vaults and may scan all assistant session records.",
+                                  "type": "boolean"
                                 }
                               }
                             }

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -102,7 +102,7 @@ export function registerAuditCommands(
         .int()
         .positive()
         .max(200)
-        .default(50)
+        .default(10)
         .describe('Maximum number of audit records to return.'),
     }),
     output: auditListResultSchema,
@@ -128,7 +128,7 @@ export function registerAuditCommands(
         .int()
         .positive()
         .max(200)
-        .default(20)
+        .default(10)
         .describe('Maximum number of recent audit records to return.'),
     }),
     output: auditListResultSchema,

--- a/packages/cli/src/commands/automation.ts
+++ b/packages/cli/src/commands/automation.ts
@@ -870,7 +870,7 @@ export function registerAutomationCommands(cli: Cli.Cli) {
         .min(1)
         .optional()
         .describe("Optional lexical filter across title, instructions, route, and metadata."),
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: automationListResultSchema,
     async run(context) {

--- a/packages/cli/src/commands/command-factory-primitives.ts
+++ b/packages/cli/src/commands/command-factory-primitives.ts
@@ -28,7 +28,7 @@ export const commonListLimitOptionSchema = z
   .int()
   .positive()
   .max(200)
-  .default(50)
+  .default(10)
   .describe('Maximum number of results to return.')
 
 export const commonDateRangeOptionDescriptions = {

--- a/packages/cli/src/commands/document.ts
+++ b/packages/cli/src/commands/document.ts
@@ -15,6 +15,7 @@ import {
   rawImportManifestResultSchema,
 } from '@murphai/vault-usecases/records'
 import { registerArtifactBackedEntityGroup } from './entity-command-groups.js'
+import { commonListLimitOptionSchema } from './command-factory-primitives.js'
 import {
   createEntityDeleteCommandConfig,
   createEventBackedEntityEditCommandConfig,
@@ -81,12 +82,14 @@ export function registerDocumentCommands(
     },
     list: {
       description: 'List imported document events with optional date bounds.',
+      limitOption: commonListLimitOptionSchema,
       output: listResultSchema,
       async run(input) {
         return services.query.listDocuments({
           vault: input.vault,
           requestId: input.requestId,
           from: input.from,
+          limit: input.limit,
           to: input.to,
         })
       },

--- a/packages/cli/src/commands/event.ts
+++ b/packages/cli/src/commands/event.ts
@@ -407,7 +407,7 @@ export function registerEventCommands(cli: Cli.Cli, services: VaultServices) {
           to: input.to,
           tag: Array.isArray(input.tag) ? input.tag : undefined,
           experiment: input.experiment,
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
         })
       },
     },

--- a/packages/cli/src/commands/export-intake-read-helpers.ts
+++ b/packages/cli/src/commands/export-intake-read-helpers.ts
@@ -428,7 +428,7 @@ export async function listStoredExportPacks(
     })
     .map((item) => item.summary)
 
-  return filtered.slice(0, options.limit ?? 50)
+  return filtered.slice(0, options.limit ?? 10)
 }
 
 export async function materializeStoredExportPack(input: {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -154,7 +154,7 @@ export function registerExportCommands(cli: Cli.Cli, services: VaultServices) {
       experiment: slugSchema
         .optional()
         .describe('Optional experiment slug filter against the stored pack scope.'),
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: exportPackListResultSchema,
     async run({ options }) {

--- a/packages/cli/src/commands/food.ts
+++ b/packages/cli/src/commands/food.ts
@@ -551,7 +551,7 @@ export function registerFoodCommands(cli: Cli.Cli, services: VaultServices) {
           vault: input.vault,
           requestId: input.requestId,
           status: input.status,
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
         })
       },
     },

--- a/packages/cli/src/commands/intake.ts
+++ b/packages/cli/src/commands/intake.ts
@@ -140,7 +140,7 @@ export function registerIntakeCommands(cli: Cli.Cli, services: VaultServices) {
       options: withBaseOptions({
         from: localDateSchema.optional(),
         to: localDateSchema.optional(),
-        limit: z.number().int().positive().max(200).default(50),
+        limit: z.number().int().positive().max(200).default(10),
       }),
       output: listResultSchema,
       async run({ options }) {

--- a/packages/cli/src/commands/knowledge.ts
+++ b/packages/cli/src/commands/knowledge.ts
@@ -156,7 +156,7 @@ export function registerKnowledgeCommands(cli: Cli.Cli) {
         .int()
         .positive()
         .max(200)
-        .default(20)
+        .default(10)
         .describe('Maximum number of knowledge pages to return.'),
     }),
     output: knowledgeListResultSchema,
@@ -246,7 +246,7 @@ export function registerKnowledgeCommands(cli: Cli.Cli) {
     description: 'Show the latest derived knowledge write-log entries in descending occurredAt order.',
     args: emptyArgsSchema,
     options: withBaseOptions({
-      limit: z.number().int().positive().max(200).default(20),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: knowledgeLogTailResultSchema,
     run({ options }) {

--- a/packages/cli/src/commands/protocol.ts
+++ b/packages/cli/src/commands/protocol.ts
@@ -221,7 +221,7 @@ export function registerProtocolCommands(
     description: "List private regimen records.",
     options: withBaseOptions({
       status: z.string().min(1).optional().describe("Optional regimen status to filter by."),
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: healthListResultSchema,
     run({ options }) {
@@ -609,7 +609,7 @@ export function registerProtocolCommands(
         .min(1)
         .optional()
         .describe("Optional public Health Commons protocol key, slug, or route id to filter by."),
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: privateProtocolListResultSchema,
     async run({ options }) {

--- a/packages/cli/src/commands/provider.ts
+++ b/packages/cli/src/commands/provider.ts
@@ -228,7 +228,7 @@ export function registerProviderCommands(
           vault: input.vault,
           requestId: input.requestId,
           status: input.status,
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
         })
       },
     },

--- a/packages/cli/src/commands/recipe.ts
+++ b/packages/cli/src/commands/recipe.ts
@@ -259,7 +259,7 @@ export function registerRecipeCommands(cli: Cli.Cli, services: VaultServices) {
           vault: input.vault,
           requestId: input.requestId,
           status: input.status,
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
         })
       },
     },

--- a/packages/cli/src/commands/samples.ts
+++ b/packages/cli/src/commands/samples.ts
@@ -917,7 +917,7 @@ export function registerSamplesCommands(
       from: localDateSchema.optional(),
       to: localDateSchema.optional(),
       quality: z.string().min(1).optional(),
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: samplesListResultSchema,
     async run({ options }) {
@@ -973,7 +973,7 @@ export function registerSamplesCommands(
       stream: z.string().min(1).optional(),
       from: localDateSchema.optional(),
       to: localDateSchema.optional(),
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: sampleBatchListResultSchema,
     async run({ options }) {

--- a/packages/cli/src/commands/scheduled-log.ts
+++ b/packages/cli/src/commands/scheduled-log.ts
@@ -75,6 +75,17 @@ export const scheduledLogRecordSchema = z
   })
   .strict();
 
+export const scheduledLogListItemSchema = scheduledLogRecordSchema
+  .omit({
+    action: true,
+    body: true,
+    markdown: true,
+  })
+  .extend({
+    actionKind: z.enum(scheduledLogActionKindValues),
+  })
+  .strict();
+
 export const scheduledLogListResultSchema = z.object({
   vault: pathSchema,
   filters: z.object({
@@ -83,7 +94,7 @@ export const scheduledLogListResultSchema = z.object({
     limit: z.number().int().positive().max(200),
   }),
   count: z.number().int().nonnegative(),
-  items: z.array(scheduledLogRecordSchema),
+  items: z.array(scheduledLogListItemSchema),
 });
 
 export const scheduledLogShowResultSchema = z.object({
@@ -115,6 +126,24 @@ export const scheduledLogStatusResultSchema = z.object({
 
 export function createScheduledLogScaffoldPayload(): ScheduledLogScaffoldPayload {
   return scheduledLogScaffoldPayloadSchema.parse(scaffoldScheduledLogPayload());
+}
+
+function toScheduledLogListItem(
+  record: z.infer<typeof scheduledLogRecordSchema>,
+): z.infer<typeof scheduledLogListItemSchema> {
+  return {
+    scheduledLogId: record.scheduledLogId,
+    slug: record.slug,
+    title: record.title,
+    status: record.status,
+    summary: record.summary,
+    schedule: record.schedule,
+    tags: record.tags,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    relativePath: record.relativePath,
+    actionKind: record.action.kind,
+  };
 }
 
 function invalidScheduledLogOption(message: string): never {
@@ -1004,7 +1033,7 @@ export function registerScheduledLogCommands(cli: Cli.Cli) {
         .min(1)
         .optional()
         .describe("Optional lexical filter across title, action, schedule, and body."),
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: scheduledLogListResultSchema,
     async run(context) {
@@ -1022,7 +1051,7 @@ export function registerScheduledLogCommands(cli: Cli.Cli) {
           limit: context.options.limit,
         },
         count: items.length,
-        items,
+        items: items.map(toScheduledLogListItem),
       };
     },
   });

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -367,7 +367,7 @@ export function registerSearchCommands(cli: Cli.Cli) {
           .int()
           .positive()
           .max(500)
-          .default(20)
+          .default(10)
           .describe('Maximum number of timeline entries to return.'),
       }),
       examples: [

--- a/packages/cli/src/commands/supplement.ts
+++ b/packages/cli/src/commands/supplement.ts
@@ -141,7 +141,7 @@ export function registerSupplementCommands(
     output: healthListResultSchema,
     async run(context) {
       return services.query.listSupplements({
-        limit: context.options.limit ?? 50,
+        limit: context.options.limit ?? 10,
         requestId: requestIdFromOptions(context.options),
         status: context.options.status,
         vault: context.options.vault,

--- a/packages/cli/src/commands/wearables.ts
+++ b/packages/cli/src/commands/wearables.ts
@@ -414,8 +414,8 @@ function withWearableListOptions() {
       .int()
       .positive()
       .max(200)
-      .default(5)
-      .describe('Maximum number of daily summaries to return. Defaults to 5.'),
+      .default(3)
+      .describe('Maximum number of daily summaries to return. Defaults to 3.'),
   })
 }
 

--- a/packages/cli/src/commands/wearables.ts
+++ b/packages/cli/src/commands/wearables.ts
@@ -64,7 +64,7 @@ const wearableResolvedMetricSchema = z.object({
   exactDuplicateCount: z.number().int().nonnegative().optional(),
   fallbackFromMetric: nullableTextSchema.optional(),
   fallbackReason: nullableTextSchema.optional(),
-  metric: z.string().min(1),
+  metric: z.string().min(1).optional(),
   occurredAt: nullableTimestampSchema.optional(),
   provider: nullableTextSchema.optional(),
   recordedAt: nullableTimestampSchema.optional(),
@@ -414,8 +414,8 @@ function withWearableListOptions() {
       .int()
       .positive()
       .max(200)
-      .default(30)
-      .describe('Maximum number of daily summaries to return.'),
+      .default(5)
+      .describe('Maximum number of daily summaries to return. Defaults to 5.'),
   })
 }
 

--- a/packages/cli/src/commands/workout.ts
+++ b/packages/cli/src/commands/workout.ts
@@ -87,8 +87,8 @@ const workoutListLimitOptionSchema = z
   .int()
   .positive()
   .max(200)
-  .default(10)
-  .describe('Maximum number of results to return. Defaults to 10.')
+  .default(5)
+  .describe('Maximum number of results to return. Defaults to 5.')
 
 interface WorkoutAddExerciseDraft {
   groupId?: string

--- a/packages/cli/src/commands/workout.ts
+++ b/packages/cli/src/commands/workout.ts
@@ -82,6 +82,13 @@ import {
 import { normalizeOccurredAtOption } from './occurred-at-option.js'
 
 const workoutSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u
+const workoutListLimitOptionSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(200)
+  .default(10)
+  .describe('Maximum number of results to return. Defaults to 10.')
 
 interface WorkoutAddExerciseDraft {
   groupId?: string
@@ -707,7 +714,7 @@ export function registerWorkoutCommands(
           description: commonDateRangeOptionDescriptions.to,
           name: 'to',
         },
-        limit: commonListLimitOptionSchema,
+        limit: workoutListLimitOptionSchema,
       },
       output: listResultSchema,
       run(input) {
@@ -1464,7 +1471,7 @@ export function registerWorkoutCommands(
     description: 'List saved workout formats.',
     args: z.object({}),
     options: withBaseOptions({
-      limit: z.number().int().positive().max(200).default(50),
+      limit: z.number().int().positive().max(200).default(10),
     }),
     output: workoutFormatListResultSchema,
     async run({ options }) {

--- a/packages/cli/src/incur.generated.ts
+++ b/packages/cli/src/incur.generated.ts
@@ -32,7 +32,7 @@ declare module 'incur' {
       'assistant self-target list': { args: {}; options: { requestId?: string } }
       'assistant self-target set': { args: { channel: string }; options: { requestId?: string; identity?: string; participant?: string; thread?: string; deliveryTarget?: string } }
       'assistant self-target show': { args: { channel: string }; options: { requestId?: string } }
-      'assistant session list': { args: {}; options: { requestId?: string } }
+      'assistant session list': { args: {}; options: { requestId?: string; limit: number } }
       'assistant session show': { args: { sessionId: string }; options: { requestId?: string } }
       'assistant status': { args: {}; options: { requestId?: string; session?: string; limit: number } }
       'assistant stop': { args: {}; options: { requestId?: string } }
@@ -89,7 +89,7 @@ declare module 'incur' {
       'document delete': { args: { id: string }; options: { requestId?: string } }
       'document edit': { args: { id: string }; options: { requestId?: string; title?: string; note?: string; occurredAt?: string | string; timeZone?: string; dayKey?: string; source?: "manual" | "import" | "device" | "derived"; tag?: string[]; clearTitle?: boolean; clearNote?: boolean; clearTimeZone?: boolean; clearDayKey?: boolean; clearSource?: boolean; clearTags?: boolean; dayKeyPolicy?: "keep" | "recompute" } }
       'document import': { args: { file: string }; options: { requestId?: string; title?: string; occurredAt?: string | string; note?: string; source?: "manual" | "import" | "device" | "derived" } }
-      'document list': { args: {}; options: { requestId?: string; from?: string; to?: string } }
+      'document list': { args: {}; options: { requestId?: string; from?: string; to?: string; limit: number } }
       'document manifest': { args: { id: string }; options: { requestId?: string } }
       'document show': { args: { id: string }; options: { requestId?: string } }
       'encounter import-json': { args: {}; options: { requestId?: string; input: string } }

--- a/packages/cli/src/incur.generated.ts
+++ b/packages/cli/src/incur.generated.ts
@@ -32,7 +32,7 @@ declare module 'incur' {
       'assistant self-target list': { args: {}; options: { requestId?: string } }
       'assistant self-target set': { args: { channel: string }; options: { requestId?: string; identity?: string; participant?: string; thread?: string; deliveryTarget?: string } }
       'assistant self-target show': { args: { channel: string }; options: { requestId?: string } }
-      'assistant session list': { args: {}; options: { requestId?: string; limit: number; repair: boolean } }
+      'assistant session list': { args: {}; options: { requestId?: string; limit: number } }
       'assistant session show': { args: { sessionId: string }; options: { requestId?: string } }
       'assistant status': { args: {}; options: { requestId?: string; session?: string; limit: number } }
       'assistant stop': { args: {}; options: { requestId?: string } }

--- a/packages/cli/src/incur.generated.ts
+++ b/packages/cli/src/incur.generated.ts
@@ -32,7 +32,7 @@ declare module 'incur' {
       'assistant self-target list': { args: {}; options: { requestId?: string } }
       'assistant self-target set': { args: { channel: string }; options: { requestId?: string; identity?: string; participant?: string; thread?: string; deliveryTarget?: string } }
       'assistant self-target show': { args: { channel: string }; options: { requestId?: string } }
-      'assistant session list': { args: {}; options: { requestId?: string; limit: number } }
+      'assistant session list': { args: {}; options: { requestId?: string; limit: number; repair: boolean } }
       'assistant session show': { args: { sessionId: string }; options: { requestId?: string } }
       'assistant status': { args: {}; options: { requestId?: string; session?: string; limit: number } }
       'assistant stop': { args: {}; options: { requestId?: string } }

--- a/packages/cli/test/assistant-cli.test.ts
+++ b/packages/cli/test/assistant-cli.test.ts
@@ -286,10 +286,15 @@ test.sequential(
 
     const listed = requireData(
       await runIsolatedCli<{
+        count: number
+        filters: {
+          limit: number
+        }
         stateRoot: string
         sessions: Array<{
           sessionId: string
           alias: string | null
+          target?: unknown
         }>
       }>(['assistant', 'session', 'list', '--vault', vaultRoot], {
         env: {
@@ -297,10 +302,13 @@ test.sequential(
         },
       }),
     )
+    assert.equal(listed.count, 1)
+    assert.equal(listed.filters.limit, 5)
     assert.equal(listed.sessions.length, 1)
     assert.equal(listed.sessions[0]?.sessionId, created.session.sessionId)
     assert.equal(listed.sessions[0]?.alias, 'telegram:bob')
     assert.equal(listed.stateRoot, statePaths.assistantStateRoot)
+    assert.equal('target' in (listed.sessions[0] ?? {}), false)
     assert.equal(
       Object.prototype.hasOwnProperty.call(listed.sessions[0] ?? {}, 'lastAssistantMessage'),
       false,

--- a/packages/cli/test/assistant-cli.test.ts
+++ b/packages/cli/test/assistant-cli.test.ts
@@ -373,6 +373,58 @@ test.sequential(
 )
 
 test.sequential(
+  'assistant session list reads legacy session files without repair',
+  async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'murph-assistant-cli-legacy-'))
+    const homeRoot = path.join(parent, 'home')
+    const vaultRoot = path.join(parent, 'vault')
+    cleanupPaths.push(parent)
+    await mkdir(homeRoot, { recursive: true })
+    await initializeVault({ vaultRoot })
+
+    await resolveAssistantSession({
+      vault: vaultRoot,
+      alias: 'legacy:older',
+      now: new Date('2026-06-29T21:00:00.000Z'),
+    })
+    const newer = await resolveAssistantSession({
+      vault: vaultRoot,
+      alias: 'legacy:newer',
+      now: new Date('2026-06-29T22:00:00.000Z'),
+    })
+    const statePaths = resolveAssistantStatePaths(vaultRoot)
+    await writeFile(
+      statePaths.indexesPath,
+      JSON.stringify({ version: 1, aliases: {}, conversationKeys: {} }),
+      'utf8',
+    )
+
+    const listed = requireData(
+      await runIsolatedCli<{
+        count: number
+        filters: {
+          limit: number
+        }
+        sessions: Array<{
+          sessionId: string
+          target?: unknown
+        }>
+      }>(['assistant', 'session', 'list', '--limit', '1', '--vault', vaultRoot], {
+        env: {
+          HOME: homeRoot,
+        },
+      }),
+    )
+
+    assert.equal(listed.count, 1)
+    assert.equal(listed.filters.limit, 1)
+    assert.equal(listed.sessions[0]?.sessionId, newer.session.sessionId)
+    assert.equal('target' in (listed.sessions[0] ?? {}), false)
+  },
+  ASSISTANT_CLI_TIMEOUT_MS,
+)
+
+test.sequential(
   'assistant session list and show redact HOME-based vault and runtime paths',
   async () => {
     const parent = await mkdtemp(path.join(tmpdir(), 'murph-assistant-cli-home-'))

--- a/packages/cli/test/assistant-cli.test.ts
+++ b/packages/cli/test/assistant-cli.test.ts
@@ -342,6 +342,37 @@ test.sequential(
 )
 
 test.sequential(
+  'assistant session list returns an empty compact page for a fresh vault',
+  async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'murph-assistant-cli-empty-'))
+    const homeRoot = path.join(parent, 'home')
+    const vaultRoot = path.join(parent, 'vault')
+    cleanupPaths.push(parent)
+    await mkdir(homeRoot, { recursive: true })
+    await initializeVault({ vaultRoot })
+
+    const listed = requireData(
+      await runIsolatedCli<{
+        count: number
+        filters: {
+          limit: number
+        }
+        sessions: unknown[]
+      }>(['assistant', 'session', 'list', '--vault', vaultRoot], {
+        env: {
+          HOME: homeRoot,
+        },
+      }),
+    )
+
+    assert.equal(listed.count, 0)
+    assert.equal(listed.filters.limit, 5)
+    assert.deepEqual(listed.sessions, [])
+  },
+  ASSISTANT_CLI_TIMEOUT_MS,
+)
+
+test.sequential(
   'assistant session list and show redact HOME-based vault and runtime paths',
   async () => {
     const parent = await mkdtemp(path.join(tmpdir(), 'murph-assistant-cli-home-'))

--- a/packages/cli/test/cli-expansion-document-meal.test.ts
+++ b/packages/cli/test/cli-expansion-document-meal.test.ts
@@ -273,8 +273,9 @@ test(
 
     assert.equal('from' in documentListSchema.options.properties, true)
     assert.equal('to' in documentListSchema.options.properties, true)
+    assert.equal('limit' in documentListSchema.options.properties, true)
     assert.equal('kind' in documentListSchema.options.properties, false)
-    assert.deepEqual(documentListSchema.options.required ?? [], [])
+    assert.deepEqual(documentListSchema.options.required ?? [], ['limit'])
 
     assert.equal('input' in documentEditSchema.options.properties, false)
     assert.equal('set' in documentEditSchema.options.properties, false)
@@ -410,7 +411,7 @@ test.sequential(
       assert.equal(requireData(listedDocuments).filters.kind, 'document')
       assert.equal(requireData(listedDocuments).filters.from, '2026-03-12')
       assert.equal(requireData(listedDocuments).filters.to, '2026-03-12')
-      assert.equal(requireData(listedDocuments).filters.limit, 50)
+      assert.equal(requireData(listedDocuments).filters.limit, 10)
       assert.equal(requireData(listedDocuments).count, 1)
       assert.deepEqual(
         requireData(listedDocuments).items.map((item) => item.id),
@@ -799,7 +800,7 @@ test.sequential(
       assert.equal(requireData(listedMeals).filters.kind, 'meal')
       assert.equal(requireData(listedMeals).filters.from, '2026-03-12')
       assert.equal(requireData(listedMeals).filters.to, '2026-03-12')
-      assert.equal(requireData(listedMeals).filters.limit, 50)
+      assert.equal(requireData(listedMeals).filters.limit, 10)
       assert.equal(requireData(listedMeals).count, 1)
       assert.deepEqual(
         requireData(listedMeals).items.map((item) => item.id),

--- a/packages/cli/test/cli-expansion-export-intake.test.ts
+++ b/packages/cli/test/cli-expansion-export-intake.test.ts
@@ -450,7 +450,7 @@ test.sequential(
         from: '2026-03-10',
         to: '2026-03-12',
         experiment: null,
-        limit: 50,
+        limit: 10,
       })
       assert.deepEqual(
         requireData(listResult).items.map((item) => item.packId),

--- a/packages/cli/test/cli-expansion-provider-event-samples.test.ts
+++ b/packages/cli/test/cli-expansion-provider-event-samples.test.ts
@@ -527,7 +527,7 @@ test.sequential(
       assert.equal(requireData(recipeList).items[0]?.kind, 'recipe')
       assert.match(
         requireData(recipeList).items[0]?.excerpt ?? '',
-        /Summary A reliable high protein salmon b/u,
+        /Summary A reliable high protein salmon/u,
       )
       assert.equal('markdown' in (requireData(recipeList).items[0] ?? {}), false)
       assert.equal(requireData(recipeList).items[0]?.data.dishType, 'dinner')

--- a/packages/cli/test/cli-output-budget.test.ts
+++ b/packages/cli/test/cli-output-budget.test.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import type { Cli } from 'incur'
+
+import { repoRoot } from './cli-test-helpers.js'
+import { localParallelCliTest as test } from './local-parallel-test.js'
+import { createVaultCli } from '../src/index.js'
+
+const DEFAULT_AGENT_VISIBLE_OUTPUT_MAX_CHARS = 15_000
+const OUTPUT_BUDGET_TIMEOUT_MS = 120_000
+
+function cliBudgetEnv() {
+  const env = { ...process.env }
+  delete env.VAULT
+  return { env }
+}
+
+async function runBudgetedRawCli(
+  cli: Cli.Cli,
+  args: readonly string[],
+  vaultRoot: string,
+): Promise<string> {
+  const output: string[] = []
+
+  await cli.serve(
+    [
+      ...args,
+      '--vault',
+      vaultRoot,
+      '--format',
+      'json',
+      '--full-output',
+    ],
+    {
+      ...cliBudgetEnv(),
+      exit: () => {},
+      stdout(chunk) {
+        output.push(chunk)
+      },
+    },
+  )
+
+  return output.join('').trim()
+}
+
+function assertWithinBudget(label: string, output: string) {
+  assert.ok(
+    output.length <= DEFAULT_AGENT_VISIBLE_OUTPUT_MAX_CHARS,
+    `${label} emitted ${output.length} chars, expected <= ${DEFAULT_AGENT_VISIBLE_OUTPUT_MAX_CHARS}`,
+  )
+}
+
+function assertOk(label: string, output: string) {
+  const parsed = JSON.parse(output) as {
+    error?: {
+      code?: string
+      message?: string
+    }
+    ok?: unknown
+  }
+  assert.equal(
+    parsed.ok,
+    true,
+    `${label} did not return an ok envelope: ${parsed.error?.code ?? 'unknown'} ${
+      parsed.error?.message ?? ''
+    }`.trim(),
+  )
+}
+
+test('representative default read commands stay within the agent-visible output budget', async () => {
+  const cli = createVaultCli()
+  const demoVaultRoot = path.join(repoRoot, 'fixtures/demo-web-vault')
+  const commands: ReadonlyArray<readonly [string, readonly string[]]> = [
+    ['root list', ['list']],
+    ['event list', ['event', 'list']],
+    ['document list', ['document', 'list']],
+    ['workout list', ['workout', 'list']],
+    ['automation list', ['automation', 'list']],
+    ['audit list', ['audit', 'list']],
+    ['search query', ['search', 'query', 'sleep']],
+    ['knowledge list', ['knowledge', 'list']],
+    ['protocol list', ['protocol', 'list']],
+    ['wearables latest', ['wearables', 'latest']],
+    ['wearables sleep list', ['wearables', 'sleep', 'list']],
+    ['wearables activity list', ['wearables', 'activity', 'list']],
+    ['wearables recovery list', ['wearables', 'recovery', 'list']],
+    ['wearables sources list', ['wearables', 'sources', 'list']],
+  ]
+
+  for (const [label, args] of commands) {
+    const output = await runBudgetedRawCli(cli, args, demoVaultRoot)
+    assertOk(label, output)
+    assertWithinBudget(label, output)
+  }
+}, OUTPUT_BUDGET_TIMEOUT_MS)
+
+test('workout list uses the compact default page size for oversized records', async () => {
+  const cli = createVaultCli()
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-cli-output-budget-'))
+  const longSummary = `Easy run ${'with detailed notes '.repeat(120)}`
+
+  try {
+    assertOk('init', await runBudgetedRawCli(cli, ['init'], vaultRoot))
+    for (let index = 0; index < 6; index += 1) {
+      assertOk(
+        `workout add ${index}`,
+        await runBudgetedRawCli(
+          cli,
+          [
+            'workout',
+            'add',
+            `${longSummary}${index}`,
+            '--duration',
+            '30',
+            '--occurred-at',
+            `2026-04-${String(index + 1).padStart(2, '0')}T07:00:00.000Z`,
+          ],
+          vaultRoot,
+        ),
+      )
+    }
+
+    const rawList = await runBudgetedRawCli(cli, ['workout', 'list'], vaultRoot)
+    const list = JSON.parse(rawList) as {
+      ok: true
+      data: {
+        filters: {
+          limit: number
+        }
+        items: unknown[]
+      }
+    }
+
+    assert.equal(list.ok, true)
+    assertWithinBudget('workout list', rawList)
+    assert.equal(list.data.filters.limit, 5)
+    assert.equal(list.data.items.length, 5)
+  } finally {
+    await rm(vaultRoot, {
+      force: true,
+      recursive: true,
+    })
+  }
+}, OUTPUT_BUDGET_TIMEOUT_MS)

--- a/packages/cli/test/device-knowledge-command-coverage.test.ts
+++ b/packages/cli/test/device-knowledge-command-coverage.test.ts
@@ -542,7 +542,7 @@ test('knowledge commands round-trip the registered CLI against a temp vault', as
   ])
   assert.equal(listed.exitCode, null)
   assert.equal(listed.envelope.ok, true)
-  assert.equal(listed.envelope.data.limit, 20)
+  assert.equal(listed.envelope.data.limit, 10)
   assert.equal(listed.envelope.data.pageCount, 1)
   assert.equal(listed.envelope.data.pages[0]?.slug, upserted.envelope.data.page.slug)
 

--- a/packages/cli/test/incur-smoke.test.ts
+++ b/packages/cli/test/incur-smoke.test.ts
@@ -1947,6 +1947,10 @@ test('assistant session list schema emits the normalized session output shape', 
   const schema = JSON.parse(
     await runSourceCliRaw(['assistant', 'session', 'list', '--schema', '--format', 'json']),
   ) as {
+    options: {
+      properties: Record<string, unknown>
+      required?: string[]
+    }
     output: {
       properties: Record<string, unknown>
       required?: string[]
@@ -1955,7 +1959,10 @@ test('assistant session list schema emits the normalized session output shape', 
 
   assert.equal('stateRoot' in schema.output.properties, true)
   assert.equal('sessions' in schema.output.properties, true)
-  assert.deepEqual(schema.output.required, ['vault', 'stateRoot', 'sessions'])
+  assert.equal('limit' in schema.options.properties, true)
+  assert.equal('filters' in schema.output.properties, true)
+  assert.equal('count' in schema.output.properties, true)
+  assert.deepEqual(schema.output.required, ['vault', 'stateRoot', 'filters', 'sessions', 'count'])
 
   const sessions = schema.output.properties.sessions as {
     items?: {
@@ -1968,7 +1975,10 @@ test('assistant session list schema emits the normalized session output shape', 
   assert.notEqual(sessionVariant, undefined)
   assert.equal('providerSessionId' in (sessionVariant?.properties ?? {}), false)
   assert.equal('providerBinding' in (sessionVariant?.properties ?? {}), false)
-  assert.equal('target' in (sessionVariant?.properties ?? {}), true)
+  assert.equal('target' in (sessionVariant?.properties ?? {}), false)
+  assert.equal('providerOptions' in (sessionVariant?.properties ?? {}), false)
+  assert.equal('model' in (sessionVariant?.properties ?? {}), true)
+  assert.equal('resumeThreadId' in (sessionVariant?.properties ?? {}), true)
 }, INCUR_SCHEMA_TIMEOUT_MS)
 
 test('assistant session show schema emits the normalized session output shape', async () => {
@@ -2177,7 +2187,7 @@ test('health list help preserves command-family option shapes', async () => {
   assert.match(documentHelp, /^\s+--from\b/mu)
   assert.match(documentHelp, /^\s+--to\b/mu)
   assert.doesNotMatch(documentHelp, /^\s+--status\b/mu)
-  assert.doesNotMatch(documentHelp, /^\s+--limit\b/mu)
+  assert.match(documentHelp, /^\s+--limit\b/mu)
 }, INCUR_HELP_TIMEOUT_MS)
 
 test('owned date-range list help reuses consistent date and limit descriptions', async () => {

--- a/packages/cli/test/search-command-coverage.test.ts
+++ b/packages/cli/test/search-command-coverage.test.ts
@@ -570,7 +570,7 @@ test('timeline forwards repeatable filters and selective entry types', async () 
     kinds: [],
     streams: [],
     entryTypes: [],
-    limit: 20,
+    limit: 10,
   })
   assert.equal(requireData(defaultTimeline.envelope).items[0]?.id, 'entry_01')
   assert.equal('data' in (requireData(defaultTimeline.envelope).items[0] ?? {}), false)
@@ -584,7 +584,7 @@ test('timeline forwards repeatable filters and selective entry types', async () 
     includeEvents: true,
     includeAssessments: true,
     includeDailySampleSummaries: true,
-    limit: 20,
+    limit: 10,
   })
 
   const filteredTimeline = await runSearchCli<{

--- a/packages/cli/test/supplement-wearables-coverage.test.ts
+++ b/packages/cli/test/supplement-wearables-coverage.test.ts
@@ -197,7 +197,7 @@ test('supplement commands exercise typed save, read, compound, and stop paths in
     vaultRoot,
   ])
   assert.equal(listedDefault.exitCode, null)
-  assert.equal(requireData(listedDefault.envelope).filters.limit, 50)
+  assert.equal(requireData(listedDefault.envelope).filters.limit, 10)
 
   const stopped = await runInProcessJsonCli<{
     regimenId: string
@@ -282,7 +282,7 @@ test('supplement list handler exercises the default limit fallback directly', as
   const listSpy = vi.spyOn(services.query, 'listSupplements').mockResolvedValue({
     vault: vaultRoot,
     filters: {
-      limit: 50,
+      limit: 10,
       status: 'active',
     },
     items: [],
@@ -302,7 +302,7 @@ test('supplement list handler exercises the default limit fallback directly', as
   assert.equal(listSpy.mock.calls[0]?.[0].vault, vaultRoot)
   assert.equal(listSpy.mock.calls[0]?.[0].requestId, null)
   assert.equal(listSpy.mock.calls[0]?.[0].status, 'active')
-  assert.equal(listSpy.mock.calls[0]?.[0].limit, 50)
+  assert.equal(listSpy.mock.calls[0]?.[0].limit, 10)
 })
 
 test('supplement search-labels calls the hosted data API with the hosted provider credential', async () => {

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -301,9 +301,9 @@ export const assistantAliasStoreSchema = z
     // Bounded sessionId -> last-activity timestamp projection so recurring
     // maintenance can pick recent sessions without scanning the directory.
     // Absent (not defaulted) for index files written before the field
-    // existed. Bounded list/maintenance readers treat that as empty until a
-    // normal assistant save warms the projection without scanning old
-    // durable session records.
+    // existed. Bounded maintenance readers treat that as empty until a normal
+    // assistant save warms the projection without scanning old durable session
+    // records; user-visible compact list reads require explicit repair.
     recentSessions: z.record(z.string(), isoTimestampSchema).optional(),
   })
   .strict()

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -298,13 +298,6 @@ export const assistantAliasStoreSchema = z
     version: z.literal(1),
     aliases: z.record(z.string(), assistantSessionIdSchema),
     conversationKeys: z.record(z.string(), assistantSessionIdSchema),
-    // Bounded sessionId -> last-activity timestamp projection so recurring
-    // maintenance can pick recent sessions without scanning the directory.
-    // Absent (not defaulted) for index files written before the field
-    // existed. Bounded maintenance readers treat that as empty until a normal
-    // assistant save warms the projection without scanning old durable session
-    // records; user-visible compact list reads require explicit repair.
-    recentSessions: z.record(z.string(), isoTimestampSchema).optional(),
   })
   .strict()
 

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -298,6 +298,7 @@ export const assistantAliasStoreSchema = z
     version: z.literal(1),
     aliases: z.record(z.string(), assistantSessionIdSchema),
     conversationKeys: z.record(z.string(), assistantSessionIdSchema),
+    recentSessions: z.record(assistantSessionIdSchema, isoTimestampSchema).optional(),
   })
   .strict()
 

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -109,6 +109,14 @@ export const assistantTurnReceiptStatusValues = [
   'blocked',
   'failed',
 ] as const
+export const assistantTurnDeliveryDispositionValues = [
+  'not-requested',
+  'queued',
+  'sent',
+  'retryable',
+  'blocked',
+  'failed',
+] as const
 export const assistantTurnTimelineEventKindValues = [
   'turn.started',
   'user.persisted',
@@ -786,20 +794,43 @@ export const assistantTurnReceiptSchema = z
     responsePreview: z.string().nullable(),
     status: z.enum(assistantTurnReceiptStatusValues),
     deliveryRequested: z.boolean(),
-    deliveryDisposition: z.enum([
-      'not-requested',
-      'queued',
-      'sent',
-      'retryable',
-      'blocked',
-      'failed',
-    ]),
+    deliveryDisposition: z.enum(assistantTurnDeliveryDispositionValues),
     deliveryIntentId: assistantOutboxIntentIdSchema.nullable(),
     startedAt: isoTimestampSchema,
     updatedAt: isoTimestampSchema,
     completedAt: isoTimestampSchema.nullable(),
     lastError: assistantDeliveryErrorSchema.nullable(),
     timeline: z.array(assistantTurnTimelineEventSchema),
+  })
+  .strict()
+
+export const assistantTurnReceiptSummaryTimelineEventSchema = z
+  .object({
+    at: isoTimestampSchema,
+    kind: z.enum(assistantTurnTimelineEventKindValues),
+    detail: z.string().nullable(),
+  })
+  .strict()
+
+export const assistantTurnReceiptSummarySchema = z
+  .object({
+    schema: z.literal('murph.assistant-turn-receipt-summary.v1'),
+    turnId: assistantTurnIdSchema,
+    sessionId: assistantSessionIdSchema,
+    provider: z.enum(assistantChatProviderValues),
+    providerModel: z.string().min(1).nullable(),
+    promptPreview: z.string().nullable(),
+    responsePreview: z.string().nullable(),
+    status: z.enum(assistantTurnReceiptStatusValues),
+    deliveryRequested: z.boolean(),
+    deliveryDisposition: z.enum(assistantTurnDeliveryDispositionValues),
+    deliveryIntentId: assistantOutboxIntentIdSchema.nullable(),
+    startedAt: isoTimestampSchema,
+    updatedAt: isoTimestampSchema,
+    completedAt: isoTimestampSchema.nullable(),
+    lastError: assistantDeliveryErrorSchema.nullable(),
+    timelineEventCount: z.number().int().nonnegative(),
+    latestTimelineEvent: assistantTurnReceiptSummaryTimelineEventSchema.nullable(),
   })
   .strict()
 
@@ -1016,7 +1047,7 @@ export const assistantStatusResultSchema = z
     diagnostics: assistantDiagnosticsSnapshotSchema,
     quarantine: assistantQuarantineSummarySchema,
     runtimeBudget: assistantRuntimeBudgetSnapshotSchema,
-    recentTurns: z.array(assistantTurnReceiptSchema),
+    recentTurns: z.array(assistantTurnReceiptSummarySchema),
     warnings: z.array(z.string()),
   })
   .strict()
@@ -1614,6 +1645,9 @@ export type AssistantTurnTimelineEvent = z.infer<
   typeof assistantTurnTimelineEventSchema
 >
 export type AssistantTurnReceipt = z.infer<typeof assistantTurnReceiptSchema>
+export type AssistantTurnReceiptSummary = z.infer<
+  typeof assistantTurnReceiptSummarySchema
+>
 export type AssistantOutboxIntent = z.infer<typeof assistantOutboxIntentSchema>
 export type AssistantDiagnosticEvent = z.infer<
   typeof assistantDiagnosticEventSchema
@@ -1797,6 +1831,8 @@ export type AssistantCronRunStatus =
   (typeof assistantCronRunStatusValues)[number]
 export type AssistantTurnReceiptStatus =
   (typeof assistantTurnReceiptStatusValues)[number]
+export type AssistantTurnDeliveryDisposition =
+  (typeof assistantTurnDeliveryDispositionValues)[number]
 export type AssistantTurnTimelineEventKind =
   (typeof assistantTurnTimelineEventKindValues)[number]
 export type AssistantOutboxStatus =

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -301,9 +301,9 @@ export const assistantAliasStoreSchema = z
     // Bounded sessionId -> last-activity timestamp projection so recurring
     // maintenance can pick recent sessions without scanning the directory.
     // Absent (not defaulted) for index files written before the field
-    // existed, so readers can tell "no projection yet" from "no sessions"
-    // and rebuild from durable session records instead of trusting a
-    // partial merge.
+    // existed. Bounded list/maintenance readers treat that as empty until a
+    // normal assistant save warms the projection without scanning old
+    // durable session records.
     recentSessions: z.record(z.string(), isoTimestampSchema).optional(),
   })
   .strict()

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -585,6 +585,31 @@ const assistantSessionOutputSchema = assistantPersistedSessionSchema
   })
   .strict()
 
+export const assistantSessionSummarySchema = z
+  .object({
+    schema: z.literal('murph.assistant-conversation.v2'),
+    conversationId: assistantSessionIdSchema,
+    sessionId: assistantSessionIdSchema,
+    alias: z.string().min(1).nullable(),
+    binding: assistantSessionBindingSchema,
+    createdAt: isoTimestampSchema,
+    updatedAt: isoTimestampSchema,
+    lastTurnAt: isoTimestampSchema.nullable(),
+    turnCount: z.number().int().nonnegative(),
+    provider: z.enum(assistantChatProviderValues),
+    model: z.string().min(1).nullable(),
+    modelProvider: z.string().min(1).nullable(),
+    reasoningEffort: z.string().min(1).nullable(),
+    sandbox: z.enum(assistantSandboxValues).nullable(),
+    approvalPolicy: z.enum(assistantApprovalPolicyValues).nullable(),
+    profile: z.string().min(1).nullable(),
+    oss: z.boolean(),
+    executionDriver: z.enum(assistantExecutionDriverValues),
+    resumeKind: z.enum(assistantResumeKindValues).nullable(),
+    resumeThreadId: z.string().min(1).nullable(),
+  })
+  .strict()
+
 function normalizeAssistantSessionRecord(
   value: z.infer<typeof assistantPersistedSessionRecordSchema>,
 ): AssistantSession {
@@ -1329,7 +1354,11 @@ export const assistantDeliverResultSchema = z.object({
 export const assistantSessionListResultSchema = z.object({
   vault: pathSchema,
   stateRoot: pathSchema,
-  sessions: z.array(assistantSessionOutputSchema),
+  filters: z.object({
+    limit: z.number().int().positive().max(50),
+  }),
+  sessions: z.array(assistantSessionSummarySchema),
+  count: z.number().int().nonnegative(),
 })
 
 export const assistantSessionShowResultSchema = z.object({
@@ -1632,6 +1661,9 @@ export type AssistantDeliverResult = z.infer<
 >
 export type AssistantSessionListResult = z.infer<
   typeof assistantSessionListResultSchema
+>
+export type AssistantSessionSummary = z.infer<
+  typeof assistantSessionSummarySchema
 >
 export type AssistantSessionShowResult = z.infer<
   typeof assistantSessionShowResultSchema

--- a/packages/operator-config/src/vault-cli-contracts.ts
+++ b/packages/operator-config/src/vault-cli-contracts.ts
@@ -703,7 +703,7 @@ export const listFilterSchema = z.object({
     .array(z.string().min(1))
     .optional()
     .describe('Optional tag filter. Repeat for multiple tags.'),
-  limit: z.number().int().positive().max(200).default(50),
+  limit: z.number().int().positive().max(200).default(10),
 })
 
 export const listItemSchema = listEntitySchema

--- a/packages/vault-usecases/src/commands/query-record-command-helpers.ts
+++ b/packages/vault-usecases/src/commands/query-record-command-helpers.ts
@@ -9,6 +9,7 @@ import {
 import { createRuntimeUnavailableError as buildRuntimeUnavailableError } from '../runtime-errors.js'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import {
+  compactListEntityData,
   inferEntityKind,
   isQueryableRecordId,
   toListEntity,
@@ -16,6 +17,8 @@ import {
 
 type JsonObject = Record<string, unknown>
 export type { QueryReadModel, QueryRecord, QueryRuntimeModule }
+
+const AUDIT_LIST_TEXT_MAX_LENGTH = 180
 
 export interface CommandEntityLink {
   id: string
@@ -156,11 +159,11 @@ export function toSampleCommandListItem(
 ): SampleCommandListItem {
   return {
     ...toCommandListItem(record),
-    data: {
+    data: compactListEntityData({
       ...record.attributes,
       status: record.status ?? undefined,
       stream: record.stream ?? undefined,
-    },
+    }),
     quality: record.status ?? null,
     stream: record.stream ?? null,
   }
@@ -169,14 +172,25 @@ export function toSampleCommandListItem(
 export function toAuditCommandListItem(
   record: QueryRecord,
 ): AuditCommandListItem {
+  const summary = truncateAuditListText(firstString(record.attributes, ['summary']))
+
   return {
     ...toCommandListItem(record),
     action: firstString(record.attributes, ['action']),
     actor: firstString(record.attributes, ['actor']),
     status: record.status ?? null,
     commandName: firstString(record.attributes, ['commandName', 'command_name']),
-    summary: firstString(record.attributes, ['summary']),
+    title: truncateAuditListText(record.title ?? null),
+    summary,
   }
+}
+
+function truncateAuditListText(value: string | null): string | null {
+  if (value === null || value.length <= AUDIT_LIST_TEXT_MAX_LENGTH) {
+    return value
+  }
+
+  return `${value.slice(0, AUDIT_LIST_TEXT_MAX_LENGTH - 3).trimEnd()}...`
 }
 
 export function matchesOptionalString(

--- a/packages/vault-usecases/src/health-cli-descriptors.ts
+++ b/packages/vault-usecases/src/health-cli-descriptors.ts
@@ -119,7 +119,7 @@ export const healthListFiltersSchema = z.object({
   to: localDateSchema.optional(),
   kind: z.string().min(1).optional(),
   status: z.string().min(1).optional(),
-  limit: z.number().int().positive().max(200).default(50),
+  limit: z.number().int().positive().max(200).default(10),
 }) satisfies z.ZodType<HealthListFilters>;
 
 export const healthListResultSchema = z.object({

--- a/packages/vault-usecases/src/usecases/document-meal-read.ts
+++ b/packages/vault-usecases/src/usecases/document-meal-read.ts
@@ -27,7 +27,7 @@ import {
 
 type DocumentMealKind = 'document' | 'meal'
 
-const DEFAULT_LIST_LIMIT = 50
+const DEFAULT_LIST_LIMIT = 10
 const OWNED_EVENT_LINK_KEYS: string[] = []
 
 export const documentLookupSchema = z
@@ -201,12 +201,14 @@ export async function showDocumentRecord(vault: string, lookup: string) {
 export async function listDocumentRecords(input: {
   vault: string
   from?: string
+  limit?: number
   to?: string
 }) {
   return listOwnedRecords({
     vault: input.vault,
     expectedKind: 'document',
     from: input.from,
+    limit: input.limit,
     to: input.to,
   })
 }

--- a/packages/vault-usecases/src/usecases/explicit-health-family-services.ts
+++ b/packages/vault-usecases/src/usecases/explicit-health-family-services.ts
@@ -1052,7 +1052,7 @@ function createRegistryDocQueryServices(
       return asListEnvelope(
         input.vault,
         {
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
           status: input.status,
         },
         records.map((record) => toRegistryDocListEntity(config, record)),
@@ -1236,7 +1236,7 @@ export function createExplicitHealthQueryServices(
         {
           from: input.from,
           to: input.to,
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
         },
         records.map((record) => toAssessmentListEntity(record)),
       );
@@ -1262,7 +1262,7 @@ export function createExplicitHealthQueryServices(
       return asListEnvelope(
         input.vault,
         {
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
           status: input.status,
         },
         records.map((record) => toRegimenListEntity(record)),
@@ -1293,12 +1293,12 @@ export function createExplicitHealthQueryServices(
           !input.commonsProtocol ||
           privateProtocolMatchesCommonsProtocol(summary, input.commonsProtocol)
         )
-        .slice(0, input.limit ?? 50);
+        .slice(0, input.limit ?? 10);
 
       return {
         vault: input.vault,
         filters: {
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
           ...(input.status ? { status: input.status } : {}),
           ...(input.commonsProtocol ? { commonsProtocol: input.commonsProtocol } : {}),
         },
@@ -1332,7 +1332,7 @@ export function createExplicitHealthQueryServices(
           from: input.from,
           status: input.status,
           to: input.to,
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
         },
         records.map((record) => toBloodTestListEntity(record)),
       );
@@ -1360,7 +1360,7 @@ export function createExplicitHealthQueryServices(
         {
           from: input.from,
           to: input.to,
-          limit: input.limit ?? 50,
+          limit: input.limit ?? 10,
         },
         records.map((record) => toImmunizationListEntity(record)),
       );

--- a/packages/vault-usecases/src/usecases/integrated-services.ts
+++ b/packages/vault-usecases/src/usecases/integrated-services.ts
@@ -129,6 +129,10 @@ const PUBLIC_WEARABLE_PROVENANCE_KEYS = new Set([
 ])
 
 const OMIT_COMPACT_WEARABLE_VALUE = Symbol("omit compact wearable value")
+const COMPACT_WEARABLE_ARRAY_LIMIT = 8
+const COMPACT_WEARABLE_DRIFT_SIGNAL_LIMIT = 8
+const COMPACT_WEARABLE_TREND_POINT_LIMIT = 14
+const COMPACT_WEARABLE_STRING_LENGTH = 160
 
 type CompactWearableValue = JsonValue | typeof OMIT_COMPACT_WEARABLE_VALUE
 
@@ -150,6 +154,13 @@ function compactWearableCommandSummaryArray(value: readonly unknown[]): JsonObje
   }
 
   return compact.filter((entry): entry is JsonObject => isJsonObjectRecord(entry))
+}
+
+function limitedCompactWearableCommandSummaryArray(
+  value: readonly unknown[],
+  limit: number,
+): JsonObject[] {
+  return compactWearableCommandSummaryArray(value).slice(0, limit)
 }
 
 function compactWearableLatestCommandSummary(value: unknown): JsonObject | null {
@@ -195,6 +206,17 @@ function compactWearableValue(value: unknown): CompactWearableValue {
   }
 
   if (!isJsonObjectRecord(value)) {
+    if (typeof value === "string") {
+      const normalized = value.trim()
+      if (normalized.length === 0) {
+        return null
+      }
+
+      return normalized.length <= COMPACT_WEARABLE_STRING_LENGTH
+        ? normalized
+        : `${normalized.slice(0, COMPACT_WEARABLE_STRING_LENGTH - 3).trimEnd()}...`
+    }
+
     return isJsonValue(value) ? value : null
   }
 
@@ -223,13 +245,17 @@ function compactWearableValue(value: unknown): CompactWearableValue {
       continue
     }
 
-    if (
-      Array.isArray(compactChild)
-      && compactChild.length === 0
-      && key !== "providers"
-      && key !== "signals"
-      && key !== "points"
-    ) {
+    if (Array.isArray(compactChild)) {
+      if (
+        compactChild.length === 0
+        && key !== "providers"
+        && key !== "signals"
+        && key !== "points"
+      ) {
+        continue
+      }
+
+      redacted[key] = compactChild.slice(0, compactWearableArrayLimitForKey(key))
       continue
     }
 
@@ -276,10 +302,6 @@ function compactWearableResolvedMetric(metric: Record<string, unknown>): Compact
 
   copyCompactStringField(selection, compact, "unit")
   copyCompactStringField(selection, compact, "provider")
-  copyCompactStringField(selection, compact, "recordedAt")
-  copyCompactStringField(selection, compact, "occurredAt")
-  copyCompactStringField(selection, compact, "title")
-  copyCompactStringField(selection, compact, "sourceKind")
   copyCompactStringField(selection, compact, "fallbackFromMetric")
   copyCompactStringField(selection, compact, "fallbackReason")
 
@@ -296,6 +318,18 @@ function compactWearableResolvedMetric(metric: Record<string, unknown>): Compact
   }
 
   return compact
+}
+
+function compactWearableArrayLimitForKey(key: string): number {
+  if (key === "signals") {
+    return COMPACT_WEARABLE_DRIFT_SIGNAL_LIMIT
+  }
+
+  if (key === "points") {
+    return COMPACT_WEARABLE_TREND_POINT_LIMIT
+  }
+
+  return COMPACT_WEARABLE_ARRAY_LIMIT
 }
 
 function compactWearableMetricConfidence(confidence: Record<string, unknown>): JsonObject {
@@ -964,6 +998,7 @@ function createIntegratedQueryServices(): QueryServices {
     },
     async listDocuments(input: CommandContext & {
       from?: string
+      limit?: number
       to?: string
     }) {
       return listDocumentsUseCase(input)
@@ -1270,11 +1305,12 @@ function createIntegratedQueryServices(): QueryServices {
     }) {
       const normalized = normalizeWearableSummaryInput(input)
       const query = await loadQueryRuntime()
-      const items = await query.summarizeWearableSleepRuntime(input.vault, normalized.queryFilters)
+      const rawItems = await query.summarizeWearableSleepRuntime(input.vault, normalized.queryFilters)
+      const items = limitedCompactWearableCommandSummaryArray(rawItems, normalized.filters.limit)
 
       return {
         filters: normalized.filters,
-        items: compactWearableCommandSummaryArray(items),
+        items,
         count: items.length,
       }
     },
@@ -1287,11 +1323,12 @@ function createIntegratedQueryServices(): QueryServices {
     }) {
       const normalized = normalizeWearableSummaryInput(input)
       const query = await loadQueryRuntime()
-      const items = await query.summarizeWearableActivityRuntime(input.vault, normalized.queryFilters)
+      const rawItems = await query.summarizeWearableActivityRuntime(input.vault, normalized.queryFilters)
+      const items = limitedCompactWearableCommandSummaryArray(rawItems, normalized.filters.limit)
 
       return {
         filters: normalized.filters,
-        items: compactWearableCommandSummaryArray(items),
+        items,
         count: items.length,
       }
     },
@@ -1304,11 +1341,12 @@ function createIntegratedQueryServices(): QueryServices {
     }) {
       const normalized = normalizeWearableSummaryInput(input)
       const query = await loadQueryRuntime()
-      const items = await query.summarizeWearableBodyStateRuntime(input.vault, normalized.queryFilters)
+      const rawItems = await query.summarizeWearableBodyStateRuntime(input.vault, normalized.queryFilters)
+      const items = limitedCompactWearableCommandSummaryArray(rawItems, normalized.filters.limit)
 
       return {
         filters: normalized.filters,
-        items: compactWearableCommandSummaryArray(items),
+        items,
         count: items.length,
       }
     },
@@ -1321,11 +1359,12 @@ function createIntegratedQueryServices(): QueryServices {
     }) {
       const normalized = normalizeWearableSummaryInput(input)
       const query = await loadQueryRuntime()
-      const items = await query.summarizeWearableRecoveryRuntime(input.vault, normalized.queryFilters)
+      const rawItems = await query.summarizeWearableRecoveryRuntime(input.vault, normalized.queryFilters)
+      const items = limitedCompactWearableCommandSummaryArray(rawItems, normalized.filters.limit)
 
       return {
         filters: normalized.filters,
-        items: compactWearableCommandSummaryArray(items),
+        items,
         count: items.length,
       }
     },
@@ -1338,11 +1377,12 @@ function createIntegratedQueryServices(): QueryServices {
     }) {
       const normalized = normalizeWearableSummaryInput(input)
       const query = await loadQueryRuntime()
-      const items = await query.summarizeWearableSourceHealthRuntime(input.vault, normalized.queryFilters)
+      const rawItems = await query.summarizeWearableSourceHealthRuntime(input.vault, normalized.queryFilters)
+      const items = limitedCompactWearableCommandSummaryArray(rawItems, normalized.filters.limit)
 
       return {
         filters: normalized.filters,
-        items: compactWearableCommandSummaryArray(items),
+        items,
         count: items.length,
       }
     },
@@ -1549,7 +1589,7 @@ function normalizeWearableProviderQueryFilter(
 
 function normalizeWearableLimit(limit: number): number {
   if (!Number.isInteger(limit) || limit <= 0) {
-    return 30
+    return 5
   }
 
   return Math.min(limit, 200)

--- a/packages/vault-usecases/src/usecases/shared.ts
+++ b/packages/vault-usecases/src/usecases/shared.ts
@@ -48,6 +48,11 @@ const DEFAULT_GENERIC_LIST_EXCLUDED_FAMILIES = new Set([
 ])
 const BLOOD_TEST_SPECIMEN_TYPE_SET = new Set<string>(BLOOD_TEST_SPECIMEN_TYPES)
 const LEGACY_RAW_MANIFEST_BASENAME = "manifest.json"
+const LIST_DATA_MAX_STRING_LENGTH = 180
+const LIST_DATA_MAX_ARRAY_ITEMS = 6
+const LIST_DATA_MAX_ARRAY_JSON_LENGTH = 600
+const LIST_DATA_MAX_OBJECT_JSON_LENGTH = 600
+const LIST_LINK_MAX_ITEMS = 8
 
 interface SharedCoreRuntime {
   parseRawImportManifest(value: unknown): RawImportManifest
@@ -624,7 +629,7 @@ export function summarizeListMarkdown(
     return normalized
   }
 
-  return `${normalized.slice(0, Math.max(1, maxLength - 1)).trimEnd()}…`
+  return `${normalized.slice(0, Math.max(1, maxLength - 3)).trimEnd()}...`
 }
 
 export function toListEntity(input: {
@@ -638,14 +643,19 @@ export function toListEntity(input: {
   links: ListEntity["links"]
   excerpt?: string | null
 }): ListEntity {
+  const data = compactListEntityData(input.data)
+  if (input.links.length > LIST_LINK_MAX_ITEMS && data.linksCount === undefined) {
+    data.linksCount = input.links.length
+  }
+
   const entity: ListEntity = {
     id: input.id,
     kind: input.kind,
     title: input.title,
     occurredAt: input.occurredAt,
     path: input.path,
-    data: input.data,
-    links: input.links,
+    data,
+    links: input.links.slice(0, LIST_LINK_MAX_ITEMS),
   }
 
   const normalizedExplicitExcerpt =
@@ -664,6 +674,120 @@ export function toListEntity(input: {
   }
 
   return entity
+}
+
+export function compactListEntityData(data: Record<string, unknown>): Record<string, unknown> {
+  const compact: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(data)) {
+    const compactValue = compactListEntityValue(value)
+    if (compactValue !== undefined) {
+      compact[key] = compactValue
+    } else {
+      addListEntityCollectionSummary(compact, key, value)
+    }
+  }
+
+  return compact
+}
+
+function compactListEntityValue(value: unknown, depth = 0): unknown {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+
+  if (
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim()
+    if (normalized.length === 0) {
+      return undefined
+    }
+
+    return normalized.length <= LIST_DATA_MAX_STRING_LENGTH
+      ? normalized
+      : `${normalized.slice(0, LIST_DATA_MAX_STRING_LENGTH - 3).trimEnd()}...`
+  }
+
+  if (Array.isArray(value)) {
+    const compactItems = value
+      .slice(0, LIST_DATA_MAX_ARRAY_ITEMS)
+      .map((entry) => compactListEntityScalarValue(entry, 120))
+      .filter((entry): entry is string | number | boolean | null => entry !== undefined)
+
+    return compactItems.length > 0 && JSON.stringify(compactItems).length <= LIST_DATA_MAX_ARRAY_JSON_LENGTH
+      ? compactItems
+      : undefined
+  }
+
+  if (isPlainObject(value) && depth < 2) {
+    const compactObject: Record<string, unknown> = {}
+
+    for (const [key, child] of Object.entries(value)) {
+      const compactChild = compactListEntityValue(child, depth + 1)
+      if (compactChild !== undefined) {
+        compactObject[key] = compactChild
+      } else {
+        addListEntityCollectionSummary(compactObject, key, child)
+      }
+    }
+
+    if (Object.keys(compactObject).length === 0) {
+      return undefined
+    }
+
+    return JSON.stringify(compactObject).length <= LIST_DATA_MAX_OBJECT_JSON_LENGTH
+      ? compactObject
+      : undefined
+  }
+
+  return undefined
+}
+
+function compactListEntityScalarValue(
+  value: unknown,
+  maxStringLength: number,
+): string | number | boolean | null | undefined {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return value
+  }
+
+  if (typeof value !== "string") {
+    return undefined
+  }
+
+  const normalized = value.trim()
+  if (normalized.length === 0) {
+    return undefined
+  }
+
+  return normalized.length <= maxStringLength
+    ? normalized
+    : `${normalized.slice(0, maxStringLength - 3).trimEnd()}...`
+}
+
+function addListEntityCollectionSummary(
+  compact: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  if (Array.isArray(value)) {
+    compact[`${key}Count`] = value.length
+    return
+  }
+
+  if (isPlainObject(value)) {
+    compact[`${key}KeyCount`] = Object.keys(value).length
+  }
 }
 
 export function toGenericShowEntity(entity: QueryEntity) {

--- a/packages/vault-usecases/src/usecases/types.ts
+++ b/packages/vault-usecases/src/usecases/types.ts
@@ -1220,6 +1220,7 @@ export interface QueryServices extends HealthQueryServiceMethods {
   listDocuments(
     input: CommandContext & {
       from?: string
+      limit?: number
       to?: string
     },
   ): Promise<ListResult>

--- a/packages/vault-usecases/src/usecases/workout-read.ts
+++ b/packages/vault-usecases/src/usecases/workout-read.ts
@@ -20,7 +20,7 @@ import {
   relativePathStrings,
 } from './vault-usecase-helpers.js'
 
-const DEFAULT_LIST_LIMIT = 50
+const DEFAULT_LIST_LIMIT = 5
 const TRACKED_WORKOUT_EVENT_KINDS = ['activity_session', 'body_measurement'] as const
 
 type TrackedWorkoutEventKind = (typeof TRACKED_WORKOUT_EVENT_KINDS)[number]

--- a/packages/vault-usecases/test/health-cli-public-seams.test.ts
+++ b/packages/vault-usecases/test/health-cli-public-seams.test.ts
@@ -126,7 +126,7 @@ describe("health CLI descriptors", () => {
     expect(healthListFiltersSchema.parse({ from: "2026-03-01", kind: "goal" })).toEqual({
       from: "2026-03-01",
       kind: "goal",
-      limit: 50,
+      limit: 10,
     });
 
     expect(

--- a/packages/vault-usecases/test/list-summary-surfaces.test.ts
+++ b/packages/vault-usecases/test/list-summary-surfaces.test.ts
@@ -80,6 +80,57 @@ describe('list summary surfaces', () => {
     expect(item).not.toHaveProperty('excerpt')
   })
 
+  it('keeps list item data to bounded scalar summary fields', () => {
+    const item = toListEntity({
+      id: 'evt_01',
+      kind: 'test',
+      title: 'Large lab payload',
+      occurredAt: '2026-04-08T12:00:00Z',
+      path: 'events/2026-04-08-labs.md',
+      data: {
+        labName: 'Function Health',
+        resultStatus: 'mixed',
+        results: [
+          { biomarker: 'LDL', value: 101 },
+          { biomarker: 'HDL', value: 61 },
+        ],
+        notes: ['first', 'second'],
+        empty: '',
+        longText: 'x'.repeat(240),
+        nested: { value: true },
+      },
+      links: [],
+    })
+
+    expect(item.data).toEqual({
+      labName: 'Function Health',
+      resultStatus: 'mixed',
+      resultsCount: 2,
+      notes: ['first', 'second'],
+      longText: `${'x'.repeat(177)}...`,
+      nested: { value: true },
+    })
+  })
+
+  it('keeps list item links bounded with an explicit count', () => {
+    const item = toListEntity({
+      id: 'exp_01',
+      kind: 'experiment',
+      title: 'Sleep experiment',
+      occurredAt: '2026-04-08T12:00:00Z',
+      path: 'experiments/sleep.md',
+      data: {},
+      links: Array.from({ length: 10 }, (_, index) => ({
+        id: `evt_${index}`,
+        kind: 'event',
+        queryable: true,
+      })),
+    })
+
+    expect(item.links).toHaveLength(8)
+    expect(item.data).toEqual({ linksCount: 10 })
+  })
+
   it('keeps helper-backed command list items aligned with show surfaces', () => {
     const item = toCommandListItem(
       buildRecord({

--- a/packages/vault-usecases/test/query-helper-coverage.test.ts
+++ b/packages/vault-usecases/test/query-helper-coverage.test.ts
@@ -153,6 +153,17 @@ describe("query record command helpers", () => {
         },
       }),
     );
+    const longAuditSummary = "x".repeat(240);
+    const longAudit = toAuditCommandListItem(
+      createQueryRecord({
+        family: "audit",
+        kind: "audit",
+        title: longAuditSummary,
+        attributes: {
+          summary: longAuditSummary,
+        },
+      }),
+    );
 
     expect(sample.quality).toBe("verified");
     expect(sample.stream).toBe("oura");
@@ -166,8 +177,6 @@ describe("query record command helpers", () => {
     expect(sampleWithoutState.stream).toBeNull();
     expect(sampleWithoutState.data).toEqual({
       source: "manual",
-      status: undefined,
-      stream: undefined,
     });
 
     expect(audit.action).toBe("update");
@@ -175,6 +184,9 @@ describe("query record command helpers", () => {
     expect(audit.status).toBe("applied");
     expect(audit.commandName).toBe("query.samples.list");
     expect(audit.summary).toBe("synced records");
+    expect(longAudit.title).toBe(`${"x".repeat(177)}...`);
+    expect(longAudit.summary).toBe(`${"x".repeat(177)}...`);
+    expect(longAudit.data.summary).toBe(`${"x".repeat(177)}...`);
   });
 });
 

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -301,7 +301,12 @@ describe("query record helpers", () => {
     assert.deepEqual(toSampleCommandListItem(record), {
       ...toCommandListItem(record),
       data: {
-        ...record.attributes,
+        action: "updated",
+        actor: "assistant",
+        commandName: "review",
+        relatedIds: ["goal_1", "goal_1"],
+        snapshotId: "profile_1",
+        summary: "Updated the record.",
         status: "active",
         stream: "stream-a",
       },
@@ -665,7 +670,7 @@ describe("record service seams", () => {
         kind: "document",
         from: "2026-04-01",
         to: "2026-04-30",
-        limit: 50,
+        limit: 10,
       },
       count: 1,
       nextCursor: null,


### PR DESCRIPTION
## Why

The CLI output audit found several successful runtime reads over roughly 20k characters. Those are expensive and noisy for model-facing use because default list/status commands were returning too many rows or full nested payload bodies.

## Goal

Ship compact default CLI read surfaces: list commands should behave like index/triage views, while detail commands remain the path for full record payloads.

## What changed

- Reduced default returned rows for model-facing list surfaces to 10, with smaller defaults for assistant sessions/onboarding and wearables where those payloads are naturally dense.
- Compacted generic/entity list row `data` to scalars, small scalar arrays, and summary counts for nested arrays/objects instead of full nested payload bodies.
- Projected assistant session list rows to metadata summaries; `assistant session show` still returns the full session.
- Projected automation and scheduled-log list rows so prompt bodies, markdown, and action payloads stay out of default list output.
- Compacted wearable summary output arrays and long strings while keeping source/detail commands available.
- Left explicit Incur discovery and payload-schema outputs unchanged because those are contract/discovery surfaces, not default runtime reads.

## Invariants to preserve

- Canonical vault storage is unchanged.
- Existing show/detail commands remain the way to inspect full records.
- Users can still pass `--limit` for broader pages when needed.
- CLI schema/config generation stays aligned with command defaults.

## Validation

- `pnpm --dir packages/operator-config typecheck`
- `pnpm --dir packages/vault-usecases typecheck`
- `pnpm --dir packages/assistant-cli typecheck`
- `pnpm --dir packages/cli typecheck`
- `pnpm --dir packages/vault-usecases test`
- `pnpm --dir packages/assistant-cli test`
- `pnpm --dir packages/cli test:source`
- `pnpm --dir packages/cli verify:package-shape`
- Synthetic oversized-record byte smoke: `event list` 11,555 chars, root `list` 11,519 chars, `automation list` 7,852 chars, `scheduled-log list` 5,502 chars.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786084534&installation_id=127572939&pr_number=474&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F474&signature=16f3ecf1cc33892a1fbc716de8abc9ed4f3518455cbc53afb29c951ffd09efba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->