### PR TITLE
Fit generated-song lyrics to the requested duration

### DIFF
--- a/apps/web/src/components/settings/hosted-email-privy-link-hand-off.tsx
+++ b/apps/web/src/components/settings/hosted-email-privy-link-hand-off.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { usePrivy } from "@privy-io/react-auth";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
+import { useAuth } from "@/src/components/hosted-onboarding/auth-dialog-provider";
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,
@@ -29,12 +30,19 @@ export function HostedEmailPrivyLinkHandOff(props: {
   onAborted: () => void;
   onSynced?: (payload: HostedEmailSyncResult) => Promise<void> | void;
 }) {
+  const { onAborted, onSynced } = props;
+  const { openAuthDialog } = useAuth();
   const { ready } = usePrivy();
+  const handleClientAuthRequired = useCallback(() => {
+    openAuthDialog();
+    onAborted();
+  }, [onAborted, openAuthDialog]);
   const controller = useHostedEmailSettingsController({
     authenticated: true,
     initialEmail: null,
-    onPrivyLinkAborted: props.onAborted,
-    onSynced: props.onSynced,
+    onClientAuthRequired: handleClientAuthRequired,
+    onPrivyLinkAborted: onAborted,
+    onSynced,
   });
   const startedRef = useRef(false);
   const { handleLinkEmail } = controller;
@@ -54,8 +62,6 @@ export function HostedEmailPrivyLinkHandOff(props: {
   // the linked payload), there is nothing further to show — close the flow.
   const completedWithoutSync =
     Boolean(controller.successMessage) && !controller.isSyncingEmailRoute;
-  const { onAborted } = props;
-
   useEffect(() => {
     if (completedWithoutSync) {
       onAborted();

--- a/apps/web/src/components/settings/hosted-email-settings-controller.ts
+++ b/apps/web/src/components/settings/hosted-email-settings-controller.ts
@@ -28,6 +28,8 @@ export interface HostedEmailSettingsInitialEmail {
 export function useHostedEmailSettingsController(input: {
   authenticated: boolean;
   initialEmail: HostedEmailSettingsInitialEmail | null;
+  /** Called when the server session exists but this browser has no Privy user yet. */
+  onClientAuthRequired?: () => void;
   /** Called when the member dismisses Privy's link modal without linking. */
   onPrivyLinkAborted?: () => void;
   onSynced?: (payload: HostedEmailSyncResult) => Promise<void> | void;
@@ -42,6 +44,7 @@ export function useHostedEmailSettingsController(input: {
   const [emailAddress, setEmailAddress] = useState(() => baseDisplayState.currentEmail?.address ?? "");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isSyncingEmailRoute, setIsSyncingEmailRoute] = useState(false);
+  const [noticeMessage, setNoticeMessage] = useState<string | null>(null);
   const [pendingEmailAddress, setPendingEmailAddress] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [verifiedEmailOverride, setVerifiedEmailOverride] = useState<HostedPrivyEmailAccount | null>(null);
@@ -87,6 +90,7 @@ export function useHostedEmailSettingsController(input: {
   const normalizedCurrentEmail = overrideDisplayState.normalizedCurrentEmail;
   const canManageEmail = input.authenticated;
   const canSendEmailUpdateCode = Boolean(effectiveCurrentEmail?.address);
+  const clientAuthenticated = privyUser !== null;
   // Privy's headless update-email flow refuses to send a code unless the
   // Privy user already has an email linked; otherwise we must link instead,
   // which Privy only supports through its own modal.
@@ -97,6 +101,7 @@ export function useHostedEmailSettingsController(input: {
 
   async function requestCodeForEmail(nextEmailAddress: string) {
     setErrorMessage(null);
+    setNoticeMessage(null);
     setSuccessMessage(null);
 
     if (!input.authenticated) {
@@ -106,6 +111,12 @@ export function useHostedEmailSettingsController(input: {
 
     if (!isValidEmailAddress(nextEmailAddress)) {
       setErrorMessage("Enter a valid email address before we send a code.");
+      return;
+    }
+
+    if (!clientAuthenticated) {
+      setNoticeMessage("Sign in on this device to manage email.");
+      input.onClientAuthRequired?.();
       return;
     }
 
@@ -137,20 +148,25 @@ export function useHostedEmailSettingsController(input: {
   }
 
   async function handleSendCode(rawEmailAddress?: string) {
+    const nextEmailAddress = normalizeEmailAddress(rawEmailAddress ?? emailAddress);
+
+    if (canSendEmailUpdateCode && !nextEmailAddress) {
+      setErrorMessage("Enter a valid email address before we send a code.");
+      return;
+    }
+
+    if (nextEmailAddress && nextEmailAddress !== emailAddress) {
+      setEmailAddress(nextEmailAddress);
+    }
+
     if (!canSendEmailUpdateCode || !canUpdatePrivyEmail) {
       handleLinkEmail();
       return;
     }
 
-    const nextEmailAddress = normalizeEmailAddress(rawEmailAddress ?? emailAddress);
-
     if (!nextEmailAddress) {
       setErrorMessage("Enter a valid email address before we send a code.");
       return;
-    }
-
-    if (nextEmailAddress !== emailAddress) {
-      setEmailAddress(nextEmailAddress);
     }
 
     await requestCodeForEmail(nextEmailAddress);
@@ -168,6 +184,7 @@ export function useHostedEmailSettingsController(input: {
 
   function handleUseAnotherEmail() {
     setErrorMessage(null);
+    setNoticeMessage(null);
     setSuccessMessage(null);
     setCode("");
     setPendingEmailAddress(null);
@@ -175,6 +192,7 @@ export function useHostedEmailSettingsController(input: {
 
   async function handleVerifyCode(rawCode?: string) {
     setErrorMessage(null);
+    setNoticeMessage(null);
     setSuccessMessage(null);
 
     const normalizedCode = (rawCode ?? code).trim();
@@ -231,12 +249,19 @@ export function useHostedEmailSettingsController(input: {
 
   function handleLinkEmail() {
     setErrorMessage(null);
+    setNoticeMessage(null);
     setSuccessMessage(null);
     setCode("");
     setPendingEmailAddress(null);
 
     if (!input.authenticated) {
       setErrorMessage("Sign in to your Murph account first, then link your email.");
+      return;
+    }
+
+    if (!clientAuthenticated) {
+      setNoticeMessage("Sign in on this device to manage email.");
+      input.onClientAuthRequired?.();
       return;
     }
 
@@ -276,6 +301,7 @@ export function useHostedEmailSettingsController(input: {
 
   async function handleSyncVerifiedEmail() {
     setErrorMessage(null);
+    setNoticeMessage(null);
     setSuccessMessage(null);
 
     if (!effectiveVerifiedEmail?.address) {
@@ -312,6 +338,7 @@ export function useHostedEmailSettingsController(input: {
   return {
     authenticated: input.authenticated,
     canManageEmail,
+    clientAuthenticated,
     code,
     effectiveCurrentEmail,
     effectiveVerifiedEmail,
@@ -323,6 +350,7 @@ export function useHostedEmailSettingsController(input: {
     isSubmittingCode,
     isSyncingEmailRoute,
     canSendEmailUpdateCode,
+    noticeMessage,
     pendingEmailAddress,
     successMessage,
     setCode,

--- a/apps/web/src/components/settings/hosted-email-settings.tsx
+++ b/apps/web/src/components/settings/hosted-email-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react";
 
+import { useAuth } from "@/src/components/hosted-onboarding/auth-dialog-provider";
 import type { HostedEmailSyncResult } from "./hosted-email-settings-helpers";
 
 import { SettingsStatusLine } from "./connected-account-card";
@@ -17,12 +18,15 @@ export function HostedEmailSettings(props: {
   changeFlow?: boolean;
   initialEmail?: HostedEmailSettingsInitialEmail | null;
   murphEmailAddress?: string | null;
+  onClientAuthRequired?: () => void;
   onSynced?: (payload: HostedEmailSyncResult) => Promise<void> | void;
 }) {
+  const { openAuthDialog } = useAuth();
   const emailInputRef = useRef<HTMLInputElement | null>(null);
   const controller = useHostedEmailSettingsController({
     authenticated: props.authenticated,
     initialEmail: props.initialEmail ?? null,
+    onClientAuthRequired: props.onClientAuthRequired ?? openAuthDialog,
     onSynced: props.onSynced,
   });
 
@@ -45,6 +49,7 @@ export function HostedEmailSettings(props: {
   const statusMessage =
     controller.errorMessage ??
     controller.successMessage ??
+    controller.noticeMessage ??
     (controller.isSyncingEmailRoute ? "Saving your email…" : null);
 
   return (
@@ -75,7 +80,7 @@ export function HostedEmailSettings(props: {
       {statusMessage ? (
         <SettingsStatusLine
           message={statusMessage}
-          tone={statusTone === "neutral" && controller.isSyncingEmailRoute ? "neutral" : statusTone}
+          tone={statusTone}
         />
       ) : null}
     </div>

--- a/apps/web/src/components/settings/hosted-settings-identity-link-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-settings-identity-link-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 
+import { useAuth } from "@/src/components/hosted-onboarding/auth-dialog-provider";
 import { HostedPrivyProvider } from "@/src/components/hosted-onboarding/privy-provider";
 import {
   Dialog,
@@ -30,6 +31,7 @@ export function HostedSettingsIdentityLinkDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const router = useRouter();
+  const { openAuthDialog } = useAuth();
   const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim();
   const clientId = process.env.NEXT_PUBLIC_PRIVY_CLIENT_ID?.trim() || null;
 
@@ -43,6 +45,10 @@ export function HostedSettingsIdentityLinkDialog({
   const closeAndRefresh = () => {
     onOpenChange(false);
     router.refresh();
+  };
+  const promptClientAuth = () => {
+    onOpenChange(false);
+    openAuthDialog();
   };
 
   // The server told us the Privy user has no email linked, which means the
@@ -105,6 +111,7 @@ export function HostedSettingsIdentityLinkDialog({
                 changeFlow={hasExisting}
                 initialEmail={toInitialEmail(account.email)}
                 murphEmailAddress={account.email.murphEmailAddress}
+                onClientAuthRequired={promptClientAuth}
                 onSynced={closeAndRefresh}
               />
             ) : null}

--- a/apps/web/test/settings-email-settings.test.ts
+++ b/apps/web/test/settings-email-settings.test.ts
@@ -272,6 +272,31 @@ describe("HostedEmailSettings", () => {
       expect(container.textContent).toContain("Opening secure window");
     });
 
+    it("closes for app reauth instead of opening Privy's modal when the client user is absent", async () => {
+      mocks.useUser.mockReturnValue({
+        refreshUser: mocks.refreshUser,
+        user: null,
+      });
+      const onAborted = vi.fn();
+      const { HostedEmailPrivyLinkHandOff } = await import(
+        "@/src/components/settings/hosted-email-privy-link-hand-off"
+      );
+
+      const { cleanup } = await renderClientComponent(
+        createElement(HostedEmailPrivyLinkHandOff, {
+          onAborted,
+        }),
+        { requireButton: false },
+      );
+      cleanupRender = cleanup;
+
+      await vi.waitFor(() => {
+        expect(onAborted).toHaveBeenCalledTimes(1);
+      });
+      expect(mocks.linkEmail).not.toHaveBeenCalled();
+      expect(mocks.sendCode).not.toHaveBeenCalled();
+    });
+
     it("closes the flow when the member dismisses Privy's modal", async () => {
       mocks.useUser.mockReturnValue({
         refreshUser: mocks.refreshUser,
@@ -331,6 +356,73 @@ describe("HostedEmailSettings", () => {
       newEmailAddress: "payer@example.com",
     });
     expect(mocks.linkEmail).not.toHaveBeenCalled();
+  });
+
+  it("asks the browser to sign in before verifying a server-provided email when the Privy client user is absent", async () => {
+    mocks.useUser.mockReturnValue({
+      refreshUser: mocks.refreshUser,
+      user: null,
+    });
+    const onClientAuthRequired = vi.fn();
+    const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
+
+    const { cleanup, container } = await renderClientComponent(
+      createElement(HostedEmailSettings, {
+        authenticated: true,
+        initialEmail: {
+          address: "payer@example.com",
+          verifiedAt: null,
+        },
+        onClientAuthRequired,
+      }),
+    );
+    cleanupRender = cleanup;
+
+    const sendCodeButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Send verification code"),
+    );
+    expect(sendCodeButton).toBeTruthy();
+
+    await act(async () => {
+      sendCodeButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(onClientAuthRequired).toHaveBeenCalledTimes(1);
+    expect(mocks.sendCode).not.toHaveBeenCalled();
+    expect(mocks.linkEmail).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Sign in on this device to manage email.");
+  });
+
+  it("asks the browser to sign in before opening Privy's link-email modal", async () => {
+    mocks.useUser.mockReturnValue({
+      refreshUser: mocks.refreshUser,
+      user: null,
+    });
+    const onClientAuthRequired = vi.fn();
+    const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
+
+    const { cleanup, container } = await renderClientComponent(
+      createElement(HostedEmailSettings, {
+        authenticated: true,
+        initialEmail: null,
+        onClientAuthRequired,
+      }),
+    );
+    cleanupRender = cleanup;
+
+    const linkButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Link email"),
+    );
+    expect(linkButton).toBeTruthy();
+
+    await act(async () => {
+      linkButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(onClientAuthRequired).toHaveBeenCalledTimes(1);
+    expect(mocks.linkEmail).not.toHaveBeenCalled();
+    expect(mocks.sendCode).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Sign in on this device to manage email.");
   });
 
   it("syncs the verified email returned by Privy's link flow", async () => {

--- a/packages/assistant-engine/skills/music-generation/SKILL.md
+++ b/packages/assistant-engine/skills/music-generation/SKILL.md
@@ -79,9 +79,16 @@ back rushed and garbled rather than trimmed. A relaxed vocal carries roughly a
 word and a half per second, and the intro and outro spend a few of those
 seconds before anyone sings — so a 15-second track holds about 18 words, a
 20-second track about 25 (a couplet or two), and a 30-second track about 40.
-Count the words in your lyrics
-before calling the tool; if you are over budget, cut lines first, and raise
-`durationSeconds` only when every remaining word earns its place.
+The budget scales with the
+duration you request — a 60-second track holds a real verse and chorus, a
+90-second track holds two.
+
+Count the words in your lyrics before calling the tool. If they run over
+budget, fix it from either side: trim the lyric, or ask for a longer track —
+both are fine, as long as words and seconds match. Reminder songs stay short
+and tight; when the song is the main event — an introduction, a celebration,
+something the user asked for — give the lyric the 45, 60, or 90 seconds it
+actually needs rather than squeezing it down.
 
 For reminder songs specifically, name the action to do now, say
 why it matters to this person, fold in at most two non-sensitive personal
@@ -95,10 +102,10 @@ instruments, tempo, key, mood — still belongs in the prompt.
 
 ## Duration
 
-`durationSeconds` is 3-300. Reminder songs are 15-30s. Shorter tracks are
-tighter and land faster. Pick the duration and the lyric together: the track
-is exactly as long as you ask for, so words beyond the budget in the Lyrics
-section get rushed, not dropped.
+`durationSeconds` is 3-300. Reminder songs are 15-30s; a song that is the
+main event can comfortably run 45-90s. Pick the duration and the lyric
+together: the track is exactly as long as you ask for, so words beyond the
+budget in the Lyrics section get rushed, not dropped.
 
 ## House style and preferences
 

--- a/packages/assistant-engine/skills/music-generation/SKILL.md
+++ b/packages/assistant-engine/skills/music-generation/SKILL.md
@@ -73,8 +73,17 @@ unmistakable. For example, the `prompt` value:
 > Upbeat roots-reggae, ~20s, warm male lead vocal. Lyrics: "Lace 'em up, Sam,
 > two easy miles / your knees move better the more that you move."
 
-Keep lyrics short: a 20-second track holds a couplet or two, not a full
-verse-chorus. For reminder songs specifically, name the action to do now, say
+Fit the lyrics to the duration, because the model will not: Eleven Music sings
+every quoted word inside the seconds you asked for, so an overlong lyric comes
+back rushed and garbled rather than trimmed. A relaxed vocal carries roughly a
+word and a half per second, and the intro and outro spend a few of those
+seconds before anyone sings — so a 15-second track holds about 18 words, a
+20-second track about 25 (a couplet or two), and a 30-second track about 40.
+Count the words in your lyrics
+before calling the tool; if you are over budget, cut lines first, and raise
+`durationSeconds` only when every remaining word earns its place.
+
+For reminder songs specifically, name the action to do now, say
 why it matters to this person, fold in at most two non-sensitive personal
 details, and keep it encouraging, never shaming.
 
@@ -87,8 +96,9 @@ instruments, tempo, key, mood — still belongs in the prompt.
 ## Duration
 
 `durationSeconds` is 3-300. Reminder songs are 15-30s. Shorter tracks are
-tighter and land faster; match the lyric and structure to the length you ask
-for.
+tighter and land faster. Pick the duration and the lyric together: the track
+is exactly as long as you ask for, so words beyond the budget in the Lyrics
+section get rushed, not dropped.
 
 ## House style and preferences
 


### PR DESCRIPTION
## Why

Someone asked Murph to introduce itself with a song in a group chat, and the generated track crammed a full verse-chorus worth of lyrics into 30 seconds: Eleven Music sings every quoted word inside the requested duration, so an overlong lyric comes back double-time and garbled instead of trimmed. The music-generation skill told the model to "keep lyrics short" but gave no budget to check against, so nothing stopped it from overwriting.

## User-visible goal

Generated songs (intros, reminder songs, hype tracks) come back at a natural singing pace: the skill now gives a concrete lyric word budget (~1.5 words/second minus intro/outro overhead; ~18 words at 15s, ~25 at 20s, ~40 at 30s), tells the model to count words before calling the tool, and to cut lines first or raise durationSeconds only when every remaining word earns its place. The Duration section now states that track length is fixed, so extra words get rushed, not dropped.

## Invariants to preserve

- Prompt-only change: no runtime code, schema, or tool-contract changes to `generate_song`.
- Existing skill rules unchanged: copyright-safe style limits, no sensitive personal details in lyrics, reggae house-style default, song-as-whole-message constraint.
- Worked examples already sit within the new budget.

Completion audit: prompt-review pass ran on Codex gpt-5.5 (high reasoning) per the completion workflow; one low finding (missing 15s anchor) accepted and fixed, no other findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786140999&installation_id=127572939&pr_number=479&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F479&signature=96c16afaa8034ec56549659b766546bad89b1457834fc79f85923755892548fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
