### PR TITLE
Ground personal health recommendations in user context before advising

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-08-understand-before-recommending.md
+++ b/agent-docs/exec-plans/completed/2026-07-08-understand-before-recommending.md
@@ -1,0 +1,64 @@
+# Understand-Before-Recommending Prompt Primitive
+
+## Goal
+
+Stop Murph from answering personal health improvement questions ("how do I
+improve my deep sleep?") with generic ChatGPT-style tip lists. Make
+context-grounded discovery a first-class top-level prompt primitive: ground in
+vault/wearable evidence first, reflect it back, ask for genuinely missing
+context one question at a time across a few messages, capture motivation for
+behavior goals, persist what is learned, and close recommendations through the
+existing behavior-change setup instead of a one-off list.
+
+Success criteria:
+
+- The static cacheable core prompt contains a new `Understand before
+  recommending:` section between product principles and behavior-change
+  collaboration.
+- The turn priority order recognizes a grounded discovery question as a valid
+  complete turn for personal-health recommendation/goal requests.
+- `sleep-recovery-readiness` mode 2 supports a bounded multi-turn discovery
+  loop when vault/wearable evidence is thin, while keeping its anti-intake and
+  anti-checklist rules.
+- `behavior-followthrough` captures the user's reason by default for new
+  goals (one narrow question), keeping the no-deep-interview constraint.
+- Prompt regression tests cover the new section and updated lines.
+- Focused assistant-engine tests and `pnpm typecheck` pass.
+
+## Scope
+
+- In: `packages/assistant-engine/src/assistant/system-prompt.ts` (new core
+  section + one turn-priority clause),
+  `packages/assistant-engine/skills/sleep-recovery-readiness/SKILL.md`,
+  `packages/assistant-engine/skills/behavior-followthrough/SKILL.md`,
+  matching prompt/skill regression tests under
+  `packages/assistant-engine/test/`.
+- Out: new workflow engines, intent classifiers, routing machinery, schema or
+  persisted-state changes, tool changes, onboarding changes, other skills.
+
+## Constraints
+
+- Our utmost priority is clean, simple, long term maintainable and composable
+  architecture with minimal complexity.
+- Prose policy only; no new runtime abstractions.
+- Match each file's existing style (header-plus-bullets prompt sections,
+  skill markdown voice).
+- Preserve Product Constitution posture: no interrogation intakes, "leave it
+  alone" stays a first-class outcome, questions must be decision-changing,
+  one question per message, no data-hoarding framing.
+- Keep the one-question-per-message texting rhythm; the change is the
+  sequence across turns, not more questions per reply.
+
+## Plan
+
+1. Add `buildAssistantUnderstandBeforeRecommendingText()` to the static core
+   prompt after product principles.
+2. Add the discovery clause to turn priority item 5.
+3. Update sleep-recovery-readiness (low-friction assessment, mode 2, response
+   contract) and behavior-followthrough (setup step 3).
+4. Update prompt/skill regression tests.
+5. Verify with focused assistant-engine tests plus `pnpm typecheck`, review,
+   and commit through `scripts/finish-task`.
+Status: completed
+Updated: 2026-07-08
+Completed: 2026-07-08

--- a/packages/assistant-engine/skills/behavior-followthrough/SKILL.md
+++ b/packages/assistant-engine/skills/behavior-followthrough/SKILL.md
@@ -105,10 +105,7 @@ If the user gave only an outcome, propose a low-burden behavior and let them edi
 
 ### 3. Capture the reason
 
-For a new goal or behavior, get the user's reason in their own words by default. If it is already clear or self-evident, use it without asking. Otherwise ask one narrow question:
-- "What do you want this to unlock?"
-- "What would make this worth doing even when you're busy?"
-- "Is this mostly about energy, pain, sleep, mood, discipline, or proving the routine can stick?"
+For a new goal or behavior, get the user's reason in their own words by default. If it is already clear or self-evident, use it without asking. Otherwise ask one narrow question in your own words, matched to this user and this moment — curious, not clinical.
 
 The reason shapes the plan, the support style, and later reminders; save it into the loop. Do not block setup on a deep motivation interview, and never re-ask a reason the user already gave.
 

--- a/packages/assistant-engine/skills/behavior-followthrough/SKILL.md
+++ b/packages/assistant-engine/skills/behavior-followthrough/SKILL.md
@@ -103,14 +103,14 @@ Examples:
 
 If the user gave only an outcome, propose a low-burden behavior and let them edit it.
 
-### 3. Capture the reason only if it helps
+### 3. Capture the reason
 
-If the user's reason is already clear, use it. If it is missing and would improve the loop, ask one narrow question:
+For a new goal or behavior, get the user's reason in their own words by default. If it is already clear or self-evident, use it without asking. Otherwise ask one narrow question:
 - "What do you want this to unlock?"
 - "What would make this worth doing even when you're busy?"
 - "Is this mostly about energy, pain, sleep, mood, discipline, or proving the routine can stick?"
 
-Do not block setup on a deep motivation interview.
+The reason shapes the plan, the support style, and later reminders; save it into the loop. Do not block setup on a deep motivation interview, and never re-ask a reason the user already gave.
 
 If the user is ambivalent, do not schedule repeated support yet. Offer a one-time tiny test, clarify what would make the behavior worth it, or defer. Commitment support starts after the user opts into the behavior or experiment.
 

--- a/packages/assistant-engine/skills/sleep-recovery-readiness/SKILL.md
+++ b/packages/assistant-engine/skills/sleep-recovery-readiness/SKILL.md
@@ -65,7 +65,7 @@ Only inspect information that could change the route:
 - plausible context such as life stress, travel, shift work, caffeine, alcohol, meals, medication, heat, or altitude;
 - device trend and data quality when wearables matter.
 
-Ask at most one decision-changing question before recommending, unless immediate safety requires more. Do not turn a simple readiness question into a full sleep intake.
+Ask at most one question per message. For acute readiness calls, one decision-changing question before recommending is usually enough. For sleep improvement requests where vault and wearable evidence is thin, follow the understand-before-recommending core rules: reflect what the data shows, then run a short discovery loop — one concrete question per message over a few messages — before naming a lever. Do not turn either path into a full sleep intake.
 
 ## The five modes
 
@@ -109,7 +109,9 @@ Find the dominant bottleneck before giving advice:
 - **Environment or exposure:** light, noise, temperature, caregiving, substances, medication, meals, work, or stimulating content plausibly interferes.
 - **Irregular schedule:** shifts, travel, school, caregiving, or rotating obligations make a conventional routine unrealistic.
 
-Pick one lever that addresses the bottleneck. If there is no meaningful impairment or repeatable problem, leave ordinary variation alone. Do not dump a generic sleep-hygiene checklist.
+Ground the bottleneck hunt in evidence before asking anything: recent sleep timing, duration, and consistency from connected wearable summaries, plus saved routines, environment facts, and prior sleep notes in the vault. Reflect what the data shows in plain language. When the bottleneck is still unclear, discovery is the expected next step, not a checklist: ask for the most useful missing facts — evening routine, bedroom temperature and light, caffeine and alcohol timing, stress, schedule — one question per message, and save the answers to the vault or memory as they arrive. Then pick one lever.
+
+If there is no meaningful impairment or repeatable problem, leave ordinary variation alone. Do not dump a generic sleep-hygiene checklist.
 
 A practical routine usually needs only:
 
@@ -211,14 +213,14 @@ Recovery support should make action easier, not make the user feel monitored or 
 
 ## Response contract
 
-Lead with the recommendation. A useful answer usually has four parts:
+Lead with the recommendation when the evidence supports a call; for a thin-evidence sleep improvement request, lead with the grounded readback and one question instead. A useful answer usually has four parts:
 
 1. **Call:** leave it alone, planned, guarded, easy/recovery, rest, recovery block, one sleep lever, or care route.
 2. **Why:** the one to three facts that actually drove the decision, plus meaningful uncertainty.
 3. **Action:** the exact guardrail, behavior, or handoff.
 4. **Recheck:** what to observe and when to change course.
 
-Ask one question only when the answer could materially change the call. Use plain language rather than exposing internal route labels or a pseudo-clinical object.
+Ask one question per message, and only when the answer could materially change the call or the lever; mode 2's bounded discovery loop counts as materially changing the lever. Use plain language rather than exposing internal route labels or a pseudo-clinical object.
 
 When another skill calls this layer, return a compact handoff:
 

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -198,6 +198,7 @@ function buildStaticCacheableCorePrompt(): string {
   return joinPromptSections(
     buildAssistantIdentityAndScopeText(),
     buildAssistantProductPrinciplesText(),
+    buildAssistantUnderstandBeforeRecommendingText(),
     buildAssistantBehaviorChangeCollaborationText(),
     buildAssistantPostActionFollowThroughText(),
     buildAssistantDelightfulRemindersText(),
@@ -664,6 +665,18 @@ Output style:
 - Do not use fenced Markdown blocks in user-facing replies unless the user genuinely needs to see exact code, commands, JSON, logs, stack traces, diffs, or other preformatted multi-line technical text. For connect, share, invite, or OAuth links, write a brief sentence and then the raw URL on its own line. In messaging channels such as iMessage, put the raw URL as the final line of the message with no text after it so the client can render it as a link preview.`;
 }
 
+function buildAssistantUnderstandBeforeRecommendingText(): string {
+  return `Understand before recommending:
+Murph's edge over a generic chatbot is context: it can see the user's actual data and remember what it learns. Advice that ignores that context fails the user even when it is technically correct.
+
+- When the user asks how to improve, fix, or work on something about their own body — sleep, energy, training, a metric, a habit — or states a new goal, do not lead with generic recommendations. Ground first: read the relevant wearable trends, vault records, memory, and visible conversation, and open the reply with what you actually found in their data before any suggestion. If nothing relevant exists, say so plainly.
+- When the grounded picture is too thin for advice meaningfully better than generic, make the first reply discovery instead of recommendations: briefly say what you can and cannot see, then ask the single most useful question. Make asks concrete and answerable in a text — bedroom temperature, last caffeine, evening routine, what a typical week looks like. Continue over the next few messages, one question at a time, until the picture supports advice specific to this person. A grounded discovery question is a complete, correct turn, not a failure to answer.
+- For behavior goals such as training more, changing diet, or chasing a performance target, understand what is driving the goal in the user's own words when it is not obvious; the reason shapes the plan and later support. Skip the question when the motivation is self-evident.
+- Save what you learn. Durable, user-useful discovery answers — environment, routines, timing, constraints, preferences, motivation in the user's own words — go to the matching canonical vault surface or memory in the same turn, so the picture compounds and the user is never asked twice. Do not persist transient task detail, sensitive psychological interpretations, or anything the user asked not to keep.
+- When you do recommend, tie one or two candidates to the user's own evidence and be honest about which lever is uncertain. Then close the loop: offer to make it stick through the behavior-change setup below — a bounded test or habit with reminders or check-ins and a review point — with one concrete default the user can accept with a simple "yes." Keep the language casual; do not call it an experiment unless the user does. A recommendation delivered as a one-off message and then forgotten is the failure mode.
+- Answer directly when the user explicitly wants a quick take, when the question is general knowledge rather than about their own body, or when safety needs an immediate answer. In chronic-illness, persistent-pain, flare, or low-capacity moments, keep the chronic-support reply contract: lead with the best current working assessment and a recommended action, with at most one material question. Discovery is a conversation, not an intake: if answers get short or the user pushes back, recommend from what you have and note what extra context would sharpen it. Concluding that nothing needs fixing stays a first-class outcome.`;
+}
+
 function buildAssistantBehaviorChangeCollaborationText(): string {
   return `Behavior-change collaboration:
 - When the user signals a recurring problem, goal, or intent to change behavior, prefer a small setup over advice: concrete behavior, low-burden default, 1-3 tracking signals, bounded review, and an off-ramp.
@@ -776,7 +789,7 @@ function buildAssistantTurnPriorityText(): string {
 2. The user's immediate need comes before onboarding, orientation, or general health coaching. If the user asks a specific question, sends health data, sends an attachment, asks to log, update, inspect, estimate, connect, research, save, or compare something, handle that immediate need fully before any optional follow-up.
 3. Follow the progress-update rules in the execution behavior guidance before genuinely long work, but never let progress updates outrank immediate safe action or create extra tool/status churn.
 4. Resolve ambiguity with available context first: recent conversation, vault reads, attached files, local evidence, connected device or wearable data, and lookup tools when they could materially answer the question. Prefer using available sources over giving the user busywork such as sending logs, restating device-derived facts, or reporting completion of an activity that Murph can verify itself. Ask only for missing subjective context, ambiguous details, consent, or facts no available source can answer.
-5. Ask a clarifying question only when the missing detail would materially change safety, the write target, or the answer.
+5. Ask a clarifying question only when the missing detail would materially change safety, the write target, or the answer. For personal-health recommendation or goal requests, missing personal context that would change the recommendation materially changes the answer: after grounding in available sources, a discovery question under the understand-before-recommending rules is a valid complete turn.
 6. Use the canonical surface for the task, complete allowed reads/writes before responding, and continue until the requested task is done or a real blocker appears.
 7. Use the minimum evidence and tool loops sufficient for a correct answer. Do not perform extra searches, scans, nudges, or optimization work that does not change the requested outcome.
 8. Use \`finish_without_reply\` only when no text reply should be sent for the current inbound message.

--- a/packages/assistant-engine/test/assistant-sleep-recovery-readiness-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-sleep-recovery-readiness-skill.test.ts
@@ -59,7 +59,10 @@ describe('assistant sleep recovery readiness skill', () => {
     )
     expect(skill).not.toMatch(/two or more[^\n]*signals?/i)
     expect(skill).toContain(
-      'Ask at most one decision-changing question before recommending',
+      'Ask at most one question per message.',
+    )
+    expect(skill).toContain(
+      'For sleep improvement requests where vault and wearable evidence is thin, follow the understand-before-recommending core rules',
     )
     expect(skill).toContain(
       'The active strength, cardio, or competition skill owns exact exercise selection',
@@ -89,6 +92,18 @@ describe('assistant sleep recovery readiness skill', () => {
     )
     expect(skill).toContain(
       'Treat common exposures as hypotheses, not moral rules',
+    )
+    expect(skill).toContain(
+      'Reflect what the data shows in plain language.',
+    )
+    expect(skill).toContain(
+      'discovery is the expected next step, not a checklist',
+    )
+    expect(skill).toContain(
+      'one question per message, and save the answers to the vault or memory as they arrive',
+    )
+    expect(skill).toContain(
+      "mode 2's bounded discovery loop counts as materially changing the lever",
     )
     expect(skill).toContain('do not impose one universal cutoff')
   })

--- a/packages/assistant-engine/test/experiment-onboarding-skill-guidance.test.ts
+++ b/packages/assistant-engine/test/experiment-onboarding-skill-guidance.test.ts
@@ -233,6 +233,14 @@ describe('experiment onboarding skill guidance', () => {
   it('keeps assumed-mode repair policy in behavior follow-through', async () => {
     const raw = await readBehaviorFollowthroughSkill()
 
+    expect(raw).toContain('### 3. Capture the reason')
+    expect(raw).toContain(
+      "For a new goal or behavior, get the user's reason in their own words by default.",
+    )
+    expect(raw).toContain(
+      'The reason shapes the plan, the support style, and later reminders; save it into the loop.',
+    )
+    expect(raw).toContain('never re-ask a reason the user already gave')
     expect(raw).toContain('For assumed-mode non-sensable experiments, silence means adherence')
     expect(raw).toContain('sauna, tretinoin, red-light, supplement')
     expect(raw).toContain(

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -1215,7 +1215,7 @@ Execution context:
       'Current Murph product base URL for user-facing app links: http://localhost:3000',
     )
     expect(promptA.cacheMetadata.staticPromptHash).toBe(
-      '7ca6fd977943768f5c8e6ca40ca01c2418f2d751dcff9f7cbcac81fa9539e807',
+      '0f7cc7aab31fb3287761de872693ab8cb00c3208ee7f8fdc7911354a2e9382f7',
     )
     expect(promptA.cacheMetadata.toolSchemaHash).toBe(
       'assistant-tool-schema-common-codex-test',
@@ -1486,6 +1486,33 @@ describe('assistant experiment onboarding guidance', () => {
     )
     expect(prompt).not.toContain(
       'When a scheduled support automation fires, choose one structured outcome: `skip` or `send_message`.',
+    )
+  })
+
+  it('grounds personal health recommendations before giving advice', () => {
+    const prompt = buildAssistantSystemPrompt(createCommonCodexPromptInput())
+
+    expect(prompt).toContain('Understand before recommending:')
+    expect(prompt).toContain(
+      'do not lead with generic recommendations. Ground first: read the relevant wearable trends, vault records, memory, and visible conversation',
+    )
+    expect(prompt).toContain(
+      'A grounded discovery question is a complete, correct turn, not a failure to answer.',
+    )
+    expect(prompt).toContain(
+      'Save what you learn. Durable, user-useful discovery answers — environment, routines, timing, constraints, preferences, motivation in the user\'s own words — go to the matching canonical vault surface or memory',
+    )
+    expect(prompt).toContain(
+      'after grounding in available sources, a discovery question under the understand-before-recommending rules is a valid complete turn.',
+    )
+    expect(prompt).toContain(
+      'Then close the loop: offer to make it stick through the behavior-change setup below',
+    )
+    expect(prompt.indexOf('Understand before recommending:')).toBeGreaterThan(
+      prompt.indexOf('Goal: Help the user understand their body in context'),
+    )
+    expect(prompt.indexOf('Behavior-change collaboration:')).toBeGreaterThan(
+      prompt.indexOf('Understand before recommending:'),
     )
   })
 


### PR DESCRIPTION
## Why this PR exists

Murph answers personal health improvement questions ("how do I improve my deep sleep?") with generic ChatGPT-style tip lists, ignoring its differentiated context: the user's vault, wearable data, and memory. Murph's job includes collecting and structuring context on the user over time; the current prompt treats questions as a cost to minimize, so it never does.

## User goal / user-visible behavior

When a user asks how to improve something about their own body or states a new goal, Murph now:

1. Grounds in what it already has (wearable trends, vault, memory) and opens with what it actually found in their data.
2. When the picture is too thin for advice better than generic, runs a short discovery loop — one concrete, textable question per message (bedroom temperature, caffeine timing, evening routine) — instead of firing off a tip list.
3. Captures the motivation behind behavior goals in the user's own words when it isn't obvious.
4. Saves everything it learns to canonical vault surfaces or memory so the picture compounds and the user is never asked twice.
5. Closes recommendations by offering to make the change stick — a casual habit/check-in setup with reminders and a review point — rather than sending a one-off list and going quiet.

Implemented as a new top-level "Understand before recommending" section in the static cacheable core prompt, one clause in the turn priority order, and supporting edits to the sleep-recovery-readiness and behavior-followthrough skills.

## Invariants the PR must preserve

- One-question-per-message texting rhythm; discovery is a bounded conversation, never an interrogation intake.
- Product Constitution posture: "leave it alone"/nothing-to-fix stays a first-class outcome; no shame, purity, or data-hoarding framing; direct answers for quick takes, general knowledge, and safety-urgent turns.
- Acute readiness calls in the sleep skill keep the single decision-changing question rule.
- Prompt-primary only: no runtime, schema, tool, or persisted-state changes.
- The static core remains one cacheable string; the staticPromptHash pin in tests matches the final text.

## Deployment skew / compatibility

Prompt-only change to the static cacheable core: it rotates the static prompt hash and thread contract fingerprint by design (known safe rotation path). Warm hosted runner containers keep serving the previous prompt until normal rollout replaces them; each version is self-consistent, there is no cross-component contract change, and no tandem deploy or immediate container rollout is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786148730&installation_id=127572939&pr_number=480&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F480&signature=52e8a8808b091dfb00bc4476be9e8dba907036a3ad127296e2fcfa2f5ba1e73c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->