### PR TITLE
Add weekly improvement coach managed automation

### DIFF
--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -124,6 +124,7 @@ const ASSISTANT_CRON_ONBOARDING_UNREADABLE_RESEARCH_SKIP_ERROR =
   'Assistant cron research-oriented managed automation skipped because assistant onboarding state could not be read.'
 const MURPH_RESEARCH_ORIENTED_MANAGED_AUTOMATION_TAGS = new Set([
   'murph-managed:weekly-health-insight',
+  'murph-managed:weekly-improvement-coach',
   'murph-managed:weekly-health-research-scout',
 ])
 // Hosted cron turns are off the user hotpath, so clean first runs prefer the

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -74,6 +74,8 @@ export const MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID =
   'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FY'
 export const MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID =
   'automation_X3GPAWV2CCHNCYHAAJ4CE2M144'
+export const MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID =
+  'automation_01K2WKKY3F8Q4R5S6T7V8W9XAB'
 export const MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID =
   'automation_01K0EXA5C0VT9F7X3KG6JMPZ5A'
 export const MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID =
@@ -110,6 +112,12 @@ const MURPH_MANAGED_WEEKLY_SCHEDULE_SPREADS: Partial<Record<
     startMinuteOfDay: 10 * 60,
     slotMinutes: 30,
     slotsPerDay: 14,
+  },
+  [MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID]: {
+    daysOfWeek: [2],
+    startMinuteOfDay: 16 * 60,
+    slotMinutes: 30,
+    slotsPerDay: 10,
   },
   [MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID]: {
     daysOfWeek: [3, 4],
@@ -268,6 +276,56 @@ export const MURPH_MANAGED_AUTOMATIONS = [
       '- Name the practical takeaway clearly: watch this context next time, measure one thing, test a hunch, ignore a misleading score, change a low-risk behavior, or ask a clinician. If the short note would be confusing, simplify the framing or choose another candidate.',
       '',
       'Do not give generic health tips, medical diagnosis, causal claims without proof, or alarmist language.',
+    ].join('\n'),
+  },
+  {
+    automationId: MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+    slug: 'weekly-improvement-coach',
+    title: 'Weekly improvement coach',
+    summary: 'A weekly check for one clearly actionable health improvement worth working on.',
+    schedule: {
+      kind: 'cron',
+      expression: '0 17 * * 2',
+    },
+    continuityPolicy: 'fresh',
+    assistantTargetOverride: {
+      reasoningEffort: 'high',
+    },
+    tags: [
+      'murph-managed:weekly-improvement-coach',
+    ],
+    instructions: [
+      'On this scheduled weekly run, find zero or one clearly actionable health improvement opportunity and, only when the evidence is strong, send one short invitation to work on it together. Most weeks the right outcome is silence; an unproven or repeated nudge is worse than no message.',
+      '',
+      'This run is the sibling of the weekly health insight, with the opposite bar: the insight scout hunts for non-obvious findings, while this run looks for obvious-but-tractable deficits the user could realistically start improving this week. Candidate domains include:',
+      '- Deep sleep or total sleep consistently well below typical reference ranges.',
+      '- Low daily activity: few active minutes or consistently low movement.',
+      '- Little or no strength training logged over recent weeks.',
+      '- Little or no cardio logged over recent weeks.',
+      '- Meal logs that skew toward low-quality food, or consistently low fiber or protein, when the user actually logs meals.',
+      '- Similar concrete, evidence-backed gaps in sleep, movement, nutrition, or recovery basics.',
+      '',
+      'Evidence gate. Every claim must survive all three checks before it can be offered:',
+      '- Capability: the metric must be positively captured by a connected, healthy source. Read `vault-cli device account list` and `vault-cli wearables sources list` first. Never infer absence of a behavior from absence of data: if no connected source captures strength workouts, "no strength training" is unknowable, not a deficit. Providers differ in what they report, so confirm the metric actually appears in this user\'s data before judging it.',
+      '- Plausibility: treat exact zeros, sudden cliffs, or values wildly inconsistent with the rest of the data as pipeline or sync bugs, not behavior. If a reading looks broken, suppress; never tell the user they are inactive because a counter reads zero.',
+      '- Sufficiency: require a real pattern window, roughly three or more weeks of reasonably continuous coverage for the metric, before calling anything consistent. One bad week is noise.',
+      '',
+      'Dedupe and pacing:',
+      '- Read `vault-cli knowledge show improvement-opportunities`. If the page is missing, treat that as no prior offers. Use `improvement-opportunities` as the only dedupe ledger; do not create per-week pages.',
+      '- Never re-offer a domain that already has a section in the ledger unless that section is at least eight weeks old and there is meaningfully new evidence, such as the situation regressing after improvement.',
+      '- Skip a domain entirely when an active or recent experiment already covers it, or when recent conversation shows the user is already working on it or has declined it.',
+      '- Read `vault-cli knowledge show weekly-health-insights` as well, and do not send something that repeats a recent weekly insight.',
+      '- Offer at most one domain per run: the one with the strongest evidence and the most realistic path to improvement.',
+      '',
+      'If nothing clears the bar, return `{"kind":"skip","privateSummary":"No improvement opportunity cleared the evidence bar."}`, suppress the scheduled message, and do not append to the ledger. Do not send a process note, a "nothing this week" message, a setup nag, or a request for better logging.',
+      '',
+      'If one domain clears every gate:',
+      '- Append one dated section to the rolling ledger before sending, using the locked append surface, for example: `vault-cli knowledge append-section improvement-opportunities YYYY-MM-DD --title "Improvement opportunities" --body <markdown> --source-path <canonical-vault-path>`. The body records the domain, the compact evidence, and that an offer was sent, so future runs can pace themselves. Cite only canonical vault source paths, never `derived/**` or `.runtime/**` paths.',
+      '- If append-section reports that the section already exists, another run created it first: read the existing section, apply the same evidence gate, and either send from it or return `{"kind":"skip","privateSummary":"Existing improvement opportunity did not clear the current send bar."}`.',
+      '- Then send one short, warm note in plain adult language: name the pattern with its compact evidence (for example, "your deep sleep has averaged about 45 minutes a night over the last month; most adults get 1.5 to 2 hours"), say in one sentence why it is worth caring about, and ask whether they want to work on it together. Population reference points are welcome here when they help the user calibrate.',
+      '- Frame it as an invitation, not a verdict or a lecture. Do not prescribe a plan in this message; if the user says yes, the follow-up conversation is where a plan or a small experiment gets designed.',
+      '',
+      'Do not diagnose, do not alarm, do not shame, and do not pad the note with generic health tips.',
     ].join('\n'),
   },
   {

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -5617,6 +5617,48 @@ describe('assistant cron runtime orchestration', () => {
     expect(current.state.nextRunAt).toBe('2026-04-09T10:00:00.000Z')
   })
 
+  it('skips managed weekly improvement coach cron before provider work while onboarding is open', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T10:20:00.000Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-managed-improvement-coach-onboarding-open-',
+    )
+    addManagedResearchAutomation({
+      tag: 'murph-managed:weekly-improvement-coach',
+      vaultRoot,
+    })
+    const { claimed, paths } = await claimFirstCanonicalCronJob(vaultRoot)
+
+    const result = await executeClaimedAssistantCronJob({
+      job: claimed,
+      paths,
+      trigger: 'scheduled',
+      vault: vaultRoot,
+    })
+
+    expect(result.run.status).toBe('skipped')
+    expect(result.run.error).toBe(
+      'Assistant cron research-oriented managed automation skipped because assistant onboarding is open.',
+    )
+    expect(cronMocks.sendAssistantMessageLocal).not.toHaveBeenCalled()
+    await expect(
+      listAssistantCronRuns({
+        job: claimed.job.jobId,
+        vault: vaultRoot,
+      }),
+    ).resolves.toMatchObject({
+      runs: [
+        expect.objectContaining({
+          status: 'skipped',
+        }),
+      ],
+    })
+    const current = await getAssistantCronJob(vaultRoot, claimed.job.jobId)
+    expect(current.state.runningAt).toBeNull()
+    expect(current.state.pendingDeliveryIntentId).toBeFalsy()
+    expect(current.state.nextRunAt).toBe('2026-04-09T10:00:00.000Z')
+  })
+
   it('fails closed before provider work when managed research onboarding state is unreadable', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-08T10:20:00.000Z'))
@@ -6849,7 +6891,10 @@ function addManagedResearchAutomation(input: {
   automationId?: string
   instructions?: string
   slug?: string
-  tag: 'murph-managed:weekly-health-insight' | 'murph-managed:weekly-health-research-scout'
+  tag:
+    | 'murph-managed:weekly-health-insight'
+    | 'murph-managed:weekly-improvement-coach'
+    | 'murph-managed:weekly-health-research-scout'
   title?: string
   vaultRoot: string
 }): void {
@@ -6857,7 +6902,9 @@ function addManagedResearchAutomation(input: {
     input.slug ??
     (input.tag === 'murph-managed:weekly-health-insight'
       ? 'weekly-health-insight'
-      : 'weekly-health-research-scout')
+      : input.tag === 'murph-managed:weekly-improvement-coach'
+        ? 'weekly-improvement-coach'
+        : 'weekly-health-research-scout')
   getVaultAutomationStore(input.vaultRoot).push({
     automationId: input.automationId ?? `automation-${slug}`,
     continuityPolicy: 'fresh',

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -16,6 +16,7 @@ import {
   MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
+  MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
@@ -73,7 +74,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -176,6 +177,35 @@ describe('applyMurphManagedAutomations core integration', () => {
     expect(insightRecord?.instructions).toContain('Suppress true-but-boring findings')
     expect(insightRecord?.instructions).toContain('missing data, messy tags')
     expect(insightRecord?.instructions).toContain('Murph cannot currently see X')
+
+    const improvementCoachRecord = await showAutomation({
+      automationId: MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+      vaultRoot,
+    })
+
+    expect(improvementCoachRecord).toMatchObject({
+      automationId: MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+      route: defaultRoute,
+      slug: 'weekly-improvement-coach',
+      status: 'active',
+      title: 'Weekly improvement coach',
+    })
+    expect(improvementCoachRecord?.assistantTargetOverride).toEqual({
+      reasoningEffort: 'high',
+    })
+    expectCronSchedule(improvementCoachRecord?.schedule)
+    expect(improvementCoachRecord?.tags).toContain('murph-managed:weekly-improvement-coach')
+    expect(improvementCoachRecord?.tags).not.toContain(ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG)
+    expect(improvementCoachRecord?.instructions).toContain('knowledge show improvement-opportunities')
+    expect(improvementCoachRecord?.instructions).toContain(
+      'knowledge append-section improvement-opportunities YYYY-MM-DD',
+    )
+    expect(improvementCoachRecord?.instructions).toContain(
+      '{"kind":"skip","privateSummary":"No improvement opportunity cleared the evidence bar."}',
+    )
+    expect(improvementCoachRecord?.instructions).toContain(
+      'Never infer absence of a behavior from absence of data',
+    )
 
     const researchScoutRecord = await showAutomation({
       automationId: MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
@@ -294,7 +324,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       },
       vaultRoot,
     })).resolves.toEqual({
-      created: 5,
+      created: 6,
       skipped: 0,
       updated: 0,
     })
@@ -359,7 +389,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       routeValidationProfile: 'hosted',
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -399,7 +429,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -436,7 +466,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
 
@@ -468,7 +498,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
   })
@@ -481,7 +511,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -530,7 +560,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -581,7 +611,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -636,7 +666,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 3,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -699,7 +729,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 3,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -766,6 +796,23 @@ describe('applyMurphManagedAutomations core integration', () => {
       title: 'My weekly research scout',
       vaultRoot,
     })
+    const userImprovementCoachAutomation = await upsertAutomation({
+      automationId: 'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FG',
+      continuityPolicy: 'preserve',
+      instructions: 'Keep this user-owned improvement coach prompt.',
+      now: new Date('2026-06-09T12:00:00.000Z'),
+      route: defaultRoute,
+      schedule: {
+        kind: 'cron',
+        expression: '0 17 * * 2',
+      },
+      slug: 'weekly-improvement-coach',
+      status: 'active',
+      summary: 'User-owned improvement coach automation.',
+      tags: ['user'],
+      title: 'My improvement coach',
+      vaultRoot,
+    })
     const userProductUpdatesAutomation = await upsertAutomation({
       automationId: 'automation_01JNW7YJ7MNE7M9Q2QWQK4Z3FB',
       continuityPolicy: 'preserve',
@@ -790,7 +837,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
 
@@ -804,6 +851,10 @@ describe('applyMurphManagedAutomations core integration', () => {
     })).resolves.toBeNull()
     await expect(showAutomation({
       automationId: MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
+      vaultRoot,
+    })).resolves.toBeNull()
+    await expect(showAutomation({
+      automationId: MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
       vaultRoot,
     })).resolves.toBeNull()
     await expect(showAutomation({
@@ -839,6 +890,16 @@ describe('applyMurphManagedAutomations core integration', () => {
       slug: 'weekly-health-research-scout',
       tags: ['user'],
       title: 'My weekly research scout',
+    })
+    await expect(showAutomation({
+      automationId: userImprovementCoachAutomation.record.automationId,
+      vaultRoot,
+    })).resolves.toMatchObject({
+      automationId: userImprovementCoachAutomation.record.automationId,
+      instructions: 'Keep this user-owned improvement coach prompt.',
+      slug: 'weekly-improvement-coach',
+      tags: ['user'],
+      title: 'My improvement coach',
     })
     await expect(showAutomation({
       automationId: userProductUpdatesAutomation.record.automationId,

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -110,6 +110,7 @@ import {
   MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
+  MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
@@ -131,6 +132,7 @@ const defaultRoute = {
 const EXPECTED_MANAGED_SPREAD_CRONS = {
   digest: { kind: 'cron', expression: '30 10 * * 2' },
   insight: { kind: 'cron', expression: '0 13 * * 0' },
+  improvementCoach: { kind: 'cron', expression: '30 17 * * 2' },
   researchScout: { kind: 'cron', expression: '0 14 * * 3' },
   productUpdates: { kind: 'cron', expression: '30 12 * * 5' },
 } as const
@@ -300,6 +302,52 @@ describe('applyMurphManagedAutomations', () => {
     )).toBe('2026-06-28T16:00:00.000Z')
   })
 
+  it('keeps the managed weekly improvement coach seed as the baseline Tuesday early-evening recurrence', () => {
+    const seed = MURPH_MANAGED_AUTOMATIONS.find(
+      (entry) => entry.automationId === MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+    )
+    if (!seed || seed.schedule.kind !== 'cron') {
+      throw new Error('Expected the weekly improvement coach to use a cron schedule.')
+    }
+
+    expect(seed.schedule.expression).toBe('0 17 * * 2')
+    expect(seed.slug).toBe('weekly-improvement-coach')
+    expect(seed.title).toBe('Weekly improvement coach')
+    expect(seed.summary).toBe(
+      'A weekly check for one clearly actionable health improvement worth working on.',
+    )
+    expect(seed.assistantTargetOverride).toEqual({
+      reasoningEffort: 'high',
+    })
+    expect(seed.tags).toContain('murph-managed:weekly-improvement-coach')
+    expect(seed.tags).not.toContain(ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG)
+    expect(seed.instructions).toContain('knowledge show improvement-opportunities')
+    expect(seed.instructions).toContain(
+      'knowledge append-section improvement-opportunities YYYY-MM-DD',
+    )
+    expect(seed.instructions).toContain(
+      '{"kind":"skip","privateSummary":"No improvement opportunity cleared the evidence bar."}',
+    )
+    expect(seed.instructions).toContain(
+      'Never infer absence of a behavior from absence of data',
+    )
+
+    const nextRunAt = findNextAssistantCronOccurrence(
+      seed.schedule.expression,
+      new Date('2026-06-18T16:00:00.000Z'),
+      'America/New_York',
+    )
+    expect(nextRunAt).toBe('2026-06-23T21:00:00.000Z')
+    if (!nextRunAt) {
+      throw new Error('Expected the weekly improvement coach cron to have a next run.')
+    }
+    expect(findNextAssistantCronOccurrence(
+      seed.schedule.expression,
+      new Date(nextRunAt),
+      'America/New_York',
+    )).toBe('2026-06-30T21:00:00.000Z')
+  })
+
   it('keeps the managed weekly health research scout seed as the baseline Wednesday evening recurrence', () => {
     const researchScoutSeed = MURPH_MANAGED_AUTOMATIONS.find(
       (seed) => seed.automationId === MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
@@ -442,11 +490,11 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
-    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledTimes(4)
+    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledTimes(5)
     const digestRecord = managedAutomationMocks.records.get(
       MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
     )
@@ -542,6 +590,37 @@ describe('applyMurphManagedAutomations', () => {
     expect(insightRecord?.instructions).toContain('Suppress true-but-boring findings')
     expect(insightRecord?.instructions).toContain('missing data, messy tags')
     expect(insightRecord?.instructions).toContain('Murph cannot currently see X')
+
+    const improvementCoachRecord = managedAutomationMocks.records.get(
+      MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+    )
+    expect(improvementCoachRecord).toMatchObject({
+      automationId: MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+      continuityPolicy: 'fresh',
+      route: defaultRoute,
+      slug: 'weekly-improvement-coach',
+      status: 'active',
+      title: 'Weekly improvement coach',
+    })
+    expect(improvementCoachRecord?.assistantTargetOverride).toEqual({
+      reasoningEffort: 'high',
+    })
+    expect(improvementCoachRecord?.schedule)
+      .toEqual(EXPECTED_MANAGED_SPREAD_CRONS.improvementCoach)
+    expect(improvementCoachRecord?.tags).toContain('murph-managed:weekly-improvement-coach')
+    expect(improvementCoachRecord?.tags).not.toContain(ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG)
+    expect(improvementCoachRecord?.instructions).toContain(
+      'knowledge show improvement-opportunities',
+    )
+    expect(improvementCoachRecord?.instructions).toContain(
+      'knowledge append-section improvement-opportunities YYYY-MM-DD',
+    )
+    expect(improvementCoachRecord?.instructions).toContain(
+      '{"kind":"skip","privateSummary":"No improvement opportunity cleared the evidence bar."}',
+    )
+    expect(improvementCoachRecord?.instructions).toContain(
+      'Never infer absence of a behavior from absence of data',
+    )
 
     const researchScoutRecord = managedAutomationMocks.records.get(
       MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
@@ -681,7 +760,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 5,
+      created: 6,
       skipped: 0,
       updated: 0,
     })
@@ -759,7 +838,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 2,
+      created: 3,
       skipped: 0,
       updated: 2,
     })
@@ -819,7 +898,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 3,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -859,7 +938,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-20T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 3,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -908,7 +987,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-20T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 3,
+      created: 4,
       skipped: 1,
       updated: 0,
     })
@@ -942,6 +1021,8 @@ describe('applyMurphManagedAutomations', () => {
       .toEqual(firstSchedules.get(MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID))
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID)?.schedule)
       .toEqual(firstSchedules.get(MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID))
+    expect(managedAutomationMocks.records.get(MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID)?.schedule)
+      .toEqual(firstSchedules.get(MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID))
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID)?.schedule)
       .toEqual(firstSchedules.get(MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID))
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID)?.schedule)
@@ -958,7 +1039,7 @@ describe('applyMurphManagedAutomations', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       stableKeyFailure: metadataError,
       stableKeyRetryNeeded: true,
       updated: 0,
@@ -974,7 +1055,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-10T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -983,6 +1064,8 @@ describe('applyMurphManagedAutomations', () => {
       .toEqual(EXPECTED_MANAGED_SPREAD_CRONS.digest)
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID)?.schedule)
       .toEqual(EXPECTED_MANAGED_SPREAD_CRONS.insight)
+    expect(managedAutomationMocks.records.get(MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID)?.schedule)
+      .toEqual(EXPECTED_MANAGED_SPREAD_CRONS.improvementCoach)
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID)?.schedule)
       .toEqual(EXPECTED_MANAGED_SPREAD_CRONS.researchScout)
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID)?.schedule)
@@ -1060,13 +1143,15 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 3,
+      created: 4,
       skipped: 1,
       updated: 0,
     })
     expect(managedAutomationMocks.records.has(MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID))
       .toBe(true)
     expect(managedAutomationMocks.records.has(MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID))
+      .toBe(true)
+    expect(managedAutomationMocks.records.has(MURPH_WEEKLY_IMPROVEMENT_COACH_AUTOMATION_ID))
       .toBe(true)
     expect(managedAutomationMocks.records.has(MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID))
       .toBe(false)
@@ -1088,7 +1173,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -1118,7 +1203,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 3,
+      created: 4,
       skipped: 1,
       updated: 0,
     })
@@ -1162,7 +1247,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -1216,7 +1301,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -1259,7 +1344,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -1301,7 +1386,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -1330,7 +1415,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -1368,7 +1453,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 3,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -1396,7 +1481,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 4,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -1423,7 +1508,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -1444,7 +1529,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -1496,6 +1581,21 @@ describe('applyMurphManagedAutomations', () => {
       tags: ['user'],
       title: 'My weekly research scout',
     })
+    managedAutomationMocks.records.set('automation_user_improvement_coach', {
+      automationId: 'automation_user_improvement_coach',
+      continuityPolicy: 'preserve',
+      instructions: 'Keep this user improvement coach prompt.',
+      route: defaultRoute,
+      schedule: {
+        kind: 'cron',
+        expression: '0 17 * * 2',
+      },
+      slug: 'weekly-improvement-coach',
+      status: 'active',
+      summary: 'User-owned improvement coach automation.',
+      tags: ['user'],
+      title: 'My improvement coach',
+    })
     managedAutomationMocks.records.set('automation_user_product_updates', {
       automationId: 'automation_user_product_updates',
       continuityPolicy: 'preserve',
@@ -1520,7 +1620,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -1541,7 +1641,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 4,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()


### PR DESCRIPTION
## What

A new quiet Murph-managed weekly automation, `weekly-improvement-coach`: on Tuesdays it looks for **zero or one clearly actionable, evidence-strong health deficit** (low deep sleep, low activity minutes, no strength training, meal quality, low fiber/protein) and sends a short invitation to work on it together. Most weeks the correct outcome is silence.

It is the sibling of `weekly-health-insight` with the opposite bar: the insight scout hunts non-obvious findings and rejects population-norm comparisons; this run targets obvious-but-tractable deficits the user could realistically start improving this week.

## Design

- **Quiet by default**: no require-send tag; the model returns the skip decision unless something genuinely clears the bar.
- **Three-layer evidence gate** in the prompt:
  - *Capability*: metric must be positively captured by a connected, healthy source (`device account list` + `wearables sources list`). Never infer absence of behavior from absence of data — if no source captures strength workouts, "no strength training" is unknowable, not a deficit.
  - *Plausibility*: exact zeros / sudden cliffs are treated as pipeline bugs, never as "you're inactive."
  - *Sufficiency*: ~3+ weeks of coverage before calling a pattern; one bad week is noise.
- **Week-over-week dedupe**: rolling `improvement-opportunities` knowledge ledger, appended before sending. Never re-offer a domain unless its entry is 8+ weeks old with meaningfully new evidence; skips domains covered by active/recent experiments or already discussed; cross-reads `weekly-health-insights` so Tuesday doesn't repeat Sunday.
- **Compute**: `reasoningEffort: 'high'` override; cron first attempts already run on the flex tier.
- **Scheduling**: seed cron `0 17 * * 2` with a Tuesday 16:00–20:30 per-vault spread entry; added to the research-oriented gate set so it stays silent while onboarding is open.

## Tests

- Seed invariants + spread-resolved cron + instruction load-bearing lines (ledger commands, exact skip JSON, absence-of-data rule) in `managed-automations.test.ts` and `managed-automations-core.test.ts`, mirroring the sibling automations.
- User-owned automation with the same slug is left untouched by the seeder.
- Cron-runtime test: onboarding-open gate skips the new tag before provider work.

## Verification

- `packages/assistant-engine`: typecheck clean, full build (incl. CLI surface contract generation) clean.
- 139/139 tests pass across the three touched suites.
- c1 xhigh deep review of the diff: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786148989&installation_id=127572939&pr_number=481&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F481&signature=c5de0e1c4e1dbe4f4d6372299e10e00715af53e03021147c9cb21f17895c770a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->