### PR TITLE
Defer snapshot cleanup after upload-session retirement

### DIFF
--- a/apps/cloudflare/src/runner-outbound.ts
+++ b/apps/cloudflare/src/runner-outbound.ts
@@ -5,6 +5,9 @@ import type {
   HostedExecutionSnapshotRef,
 } from "@murphai/hosted-execution/contracts";
 import type {
+  HostedWorkspaceState,
+} from "@murphai/hosted-execution/runtime-control";
+import type {
   HostedWorkspaceSnapshotOrphanCandidate,
   HostedWorkspaceSnapshotUploadSession,
   WorkspaceSnapshotR2BucketLike,
@@ -1289,14 +1292,31 @@ async function handleRunnerWorkspaceSnapshotCompleteRequest(input: {
   }
 
   if (Date.parse(session.expiresAt) <= Date.now()) {
-    await retireWorkspaceSnapshotUploadSession({
+    const alreadyCurrentResponse = await completeExpiredCurrentWorkspaceSnapshotUploadSession({
       bucket: input.bucket,
-      deleteObject: true,
       env: input.env,
-      objectKey: session.objectKey,
-      snapshotId: input.snapshotId,
+      environment: input.environment,
+      request: input.request,
+      session,
       userId: input.userId,
     });
+    if (alreadyCurrentResponse) {
+      return alreadyCurrentResponse;
+    }
+    try {
+      await recordWorkspaceSnapshotObjectCleanup(input.env, {
+        objectKey: session.objectKey,
+        snapshotId: input.snapshotId,
+        userId: input.userId,
+      });
+      await deleteWorkspaceSnapshotUploadSession({
+        env: input.env,
+        snapshotId: input.snapshotId,
+        userId: input.userId,
+      });
+    } catch {
+      return jsonError("Hosted workspace snapshot cleanup state is unavailable.", 503);
+    }
     return jsonError("Hosted workspace snapshot upload session expired.", 410);
   }
 
@@ -1435,30 +1455,42 @@ async function handleRunnerWorkspaceSnapshotCompleteRequest(input: {
     return jsonError("Hosted workspace snapshot checkpoint write fence is stale.", 409);
   }
 
+  const retireAfterAmbiguousCheckpoint = async (): Promise<Response | null> => {
+    try {
+      await retireAmbiguousWorkspaceSnapshotUploadSession({
+        env: input.env,
+        session,
+        snapshotRef,
+        snapshotId: input.snapshotId,
+        userId: input.userId,
+      });
+      return null;
+    } catch {
+      return jsonError("Hosted workspace snapshot cleanup state is unavailable.", 503);
+    }
+  };
+
   const currentWriteFence = await requireWorkspaceSnapshotWriteFence({
     env: input.env,
     request: input.request,
     userId: input.userId,
   });
   if (!currentWriteFence) {
-    await retireWorkspaceSnapshotUploadSession({
-      bucket: input.bucket,
-      deleteObject: true,
-      env: input.env,
-      objectKey: snapshotRef.objectKey,
-      snapshotId: input.snapshotId,
-      userId: input.userId,
-    });
+    const cleanupResponse = await retireAfterAmbiguousCheckpoint();
+    if (cleanupResponse) {
+      return cleanupResponse;
+    }
     return jsonError("Hosted workspace snapshot upload session is stale.", 409);
   }
 
   let preCheckpointReplacedSnapshotRef: HostedExecutionSnapshotRefValue | null = null;
   try {
-    preCheckpointReplacedSnapshotRef = await readCurrentHostedWorkspaceSnapshotRef({
+    const preCheckpointWorkspace = await readCurrentHostedWorkspace({
       environment: input.environment,
       fetchImpl: fetch,
       userId: input.userId,
     });
+    preCheckpointReplacedSnapshotRef = preCheckpointWorkspace?.snapshotRef ?? null;
   } catch {
     return jsonError("Hosted workspace snapshot current state is unavailable.", 502);
   }
@@ -1480,20 +1512,6 @@ async function handleRunnerWorkspaceSnapshotCompleteRequest(input: {
     }
   }
 
-  const retireAfterAmbiguousCheckpoint = async (): Promise<Response | null> => {
-    try {
-      await retireAmbiguousWorkspaceSnapshotUploadSession({
-        env: input.env,
-        session,
-        snapshotRef,
-        snapshotId: input.snapshotId,
-        userId: input.userId,
-      });
-      return null;
-    } catch {
-      return jsonError("Hosted workspace snapshot cleanup state is unavailable.", 503);
-    }
-  };
   let checkpointResponse: Response;
   try {
     checkpointResponse = await fetchHostedExecutionWorkspaceSnapshotCheckpoint({
@@ -1652,16 +1670,11 @@ async function retireAmbiguousWorkspaceSnapshotUploadSession(input: {
   snapshotRef: HostedWorkspaceSnapshotV2Ref;
   userId: string;
 }): Promise<void> {
-  const uploadedObjectRecorded = await recordWorkspaceSnapshotOrphanCandidate(input.env, {
-    createdAt: new Date().toISOString(),
+  await recordWorkspaceSnapshotObjectCleanup(input.env, {
     objectKey: input.snapshotRef.objectKey,
-    schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
     snapshotId: input.snapshotId,
     userId: input.userId,
   });
-  if (!uploadedObjectRecorded) {
-    throw new Error("Hosted workspace snapshot orphan recording is unavailable.");
-  }
 
   const replacedSnapshotRef = input.session.replacedSnapshotRef ?? null;
   if (replacedSnapshotRef) {
@@ -1680,6 +1693,26 @@ async function retireAmbiguousWorkspaceSnapshotUploadSession(input: {
     snapshotId: input.snapshotId,
     userId: input.userId,
   });
+}
+
+async function recordWorkspaceSnapshotObjectCleanup(
+  env: RunnerOutboundEnvironmentSource,
+  input: {
+    objectKey: string;
+    snapshotId: string;
+    userId: string;
+  },
+): Promise<void> {
+  const recorded = await recordWorkspaceSnapshotOrphanCandidate(env, {
+    createdAt: new Date().toISOString(),
+    objectKey: input.objectKey,
+    schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
+    snapshotId: input.snapshotId,
+    userId: input.userId,
+  });
+  if (!recorded) {
+    throw new Error("Hosted workspace snapshot orphan recording is unavailable.");
+  }
 }
 
 function isReplacementRefSameAsSnapshotRef(
@@ -1708,6 +1741,14 @@ async function deleteReplacedWorkspaceSnapshotRef(input: {
     ) {
       return true;
     }
+    const deleted = await deleteWorkspaceSnapshotObjectBestEffort({
+      bucket: input.bucket,
+      env: input.env,
+      objectKey: replacedSnapshotRef.objectKey,
+    });
+    if (deleted) {
+      return true;
+    }
     const orphanRecorded = await recordWorkspaceSnapshotOrphanCandidate(input.env, {
       createdAt: new Date().toISOString(),
       objectKey: replacedSnapshotRef.objectKey,
@@ -1715,22 +1756,9 @@ async function deleteReplacedWorkspaceSnapshotRef(input: {
       snapshotId: replacedSnapshotRef.snapshotId,
       userId: replacedSnapshotRef.userId,
     }).catch(() => false);
-    const deleted = await deleteWorkspaceSnapshotObjectBestEffort({
-      bucket: input.bucket,
-      env: input.env,
-      objectKey: replacedSnapshotRef.objectKey,
-    });
-    return orphanRecorded || deleted;
+    return orphanRecorded;
   }
 
-  const orphanRecorded = await recordWorkspaceSnapshotOrphanCandidate(input.env, {
-    createdAt: new Date().toISOString(),
-    kind: "legacy_workspace_snapshot",
-    schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
-    snapshotId: `legacy-${input.snapshotRef.snapshotId}`,
-    snapshotRef: replacedSnapshotRef,
-    userId: input.snapshotRef.userId,
-  }).catch(() => false);
   const deleted = await deleteReplacedLegacyWorkspaceSnapshotBundles({
     env: input.env,
     environment: input.environment,
@@ -1740,7 +1768,18 @@ async function deleteReplacedWorkspaceSnapshotRef(input: {
     () => true,
     () => false,
   );
-  return orphanRecorded || deleted;
+  if (deleted) {
+    return true;
+  }
+  const orphanRecorded = await recordWorkspaceSnapshotOrphanCandidate(input.env, {
+    createdAt: new Date().toISOString(),
+    kind: "legacy_workspace_snapshot",
+    schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
+    snapshotId: `legacy-${input.snapshotRef.snapshotId}`,
+    snapshotRef: replacedSnapshotRef,
+    userId: input.snapshotRef.userId,
+  }).catch(() => false);
+  return orphanRecorded;
 }
 
 async function recordReplacedWorkspaceSnapshotOrphanCandidate(input: {
@@ -1834,6 +1873,90 @@ async function completeAlreadyCheckpointedWorkspaceSnapshotCleanup(input: {
     },
     ok: true,
     snapshotRef: input.snapshotRef,
+  });
+}
+
+async function completeExpiredCurrentWorkspaceSnapshotUploadSession(input: {
+  bucket: WorkspaceSnapshotR2BucketLike | null;
+  env: RunnerOutboundEnvironmentSource;
+  environment: ReturnType<typeof readHostedExecutionEnvironment>;
+  request: Request;
+  session: HostedWorkspaceSnapshotUploadSession;
+  userId: string;
+}): Promise<Response | null> {
+  let currentWorkspace: HostedWorkspaceState | null;
+  try {
+    currentWorkspace = await readCurrentHostedWorkspace({
+      environment: input.environment,
+      fetchImpl: fetch,
+      userId: input.userId,
+    });
+  } catch {
+    return jsonError("Hosted workspace snapshot current state is unavailable.", 502);
+  }
+
+  const currentSnapshotRef = currentWorkspace?.snapshotRef ?? null;
+  if (
+    !currentWorkspace
+    || !isHostedWorkspaceSnapshotV2Ref(currentSnapshotRef)
+    || currentSnapshotRef.snapshotId !== input.session.snapshotId
+    || currentSnapshotRef.objectKey !== input.session.objectKey
+    || !(await isHostedWorkspaceSnapshotV2RefOwnedByUser({
+      snapshotRef: currentSnapshotRef,
+      userId: input.userId,
+    }))
+  ) {
+    return null;
+  }
+
+  if (
+    !/^[0-9]+$/u.test(currentWorkspace.version)
+    || !/^[0-9]+$/u.test(input.session.workspaceVersion)
+    || BigInt(currentWorkspace.version) <= BigInt(input.session.workspaceVersion)
+  ) {
+    return jsonError("Hosted workspace snapshot upload session is stale.", 409);
+  }
+
+  const currentWriteFence = await requireWorkspaceSnapshotWriteFence({
+    env: input.env,
+    request: input.request,
+    userId: input.userId,
+  });
+  if (!currentWriteFence || currentWriteFence.workspaceVersion !== input.session.workspaceVersion) {
+    return jsonError("Hosted workspace snapshot upload session is stale.", 409);
+  }
+
+  const replacedSnapshotRef = input.session.replacedSnapshotRef ?? null;
+  if (replacedSnapshotRef) {
+    const replacedSnapshotCleanupSucceeded = await deleteReplacedWorkspaceSnapshotRef({
+      bucket: input.bucket,
+      env: input.env,
+      environment: input.environment,
+      replacedSnapshotRef,
+      snapshotRef: currentSnapshotRef,
+    });
+    if (!replacedSnapshotCleanupSucceeded) {
+      return jsonError("Hosted workspace replaced snapshot cleanup failed.", 503);
+    }
+  }
+
+  await retireWorkspaceSnapshotUploadSession({
+    bucket: input.bucket,
+    deleteObject: false,
+    env: input.env,
+    objectKey: currentSnapshotRef.objectKey,
+    snapshotId: currentSnapshotRef.snapshotId,
+    userId: input.userId,
+  }).catch(() => undefined);
+
+  return json({
+    checkpoint: {
+      checkpointed: true,
+      ...(replacedSnapshotRef ? { replacedSnapshotRef } : {}),
+      workspace: currentWorkspace,
+    },
+    ok: true,
+    snapshotRef: currentSnapshotRef,
   });
 }
 
@@ -1972,31 +2095,33 @@ async function retireWorkspaceSnapshotUploadSession(input: {
   deleteObject: boolean;
   env: RunnerOutboundEnvironmentSource;
   objectKey?: string;
-  recordOrphanCandidate?: boolean;
   snapshotId: string;
   userId: string;
 }): Promise<void> {
-  if (input.recordOrphanCandidate && input.objectKey) {
-    await recordWorkspaceSnapshotOrphanCandidate(input.env, {
-      createdAt: new Date().toISOString(),
+  if (input.deleteObject && input.objectKey) {
+    const deleted = await deleteWorkspaceSnapshotObjectBestEffort({
+      bucket: input.bucket,
+      env: input.env,
       objectKey: input.objectKey,
-      schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
-      snapshotId: input.snapshotId,
-      userId: input.userId,
-    }).catch(() => undefined);
+    });
+    if (!deleted) {
+      const retained = await recordWorkspaceSnapshotOrphanCandidate(input.env, {
+        createdAt: new Date().toISOString(),
+        objectKey: input.objectKey,
+        schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
+        snapshotId: input.snapshotId,
+        userId: input.userId,
+      }).catch(() => false);
+      if (!retained) {
+        throw new Error("Hosted workspace snapshot object cleanup could not be retained.");
+      }
+    }
   }
   await deleteWorkspaceSnapshotUploadSession({
     env: input.env,
     snapshotId: input.snapshotId,
     userId: input.userId,
   });
-  if (input.deleteObject && input.objectKey) {
-    await deleteWorkspaceSnapshotObjectBestEffort({
-      bucket: input.bucket,
-      env: input.env,
-      objectKey: input.objectKey,
-    });
-  }
 }
 
 async function deleteWorkspaceSnapshotObjectBestEffort(input: {
@@ -2206,11 +2331,11 @@ async function fetchHostedExecutionWorkspaceSnapshotCheckpoint(input: {
   });
 }
 
-async function readCurrentHostedWorkspaceSnapshotRef(input: {
+async function readCurrentHostedWorkspace(input: {
   environment: ReturnType<typeof readHostedExecutionEnvironment>;
   fetchImpl: typeof fetch;
   userId: string;
-}): Promise<HostedExecutionSnapshotRefValue | null> {
+}): Promise<HostedWorkspaceState | null> {
   const response = await fetchHostedExecutionWebControlPlaneResponse({
     ...(input.environment.hostedWebAllowHttpHosts
       ? { allowHttpHosts: input.environment.hostedWebAllowHttpHosts }
@@ -2230,7 +2355,7 @@ async function readCurrentHostedWorkspaceSnapshotRef(input: {
   if (workspaceRead.workspace && workspaceRead.workspace.userId !== input.userId) {
     throw new Error("Hosted workspace read user mismatch.");
   }
-  return workspaceRead.workspace?.snapshotRef ?? null;
+  return workspaceRead.workspace ?? null;
 }
 
 function readWorkspaceSnapshotAad(value: unknown, label: string): HostedWorkspaceSnapshotV2Aad {

--- a/apps/cloudflare/src/user-runner/workspace-snapshot-sessions.ts
+++ b/apps/cloudflare/src/user-runner/workspace-snapshot-sessions.ts
@@ -260,7 +260,9 @@ export function createWorkspaceSnapshotSessionService(input: {
         && currentSession.snapshotId === deleteInput.snapshotId
       ) {
         return {
-          deleted: await input.state.storage.delete(workspaceSnapshotUploadSessionCurrentStorageKey()),
+          deleted: await input.state.storage.delete(
+            workspaceSnapshotUploadSessionCurrentStorageKey(),
+          ),
         };
       }
       return { deleted: false };
@@ -414,7 +416,7 @@ async function syncWorkspaceSnapshotOrphanCandidateAlarm(input: {
     return;
   }
   const currentAlarm = await input.state.storage.getAlarm();
-  if (currentAlarm !== null && currentAlarm <= nextAtMs) {
+  if (currentAlarm === nextAtMs) {
     return;
   }
   await input.state.storage.setAlarm(nextAtMs);

--- a/apps/cloudflare/test/runner-outbound.test.ts
+++ b/apps/cloudflare/test/runner-outbound.test.ts
@@ -4790,17 +4790,8 @@ describe("handleRunnerOutboundRequest", () => {
 
     expect(response.status).toBe(200);
     expect(deleteObject).toHaveBeenCalledWith(replacedObjectKey);
-    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).toHaveBeenCalledWith({
-      createdAt: expect.stringMatching(/^20/u),
-      objectKey: replacedObjectKey,
-      schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
-      snapshotId: replacedSnapshotId,
-      userId: "member_123",
-    });
-    expect(runner.workspaceSnapshotOrphanCandidates.get(replacedSnapshotId)).toMatchObject({
-      objectKey: replacedObjectKey,
-      snapshotId: replacedSnapshotId,
-    });
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).not.toHaveBeenCalled();
+    expect(runner.workspaceSnapshotOrphanCandidates.has(replacedSnapshotId)).toBe(false);
   });
 
   it("deletes replaced legacy workspace snapshot bundles and artifacts after checkpoint CAS", async () => {
@@ -4914,19 +4905,8 @@ describe("handleRunnerOutboundRequest", () => {
       legacyDeltaRef.key,
       legacyArtifactKey,
     ]));
-    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).toHaveBeenCalledWith({
-      createdAt: expect.stringMatching(/^20/u),
-      kind: "legacy_workspace_snapshot",
-      schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
-      snapshotId: `legacy-${snapshotId}`,
-      snapshotRef: replacedSnapshotRef,
-      userId: "member_123",
-    });
-    expect(runner.workspaceSnapshotOrphanCandidates.get(`legacy-${snapshotId}`)).toMatchObject({
-      kind: "legacy_workspace_snapshot",
-      snapshotId: `legacy-${snapshotId}`,
-      snapshotRef: replacedSnapshotRef,
-    });
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).not.toHaveBeenCalled();
+    expect(runner.workspaceSnapshotOrphanCandidates.has(`legacy-${snapshotId}`)).toBe(false);
     expect(fixture.fetchMock).toHaveBeenCalledOnce();
   });
 
@@ -5301,13 +5281,7 @@ describe("handleRunnerOutboundRequest", () => {
       }),
     }));
     expect(deleteObject).toHaveBeenCalledWith(replacedObjectKey);
-    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).toHaveBeenCalledWith({
-      createdAt: expect.stringMatching(/^20/u),
-      objectKey: replacedObjectKey,
-      schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
-      snapshotId: replacedSnapshotId,
-      userId: "member_123",
-    });
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).not.toHaveBeenCalled();
     expect(runner.deleteHostedWorkspaceSnapshotUploadSession).toHaveBeenCalledWith({
       snapshotId,
       userId: "member_123",
@@ -5838,6 +5812,69 @@ describe("handleRunnerOutboundRequest", () => {
     expect(deleteObject).toHaveBeenCalledWith(objectKey);
   });
 
+  it("retains uploaded snapshot cleanup before deleting an aborted session when object deletion fails", async () => {
+    const runner = createWorkspaceVersionAwareUserRunner();
+    const snapshotId = "snapshot_abort_delete_failure";
+    const objectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId,
+      userId: "member_123",
+    });
+    const snapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 4,
+      encryptedObjectSha256: "a".repeat(64),
+      objectKey,
+      snapshotId,
+      userId: "member_123",
+    });
+    runner.workspaceSnapshotUploadSessions.set(snapshotId, createWorkspaceSnapshotUploadSession(snapshotRef));
+    const deleteObject = vi.fn(async () => {
+      throw new Error("R2 delete failed");
+    });
+    const env = createRunnerOutboundEnv({
+      BUNDLES: createWorkspaceSnapshotBucket(
+        async (key) => ({ key, size: 4 }),
+        async (key) => ({ key, size: 4 }),
+        deleteObject,
+      ),
+      USER_RUNNER: {
+        getByName: runner.getByName,
+      },
+    });
+
+    const response = await handleRunnerOutboundRequest(
+      createWorkspaceSnapshotAbortRequest({
+        objectKey,
+        snapshotId,
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      aborted: true,
+      ok: true,
+    });
+    expect(deleteObject).toHaveBeenCalledWith(objectKey);
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).toHaveBeenCalledWith({
+      createdAt: expect.stringMatching(/^20/u),
+      objectKey,
+      schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
+      snapshotId,
+      userId: "member_123",
+    });
+    expect(runner.workspaceSnapshotOrphanCandidates.get(snapshotId)).toEqual(
+      expect.objectContaining({
+        objectKey,
+        snapshotId,
+        userId: "member_123",
+      }),
+    );
+    expect(runner.deleteHostedWorkspaceSnapshotUploadSession).toHaveBeenCalledOnce();
+    expect(runner.workspaceSnapshotUploadSessions.has(snapshotId)).toBe(false);
+  });
+
   it("lets a stale invocation abort its own active workspace snapshot upload session", async () => {
     const runner = createWorkspaceVersionAwareUserRunner({
       leaseGeneration: "10",
@@ -6189,7 +6226,404 @@ describe("handleRunnerOutboundRequest", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("retires workspace snapshot upload sessions when complete sees a replaced active write fence", async () => {
+  it("retains expired non-current completion object cleanup instead of deleting inline", async () => {
+    const runner = createWorkspaceVersionAwareUserRunner();
+    const snapshotId = "snapshot_complete_expired_non_current_cleanup";
+    const objectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId,
+      userId: "member_123",
+    });
+    const snapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 4,
+      encryptedObjectSha256: "a".repeat(64),
+      objectKey,
+      snapshotId,
+      userId: "member_123",
+    });
+    runner.workspaceSnapshotUploadSessions.set(
+      snapshotId,
+      createWorkspaceSnapshotUploadSession(snapshotRef, {
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    const deleteObject = vi.fn(async () => {});
+    const env = createRunnerOutboundEnv({
+      BUNDLES: createWorkspaceSnapshotBucket(
+        async (key) => ({ key, size: 4 }),
+        async (key) => ({
+          checksums: createWorkspaceSnapshotHeadChecksums(snapshotRef),
+          customMetadata: createWorkspaceSnapshotHeadMetadata(snapshotRef),
+          key,
+          size: 4,
+        }),
+        deleteObject,
+      ),
+      USER_RUNNER: {
+        getByName: runner.getByName,
+      },
+    });
+    const fetchMock = createWorkspaceSnapshotCompleteWebFetchMock({
+      currentSnapshotRef: null,
+      onCheckpoint: () => {
+        throw new Error("expired completion should not checkpoint again");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleRunnerOutboundRequest(
+      createWorkspaceSnapshotCompleteRequest({
+        snapshotId,
+        snapshotRef,
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    );
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({
+      error: "Hosted workspace snapshot upload session expired.",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(deleteObject).not.toHaveBeenCalled();
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).toHaveBeenCalledWith({
+      createdAt: expect.stringMatching(/^20/u),
+      objectKey,
+      schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
+      snapshotId,
+      userId: "member_123",
+    });
+    expect(runner.deleteHostedWorkspaceSnapshotUploadSession).toHaveBeenCalledWith({
+      snapshotId,
+      userId: "member_123",
+    });
+    expect(runner.workspaceSnapshotUploadSessions.has(snapshotId)).toBe(false);
+  });
+
+  it("does not delete the current workspace snapshot object when an expired completion retry cleans up replaced state", async () => {
+    const runner = createWorkspaceVersionAwareUserRunner();
+    const snapshotId = "snapshot_complete_expired_current_retry";
+    const objectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId,
+      userId: "member_123",
+    });
+    const snapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 4,
+      encryptedObjectSha256: "a".repeat(64),
+      objectKey,
+      snapshotId,
+      userId: "member_123",
+    });
+    const replacedSnapshotId = "snapshot_complete_expired_current_replaced";
+    const replacedObjectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId: replacedSnapshotId,
+      userId: "member_123",
+    });
+    const replacedSnapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 5,
+      encryptedObjectSha256: "b".repeat(64),
+      objectKey: replacedObjectKey,
+      snapshotId: replacedSnapshotId,
+      userId: "member_123",
+    });
+    runner.workspaceSnapshotUploadSessions.set(
+      snapshotId,
+      createWorkspaceSnapshotUploadSession(snapshotRef, {
+        expiresAt: "2000-01-01T00:00:00.000Z",
+        replacedSnapshotRef,
+      }),
+    );
+    const deleteObject = vi.fn(async () => {});
+    const env = createRunnerOutboundEnv({
+      BUNDLES: createWorkspaceSnapshotBucket(
+        async (key) => ({ key, size: 4 }),
+        async (key) => ({
+          checksums: createWorkspaceSnapshotHeadChecksums(snapshotRef),
+          customMetadata: createWorkspaceSnapshotHeadMetadata(snapshotRef),
+          key,
+          size: 4,
+        }),
+        deleteObject,
+      ),
+      USER_RUNNER: {
+        getByName: runner.getByName,
+      },
+    });
+    const fetchMock = createWorkspaceSnapshotCompleteWebFetchMock({
+      currentSnapshotRef: snapshotRef,
+      currentWorkspaceVersion: "5",
+      onCheckpoint: () => {
+        throw new Error("expired current retry should not checkpoint again");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleRunnerOutboundRequest(
+      createWorkspaceSnapshotCompleteRequest({
+        snapshotId,
+        snapshotRef,
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    );
+
+    const responseBody = requireTestObject(await response.json(), "expired current retry response");
+    expect(response.status).toBe(200);
+    expect(responseBody.checkpoint).toEqual(expect.objectContaining({
+      checkpointed: true,
+      replacedSnapshotRef,
+      workspace: expect.objectContaining({
+        snapshotRef: expect.objectContaining({
+          objectKey,
+          snapshotId,
+        }),
+      }),
+    }));
+    expect(responseBody.snapshotRef).toEqual(expect.objectContaining({
+      objectKey,
+      snapshotId,
+    }));
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(deleteObject).toHaveBeenCalledWith(replacedObjectKey);
+    expect(deleteObject).not.toHaveBeenCalledWith(objectKey);
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).not.toHaveBeenCalled();
+    expect(runner.deleteHostedWorkspaceSnapshotUploadSession).toHaveBeenCalledWith({
+      snapshotId,
+      userId: "member_123",
+    });
+    expect(runner.workspaceSnapshotUploadSessions.has(snapshotId)).toBe(false);
+  });
+
+  it("keeps an expired current workspace snapshot retry when the active write fence moved", async () => {
+    const runner = createWorkspaceVersionAwareUserRunner({
+      leaseGeneration: "10",
+    });
+    const snapshotId = "snapshot_complete_expired_current_moved_fence";
+    const objectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId,
+      userId: "member_123",
+    });
+    const snapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 4,
+      encryptedObjectSha256: "a".repeat(64),
+      objectKey,
+      snapshotId,
+      userId: "member_123",
+    });
+    runner.workspaceSnapshotUploadSessions.set(
+      snapshotId,
+      createWorkspaceSnapshotUploadSession(snapshotRef, {
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    const deleteObject = vi.fn(async () => {});
+    const env = createRunnerOutboundEnv({
+      BUNDLES: createWorkspaceSnapshotBucket(
+        async (key) => ({ key, size: 4 }),
+        async (key) => ({
+          checksums: createWorkspaceSnapshotHeadChecksums(snapshotRef),
+          customMetadata: createWorkspaceSnapshotHeadMetadata(snapshotRef),
+          key,
+          size: 4,
+        }),
+        deleteObject,
+      ),
+      USER_RUNNER: {
+        getByName: runner.getByName,
+      },
+    });
+    const fetchMock = createWorkspaceSnapshotCompleteWebFetchMock({
+      currentSnapshotRef: snapshotRef,
+      currentWorkspaceVersion: "5",
+      onCheckpoint: () => {
+        throw new Error("expired current retry should not checkpoint again");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleRunnerOutboundRequest(
+      createWorkspaceSnapshotCompleteRequest({
+        snapshotId,
+        snapshotRef,
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Hosted workspace snapshot upload session is stale.",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(runner.validateRuntimeWriteFence).toHaveBeenCalledWith({
+      attemptId: "attempt_1",
+      generation: "9",
+      userId: "member_123",
+    });
+    expect(deleteObject).not.toHaveBeenCalled();
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).not.toHaveBeenCalled();
+    expect(runner.deleteHostedWorkspaceSnapshotUploadSession).not.toHaveBeenCalled();
+    expect(runner.workspaceSnapshotUploadSessions.has(snapshotId)).toBe(true);
+  });
+
+  it("keeps an expired current workspace snapshot retry when web has not advanced past the session version", async () => {
+    const runner = createWorkspaceVersionAwareUserRunner();
+    const snapshotId = "snapshot_complete_expired_current_pre_checkpoint";
+    const objectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId,
+      userId: "member_123",
+    });
+    const snapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 4,
+      encryptedObjectSha256: "a".repeat(64),
+      objectKey,
+      snapshotId,
+      userId: "member_123",
+    });
+    runner.workspaceSnapshotUploadSessions.set(
+      snapshotId,
+      createWorkspaceSnapshotUploadSession(snapshotRef, {
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    const deleteObject = vi.fn(async () => {});
+    const env = createRunnerOutboundEnv({
+      BUNDLES: createWorkspaceSnapshotBucket(
+        async (key) => ({ key, size: 4 }),
+        async (key) => ({
+          checksums: createWorkspaceSnapshotHeadChecksums(snapshotRef),
+          customMetadata: createWorkspaceSnapshotHeadMetadata(snapshotRef),
+          key,
+          size: 4,
+        }),
+        deleteObject,
+      ),
+      USER_RUNNER: {
+        getByName: runner.getByName,
+      },
+    });
+    const fetchMock = createWorkspaceSnapshotCompleteWebFetchMock({
+      currentSnapshotRef: snapshotRef,
+      currentWorkspaceVersion: "4",
+      onCheckpoint: () => {
+        throw new Error("expired current retry should not checkpoint again");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleRunnerOutboundRequest(
+      createWorkspaceSnapshotCompleteRequest({
+        snapshotId,
+        snapshotRef,
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Hosted workspace snapshot upload session is stale.",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(runner.validateRuntimeWriteFence).not.toHaveBeenCalled();
+    expect(deleteObject).not.toHaveBeenCalled();
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).not.toHaveBeenCalled();
+    expect(runner.deleteHostedWorkspaceSnapshotUploadSession).not.toHaveBeenCalled();
+    expect(runner.workspaceSnapshotUploadSessions.has(snapshotId)).toBe(true);
+  });
+
+  it("keeps an expired current workspace snapshot retry when replaced cleanup still fails", async () => {
+    const runner = createWorkspaceVersionAwareUserRunner();
+    const snapshotId = "snapshot_complete_expired_current_retry_cleanup_fails";
+    const objectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId,
+      userId: "member_123",
+    });
+    const snapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 4,
+      encryptedObjectSha256: "a".repeat(64),
+      objectKey,
+      snapshotId,
+      userId: "member_123",
+    });
+    const replacedSnapshotId = "snapshot_complete_expired_current_replaced_cleanup_fails";
+    const replacedObjectKey = await hostedWorkspaceSnapshotObjectKey({
+      snapshotId: replacedSnapshotId,
+      userId: "member_123",
+    });
+    const replacedSnapshotRef = createWorkspaceSnapshotV2Ref({
+      encryptedByteSize: 5,
+      encryptedObjectSha256: "b".repeat(64),
+      objectKey: replacedObjectKey,
+      snapshotId: replacedSnapshotId,
+      userId: "member_123",
+    });
+    runner.recordHostedWorkspaceSnapshotOrphanCandidate.mockImplementationOnce(async () => {
+      throw new Error("orphan recording failed");
+    });
+    runner.workspaceSnapshotUploadSessions.set(
+      snapshotId,
+      createWorkspaceSnapshotUploadSession(snapshotRef, {
+        expiresAt: "2000-01-01T00:00:00.000Z",
+        replacedSnapshotRef,
+      }),
+    );
+    const deleteObject = vi.fn(async () => {
+      throw new Error("R2 delete failed");
+    });
+    const env = createRunnerOutboundEnv({
+      BUNDLES: createWorkspaceSnapshotBucket(
+        async (key) => ({ key, size: 4 }),
+        async (key) => ({
+          checksums: createWorkspaceSnapshotHeadChecksums(snapshotRef),
+          customMetadata: createWorkspaceSnapshotHeadMetadata(snapshotRef),
+          key,
+          size: 4,
+        }),
+        deleteObject,
+      ),
+      USER_RUNNER: {
+        getByName: runner.getByName,
+      },
+    });
+    const fetchMock = createWorkspaceSnapshotCompleteWebFetchMock({
+      currentSnapshotRef: snapshotRef,
+      currentWorkspaceVersion: "5",
+      onCheckpoint: () => {
+        throw new Error("expired current retry should not checkpoint again");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleRunnerOutboundRequest(
+      createWorkspaceSnapshotCompleteRequest({
+        snapshotId,
+        snapshotRef,
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Hosted workspace replaced snapshot cleanup failed.",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(deleteObject).toHaveBeenCalledWith(replacedObjectKey);
+    expect(deleteObject).not.toHaveBeenCalledWith(objectKey);
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).toHaveBeenCalledOnce();
+    expect(runner.deleteHostedWorkspaceSnapshotUploadSession).not.toHaveBeenCalled();
+    expect(runner.workspaceSnapshotUploadSessions.get(snapshotId)).toMatchObject({
+      replacedSnapshotRef,
+      snapshotId,
+    });
+  });
+
+  it("defers snapshot object cleanup when complete sees a replaced active write fence", async () => {
     const runner = createWorkspaceVersionAwareUserRunner({
       leaseGeneration: "10",
     });
@@ -6246,7 +6680,14 @@ describe("handleRunnerOutboundRequest", () => {
     });
     expect(runner.deleteHostedWorkspaceSnapshotUploadSession).toHaveBeenCalledOnce();
     expect(runner.workspaceSnapshotUploadSessions.has(snapshotId)).toBe(false);
-    expect(deleteObject).toHaveBeenCalledWith(objectKey);
+    expect(deleteObject).not.toHaveBeenCalled();
+    expect(runner.recordHostedWorkspaceSnapshotOrphanCandidate).toHaveBeenCalledWith({
+      createdAt: expect.stringMatching(/^20/u),
+      objectKey,
+      schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
+      snapshotId,
+      userId: "member_123",
+    });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -8781,6 +9222,7 @@ function createHostedWorkspaceCheckpointResponseWithSnapshotRef(
 
 function createHostedWorkspaceReadResponse(
   snapshotRef: NonNullable<HostedWorkspaceReadResponse["workspace"]>["snapshotRef"] = null,
+  version = "4",
 ): HostedWorkspaceReadResponse {
   return {
     fetchedAt: "2026-04-26T00:00:05.000Z",
@@ -8794,15 +9236,16 @@ function createHostedWorkspaceReadResponse(
       snapshotRef,
       updatedAt: "2026-04-26T00:00:05.000Z",
       userId: "member_123",
-      version: "4",
+      version,
     },
   };
 }
 
 function createHostedWorkspaceReadFetchResponse(
   snapshotRef: NonNullable<HostedWorkspaceReadResponse["workspace"]>["snapshotRef"] = null,
+  version = "4",
 ): Response {
-  return new Response(JSON.stringify(createHostedWorkspaceReadResponse(snapshotRef)), {
+  return new Response(JSON.stringify(createHostedWorkspaceReadResponse(snapshotRef, version)), {
     headers: {
       "content-type": "application/json; charset=utf-8",
     },
@@ -8819,11 +9262,15 @@ function isHostedWorkspaceReadFetch(args: Parameters<typeof fetch>): boolean {
 
 function createWorkspaceSnapshotCompleteWebFetchMock(input: {
   currentSnapshotRef?: NonNullable<HostedWorkspaceReadResponse["workspace"]>["snapshotRef"];
+  currentWorkspaceVersion?: string;
   onCheckpoint(args: Parameters<typeof fetch>): Promise<Response> | Response;
 }): ReturnType<typeof vi.fn<typeof fetch>> {
   return vi.fn<typeof fetch>(async (...args: Parameters<typeof fetch>): Promise<Response> => {
     if (isHostedWorkspaceReadFetch(args)) {
-      return createHostedWorkspaceReadFetchResponse(input.currentSnapshotRef ?? null);
+      return createHostedWorkspaceReadFetchResponse(
+        input.currentSnapshotRef ?? null,
+        input.currentWorkspaceVersion ?? "4",
+      );
     }
     return await input.onCheckpoint(args);
   });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -3666,6 +3666,44 @@ describe("HostedUserRunner execution coordination", () => {
     expect(alarms.at(-1)).toBe("deleted");
   });
 
+  it("does not scan orphan candidates when deleting an upload session", async () => {
+    const currentObjectKey =
+      `${await hostedWorkspaceSnapshotUserPrefix({ userId: TEST_USER_ID })}snapshot_delete_no_scan_session.snapshot.enc`;
+    const storageList = vi.fn();
+    const { runner, storageValues } = createRunnerHarness({
+      onStorageList: storageList,
+    });
+    storageValues.set(
+      workspaceSnapshotUploadSessionCurrentStorageKey(),
+      createWorkspaceSnapshotUploadSessionForTest({
+        objectKey: currentObjectKey,
+        snapshotId: "snapshot_delete_no_scan_session",
+      }),
+    );
+    const userPrefix = await hostedWorkspaceSnapshotUserPrefix({ userId: TEST_USER_ID });
+    for (let i = 0; i < 1_500; i += 1) {
+      const snapshotId = `snapshot_delete_no_scan_orphan_${i}`;
+      storageValues.set(
+        workspaceSnapshotOrphanCandidateStorageKey(snapshotId),
+        {
+          createdAt: "2026-04-26T00:00:00.000Z",
+          objectKey: `${userPrefix}${snapshotId}.snapshot.enc`,
+          schema: HOSTED_WORKSPACE_SNAPSHOT_ORPHAN_CANDIDATE_SCHEMA,
+          snapshotId,
+          userId: TEST_USER_ID,
+        },
+      );
+    }
+
+    await expect(runner.deleteHostedWorkspaceSnapshotUploadSession({
+      snapshotId: "snapshot_delete_no_scan_session",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({ deleted: true });
+
+    expect(storageValues.get(workspaceSnapshotUploadSessionCurrentStorageKey())).toBeUndefined();
+    expect(storageList).not.toHaveBeenCalled();
+  });
+
   it("cleans replaced workspace snapshots retained on the current upload session", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
@@ -4081,6 +4119,7 @@ function createDurableObjectState(input: {
   sql: TestSqlStorageLike;
 } {
   const alarms: string[] = [];
+  let activeAlarm: number | null = null;
   const sql = createTestSqlStorage();
   const waitUntilPromises: Promise<unknown>[] = [];
   const values = new Map<string, unknown>();
@@ -4090,10 +4129,11 @@ function createDurableObjectState(input: {
       if (input.alarmDeleteError) {
         throw input.alarmDeleteError;
       }
+      activeAlarm = null;
       alarms.push("deleted");
     },
     get: async <T>(key: string): Promise<T | undefined> => values.get(key) as T | undefined,
-    getAlarm: async () => null,
+    getAlarm: async () => activeAlarm,
     list: async <T>(options: { prefix?: string } = {}): Promise<Map<string, T>> => {
       await input.onStorageList?.(options);
       const result = new Map<string, T>();
@@ -4111,6 +4151,7 @@ function createDurableObjectState(input: {
       const date = scheduledTime instanceof Date
         ? scheduledTime
         : new Date(scheduledTime);
+      activeAlarm = date.getTime();
       alarms.push(date.toISOString());
     },
     sql,


### PR DESCRIPTION
## Why
Mountain ReviewGPT found that workspace snapshot completion could delete or retire upload-session state while follow-up cleanup still needed a single safe owner. Follow-up Mountain rounds caught stale-alarm replacement, delete-before-object-cleanup, expired-current-retry object deletion, in-flight expiry deletion, stale-fence retry deletion, and delete-time cleanup scans.

## User-visible goal
Keep hosted workspace snapshot cleanup safe and owner-driven after checkpoint completion, while preserving retryable cleanup ownership for uploaded snapshot objects and never deleting the workspace's current or possibly-in-flight-current snapshot object from stale or expired completion retries.

## Invariants preserved
- Workspace snapshot sessions remain the sole owner of snapshot orphan/session cleanup alarms.
- Runtime-processing code does not regain alarm coordination.
- Upload-session deletion is an exact-key operation and does not scan the orphan-candidate prefix on the completion path.
- A stale one-shot cleanup alarm may remain after upload-session deletion; the alarm owner clears or re-arms it on the next cleanup pass instead of making user-visible completion pay for a growing-state scan.
- `deleteObject: true` retire paths delete the uploaded object first, or durably record an orphan candidate before deleting the upload session.
- Expired completion retries consult the web workspace source of truth before deleting an uploaded object; if the upload is already current, only replaced-snapshot cleanup can proceed.
- Expired completion retries that are not already current retain uploaded-object cleanup for the existing orphan owner instead of deleting inline, so concurrent in-flight checkpoints cannot publish a deleted object.
- Stale active-fence completion retries convert uploaded-object cleanup into the existing orphan-candidate path instead of deleting inline.
- Successful replaced-snapshot deletes do not create durable orphan bookkeeping or stale cleanup alarms; orphan candidates are recorded only when direct deletion fails or checkpoint outcome is ambiguous.

## Deployment skew / compatibility
Cloudflare-only change. Old and new Worker/DO code can coexist during rollout because the durable session/orphan-candidate shapes are unchanged. Existing stale alarms remain harmless; the alarm owner clears or re-arms them on the next cleanup pass, and new upload-session deletion no longer performs a growing candidate scan.

## Verification
- `pnpm --dir . exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts -t "orphan candidates|upload session|no_scan|snapshot cleanup alarm"`
- `pnpm --dir . exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/user-runner-alarm.test.ts`
- `pnpm --dir . exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-outbound.test.ts`
- `pnpm --dir apps/cloudflare typecheck`
- `pnpm --dir apps/cloudflare verify`
- `git diff --check`

Follow-up to #486 Mountain ReviewGPT finding.