### PR TITLE
Keep Junction compact daily vitals enabled

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-09-junction-daily-vitals.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-junction-daily-vitals.md
@@ -1,0 +1,62 @@
+# Junction daily vitals
+
+## Goal
+
+Fix the Junction Apple HealthKit path so product-needed daily SpO2 and
+respiratory-rate facts are not silently dropped going forward.
+
+Success criteria:
+
+- Reproduce the current failure mode with focused tests: a Junction config or
+  import path that keeps summaries but omits compact daily vitals.
+- Preserve the architecture rule that dense timeseries are not stored by
+  default.
+- Ensure `blood_oxygen` and `respiratory_rate` land through the compact daily
+  Junction timeseries path when Junction exposes them.
+- Verify focused device-sync/importer coverage plus typecheck.
+
+## Constraints
+
+- Do not store dense provider sample arrays or real user health payloads in
+  committed fixtures.
+- Keep provider-specific behavior in the Junction provider/importer seams.
+- Preserve existing summary ingestion, source attribution, and optional-resource
+  skip metadata.
+- Do not expose local identifiers, full paths, secrets, provider account ids, or
+  raw health values in committed artifacts or handoff text.
+
+## Approach
+
+1. Inspect current Junction config normalization, timeseries fetch scheduling,
+   and importer daily aggregate mapping.
+2. Add a regression for legacy/explicit `JUNCTION_TIMESERIES_RESOURCES` config
+   that would otherwise drop required daily vitals.
+3. Patch the smallest owner boundary so required compact vitals stay present
+   while dense resources remain opt-in/excluded.
+4. Run focused tests/typecheck and review the diff.
+
+## State
+
+Ready to close.
+
+## Notes
+
+- User-provided Apple Health export contains daily WHOOP-written SpO2 and
+  respiratory-rate records, while the supplied vault raw Junction ingests have
+  no `timeseriesResources`.
+- Current importer already supports compact daily `blood_oxygen` and
+  `respiratory_rate` observations when the Junction snapshot contains those
+  resources.
+- Verification:
+  - `pnpm --dir packages/device-syncd test -- provider-manifests.test.ts junction-provider.test.ts`
+    passed.
+  - `pnpm --dir packages/device-syncd typecheck` passed.
+  - `pnpm --dir packages/device-syncd test:coverage` passed.
+  - `pnpm build:test-runtime:prepared` passed to prepare generated package
+    artifacts in the fresh worktree.
+  - Root `pnpm typecheck` reached green package/app typecheck fanout after
+    prepared artifacts, but the independent workspace-boundary preflight did
+    not exit and was interrupted.
+Status: completed
+Updated: 2026-07-09
+Completed: 2026-07-09

--- a/packages/device-syncd/src/config/junction-config.ts
+++ b/packages/device-syncd/src/config/junction-config.ts
@@ -1,4 +1,7 @@
 import {
+  JUNCTION_DEFAULT_TIMESERIES_RESOURCES,
+} from "@murphai/importers/device-providers/junction-resources";
+import {
   JUNCTION_API_KEY_ENV_KEYS,
   JUNCTION_CLIENT_USER_ID_SECRET_ENV_KEYS,
   JUNCTION_ENV_ENV_KEYS,
@@ -54,7 +57,7 @@ export function readConfiguredJunctionDeviceSyncProviderConfig(
     region: parseJunctionRegion(region),
     providerFilter: parseCsvEnv(env, JUNCTION_PROVIDER_FILTER_ENV_KEYS),
     summaryResources: parseCsvEnv(env, JUNCTION_SUMMARY_RESOURCES_ENV_KEYS),
-    timeseriesResources: parseCsvEnv(env, JUNCTION_TIMESERIES_RESOURCES_ENV_KEYS),
+    timeseriesResources: parseJunctionTimeseriesResourcesEnv(env),
     summaryBackfillDays: parseIntegerEnv(env, JUNCTION_SUMMARY_BACKFILL_DAYS_ENV_KEYS),
     timeseriesBackfillDays: parseIntegerEnv(env, JUNCTION_TIMESERIES_BACKFILL_DAYS_ENV_KEYS),
     reconcileDays: parseIntegerEnv(env, JUNCTION_RECONCILE_DAYS_ENV_KEYS),
@@ -66,6 +69,15 @@ export function readConfiguredJunctionDeviceSyncProviderConfig(
 
   assertValidJunctionClientConfig(config);
   return config;
+}
+
+function parseJunctionTimeseriesResourcesEnv(env: DeviceSyncEnvSource): string[] | undefined {
+  const resources = parseCsvEnv(env, JUNCTION_TIMESERIES_RESOURCES_ENV_KEYS);
+  if (!resources || resources.length === 0) {
+    return resources;
+  }
+
+  return [...new Set([...JUNCTION_DEFAULT_TIMESERIES_RESOURCES, ...resources])];
 }
 
 function parseJunctionEnvironment(value: string): JunctionEnvironment {

--- a/packages/device-syncd/src/config/provider-manifests.ts
+++ b/packages/device-syncd/src/config/provider-manifests.ts
@@ -751,7 +751,12 @@ function normalizeOptionalJunctionResourceList(
     );
   }
 
-  return [...new Set(normalized.filter((entry) => allowedResourceSet.has(entry)))];
+  const enabledResources = normalized.filter((entry) => allowedResourceSet.has(entry));
+  if (value !== undefined && value.length > 0 && enabledResources.length === 0) {
+    return [...new Set(defaults)];
+  }
+
+  return [...new Set(enabledResources)];
 }
 
 function booleanJobField(

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -395,7 +395,7 @@ test("Junction omitted timeseries config defaults to compact resources only", as
   assert.equal(importedSnapshots.length, 1);
 });
 
-test("Junction stale dense timeseries config is accepted and dropped", async () => {
+test("Junction stale dense timeseries config falls back to compact daily defaults", async () => {
   const requests: string[] = [];
   const importedSnapshots: unknown[] = [];
   const provider = createJunctionDeviceSyncProvider({
@@ -416,17 +416,38 @@ test("Junction stale dense timeseries config is accepted and dropped", async () 
             slug: "garmin",
             name: "Garmin",
             status: "connected",
-            resource_availability: {
-              activity: true,
-              steps: true,
-              heartrate: true,
-            },
+            resource_availability: Object.fromEntries([
+              "activity",
+              ...JUNCTION_DEFAULT_TIMESERIES_RESOURCES,
+              "steps",
+              "heartrate",
+            ].map((resource) => [resource, true])),
           }],
         });
       }
 
       if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
         return createJsonResponse({ data: [] });
+      }
+
+      const timeseriesResource = new URL(url).pathname.match(/^\/v2\/timeseries\/junction-user-1\/([^/]+)\/grouped$/u)?.[1];
+      if (timeseriesResource) {
+        assert.ok(
+          (JUNCTION_DEFAULT_TIMESERIES_RESOURCES as readonly string[]).includes(timeseriesResource),
+          `Unexpected default timeseries resource: ${timeseriesResource}`,
+        );
+        return createJsonResponse({
+          groups: {
+            garmin: [{
+              data: [{
+                timestamp: "2026-04-02T12:00:00.000Z",
+                unit: timeseriesResource === "blood_oxygen" ? "%" : "count",
+                value: timeseriesResource === "blood_oxygen" ? 97 : 24,
+              }],
+              source: { provider: "garmin", type: "watch" },
+            }],
+          },
+        });
       }
 
       throw new Error(`Unexpected request: ${url}`);
@@ -444,13 +465,30 @@ test("Junction stale dense timeseries config is accepted and dropped", async () 
         return { imported: true };
       },
     }),
-    createJob("reconcile", {
+    createJob("backfill", {
       windowStart: "2026-04-02T00:00:00.000Z",
       windowEnd: "2026-04-03T00:00:00.000Z",
     }),
   );
 
-  assert.equal(requests.some((url) => url.includes("/v2/timeseries/")), false);
+  const requestedTimeseriesResources = requests
+    .map((url) => new URL(url).pathname.match(/^\/v2\/timeseries\/junction-user-1\/([^/]+)\/grouped$/u)?.[1])
+    .filter((resource): resource is string => Boolean(resource));
+
+  assert.deepEqual(
+    [...new Set(requestedTimeseriesResources)].sort(),
+    [...JUNCTION_DEFAULT_TIMESERIES_RESOURCES].sort(),
+  );
+  assert.equal(
+    requests.every((url) =>
+      !url.includes("heartrate") &&
+      !url.includes("steps") &&
+      !url.includes("distance") &&
+      !url.includes("calories_active") &&
+      !url.includes("weight")
+    ),
+    true,
+  );
   assert.equal(importedSnapshots.length, 1);
 });
 

--- a/packages/device-syncd/test/provider-manifests.test.ts
+++ b/packages/device-syncd/test/provider-manifests.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { JUNCTION_DEFAULT_TIMESERIES_RESOURCES } from "@murphai/importers/device-providers/junction-resources";
 import {
   cloneConfiguredDeviceSyncRuntimeConfig,
   cloneSerializableConfiguredDeviceSyncProviderConfigs,
@@ -27,6 +28,7 @@ import {
   resolveConfiguredDeviceSyncProviderManifest as rootResolveConfiguredDeviceSyncProviderManifest,
 } from "@murphai/device-syncd";
 import { resolveDeviceProviderConnectionDescriptor } from "@murphai/importers/device-providers/provider-descriptors";
+import { normalizeJunctionDeviceSyncRuntimeConfig } from "../src/config/provider-manifests.ts";
 
 describe("deviceSyncProviderManifests", () => {
   it("keeps provider ids, descriptors, and capabilities aligned", () => {
@@ -102,7 +104,17 @@ describe("deviceSyncProviderManifests", () => {
       JUNCTION_TIMESERIES_RESOURCES: "steps,heart_rate",
     });
 
-    expect(configs.junction?.timeseriesResources).toEqual(["steps", "heart_rate"]);
+    const junctionConfig = configs.junction;
+    expect(junctionConfig?.timeseriesResources).toEqual([
+      ...JUNCTION_DEFAULT_TIMESERIES_RESOURCES,
+      "steps",
+      "heart_rate",
+    ]);
+    if (!junctionConfig) {
+      throw new Error("Expected Junction config to be present.");
+    }
+    expect(normalizeJunctionDeviceSyncRuntimeConfig(junctionConfig).timeseriesResources)
+      .toEqual([...JUNCTION_DEFAULT_TIMESERIES_RESOURCES]);
     expect(() => createConfiguredDeviceSyncProvidersFromConfigs(configs)).not.toThrow();
   });
 


### PR DESCRIPTION
## Why this PR exists

Apple Health can expose daily blood oxygen and respiratory rate through Junction timeseries resources, but a stale dense `JUNCTION_TIMESERIES_RESOURCES` override could normalize to no compact timeseries resources. That left imports with summaries only.

## User goal / user-visible behavior

Junction Apple HealthKit imports should continue pulling compact daily aggregate vitals such as `blood_oxygen` and `respiratory_rate` without enabling dense sample streams.

## What changed

- Treat non-empty Junction timeseries env overrides as additive to compact default resources.
- Make runtime normalization fall back to compact defaults when a stale dense-only list filters to no enabled resources.
- Update regression tests to prove dense names are not fetched and compact defaults are still requested.

## Invariants to preserve

- Do not fetch dense Junction resources like `heartrate`, `steps`, `distance`, `calories_active`, or `weight` by default.
- Do not store raw or full timeseries sample arrays in fixtures.
- Keep direct provider config overrides available for focused diagnostics and tests.

## Validation

- `pnpm --dir packages/device-syncd test -- provider-manifests.test.ts junction-provider.test.ts`
- `pnpm --dir packages/device-syncd typecheck`
- `pnpm --dir packages/device-syncd test:coverage`
- `pnpm build:test-runtime:prepared`
- `pnpm typecheck` was attempted after prepared artifacts; package/app typecheck fanout completed, but the independent workspace-boundary preflight did not exit and was interrupted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786161961&installation_id=127572939&pr_number=489&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F489&signature=2c859d7bdc15f7bd1f7c4ddb6ef2136471e393d21212b8d998a86170269ac78f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->