### PR TITLE
Fix hosted system mailbox wake after import-only checkpoint

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-09-retell-system-mailbox-wake.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-retell-system-mailbox-wake.md
@@ -1,0 +1,26 @@
+# Retell System Mailbox Wake
+
+## Goal
+
+Ensure imported hosted system-mailbox notifications, including Retell phone-call results, always schedule an assistant wake when mailbox import progress is checkpointed before the assistant phase can drain the item.
+
+## Constraints
+
+- Keep the fix in the hosted runtime owner boundary.
+- Do not hard-code Retell or phone-call behavior into the generic runtime path.
+- Preserve foreground conversation priority and existing mailbox budget behavior.
+
+## Plan
+
+1. Add system-mailbox wake preservation to import-only/deferred mailbox checkpoint paths.
+2. Add an entrypoint regression covering a system-lane item imported before assistant phase execution.
+3. Run focused hosted-runtime tests and typecheck.
+
+## Verification
+
+- `pnpm --dir packages/assistant-runtime typecheck`
+- `pnpm --dir packages/assistant-runtime test -- test/hosted-runtime-workspace-entrypoint.test.ts -t "schedules a system-mailbox wake"`
+- `bash scripts/workspace-verify.sh test:diff packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts`
+Status: completed
+Updated: 2026-07-09
+Completed: 2026-07-09

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -84,6 +84,7 @@ import type {
   HostedWorkspaceArtifactMaterializer,
 } from "./hosted-runtime/models.ts";
 import type {
+  HostedMailboxImportLoopResult,
   HostedMailboxResolvedImportItem,
 } from "./hosted-runtime/mailbox-import.ts";
 import {
@@ -148,6 +149,7 @@ import {
 } from "./hosted-runtime/context.ts";
 import {
   enqueueHostedSystemMailboxItem,
+  resolveHostedSystemMailboxNextWakeCandidate,
 } from "./hosted-runtime/system-mailbox.ts";
 import {
   collectHostedPendingAssistantInputMediaRetentionProtections,
@@ -1185,16 +1187,30 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       const redactedStatus = buildHostedMailboxImportRedactedStatus(
         initialMailboxImport.importResult,
       );
+      const systemMailboxWake = await resolveDeferredMailboxImportSystemMailboxWake(
+        initialMailboxImport.importResult,
+        restored.vaultRoot,
+      );
       const nextWake = resolveHostedWorkspaceRunNextWake({
         assistantPhaseResult: null,
         committedWorkspace: workspaceRead.workspace,
         mailboxImportRetryAt: initialMailboxImport.importResult.nextRetryAt ?? null,
         nowMs: Date.now(),
       });
-      const returnedNextWake = selectEarliestHostedRuntimeWake([
+      const checkpointNextWake = selectEarliestHostedRuntimeWake([
         {
           at: nextWake.nextWakeAt,
           reason: nextWake.nextWakeReason,
+        },
+        {
+          at: systemMailboxWake.at,
+          reason: systemMailboxWake.reason,
+        },
+      ]);
+      const returnedNextWake = selectEarliestHostedRuntimeWake([
+        {
+          at: checkpointNextWake.nextWakeAt,
+          reason: checkpointNextWake.nextWakeReason,
         },
         {
           at: workspaceRead.workspace?.inboxMediaRetentionWakeAt ?? null,
@@ -1210,8 +1226,8 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       if (initialMailboxImportRequiresCheckpoint || hostedVaultFormatMigrationRequiresCheckpoint) {
         emitPhaseLog({
           details: {
-            nextWakeAtPresent: nextWake.nextWakeAt !== null,
-            nextWakeReasonPresent: nextWake.nextWakeReason !== null,
+            nextWakeAtPresent: checkpointNextWake.nextWakeAt !== null,
+            nextWakeReasonPresent: checkpointNextWake.nextWakeReason !== null,
           },
           input,
           phase: "checkpoint",
@@ -1223,8 +1239,8 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           assertRuntimeNotAborted,
           checkpointRequestBuilder,
           expectedUserId: input.request.userId,
-          nextWakeAt: nextWake.nextWakeAt,
-          nextWakeReason: nextWake.nextWakeReason,
+          nextWakeAt: checkpointNextWake.nextWakeAt,
+          nextWakeReason: checkpointNextWake.nextWakeReason,
           inboxMediaRetentionWakeAt: workspaceRead.workspace?.inboxMediaRetentionWakeAt ?? null,
           issueExportPort: runtime.platform.issueExportPort ?? null,
           redactedStatus,
@@ -2068,9 +2084,9 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         shouldRun(initialMailboxImport: HostedMailboxImportCheckpointResult): boolean;
         signal?: AbortSignal;
       }): Promise<boolean> => {
-        const recordDeferredMailboxImportBeforeYield = (
+        const recordDeferredMailboxImportBeforeYield = async (
           mailboxImport: HostedMailboxImportCheckpointResult,
-        ): void => {
+        ): Promise<void> => {
           if (
             mailboxImport.stateChanged
             || mailboxImport.importResult.importedCount > 0
@@ -2096,6 +2112,23 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               ? "scheduled"
               : invocationStatus;
           }
+          const systemMailboxWake = await resolveDeferredMailboxImportSystemMailboxWake(
+            mailboxImport.importResult,
+            restored.vaultRoot,
+          );
+          pendingWake = selectEarliestHostedRuntimeWake([
+            {
+              at: pendingWake.nextWakeAt,
+              reason: pendingWake.nextWakeReason,
+            },
+            {
+              at: systemMailboxWake.at,
+              reason: systemMailboxWake.reason,
+            },
+          ]);
+          invocationStatus = pendingWake.nextWakeAt !== null
+            ? "scheduled"
+            : invocationStatus;
           if (mailboxImport.checkpointDeferred && mailboxImport.stateChanged) {
             runtimeStateDirty = true;
             markIdleCheckpointTimerAfterDirtyWork();
@@ -2125,7 +2158,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           signal: input.signal ?? runtimeAbortController.signal,
         });
         if (!shouldContinue() || !input.shouldRun(initialMailboxImport)) {
-          recordDeferredMailboxImportBeforeYield(initialMailboxImport);
+          await recordDeferredMailboxImportBeforeYield(initialMailboxImport);
           return false;
         }
         try {
@@ -2138,7 +2171,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           });
         } catch (error) {
           if (!runtimeAbortController.signal.aborted && !shouldContinue()) {
-            recordDeferredMailboxImportBeforeYield(initialMailboxImport);
+            await recordDeferredMailboxImportBeforeYield(initialMailboxImport);
           }
           throw error;
         }
@@ -4059,6 +4092,23 @@ function shouldCheckpointHostedReplayBudgetProgressBeforeForeground(input: {
     && consumedConversationSeq !== null
     && nextConversationSeq > previousConversationSeq
     && nextConversationSeq <= consumedConversationSeq;
+}
+
+async function resolveDeferredMailboxImportSystemMailboxWake(
+  importResult: HostedMailboxImportLoopResult,
+  vaultRoot: string,
+): Promise<{
+  at: string | null;
+  reason: string | null;
+}> {
+  if ((importResult.importedSystemMailboxItemIds?.length ?? 0) === 0) {
+    return {
+      at: null,
+      reason: null,
+    };
+  }
+
+  return await resolveHostedSystemMailboxNextWakeCandidate({ vaultRoot });
 }
 
 function parseHostedMailboxSeqOrNull(value: string | null | undefined): bigint | null {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -207,6 +207,9 @@ import {
 import {
   enqueueHostedSystemMailboxItem,
 } from "../src/hosted-runtime/system-mailbox.ts";
+import {
+  readHostedSystemMailboxState,
+} from "../src/hosted-runtime/system-mailbox-state.ts";
 import type {
   HostedRuntimeDeviceSyncPort,
   HostedRuntimeMailboxPort,
@@ -18356,6 +18359,90 @@ describe("hosted workspace runtime entrypoint", () => {
         },
         status: "budget_exhausted",
       });
+    } finally {
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
+  test("schedules a system-mailbox wake when import checkpoints before assistant phase", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const imported: string[] = [];
+    const systemItem = createMailboxItem({
+      id: "mailbox_item_entrypoint_import_checkpoint_system_wake",
+      kind: "runtime.manual-requested",
+      lane: "system",
+      laneSeq: "1",
+    });
+    const conversationItem = createMailboxItem({
+      id: "mailbox_item_entrypoint_import_checkpoint_deferred_conversation",
+      laneSeq: "1",
+    });
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_import_checkpoint_system_wake",
+            budget: {
+              maxMailboxItems: 1,
+            },
+            leaseGeneration: "7",
+            userId: TEST_USER_ID,
+            workspaceVersion: "0",
+          },
+        }),
+        {
+          async createCheckpointSnapshot(snapshotInput) {
+            events.push(`snapshot:${snapshotInput.reason}`);
+            return {
+              snapshotRef: createBundleRef({
+                hash: "8".repeat(64),
+                key: "users/bundles/member-synthetic/import-checkpoint-system-wake.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem(item) {
+            imported.push(`${item.item.lane}:${item.item.laneSeq}`);
+            if (item.item.lane !== "system") {
+              throw new Error("Conversation item should be budget-deferred before import.");
+            }
+            return await importRuntimeControlSystemMailboxItemForTest({
+              item: item.item,
+              vaultRoot,
+            });
+          },
+          platform: createPlatform({
+            mailboxPort: createMailboxPort({
+              events,
+              items: [systemItem, conversationItem],
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({ version: "0" }),
+            }),
+          }),
+          async runAssistantPhase() {
+            throw new Error("Import-only system wake scheduling should not run assistant phase.");
+          },
+          vaultRoot,
+        },
+      );
+
+      const systemMailbox = await readHostedSystemMailboxState(vaultRoot);
+      assert.deepEqual(imported, ["system:1"]);
+      assert.equal(systemMailbox.pending.length, 1);
+      assert.equal(systemMailbox.pending[0]?.attemptCount, 0);
+      assert.equal(checkpointRequests[0]?.nextWakeAt, TEST_NOW);
+      assert.equal(checkpointRequests[0]?.nextWakeReason, "assistant");
+      assert.equal(result.nextWakeAt, TEST_NOW);
+      assert.equal(result.status, "scheduled");
     } finally {
       vi.useRealTimers();
       await removeTempRoot(vaultRoot);


### PR DESCRIPTION
## Why
Retell phone-call results and other system-lane notifications can be imported into the hosted system mailbox before an assistant phase gets a chance to drain them. In import-only/deferred paths, the runtime checkpointed mailbox progress without carrying the queued system-mailbox wake, leaving the item pending with no dispatch attempt.

## User-visible goal
When a phone call result lands, Murph should schedule the follow-up assistant wake needed to notify the member instead of waiting for another user message or manual inspection.

## Invariants to preserve
- Foreground conversation input still has priority over background/system work.
- Inbox media retention remains owned by its separate wake field, not `workspace.nextWakeAt`.
- The hosted runtime remains generic; no Retell-specific dispatch shortcut is added.

## Verification
- `pnpm --dir packages/assistant-runtime typecheck`
- `pnpm --dir packages/assistant-runtime test -- test/hosted-runtime-workspace-entrypoint.test.ts -t "schedules a system-mailbox wake"`
- `bash scripts/workspace-verify.sh test:diff packages/assistant-runtime/src/hosted-runtime.ts packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786204086&installation_id=127572939&pr_number=491&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F491&signature=4d84182d94cda0116ce9601203c3cbd1d1edc5a24fe9192ddc5bc4d570da1530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->