### PR TITLE
fix(hosted): preserve usage notice markers for rollout

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-09-pr495-reviewgpt-round1.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-pr495-reviewgpt-round1.md
@@ -1,0 +1,45 @@
+# PR 495 ReviewGPT Round 1
+
+## Goal
+
+Collapse usage-limit notice marker ownership so allowance bookkeeping never reads or writes `limitNoticeSentAt`; only the existing claim and exact-release protocol owns it.
+
+## Constraints
+
+- Preserve all behavior and rollout invariants from the phase-one prerequisite.
+- Add no state, schema, helper layer, or compatibility machinery.
+- Keep the change within the allowance owner and focused tests.
+
+## Working Set
+
+- `apps/web/src/lib/hosted-execution/usage-allowance.ts`
+- `apps/web/test/hosted-execution-usage-allowance.test.ts`
+
+## Plan
+
+1. Delete marker reads and pass-through writes from allowance-period normalization and limit changes.
+2. Update focused assertions to prove those updates omit the marker.
+3. Run focused verification and the affected coverage audit.
+4. Close the plan, push, and rerun ReviewGPT against the new PR head.
+
+## Verification
+
+- Focused hosted usage-allowance tests.
+- Hosted-web typecheck and targeted lint.
+- `pnpm test:diff` for the touched owner.
+- `git diff --check` and privacy identifier scan.
+
+## State
+
+Complete. ReviewGPT's single complexity-collapse finding was accepted and implemented.
+
+## Outcomes
+
+- Allowance maintenance no longer selects, compares, threads, or writes the notice marker.
+- The existing atomic claim and exact-timestamp release are the only production marker writers.
+- The obsolete one-property metadata object was reduced to a scalar `blockedAt` resolver.
+- Coverage audit found the existing behavioral assertions sufficient and made no edits; a projection-shape assertion was rejected because it would add coupling without protecting user behavior.
+- Focused tests passed (109 across the allowance owner and send/release path), hosted-web typecheck and targeted lint passed, and diff-aware verification passed (4,026 tests passed, 9 skipped, with dev smoke and production build).
+Status: completed
+Updated: 2026-07-09
+Completed: 2026-07-09

--- a/agent-docs/exec-plans/completed/2026-07-09-usage-notice-marker-handoff.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-usage-notice-marker-handoff.md
@@ -1,0 +1,46 @@
+# Usage Notice Marker Handoff
+
+## Goal
+
+Make the existing per-period usage-limit notice marker monotonic across same-period allowance normalization, limit increases, and later spend accounting so PR 465 can use it as a safe rollout handoff.
+
+## Constraints
+
+- Preserve the existing claimant and sender behavior on `main`, including exact-marker release after a failed send.
+- Add no schema, rollout state, compatibility layer, or new abstraction.
+- Keep the change limited to the allowance owner and focused proof.
+- Deploy and drain this prerequisite before deploying PR 465.
+
+## Working Set
+
+- `apps/web/src/lib/hosted-execution/usage-allowance.ts`
+- `apps/web/test/hosted-execution-usage-allowance.test.ts`
+
+## Plan
+
+1. Preserve `limitNoticeSentAt` during same-period metadata normalization and limit increases.
+2. Stop spend accounting from clearing the marker.
+3. Prove all three paths with focused tests and hosted-web verification.
+4. Run required completion audits, close the plan, and publish a prerequisite PR.
+
+## Verification
+
+- Focused hosted usage-allowance tests.
+- Hosted-web typecheck and targeted lint.
+- `pnpm test:diff` for the touched owner.
+- `git diff --check` and privacy identifier scan.
+
+## State
+
+Complete. The marker remains owned by the existing claim/release path while allowance normalization, limit changes, and spend accounting no longer reopen a notified period.
+
+## Outcomes
+
+- Production behavior changed with two additions and seven deletions; no state, schema, helper, or abstraction was added.
+- Security/privacy review found no medium-or-higher finding and confirmed exact-timestamp failure release remains intact.
+- Coverage review found the existing normalization, limit-increase, spend-SQL, claim, and release assertions sufficient and made no edits.
+- Parent scope/shape and final reviews found no justified simplification beyond the current net-deletion diff.
+- Focused tests, hosted-web typecheck, targeted lint, diff-aware hosted-web verification, production build, diff check, and privacy scan passed.
+Status: completed
+Updated: 2026-07-09
+Completed: 2026-07-09

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -1409,7 +1409,6 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
       billingPlanCode: true,
       blockedAt: true,
       lastUsageAt: true,
-      limitNoticeSentAt: true,
       limitUsdMicros: true,
       periodEnd: true,
       periodStart: true,
@@ -1425,18 +1424,14 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
     current.periodEnd.getTime() === resolved.periodEnd.getTime();
 
   if (periodMatches) {
-    const metadata = buildHostedAiUsageAllowancePeriodMetadata({
+    const blockedAt = resolveHostedAiUsageAllowanceBlockedAt({
       blockedAt: current.blockedAt,
-      limitNoticeSentAt: current.limitNoticeSentAt,
       limitUsdMicros: current.limitUsdMicros,
       now: input.now,
       spentUsdMicros: current.spentUsdMicros,
     });
 
-    if (
-      !sameNullableTime(current.blockedAt, metadata.blockedAt) ||
-      !sameNullableTime(current.limitNoticeSentAt, metadata.limitNoticeSentAt)
-    ) {
+    if (!sameNullableTime(current.blockedAt, blockedAt)) {
       await input.tx.hostedAiUsagePeriod.update({
         where: {
           memberId_periodStart: {
@@ -1445,8 +1440,7 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
           },
         },
         data: {
-          blockedAt: metadata.blockedAt,
-          limitNoticeSentAt: metadata.limitNoticeSentAt,
+          blockedAt,
           updatedAt: input.now,
         },
       });
@@ -1464,9 +1458,8 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
     };
   }
 
-  const metadata = buildHostedAiUsageAllowancePeriodMetadata({
+  const blockedAt = resolveHostedAiUsageAllowanceBlockedAt({
     blockedAt: current.blockedAt,
-    limitNoticeSentAt: current.limitNoticeSentAt,
     limitUsdMicros: resolved.limitUsdMicros,
     now: input.now,
     spentUsdMicros: current.spentUsdMicros,
@@ -1480,9 +1473,8 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
     },
     data: {
       billingPlanCode: resolved.billingPlanCode,
-      blockedAt: metadata.blockedAt,
+      blockedAt,
       limitUsdMicros: resolved.limitUsdMicros,
-      limitNoticeSentAt: metadata.limitNoticeSentAt,
       periodEnd: resolved.periodEnd,
       updatedAt: input.now,
     },
@@ -1867,27 +1859,17 @@ function buildHostedPulseTrialPendingBillingDeniedPeriod(input: {
   };
 }
 
-function buildHostedAiUsageAllowancePeriodMetadata(input: {
+function resolveHostedAiUsageAllowanceBlockedAt(input: {
   blockedAt: Date | null;
-  limitNoticeSentAt: Date | null;
   limitUsdMicros: bigint;
   now: Date;
   spentUsdMicros: bigint;
-}): {
-  blockedAt: Date | null;
-  limitNoticeSentAt: Date | null;
-} {
+}): Date | null {
   if (input.spentUsdMicros < input.limitUsdMicros) {
-    return {
-      blockedAt: null,
-      limitNoticeSentAt: input.limitNoticeSentAt,
-    };
+    return null;
   }
 
-  return {
-    blockedAt: input.blockedAt ?? input.now,
-    limitNoticeSentAt: input.limitNoticeSentAt,
-  };
+  return input.blockedAt ?? input.now;
 }
 
 function sameNullableTime(left: Date | null, right: Date | null): boolean {

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -1464,7 +1464,6 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
     };
   }
 
-  const limitIncreased = current.limitUsdMicros < resolved.limitUsdMicros;
   const metadata = buildHostedAiUsageAllowancePeriodMetadata({
     blockedAt: current.blockedAt,
     limitNoticeSentAt: current.limitNoticeSentAt,
@@ -1483,7 +1482,7 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
       billingPlanCode: resolved.billingPlanCode,
       blockedAt: metadata.blockedAt,
       limitUsdMicros: resolved.limitUsdMicros,
-      limitNoticeSentAt: limitIncreased ? null : metadata.limitNoticeSentAt,
+      limitNoticeSentAt: metadata.limitNoticeSentAt,
       periodEnd: resolved.periodEnd,
       updatedAt: input.now,
     },
@@ -1607,10 +1606,6 @@ async function accountHostedAiUsageAllowancePeriodSpendTx(input: {
     SET
       "spent_usd_micros" = "spent_usd_micros" + ${input.costUsdMicros},
       "last_usage_at" = GREATEST(COALESCE("last_usage_at", ${input.recordOccurredAt}), ${input.recordOccurredAt}),
-      "limit_notice_sent_at" = CASE
-        WHEN "spent_usd_micros" < "limit_usd_micros" THEN NULL
-        ELSE "limit_notice_sent_at"
-      END,
       "blocked_at" = CASE
         WHEN "spent_usd_micros" + ${input.costUsdMicros} >= "limit_usd_micros" THEN
           CASE
@@ -1885,7 +1880,7 @@ function buildHostedAiUsageAllowancePeriodMetadata(input: {
   if (input.spentUsdMicros < input.limitUsdMicros) {
     return {
       blockedAt: null,
-      limitNoticeSentAt: null,
+      limitNoticeSentAt: input.limitNoticeSentAt,
     };
   }
 

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -2047,12 +2047,12 @@ describe("resolveHostedAiUsageGate", () => {
     expect(update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         blockedAt: null,
-        limitNoticeSentAt: priorNoticeSentAt,
         limitUsdMicros: 25_000_000n,
       }),
     }));
     const updateData = (update.mock.calls[0]?.[0] as { data?: Record<string, unknown> } | undefined)
       ?.data;
+    expect(updateData).not.toHaveProperty("limitNoticeSentAt");
     expect(updateData).not.toHaveProperty("spentUsdMicros");
   });
 
@@ -2168,11 +2168,11 @@ describe("resolveHostedAiUsageGate", () => {
     expect(update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         blockedAt: null,
-        limitNoticeSentAt: new Date("2026-04-20T12:01:00.000Z"),
       }),
     }));
     const updateData = (update.mock.calls[0]?.[0] as { data?: Record<string, unknown> } | undefined)
       ?.data;
+    expect(updateData).not.toHaveProperty("limitNoticeSentAt");
     expect(updateData).not.toHaveProperty("lastUsageAt");
     expect(updateData).not.toHaveProperty("spentUsdMicros");
   });

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -1004,7 +1004,7 @@ describe("accountHostedAiUsageForAllowanceTx", () => {
     expect(sqlText).toContain('UPDATE "hosted_ai_usage_period"');
     expect(sqlText).toContain('"spent_usd_micros" = "spent_usd_micros" +');
     expect(sqlText).toContain('"last_usage_at" = GREATEST');
-    expect(sqlText).toContain('"limit_notice_sent_at" = CASE');
+    expect(sqlText).not.toContain('"limit_notice_sent_at"');
     expect(sqlText).toContain('"blocked_at" = CASE');
     expect(sqlText).toContain('OR "blocked_at" IS NULL');
     expect(params).toEqual([
@@ -2012,7 +2012,8 @@ describe("resolveHostedAiUsageGate", () => {
     });
   });
 
-  it("raises the current period limit on upgrade without lowering spend", async () => {
+  it("raises the current period limit without lowering spend or clearing the sent notice", async () => {
+    const priorNoticeSentAt = new Date("2026-03-28T12:00:00.000Z");
     const update = vi.fn(async (args?: unknown) => {
       void args;
       return {
@@ -2025,6 +2026,7 @@ describe("resolveHostedAiUsageGate", () => {
     });
     const prisma = createGatePrisma({
       billingPlanCode: "launch_edge_monthly",
+      limitNoticeSentAt: priorNoticeSentAt,
       limitUsdMicros: 10_000_000n,
       periodEnd: new Date("2026-04-01T00:00:00.000Z"),
       periodStart: new Date("2026-03-01T00:00:00.000Z"),
@@ -2045,7 +2047,7 @@ describe("resolveHostedAiUsageGate", () => {
     expect(update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         blockedAt: null,
-        limitNoticeSentAt: null,
+        limitNoticeSentAt: priorNoticeSentAt,
         limitUsdMicros: 25_000_000n,
       }),
     }));
@@ -2118,7 +2120,7 @@ describe("resolveHostedAiUsageGate", () => {
     expect(updateData).not.toHaveProperty("spentUsdMicros");
   });
 
-  it("clears stale block and notice metadata after a manual period-counter reset", async () => {
+  it("clears stale block metadata without clearing the sent notice marker", async () => {
     const aggregate = vi.fn(async () => ({
       _max: {
         occurredAt: new Date("2026-04-20T12:00:00.000Z"),
@@ -2166,7 +2168,7 @@ describe("resolveHostedAiUsageGate", () => {
     expect(update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         blockedAt: null,
-        limitNoticeSentAt: null,
+        limitNoticeSentAt: new Date("2026-04-20T12:01:00.000Z"),
       }),
     }));
     const updateData = (update.mock.calls[0]?.[0] as { data?: Record<string, unknown> } | undefined)
@@ -2903,6 +2905,7 @@ function createGatePrisma(input: {
     periodStart: Date;
     spentUsdMicros: bigint;
   } | null;
+  limitNoticeSentAt?: Date | null;
   limitUsdMicros?: bigint;
   periodEnd?: Date;
   periodStart?: Date;
@@ -2956,7 +2959,7 @@ function createGatePrisma(input: {
     lastUsageAt: input.spentUsdMicros > 0n
       ? new Date(periodStart.getTime() + 60_000)
       : null,
-    limitNoticeSentAt: null,
+    limitNoticeSentAt: input.limitNoticeSentAt ?? null,
     limitUsdMicros: input.limitUsdMicros ?? 10_000_000n,
     periodEnd,
     periodStart,


### PR DESCRIPTION
## Why this PR exists

PR #465 moves usage-limit notice delivery to a durable owner. The currently deployed allowance code can clear an already-set per-period notice marker during same-period normalization, a limit increase, or later spend accounting, which leaves a duplicate-notice window while old and new web releases overlap.

This phase-one prerequisite makes the existing marker stable before delivery ownership changes.

## User goal / user-visible behavior

Users should receive at most one usage-limit notice per allowance period while a genuinely failed send can still release its exact claim and retry. This prerequisite lets the durable delivery change roll out without reopening already-notified periods.

## What changed

- Remove notice-marker reads and pass-through writes from allowance normalization and in-period plan changes.
- Stop spend accounting from writing or clearing the marker.
- Keep the existing atomic claim as the only setter and exact-timestamp failed-send release as the only clearer.
- Reduce the obsolete one-property metadata object to a scalar `blockedAt` resolver.

No schema, rollout state, feature flag, or new abstraction was added.

## Invariants

- Usage allowance and entitlement decisions remain based on spend versus limit; the notice marker never grants access.
- The existing claimant remains the only path that sets the marker in this release.
- A failed old sender can still clear only its own exact timestamp claim.
- Normalization, limit changes, and spend accounting must not reopen a notice within the same allowance period.
- A new allowance period still starts with a fresh marker.

## Rollout

1. Deploy this PR to the hosted web application.
2. Confirm the production alias points to this release and allow older web requests/functions to drain.
3. Treat this release as the rollback floor.
4. Only then deploy PR #465.

This release remains compatible with the current claimant/sender. Deploying PR #465 before phase one has fully drained would preserve the duplicate-notice window this prerequisite is intended to close.

## Verification

- Focused allowance-owner and send/release tests: 109 passed.
- Hosted-web typecheck and targeted ESLint passed.
- Diff-aware hosted-web verification passed: 4,026 tests passed, 9 skipped; dev smoke, lint, and production build passed.
- Security/privacy audit found no medium-or-higher issue.
- Fresh coverage audit found the existing direct assertions sufficient and made no changes.
- ReviewGPT round 1 found the remaining pass-through ownership; the accepted fix deleted it and reduced the data flow.
- ReviewGPT round 2 verified the final pushed head with no Critical, High, complexity-collapse, or invariant-violation finding.
- `git diff --check` and privacy identifier scan passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786216142&installation_id=127572939&pr_number=495&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F495&signature=58db94731c6c101a68515635b0dd31d53ad1ee1db8d468af5c69fe0b736ca197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

