### PR TITLE
Relax assistant style settings prompt

### DIFF
--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -68,7 +68,6 @@ import type {
 } from '../hosted-tool-context.js'
 import {
   buildAssistantNotificationDecisionSystemPromptWithCacheMetadata,
-  buildAssistantStyleSettingsDynamicPrompt,
   buildAssistantSystemPromptWithCacheMetadata,
   resolveAssistantMurphProductBaseUrl,
   type AssistantPromptCacheMetadata,
@@ -468,14 +467,6 @@ export async function resolveAssistantRouteTurnPlan(input: {
   const hostedDynamicContextPrompts = maintenanceTurn
     ? []
     : input.executionContext?.hosted?.dynamicContextPrompts ?? []
-  const assistantStyleSettingsPrompt =
-    !maintenanceTurn && input.profile.promptProfile === 'conversation'
-      ? buildAssistantStyleSettingsDynamicPrompt(input.input.prompt)
-      : null
-  const assistantDynamicContextPrompts = [
-    ...hostedDynamicContextPrompts,
-    ...(assistantStyleSettingsPrompt ? [assistantStyleSettingsPrompt] : []),
-  ]
   const promptCapabilityAvailability = resolveAssistantPromptCapabilityAvailability({
     executionContext: input.executionContext,
   })
@@ -532,7 +523,7 @@ export async function resolveAssistantRouteTurnPlan(input: {
     input.profile.promptProfile === 'notification-decision'
       ? buildAssistantNotificationDecisionSystemPromptWithCacheMetadata({
             assistantContextSnapshotPrompt,
-            assistantDynamicContextPrompts,
+            assistantDynamicContextPrompts: hostedDynamicContextPrompts,
             maintenanceTurn,
             assistantHostedDeviceConnectAvailable:
               promptCapabilityAvailability.assistantHostedDeviceConnectAvailable,
@@ -549,7 +540,7 @@ export async function resolveAssistantRouteTurnPlan(input: {
       : buildAssistantSystemPromptWithCacheMetadata({
             assistantCliContract: options.assistantCliContract,
             assistantContextSnapshotPrompt,
-            assistantDynamicContextPrompts,
+            assistantDynamicContextPrompts: hostedDynamicContextPrompts,
             assistantHostedDeviceConnectAvailable:
               promptCapabilityAvailability.assistantHostedDeviceConnectAvailable,
             assistantHostedDeviceConnectProviders:

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -122,35 +122,6 @@ function normalizeAssistantDynamicContextPrompts(
     .filter((prompt) => prompt.length > 0);
 }
 
-const ASSISTANT_STYLE_SETTINGS_TARGET_PATTERN =
-  /\b(?:murph|you|your|assistant)\b/iu;
-const ASSISTANT_STYLE_SETTINGS_CHANGE_PATTERN =
-  /\b(?:adjust|be|change|choose|customize|make|pick|prefer|preference|set|speak|switch|talk|text|tweak|update|write)\b/iu;
-const ASSISTANT_STYLE_SETTINGS_STYLE_PATTERN =
-  /\b(?:casual|direct|formal|sound|sounds|speak|speaks|style|talk|talks|texting|tone|voice|warmer|write|writes|writing)\b/iu;
-
-export function buildAssistantStyleSettingsDynamicPrompt(
-  currentUserPrompt: string | null | undefined,
-): string | null {
-  const prompt = currentUserPrompt?.trim() ?? "";
-  if (!prompt) {
-    return null;
-  }
-
-  if (
-    !ASSISTANT_STYLE_SETTINGS_TARGET_PATTERN.test(prompt)
-    || !ASSISTANT_STYLE_SETTINGS_CHANGE_PATTERN.test(prompt)
-    || !ASSISTANT_STYLE_SETTINGS_STYLE_PATTERN.test(prompt)
-  ) {
-    return null;
-  }
-
-  return [
-    "Assistant style settings:",
-    "- The member is asking about changing Murph's voice, tone, or texting style. Casually mention once that they can change it at `/settings?voice=true` if useful. Do not push the setting beyond answering this request.",
-  ].join("\n");
-}
-
 function renderAssistantToolNameAliases(
   prompt: string,
   aliases: Readonly<Record<string, string>> | null | undefined
@@ -265,6 +236,7 @@ function buildStableRouteCapabilityPrompt(
     buildAssistantPhoneCallGuidanceText(),
     buildAssistantConnectedAppsGuidanceText(),
     buildAssistantProductFeedbackGuidanceText(),
+    buildAssistantStyleSettingsGuidanceText(),
     buildAssistantFamilyPlanGuidanceText(),
     buildAssistantHabitatGuidanceText(),
     buildAssistantHostedGroupGuidanceText(),
@@ -354,6 +326,13 @@ function buildAssistantProductFeedbackGuidanceText(): string {
   return [
     "Product feedback:",
     "- When `murph.submit_product_feedback` is available, capture explicit Murph product frustration, feature requests, interest in shipped changelog or feature-catalog items, clear inferred workflow friction, and repeated Murph-observed product or tool friction. Record only the structured kind, a concise product-only summary, and relevant changelog item ids when known, then continue helping. Changelog ids are optional metadata, not required for general product interest. Start inferred summaries with `Speculative:` and assistant-observed summaries with `Murph-observed:`. Do not log vague low-confidence guesses. Never include tags, topics, raw user wording, raw conversation text, health details, identifiers, contact details, secrets, or provider payloads.",
+  ].join("\n");
+}
+
+function buildAssistantStyleSettingsGuidanceText(): string {
+  return [
+    "Assistant style settings:",
+    "- Members can change Murph's voice, tone, or texting style at `/settings?voice=true`. Mention this casually when they ask how to change how Murph sounds or writes; do not push it otherwise.",
   ].join("\n");
 }
 

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -6,7 +6,6 @@ import {
   resolveAssistantModelBehaviorProfile,
 } from '../src/assistant/model-behavior.js'
 import {
-  buildAssistantStyleSettingsDynamicPrompt,
   buildAssistantSystemPrompt,
   buildAssistantSystemPromptLayers,
   buildAssistantSystemPromptWithCacheMetadata,
@@ -148,47 +147,18 @@ describe('assistant execution prompt contract', () => {
     expect(formalLayers.threadContextPrompt).toContain('no slang')
   })
 
-  it('keeps the settings voice deep link out of the default stable prompt', () => {
+  it('keeps the assistant style settings fact in the stable route prompt', () => {
     const layers = buildAssistantSystemPromptLayers(createCommonCodexPromptInput())
 
-    expect(layers.prompt).not.toContain('/settings?voice=true')
-    expect(layers.stableRouteCapabilityPrompt).not.toContain(
+    expect(layers.prompt).toContain('/settings?voice=true')
+    expect(layers.stableRouteCapabilityPrompt).toContain(
       '/settings?voice=true',
+    )
+    expect(layers.stableRouteCapabilityPrompt).toContain(
+      'when they ask how to change how Murph sounds or writes',
     )
     expect(layers.threadContextPrompt).not.toContain('/settings?voice=true')
-  })
-
-  it('mentions the settings voice deep link through dynamic context for current style-change asks', () => {
-    const stylePrompt = buildAssistantStyleSettingsDynamicPrompt(
-      'Can you change your voice?',
-    )
-    if (!stylePrompt) {
-      throw new Error('Expected assistant style settings prompt.')
-    }
-
-    expect(stylePrompt).toContain('/settings?voice=true')
-    expect(
-      buildAssistantStyleSettingsDynamicPrompt('What happened to my HRV?'),
-    ).toBeNull()
-
-    const baseline = buildAssistantSystemPromptWithCacheMetadata(
-      createCommonCodexPromptInput(),
-    )
-    const withStylePrompt = buildAssistantSystemPromptWithCacheMetadata(
-      createCommonCodexPromptInput({
-        assistantDynamicContextPrompts: [stylePrompt],
-      }),
-    )
-
-    expect(withStylePrompt.layers.dynamicTurnContextPrompt).toContain(
-      '/settings?voice=true',
-    )
-    expect(withStylePrompt.layers.stableRouteCapabilityPrompt).not.toContain(
-      '/settings?voice=true',
-    )
-    expect(
-      withStylePrompt.cacheMetadata.stableRouteCapabilityPromptHash,
-    ).toBe(baseline.cacheMetadata.stableRouteCapabilityPromptHash)
+    expect(layers.dynamicTurnContextPrompt).not.toContain('/settings?voice=true')
   })
 
   it('requires pending vault-file approvals to include the returned handoff link and approved sends to avoid stock queue copy', () => {


### PR DESCRIPTION
## Why this PR exists

Murph could fail to recognize ordinary texting shorthand such as a follow-up asking where to change its voice because the capability was hidden behind a strict per-message keyword classifier.

## User goal / user-visible behavior

When a member asks how to change how Murph sounds or writes, Murph knows to mention the existing /settings?voice=true control casually. Murph does not proactively push the setting.

## Invariants

- The settings fact stays in the conversational stable-route prompt only; notification-decision and maintenance prompts remain unchanged.
- Hosted dynamic context is passed through unchanged.
- No brittle message classifier or new runtime state is introduced.

## Verification

- Assistant-engine prompt behavior: 51 tests passed.
- Assistant-engine typecheck passed.
- Full assistant-engine suite in diff verification: 1,992 passed, 4 skipped.
- Dedicated prompt review: zero evidence-backed findings.
- Affected runtime audio and workspace-runner tests pass in isolation (3 and 79 tests). The broad diff verifier is blocked by an unrelated workspace-entrypoint race: batch-full foreground rerun leaves later foreground wake pending also fails when selected alone, in a mocked path that overrides the assistant phase and never invokes the changed prompt-planning code.

## Deployment skew / compatibility

This only changes the hosted runner prompt bundle and is backward compatible with the existing settings UI. No tandem web deploy or immediate container rollout is required; warm runners may retain the old response until normal replacement. After rollout, smoke-test a conversational request to change Murph's voice and confirm Murph points to the settings control without surfacing it in unrelated conversations.