### PR TITLE
chore(review-gpt): use GPT-5.6 Sol

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-09-review-gpt-5-6-sol.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-review-gpt-5-6-sol.md
@@ -1,0 +1,37 @@
+# ReviewGPT GPT-5.6 Sol Rollout
+
+## Goal
+
+Use the released ReviewGPT patch that targets GPT-5.6 Sol, and make that model Murph's explicit ReviewGPT default.
+
+## Constraints
+
+- Preserve the existing ReviewGPT PR workflow and thinking-level configuration.
+- Keep the dependency supply-chain exception exact and limited to the new patch release.
+- Update the manifest, lockfile, config, and release guard together.
+- Do not alter immutable completed plans that mention older ReviewGPT versions or models.
+
+## Plan
+
+1. Publish the verified ReviewGPT patch with the canonical `gpt-5.6-sol` alias.
+2. Update Murph's ReviewGPT dependency, exact release-age exception, and lockfile.
+3. Switch Murph's ReviewGPT model override to `gpt-5.6-sol` and update its release guard.
+4. Run focused checks, dependency checks, the truthful diff-scoped verification lane, and required completion review.
+5. Commit the scoped change, push the task branch, and open a PR.
+
+## Verification
+
+- `bash -n scripts/review-gpt.config.sh`
+- Focused release-script coverage guard test
+- `pnpm deps:guard`
+- `pnpm deps:audit`
+- `pnpm deps:ignored-builds`
+- `pnpm install --frozen-lockfile`
+- `pnpm test:diff` over the touched manifest, lockfile, config, and guard test
+
+## State
+
+Complete. ReviewGPT 0.5.99 is published and Murph now resolves that release with `gpt-5.6-sol` as its explicit default. The focused contract test, dependency guards, frozen install, package build, canonical diff-scoped verification, and required security/privacy and coverage-write audits passed. `pnpm deps:audit` remains blocked only by existing unrelated advisories outside the ReviewGPT dependency path; this lockfile update introduced no transitive dependency changes.
+Status: completed
+Updated: 2026-07-09
+Completed: 2026-07-09

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.99",
+    "@cobuild/review-gpt": "^0.5.100",
     "@murphai/hosted-local-harness": "workspace:*",
     "@murphai/health-metrics": "workspace:*",
     "@types/node": "^25.6.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.98",
+    "@cobuild/review-gpt": "^0.5.99",
     "@murphai/hosted-local-harness": "workspace:*",
     "@murphai/health-metrics": "workspace:*",
     "@types/node": "^25.6.2",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -280,8 +280,8 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.98')
-    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.98')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.99')
+    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.99')
     expect(pnpmWorkspace.match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]?.trim()).toBe(
       'incur@0.4.5: patches/incur@0.4.5.patch',
     )
@@ -291,7 +291,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptConfig).toContain('repo_context_url=""')
     expect(reviewGptConfig).toContain('attach_artifacts=1')
     expect(reviewGptConfig).toContain('app_connector="current"')
-    expect(reviewGptConfig).toContain('model="gpt-5.5-pro"')
+    expect(reviewGptConfig).toContain('model="gpt-5.6-sol"')
     expect(reviewGptConfig).toContain('thinking="current"')
     expect(reviewGptConfig).toContain('snapshot_attachment_name="repo.snapshot.zip"')
     expect(reviewGptConfig).toContain('repomix_attachment_format="zip"')

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -280,8 +280,8 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.99')
-    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.99')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.100')
+    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.100')
     expect(pnpmWorkspace.match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]?.trim()).toBe(
       'incur@0.4.5: patches/incur@0.4.5.patch',
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15
       '@cobuild/review-gpt':
-        specifier: ^0.5.99
-        version: 0.5.99(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
+        specifier: ^0.5.100
+        version: 0.5.100(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
       '@murphai/health-metrics':
         specifier: workspace:*
         version: link:packages/health-metrics
@@ -1289,8 +1289,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.99':
-    resolution: {integrity: sha512-h1zuP1l6rBahjfO31VJ/F9mqnFH8oBaYPfetgKnhTBIy/Tx9TKax+c7ERkpOaWoEziDkPBrlkYUZyGr0m+w4kQ==}
+  '@cobuild/review-gpt@0.5.100':
+    resolution: {integrity: sha512-ZAjr6hkTkaXSCO5N4tl2kZ1fX2SMdoLlo8F4mG35ymyJ2GHb+io7VrVWmYccoWqZeSY6w9ZlMs9HIKZ4cC8sjg==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10443,7 +10443,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15': {}
 
-  '@cobuild/review-gpt@0.5.99(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
+  '@cobuild/review-gpt@0.5.100(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15
       incur: 0.4.5(patch_hash=a4a70545bebf677aebb5ab89bf04d130ba1469d166e0e08e00096f4158f73a2e)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15
       '@cobuild/review-gpt':
-        specifier: ^0.5.98
-        version: 0.5.98(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
+        specifier: ^0.5.99
+        version: 0.5.99(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
       '@murphai/health-metrics':
         specifier: workspace:*
         version: link:packages/health-metrics
@@ -1289,8 +1289,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.98':
-    resolution: {integrity: sha512-sAOf1a/kKXV5v/39A3fKx2QERBjij2v3VeVNgBPZUIBiGX/L+nLJoG7mnpMCW6riSrgY6QEwrm0NjWFQI/suLg==}
+  '@cobuild/review-gpt@0.5.99':
+    resolution: {integrity: sha512-h1zuP1l6rBahjfO31VJ/F9mqnFH8oBaYPfetgKnhTBIy/Tx9TKax+c7ERkpOaWoEziDkPBrlkYUZyGr0m+w4kQ==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10443,7 +10443,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15': {}
 
-  '@cobuild/review-gpt@0.5.98(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
+  '@cobuild/review-gpt@0.5.99(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15
       incur: 0.4.5(patch_hash=a4a70545bebf677aebb5ab89bf04d130ba1469d166e0e08e00096f4158f73a2e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.98'
+  - '@cobuild/review-gpt@0.5.99'
   - '@openai/codex@0.144.0||0.144.0-darwin-arm64||0.144.0-darwin-x64||0.144.0-linux-arm64||0.144.0-linux-x64||0.144.0-win32-arm64||0.144.0-win32-x64'
   - '@temporalio/activity@1.16.3'
   - '@temporalio/client@1.16.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.99'
+  - '@cobuild/review-gpt@0.5.100'
   - '@openai/codex@0.144.0||0.144.0-darwin-arm64||0.144.0-darwin-x64||0.144.0-linux-arm64||0.144.0-linux-x64||0.144.0-win32-arm64||0.144.0-win32-x64'
   - '@temporalio/activity@1.16.3'
   - '@temporalio/client@1.16.3'

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -137,7 +137,7 @@ package_script="scripts/package-audit-context-full.sh"
 # composer to have no app connector selected before auto-send because review
 # context must come from the guarded ZIP and repomix attachments.
 app_connector="current"
-model="gpt-5.5-pro"
+model="gpt-5.6-sol"
 thinking="current"
 snapshot_attachment_name="repo.snapshot.zip"
 repomix_attachment_format="zip"


### PR DESCRIPTION
## Why this PR exists

ReviewGPT 0.5.100 adds selector-aware GPT-5.6 Sol support plus authoritative response-model verification, and Murph needs to consume that release instead of continuing to select GPT-5.5 Pro.

## User goal / user-visible behavior

Murph ReviewGPT workflows select GPT-5.6 Sol by default and can complete waited reviews on that model.

## What changed

- Upgrade the ReviewGPT development dependency and lockfile resolution to 0.5.100.
- Keep the minimum-release-age exception exact to the published patch.
- Change Murph’s explicit ReviewGPT model target to gpt-5.6-sol.
- Update the existing release/config contract test.

## Invariants to preserve

- Keep ReviewGPT thinking selection at current.
- Keep the app connector at current so guarded ZIP and repomix attachments remain the review context.
- Keep send, wait, capture, and PR-review lifecycle behavior unchanged.
- Keep the dependency release-age exception exact to 0.5.100 and the lockfile registry resolution reproducible.

## Verification

- ReviewGPT 0.5.100: typecheck, 157 tests, release checks, trusted publish, and registry integrity passed.
- Murph ReviewGPT dry-run resolved 0.5.100 and selected gpt-5.6-sol.
- Focused ReviewGPT config/version contract test passed.
- pnpm build passed.
- The full canonical pnpm test:diff lane passed on the initial dependency/config head.
- The final 0.5.100 rerun passed scoped typechecks and relevant tests, then encountered an unrelated assistant-runtime timing test; that exact test passed immediately standalone.
- pnpm install --frozen-lockfile passed.
- Dependency guard and ignored-build checks passed.
- Security/privacy and coverage-write completion audits found no issues.

## Known baseline

pnpm deps:audit continues to report existing advisories in unrelated dependency paths; this patch changes no ReviewGPT transitive dependencies.