### PR TITLE
Fix Junction historical sync recovery

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-09-garmin-history-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-garmin-history-recovery.md
@@ -1,0 +1,115 @@
+# Make Junction historical sync recover per resource
+
+Status: completed
+Created: 2026-07-09
+Updated: 2026-07-10
+
+## Goal
+
+- Make Junction-backed historical sync self-heal without vendor support when
+  one resource family (especially Garmin sleep) is still missing after another
+  family (such as activity) has imported successfully.
+
+## Success criteria
+
+- Historical progress cannot be marked complete by an unrelated resource.
+- Missing eligible resources retain a bounded, durable recovery obligation
+  that the existing device-sync scheduler can derive after restart/hydration.
+- Recovery reuses the existing provider job, scheduling, metadata, and
+  idempotent import seams; it adds no service, queue, or second state owner.
+- Existing successful/empty/exhausted retry behavior remains bounded and
+  compatible with previously persisted connection metadata.
+- Focused regression tests reproduce the partial-history failure and prove
+  recovery; package verification, typecheck, direct scenario proof, and all
+  routed completion audits pass.
+
+## Scope
+
+- In scope: Junction historical progress semantics, follow-up derivation,
+  provider-owned metadata, focused device-sync tests, and matching durable
+  documentation when the invariant changes.
+- Out of scope: new provider infrastructure, manual support tooling, account
+  reconnect/deregistration flows, synthetic sleep data, frontend changes, and
+  unrelated webhook-carrier limits without evidence that they caused this
+  incident.
+
+## Constraints
+
+- Technical constraints: preserve push-primary Garmin sleep carriers, the
+  unconditional rolling pull floor, bounded windows/retries, stable job
+  idempotency, source projection ownership, and canonical writes through core.
+- Product/process constraints: default to deletion and simplicity, persist
+  only the minimum versioned provider-owned state, preserve unrelated work,
+  redact identifiers, and finish through the scoped worktree/PR workflow.
+
+## Risks and mitigations
+
+1. Risk: treating legitimately empty optional resources as permanent failures
+   can create an unbounded polling loop.
+   Mitigation: keep the existing bounded retry ladder and make terminal state
+   explicit per tracked obligation.
+2. Risk: changing metadata shape can strand connections created by older code.
+   Mitigation: derive a safe legacy interpretation and test hydration from the
+   currently persisted shape.
+3. Risk: retries can duplicate records or suppress the normal pull floor.
+   Mitigation: reuse stable window dedupe keys and idempotent external resource
+   identities; never move the rolling floor later.
+
+## Tasks
+
+1. Trace current Junction job, metadata, scheduler, and test contracts; write a
+   failing partial-history regression.
+2. Choose the smallest resource-aware progress representation compatible with
+   existing metadata and implement it at the Junction provider boundary.
+3. Prove partial success, empty retry, exhaustion, restart hydration, and
+   ordinary complete-history behavior with focused tests.
+4. Update the durable ingestion/backfill documentation if the contract changes.
+5. Run scoped verification, direct scenario proof, required specialist audits,
+   parent final review, scoped commit, PR review loop, and merge-conflict proof.
+
+## Decisions
+
+- The recovery owner remains `packages/device-syncd`; no vendor-support or
+  operator action is part of the correctness path.
+- A provider cannot create data the upstream account never exposes, but Murph
+  must keep retrying any still-unverified historical obligation within its
+  bounded policy and import asynchronously delivered records whenever they
+  arrive.
+- Completion is derived in memory from fresh `(source provider, resource)`
+  availability and useful records. No per-resource map or second state owner
+  is persisted.
+- One scalar coverage-policy version lazily reopens legacy terminal outcomes;
+  the existing exact-window retry metadata remains the only durable recovery
+  state and the existing ladder remains the only retry owner.
+- An incomplete delayed pass uses Junction's provider-scoped historical-pull
+  endpoint after all timeseries continuations finish. The initial connect pass
+  does not duplicate Junction Link's export request, and trigger failures are
+  logged without identifiers while the bounded ladder still advances.
+- Resource-aware completion applies only to the connect-time historical
+  window. Manual and connection-event backfills retain their established
+  any-useful-record stop condition and do not inherit the connect repair
+  policy.
+
+## Verification
+
+- Commands to run: focused Vitest while iterating; `pnpm test:diff` for every
+  touched owner; direct provider-job scenario; privacy/diff checks; routed
+  security-privacy and coverage-write audits; PR ReviewGPT loop.
+- Expected outcomes: no unrelated resource can satisfy sleep history, retries
+  remain bounded and restart-safe, all selected checks pass, and no sensitive
+  identifier appears in the diff.
+
+## Verification results
+
+- Device-sync typecheck passed.
+- Device-sync coverage passed: 40 files, 727 tests, 88.91% statements and
+  79.35% branches.
+- Focused provider tests proved source/resource isolation, provider
+  allowlisting and deduplication, trigger failure, cancellation, legacy repair,
+  hosted metadata precedence, non-connect behavior, and redacted diagnostics.
+- All 14 affected workspace typechecks passed. The full affected-workspace test
+  gate stopped on an unchanged assistant CLI cold-import timing test at its
+  fixed 30-second limit; the isolated failing test passed on rerun.
+- Security/privacy, coverage-write, and parent simplicity reviews found no
+  remaining medium-or-higher issue.
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-09-garmin-history-review-fixes.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-garmin-history-review-fixes.md
@@ -1,0 +1,93 @@
+# Harden Garmin historical recovery after PR review
+
+Status: completed
+Created: 2026-07-09
+Updated: 2026-07-10
+
+## Goal
+
+- Preserve resource-aware Garmin history recovery while removing the
+  support-gated Junction mutation and making the remaining self-service path
+  safe under mixed runner versions.
+
+## Success criteria
+
+- No default-disabled Junction API is part of the recovery path.
+- Old runners cannot convert current resource-aware progress into trusted
+  account-level completion.
+- Missing Garmin history gets bounded observation retries, then a precise
+  self-service disconnect-and-reconnect signal through existing source-health
+  surfaces; current data ingestion remains active.
+- Authenticated late Garmin history can satisfy the exact missing
+  source/resource obligations even when Junction REST remains stale.
+- Disconnect and historical progress remain monotonic across hosted/local
+  hydration and mixed runner versions.
+- The stale hosted-metadata cap assertion is corrected and CI is green.
+
+## Scope
+
+- Junction historical status encoding, source-health projection, hosted
+  reconnect guidance, focused regressions, matching docs, and PR verification.
+- No new service, queue, retry owner, broad egress handler, automatic provider
+  deregistration, or frontend architecture.
+
+## Decisions
+
+- Delete `bulk_trigger_historical_pull`: Junction documents it as a Link
+  Migration capability disabled by default, and a new hosted mutation would
+  also require a complete Worker-owned credential boundary.
+- Encode the policy version in the existing status scalar. A legacy writer can
+  overwrite it only with a legacy value, which current code reopens safely.
+- Use the existing per-source health record for the exact provider that still
+  lacks history. Keep ingestion active until the member explicitly confirms the
+  existing connection-wide disconnect, whose scope may include other Junction
+  sources, and then reconnects Garmin.
+- Persist authenticated canonical late arrivals in one bounded, versioned,
+  window-scoped source/resource scalar. Union it with fresh REST coverage in
+  the existing exact-window job; do not add a queue, table, or vault read seam.
+- Advance the source ordering timestamp on disconnect so a warm runner cannot
+  publish stale connected/error state over a hosted terminal snapshot.
+- Ignore providers outside the configured Junction filter when evaluating
+  coverage obligations.
+- Treat only advertised activity, sleep, and sleep-cycle families as absence
+  obligations. Junction availability is capability metadata, so sparse
+  workouts and body measurements cannot create false reconnect alarms.
+- Hydrate persisted connection-source rows into the hosted runner before jobs
+  execute. This keeps the control plane as the source of truth and lets an
+  entirely empty provider response retain the member's requested source without
+  adding provider-specific retry metadata.
+- Project exhausted historical recovery as a semantic connection reset in the
+  browser surface. Suppress connect-only reconnect, require the existing
+  account-scoped confirmation, then expose the ordinary Connect action.
+- Persist a semantic warning when provider-side reset fails and tell the member
+  to remove the provider connection manually before reconnecting; local
+  disconnect remains authoritative.
+- Derive the unfinished-reset browser semantic at the server response boundary,
+  so a shared connection shows the same recovery guidance regardless of which
+  sibling source initiated the account-scoped disconnect.
+- Clear a persisted revoke warning in the same transaction that successfully
+  removes the retained provider credential on retry, without emitting another
+  disconnect signal, mailbox item, or wake.
+- Treat an accepted `connectedAt` change as a new connection epoch. Do not merge
+  prior unpublished historical progress or evidence into that epoch, even when
+  UTC day-flooring produces the same historical window.
+
+## Verification
+
+- Device-sync coverage: 40 files, 752 tests; 89.04% statements and 79.70%
+  branches. Device-sync typecheck passed.
+- Assistant-runtime: 70 files, 1,497 passed and 2 skipped. Assistant-runtime
+  typecheck passed.
+- Focused web recovery surface: 4 files, 151 tests. Web typecheck passed.
+- Security/privacy audit found no medium-or-higher issue. Frontend and
+  simplicity reviews found three concrete state/copy edge cases; all are fixed
+  with focused regressions and the final reviews report no remaining material
+  findings.
+- Diff/privacy checks passed, including absence of incident identifiers, local
+  paths and identities, personal contact data, credentials, and the unsupported
+  Junction client mutation.
+- The affected-workspace gate passed: 14 dependent package typechecks and
+  tests, the hosted-local package boundary, the full web verification (4,046
+  tests), and the Cloudflare verification (1,679 tests).
+- PR ReviewGPT and final CI remain after the scoped commit/rebase/push.
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-10-pr516-reviewgpt-fixes.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr516-reviewgpt-fixes.md
@@ -1,0 +1,69 @@
+# Close PR 516 ReviewGPT findings
+
+Status: completed
+Created: 2026-07-10
+Updated: 2026-07-10
+
+## Goal
+
+- Preserve Garmin historical recovery as one monotonic account/source decision
+  across mixed runner versions, source hydration, stale writes, future protocol
+  versions, and concurrent disconnect/reconnect epochs.
+
+## Success criteria
+
+- Legacy or stale runners cannot replace current/future historical progress or
+  clear a required source reset.
+- Hosted hydration produces one semantic Junction source per provider identity.
+- Account progress and its source recovery marker advance together or not at
+  all when source compare-and-swap state is stale.
+- Direct webhooks import canonical events without overwriting opaque
+  future-version evidence.
+- A stale disconnect cannot revoke or clear a newer connection/token epoch.
+- Focused production-boundary regressions, package tests, typechecks, final
+  audits, ReviewGPT, and PR CI pass on the final head.
+
+## Scope
+
+- Existing hosted device-sync authority, Junction source identity/progress,
+  disconnect fencing, and focused tests/docs only.
+- No new durable store, queue, resolver service, retry owner, or compatibility
+  manager.
+
+## Decisions
+
+- Reproduce each ReviewGPT claim before fixing it and reject speculative
+  compatibility machinery when the mixed-version state is unreachable.
+- Keep coupled recovery truth at an existing owner boundary and prefer
+  rejecting a stale transition over adding repair loops.
+- Preserve opaque future protocol values byte-for-byte.
+- Fence disconnect against the existing connection and credential epochs;
+  serialize existing-row reconnect writes through the existing mutation lock.
+- Carry the seeded row's existing `updatedAt` receipt in one-time connection
+  state, reject missing/stale receipts before provider completion, and enforce
+  the same receipt again inside the existing upsert transaction.
+- Keep setup cleanup terminal: both stores return disconnected rows unchanged,
+  even if a timestamp collision would otherwise satisfy the epoch check.
+
+## Verification
+
+- Device sync: typecheck passed; 40 test files and 755 tests passed.
+- Assistant runtime: typecheck passed; 70 test files and 1,503 tests passed,
+  with 2 existing skips.
+- Hosted web: typecheck and scoped ESLint passed; 374 test files and 4,122
+  tests passed, with 1 file and 9 existing skips. The final focused Prisma
+  boundary run passed 33 tests.
+- Security/privacy re-audit found zero evidence-backed medium-or-higher
+  findings after the connection/source/setup epoch fixes and terminal-state
+  parity guard.
+- Required coverage-write audit found no proof gap and made no edits. Its exact
+  diff-aware gate passed: device sync 755 tests, assistant runtime 1,503 tests
+  with 2 skips, web 4,123 tests with 9 skips, Cloudflare 1,687 tests, all
+  affected typechecks and guards, package boundaries, lint, dev smoke, and the
+  production web build.
+- Direct proof covers future status without legacy windows, canonical late
+  webhook import without future metadata mutation, source/reset coupling,
+  accepted and rejected reconnect epochs, atomic disconnect snapshots, stale
+  setup cleanup, and seeded callback/upsert revision checks.
+- Final ReviewGPT and final-head PR CI are pending.
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-10-pr516-reviewgpt-round3-fixes.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr516-reviewgpt-round3-fixes.md
@@ -1,0 +1,82 @@
+# Harden connection-epoch guards after PR review
+
+Status: completed
+Created: 2026-07-10
+Updated: 2026-07-10
+
+## Goal
+
+- Preserve Garmin historical recovery while making seeded callbacks and
+  disconnect warnings consistent with the existing immutable connection epoch.
+
+## Success criteria
+
+- Authenticated early webhooks cannot invalidate a legitimate seeded callback.
+- Seeded callbacks remain compatible with already-issued OAuth state and reject
+  a genuinely replaced connection epoch.
+- Provider-revoke failures classify historical-reset guidance from the same
+  locked snapshot that finalizes the disconnect.
+- A late connection-established hook cannot recreate connected source, signal,
+  or wake state after disconnect or replacement of the connection epoch.
+- No new table, queue, service, lifecycle manager, or persisted state is added.
+- Focused regressions, affected-workspace verification, completion audits, PR
+  ReviewGPT, and final CI pass.
+
+## Scope
+
+- Seeded setup epoch guards, setup cleanup guards, disconnect warning
+  classification, focused tests, and any directly matching durable contract
+  wording.
+- No provider-side revocation protocol, synthetic historical data, new
+  background work, or unrelated device-connect behavior.
+
+## Decisions
+
+- Use `connectedAt`, the existing immutable connection epoch, instead of the
+  mutable row revision for seeded callback and cleanup ownership.
+- Derive the seeded epoch from the OAuth state creation time already written in
+  the same seed operation; delete the redundant state metadata revision.
+- Carry only the sanitized provider failure across remote revocation. Derive
+  reset-specific guidance inside the existing final mutation lock and
+  transaction from fresh account and source state.
+- Reuse the same mutation lock and immutable epoch for connection-established
+  source, signal, and mailbox persistence; skip stale hook work.
+- Accept the pre-existing provider-side revoke/reconnect race as a provider API
+  limitation; do not add a durable revocation state machine without provider
+  epoch support or concrete product evidence.
+
+## Tasks
+
+1. Reproduce both review signals and confirm hosted/SQLite parity.
+2. Replace mutable revision guards with the existing connection epoch and add
+   compatibility/race regressions.
+3. Move revoke-warning classification and connection-established persistence
+   into their matching existing mutation locks.
+4. Run focused checks, all routed audits, affected-workspace verification,
+   scoped commit/push, ReviewGPT, and final PR checks.
+
+## Verification
+
+- Focused device-sync and web tests plus their package typechecks.
+- Full affected-workspace `pnpm test:diff` gate.
+- Security/privacy, coverage-write, state-consistency, and simplicity audits.
+- Diff/privacy scan, ReviewGPT against the final pushed head, and final CI.
+
+## Verification results
+
+- Focused device-sync tests: 95 passed.
+- Focused web Prisma/wake tests: 89 passed.
+- Device-sync coverage suite: 771 passed; 89.1% statements and 79.8%
+  branches.
+- Full affected-workspace gate passed, including all 14 affected package
+  typechecks, dependency and boundary guards, web lint/dev smoke/production
+  build, 4,237 web tests, and 1,690 Cloudflare tests.
+- Coverage-write audit found no unresolved gaps.
+- Security/privacy audit found no actionable critical, high, or medium issues;
+  the added-line privacy scan was clean.
+- State-consistency review found and resolved a late connection-established
+  hook race by reusing the existing connection mutation lock and epoch guard.
+- Simplicity review confirmed the correction adds no persisted state or new
+  lifecycle abstraction.
+- `git diff --check` passed.
+Completed: 2026-07-10

--- a/agent-docs/operations/device-sync-ingestion-invariants.md
+++ b/agent-docs/operations/device-sync-ingestion-invariants.md
@@ -1,6 +1,6 @@
 # Device Sync Ingestion Invariants
 
-Last verified: 2026-06-10
+Last verified: 2026-07-09
 
 ## Purpose
 
@@ -12,7 +12,7 @@ quietly completed without importing or fetching anything.
 
 The ingestion model is now additive: push and pull are complementary, neither
 gates the other, and no branch can complete without import-or-fetch. Treat the
-five invariants below as constraints that any change to webhook construction,
+six invariants below as constraints that any change to webhook construction,
 resource-job execution, or scheduled reconcile must preserve.
 
 These are durable behavioral invariants. The current owning code lives in
@@ -64,6 +64,19 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
    (more imports, more visible skips); it must never make it quieter (a new
    silent skip, a deferred floor, a gated import).
 
+6. **Historical completion is source/resource coverage, not account-level
+   traffic.** A useful activity record cannot complete an advertised sleep
+   obligation, and one connected source cannot satisfy another source's
+   obligation. Junction connect-window backfills derive the current
+   `(source provider, resource)` obligations from fresh availability, persist
+   only a scalar coverage-policy version plus the existing bounded retry
+   progress, and lazily reevaluate terminal results written by older policy.
+   After the initial export has had one pass, an incomplete pass may request
+   one provider-level historical export per pending Junction Link source. It
+   does so only after all job continuations finish, and a trigger failure still
+   advances the existing bounded ladder. `exhausted` ends polling; it never
+   blocks a late push-primary webhook from importing.
+
 ## Consequences for changes
 
 - Do not reintroduce a usefulness/import-vs-skip gate on the webhook path. The
@@ -79,6 +92,10 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
 - Per-resource webhook recovery must coalesce on the shared dirty-state key
   (one floor wake per clean→dirty transition), not emit a unique-window job per
   webhook, so bursts do not fight storm-coalescing.
+- Do not replace historical coverage with a single `has any records` flag, a
+  per-resource job fan-out, or another retry store. The exact-window job,
+  scalar connection metadata, and provider-owned bounded ladder are the one
+  recovery path.
 
 ## Related docs
 

--- a/agent-docs/operations/device-sync-ingestion-invariants.md
+++ b/agent-docs/operations/device-sync-ingestion-invariants.md
@@ -67,15 +67,38 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
 6. **Historical completion is source/resource coverage, not account-level
    traffic.** A useful activity record cannot complete an advertised sleep
    obligation, and one connected source cannot satisfy another source's
-   obligation. Junction connect-window backfills derive the current
-   `(source provider, resource)` obligations from fresh availability, persist
-   only a scalar coverage-policy version plus the existing bounded retry
-   progress, and lazily reevaluate terminal results written by older policy.
-   After the initial export has had one pass, an incomplete pass may request
-   one provider-level historical export per pending Junction Link source. It
-   does so only after all job continuations finish, and a trigger failure still
-   advances the existing bounded ladder. `exhausted` ends polling; it never
-   blocks a late push-primary webhook from importing.
+   obligation. Junction connect-window backfills derive high-signal daily
+   `(source provider, resource)` obligations for activity, sleep, and
+   `sleep_cycle` from fresh availability. Availability is capability evidence,
+   not proof that sparse resources such as workouts or body measurements should
+   contain a row, so those resources do not become absence obligations. The
+   coverage-policy version is encoded in the existing status scalar, alongside
+   the existing bounded retry progress; there is no separate policy metadata
+   field or second retry store. Garmin sends requested history asynchronously
+   and incrementally through daily-data webhooks, so the bounded ladder observes
+   for that arrival and late webhooks remain importable after `exhausted` ends
+   polling. After an authenticated old-window webhook produces canonical events,
+   one bounded, window-scoped scalar records exactly that source/resource proof.
+   The existing deduplicated coverage verification unions the proof with fresh
+   REST rows; complete late coverage clears the source error even when Garmin's
+   REST sleep response remains empty. If Garmin coverage is still incomplete,
+   only the pending source is marked reconnect-required while current ingestion
+   remains active. Hosted
+   execution hydrates the control plane's persisted connection-source rows
+   before running provider jobs, so an entirely empty provider response can
+   still be attributed to the source the member connected. Restarting the
+   export is an explicit member choice through the existing settings flow:
+   confirm the connection-wide disconnect, then reconnect Garmin. That reset
+   can disconnect other wearables on the same Junction connection, so the UI and
+   assistant must explain the scope before confirmation. If provider-side
+   deregistration fails, local disconnect still completes, but the member must
+   remove the connection in the wearable provider account before reconnecting.
+   That unfinished-reset state rides the disconnected connection's existing
+   durable error code (`HISTORICAL_RESET_REVOKE_FAILED`), so the settings and
+   connect surfaces keep projecting the manual-removal guidance across refresh
+   until a fresh established connection clears it; there is no separate warning
+   store. Recovery does not use an automatic export endpoint, operator action,
+   or vendor support.
 
 ## Consequences for changes
 

--- a/agent-docs/operations/device-sync-ingestion-invariants.md
+++ b/agent-docs/operations/device-sync-ingestion-invariants.md
@@ -1,6 +1,6 @@
 # Device Sync Ingestion Invariants
 
-Last verified: 2026-07-09
+Last verified: 2026-07-10
 
 ## Purpose
 
@@ -97,8 +97,25 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
    durable error code (`HISTORICAL_RESET_REVOKE_FAILED`), so the settings and
    connect surfaces keep projecting the manual-removal guidance across refresh
    until a fresh established connection clears it; there is no separate warning
-   store. Recovery does not use an automatic export endpoint, operator action,
-   or vendor support.
+   store. At the hosted authority boundary, coverage metadata and the source
+   reset signal are one coupled decision: legacy runners cannot replace
+   current/future progress, reset-required is valid exactly while progress is
+   `exhausted`, and a stale participating source rejects the account transition
+   for retry from a fresh snapshot. Junction source-only writes carry the same
+   connection-epoch fence as account writes. Hydration resolves Junction
+   sources by semantic provider identity and lets an accepted reconnect epoch
+   replace older local source state, so hosted/local keys or timestamps cannot
+   create competing source owners. Future ownership comes from the versioned
+   status scalar rather than today's window fields; opaque future progress and
+   evidence remain unchanged while canonical webhook import continues.
+   Disconnect captures its connection and credential epoch atomically, then
+   rechecks `connectedAt` and OAuth `tokenVersion` under the existing mutation
+   lock. Setup-failure cleanup similarly compare-and-sets the captured
+   `updatedAt` epoch. Seeded connection flows carry that same revision in their
+   one-time state and recheck it inside the existing upsert transaction, so an
+   old callback cannot adopt, replace, or fail a newer reconnect. Stale work
+   therefore cannot clear a newer local connection or token. Recovery does not
+   use an automatic export endpoint, operator action, or vendor support.
 
 ## Consequences for changes
 

--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -45,7 +45,7 @@ import type {
 } from "./connect-page-types";
 
 interface HostedDeviceSyncDisconnectResponse {
-  warning?: { code: string; message: string };
+  warning?: { historicalResetIncomplete?: boolean; message: string };
 }
 
 export type { ConnectCallbackInput, InitialDeviceConnectIntent } from "./connect-page-types";
@@ -276,7 +276,7 @@ export function ConnectSourcesGrid({
         kind: result.warning?.message ? "warning" : "success",
         title: "Source disconnected",
         message: result.warning?.message
-          ? `${resolveDisconnectSuccessMessage(source)} The provider did not fully confirm, so check that account if you want access removed there too.`
+          ? `${resolveDisconnectSuccessMessage(source)} ${resolveDisconnectWarningDetail(result.warning)}`
           : resolveDisconnectSuccessMessage(source),
       });
     } catch (error) {
@@ -418,4 +418,12 @@ function resolveDisconnectFailureMessage(source: ConnectSource): string {
   return source.disconnectScope === "junction_account"
     ? "We could not disconnect this connection right now."
     : `We could not disconnect ${source.name} right now.`;
+}
+
+// Keyed off the response semantic, not the clicked card: a shared connection can be
+// disconnected from a healthy sibling card while the historical reset lives elsewhere.
+function resolveDisconnectWarningDetail(warning: { historicalResetIncomplete?: boolean }): string {
+  return warning.historicalResetIncomplete
+    ? "The historical reset did not finish. Remove the old connection in your wearable provider account before reconnecting here."
+    : "The provider did not fully confirm, so check that account if you want access removed there too.";
 }

--- a/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
@@ -94,6 +94,7 @@ export function markLocallyDisconnectedSources(
       connectProvider,
       disconnectConnectionId,
       disconnectScope,
+      recoveryKind,
       requiresReconnect,
       ...locallyDisconnectedSource
     } = source;
@@ -101,6 +102,7 @@ export function markLocallyDisconnectedSources(
     void connectProvider;
     void disconnectConnectionId;
     void disconnectScope;
+    void recoveryKind;
     void requiresReconnect;
 
     return {
@@ -254,7 +256,13 @@ export function resolveConnectIntentStartSource(
   sources: readonly ConnectSource[],
 ): ConnectSource | null {
   const source = findInitialConnectIntentSource(intent, sources);
-  if (!source || (source.connected && !source.requiresReconnect)) {
+  // A connection-reset source must not auto-start a plain connect: the existing
+  // connection has to be disconnected first.
+  if (
+    !source
+    || (source.connected && !source.requiresReconnect)
+    || source.recoveryKind === "connection_reset"
+  ) {
     return null;
   }
 

--- a/apps/web/app/(dashboard)/connect/connect-page-types.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-types.ts
@@ -12,9 +12,11 @@ export type ConnectSource = {
   description: string;
   disconnectConnectionId?: string;
   disconnectScope?: "junction_account";
+  historicalResetIncomplete?: boolean;
   id: string;
   logo: LogoAsset;
   name: string;
+  recoveryKind?: "connection_reset";
   requiresReconnect?: boolean;
   unavailableActionLabel?: string;
   unavailableMessage?: string;

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -25,12 +25,17 @@ export function SourceCard({
   const isAvailable = Boolean(source.connectTarget);
   const canStart = authenticated && isAvailable;
   const canDisconnect = authenticated && Boolean(source.disconnectConnectionId);
+  const requiresConnectionReset = source.recoveryKind === "connection_reset";
+  const historicalResetIncomplete = source.historicalResetIncomplete === true
+    && !source.connected
+    && !requiresConnectionReset
+    && !source.requiresReconnect;
   const actionLabel = source.requiresReconnect ? "Reconnect" : "Connect";
   const disconnectAriaLabel = resolveDisconnectAriaLabel(source);
   const reconnectUnavailable = source.requiresReconnect && !isAvailable;
   const showReconnectStateDisconnect = canDisconnect
-    && (reconnectUnavailable || source.disconnectScope === "junction_account");
-  const unavailableMessage = !source.requiresReconnect && !isAvailable
+    && (reconnectUnavailable || requiresConnectionReset || source.disconnectScope === "junction_account");
+  const unavailableMessage = !source.requiresReconnect && !requiresConnectionReset && !isAvailable
     ? source.unavailableMessage
     : undefined;
 
@@ -39,6 +44,8 @@ export function SourceCard({
       <div className="absolute top-3 right-3 sm:top-4 sm:right-4">
         <SourceStatusDot
           connected={source.connected}
+          historicalResetIncomplete={historicalResetIncomplete}
+          requiresConnectionReset={requiresConnectionReset}
           requiresReconnect={source.requiresReconnect}
           sourceName={source.name}
         />
@@ -48,7 +55,15 @@ export function SourceCard({
         <SourceLogo source={source} />
       </div>
 
-      <div className="flex flex-1 items-center gap-4 sm:flex-col sm:items-stretch sm:gap-0">
+      {/* The reset messages are too wide to share the base-breakpoint row with the
+          source details, so those cards stack vertically on phone widths. */}
+      <div
+        className={
+          requiresConnectionReset || historicalResetIncomplete
+            ? "flex flex-1 flex-col items-stretch gap-3 sm:gap-0"
+            : "flex flex-1 items-center gap-4 sm:flex-col sm:items-stretch sm:gap-0"
+        }
+      >
         <div className="min-w-0 flex-1 sm:mb-5 sm:flex-none">
           <h2 className="font-serif text-lg font-semibold text-foreground">
             {source.name}
@@ -79,11 +94,19 @@ export function SourceCard({
           </div>
         ) : (
           <div className="flex shrink-0 flex-col items-start gap-2 sm:mt-auto sm:shrink">
-            {source.requiresReconnect ? (
+            {requiresConnectionReset ? (
+              <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
+                {`${source.name} needs a fresh connection. Disconnect it first, then connect it again.`}
+              </p>
+            ) : source.requiresReconnect ? (
               <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
                 {reconnectUnavailable
                   ? `${source.name} needs attention from the connected app before Murph can keep syncing it.`
                   : `Please reconnect ${source.name} to resume syncing.`}
+              </p>
+            ) : historicalResetIncomplete ? (
+              <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
+                {`The last reset for ${source.name} did not finish. Remove the old connection in your wearable provider account, then connect it again here.`}
               </p>
             ) : null}
             {unavailableMessage ? (
@@ -103,7 +126,7 @@ export function SourceCard({
               >
                 {source.unavailableActionLabel}
               </Button>
-            ) : reconnectUnavailable || unavailableMessage ? null : (
+            ) : reconnectUnavailable || requiresConnectionReset || unavailableMessage ? null : (
               <Button
                 type="button"
                 disabled={!canStart || pending}
@@ -146,14 +169,19 @@ function resolveDisconnectAriaLabel(source: ConnectSource): string {
 
 function SourceStatusDot({
   connected = false,
+  historicalResetIncomplete = false,
+  requiresConnectionReset = false,
   requiresReconnect = false,
   sourceName,
 }: {
   connected?: boolean;
+  historicalResetIncomplete?: boolean;
+  requiresConnectionReset?: boolean;
   requiresReconnect?: boolean;
   sourceName: string;
 }) {
-  const state = requiresReconnect ? "needs-access" : connected ? "connected" : "idle";
+  const needsAttention = requiresReconnect || requiresConnectionReset || historicalResetIncomplete;
+  const state = needsAttention ? "needs-access" : connected ? "connected" : "idle";
 
   return (
     <>
@@ -161,7 +189,7 @@ function SourceStatusDot({
         aria-hidden="true"
         data-connection-state={state}
         className={
-          requiresReconnect
+          needsAttention
             ? "block size-2.5 rounded-full bg-amber-500 shadow-[0_0_0_3px_rgba(245,158,11,0.18)]"
             : connected
             ? "block size-2.5 rounded-full bg-emerald-500 shadow-[0_0_0_3px_rgba(16,185,129,0.14)]"
@@ -169,7 +197,15 @@ function SourceStatusDot({
         }
       />
       <span className="sr-only">
-        {sourceName} {requiresReconnect ? "needs reconnect" : connected ? "connected" : "not connected"}
+        {sourceName} {requiresConnectionReset
+          ? "needs a fresh connection"
+          : requiresReconnect
+          ? "needs reconnect"
+          : historicalResetIncomplete
+          ? "needs its old connection removed"
+          : connected
+          ? "connected"
+          : "not connected"}
       </span>
     </>
   );

--- a/apps/web/app/(dashboard)/connect/connect-source-order.ts
+++ b/apps/web/app/(dashboard)/connect/connect-source-order.ts
@@ -1,6 +1,8 @@
 type OrderedConnectSource = {
   connected?: boolean;
+  historicalResetIncomplete?: boolean;
   id: string;
+  recoveryKind?: "connection_reset";
   requiresReconnect?: boolean;
 };
 
@@ -52,8 +54,12 @@ export function sortConnectSourcesByConnectionState<TSource extends OrderedConne
     .sort((left, right) => {
       const leftConnected = Boolean(left.source.connected);
       const rightConnected = Boolean(right.source.connected);
-      const leftRequiresReconnect = Boolean(left.source.requiresReconnect);
-      const rightRequiresReconnect = Boolean(right.source.requiresReconnect);
+      const leftRequiresReconnect = Boolean(
+        left.source.requiresReconnect || left.source.recoveryKind || left.source.historicalResetIncomplete,
+      );
+      const rightRequiresReconnect = Boolean(
+        right.source.requiresReconnect || right.source.recoveryKind || right.source.historicalResetIncomplete,
+      );
 
       if (leftRequiresReconnect !== rightRequiresReconnect) {
         return leftRequiresReconnect ? -1 : 1;

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -35,7 +35,12 @@ type ConnectPageSearchParams = Record<string, string | string[] | undefined>;
 type ConnectSourceUi = Omit<ConnectSource, "id">;
 type ConnectSettingsSourceMatch = Pick<
   HostedDeviceSyncSettingsSource,
-  "connectSourceId" | "connectTarget" | "provider" | "state" | "upstreamSources"
+  | "connectSourceId"
+  | "connectTarget"
+  | "historicalResetIncomplete"
+  | "provider"
+  | "state"
+  | "upstreamSources"
 > & {
   connectionId?: string | null;
   primaryAction?: HostedDeviceSyncSettingsSource["primaryAction"];
@@ -45,10 +50,12 @@ type ConnectSourceConnectionState = {
   connectProvider: string | null;
   connectTarget: string | null;
   disconnectScope?: ConnectSourceDisconnectScope;
+  recoveryKind?: ConnectSourceRecoveryKind;
   requiresReconnect: boolean;
   sourceId: string;
   state: "active" | "reauthorization_required";
 };
+type ConnectSourceRecoveryKind = NonNullable<ConnectSource["recoveryKind"]>;
 type ConnectSourceDisconnectScope = NonNullable<ConnectSource["disconnectScope"]>;
 
 const DISPLAY_ONLY_CONNECT_SOURCE_IDS = new Set<string>(["apple-health"]);
@@ -233,11 +240,13 @@ export default async function ConnectPage({
   const resolvedSearchParams = searchParams ? await searchParams : {};
   const auth = await getHostedDashboardPageAuthSnapshot();
   const connectedSourceIds = new Set<string>();
+  const recoveryKindBySourceId = new Map<string, ConnectSourceRecoveryKind>();
   const reconnectSourceIds = new Set<string>();
   const reconnectProviderBySourceId = new Map<string, string>();
   const reconnectTargetBySourceId = new Map<string, string>();
   const disconnectConnectionIdBySourceId = new Map<string, string>();
   const disconnectScopeBySourceId = new Map<string, ConnectSourceDisconnectScope>();
+  let historicalResetIncompleteSourceIds = new Set<string>();
   let initialLoadError: ConnectPageInitialLoadError | null = null;
   const recoveryContactAction = await resolveDeviceConnectRecoveryContactAction(
     Boolean(auth.authenticatedMember),
@@ -250,7 +259,9 @@ export default async function ConnectPage({
       });
       for (const connection of resolveConnectSourceConnectionStates(CONNECT_SOURCES, response.sources)) {
         const sourceId = connection.sourceId;
-        if (connection.requiresReconnect) {
+        if (connection.recoveryKind) {
+          recoveryKindBySourceId.set(sourceId, connection.recoveryKind);
+        } else if (connection.requiresReconnect) {
           reconnectSourceIds.add(sourceId);
         } else if (connection.state === "active") {
           connectedSourceIds.add(sourceId);
@@ -270,6 +281,8 @@ export default async function ConnectPage({
           }
         }
       }
+      historicalResetIncompleteSourceIds =
+        resolveHistoricalResetIncompleteConnectSourceIds(CONNECT_SOURCES, response.sources);
     } catch (error) {
       initialLoadError = isHostedOnboardingError(error)
         ? {
@@ -285,9 +298,11 @@ export default async function ConnectPage({
     connectedSourceIds,
     disconnectConnectionIdBySourceId,
     disconnectScopeBySourceId,
+    historicalResetIncompleteSourceIds,
     reconnectProviderBySourceId,
     reconnectSourceIds,
     reconnectTargetBySourceId,
+    recoveryKindBySourceId,
   });
 
   return (
@@ -358,9 +373,11 @@ export function resolveConfiguredConnectSources(
     connectedSourceIds?: ReadonlySet<string>;
     disconnectConnectionIdBySourceId?: ReadonlyMap<string, string>;
     disconnectScopeBySourceId?: ReadonlyMap<string, ConnectSourceDisconnectScope>;
+    historicalResetIncompleteSourceIds?: ReadonlySet<string>;
     reconnectProviderBySourceId?: ReadonlyMap<string, string>;
     reconnectSourceIds?: ReadonlySet<string>;
     reconnectTargetBySourceId?: ReadonlyMap<string, string>;
+    recoveryKindBySourceId?: ReadonlyMap<string, ConnectSourceRecoveryKind>;
   } = {},
 ): ConnectSource[] {
   const connectTargetBySourceId = new Map(
@@ -373,7 +390,11 @@ export function resolveConfiguredConnectSources(
     sources.map((source) => {
       const connectTarget = connectTargetBySourceId.get(source.id);
       const connected = options.connectedSourceIds?.has(source.id) === true;
-      const requiresReconnect = !connected && options.reconnectSourceIds?.has(source.id) === true;
+      const recoveryKind = !connected ? options.recoveryKindBySourceId?.get(source.id) : undefined;
+      const requiresReconnect = !connected && !recoveryKind
+        && options.reconnectSourceIds?.has(source.id) === true;
+      const historicalResetIncomplete = !connected && !recoveryKind && !requiresReconnect
+        && options.historicalResetIncompleteSourceIds?.has(source.id) === true;
       const disconnectConnectionId = options.disconnectConnectionIdBySourceId?.get(source.id);
       const disconnectScope = options.disconnectScopeBySourceId?.get(source.id);
       const reconnectProvider = options.reconnectProviderBySourceId?.get(source.id);
@@ -386,6 +407,8 @@ export function resolveConfiguredConnectSources(
         ...(resolvedConnectTarget ? { connectTarget: resolvedConnectTarget } : {}),
         ...(disconnectConnectionId ? { disconnectConnectionId } : {}),
         ...(disconnectScope ? { disconnectScope } : {}),
+        ...(historicalResetIncomplete ? { historicalResetIncomplete } : {}),
+        ...(recoveryKind ? { recoveryKind } : {}),
         ...(requiresReconnect ? { requiresReconnect } : {}),
         ...(connected ? { connected } : {}),
       };
@@ -400,6 +423,55 @@ export function resolveConnectSourceConnectionStates(
   return resolveConnectSourceConnectionMatches(sources, settingsSources, {
     includeReauthorizationRequired: true,
   });
+}
+
+// A disconnected connection can still carry the persisted unfinished-reset warning.
+// Map it to the visible connect sources it covered so the connect page can keep
+// showing the manual provider-removal guidance next to the ordinary Connect action.
+export function resolveHistoricalResetIncompleteConnectSourceIds(
+  sources: readonly Pick<ConnectSource, "id">[],
+  settingsSources: readonly ConnectSettingsSourceMatch[],
+): Set<string> {
+  const visibleSourceIds = new Set(sources.map((source) => source.id));
+  const sourceIdByDirectProvider = new Map<string, string>();
+  for (const source of sources) {
+    const directProvider = normalizeDeviceSyncConnectTargetKey(source.id);
+    if (directProvider) {
+      sourceIdByDirectProvider.set(directProvider, source.id);
+    }
+  }
+  const resetIncompleteSourceIds = new Set<string>();
+
+  for (const source of settingsSources) {
+    if (source.state !== "disconnected" || source.historicalResetIncomplete !== true) {
+      continue;
+    }
+
+    const provider = normalizeDeviceSyncConnectTargetKey(source.provider);
+    const configuredSourceId = normalizeDeviceConnectSourceId(source.connectSourceId ?? null);
+    if (configuredSourceId && visibleSourceIds.has(configuredSourceId)) {
+      resetIncompleteSourceIds.add(configuredSourceId);
+    }
+    const directSourceId = provider ? sourceIdByDirectProvider.get(provider) : null;
+    if (directSourceId) {
+      resetIncompleteSourceIds.add(directSourceId);
+    }
+    if (provider !== "junction") {
+      continue;
+    }
+
+    for (const upstreamSource of source.upstreamSources) {
+      const sourceProviderSlug = normalizeDeviceSyncConnectTargetKey(upstreamSource.sourceProviderSlug);
+      const sourceId = sourceProviderSlug
+        ? resolveDeviceConnectSourceIdForJunctionProviderSlug(sourceProviderSlug)
+        : null;
+      if (sourceId && visibleSourceIds.has(sourceId)) {
+        resetIncompleteSourceIds.add(sourceId);
+      }
+    }
+  }
+
+  return resetIncompleteSourceIds;
 }
 
 export function resolveConnectedConnectSourceIds(
@@ -506,14 +578,19 @@ function resolveConnectSourceConnectionMatches(
         continue;
       }
 
+      const upstreamNeedsConnectionReset = upstreamSource.recoveryKind === "connection_reset";
       const upstreamOwnRequiresReconnect = upstreamSource.requiresReconnect === true;
       const upstreamInheritsSourceReconnect =
         sourceRequiresReconnect
         && unambiguousJunctionReconnectUpstreamCount === 1
         && isLiveJunctionUpstreamSource(upstreamSource);
-      const upstreamRequiresReconnect = parentRequiresReconnect
+      // A connection reset never offers reconnect: the existing connection has to be
+      // disconnected before a fresh connect can restart the historical export.
+      const upstreamRequiresReconnect = !upstreamNeedsConnectionReset && (
+        parentRequiresReconnect
         || upstreamOwnRequiresReconnect
-        || upstreamInheritsSourceReconnect;
+        || upstreamInheritsSourceReconnect
+      );
       const upstreamConnectProvider = upstreamSource.connectProvider
         ? normalizeDeviceSyncConnectTargetKey(upstreamSource.connectProvider)
         : provider;
@@ -526,6 +603,7 @@ function resolveConnectSourceConnectionMatches(
         sourceState === "active"
         && upstreamSource.status !== "connected"
         && !upstreamRequiresReconnect
+        && !upstreamNeedsConnectionReset
       ) {
         continue;
       }
@@ -539,7 +617,12 @@ function resolveConnectSourceConnectionMatches(
           connectionId: disconnect.connectionId,
           connectProvider: upstreamRequiresReconnect ? upstreamConnectProvider : provider,
           connectTarget: upstreamRequiresReconnect ? upstreamConnectTarget : null,
-          ...(disconnect.scope ? { disconnectScope: disconnect.scope } : {}),
+          // Resetting always disconnects the whole shared Junction connection, so keep
+          // the disconnect account-scoped even when this is its only source.
+          ...(disconnect.scope || (upstreamNeedsConnectionReset && disconnect.connectionId)
+            ? { disconnectScope: "junction_account" as const }
+            : {}),
+          ...(upstreamNeedsConnectionReset ? { recoveryKind: "connection_reset" as const } : {}),
           requiresReconnect: upstreamRequiresReconnect,
           sourceId,
           state: sourceState,
@@ -618,7 +701,7 @@ function compareConnectSourceStatePriority(
 }
 
 function connectSourceStatePriority(connection: ConnectSourceConnectionState): number {
-  if (connection.state === "active" && connection.requiresReconnect) {
+  if (connection.state === "active" && (connection.requiresReconnect || connection.recoveryKind)) {
     return 5;
   }
 

--- a/apps/web/src/lib/device-sync/browser-connection-source.ts
+++ b/apps/web/src/lib/device-sync/browser-connection-source.ts
@@ -1,9 +1,14 @@
+import { requiresHistoricalResetDeviceSyncSource } from "@murphai/device-syncd/public-account";
+
 import type { HostedDeviceConnectionSource } from "./prisma-store/sources";
+
+export type HostedBrowserDeviceSyncConnectionSourceRecoveryKind = "connection_reset";
 
 export interface HostedBrowserDeviceSyncConnectionSource {
   connectionId: string;
   firstSeenAt: string;
   lastSeenAt: string;
+  recoveryKind?: HostedBrowserDeviceSyncConnectionSourceRecoveryKind;
   requiresReconnect?: boolean;
   resourceCount: number;
   sourceProviderSlug: string;
@@ -14,10 +19,13 @@ export function toHostedBrowserDeviceSyncConnectionSource(
   source: HostedDeviceConnectionSource,
   browserConnectionId: string,
 ): HostedBrowserDeviceSyncConnectionSource {
+  const recoveryKind = resolveConnectionSourceRecoveryKind(source);
+
   return {
     connectionId: browserConnectionId,
     firstSeenAt: source.firstSeenAt,
     lastSeenAt: source.lastSeenAt,
+    ...(recoveryKind ? { recoveryKind } : {}),
     ...(requiresConnectionSourceReconnect(source) ? { requiresReconnect: true } : {}),
     resourceCount: countSourceResources(source.resourceAvailabilitySummary),
     sourceProviderSlug: source.sourceProviderSlug,
@@ -60,4 +68,13 @@ function requiresConnectionSourceReconnect(source: HostedDeviceConnectionSource)
   return source.status === "error"
     && source.lastErrorCode !== null
     && CONNECTION_SOURCE_RECONNECT_ERROR_CODES.has(source.lastErrorCode);
+}
+
+// Historical exports cannot restart on a reconnect alone: the provider requires the
+// existing connection to be deregistered first, so project the semantic recovery
+// kind instead of the raw error code or an ordinary reconnect flag.
+export function resolveConnectionSourceRecoveryKind(
+  source: HostedDeviceConnectionSource,
+): HostedBrowserDeviceSyncConnectionSourceRecoveryKind | null {
+  return requiresHistoricalResetDeviceSyncSource(source) ? "connection_reset" : null;
 }

--- a/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
+++ b/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
@@ -1,10 +1,17 @@
-import { sanitizeStoredDeviceSyncMetadata } from "@murphai/device-syncd/public-account";
+import {
+  requiresHistoricalResetDeviceSyncSource,
+  sanitizeStoredDeviceSyncMetadata,
+} from "@murphai/device-syncd/public-account";
 import type { PublicDeviceSyncAccount } from "@murphai/device-syncd/types";
 import {
+  canCurrentRuntimeMutateJunctionHistoricalBackfillProgress,
+  JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
+  mergeHostedDeviceSyncConnectionMetadata,
   parseHostedExecutionDeviceSyncRuntimeApplyRequest,
   parseHostedExecutionDeviceSyncDirtyAckRequest,
   parseHostedExecutionDeviceSyncDirtyPendingRequest,
   parseHostedExecutionDeviceSyncRuntimeSnapshotRequest,
+  readJunctionHistoricalBackfillProgress,
   sanitizeHostedRuntimeDiagnosticText,
   sanitizeHostedExecutionDeviceSyncRuntimeCredentialMetadata,
   type HostedExecutionDeviceSyncRuntimeApplyEntry,
@@ -220,9 +227,16 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
             includeCredentialMaterial: true,
           },
         );
+        const historicalMetadataResolution = resolveHostedRuntimeHistoricalMetadata({
+          baselineMetadata: baseline.connection.metadata,
+          candidateMetadata: update.connection?.metadata,
+          provider: record.provider,
+        });
         const sourceUpdates = resolveHostedRuntimeSourceUpdatesToApply({
           connectionId: record.id,
           currentSources: sources,
+          historicalMetadata: historicalMetadataResolution?.metadata
+            ?? baseline.connection.metadata,
           provider: record.provider,
           updates: update.sources ?? [],
         });
@@ -230,10 +244,19 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
         const credentialMutationRequested = update.credential !== undefined;
         const sourceMutationRequested = sourceUpdates.toApply.length > 0;
         const sourceVersionMismatch =
-          (update.sources?.length ?? 0) > 0 && sourceUpdates.staleCount > 0 && !sourceMutationRequested;
+          (update.sources?.length ?? 0) > 0 && sourceUpdates.staleCount > 0;
+        const historicalResetStateMismatch = isHostedRuntimeHistoricalResetStateInconsistent({
+          currentSources: sources,
+          historicalMetadata: historicalMetadataResolution?.metadata
+            ?? baseline.connection.metadata,
+          provider: record.provider,
+          sourceUpdates: sourceUpdates.toApply,
+        });
         const connectionWriteRequested =
           stateMutationRequested || credentialMutationRequested || sourceMutationRequested;
-        const connectionVersionMismatch = stateMutationRequested
+        const junctionSourceMutationRequested = record.provider.trim().toLowerCase() === "junction"
+          && (update.sources?.length ?? 0) > 0;
+        const connectionVersionMismatch = (stateMutationRequested || junctionSourceMutationRequested)
           && (baseline.connection.updatedAt ?? null) !== update.observedUpdatedAt;
         const baselineTokenVersion = getHostedRuntimeOAuthTokenBundle(baseline.credential)?.tokenVersion ?? null;
         const tokenVersionMismatch = hostedRuntimeCredentialMutationRequiresTokenFence(update)
@@ -241,7 +264,12 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
         const tokenRefreshLeaseConflict = hostedRuntimeCredentialMutationRequiresTokenFence(update)
           && hasHostedRuntimeRefreshLeaseForTokenVersion(record, baselineTokenVersion);
         const versionMismatch =
-          connectionVersionMismatch || tokenVersionMismatch || tokenRefreshLeaseConflict;
+          connectionVersionMismatch
+          || tokenVersionMismatch
+          || tokenRefreshLeaseConflict
+          || (stateMutationRequested && sourceVersionMismatch)
+          || historicalMetadataResolution?.rejected === true
+          || historicalResetStateMismatch;
         const credentialUpdate = update.credential === undefined
           ? undefined
           : resolveHostedRuntimeCredentialUpdate(update.credential);
@@ -267,7 +295,8 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
             nextAccount.displayName = update.connection.displayName ?? null;
           }
           if (Object.prototype.hasOwnProperty.call(update.connection, "metadata")) {
-            nextAccount.metadata = sanitizeStoredDeviceSyncMetadata(update.connection.metadata ?? {});
+            nextAccount.metadata = historicalMetadataResolution?.metadata
+              ?? sanitizeStoredDeviceSyncMetadata(update.connection.metadata ?? {});
           }
           if (Object.prototype.hasOwnProperty.call(update.connection, "scopes")) {
             nextAccount.scopes = [...(update.connection.scopes ?? [])];
@@ -305,7 +334,7 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
         }
 
         let tokenUpdate: HostedExecutionDeviceSyncRuntimeApplyEntry["tokenUpdate"];
-        if (versionMismatch) {
+        if (versionMismatch && update.credential !== undefined) {
           tokenUpdate = "skipped_version_mismatch";
         } else if (update.credential !== undefined) {
           if (!credentialUpdate) {
@@ -660,9 +689,94 @@ function toHostedRuntimeConnectionSourceSnapshot(
   };
 }
 
+function resolveHostedRuntimeHistoricalMetadata(input: {
+  baselineMetadata: Record<string, unknown>;
+  candidateMetadata: Record<string, unknown> | undefined;
+  provider: string;
+}): { metadata: Record<string, unknown>; rejected: boolean } | null {
+  if (input.candidateMetadata === undefined) {
+    return null;
+  }
+
+  const candidateMetadata = sanitizeStoredDeviceSyncMetadata(input.candidateMetadata);
+  if (input.provider.trim().toLowerCase() !== "junction") {
+    return { metadata: candidateMetadata, rejected: false };
+  }
+
+  const baselineMetadata = sanitizeStoredDeviceSyncMetadata(input.baselineMetadata);
+  const baselineProgressMutable = canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(
+    baselineMetadata,
+  );
+  const resolvedMetadata = baselineProgressMutable
+    ? mergeHostedDeviceSyncConnectionMetadata({
+        hostedMetadata: baselineMetadata,
+        localConnectionStateUnpublished: true,
+        localMetadata: candidateMetadata,
+      }).metadata
+    : baselineMetadata;
+  const metadata: Record<string, unknown> = { ...candidateMetadata };
+  let rejected = false;
+
+  for (const key of Object.values(JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS)) {
+    const candidateHasKey = Object.prototype.hasOwnProperty.call(candidateMetadata, key);
+    const resolvedHasKey = Object.prototype.hasOwnProperty.call(resolvedMetadata, key);
+    if (
+      candidateHasKey !== resolvedHasKey
+      || (candidateHasKey && !Object.is(candidateMetadata[key], resolvedMetadata[key]))
+    ) {
+      if (
+        !baselineProgressMutable
+        || key !== JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence
+      ) {
+        rejected = true;
+      }
+    }
+
+    if (resolvedHasKey) {
+      metadata[key] = resolvedMetadata[key];
+    } else {
+      delete metadata[key];
+    }
+  }
+
+  return { metadata, rejected };
+}
+
+function isHostedRuntimeHistoricalResetStateInconsistent(input: {
+  currentSources: readonly HostedDeviceConnectionSource[];
+  historicalMetadata: Record<string, unknown>;
+  provider: string;
+  sourceUpdates: readonly HostedExecutionDeviceSyncRuntimeConnectionSourceUpdate[];
+}): boolean {
+  if (input.provider.trim().toLowerCase() !== "junction") {
+    return false;
+  }
+
+  if (!canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(input.historicalMetadata)) {
+    return false;
+  }
+
+  const sourcesByProvider = new Map<
+    string,
+    HostedDeviceConnectionSource | HostedExecutionDeviceSyncRuntimeConnectionSourceUpdate
+  >();
+  for (const source of input.currentSources) {
+    sourcesByProvider.set(source.sourceProviderSlug.trim().toLowerCase(), source);
+  }
+  for (const source of input.sourceUpdates) {
+    sourcesByProvider.set(source.sourceProviderSlug.trim().toLowerCase(), source);
+  }
+
+  const resetRequired = readJunctionHistoricalBackfillProgress(input.historicalMetadata)?.status
+    === "exhausted";
+  const resetPresent = [...sourcesByProvider.values()].some(requiresHistoricalResetDeviceSyncSource);
+  return resetRequired !== resetPresent;
+}
+
 function resolveHostedRuntimeSourceUpdatesToApply(input: {
   connectionId: string;
   currentSources: readonly HostedDeviceConnectionSource[];
+  historicalMetadata: Record<string, unknown>;
   provider: string;
   updates: readonly HostedExecutionDeviceSyncRuntimeConnectionSourceUpdate[];
 }): {
@@ -674,15 +788,35 @@ function resolveHostedRuntimeSourceUpdatesToApply(input: {
   );
   const toApply: HostedExecutionDeviceSyncRuntimeConnectionSourceUpdate[] = [];
   let staleCount = 0;
+  const historicalProgressMutable =
+    canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(input.historicalMetadata);
+  const historicalResetRequired = historicalProgressMutable
+    && readJunctionHistoricalBackfillProgress(input.historicalMetadata)?.status === "exhausted";
 
   for (const rawUpdate of input.updates) {
-    const { sourceInstanceKeyCanonicalized, update } = normalizeHostedRuntimeSourceUpdateForProvider({
+    const normalized = normalizeHostedRuntimeSourceUpdateForProvider({
       connectionId: input.connectionId,
       provider: input.provider,
       update: rawUpdate,
     });
+    const sourceInstanceKeyCanonicalized = normalized.sourceInstanceKeyCanonicalized;
+    let update = normalized.update;
     const current = currentByInstanceKey.get(update.sourceInstanceKey) ?? null;
     const currentLastSeenAt = current?.lastSeenAt ?? null;
+
+    if (
+      (historicalResetRequired || !historicalProgressMutable)
+      && current
+      && requiresHistoricalResetDeviceSyncSource(current)
+      && !requiresHistoricalResetDeviceSyncSource(update)
+    ) {
+      update = {
+        ...update,
+        lastErrorCode: current.lastErrorCode,
+        lastErrorMessage: current.lastErrorMessage,
+        status: "error",
+      };
+    }
 
     if (sourceInstanceKeyCanonicalized) {
       if (current && isHostedRuntimeTimestampOlder(update.lastSeenAt, currentLastSeenAt)) {

--- a/apps/web/src/lib/device-sync/prisma-store.ts
+++ b/apps/web/src/lib/device-sync/prisma-store.ts
@@ -6,6 +6,7 @@ import type {
   DeviceSyncPublicIngressStore,
   DeviceSyncWebhookTraceClaimResult,
   MarkPublicDeviceSyncConnectionSetupFailedInput,
+  MarkPublicDeviceSyncConnectionSetupFailedResult,
   OAuthStateRecord,
   PublicDeviceSyncAccount,
   UpsertPublicDeviceSyncConnectionInput,
@@ -154,7 +155,7 @@ export class PrismaDeviceSyncControlPlaneStore
 
   async markConnectionSetupFailed(
     input: MarkPublicDeviceSyncConnectionSetupFailedInput,
-  ): Promise<PublicDeviceSyncAccount | null> {
+  ): Promise<MarkPublicDeviceSyncConnectionSetupFailedResult> {
     return this.connections.markConnectionSetupFailed(input);
   }
 

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -147,7 +147,7 @@ export class PrismaHostedConnectionStore {
     const setupWrite = buildHostedConnectionSetupWrite(input, connectedAt, "create");
 
     const result = await this.prisma.$transaction(async (tx) => {
-      const existing = await tx.deviceConnection.findUnique({
+      let existing = await tx.deviceConnection.findUnique({
         where: {
           provider_providerAccountBlindIndex: {
             provider: input.provider,
@@ -156,6 +156,19 @@ export class PrismaHostedConnectionStore {
         },
         ...hostedConnectionRecordArgs,
       });
+
+      if (existing) {
+        await tx.$executeRaw`select pg_advisory_xact_lock(hashtext(${existing.id}))`;
+        existing = await tx.deviceConnection.findUnique({
+          where: {
+            provider_providerAccountBlindIndex: {
+              provider: input.provider,
+              providerAccountBlindIndex,
+            },
+          },
+          ...hostedConnectionRecordArgs,
+        });
+      }
 
       if (existing) {
         assertHostedUpsertExistingConnectionGuard(existing, input.existingAccountGuard ?? null);
@@ -380,6 +393,7 @@ export class PrismaHostedConnectionStore {
     input: MarkPublicDeviceSyncConnectionSetupFailedInput,
   ): Promise<PublicDeviceSyncAccount | null> {
     const record = await this.prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`select pg_advisory_xact_lock(hashtext(${input.accountId}))`;
       const existing = await tx.deviceConnection.findUnique({
         where: {
           id: input.accountId,
@@ -389,6 +403,13 @@ export class PrismaHostedConnectionStore {
 
       if (!existing) {
         return null;
+      }
+      if (
+        input.expectedUpdatedAt === null
+        || existing.updatedAt.toISOString() !== input.expectedUpdatedAt
+        || existing.status === "disconnected"
+      ) {
+        return existing;
       }
 
       return tx.deviceConnection.update({
@@ -1045,6 +1066,15 @@ function assertHostedUpsertExistingConnectionGuard(
     throw deviceSyncError({
       code: "CONNECTION_ALREADY_DISCONNECTED",
       message: "Device sync connection callback was received after the seeded account was disconnected.",
+      retryable: false,
+      httpStatus: 409,
+    });
+  }
+
+  if (existing.updatedAt.toISOString() !== guard.expectedUpdatedAt) {
+    throw deviceSyncError({
+      code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
+      message: "Device sync connection changed after this connection flow started.",
       retryable: false,
       httpStatus: 409,
     });

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -6,6 +6,7 @@ import {
 } from "@murphai/device-syncd/public-account";
 import {
   type MarkPublicDeviceSyncConnectionSetupFailedInput,
+  type MarkPublicDeviceSyncConnectionSetupFailedResult,
   type ProviderAuthTokens,
   type PublicDeviceSyncAccount,
   type UpsertPublicDeviceSyncConnectionInput,
@@ -391,8 +392,8 @@ export class PrismaHostedConnectionStore {
 
   async markConnectionSetupFailed(
     input: MarkPublicDeviceSyncConnectionSetupFailedInput,
-  ): Promise<PublicDeviceSyncAccount | null> {
-    const record = await this.prisma.$transaction(async (tx) => {
+  ): Promise<MarkPublicDeviceSyncConnectionSetupFailedResult> {
+    const result = await this.prisma.$transaction(async (tx) => {
       await tx.$executeRaw`select pg_advisory_xact_lock(hashtext(${input.accountId}))`;
       const existing = await tx.deviceConnection.findUnique({
         where: {
@@ -402,17 +403,17 @@ export class PrismaHostedConnectionStore {
       });
 
       if (!existing) {
-        return null;
+        return { applied: false, record: null };
       }
       if (
-        input.expectedUpdatedAt === null
-        || existing.updatedAt.toISOString() !== input.expectedUpdatedAt
+        input.expectedConnectedAt === null
+        || existing.connectedAt.toISOString() !== input.expectedConnectedAt
         || existing.status === "disconnected"
       ) {
-        return existing;
+        return { applied: false, record: existing };
       }
 
-      return tx.deviceConnection.update({
+      const record = await tx.deviceConnection.update({
         where: {
           id: input.accountId,
         },
@@ -435,9 +436,13 @@ export class PrismaHostedConnectionStore {
         },
         ...hostedConnectionRecordArgs,
       });
+      return { applied: true, record };
     });
 
-    return record ? await this.buildDurableConnectionRecord(record) : null;
+    return {
+      account: result.record ? await this.buildDurableConnectionRecord(result.record) : null,
+      applied: result.applied,
+    };
   }
 
   async syncDurableConnectionState(
@@ -1071,7 +1076,7 @@ function assertHostedUpsertExistingConnectionGuard(
     });
   }
 
-  if (existing.updatedAt.toISOString() !== guard.expectedUpdatedAt) {
+  if (existing.connectedAt.toISOString() !== guard.expectedConnectedAt) {
     throw deviceSyncError({
       code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
       message: "Device sync connection changed after this connection flow started.",

--- a/apps/web/src/lib/device-sync/prisma-store/sources.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/sources.ts
@@ -184,6 +184,7 @@ export class PrismaHostedConnectionSourceStore {
       data: {
         lastErrorCode: null,
         lastErrorMessage: null,
+        lastSeenAt: updatedAt,
         status: "disconnected",
         updatedAt,
       },

--- a/apps/web/src/lib/device-sync/public-ingress-service.ts
+++ b/apps/web/src/lib/device-sync/public-ingress-service.ts
@@ -4,6 +4,9 @@ import {
 } from "@murphai/device-syncd/public-ingress";
 import { deviceSyncError } from "@murphai/device-syncd/errors";
 import {
+  DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE,
+} from "@murphai/device-syncd/public-account";
+import {
   DEFAULT_DEVICE_SYNC_HTTP_BODY_LIMIT_BYTES,
   DEVICE_SYNC_WEBHOOK_TRACE_COMPLETED,
   type BeginConnectionResult,
@@ -237,7 +240,7 @@ export class HostedDeviceSyncPublicIngressService {
 
   async disconnectConnection(userId: string, connectionId: string): Promise<{
     connection: HostedBrowserDeviceSyncConnection;
-    warning?: { code: string; message: string };
+    warning?: { code: string; historicalResetIncomplete?: true; message: string };
   }> {
     const connection = await this.requireOwnedBrowserConnection(userId, connectionId);
     const disconnected = await disconnectHostedDeviceSyncConnection({
@@ -248,8 +251,19 @@ export class HostedDeviceSyncPublicIngressService {
     });
 
     return {
-      ...disconnected,
       connection: this.toBrowserConnection(disconnected.connection),
+      // The browser chooses the manual-removal-before-reconnect guidance from this
+      // semantic flag instead of matching internal warning codes.
+      ...(disconnected.warning
+        ? {
+            warning: {
+              ...disconnected.warning,
+              ...(disconnected.warning.code === DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE
+                ? { historicalResetIncomplete: true as const }
+                : {}),
+            },
+          }
+        : {}),
     };
   }
 

--- a/apps/web/src/lib/device-sync/settings-surface.ts
+++ b/apps/web/src/lib/device-sync/settings-surface.ts
@@ -2,6 +2,7 @@ import type { PublicProviderDescriptor } from "@murphai/device-syncd/types";
 import type { ConfiguredDeviceSyncProviderKey } from "@murphai/device-syncd/connect-config";
 
 import { formatDeviceSyncProviderLabel } from "@murphai/device-syncd/provider-label";
+import { isHistoricalResetIncompleteDeviceSyncAccount } from "@murphai/device-syncd/public-account";
 
 import type { HostedBrowserDeviceSyncConnectionSource } from "./browser-connection-source";
 import type { HostedBrowserDeviceSyncConnection } from "./public-connection";
@@ -41,6 +42,10 @@ export interface HostedDeviceSyncSettingsSource {
   displayName: string | null;
   guidance: string;
   headline: string;
+  // Set on a disconnected connection whose provider-side revoke failed while a
+  // historical reset was pending: the member must remove the old connection in the
+  // wearable provider account before reconnecting.
+  historicalResetIncomplete?: true;
   lastActivityAt: string | null;
   lastSuccessfulSyncAt: string | null;
   lastWebhookAt: string | null;
@@ -63,6 +68,7 @@ export interface HostedDeviceSyncSettingsUpstreamSource {
   connectSourceId?: string | null;
   connectTarget?: string | null;
   providerLabel: string;
+  recoveryKind?: HostedBrowserDeviceSyncConnectionSource["recoveryKind"];
   requiresReconnect?: boolean;
   resourceCount: number;
   sourceProviderSlug: string;
@@ -229,26 +235,34 @@ function buildConnectedSource(input: {
     : null;
   const connectedAgeMs = ageInMilliseconds(connection.connectedAt, now);
   const setupPhase = connection.setupPhase ?? null;
-  const reconnectSource = findReconnectRequiredUpstreamSource(input.upstreamSources);
+  const reconnectSource = findRecoveryRequiredUpstreamSource(input.upstreamSources);
+  const needsConnectionReset = reconnectSource?.recoveryKind === "connection_reset";
   const sourceReconnectTarget = reconnectSource
     ? resolveUpstreamSourceReconnectTarget(reconnectSource)
     : null;
-  const sourceReconnectAction = reconnectSource
+  const sourceReconnectAction = reconnectSource && !needsConnectionReset
     ? buildReconnectAction(sourceReconnectTarget)
     : null;
 
   if (connection.status === "disconnected") {
+    const resetIncomplete = isHistoricalResetIncompleteDeviceSyncAccount(connection);
+
     return {
       connectionId: connection.id,
       connectedAt: connection.connectedAt,
       connectSourceId: input.connectTarget?.connectSourceId ?? null,
       connectTarget: input.connectTarget?.connectTarget ?? null,
-      detail: lastSuccessfulSyncAt
-        ? "This source is disconnected. Your past history stays in place."
-        : "This source is disconnected.",
+      detail: resetIncomplete
+        ? "This source is disconnected, but the last reset did not finish in your wearable provider account."
+        : lastSuccessfulSyncAt
+          ? "This source is disconnected. Your past history stays in place."
+          : "This source is disconnected.",
       displayName,
-      guidance: "Past history stays in place.",
+      guidance: resetIncomplete
+        ? "Remove the old connection in your wearable provider account, then connect it again here."
+        : "Past history stays in place.",
       headline: "Disconnected",
+      ...(resetIncomplete ? { historicalResetIncomplete: true } : {}),
       lastActivityAt,
       lastSuccessfulSyncAt,
       lastWebhookAt: connection.lastWebhookAt,
@@ -259,8 +273,8 @@ function buildConnectedSource(input: {
       providerLabel,
       secondaryAction: null,
       state: connection.status,
-      statusLabel: "Disconnected",
-      tone: "muted",
+      statusLabel: resetIncomplete ? "Needs attention" : "Disconnected",
+      tone: resetIncomplete ? "attention" : "muted",
       updatedAt: connection.updatedAt,
       upstreamSources: input.upstreamSources,
     } satisfies HostedDeviceSyncSettingsSource;
@@ -348,11 +362,15 @@ function buildConnectedSource(input: {
       connectedAt: connection.connectedAt,
       connectSourceId: sourceReconnectTarget?.connectSourceId ?? null,
       connectTarget: sourceReconnectTarget?.connectTarget ?? null,
-      detail: `${reconnectSource.providerLabel} needs to be reconnected before Murph can keep syncing it.`,
+      detail: needsConnectionReset
+        ? `${reconnectSource.providerLabel} needs a fresh connection before Murph can bring in its history.`
+        : `${reconnectSource.providerLabel} needs to be reconnected before Murph can keep syncing it.`,
       displayName,
-      guidance: sourceReconnectAction
-        ? "Reconnect this source to refresh access, or disconnect it if you no longer need it."
-        : "Disconnect this source if you no longer need it.",
+      guidance: needsConnectionReset
+        ? "Disconnect this source first, then connect it again to start a fresh sync."
+        : sourceReconnectAction
+          ? "Reconnect this source to refresh access, or disconnect it if you no longer need it."
+          : "Disconnect this source if you no longer need it.",
       headline: "Access needs attention",
       lastActivityAt,
       lastSuccessfulSyncAt,
@@ -367,7 +385,7 @@ function buildConnectedSource(input: {
         label: "Disconnect",
       },
       state: connection.status,
-      statusLabel: "Needs access",
+      statusLabel: needsConnectionReset ? "Needs attention" : "Needs access",
       tone: "attention",
       updatedAt: connection.updatedAt,
       upstreamSources: input.upstreamSources,
@@ -778,6 +796,7 @@ function toSettingsUpstreamSource(
 ): HostedDeviceSyncSettingsUpstreamSource {
   return {
     providerLabel: formatHostedDeviceSyncSourceLabel(source.sourceProviderSlug),
+    ...(source.recoveryKind ? { recoveryKind: source.recoveryKind } : {}),
     ...(source.requiresReconnect ? { requiresReconnect: true } : {}),
     resourceCount: source.resourceCount,
     sourceProviderSlug: source.sourceProviderSlug,
@@ -785,12 +804,12 @@ function toSettingsUpstreamSource(
   };
 }
 
-function findReconnectRequiredUpstreamSource(
+function findRecoveryRequiredUpstreamSource(
   sources: readonly HostedDeviceSyncSettingsUpstreamSource[],
 ): HostedDeviceSyncSettingsUpstreamSource | null {
   return sources.find((source) =>
     source.status === "error"
-    && source.requiresReconnect === true
+    && (source.requiresReconnect === true || source.recoveryKind === "connection_reset")
   ) ?? null;
 }
 

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -94,7 +94,7 @@ export async function disconnectHostedDeviceSyncConnection(input: {
   }
 
   let providerConfigRevokeSucceeded = false;
-  let warning: { code: string; message: string } | undefined;
+  let revokeFailure: { code: string; message: string } | undefined;
 
   if (storedAccount) {
     const provider = input.registry.get(existing.provider);
@@ -117,21 +117,7 @@ export async function disconnectHostedDeviceSyncConnection(input: {
           error instanceof Error ? error.message : "Provider revoke request failed during disconnect.",
         ) ?? "Provider revoke request failed during disconnect.";
 
-        // A retried disconnect runs after the first attempt already cleared the source
-        // markers, so the disconnected account's own error code is the remaining evidence
-        // that this revoke failure belongs to a pending historical reset.
-        warning = (
-          isHistoricalResetIncompleteDeviceSyncAccount(existing)
-          || await connectionHasHistoricalResetSource(input.store, input.connectionId)
-        )
-          ? {
-            code: DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE,
-            message: HISTORICAL_RESET_REVOKE_WARNING_MESSAGE,
-          }
-          : {
-            code,
-            message,
-          };
+        revokeFailure = { code, message };
       }
     }
   }
@@ -161,6 +147,19 @@ export async function disconnectHostedDeviceSyncConnection(input: {
     ) {
       connectionChangedDuringDisconnectError();
     }
+
+    const warning = revokeFailure
+      ? (
+          isHistoricalResetIncompleteDeviceSyncAccount(freshExisting)
+          || (await input.store.listConnectionSources(input.connectionId, tx))
+            .some(requiresHistoricalResetDeviceSyncSource)
+        )
+        ? {
+            code: DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE,
+            message: HISTORICAL_RESET_REVOKE_WARNING_MESSAGE,
+          }
+        : revokeFailure
+      : undefined;
 
     if (
       freshExisting.status === "disconnected"
@@ -196,6 +195,7 @@ export async function disconnectHostedDeviceSyncConnection(input: {
       return {
         connection: clearedConnection,
         mailboxItemId: null,
+        warning: undefined,
       };
     }
 
@@ -206,6 +206,7 @@ export async function disconnectHostedDeviceSyncConnection(input: {
       return {
         connection: freshExisting,
         mailboxItemId: null,
+        warning,
       };
     }
 
@@ -280,6 +281,7 @@ export async function disconnectHostedDeviceSyncConnection(input: {
     return {
       connection: disconnectedConnection,
       mailboxItemId: mailboxAppend.item.id,
+      warning,
     };
   });
 
@@ -289,7 +291,7 @@ export async function disconnectHostedDeviceSyncConnection(input: {
 
   return {
     connection: disconnectResult.connection,
-    ...(warning ? { warning } : {}),
+    ...(disconnectResult.warning ? { warning: disconnectResult.warning } : {}),
   };
 }
 
@@ -358,24 +360,13 @@ function connectionChangedDuringDisconnectError(): never {
   });
 }
 
-// A Junction historical reset requires deregistering the provider-side connection, so a
-// failed revoke mid-reset needs a stable warning identity the browser can explain instead
-// of the raw provider error. Sources still carry the recovery error code at this point;
-// the disconnect transaction only clears it afterwards.
-async function connectionHasHistoricalResetSource(
-  store: PrismaDeviceSyncControlPlaneStore,
-  connectionId: string,
-): Promise<boolean> {
-  const sources = await store.listConnectionSources(connectionId);
-
-  return sources.some(requiresHistoricalResetDeviceSyncSource);
-}
-
 export async function handleHostedDeviceSyncConnectionEstablished(input: {
   account: {
+    connectedAt: string;
     id: string;
     provider: string;
     scopes: string[];
+    status: PublicDeviceSyncAccount["status"];
   };
   sourceProviderSlug?: string | null;
   connection: Pick<ProviderConnectionResult, "initialJobs" | "nextReconcileAt">;
@@ -408,10 +399,18 @@ export async function handleHostedDeviceSyncConnectionEstablished(input: {
     source: "connection-established",
     userId: ownerId,
   });
-  await persistHostedDeviceSyncWake({
-    wake,
-    store: input.store,
-    persist: async (tx) => {
+  const mailboxAppend = await input.store.withConnectionMutationLock(
+    input.account.id,
+    async (tx) => {
+      const current = await input.store.getConnectionForUser(ownerId, input.account.id, tx);
+      if (
+        !current
+        || current.status !== input.account.status
+        || current.connectedAt !== input.account.connectedAt
+      ) {
+        return null;
+      }
+
       const linkedSource = resolveHostedJunctionLinkedSource({
         account: input.account,
         sourceProviderSlug: input.sourceProviderSlug ?? null,
@@ -438,8 +437,23 @@ export async function handleHostedDeviceSyncConnectionEstablished(input: {
         createdAt: input.now,
         tx,
       });
+
+      return appendHostedMailboxEnvelopeTx({
+        envelope: wake,
+        tx,
+      });
     },
-  });
+  );
+
+  if (
+    mailboxAppend
+    && (
+      mailboxAppend.inserted
+      || (mailboxAppend.duplicate && !mailboxAppend.dedupeConflict)
+    )
+  ) {
+    await startHostedDeviceSyncWakeWorkflow(mailboxAppend.item.id);
+  }
 }
 
 function resolveHostedJunctionLinkedSource(input: {

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -66,18 +66,26 @@ export async function disconnectHostedDeviceSyncConnection(input: {
   connection: PublicDeviceSyncAccount;
   warning?: { code: string; message: string };
 }> {
-  const existing = await input.store.getConnectionForUser(input.userId, input.connectionId);
+  const target = await input.store.withConnectionMutationLock(input.connectionId, async (tx) => {
+    const connection = await input.store.getConnectionForUser(input.userId, input.connectionId, tx);
+    if (!connection) {
+      throw deviceSyncError({
+        code: "CONNECTION_NOT_FOUND",
+        message: "Hosted device-sync connection was not found for the current user.",
+        retryable: false,
+        httpStatus: 404,
+      });
+    }
 
-  if (!existing) {
-    throw deviceSyncError({
-      code: "CONNECTION_NOT_FOUND",
-      message: "Hosted device-sync connection was not found for the current user.",
-      retryable: false,
-      httpStatus: 404,
-    });
-  }
-
-  const storedAccount = await input.store.getStoredConnectionAccountForUser(input.userId, input.connectionId);
+    const storedAccount = await input.store.getStoredConnectionAccountForUser(
+      input.userId,
+      input.connectionId,
+      tx,
+    );
+    return { connection, storedAccount };
+  });
+  const existing = target.connection;
+  const storedAccount = target.storedAccount;
 
   if (existing.status === "disconnected" && !storedAccount) {
     return {
@@ -147,7 +155,10 @@ export async function disconnectHostedDeviceSyncConnection(input: {
       tx,
     );
 
-    if (storedAccount && !storedAccountMatchesDisconnectTarget(storedAccount, freshStoredAccount)) {
+    if (
+      !publicAccountMatchesDisconnectTarget(existing, freshExisting)
+      || !storedAccountMatchesDisconnectTarget(storedAccount, freshStoredAccount)
+    ) {
       connectionChangedDuringDisconnectError();
     }
 
@@ -314,6 +325,7 @@ function storedAccountMatchesDisconnectTarget(
   if (
     expected.provider !== current.provider
     || expected.externalAccountId !== current.externalAccountId
+    || expected.connectedAt !== current.connectedAt
     || expected.credential.kind !== current.credential.kind
   ) {
     return false;
@@ -325,7 +337,16 @@ function storedAccountMatchesDisconnectTarget(
       && expected.credential.providerConfigKey === current.credential.providerConfigKey;
   }
 
-  return true;
+  return expected.tokenVersion === current.tokenVersion;
+}
+
+function publicAccountMatchesDisconnectTarget(
+  expected: PublicDeviceSyncAccount,
+  current: PublicDeviceSyncAccount,
+): boolean {
+  return expected.provider === current.provider
+    && expected.externalAccountId === current.externalAccountId
+    && expected.connectedAt === current.connectedAt;
 }
 
 function connectionChangedDuringDisconnectError(): never {

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -15,6 +15,11 @@ import {
   shapeHostedDeviceSyncJobHintPayload,
 } from "@murphai/device-syncd/hosted-hints";
 import {
+  DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE,
+  isHistoricalResetIncompleteDeviceSyncAccount,
+  requiresHistoricalResetDeviceSyncSource,
+} from "@murphai/device-syncd/public-account";
+import {
   sanitizeHostedRuntimeErrorCode,
   sanitizeHostedRuntimeErrorText,
   type HostedExecutionDeviceSyncJobHint,
@@ -47,6 +52,10 @@ import {
 } from "./shared";
 
 const HOSTED_DEVICE_SYNC_WAKE_EVENT_SCHEMA = "v1";
+
+const HISTORICAL_RESET_REVOKE_WARNING_MESSAGE =
+  "Provider revoke did not complete while a historical data reset is pending. "
+  + "Remove the connection in the provider account before reconnecting.";
 
 export async function disconnectHostedDeviceSyncConnection(input: {
   connectionId: string;
@@ -100,10 +109,21 @@ export async function disconnectHostedDeviceSyncConnection(input: {
           error instanceof Error ? error.message : "Provider revoke request failed during disconnect.",
         ) ?? "Provider revoke request failed during disconnect.";
 
-        warning = {
-          code,
-          message,
-        };
+        // A retried disconnect runs after the first attempt already cleared the source
+        // markers, so the disconnected account's own error code is the remaining evidence
+        // that this revoke failure belongs to a pending historical reset.
+        warning = (
+          isHistoricalResetIncompleteDeviceSyncAccount(existing)
+          || await connectionHasHistoricalResetSource(input.store, input.connectionId)
+        )
+          ? {
+            code: DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE,
+            message: HISTORICAL_RESET_REVOKE_WARNING_MESSAGE,
+          }
+          : {
+            code,
+            message,
+          };
       }
     }
   }
@@ -148,8 +168,22 @@ export async function disconnectHostedDeviceSyncConnection(input: {
         throw connectionChangedDuringDisconnectError();
       }
 
+      const clearedConnection: PublicDeviceSyncAccount = (
+        freshExisting.lastErrorCode !== null || freshExisting.lastErrorMessage !== null
+      )
+        ? {
+            ...freshExisting,
+            lastErrorCode: null,
+            lastErrorMessage: null,
+            updatedAt: now,
+          }
+        : freshExisting;
+      if (clearedConnection !== freshExisting) {
+        await input.store.syncDurableConnectionState(clearedConnection, tx);
+      }
+
       return {
-        connection: freshExisting,
+        connection: clearedConnection,
         mailboxItemId: null,
       };
     }
@@ -301,6 +335,19 @@ function connectionChangedDuringDisconnectError(): never {
     retryable: true,
     httpStatus: 409,
   });
+}
+
+// A Junction historical reset requires deregistering the provider-side connection, so a
+// failed revoke mid-reset needs a stable warning identity the browser can explain instead
+// of the raw provider error. Sources still carry the recovery error code at this point;
+// the disconnect transaction only clears it afterwards.
+async function connectionHasHistoricalResetSource(
+  store: PrismaDeviceSyncControlPlaneStore,
+  connectionId: string,
+): Promise<boolean> {
+  const sources = await store.listConnectionSources(connectionId);
+
+  return sources.some(requiresHistoricalResetDeviceSyncSource);
 }
 
 export async function handleHostedDeviceSyncConnectionEstablished(input: {

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -1441,6 +1441,176 @@ test("ConnectPage keeps account disconnects visible when all Junction children n
   assert.equal(markup.match(/aria-label="Disconnect account"/gu)?.length, 2);
 });
 
+test("ConnectPage projects Junction connection-reset sources with account-scoped disconnects", async () => {
+  const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
+
+  assert.deepEqual(
+    resolveConnectSourceConnectionStates([{ id: "garmin" }], [
+      {
+        connectionId: "dsc_junction_garmin",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Garmin",
+            recoveryKind: "connection_reset",
+            resourceCount: 3,
+            sourceProviderSlug: "garmin",
+            status: "error",
+          },
+        ],
+      },
+    ]),
+    [{
+      connectionId: "dsc_junction_garmin",
+      connectProvider: "junction",
+      connectTarget: null,
+      disconnectScope: "junction_account",
+      recoveryKind: "connection_reset",
+      requiresReconnect: false,
+      sourceId: "garmin",
+      state: "active",
+    }],
+  );
+});
+
+test("ConnectPage keeps single-source Junction historical recovery on disconnect, never reconnect", async () => {
+  vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+  vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+  vi.stubEnv("JUNCTION_ENV", "sandbox");
+  vi.stubEnv("JUNCTION_PROVIDER_FILTER", "garmin");
+  vi.stubEnv("JUNCTION_REGION", "us");
+
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-07-09T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_garmin",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Garmin",
+            recoveryKind: "connection_reset",
+            resourceCount: 3,
+            sourceProviderSlug: "garmin",
+            status: "error",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Garmin needs a fresh connection/u);
+  assert.match(markup, /Disconnect it first, then connect it again\./u);
+  assert.match(markup, /data-connection-state="needs-access"/u);
+  assert.doesNotMatch(markup, /aria-label="Reconnect Garmin"/u);
+  assert.doesNotMatch(markup, /aria-label="Connect Garmin"/u);
+  assert.doesNotMatch(markup, /Garmin connected/u);
+  assert.match(markup, /aria-label="Disconnect account"/u);
+});
+
+test("ConnectPage keeps multi-source Junction historical recovery on disconnect, never reconnect", async () => {
+  vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+  vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+  vi.stubEnv("JUNCTION_ENV", "sandbox");
+  vi.stubEnv("JUNCTION_PROVIDER_FILTER", "garmin");
+  vi.stubEnv("JUNCTION_REGION", "us");
+
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-07-09T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_multi",
+        provider: "junction",
+        state: "active",
+        upstreamSources: [
+          {
+            providerLabel: "Garmin",
+            recoveryKind: "connection_reset",
+            resourceCount: 3,
+            sourceProviderSlug: "garmin",
+            status: "error",
+          },
+          {
+            providerLabel: "WHOOP",
+            resourceCount: 3,
+            sourceProviderSlug: "whoop_v2",
+            status: "connected",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Garmin needs a fresh connection/u);
+  assert.match(markup, /Whoop connected/u);
+  assert.doesNotMatch(markup, /aria-label="Reconnect Garmin"/u);
+  assert.doesNotMatch(markup, /aria-label="Connect Garmin"/u);
+  assert.equal(markup.match(/aria-label="Disconnect account"/gu)?.length, 2);
+});
+
+test("SourceCard stacks connection-reset content vertically at the base breakpoint", async () => {
+  const { SourceCard } = await import("../app/(dashboard)/connect/connect-source-card");
+  const logo = { className: "size-11 object-contain", height: 44, src: "/logo.png", width: 44 };
+  const cardProps = {
+    authenticated: true,
+    errorMessage: null,
+    onDisconnectTargetChange: () => {},
+    onStartConnection: async () => {},
+    pending: false,
+    pendingDisconnect: false,
+  };
+
+  const resetMarkup = renderToStaticMarkup(createElement(SourceCard, {
+    ...cardProps,
+    source: {
+      description: "Garmin workouts, sleep, stress, heart, body battery, and activity data.",
+      disconnectConnectionId: "dsc_junction_garmin",
+      disconnectScope: "junction_account" as const,
+      id: "garmin",
+      logo,
+      name: "Garmin",
+      recoveryKind: "connection_reset" as const,
+    },
+  }));
+
+  assert.match(
+    resetMarkup,
+    /Garmin needs a fresh connection\. Disconnect it first, then connect it again\./u,
+  );
+  // The reset message can be up to 22rem wide, so the card content must stack at
+  // the base breakpoint instead of squeezing the source details in the shared
+  // horizontal row under the card's overflow-hidden.
+  assert.match(resetMarkup, /class="flex flex-1 flex-col items-stretch gap-3 sm:gap-0"/u);
+  assert.doesNotMatch(resetMarkup, /items-center gap-4/u);
+  assert.match(resetMarkup, /aria-label="Disconnect account"/u);
+  assert.doesNotMatch(resetMarkup, /aria-label="(?:Connect|Reconnect) Garmin"/u);
+
+  const ordinaryMarkup = renderToStaticMarkup(createElement(SourceCard, {
+    ...cardProps,
+    source: {
+      description: "Garmin workouts, sleep, stress, heart, body battery, and activity data.",
+      id: "garmin",
+      logo,
+      name: "Garmin",
+    },
+  }));
+
+  assert.match(
+    ordinaryMarkup,
+    /class="flex flex-1 items-center gap-4 sm:flex-col sm:items-stretch sm:gap-0"/u,
+  );
+});
+
 test("ConnectPage lets active reconnect rows win over stale reconnectable rows", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 
@@ -1585,8 +1755,90 @@ test("ConnectPage keeps disconnected Junction sources quiet and connectable", as
   assert.match(markup, /data-connection-state="idle"/u);
   assert.match(markup, /aria-label="Connect Oura"/u);
   assert.doesNotMatch(markup, /Oura needs reconnect/u);
+  assert.doesNotMatch(markup, /did not finish/u);
   assert.doesNotMatch(markup, /aria-label="Reconnect Oura"/u);
   assert.doesNotMatch(markup, /aria-label="Disconnect Oura"/u);
+});
+
+test("ConnectPage keeps unfinished-reset guidance visible on disconnected Junction sources", async () => {
+  vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+  vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+  vi.stubEnv("JUNCTION_ENV", "sandbox");
+  vi.stubEnv("JUNCTION_PROVIDER_FILTER", "garmin");
+  vi.stubEnv("JUNCTION_REGION", "us");
+
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-07-10T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_junction_garmin",
+        historicalResetIncomplete: true,
+        provider: "junction",
+        state: "disconnected",
+        upstreamSources: [
+          {
+            providerLabel: "Garmin",
+            resourceCount: 0,
+            sourceProviderSlug: "garmin",
+            status: "disconnected",
+          },
+        ],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(
+    markup,
+    /The last reset for Garmin did not finish\. Remove the old connection in your wearable provider account, then connect it again here\./u,
+  );
+  assert.match(markup, /aria-label="Connect Garmin"/u);
+  assert.match(markup, /data-connection-state="needs-access"/u);
+  assert.doesNotMatch(markup, /HISTORICAL_RESET_REVOKE_FAILED/u);
+  assert.doesNotMatch(markup, /aria-label="Reconnect Garmin"/u);
+  assert.doesNotMatch(markup, /aria-label="Disconnect account"/u);
+});
+
+test("resolveHistoricalResetIncompleteConnectSourceIds maps direct and Junction disconnected sources", async () => {
+  const { resolveHistoricalResetIncompleteConnectSourceIds } = await import("../app/(dashboard)/connect/page");
+
+  const sourceIds = resolveHistoricalResetIncompleteConnectSourceIds(
+    [{ id: "whoop" }, { id: "garmin" }],
+    [
+      {
+        connectionId: "dsc_whoop_direct",
+        historicalResetIncomplete: true,
+        provider: "whoop",
+        state: "disconnected",
+        upstreamSources: [],
+      },
+      {
+        connectionId: "dsc_junction_garmin",
+        historicalResetIncomplete: true,
+        provider: "junction",
+        state: "disconnected",
+        upstreamSources: [
+          {
+            providerLabel: "Garmin",
+            resourceCount: 0,
+            sourceProviderSlug: "garmin",
+            status: "disconnected",
+          },
+        ],
+      },
+      {
+        connectionId: "dsc_oura_plain",
+        provider: "oura",
+        state: "disconnected",
+        upstreamSources: [],
+      },
+    ],
+  );
+
+  assert.deepEqual([...sourceIds].sort(), ["garmin", "whoop"]);
 });
 
 test("ConnectPage keeps configured sources visible but renders sign-in actions when signed out", async () => {
@@ -2382,6 +2634,300 @@ test("ConnectSourcesGrid uses account-scoped disconnect copy without naming Junc
     assert.match(rendered.container.textContent ?? "", /Disconnected this connection\. Your history is still saved\./);
   });
   assert.equal(fetch.mock.calls[0]?.[0], "/api/settings/device-sync/connections/dsc_junction_multi/disconnect");
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid walks connection-reset sources through account disconnect then connect", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({});
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connectTarget: "garmin",
+        description: "Workouts, sleep, stress, heart rate, and body battery.",
+        disconnectConnectionId: "dsc_junction_garmin",
+        disconnectScope: "junction_account",
+        id: "garmin",
+        logo: {
+          className: "size-11 object-contain",
+          height: 44,
+          src: "/brand-logos/connect/garmin.png",
+          width: 44,
+        },
+        name: "Garmin",
+        recoveryKind: "connection_reset",
+      },
+    ],
+  }));
+
+  assert.match(
+    rendered.container.textContent ?? "",
+    /Garmin needs a fresh connection\. Disconnect it first, then connect it again\./,
+  );
+  assert.equal(rendered.container.querySelector("button[aria-label='Reconnect Garmin']"), null);
+  assert.equal(rendered.container.querySelector("button[aria-label='Connect Garmin']"), null);
+
+  const disconnectButton = rendered.container.querySelector("button[aria-label='Disconnect account']");
+  assert.ok(disconnectButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    disconnectButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  assert.match(rendered.container.textContent ?? "", /Disconnect account\?/);
+  assert.match(
+    rendered.container.textContent ?? "",
+    /Murph will stop syncing new data from every source in this connection\. Your history is kept\./,
+  );
+
+  const confirmButton = [...rendered.container.querySelectorAll("button")]
+    .filter((button) => button.textContent === "Disconnect")
+    .at(-1);
+  assert.ok(confirmButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    confirmButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(rendered.container.textContent ?? "", /Disconnected this connection\. Your history is still saved\./);
+  });
+  assert.equal(fetch.mock.calls[0]?.[0], "/api/settings/device-sync/connections/dsc_junction_garmin/disconnect");
+
+  const connectButton = rendered.container.querySelector("button[aria-label='Connect Garmin']");
+  assert.ok(connectButton instanceof rendered.window.HTMLButtonElement);
+  assert.equal(connectButton.textContent, "Connect");
+  assert.doesNotMatch(rendered.container.textContent ?? "", /needs a fresh connection/u);
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid explains an unfinished historical reset when disconnect returns a warning", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({
+      warning: {
+        code: "HISTORICAL_RESET_REVOKE_FAILED",
+        historicalResetIncomplete: true,
+        message: "Provider revoke did not complete while a historical data reset is pending. "
+          + "Remove the connection in the provider account before reconnecting.",
+      },
+    });
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connectTarget: "garmin",
+        description: "Workouts, sleep, stress, heart rate, and body battery.",
+        disconnectConnectionId: "dsc_junction_garmin",
+        disconnectScope: "junction_account",
+        id: "garmin",
+        logo: {
+          className: "size-11 object-contain",
+          height: 44,
+          src: "/brand-logos/connect/garmin.png",
+          width: 44,
+        },
+        name: "Garmin",
+        recoveryKind: "connection_reset",
+      },
+    ],
+  }));
+
+  const disconnectButton = rendered.container.querySelector("button[aria-label='Disconnect account']");
+  assert.ok(disconnectButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    disconnectButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  const confirmButton = [...rendered.container.querySelectorAll("button")]
+    .filter((button) => button.textContent === "Disconnect")
+    .at(-1);
+  assert.ok(confirmButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    confirmButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Disconnected this connection\. Your history is still saved\. The historical reset did not finish\. Remove the old connection in your wearable provider account before reconnecting here\./,
+    );
+  });
+  assert.equal(fetch.mock.calls[0]?.[0], "/api/settings/device-sync/connections/dsc_junction_garmin/disconnect");
+  assert.doesNotMatch(rendered.container.textContent ?? "", /did not fully confirm/u);
+
+  const connectButton = rendered.container.querySelector("button[aria-label='Connect Garmin']");
+  assert.ok(connectButton instanceof rendered.window.HTMLButtonElement);
+  assert.equal(connectButton.textContent, "Connect");
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid explains an unfinished historical reset when a healthy sibling card starts the disconnect", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({
+      warning: {
+        code: "HISTORICAL_RESET_REVOKE_FAILED",
+        historicalResetIncomplete: true,
+        message: "Provider revoke did not complete while a historical data reset is pending. "
+          + "Remove the connection in the provider account before reconnecting.",
+      },
+    });
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connectTarget: "garmin",
+        description: "Workouts, sleep, stress, heart rate, and body battery.",
+        disconnectConnectionId: "dsc_junction_multi",
+        disconnectScope: "junction_account",
+        id: "garmin",
+        logo: {
+          className: "size-11 object-contain",
+          height: 44,
+          src: "/brand-logos/connect/garmin.png",
+          width: 44,
+        },
+        name: "Garmin",
+        recoveryKind: "connection_reset",
+      },
+      {
+        connectTarget: "whoop",
+        connected: true,
+        description: "Recovery, strain, sleep, and heart rate.",
+        disconnectConnectionId: "dsc_junction_multi",
+        disconnectScope: "junction_account",
+        id: "whoop",
+        logo: {
+          className: "h-auto max-h-7 w-auto max-w-[8rem] object-contain",
+          height: 15,
+          src: "/brand-logos/connect/whoop.svg",
+          width: 96,
+        },
+        name: "Whoop",
+      },
+    ],
+  }));
+
+  // Start the shared-account disconnect from the healthy Whoop card, not the
+  // Garmin card that carries the historical reset.
+  const disconnectButton = [...rendered.container.querySelectorAll("button[aria-label='Disconnect account']")]
+    .find((button) => button.closest("div.relative")?.textContent?.includes("Whoop"));
+  assert.ok(disconnectButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    disconnectButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  const confirmButton = [...rendered.container.querySelectorAll("button")]
+    .filter((button) => button.textContent === "Disconnect")
+    .at(-1);
+  assert.ok(confirmButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    confirmButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Disconnected this connection\. Your history is still saved\. The historical reset did not finish\. Remove the old connection in your wearable provider account before reconnecting here\./,
+    );
+  });
+  assert.equal(fetch.mock.calls[0]?.[0], "/api/settings/device-sync/connections/dsc_junction_multi/disconnect");
+  assert.doesNotMatch(rendered.container.textContent ?? "", /did not fully confirm/u);
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid keeps ordinary disconnect warnings generic", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({
+      warning: {
+        code: "PROVIDER_REVOKE_FAILED",
+        message: "Provider revoke request failed during disconnect.",
+      },
+    });
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connectTarget: "whoop",
+        connected: true,
+        description: "Recovery, strain, sleep, and heart rate.",
+        disconnectConnectionId: "dsc_whoop_123",
+        id: "whoop",
+        logo: {
+          className: "h-auto max-h-7 w-auto max-w-[8rem] object-contain",
+          height: 15,
+          src: "/brand-logos/connect/whoop.svg",
+          width: 96,
+        },
+        name: "Whoop",
+      },
+    ],
+  }));
+
+  const disconnectButton = rendered.container.querySelector("button[aria-label='Disconnect Whoop']");
+  assert.ok(disconnectButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    disconnectButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  const confirmButton = [...rendered.container.querySelectorAll("button")]
+    .filter((button) => button.textContent === "Disconnect")
+    .at(-1);
+  assert.ok(confirmButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    confirmButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Disconnected Whoop\. Your history is still saved\. The provider did not fully confirm, so check that account if you want access removed there too\./,
+    );
+  });
+  assert.equal(fetch.mock.calls[0]?.[0], "/api/settings/device-sync/connections/dsc_whoop_123/disconnect");
+  assert.doesNotMatch(rendered.container.textContent ?? "", /historical reset/iu);
 
   await rendered.cleanup();
 });

--- a/apps/web/test/device-sync-hosted-runtime-authority.test.ts
+++ b/apps/web/test/device-sync-hosted-runtime-authority.test.ts
@@ -738,6 +738,7 @@ describe("applyHostedDeviceSyncRuntimeResult", () => {
           updates: [
             {
               connectionId: hostedConnectionId,
+              observedUpdatedAt: "2026-05-26T17:35:33.451Z",
               sources: [
                 {
                   displayName: null,
@@ -787,6 +788,583 @@ describe("applyHostedDeviceSyncRuntimeResult", () => {
     expect(harness.upsertConnectionSource).not.toHaveBeenCalledWith(expect.objectContaining({
       sourceInstanceKey: runtimeSourceInstanceKey,
     }));
+  });
+
+  it("rejects a legacy Junction runner that would erase current exhausted recovery state", async () => {
+    const hostedConnectionId = "conn_junction_exhausted";
+    const runtimeLocalAccountId = "dsa_legacy_runtime";
+    const windowStart = "2026-04-01T00:00:00.000Z";
+    const windowEnd = "2026-04-03T00:00:00.000Z";
+    const canonicalSourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+      connectionId: hostedConnectionId,
+      sourceProviderSlug: "garmin",
+    });
+    const runtimeSourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+      connectionId: runtimeLocalAccountId,
+      sourceProviderSlug: "garmin",
+    });
+    expect(canonicalSourceInstanceKey).toBeTruthy();
+    expect(runtimeSourceInstanceKey).toBeTruthy();
+    if (!canonicalSourceInstanceKey || !runtimeSourceInstanceKey) {
+      throw new Error("Expected Junction source keys for the authority regression.");
+    }
+
+    const exhaustedMetadata = {
+      junctionHistoricalBackfillEmptyAttempts: 5,
+      junctionHistoricalBackfillEvidence: `e1|${windowStart}|${windowEnd}|garmin:1`,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+      junctionHistoricalBackfillWindowEnd: windowEnd,
+      junctionHistoricalBackfillWindowStart: windowStart,
+    };
+    const harness = createAuthorityHarness({
+      connectionSources: [
+        {
+          connectionId: hostedConnectionId,
+          displayName: "Garmin",
+          firstSeenAt: "2026-04-01T09:00:00.000Z",
+          lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+          lastErrorMessage: "Historical data remained incomplete.",
+          lastSeenAt: "2026-04-04T09:00:00.000Z",
+          resourceAvailabilitySummary: { activity: true, sleep: true },
+          sourceInstanceKey: canonicalSourceInstanceKey,
+          sourceProviderSlug: "garmin",
+          status: "error",
+        },
+      ],
+      record: buildHostedRecord({
+        id: hostedConnectionId,
+        metadata: exhaustedMetadata,
+        provider: "junction",
+      }),
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [
+            {
+              connection: {
+                metadata: {
+                  junctionHistoricalBackfillEmptyAttempts: 0,
+                  junctionHistoricalBackfillLastEmptyAt: null,
+                  junctionHistoricalBackfillStatus: "complete",
+                  junctionHistoricalBackfillWindowEnd: windowEnd,
+                  junctionHistoricalBackfillWindowStart: windowStart,
+                },
+              },
+              connectionId: hostedConnectionId,
+              observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+              sources: [
+                {
+                  displayName: "Garmin",
+                  firstSeenAt: "2026-04-01T09:00:00.000Z",
+                  lastErrorCode: null,
+                  lastErrorMessage: null,
+                  lastSeenAt: "2026-04-04T09:05:00.000Z",
+                  observedLastSeenAt: null,
+                  resourceAvailabilitySummary: { activity: true, sleep: true },
+                  sourceInstanceKey: runtimeSourceInstanceKey,
+                  sourceProviderSlug: "garmin",
+                  status: "connected",
+                },
+              ],
+            },
+          ],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(response.updates[0]?.writeUpdate).toBe("skipped_version_mismatch");
+    expect(harness.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(harness.upsertConnectionSource).not.toHaveBeenCalled();
+    expect(harness.record.metadata).toEqual(exhaustedMetadata);
+  });
+
+  it("rejects exhausted Junction progress without a durable reset signal", async () => {
+    const hostedConnectionId = "conn_junction_missing_reset_signal";
+    const sourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+      connectionId: hostedConnectionId,
+      sourceProviderSlug: "garmin",
+    });
+    expect(sourceInstanceKey).toBeTruthy();
+    if (!sourceInstanceKey) {
+      throw new Error("Expected a Junction source key for the reset-signal regression.");
+    }
+    const windowStart = "2026-04-01T00:00:00.000Z";
+    const windowEnd = "2026-04-03T00:00:00.000Z";
+    const retryingMetadata = {
+      junctionHistoricalBackfillEmptyAttempts: 1,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      junctionHistoricalBackfillWindowEnd: windowEnd,
+      junctionHistoricalBackfillWindowStart: windowStart,
+    };
+    const harness = createAuthorityHarness({
+      connectionSources: [
+        {
+          connectionId: hostedConnectionId,
+          displayName: "Garmin",
+          firstSeenAt: "2026-04-01T09:00:00.000Z",
+          lastErrorCode: null,
+          lastErrorMessage: null,
+          lastSeenAt: "2026-04-06T10:00:00.000Z",
+          resourceAvailabilitySummary: { activity: true },
+          sourceInstanceKey,
+          sourceProviderSlug: "garmin",
+          status: "connected",
+        },
+      ],
+      record: buildHostedRecord({
+        id: hostedConnectionId,
+        metadata: retryingMetadata,
+        provider: "junction",
+      }),
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [
+            {
+              connection: {
+                metadata: {
+                  junctionHistoricalBackfillEmptyAttempts: 5,
+                  junctionHistoricalBackfillLastEmptyAt: "2026-04-06T10:05:00.000Z",
+                  junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+                  junctionHistoricalBackfillWindowEnd: windowEnd,
+                  junctionHistoricalBackfillWindowStart: windowStart,
+                },
+              },
+              connectionId: hostedConnectionId,
+              observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+            },
+          ],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(response.updates[0]?.writeUpdate).toBe("skipped_version_mismatch");
+    expect(harness.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(harness.upsertConnectionSource).not.toHaveBeenCalled();
+    expect(harness.record.metadata).toEqual(retryingMetadata);
+  });
+
+  it("keeps Junction historical progress and its reset marker bidirectionally consistent", async () => {
+    const hostedConnectionId = "conn_junction_reset_consistency";
+    const sourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+      connectionId: hostedConnectionId,
+      sourceProviderSlug: "garmin",
+    });
+    if (!sourceInstanceKey) {
+      throw new Error("Expected a Junction source key for reset consistency.");
+    }
+    const windowStart = "2026-04-01T00:00:00.000Z";
+    const windowEnd = "2026-04-03T00:00:00.000Z";
+    const progress = (status: "complete" | "exhausted" | "retrying") => ({
+      junctionHistoricalBackfillEmptyAttempts: status === "exhausted" ? 5 : 1,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-06T10:00:00.000Z",
+      junctionHistoricalBackfillStatus: `coverage_v2_${status}`,
+      junctionHistoricalBackfillWindowEnd: windowEnd,
+      junctionHistoricalBackfillWindowStart: windowStart,
+    });
+    const source = (resetRequired: boolean, lastSeenAt: string) => ({
+      connectionId: hostedConnectionId,
+      displayName: "Garmin",
+      firstSeenAt: "2026-04-01T09:00:00.000Z",
+      lastErrorCode: resetRequired ? "HISTORICAL_DATA_RECONNECT_REQUIRED" : null,
+      lastErrorMessage: resetRequired ? "Historical data remained incomplete." : null,
+      lastSeenAt,
+      resourceAvailabilitySummary: { activity: true },
+      sourceInstanceKey,
+      sourceProviderSlug: "garmin",
+      status: resetRequired ? "error" as const : "connected" as const,
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const cases = [
+      {
+        expectedWrite: "skipped_version_mismatch",
+        name: "marker without exhausted progress",
+        storedMetadata: progress("retrying"),
+        storedSource: source(false, "2026-04-06T10:00:00.000Z"),
+        update: {
+          connectionId: hostedConnectionId,
+          observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+          sources: [{
+            ...source(true, "2026-04-06T10:05:00.000Z"),
+            connectionId: undefined,
+            observedLastSeenAt: "2026-04-06T10:00:00.000Z",
+          }],
+        },
+      },
+      {
+        expectedWrite: "skipped_version_mismatch",
+        name: "completed progress without marker clear",
+        storedMetadata: progress("exhausted"),
+        storedSource: source(true, "2026-04-06T10:00:00.000Z"),
+        update: {
+          connection: { metadata: progress("complete") },
+          connectionId: hostedConnectionId,
+          observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+        },
+      },
+      {
+        expectedWrite: "applied",
+        name: "completed progress with marker clear",
+        storedMetadata: progress("exhausted"),
+        storedSource: source(true, "2026-04-06T10:00:00.000Z"),
+        update: {
+          connection: { metadata: progress("complete") },
+          connectionId: hostedConnectionId,
+          observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+          sources: [{
+            ...source(false, "2026-04-06T10:05:00.000Z"),
+            connectionId: undefined,
+            observedLastSeenAt: "2026-04-06T10:00:00.000Z",
+          }],
+        },
+      },
+    ] as const;
+
+    for (const scenario of cases) {
+      const harness = createAuthorityHarness({
+        connectionSources: [scenario.storedSource],
+        record: buildHostedRecord({
+          id: hostedConnectionId,
+          metadata: scenario.storedMetadata,
+          provider: "junction",
+        }),
+      });
+      const response = await applyHostedDeviceSyncRuntimeResult({
+        request: new Request("https://example.test/device-sync/runtime/apply", {
+          body: JSON.stringify({ updates: [scenario.update], userId: "user_123" }),
+          method: "POST",
+        }),
+        trustedUserId: "user_123",
+      });
+
+      expect(response.updates[0]?.writeUpdate, scenario.name).toBe(scenario.expectedWrite);
+      if (scenario.expectedWrite === "applied") {
+        expect(harness.syncDurableConnectionState, scenario.name).toHaveBeenCalledTimes(1);
+        expect(harness.upsertConnectionSource, scenario.name).toHaveBeenCalledWith(
+          expect.objectContaining({ lastErrorCode: null, status: "connected" }),
+        );
+      } else {
+        expect(harness.syncDurableConnectionState, scenario.name).not.toHaveBeenCalled();
+        expect(harness.upsertConnectionSource, scenario.name).not.toHaveBeenCalled();
+      }
+    }
+  });
+
+  it("applies monotonic Junction evidence unions without a permanent version mismatch", async () => {
+    const windowStart = "2026-04-01T00:00:00.000Z";
+    const windowEnd = "2026-04-03T00:00:00.000Z";
+    const baselineMetadata = {
+      junctionHistoricalBackfillEmptyAttempts: 1,
+      junctionHistoricalBackfillEvidence: `e1|${windowStart}|${windowEnd}|garmin:1`,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      junctionHistoricalBackfillWindowEnd: windowEnd,
+      junctionHistoricalBackfillWindowStart: windowStart,
+    };
+    const harness = createAuthorityHarness({
+      record: buildHostedRecord({
+        id: "conn_junction_evidence_union",
+        metadata: baselineMetadata,
+        provider: "junction",
+      }),
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [
+            {
+              connection: {
+                metadata: {
+                  ...baselineMetadata,
+                  junctionHistoricalBackfillEvidence:
+                    `e1|${windowStart}|${windowEnd}|oura:2`,
+                  providerCursor: "cursor-next",
+                },
+              },
+              connectionId: "conn_junction_evidence_union",
+              observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+            },
+          ],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(response.updates[0]?.writeUpdate).toBe("applied");
+    expect(harness.syncDurableConnectionState).toHaveBeenCalledTimes(1);
+    expect(harness.record.metadata).toEqual({
+      ...baselineMetadata,
+      junctionHistoricalBackfillEvidence:
+        `e1|${windowStart}|${windowEnd}|garmin:1,oura:2`,
+      providerCursor: "cursor-next",
+    });
+  });
+
+  it("preserves a Junction reset marker on source-only updates while progress is exhausted", async () => {
+    const hostedConnectionId = "conn_junction_source_marker";
+    const sourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+      connectionId: hostedConnectionId,
+      sourceProviderSlug: "garmin",
+    });
+    expect(sourceInstanceKey).toBeTruthy();
+    if (!sourceInstanceKey) {
+      throw new Error("Expected a Junction source key for the reset-marker regression.");
+    }
+    const windowStart = "2026-04-01T00:00:00.000Z";
+    const windowEnd = "2026-04-03T00:00:00.000Z";
+    const harness = createAuthorityHarness({
+      connectionSources: [
+        {
+          connectionId: hostedConnectionId,
+          displayName: "Garmin",
+          firstSeenAt: "2026-04-01T09:00:00.000Z",
+          lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+          lastErrorMessage: "Historical data remained incomplete.",
+          lastSeenAt: "2026-04-06T10:00:00.000Z",
+          resourceAvailabilitySummary: { activity: true },
+          sourceInstanceKey,
+          sourceProviderSlug: "garmin",
+          status: "error",
+        },
+      ],
+      record: buildHostedRecord({
+        id: hostedConnectionId,
+        metadata: {
+          junctionHistoricalBackfillEmptyAttempts: 5,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-06T10:00:00.000Z",
+          junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+          junctionHistoricalBackfillWindowEnd: windowEnd,
+          junctionHistoricalBackfillWindowStart: windowStart,
+        },
+        provider: "junction",
+      }),
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [
+            {
+              connectionId: hostedConnectionId,
+              observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+              sources: [
+                {
+                  displayName: "Garmin",
+                  firstSeenAt: "2026-04-01T09:00:00.000Z",
+                  lastErrorCode: null,
+                  lastErrorMessage: null,
+                  lastSeenAt: "2026-04-06T10:05:00.000Z",
+                  observedLastSeenAt: "2026-04-06T10:00:00.000Z",
+                  resourceAvailabilitySummary: { activity: true, sleep: true },
+                  sourceInstanceKey,
+                  sourceProviderSlug: "garmin",
+                  status: "connected",
+                },
+              ],
+            },
+          ],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(response.updates[0]?.writeUpdate).toBe("applied");
+    expect(harness.upsertConnectionSource).toHaveBeenCalledWith(expect.objectContaining({
+      lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+      lastErrorMessage: "Historical data remained incomplete.",
+      sourceInstanceKey,
+      status: "error",
+    }));
+  });
+
+  it("rejects a Junction source-only write from an older connection epoch", async () => {
+    const hostedConnectionId = "conn_junction_stale_epoch";
+    const sourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+      connectionId: hostedConnectionId,
+      sourceProviderSlug: "garmin",
+    });
+    if (!sourceInstanceKey) {
+      throw new Error("Expected a Junction source key for the connection-epoch regression.");
+    }
+    const harness = createAuthorityHarness({
+      connectionSources: [
+        {
+          connectionId: hostedConnectionId,
+          displayName: "Garmin",
+          firstSeenAt: "2026-04-06T09:00:00.000Z",
+          lastErrorCode: null,
+          lastErrorMessage: null,
+          lastSeenAt: "2026-04-06T10:05:00.000Z",
+          resourceAvailabilitySummary: { activity: true },
+          sourceInstanceKey,
+          sourceProviderSlug: "garmin",
+          status: "connected",
+        },
+      ],
+      record: buildHostedRecord({
+        id: hostedConnectionId,
+        provider: "junction",
+        updatedAt: "2026-04-06T10:10:00.000Z",
+      }),
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [
+            {
+              connectionId: hostedConnectionId,
+              observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+              sources: [
+                {
+                  displayName: "Garmin",
+                  firstSeenAt: "2026-04-06T09:00:00.000Z",
+                  lastErrorCode: null,
+                  lastErrorMessage: null,
+                  lastSeenAt: "2026-04-06T10:15:00.000Z",
+                  observedLastSeenAt: "2026-04-06T10:05:00.000Z",
+                  resourceAvailabilitySummary: { activity: true, sleep: true },
+                  sourceInstanceKey,
+                  sourceProviderSlug: "garmin",
+                  status: "connected",
+                },
+              ],
+            },
+          ],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(response.updates[0]?.writeUpdate).toBe("skipped_version_mismatch");
+    expect(harness.upsertConnectionSource).not.toHaveBeenCalled();
+    expect(harness.syncDurableConnectionState).not.toHaveBeenCalled();
+  });
+
+  it("rejects a coupled Junction progress transition when its source fence is stale", async () => {
+    const hostedConnectionId = "conn_junction_source_race";
+    const sourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+      connectionId: hostedConnectionId,
+      sourceProviderSlug: "garmin",
+    });
+    expect(sourceInstanceKey).toBeTruthy();
+    if (!sourceInstanceKey) {
+      throw new Error("Expected a Junction source key for the source-fence regression.");
+    }
+    const windowStart = "2026-04-01T00:00:00.000Z";
+    const windowEnd = "2026-04-03T00:00:00.000Z";
+    const retryingMetadata = {
+      junctionHistoricalBackfillEmptyAttempts: 1,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      junctionHistoricalBackfillWindowEnd: windowEnd,
+      junctionHistoricalBackfillWindowStart: windowStart,
+    };
+    const harness = createAuthorityHarness({
+      connectionSources: [
+        {
+          connectionId: hostedConnectionId,
+          displayName: "Garmin",
+          firstSeenAt: "2026-04-01T09:00:00.000Z",
+          lastErrorCode: null,
+          lastErrorMessage: null,
+          lastSeenAt: "2026-04-06T10:10:00.000Z",
+          resourceAvailabilitySummary: { activity: true },
+          sourceInstanceKey,
+          sourceProviderSlug: "garmin",
+          status: "connected",
+        },
+      ],
+      record: buildHostedRecord({
+        id: hostedConnectionId,
+        metadata: retryingMetadata,
+        provider: "junction",
+      }),
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [
+            {
+              connection: {
+                metadata: {
+                  junctionHistoricalBackfillEmptyAttempts: 5,
+                  junctionHistoricalBackfillLastEmptyAt: "2026-04-06T10:05:00.000Z",
+                  junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+                  junctionHistoricalBackfillWindowEnd: windowEnd,
+                  junctionHistoricalBackfillWindowStart: windowStart,
+                },
+              },
+              connectionId: hostedConnectionId,
+              observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+              sources: [
+                {
+                  displayName: "Garmin",
+                  firstSeenAt: "2026-04-01T09:00:00.000Z",
+                  lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+                  lastErrorMessage: "Historical data remained incomplete.",
+                  lastSeenAt: "2026-04-06T10:05:00.000Z",
+                  observedLastSeenAt: "2026-04-06T10:00:00.000Z",
+                  resourceAvailabilitySummary: { activity: true },
+                  sourceInstanceKey,
+                  sourceProviderSlug: "garmin",
+                  status: "error",
+                },
+              ],
+            },
+          ],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(response.updates[0]?.writeUpdate).toBe("skipped_version_mismatch");
+    expect(harness.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(harness.upsertConnectionSource).not.toHaveBeenCalled();
+    expect(harness.record.metadata).toEqual(retryingMetadata);
   });
 
   it("skips stale runtime source availability updates", async () => {

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -1,3 +1,4 @@
+import { DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE } from "@murphai/device-syncd/public-account";
 import { DEFAULT_DEVICE_SYNC_HTTP_BODY_LIMIT_BYTES } from "@murphai/device-syncd/public-ingress";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1043,15 +1044,18 @@ describe("hosted device-sync wakes", () => {
       .mockResolvedValueOnce(disconnectedConnection);
     const publicConnectionId = buildPublicConnectionId("dsc_123");
 
-    await expect(controlPlane.disconnectConnection("user-123", publicConnectionId)).resolves.toMatchObject({
+    const result = await controlPlane.disconnectConnection("user-123", publicConnectionId);
+
+    expect(result).toMatchObject({
       connection: {
         id: publicConnectionId,
         status: "disconnected",
       },
-      warning: {
-        code: "PROVIDER_REVOKE_FAILED",
-        message: "authorization=[redacted] refresh_token=[redacted]",
-      },
+    });
+    // Exact shape: an ordinary revoke failure must not carry the historical-reset flag.
+    expect(result.warning).toEqual({
+      code: "PROVIDER_REVOKE_FAILED",
+      message: "authorization=[redacted] refresh_token=[redacted]",
     });
 
     expect(revokeAccess).toHaveBeenCalledTimes(1);
@@ -1075,6 +1079,170 @@ describe("hosted device-sync wakes", () => {
         }),
       }),
     );
+  });
+
+  it("returns a stable historical-reset warning when revoke fails during Junction historical recovery", async () => {
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
+    );
+    const activeConnection = buildHostedConnection({
+      provider: "junction",
+    });
+    const revokeAccess = vi.fn(async () => {
+      throw new Error("junction deregistration failed upstream");
+    });
+    mocks.registryGet.mockReturnValue({
+      connectionHandler: {
+        revokeAccess,
+      },
+    });
+    mocks.listConnectionsForUser.mockResolvedValue([activeConnection]);
+    mocks.getConnectionForUser.mockResolvedValue(activeConnection);
+    mocks.listConnectionSources.mockResolvedValueOnce([
+      {
+        id: "src_garmin",
+        connectionId: "dsc_123",
+        sourceInstanceKey: "jxn_hidden",
+        sourceProviderSlug: "garmin",
+        displayName: null,
+        status: "error",
+        resourceAvailabilitySummary: null,
+        lastErrorCode: DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
+        lastErrorMessage: "Historical data requires reconnecting this source.",
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-07-09T08:50:48.000Z",
+        createdAt: "2026-04-01T08:00:00.000Z",
+        updatedAt: "2026-07-09T08:50:48.000Z",
+      },
+    ]);
+    const publicConnectionId = buildPublicConnectionId("dsc_123");
+
+    const result = await controlPlane.disconnectConnection("user-123", publicConnectionId);
+
+    expect(result.connection).toMatchObject({
+      id: publicConnectionId,
+      status: "disconnected",
+    });
+    expect(result.warning).toEqual({
+      code: "HISTORICAL_RESET_REVOKE_FAILED",
+      historicalResetIncomplete: true,
+      message: "Provider revoke did not complete while a historical data reset is pending. "
+        + "Remove the connection in the provider account before reconnecting.",
+    });
+    expect(mocks.listConnectionSources).toHaveBeenCalledWith("dsc_123");
+    expect(mocks.createSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        revokeWarning: {
+          code: "HISTORICAL_RESET_REVOKE_FAILED",
+          message: "Provider revoke did not complete while a historical data reset is pending. "
+            + "Remove the connection in the provider account before reconnecting.",
+        },
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain("deregistration failed upstream");
+  });
+
+  it("keeps the historical-reset warning when a repeated disconnect fails revoke after sources were cleared", async () => {
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
+    );
+    const disconnectedConnection = buildHostedConnection({
+      lastErrorCode: "HISTORICAL_RESET_REVOKE_FAILED",
+      lastErrorMessage: "Provider revoke did not complete while a historical data reset is pending. "
+        + "Remove the connection in the provider account before reconnecting.",
+      provider: "junction",
+      status: "disconnected",
+    });
+    const revokeAccess = vi.fn(async () => {
+      throw new Error("junction deregistration failed upstream again");
+    });
+    mocks.registryGet.mockReturnValue({
+      connectionHandler: {
+        revokeAccess,
+      },
+    });
+    mocks.listConnectionsForUser.mockResolvedValue([disconnectedConnection]);
+    mocks.getConnectionForUser.mockResolvedValue(disconnectedConnection);
+    mocks.getStoredConnectionAccountForUser.mockResolvedValue(buildProviderConfigStoredConnection({
+      externalAccountId: "junction-user-123",
+      lastErrorCode: "HISTORICAL_RESET_REVOKE_FAILED",
+      provider: "junction",
+      status: "disconnected",
+    }));
+    // The first disconnect attempt already cleared the source recovery markers.
+    mocks.listConnectionSources.mockResolvedValue([]);
+    const publicConnectionId = buildPublicConnectionId("dsc_123");
+
+    const result = await controlPlane.disconnectConnection("user-123", publicConnectionId);
+
+    expect(revokeAccess).toHaveBeenCalledTimes(1);
+    expect(result.connection).toMatchObject({
+      id: publicConnectionId,
+      lastErrorCode: "HISTORICAL_RESET_REVOKE_FAILED",
+      status: "disconnected",
+    });
+    expect(result.warning).toEqual({
+      code: "HISTORICAL_RESET_REVOKE_FAILED",
+      historicalResetIncomplete: true,
+      message: "Provider revoke did not complete while a historical data reset is pending. "
+        + "Remove the connection in the provider account before reconnecting.",
+    });
+    expect(mocks.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain("deregistration failed upstream");
+    expect(JSON.stringify(result)).not.toContain("PROVIDER_REVOKE_FAILED");
+  });
+
+  it("clears a historical-reset warning when a repeated disconnect finishes remote revoke", async () => {
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
+    );
+    const disconnectedConnection = buildHostedConnection({
+      lastErrorCode: "HISTORICAL_RESET_REVOKE_FAILED",
+      lastErrorMessage: "Remove the old provider connection before reconnecting.",
+      provider: "junction",
+      status: "disconnected",
+    });
+    const storedConnection = buildProviderConfigStoredConnection({
+      externalAccountId: "junction-user-123",
+      lastErrorCode: "HISTORICAL_RESET_REVOKE_FAILED",
+      provider: "junction",
+      status: "disconnected",
+    });
+    const revokeAccess = vi.fn(async () => {});
+    mocks.registryGet.mockReturnValue({
+      connectionHandler: {
+        revokeAccess,
+      },
+    });
+    mocks.listConnectionsForUser.mockResolvedValue([disconnectedConnection]);
+    mocks.getConnectionForUser.mockResolvedValue(disconnectedConnection);
+    mocks.getStoredConnectionAccountForUser.mockResolvedValue(storedConnection);
+    const publicConnectionId = buildPublicConnectionId("dsc_123");
+
+    const result = await controlPlane.disconnectConnection("user-123", publicConnectionId);
+
+    expect(revokeAccess).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      connection: expect.objectContaining({
+        id: publicConnectionId,
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        status: "disconnected",
+      }),
+    });
+    expect(mocks.clearStoredProviderConfigCredential).toHaveBeenCalledTimes(1);
+    expect(mocks.syncDurableConnectionState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "dsc_123",
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        status: "disconnected",
+      }),
+      mocks.prismaTx,
+    );
+    expect(mocks.createSignal).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+    expect(mocks.signalHostedDeviceSyncMailboxRuntime).not.toHaveBeenCalled();
   });
 
   it("fails disconnect when the runtime no longer has provider identity to reseed", async () => {
@@ -1218,6 +1386,58 @@ describe("hosted device-sync wakes", () => {
       },
     ]);
     expect(JSON.stringify(result.connectionSources)).not.toContain("TOKEN_REFRESH_FAILED");
+  });
+
+  it("projects historical-data reconnect-required source errors as connection-reset recovery", async () => {
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/settings/device-sync"),
+    );
+    mocks.listConnectionsForUser.mockResolvedValue([
+      buildHostedConnection({
+        id: "dsc_junction_garmin",
+        displayName: "Junction",
+        provider: "junction",
+      }),
+    ]);
+    mocks.listConnectionSources.mockResolvedValueOnce([
+      {
+        id: "src_garmin",
+        connectionId: "dsc_junction_garmin",
+        sourceInstanceKey: "jxn_hidden",
+        sourceProviderSlug: "garmin",
+        displayName: null,
+        status: "error",
+        resourceAvailabilitySummary: {
+          activity: true,
+          sleep: true,
+          workouts: true,
+        },
+        lastErrorCode: DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
+        lastErrorMessage: "Historical data requires reconnecting this source.",
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-07-09T08:50:48.000Z",
+        createdAt: "2026-04-01T08:00:00.000Z",
+        updatedAt: "2026-07-09T08:50:48.000Z",
+      },
+    ]);
+
+    const result = await controlPlane.listConnections("user-123");
+
+    expect(result.connectionSources).toEqual([
+      {
+        connectionId: buildPublicConnectionId("dsc_junction_garmin"),
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-07-09T08:50:48.000Z",
+        recoveryKind: "connection_reset",
+        resourceCount: 3,
+        sourceProviderSlug: "garmin",
+        status: "error",
+      },
+    ]);
+    expect(JSON.stringify(result.connectionSources)).not.toContain("requiresReconnect");
+    expect(JSON.stringify(result.connectionSources)).not.toContain(
+      DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
+    );
   });
 
   it("resolves browser status reads through the opaque browser connection id", async () => {

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -1215,7 +1215,7 @@ describe("hosted device-sync wakes", () => {
     expect(mocks.signalHostedDeviceSyncMailboxRuntime).not.toHaveBeenCalled();
   });
 
-  it("sanitizes revoke failures before they fan out to runtime state, signals, dispatches, and the browser response", async () => {
+  it("uses the locked source snapshot after a historical marker clears while sanitizing revoke failures", async () => {
     const controlPlane = createHostedDeviceSyncPublicIngressService(
       new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
     );
@@ -1225,7 +1225,12 @@ describe("hosted device-sync wakes", () => {
       lastErrorMessage: "authorization=[redacted] refresh_token=[redacted]",
       status: "disconnected",
     });
+    let currentSources = [{
+      lastErrorCode: DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
+      status: "error",
+    }];
     const revokeAccess = vi.fn(async () => {
+      currentSources = [];
       throw new Error("authorization=Bearer secret-token refresh_token=refresh-secret");
     });
     mocks.registryGet.mockReturnValue({
@@ -1237,6 +1242,7 @@ describe("hosted device-sync wakes", () => {
     mocks.getConnectionForUser
       .mockResolvedValueOnce(activeConnection)
       .mockResolvedValueOnce(disconnectedConnection);
+    mocks.listConnectionSources.mockImplementation(async () => currentSources);
     const publicConnectionId = buildPublicConnectionId("dsc_123");
 
     const result = await controlPlane.disconnectConnection("user-123", publicConnectionId);
@@ -1254,6 +1260,7 @@ describe("hosted device-sync wakes", () => {
     });
 
     expect(revokeAccess).toHaveBeenCalledTimes(1);
+    expect(mocks.listConnectionSources).toHaveBeenCalledWith("dsc_123", mocks.prismaTx);
     expect(mocks.createSignal).toHaveBeenCalledWith(
       expect.objectContaining({
         revokeWarning: {
@@ -1276,14 +1283,19 @@ describe("hosted device-sync wakes", () => {
     );
   });
 
-  it("returns a stable historical-reset warning when revoke fails during Junction historical recovery", async () => {
+  it("uses a historical-reset marker that appears during provider revoke from the locked source snapshot", async () => {
     const controlPlane = createHostedDeviceSyncPublicIngressService(
       new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
     );
     const activeConnection = buildHostedConnection({
       provider: "junction",
     });
+    let currentSources: Array<{ lastErrorCode: string; status: string }> = [];
     const revokeAccess = vi.fn(async () => {
+      currentSources = [{
+        lastErrorCode: DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
+        status: "error",
+      }];
       throw new Error("junction deregistration failed upstream");
     });
     mocks.registryGet.mockReturnValue({
@@ -1293,23 +1305,7 @@ describe("hosted device-sync wakes", () => {
     });
     mocks.listConnectionsForUser.mockResolvedValue([activeConnection]);
     mocks.getConnectionForUser.mockResolvedValue(activeConnection);
-    mocks.listConnectionSources.mockResolvedValueOnce([
-      {
-        id: "src_garmin",
-        connectionId: "dsc_123",
-        sourceInstanceKey: "jxn_hidden",
-        sourceProviderSlug: "garmin",
-        displayName: null,
-        status: "error",
-        resourceAvailabilitySummary: null,
-        lastErrorCode: DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
-        lastErrorMessage: "Historical data requires reconnecting this source.",
-        firstSeenAt: "2026-04-01T08:00:00.000Z",
-        lastSeenAt: "2026-07-09T08:50:48.000Z",
-        createdAt: "2026-04-01T08:00:00.000Z",
-        updatedAt: "2026-07-09T08:50:48.000Z",
-      },
-    ]);
+    mocks.listConnectionSources.mockImplementation(async () => currentSources);
     const publicConnectionId = buildPublicConnectionId("dsc_123");
 
     const result = await controlPlane.disconnectConnection("user-123", publicConnectionId);
@@ -1324,7 +1320,7 @@ describe("hosted device-sync wakes", () => {
       message: "Provider revoke did not complete while a historical data reset is pending. "
         + "Remove the connection in the provider account before reconnecting.",
     });
-    expect(mocks.listConnectionSources).toHaveBeenCalledWith("dsc_123");
+    expect(mocks.listConnectionSources).toHaveBeenCalledWith("dsc_123", mocks.prismaTx);
     expect(mocks.createSignal).toHaveBeenCalledWith(
       expect.objectContaining({
         revokeWarning: {
@@ -1673,6 +1669,12 @@ describe("hosted device-sync wakes", () => {
 
     await controlPlane.handleOAuthCallback("oura");
 
+    expect(mocks.withConnectionMutationLock).toHaveBeenCalledWith("dsc_123", expect.any(Function));
+    expect(mocks.getConnectionForUser).toHaveBeenCalledWith(
+      "user-123",
+      "dsc_123",
+      mocks.prismaTx,
+    );
     expect(mocks.createSignal).toHaveBeenCalledWith(
       expect.objectContaining({
         connectionId: "dsc_123",
@@ -1705,9 +1707,38 @@ describe("hosted device-sync wakes", () => {
         tx: mocks.prismaTx,
       }),
     );
+    expect(mocks.signalHostedDeviceSyncMailboxRuntime).toHaveBeenCalledWith({
+      mailboxItemId: "mailbox_123",
+    });
     expect(mocks.ensureWebhookSubscriptions).toHaveBeenCalledWith({
       publicBaseUrl: "https://control.example.test/api/device-sync",
     });
+  });
+
+  it.each([
+    ["a missing account", null],
+    ["a disconnected account", buildHostedConnection({ status: "disconnected" })],
+    ["a newer connection epoch", buildHostedConnection({
+      connectedAt: "2026-03-26T12:01:00.000Z",
+    })],
+  ])("does not persist a late connection-established wake over %s", async (_label, current) => {
+    mocks.getConnectionForUser.mockResolvedValue(current);
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/device-sync/oauth/oura/callback?code=abc&state=xyz"),
+    );
+
+    await controlPlane.handleOAuthCallback("oura");
+
+    expect(mocks.withConnectionMutationLock).toHaveBeenCalledWith("dsc_123", expect.any(Function));
+    expect(mocks.getConnectionForUser).toHaveBeenCalledWith(
+      "user-123",
+      "dsc_123",
+      mocks.prismaTx,
+    );
+    expect(mocks.upsertConnectionSource).not.toHaveBeenCalled();
+    expect(mocks.createSignal).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+    expect(mocks.signalHostedDeviceSyncMailboxRuntime).not.toHaveBeenCalled();
   });
 
   it("durably upserts a Junction source row from the connected ingress hook", async () => {

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -836,6 +836,201 @@ describe("hosted device-sync wakes", () => {
     expect(mocks.appendHostedMailboxEnvelope).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects a stale disconnect when OAuth tokens rotate during provider revoke", async () => {
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
+    );
+    const beforeRefresh = buildHostedConnection({
+      accessTokenExpiresAt: "2026-03-26T12:05:00.000Z",
+    });
+    const afterRefresh = buildHostedConnection({
+      accessTokenExpiresAt: "2026-03-26T13:00:00.000Z",
+      updatedAt: "2026-03-26T12:01:00.000Z",
+    });
+    const beforeRefreshStored = buildStoredConnection({
+      accessTokenExpiresAt: "2026-03-26T12:05:00.000Z",
+    });
+    const afterRefreshStored = {
+      ...buildStoredConnection({
+        accessTokenExpiresAt: "2026-03-26T13:00:00.000Z",
+        updatedAt: "2026-03-26T12:01:00.000Z",
+      }),
+      tokenVersion: 3,
+    };
+    let currentConnection = beforeRefresh;
+    let currentStoredConnection = beforeRefreshStored;
+    let releaseRevoke: (() => void) | undefined;
+    let markRevokeStarted: (() => void) | undefined;
+    const revokeStarted = new Promise<void>((resolve) => {
+      markRevokeStarted = resolve;
+    });
+    const revokeBlocked = new Promise<void>((resolve) => {
+      releaseRevoke = resolve;
+    });
+    const revokeAccess = vi.fn(async () => {
+      markRevokeStarted?.();
+      await revokeBlocked;
+    });
+    mocks.registryGet.mockReturnValue({
+      connectionHandler: {
+        revokeAccess,
+      },
+    });
+    mocks.listConnectionsForUser.mockResolvedValue([beforeRefresh]);
+    mocks.getConnectionForUser.mockImplementation(async () => currentConnection);
+    mocks.getStoredConnectionAccountForUser.mockImplementation(async () => currentStoredConnection);
+    const publicConnectionId = buildPublicConnectionId("dsc_123");
+
+    const disconnect = controlPlane.disconnectConnection("user-123", publicConnectionId);
+    await revokeStarted;
+    currentConnection = afterRefresh;
+    currentStoredConnection = afterRefreshStored;
+    releaseRevoke?.();
+
+    await expect(disconnect).rejects.toMatchObject({
+      code: "CONNECTION_CHANGED_DURING_DISCONNECT",
+      httpStatus: 409,
+      retryable: true,
+    });
+    expect(revokeAccess).toHaveBeenCalledWith(beforeRefreshStored);
+    expect(mocks.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(mocks.markConnectionSourcesDisconnected).not.toHaveBeenCalled();
+    expect(mocks.persistStoredConnectionTokenBundle).not.toHaveBeenCalled();
+    expect(mocks.clearStoredProviderConfigCredential).not.toHaveBeenCalled();
+    expect(mocks.createSignal).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+    expect(mocks.signalHostedDeviceSyncMailboxRuntime).not.toHaveBeenCalled();
+    expect(mocks.nudgeHostedRunnerUserBestEffortResult).not.toHaveBeenCalled();
+  });
+
+  it("leaves a reconnect alone after atomically observing a disconnected credential-less epoch", async () => {
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
+    );
+    const beforeReconnect = buildHostedConnection({ status: "disconnected" });
+    const afterReconnect = buildHostedConnection({
+      connectedAt: "2026-03-26T12:01:00.000Z",
+      updatedAt: "2026-03-26T12:01:00.000Z",
+    });
+    const afterReconnectStored = buildStoredConnection({
+      connectedAt: "2026-03-26T12:01:00.000Z",
+      updatedAt: "2026-03-26T12:01:00.000Z",
+    });
+    let currentConnection = beforeReconnect;
+    let currentStoredConnection: ReturnType<typeof buildStoredConnection> | null = null;
+    let lockCount = 0;
+    mocks.listConnectionsForUser.mockResolvedValue([beforeReconnect]);
+    mocks.getConnectionForUser.mockImplementation(async () => currentConnection);
+    mocks.getStoredConnectionAccountForUser.mockImplementation(async () => currentStoredConnection);
+    mocks.withConnectionMutationLock.mockImplementation(async (
+      _connectionId: string,
+      callback: (tx: typeof mocks.prismaTx) => Promise<unknown>,
+    ) => {
+      lockCount += 1;
+      const result = await callback(mocks.prismaTx);
+      if (lockCount === 1) {
+        currentConnection = afterReconnect;
+        currentStoredConnection = afterReconnectStored;
+      }
+      return result;
+    });
+
+    await expect(
+      controlPlane.disconnectConnection("user-123", buildPublicConnectionId("dsc_123")),
+    ).resolves.toMatchObject({
+      connection: {
+        status: "disconnected",
+      },
+    });
+
+    expect(lockCount).toBe(1);
+    expect(mocks.getConnectionForUser.mock.calls[0]?.[2]).toBe(mocks.prismaTx);
+    expect(mocks.getStoredConnectionAccountForUser.mock.calls[0]?.[2]).toBe(mocks.prismaTx);
+    expect(mocks.registryGet).not.toHaveBeenCalled();
+    expect(mocks.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(mocks.persistStoredConnectionTokenBundle).not.toHaveBeenCalled();
+    expect(mocks.createSignal).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale disconnect when a reconnect epoch lands during provider revoke", async () => {
+    const controlPlane = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
+    );
+    const beforeReconnect = buildHostedConnection({
+      displayName: "Junction",
+      externalAccountId: "junction-user-123",
+      provider: "junction",
+      scopes: [],
+    });
+    const afterReconnect = buildHostedConnection({
+      connectedAt: "2026-03-26T12:01:00.000Z",
+      displayName: "Junction",
+      externalAccountId: "junction-user-123",
+      provider: "junction",
+      scopes: [],
+      updatedAt: "2026-03-26T12:01:00.000Z",
+    });
+    const beforeReconnectStored = buildProviderConfigStoredConnection({
+      displayName: "Junction",
+      externalAccountId: "junction-user-123",
+      provider: "junction",
+      scopes: [],
+    });
+    const afterReconnectStored = buildProviderConfigStoredConnection({
+      connectedAt: "2026-03-26T12:01:00.000Z",
+      displayName: "Junction",
+      externalAccountId: "junction-user-123",
+      provider: "junction",
+      scopes: [],
+      updatedAt: "2026-03-26T12:01:00.000Z",
+    });
+    let currentConnection = beforeReconnect;
+    let currentStoredConnection = beforeReconnectStored;
+    let releaseRevoke: (() => void) | undefined;
+    let markRevokeStarted: (() => void) | undefined;
+    const revokeStarted = new Promise<void>((resolve) => {
+      markRevokeStarted = resolve;
+    });
+    const revokeBlocked = new Promise<void>((resolve) => {
+      releaseRevoke = resolve;
+    });
+    const revokeAccess = vi.fn(async () => {
+      markRevokeStarted?.();
+      await revokeBlocked;
+    });
+    mocks.registryGet.mockReturnValue({
+      connectionHandler: {
+        revokeAccess,
+      },
+    });
+    mocks.listConnectionsForUser.mockResolvedValue([beforeReconnect]);
+    mocks.getConnectionForUser.mockImplementation(async () => currentConnection);
+    mocks.getStoredConnectionAccountForUser.mockImplementation(async () => currentStoredConnection);
+    const publicConnectionId = buildPublicConnectionId("dsc_123");
+
+    const disconnect = controlPlane.disconnectConnection("user-123", publicConnectionId);
+    await revokeStarted;
+    currentConnection = afterReconnect;
+    currentStoredConnection = afterReconnectStored;
+    releaseRevoke?.();
+
+    await expect(disconnect).rejects.toMatchObject({
+      code: "CONNECTION_CHANGED_DURING_DISCONNECT",
+      httpStatus: 409,
+      retryable: true,
+    });
+    expect(revokeAccess).toHaveBeenCalledWith(beforeReconnectStored);
+    expect(mocks.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(mocks.markConnectionSourcesDisconnected).not.toHaveBeenCalled();
+    expect(mocks.persistStoredConnectionTokenBundle).not.toHaveBeenCalled();
+    expect(mocks.clearStoredProviderConfigCredential).not.toHaveBeenCalled();
+    expect(mocks.createSignal).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+    expect(mocks.signalHostedDeviceSyncMailboxRuntime).not.toHaveBeenCalled();
+    expect(mocks.nudgeHostedRunnerUserBestEffortResult).not.toHaveBeenCalled();
+  });
+
   it("revokes active provider-config connections during hosted disconnect", async () => {
     const controlPlane = createHostedDeviceSyncPublicIngressService(
       new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
@@ -1250,16 +1445,11 @@ describe("hosted device-sync wakes", () => {
       new Request("https://control.example.test/api/settings/device-sync/connections/dsc_123/disconnect"),
     );
     const activeConnection = buildHostedConnection();
-    const disconnectedConnection = buildHostedConnection({
-      status: "disconnected",
-    });
     mocks.listConnectionsForUser.mockResolvedValue([activeConnection]);
-    mocks.getConnectionForUser
-      .mockResolvedValueOnce(activeConnection)
-      .mockResolvedValueOnce(disconnectedConnection);
+    mocks.getConnectionForUser.mockResolvedValue(activeConnection);
     const publicConnectionId = buildPublicConnectionId("dsc_123");
 
-    mocks.getStoredConnectionAccountForUser.mockResolvedValueOnce(null);
+    mocks.getStoredConnectionAccountForUser.mockResolvedValue(null);
 
     await expect(controlPlane.disconnectConnection("user-123", publicConnectionId)).resolves.toMatchObject({
       connection: {

--- a/apps/web/test/device-sync-settings-surface.test.ts
+++ b/apps/web/test/device-sync-settings-surface.test.ts
@@ -276,6 +276,8 @@ describe("buildHostedDeviceSyncSettingsSources", () => {
         sourceProviderSlug: null,
       }],
       connections: [buildConnection({
+        lastErrorCode: "PROVIDER_REVOKE_FAILED",
+        lastErrorMessage: "Provider revoke request failed during disconnect.",
         lastSyncCompletedAt: "2026-03-28T07:00:00.000Z",
         status: "disconnected",
       })],
@@ -290,7 +292,54 @@ describe("buildHostedDeviceSyncSettingsSources", () => {
       secondaryAction: null,
       state: "disconnected",
       statusLabel: "Disconnected",
+      tone: "muted",
     });
+    expect(source?.historicalResetIncomplete).toBeUndefined();
+  });
+
+  it("projects an unfinished historical reset on the disconnected source", () => {
+    const [source] = buildHostedDeviceSyncSettingsSources({
+      connectionSources: [{
+        connectionId: "dspc_junction_garmin",
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-07-09T09:00:00.000Z",
+        resourceCount: 0,
+        sourceProviderSlug: "garmin",
+        status: "disconnected",
+      }],
+      connectTargets: [{
+        connectSourceId: "garmin",
+        connectTarget: "garmin",
+        provider: "junction",
+        sourceProviderSlug: "garmin",
+      }],
+      connections: [buildConnection({
+        id: "dspc_junction_garmin",
+        lastErrorCode: "HISTORICAL_RESET_REVOKE_FAILED",
+        lastErrorMessage: "Provider revoke did not complete while a historical data reset is pending. "
+          + "Remove the connection in the provider account before reconnecting.",
+        lastSyncCompletedAt: "2026-07-09T07:00:00.000Z",
+        provider: "junction",
+        status: "disconnected",
+        updatedAt: "2026-07-09T09:00:00.000Z",
+      })],
+      now: new Date("2026-07-09T12:00:00.000Z"),
+      providers: [JUNCTION_PROVIDER],
+    });
+
+    expect(source).toMatchObject({
+      detail: "This source is disconnected, but the last reset did not finish in your wearable provider account.",
+      guidance: "Remove the old connection in your wearable provider account, then connect it again here.",
+      headline: "Disconnected",
+      historicalResetIncomplete: true,
+      primaryAction: null,
+      secondaryAction: null,
+      state: "disconnected",
+      statusLabel: "Needs attention",
+      tone: "attention",
+    });
+    expect(JSON.stringify(source)).not.toContain("HISTORICAL_RESET_REVOKE_FAILED");
+    expect(JSON.stringify(source)).not.toContain("Provider revoke did not complete");
   });
 
   it("uses the Junction reconnect target when direct and Junction targets share a visible source", () => {
@@ -377,6 +426,59 @@ describe("buildHostedDeviceSyncSettingsSources", () => {
       statusLabel: "Needs access",
       tone: "attention",
     });
+  });
+
+  it("surfaces Junction historical connection resets as disconnect-first recovery", () => {
+    const [source] = buildHostedDeviceSyncSettingsSources({
+      connectionSources: [{
+        connectionId: "dspc_junction_garmin",
+        firstSeenAt: "2026-04-01T08:00:00.000Z",
+        lastSeenAt: "2026-07-09T08:50:48.000Z",
+        recoveryKind: "connection_reset",
+        resourceCount: 3,
+        sourceProviderSlug: "garmin",
+        status: "error",
+      }],
+      connectTargets: [{
+        connectSourceId: "garmin",
+        connectTarget: "garmin",
+        provider: "junction",
+        sourceProviderSlug: "garmin",
+      }],
+      connections: [buildConnection({
+        id: "dspc_junction_garmin",
+        lastSyncCompletedAt: "2026-07-09T07:00:00.000Z",
+        provider: "junction",
+        status: "active",
+        updatedAt: "2026-07-09T08:50:48.000Z",
+      })],
+      now: new Date("2026-07-09T12:00:00.000Z"),
+      providers: [JUNCTION_PROVIDER],
+    });
+
+    expect(source).toMatchObject({
+      detail: "Garmin needs a fresh connection before Murph can bring in its history.",
+      guidance: "Disconnect this source first, then connect it again to start a fresh sync.",
+      headline: "Access needs attention",
+      primaryAction: null,
+      providerLabel: "Garmin",
+      secondaryAction: { kind: "disconnect", label: "Disconnect" },
+      state: "active",
+      statusLabel: "Needs attention",
+      tone: "attention",
+    });
+    expect(source?.upstreamSources).toEqual([
+      {
+        connectProvider: "junction",
+        connectSourceId: "garmin",
+        connectTarget: "garmin",
+        providerLabel: "Garmin",
+        recoveryKind: "connection_reset",
+        resourceCount: 3,
+        sourceProviderSlug: "garmin",
+        status: "error",
+      },
+    ]);
   });
 
   it("targets the reconnect-required Junction source when another child source is connected", () => {

--- a/apps/web/test/prisma-store-connection-sources.test.ts
+++ b/apps/web/test/prisma-store-connection-sources.test.ts
@@ -416,12 +416,14 @@ describe("PrismaDeviceSyncControlPlaneStore connection source projection", () =>
     expect(records.get(sourceMapKey("dsc_parent", "src_oura_a"))).toMatchObject({
       lastErrorCode: null,
       lastErrorMessage: null,
+      lastSeenAt: new Date("2026-03-26T12:00:00.000Z"),
       status: "disconnected",
       updatedAt: new Date("2026-03-26T12:00:00.000Z"),
     });
     expect(records.get(sourceMapKey("dsc_parent", "src_garmin_a"))).toMatchObject({
       lastErrorCode: null,
       lastErrorMessage: null,
+      lastSeenAt: new Date("2026-03-26T12:00:00.000Z"),
       status: "disconnected",
       updatedAt: new Date("2026-03-26T12:00:00.000Z"),
     });
@@ -434,6 +436,7 @@ describe("PrismaDeviceSyncControlPlaneStore connection source projection", () =>
     });
     expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
+        lastSeenAt: new Date("2026-03-26T12:00:00.000Z"),
         status: "disconnected",
       }),
       where: {

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -570,11 +570,12 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(createCalled).toBe(false);
   });
 
-  it("updates an existing connection without writing a Prisma secret row", async () => {
+  it("accepts a guarded callback after mutable connection observations change", async () => {
     const existing = createConnection({
       id: "dsc_123",
       provider: "oura",
       status: "active",
+      updatedAt: new Date("2026-03-25T00:30:00.000Z"),
       userId: "user-123",
     });
     const updated = createConnection({
@@ -623,6 +624,11 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       },
       metadata: {
         region: "ca",
+      },
+      existingAccountGuard: {
+        expectedAccountId: "dsc_123",
+        expectedConnectedAt: "2026-03-25T00:00:00.000Z",
+        rejectIfDisconnected: true,
       },
       connectedAt: "2026-03-25T00:00:00.000Z",
       nextReconcileAt: "2026-03-25T05:00:00.000Z",
@@ -900,7 +906,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       metadata: {},
       existingAccountGuard: {
         expectedAccountId: "dsc_123",
-        expectedUpdatedAt: existing.updatedAt.toISOString(),
+        expectedConnectedAt: existing.connectedAt.toISOString(),
         rejectIfDisconnected: true,
       },
       connectedAt: "2026-03-26T03:00:00.000Z",
@@ -912,7 +918,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(tx.deviceConnection.update).not.toHaveBeenCalled();
   });
 
-  it("rejects guarded hosted callback upserts after the seeded connection revision changes", async () => {
+  it("rejects guarded hosted callback upserts after the seeded connection epoch changes", async () => {
     const existing = createConnection({
       accessTokenEncrypted: null,
       id: "dsc_123",
@@ -922,6 +928,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       setupPhase: "source_confirmed",
       status: "active",
       tokenVersion: null,
+      connectedAt: new Date("2026-03-26T03:30:00.000Z"),
       updatedAt: new Date("2026-03-26T03:30:00.000Z"),
       userId: "user-123",
     });
@@ -955,7 +962,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       metadata: {},
       existingAccountGuard: {
         expectedAccountId: "dsc_123",
-        expectedUpdatedAt: "2026-03-26T03:00:00.000Z",
+        expectedConnectedAt: "2026-03-26T03:00:00.000Z",
         rejectIfDisconnected: true,
       },
       connectedAt: "2026-03-26T04:00:00.000Z",
@@ -979,6 +986,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       refreshTokenEncrypted: "enc:refresh-token",
       status: "active",
       tokenVersion: 3,
+      updatedAt: new Date("2026-03-25T00:30:00.000Z"),
     });
 
     const lockConnectionMutation = vi.fn(async () => 0);
@@ -1007,7 +1015,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
 
     const result = await store.markConnectionSetupFailed({
       accountId: "dsc_123",
-      expectedUpdatedAt: "2026-03-25T00:00:00.000Z",
+      expectedConnectedAt: "2026-03-25T00:00:00.000Z",
       now: "2026-03-26T06:00:00.000Z",
       code: "OAUTH_SETUP_FAILED",
       message: "post-connect setup failed",
@@ -1038,13 +1046,16 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(lockConnectionMutation.mock.invocationCallOrder[0]).toBeLessThan(
       tx.deviceConnection.findUnique.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
-    expect(result).toEqual(expect.objectContaining({
+    expect(result).toEqual({
+      applied: true,
+      account: expect.objectContaining({
       accessTokenExpiresAt: null,
       lastErrorCode: "OAUTH_SETUP_FAILED",
       lastErrorMessage: "post-connect setup failed",
       nextReconcileAt: null,
       status: "reauthorization_required",
-    }));
+      }),
+    });
     expect(stored.accessTokenEncrypted).toBeNull();
     expect(stored.refreshTokenEncrypted).toBeNull();
     expect(stored.refreshLeaseOwner).toBeNull();
@@ -1086,7 +1097,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
 
     const result = await store.markConnectionSetupFailed({
       accountId: "dsc_123",
-      expectedUpdatedAt: "2026-03-25T00:00:00.000Z",
+      expectedConnectedAt: "2026-03-25T00:00:00.000Z",
       now: "2026-03-26T06:00:00.000Z",
       code: "OAUTH_SETUP_FAILED",
       message:
@@ -1098,7 +1109,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
         lastErrorMessage: null,
       }),
     }));
-    expect(result?.lastErrorMessage).toBeNull();
+    expect(result.account?.lastErrorMessage).toBeNull();
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain("api.example.test");
     expect(serialized).not.toContain("owner@example.test");
@@ -1133,18 +1144,21 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
 
     const result = await store.markConnectionSetupFailed({
       accountId: stored.id,
-      expectedUpdatedAt: "2026-03-26T06:00:00.000Z",
+      expectedConnectedAt: "2026-03-26T06:00:00.000Z",
       now: "2026-03-26T07:05:00.000Z",
       code: "OAUTH_SETUP_FAILED",
       message: "stale setup failure",
     });
 
     expect(update).not.toHaveBeenCalled();
-    expect(result).toEqual(expect.objectContaining({
-      accessTokenExpiresAt: "2026-03-26T08:00:00.000Z",
-      lastErrorCode: null,
-      status: "active",
-    }));
+    expect(result).toEqual({
+      applied: false,
+      account: expect.objectContaining({
+        accessTokenExpiresAt: "2026-03-26T08:00:00.000Z",
+        lastErrorCode: null,
+        status: "active",
+      }),
+    });
   });
 
   it("leaves a disconnected connection unchanged when setup cleanup has the same timestamp", async () => {
@@ -1174,17 +1188,20 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
 
     const result = await store.markConnectionSetupFailed({
       accountId: stored.id,
-      expectedUpdatedAt: stored.updatedAt.toISOString(),
+      expectedConnectedAt: stored.connectedAt.toISOString(),
       now: "2026-03-26T07:05:00.000Z",
       code: "OAUTH_SETUP_FAILED",
       message: "late setup failure",
     });
 
     expect(update).not.toHaveBeenCalled();
-    expect(result).toEqual(expect.objectContaining({
-      lastErrorCode: null,
-      status: "disconnected",
-    }));
+    expect(result).toEqual({
+      applied: false,
+      account: expect.objectContaining({
+        lastErrorCode: null,
+        status: "disconnected",
+      }),
+    });
   });
 
   it("serves ordinary hosted connection lists from durable Prisma metadata without live runtime reads", async () => {

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -586,10 +586,14 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       userId: "user-123",
     });
 
+    const lockConnectionMutation = vi.fn(async () => 0);
+    const findConnection = vi.fn(async () => cloneConnection(existing));
+    const updateConnection = vi.fn(async () => cloneConnection(updated));
     const tx = {
+      $executeRaw: lockConnectionMutation,
       deviceConnection: {
-        findUnique: async () => cloneConnection(existing),
-        update: async () => cloneConnection(updated),
+        findUnique: findConnection,
+        update: updateConnection,
       },
       deviceConnectionSecret: {
         upsert: vi.fn(async () => {
@@ -626,6 +630,14 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       id: "dsc_123",
       metadata: {},
     }));
+    expect(lockConnectionMutation).toHaveBeenCalledWith(
+      ["select pg_advisory_xact_lock(hashtext(", "))"],
+      "dsc_123",
+    );
+    expect(findConnection).toHaveBeenCalledTimes(2);
+    expect(lockConnectionMutation.mock.invocationCallOrder[0]).toBeLessThan(
+      updateConnection.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(tx.deviceConnectionSecret.upsert).not.toHaveBeenCalled();
   });
 
@@ -648,6 +660,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     });
 
     const tx = {
+      $executeRaw: vi.fn(async () => 0),
       deviceConnection: {
         findUnique: vi.fn(async () => cloneConnection(existing)),
         create: vi.fn(async () => {
@@ -729,6 +742,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     });
 
     const tx = {
+      $executeRaw: vi.fn(async () => 0),
       deviceConnection: {
         findUnique: async () => cloneConnection(stored),
         update: updateConnection,
@@ -805,6 +819,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     });
 
     const tx = {
+      $executeRaw: vi.fn(async () => 0),
       deviceConnection: {
         findUnique: vi.fn(async () => cloneConnection(existing)),
         update: updateConnection,
@@ -854,6 +869,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     });
 
     const tx = {
+      $executeRaw: vi.fn(async () => 0),
       deviceConnection: {
         findUnique: vi.fn(async () => cloneConnection(existing)),
         update: vi.fn(async () => {
@@ -884,12 +900,68 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       metadata: {},
       existingAccountGuard: {
         expectedAccountId: "dsc_123",
+        expectedUpdatedAt: existing.updatedAt.toISOString(),
         rejectIfDisconnected: true,
       },
       connectedAt: "2026-03-26T03:00:00.000Z",
       nextReconcileAt: "2026-03-26T09:00:00.000Z",
     })).rejects.toMatchObject({
       code: "CONNECTION_ALREADY_DISCONNECTED",
+      httpStatus: 409,
+    });
+    expect(tx.deviceConnection.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects guarded hosted callback upserts after the seeded connection revision changes", async () => {
+    const existing = createConnection({
+      accessTokenEncrypted: null,
+      id: "dsc_123",
+      keyVersion: null,
+      provider: "junction",
+      refreshTokenEncrypted: null,
+      setupPhase: "source_confirmed",
+      status: "active",
+      tokenVersion: null,
+      updatedAt: new Date("2026-03-26T03:30:00.000Z"),
+      userId: "user-123",
+    });
+    const tx = {
+      $executeRaw: vi.fn(async () => 0),
+      deviceConnection: {
+        findUnique: vi.fn(async () => cloneConnection(existing)),
+        update: vi.fn(async () => {
+          throw new Error("stale seeded callbacks should not update the newer connection");
+        }),
+      },
+    };
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      codec: TEST_CODEC,
+      prisma: {
+        $transaction: async <TResult>(callback: (transaction: typeof tx) => Promise<TResult>) => callback(tx),
+      } as never,
+      providerAccountBlindIndexKey: BLIND_INDEX_KEY,
+    });
+
+    await expect(store.upsertConnection({
+      ownerId: "user-123",
+      provider: "junction",
+      externalAccountId: "acct_456",
+      displayName: "Garmin",
+      scopes: [],
+      credential: {
+        kind: "provider_config",
+        providerConfigKey: "junction",
+      },
+      metadata: {},
+      existingAccountGuard: {
+        expectedAccountId: "dsc_123",
+        expectedUpdatedAt: "2026-03-26T03:00:00.000Z",
+        rejectIfDisconnected: true,
+      },
+      connectedAt: "2026-03-26T04:00:00.000Z",
+      nextReconcileAt: null,
+    })).rejects.toMatchObject({
+      code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
       httpStatus: 409,
     });
     expect(tx.deviceConnection.update).not.toHaveBeenCalled();
@@ -909,7 +981,9 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       tokenVersion: 3,
     });
 
+    const lockConnectionMutation = vi.fn(async () => 0);
     const tx = {
+      $executeRaw: lockConnectionMutation,
       deviceConnection: {
         findUnique: vi.fn(async () => cloneConnection(stored)),
         update: vi.fn(async ({ data }: { data: Partial<MutableConnectionRecord> }) => {
@@ -933,6 +1007,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
 
     const result = await store.markConnectionSetupFailed({
       accountId: "dsc_123",
+      expectedUpdatedAt: "2026-03-25T00:00:00.000Z",
       now: "2026-03-26T06:00:00.000Z",
       code: "OAUTH_SETUP_FAILED",
       message: "post-connect setup failed",
@@ -956,6 +1031,13 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
         tokenVersion: null,
       }),
     }));
+    expect(lockConnectionMutation).toHaveBeenCalledWith(
+      ["select pg_advisory_xact_lock(hashtext(", "))"],
+      "dsc_123",
+    );
+    expect(lockConnectionMutation.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.deviceConnection.findUnique.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(result).toEqual(expect.objectContaining({
       accessTokenExpiresAt: null,
       lastErrorCode: "OAUTH_SETUP_FAILED",
@@ -980,6 +1062,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     });
 
     const tx = {
+      $executeRaw: vi.fn(async () => 0),
       deviceConnection: {
         findUnique: vi.fn(async () => cloneConnection(stored)),
         update: vi.fn(async ({ data }: { data: Partial<MutableConnectionRecord> }) => {
@@ -1003,6 +1086,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
 
     const result = await store.markConnectionSetupFailed({
       accountId: "dsc_123",
+      expectedUpdatedAt: "2026-03-25T00:00:00.000Z",
       now: "2026-03-26T06:00:00.000Z",
       code: "OAUTH_SETUP_FAILED",
       message:
@@ -1019,6 +1103,88 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(serialized).not.toContain("api.example.test");
     expect(serialized).not.toContain("owner@example.test");
     expect(serialized).not.toContain("secret-token");
+  });
+
+  it("leaves a newer connection epoch unchanged when setup cleanup is stale", async () => {
+    const stored = createConnection({
+      accessTokenEncrypted: "enc:new-access-token",
+      accessTokenExpiresAt: new Date("2026-03-26T08:00:00.000Z"),
+      keyVersion: "v1",
+      refreshTokenEncrypted: "enc:new-refresh-token",
+      status: "active",
+      tokenVersion: 4,
+      updatedAt: new Date("2026-03-26T07:00:00.000Z"),
+    });
+    const update = vi.fn();
+    const tx = {
+      $executeRaw: vi.fn(async () => 0),
+      deviceConnection: {
+        findUnique: vi.fn(async () => cloneConnection(stored)),
+        update,
+      },
+    };
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      codec: TEST_CODEC,
+      prisma: {
+        $transaction: async <TResult>(callback: (transaction: typeof tx) => Promise<TResult>) => callback(tx),
+      } as never,
+      providerAccountBlindIndexKey: BLIND_INDEX_KEY,
+    });
+
+    const result = await store.markConnectionSetupFailed({
+      accountId: stored.id,
+      expectedUpdatedAt: "2026-03-26T06:00:00.000Z",
+      now: "2026-03-26T07:05:00.000Z",
+      code: "OAUTH_SETUP_FAILED",
+      message: "stale setup failure",
+    });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({
+      accessTokenExpiresAt: "2026-03-26T08:00:00.000Z",
+      lastErrorCode: null,
+      status: "active",
+    }));
+  });
+
+  it("leaves a disconnected connection unchanged when setup cleanup has the same timestamp", async () => {
+    const stored = createConnection({
+      accessTokenEncrypted: null,
+      keyVersion: null,
+      refreshTokenEncrypted: null,
+      status: "disconnected",
+      tokenVersion: null,
+      updatedAt: new Date("2026-03-26T07:00:00.000Z"),
+    });
+    const update = vi.fn();
+    const tx = {
+      $executeRaw: vi.fn(async () => 0),
+      deviceConnection: {
+        findUnique: vi.fn(async () => cloneConnection(stored)),
+        update,
+      },
+    };
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      codec: TEST_CODEC,
+      prisma: {
+        $transaction: async <TResult>(callback: (transaction: typeof tx) => Promise<TResult>) => callback(tx),
+      } as never,
+      providerAccountBlindIndexKey: BLIND_INDEX_KEY,
+    });
+
+    const result = await store.markConnectionSetupFailed({
+      accountId: stored.id,
+      expectedUpdatedAt: stored.updatedAt.toISOString(),
+      now: "2026-03-26T07:05:00.000Z",
+      code: "OAUTH_SETUP_FAILED",
+      message: "late setup failure",
+    });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({
+      lastErrorCode: null,
+      status: "disconnected",
+    }));
   });
 
   it("serves ordinary hosted connection lists from durable Prisma metadata without live runtime reads", async () => {

--- a/docs/device-provider-compatibility-matrix.md
+++ b/docs/device-provider-compatibility-matrix.md
@@ -71,6 +71,13 @@ safe: keep both the inline import and the floor. This follows the device-sync
 ingestion invariants — push delivers early, pull guarantees eventually, and
 neither path gates the other.
 
+Junction historical progress is evaluated per advertised source/resource
+pair. Data in another family (for example activity) is not evidence that
+Garmin sleep or `sleep_cycle` landed. After the initial connect export, an
+incomplete delayed backfill can re-request that source's historical export
+through Junction's provider API; the existing bounded ladder owns those
+attempts, while direct sleep webhooks remain the authoritative carrier.
+
 ## Existing canonical shapes to prefer
 
 When adding a provider, prefer these existing shapes before inventing new ones.

--- a/docs/device-provider-compatibility-matrix.md
+++ b/docs/device-provider-compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Device Provider Compatibility Matrix
 
-Last verified: 2026-06-10
+Last verified: 2026-07-09
 
 ## Purpose
 
@@ -71,12 +71,28 @@ safe: keep both the inline import and the floor. This follows the device-sync
 ingestion invariants — push delivers early, pull guarantees eventually, and
 neither path gates the other.
 
-Junction historical progress is evaluated per advertised source/resource
-pair. Data in another family (for example activity) is not evidence that
-Garmin sleep or `sleep_cycle` landed. After the initial connect export, an
-incomplete delayed backfill can re-request that source's historical export
-through Junction's provider API; the existing bounded ladder owns those
-attempts, while direct sleep webhooks remain the authoritative carrier.
+Junction historical progress is evaluated per advertised high-signal daily
+source/resource pair: activity, sleep, and `sleep_cycle`. Data in another
+family (for example activity) is not evidence that Garmin sleep or
+`sleep_cycle` landed. Availability describes capability, so empty sparse
+resources such as workouts or body measurements are not treated as failed
+exports. Garmin delivers requested history
+asynchronously and incrementally through daily-data webhooks, so Murph observes
+that resource-aware coverage with its existing bounded ladder and accepts late
+webhooks after polling ends. An authenticated old-window webhook that produces
+canonical events records bounded source/resource evidence for the exact connect
+window. The existing deduplicated verification unions that evidence with fresh
+REST rows, so complete late coverage clears the source error even when Garmin's
+REST sleep response stays empty. If coverage remains incomplete, Murph marks
+only the pending source reconnect-required while current ingestion stays active.
+To restart the export, the member explicitly confirms the existing
+connection-wide disconnect and then reconnects Garmin; this can disconnect
+other wearables on the same Junction connection and must be explained before
+confirmation. If remote deregistration fails, the local disconnect still stands
+and the member is told to remove the connection in the wearable provider account
+before reconnecting. Recovery does not depend on an automatic export endpoint,
+operator action, or vendor support.
+Direct sleep webhooks remain the authoritative carrier.
 
 ## Existing canonical shapes to prefer
 

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 
+import { buildJunctionProviderSourceInstanceKey } from "@murphai/device-syncd/connect-config";
 import { buildDeviceSyncTokenCipherOptions, createSecretCodec } from "@murphai/device-syncd/local-secret-codec";
+import { requiresHistoricalResetDeviceSyncSource } from "@murphai/device-syncd/public-account";
 import type { DeviceSyncService } from "@murphai/device-syncd/service";
 import type {
   DeviceSyncJobInput,
@@ -9,8 +11,10 @@ import type {
   StoredDeviceSyncAccount,
 } from "@murphai/device-syncd/types";
 import {
+  JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
   mergeHostedDeviceSyncConnectionMetadata,
   normalizeHostedDeviceSyncJobHints,
+  readJunctionHistoricalBackfillStatus,
   resolveHostedDeviceSyncWakeContext,
   sanitizeHostedExecutionDeviceSyncRuntimeCredentialMetadata,
   serializeHostedExecutionDeviceSyncDirtyPayloadIdentity,
@@ -121,9 +125,13 @@ export async function syncHostedDeviceSyncControlPlaneState(input: {
       continue;
     }
 
+    const hostedConnectionEpochChanged = Boolean(
+      existing && existing.connectedAt !== stored.connectedAt,
+    );
     const terminalStatus = readHostedTerminalDeviceSyncStatus(stored);
+    const localSources = store.listConnectionSources({ connectionId: stored.id });
     const localSourcesByKey = new Map(
-      store.listConnectionSources({ connectionId: stored.id }).map(
+      localSources.map(
         (source) => [source.sourceInstanceKey, source] as const,
       ),
     );
@@ -132,18 +140,30 @@ export async function syncHostedDeviceSyncControlPlaneState(input: {
         continue;
       }
 
-      const localSource = localSourcesByKey.get(source.sourceInstanceKey);
+      const sourceInstanceKey = resolveHostedHydrationSourceInstanceKey({
+        entry,
+        localSources,
+        source,
+        sourceInstanceKey: source.sourceInstanceKey,
+      });
+      const localSource = localSourcesByKey.get(sourceInstanceKey);
       if (
         !terminalStatus
         && localSource
-        && Date.parse(localSource.lastSeenAt) >= Date.parse(source.lastSeenAt)
+        && shouldPreserveLocalHydrationSource({
+          hostedConnectionEpochChanged,
+          localSource,
+          metadata: stored.metadata,
+          provider: entry.connection.provider,
+          source,
+        })
       ) {
         continue;
       }
 
       const hydratedSource = store.upsertConnectionSource({
         connectionId: stored.id,
-        sourceInstanceKey: source.sourceInstanceKey,
+        sourceInstanceKey,
         sourceProviderSlug: source.sourceProviderSlug,
         displayName: source.displayName,
         status: source.status,
@@ -155,7 +175,7 @@ export async function syncHostedDeviceSyncControlPlaneState(input: {
         firstSeenAt: source.firstSeenAt,
         lastSeenAt: source.lastSeenAt,
       });
-      localSourcesByKey.set(source.sourceInstanceKey, hydratedSource);
+      localSourcesByKey.set(sourceInstanceKey, hydratedSource);
     }
 
     if (terminalStatus) {
@@ -198,6 +218,63 @@ export async function syncHostedDeviceSyncControlPlaneState(input: {
   }
 
   return state;
+}
+
+function resolveHostedHydrationSourceInstanceKey(input: {
+  entry: HostedDeviceSyncRuntimeConnectionSnapshot;
+  localSources: readonly StoredDeviceConnectionSource[];
+  source: NonNullable<HostedDeviceSyncRuntimeConnectionSnapshot["sources"]>[number];
+  sourceInstanceKey: string;
+}): string {
+  if (input.entry.connection.provider.trim().toLowerCase() !== "junction") {
+    return input.sourceInstanceKey;
+  }
+
+  const canonicalSourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+    connectionId: input.entry.connection.id,
+    sourceProviderSlug: input.source.sourceProviderSlug,
+  });
+  const matchingSource = input.localSources.find((source) =>
+    source.sourceInstanceKey === canonicalSourceInstanceKey
+  ) ?? input.localSources.find((source) =>
+    source.sourceInstanceKey === input.sourceInstanceKey
+  ) ?? input.localSources.find((source) =>
+    source.sourceProviderSlug === input.source.sourceProviderSlug
+  );
+
+  return matchingSource?.sourceInstanceKey
+    ?? canonicalSourceInstanceKey
+    ?? input.sourceInstanceKey;
+}
+
+function shouldPreserveLocalHydrationSource(input: {
+  hostedConnectionEpochChanged: boolean;
+  localSource: StoredDeviceConnectionSource;
+  metadata: Record<string, unknown>;
+  provider: string;
+  source: NonNullable<HostedDeviceSyncRuntimeConnectionSnapshot["sources"]>[number];
+}): boolean {
+  if (input.hostedConnectionEpochChanged) {
+    return false;
+  }
+
+  if (input.provider.trim().toLowerCase() === "junction") {
+    const historicalStatus = readJunctionHistoricalBackfillStatus(
+      input.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status],
+    );
+    if (historicalStatus?.status !== "exhausted") {
+      return Date.parse(input.localSource.lastSeenAt) >= Date.parse(input.source.lastSeenAt);
+    }
+
+    if (requiresHistoricalResetDeviceSyncSource(input.source)) {
+      return false;
+    }
+    if (requiresHistoricalResetDeviceSyncSource(input.localSource)) {
+      return true;
+    }
+  }
+
+  return Date.parse(input.localSource.lastSeenAt) >= Date.parse(input.source.lastSeenAt);
 }
 
 export async function reconcileHostedDeviceSyncControlPlaneState(input: {

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -122,6 +122,42 @@ export async function syncHostedDeviceSyncControlPlaneState(input: {
     }
 
     const terminalStatus = readHostedTerminalDeviceSyncStatus(stored);
+    const localSourcesByKey = new Map(
+      store.listConnectionSources({ connectionId: stored.id }).map(
+        (source) => [source.sourceInstanceKey, source] as const,
+      ),
+    );
+    for (const source of entry.sources ?? []) {
+      if (!source.sourceInstanceKey) {
+        continue;
+      }
+
+      const localSource = localSourcesByKey.get(source.sourceInstanceKey);
+      if (
+        !terminalStatus
+        && localSource
+        && Date.parse(localSource.lastSeenAt) >= Date.parse(source.lastSeenAt)
+      ) {
+        continue;
+      }
+
+      const hydratedSource = store.upsertConnectionSource({
+        connectionId: stored.id,
+        sourceInstanceKey: source.sourceInstanceKey,
+        sourceProviderSlug: source.sourceProviderSlug,
+        displayName: source.displayName,
+        status: source.status,
+        ...(source.resourceAvailabilitySummary === undefined
+          ? {}
+          : { resourceAvailabilitySummary: source.resourceAvailabilitySummary }),
+        lastErrorCode: source.lastErrorCode,
+        lastErrorMessage: source.lastErrorMessage,
+        firstSeenAt: source.firstSeenAt,
+        lastSeenAt: source.lastSeenAt,
+      });
+      localSourcesByKey.set(source.sourceInstanceKey, hydratedSource);
+    }
+
     if (terminalStatus) {
       markHostedTerminalDeviceSyncJobsDead({
         accountId: stored.id,
@@ -660,7 +696,7 @@ function buildHostedDeviceSyncRuntimeConnectionUpdate(input: {
     connectionId: input.hostedConnectionId,
     observedUpdatedAt: baselineConnection?.updatedAt ?? null,
   };
-  const sources = input.sourceApplyEnabled
+  const sources = input.sourceApplyEnabled && input.account.status !== "disconnected"
     ? buildHostedDeviceSyncRuntimeConnectionSourceUpdates(
         input.sources,
         input.baseline?.sources ?? [],
@@ -1129,6 +1165,12 @@ function buildHostedAccountHydrationInput(input: {
     nextObservedTokenVersion: hostedTokenVersion,
     previousObservedTokenVersion: previousHostedObservedTokenVersion,
   });
+  const hostedConnectionEpochChanged = Boolean(
+    input.existing
+      && !hostedConnectionStateStale
+      && !hostedConnectionStateReplayed
+      && input.existing.connectedAt !== hostedConnection.connectedAt,
+  );
   const shouldClearTokens = hostedCredential.kind === "none"
     && !hostedConnectionStateStale
     && !hostedConnectionStateReplayed
@@ -1152,12 +1194,13 @@ function buildHostedAccountHydrationInput(input: {
   );
   const localConnectionStateUnpublished = Boolean(
     input.existing
+      && !hostedConnectionEpochChanged
       && input.existing.localConnectionRevision !== input.existing.hostedObservedConnectionRevision,
   );
   const hydratedMetadata = mergeHostedDeviceSyncConnectionMetadata({
     hostedMetadata: hostedConnection.metadata,
     localConnectionStateUnpublished,
-    localMetadata: input.existing?.metadata,
+    localMetadata: hostedConnectionEpochChanged ? undefined : input.existing?.metadata,
   });
   const preserveUnpublishedLocalProviderProgress = Boolean(
     input.existing

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-status-prompt.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-status-prompt.ts
@@ -1,4 +1,5 @@
 import {
+  DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
   isDeviceSyncConnectionSetupConfirmed,
   isEstablishedDeviceSyncConnection,
 } from "@murphai/device-syncd/public-account";
@@ -34,6 +35,7 @@ interface HostedDeviceSyncReconnectNotice {
 }
 
 const HOSTED_DEVICE_SYNC_RECONNECT_REQUIRED_SOURCE_ERROR_CODES = new Set([
+  DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
   "INVALID_GRANT",
   "OAUTH_REAUTHORIZATION_REQUIRED",
   "PROVIDER_CREDENTIAL_ERROR",
@@ -396,6 +398,11 @@ function addHostedDeviceSyncReconnectNotice(
 function renderHostedDeviceSyncReconnectNoticeLine(
   notice: HostedDeviceSyncReconnectNotice,
 ): string {
+  if (notice.errorCode === DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE) {
+    const recoveryLabel = notice.sourceProviderSlug === "garmin" ? "Garmin" : notice.label;
+    return `- ${notice.label} historical data remained incomplete after bounded sync checks (error \`${notice.errorCode}\`). Current data may still arrive. Do not send a connect-only link because it cannot restart the historical export. Guide the member to wearable settings, explain that the existing connection reset may also disconnect other wearables on that shared connection, and ask them to explicitly confirm the disconnect before reconnecting ${recoveryLabel}.`;
+  }
+
   const subjectText = notice.sourceProviderSlug
     ? `source \`${notice.sourceProviderSlug}\` is`
     : "account is";

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -542,6 +542,324 @@ describe("hosted device-sync runtime", () => {
     }
   });
 
+  test("sync seeds hosted connection sources without overwriting unpublished local state", async () => {
+    const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
+      "hosted-device-sync-runtime-",
+    );
+    await mkdir(vaultRoot, { recursive: true });
+
+    const service = createDeviceSyncServiceForVault(vaultRoot);
+
+    try {
+      const begin = await service.startConnection({ provider: "demo" });
+      const connected = await service.handleOAuthCallback({
+        code: "source-hydration",
+        provider: "demo",
+        state: begin.state,
+      });
+      let snapshot = buildRuntimeSnapshot({
+        connectionId: "hosted_conn_source_hydration",
+        externalAccountId: connected.account.externalAccountId,
+        sources: [
+          {
+            displayName: "Garmin",
+            firstSeenAt: "2026-04-01T09:00:00.000Z",
+            lastErrorCode: null,
+            lastErrorMessage: null,
+            lastSeenAt: "2026-04-04T09:00:00.000Z",
+            resourceCount: 2,
+            resourceAvailabilitySummary: {
+              activity: true,
+              sleep: true,
+            },
+            sourceInstanceKey: "hosted-source-garmin",
+            sourceProviderSlug: "garmin",
+            status: "connected",
+          },
+          {
+            displayName: null,
+            firstSeenAt: "2026-04-01T09:00:00.000Z",
+            lastErrorCode: null,
+            lastErrorMessage: null,
+            lastSeenAt: "2026-04-04T09:00:00.000Z",
+            resourceCount: 0,
+            sourceProviderSlug: "legacy",
+            status: "connected",
+          },
+        ],
+      });
+      const deviceSyncPort: HostedRuntimeDeviceSyncPort = {
+        ...createNoDirtyStateDeviceSyncPortMethods(),
+        async applyUpdates() {
+          throw new Error("applyUpdates should not be called during sync");
+        },
+        async createConnectLink() {
+          throw new Error("createConnectLink should not be called during sync");
+        },
+        async fetchSnapshot() {
+          return snapshot;
+        },
+      };
+
+      await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:10:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+
+      const seededSources = getStore(service).listConnectionSources({
+        connectionId: connected.account.id,
+      });
+      assert.equal(seededSources.length, 1);
+      const [seededSource] = seededSources;
+      assert.ok(seededSource);
+      assert.deepEqual(
+        {
+          displayName: seededSource.displayName,
+          firstSeenAt: seededSource.firstSeenAt,
+          lastErrorCode: seededSource.lastErrorCode,
+          lastErrorMessage: seededSource.lastErrorMessage,
+          lastSeenAt: seededSource.lastSeenAt,
+          resourceAvailabilitySummary: seededSource.resourceAvailabilitySummary,
+          sourceInstanceKey: seededSource.sourceInstanceKey,
+          sourceProviderSlug: seededSource.sourceProviderSlug,
+          status: seededSource.status,
+        },
+        {
+          displayName: "Garmin",
+          firstSeenAt: "2026-04-01T09:00:00.000Z",
+          lastErrorCode: null,
+          lastErrorMessage: null,
+          lastSeenAt: "2026-04-04T09:00:00.000Z",
+          resourceAvailabilitySummary: {
+            activity: true,
+            sleep: true,
+          },
+          sourceInstanceKey: "hosted-source-garmin",
+          sourceProviderSlug: "garmin",
+          status: "connected",
+        },
+      );
+
+      snapshot = buildRuntimeSnapshot({
+        connectionId: "hosted_conn_source_hydration",
+        externalAccountId: connected.account.externalAccountId,
+        sources: [
+          {
+            displayName: "Garmin updated",
+            firstSeenAt: "2026-04-01T09:00:00.000Z",
+            lastErrorCode: null,
+            lastErrorMessage: null,
+            lastSeenAt: "2026-04-06T09:12:00.000Z",
+            resourceCount: 3,
+            resourceAvailabilitySummary: {
+              activity: true,
+              hypnogram: true,
+              sleep: true,
+            },
+            sourceInstanceKey: "hosted-source-garmin",
+            sourceProviderSlug: "garmin",
+            status: "unavailable",
+          },
+        ],
+      });
+      await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:13:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+      const [refreshedSource] = getStore(service).listConnectionSources({
+        connectionId: connected.account.id,
+      });
+
+      assert.equal(refreshedSource?.displayName, "Garmin updated");
+      assert.equal(refreshedSource?.status, "unavailable");
+      assert.equal(refreshedSource?.lastSeenAt, "2026-04-06T09:12:00.000Z");
+      assert.deepEqual(refreshedSource?.resourceAvailabilitySummary, {
+        activity: true,
+        hypnogram: true,
+        sleep: true,
+      });
+      assert.ok(refreshedSource);
+
+      getStore(service).upsertConnectionSource({
+        connectionId: connected.account.id,
+        sourceInstanceKey: refreshedSource.sourceInstanceKey,
+        sourceProviderSlug: refreshedSource.sourceProviderSlug,
+        displayName: refreshedSource.displayName,
+        status: "error",
+        resourceAvailabilitySummary: refreshedSource.resourceAvailabilitySummary,
+        lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+        lastErrorMessage: "Historical data remained incomplete.",
+        firstSeenAt: refreshedSource.firstSeenAt,
+        lastSeenAt: "2026-04-06T09:15:00.000Z",
+      });
+
+      const repeatedState = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:20:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+      const [preservedSource] = getStore(service).listConnectionSources({
+        connectionId: connected.account.id,
+      });
+
+      assert.equal(repeatedState.snapshot?.connections[0]?.sources?.[0]?.status, "unavailable");
+      assert.equal(preservedSource?.status, "error");
+      assert.equal(preservedSource?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
+      assert.equal(preservedSource?.lastSeenAt, "2026-04-06T09:15:00.000Z");
+    } finally {
+      closeHostedRuntimeDeviceSyncService(service);
+      await cleanup();
+    }
+  });
+
+  test.each([
+    {
+      localLastSeenAt: "2026-04-06T09:20:00.000Z",
+      timestampOrder: "newer than",
+    },
+    {
+      localLastSeenAt: "2026-04-06T09:15:00.000Z",
+      timestampOrder: "equal to",
+    },
+  ])("a hosted source disconnect replaces warm local source state $timestampOrder the hosted timestamp and cannot be republished", async ({
+    localLastSeenAt,
+  }) => {
+    const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
+      "hosted-device-sync-runtime-",
+    );
+    await mkdir(vaultRoot, { recursive: true });
+
+    const service = createDeviceSyncServiceForVault(vaultRoot);
+
+    try {
+      const begin = await service.startConnection({ provider: "demo" });
+      const connected = await service.handleOAuthCallback({
+        code: "source-disconnect-hydration",
+        provider: "demo",
+        state: begin.state,
+      });
+      getStore(service).upsertConnectionSource({
+        connectionId: connected.account.id,
+        displayName: "Garmin",
+        firstSeenAt: "2026-04-01T09:00:00.000Z",
+        lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+        lastErrorMessage: "Historical data remained incomplete.",
+        lastSeenAt: localLastSeenAt,
+        resourceAvailabilitySummary: {
+          activity: true,
+          sleep: true,
+        },
+        sourceInstanceKey: "hosted-source-garmin",
+        sourceProviderSlug: "garmin",
+        status: "error",
+      });
+
+      const snapshot = buildRuntimeSnapshot({
+        capabilities: {
+          connectionSourceApply: true,
+        },
+        connectionId: "hosted_conn_source_disconnect_hydration",
+        externalAccountId: connected.account.externalAccountId,
+        hostedUpdatedAt: "2026-04-06T09:15:00.000Z",
+        sources: [
+          {
+            displayName: "Garmin",
+            firstSeenAt: "2026-04-01T09:00:00.000Z",
+            lastErrorCode: null,
+            lastErrorMessage: null,
+            lastSeenAt: "2026-04-06T09:15:00.000Z",
+            resourceCount: 2,
+            resourceAvailabilitySummary: {
+              activity: true,
+              sleep: true,
+            },
+            sourceInstanceKey: "hosted-source-garmin",
+            sourceProviderSlug: "garmin",
+            status: "disconnected",
+          },
+        ],
+        status: "disconnected",
+        tokenBundle: null,
+      });
+      const appliedRequests: ApplyUpdatesRequest[] = [];
+      const deviceSyncPort: HostedRuntimeDeviceSyncPort = {
+        ...createNoDirtyStateDeviceSyncPortMethods(),
+        async applyUpdates(input): Promise<HostedExecutionDeviceSyncRuntimeApplyResponse> {
+          appliedRequests.push(input);
+          return {
+            appliedAt: "2026-04-06T09:17:01.000Z",
+            updates: [],
+            userId: "member_123",
+          };
+        },
+        async createConnectLink() {
+          throw new Error("createConnectLink should not be called during sync or reconciliation");
+        },
+        async fetchSnapshot() {
+          return snapshot;
+        },
+      };
+      const disconnectedState = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:16:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+
+      const [disconnectedSource] = getStore(service).listConnectionSources({
+        connectionId: connected.account.id,
+      });
+      assert.equal(disconnectedSource?.status, "disconnected");
+      assert.equal(disconnectedSource?.lastErrorCode, null);
+      assert.equal(disconnectedSource?.lastErrorMessage, null);
+      assert.equal(disconnectedSource?.lastSeenAt, "2026-04-06T09:15:00.000Z");
+
+      getStore(service).upsertConnectionSource({
+        connectionId: connected.account.id,
+        displayName: "Garmin",
+        firstSeenAt: "2026-04-01T09:00:00.000Z",
+        lastErrorCode: "LATE_RUNNER_UPDATE",
+        lastErrorMessage: "A runner job completed after disconnect hydration.",
+        lastSeenAt: "2026-04-06T09:18:00.000Z",
+        resourceAvailabilitySummary: {
+          activity: true,
+          sleep: true,
+        },
+        sourceInstanceKey: "hosted-source-garmin",
+        sourceProviderSlug: "garmin",
+        status: "error",
+      });
+      const [lateRunnerSource] = getStore(service).listConnectionSources({
+        connectionId: connected.account.id,
+      });
+      assert.equal(lateRunnerSource?.status, "error");
+      assert.equal(lateRunnerSource?.lastSeenAt, "2026-04-06T09:18:00.000Z");
+
+      await reconcileHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:17:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+        state: disconnectedState,
+      });
+
+      assert.deepEqual(appliedRequests, [
+        {
+          occurredAt: "2026-04-06T09:17:00.000Z",
+          updates: [],
+        },
+      ]);
+    } finally {
+      closeHostedRuntimeDeviceSyncService(service);
+      await cleanup();
+    }
+  });
+
   test("reconciliation projects local connection sources only when hosted supports source apply", async () => {
     const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
       "hosted-device-sync-runtime-",
@@ -4839,8 +5157,6 @@ describe("hosted device-sync runtime", () => {
       assert.equal(retryJobsAfterEmptyBackfill.length, 0);
       assert.deepEqual(
         {
-          junctionHistoricalBackfillCoverageVersion:
-            afterEmptyBackfill?.metadata.junctionHistoricalBackfillCoverageVersion,
           junctionHistoricalBackfillEmptyAttempts:
             afterEmptyBackfill?.metadata.junctionHistoricalBackfillEmptyAttempts,
           junctionHistoricalBackfillLastEmptyAt:
@@ -4855,8 +5171,7 @@ describe("hosted device-sync runtime", () => {
         {
           junctionHistoricalBackfillEmptyAttempts: 1,
           junctionHistoricalBackfillLastEmptyAt: executedAt,
-          junctionHistoricalBackfillCoverageVersion: 1,
-          junctionHistoricalBackfillStatus: "retrying",
+          junctionHistoricalBackfillStatus: "coverage_v2_retrying",
           junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
           junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
         },
@@ -4897,8 +5212,7 @@ describe("hosted device-sync runtime", () => {
         hosted: true,
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: executedAt,
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
       });
@@ -4917,8 +5231,7 @@ describe("hosted device-sync runtime", () => {
         hosted: true,
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: executedAt,
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
       });
@@ -4944,6 +5257,139 @@ describe("hosted device-sync runtime", () => {
     }
   });
 
+  test("sync starts fresh Junction history recovery for a same-day reconnect epoch", async () => {
+    const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
+      "hosted-device-sync-runtime-",
+    );
+    await mkdir(vaultRoot, { recursive: true });
+
+    const connectionId = "hosted_conn_same_day_reconnect";
+    const externalAccountId = "junction-same-day-reconnect";
+    const originalConnectedAt = "2026-04-03T08:00:00.000Z";
+    const reconnectedAt = "2026-04-03T08:05:00.000Z";
+    const originalWindowStart = "2026-04-01T00:00:00.000Z";
+    const originalWindowEnd = "2026-04-03T00:00:00.000Z";
+    const [provider] = createConfiguredDeviceSyncProvidersFromConfigs({
+      junction: {
+        apiKey: "sk_us_test_123",
+        clientUserIdSecret: "junction-client-user-id-secret",
+        environment: "sandbox",
+        fetchImpl: async () => {
+          throw new Error("Junction network access is not expected during hydration or scheduling.");
+        },
+        region: "us",
+        summaryBackfillDays: 2,
+        summaryResources: ["activity"],
+        timeseriesResources: [],
+      },
+    });
+    assert.ok(provider);
+    const service = createDeviceSyncServiceForVault(vaultRoot, [provider]);
+
+    try {
+      let hostedSnapshot = buildRuntimeSnapshot({
+        connectedAt: originalConnectedAt,
+        connectionId,
+        credential: {
+          credentialMetadata: {},
+          kind: "provider_config",
+          providerConfigKey: "junction",
+        },
+        externalAccountId,
+        hostedUpdatedAt: "2026-04-04T00:00:10.000Z",
+        localState: {
+          nextReconcileAt: "2026-04-04T02:00:00.000Z",
+        },
+        metadata: {},
+        provider: "junction",
+      });
+      const deviceSyncPort: HostedRuntimeDeviceSyncPort = {
+        ...createNoDirtyStateDeviceSyncPortMethods(),
+        async applyUpdates() {
+          throw new Error("applyUpdates should not be called during hydration.");
+        },
+        async createConnectLink() {
+          throw new Error("createConnectLink should not be called during hydration.");
+        },
+        async fetchSnapshot() {
+          return hostedSnapshot;
+        },
+      };
+
+      const initialState = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-04T00:00:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+      const localAccountId = initialState.hostedToLocalAccountIds.get(connectionId);
+      assert.ok(localAccountId);
+
+      getStore(service).patchAccount(localAccountId, {
+        metadata: {
+          junctionHistoricalBackfillEmptyAttempts: 5,
+          junctionHistoricalBackfillEvidence:
+            `e1|${originalWindowStart}|${originalWindowEnd}|garmin:1`,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+          junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+          junctionHistoricalBackfillWindowEnd: originalWindowEnd,
+          junctionHistoricalBackfillWindowStart: originalWindowStart,
+        },
+        nextReconcileAt: "2026-04-04T03:00:00.000Z",
+      });
+      const unpublishedAccount = getStore(service).getAccountById(localAccountId);
+      assert.notEqual(
+        unpublishedAccount?.localConnectionRevision,
+        unpublishedAccount?.hostedObservedConnectionRevision,
+      );
+
+      hostedSnapshot = buildRuntimeSnapshot({
+        connectedAt: reconnectedAt,
+        connectionId,
+        credential: {
+          credentialMetadata: {},
+          kind: "provider_config",
+          providerConfigKey: "junction",
+        },
+        externalAccountId,
+        hostedUpdatedAt: "2026-04-04T00:00:40.000Z",
+        localState: {
+          nextReconcileAt: "2026-04-04T01:00:00.000Z",
+        },
+        metadata: {
+          hostedConnectionEpoch: "fresh",
+        },
+        provider: "junction",
+      });
+
+      await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-04T01:00:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+
+      const reconnectedAccount = getStore(service).getAccountById(localAccountId);
+      assert.equal(reconnectedAccount?.connectedAt, reconnectedAt);
+      assert.deepEqual(reconnectedAccount?.metadata, {
+        hostedConnectionEpoch: "fresh",
+      });
+
+      await service.runSchedulerOnce();
+      const backfillJobs = readJobsForAccount(service, localAccountId).filter(
+        (job) => job.kind === "backfill" && job.status === "queued",
+      );
+      assert.equal(backfillJobs.length, 1);
+      assert.deepEqual(JSON.parse(backfillJobs[0]?.payloadJson ?? "{}"), {
+        windowEnd: originalWindowEnd,
+        windowStart: originalWindowStart,
+      });
+    } finally {
+      closeHostedRuntimeDeviceSyncService(service);
+      await cleanup();
+    }
+  });
+
   test("sync preserves unpublished retry metadata alongside capped hosted metadata", async () => {
     const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
       "hosted-device-sync-runtime-",
@@ -4960,13 +5406,12 @@ describe("hosted device-sync runtime", () => {
     const localRetryMetadata = {
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     };
     const expectedCappedHostedMetadata = Object.fromEntries(
-      Array.from({ length: 10 }, (_, index) => [`hostedKey${index}`, `hosted-value-${index}`]),
+      Array.from({ length: 11 }, (_, index) => [`hostedKey${index}`, `hosted-value-${index}`]),
     );
     const expectedMergedMetadata = {
       ...localRetryMetadata,
@@ -5083,8 +5528,7 @@ describe("hosted device-sync runtime", () => {
     const localCompleteMetadata = {
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     };
@@ -5092,8 +5536,7 @@ describe("hosted device-sync runtime", () => {
       hosted: true,
       junctionHistoricalBackfillEmptyAttempts: 5,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "exhausted",
+      junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     };
@@ -5214,8 +5657,7 @@ describe("hosted device-sync runtime", () => {
     const localBackfillMetadata = {
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     };
@@ -5223,8 +5665,7 @@ describe("hosted device-sync runtime", () => {
       hosted: true,
       junctionHistoricalBackfillEmptyAttempts: 2,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:10:00.000Z",
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     };

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -4839,6 +4839,8 @@ describe("hosted device-sync runtime", () => {
       assert.equal(retryJobsAfterEmptyBackfill.length, 0);
       assert.deepEqual(
         {
+          junctionHistoricalBackfillCoverageVersion:
+            afterEmptyBackfill?.metadata.junctionHistoricalBackfillCoverageVersion,
           junctionHistoricalBackfillEmptyAttempts:
             afterEmptyBackfill?.metadata.junctionHistoricalBackfillEmptyAttempts,
           junctionHistoricalBackfillLastEmptyAt:
@@ -4853,6 +4855,7 @@ describe("hosted device-sync runtime", () => {
         {
           junctionHistoricalBackfillEmptyAttempts: 1,
           junctionHistoricalBackfillLastEmptyAt: executedAt,
+          junctionHistoricalBackfillCoverageVersion: 1,
           junctionHistoricalBackfillStatus: "retrying",
           junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
           junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -4894,6 +4897,7 @@ describe("hosted device-sync runtime", () => {
         hosted: true,
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: executedAt,
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -4913,6 +4917,7 @@ describe("hosted device-sync runtime", () => {
         hosted: true,
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: executedAt,
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -4955,12 +4960,13 @@ describe("hosted device-sync runtime", () => {
     const localRetryMetadata = {
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     };
     const expectedCappedHostedMetadata = Object.fromEntries(
-      Array.from({ length: 11 }, (_, index) => [`hostedKey${index}`, `hosted-value-${index}`]),
+      Array.from({ length: 10 }, (_, index) => [`hostedKey${index}`, `hosted-value-${index}`]),
     );
     const expectedMergedMetadata = {
       ...localRetryMetadata,
@@ -5077,6 +5083,7 @@ describe("hosted device-sync runtime", () => {
     const localCompleteMetadata = {
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "complete",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -5085,6 +5092,7 @@ describe("hosted device-sync runtime", () => {
       hosted: true,
       junctionHistoricalBackfillEmptyAttempts: 5,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "exhausted",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -5206,6 +5214,7 @@ describe("hosted device-sync runtime", () => {
     const localBackfillMetadata = {
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -5214,6 +5223,7 @@ describe("hosted device-sync runtime", () => {
       hosted: true,
       junctionHistoricalBackfillEmptyAttempts: 2,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:10:00.000Z",
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, test, vi } from "vitest";
 import { openSqliteRuntimeDatabase } from "@murphai/runtime-state/node";
 
 import { createConfiguredDeviceSyncProvidersFromConfigs } from "@murphai/device-syncd/config";
+import { buildJunctionProviderSourceInstanceKey } from "@murphai/device-syncd/connect-config";
 import { buildDeviceSyncTokenCipherOptions, createSecretCodec } from "@murphai/device-syncd/local-secret-codec";
 import { deviceSyncError } from "@murphai/device-syncd/errors";
 import {
@@ -711,6 +712,195 @@ describe("hosted device-sync runtime", () => {
       assert.equal(preservedSource?.status, "error");
       assert.equal(preservedSource?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
       assert.equal(preservedSource?.lastSeenAt, "2026-04-06T09:15:00.000Z");
+    } finally {
+      closeHostedRuntimeDeviceSyncService(service);
+      await cleanup();
+    }
+  });
+
+  test("sync reuses one semantic Junction source across hosted and local key spaces", async () => {
+    const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
+      "hosted-device-sync-runtime-",
+    );
+    await mkdir(vaultRoot, { recursive: true });
+
+    const [provider] = createConfiguredDeviceSyncProvidersFromConfigs({
+      junction: {
+        apiKey: "sk_us_test_123",
+        clientUserIdSecret: "junction-client-user-id-secret",
+        environment: "sandbox",
+        fetchImpl: async () => {
+          throw new Error("Junction network access is not expected during source hydration.");
+        },
+        region: "us",
+        summaryBackfillDays: 2,
+        summaryResources: ["activity", "sleep"],
+        timeseriesResources: [],
+      },
+    });
+    assert.ok(provider);
+    const service = createDeviceSyncServiceForVault(vaultRoot, [provider]);
+    const hostedConnectionId = "hosted_conn_junction_source_identity";
+    const externalAccountId = "junction-source-identity";
+    const windowStart = "2026-04-01T00:00:00.000Z";
+    const windowEnd = "2026-04-03T00:00:00.000Z";
+    const exhaustedMetadata = {
+      junctionHistoricalBackfillEmptyAttempts: 5,
+      junctionHistoricalBackfillEvidence: `e1|${windowStart}|${windowEnd}|garmin:1`,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+      junctionHistoricalBackfillWindowEnd: windowEnd,
+      junctionHistoricalBackfillWindowStart: windowStart,
+    };
+    let hostedSnapshot = buildRuntimeSnapshot({
+      connectionId: hostedConnectionId,
+      credential: {
+        credentialMetadata: {},
+        kind: "provider_config",
+        providerConfigKey: "junction",
+      },
+      externalAccountId,
+      metadata: exhaustedMetadata,
+      provider: "junction",
+    });
+    const deviceSyncPort: HostedRuntimeDeviceSyncPort = {
+      ...createNoDirtyStateDeviceSyncPortMethods(),
+      async applyUpdates() {
+        throw new Error("applyUpdates should not be called during source hydration.");
+      },
+      async createConnectLink() {
+        throw new Error("createConnectLink should not be called during source hydration.");
+      },
+      async fetchSnapshot() {
+        return hostedSnapshot;
+      },
+    };
+
+    try {
+      const state = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:00:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+      const localAccountId = state.hostedToLocalAccountIds.get(hostedConnectionId);
+      assert.ok(localAccountId);
+      const localSourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+        connectionId: localAccountId,
+        sourceProviderSlug: "garmin",
+      });
+      const hostedSourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+        connectionId: hostedConnectionId,
+        sourceProviderSlug: "garmin",
+      });
+      assert.ok(localSourceInstanceKey);
+      assert.ok(hostedSourceInstanceKey);
+      assert.notEqual(localSourceInstanceKey, hostedSourceInstanceKey);
+
+      getStore(service).upsertConnectionSource({
+        connectionId: localAccountId,
+        displayName: "Garmin",
+        firstSeenAt: "2026-04-01T09:00:00.000Z",
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        lastSeenAt: "2026-04-06T09:20:00.000Z",
+        resourceAvailabilitySummary: { activity: true },
+        sourceInstanceKey: localSourceInstanceKey,
+        sourceProviderSlug: "garmin",
+        status: "connected",
+      });
+      hostedSnapshot = buildRuntimeSnapshot({
+        connectionId: hostedConnectionId,
+        credential: {
+          credentialMetadata: {},
+          kind: "provider_config",
+          providerConfigKey: "junction",
+        },
+        externalAccountId,
+        metadata: exhaustedMetadata,
+        provider: "junction",
+        sources: [
+          {
+            displayName: "Garmin",
+            firstSeenAt: "2026-04-01T09:00:00.000Z",
+            lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+            lastErrorMessage: "Historical data remained incomplete.",
+            lastSeenAt: "2026-04-06T09:15:00.000Z",
+            resourceCount: 2,
+            resourceAvailabilitySummary: { activity: true, sleep: true },
+            sourceInstanceKey: hostedSourceInstanceKey,
+            sourceProviderSlug: "garmin",
+            status: "error",
+          },
+        ],
+      });
+
+      await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:25:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+
+      const sources = getStore(service).listConnectionSources({
+        connectionId: localAccountId,
+      });
+      assert.equal(sources.length, 1);
+      assert.equal(sources[0]?.sourceInstanceKey, localSourceInstanceKey);
+      assert.equal(sources[0]?.sourceProviderSlug, "garmin");
+      assert.equal(sources[0]?.status, "error");
+      assert.equal(
+        sources[0]?.lastErrorCode,
+        "HISTORICAL_DATA_RECONNECT_REQUIRED",
+      );
+      assert.deepEqual(sources[0]?.resourceAvailabilitySummary, {
+        activity: true,
+        sleep: true,
+      });
+
+      hostedSnapshot = buildRuntimeSnapshot({
+        connectedAt: "2026-04-06T09:30:00.000Z",
+        connectionId: hostedConnectionId,
+        credential: {
+          credentialMetadata: {},
+          kind: "provider_config",
+          providerConfigKey: "junction",
+        },
+        externalAccountId,
+        hostedUpdatedAt: "2026-04-06T09:30:00.000Z",
+        metadata: {},
+        provider: "junction",
+        sources: [
+          {
+            displayName: "Garmin",
+            firstSeenAt: "2026-04-01T09:00:00.000Z",
+            lastErrorCode: null,
+            lastErrorMessage: null,
+            lastSeenAt: "2026-04-06T09:10:00.000Z",
+            resourceCount: 1,
+            resourceAvailabilitySummary: { activity: true },
+            sourceInstanceKey: hostedSourceInstanceKey,
+            sourceProviderSlug: "garmin",
+            status: "connected",
+          },
+        ],
+      });
+
+      await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-06T09:35:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+      });
+
+      const reconnectedSources = getStore(service).listConnectionSources({
+        connectionId: localAccountId,
+      });
+      assert.equal(reconnectedSources.length, 1);
+      assert.equal(reconnectedSources[0]?.sourceInstanceKey, localSourceInstanceKey);
+      assert.equal(reconnectedSources[0]?.status, "connected");
+      assert.equal(reconnectedSources[0]?.lastErrorCode, null);
+      assert.equal(reconnectedSources[0]?.lastSeenAt, "2026-04-06T09:10:00.000Z");
     } finally {
       closeHostedRuntimeDeviceSyncService(service);
       await cleanup();

--- a/packages/assistant-runtime/test/hosted-runtime-device-sync-status-prompt.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-device-sync-status-prompt.test.ts
@@ -188,6 +188,42 @@ describe("hosted device sync status prompt", () => {
     expect(prompt).toContain("verify it with `vault-cli wearables sources list --format json`");
   });
 
+  it("guides Garmin historical recovery through the confirmed connection reset", () => {
+    const prompt = buildHostedDeviceSyncStatusPromptFromSnapshot({
+      reconnectTargets: [
+        {
+          connectTarget: "garmin",
+          label: "Garmin",
+          provider: "junction",
+          sourceProviderSlug: "garmin",
+        },
+      ],
+      snapshot: buildSnapshot({
+        sources: [
+          {
+            displayName: null,
+            firstSeenAt: "2026-06-01T00:00:00.000Z",
+            lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+            lastErrorMessage: "Historical data remained incomplete.",
+            lastSeenAt: "2026-06-29T00:00:00.000Z",
+            resourceCount: 0,
+            sourceProviderSlug: "garmin",
+            status: "error",
+          },
+        ],
+      }),
+    });
+
+    expect(prompt).toContain("Garmin historical data remained incomplete after bounded sync checks");
+    expect(prompt).toContain("Current data may still arrive");
+    expect(prompt).toContain("Do not send a connect-only link");
+    expect(prompt).toContain("wearable settings");
+    expect(prompt).toContain("may also disconnect other wearables on that shared connection");
+    expect(prompt).toContain("explicitly confirm the disconnect before reconnecting Garmin");
+    expect(prompt).not.toContain("vault-cli device connect garmin --format json");
+    expect(prompt).not.toContain("deregisters only Garmin");
+  });
+
   it("normalizes lowercase reconnect error codes", () => {
     const prompt = buildHostedDeviceSyncStatusPromptFromSnapshot({
       reconnectTargets: [

--- a/packages/device-syncd/README.md
+++ b/packages/device-syncd/README.md
@@ -69,6 +69,14 @@ HTTP/env shapes.
 
 Garmin and the hosted `/connect` catalog connect through Junction Link when Junction credentials are configured. Leave `JUNCTION_PROVIDER_FILTER` unset or empty to use the shared default list that matches `/connect`; set it only to narrow the enabled Junction targets for an environment.
 
+Junction connect-time history is tracked per advertised source/resource pair,
+not by a single account-level "has data" flag. An activity row therefore
+cannot close a missing sleep obligation. Incomplete delayed passes reuse the
+existing bounded backfill ladder to request one provider-level historical
+export for each pending Junction Link source; no operator or support action is
+part of the recovery path. Legacy terminal metadata is reevaluated lazily, and
+late webhooks remain importable even after the polling budget is exhausted.
+
 WHOOP uses OAuth plus webhooks.
 Strava uses OAuth, polling, and optional app-global webhooks.
 

--- a/packages/device-syncd/README.md
+++ b/packages/device-syncd/README.md
@@ -86,8 +86,13 @@ the exact connect window. The existing deduplicated verification unions that
 evidence with fresh REST rows, and complete late coverage clears the source
 error even when Garmin's REST sleep response remains empty. If Garmin coverage
 is still incomplete, only the pending source is marked reconnect-required while
-current ingestion remains active. To restart the export, the member explicitly
-confirms the existing connection-wide disconnect and then reconnects Garmin.
+current ingestion remains active. Hosted apply treats that progress and source
+signal as one monotonic transition: stale or legacy writers cannot clear either
+half, a reset signal exists exactly while progress is exhausted, source-only
+writes stay in their observed connection epoch, future versions stay opaque,
+and hosted/local source keys collapse to one semantic provider source. To
+restart the export, the member explicitly confirms the existing connection-wide
+disconnect and then reconnects Garmin.
 That reset can disconnect other wearables on the same Junction connection, so
 its scope must be explained before confirmation. A failed provider-side
 deregistration still completes the local disconnect, but the member must remove

--- a/packages/device-syncd/README.md
+++ b/packages/device-syncd/README.md
@@ -69,13 +69,31 @@ HTTP/env shapes.
 
 Garmin and the hosted `/connect` catalog connect through Junction Link when Junction credentials are configured. Leave `JUNCTION_PROVIDER_FILTER` unset or empty to use the shared default list that matches `/connect`; set it only to narrow the enabled Junction targets for an environment.
 
-Junction connect-time history is tracked per advertised source/resource pair,
-not by a single account-level "has data" flag. An activity row therefore
-cannot close a missing sleep obligation. Incomplete delayed passes reuse the
-existing bounded backfill ladder to request one provider-level historical
-export for each pending Junction Link source; no operator or support action is
-part of the recovery path. Legacy terminal metadata is reevaluated lazily, and
-late webhooks remain importable even after the polling budget is exhausted.
+Junction connect-time history is tracked per advertised high-signal daily
+source/resource pair (activity, sleep, and `sleep_cycle`), not by a single
+account-level "has data" flag. An activity row therefore cannot close a missing
+sleep obligation. Availability describes capability, so empty sparse resources
+such as workouts or body measurements do not become failed-export signals.
+Garmin history arrives asynchronously
+and incrementally through daily-data webhooks, so incomplete delayed passes use
+the existing bounded backfill ladder to observe resource-aware coverage rather
+than call a separate export endpoint. The coverage-policy version is encoded in
+the existing status scalar instead of adding another metadata field or retry
+store. Legacy terminal metadata is reevaluated lazily, and late webhooks remain
+importable even after the polling budget is exhausted. Authenticated old-window
+webhooks that produce canonical events add bounded source/resource evidence for
+the exact connect window. The existing deduplicated verification unions that
+evidence with fresh REST rows, and complete late coverage clears the source
+error even when Garmin's REST sleep response remains empty. If Garmin coverage
+is still incomplete, only the pending source is marked reconnect-required while
+current ingestion remains active. To restart the export, the member explicitly
+confirms the existing connection-wide disconnect and then reconnects Garmin.
+That reset can disconnect other wearables on the same Junction connection, so
+its scope must be explained before confirmation. A failed provider-side
+deregistration still completes the local disconnect, but the member must remove
+the connection in the wearable provider account before reconnecting. Recovery
+does not depend on an automatic export endpoint, operator action, or vendor
+support.
 
 WHOOP uses OAuth plus webhooks.
 Strava uses OAuth, polling, and optional app-global webhooks.

--- a/packages/device-syncd/src/hosted-runtime.ts
+++ b/packages/device-syncd/src/hosted-runtime.ts
@@ -1,11 +1,22 @@
 import { sanitizeStoredDeviceSyncMetadata } from "./metadata.ts";
 import {
+  canCurrentRuntimeMutateJunctionHistoricalBackfillProgress,
+  JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
   mergeHostedJunctionHistoricalBackfillMetadata,
+  readJunctionHistoricalBackfillProgress,
+  readJunctionHistoricalBackfillStatus,
 } from "./junction-historical-backfill-progress.ts";
 import type {
   DeviceConnectionSourceResourceAvailabilitySummary,
   DeviceConnectionSourceStatus,
 } from "./client.ts";
+
+export {
+  canCurrentRuntimeMutateJunctionHistoricalBackfillProgress,
+  JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
+  readJunctionHistoricalBackfillProgress,
+  readJunctionHistoricalBackfillStatus,
+};
 
 export const HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_SNAPSHOT_PATH =
   "/api/internal/device-sync/runtime/snapshot";

--- a/packages/device-syncd/src/junction-historical-backfill-progress.ts
+++ b/packages/device-syncd/src/junction-historical-backfill-progress.ts
@@ -30,7 +30,7 @@ export interface JunctionHistoricalBackfillEvidence {
   windowStart: string;
 }
 
-export interface JunctionHistoricalBackfillProgress {
+interface JunctionHistoricalBackfillProgress {
   coverageVersion: number;
   emptyAttempts: number;
   lastEmptyAt: string | null;
@@ -47,14 +47,6 @@ export const JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS = Object.freeze({
   windowEnd: "junctionHistoricalBackfillWindowEnd",
   evidence: "junctionHistoricalBackfillEvidence",
 } as const);
-
-const JUNCTION_HISTORICAL_BACKFILL_METADATA_KEY_SET = new Set<string>(
-  Object.values(JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS),
-);
-
-export function isJunctionHistoricalBackfillMetadataKey(key: string): boolean {
-  return JUNCTION_HISTORICAL_BACKFILL_METADATA_KEY_SET.has(key);
-}
 
 export function readJunctionHistoricalBackfillProgress(
   metadata: Record<string, unknown>,
@@ -79,7 +71,17 @@ export function readJunctionHistoricalBackfillProgress(
   };
 }
 
-export function shouldPreserveLocalJunctionHistoricalBackfillProgress(input: {
+export function canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(
+  metadata: Record<string, unknown>,
+): boolean {
+  const coverageVersion = readJunctionHistoricalBackfillCoverageVersion(
+    metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status],
+  );
+  return coverageVersion === null
+    || coverageVersion <= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION;
+}
+
+function shouldPreserveLocalJunctionHistoricalBackfillProgress(input: {
   hostedMetadata: Record<string, unknown>;
   localConnectionStateUnpublished: boolean;
   localMetadata: Record<string, unknown>;
@@ -142,6 +144,23 @@ export function mergeHostedJunctionHistoricalBackfillMetadata(input: {
   localConnectionStateUnpublished: boolean;
   localMetadata: Record<string, unknown>;
 }): { metadata: Record<string, unknown>; preservedLocalProgress: boolean } {
+  if (!canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(input.hostedMetadata)) {
+    return {
+      metadata: { ...input.hostedMetadata },
+      preservedLocalProgress: false,
+    };
+  }
+
+  if (
+    input.localConnectionStateUnpublished
+    && !canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(input.localMetadata)
+  ) {
+    return {
+      metadata: { ...input.hostedMetadata, ...input.localMetadata },
+      preservedLocalProgress: true,
+    };
+  }
+
   const preserveLocalProgressMetadata = shouldPreserveLocalJunctionHistoricalBackfillProgress(input);
   const localEvidence = readJunctionHistoricalBackfillEvidence(
     input.localMetadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
@@ -235,6 +254,20 @@ export function readJunctionHistoricalBackfillStatus(
   const coverageVersion = Number(match[1]);
   const status = match[2] as JunctionHistoricalBackfillStatus;
   return Number.isSafeInteger(coverageVersion) ? { coverageVersion, status } : null;
+}
+
+function readJunctionHistoricalBackfillCoverageVersion(value: unknown): number | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const match = /^coverage_v([1-9]\d*)_/u.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const coverageVersion = Number(match[1]);
+  return Number.isSafeInteger(coverageVersion) ? coverageVersion : null;
 }
 
 export function addJunctionHistoricalBackfillEvidence(input: {

--- a/packages/device-syncd/src/junction-historical-backfill-progress.ts
+++ b/packages/device-syncd/src/junction-historical-backfill-progress.ts
@@ -1,6 +1,34 @@
+import { DEVICE_SYNC_METADATA_MAX_STRING_LENGTH } from "./metadata.ts";
+
 export type JunctionHistoricalBackfillStatus = "complete" | "exhausted" | "retrying";
 
-export const JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION = 1;
+export const JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION = 2;
+const JUNCTION_HISTORICAL_BACKFILL_CURRENT_STATUS_PREFIX =
+  `coverage_v${JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION}_`;
+const JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_ENCODING_VERSION = 1;
+const JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_PREFIX =
+  `e${JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_ENCODING_VERSION}`;
+const JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_SOURCE_PATTERN = /^[a-z0-9][a-z0-9_-]*$/u;
+const JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_BLOCKED_SOURCES = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+const JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_RESOURCE_BITS = Object.freeze({
+  activity: 1,
+  sleep: 2,
+  sleep_cycle: 4,
+} as const);
+const JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_ALL_BITS = 7;
+
+export type JunctionHistoricalBackfillEvidenceResource =
+  keyof typeof JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_RESOURCE_BITS;
+
+export interface JunctionHistoricalBackfillEvidence {
+  resourcesByProvider: Record<string, number>;
+  windowEnd: string;
+  windowStart: string;
+}
 
 export interface JunctionHistoricalBackfillProgress {
   coverageVersion: number;
@@ -12,12 +40,12 @@ export interface JunctionHistoricalBackfillProgress {
 }
 
 export const JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS = Object.freeze({
-  coverageVersion: "junctionHistoricalBackfillCoverageVersion",
   status: "junctionHistoricalBackfillStatus",
   emptyAttempts: "junctionHistoricalBackfillEmptyAttempts",
   lastEmptyAt: "junctionHistoricalBackfillLastEmptyAt",
   windowStart: "junctionHistoricalBackfillWindowStart",
   windowEnd: "junctionHistoricalBackfillWindowEnd",
+  evidence: "junctionHistoricalBackfillEvidence",
 } as const);
 
 const JUNCTION_HISTORICAL_BACKFILL_METADATA_KEY_SET = new Set<string>(
@@ -31,23 +59,21 @@ export function isJunctionHistoricalBackfillMetadataKey(key: string): boolean {
 export function readJunctionHistoricalBackfillProgress(
   metadata: Record<string, unknown>,
 ): JunctionHistoricalBackfillProgress | null {
-  const status = readJunctionHistoricalBackfillStatus(
+  const statusState = readJunctionHistoricalBackfillStatus(
     metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status],
   );
   const windowStart = readMetadataString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]);
   const windowEnd = readMetadataString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd]);
 
-  if (!status || !windowStart || !windowEnd) {
+  if (!statusState || !windowStart || !windowEnd) {
     return null;
   }
 
   return {
-    coverageVersion: readMetadataNumber(
-      metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.coverageVersion],
-    ),
+    coverageVersion: statusState.coverageVersion,
     emptyAttempts: readMetadataNumber(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts]),
     lastEmptyAt: readMetadataString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.lastEmptyAt]),
-    status,
+    status: statusState.status,
     windowEnd,
     windowStart,
   };
@@ -62,9 +88,19 @@ export function shouldPreserveLocalJunctionHistoricalBackfillProgress(input: {
     return false;
   }
 
+  const localEvidence = readJunctionHistoricalBackfillEvidence(
+    input.localMetadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+  );
+  const hostedEvidence = readJunctionHistoricalBackfillEvidence(
+    input.hostedMetadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+  );
+  const localEvidenceAdvanced = hasAdditionalJunctionHistoricalBackfillEvidence(
+    localEvidence,
+    hostedEvidence,
+  );
   const localProgress = readJunctionHistoricalBackfillProgress(input.localMetadata);
   if (!localProgress) {
-    return false;
+    return localEvidenceAdvanced;
   }
 
   const hostedProgress = readJunctionHistoricalBackfillProgress(input.hostedMetadata);
@@ -88,14 +124,17 @@ export function shouldPreserveLocalJunctionHistoricalBackfillProgress(input: {
       return false;
     }
 
-    return compareJunctionRetryProgress(localProgress, hostedProgress) > 0;
+    const retryComparison = compareJunctionRetryProgress(localProgress, hostedProgress);
+    return retryComparison > 0 || (retryComparison === 0 && localEvidenceAdvanced);
   }
 
   if (localProgress.status === "complete") {
-    return hostedProgress.status !== "complete";
+    return hostedProgress.status !== "complete"
+      || (hostedProgress.status === "complete" && localEvidenceAdvanced);
   }
 
-  return hostedProgress.status === "retrying";
+  return hostedProgress.status === "retrying"
+    || (hostedProgress.status === "exhausted" && localEvidenceAdvanced);
 }
 
 export function mergeHostedJunctionHistoricalBackfillMetadata(input: {
@@ -103,22 +142,67 @@ export function mergeHostedJunctionHistoricalBackfillMetadata(input: {
   localConnectionStateUnpublished: boolean;
   localMetadata: Record<string, unknown>;
 }): { metadata: Record<string, unknown>; preservedLocalProgress: boolean } {
-  const preservedLocalProgress = shouldPreserveLocalJunctionHistoricalBackfillProgress(input);
+  const preserveLocalProgressMetadata = shouldPreserveLocalJunctionHistoricalBackfillProgress(input);
+  const localEvidence = readJunctionHistoricalBackfillEvidence(
+    input.localMetadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+  );
+  const hostedEvidence = readJunctionHistoricalBackfillEvidence(
+    input.hostedMetadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+  );
+  const selectedProgress = readJunctionHistoricalBackfillProgress(
+    preserveLocalProgressMetadata ? input.localMetadata : input.hostedMetadata,
+  );
+  const mergedEvidence = selectJunctionHistoricalBackfillEvidence({
+    hostedEvidence,
+    hostedValue: input.hostedMetadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+    localEvidence,
+    localValue: input.localMetadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+    preferLocal: preserveLocalProgressMetadata,
+    selectedProgress,
+  });
+  const selectedEvidence = readJunctionHistoricalBackfillEvidence(mergedEvidence);
+  const preservedLocalProgress = preserveLocalProgressMetadata || (
+    input.localConnectionStateUnpublished
+    && doesSelectedJunctionEvidenceIncludeLocalProgress(
+      selectedEvidence,
+      localEvidence,
+      hostedEvidence,
+    )
+  );
 
-  if (!preservedLocalProgress) {
-    return { metadata: { ...input.hostedMetadata }, preservedLocalProgress };
+  if (!preserveLocalProgressMetadata) {
+    const metadata: Record<string, unknown> = {};
+    if (mergedEvidence) {
+      metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence] = mergedEvidence;
+    }
+    for (const [key, value] of Object.entries(input.hostedMetadata)) {
+      if (
+        key !== JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence
+        && !Object.prototype.hasOwnProperty.call(metadata, key)
+      ) {
+        metadata[key] = value;
+      }
+    }
+    return { metadata, preservedLocalProgress };
   }
 
   const metadata: Record<string, unknown> = {};
 
-  for (const [key, value] of Object.entries(input.localMetadata)) {
-    if (isJunctionHistoricalBackfillMetadataKey(key)) {
-      metadata[key] = value;
+  for (const key of Object.values(JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS)) {
+    if (key === JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence) {
+      if (mergedEvidence) {
+        metadata[key] = mergedEvidence;
+      }
+    } else if (Object.prototype.hasOwnProperty.call(input.localMetadata, key)) {
+      metadata[key] = input.localMetadata[key];
     }
   }
 
   for (const [key, value] of Object.entries(input.hostedMetadata)) {
-    if (!Object.prototype.hasOwnProperty.call(metadata, key)) {
+    if (
+      key !== JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence
+      && !Object.prototype.hasOwnProperty.call(metadata, key)
+    ) {
       metadata[key] = value;
     }
   }
@@ -126,8 +210,270 @@ export function mergeHostedJunctionHistoricalBackfillMetadata(input: {
   return { metadata, preservedLocalProgress };
 }
 
-function readJunctionHistoricalBackfillStatus(value: unknown): JunctionHistoricalBackfillStatus | null {
-  return value === "complete" || value === "exhausted" || value === "retrying" ? value : null;
+export function encodeJunctionHistoricalBackfillStatus(
+  status: JunctionHistoricalBackfillStatus,
+): string {
+  return `${JUNCTION_HISTORICAL_BACKFILL_CURRENT_STATUS_PREFIX}${status}`;
+}
+
+export function readJunctionHistoricalBackfillStatus(
+  value: unknown,
+): { coverageVersion: number; status: JunctionHistoricalBackfillStatus } | null {
+  if (value === "complete" || value === "exhausted" || value === "retrying") {
+    return { coverageVersion: 0, status: value };
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const match = /^coverage_v([1-9]\d*)_(complete|exhausted|retrying)$/u.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const coverageVersion = Number(match[1]);
+  const status = match[2] as JunctionHistoricalBackfillStatus;
+  return Number.isSafeInteger(coverageVersion) ? { coverageVersion, status } : null;
+}
+
+export function addJunctionHistoricalBackfillEvidence(input: {
+  existingValue: unknown;
+  providerSlug: string;
+  resource: JunctionHistoricalBackfillEvidenceResource;
+  windowEnd: string;
+  windowStart: string;
+}): string | null {
+  const existing = readJunctionHistoricalBackfillEvidence(input.existingValue);
+  const resourcesByProvider = existing
+      && existing.windowStart === input.windowStart
+      && existing.windowEnd === input.windowEnd
+    ? { ...existing.resourcesByProvider }
+    : {};
+  const providerSlug = input.providerSlug.trim().toLowerCase();
+  if (!isSafeJunctionHistoricalBackfillEvidenceSource(providerSlug)) {
+    return null;
+  }
+
+  resourcesByProvider[providerSlug] =
+    (resourcesByProvider[providerSlug] ?? 0)
+    | JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_RESOURCE_BITS[input.resource];
+  return encodeJunctionHistoricalBackfillEvidence({
+    resourcesByProvider,
+    windowEnd: input.windowEnd,
+    windowStart: input.windowStart,
+  });
+}
+
+export function readJunctionHistoricalBackfillEvidence(
+  value: unknown,
+): JunctionHistoricalBackfillEvidence | null {
+  if (typeof value !== "string" || !value || value.length > DEVICE_SYNC_METADATA_MAX_STRING_LENGTH) {
+    return null;
+  }
+
+  const parts = value.split("|");
+  if (parts.length !== 4 || parts[0] !== JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_PREFIX) {
+    return null;
+  }
+  const [, windowStart, windowEnd, encodedProviders] = parts;
+  if (!isCanonicalIsoTimestamp(windowStart) || !isCanonicalIsoTimestamp(windowEnd)) {
+    return null;
+  }
+  if (Date.parse(windowStart) >= Date.parse(windowEnd) || !encodedProviders) {
+    return null;
+  }
+
+  const resourcesByProvider: Record<string, number> = {};
+  for (const entry of encodedProviders.split(",")) {
+    const separatorIndex = entry.lastIndexOf(":");
+    if (separatorIndex <= 0 || separatorIndex === entry.length - 1) {
+      return null;
+    }
+    const providerSlug = entry.slice(0, separatorIndex);
+    const mask = Number(entry.slice(separatorIndex + 1));
+    if (
+      !isSafeJunctionHistoricalBackfillEvidenceSource(providerSlug)
+      || Object.prototype.hasOwnProperty.call(resourcesByProvider, providerSlug)
+      || !Number.isInteger(mask)
+      || mask <= 0
+      || (mask & ~JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_ALL_BITS) !== 0
+    ) {
+      return null;
+    }
+    resourcesByProvider[providerSlug] = mask;
+  }
+
+  const evidence = { resourcesByProvider, windowEnd, windowStart };
+  return encodeJunctionHistoricalBackfillEvidence(evidence) === value ? evidence : null;
+}
+
+export function hasJunctionHistoricalBackfillEvidence(
+  evidence: JunctionHistoricalBackfillEvidence | null,
+  providerSlug: string,
+  resource: JunctionHistoricalBackfillEvidenceResource,
+  windowStart: string,
+  windowEnd: string,
+): boolean {
+  if (!evidence || evidence.windowStart !== windowStart || evidence.windowEnd !== windowEnd) {
+    return false;
+  }
+  const mask = evidence.resourcesByProvider[providerSlug] ?? 0;
+  return (mask & JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_RESOURCE_BITS[resource]) !== 0;
+}
+
+function encodeJunctionHistoricalBackfillEvidence(
+  evidence: JunctionHistoricalBackfillEvidence,
+): string | null {
+  if (
+    !isCanonicalIsoTimestamp(evidence.windowStart)
+    || !isCanonicalIsoTimestamp(evidence.windowEnd)
+    || Date.parse(evidence.windowStart) >= Date.parse(evidence.windowEnd)
+  ) {
+    return null;
+  }
+
+  const encodedProviders = Object.entries(evidence.resourcesByProvider)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([providerSlug, mask]) =>
+      isSafeJunctionHistoricalBackfillEvidenceSource(providerSlug)
+        && Number.isInteger(mask)
+        && mask > 0
+        && (mask & ~JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_ALL_BITS) === 0
+        ? [`${providerSlug}:${mask}`]
+        : []
+    )
+    .join(",");
+  if (!encodedProviders) {
+    return null;
+  }
+
+  const encoded = [
+    JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_PREFIX,
+    evidence.windowStart,
+    evidence.windowEnd,
+    encodedProviders,
+  ].join("|");
+  return encoded.length <= DEVICE_SYNC_METADATA_MAX_STRING_LENGTH ? encoded : null;
+}
+
+function mergeJunctionHistoricalBackfillEvidence(
+  left: JunctionHistoricalBackfillEvidence | null,
+  right: JunctionHistoricalBackfillEvidence | null,
+): string | null {
+  if (!left) {
+    return right ? encodeJunctionHistoricalBackfillEvidence(right) : null;
+  }
+  if (!right) {
+    return encodeJunctionHistoricalBackfillEvidence(left);
+  }
+  if (left.windowStart !== right.windowStart || left.windowEnd !== right.windowEnd) {
+    return null;
+  }
+
+  const resourcesByProvider = { ...right.resourcesByProvider };
+  for (const [providerSlug, mask] of Object.entries(left.resourcesByProvider)) {
+    resourcesByProvider[providerSlug] = (resourcesByProvider[providerSlug] ?? 0) | mask;
+  }
+  return encodeJunctionHistoricalBackfillEvidence({
+    resourcesByProvider,
+    windowEnd: left.windowEnd,
+    windowStart: left.windowStart,
+  });
+}
+
+function selectJunctionHistoricalBackfillEvidence(input: {
+  hostedEvidence: JunctionHistoricalBackfillEvidence | null;
+  hostedValue: unknown;
+  localEvidence: JunctionHistoricalBackfillEvidence | null;
+  localValue: unknown;
+  preferLocal: boolean;
+  selectedProgress: JunctionHistoricalBackfillProgress | null;
+}): string | null {
+  if (input.selectedProgress) {
+    if (input.selectedProgress.coverageVersion > JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION) {
+      const preferredValue = input.preferLocal ? input.localValue : input.hostedValue;
+      return typeof preferredValue === "string" ? preferredValue : null;
+    }
+
+    return mergeJunctionHistoricalBackfillEvidence(
+      evidenceMatchesProgress(input.localEvidence, input.selectedProgress)
+        ? input.localEvidence
+        : null,
+      evidenceMatchesProgress(input.hostedEvidence, input.selectedProgress)
+        ? input.hostedEvidence
+        : null,
+    );
+  }
+
+  const merged = mergeJunctionHistoricalBackfillEvidence(
+    input.localEvidence,
+    input.hostedEvidence,
+  );
+  if (merged) {
+    return merged;
+  }
+
+  const preferredEvidence = input.preferLocal ? input.localEvidence : input.hostedEvidence;
+  return preferredEvidence ? encodeJunctionHistoricalBackfillEvidence(preferredEvidence) : null;
+}
+
+function evidenceMatchesProgress(
+  evidence: JunctionHistoricalBackfillEvidence | null,
+  progress: JunctionHistoricalBackfillProgress,
+): boolean {
+  return evidence?.windowStart === progress.windowStart
+    && evidence.windowEnd === progress.windowEnd;
+}
+
+function hasAdditionalJunctionHistoricalBackfillEvidence(
+  local: JunctionHistoricalBackfillEvidence | null,
+  hosted: JunctionHistoricalBackfillEvidence | null,
+): boolean {
+  if (!local) {
+    return false;
+  }
+  if (!hosted) {
+    return true;
+  }
+  if (local.windowStart !== hosted.windowStart || local.windowEnd !== hosted.windowEnd) {
+    return false;
+  }
+  return Object.entries(local.resourcesByProvider).some(([providerSlug, localMask]) =>
+    (localMask & ~(hosted.resourcesByProvider[providerSlug] ?? 0)) !== 0
+  );
+}
+
+function doesSelectedJunctionEvidenceIncludeLocalProgress(
+  selected: JunctionHistoricalBackfillEvidence | null,
+  local: JunctionHistoricalBackfillEvidence | null,
+  hosted: JunctionHistoricalBackfillEvidence | null,
+): boolean {
+  if (
+    !selected
+    || !local
+    || selected.windowStart !== local.windowStart
+    || selected.windowEnd !== local.windowEnd
+  ) {
+    return false;
+  }
+  if (!hosted || hosted.windowStart !== local.windowStart || hosted.windowEnd !== local.windowEnd) {
+    return true;
+  }
+  return hasAdditionalJunctionHistoricalBackfillEvidence(local, hosted);
+}
+
+function isCanonicalIsoTimestamp(value: string | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function isSafeJunctionHistoricalBackfillEvidenceSource(value: string): boolean {
+  return JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_SOURCE_PATTERN.test(value)
+    && !JUNCTION_HISTORICAL_BACKFILL_EVIDENCE_BLOCKED_SOURCES.has(value);
 }
 
 function compareJunctionRetryProgress(

--- a/packages/device-syncd/src/junction-historical-backfill-progress.ts
+++ b/packages/device-syncd/src/junction-historical-backfill-progress.ts
@@ -1,6 +1,9 @@
 export type JunctionHistoricalBackfillStatus = "complete" | "exhausted" | "retrying";
 
+export const JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION = 1;
+
 export interface JunctionHistoricalBackfillProgress {
+  coverageVersion: number;
   emptyAttempts: number;
   lastEmptyAt: string | null;
   status: JunctionHistoricalBackfillStatus;
@@ -9,6 +12,7 @@ export interface JunctionHistoricalBackfillProgress {
 }
 
 export const JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS = Object.freeze({
+  coverageVersion: "junctionHistoricalBackfillCoverageVersion",
   status: "junctionHistoricalBackfillStatus",
   emptyAttempts: "junctionHistoricalBackfillEmptyAttempts",
   lastEmptyAt: "junctionHistoricalBackfillLastEmptyAt",
@@ -38,6 +42,9 @@ export function readJunctionHistoricalBackfillProgress(
   }
 
   return {
+    coverageVersion: readMetadataNumber(
+      metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.coverageVersion],
+    ),
     emptyAttempts: readMetadataNumber(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts]),
     lastEmptyAt: readMetadataString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.lastEmptyAt]),
     status,
@@ -70,6 +77,10 @@ export function shouldPreserveLocalJunctionHistoricalBackfillProgress(input: {
     || localProgress.windowEnd !== hostedProgress.windowEnd
   ) {
     return false;
+  }
+
+  if (localProgress.coverageVersion !== hostedProgress.coverageVersion) {
+    return localProgress.coverageVersion > hostedProgress.coverageVersion;
   }
 
   if (localProgress.status === "retrying") {

--- a/packages/device-syncd/src/providers/junction-client.ts
+++ b/packages/device-syncd/src/providers/junction-client.ts
@@ -107,12 +107,6 @@ export interface JunctionRefreshUserDataInput {
   userId: string;
 }
 
-export interface JunctionHistoricalPullTriggerInput {
-  providerSlug: string;
-  signal?: AbortSignal | null;
-  userId: string;
-}
-
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_GET_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAY_MS = 500;
@@ -394,31 +388,6 @@ export class JunctionClient {
     );
   }
 
-  async triggerHistoricalPull(input: JunctionHistoricalPullTriggerInput): Promise<void> {
-    const providerSlug = normalizeJunctionProviderSlug(input.providerSlug);
-    if (!providerSlug) {
-      throw new TypeError("Junction historical pull requires a provider slug.");
-    }
-    const userId = normalizeString(input.userId);
-    if (!userId) {
-      throw new TypeError("Junction historical pull requires a Junction user id.");
-    }
-
-    await this.requestJson<unknown>(
-      "POST",
-      "/v2/link/bulk_trigger_historical_pull",
-      {
-        user_ids: [userId],
-        provider: providerSlug,
-        wait_for_completion: false,
-      },
-      {
-        endpointKind: "junction_link_bulk_trigger_historical_pull",
-        signal: input.signal ?? null,
-      },
-    );
-  }
-
   private async fetchWindowedCollection(
     path: string,
     input: JunctionWindowInput,
@@ -621,10 +590,6 @@ function resolveJunctionEndpointKind(path: string): string {
 
   if (pathname === "/v2/link/token") {
     return "junction_link_token_create";
-  }
-
-  if (pathname === "/v2/link/bulk_trigger_historical_pull") {
-    return "junction_link_bulk_trigger_historical_pull";
   }
 
   if (pathname.startsWith("/v2/user/refresh/")) {

--- a/packages/device-syncd/src/providers/junction-client.ts
+++ b/packages/device-syncd/src/providers/junction-client.ts
@@ -107,6 +107,12 @@ export interface JunctionRefreshUserDataInput {
   userId: string;
 }
 
+export interface JunctionHistoricalPullTriggerInput {
+  providerSlug: string;
+  signal?: AbortSignal | null;
+  userId: string;
+}
+
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_GET_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAY_MS = 500;
@@ -388,6 +394,31 @@ export class JunctionClient {
     );
   }
 
+  async triggerHistoricalPull(input: JunctionHistoricalPullTriggerInput): Promise<void> {
+    const providerSlug = normalizeJunctionProviderSlug(input.providerSlug);
+    if (!providerSlug) {
+      throw new TypeError("Junction historical pull requires a provider slug.");
+    }
+    const userId = normalizeString(input.userId);
+    if (!userId) {
+      throw new TypeError("Junction historical pull requires a Junction user id.");
+    }
+
+    await this.requestJson<unknown>(
+      "POST",
+      "/v2/link/bulk_trigger_historical_pull",
+      {
+        user_ids: [userId],
+        provider: providerSlug,
+        wait_for_completion: false,
+      },
+      {
+        endpointKind: "junction_link_bulk_trigger_historical_pull",
+        signal: input.signal ?? null,
+      },
+    );
+  }
+
   private async fetchWindowedCollection(
     path: string,
     input: JunctionWindowInput,
@@ -590,6 +621,10 @@ function resolveJunctionEndpointKind(path: string): string {
 
   if (pathname === "/v2/link/token") {
     return "junction_link_token_create";
+  }
+
+  if (pathname === "/v2/link/bulk_trigger_historical_pull") {
+    return "junction_link_bulk_trigger_historical_pull";
   }
 
   if (pathname.startsWith("/v2/user/refresh/")) {

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -32,6 +32,7 @@ import {
 } from "../hosted-runtime.ts";
 import {
   addJunctionHistoricalBackfillEvidence,
+  canCurrentRuntimeMutateJunctionHistoricalBackfillProgress,
   encodeJunctionHistoricalBackfillStatus,
   hasJunctionHistoricalBackfillEvidence,
   JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION,
@@ -707,6 +708,10 @@ export function createJunctionDeviceSyncProvider(
     now: string,
   ): DeviceSyncJobInput[] {
     const metadata = account.metadata;
+    if (!canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(metadata)) {
+      return [];
+    }
+
     const statusState = readHistoricalBackfillStatus(metadata);
     const status = statusState?.status ?? null;
     const connectWindow = buildConnectHistoricalBackfillWindow(account, summaryBackfillDays);
@@ -718,13 +723,6 @@ export function createJunctionDeviceSyncProvider(
     const coverageVersion = statusState?.coverageVersion ?? 0;
     const hasCurrentCoverageSemantics =
       coverageVersion >= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION;
-
-    if (
-      coverageVersion > JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
-      && metadataMatchesConnectWindow
-    ) {
-      return [];
-    }
 
     if (
       hasCurrentCoverageSemantics
@@ -1703,7 +1701,8 @@ export function createJunctionDeviceSyncProvider(
   ): ProviderJobResult {
     const eventType = normalizeString(job.payload.eventType);
     if (
-      canonicalEventCount <= 0
+      !canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(context.account.metadata)
+      || canonicalEventCount <= 0
       || !eventType
       || !isJunctionDataEvent(eventType)
       || !providerFilter.includes(directInput.sourceProviderSlug)
@@ -4790,15 +4789,7 @@ function buildHistoricalBackfillFollowUp(input: {
   windowStart: string;
   windowEnd: string;
 }): JunctionHistoricalBackfillFollowUp {
-  const existingStatus = readHistoricalBackfillStatus(input.metadata);
-  if (
-    existingStatus
-    && existingStatus.coverageVersion > JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
-    && normalizeString(input.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart])
-      === input.windowStart
-    && normalizeString(input.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd])
-      === input.windowEnd
-  ) {
+  if (!canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(input.metadata)) {
     return {};
   }
 

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -31,6 +31,7 @@ import {
   sanitizeHostedRuntimeDiagnosticText,
 } from "../hosted-runtime.ts";
 import {
+  JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION,
   JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
   type JunctionHistoricalBackfillStatus,
 } from "../junction-historical-backfill-progress.ts";
@@ -54,6 +55,7 @@ import {
 import {
   buildJunctionProviderSourceInstanceKey,
   JUNCTION_DEFAULT_PROVIDER_FILTER,
+  JUNCTION_LINK_PROVIDER_SLUGS,
   normalizeJunctionProviderFilter,
 } from "../config/junction-connect-sources.ts";
 import type {
@@ -104,6 +106,11 @@ export {
 
 interface JunctionTimeseriesImportResult {
   yieldedAt: string | null;
+}
+
+interface JunctionHistoricalBackfillCoverage {
+  complete: boolean;
+  pendingProviderSlugs: string[];
 }
 
 type JunctionHistoricalBackfillFollowUp = Pick<ProviderJobResult, "metadataPatch" | "nextReconcileAt" | "scheduledJobs">;
@@ -688,12 +695,19 @@ export function createJunctionDeviceSyncProvider(
     const metadataMatchesConnectWindow =
       metadataWindowStart === connectWindow.windowStart
       && metadataWindowEnd === connectWindow.windowEnd;
+    const coverageVersion = readHistoricalBackfillCoverageVersion(metadata);
+    const hasCurrentCoverageSemantics =
+      coverageVersion >= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION;
 
-    if ((status === "complete" || status === "exhausted") && metadataMatchesConnectWindow) {
+    if (
+      hasCurrentCoverageSemantics
+      && (status === "complete" || status === "exhausted")
+      && metadataMatchesConnectWindow
+    ) {
       return [];
     }
 
-    if (status === "retrying" && metadataMatchesConnectWindow) {
+    if (hasCurrentCoverageSemantics && status === "retrying" && metadataMatchesConnectWindow) {
       const retryAt = readPendingConnectHistoricalBackfillRetryAt(account);
       const retryAtMs = retryAt ? Date.parse(retryAt) : NaN;
       if (retryAt && Number.isFinite(retryAtMs) && Date.parse(now) < retryAtMs) {
@@ -807,7 +821,15 @@ export function createJunctionDeviceSyncProvider(
     if (profileSummaryResult.records.length > 0) {
       summaries[JUNCTION_PROFILE_SUMMARY_RESOURCE] = profileSummaryResult.records;
     }
-    const historicalSummaryHasRecords = hasJunctionHistoricalBackfillSummaryRecords(summaries, sourceProviders);
+    const historicalSummaryCoverage = evaluateJunctionHistoricalBackfillCoverage(
+      summaries,
+      sourceProviders,
+      summaryResources,
+    );
+    const historicalSummaryHasRecords = hasJunctionHistoricalBackfillSummaryRecords(
+      summaries,
+      sourceProviders,
+    );
     const summaryHasFetchedRecords = hasJunctionSnapshotRecords(summaries);
     const baseTimeseriesWindowStart = job.kind === "backfill"
       ? maxIsoTimestamp(window.windowStart, subtractDays(window.windowEnd, timeseriesBackfillDays))
@@ -861,10 +883,18 @@ export function createJunctionDeviceSyncProvider(
     }
 
     const isConnectHistoricalBackfill = isConnectHistoricalBackfillWindow(context.account, window);
+    if (
+      job.kind === "backfill"
+      && isConnectHistoricalBackfill
+      && !historicalSummaryCoverage.complete
+      && shouldTriggerJunctionHistoricalPull(context.account.metadata, window)
+    ) {
+      await triggerPendingJunctionHistoricalPulls(context, historicalSummaryCoverage.pendingProviderSlugs);
+    }
     const backfillFollowUp = job.kind === "backfill"
       ? isConnectHistoricalBackfill
         ? buildHistoricalBackfillFollowUp({
-            hasRecords: historicalSummaryHasRecords,
+            coverageComplete: historicalSummaryCoverage.complete,
             metadata: context.account.metadata,
             now: context.now,
             windowStart: window.windowStart,
@@ -894,6 +924,40 @@ export function createJunctionDeviceSyncProvider(
       ),
       skippedOptionalResources,
     );
+  }
+
+  async function triggerPendingJunctionHistoricalPulls(
+    context: ProviderJobContext,
+    pendingProviderSlugs: readonly string[],
+  ): Promise<void> {
+    const eligibleProviderSlugs = new Set(JUNCTION_LINK_PROVIDER_SLUGS);
+
+    for (const providerSlug of pendingProviderSlugs) {
+      if (!providerFilter.includes(providerSlug) || !eligibleProviderSlugs.has(providerSlug)) {
+        continue;
+      }
+
+      try {
+        await client.triggerHistoricalPull({
+          providerSlug,
+          signal: context.signal ?? null,
+          userId: context.account.externalAccountId,
+        });
+      } catch (error) {
+        if (context.signal?.aborted) {
+          throw error;
+        }
+
+        context.logger.warn?.("Junction historical pull trigger failed; bounded recovery will retry later.", {
+          endpointKind: "junction_link_bulk_trigger_historical_pull",
+          errorCode: isDeviceSyncError(error) ? error.code : "JUNCTION_HISTORICAL_PULL_TRIGGER_FAILED",
+          provider: "junction",
+          responseStatus: readJunctionDiagnosticResponseStatus(error),
+          retryable: isDeviceSyncError(error) ? error.retryable : false,
+          sourceProviderSlug: providerSlug,
+        });
+      }
+    }
   }
 
   function readJunctionDirectResourceJobInput(
@@ -3184,7 +3248,7 @@ function listJunctionDiagnosticAvailableResourcesForSlug(
     }
 
     for (const [key, value] of Object.entries(provider.resourceAvailability)) {
-      if (normalizeProviderSlug(key) && value !== false && value !== null && value !== undefined) {
+      if (normalizeProviderSlug(key) && isJunctionResourceAdvertisedAvailable(value)) {
         resourceNames.add(key);
       }
     }
@@ -3199,6 +3263,7 @@ function readJunctionHistoricalBackfillMetadata(
   metadata: Record<string, unknown>,
 ): Record<string, unknown> {
   return {
+    coverageVersion: readHistoricalBackfillCoverageVersion(metadata),
     status: normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]) ?? null,
     emptyAttempts: typeof metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts] === "number"
       ? metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts]
@@ -3950,6 +4015,102 @@ function hasJunctionHistoricalBackfillSummaryRecords(
   );
 }
 
+function evaluateJunctionHistoricalBackfillCoverage(
+  snapshot: Record<string, unknown[]>,
+  sourceProviders: readonly JunctionProviderConnection[],
+  configuredSummaryResources: readonly string[],
+): JunctionHistoricalBackfillCoverage {
+  const configuredResources = new Set<string>(
+    configuredSummaryResources.filter(isJunctionHistoricalBackfillCompletionSummaryResource),
+  );
+  const requiredResourcesByProvider = new Map<string, Set<string>>();
+
+  for (const provider of sourceProviders) {
+    if (mapJunctionSourceStatus(provider.status) === "disconnected") {
+      continue;
+    }
+
+    const providerSlug = normalizeProviderSlug(provider.origin.sourceProviderSlug ?? provider.slug);
+    if (!providerSlug) {
+      continue;
+    }
+
+    for (const [rawResource, availability] of Object.entries(provider.resourceAvailability)) {
+      const resource = normalizeJunctionResourceName(rawResource);
+      if (
+        !resource
+        || !configuredResources.has(resource)
+        || !isJunctionResourceAdvertisedAvailable(availability)
+      ) {
+        continue;
+      }
+
+      const requiredResources = requiredResourcesByProvider.get(providerSlug) ?? new Set<string>();
+      requiredResources.add(resource);
+      requiredResourcesByProvider.set(providerSlug, requiredResources);
+    }
+  }
+
+  const coveredResourcesByProvider = new Map<string, Set<string>>();
+  const sourceReferences = buildJunctionSourceReferenceMap(sourceProviders);
+
+  for (const [resource, records] of Object.entries(snapshot)) {
+    if (!isJunctionHistoricalBackfillCompletionSummaryResource(resource)) {
+      continue;
+    }
+
+    for (const record of records) {
+      for (const { entry, originFallback } of expandJunctionHistoricalBackfillSummaryRecord(record)) {
+        const providerSlug = normalizeProviderSlug(
+          resolveJunctionSummarySourceProviderSlug(entry, originFallback, sourceReferences),
+        );
+        if (
+          !providerSlug
+          || !requiredResourcesByProvider.get(providerSlug)?.has(resource)
+          || !hasUsefulJunctionHistoricalBackfillSummaryRecord(resource, entry, providerSlug)
+        ) {
+          continue;
+        }
+
+        const coveredResources = coveredResourcesByProvider.get(providerSlug) ?? new Set<string>();
+        coveredResources.add(resource);
+        coveredResourcesByProvider.set(providerSlug, coveredResources);
+      }
+    }
+  }
+
+  const pendingProviderSlugs = [...requiredResourcesByProvider.entries()]
+    .filter(([providerSlug, requiredResources]) => {
+      const coveredResources = coveredResourcesByProvider.get(providerSlug);
+      return [...requiredResources].some((resource) => !coveredResources?.has(resource));
+    })
+    .map(([providerSlug]) => providerSlug)
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    complete: requiredResourcesByProvider.size > 0 && pendingProviderSlugs.length === 0,
+    pendingProviderSlugs,
+  };
+}
+
+function isJunctionResourceAdvertisedAvailable(value: unknown): boolean {
+  if (value === true) {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().toLowerCase() === "available";
+  }
+
+  const record = readPlainObject(value);
+  if (!record) {
+    return false;
+  }
+
+  return record.available === true
+    || normalizeString(record.status)?.toLowerCase() === "available";
+}
+
 function isJunctionHistoricalBackfillCompletionSummaryResource(
   resource: string,
 ): resource is JunctionHistoricalBackfillCompletionSummaryResource {
@@ -4348,13 +4509,13 @@ function isJunctionSourceSpecificFloatingTimestampProvider(sourceProviderSlug: s
 }
 
 function buildHistoricalBackfillFollowUp(input: {
-  hasRecords: boolean;
+  coverageComplete: boolean;
   metadata: Record<string, unknown>;
   now: string;
   windowStart: string;
   windowEnd: string;
 }): JunctionHistoricalBackfillFollowUp {
-  if (input.hasRecords) {
+  if (input.coverageComplete) {
     return {
       metadataPatch: buildHistoricalBackfillMetadataPatch({
         status: "complete",
@@ -4416,6 +4577,13 @@ function readPendingHistoricalBackfillRetryAt(
   windowStart: string,
   windowEnd: string,
 ): string | null {
+  if (
+    readHistoricalBackfillCoverageVersion(metadata)
+      < JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+  ) {
+    return null;
+  }
+
   const status = normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]);
 
   if (status !== "retrying") {
@@ -4490,6 +4658,8 @@ function buildHistoricalBackfillMetadataPatch(input: {
   windowEnd: string;
 }): Record<string, unknown> {
   return {
+    [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.coverageVersion]:
+      JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION,
     [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]: input.status,
     [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts]: input.emptyAttempts,
     [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.lastEmptyAt]: input.lastEmptyAt,
@@ -4504,7 +4674,9 @@ function hasHistoricalBackfillWindowStatus(
   windowStart: string,
   windowEnd: string,
 ): boolean {
-  return normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]) === status
+  return readHistoricalBackfillCoverageVersion(metadata)
+      >= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+    && normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]) === status
     && normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]) === windowStart
     && normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd]) === windowEnd;
 }
@@ -4515,7 +4687,9 @@ function readHistoricalBackfillEmptyAttempts(
   windowEnd: string,
 ): number {
   if (
-    normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]) !== windowStart
+    readHistoricalBackfillCoverageVersion(metadata)
+      < JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+    || normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]) !== windowStart
     || normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd]) !== windowEnd
   ) {
     return 0;
@@ -4524,6 +4698,37 @@ function readHistoricalBackfillEmptyAttempts(
   const rawAttempts = metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts];
   return typeof rawAttempts === "number" && Number.isInteger(rawAttempts) && rawAttempts >= 0
     ? rawAttempts
+    : 0;
+}
+
+function shouldTriggerJunctionHistoricalPull(
+  metadata: Record<string, unknown>,
+  window: { windowEnd: string; windowStart: string },
+): boolean {
+  const metadataWindowStart = normalizeString(
+    metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart],
+  );
+  const metadataWindowEnd = normalizeString(
+    metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd],
+  );
+  if (metadataWindowStart !== window.windowStart || metadataWindowEnd !== window.windowEnd) {
+    return false;
+  }
+
+  const status = normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]);
+  if (status !== "complete" && status !== "exhausted" && status !== "retrying") {
+    return false;
+  }
+
+  return readHistoricalBackfillCoverageVersion(metadata)
+      < JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+    || readHistoricalBackfillEmptyAttempts(metadata, window.windowStart, window.windowEnd) > 0;
+}
+
+function readHistoricalBackfillCoverageVersion(metadata: Record<string, unknown>): number {
+  const rawVersion = metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.coverageVersion];
+  return typeof rawVersion === "number" && Number.isInteger(rawVersion) && rawVersion >= 0
+    ? rawVersion
     : 0;
 }
 

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -31,11 +31,19 @@ import {
   sanitizeHostedRuntimeDiagnosticText,
 } from "../hosted-runtime.ts";
 import {
+  addJunctionHistoricalBackfillEvidence,
+  encodeJunctionHistoricalBackfillStatus,
+  hasJunctionHistoricalBackfillEvidence,
   JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION,
   JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
+  readJunctionHistoricalBackfillEvidence,
+  readJunctionHistoricalBackfillStatus,
+  type JunctionHistoricalBackfillEvidence,
+  type JunctionHistoricalBackfillEvidenceResource,
   type JunctionHistoricalBackfillStatus,
 } from "../junction-historical-backfill-progress.ts";
 import { DEVICE_SYNC_METADATA_MAX_STRING_LENGTH } from "../metadata.ts";
+import { DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE } from "../public-account.ts";
 import {
   assertValidJunctionClientUserIdSecret,
   normalizeJunctionDeviceSyncRuntimeConfig,
@@ -55,7 +63,6 @@ import {
 import {
   buildJunctionProviderSourceInstanceKey,
   JUNCTION_DEFAULT_PROVIDER_FILTER,
-  JUNCTION_LINK_PROVIDER_SLUGS,
   normalizeJunctionProviderFilter,
 } from "../config/junction-connect-sources.ts";
 import type {
@@ -169,6 +176,18 @@ type JunctionHistoricalBackfillCompletionSummaryResource =
   (typeof JUNCTION_HISTORICAL_BACKFILL_COMPLETION_SUMMARY_RESOURCES)[number];
 const JUNCTION_HISTORICAL_BACKFILL_COMPLETION_SUMMARY_RESOURCE_SET = new Set<string>(
   JUNCTION_HISTORICAL_BACKFILL_COMPLETION_SUMMARY_RESOURCES,
+);
+// Resource availability describes permission/capability, not whether the
+// member should have a row. Limit connect-window obligations to high-signal
+// daily families; sparse sessions such as workouts and body measurements still
+// count as useful data, but their absence is not evidence of a failed export.
+const JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCES = Object.freeze([
+  "activity",
+  "sleep",
+  "sleep_cycle",
+] as const satisfies readonly JunctionHistoricalBackfillEvidenceResource[]);
+const JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCE_SET = new Set<string>(
+  JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCES,
 );
 
 type JunctionOptionalResourceFailureReason = "not_found" | "unavailable" | "unsupported" | "ambiguous";
@@ -688,16 +707,24 @@ export function createJunctionDeviceSyncProvider(
     now: string,
   ): DeviceSyncJobInput[] {
     const metadata = account.metadata;
-    const status = normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]);
+    const statusState = readHistoricalBackfillStatus(metadata);
+    const status = statusState?.status ?? null;
     const connectWindow = buildConnectHistoricalBackfillWindow(account, summaryBackfillDays);
     const metadataWindowStart = normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]);
     const metadataWindowEnd = normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd]);
     const metadataMatchesConnectWindow =
       metadataWindowStart === connectWindow.windowStart
       && metadataWindowEnd === connectWindow.windowEnd;
-    const coverageVersion = readHistoricalBackfillCoverageVersion(metadata);
+    const coverageVersion = statusState?.coverageVersion ?? 0;
     const hasCurrentCoverageSemantics =
       coverageVersion >= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION;
+
+    if (
+      coverageVersion > JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+      && metadataMatchesConnectWindow
+    ) {
+      return [];
+    }
 
     if (
       hasCurrentCoverageSemantics
@@ -793,6 +820,7 @@ export function createJunctionDeviceSyncProvider(
     }
 
     const window = resolveJobWindow(job, context.now, job.kind === "backfill" ? summaryBackfillDays : reconcileDays);
+    const isConnectHistoricalBackfill = isConnectHistoricalBackfillWindow(context.account, window);
     const sourceProviders = await client.listUserProviders(context.account.externalAccountId, {
       signal: context.signal ?? null,
     });
@@ -825,6 +853,13 @@ export function createJunctionDeviceSyncProvider(
       summaries,
       sourceProviders,
       summaryResources,
+      providerFilter,
+      isConnectHistoricalBackfill
+        ? readJunctionHistoricalBackfillEvidence(
+            context.account.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+          )
+        : null,
+      window,
     );
     const historicalSummaryHasRecords = hasJunctionHistoricalBackfillSummaryRecords(
       summaries,
@@ -882,15 +917,6 @@ export function createJunctionDeviceSyncProvider(
       }
     }
 
-    const isConnectHistoricalBackfill = isConnectHistoricalBackfillWindow(context.account, window);
-    if (
-      job.kind === "backfill"
-      && isConnectHistoricalBackfill
-      && !historicalSummaryCoverage.complete
-      && shouldTriggerJunctionHistoricalPull(context.account.metadata, window)
-    ) {
-      await triggerPendingJunctionHistoricalPulls(context, historicalSummaryCoverage.pendingProviderSlugs);
-    }
     const backfillFollowUp = job.kind === "backfill"
       ? isConnectHistoricalBackfill
         ? buildHistoricalBackfillFollowUp({
@@ -908,6 +934,48 @@ export function createJunctionDeviceSyncProvider(
             windowEnd: window.windowEnd,
           })
       : {};
+    const historicalStatusAfterJob = readJunctionHistoricalBackfillStatus(
+      backfillFollowUp.metadataPatch?.[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status],
+    ) ?? readHistoricalBackfillStatus(context.account.metadata);
+    const historicalStatusBeforeJob = readHistoricalBackfillStatus(context.account.metadata);
+    if (
+      isConnectHistoricalBackfill
+      && (
+        !historicalStatusBeforeJob
+        || historicalStatusBeforeJob.coverageVersion
+          <= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+      )
+      && (
+        historicalStatusAfterJob?.status === "exhausted"
+        || (
+          historicalSummaryCoverage.complete
+          && historicalStatusBeforeJob?.status === "exhausted"
+        )
+      )
+    ) {
+      const pendingProviderSlugs = new Set(historicalSummaryCoverage.pendingProviderSlugs);
+      const hasCoveredProvider = sourceProviders.some((provider) => {
+        const providerSlug = normalizeProviderSlug(
+          provider.origin.sourceProviderSlug ?? provider.slug,
+        );
+        return providerSlug !== null
+          && providerFilter.includes(providerSlug)
+          && mapJunctionSourceStatus(provider.status) !== "disconnected"
+          && !pendingProviderSlugs.has(providerSlug);
+      });
+      if (historicalSummaryCoverage.complete || hasCoveredProvider) {
+        await projectJunctionSources(context, sourceProviders, {
+          preserveHistoricalReconnectProviderSlugs:
+            historicalSummaryCoverage.pendingProviderSlugs,
+        });
+      }
+      if (!historicalSummaryCoverage.complete) {
+        await markJunctionHistoricalReconnectRequired(
+          context,
+          historicalSummaryCoverage.pendingProviderSlugs,
+        );
+      }
+    }
     const nextReconcileAt = backfillFollowUp.nextReconcileAt ?? resolveJunctionNextReconcileAt(
       context.account,
       context.now,
@@ -926,37 +994,70 @@ export function createJunctionDeviceSyncProvider(
     );
   }
 
-  async function triggerPendingJunctionHistoricalPulls(
+  async function markJunctionHistoricalReconnectRequired(
     context: ProviderJobContext,
     pendingProviderSlugs: readonly string[],
   ): Promise<void> {
-    const eligibleProviderSlugs = new Set(JUNCTION_LINK_PROVIDER_SLUGS);
+    if (!context.upsertConnectionSource) {
+      return;
+    }
 
-    for (const providerSlug of pendingProviderSlugs) {
-      if (!providerFilter.includes(providerSlug) || !eligibleProviderSlugs.has(providerSlug)) {
+    const existingSources = context.listConnectionSources
+      ? await context.listConnectionSources()
+      : [];
+    const existingByInstanceKey = new Map(
+      existingSources.map((source) => [source.sourceInstanceKey, source] as const),
+    );
+    const recoveryProviderSlugs = new Set(
+      pendingProviderSlugs
+        .map(normalizeProviderSlug)
+        .filter((providerSlug): providerSlug is string => providerSlug !== null),
+    );
+    if (recoveryProviderSlugs.size === 0) {
+      for (const source of existingSources) {
+        const providerSlug = normalizeProviderSlug(source.sourceProviderSlug);
+        if (source.status !== "disconnected" && providerSlug) {
+          recoveryProviderSlugs.add(providerSlug);
+        }
+      }
+    }
+
+    for (const providerSlug of recoveryProviderSlugs) {
+      if (!providerFilter.includes(providerSlug)) {
         continue;
       }
 
-      try {
-        await client.triggerHistoricalPull({
-          providerSlug,
-          signal: context.signal ?? null,
-          userId: context.account.externalAccountId,
-        });
-      } catch (error) {
-        if (context.signal?.aborted) {
-          throw error;
-        }
-
-        context.logger.warn?.("Junction historical pull trigger failed; bounded recovery will retry later.", {
-          endpointKind: "junction_link_bulk_trigger_historical_pull",
-          errorCode: isDeviceSyncError(error) ? error.code : "JUNCTION_HISTORICAL_PULL_TRIGGER_FAILED",
-          provider: "junction",
-          responseStatus: readJunctionDiagnosticResponseStatus(error),
-          retryable: isDeviceSyncError(error) ? error.retryable : false,
-          sourceProviderSlug: providerSlug,
-        });
+      const projectedSourceInstanceKey = buildJunctionProviderSourceInstanceKey({
+        connectionId: context.account.id,
+        sourceProviderSlug: providerSlug,
+      });
+      if (!projectedSourceInstanceKey) {
+        continue;
       }
+
+      const existing = existingByInstanceKey.get(projectedSourceInstanceKey) ?? existingSources.find(
+        (source) =>
+          normalizeProviderSlug(source.sourceProviderSlug) === providerSlug,
+      );
+      if (
+        existing?.status === "error"
+        && existing.lastErrorCode === DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE
+      ) {
+        continue;
+      }
+      await context.upsertConnectionSource({
+        sourceInstanceKey: existing?.sourceInstanceKey ?? projectedSourceInstanceKey,
+        sourceProviderSlug: providerSlug,
+        displayName: existing?.displayName ?? null,
+        status: "error",
+        ...(existing
+          ? { resourceAvailabilitySummary: existing.resourceAvailabilitySummary }
+          : {}),
+        lastErrorCode: DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE,
+        lastErrorMessage:
+          "Historical data remained incomplete after bounded observation. A member-confirmed connection reset is required to restart its history export.",
+        lastSeenAt: context.now,
+      });
     }
   }
 
@@ -1393,7 +1494,7 @@ export function createJunctionDeviceSyncProvider(
         const sourceProviders = shouldLoadJunctionDirectResourceSourceProviders(directInput)
           ? await loadSourceProviders()
           : [];
-        await importJunctionDirectResourceSnapshot(
+        const canonicalEventCount = await importJunctionDirectResourceSnapshot(
           context,
           sourceProviders,
           directInput.windowStart,
@@ -1401,9 +1502,18 @@ export function createJunctionDeviceSyncProvider(
           directInput.resource,
           [directInput.record],
         );
-        return {
-          nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-        };
+        return withJunctionHistoricalCoverageVerification(
+          context,
+          job,
+          window,
+          withJunctionDirectHistoricalBackfillEvidence(
+            context,
+            job,
+            directInput,
+            canonicalEventCount,
+            { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
+          ),
+        );
       }
 
       if (inferredCategory === "timeseries") {
@@ -1429,12 +1539,17 @@ export function createJunctionDeviceSyncProvider(
             skippedOptionalResources,
           );
         }
-        return withJunctionSkippedResourceMetadata(
+        return withJunctionHistoricalCoverageVerification(
           context,
-          {
-            nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-          },
-          skippedOptionalResources,
+          job,
+          window,
+          withJunctionSkippedResourceMetadata(
+            context,
+            {
+              nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+            },
+            skippedOptionalResources,
+          ),
         );
       }
 
@@ -1469,12 +1584,17 @@ export function createJunctionDeviceSyncProvider(
       timeseries: {},
     });
 
-    return withJunctionSkippedResourceMetadata(
+    return withJunctionHistoricalCoverageVerification(
       context,
-      {
-        nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-      },
-      skippedOptionalResources,
+      job,
+      window,
+      withJunctionSkippedResourceMetadata(
+        context,
+        {
+          nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+        },
+        skippedOptionalResources,
+      ),
     );
   }
 
@@ -1528,6 +1648,104 @@ export function createJunctionDeviceSyncProvider(
     return scheduledAt && Date.parse(scheduledAt) <= Date.parse(latestAt)
       ? scheduledAt
       : latestAt;
+  }
+
+  function withJunctionHistoricalCoverageVerification(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+    resourceWindow: { windowEnd: string; windowStart: string },
+    result: ProviderJobResult,
+  ): ProviderJobResult {
+    const historicalState = readHistoricalBackfillStatus(context.account.metadata);
+    const eventType = normalizeString(job.payload.eventType);
+    if (
+      !historicalState
+      || historicalState.coverageVersion > JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+      || historicalState.status !== "exhausted"
+      || !eventType
+      || !isJunctionDataEvent(eventType)
+    ) {
+      return result;
+    }
+
+    const connectWindow = buildConnectHistoricalBackfillWindow(
+      context.account,
+      summaryBackfillDays,
+    );
+    if (
+      Date.parse(resourceWindow.windowStart) >= Date.parse(connectWindow.windowEnd)
+      || Date.parse(resourceWindow.windowEnd) <= Date.parse(connectWindow.windowStart)
+    ) {
+      return result;
+    }
+
+    return {
+      ...result,
+      scheduledJobs: [
+        ...(result.scheduledJobs ?? []),
+        buildExactWindowJob({
+          availableAt: context.now,
+          kind: "backfill",
+          priority: JUNCTION_HISTORICAL_BACKFILL_RETRY_PRIORITY,
+          windowEnd: connectWindow.windowEnd,
+          windowStart: connectWindow.windowStart,
+        }),
+      ],
+    };
+  }
+
+  function withJunctionDirectHistoricalBackfillEvidence(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+    directInput: JunctionDirectResourceJobInput,
+    canonicalEventCount: number,
+    result: ProviderJobResult,
+  ): ProviderJobResult {
+    const eventType = normalizeString(job.payload.eventType);
+    if (
+      canonicalEventCount <= 0
+      || !eventType
+      || !isJunctionDataEvent(eventType)
+      || !providerFilter.includes(directInput.sourceProviderSlug)
+      || !isJunctionHistoricalBackfillRequiredSummaryResource(directInput.resource)
+    ) {
+      return result;
+    }
+
+    const connectWindow = buildConnectHistoricalBackfillWindow(
+      context.account,
+      summaryBackfillDays,
+    );
+    if (
+      Date.parse(directInput.windowStart) >= Date.parse(connectWindow.windowEnd)
+      || Date.parse(directInput.windowEnd) <= Date.parse(connectWindow.windowStart)
+    ) {
+      return result;
+    }
+
+    const evidence = addJunctionHistoricalBackfillEvidence({
+      existingValue:
+        context.account.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
+      providerSlug: directInput.sourceProviderSlug,
+      resource: directInput.resource,
+      windowEnd: connectWindow.windowEnd,
+      windowStart: connectWindow.windowStart,
+    });
+    if (!evidence) {
+      context.logger.warn?.("Junction historical push evidence exceeded bounded metadata limits.", {
+        provider: "junction",
+        resource: directInput.resource,
+      });
+      return result;
+    }
+
+    return {
+      ...result,
+      metadataPatch: {
+        ...(result.metadataPatch ?? {}),
+        [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence]: evidence,
+      },
+    };
   }
 
   async function verifyAndParseWebhook(
@@ -1854,10 +2072,10 @@ export function createJunctionDeviceSyncProvider(
     windowEnd: string,
     resource: string,
     records: readonly Record<string, unknown>[],
-  ): Promise<void> {
+  ): Promise<number> {
     const snapshots: Record<string, unknown[]> = { [resource]: [...records] };
 
-    await context.importSnapshot({
+    const receipt = await context.importSnapshot({
       provider: "junction",
       accountId: buildJunctionImportAccountId(context.account.externalAccountId),
       connectionId: context.account.id,
@@ -1870,6 +2088,7 @@ export function createJunctionDeviceSyncProvider(
       }),
       timeseries: {},
     });
+    return readProviderSnapshotCanonicalEventCount(receipt);
   }
 
   async function fetchOptionalJunctionResourceRecords(
@@ -3262,9 +3481,10 @@ function listJunctionDiagnosticAvailableResourcesForSlug(
 function readJunctionHistoricalBackfillMetadata(
   metadata: Record<string, unknown>,
 ): Record<string, unknown> {
+  const statusState = readHistoricalBackfillStatus(metadata);
   return {
-    coverageVersion: readHistoricalBackfillCoverageVersion(metadata),
-    status: normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]) ?? null,
+    coverageVersion: statusState?.coverageVersion ?? 0,
+    status: statusState?.status ?? null,
     emptyAttempts: typeof metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts] === "number"
       ? metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts]
       : null,
@@ -4019,19 +4239,48 @@ function evaluateJunctionHistoricalBackfillCoverage(
   snapshot: Record<string, unknown[]>,
   sourceProviders: readonly JunctionProviderConnection[],
   configuredSummaryResources: readonly string[],
+  providerFilter: readonly string[],
+  historicalPushEvidence: JunctionHistoricalBackfillEvidence | null,
+  window: { windowEnd: string; windowStart: string },
 ): JunctionHistoricalBackfillCoverage {
+  const configuredProviderSlugs = new Set(providerFilter);
   const configuredResources = new Set<string>(
-    configuredSummaryResources.filter(isJunctionHistoricalBackfillCompletionSummaryResource),
+    configuredSummaryResources.filter((resource) =>
+      JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCE_SET.has(resource)
+    ),
   );
   const requiredResourcesByProvider = new Map<string, Set<string>>();
+  const connectedProviderSlugs = new Set<string>();
+  const pendingProviderSlugs = new Set<string>();
+  const providerStatusBySlug = new Map<string, DeviceConnectionSourceStatus>();
 
   for (const provider of sourceProviders) {
-    if (mapJunctionSourceStatus(provider.status) === "disconnected") {
+    const providerSlug = normalizeProviderSlug(provider.origin.sourceProviderSlug ?? provider.slug);
+    if (!providerSlug || !configuredProviderSlugs.has(providerSlug)) {
       continue;
     }
+    const status = mapJunctionSourceStatus(provider.status);
+    const existingStatus = providerStatusBySlug.get(providerSlug);
+    providerStatusBySlug.set(
+      providerSlug,
+      existingStatus ? mergeJunctionSourceStatus(existingStatus, status) : status,
+    );
+  }
 
+  for (const [providerSlug, status] of providerStatusBySlug.entries()) {
+    if (status === "disconnected") {
+      continue;
+    }
+    if (status !== "connected") {
+      pendingProviderSlugs.add(providerSlug);
+      continue;
+    }
+    connectedProviderSlugs.add(providerSlug);
+  }
+
+  for (const provider of sourceProviders) {
     const providerSlug = normalizeProviderSlug(provider.origin.sourceProviderSlug ?? provider.slug);
-    if (!providerSlug) {
+    if (!providerSlug || providerStatusBySlug.get(providerSlug) !== "connected") {
       continue;
     }
 
@@ -4052,6 +4301,24 @@ function evaluateJunctionHistoricalBackfillCoverage(
   }
 
   const coveredResourcesByProvider = new Map<string, Set<string>>();
+  for (const [providerSlug, requiredResources] of requiredResourcesByProvider.entries()) {
+    for (const resource of requiredResources) {
+      if (
+        isJunctionHistoricalBackfillRequiredSummaryResource(resource)
+        && hasJunctionHistoricalBackfillEvidence(
+          historicalPushEvidence,
+          providerSlug,
+          resource,
+          window.windowStart,
+          window.windowEnd,
+        )
+      ) {
+        const coveredResources = coveredResourcesByProvider.get(providerSlug) ?? new Set<string>();
+        coveredResources.add(resource);
+        coveredResourcesByProvider.set(providerSlug, coveredResources);
+      }
+    }
+  }
   const sourceReferences = buildJunctionSourceReferenceMap(sourceProviders);
 
   for (const [resource, records] of Object.entries(snapshot)) {
@@ -4079,18 +4346,26 @@ function evaluateJunctionHistoricalBackfillCoverage(
     }
   }
 
-  const pendingProviderSlugs = [...requiredResourcesByProvider.entries()]
-    .filter(([providerSlug, requiredResources]) => {
-      const coveredResources = coveredResourcesByProvider.get(providerSlug);
-      return [...requiredResources].some((resource) => !coveredResources?.has(resource));
-    })
-    .map(([providerSlug]) => providerSlug)
+  for (const [providerSlug, requiredResources] of requiredResourcesByProvider.entries()) {
+    const coveredResources = coveredResourcesByProvider.get(providerSlug);
+    if ([...requiredResources].some((resource) => !coveredResources?.has(resource))) {
+      pendingProviderSlugs.add(providerSlug);
+    }
+  }
+
+  const sortedPendingProviderSlugs = [...pendingProviderSlugs]
     .sort((left, right) => left.localeCompare(right));
 
   return {
-    complete: requiredResourcesByProvider.size > 0 && pendingProviderSlugs.length === 0,
-    pendingProviderSlugs,
+    complete: connectedProviderSlugs.size > 0 && sortedPendingProviderSlugs.length === 0,
+    pendingProviderSlugs: sortedPendingProviderSlugs,
   };
+}
+
+function isJunctionHistoricalBackfillRequiredSummaryResource(
+  resource: string,
+): resource is JunctionHistoricalBackfillEvidenceResource {
+  return JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCE_SET.has(resource);
 }
 
 function isJunctionResourceAdvertisedAvailable(value: unknown): boolean {
@@ -4515,6 +4790,18 @@ function buildHistoricalBackfillFollowUp(input: {
   windowStart: string;
   windowEnd: string;
 }): JunctionHistoricalBackfillFollowUp {
+  const existingStatus = readHistoricalBackfillStatus(input.metadata);
+  if (
+    existingStatus
+    && existingStatus.coverageVersion > JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+    && normalizeString(input.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart])
+      === input.windowStart
+    && normalizeString(input.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd])
+      === input.windowEnd
+  ) {
+    return {};
+  }
+
   if (input.coverageComplete) {
     return {
       metadataPatch: buildHistoricalBackfillMetadataPatch({
@@ -4579,12 +4866,12 @@ function readPendingHistoricalBackfillRetryAt(
 ): string | null {
   if (
     readHistoricalBackfillCoverageVersion(metadata)
-      < JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+      !== JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
   ) {
     return null;
   }
 
-  const status = normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]);
+  const status = readHistoricalBackfillStatus(metadata)?.status ?? null;
 
   if (status !== "retrying") {
     return null;
@@ -4658,9 +4945,8 @@ function buildHistoricalBackfillMetadataPatch(input: {
   windowEnd: string;
 }): Record<string, unknown> {
   return {
-    [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.coverageVersion]:
-      JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION,
-    [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]: input.status,
+    [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]:
+      encodeJunctionHistoricalBackfillStatus(input.status),
     [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.emptyAttempts]: input.emptyAttempts,
     [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.lastEmptyAt]: input.lastEmptyAt,
     [JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]: input.windowStart,
@@ -4675,8 +4961,8 @@ function hasHistoricalBackfillWindowStatus(
   windowEnd: string,
 ): boolean {
   return readHistoricalBackfillCoverageVersion(metadata)
-      >= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
-    && normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]) === status
+      === JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+    && readHistoricalBackfillStatus(metadata)?.status === status
     && normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]) === windowStart
     && normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd]) === windowEnd;
 }
@@ -4688,7 +4974,7 @@ function readHistoricalBackfillEmptyAttempts(
 ): number {
   if (
     readHistoricalBackfillCoverageVersion(metadata)
-      < JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+      !== JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
     || normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart]) !== windowStart
     || normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd]) !== windowEnd
   ) {
@@ -4701,35 +4987,17 @@ function readHistoricalBackfillEmptyAttempts(
     : 0;
 }
 
-function shouldTriggerJunctionHistoricalPull(
-  metadata: Record<string, unknown>,
-  window: { windowEnd: string; windowStart: string },
-): boolean {
-  const metadataWindowStart = normalizeString(
-    metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowStart],
+function readHistoricalBackfillStatus(metadata: Record<string, unknown>): {
+  coverageVersion: number;
+  status: JunctionHistoricalBackfillStatus;
+} | null {
+  return readJunctionHistoricalBackfillStatus(
+    metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status],
   );
-  const metadataWindowEnd = normalizeString(
-    metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.windowEnd],
-  );
-  if (metadataWindowStart !== window.windowStart || metadataWindowEnd !== window.windowEnd) {
-    return false;
-  }
-
-  const status = normalizeString(metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.status]);
-  if (status !== "complete" && status !== "exhausted" && status !== "retrying") {
-    return false;
-  }
-
-  return readHistoricalBackfillCoverageVersion(metadata)
-      < JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
-    || readHistoricalBackfillEmptyAttempts(metadata, window.windowStart, window.windowEnd) > 0;
 }
 
 function readHistoricalBackfillCoverageVersion(metadata: Record<string, unknown>): number {
-  const rawVersion = metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.coverageVersion];
-  return typeof rawVersion === "number" && Number.isInteger(rawVersion) && rawVersion >= 0
-    ? rawVersion
-    : 0;
+  return readHistoricalBackfillStatus(metadata)?.coverageVersion ?? 0;
 }
 
 function readHistoricalBackfillJobEmptyAttempts(job: DeviceSyncJobRecord): number {
@@ -5763,6 +6031,10 @@ function describeJunctionWebhookIdentityCandidateDiagnostics(
 async function projectJunctionSources(
   context: ProviderJobContext,
   providers: readonly JunctionProviderConnection[],
+  options: {
+    preserveHistoricalReconnect?: boolean;
+    preserveHistoricalReconnectProviderSlugs?: readonly string[];
+  } = {},
 ): Promise<void> {
   if (!context.upsertConnectionSource) {
     context.logger.warn?.("Junction source projection skipped because the job context does not expose source storage.", {
@@ -5771,20 +6043,59 @@ async function projectJunctionSources(
     return;
   }
 
+  const historicalState = readHistoricalBackfillStatus(context.account.metadata);
+  const preserveHistoricalReconnect = options.preserveHistoricalReconnect ?? (
+    options.preserveHistoricalReconnectProviderSlugs !== undefined
+    || (
+      historicalState !== null
+      && historicalState.coverageVersion >= JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
+      && historicalState.status === "exhausted"
+    )
+  );
+  const preserveHistoricalReconnectProviderSlugs =
+    options.preserveHistoricalReconnectProviderSlugs === undefined
+      ? null
+      : new Set(options.preserveHistoricalReconnectProviderSlugs);
+  const existingSources = context.listConnectionSources
+    ? await context.listConnectionSources()
+    : [];
+  const existingByInstanceKey = new Map(
+    existingSources.map((source) => [source.sourceInstanceKey, source] as const),
+  );
+
   for (const source of projectJunctionSourcesByProviderSlug(
     context.account.id,
     providers,
   )) {
+    const existing = existingByInstanceKey.get(source.sourceInstanceKey) ?? existingSources.find(
+      (candidate) =>
+        normalizeProviderSlug(candidate.sourceProviderSlug) === source.sourceProviderSlug,
+    );
+    const keepHistoricalReconnect =
+      preserveHistoricalReconnect
+      && (
+        preserveHistoricalReconnectProviderSlugs === null
+        || preserveHistoricalReconnectProviderSlugs.has(source.sourceProviderSlug)
+      )
+      && source.status !== "disconnected"
+      && existing?.status === "error"
+      && existing.lastErrorCode === DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE;
+    const historicalReconnectError = keepHistoricalReconnect ? existing : null;
     await context.upsertConnectionSource({
-      sourceInstanceKey: source.sourceInstanceKey,
+      sourceInstanceKey: existing?.sourceInstanceKey ?? source.sourceInstanceKey,
       sourceProviderSlug: source.sourceProviderSlug,
-      displayName: null,
-      status: source.status,
+      displayName: existing?.displayName ?? null,
+      status: keepHistoricalReconnect ? "error" : source.status,
       resourceAvailabilitySummary: source.resourceAvailabilitySummary,
       // Only assert error fields when this projection saw an errored entry;
       // omitting the keys lets the store preserve existing detail while the
       // status stays "error" and auto-clear it once the status recovers.
-      ...(source.lastErrorCode !== null || source.lastErrorMessage !== null
+      ...(historicalReconnectError
+        ? {
+            lastErrorCode: historicalReconnectError.lastErrorCode,
+            lastErrorMessage: historicalReconnectError.lastErrorMessage,
+          }
+        : source.lastErrorCode !== null || source.lastErrorMessage !== null
         ? { lastErrorCode: source.lastErrorCode, lastErrorMessage: source.lastErrorMessage }
         : {}),
       lastSeenAt: context.now,
@@ -6062,6 +6373,11 @@ function readPlainObject(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
+}
+
+function readProviderSnapshotCanonicalEventCount(value: unknown): number {
+  const count = readPlainObject(value)?.canonicalEventCount;
+  return typeof count === "number" && Number.isSafeInteger(count) && count > 0 ? count : 0;
 }
 
 function base32UrlEncode(input: Buffer): string {

--- a/packages/device-syncd/src/public-account.ts
+++ b/packages/device-syncd/src/public-account.ts
@@ -1,5 +1,34 @@
 import type { PublicDeviceSyncAccount } from "./types.ts";
 
+export const DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE =
+  "HISTORICAL_DATA_RECONNECT_REQUIRED";
+
+export const DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE =
+  "HISTORICAL_RESET_REVOKE_FAILED";
+
+// A Junction historical export can only restart after the provider-side connection is
+// deregistered, so recovery state rides the existing durable error-code scalars. These
+// predicates are the single reading of that state for the disconnect path and the
+// browser/settings projections.
+export function requiresHistoricalResetDeviceSyncSource(source: {
+  lastErrorCode?: string | null;
+  status?: string | null;
+}): boolean {
+  return source.status === "error"
+    && source.lastErrorCode === DEVICE_SYNC_HISTORICAL_DATA_RECONNECT_REQUIRED_ERROR_CODE;
+}
+
+// True for a disconnected account whose provider-side revoke failed while a historical
+// reset was pending: the member must remove the old connection in the wearable provider
+// account before reconnecting. A fresh established connection clears the code.
+export function isHistoricalResetIncompleteDeviceSyncAccount(account: {
+  lastErrorCode?: string | null;
+  status?: string | null;
+}): boolean {
+  return account.status === "disconnected"
+    && account.lastErrorCode === DEVICE_SYNC_HISTORICAL_RESET_REVOKE_FAILED_ERROR_CODE;
+}
+
 export function isEstablishedDeviceSyncConnection(connection: {
   setupPhase?: string | null;
   status?: string | null;

--- a/packages/device-syncd/src/public-ingress.ts
+++ b/packages/device-syncd/src/public-ingress.ts
@@ -69,6 +69,8 @@ const SEEDED_CONNECTION_EXTERNAL_ACCOUNT_ID_STATE_METADATA_KEY =
   "__murphSeededConnectionExternalAccountId";
 const SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY =
   "__murphSeededConnectionSetupExpiresAt";
+const SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY =
+  "__murphSeededConnectionUpdatedAt";
 const CONNECT_SOURCE_ID_STATE_METADATA_KEY =
   "__murphConnectSourceId";
 const CONNECT_TARGET_STATE_METADATA_KEY =
@@ -304,6 +306,7 @@ function buildProviderConnectionStateMetadata(
   delete providerMetadata[SEEDED_CONNECTION_ACCOUNT_ID_STATE_METADATA_KEY];
   delete providerMetadata[SEEDED_CONNECTION_EXTERNAL_ACCOUNT_ID_STATE_METADATA_KEY];
   delete providerMetadata[SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY];
+  delete providerMetadata[SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
   delete providerMetadata[CONNECT_SOURCE_ID_STATE_METADATA_KEY];
   delete providerMetadata[CONNECT_TARGET_STATE_METADATA_KEY];
   delete providerMetadata[SOURCE_PROVIDER_SLUG_STATE_METADATA_KEY];
@@ -317,6 +320,7 @@ function sanitizeConnectionStateMetadata(
   delete metadata[SEEDED_CONNECTION_ACCOUNT_ID_STATE_METADATA_KEY];
   delete metadata[SEEDED_CONNECTION_EXTERNAL_ACCOUNT_ID_STATE_METADATA_KEY];
   delete metadata[SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY];
+  delete metadata[SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
   delete metadata[CONNECT_SOURCE_ID_STATE_METADATA_KEY];
   delete metadata[CONNECT_TARGET_STATE_METADATA_KEY];
   delete metadata[SOURCE_PROVIDER_SLUG_STATE_METADATA_KEY];
@@ -367,6 +371,13 @@ function readSeededConnectionSetupExpiresAt(
   return typeof value === "string" ? normalizeString(value) ?? null : null;
 }
 
+function readSeededConnectionUpdatedAt(
+  metadata: Record<string, unknown> | undefined,
+): string | null {
+  const value = metadata?.[SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
+  return typeof value === "string" ? normalizeString(value) ?? null : null;
+}
+
 function readConnectSourceId(
   metadata: Record<string, unknown> | undefined,
 ): string | null {
@@ -393,6 +404,7 @@ function setSeededConnectionStateMetadata(
   return {
     ...metadata,
     [SEEDED_CONNECTION_ACCOUNT_ID_STATE_METADATA_KEY]: account.id,
+    [SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY]: account.updatedAt,
     ...(setupExpiresAt
       ? { [SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY]: setupExpiresAt }
       : {}),
@@ -596,7 +608,14 @@ export class DeviceSyncPublicIngress {
       });
     } catch (error) {
       if (seededAccount) {
-        await this.markSeededConnectionSetupFailed(provider, seededAccount.id, null, now, error);
+        await this.markSeededConnectionSetupFailed(
+          provider,
+          seededAccount.id,
+          seededAccount.updatedAt,
+          null,
+          now,
+          error,
+        );
       }
       throw error;
     }
@@ -860,6 +879,7 @@ export class DeviceSyncPublicIngress {
     const seededAccountId = readSeededConnectionAccountId(stateRecord.metadata);
     let seededExternalAccountId = readSeededConnectionExternalAccountId(stateRecord.metadata);
     const seededSetupExpiresAt = readSeededConnectionSetupExpiresAt(stateRecord.metadata);
+    const seededUpdatedAt = readSeededConnectionUpdatedAt(stateRecord.metadata);
     const connectSourceId = readConnectSourceId(stateRecord.metadata);
     const connectTarget = readConnectTarget(stateRecord.metadata);
     const sourceProviderSlug = readSourceProviderSlug(stateRecord.metadata);
@@ -869,6 +889,17 @@ export class DeviceSyncPublicIngress {
       provider: provider.provider,
       returnTo,
     };
+    if (seededAccountId && !seededUpdatedAt) {
+      throw attachOAuthCallbackContext(
+        deviceSyncError({
+          code: "OAUTH_STATE_INVALID",
+          message: "OAuth state is missing its seeded connection revision.",
+          retryable: false,
+          httpStatus: 400,
+        }),
+        callbackContext,
+      );
+    }
     let connection: ProviderConnectionResult | null = null;
     let account: PublicDeviceSyncAccount | null = null;
     let connectionPersisted = false;
@@ -882,6 +913,42 @@ export class DeviceSyncPublicIngress {
           message: "Device sync connection callback referenced a seeded account for another provider.",
           retryable: false,
           httpStatus: 400,
+        }),
+        callbackContext,
+      );
+    }
+
+    if (seededAccountId && !seededAccount) {
+      throw attachOAuthCallbackContext(
+        deviceSyncError({
+          code: "CONNECTION_SEEDED_ACCOUNT_MISMATCH",
+          message: "Device sync connection callback referenced an unexpected seeded account.",
+          retryable: false,
+          httpStatus: 400,
+        }),
+        callbackContext,
+      );
+    }
+
+    if (seededAccount?.status === "disconnected") {
+      throw attachOAuthCallbackContext(
+        deviceSyncError({
+          code: "CONNECTION_ALREADY_DISCONNECTED",
+          message: "Device sync connection callback was received after the seeded account was disconnected.",
+          retryable: false,
+          httpStatus: 409,
+        }),
+        callbackContext,
+      );
+    }
+
+    if (seededAccount && seededAccount.updatedAt !== seededUpdatedAt) {
+      throw attachOAuthCallbackContext(
+        deviceSyncError({
+          code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
+          message: "Device sync connection changed after this connection flow started.",
+          retryable: false,
+          httpStatus: 409,
         }),
         callbackContext,
       );
@@ -981,6 +1048,7 @@ export class DeviceSyncPublicIngress {
         existingAccountGuard: seededAccountId
           ? {
               expectedAccountId: seededAccountId,
+              expectedUpdatedAt: seededUpdatedAt!,
               rejectIfDisconnected: true,
             }
           : null,
@@ -1017,7 +1085,14 @@ export class DeviceSyncPublicIngress {
           } else if (isSeededAccountDisconnectedGuardError(error)) {
             await this.cleanupFailedOAuthConnection(provider, connection, now);
           } else if (seededAccountId) {
-            await this.markSeededConnectionSetupFailed(provider, seededAccountId, connection, now, error);
+            await this.markSeededConnectionSetupFailed(
+              provider,
+              seededAccountId,
+              seededUpdatedAt,
+              connection,
+              now,
+              error,
+            );
           } else {
             await this.cleanupFailedOAuthConnection(provider, connection, now);
           }
@@ -1026,7 +1101,14 @@ export class DeviceSyncPublicIngress {
         }
       } else if (seededAccountId) {
         try {
-          await this.markSeededConnectionSetupFailed(provider, seededAccountId, null, now, error);
+          await this.markSeededConnectionSetupFailed(
+            provider,
+            seededAccountId,
+            seededUpdatedAt,
+            null,
+            now,
+            error,
+          );
         } catch (cleanupError) {
           throw attachOAuthCallbackContext(cleanupError, callbackContext);
         }
@@ -1368,6 +1450,7 @@ export class DeviceSyncPublicIngress {
     try {
       markedAccount = await this.store.markConnectionSetupFailed({
         accountId: account.id,
+        expectedUpdatedAt: account.updatedAt,
         now,
         code: failure.code,
         message: failure.message,
@@ -1408,6 +1491,7 @@ export class DeviceSyncPublicIngress {
   private async markSeededConnectionSetupFailed(
     provider: DeviceSyncProvider,
     accountId: string,
+    expectedUpdatedAt: string | null,
     connection: ProviderConnectionResult | null,
     now: string,
     error: unknown,
@@ -1421,6 +1505,7 @@ export class DeviceSyncPublicIngress {
     try {
       markedAccount = await this.store.markConnectionSetupFailed({
         accountId,
+        expectedUpdatedAt,
         now,
         code: failure.code,
         message: failure.message,

--- a/packages/device-syncd/src/public-ingress.ts
+++ b/packages/device-syncd/src/public-ingress.ts
@@ -41,6 +41,7 @@ import type {
   HandleConnectionCallbackInput,
   HandleOAuthCallbackInput,
   HandleWebhookResult,
+  MarkPublicDeviceSyncConnectionSetupFailedResult,
   ProviderAuthTokens,
   ProviderConnectionResult,
   ProviderBeginConnectionResult,
@@ -69,7 +70,7 @@ const SEEDED_CONNECTION_EXTERNAL_ACCOUNT_ID_STATE_METADATA_KEY =
   "__murphSeededConnectionExternalAccountId";
 const SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY =
   "__murphSeededConnectionSetupExpiresAt";
-const SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY =
+const LEGACY_SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY =
   "__murphSeededConnectionUpdatedAt";
 const CONNECT_SOURCE_ID_STATE_METADATA_KEY =
   "__murphConnectSourceId";
@@ -306,7 +307,7 @@ function buildProviderConnectionStateMetadata(
   delete providerMetadata[SEEDED_CONNECTION_ACCOUNT_ID_STATE_METADATA_KEY];
   delete providerMetadata[SEEDED_CONNECTION_EXTERNAL_ACCOUNT_ID_STATE_METADATA_KEY];
   delete providerMetadata[SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY];
-  delete providerMetadata[SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
+  delete providerMetadata[LEGACY_SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
   delete providerMetadata[CONNECT_SOURCE_ID_STATE_METADATA_KEY];
   delete providerMetadata[CONNECT_TARGET_STATE_METADATA_KEY];
   delete providerMetadata[SOURCE_PROVIDER_SLUG_STATE_METADATA_KEY];
@@ -320,7 +321,7 @@ function sanitizeConnectionStateMetadata(
   delete metadata[SEEDED_CONNECTION_ACCOUNT_ID_STATE_METADATA_KEY];
   delete metadata[SEEDED_CONNECTION_EXTERNAL_ACCOUNT_ID_STATE_METADATA_KEY];
   delete metadata[SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY];
-  delete metadata[SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
+  delete metadata[LEGACY_SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
   delete metadata[CONNECT_SOURCE_ID_STATE_METADATA_KEY];
   delete metadata[CONNECT_TARGET_STATE_METADATA_KEY];
   delete metadata[SOURCE_PROVIDER_SLUG_STATE_METADATA_KEY];
@@ -371,13 +372,6 @@ function readSeededConnectionSetupExpiresAt(
   return typeof value === "string" ? normalizeString(value) ?? null : null;
 }
 
-function readSeededConnectionUpdatedAt(
-  metadata: Record<string, unknown> | undefined,
-): string | null {
-  const value = metadata?.[SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY];
-  return typeof value === "string" ? normalizeString(value) ?? null : null;
-}
-
 function readConnectSourceId(
   metadata: Record<string, unknown> | undefined,
 ): string | null {
@@ -404,7 +398,6 @@ function setSeededConnectionStateMetadata(
   return {
     ...metadata,
     [SEEDED_CONNECTION_ACCOUNT_ID_STATE_METADATA_KEY]: account.id,
-    [SEEDED_CONNECTION_UPDATED_AT_STATE_METADATA_KEY]: account.updatedAt,
     ...(setupExpiresAt
       ? { [SEEDED_CONNECTION_SETUP_EXPIRES_AT_STATE_METADATA_KEY]: setupExpiresAt }
       : {}),
@@ -611,7 +604,7 @@ export class DeviceSyncPublicIngress {
         await this.markSeededConnectionSetupFailed(
           provider,
           seededAccount.id,
-          seededAccount.updatedAt,
+          seededAccount.connectedAt,
           null,
           now,
           error,
@@ -879,7 +872,7 @@ export class DeviceSyncPublicIngress {
     const seededAccountId = readSeededConnectionAccountId(stateRecord.metadata);
     let seededExternalAccountId = readSeededConnectionExternalAccountId(stateRecord.metadata);
     const seededSetupExpiresAt = readSeededConnectionSetupExpiresAt(stateRecord.metadata);
-    const seededUpdatedAt = readSeededConnectionUpdatedAt(stateRecord.metadata);
+    const seededConnectedAt = seededAccountId ? stateRecord.createdAt : null;
     const connectSourceId = readConnectSourceId(stateRecord.metadata);
     const connectTarget = readConnectTarget(stateRecord.metadata);
     const sourceProviderSlug = readSourceProviderSlug(stateRecord.metadata);
@@ -889,17 +882,6 @@ export class DeviceSyncPublicIngress {
       provider: provider.provider,
       returnTo,
     };
-    if (seededAccountId && !seededUpdatedAt) {
-      throw attachOAuthCallbackContext(
-        deviceSyncError({
-          code: "OAUTH_STATE_INVALID",
-          message: "OAuth state is missing its seeded connection revision.",
-          retryable: false,
-          httpStatus: 400,
-        }),
-        callbackContext,
-      );
-    }
     let connection: ProviderConnectionResult | null = null;
     let account: PublicDeviceSyncAccount | null = null;
     let connectionPersisted = false;
@@ -942,7 +924,7 @@ export class DeviceSyncPublicIngress {
       );
     }
 
-    if (seededAccount && seededAccount.updatedAt !== seededUpdatedAt) {
+    if (seededAccount && seededAccount.connectedAt !== seededConnectedAt) {
       throw attachOAuthCallbackContext(
         deviceSyncError({
           code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
@@ -1048,7 +1030,7 @@ export class DeviceSyncPublicIngress {
         existingAccountGuard: seededAccountId
           ? {
               expectedAccountId: seededAccountId,
-              expectedUpdatedAt: seededUpdatedAt!,
+              expectedConnectedAt: seededConnectedAt!,
               rejectIfDisconnected: true,
             }
           : null,
@@ -1088,7 +1070,7 @@ export class DeviceSyncPublicIngress {
             await this.markSeededConnectionSetupFailed(
               provider,
               seededAccountId,
-              seededUpdatedAt,
+              seededConnectedAt,
               connection,
               now,
               error,
@@ -1104,7 +1086,7 @@ export class DeviceSyncPublicIngress {
           await this.markSeededConnectionSetupFailed(
             provider,
             seededAccountId,
-            seededUpdatedAt,
+            seededConnectedAt,
             null,
             now,
             error,
@@ -1443,14 +1425,12 @@ export class DeviceSyncPublicIngress {
     now: string,
     error: unknown,
   ): Promise<void> {
-    await this.cleanupFailedOAuthConnection(provider, connection, now);
-
     const failure = summarizeOAuthSetupFailure(error);
-    let markedAccount: PublicDeviceSyncAccount | null;
+    let markResult: MarkPublicDeviceSyncConnectionSetupFailedResult;
     try {
-      markedAccount = await this.store.markConnectionSetupFailed({
+      markResult = await this.store.markConnectionSetupFailed({
         accountId: account.id,
-        expectedUpdatedAt: account.updatedAt,
+        expectedConnectedAt: account.connectedAt,
         now,
         code: failure.code,
         message: failure.message,
@@ -1475,7 +1455,7 @@ export class DeviceSyncPublicIngress {
       });
     }
 
-    if (!markedAccount) {
+    if (!markResult.account) {
       throw deviceSyncError({
         code: "OAUTH_SETUP_CLEANUP_FAILED",
         message: "OAuth connection setup failed after persistence, and stored-token cleanup could not confirm the account.",
@@ -1486,26 +1466,26 @@ export class DeviceSyncPublicIngress {
         },
       });
     }
+
+    if (markResult.applied) {
+      await this.cleanupFailedOAuthConnection(provider, connection, now);
+    }
   }
 
   private async markSeededConnectionSetupFailed(
     provider: DeviceSyncProvider,
     accountId: string,
-    expectedUpdatedAt: string | null,
+    expectedConnectedAt: string | null,
     connection: ProviderConnectionResult | null,
     now: string,
     error: unknown,
   ): Promise<void> {
-    if (connection) {
-      await this.cleanupFailedOAuthConnection(provider, connection, now);
-    }
-
     const failure = summarizeOAuthSetupFailure(error);
-    let markedAccount: PublicDeviceSyncAccount | null;
+    let markResult: MarkPublicDeviceSyncConnectionSetupFailedResult;
     try {
-      markedAccount = await this.store.markConnectionSetupFailed({
+      markResult = await this.store.markConnectionSetupFailed({
         accountId,
-        expectedUpdatedAt,
+        expectedConnectedAt,
         now,
         code: failure.code,
         message: failure.message,
@@ -1529,7 +1509,7 @@ export class DeviceSyncPublicIngress {
       });
     }
 
-    if (!markedAccount) {
+    if (!markResult.account) {
       throw deviceSyncError({
         code: "CONNECTION_SETUP_CLEANUP_FAILED",
         message: "Seeded device sync connection setup failed, and setup failure could not confirm the account.",
@@ -1539,6 +1519,9 @@ export class DeviceSyncPublicIngress {
           setupFailureCode: failure.code,
         },
       });
+    }
+    if (markResult.applied && connection) {
+      await this.cleanupFailedOAuthConnection(provider, connection, now);
     }
   }
 }

--- a/packages/device-syncd/src/service.ts
+++ b/packages/device-syncd/src/service.ts
@@ -291,6 +291,7 @@ class DeviceSyncServiceController {
         markConnectionSetupFailed: (record) => {
           const account = this.store.markConnectionSetupFailed(
             record.accountId,
+            record.expectedUpdatedAt,
             record.now,
             record.code,
             record.message,

--- a/packages/device-syncd/src/service.ts
+++ b/packages/device-syncd/src/service.ts
@@ -57,6 +57,7 @@ import type {
   ProviderAuthTokens,
   ProviderJobContext,
   ProviderJobBatchDescriptor,
+  ProviderSnapshotImportReceipt,
   PublicDeviceSyncAccount,
   PublicProviderDescriptor,
   QueueManualReconcileResult,
@@ -875,11 +876,15 @@ class DeviceSyncServiceController {
         throwIfAborted: assertJobExecutionNotYielded,
         importSnapshot: async (snapshot: unknown) => {
           ensureExecutionActive();
-          return this.importer.importDeviceProviderSnapshot({
+          const importResult = await this.importer.importDeviceProviderSnapshot({
             provider: provider.provider,
             snapshot,
             vaultRoot: this.vaultRoot,
           });
+          const receipt: ProviderSnapshotImportReceipt = {
+            canonicalEventCount: readCanonicalDeviceImportEventCount(importResult),
+          };
+          return receipt;
         },
         upsertConnectionSource: (input) => {
           ensureExecutionActive();
@@ -1969,6 +1974,11 @@ function toPlainRecord(value: unknown): Record<string, unknown> | null {
   }
 
   return value as Record<string, unknown>;
+}
+
+function readCanonicalDeviceImportEventCount(value: unknown): number {
+  const record = toPlainRecord(value);
+  return record && Array.isArray(record.events) ? record.events.length : 0;
 }
 
 function formatValidationPath(value: unknown): string {

--- a/packages/device-syncd/src/service.ts
+++ b/packages/device-syncd/src/service.ts
@@ -289,14 +289,17 @@ class DeviceSyncServiceController {
             }),
           ),
         markConnectionSetupFailed: (record) => {
-          const account = this.store.markConnectionSetupFailed(
+          const result = this.store.markConnectionSetupFailed(
             record.accountId,
-            record.expectedUpdatedAt,
+            record.expectedConnectedAt,
             record.now,
             record.code,
             record.message,
           );
-          return account ? this.toPublicAccount(account) : null;
+          return {
+            account: result.account ? this.toPublicAccount(result.account) : null,
+            applied: result.applied,
+          };
         },
         getConnectionById: (accountId) => {
           const account = this.store.getAccountById(accountId);

--- a/packages/device-syncd/src/store.ts
+++ b/packages/device-syncd/src/store.ts
@@ -354,11 +354,19 @@ export class SqliteDeviceSyncStore {
 
   markConnectionSetupFailed(
     accountId: string,
+    expectedUpdatedAt: string | null,
     now: string,
     code: string,
     message: string,
   ): StoredDeviceSyncAccount | null {
-    return markStoredConnectionSetupFailed(this.database, accountId, now, code, message);
+    return markStoredConnectionSetupFailed(
+      this.database,
+      accountId,
+      expectedUpdatedAt,
+      now,
+      code,
+      message,
+    );
   }
 
   enqueueJob(input: DeviceSyncEnqueueJobInput): DeviceSyncJobRecord {

--- a/packages/device-syncd/src/store.ts
+++ b/packages/device-syncd/src/store.ts
@@ -354,15 +354,15 @@ export class SqliteDeviceSyncStore {
 
   markConnectionSetupFailed(
     accountId: string,
-    expectedUpdatedAt: string | null,
+    expectedConnectedAt: string | null,
     now: string,
     code: string,
     message: string,
-  ): StoredDeviceSyncAccount | null {
+  ): { account: StoredDeviceSyncAccount | null; applied: boolean } {
     return markStoredConnectionSetupFailed(
       this.database,
       accountId,
-      expectedUpdatedAt,
+      expectedConnectedAt,
       now,
       code,
       message,

--- a/packages/device-syncd/src/store/accounts.ts
+++ b/packages/device-syncd/src/store/accounts.ts
@@ -981,7 +981,7 @@ function assertAccountUpsertExistingGuard(
     });
   }
 
-  if (existing.updatedAt !== guard.expectedUpdatedAt) {
+  if (existing.connectedAt !== guard.expectedConnectedAt) {
     throw deviceSyncError({
       code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
       message: "Device sync connection changed after this connection flow started.",

--- a/packages/device-syncd/src/store/accounts.ts
+++ b/packages/device-syncd/src/store/accounts.ts
@@ -980,6 +980,15 @@ function assertAccountUpsertExistingGuard(
       httpStatus: 409,
     });
   }
+
+  if (existing.updatedAt !== guard.expectedUpdatedAt) {
+    throw deviceSyncError({
+      code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
+      message: "Device sync connection changed after this connection flow started.",
+      retryable: false,
+      httpStatus: 409,
+    });
+  }
 }
 
 export function patchAccount(

--- a/packages/device-syncd/src/store/sync-state.ts
+++ b/packages/device-syncd/src/store/sync-state.ts
@@ -198,7 +198,7 @@ export function markSyncFailed(
 export function markConnectionSetupFailed(
   database: DatabaseSync,
   accountId: string,
-  expectedUpdatedAt: string | null,
+  expectedConnectedAt: string | null,
   now: string,
   code: string,
   message: string,
@@ -206,10 +206,10 @@ export function markConnectionSetupFailed(
   return withImmediateTransaction(database, () => {
     const existing = getAccountById(database, accountId);
     if (!existing) {
-      return null;
+      return { account: null, applied: false };
     }
-    if (expectedUpdatedAt === null || existing.updatedAt !== expectedUpdatedAt) {
-      return existing;
+    if (expectedConnectedAt === null || existing.connectedAt !== expectedConnectedAt) {
+      return { account: existing, applied: false };
     }
 
     const connectionResult = database.prepare(`
@@ -223,7 +223,7 @@ export function markConnectionSetupFailed(
     `).run(now, accountId) as { changes: number };
 
     if ((connectionResult.changes ?? 0) === 0) {
-      return getAccountById(database, accountId);
+      return { account: getAccountById(database, accountId), applied: false };
     }
 
     database.prepare(`
@@ -261,7 +261,7 @@ export function markConnectionSetupFailed(
       accountId,
     );
 
-    return getAccountById(database, accountId);
+    return { account: getAccountById(database, accountId), applied: true };
   });
 }
 

--- a/packages/device-syncd/src/store/sync-state.ts
+++ b/packages/device-syncd/src/store/sync-state.ts
@@ -198,15 +198,20 @@ export function markSyncFailed(
 export function markConnectionSetupFailed(
   database: DatabaseSync,
   accountId: string,
+  expectedUpdatedAt: string | null,
   now: string,
   code: string,
   message: string,
 ) {
-  if (!getAccountById(database, accountId)) {
-    return null;
-  }
-
   return withImmediateTransaction(database, () => {
+    const existing = getAccountById(database, accountId);
+    if (!existing) {
+      return null;
+    }
+    if (expectedUpdatedAt === null || existing.updatedAt !== expectedUpdatedAt) {
+      return existing;
+    }
+
     const connectionResult = database.prepare(`
       update device_connection
       set status = 'reauthorization_required',

--- a/packages/device-syncd/src/types.ts
+++ b/packages/device-syncd/src/types.ts
@@ -264,6 +264,7 @@ export interface ProviderConnectionSeed {
 
 export interface UpsertPublicDeviceSyncExistingAccountGuard {
   expectedAccountId: string;
+  expectedUpdatedAt: string;
   rejectIfDisconnected?: boolean;
 }
 
@@ -287,6 +288,7 @@ export interface UpsertPublicDeviceSyncConnectionInput {
 
 export interface MarkPublicDeviceSyncConnectionSetupFailedInput {
   accountId: string;
+  expectedUpdatedAt: string | null;
   now: string;
   code: string;
   message: string;

--- a/packages/device-syncd/src/types.ts
+++ b/packages/device-syncd/src/types.ts
@@ -620,6 +620,10 @@ export interface ProviderScheduleResult {
   nextReconcileAt?: string | null;
 }
 
+export interface ProviderSnapshotImportReceipt {
+  canonicalEventCount: number;
+}
+
 export interface ProviderJobContext {
   account: DeviceSyncAccount;
   now: string;

--- a/packages/device-syncd/src/types.ts
+++ b/packages/device-syncd/src/types.ts
@@ -264,7 +264,7 @@ export interface ProviderConnectionSeed {
 
 export interface UpsertPublicDeviceSyncExistingAccountGuard {
   expectedAccountId: string;
-  expectedUpdatedAt: string;
+  expectedConnectedAt: string;
   rejectIfDisconnected?: boolean;
 }
 
@@ -288,10 +288,15 @@ export interface UpsertPublicDeviceSyncConnectionInput {
 
 export interface MarkPublicDeviceSyncConnectionSetupFailedInput {
   accountId: string;
-  expectedUpdatedAt: string | null;
+  expectedConnectedAt: string | null;
   now: string;
   code: string;
   message: string;
+}
+
+export interface MarkPublicDeviceSyncConnectionSetupFailedResult {
+  account: PublicDeviceSyncAccount | null;
+  applied: boolean;
 }
 
 export interface UpsertPublicDeviceSyncConnectionResult {
@@ -358,7 +363,8 @@ export interface DeviceSyncPublicIngressStore {
   ): UpsertPublicDeviceSyncConnectionResult | Promise<UpsertPublicDeviceSyncConnectionResult>;
   markConnectionSetupFailed(
     input: MarkPublicDeviceSyncConnectionSetupFailedInput,
-  ): PublicDeviceSyncAccount | null | Promise<PublicDeviceSyncAccount | null>;
+  ): MarkPublicDeviceSyncConnectionSetupFailedResult
+    | Promise<MarkPublicDeviceSyncConnectionSetupFailedResult>;
   getConnectionById(
     accountId: string,
   ): PublicDeviceSyncAccount | null | Promise<PublicDeviceSyncAccount | null>;

--- a/packages/device-syncd/test/hosted-runtime.test.ts
+++ b/packages/device-syncd/test/hosted-runtime.test.ts
@@ -20,6 +20,65 @@ import {
 } from "../src/hosted-runtime.ts";
 
 describe("mergeHostedDeviceSyncConnectionMetadata", () => {
+  it("preserves current local Junction retry progress over hosted legacy completion", () => {
+    const result = mergeHostedDeviceSyncConnectionMetadata({
+      hostedMetadata: {
+        hostedOnly: true,
+        junctionHistoricalBackfillStatus: "complete",
+        junctionHistoricalBackfillEmptyAttempts: 0,
+        junctionHistoricalBackfillLastEmptyAt: null,
+        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      },
+      localConnectionStateUnpublished: true,
+      localMetadata: {
+        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillEmptyAttempts: 1,
+        junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
+        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+        junctionHistoricalBackfillCoverageVersion: 1,
+      },
+    });
+
+    expect(result.preservedLocalProgress).toBe(true);
+    expect(result.metadata).toEqual({
+      hostedOnly: true,
+      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillEmptyAttempts: 1,
+      junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
+      junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      junctionHistoricalBackfillCoverageVersion: 1,
+    });
+  });
+
+  it("accepts current hosted Junction completion over local legacy retry progress", () => {
+    const hostedMetadata = {
+      hostedOnly: true,
+      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillEmptyAttempts: 0,
+      junctionHistoricalBackfillLastEmptyAt: null,
+      junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      junctionHistoricalBackfillCoverageVersion: 1,
+    };
+    const result = mergeHostedDeviceSyncConnectionMetadata({
+      hostedMetadata,
+      localConnectionStateUnpublished: true,
+      localMetadata: {
+        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillEmptyAttempts: 3,
+        junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
+        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      },
+    });
+
+    expect(result.preservedLocalProgress).toBe(false);
+    expect(result.metadata).toEqual(hostedMetadata);
+  });
+
   it("preserves newer unpublished local Junction retry metadata", () => {
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata: {

--- a/packages/device-syncd/test/hosted-runtime.test.ts
+++ b/packages/device-syncd/test/hosted-runtime.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import * as hostedRuntime from "../src/hosted-runtime.ts";
 import {
+  addJunctionHistoricalBackfillEvidence,
+  readJunctionHistoricalBackfillEvidence,
+} from "../src/junction-historical-backfill-progress.ts";
+import { DEVICE_SYNC_METADATA_MAX_STRING_LENGTH } from "../src/metadata.ts";
+import {
   buildHostedExecutionDeviceSyncConnectLinkPath,
   isHostedRuntimeIdShapedDiagnosticToken,
   mergeHostedDeviceSyncConnectionMetadata,
@@ -32,36 +37,33 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
       },
       localConnectionStateUnpublished: true,
       localMetadata: {
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
         junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
-        junctionHistoricalBackfillCoverageVersion: 1,
       },
     });
 
     expect(result.preservedLocalProgress).toBe(true);
     expect(result.metadata).toEqual({
       hostedOnly: true,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
       junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
-      junctionHistoricalBackfillCoverageVersion: 1,
     });
   });
 
   it("accepts current hosted Junction completion over local legacy retry progress", () => {
     const hostedMetadata = {
       hostedOnly: true,
-      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
       junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
-      junctionHistoricalBackfillCoverageVersion: 1,
     };
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata,
@@ -83,7 +85,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata: {
         hostedOnly: true,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -92,7 +94,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
       localConnectionStateUnpublished: true,
       localMetadata: {
         localOnly: true,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 2,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:15:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -103,7 +105,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
     expect(result.preservedLocalProgress).toBe(true);
     expect(result.metadata).toEqual({
       hostedOnly: true,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillEmptyAttempts: 2,
       junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:15:00.000Z",
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -114,7 +116,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
   it("keeps hosted Junction retry metadata when local retry progress is stale", () => {
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata: {
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 2,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:15:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -122,7 +124,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
       },
       localConnectionStateUnpublished: true,
       localMetadata: {
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -132,7 +134,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
 
     expect(result.preservedLocalProgress).toBe(false);
     expect(result.metadata).toEqual({
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillEmptyAttempts: 2,
       junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:15:00.000Z",
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -147,7 +149,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
       ),
       localConnectionStateUnpublished: true,
       localMetadata: {
-        junctionHistoricalBackfillStatus: "complete",
+        junctionHistoricalBackfillStatus: "coverage_v2_complete",
         junctionHistoricalBackfillEmptyAttempts: 0,
         junctionHistoricalBackfillLastEmptyAt: null,
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -169,7 +171,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata: {
         hostedOnly: true,
-        junctionHistoricalBackfillStatus: "exhausted",
+        junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
         junctionHistoricalBackfillEmptyAttempts: 5,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -178,7 +180,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
       localConnectionStateUnpublished: true,
       localMetadata: {
         localOnly: true,
-        junctionHistoricalBackfillStatus: "complete",
+        junctionHistoricalBackfillStatus: "coverage_v2_complete",
         junctionHistoricalBackfillEmptyAttempts: 0,
         junctionHistoricalBackfillLastEmptyAt: null,
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -189,7 +191,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
     expect(result.preservedLocalProgress).toBe(true);
     expect(result.metadata).toEqual({
       hostedOnly: true,
-      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -200,7 +202,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
   it("keeps hosted complete progress ahead of unpublished local retry progress", () => {
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata: {
-        junctionHistoricalBackfillStatus: "complete",
+        junctionHistoricalBackfillStatus: "coverage_v2_complete",
         junctionHistoricalBackfillEmptyAttempts: 0,
         junctionHistoricalBackfillLastEmptyAt: null,
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -208,7 +210,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
       },
       localConnectionStateUnpublished: true,
       localMetadata: {
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 3,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:30:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -218,7 +220,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
 
     expect(result.preservedLocalProgress).toBe(false);
     expect(result.metadata).toEqual({
-      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -229,7 +231,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
   it("keeps hosted progress when local progress has already been published", () => {
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata: {
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -237,7 +239,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
       },
       localConnectionStateUnpublished: false,
       localMetadata: {
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 2,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:15:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
@@ -247,12 +249,191 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
 
     expect(result.preservedLocalProgress).toBe(false);
     expect(result.metadata).toEqual({
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
       junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
     });
+  });
+
+  it("unions same-window Junction push evidence monotonically", () => {
+    const hostedMetadata = {
+      junctionHistoricalBackfillEvidence:
+        "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1",
+      junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+      junctionHistoricalBackfillEmptyAttempts: 5,
+      junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
+      junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+    };
+    const localMetadata = {
+      ...hostedMetadata,
+      junctionHistoricalBackfillEvidence:
+        "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:2",
+    };
+
+    for (const localConnectionStateUnpublished of [true, false]) {
+      const result = mergeHostedDeviceSyncConnectionMetadata({
+        hostedMetadata,
+        localConnectionStateUnpublished,
+        localMetadata,
+      });
+      expect(result.metadata.junctionHistoricalBackfillEvidence).toBe(
+        "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:3",
+      );
+    }
+  });
+
+  it("keeps evidence matching selected progress when hosted and local evidence windows differ", () => {
+    const result = mergeHostedDeviceSyncConnectionMetadata({
+      hostedMetadata: {
+        junctionHistoricalBackfillEvidence:
+          "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1",
+        junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+        junctionHistoricalBackfillEmptyAttempts: 5,
+        junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
+        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      },
+      localConnectionStateUnpublished: true,
+      localMetadata: {
+        junctionHistoricalBackfillEvidence:
+          "e1|2025-12-19T00:00:00.000Z|2026-03-19T00:00:00.000Z|garmin:2",
+        junctionHistoricalBackfillStatus: "coverage_v2_complete",
+        junctionHistoricalBackfillEmptyAttempts: 0,
+        junctionHistoricalBackfillLastEmptyAt: null,
+        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      },
+    });
+
+    expect(result.preservedLocalProgress).toBe(true);
+    expect(result.metadata.junctionHistoricalBackfillStatus).toBe("coverage_v2_complete");
+    expect(result.metadata.junctionHistoricalBackfillEvidence).toBe(
+      "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1",
+    );
+  });
+
+  it("marks selected local evidence unpublished when equal progress has stale hosted evidence", () => {
+    const sharedProgress = {
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      junctionHistoricalBackfillEmptyAttempts: 2,
+      junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
+      junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+    };
+    const result = mergeHostedDeviceSyncConnectionMetadata({
+      hostedMetadata: {
+        ...sharedProgress,
+        junctionHistoricalBackfillEvidence:
+          "e1|2025-12-19T00:00:00.000Z|2026-03-19T00:00:00.000Z|garmin:1",
+      },
+      localConnectionStateUnpublished: true,
+      localMetadata: {
+        ...sharedProgress,
+        junctionHistoricalBackfillEvidence:
+          "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:2",
+      },
+    });
+
+    expect(result.preservedLocalProgress).toBe(true);
+    expect(result.metadata.junctionHistoricalBackfillEvidence).toBe(
+      "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:2",
+    );
+  });
+
+  it("preserves opaque hosted evidence owned by selected future progress", () => {
+    const opaqueEvidence = "future-hosted-evidence-format";
+    const result = mergeHostedDeviceSyncConnectionMetadata({
+      hostedMetadata: {
+        junctionHistoricalBackfillEvidence: opaqueEvidence,
+        junctionHistoricalBackfillStatus: "coverage_v3_exhausted",
+        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      },
+      localConnectionStateUnpublished: true,
+      localMetadata: {
+        junctionHistoricalBackfillEvidence:
+          "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1",
+        junctionHistoricalBackfillStatus: "coverage_v2_complete",
+        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+      },
+    });
+
+    expect(result.preservedLocalProgress).toBe(false);
+    expect(result.metadata.junctionHistoricalBackfillStatus).toBe("coverage_v3_exhausted");
+    expect(result.metadata.junctionHistoricalBackfillEvidence).toBe(opaqueEvidence);
+  });
+
+  it.each([
+    ["wrong encoding version", "e2|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1"],
+    ["wrong field count", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1|extra"],
+    ["noncanonical start", "e1|2025-12-20T00:00:00Z|2026-03-20T00:00:00.000Z|garmin:1"],
+    ["reversed window", "e1|2026-03-20T00:00:00.000Z|2025-12-20T00:00:00.000Z|garmin:1"],
+    ["empty providers", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|"],
+    ["malformed provider entry", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin"],
+    ["duplicate provider", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1,garmin:2"],
+    ["noncanonical provider order", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|oura:1,garmin:2"],
+    ["zero mask", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:0"],
+    ["fractional mask", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:1.5"],
+    ["unknown mask bit", "e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|garmin:8"],
+    ["oversized scalar", "x".repeat(DEVICE_SYNC_METADATA_MAX_STRING_LENGTH + 1)],
+  ])("rejects malformed Junction push evidence: %s", (_label, value) => {
+    expect(readJunctionHistoricalBackfillEvidence(value)).toBeNull();
+  });
+
+  it("fails closed when evidence additions cannot be encoded canonically or within metadata limits", () => {
+    const windowStart = "2025-12-20T00:00:00.000Z";
+    const windowEnd = "2026-03-20T00:00:00.000Z";
+    expect(addJunctionHistoricalBackfillEvidence({
+      existingValue: null,
+      providerSlug: "garmin",
+      resource: "sleep",
+      windowStart: "2025-12-20T00:00:00Z",
+      windowEnd,
+    })).toBeNull();
+    expect(addJunctionHistoricalBackfillEvidence({
+      existingValue: null,
+      providerSlug: "garmin",
+      resource: "sleep",
+      windowStart: windowEnd,
+      windowEnd: windowStart,
+    })).toBeNull();
+
+    const nearLimitEvidence = [
+      "e1",
+      windowStart,
+      windowEnd,
+      Array.from({ length: 29 }, (_, index) => `p${String(index).padStart(3, "0")}:1`).join(","),
+    ].join("|");
+    expect(nearLimitEvidence).toHaveLength(DEVICE_SYNC_METADATA_MAX_STRING_LENGTH - 1);
+    expect(readJunctionHistoricalBackfillEvidence(nearLimitEvidence)).not.toBeNull();
+    expect(addJunctionHistoricalBackfillEvidence({
+      existingValue: nearLimitEvidence,
+      providerSlug: "zzzz",
+      resource: "activity",
+      windowStart,
+      windowEnd,
+    })).toBeNull();
+  });
+
+  it("rejects prototype-sensitive provider names in Junction push evidence", () => {
+    for (const providerSlug of ["__proto__", "constructor", "prototype"]) {
+      expect(
+        readJunctionHistoricalBackfillEvidence(
+          `e1|2025-12-20T00:00:00.000Z|2026-03-20T00:00:00.000Z|${providerSlug}:1`,
+        ),
+      ).toBeNull();
+      expect(addJunctionHistoricalBackfillEvidence({
+        existingValue: null,
+        providerSlug,
+        resource: "activity",
+        windowStart: "2025-12-20T00:00:00.000Z",
+        windowEnd: "2026-03-20T00:00:00.000Z",
+      })).toBeNull();
+    }
   });
 });
 
@@ -980,7 +1161,7 @@ describe("parseHostedExecutionDeviceSyncRuntimeApplyRequest", () => {
             accountStatus: "reauthorization_required",
             code: "WHOOP_TOKEN_REQUEST_FAILED",
             details: {
-              providerResponseErrorCode: "11649ed4-27e2-4718-959f-d68de1d1a120f",
+              providerResponseErrorCode: "00000000-0000-4000-8000-000000000003f",
               providerOAuthErrorCode: "invalid_grant",
               providerOAuthErrorDescription: "Refresh token expired.",
             },
@@ -2241,7 +2422,7 @@ describe("parseHostedExecutionDeviceSyncRuntimeApplyRequest", () => {
 
 describe("sanitizeHostedRuntimeDiagnosticText", () => {
   it("classifies standalone id-shaped diagnostic tokens", () => {
-    expect(isHostedRuntimeIdShapedDiagnosticToken("11649ed4-27e2-4718-959f-d68de1d1a120")).toBe(true);
+    expect(isHostedRuntimeIdShapedDiagnosticToken("00000000-0000-4000-8000-000000000003")).toBe(true);
     expect(isHostedRuntimeIdShapedDiagnosticToken("a1".repeat(16))).toBe(true);
     expect(isHostedRuntimeIdShapedDiagnosticToken("invalid_request")).toBe(false);
     expect(isHostedRuntimeIdShapedDiagnosticToken("value_error.date")).toBe(false);
@@ -2253,12 +2434,12 @@ describe("sanitizeHostedRuntimeDiagnosticText", () => {
   it("masks long opaque tokens in place instead of dropping the whole text", () => {
     expect(
       sanitizeHostedRuntimeDiagnosticText(
-        "Team 11649ed4-27e2-4718-959f-d68de1d1a120 is not configured for sleep_cycle.",
+        "Team 00000000-0000-4000-8000-000000000003 is not configured for sleep_cycle.",
       ),
     ).toBe("Team <redacted-id> is not configured for sleep_cycle.");
     expect(
       sanitizeHostedRuntimeDiagnosticText(
-        "record 11649ed4-27e2-4718-959f-d68de1d1a120 was rejected upstream.",
+        "record 00000000-0000-4000-8000-000000000003 was rejected upstream.",
       ),
     ).toBe("record <redacted-token> was rejected upstream.");
   });
@@ -2567,7 +2748,7 @@ describe("sanitizeHostedRuntimeDiagnosticText", () => {
   it("masks multiple unsafe spans in one string", () => {
     expect(
       sanitizeHostedRuntimeDiagnosticText(
-        "user 0123456789abcdef0123456789abcdef01 denied; retry as 11649ed4-27e2-4718-959f-d68de1d1a120",
+        "user 0123456789abcdef0123456789abcdef01 denied; retry as 00000000-0000-4000-8000-000000000003",
       ),
     ).toBe("user <redacted-id> denied; retry as <redacted-token>");
   });

--- a/packages/device-syncd/test/hosted-runtime.test.ts
+++ b/packages/device-syncd/test/hosted-runtime.test.ts
@@ -348,9 +348,7 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
     const result = mergeHostedDeviceSyncConnectionMetadata({
       hostedMetadata: {
         junctionHistoricalBackfillEvidence: opaqueEvidence,
-        junctionHistoricalBackfillStatus: "coverage_v3_exhausted",
-        junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
-        junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
+        junctionHistoricalBackfillStatus: "coverage_v3_deferred",
       },
       localConnectionStateUnpublished: true,
       localMetadata: {
@@ -363,8 +361,33 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
     });
 
     expect(result.preservedLocalProgress).toBe(false);
-    expect(result.metadata.junctionHistoricalBackfillStatus).toBe("coverage_v3_exhausted");
+    expect(result.metadata.junctionHistoricalBackfillStatus).toBe("coverage_v3_deferred");
     expect(result.metadata.junctionHistoricalBackfillEvidence).toBe(opaqueEvidence);
+  });
+
+  it("preserves unpublished opaque local progress owned by a future runtime", () => {
+    const result = mergeHostedDeviceSyncConnectionMetadata({
+      hostedMetadata: {
+        hostedOnly: "current",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      },
+      localConnectionStateUnpublished: true,
+      localMetadata: {
+        junctionHistoricalBackfillEvidence: "e2|opaque-future-evidence",
+        junctionHistoricalBackfillStatus: "coverage_v3_deferred",
+        localOnly: "future",
+      },
+    });
+
+    expect(result).toEqual({
+      metadata: {
+        hostedOnly: "current",
+        junctionHistoricalBackfillEvidence: "e2|opaque-future-evidence",
+        junctionHistoricalBackfillStatus: "coverage_v3_deferred",
+        localOnly: "future",
+      },
+      preservedLocalProgress: true,
+    });
   });
 
   it.each([

--- a/packages/device-syncd/test/junction-historical-backfill.test.ts
+++ b/packages/device-syncd/test/junction-historical-backfill.test.ts
@@ -171,6 +171,7 @@ test("Junction sleep-cycle historical backfill marks staged records complete", a
   });
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
@@ -220,6 +221,7 @@ test("Junction sleep-cycle id-only historical backfill keeps retrying", async ()
   });
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
@@ -239,6 +241,7 @@ for (const stageCount of [0, -1]) {
     });
 
     assert.deepEqual(result.metadataPatch, {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",

--- a/packages/device-syncd/test/junction-historical-backfill.test.ts
+++ b/packages/device-syncd/test/junction-historical-backfill.test.ts
@@ -171,8 +171,7 @@ test("Junction sleep-cycle historical backfill marks staged records complete", a
   });
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -208,7 +207,7 @@ for (const [label, summaryRecord] of [
   test(`Junction sleep-cycle historical backfill marks ${label} records complete`, async () => {
     const { importedSnapshots, result } = await executeBackfill(summaryRecord);
 
-    assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "complete");
+    assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "coverage_v2_complete");
     assert.equal(result.scheduledJobs, undefined);
     assert.equal(importedSnapshots.length, 1);
   });
@@ -221,8 +220,7 @@ test("Junction sleep-cycle id-only historical backfill keeps retrying", async ()
   });
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -241,8 +239,7 @@ for (const stageCount of [0, -1]) {
     });
 
     assert.deepEqual(result.metadataPatch, {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -7,6 +7,7 @@ import {
 import { test } from "vitest";
 
 import { DeviceSyncError } from "../src/errors.ts";
+import { mergeStoredDeviceSyncMetadataPatch } from "../src/metadata.ts";
 import {
   buildJunctionClientUserId,
   createJunctionDeviceSyncProvider,
@@ -180,6 +181,33 @@ function createJunctionJobContext(overrides: Partial<ProviderJobContext> = {}): 
     refreshAccountTokens: async () => account,
     logger: {},
     ...overrides,
+  };
+}
+
+function createConnectionSource(
+  overrides: Omit<Partial<DeviceConnectionSourceRecord>, "firstSeenAt"> & {
+    firstSeenAt?: string | null;
+  } = {},
+): DeviceConnectionSourceRecord {
+  const { firstSeenAt, ...sourceOverrides } = overrides;
+  return {
+    id: "src-garmin",
+    connectionId: "acct-junction-1",
+    sourceInstanceKey: requireValue(buildJunctionProviderSourceInstanceKey({
+      connectionId: "acct-junction-1",
+      sourceProviderSlug: "garmin",
+    }), "Garmin source key should be available."),
+    sourceProviderSlug: "garmin",
+    displayName: null,
+    status: "connected",
+    resourceAvailabilitySummary: { activity: true },
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    lastSeenAt: "2026-04-03T00:00:00.000Z",
+    createdAt: "2026-04-03T00:00:00.000Z",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+    ...sourceOverrides,
+    firstSeenAt: firstSeenAt ?? "2026-04-03T00:00:00.000Z",
   };
 }
 
@@ -644,8 +672,7 @@ test("Junction empty historical backfill records progress and stores the retry w
 
   assert.equal(importedSnapshots.length, 0);
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -719,8 +746,7 @@ test("Junction due historical backfill retry does not make ordinary reconcile ow
     account: createAccount({
       connectedAt: "2026-04-03T00:00:00.000Z",
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -780,8 +806,7 @@ test("Junction materialized due historical backfill retry advances normal reconc
     account: createAccount({
       connectedAt: "2026-04-03T00:00:00.000Z",
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -800,7 +825,7 @@ test("Junction materialized due historical backfill retry advances normal reconc
     }),
   );
 
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "complete");
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "coverage_v2_complete");
   assert.equal(result.nextReconcileAt, "2026-04-04T01:15:00.000Z");
 });
 
@@ -809,8 +834,7 @@ test("Junction exact-window backfill preserves a pending metadata retry before i
     reconcileIntervalMs: 60 * 60_000,
   });
   const metadata = {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -843,8 +867,7 @@ test("Junction retrying historical backfill without attempts uses the first retr
   const executor = requireValue(provider.jobExecutor, "Junction provider should expose a job executor.");
   const retryingAccount = createStoredAccount({
     metadata: {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
@@ -968,7 +991,7 @@ test("Junction non-connect backfill window uses bounded job retry without histor
   assert.equal(importedSnapshots.length, 1);
 });
 
-test("Junction useful summary historical backfill marks the historical window complete", async () => {
+test("Junction useful daily history completes when an available sparse body resource is empty", async () => {
   const importedSnapshots: unknown[] = [];
   const requests: string[] = [];
   const provider = createJunctionProvider(async (input) => {
@@ -985,7 +1008,7 @@ test("Junction useful summary historical backfill marks the historical window co
             status: "connected",
             resource_availability: {
               activity: true,
-              body: { status: "unavailable" },
+              body: true,
               heartrate: true,
             },
           },
@@ -1020,8 +1043,7 @@ test("Junction useful summary historical backfill marks the historical window co
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -1038,6 +1060,59 @@ test("Junction useful summary historical backfill marks the historical window co
     "2026-04-01T00:00:00.000Z",
     "2026-04-03T00:00:00.000Z",
   );
+});
+
+test("Junction connected sources with only sparse resources have no completion obligations", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              body: true,
+              workouts: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (
+      url.startsWith("https://api.sandbox.us.junction.com/v2/summary/body/junction-user-1")
+      || url.startsWith("https://api.sandbox.us.junction.com/v2/summary/workouts/junction-user-1")
+    ) {
+      return createJsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["body", "workouts"],
+    timeseriesResources: [],
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext(),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
+    junctionHistoricalBackfillEmptyAttempts: 0,
+    junctionHistoricalBackfillLastEmptyAt: null,
+    junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+    junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+  });
+  assert.equal(result.scheduledJobs, undefined);
 });
 
 test("Junction partial activity history does not complete advertised sleep history", async () => {
@@ -1093,8 +1168,7 @@ test("Junction partial activity history does not complete advertised sleep histo
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -1172,336 +1246,10 @@ test("Junction historical coverage does not let one source satisfy another sourc
     }),
   );
 
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "coverage_v2_retrying");
   assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 1);
   assertConnectBackfillRetryWake(result, "2026-04-04T00:15:00.000Z");
   assert.equal(importedSnapshots.length, 1);
-});
-
-test("Junction legacy partial history re-triggers the provider export once", async () => {
-  let triggerRequests = 0;
-  let triggerBody: Record<string, unknown> | null = null;
-  const provider = createJunctionProvider(async (input, init) => {
-    const url = readUrl(input);
-
-    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
-      return createJsonResponse({
-        providers: [
-          {
-            id: "provider-garmin-1",
-            slug: "garmin",
-            name: "Garmin",
-            status: "connected",
-            resource_availability: {
-              activity: true,
-              sleep: true,
-              sleep_cycle: true,
-            },
-          },
-        ],
-      });
-    }
-
-    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
-      return createJsonResponse({
-        data: [{ id: "activity-1", connectionId: "provider-garmin-1", steps: 1234 }],
-      });
-    }
-
-    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
-      return createJsonResponse({ data: [] });
-    }
-
-    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep_cycle/junction-user-1")) {
-      return createJsonResponse({ data: [] });
-    }
-
-    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
-      triggerRequests += 1;
-      assert.equal(init?.method, "POST");
-      triggerBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
-      return new Response(null, { status: 202 });
-    }
-
-    throw new Error(`Unexpected request: ${url}`);
-  }, {
-    summaryResources: ["activity", "sleep", "sleep_cycle"],
-  });
-
-  const result = await executeJunctionJob(
-    provider,
-    createJunctionJobContext({
-      now: "2026-04-04T00:00:00.000Z",
-      account: createAccount({
-        metadata: {
-          junctionHistoricalBackfillStatus: "complete",
-          junctionHistoricalBackfillEmptyAttempts: 0,
-          junctionHistoricalBackfillLastEmptyAt: null,
-          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
-        },
-      }),
-    }),
-    createJob("backfill", {
-      windowStart: "2026-04-01T00:00:00.000Z",
-      windowEnd: "2026-04-03T00:00:00.000Z",
-    }),
-  );
-
-  assert.deepEqual(triggerBody, {
-    user_ids: ["junction-user-1"],
-    provider: "garmin",
-    wait_for_completion: false,
-  });
-  assert.equal(triggerRequests, 1);
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillCoverageVersion, 1);
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 1);
-});
-
-test("Junction delayed recovery triggers each pending Link provider once", async () => {
-  const triggerBodies: Record<string, unknown>[] = [];
-  const provider = createJunctionProvider(async (input, init) => {
-    const url = readUrl(input);
-
-    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
-      return createJsonResponse({
-        providers: [
-          {
-            id: "provider-garmin-1",
-            slug: "garmin",
-            name: "Garmin",
-            status: "connected",
-            resource_availability: {
-              sleep: true,
-              sleep_cycle: { available: true },
-            },
-          },
-          {
-            id: "provider-health-connect-1",
-            slug: "health_connect",
-            name: "Health Connect",
-            status: "connected",
-            resource_availability: {
-              activity: "available",
-            },
-          },
-        ],
-      });
-    }
-
-    if (
-      url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")
-      || url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")
-      || url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep_cycle/junction-user-1")
-    ) {
-      return createJsonResponse({ data: [] });
-    }
-
-    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
-      triggerBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
-      return new Response(null, { status: 202 });
-    }
-
-    throw new Error(`Unexpected request: ${url}`);
-  }, {
-    summaryResources: ["activity", "sleep", "sleep_cycle"],
-  });
-
-  const result = await executeJunctionJob(
-    provider,
-    createJunctionJobContext({
-      now: "2026-04-04T00:15:00.000Z",
-      account: createAccount({
-        metadata: {
-          junctionHistoricalBackfillCoverageVersion: 1,
-          junctionHistoricalBackfillStatus: "retrying",
-          junctionHistoricalBackfillEmptyAttempts: 1,
-          junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
-          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
-        },
-      }),
-    }),
-    createJob("backfill", {
-      windowStart: "2026-04-01T00:00:00.000Z",
-      windowEnd: "2026-04-03T00:00:00.000Z",
-    }),
-  );
-
-  assert.deepEqual(triggerBodies, [
-    {
-      user_ids: ["junction-user-1"],
-      provider: "garmin",
-      wait_for_completion: false,
-    },
-  ]);
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 2);
-});
-
-test("Junction historical trigger failure preserves imports and advances bounded recovery", async () => {
-  const importedSnapshots: unknown[] = [];
-  const warnings: Record<string, unknown>[] = [];
-  let triggerRequests = 0;
-  const provider = createJunctionProvider(async (input) => {
-    const url = readUrl(input);
-
-    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
-      return createJsonResponse({
-        providers: [
-          {
-            id: "provider-garmin-1",
-            slug: "garmin",
-            name: "Garmin",
-            status: "connected",
-            resource_availability: {
-              activity: true,
-              sleep: true,
-            },
-          },
-        ],
-      });
-    }
-
-    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
-      return createJsonResponse({
-        data: [{ id: "activity-1", connectionId: "provider-garmin-1", steps: 1234 }],
-      });
-    }
-
-    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
-      return createJsonResponse({ data: [] });
-    }
-
-    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
-      triggerRequests += 1;
-      return createJsonResponse({ detail: "not available" }, 422);
-    }
-
-    throw new Error(`Unexpected request: ${url}`);
-  }, {
-    summaryResources: ["activity", "sleep"],
-  });
-
-  const result = await executeJunctionJob(
-    provider,
-    createJunctionJobContext({
-      now: "2026-04-04T00:15:00.000Z",
-      account: createAccount({
-        metadata: {
-          junctionHistoricalBackfillCoverageVersion: 1,
-          junctionHistoricalBackfillStatus: "retrying",
-          junctionHistoricalBackfillEmptyAttempts: 1,
-          junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
-          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
-        },
-      }),
-      importSnapshot: async (snapshot) => {
-        importedSnapshots.push(snapshot);
-        return { imported: true };
-      },
-      logger: {
-        warn(_message, context) {
-          warnings.push(context ?? {});
-        },
-      },
-    }),
-    createJob("backfill", {
-      windowStart: "2026-04-01T00:00:00.000Z",
-      windowEnd: "2026-04-03T00:00:00.000Z",
-    }),
-  );
-
-  assert.equal(triggerRequests, 1);
-  assert.equal(importedSnapshots.length, 1);
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
-  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 2);
-  assertConnectBackfillRetryWake(result, "2026-04-04T01:15:00.000Z");
-  assert.deepEqual(warnings, [
-    {
-      endpointKind: "junction_link_bulk_trigger_historical_pull",
-      errorCode: "JUNCTION_API_REQUEST_FAILED",
-      provider: "junction",
-      responseStatus: 422,
-      retryable: false,
-      sourceProviderSlug: "garmin",
-    },
-  ]);
-});
-
-test("Junction historical trigger propagates parent cancellation", async () => {
-  const abortController = new AbortController();
-  const triggerAbort = new Error("historical trigger aborted");
-  const warnings: Record<string, unknown>[] = [];
-  const provider = createJunctionProvider(async (input) => {
-    const url = readUrl(input);
-
-    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
-      return createJsonResponse({
-        providers: [
-          {
-            id: "provider-garmin-1",
-            slug: "garmin",
-            name: "Garmin",
-            status: "connected",
-            resource_availability: {
-              activity: true,
-            },
-          },
-        ],
-      });
-    }
-
-    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
-      return createJsonResponse({ data: [] });
-    }
-
-    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
-      abortController.abort();
-      throw triggerAbort;
-    }
-
-    throw new Error(`Unexpected request: ${url}`);
-  });
-
-  await assert.rejects(
-    () => executeJunctionJob(
-      provider,
-      createJunctionJobContext({
-        now: "2026-04-04T00:15:00.000Z",
-        signal: abortController.signal,
-        logger: {
-          warn(_message, context) {
-            warnings.push(context ?? {});
-          },
-        },
-        account: createAccount({
-          metadata: {
-            junctionHistoricalBackfillCoverageVersion: 1,
-            junctionHistoricalBackfillStatus: "retrying",
-            junctionHistoricalBackfillEmptyAttempts: 1,
-            junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
-            junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-            junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
-          },
-        }),
-      }),
-      createJob("backfill", {
-        windowStart: "2026-04-01T00:00:00.000Z",
-        windowEnd: "2026-04-03T00:00:00.000Z",
-      }),
-    ),
-    (error: unknown) => {
-      if (!(error instanceof DeviceSyncError)) {
-        return false;
-      }
-      assert.equal(error.code, "JUNCTION_API_REQUEST_FAILED");
-      return true;
-    },
-  );
-  assert.deepEqual(warnings, []);
 });
 
 test("Junction backfill diagnostic reports redacted provider call counts", async () => {
@@ -2231,8 +1979,7 @@ for (const testCase of usefulHistoricalSummaryCompletionCases) {
     );
 
     assert.deepEqual(result.metadataPatch, {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2360,7 +2107,7 @@ for (const testCase of [
     },
   },
 ] as const) {
-  test(`Junction ${testCase.label} raw-only summary keeps the historical window retrying`, async () => {
+  test(`Junction ${testCase.label} raw-only summary does not create a historical obligation`, async () => {
     const importedSnapshots: unknown[] = [];
     const provider = createJunctionProvider(async (input) => {
       const url = readUrl(input);
@@ -2406,14 +2153,13 @@ for (const testCase of [
     );
 
     assert.deepEqual(result.metadataPatch, {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
-      junctionHistoricalBackfillEmptyAttempts: 1,
-      junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
+      junctionHistoricalBackfillEmptyAttempts: 0,
+      junctionHistoricalBackfillLastEmptyAt: null,
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
     });
-    assertConnectBackfillRetryWake(result, "2026-04-04T00:15:00.000Z");
+    assert.equal(result.scheduledJobs, undefined);
     assert.equal(importedSnapshots.length, 1);
   });
 }
@@ -2464,8 +2210,7 @@ for (const summaryResource of ["sleep", "workouts", "body"] as const) {
     );
 
     assert.deepEqual(result.metadataPatch, {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2529,8 +2274,7 @@ test("Junction sleep_cycle stage-count-only historical backfill marks the histor
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2545,7 +2289,7 @@ test("Junction sleep_cycle stage-count-only historical backfill marks the histor
   assertJunctionWindowQuery(summaryRequest, "2026-04-01", "2026-04-02");
 });
 
-for (const summaryResource of ["activity", "sleep", "workouts", "body"] as const) {
+for (const summaryResource of ["activity", "sleep"] as const) {
   test(`Junction ${summaryResource} id-only historical backfill keeps the summary window retrying`, async () => {
     const importedSnapshots: unknown[] = [];
     const provider = createJunctionProvider(async (input) => {
@@ -2592,8 +2336,7 @@ for (const summaryResource of ["activity", "sleep", "workouts", "body"] as const
     );
 
     assert.deepEqual(result.metadataPatch, {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2611,15 +2354,9 @@ const floatingSessionOnlySummaryRecordByResource = {
     startAt: "2026-04-02T01:00:00",
     endAt: "2026-04-02T08:00:00",
   },
-  workouts: {
-    id: "workouts-1",
-    connectionId: "provider-garmin-1",
-    startAt: "2026-04-02T12:00:00",
-    endAt: "2026-04-02T13:00:00",
-  },
-} satisfies Record<"sleep" | "workouts", Record<string, unknown>>;
+} satisfies Record<"sleep", Record<string, unknown>>;
 
-for (const summaryResource of ["sleep", "workouts"] as const) {
+for (const summaryResource of ["sleep"] as const) {
   test(`Junction ${summaryResource} floating session-only historical backfill keeps the summary window retrying`, async () => {
     const importedSnapshots: unknown[] = [];
     const provider = createJunctionProvider(async (input) => {
@@ -2666,8 +2403,7 @@ for (const summaryResource of ["sleep", "workouts"] as const) {
     );
 
     assert.deepEqual(result.metadataPatch, {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2722,8 +2458,7 @@ test("Junction useful summary without source linkage keeps the historical window
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2778,8 +2513,7 @@ test("Junction floating-provider metric-only summary keeps the historical window
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2836,8 +2570,7 @@ test("Junction source envelope summary historical backfill marks the historical 
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -2908,8 +2641,7 @@ test("Junction compact timeseries-only historical backfill keeps the summary win
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -3046,8 +2778,7 @@ test("Junction yielded connect-window backfills keep owner window and resume wit
     [["2026-04-02", "2026-04-02"]],
   );
   assert.deepEqual(secondResult.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: ownerWindowStart,
@@ -3068,7 +2799,7 @@ test("Junction yielded connect-window backfills keep owner window and resume wit
   );
 });
 
-test("Junction profile-only historical backfill keeps the summary window retrying", async () => {
+test("Junction profile-only historical backfill has no historical completion obligation", async () => {
   const importedSnapshots: unknown[] = [];
   const requests: string[] = [];
   const provider = createJunctionProvider(async (input) => {
@@ -3116,14 +2847,13 @@ test("Junction profile-only historical backfill keeps the summary window retryin
 
   assert.deepEqual(result.metadataPatch, {
     junctionProfileSummaryCheckedAt: "2026-04-04T00:00:00.000Z",
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "retrying",
-    junctionHistoricalBackfillEmptyAttempts: 1,
-    junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
+    junctionHistoricalBackfillEmptyAttempts: 0,
+    junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
   });
-  assertConnectBackfillRetryWake(result, "2026-04-04T00:15:00.000Z");
+  assert.equal(result.scheduledJobs, undefined);
   assert.equal(importedSnapshots.length, 1);
   const profileRequest = requireValue(
     requests.find((url) => new URL(url).pathname.includes("/v2/summary/profile/")),
@@ -3188,17 +2918,22 @@ test("Junction scheduled polling skips profile after the one-shot profile marker
 
 test("Junction empty historical backfill stops retrying after the bounded budget", async () => {
   const provider = createEmptyJunctionBackfillProvider();
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 4,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
         junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       },
     }),
+    listConnectionSources: () => [],
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return createConnectionSource(input);
+    },
   });
 
   const result = await executeJunctionJob(
@@ -3211,29 +2946,243 @@ test("Junction empty historical backfill stops retrying after the bounded budget
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "exhausted",
+    junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
     junctionHistoricalBackfillEmptyAttempts: 5,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
   });
   assert.equal(result.scheduledJobs, undefined);
+  assert.equal(upserts.length, 2);
+  assert.equal(upserts[0]?.status, "connected");
+  assert.equal(upserts[1]?.status, "error");
+  assert.equal(
+    upserts[1]?.lastErrorCode,
+    "HISTORICAL_DATA_RECONNECT_REQUIRED",
+  );
 });
 
-test("Junction exhausted historical backfill is terminal until the same window has data", async () => {
+test("Junction non-connected source with empty availability cannot complete historical coverage", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "error",
+            resource_availability: {},
+            error_details: {
+              error_type: "provider_temporarily_unavailable",
+              error_message: "Temporary provider failure.",
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+          junctionHistoricalBackfillEmptyAttempts: 4,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+      listConnectionSources: () => [],
+      upsertConnectionSource: (input) => {
+        upserts.push(input);
+        return createConnectionSource(input);
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "coverage_v2_exhausted");
+  assert.equal(result.scheduledJobs, undefined);
+  assert.equal(upserts.at(-1)?.sourceProviderSlug, "garmin");
+  assert.equal(upserts.at(-1)?.status, "error");
+  assert.equal(upserts.at(-1)?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
+});
+
+test("Junction empty provider list marks the existing active source after bounded observation", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({ providers: [] });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  const existingSource = createConnectionSource({
+    sourceInstanceKey: "hosted-source-garmin",
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+          junctionHistoricalBackfillEmptyAttempts: 4,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+      listConnectionSources: () => [existingSource],
+      upsertConnectionSource: (input) => {
+        upserts.push(input);
+        return createConnectionSource(input);
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "coverage_v2_exhausted");
+  assert.equal(result.scheduledJobs, undefined);
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0]?.sourceInstanceKey, existingSource.sourceInstanceKey);
+  assert.equal(upserts[0]?.sourceProviderSlug, "garmin");
+  assert.equal(upserts[0]?.status, "error");
+  assert.equal(upserts[0]?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
+});
+
+test("Junction bounded historical retries mark only sources with incomplete coverage", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+              sleep: true,
+            },
+          },
+          {
+            id: "provider-fitbit-1",
+            slug: "fitbit",
+            name: "Fitbit",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [
+          { id: "garmin-activity-1", connectionId: "provider-garmin-1", steps: 4321 },
+          { id: "fitbit-activity-1", connectionId: "provider-fitbit-1", steps: 1234 },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "sleep"],
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+          junctionHistoricalBackfillEmptyAttempts: 4,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+      listConnectionSources: () => [],
+      upsertConnectionSource: (input) => {
+        upserts.push(input);
+        return createConnectionSource(input);
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "coverage_v2_exhausted");
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 5);
+  const erroredSources = upserts.filter((source) => source.status === "error");
+  assert.equal(erroredSources.length, 1);
+  assert.equal(erroredSources[0]?.sourceProviderSlug, "garmin");
+  assert.equal(erroredSources[0]?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
+  assert.equal(
+    upserts.some((source) => source.sourceProviderSlug === "fitbit" && source.status === "error"),
+    false,
+  );
+});
+
+test("Junction exhausted historical backfill preserves reconnect-required source health", async () => {
   const provider = createEmptyJunctionBackfillProvider();
+  const historicalError = createConnectionSource({
+    status: "error",
+    lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+    lastErrorMessage: "Historical data remained incomplete.",
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "exhausted",
+        junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
         junctionHistoricalBackfillEmptyAttempts: 5,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
         junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       },
     }),
+    listConnectionSources: () => [historicalError],
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return createConnectionSource(input);
+    },
   });
 
   const result = await executeJunctionJob(
@@ -3247,9 +3196,292 @@ test("Junction exhausted historical backfill is terminal until the same window h
 
   assert.equal(result.metadataPatch, undefined);
   assert.equal(result.scheduledJobs, undefined);
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0]?.status, "error");
+  assert.equal(upserts[0]?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
+});
+
+test("Junction exhausted historical backfill reasserts a missing reconnect marker", async () => {
+  const provider = createEmptyJunctionBackfillProvider();
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+  const context = createJunctionJobContext({
+    account: createAccount({
+      metadata: {
+        junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+        junctionHistoricalBackfillEmptyAttempts: 5,
+        junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
+        junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+      },
+    }),
+    listConnectionSources: () => [createConnectionSource({
+      status: "error",
+      lastErrorCode: "TOKEN_REFRESH_FAILED",
+      lastErrorMessage: "Transient provider error.",
+    })],
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return createConnectionSource(input);
+    },
+  });
+
+  await executeJunctionJob(
+    provider,
+    context,
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(upserts.at(-1)?.status, "error");
+  assert.equal(upserts.at(-1)?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
+});
+
+test("Junction exhausted history marker survives a transient upstream provider error", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "error",
+            error_details: {
+              error_type: "provider_temporarily_unavailable",
+              error_message: "Temporary provider failure.",
+              errored_at: "2026-04-03T00:00:00.000Z",
+            },
+            resource_availability: { activity: true },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity"],
+    timeseriesResources: [],
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+
+  await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+          junctionHistoricalBackfillEmptyAttempts: 5,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+      listConnectionSources: () => [createConnectionSource({
+        status: "error",
+        lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+        lastErrorMessage: "Historical data remained incomplete.",
+      })],
+      upsertConnectionSource: (input) => {
+        upserts.push(input);
+        return createConnectionSource(input);
+      },
+    }),
+    createJob("reconcile", {
+      windowStart: "2026-04-02T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(upserts[0]?.status, "error");
+  assert.equal(upserts[0]?.lastErrorCode, "HISTORICAL_DATA_RECONNECT_REQUIRED");
+  assert.equal(upserts[0]?.lastErrorMessage, "Historical data remained incomplete.");
+});
+
+test("Junction source projection clears historical reconnect health after connection metadata resets", async () => {
+  const provider = createEmptyJunctionBackfillProvider();
+  const existingSource = createConnectionSource({
+    sourceInstanceKey: "hosted-source-garmin",
+    status: "error",
+    lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+    lastErrorMessage: "Historical data remained incomplete.",
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+
+  await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({ metadata: {} }),
+      listConnectionSources: () => [existingSource],
+      upsertConnectionSource: (input) => {
+        upserts.push(input);
+        return createConnectionSource(input);
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(upserts[0]?.sourceInstanceKey, existingSource.sourceInstanceKey);
+  assert.equal(upserts[0]?.status, "connected");
+  assert.equal(Object.hasOwn(upserts[0] ?? {}, "lastErrorCode"), false);
+  assert.equal(Object.hasOwn(upserts[0] ?? {}, "lastErrorMessage"), false);
+});
+
+test("Junction late historical data queues one connect-window verification after exhaustion", async () => {
+  const importedSnapshots: unknown[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    throw new Error(`Unexpected request: ${readUrl(input)}`);
+  });
+  const account = createAccount({
+    metadata: {
+      junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+      junctionHistoricalBackfillEmptyAttempts: 5,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+    },
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account,
+      now: "2026-04-05T00:00:00.000Z",
+      importSnapshot: async (snapshot) => {
+        importedSnapshots.push(snapshot);
+        return { canonicalEventCount: 1 };
+      },
+    }),
+    createJob("resource", {
+      eventType: "daily.data.activity.created",
+      objectId: "late-activity",
+      occurredAt: "2026-04-02T00:00:00.000Z",
+      resource: "activity",
+      resourceCategory: "summary",
+      sourceProviderSlug: "garmin",
+      webhookDataJson: JSON.stringify({
+        date: "2026-04-02",
+        id: "late-activity",
+        sourceProviderSlug: "garmin",
+        steps: 4321,
+      }),
+      windowStart: "2026-04-02T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(importedSnapshots.length, 1);
+  assert.equal(
+    result.metadataPatch?.junctionHistoricalBackfillEvidence,
+    "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:1",
+  );
+  assert.equal(result.scheduledJobs?.length, 1);
+  assert.equal(result.scheduledJobs?.[0]?.kind, "backfill");
+  assert.equal(result.scheduledJobs?.[0]?.availableAt, "2026-04-05T00:00:00.000Z");
+  assert.equal(
+    result.scheduledJobs?.[0]?.dedupeKey,
+    buildExpectedJunctionDedupeKey(
+      "backfill",
+      "2026-04-01T00:00:00.000Z",
+      "2026-04-03T00:00:00.000Z",
+    ),
+  );
+  assert.deepEqual(result.scheduledJobs?.[0]?.payload, {
+    windowStart: "2026-04-01T00:00:00.000Z",
+    windowEnd: "2026-04-03T00:00:00.000Z",
+  });
+
+  const currentResult = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account,
+      now: "2026-04-05T00:00:00.000Z",
+      importSnapshot: async () => ({ canonicalEventCount: 1 }),
+    }),
+    createJob("resource", {
+      eventType: "daily.data.activity.created",
+      objectId: "current-activity",
+      occurredAt: "2026-04-04T00:00:00.000Z",
+      resource: "activity",
+      resourceCategory: "summary",
+      sourceProviderSlug: "garmin",
+      webhookDataJson: JSON.stringify({
+        date: "2026-04-04",
+        id: "current-activity",
+        sourceProviderSlug: "garmin",
+        steps: 1234,
+      }),
+      windowStart: "2026-04-04T00:00:00.000Z",
+      windowEnd: "2026-04-05T00:00:00.000Z",
+    }),
+  );
+  assert.equal(currentResult.scheduledJobs, undefined);
+  assert.equal(currentResult.metadataPatch, undefined);
+});
+
+test("Junction direct pushes without canonical events or from another source do not become history evidence", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    throw new Error(`Unexpected request: ${readUrl(input)}`);
+  }, {
+    providerFilter: ["garmin"],
+  });
+  const basePayload = {
+    eventType: "daily.data.activity.created",
+    occurredAt: "2026-04-02T00:00:00.000Z",
+    resource: "activity",
+    resourceCategory: "summary",
+    windowStart: "2026-04-02T00:00:00.000Z",
+    windowEnd: "2026-04-03T00:00:00.000Z",
+  };
+
+  const emptyImportResult = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      importSnapshot: async () => ({ canonicalEventCount: 0 }),
+    }),
+    createJob("resource", {
+      ...basePayload,
+      objectId: "empty-activity",
+      sourceProviderSlug: "garmin",
+      webhookDataJson: JSON.stringify({
+        id: "empty-activity",
+        sourceProviderSlug: "garmin",
+      }),
+    }),
+  );
+  assert.equal(emptyImportResult.metadataPatch, undefined);
+
+  const otherSourceResult = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      importSnapshot: async () => ({ canonicalEventCount: 1 }),
+    }),
+    createJob("resource", {
+      ...basePayload,
+      objectId: "other-source-activity",
+      sourceProviderSlug: "oura",
+      webhookDataJson: JSON.stringify({
+        id: "other-source-activity",
+        sourceProviderSlug: "oura",
+        steps: 1000,
+      }),
+    }),
+  );
+  assert.equal(otherSourceResult.metadataPatch, undefined);
 });
 
 test("Junction exhausted historical backfill completes when the same window later has data", async () => {
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
   const provider = createJunctionProvider(async (input) => {
     const url = readUrl(input);
 
@@ -3278,14 +3510,22 @@ test("Junction exhausted historical backfill completes when the same window late
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "exhausted",
+        junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
         junctionHistoricalBackfillEmptyAttempts: 5,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
         junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
       },
     }),
+    listConnectionSources: () => [createConnectionSource({
+      status: "error",
+      lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+      lastErrorMessage: "Historical data remained incomplete.",
+    })],
+    upsertConnectionSource: (input) => {
+      upserts.push(input);
+      return createConnectionSource(input);
+    },
   });
 
   const result = await executeJunctionJob(
@@ -3298,14 +3538,357 @@ test("Junction exhausted historical backfill completes when the same window late
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
     junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
   });
   assert.equal(result.scheduledJobs, undefined);
+  assert.equal(upserts.length, 2);
+  assert.equal(upserts[0]?.status, "error");
+  assert.equal(upserts[1]?.status, "connected");
+  assert.equal(Object.hasOwn(upserts[1] ?? {}, "lastErrorCode"), false);
+
+  const futureVersionUpserts: Array<
+    Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]
+  > = [];
+  const futureVersionResult = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillStatus: "coverage_v3_exhausted",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+      listConnectionSources: () => [createConnectionSource({
+        status: "error",
+        lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+        lastErrorMessage: "Future coverage owns this state.",
+      })],
+      upsertConnectionSource: (input) => {
+        futureVersionUpserts.push(input);
+        return createConnectionSource(input);
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+  assert.equal(futureVersionResult.metadataPatch, undefined);
+  assert.equal(futureVersionUpserts.length, 1);
+  assert.equal(futureVersionUpserts[0]?.status, "error");
+  assert.equal(
+    futureVersionUpserts[0]?.lastErrorCode,
+    "HISTORICAL_DATA_RECONNECT_REQUIRED",
+  );
+});
+
+test("Junction connect-window coverage unions fresh REST rows with matching imported push evidence", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [{
+          id: "provider-garmin-1",
+          slug: "garmin",
+          name: "Garmin",
+          status: "connected",
+          resource_availability: { activity: true, sleep: true },
+        }],
+      });
+    }
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ connectionId: "provider-garmin-1", id: "activity-rest-1", steps: 4321 }],
+      });
+    }
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    providerFilter: ["garmin"],
+    summaryResources: ["activity", "sleep"],
+  });
+  const job = createJob("backfill", {
+    windowStart: "2026-04-01T00:00:00.000Z",
+    windowEnd: "2026-04-03T00:00:00.000Z",
+  });
+
+  const matchingResult = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillEvidence:
+            "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:2",
+        },
+      }),
+    }),
+    job,
+  );
+  assert.equal(
+    matchingResult.metadataPatch?.junctionHistoricalBackfillStatus,
+    "coverage_v2_complete",
+  );
+
+  for (const evidence of [
+    "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|oura:2",
+    "e1|2026-03-31T00:00:00.000Z|2026-04-02T00:00:00.000Z|garmin:2",
+  ]) {
+    const result = await executeJunctionJob(
+      provider,
+      createJunctionJobContext({
+        account: createAccount({ metadata: { junctionHistoricalBackfillEvidence: evidence } }),
+      }),
+      job,
+    );
+    assert.equal(
+      result.metadataPatch?.junctionHistoricalBackfillStatus,
+      "coverage_v2_retrying",
+      evidence,
+    );
+  }
+});
+
+test("Junction authenticated late sleep pushes recover an exhausted historical window", async () => {
+  const windowStart = "2026-04-01T00:00:00.000Z";
+  const windowEnd = "2026-04-03T00:00:00.000Z";
+  const requests: string[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+    requests.push(url);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [{
+          id: "provider-garmin-1",
+          slug: "garmin",
+          name: "Garmin",
+          status: "connected",
+          resource_availability: {
+            activity: true,
+            sleep: true,
+            sleep_cycle: true,
+          },
+        }],
+      });
+    }
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ connectionId: "provider-garmin-1", id: "activity-rest-1", steps: 4321 }],
+      });
+    }
+    if (
+      url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")
+      || url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep_cycle/junction-user-1")
+    ) {
+      return createJsonResponse({ data: [] });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    providerFilter: ["garmin"],
+    summaryResources: ["activity", "sleep", "sleep_cycle"],
+    timeseriesResources: [],
+    webhookSecret: "whsec_d2ViaG9vay10ZXN0LXNlY3JldA==",
+  });
+  let metadata: Record<string, unknown> = {
+    junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+    junctionHistoricalBackfillEmptyAttempts: 5,
+    junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
+    junctionHistoricalBackfillWindowStart: windowStart,
+    junctionHistoricalBackfillWindowEnd: windowEnd,
+  };
+  let verificationJob: DeviceSyncJobInput | undefined;
+  const importedPushResources: string[] = [];
+
+  for (const testCase of [
+    {
+      data: {
+        date: "2026-04-02",
+        end_time: "2026-04-02T11:15:00.000Z",
+        id: "late-garmin-sleep-1",
+        resource: "sleep",
+        source: { provider: "garmin" },
+        start_time: "2026-04-02T03:30:00.000Z",
+        total_sleep_minutes: 420,
+      },
+      eventType: "historical.data.sleep.created",
+      expectedEvidence:
+        "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:2",
+      expectedResource: "sleep",
+      messageId: "msg_late_garmin_sleep_1",
+    },
+    {
+      data: {
+        date: "2026-04-02",
+        end: "2026-04-02T04:25:00.000Z",
+        id: "late-garmin-hypnogram-1",
+        resource: "hypnogram",
+        source: { provider: "garmin" },
+        start: "2026-04-02T04:00:00.000Z",
+        stages: [{
+          endAt: "2026-04-02T04:25:00.000Z",
+          stage: "deep",
+          startAt: "2026-04-02T04:00:00.000Z",
+        }],
+      },
+      eventType: "historical.data.hypnogram.created",
+      expectedEvidence:
+        "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:6",
+      expectedResource: "sleep_cycle",
+      messageId: "msg_late_garmin_hypnogram_1",
+    },
+  ] as const) {
+    const webhook = createJunctionSvixWebhook({
+      body: {
+        event_type: testCase.eventType,
+        user_id: "junction-user-1",
+        data: testCase.data,
+      },
+      messageId: testCase.messageId,
+      timestamp: "1775174400",
+    });
+    const parsed = await requireJunctionWebhookHandler(provider).verifyAndParseWebhook({
+      headers: webhook.headers,
+      rawBody: webhook.rawBody,
+      now: "2026-04-03T00:00:00.000Z",
+    });
+    const parsedJob = parsed.jobs[0];
+    assert.ok(parsedJob);
+    assert.equal(parsed.acceptanceMode, "durable_webhook_work");
+    assert.equal(parsedJob.kind, "resource");
+    assert.equal(parsedJob.payload?.resource, testCase.expectedResource);
+
+    const result = await executeJunctionJob(
+      provider,
+      createJunctionJobContext({
+        account: createAccount({ metadata }),
+        importSnapshot: async (snapshot) => {
+          const summaries = (snapshot as { summaries?: Record<string, unknown[]> }).summaries ?? {};
+          importedPushResources.push(...Object.keys(summaries));
+          return { canonicalEventCount: 1 };
+        },
+        now: "2026-04-03T00:00:00.000Z",
+      }),
+      createJob(parsedJob.kind, parsedJob.payload ?? {}),
+    );
+
+    assert.equal(
+      result.metadataPatch?.junctionHistoricalBackfillEvidence,
+      testCase.expectedEvidence,
+    );
+    verificationJob = result.scheduledJobs?.find((job) => job.kind === "backfill");
+    assert.deepEqual(verificationJob?.payload, { windowEnd, windowStart });
+    metadata = mergeStoredDeviceSyncMetadataPatch(metadata, result.metadataPatch);
+  }
+
+  assert.deepEqual(importedPushResources, ["sleep", "sleep_cycle"]);
+  assert.equal(
+    metadata.junctionHistoricalBackfillEvidence,
+    "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:6",
+  );
+  assert.ok(verificationJob);
+
+  const existingSource = createConnectionSource({
+    status: "error",
+    lastErrorCode: "HISTORICAL_DATA_RECONNECT_REQUIRED",
+    lastErrorMessage: "Historical data remained incomplete.",
+  });
+  const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
+  let verificationSnapshot: unknown = null;
+  const verificationResult = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({ metadata }),
+      importSnapshot: async (snapshot) => {
+        verificationSnapshot = snapshot;
+        return { canonicalEventCount: 1 };
+      },
+      listConnectionSources: () => [existingSource],
+      now: "2026-04-03T00:01:00.000Z",
+      upsertConnectionSource: (input) => {
+        upserts.push(input);
+        return createConnectionSource(input);
+      },
+    }),
+    createJob(verificationJob.kind, verificationJob.payload ?? {}),
+  );
+
+  const verificationSummaries = (verificationSnapshot as {
+    summaries?: Record<string, unknown[]>;
+  }).summaries;
+  assert.equal(verificationSummaries?.activity?.length, 1);
+  assert.deepEqual(verificationSummaries?.sleep, []);
+  assert.deepEqual(verificationSummaries?.sleep_cycle, []);
+  assert.equal(
+    verificationResult.metadataPatch?.junctionHistoricalBackfillStatus,
+    "coverage_v2_complete",
+  );
+  const completedMetadata = mergeStoredDeviceSyncMetadataPatch(
+    metadata,
+    verificationResult.metadataPatch,
+  );
+  assert.equal(completedMetadata.junctionHistoricalBackfillStatus, "coverage_v2_complete");
+  assert.equal(
+    completedMetadata.junctionHistoricalBackfillEvidence,
+    "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:6",
+  );
+  assert.ok(requests.some((url) => url.includes("/v2/summary/activity/")));
+  assert.ok(requests.some((url) => url.includes("/v2/summary/sleep/")));
+  assert.ok(requests.some((url) => url.includes("/v2/summary/sleep_cycle/")));
+  assert.equal(upserts.at(-1)?.status, "connected");
+  assert.equal(Object.hasOwn(upserts.at(-1) ?? {}, "lastErrorCode"), false);
+  assert.equal(Object.hasOwn(upserts.at(-1) ?? {}, "lastErrorMessage"), false);
+});
+
+test("Junction coverage ignores errored sources outside the normalized provider filter", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: { activity: true },
+          },
+          {
+            id: "provider-other-1",
+            slug: "fitbit",
+            name: "Other source",
+            status: "error",
+            resource_availability: { activity: true },
+          },
+        ],
+      });
+    }
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ connectionId: "provider-garmin-1", id: "activity-rest-1", steps: 4321 }],
+      });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    providerFilter: [" GARMIN ", "garmin"],
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext(),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "coverage_v2_complete");
 });
 
 test("Junction reconcile data does not complete pending historical backfill", async () => {
@@ -3336,8 +3919,7 @@ test("Junction reconcile data does not complete pending historical backfill", as
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-01-03T00:00:00.000Z",
@@ -3943,12 +4525,12 @@ test("Junction beginConnection resolves or creates a user, returns Link URL, and
   assert.equal(requests.every((request) => request.headers.get("x-vital-api-key") === "sk_us_test_123"), true);
 });
 
-test("Junction beginConnection dispatches Link directly to the requested source provider", async () => {
-  const requests: Array<{ body: unknown; url: string }> = [];
+test("Junction beginConnection dispatches Link directly without mutating the requested source provider", async () => {
+  const requests: Array<{ body: unknown; method: string; url: string }> = [];
   const provider = createJunctionProvider(async (input, init) => {
     const url = readUrl(input);
     const body = typeof init?.body === "string" ? JSON.parse(init.body) as unknown : null;
-    requests.push({ body, url });
+    requests.push({ body, method: init?.method ?? "GET", url });
 
     if (url.startsWith("https://api.sandbox.us.junction.com/v2/user/resolve/")) {
       return createJsonResponse({ id: "junction-user-1" });
@@ -3981,6 +4563,19 @@ test("Junction beginConnection dispatches Link directly to the requested source 
   assert.equal(
     typeof linkBody === "object" && linkBody !== null && "filter_on_providers" in linkBody,
     false,
+  );
+  assert.deepEqual(
+    requests.map((request) => {
+      const pathname = new URL(request.url).pathname;
+      return [
+        request.method,
+        pathname.startsWith("/v2/user/resolve/") ? "/v2/user/resolve/:clientUserId" : pathname,
+      ];
+    }),
+    [
+      ["GET", "/v2/user/resolve/:clientUserId"],
+      ["POST", "/v2/link/token"],
+    ],
   );
 });
 
@@ -4105,16 +4700,39 @@ test("Junction scheduled pass repairs legacy completion and honors current termi
     windowEnd: "2026-04-03T00:00:00.000Z",
   });
 
+  const priorCoverageVersion = executor.createScheduledJobs?.(
+    createStoredAccount({
+      metadata: {
+        junctionHistoricalBackfillStatus: "coverage_v1_complete",
+        junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+      },
+    }),
+    "2026-04-03T12:34:56.000Z",
+  );
+  assert.equal(
+    priorCoverageVersion?.jobs.filter((job) => job.kind === "backfill").length,
+    1,
+  );
+
   for (const metadata of [
     {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillStatus: "coverage_v2_complete",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
     },
     {
-      junctionHistoricalBackfillCoverageVersion: 1,
-      junctionHistoricalBackfillStatus: "exhausted",
+      junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+    },
+    {
+      junctionHistoricalBackfillStatus: "coverage_v3_complete",
+      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+    },
+    {
+      junctionHistoricalBackfillStatus: "coverage_v3_retrying",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
       junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
     },
@@ -4135,8 +4753,7 @@ test("Junction scheduled pass repairs legacy completion and honors current termi
   const completeOtherWindow = executor.createScheduledJobs?.(
     createStoredAccount({
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "complete",
+        junctionHistoricalBackfillStatus: "coverage_v2_complete",
         junctionHistoricalBackfillWindowStart: "2026-04-02T00:00:00.000Z",
         junctionHistoricalBackfillWindowEnd: "2026-04-04T00:00:00.000Z",
       },
@@ -4154,8 +4771,7 @@ test("Junction scheduled pass repairs legacy completion and honors current termi
   const retryingOtherWindow = executor.createScheduledJobs?.(
     createStoredAccount({
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-03T12:30:00.000Z",
         junctionHistoricalBackfillWindowStart: "2026-04-02T00:00:00.000Z",
@@ -4169,6 +4785,31 @@ test("Junction scheduled pass repairs legacy completion and honors current termi
     windowStart: "2026-04-01T00:00:00.000Z",
     windowEnd: "2026-04-03T00:00:00.000Z",
   });
+});
+
+test("Junction scheduled pass reopens progress overwritten by a legacy runner", () => {
+  const provider = createJunctionProvider(async (input) => {
+    throw new Error(`Unexpected request: ${readUrl(input)}`);
+  });
+  const executor = requireValue(provider.jobExecutor, "Junction provider should expose a job executor.");
+  const currentProgress = {
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+    junctionHistoricalBackfillEmptyAttempts: 2,
+    junctionHistoricalBackfillLastEmptyAt: "2026-04-03T12:30:00.000Z",
+    junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+    junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+  };
+  const overwrittenByLegacyRunner = mergeStoredDeviceSyncMetadataPatch(currentProgress, {
+    junctionHistoricalBackfillStatus: "complete",
+  });
+
+  const scheduled = executor.createScheduledJobs?.(
+    createStoredAccount({ metadata: overwrittenByLegacyRunner }),
+    "2026-04-03T12:34:56.000Z",
+  );
+
+  assert.equal(overwrittenByLegacyRunner.junctionHistoricalBackfillStatus, "complete");
+  assert.equal(scheduled?.jobs.filter((job) => job.kind === "backfill").length, 1);
 });
 
 test("Junction reconcile keeps summaries current while compact timeseries stays on closed days", async () => {
@@ -5901,8 +6542,7 @@ test("Junction polling updates source projection and imports bounded summary/tim
   );
 
   assert.deepEqual(result.metadataPatch, {
-    junctionHistoricalBackfillCoverageVersion: 1,
-    junctionHistoricalBackfillStatus: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
     junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -7336,7 +7976,7 @@ test("Junction ambiguous skip detail masks embedded ids from provider prose", as
 
     if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep_cycle/junction-user-1")) {
       return createJsonResponse({
-        detail: "Team 11649ed4-27e2-4718-959f-d68de1d1a120 is not configured for sleep_cycle.",
+        detail: "Team 00000000-0000-4000-8000-000000000001 is not configured for sleep_cycle.",
       }, 422);
     }
 
@@ -7369,7 +8009,10 @@ test("Junction ambiguous skip detail masks embedded ids from provider prose", as
     warnings[0]?.responseDetail,
     "Team <redacted-id> is not configured for sleep_cycle.",
   );
-  assert.equal(JSON.stringify(result.metadataPatch).includes("11649ed4"), false);
+  assert.equal(
+    JSON.stringify(result.metadataPatch).includes("00000000-0000-4000-8000-000000000001"),
+    false,
+  );
 });
 
 test("Junction ambiguous skip detail drops id-shaped provider error codes", async () => {
@@ -7394,7 +8037,7 @@ test("Junction ambiguous skip detail drops id-shaped provider error codes", asyn
 
     if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep_cycle/junction-user-1")) {
       return createJsonResponse({
-        code: "11649ed4-27e2-4718-959f-d68de1d1a120",
+        code: "00000000-0000-4000-8000-000000000002",
         message: "sleep_cycle disabled",
       }, 422);
     }
@@ -7422,8 +8065,14 @@ test("Junction ambiguous skip detail drops id-shaped provider error codes", asyn
 
   assert.equal(result.metadataPatch?.junctionSkippedResourceLastDetail, "sleep_cycle disabled");
   assert.equal(warnings[0]?.responseDetail, "sleep_cycle disabled");
-  assert.equal(JSON.stringify(warnings).includes("11649ed4"), false);
-  assert.equal(JSON.stringify(result.metadataPatch).includes("11649ed4"), false);
+  assert.equal(
+    JSON.stringify(warnings).includes("00000000-0000-4000-8000-000000000002"),
+    false,
+  );
+  assert.equal(
+    JSON.stringify(result.metadataPatch).includes("00000000-0000-4000-8000-000000000002"),
+    false,
+  );
 });
 
 test("Junction ambiguous skip detail reads FastAPI-shaped sleep_cycle validation arrays", async () => {
@@ -9183,12 +9832,12 @@ test("Junction large daily summary webhook payloads import inline without REST f
   assert.equal(parsed.jobs[0]?.payload?.windowStart, "2026-04-02T00:00:00.000Z");
   assert.equal(parsed.jobs[0]?.payload?.windowEnd, "2026-04-03T00:00:00.000Z");
 
-  await executeJunctionJob(
+  const result = await executeJunctionJob(
     provider,
     createJunctionJobContext({
       importSnapshot: async (snapshot) => {
         importedSnapshots.push(snapshot);
-        return { imported: true };
+        return { canonicalEventCount: 1 };
       },
     }),
     createJob("resource", parsed.jobs[0]?.payload ?? {}),
@@ -9203,6 +9852,10 @@ test("Junction large daily summary webhook payloads import inline without REST f
   assert.equal(snapshot.summaries?.activity?.[0]?.steps, 9999);
   assert.deepEqual(snapshot.timeseries, {});
   assert.doesNotMatch(JSON.stringify(importedSnapshots), /junction-user-1/u);
+  assert.equal(
+    result.metadataPatch?.junctionHistoricalBackfillEvidence,
+    "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:1",
+  );
 });
 
 test("Junction nested compact timeseries webhooks use sample timestamps for stable jobs", async () => {

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -644,6 +644,7 @@ test("Junction empty historical backfill records progress and stores the retry w
 
   assert.equal(importedSnapshots.length, 0);
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -718,6 +719,7 @@ test("Junction due historical backfill retry does not make ordinary reconcile ow
     account: createAccount({
       connectedAt: "2026-04-03T00:00:00.000Z",
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -778,6 +780,7 @@ test("Junction materialized due historical backfill retry advances normal reconc
     account: createAccount({
       connectedAt: "2026-04-03T00:00:00.000Z",
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -806,6 +809,7 @@ test("Junction exact-window backfill preserves a pending metadata retry before i
     reconcileIntervalMs: 60 * 60_000,
   });
   const metadata = {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -839,6 +843,7 @@ test("Junction retrying historical backfill without attempts uses the first retr
   const executor = requireValue(provider.jobExecutor, "Junction provider should expose a job executor.");
   const retryingAccount = createStoredAccount({
     metadata: {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
@@ -885,6 +890,7 @@ test("Junction non-connect backfill window uses bounded job retry without histor
             status: "connected",
             resource_availability: {
               activity: true,
+              sleep: true,
             },
           },
         ],
@@ -895,7 +901,13 @@ test("Junction non-connect backfill window uses bounded job retry without histor
       return createJsonResponse({ data: activityRecords });
     }
 
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
     throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "sleep"],
   });
   const context = createJunctionJobContext({
     now: "2026-04-04T00:00:00.000Z",
@@ -973,6 +985,7 @@ test("Junction useful summary historical backfill marks the historical window co
             status: "connected",
             resource_availability: {
               activity: true,
+              body: { status: "unavailable" },
               heartrate: true,
             },
           },
@@ -983,7 +996,13 @@ test("Junction useful summary historical backfill marks the historical window co
     if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
       return createJsonResponse({ data: [{ id: "activity-1", connectionId: "provider-garmin-1", steps: 1234 }] });
     }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/body/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
     throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "body"],
   });
 
   const result = await executeJunctionJob(
@@ -1001,6 +1020,7 @@ test("Junction useful summary historical backfill marks the historical window co
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
@@ -1020,6 +1040,470 @@ test("Junction useful summary historical backfill marks the historical window co
   );
 });
 
+test("Junction partial activity history does not complete advertised sleep history", async () => {
+  const importedSnapshots: unknown[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+              sleep: { status: "available" },
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ id: "activity-1", connectionId: "provider-garmin-1", steps: 1234 }],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "sleep"],
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      now: "2026-04-04T00:00:00.000Z",
+      importSnapshot: async (snapshot) => {
+        importedSnapshots.push(snapshot);
+        return { imported: true };
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
+    junctionHistoricalBackfillStatus: "retrying",
+    junctionHistoricalBackfillEmptyAttempts: 1,
+    junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+    junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+    junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+  });
+  assertConnectBackfillRetryWake(result, "2026-04-04T00:15:00.000Z");
+  assert.equal(importedSnapshots.length, 1);
+});
+
+test("Junction historical coverage does not let one source satisfy another source", async () => {
+  const importedSnapshots: unknown[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+              body: { status: "unavailable" },
+              sleep: { status: "available" },
+            },
+          },
+          {
+            id: "provider-fitbit-1",
+            slug: "fitbit",
+            name: "Fitbit",
+            status: "connected",
+            resource_availability: {
+              sleep: "available",
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ id: "activity-1", connectionId: "provider-garmin-1", steps: 1234 }],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ id: "sleep-fitbit-1", connectionId: "provider-fitbit-1", duration: 28_800 }],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/body/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "sleep", "body"],
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      now: "2026-04-04T00:00:00.000Z",
+      importSnapshot: async (snapshot) => {
+        importedSnapshots.push(snapshot);
+        return { imported: true };
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 1);
+  assertConnectBackfillRetryWake(result, "2026-04-04T00:15:00.000Z");
+  assert.equal(importedSnapshots.length, 1);
+});
+
+test("Junction legacy partial history re-triggers the provider export once", async () => {
+  let triggerRequests = 0;
+  let triggerBody: Record<string, unknown> | null = null;
+  const provider = createJunctionProvider(async (input, init) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+              sleep: true,
+              sleep_cycle: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ id: "activity-1", connectionId: "provider-garmin-1", steps: 1234 }],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep_cycle/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
+      triggerRequests += 1;
+      assert.equal(init?.method, "POST");
+      triggerBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(null, { status: 202 });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "sleep", "sleep_cycle"],
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      now: "2026-04-04T00:00:00.000Z",
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillStatus: "complete",
+          junctionHistoricalBackfillEmptyAttempts: 0,
+          junctionHistoricalBackfillLastEmptyAt: null,
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.deepEqual(triggerBody, {
+    user_ids: ["junction-user-1"],
+    provider: "garmin",
+    wait_for_completion: false,
+  });
+  assert.equal(triggerRequests, 1);
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillCoverageVersion, 1);
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 1);
+});
+
+test("Junction delayed recovery triggers each pending Link provider once", async () => {
+  const triggerBodies: Record<string, unknown>[] = [];
+  const provider = createJunctionProvider(async (input, init) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              sleep: true,
+              sleep_cycle: { available: true },
+            },
+          },
+          {
+            id: "provider-health-connect-1",
+            slug: "health_connect",
+            name: "Health Connect",
+            status: "connected",
+            resource_availability: {
+              activity: "available",
+            },
+          },
+        ],
+      });
+    }
+
+    if (
+      url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")
+      || url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")
+      || url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep_cycle/junction-user-1")
+    ) {
+      return createJsonResponse({ data: [] });
+    }
+
+    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
+      triggerBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response(null, { status: 202 });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "sleep", "sleep_cycle"],
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      now: "2026-04-04T00:15:00.000Z",
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillCoverageVersion: 1,
+          junctionHistoricalBackfillStatus: "retrying",
+          junctionHistoricalBackfillEmptyAttempts: 1,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.deepEqual(triggerBodies, [
+    {
+      user_ids: ["junction-user-1"],
+      provider: "garmin",
+      wait_for_completion: false,
+    },
+  ]);
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 2);
+});
+
+test("Junction historical trigger failure preserves imports and advances bounded recovery", async () => {
+  const importedSnapshots: unknown[] = [];
+  const warnings: Record<string, unknown>[] = [];
+  let triggerRequests = 0;
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+              sleep: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({
+        data: [{ id: "activity-1", connectionId: "provider-garmin-1", steps: 1234 }],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/sleep/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
+      triggerRequests += 1;
+      return createJsonResponse({ detail: "not available" }, 422);
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  }, {
+    summaryResources: ["activity", "sleep"],
+  });
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      now: "2026-04-04T00:15:00.000Z",
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillCoverageVersion: 1,
+          junctionHistoricalBackfillStatus: "retrying",
+          junctionHistoricalBackfillEmptyAttempts: 1,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+      importSnapshot: async (snapshot) => {
+        importedSnapshots.push(snapshot);
+        return { imported: true };
+      },
+      logger: {
+        warn(_message, context) {
+          warnings.push(context ?? {});
+        },
+      },
+    }),
+    createJob("backfill", {
+      windowStart: "2026-04-01T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }),
+  );
+
+  assert.equal(triggerRequests, 1);
+  assert.equal(importedSnapshots.length, 1);
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillStatus, "retrying");
+  assert.equal(result.metadataPatch?.junctionHistoricalBackfillEmptyAttempts, 2);
+  assertConnectBackfillRetryWake(result, "2026-04-04T01:15:00.000Z");
+  assert.deepEqual(warnings, [
+    {
+      endpointKind: "junction_link_bulk_trigger_historical_pull",
+      errorCode: "JUNCTION_API_REQUEST_FAILED",
+      provider: "junction",
+      responseStatus: 422,
+      retryable: false,
+      sourceProviderSlug: "garmin",
+    },
+  ]);
+});
+
+test("Junction historical trigger propagates parent cancellation", async () => {
+  const abortController = new AbortController();
+  const triggerAbort = new Error("historical trigger aborted");
+  const warnings: Record<string, unknown>[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    const url = readUrl(input);
+
+    if (url === "https://api.sandbox.us.junction.com/v2/user/providers/junction-user-1") {
+      return createJsonResponse({
+        providers: [
+          {
+            id: "provider-garmin-1",
+            slug: "garmin",
+            name: "Garmin",
+            status: "connected",
+            resource_availability: {
+              activity: true,
+            },
+          },
+        ],
+      });
+    }
+
+    if (url.startsWith("https://api.sandbox.us.junction.com/v2/summary/activity/junction-user-1")) {
+      return createJsonResponse({ data: [] });
+    }
+
+    if (url === "https://api.sandbox.us.junction.com/v2/link/bulk_trigger_historical_pull") {
+      abortController.abort();
+      throw triggerAbort;
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  });
+
+  await assert.rejects(
+    () => executeJunctionJob(
+      provider,
+      createJunctionJobContext({
+        now: "2026-04-04T00:15:00.000Z",
+        signal: abortController.signal,
+        logger: {
+          warn(_message, context) {
+            warnings.push(context ?? {});
+          },
+        },
+        account: createAccount({
+          metadata: {
+            junctionHistoricalBackfillCoverageVersion: 1,
+            junctionHistoricalBackfillStatus: "retrying",
+            junctionHistoricalBackfillEmptyAttempts: 1,
+            junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
+            junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+            junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+          },
+        }),
+      }),
+      createJob("backfill", {
+        windowStart: "2026-04-01T00:00:00.000Z",
+        windowEnd: "2026-04-03T00:00:00.000Z",
+      }),
+    ),
+    (error: unknown) => {
+      if (!(error instanceof DeviceSyncError)) {
+        return false;
+      }
+      assert.equal(error.code, "JUNCTION_API_REQUEST_FAILED");
+      return true;
+    },
+  );
+  assert.deepEqual(warnings, []);
+});
+
 test("Junction backfill diagnostic reports redacted provider call counts", async () => {
   const requests: string[] = [];
   const provider = createJunctionProvider(async (input) => {
@@ -1037,6 +1521,7 @@ test("Junction backfill diagnostic reports redacted provider call counts", async
             resource_availability: {
               activity: true,
               heartrate: true,
+              sleep: { status: "unavailable" },
             },
           },
         ],
@@ -1089,6 +1574,9 @@ test("Junction backfill diagnostic reports redacted provider call counts", async
   const timeseriesProbe = diagnostic.timeseriesProbe as {
     resources?: Array<{ recordCount?: number; resource?: string }>;
   };
+  const sourceProviders = diagnostic.sourceProviders as {
+    sources?: Array<{ resourceCount?: number; resources?: string[]; sourceKey?: string }>;
+  };
 
   assert.equal(summary.hasUsefulHistoricalRecords, true);
   assert.deepEqual(summary.resources?.map((entry) => [entry.resource, entry.recordCount]), [
@@ -1097,6 +1585,11 @@ test("Junction backfill diagnostic reports redacted provider call counts", async
   assert.deepEqual(timeseriesProbe.resources?.map((entry) => [entry.resource, entry.recordCount]), [
     ["blood_oxygen", 1],
   ]);
+  assert.deepEqual(sourceProviders.sources, [{
+    resourceCount: 2,
+    resources: ["activity", "heartrate"],
+    sourceKey: "source_1",
+  }]);
   const summaryRequest = requireValue(
     requests.find((url) => url.includes("/v2/summary/activity/")),
     "Junction backfill diagnostic should inspect summary data.",
@@ -1738,6 +2231,7 @@ for (const testCase of usefulHistoricalSummaryCompletionCases) {
     );
 
     assert.deepEqual(result.metadataPatch, {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "complete",
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
@@ -1912,6 +2406,7 @@ for (const testCase of [
     );
 
     assert.deepEqual(result.metadataPatch, {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -1969,6 +2464,7 @@ for (const summaryResource of ["sleep", "workouts", "body"] as const) {
     );
 
     assert.deepEqual(result.metadataPatch, {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "complete",
       junctionHistoricalBackfillEmptyAttempts: 0,
       junctionHistoricalBackfillLastEmptyAt: null,
@@ -2033,6 +2529,7 @@ test("Junction sleep_cycle stage-count-only historical backfill marks the histor
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
@@ -2095,6 +2592,7 @@ for (const summaryResource of ["activity", "sleep", "workouts", "body"] as const
     );
 
     assert.deepEqual(result.metadataPatch, {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -2168,6 +2666,7 @@ for (const summaryResource of ["sleep", "workouts"] as const) {
     );
 
     assert.deepEqual(result.metadataPatch, {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillStatus: "retrying",
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -2223,6 +2722,7 @@ test("Junction useful summary without source linkage keeps the historical window
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -2278,6 +2778,7 @@ test("Junction floating-provider metric-only summary keeps the historical window
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -2335,6 +2836,7 @@ test("Junction source envelope summary historical backfill marks the historical 
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
@@ -2406,6 +2908,7 @@ test("Junction compact timeseries-only historical backfill keeps the summary win
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -2543,6 +3046,7 @@ test("Junction yielded connect-window backfills keep owner window and resume wit
     [["2026-04-02", "2026-04-02"]],
   );
   assert.deepEqual(secondResult.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
@@ -2612,6 +3116,7 @@ test("Junction profile-only historical backfill keeps the summary window retryin
 
   assert.deepEqual(result.metadataPatch, {
     junctionProfileSummaryCheckedAt: "2026-04-04T00:00:00.000Z",
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "retrying",
     junctionHistoricalBackfillEmptyAttempts: 1,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -2686,6 +3191,7 @@ test("Junction empty historical backfill stops retrying after the bounded budget
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 4,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
@@ -2705,6 +3211,7 @@ test("Junction empty historical backfill stops retrying after the bounded budget
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "exhausted",
     junctionHistoricalBackfillEmptyAttempts: 5,
     junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
@@ -2719,6 +3226,7 @@ test("Junction exhausted historical backfill is terminal until the same window h
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "exhausted",
         junctionHistoricalBackfillEmptyAttempts: 5,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
@@ -2770,6 +3278,7 @@ test("Junction exhausted historical backfill completes when the same window late
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "exhausted",
         junctionHistoricalBackfillEmptyAttempts: 5,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
@@ -2789,6 +3298,7 @@ test("Junction exhausted historical backfill completes when the same window late
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,
@@ -2826,6 +3336,7 @@ test("Junction reconcile data does not complete pending historical backfill", as
   const context = createJunctionJobContext({
     account: createAccount({
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-02T00:00:00.000Z",
@@ -3571,29 +4082,60 @@ test("Junction scheduled polling uses stable closed-day windows", () => {
   assert.equal(derivedBackfill?.dedupeKey, second?.jobs[1]?.dedupeKey);
 });
 
-test("Junction scheduled pass derives historical backfill work only until a terminal status", () => {
+test("Junction scheduled pass repairs legacy completion and honors current terminal status", () => {
   const provider = createJunctionProvider(async (input) => {
     throw new Error(`Unexpected request: ${readUrl(input)}`);
   });
   const executor = requireValue(provider.jobExecutor, "Junction provider should expose a job executor.");
 
-  for (const status of ["complete", "exhausted"] as const) {
+  const legacyComplete = executor.createScheduledJobs?.(
+    createStoredAccount({
+      metadata: {
+        junctionHistoricalBackfillStatus: "complete",
+        junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+      },
+    }),
+    "2026-04-03T12:34:56.000Z",
+  );
+  const legacyRepairJobs = legacyComplete?.jobs.filter((job) => job.kind === "backfill") ?? [];
+  assert.equal(legacyRepairJobs.length, 1);
+  assert.deepEqual(legacyRepairJobs[0]?.payload, {
+    windowStart: "2026-04-01T00:00:00.000Z",
+    windowEnd: "2026-04-03T00:00:00.000Z",
+  });
+
+  for (const metadata of [
+    {
+      junctionHistoricalBackfillCoverageVersion: 1,
+      junctionHistoricalBackfillStatus: "complete",
+      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+    },
+    {
+      junctionHistoricalBackfillCoverageVersion: 1,
+      junctionHistoricalBackfillStatus: "exhausted",
+      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+    },
+  ] as const) {
     const scheduled = executor.createScheduledJobs?.(
       createStoredAccount({
-        metadata: {
-          junctionHistoricalBackfillStatus: status,
-          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
-        },
+        metadata,
       }),
       "2026-04-03T12:34:56.000Z",
     );
-    assert.equal(scheduled?.jobs.some((job) => job.kind === "backfill"), false, status);
+    assert.equal(
+      scheduled?.jobs.some((job) => job.kind === "backfill"),
+      false,
+      metadata.junctionHistoricalBackfillStatus,
+    );
   }
 
   const completeOtherWindow = executor.createScheduledJobs?.(
     createStoredAccount({
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "complete",
         junctionHistoricalBackfillWindowStart: "2026-04-02T00:00:00.000Z",
         junctionHistoricalBackfillWindowEnd: "2026-04-04T00:00:00.000Z",
@@ -3612,6 +4154,7 @@ test("Junction scheduled pass derives historical backfill work only until a term
   const retryingOtherWindow = executor.createScheduledJobs?.(
     createStoredAccount({
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-03T12:30:00.000Z",
@@ -5358,6 +5901,7 @@ test("Junction polling updates source projection and imports bounded summary/tim
   );
 
   assert.deepEqual(result.metadataPatch, {
+    junctionHistoricalBackfillCoverageVersion: 1,
     junctionHistoricalBackfillStatus: "complete",
     junctionHistoricalBackfillEmptyAttempts: 0,
     junctionHistoricalBackfillLastEmptyAt: null,

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -3480,6 +3480,55 @@ test("Junction direct pushes without canonical events or from another source do 
   assert.equal(otherSourceResult.metadataPatch, undefined);
 });
 
+test("Junction direct pushes preserve opaque future historical evidence after import", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    throw new Error(`Unexpected request: ${readUrl(input)}`);
+  }, {
+    providerFilter: ["garmin"],
+  });
+  const futureStatus = "coverage_v3_exhausted";
+  const futureEvidence = "e2|opaque-future-evidence";
+  const account = createAccount({
+    metadata: {
+      junctionHistoricalBackfillEvidence: futureEvidence,
+      junctionHistoricalBackfillStatus: futureStatus,
+    },
+  });
+  let importCount = 0;
+
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account,
+      importSnapshot: async () => {
+        importCount += 1;
+        return { canonicalEventCount: 1 };
+      },
+    }),
+    createJob("resource", {
+      eventType: "daily.data.activity.created",
+      objectId: "future-evidence-activity",
+      occurredAt: "2026-04-02T00:00:00.000Z",
+      resource: "activity",
+      resourceCategory: "summary",
+      sourceProviderSlug: "garmin",
+      webhookDataJson: JSON.stringify({
+        date: "2026-04-02",
+        id: "future-evidence-activity",
+        sourceProviderSlug: "garmin",
+        steps: 4321,
+      }),
+      windowEnd: "2026-04-03T00:00:00.000Z",
+      windowStart: "2026-04-02T00:00:00.000Z",
+    }),
+  );
+  const metadata = mergeStoredDeviceSyncMetadataPatch(account.metadata, result.metadataPatch);
+
+  assert.equal(importCount, 1);
+  assert.equal(metadata.junctionHistoricalBackfillStatus, futureStatus);
+  assert.equal(metadata.junctionHistoricalBackfillEvidence, futureEvidence);
+});
+
 test("Junction exhausted historical backfill completes when the same window later has data", async () => {
   const upserts: Array<Parameters<NonNullable<ProviderJobContext["upsertConnectionSource"]>>[0]> = [];
   const provider = createJunctionProvider(async (input) => {
@@ -3559,8 +3608,6 @@ test("Junction exhausted historical backfill completes when the same window late
       account: createAccount({
         metadata: {
           junctionHistoricalBackfillStatus: "coverage_v3_exhausted",
-          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
         },
       }),
       listConnectionSources: () => [createConnectionSource({
@@ -4728,13 +4775,9 @@ test("Junction scheduled pass repairs legacy completion and honors current termi
     },
     {
       junctionHistoricalBackfillStatus: "coverage_v3_complete",
-      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
     },
     {
-      junctionHistoricalBackfillStatus: "coverage_v3_retrying",
-      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
-      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+      junctionHistoricalBackfillStatus: "coverage_v3_deferred",
     },
   ] as const) {
     const scheduled = executor.createScheduledJobs?.(

--- a/packages/device-syncd/test/provider-diagnostics.test.ts
+++ b/packages/device-syncd/test/provider-diagnostics.test.ts
@@ -7,7 +7,7 @@ import { inspectProviderErrorBody } from "../src/providers/provider-diagnostics.
 test("provider diagnostics drop id-shaped error codes while preserving safe descriptions", () => {
   assert.deepEqual(
     inspectProviderErrorBody(JSON.stringify({
-      code: "11649ed4-27e2-4718-959f-d68de1d1a120",
+      code: "00000000-0000-4000-8000-000000000004",
       message: "sleep_cycle disabled",
     })),
     {

--- a/packages/device-syncd/test/public-ingress.test.ts
+++ b/packages/device-syncd/test/public-ingress.test.ts
@@ -204,6 +204,7 @@ class InMemoryPublicIngressStore implements DeviceSyncPublicIngressStore {
   markConnectionSetupFailed(input: {
     accountId: string;
     code: string;
+    expectedUpdatedAt: string | null;
     message: string;
     now: string;
   }): PublicDeviceSyncAccount | null {
@@ -214,6 +215,9 @@ class InMemoryPublicIngressStore implements DeviceSyncPublicIngressStore {
     const existing = this.accounts.get(input.accountId) ?? null;
     if (!existing) {
       return null;
+    }
+    if (input.expectedUpdatedAt === null || existing.updatedAt !== input.expectedUpdatedAt) {
+      return existing;
     }
 
     const record: PublicDeviceSyncAccount = {
@@ -376,6 +380,15 @@ function assertExistingAccountGuard(
     throw deviceSyncError({
       code: "CONNECTION_ALREADY_DISCONNECTED",
       message: "Device sync connection callback was received after the seeded account was disconnected.",
+      retryable: false,
+      httpStatus: 409,
+    });
+  }
+
+  if (existing.updatedAt !== guard.expectedUpdatedAt) {
+    throw deviceSyncError({
+      code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
+      message: "Device sync connection changed after this connection flow started.",
       retryable: false,
       httpStatus: 409,
     });
@@ -1183,6 +1196,107 @@ test("public ingress rejects stale external-link callbacks after seeded accounts
   const disconnected = store.getConnectionByExternalAccount("junction", "external-account-1");
   assert.equal(disconnected?.status, "disconnected");
   assert.equal(disconnected?.setupPhase, "pending_link");
+  assert.equal(completeCalls, 0);
+});
+
+test("public ingress rejects seeded callbacks after the connection starts a newer epoch", async () => {
+  const store = new InMemoryPublicIngressStore();
+  let completeCalls = 0;
+  const provider = createFakeProvider({
+    provider: "junction",
+    credentialPolicy: {
+      kind: "provider_config",
+      providerConfigKey: "junction",
+    },
+    descriptor: {
+      provider: "junction",
+      displayName: "Junction",
+      transportModes: ["external_link", "scheduled_poll"],
+      connection: {
+        kind: "external_link",
+        callbackPath: "/connect/junction/callback",
+      },
+      normalization: {
+        metricFamilies: ["activity"],
+        snapshotParser: "schema",
+      },
+      sourcePriorityHints: {
+        defaultPriority: 60,
+        metricFamilies: {
+          activity: 60,
+        },
+      },
+    },
+    async beginConnection(input) {
+      return {
+        authorizationUrl: `https://junction.example/link?murph_state=${input.state}`,
+        connectionSeed: {
+          externalAccountId: "external-account-1",
+          credential: {
+            kind: "provider_config",
+            providerConfigKey: "junction",
+          },
+        },
+      };
+    },
+    async completeConnection() {
+      completeCalls += 1;
+      return {
+        externalAccountId: "external-account-1",
+        credential: {
+          kind: "provider_config",
+          providerConfigKey: "junction",
+        },
+      };
+    },
+  });
+  const ingress = createDeviceSyncPublicIngress({
+    publicBaseUrl: "https://sync.example.test/device-sync",
+    registry: createDeviceSyncRegistry([provider]),
+    store,
+  });
+
+  const begin = await ingress.startConnection({
+    provider: "junction",
+    ownerId: "<REDACTED_OWNER_ID>",
+  });
+  const seeded = store.getConnectionByExternalAccount("junction", "external-account-1");
+  assert.ok(seeded);
+  const reconnected = store.upsertConnection({
+    provider: "junction",
+    externalAccountId: "external-account-1",
+    displayName: "Garmin",
+    setupPhase: "source_confirmed",
+    scopes: [],
+    credential: {
+      kind: "provider_config",
+      providerConfigKey: "junction",
+    },
+    metadata: { connectionEpoch: "new" },
+    connectedAt: "2099-04-27T00:00:00.000Z",
+    nextReconcileAt: null,
+  });
+
+  await assert.rejects(
+    () =>
+      ingress.handleConnectionCallback({
+        provider: "junction",
+        query: new URLSearchParams({
+          murph_state: begin.state,
+          result: "success",
+        }),
+      }),
+    (error: unknown) =>
+      error instanceof DeviceSyncError
+      && error.code === "CONNECTION_SEEDED_ACCOUNT_CHANGED"
+      && error.httpStatus === 409,
+  );
+
+  const current = store.getConnectionByExternalAccount("junction", "external-account-1");
+  assert.equal(current?.id, reconnected.id);
+  assert.equal(current?.connectedAt, reconnected.connectedAt);
+  assert.deepEqual(current?.metadata, { connectionEpoch: "new" });
+  assert.equal(current?.status, "active");
   assert.equal(completeCalls, 0);
 });
 

--- a/packages/device-syncd/test/public-ingress.test.ts
+++ b/packages/device-syncd/test/public-ingress.test.ts
@@ -204,20 +204,20 @@ class InMemoryPublicIngressStore implements DeviceSyncPublicIngressStore {
   markConnectionSetupFailed(input: {
     accountId: string;
     code: string;
-    expectedUpdatedAt: string | null;
+    expectedConnectedAt: string | null;
     message: string;
     now: string;
-  }): PublicDeviceSyncAccount | null {
+  }): { account: PublicDeviceSyncAccount | null; applied: boolean } {
     if (this.markConnectionSetupFailedError) {
       throw this.markConnectionSetupFailedError;
     }
 
     const existing = this.accounts.get(input.accountId) ?? null;
     if (!existing) {
-      return null;
+      return { account: null, applied: false };
     }
-    if (input.expectedUpdatedAt === null || existing.updatedAt !== input.expectedUpdatedAt) {
-      return existing;
+    if (input.expectedConnectedAt === null || existing.connectedAt !== input.expectedConnectedAt) {
+      return { account: existing, applied: false };
     }
 
     const record: PublicDeviceSyncAccount = {
@@ -233,7 +233,7 @@ class InMemoryPublicIngressStore implements DeviceSyncPublicIngressStore {
       updatedAt: input.now,
     };
     this.accounts.set(input.accountId, record);
-    return record;
+    return { account: record, applied: true };
   }
 
   getConnectionByExternalAccount(provider: string, externalAccountId: string): PublicDeviceSyncAccount | null {
@@ -385,7 +385,7 @@ function assertExistingAccountGuard(
     });
   }
 
-  if (existing.updatedAt !== guard.expectedUpdatedAt) {
+  if (existing.connectedAt !== guard.expectedConnectedAt) {
     throw deviceSyncError({
       code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
       message: "Device sync connection changed after this connection flow started.",
@@ -907,7 +907,15 @@ test("public ingress persists validated provider-config connection seeds before 
   });
   const stateRecord = store.peekOAuthState(begin.state);
   assert.equal(stateRecord?.ownerId, "<REDACTED_OWNER_ID>");
+  assert.equal(stateRecord?.createdAt, account?.connectedAt);
   assert.equal(Object.prototype.hasOwnProperty.call(stateRecord?.metadata ?? {}, "ownerId"), false);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      stateRecord?.metadata ?? {},
+      "__murphSeededConnectionUpdatedAt",
+    ),
+    false,
+  );
   assert.equal(
     account ? Object.values(stateRecord?.metadata ?? {}).includes(account.id) : false,
     true,
@@ -915,7 +923,7 @@ test("public ingress persists validated provider-config connection seeds before 
   assert.equal(Object.values(stateRecord?.metadata ?? {}).includes("external-account-1"), false);
 });
 
-test("public ingress completes external-link callbacks with sanitized state metadata and setup phase", async () => {
+test("public ingress completes seeded external-link callbacks after mutable webhook observations", async () => {
   const store = new InMemoryPublicIngressStore();
   let callbackStateMetadata: Record<string, unknown> | undefined;
   let callbackSeededExternalAccountId: string | null | undefined;
@@ -978,6 +986,7 @@ test("public ingress completes external-link callbacks with sanitized state meta
           kind: "provider_config",
           providerConfigKey: "junction",
         },
+        metadata: { ...input.stateMetadata },
       };
     },
   });
@@ -994,6 +1003,20 @@ test("public ingress completes external-link callbacks with sanitized state meta
   });
   const seeded = store.getConnectionByExternalAccount("junction", "external-account-1");
   assert.ok(seeded?.setupExpiresAt);
+  const stateRecord = store.peekOAuthState(begin.state);
+  assert.ok(stateRecord);
+  store.createOAuthState({
+    ...stateRecord,
+    metadata: {
+      ...stateRecord.metadata,
+      __murphSeededConnectionUpdatedAt: seeded.updatedAt,
+    },
+  });
+  const seededConnectedAt = seeded.connectedAt;
+  store.markWebhookReceived(seeded.id, "2099-04-26T23:59:59.000Z");
+  const observed = store.getConnectionById(seeded.id);
+  assert.equal(observed?.connectedAt, seededConnectedAt);
+  assert.notEqual(observed?.updatedAt, seeded.updatedAt);
   const completed = await ingress.handleConnectionCallback({
     provider: "junction",
     query: new URLSearchParams({
@@ -1007,9 +1030,24 @@ test("public ingress completes external-link callbacks with sanitized state meta
   });
   assert.equal(callbackSeededExternalAccountId, "external-account-1");
   assert.equal(Object.prototype.hasOwnProperty.call(callbackStateMetadata ?? {}, "ownerId"), false);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      callbackStateMetadata ?? {},
+      "__murphSeededConnectionUpdatedAt",
+    ),
+    false,
+  );
   assert.equal(completed.account.setupPhase, "source_confirmed");
   assert.equal(completed.account.setupExpiresAt, null);
   assert.equal(completed.account.externalAccountId, "external-account-1");
+  assert.equal(completed.account.id, seeded.id);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      completed.account.metadata,
+      "__murphSeededConnectionUpdatedAt",
+    ),
+    false,
+  );
   assert.equal(Object.values(callbackStateMetadata ?? {}).includes(completed.account.id), false);
 });
 
@@ -3261,13 +3299,16 @@ test("public ingress revokes and marks setup failure after post-persistence OAut
     registry: createDeviceSyncRegistry([
       createFakeProvider({
         async revokeAccess(account) {
+          const failed = store.getConnectionByExternalAccount("demo", account.externalAccountId);
+          assert.equal(failed?.status, "reauthorization_required");
           revokeCalls.push(account.externalAccountId);
         },
       }),
     ]),
     store,
     hooks: {
-      onConnectionEstablished() {
+      onConnectionEstablished({ account }) {
+        store.markWebhookReceived(account.id, "2099-04-26T23:59:59.000Z");
         throw hookError;
       },
     },
@@ -3291,6 +3332,7 @@ test("public ingress revokes and marks setup failure after post-persistence OAut
   assert.ok(storedAccount);
   assert.equal(storedAccount.id, "acct_01");
   assert.equal(storedAccount.status, "reauthorization_required");
+  assert.equal(storedAccount.lastWebhookAt, "2099-04-26T23:59:59.000Z");
   assert.equal(storedAccount.accessTokenExpiresAt, null);
   assert.equal(storedAccount.lastErrorCode, "OAUTH_SETUP_FAILED");
   assert.equal(
@@ -3301,7 +3343,7 @@ test("public ingress revokes and marks setup failure after post-persistence OAut
   assert.equal(storedAccount.nextReconcileAt, null);
 });
 
-test("public ingress surfaces persisted OAuth cleanup failures after post-persistence hook failures", async () => {
+test("public ingress surfaces persisted OAuth cleanup failures before provider revocation", async () => {
   const store = new InMemoryPublicIngressStore();
   const revokeCalls: string[] = [];
   const hookError = new Error("post-persist hook failure");
@@ -3349,8 +3391,62 @@ test("public ingress surfaces persisted OAuth cleanup failures after post-persis
     },
   );
 
-  assert.deepEqual(revokeCalls, ["demo-persisted"]);
+  assert.deepEqual(revokeCalls, []);
   assert.equal(store.hasOAuthState(begin.state), false);
+});
+
+test("public ingress skips provider revocation when post-persistence setup cleanup loses its epoch", async () => {
+  const store = new InMemoryPublicIngressStore();
+  const revokeCalls: string[] = [];
+  const hookError = new Error("post-persist hook failure");
+  const ingress = createDeviceSyncPublicIngress({
+    publicBaseUrl: "https://sync.example.test/device-sync",
+    registry: createDeviceSyncRegistry([
+      createFakeProvider({
+        async revokeAccess(account) {
+          revokeCalls.push(account.externalAccountId);
+        },
+      }),
+    ]),
+    store,
+    hooks: {
+      onConnectionEstablished({ account }) {
+        store.upsertConnection({
+          provider: account.provider,
+          externalAccountId: account.externalAccountId,
+          displayName: "New connection epoch",
+          scopes: account.scopes,
+          tokens: {
+            accessToken: "<REDACTED_NEW_ACCESS_TOKEN>",
+            refreshToken: "<REDACTED_NEW_REFRESH_TOKEN>",
+          },
+          metadata: { connectionEpoch: "new" },
+          connectedAt: "2099-04-27T00:00:00.000Z",
+          nextReconcileAt: null,
+        });
+        throw hookError;
+      },
+    },
+  });
+
+  const begin = await ingress.startConnection({ provider: "demo" });
+
+  await assert.rejects(
+    () =>
+      ingress.handleOAuthCallback({
+        provider: "demo",
+        state: begin.state,
+        code: "persisted",
+      }),
+    (error: unknown) => error === hookError,
+  );
+
+  assert.deepEqual(revokeCalls, []);
+  assert.equal(store.hasOAuthState(begin.state), false);
+  const storedAccount = store.getConnectionByExternalAccount("demo", "demo-persisted");
+  assert.equal(storedAccount?.status, "active");
+  assert.equal(storedAccount?.connectedAt, "2099-04-27T00:00:00.000Z");
+  assert.deepEqual(storedAccount?.metadata, { connectionEpoch: "new" });
 });
 
 test("public ingress does not burn valid oauth state on provider mismatch", async () => {

--- a/packages/device-syncd/test/service.test.ts
+++ b/packages/device-syncd/test/service.test.ts
@@ -3696,6 +3696,7 @@ test("manual reconcile preserves delayed Junction retry metadata timing", async 
       },
       connectedAt: ownerWindowEnd,
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -3945,6 +3946,7 @@ test("device sync scheduler materializes Junction metadata retry when it is due"
       },
       connectedAt: ownerWindowEnd,
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -4053,6 +4055,7 @@ test("device sync scheduler rematerializes dead Junction metadata retries", asyn
       },
       connectedAt: ownerWindowEnd,
       metadata: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillStatus: "retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
@@ -6868,6 +6871,7 @@ test("sqlite store prioritizes metadataPatch entries when capped metadata is ful
   assert.equal(
     store.markSyncSucceeded(created.id, "2026-03-20T12:00:00.000Z", null, {
       metadataPatch: {
+        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
         junctionHistoricalBackfillStatus: "retrying",
@@ -6881,6 +6885,7 @@ test("sqlite store prioritizes metadataPatch entries when capped metadata is ful
   const metadata = store.getAccountById(created.id)?.metadata ?? {};
   assert.deepEqual(
     {
+      junctionHistoricalBackfillCoverageVersion: metadata.junctionHistoricalBackfillCoverageVersion,
       junctionHistoricalBackfillEmptyAttempts: metadata.junctionHistoricalBackfillEmptyAttempts,
       junctionHistoricalBackfillLastEmptyAt: metadata.junctionHistoricalBackfillLastEmptyAt,
       junctionHistoricalBackfillStatus: metadata.junctionHistoricalBackfillStatus,
@@ -6888,6 +6893,7 @@ test("sqlite store prioritizes metadataPatch entries when capped metadata is ful
       junctionHistoricalBackfillWindowStart: metadata.junctionHistoricalBackfillWindowStart,
     },
     {
+      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
       junctionHistoricalBackfillStatus: "retrying",

--- a/packages/device-syncd/test/service.test.ts
+++ b/packages/device-syncd/test/service.test.ts
@@ -499,6 +499,44 @@ test("device sync service connects, imports, and deduplicates webhook traces", a
   close();
 });
 
+test("device sync service reports canonical imported event counts to provider jobs", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-syncd-import-receipt");
+  let importReceipt: unknown = null;
+  const { service, close } = createServiceFixture({
+    secret: "secret-for-tests",
+    config: {
+      vaultRoot,
+      publicBaseUrl: "https://sync.example.test/device-sync",
+      stateDatabasePath: path.join(vaultRoot, ".runtime", "device-syncd.sqlite"),
+    },
+    importer: {
+      async importDeviceProviderSnapshot() {
+        return { events: [{ kind: "activity" }, { kind: "sleep" }] };
+      },
+    },
+    providers: [createFakeProvider({
+      async executeJob(context) {
+        importReceipt = await context.importSnapshot({ provider: "demo" });
+        return {};
+      },
+    })],
+  });
+
+  try {
+    const begin = await service.startConnection({ provider: "demo" });
+    await service.handleOAuthCallback({
+      provider: "demo",
+      state: begin.state,
+      code: "import-receipt",
+    });
+    await service.runWorkerOnce();
+
+    assert.deepEqual(importReceipt, { canonicalEventCount: 2 });
+  } finally {
+    close();
+  }
+});
+
 test("device sync job context lets providers update source projections", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-syncd-source-projection-context");
   let listedInsideJob = 0;
@@ -3696,8 +3734,7 @@ test("manual reconcile preserves delayed Junction retry metadata timing", async 
       },
       connectedAt: ownerWindowEnd,
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: ownerWindowStart,
@@ -3809,7 +3846,7 @@ test("device sync service wakes Junction retrying historical backfill at the ret
     assert.equal(processedJob?.kind, "backfill");
 
     const afterEmptyBackfill = store.getAccountById(account.id);
-    assert.equal(afterEmptyBackfill?.metadata.junctionHistoricalBackfillStatus, "retrying");
+    assert.equal(afterEmptyBackfill?.metadata.junctionHistoricalBackfillStatus, "coverage_v2_retrying");
     assert.equal(afterEmptyBackfill?.metadata.junctionHistoricalBackfillEmptyAttempts, 1);
     assert.equal(afterEmptyBackfill?.metadata.junctionHistoricalBackfillLastEmptyAt, executedAt);
     assert.equal(afterEmptyBackfill?.nextReconcileAt, retryDueAt);
@@ -3946,8 +3983,7 @@ test("device sync scheduler materializes Junction metadata retry when it is due"
       },
       connectedAt: ownerWindowEnd,
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: ownerWindowStart,
@@ -4055,8 +4091,7 @@ test("device sync scheduler rematerializes dead Junction metadata retries", asyn
       },
       connectedAt: ownerWindowEnd,
       metadata: {
-        junctionHistoricalBackfillCoverageVersion: 1,
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-04-04T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: ownerWindowStart,
@@ -6871,10 +6906,9 @@ test("sqlite store prioritizes metadataPatch entries when capped metadata is ful
   assert.equal(
     store.markSyncSucceeded(created.id, "2026-03-20T12:00:00.000Z", null, {
       metadataPatch: {
-        junctionHistoricalBackfillCoverageVersion: 1,
         junctionHistoricalBackfillEmptyAttempts: 1,
         junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
-        junctionHistoricalBackfillStatus: "retrying",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
         junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
         junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
       },
@@ -6885,7 +6919,6 @@ test("sqlite store prioritizes metadataPatch entries when capped metadata is ful
   const metadata = store.getAccountById(created.id)?.metadata ?? {};
   assert.deepEqual(
     {
-      junctionHistoricalBackfillCoverageVersion: metadata.junctionHistoricalBackfillCoverageVersion,
       junctionHistoricalBackfillEmptyAttempts: metadata.junctionHistoricalBackfillEmptyAttempts,
       junctionHistoricalBackfillLastEmptyAt: metadata.junctionHistoricalBackfillLastEmptyAt,
       junctionHistoricalBackfillStatus: metadata.junctionHistoricalBackfillStatus,
@@ -6893,10 +6926,9 @@ test("sqlite store prioritizes metadataPatch entries when capped metadata is ful
       junctionHistoricalBackfillWindowStart: metadata.junctionHistoricalBackfillWindowStart,
     },
     {
-      junctionHistoricalBackfillCoverageVersion: 1,
       junctionHistoricalBackfillEmptyAttempts: 1,
       junctionHistoricalBackfillLastEmptyAt: "2026-03-20T12:00:00.000Z",
-      junctionHistoricalBackfillStatus: "retrying",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
       junctionHistoricalBackfillWindowEnd: "2026-03-20T00:00:00.000Z",
       junctionHistoricalBackfillWindowStart: "2025-12-20T00:00:00.000Z",
     },

--- a/packages/device-syncd/test/store.test.ts
+++ b/packages/device-syncd/test/store.test.ts
@@ -3193,7 +3193,7 @@ test("device sync store clears tokens and requires reauthorization after connect
   const store = new SqliteDeviceSyncStore(path.join(tempDir, "state.sqlite"));
 
   try {
-    assert.equal(
+    assert.deepEqual(
       store.markConnectionSetupFailed(
         "missing-account",
         null,
@@ -3201,7 +3201,7 @@ test("device sync store clears tokens and requires reauthorization after connect
         "OAUTH_DENIED",
         "operator denied access",
       ),
-      null,
+      { account: null, applied: false },
     );
 
     const account = store.upsertAccount({
@@ -3219,25 +3219,27 @@ test("device sync store clears tokens and requires reauthorization after connect
       connectedAt: "2026-04-07T00:00:00.000Z",
       nextReconcileAt: "2026-04-07T01:00:00.000Z",
     });
+    store.markWebhookReceived(account.id, "2026-04-07T00:20:00.000Z");
 
     const failed = store.markConnectionSetupFailed(
       account.id,
-      account.updatedAt,
+      account.connectedAt,
       "2026-04-07T00:30:00.000Z",
       "OAUTH_DENIED",
       "operator denied access",
     );
 
-    assert.equal(failed?.id, account.id);
-    assert.equal(failed?.status, "reauthorization_required");
-    assertStoredCredentialKind(failed, "none");
-    assert.equal(failed?.accessTokenExpiresAt, null);
-    assert.equal(failed?.lastSyncErrorAt, "2026-04-07T00:30:00.000Z");
-    assert.equal(failed?.lastErrorCode, "OAUTH_DENIED");
-    assert.equal(failed?.lastErrorMessage, "operator denied access");
-    assert.equal(failed?.nextReconcileAt, null);
-    assert.equal(failed?.localConnectionRevision, account.localConnectionRevision + 1);
-    assert.equal(failed?.localTokenRevision, account.localTokenRevision + 1);
+    assert.equal(failed.applied, true);
+    assert.equal(failed.account?.id, account.id);
+    assert.equal(failed.account?.status, "reauthorization_required");
+    assertStoredCredentialKind(failed.account, "none");
+    assert.equal(failed.account?.accessTokenExpiresAt, null);
+    assert.equal(failed.account?.lastSyncErrorAt, "2026-04-07T00:30:00.000Z");
+    assert.equal(failed.account?.lastErrorCode, "OAUTH_DENIED");
+    assert.equal(failed.account?.lastErrorMessage, "operator denied access");
+    assert.equal(failed.account?.nextReconcileAt, null);
+    assert.equal(failed.account?.localConnectionRevision, account.localConnectionRevision + 1);
+    assert.equal(failed.account?.localTokenRevision, account.localTokenRevision + 1);
 
     const credentialState = readCredentialStateForTesting(store, account.id);
     assert.ok(credentialState);
@@ -3257,7 +3259,7 @@ test("device sync store clears tokens and requires reauthorization after connect
       hosted_observed_token_version: null,
       hosted_observed_updated_at: null,
       last_error_code: "OAUTH_DENIED",
-      last_webhook_at: null,
+      last_webhook_at: "2026-04-07T00:20:00.000Z",
       local_connection_revision: account.localConnectionRevision + 1,
       local_token_revision: account.localTokenRevision + 1,
       next_reconcile_at: null,
@@ -3281,19 +3283,20 @@ test("device sync store clears tokens and requires reauthorization after connect
     const disconnected = store.disconnectAccount(raceAccount.id, "2026-04-07T00:20:00.000Z");
     const blockedFailure = store.markConnectionSetupFailed(
       raceAccount.id,
-      raceAccount.updatedAt,
+      raceAccount.connectedAt,
       "2026-04-07T00:30:00.000Z",
       "OAUTH_DENIED",
       "operator denied access",
     );
 
-    assert.equal(blockedFailure?.status, "disconnected");
-    assert.equal(blockedFailure?.setupPhase, null);
-    assertStoredCredentialKind(blockedFailure, "none");
-    assert.equal(blockedFailure?.disconnectGeneration, disconnected.disconnectGeneration);
-    assert.equal(blockedFailure?.localConnectionRevision, disconnected.localConnectionRevision);
-    assert.equal(blockedFailure?.localTokenRevision, disconnected.localTokenRevision);
-    assert.equal(blockedFailure?.lastErrorCode, null);
+    assert.equal(blockedFailure.applied, false);
+    assert.equal(blockedFailure.account?.status, "disconnected");
+    assert.equal(blockedFailure.account?.setupPhase, null);
+    assertStoredCredentialKind(blockedFailure.account, "none");
+    assert.equal(blockedFailure.account?.disconnectGeneration, disconnected.disconnectGeneration);
+    assert.equal(blockedFailure.account?.localConnectionRevision, disconnected.localConnectionRevision);
+    assert.equal(blockedFailure.account?.localTokenRevision, disconnected.localTokenRevision);
+    assert.equal(blockedFailure.account?.lastErrorCode, null);
 
     const epochOne = store.upsertAccount({
       provider: "demo",
@@ -3336,7 +3339,7 @@ test("device sync store clears tokens and requires reauthorization after connect
           },
           existingAccountGuard: {
             expectedAccountId: epochOne.id,
-            expectedUpdatedAt: epochOne.updatedAt,
+            expectedConnectedAt: epochOne.connectedAt,
             rejectIfDisconnected: true,
           },
           connectedAt: "2026-04-07T00:50:00.000Z",
@@ -3356,16 +3359,17 @@ test("device sync store clears tokens and requires reauthorization after connect
     );
     const staleFailure = store.markConnectionSetupFailed(
       epochTwo.id,
-      epochOne.updatedAt,
+      epochOne.connectedAt,
       "2026-04-07T00:50:00.000Z",
       "OAUTH_DENIED",
       "stale setup failure",
     );
 
-    assert.equal(staleFailure?.status, "active");
-    assert.equal(staleFailure?.updatedAt, epochTwo.updatedAt);
-    assertStoredCredentialKind(staleFailure, "oauth_tokens");
-    assert.equal(staleFailure?.lastErrorCode, null);
+    assert.equal(staleFailure.applied, false);
+    assert.equal(staleFailure.account?.status, "active");
+    assert.equal(staleFailure.account?.updatedAt, epochTwo.updatedAt);
+    assertStoredCredentialKind(staleFailure.account, "oauth_tokens");
+    assert.equal(staleFailure.account?.lastErrorCode, null);
   } finally {
     store.close();
     await rm(tempDir, {

--- a/packages/device-syncd/test/store.test.ts
+++ b/packages/device-syncd/test/store.test.ts
@@ -3196,6 +3196,7 @@ test("device sync store clears tokens and requires reauthorization after connect
     assert.equal(
       store.markConnectionSetupFailed(
         "missing-account",
+        null,
         "2026-04-07T00:30:00.000Z",
         "OAUTH_DENIED",
         "operator denied access",
@@ -3221,6 +3222,7 @@ test("device sync store clears tokens and requires reauthorization after connect
 
     const failed = store.markConnectionSetupFailed(
       account.id,
+      account.updatedAt,
       "2026-04-07T00:30:00.000Z",
       "OAUTH_DENIED",
       "operator denied access",
@@ -3279,6 +3281,7 @@ test("device sync store clears tokens and requires reauthorization after connect
     const disconnected = store.disconnectAccount(raceAccount.id, "2026-04-07T00:20:00.000Z");
     const blockedFailure = store.markConnectionSetupFailed(
       raceAccount.id,
+      raceAccount.updatedAt,
       "2026-04-07T00:30:00.000Z",
       "OAUTH_DENIED",
       "operator denied access",
@@ -3291,6 +3294,78 @@ test("device sync store clears tokens and requires reauthorization after connect
     assert.equal(blockedFailure?.localConnectionRevision, disconnected.localConnectionRevision);
     assert.equal(blockedFailure?.localTokenRevision, disconnected.localTokenRevision);
     assert.equal(blockedFailure?.lastErrorCode, null);
+
+    const epochOne = store.upsertAccount({
+      provider: "demo",
+      externalAccountId: "demo-setup-epoch",
+      displayName: "Setup Epoch One",
+      scopes: ["offline"],
+      tokens: {
+        accessToken: "epoch-one-access",
+        accessTokenEncrypted: "enc:epoch-one-access",
+        refreshToken: "epoch-one-refresh",
+        refreshTokenEncrypted: "enc:epoch-one-refresh",
+      },
+      connectedAt: "2026-04-07T00:40:00.000Z",
+      nextReconcileAt: "2026-04-07T01:40:00.000Z",
+    });
+    const epochTwo = store.upsertAccount({
+      provider: "demo",
+      externalAccountId: "demo-setup-epoch",
+      displayName: "Setup Epoch Two",
+      scopes: ["offline"],
+      tokens: {
+        accessToken: "epoch-two-access",
+        accessTokenEncrypted: "enc:epoch-two-access",
+        refreshToken: "epoch-two-refresh",
+        refreshTokenEncrypted: "enc:epoch-two-refresh",
+      },
+      connectedAt: "2026-04-07T00:45:00.000Z",
+      nextReconcileAt: "2026-04-07T01:45:00.000Z",
+    });
+    assert.throws(
+      () =>
+        store.upsertAccount({
+          provider: "demo",
+          externalAccountId: "demo-setup-epoch",
+          displayName: "Stale Setup Epoch",
+          scopes: ["offline"],
+          tokens: {
+            accessToken: "stale-epoch-access",
+            accessTokenEncrypted: "enc:stale-epoch-access",
+          },
+          existingAccountGuard: {
+            expectedAccountId: epochOne.id,
+            expectedUpdatedAt: epochOne.updatedAt,
+            rejectIfDisconnected: true,
+          },
+          connectedAt: "2026-04-07T00:50:00.000Z",
+          nextReconcileAt: null,
+        }),
+      (error: unknown) =>
+        error instanceof Error
+        && "code" in error
+        && error.code === "CONNECTION_SEEDED_ACCOUNT_CHANGED",
+    );
+    const guardedEpoch = store.getAccountById(epochTwo.id);
+    assert.equal(guardedEpoch?.updatedAt, epochTwo.updatedAt);
+    assert.equal(guardedEpoch?.displayName, "Setup Epoch Two");
+    assert.equal(
+      requireStoredOAuthCredential(guardedEpoch).accessTokenEncrypted,
+      "enc:epoch-two-access",
+    );
+    const staleFailure = store.markConnectionSetupFailed(
+      epochTwo.id,
+      epochOne.updatedAt,
+      "2026-04-07T00:50:00.000Z",
+      "OAUTH_DENIED",
+      "stale setup failure",
+    );
+
+    assert.equal(staleFailure?.status, "active");
+    assert.equal(staleFailure?.updatedAt, epochTwo.updatedAt);
+    assertStoredCredentialKind(staleFailure, "oauth_tokens");
+    assert.equal(staleFailure?.lastErrorCode, null);
   } finally {
     store.close();
     await rm(tempDir, {


### PR DESCRIPTION
## Why

Junction historical recovery inferred whole-account completion from any useful historical row. Garmin activity could therefore mark recovery complete while sleep or sleep-cycle history was still missing, leaving the account permanently quiet even though Garmin exports history asynchronously.

## User goal

Members should receive every available Garmin activity, sleep, and sleep-cycle record while current ingestion continues. If Junction cannot provide required history after Murph's existing bounded retry ladder, Murph should offer a precise, member-confirmed disconnect/reconnect reset instead of silently claiming completion or requiring a support escalation.

Murph still uses Junction's data plane and never invents data Junction did not export.

## Invariants

- Only canonical imported data for the matching source, resource, and recovery window counts as coverage.
- Late canonical webhooks always import and may advance historical evidence.
- Exhausted progress and its source reset marker remain coupled.
- Legacy or stale runners cannot replace current or future protocol state.
- Future protocol versions own state through the status scalar; their opaque metadata remains untouched.
- Stale connection, credential, source, setup, disconnect, reconnect, or connection-established work cannot mutate a newer connection epoch.
- Current ingestion remains live while historical recovery is incomplete.

## Implementation

- Track activity, sleep, and sleep-cycle coverage independently for each Junction source.
- Reuse the existing bounded retry ladder, then mark only incomplete sources for reset.
- Merge late canonical webhook evidence with matching REST evidence.
- Preserve protocol-version ownership and opaque future metadata.
- Apply historical metadata, source health, and reset-marker changes atomically.
- Use the existing immutable `connectedAt` epoch and mutation lock for callback, setup, disconnect, reconnect, and connection-established races.
- Keep reset recovery member-confirmed through disconnect/reconnect.
- Add no tables, services, queues, managers, dependencies, or migrations.

## Verification

- Full affected-workspace gate passed before the final review delta: all 14 affected package typechecks, dependency and boundary guards, web lint/dev smoke/production build, 771 device-sync tests, 4,237 web tests, and 1,690 Cloudflare tests.
- Final rebased-head checks passed: 95 focused device-sync tests, 89 focused web Prisma/wake tests, and both affected typechecks.
- Prepared packaged CLI path passed 1,045 tests, including all device CLI tests.
- Coverage-write audit: no remaining stable owner-boundary coverage gaps.
- Security/privacy audit: no actionable critical, high, or medium findings and no identifier or credential leakage.
- State-consistency and simplicity audits: no remaining actionable findings; the final correction reuses one immutable epoch, one explicit compare-and-set result, and existing transactions/locks.
- Final-head ReviewGPT pass completed on the exact GPT-5.6 Sol model with zero accepted findings.
- Final-head GitHub Actions: all checks passed. The Vercel preview remains externally queued behind the shared project deployment backlog; it has not started or failed.

## Deployment

Deploy the web/control plane first, then the hosted runtime bundle. No database migration or immediate container rollout is required. OAuth states are compatible in both directions with the current deployed reader: the new guard derives its immutable epoch from the state creation time already shared with the seeded connection, while the current reader ignores that extra authority check.

Warm old runners are tolerated during rollout; the control plane rejects stale protocol writes and runners retry from a fresh snapshot.

Post-deploy:

- Confirm a new Garmin connection completes when an authenticated webhook arrives before its callback.
- Confirm activity, sleep, and sleep-cycle coverage advances independently while current ingestion continues.
- Confirm a late canonical webhook advances matching evidence.
- Confirm exhausted recovery exposes the correct reset marker and member-confirmed disconnect/reconnect flow.
- Confirm a disconnect racing a late connection-established hook leaves the connection and source disconnected.
- Check for sustained version-mismatch, stale-write, or callback-restart loops after rollout.
