### PR TITLE
Rewrite baseline invariants around simplicity and fast replies

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-09-baseline-invariants-rewrite.md
+++ b/agent-docs/exec-plans/completed/2026-07-09-baseline-invariants-rewrite.md
@@ -1,0 +1,65 @@
+# Baseline invariants rewrite
+
+Status: completed
+Created: 2026-07-09
+Updated: 2026-07-10
+
+## Goal
+
+- Replace the mechanism-heavy baseline with a smaller durable rulebook centered on deletion, simple composable ownership, native Codex capability, and fast foreground replies.
+- Keep the correctness, privacy, replay, deployment, and state-ownership boundaries that prevent recurring production failures.
+
+## Success criteria
+
+- `docs/contracts/00-invariants.md` states only cross-cutting, mechanism-independent rules.
+- Foreground reply work is explicitly protected from background work, routine checkpoints, diagnostics, unrelated backlog, and optional cleanup.
+- Codex CLI/App Server native behavior is trusted by default; Murph-side babysitting requires measured proof and stays limited to Murph-owned boundaries.
+- Exact file paths, package rosters, numeric tuning, incident narratives, and rollout case law move to their existing owner docs/tests or disappear from the baseline.
+- The final Markdown is shorter, easier to apply, and passes docs-only verification and privacy readback.
+
+## Scope
+
+- In scope:
+  - Rewrite `docs/contracts/00-invariants.md`.
+  - Preserve links to detailed owner contracts where useful.
+  - Record and close this execution plan through the normal docs-only workflow.
+- Out of scope:
+  - Runtime fixes for the two foreground-path gaps found during the audit.
+  - Changes to owner docs, code, tests, configuration, or deployed behavior.
+  - New numeric SLOs or implementation inventories.
+
+## Constraints
+
+- Default to deletion and the fewest owners, states, branches, and hidden transitions.
+- Preserve authorized user-critical flows, durable accepted-input obligations, replay safety, and fail-closed authority/privacy boundaries.
+- Distinguish bounded background work from live foreground admission; do not recreate the cumulative foreground cap removed by PR 453.
+- Preserve the minimum durability barrier needed before irreversible delivery while excluding unrelated work from that barrier.
+- Keep personal identifiers, local paths, secrets, and raw user data out of the document and commit.
+
+## Tasks
+
+1. Consolidate the current 29-section rulebook into a small principle-first structure.
+2. Strengthen radical simplicity, Codex native trust, foreground reply critical-path, progress, and bounded-growth rules.
+3. Remove mechanism inventory, PR case law, exact thresholds, and stale frozen choices.
+4. Read back the document, inspect the diff, run docs-only verification, and perform the parent final review.
+5. Finish the scoped plan commit, push the branch, open the docs PR, and land it when merge-ready.
+
+## Verification
+
+- Read back the complete rewritten document: passed.
+- `git diff --check`: passed.
+- Independent simplicity and invariant-correctness reviews: passed after incorporating checkpoint, external-call, identity, supersession, and harness-boundary clarifications.
+- Search the diff for personal identifiers, home-directory paths, secrets, stale PR case law, and removed mechanism-specific strings: passed.
+- Confirm only Markdown plan/ledger/invariant files changed before `scripts/finish-task`: passed.
+- `pnpm docs:drift`: passed.
+- `pnpm typecheck`: passed after preparing clean-worktree package entrypoints with `pnpm build:workspace:incremental`.
+- `pnpm test`: not required for the text-only Markdown task class. The first broad run inherited a TTY and opened interactive CLI prompts; a `CI=1` rerun produced no failures but was stopped after a bounded resource-contention window. Contracts artifact verification and fixture/scenario integrity passed.
+- Confirm the final branch merges cleanly with current `origin/main`: passed; the branch was refreshed with no base divergence before the scoped commit.
+
+## Decisions
+
+- Keep the baseline outcome-focused; exact mechanisms, package rosters, thresholds, and incident history remain in owner docs and executable tests.
+- Treat native Codex lifecycle, continuity, steering, tools, memory, and orchestration as integration surfaces, not features for Murph to shadow or supervise.
+- Permit only current-turn durability barriers on the foreground path; routine workspace snapshots and unrelated maintenance remain idle-only and interruptible.
+- Preserve the two observed runtime gaps as follow-up implementation work rather than mixing speculative code changes into this documentation task.
+Completed: 2026-07-10

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -1,183 +1,213 @@
 # Baseline Invariants
 
-This file is the durable rulebook. Each rule states a trigger and the required
-response; incident history, protocol case law, and mechanism detail live in the
-referenced docs. Where a rule names an anti-pattern PR, the citation is
-rationale, not a live mechanism.
+This file contains Murph's cross-cutting engineering rules. Product behavior
+belongs in product specs. Protocol details, file paths, provider fields,
+numeric tuning, incident history, and rollout case law belong in owner docs and
+executable tests.
 
-## Implementation Bias
+## Admission Test
 
-- Prefer simple, composable primitives over abstractions. A new abstraction must remove real duplication, clarify ownership, or make an invariant easier to enforce.
-- Treat improving agent capability as a design input. Add code around agents only for hard guarantees — security, privacy, state integrity, idempotency, latency/retry bounds, protocol compatibility, or failures proven by tests or production evidence that prompt/tool guidance cannot cover. Do not preserve today's model limitations as permanent architecture.
-- Review, audit, and ReviewGPT findings are inputs to engineering judgment, not architecture ownership. Before writing the first fix commit for a finding, evaluate the deletion, sibling-contract, or owner-boundary response; a finding fixed by adding a new state owner, lifecycle, queue, or manager when a tighter existing owner or one-source derivation preserves the invariant is a rejected fix, whoever suggested it.
-- Operator/ops needs default to existing product flows, the CLI, or documented manual repair against the source of truth. A new ops route or page requires demonstrated recurring need and a deletion path (anti-pattern: PR 342's ops invite sender, deleted 48 hours later by PR 361).
-- Keep production source free of branches, exports, routes, helpers, fixtures, and flags that exist only for tests or harnesses. If a test needs a new seam, make it a real production seam with clear runtime ownership, or keep it in test files and test-specific composition.
+- A baseline invariant must protect a recurring cross-cutting failure class or
+  an irreversible boundary, survive changes to today's mechanism or provider,
+  and name an outcome that can be proved.
+- Keep owner-specific requirements in owner contracts and tests. Repeated
+  incidents trigger first-principles design review, not another automatic rule
+  or mechanism.
 
-## Codex Is The Substrate
+## Radical Simplicity
 
-- Codex App Server is a production-grade runtime, not a component to defend against. Prefer Codex-native capabilities — thread resume, steering, subagents, web search, memory, process lifecycle, OpenAI transport — over Murph-side reimplementations, wrappers, or policing layers. A Murph-side layer that duplicates or supervises a Codex-native capability requires production evidence that the native path cannot meet the requirement, not a hypothetical failure.
-- The default posture is one warm Codex App Server per Node runtime/container, reused across turns for the life of the container. Warm reuse is the contract; restart and poisoning are narrow recovery exceptions with proven triggers. Turn-scoped data — prompt text, session ids, turn ids, delivery facts — must never enter process identity or child env in a way that restarts a healthy process.
-- The hard guarantees Murph does own at this seam: parent-thread output is accepted only when tagged with the current turn id, so a stale turn cannot inject into a new one; active turns are stopped through the explicit abort/interrupt path, never by killing the process under them; stale or mismatched resume state falls back to a fresh thread for the same user turn instead of failing to reply.
-- Process babysitting is the named anti-pattern: PID sweeps, process classifiers, shadow lifecycle managers, and parallel orchestration state (PR 350 deleted ~3,000 lines of it).
+- Default to deletion. Before adding code, an abstraction, dependency, service,
+  configuration, state, or process, state the current proven requirement and
+  show why deletion, reordering, an existing owner, a stable key, or a native
+  platform primitive cannot meet it.
+- Prefer fewer owners, states, branches, concepts, and hidden transitions. Add
+  an abstraction only when it removes real duplication, clarifies ownership
+  and data flow, or mechanically enforces a hard invariant.
+- Add complexity only for a failing production-faithful test, a measured
+  bottleneck, a security or privacy requirement, or a concrete current product
+  need. A review finding alone does not justify machinery.
+- When successive fixes add state or branches to repair the same mechanism,
+  stop patching. Restate the required outcomes and redesign from the smallest
+  primitive that satisfies the proven failures.
+- Each temporary migration, compatibility path, repair path, or test scaffold
+  has one owner and a concrete removal condition.
+- Optimize first by deleting work, narrowing dependencies, removing duplicate
+  reads, or moving optional work off-path.
 
-## Durable Authority
+## Trust Codex Native Capabilities
 
-- Any operation that resumes, wakes, mutates, egresses, delivers, deletes, exports, or recovers user state must revalidate an explicit durable authority tuple owned by the source-of-truth plane. Process-local pointers, cached "active" state, dashboard state, session presence, and provider callback state may optimize only after durable authority is proven.
-- A session proves who is present, not that an action is authorized. Destructive, sensitive, or lifecycle-specific actions bind to the narrow action, user/member, route/target, attempt/lease/fence, freshness proof, or row lock that owns that action.
-- Model-supplied tool arguments are requests, never authority. Delivery targets, thread ids, member ids, and scopes are injected server-side from the current wake's proven authority and re-asserted at the durable boundary.
-- If authority is missing, stale, ambiguous, or mismatched, fail closed or fall back to the narrower safe flow. Provider success and container identity are not authorization.
+- Treat Codex CLI and Codex App Server as the capable execution substrate. If
+  Codex owns a capability — process lifecycle, thread continuity and resume,
+  steering, streaming and transport fallback, tool use, web search, memory, or
+  subagents — Murph integrates it instead of reimplementing or supervising it.
+- Keep the Codex adapter thin. Do not add PID sweeps, process classifiers,
+  shadow lifecycle or thread and turn state, watchdogs, retry and fallback
+  loops, or orchestration that duplicates Codex. Add Murph-side machinery only
+  after a measured production gap or production-faithful failing test shows
+  native Codex cannot satisfy a named invariant. Do not encode today's model
+  limitations as permanent supervision.
+- Murph owns the boundary around Codex: accepted-work durability; user, target,
+  authorization, and current-turn identity; stale-output rejection and explicit
+  abort; privacy; canonical writes; provider credential and delivery authority;
+  and irreversible effects. Warm reuse is an optimization, never authority.
 
-## User Reply Primacy
+## Foreground Reply Critical Path
 
-- Every accepted inbound user message creates a durable obligation to reply. The obligation survives crashes, restarts, deploys, and runner replacement, and it clears only on a delivered reply or an explicitly recorded product-policy non-reply decision (such as the AI usage gate or a suppression with a decision record). Silence is never a valid terminal state.
-- Replying to the user's current message outranks everything else the system could do. Background work, maintenance, checkpoints, cleanup, cost controls, and internal gates yield to or fail toward the reply path; a gate or dependency outage on that path must still end in a user-visible outcome — a reply or a policy message — never a dropped message.
-- The obligation is at-least-once; delivery is at-most-once through the stable-identity and transport-matched-consumption rules. From accept to delivery there is terminal evidence (delivered, superseded, or suppressed-with-reason) that a restarted or replayed runtime keys on, so recovery always knows whether the user is still waiting.
+- A durably accepted current conversation message is the runtime's
+  highest-priority work.
+- From durable acceptance through provider start and durable reply handoff,
+  await only the current input, current authority and decryption, routing,
+  minimal current-conversation context, assistant execution, and minimum
+  delivery-intent state required for that reply.
+- Projection, enrichment, diagnostics, telemetry, usage accounting, retention,
+  compaction, cleanup, device sync, browser refresh, cron, replay catch-up, and
+  unrelated mailbox work stay off that path. Keep their static dependency
+  closure and initialization off-path too, not only their explicit waits.
+- Signal foreground availability at the earliest durable staging boundary,
+  before projection, full import completion, maintenance, or routine
+  checkpointing. Typing or activity signals are best-effort and cannot delay
+  provider start.
+- Background work runs in finite abortable units, checks for fresh input before
+  each unit, and derives continuation from durable owner state. Preemption
+  defers work; it never drops it.
+- A foreground prerequisite is a named current fact, not a generic lane or
+  backlog. Bound unavoidable pre-provider and pre-delivery collections and
+  waits, but never let background, replay, maintenance, or diagnostic budgets
+  cap fresh accepted input.
+- Routine hosted workspace snapshot publication is idle-only and interruptible.
+  Current-turn durability barriers may run only for facts the current reply or
+  effect consumes. Before provider start, that is limited to accepted-input and
+  turn-ownership proof; before an irreversible send, to the minimal outbox
+  identity and intent needed for replay safety. Unrelated work cannot join.
+- Once a reply is ready, optional logging, telemetry, usage flushing, typing
+  teardown, cleanup, or reconciliation cannot delay delivery. Attempt-bound
+  acceptance, staging, local-turn, first-output, and delivery telemetry is
+  content-free, best-effort, and nonblocking.
+
+## Accepted Work And External Effects
+
+- Every durably accepted conversational input reaches a restart-safe terminal
+  disposition: delivered response, explicit policy non-reply, or an explicit
+  durable supersession record naming the later accepted input. Accidental
+  silence is not terminal.
+- Product, dedupe, revision, and effect identities derive from stable product
+  or provider facts. Attempt identities are unique to one attempt. These roles
+  remain distinct across retry, replay, overlapping ingestion, restart, reorder,
+  resend, and migration re-entry.
+- Validate target, configuration, and authority before claiming an irreversible
+  effect. Persist the minimum effect identity and intent before the provider
+  call.
+- Once a non-idempotent provider call may have started, ambiguous failure does
+  not release the claim or permit blind resend without provider idempotency or
+  proof that the effect did not begin. Acknowledge, clean up, or advance
+  progress only after terminal or durable pending evidence.
+
+## Authority, Ownership, And State
+
+- Each fact that can change a durable decision has one owning source and one
+  resolver. Caches, projections, snapshots, runtime state, aggregates, and
+  provider callbacks are accelerators unless the owner contract says otherwise.
+- Validate durable authority when an operation crosses a lifetime, target, or
+  irreversible-effect boundary. Carry narrow typed proof within that bounded
+  operation instead of making sibling layers rediscover it. Model-supplied
+  targets are requests, never authority.
+- Match state lifetime to scope. User-facing or queryable product truth never
+  begins in process, request, turn, assistant-runtime, wake, orchestration, or
+  other operational state. Durable obligations must be derivable from owned
+  durable metadata on every pass.
+- Canonical vault writes go through the owning canonical API with provenance.
+  Importers prepare data; CLIs, assistants, and runtimes call the owner.
+  Transcripts, projections, and runtime state are never promoted implicitly.
+- Workspace packages use declared public entrypoints and keep dependencies
+  one-way and acyclic. Shared behavior moves to the lower owning package instead
+  of reaching into sibling internals or creating circular re-exports.
+- Provenance-bearing raw evidence and append-only records are immutable by
+  default. Repair is an explicit owner primitive with precondition proof and a
+  metadata-only audit trail.
+- A guard or authority change is complete only when every path to the protected
+  effect routes through it durably or is proved unreachable.
+
+## Ordered Progress And Bounded Work
+
+- Cursors, watermarks, sequences, pending-input indexes, and pagination use one
+  total, transitive, owner-shared ordering primitive. Import progress is not
+  handling progress.
+- Progress never advances past accepted work without terminal or durable
+  pending evidence. A checkpoint cannot make an unhandled obligation disappear.
+- Commit durable work before signaling. A wake is a droppable, replayable
+  latency hint, never product truth. One owner records the next durable
+  decision; consumers do not recreate due or defer policy.
+- Any retrying, paging, or open-ended loop has a progress measure and a
+  no-progress exit. Every potentially unbounded wait or unit of background work
+  has an item, time, or attempt bound plus an abort or durable continuation
+  path. Foreground latency must not grow without bound with unrelated history,
+  backlog, workspace size, file count, transcripts, or logs.
+
+## Provider And Runtime Boundaries
+
+- Side effects, automations, notifications, and provider calls need a concrete
+  authorized target before execution. Invalid routes and unauthorized actions
+  fail before model or provider work; do not add a queue or repair worker to
+  compensate for an invalid shape.
+- Provider shapes come from a pinned canonical SDK or published typed contract.
+  A bespoke boundary needs a documented reason and exact-shape tests. On the
+  foreground path, an external call may fail or delay a reply only when the
+  current input needs its result. Each provider or network wait declares the
+  applicable deadline, idle timeout, abort, fallback, and retry behavior in its
+  owner contract.
+- Execution planes stay thin. Platform coordination, secret injection,
+  workspace transport, and write fences remain separate from assistant business
+  logic, canonical data semantics, and product state.
 
 ## Product-Critical Flow Preservation
 
-- Do not fix safety, reliability, privacy, auth, or review findings by disabling, silently dropping, or degrading an existing user-critical flow unless the user explicitly asks for that product change. User-critical flows include onboarding, signup and welcome delivery, replies to a current inbound message, billing and access transitions, authentication, device/data sync, and privacy or safety controls.
-- Any change that tightens a guard, permission check, egress policy, retry rule, or delivery decision must preserve an authorized success path for the existing UX, proven with a production-faithful test or owner-level integration check.
-- Any gate that depends on an external model or provider must declare, when it is introduced, its per-flow disposition when that dependency is unavailable; user-critical flows bias fail-open. Changing a disposition afterward is a product decision, not a fix (anti-pattern: PRs 324/334 decided the first-contact classifier's disposition twice in 24 hours).
-- If safety and UX conflict, stop and surface the tradeoff. Never ship a silent no-op, dropped message, or unreachable recovery path as a safety fix.
+- Safety, reliability, privacy, authentication, and review fixes preserve the
+  authorized success path for existing critical flows. Disabling, silently
+  dropping, or degrading the flow is a product decision, not a technical fix.
+- Identity, authentication, consent, privacy, recipient, and irreversible-effect
+  authority fail closed. An advisory dependency may degrade only into an
+  already-authorized narrower path and never silently suppress an accepted
+  reply.
 
-## Stable Idempotency Identity
+## Deployment Compatibility
 
-- Durable product identity, dedupe identity, idempotency keys, and revision identity derive from stable product/provider facts — never machine-local rows, runtime-local ids, mutable provider versions, media URLs, callback timing, or session-specific storage.
-- Where paths intentionally overlap — retry, replay, push+pull ingestion, warm/cold restart, webhook reorder, outbox resend, migration re-entry — the shared identity makes overlap safe by construction.
-- A new write path is complete only when it names its stable identity, states which mutable fields are excluded, and has a regression proving overlap does not duplicate or lose the user-visible fact.
+- Cross-plane changes state safe deploy order, warm-old-bundle behavior,
+  rollback floor, and whether coordinated deployment is required.
+- Schema and protocol evolution is additive-first. Compatibility stays
+  legacy-facing, includes a removal condition, and is deleted after verified
+  production drain.
 
-## Transport-Matched Consumption
+## Observability And Bounded Growth
 
-- Anything consumed over an at-least-once channel — webhook, provider callback, browser navigation, wake, job chain — must tolerate redelivery by construction: mark, don't delete.
-- Stamp the durable fact at the instant it becomes true (delivery-accept, not a later checkpoint). A fact that becomes durable only minutes after the event is a duplicate-effect window.
-- Replay gets a typed non-error resolution: indistinguishable from the first success to the user, distinguishable in the record.
+- Observability work never adds user latency. Diagnostics never block provider
+  start or delivery. Once the active reply cannot continue, a bounded
+  best-effort crash record may run.
+- Capture structured errors at the root boundary, apply shared redaction, and
+  preserve a stable code plus useful redacted cause. Never expose secrets,
+  message content, private identifiers, or local paths in external artifacts.
+- Growing persisted collections declare ownership, retention, indexing or
+  pagination, snapshot treatment, and cardinality or byte limits. Hosted
+  workspace files also follow `docs/contracts/06-hosted-workspace-file-count.md`.
 
-## Minimal Mechanism Bias
+## Executable Proof
 
-- For "do this exactly once," start with a stable identity, a uniqueness constraint, and an idempotent write the losing caller can no-op on. If each write, send, or row a path produces is individually retry-safe, a top-level processing fence usually adds failure modes (stuck leases, owner mismatch on redeploy, replay-vs-reclaim races) without removing any.
-- Before adding a second durable-state mechanism to an existing protocol — proof table, lease, reconciler, derived floor — write down the one-column/one-key alternative and prove it insufficient.
-- Fix-loop length is a design trigger with a required response: when one protocol accumulates double-digit scoped "preserve/scope/fence/reclaim" fixes, the next change is a target-design rewrite to the smallest primitive the proven failures require, not another fix. Named anti-patterns: PR 320, and PR 381 (shelved at ~50 review rounds), whose one-column rewrite (PRs 383–385) deleted the proof machinery and made the previously unsafe direct wake safe by construction.
+- Make hot-path size, dependency closure, call ordering, scan complexity, state
+  placement, provider shape, and replay boundaries executable with
+  deterministic tests when prose cannot prevent drift.
+- Numeric latency budgets, retry counts, scan limits, and output limits live in
+  owner protocol or SLO docs and tests so they can be measured and ratcheted
+  without turning this file into configuration.
+- Codex test doubles sit behind the production adapter. They may fake unsafe
+  external edges, credentials, time, and deliberate failures; they must not
+  maintain a second Codex lifecycle, protocol, scheduler, supervisor, or retry
+  system. Harness-only needs stay in test composition; production branches,
+  flags, routes, exports, lifecycle state, or protocol machinery never exist
+  solely for tests.
+- A feature is complete only when its user-visible outcome is reachable through
+  the wired production path.
 
-## Observable Outcomes
-
-- Any path that can suppress, skip, or drop a user-visible effect returns a typed outcome and lands a queryable, metadata-only decision record. A silent no-op on a user-facing action is a defect even when the suppression is correct.
-- A persisted pending effect names the condition under which it is still valid and is observably superseded when that condition stops holding; a scheduler or harness retry must not deliver a stale effect.
-- A feature's stated user-visible goal must be proven reachable through the actually wired production path end to end before merge. A route with no caller, a tool action the model cannot invoke, or a field that persists null is an unfinished PR, even when every unit test of the pieces is green.
-
-## One Fact, One Resolver
-
-- A decision-grade predicate — access, capability, entitlement, identity — has exactly one owning resolver. A second exported variant may exist only when named by what it distinctly means, and a field must not carry two meanings.
-- Every user-visible gate, billing/usage decision, experiment outcome, lifecycle automation, or safety/freshness claim names its authoritative source. Caches, current-period aggregates, sparse entity models, snapshots, and projections are accelerators unless their owner contract explicitly makes them the decision source; reads that enforce limits or report status reconcile against the authority, and bounded aggregates are repaired only in the owning mutating path.
-- Decision-grade metric-window comparisons use normalized metric points plus the shared metric series/window primitives; wearable day summaries are presentation context, not analysis truth.
-
-## State Lifetime And Durable Obligations
-
-- Match state lifetime to scope: process state is for process configuration only. Request, turn, message, delivery, and user-action facts are explicit operation data or owned by a runtime object with that same lifetime.
-- Durable obligations — retry ladders, backfill schedules, pending follow-ups — must be derivable from owned durable metadata on every pass. An obligation that exists only in an in-flight job chain, process memory, or a file that workspace restore deletes is lost state waiting to happen.
-
-## Ordered Progress
-
-- Any persisted cursor, sequence, watermark, pending-input index, or paginated read uses one total, transitive, owner-shared ordering primitive. Do not duplicate timestamp comparators or pick timestamp fields pairwise.
-- Explicit causal anchors beat positional heuristics: provider reply ids, selected input ids, and server sequences resolve before "latest", grouping, watermarks, or time-window fallbacks. Import progress is not handling progress; events with different explicit anchors are never grouped into one turn.
-- Consume/clear/advance only from owner-provided per-item authority or cursor coverage plus terminal evidence. Do not advance a lane high-water past pending lower work when a per-item stamp is the simpler durable truth.
-
-## Provider Contracts
-
-- An automation, assistant side effect, notification, or provider call carries a concrete deliverable/authorized target before it persists as executable. Continuity locators, thread ids, placeholders, and route hints are context, not targets. Invalid routes and unauthorized operations fail before model execution, delivery, or provider mutation — never add a scheduler, queue, or repair worker to compensate for an invalid route shape.
-- Provider request and response shapes come from the provider's pinned canonical SDK or published typed contract. A bespoke boundary needs a documented reason (SDK too heavy, unpinnable, stale, or wrong authority owner) plus focused tests over the exact provider JSON shape.
-- A fail-closed decision over provider-supplied data covers the provider's documented payload variants — item-level vs top-level fields, optional or removed flags, casing differences — with regressions before shipping.
-- An external call may fail a job or turn only if the current input actually requires its result. Optional enrichment skips with a recorded typed reason, and calls whose result the input cannot use do not run.
-
-## Enforcement-Point Completeness
-
-- A new guard, preflight, or authority check is complete only when every path that can reach the guarded side effect is enumerated and either routed through the check durably or shown unreachable. An in-memory filter at a sibling boundary does not count.
-- Every persisted wake, retry, or deadline has exactly one producing owner that records the current decision from decision-time state. Consumers select but never recompute due/defer logic, and appended state replaces stale wakes instead of preserving them.
-
-## Deploy Skew
-
-- Any change spanning web, Cloudflare, the runner bundle, or Temporal states its safe deploy order, its behavior under gradual container rollout (warm old-bundle containers), whether `container_rollout=immediate` is required, and its rollback floor.
-- Schema changes are additive-first. Compatibility branches are deleted only after verified production drain, and the removal step is scheduled in the same change that lands the compatibility path.
-- The legacy direct Telegram usage-limit sender retains its period marker after any send exception because the Bot API request may already have started. Configuration and target validation happen before the marker claim. This deployed behavior is a rollback prerequisite for PR 465; do not reintroduce post-dispatch marker release without provider idempotency or equivalent proof that delivery did not start.
-
-## Executable Invariants
-
-- If an invariant exists to keep a hot path small, a protocol boundary faithful, or a dependency surface narrow, make it executable with deterministic graph, byte, package-surface, shape, or protocol-contract tests. A docs-only invariant is not enough when one static import or shim drift can silently defeat it.
-- Test doubles stand behind the real production adapter/protocol; they never reimplement owned protocols in parallel. Prefer the real binary, library, or protocol with stubbed external provider edges; stub only provider edges, secrets, clocks, or failure cases that cannot safely run in repo automation.
-- Every abstraction, shim, compatibility layer, or generated harness has an owner, a deletion path, and a reason stronger than convenience. If the simpler path is deleting the shim and exercising the production seam, delete it.
-
-## Latency And Scan Bounds
-
-- Do not add unbounded linear-or-worse scans over any growing collection — repo files, vault records, runtime state, database rows, object-store keys, mailbox items, transcripts, logs, API result sets, or in-memory accumulators. Any path that can run during user-visible work, recurring jobs, deploy checks, or normal local commands uses a bounded window, limit, cursor, index, exact key lookup, or explicit pagination. Intentional full scans are limited to bounded fixture data, one-shot migrations, offline/admin repair tools, or diagnostics with a documented size cap.
-
-## Hosted Workspace File Cardinality
-
-- Hosted workspace restore/checkpoint treats file count as a latency, memory, and privacy budget; a routine feature must not create an unbounded number of small files just because each file is small. A new workspace write family classifies the state, chooses a compact storage shape, and defines snapshot inclusion and retention before shipping. Detailed rule: `docs/contracts/06-hosted-workspace-file-count.md`.
-
-## Canonical Storage
-
-- Human-facing truth lives in Markdown: `CORE.md`, `journal/`, and `bank/`.
-- Machine-facing truth lives in JSONL: `ledger/events`, display-grade `ledger/metric-samples`, explicit raw/debug `ledger/samples`, and `audit`. Generic `ledger/samples` shards are not part of the default query/read/browser model.
-- Imported originals live in `raw/` and are immutable once copied into the vault, except explicit core-owned repair tombstones that prove the old manifest byte/SHA and preserve durable product facts.
-
-## Write Authority
-
-- Only `packages/core` may mutate canonical vault data. `packages/importers` may parse and prepare external data, but all canonical writes call core APIs. `packages/cli` never writes vault files directly.
-
-## Agent-Visible CLI Payloads
-
-- Agent-primary `add`, `save`, and `edit` commands expose their normal input shape through native Incur args and options so `--help`, `--schema`, `--llms`, MCP, and generated skills stay truthful. Batch or document-derived JSON payloads are explicitly named escape hatches such as `import-json`/`import-jsonl`, never hidden behind canonical typed command names.
-- Every agent-visible command that accepts a complex `--input @file|-` payload provides a paired Incur-discoverable shape path — a sibling `payload-schema` command with `scaffold` as a representative payload — sharing the runtime importer's normalization/schema path where practical. Agents must not have to infer payload shapes from source, tests, or stale docs.
-- Default agent-visible read/status/list/tail surfaces return bounded summaries suitable for a single model tool result. Growing fields such as markdown bodies, assistant timelines, raw provenance, manifest payloads, nested telemetry arrays, and long instruction text stay out of defaults unless the command is an explicit detail/export/schema surface.
-- Any new default CLI read surface that can grow with vault size needs a deterministic output-budget regression. The representative `--full-output --format json` default response should stay under roughly 15k characters on oversized fixtures; callers that need more data must use an explicit `show`, manifest/export/materialize command, or raised `--limit`.
-
-## Assistant Boundary
-
-- Agent layers, MCP surfaces, and future UIs call `murph`, `vault-cli`, or exported package APIs; no agent gets arbitrary write access to vault files as part of the public contract.
-- Assistant runtime state lives under `vault/.runtime/operations/assistant/**`. If a datum is user-facing, queryable, or something future features will build on, it belongs in canonical vault records or explicit derived materializations, never assistant runtime state. Durable user-facing memory and scheduled prompt configuration are canonical vault records.
-
-## User-Facing Message Sends
-
-- Do not hard-code messages that automatically send to users, except for the AI usage gate, signup link delivery, first welcome, Linq daily text quota, Linq home-thread redirect, and billing cancellation feedback email. The Linq quota and home-thread redirects are narrowly scoped policy responses that preserve admission/routing invariants before assistant generation runs. All other automatic outbound user messages must come from the normal AI-gated assistant path, an explicit user/operator-authored message, or another reviewed product-copy surface that is not sent automatically.
-- Any deterministic message that can send identically to more than one recipient renders from the seeded variant bank in `apps/web/src/lib/hosted-messages/user-facing-messages.ts`: at least 20 structurally distinct variants per class, selected by a stable per-recipient seed, never a single fixed string. Sending identical copy to many recipients is an iMessage spam signal (`agent-docs/operations/imessage-deliverability.md`), so the variant floor is enforced at module import and in the corpus test. This binds the allowed hard-coded classes above and any transactional onboarding, family, or group reply that would otherwise send fixed text. Managed automations satisfy it by composing each send through the AI-gated path instead of a fixed script, which is why they carry instructions rather than message text.
-
-## Hosted Foreground Priority
-
-- User conversation messages are the highest-priority hosted runtime work. Background device sync, provider cleanup, browser-vault refresh, maintenance, and idle checkpointing never block assistant admission or reply delivery, and idle-only work is preemptible: it yields, aborts, or reschedules when fresh user input arrives.
-- After foreground work dirties hosted runtime state, the configured idle checkpoint delay is a lower bound for starting the next runtime-owned checkpoint. Due or projected wakes, budget exhaustion, and deferred durable follow-ups may preserve wake metadata for that checkpoint, but they must not pull it earlier than the idle timer; explicit shutdown cleanup is the narrow exception because the runtime is already exiting.
-- Assistant reply code must not import, call, await, or coordinate with device-sync execution. Device sync may preserve a follow-up wake or recovery marker, but it stays out of the foreground reply path.
-- Preemption is not permission to publish partial or corrupt state: wrong-user authority, stale leases, invalid auth, undecryptable mailbox payloads, and checkpoint compare-and-swap conflicts still fail closed.
-- Observability writes are never user latency. Runtime logs, latency traces, diagnostics, and metrics are queued or fire-and-forget off the user-visible reply path and flushed at invocation end or idle, preserving enqueue order and logical timestamps. Bounded exception: warn/error crash-tail writes may block so failure forensics stay durable. Making an instrumentation write synchronous requires a documented correctness reason, not convenience.
-
-## Hosted Runner Boundary
-
-- Cloudflare stays a thin execution runner over the same Murph runtime used locally. It owns platform coordination, workspace restore/checkpoint transport, write fences, secret injection, and explicit runner shutdown; assistant business logic, vault semantics, Codex orchestration policy, and product state belong to the Murph runtime and hosted web owners. "Thin" means no business logic, not low line count.
-- Warm reuse — container shell, workspace root, Codex process — is an optimization, never authority. Each message enters through the assistant input spine, revalidates current user/write-fence/config authority, uses invocation-local cache/temp state, and falls back to cold restore or process restart when safe reuse cannot be proven.
-- Cloudflare container and Durable Object RPC methods are platform stub methods, not ordinary callbacks: invoke them directly on the stub, and keep test harnesses on that direct-call contract so local tests catch receiver/proxy bugs.
-- All provider egress is Worker-mediated. Adding a new runtime tool, provider method, or provider API path is incomplete until the egress allowlist, sentinel credential rewrite, and focused regressions cover the exact upstream operation. Provider credentials in native slots identify provider/user/runner only; Worker egress validates current server-owned runtime state before injecting Worker-owned secrets, and container identifiers are not authorization.
-- Keep one user-visible output as one typed value until its durable boundary; no hidden staging paths without a concrete product or reliability need.
-- Detailed protocol case law: `agent-docs/references/hosted-runtime-protocol.md`.
-
-## Observability And Logging
-
-- Capture concrete structured error context at the root failure boundary, pass it through the shared redaction helper, then emit. No caller-local partial log shapes, one-off scrubbers, or coarse replacement buckets that discard status, provider code, retryability, operation, or cause before the boundary sees them.
-- Error records keep both a stable machine-readable code and a redacted human-readable message/cause chain, end to end — persisted downstream copies included.
-- Redaction masks the smallest unsafe span, not the artifact: a redactor that nulls a whole diagnostic value recreates the blindness it exists to prevent (anti-pattern: PRs 366/376). Structured content is extracted typed, never prose-masked.
-
-## Append-Only Bias
-
-- `raw/` is immutable by default; any repair rewrite is a named core primitive with manifest proof, metadata-only audit, and no raw payload leakage.
-- `ledger/*.jsonl` and `audit/*.jsonl` are append-only by default; any future shard deletion needs its own named repair proof and architecture update.
-- Markdown docs may change only in explicitly human-facing areas.
-
-## Deferred Complexity
-
-- No SQLite as canonical health storage. Rebuildable projections live under `.runtime/projections/**`; durable operational SQLite is allowed only for explicitly owned runtime stores with migrations and a documented snapshot/backup policy, such as device-sync state under `.runtime/operations/device-sync/state.sqlite`.
-- Lexical search flows through the query projection. Vector search, OCR-heavy lab parsing, and local-model requirements stay deferred unless explicitly added to the contract.
-- No automatic promotion of chat transcripts into canonical health state. The overnight memory consolidation automation is the one approved transcript-promotion boundary, deliberately narrower than health state: non-health durable user context only, written through `vault-cli memory upsert`/`vault-cli memory update`, sourced solely from the engine-supplied bounded conversation-evidence window, and never medical or health details, credentials, identifiers, or transient task detail.
-
-## Frozen Current Choices
-
-- Product CLI: `murph`. Raw explicit-vault CLI and operator surface: `vault-cli`.
-- Public packages: `@murphai/murph`, `@murphai/openclaw-plugin`, `@murphai/contracts`, `@murphai/hosted-execution`, `@murphai/gateway-core`.
-- Workspace-private package families: `core`, `query`, `importers`, `parsers`, `health-metrics`, `health-commons`, `exercise-library`, `device-syncd`, `inboxd`, `inbox-services`, `messaging-ingress`, `runtime-state`, `assistant-engine`, `assistant-runtime`, `assistantd`, `operator-config`, `vault-usecases`, `assistant-cli`, `setup-cli`, `hosted-orchestrator-temporal`, `cloudflare-hosted-control`, `hosted-local-harness`.
-- This roster must match the actual `packages/*` manifests; update it in the same change that adds, removes, or renames a package.
+Detailed owners: `ARCHITECTURE.md`, `agent-docs/PRODUCT_SENSE.md`,
+`agent-docs/PRODUCT_CONSTITUTION.md`, `agent-docs/SECURITY.md`,
+`agent-docs/RELIABILITY.md`, `agent-docs/references/hosted-runtime-protocol.md`,
+`docs/contracts/03-command-surface.md`, and
+`agent-docs/operations/imessage-deliverability.md`.

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -111,10 +111,10 @@ executable tests.
   irreversible-effect boundary. Carry narrow typed proof within that bounded
   operation instead of making sibling layers rediscover it. Model-supplied
   targets are requests, never authority.
-- Match state lifetime to scope. User-facing or queryable product truth never
-  begins in process, request, turn, assistant-runtime, wake, orchestration, or
-  other operational state. Durable obligations must be derivable from owned
-  durable metadata on every pass.
+- Match state lifetime to scope. User-facing or queryable product truth is
+  never assistant runtime state and never begins in process, request, turn,
+  wake, orchestration, or other operational state. Durable obligations must be
+  derivable from owned durable metadata on every pass.
 - Canonical vault writes go through the owning canonical API with provenance.
   Importers prepare data; CLIs, assistants, and runtimes call the owner.
   Transcripts, projections, and runtime state are never promoted implicitly.


### PR DESCRIPTION
## Why

The baseline invariant document had accumulated mechanism inventories, frozen implementation choices, and incident case law. That made the durable rules harder to see and encouraged preserving complexity instead of challenging it.

## User-visible goal

Give Murph a small, durable engineering rulebook that makes radical simplicity, native Codex capability, and fast foreground replies the defaults, while retaining the correctness boundaries that protect accepted work and irreversible effects.

## What changed

- Reduced the baseline from 29 mechanism-heavy sections to 12 outcome-focused sections.
- Made deletion, fewer owners/states/branches, and proof before added complexity explicit.
- Added a strong native-Codex boundary: integrate Codex lifecycle, continuity, steering, tools, memory, and orchestration instead of shadowing or babysitting them.
- Defined the foreground reply critical path so routine checkpoints, diagnostics, telemetry, enrichment, replay, cleanup, and unrelated backlog cannot block a current reply.
- Preserved durable accepted-work disposition, authority, replay/idempotency, state ownership, bounded progress, provider, deployment, privacy, and critical-flow rules.
- Moved mechanism detail, package rosters, thresholds, and incident history back to owner docs and executable tests.

## Invariants to preserve

- Accepted current-conversation work remains highest priority and reaches an explicit restart-safe disposition.
- Only current-turn facts may create foreground durability barriers; unrelated work stays idle-only and interruptible.
- Murph retains authority over identity, authorization, privacy, canonical writes, delivery, and irreversible effects around Codex.
- Product truth has one durable owner; progress cannot advance past unmet obligations.
- Safety and reliability fixes preserve authorized product-critical success paths.

This is documentation-only and changes no runtime behavior.

## Verification

- Full document readback and independent simplicity/correctness reviews
- `git diff --check`
- Reference, privacy, stale-case-law, and mechanism-specific-string scans
- `pnpm docs:drift`
- `pnpm build:workspace:incremental`
- `pnpm typecheck`
- Contracts artifact verification and fixture/scenario-manifest integrity passed

The repository classifies text-only Markdown changes as requiring docs-specific verification rather than the broad runtime test suite. A broad local run was additionally attempted; its interactive-terminal run was invalid, and a non-interactive rerun produced no failures before being stopped after a bounded shared-machine contention window.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786250174&installation_id=127572939&pr_number=518&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F518&signature=cbad33380d1853bb55719c421602d1093c61eede792b6c8b7d3ae670775d8f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->