### PR TITLE
Fix group chat onboarding routing

### DIFF
--- a/.github/workflows/host-support.yml
+++ b/.github/workflows/host-support.yml
@@ -191,6 +191,10 @@ jobs:
           for package_dir in ${{ matrix.packages }}; do
             if [[ "$package_dir" == "packages/cli" ]]; then
               env MURPH_PREPARED_CLI_RUNTIME_ARTIFACTS=1 MURPH_VITEST_MAX_WORKERS=50% pnpm exec vitest run --config packages/cli/vitest.workspace.ts --coverage
+            elif [[ "$package_dir" == "packages/assistant-engine" ]]; then
+              # The serialized coverage worker exceeds V8's default heap near
+              # the end of this package's 2,000-test suite.
+              env NODE_OPTIONS=--max-old-space-size=6144 MURPH_VITEST_MAX_WORKERS=50% pnpm --dir "$package_dir" test:coverage
             else
               env MURPH_VITEST_MAX_WORKERS=50% pnpm --dir "$package_dir" test:coverage
             fi

--- a/agent-docs/exec-plans/completed/2026-07-10-group-chat-onboarding-guard.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-group-chat-onboarding-guard.md
@@ -1,0 +1,72 @@
+# Group-chat onboarding guard
+
+Status: completed
+Updated: 2026-07-10
+
+## Why
+
+A production iMessage group-chat turn entered Murph's personal onboarding flow
+and asked one participant for profile and health-goal details. Group containers
+must stay in group mode; personal onboarding belongs only to the member's
+private conversation.
+
+## Evidence and decision gate
+
+- Production metadata shows two distinct inbound turns. Each produced one
+  assistant cycle and its intentionally split outbound bubbles; no duplicate
+  webhook, model retry, or transport retry explains the behavior.
+- Both turns reached the personal active-member planner path instead of the
+  thread-container route. Existing safe diagnostics did not record the webhook
+  group flag, provider version, or imported directness, so they cannot
+  distinguish a missing flag from an incorrectly direct flag.
+- The current Linq webhook schema carries group truth on the chat object, while
+  the canonical chat-read endpoint also returns that truth. Resolve inbound
+  iMessage classification from the canonical chat record before planning when
+  the webhook does not already attest a group, with a bounded lookup.
+- Classification must be stable across at-least-once webhook retries. If the
+  canonical read fails or omits group truth, return a retryable server failure
+  before any receipt, route, or mailbox write; falling back to the signed
+  webhook could route one delivery personally and a later retry to the group
+  container because those owners have different dedupe scopes.
+- Independently prevent personal onboarding guidance whenever existing
+  conversation policy says the effective thread is a group. Preserve direct
+  and unknown-directness onboarding behavior.
+- Do not add persisted state, a second heuristic classifier, or speculative
+  compatibility parsing for a payload shape that could not have reached the
+  observed planner path.
+
+## Scope
+
+Owners are Linq chat classification at hosted web ingress and onboarding
+guidance admission in assistant route planning. Focused changes live in the
+existing Linq client/webhook service and assistant planning primitive, with
+their direct tests. Preserve direct-message onboarding, current-inbound
+replies, group tools, and existing delivery behavior.
+
+## Verification
+
+- Focused hosted-web regressions: 171/171 passed, covering stale and omitted
+  webhook directness, canonical group/direct classification, unavailable
+  classification fail-closed behavior, caller cancellation, retryable HTTP
+  status, and the existing Linq ingress surface.
+- Focused assistant planning regressions: 32/32 passed, covering group
+  suppression plus explicit-direct and unknown-directness onboarding controls.
+- Diff-aware guards and all six affected package typechecks passed. Its
+  assistant-engine surface passed 2,009 tests; eight load-sensitive timing
+  tests in two unchanged assistant-runtime files failed under the saturated
+  broad run, then both files passed 195/195 in an isolated serial rerun.
+- Hosted-web lint completed with zero errors; changed-file lint and
+  `git diff --check` passed.
+- Security/privacy re-audit found no medium-or-higher issue after the
+  fail-closed retry correction. Coverage-write added omitted-directness and
+  explicit-direct controls, with no remaining scoped coverage finding.
+- Parent diff review and PR review loop on the final head.
+
+## Deployment
+
+No persisted-data migration is required. Deploy the Cloudflare assistant
+runtime guard before the hosted web ingress correction, then verify one group
+turn routes to a thread container without onboarding guidance. The reverse
+order leaves a temporary window where correctly routed fresh group containers
+can still receive the old onboarding instructions.
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-10-pr522-assistant-coverage-memory.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr522-assistant-coverage-memory.md
@@ -1,0 +1,41 @@
+# PR 522 Assistant Coverage Memory
+
+## Goal
+
+Make the assistant-engine release coverage check complete reliably after two
+same-head CI runs exhausted the default V8 heap after all package tests passed.
+
+## Constraints
+
+- Keep the change scoped to CI verification; do not alter product behavior or
+  weaken coverage.
+- Preserve the existing serialized CI test behavior and package shard layout.
+- Increase memory only for the assistant-engine coverage command.
+- Verify the exact CI-mode command locally before pushing.
+
+## Working Set
+
+- `.github/workflows/host-support.yml`
+- `agent-docs/exec-plans/active/COORDINATION_LEDGER.md`
+
+## Verification Plan
+
+- Run the assistant-engine coverage command with CI-mode concurrency and the
+  scoped heap setting.
+- Run workflow/repository verification and typecheck.
+- Push the exact head and require the assistant coverage CI shard to pass.
+- Complete a valid exact-head ReviewGPT round after CI is green.
+
+## Verification Results
+
+- The exact serialized CI-mode assistant-engine coverage command passed: 142
+  files passed, 1 skipped; 2,009 tests passed, 4 skipped.
+- Repository verification-tool tests passed: 18 files and 300 tests.
+- Full workspace typecheck passed.
+- Doc gardening completed with zero issues.
+- Independent focused review found no evidence-backed medium-or-higher issue;
+  the heap override is limited to the one failing package command.
+
+Status: completed
+Updated: 2026-07-10
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-10-pr522-reviewgpt-followup.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr522-reviewgpt-followup.md
@@ -1,0 +1,69 @@
+# PR 522 ReviewGPT Follow-up
+
+## Goal
+
+Resolve every evidence-backed finding from the final-head review of the group-chat
+onboarding guard while preserving direct-message onboarding and bounded webhook
+ingress.
+
+## Constraints
+
+- Keep group/directness as tri-state data until a decision explicitly requires a
+  boolean attestation.
+- Preserve existing direct SMS/RCS onboarding when provider directness is unknown.
+- Bound canonical Linq chat classification across both headers and response-body
+  consumption, with caller cancellation preserved.
+- Use only the documented canonical Linq chat-read response shape.
+- Do not modify the archived original execution plan.
+- Keep the deployment handoff coordinated: the guarded runner bundle must fully
+  replace old warm runners before corrected web ingress is deployed.
+
+## Working Set
+
+- `apps/web/src/lib/hosted-onboarding/linq-client.ts`
+- `apps/web/src/lib/linq/api.ts`
+- `apps/web/src/lib/hosted-onboarding/webhook-service.ts`
+- `apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts`
+- focused hosted onboarding tests
+- `packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts`
+- focused assistant runtime and planning tests
+- PR deployment description
+
+## Verification Plan
+
+- Focused regression tests for SMS/RCS unknown directness and iMessage group/direct
+  classification.
+- Real HTTP-server tests proving the classification deadline and caller abort cover
+  a stalled response body.
+- Full web typecheck, full web tests, lint, and diff/privacy checks.
+- Completion re-audits for the accepted findings.
+- Push the final head, wait for green CI, and rerun ReviewGPT until zero accepted
+  findings on a valid exact-head round.
+
+## Review Resolution
+
+- Accepted: omitted SMS/RCS directness was being collapsed to confirmed group.
+  Semantic directness is now tri-state through webhook planning and mailbox import;
+  direct-chat attestation remains boolean only where route binding requires it.
+- Accepted: the chat-read deadline ended after response headers. One shared Linq
+  request primitive now owns fetch, response-body consumption, timeout, and caller
+  cancellation as a single operation.
+- Deployment concern already covered in the PR contract: runner first with immediate
+  rollout or verified old-runner drain. The final PR description must name the
+  deployed bundle-fingerprint smoke and rollback floor explicitly.
+- Accepted: the chat-read parser admitted an undocumented nested webhook shape. It
+  now accepts only the pinned SDK's canonical top-level Chat response.
+
+## Verification Results
+
+- Focused hosted web regressions: 137 passed.
+- Explicit thread-route regressions: 30 passed.
+- Focused assistant-runtime mailbox regressions: 58 passed.
+- Full serialized diff lane passed, including 1,495 assistant-runtime tests, 4,048
+  hosted web tests, 1,679 Cloudflare tests, production web build/typecheck/lint,
+  dependency/boundary guards, and runtime smoke checks.
+- Reliability, product-flow/privacy, and simplicity/provider-boundary re-audits:
+  no evidence-backed medium-or-higher findings.
+Status: completed
+Updated: 2026-07-10
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-10-pr522-reviewgpt-round6.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr522-reviewgpt-round6.md
@@ -1,0 +1,45 @@
+# PR 522 ReviewGPT Round 6
+
+## Goal
+
+Close the validated final-review findings without weakening group-chat privacy:
+classify ambiguous inbound Linq chats before mutation, let durable thread routes
+avoid unnecessary provider reads, preserve legacy ambiguous-message fail-closed
+behavior, and make the coordinated rollout contract operationally executable.
+
+## Constraints
+
+- A durable `HostedThreadRoute` remains the group-container authority.
+- Route-less inbound Linq traffic must not reach personal onboarding without
+  canonical direct/group truth.
+- Persisted `false` and `null` directness remain fail-closed in the runner.
+- Do not hold a database transaction open across a Linq network request.
+- Prefer the existing route store, canonical chat reader, and planning branches;
+  add no new durable state or compatibility manager.
+- Preserve metadata-only diagnostics and retry-before-mutation behavior.
+
+## Implementation
+
+1. Resolve Prisma before classification and pre-read an existing Linq thread
+   route for ambiguous inbound messages.
+2. When a route exists, inject conservative group truth and skip canonical Linq
+   lookup; keep the planner's transactional route re-read authoritative.
+3. When no route exists, canonicalize every inbound Linq service, including SMS
+   and RCS, before planning.
+4. Add focused regressions for routed canonical-failure bypass, SMS/RCS direct and
+   group classification, and retryable pre-mutation classification failure.
+5. Strengthen the PR rollout contract to hold web production until guarded runner
+   convergence and the old-container drain window are proven.
+
+## Verification
+
+- Focused hosted-web classification and thread-route tests.
+- Focused assistant channel/import/planning tests preserving legacy ambiguity.
+- Web and affected package typechecks/lint.
+- Required diff-aware/full verification and completion audits.
+- Green PR CI and a valid exact-head ReviewGPT round using both a 120-minute
+  browser timeout and response timeout.
+
+Status: completed
+Updated: 2026-07-10
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-10-pr522-routed-group-directness.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr522-routed-group-directness.md
@@ -1,0 +1,51 @@
+# PR 522 Routed Group Directness
+
+## Goal
+
+Make the durable Linq thread-container route the audience authority so every
+routed group wake remains non-direct even if later provider metadata is missing
+or temporarily reports a direct chat.
+
+## Constraints
+
+- Linq `HostedThreadRoute` is a group-container route; do not let mutable
+  provider metadata relabel its shared audience.
+- Keep tri-state provider directness for member/private paths without a durable
+  thread-container route.
+- Use the existing route primitive as proof; add no state or abstraction.
+- Preserve the existing mailbox and assistant-planning boundaries.
+
+## Working Set
+
+- `apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts`
+- `apps/web/test/hosted-onboarding-linq-thread-route.test.ts`
+- existing mailbox-import and assistant-planning regression coverage
+- `agent-docs/exec-plans/active/COORDINATION_LEDGER.md`
+
+## Verification Plan
+
+- Prove existing routed turns emit `threadIsDirect: false` when provider
+  directness is group, unknown, or direct.
+- Re-run mailbox-import and assistant-planning regressions that preserve false
+  and suppress onboarding.
+- Run web typecheck, targeted lint, and the serialized diff lane.
+- Run independent completion review and privacy checks.
+- Commit, push, require green exact-head CI, and rerun ReviewGPT.
+
+## Verification Results
+
+- Independent code-path validation confirmed that provider `true` or `null`
+  could overwrite stored routed-group directness and re-enable onboarding.
+- Routed-thread tests passed: 30 tests, covering group, omitted, and
+  contradictory direct provider metadata as non-direct.
+- Mailbox-import preservation passed: 58 tests.
+- Conversation-policy and onboarding-planning seams passed: 51 tests.
+- Web typecheck and targeted lint passed.
+- The serialized diff lane passed, including 4,048 web tests, production build,
+  typecheck, lint with zero errors, and development smoke.
+- Diff/privacy scans passed, and completion audit found no evidence-backed
+  medium-or-higher issue.
+
+Status: completed
+Updated: 2026-07-10
+Completed: 2026-07-10

--- a/agent-docs/exec-plans/completed/2026-07-10-pr522-service-classifier-owner.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr522-service-classifier-owner.md
@@ -1,0 +1,46 @@
+# PR 522 Service Classifier Ownership
+
+## Goal
+
+Remove the duplicate webhook-layer Linq service classifier so the messaging
+ingress parser remains the sole owner of service precedence before canonical
+iMessage chat classification.
+
+## Constraints
+
+- Keep the exact-chat lookup as the sole owner of group/direct truth for
+  resolved iMessage traffic.
+- Preserve SMS/RCS handling without the canonical chat dependency.
+- Delete duplicate normalization instead of adding another abstraction.
+- Keep the change limited to the current PR's webhook planning boundary and a
+  focused regression test.
+
+## Working Set
+
+- `apps/web/src/lib/hosted-onboarding/webhook-service.ts`
+- `apps/web/test/hosted-onboarding-linq-dispatch.test.ts`
+- `agent-docs/exec-plans/active/COORDINATION_LEDGER.md`
+
+## Verification Plan
+
+- Prove a resolved SMS/RCS event with conflicting preferred-service metadata
+  bypasses the canonical iMessage chat lookup.
+- Run the focused hosted onboarding dispatch suite and web typecheck.
+- Run required diff/privacy checks and completion review.
+- Commit, push, wait for green exact-head CI, and rerun ReviewGPT.
+
+## Verification Results
+
+- The focused dispatch suite passed: 118 tests.
+- Web typecheck and targeted lint passed.
+- The serialized diff lane passed, including 4,048 web tests, production build,
+  typecheck, lint with zero errors, and development smoke.
+- Diff and privacy scans passed.
+- Independent validation reproduced the old parser/classifier disagreement and
+  confirmed the regression fails the old implementation.
+- Completion audit found no evidence-backed medium-or-higher correctness,
+  reliability, security/privacy, or simplicity issue.
+
+Status: completed
+Updated: 2026-07-10
+Completed: 2026-07-10

--- a/apps/cloudflare/test/helpers/hosted-local-dev-harness.test.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-dev-harness.test.ts
@@ -93,7 +93,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-it("passes the harness process pid to hosted web dev for orphan cleanup", async () => {
+it("passes host-only web overrides with the harness process pid", async () => {
   const { startHostedLocalDevHarness } = await import("./hosted-local-dev-harness.js");
 
   const harness = await startHostedLocalDevHarness({
@@ -102,6 +102,9 @@ it("passes the harness process pid to hosted web dev for orphan cleanup", async 
       NEXT_DIST_DIR_MODE: "smoke",
     },
     persistDirPrefix: "murph-hosted-local-test-",
+    webProcessEnvOverrides: {
+      LINQ_API_BASE_URL: "http://127.0.0.1:4011",
+    },
   });
 
   await harness.stop();
@@ -113,6 +116,9 @@ it("passes the harness process pid to hosted web dev for orphan cleanup", async 
       NEXT_DIST_DIR_SUFFIX: expect.stringMatching(/^e2e-[a-f0-9-]+$/),
     }),
     pipeOutput: false,
+    webProcessEnvOverrides: {
+      LINQ_API_BASE_URL: "http://127.0.0.1:4011",
+    },
   });
 });
 

--- a/apps/cloudflare/test/helpers/hosted-local-dev-harness.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-dev-harness.ts
@@ -97,6 +97,7 @@ export async function startHostedLocalDevHarness(input: {
   statusPath?: (userId: string) => string;
   streamLogs?: boolean;
   testControls?: boolean;
+  webProcessEnvOverrides?: NodeJS.ProcessEnv;
 }): Promise<HostedLocalDevHarness> {
   const config = resolveHostedLocalDevConfig(input.env);
   const workerBaseUrl =
@@ -155,6 +156,9 @@ export async function startHostedLocalDevHarness(input: {
     stack = await startHostedLocalDevStack({
       env: runtimeEnv,
       pipeOutput: streamLogs,
+      ...(input.webProcessEnvOverrides
+        ? { webProcessEnvOverrides: input.webProcessEnvOverrides }
+        : {}),
     });
 
     try {

--- a/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHostedLocalFullStackWebProcessEnvOverrides,
+} from "./hosted-local-full-stack-scenario.js";
+
+describe("hosted local full-stack web process environment", () => {
+  it("gives the host web process loopback access to the shared Linq stub", () => {
+    expect(buildHostedLocalFullStackWebProcessEnvOverrides({
+      LINQ_API_BASE_URL: "http://host.docker.internal:4011/api/partner/v3",
+    })).toEqual({
+      LINQ_API_BASE_URL: "http://127.0.0.1:4011/api/partner/v3",
+    });
+  });
+
+  it("does not replace a non-stub Linq origin", () => {
+    expect(buildHostedLocalFullStackWebProcessEnvOverrides({
+      LINQ_API_BASE_URL: "https://api.linqapp.com/api/partner/v3",
+    })).toEqual({});
+  });
+});

--- a/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.ts
@@ -310,6 +310,7 @@ export async function startHostedLocalFullStackScenario(input: {
       statusPath: (userId: string) => `/internal/users/${encodeURIComponent(userId)}/status`,
       streamLogs: input.streamLogs,
       testControls,
+      webProcessEnvOverrides: buildHostedLocalFullStackWebProcessEnvOverrides(runtimeEnv),
     });
     preparedRunnerBundleCacheKeys.add(runnerBundleCacheKey);
     const scenarioHarness = harness;
@@ -501,6 +502,34 @@ export async function startHostedLocalFullStackScenario(input: {
     await localDatabase.cleanup().catch(() => {});
     throw error;
   }
+}
+
+export function buildHostedLocalFullStackWebProcessEnvOverrides(
+  source: Readonly<NodeJS.ProcessEnv>,
+): NodeJS.ProcessEnv {
+  const configuredLinqBaseUrl = source.LINQ_API_BASE_URL?.trim();
+  if (!configuredLinqBaseUrl) {
+    return {};
+  }
+
+  let linqBaseUrl: URL;
+  try {
+    linqBaseUrl = new URL(configuredLinqBaseUrl);
+  } catch {
+    return {};
+  }
+
+  // The Linq E2E stub listens on one host port. Runner containers reach that
+  // port through Docker's host alias, while the host web process must use
+  // loopback on Linux. Keep the runner URL authoritative everywhere else.
+  if (linqBaseUrl.protocol !== "http:" || linqBaseUrl.hostname !== "host.docker.internal") {
+    return {};
+  }
+
+  linqBaseUrl.hostname = "127.0.0.1";
+  return {
+    LINQ_API_BASE_URL: linqBaseUrl.toString().replace(/\/$/u, ""),
+  };
 }
 
 function resolveHostedLocalScenarioTestControls(input: {

--- a/apps/cloudflare/test/helpers/hosted-local-linq-support.test.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-linq-support.test.ts
@@ -5,10 +5,30 @@ import type {
 } from "@murphai/hosted-execution/runtime-control";
 
 import {
+  startHostedLocalLinqStub,
   shouldExpireHostedLocalLinqWaitInFlightForStatus,
   shouldNudgeHostedLocalLinqWaitForStatus,
   shouldRunHostedLocalLinqWaitAlarmInvocationForStatus,
 } from "./hosted-local-linq-support.js";
+
+describe("hosted local Linq provider stub", () => {
+  it("serves canonical direct-chat summaries through its shared runtime URL", async () => {
+    const stub = await startHostedLocalLinqStub();
+
+    try {
+      const response = await fetch(`${stub.runnerBaseUrl}/chats/chat_direct`);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        handles: [],
+        id: "chat_direct",
+        is_group: false,
+      });
+    } finally {
+      await stub.stop();
+    }
+  });
+});
 
 describe("hosted local Linq wait recovery policy", () => {
   it("does not nudge active, errored, or caught-up runner status", () => {

--- a/apps/cloudflare/test/helpers/hosted-local-linq-support.test.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-linq-support.test.ts
@@ -16,7 +16,8 @@ describe("hosted local Linq provider stub", () => {
     const stub = await startHostedLocalLinqStub();
 
     try {
-      const response = await fetch(`${stub.runnerBaseUrl}/chats/chat_direct`);
+      expect(new URL(stub.runnerBaseUrl).hostname).toBe("host.docker.internal");
+      const response = await fetch(`${stub.baseUrl}/chats/chat_direct`);
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toEqual({

--- a/apps/cloudflare/test/helpers/hosted-local-linq-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-linq-support.ts
@@ -43,6 +43,7 @@ const hostedLocalLinqObservedRequestWaitTimeoutMs = 180_000;
 const hostedLocalLinqWaitExpireAfterInFlightMs = 30_000;
 const hostedLocalLinqWaitNudgeAfterMailboxLagMs = 15_000;
 const hostedLocalLinqWaitAlarmAfterPendingDeliveryMs = 2_000;
+const hostedLocalRunnerProviderHost = "host.docker.internal";
 
 type HostedLinqInboundPartInput =
   | {
@@ -319,6 +320,7 @@ export async function startHostedLocalLinqStub(input: {
   const baseUrl = `http://127.0.0.1:${tcpPort}`;
   const containerBaseUrl =
     `http://${formatHostedLocalLinqUrlHost(resolveHostedLocalLinqContainerHost())}:${tcpPort}`;
+  const runnerBaseUrl = `http://${hostedLocalRunnerProviderHost}:${tcpPort}`;
   attachmentDownloadBaseUrl = `${baseUrl}${linqAttachmentDownloadBasePath}`;
   attachmentDownloadContainerBaseUrl =
     `${containerBaseUrl}${linqAttachmentDownloadBasePath}`;
@@ -449,9 +451,7 @@ export async function startHostedLocalLinqStub(input: {
 
       return latestMessageId;
     },
-    // The full-stack harness shares this value with the host web process.
-    // Runner container env construction rewrites loopback to its host alias.
-    runnerBaseUrl: baseUrl,
+    runnerBaseUrl,
     stop: async () => {
       await stopHttpStubServer(activeServer);
       server = null;

--- a/apps/cloudflare/test/helpers/hosted-local-linq-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-linq-support.ts
@@ -43,7 +43,6 @@ const hostedLocalLinqObservedRequestWaitTimeoutMs = 180_000;
 const hostedLocalLinqWaitExpireAfterInFlightMs = 30_000;
 const hostedLocalLinqWaitNudgeAfterMailboxLagMs = 15_000;
 const hostedLocalLinqWaitAlarmAfterPendingDeliveryMs = 2_000;
-const hostedLocalRunnerProviderHost = "host.docker.internal";
 
 type HostedLinqInboundPartInput =
   | {
@@ -201,6 +200,16 @@ export async function startHostedLocalLinqStub(input: {
       return;
     }
 
+    if (request.method === "GET" && request.url && /^\/chats\/[^/]+$/u.test(request.url)) {
+      const chatId = decodeURIComponent(request.url.split("/")[2] ?? "unknown");
+      writeJsonResponse(response, 200, {
+        handles: [],
+        id: chatId,
+        is_group: false,
+      });
+      return;
+    }
+
     if (
       request.method === "POST"
       && request.url
@@ -310,7 +319,6 @@ export async function startHostedLocalLinqStub(input: {
   const baseUrl = `http://127.0.0.1:${tcpPort}`;
   const containerBaseUrl =
     `http://${formatHostedLocalLinqUrlHost(resolveHostedLocalLinqContainerHost())}:${tcpPort}`;
-  const runnerBaseUrl = `http://${hostedLocalRunnerProviderHost}:${tcpPort}`;
   attachmentDownloadBaseUrl = `${baseUrl}${linqAttachmentDownloadBasePath}`;
   attachmentDownloadContainerBaseUrl =
     `${containerBaseUrl}${linqAttachmentDownloadBasePath}`;
@@ -441,7 +449,9 @@ export async function startHostedLocalLinqStub(input: {
 
       return latestMessageId;
     },
-    runnerBaseUrl,
+    // The full-stack harness shares this value with the host web process.
+    // Runner container env construction rewrites loopback to its host alias.
+    runnerBaseUrl: baseUrl,
     stop: async () => {
       await stopHttpStubServer(activeServer);
       server = null;

--- a/apps/web/src/lib/hosted-onboarding/linq-client.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-client.ts
@@ -192,16 +192,23 @@ export type HostedLinqChatHandleSummary = {
   status: string | null;
 };
 
-export async function getHostedLinqChatHandles(input: {
+export type HostedLinqChatSummary = {
+  handles: HostedLinqChatHandleSummary[];
+  isGroup: boolean | null;
+};
+
+export async function getHostedLinqChatSummary(input: {
   chatId: string;
   signal?: AbortSignal;
-}): Promise<HostedLinqChatHandleSummary[]> {
+  timeoutMs?: number;
+}): Promise<HostedLinqChatSummary> {
   const response = await fetchHostedLinqApiOrThrow({
     method: "GET",
     operation: "chat read",
     path: `chats/${encodeURIComponent(normalizeRequiredString(input.chatId, "chat id"))}`,
     signal: input.signal,
     timeoutMessage: "Linq chat read timed out.",
+    timeoutMs: input.timeoutMs,
   });
 
   if (!response.ok) {
@@ -213,18 +220,34 @@ export async function getHostedLinqChatHandles(input: {
   }
 
   const payload = await readHostedLinqOptionalJsonResponse<{
-    chat?: { handles?: unknown } | null;
+    chat?: { handles?: unknown; is_group?: unknown } | null;
     handles?: unknown;
+    is_group?: unknown;
   }>(response);
   const handles = Array.isArray(payload?.handles)
     ? payload.handles
     : Array.isArray(payload?.chat?.handles)
       ? payload.chat.handles
       : [];
+  const isGroup = typeof payload?.is_group === "boolean"
+    ? payload.is_group
+    : typeof payload?.chat?.is_group === "boolean"
+      ? payload.chat.is_group
+      : null;
 
-  return handles
-    .map(parseHostedLinqChatHandleSummary)
-    .filter((handle): handle is HostedLinqChatHandleSummary => handle !== null);
+  return {
+    handles: handles
+      .map(parseHostedLinqChatHandleSummary)
+      .filter((handle): handle is HostedLinqChatHandleSummary => handle !== null),
+    isGroup,
+  };
+}
+
+export async function getHostedLinqChatHandles(input: {
+  chatId: string;
+  signal?: AbortSignal;
+}): Promise<HostedLinqChatHandleSummary[]> {
+  return (await getHostedLinqChatSummary(input)).handles;
 }
 
 function parseHostedLinqChatHandleSummary(value: unknown): HostedLinqChatHandleSummary | null {
@@ -411,6 +434,7 @@ async function fetchHostedLinqApiOrThrow(input: {
   path: string;
   signal?: AbortSignal;
   timeoutMessage: string;
+  timeoutMs?: number;
 }): Promise<Response> {
   const { apiBaseUrl, apiToken } = requireHostedOnboardingLinqConfig();
 
@@ -422,6 +446,7 @@ async function fetchHostedLinqApiOrThrow(input: {
       method: input.method,
       path: input.path,
       signal: input.signal,
+      timeoutMs: input.timeoutMs,
     });
   } catch (error) {
     if (error instanceof LinqApiTimeoutError) {

--- a/apps/web/src/lib/hosted-onboarding/linq-client.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-client.ts
@@ -6,6 +6,7 @@ import {
 } from "@murphai/hosted-execution/runtime-control";
 import type { TextPart } from "@linqapp/sdk/resources";
 import type {
+  Chat,
   ChatCreateParams,
   ChatCreateResponse,
   ChatUpdateParams,
@@ -13,7 +14,7 @@ import type {
   MessageSendResponse,
 } from "@linqapp/sdk/resources/chats";
 
-import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
+import { fetchLinqApi, fetchLinqApiJson, LinqApiTimeoutError } from "../linq/api";
 import { hostedOnboardingError, isHostedOnboardingError } from "./errors";
 import { requireHostedOnboardingLinqConfig } from "./runtime";
 import { normalizeNullableString } from "./shared";
@@ -202,9 +203,8 @@ export async function getHostedLinqChatSummary(input: {
   signal?: AbortSignal;
   timeoutMs?: number;
 }): Promise<HostedLinqChatSummary> {
-  const response = await fetchHostedLinqApiOrThrow({
+  const response = await fetchHostedLinqJsonApiOrThrow({
     method: "GET",
-    operation: "chat read",
     path: `chats/${encodeURIComponent(normalizeRequiredString(input.chatId, "chat id"))}`,
     signal: input.signal,
     timeoutMessage: "Linq chat read timed out.",
@@ -219,27 +219,33 @@ export async function getHostedLinqChatSummary(input: {
     });
   }
 
-  const payload = await readHostedLinqOptionalJsonResponse<{
-    chat?: { handles?: unknown; is_group?: unknown } | null;
-    handles?: unknown;
-    is_group?: unknown;
-  }>(response);
-  const handles = Array.isArray(payload?.handles)
-    ? payload.handles
-    : Array.isArray(payload?.chat?.handles)
-      ? payload.chat.handles
-      : [];
-  const isGroup = typeof payload?.is_group === "boolean"
-    ? payload.is_group
-    : typeof payload?.chat?.is_group === "boolean"
-      ? payload.chat.is_group
-      : null;
+  const payload = readHostedLinqCanonicalChat(response.payload);
+  const handles: Chat["handles"] = payload?.handles ?? [];
+  const isGroup: Chat["is_group"] | null = payload?.is_group ?? null;
 
   return {
     handles: handles
       .map(parseHostedLinqChatHandleSummary)
       .filter((handle): handle is HostedLinqChatHandleSummary => handle !== null),
     isGroup,
+  };
+}
+
+function readHostedLinqCanonicalChat(
+  value: unknown,
+): Pick<Chat, "handles" | "is_group"> | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.handles) || typeof record.is_group !== "boolean") {
+    return null;
+  }
+
+  return {
+    handles: record.handles,
+    is_group: record.is_group,
   };
 }
 
@@ -443,6 +449,38 @@ async function fetchHostedLinqApiOrThrow(input: {
       apiBaseUrl,
       apiToken,
       body: input.body,
+      method: input.method,
+      path: input.path,
+      signal: input.signal,
+      timeoutMs: input.timeoutMs,
+    });
+  } catch (error) {
+    if (error instanceof LinqApiTimeoutError) {
+      throw hostedOnboardingError({
+        code: "LINQ_SEND_FAILED",
+        message: input.timeoutMessage,
+        httpStatus: 502,
+        retryable: true,
+      });
+    }
+
+    throw error;
+  }
+}
+
+async function fetchHostedLinqJsonApiOrThrow(input: {
+  method: string;
+  path: string;
+  signal?: AbortSignal;
+  timeoutMessage: string;
+  timeoutMs?: number;
+}) {
+  const { apiBaseUrl, apiToken } = requireHostedOnboardingLinqConfig();
+
+  try {
+    return await fetchLinqApiJson({
+      apiBaseUrl,
+      apiToken,
       method: input.method,
       path: input.path,
       signal: input.signal,

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -1137,7 +1137,7 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
         parts: messageEvent.data.message.parts,
         service: messageEvent.data.service ?? null,
       }),
-      threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
+      threadIsDirect: false,
       ...(messageEvent.data.message.reply_to?.message_id === undefined
         ? {}
         : { replyToMessageId: messageEvent.data.message.reply_to.message_id }),

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -601,7 +601,7 @@ export async function planHostedOnboardingLinqWebhook(input: {
           parts: messageEvent.data.message.parts,
           service: messageEvent.data.service ?? null,
         }),
-        threadIsDirect: isHostedLinqDirectChatAttested(messageEvent),
+        threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
         ...(messageEvent.data.message.reply_to?.message_id === undefined
           ? {}
           : { replyToMessageId: messageEvent.data.message.reply_to.message_id }),
@@ -902,7 +902,7 @@ export async function planHostedOnboardingLinqWebhook(input: {
       occurredAt,
       service: messageEvent.data.service ?? null,
       sourceEventId: input.event.event_id,
-      threadIsDirect: isHostedLinqDirectChatAttested(messageEvent),
+      threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
     }),
     buildHostedLinqWebhookPlannerDetails(input.event, context, {
       chatDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
@@ -1137,7 +1137,7 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
         parts: messageEvent.data.message.parts,
         service: messageEvent.data.service ?? null,
       }),
-      threadIsDirect: isHostedLinqDirectChatAttested(messageEvent),
+      threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
       ...(messageEvent.data.message.reply_to?.message_id === undefined
         ? {}
         : { replyToMessageId: messageEvent.data.message.reply_to.message_id }),
@@ -1883,6 +1883,13 @@ function isHostedLinqDirectChatAttested(
   messageEvent: HostedLinqMessageReceivedEvent,
 ): boolean {
   return messageEvent.data.chat?.is_group === false;
+}
+
+function resolveHostedLinqThreadIsDirect(
+  messageEvent: HostedLinqMessageReceivedEvent,
+): boolean | null {
+  const isGroup = messageEvent.data.chat?.is_group;
+  return typeof isGroup === "boolean" ? !isGroup : null;
 }
 
 async function readRetryableUnsentFallbackRecipientPhone(input: {

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -19,6 +19,9 @@ import {
   type HostedOnboardingLinqWebhookResponse,
 } from "./webhook-provider-linq";
 import {
+  isHostedLinqIMessageService,
+} from "./webhook-provider-linq-shared";
+import {
   planHostedOnboardingTelegramWebhook,
   type HostedOnboardingTelegramWebhookResponse,
 } from "./webhook-provider-telegram";
@@ -449,7 +452,10 @@ async function resolveHostedLinqPlanningEvent(input: {
     return messageEvent;
   }
 
-  if (messageEvent.data.is_from_me || !isHostedLinqIMessage(messageEvent)) {
+  if (
+    messageEvent.data.is_from_me
+    || !isHostedLinqIMessageService(messageEvent.data.service)
+  ) {
     if (webhookIsGroup === false) {
       logHostedLinqChatClassification("webhook-direct");
     }
@@ -500,17 +506,6 @@ async function resolveHostedLinqPlanningEvent(input: {
       },
     },
   };
-}
-
-function isHostedLinqIMessage(
-  event: ReturnType<typeof requireHostedLinqMessageReceivedEvent>,
-): boolean {
-  return [
-    event.data.preferred_service,
-    event.data.service,
-    event.data.sender_handle?.service,
-    event.data.chat?.owner_handle?.service,
-  ].some((service) => service?.trim().toLowerCase() === "imessage");
 }
 
 function logHostedLinqChatClassification(

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -9,6 +9,10 @@ import {
   sendHostedLinqReadReceipt,
   verifyAndParseHostedLinqWebhookRequest,
 } from "./linq";
+import {
+  getHostedLinqChatSummary,
+} from "./linq-client";
+import { hostedOnboardingError } from "./errors";
 import { assertHostedTelegramWebhookSecret, parseHostedTelegramWebhookUpdate } from "./telegram";
 import {
   planHostedOnboardingLinqWebhook,
@@ -96,6 +100,8 @@ export type {
 } from "./webhook-service-types";
 
 type HostedWebhookPostResponseScheduler = (task: () => Promise<void>) => void;
+
+const HOSTED_LINQ_CHAT_CLASSIFICATION_TIMEOUT_MS = 1_500;
 
 export async function handleHostedOnboardingLinqWebhook(input: {
   rawBody: string;
@@ -216,6 +222,11 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       return response;
     }
 
+    const planningEvent = await resolveHostedLinqPlanningEvent({
+      event,
+      signal: input.signal,
+    });
+
     const currentInboundReply: HostedLinqCurrentInboundReplyProof | null =
       event.event_type === "message.received"
         ? buildHostedLinqCurrentInboundReplyProof(event)
@@ -248,7 +259,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
           prisma,
           (transaction) =>
             planHostedOnboardingLinqWebhook({
-              event,
+              event: planningEvent,
               firstContactAdmitted: recordedAdmission?.kind === "allow",
               requireFirstContactAdmission,
               prisma: transaction,
@@ -276,7 +287,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
               prisma,
               (transaction) =>
                 planHostedOnboardingLinqWebhook({
-                  event,
+                  event: planningEvent,
                   firstContactAdmitted: true,
                   requireFirstContactAdmission,
                   prisma: transaction,
@@ -329,7 +340,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
                 prisma,
                 (transaction) =>
                   planHostedOnboardingLinqWebhook({
-                    event,
+                    event: planningEvent,
                     firstContactAdmitted: true,
                     requireFirstContactAdmission,
                     prisma: transaction,
@@ -421,6 +432,98 @@ export async function handleHostedOnboardingLinqWebhook(input: {
     });
     throw error;
   }
+}
+
+async function resolveHostedLinqPlanningEvent(input: {
+  event: Parameters<typeof requireHostedLinqMessageReceivedEvent>[0];
+  signal?: AbortSignal;
+}): Promise<Parameters<typeof requireHostedLinqMessageReceivedEvent>[0]> {
+  if (input.event.event_type !== "message.received") {
+    return input.event;
+  }
+
+  const messageEvent = requireHostedLinqMessageReceivedEvent(input.event);
+  const webhookIsGroup = messageEvent.data.chat?.is_group;
+  if (webhookIsGroup === true) {
+    logHostedLinqChatClassification("webhook-group");
+    return messageEvent;
+  }
+
+  if (messageEvent.data.is_from_me || !isHostedLinqIMessage(messageEvent)) {
+    if (webhookIsGroup === false) {
+      logHostedLinqChatClassification("webhook-direct");
+    }
+    return messageEvent;
+  }
+
+  let canonicalIsGroup: boolean | null;
+  try {
+    const summary = await getHostedLinqChatSummary({
+      chatId: messageEvent.data.chat_id,
+      timeoutMs: HOSTED_LINQ_CHAT_CLASSIFICATION_TIMEOUT_MS,
+      ...(input.signal ? { signal: input.signal } : {}),
+    });
+    canonicalIsGroup = summary.isGroup;
+  } catch (error) {
+    logHostedLinqChatClassification("canonical-unavailable");
+    if (input.signal?.aborted) {
+      throw error;
+    }
+    throw hostedOnboardingError({
+      cause: error,
+      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      httpStatus: 502,
+      message: "Linq chat classification is unavailable.",
+      retryable: true,
+    });
+  }
+
+  if (canonicalIsGroup === null) {
+    logHostedLinqChatClassification("canonical-unavailable");
+    throw hostedOnboardingError({
+      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      httpStatus: 502,
+      message: "Linq chat classification is unavailable.",
+      retryable: true,
+    });
+  }
+
+  logHostedLinqChatClassification(canonicalIsGroup ? "canonical-group" : "canonical-direct");
+  return {
+    ...messageEvent,
+    data: {
+      ...messageEvent.data,
+      chat: {
+        id: messageEvent.data.chat_id,
+        ...(messageEvent.data.chat ?? {}),
+        is_group: canonicalIsGroup,
+      },
+    },
+  };
+}
+
+function isHostedLinqIMessage(
+  event: ReturnType<typeof requireHostedLinqMessageReceivedEvent>,
+): boolean {
+  return [
+    event.data.preferred_service,
+    event.data.service,
+    event.data.sender_handle?.service,
+    event.data.chat?.owner_handle?.service,
+  ].some((service) => service?.trim().toLowerCase() === "imessage");
+}
+
+function logHostedLinqChatClassification(
+  outcome:
+    | "canonical-direct"
+    | "canonical-group"
+    | "canonical-unavailable"
+    | "webhook-direct"
+    | "webhook-group",
+): void {
+  logHostedOnboardingDiagnostic("hosted-onboarding.webhook.linq.chat-classification", {
+    outcome,
+  });
 }
 
 async function maybeSendHostedLinqIngressReadReceipt(input: {

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -19,9 +19,6 @@ import {
   type HostedOnboardingLinqWebhookResponse,
 } from "./webhook-provider-linq";
 import {
-  isHostedLinqIMessageService,
-} from "./webhook-provider-linq-shared";
-import {
   planHostedOnboardingTelegramWebhook,
   type HostedOnboardingTelegramWebhookResponse,
 } from "./webhook-provider-telegram";
@@ -78,6 +75,7 @@ import {
 } from "./webhook-service-wake";
 import {
   assertHostedThreadRouteEgressAuthority,
+  readHostedThreadRouteByThreadIdentity,
 } from "../hosted-routing/thread-route-store";
 import {
   assertHostedLinqRouteAuthorityMatchesTarget,
@@ -225,8 +223,11 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       return response;
     }
 
+    input.signal?.throwIfAborted();
+    const prisma = input.prisma ?? getPrisma();
     const planningEvent = await resolveHostedLinqPlanningEvent({
       event,
+      prisma,
       signal: input.signal,
     });
 
@@ -235,7 +236,6 @@ export async function handleHostedOnboardingLinqWebhook(input: {
         ? buildHostedLinqCurrentInboundReplyProof(event)
         : null;
 
-    const prisma = input.prisma ?? getPrisma();
     const planTiming = startHostedOnboardingTiming(
       "hosted-onboarding.webhook.linq.plan",
       {
@@ -439,6 +439,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
 
 async function resolveHostedLinqPlanningEvent(input: {
   event: Parameters<typeof requireHostedLinqMessageReceivedEvent>[0];
+  prisma: PrismaClient;
   signal?: AbortSignal;
 }): Promise<Parameters<typeof requireHostedLinqMessageReceivedEvent>[0]> {
   if (input.event.event_type !== "message.received") {
@@ -452,49 +453,59 @@ async function resolveHostedLinqPlanningEvent(input: {
     return messageEvent;
   }
 
-  if (
-    messageEvent.data.is_from_me
-    || !isHostedLinqIMessageService(messageEvent.data.service)
-  ) {
+  if (messageEvent.data.is_from_me) {
     if (webhookIsGroup === false) {
       logHostedLinqChatClassification("webhook-direct");
     }
     return messageEvent;
   }
 
-  let canonicalIsGroup: boolean | null;
-  try {
-    const summary = await getHostedLinqChatSummary({
-      chatId: messageEvent.data.chat_id,
-      timeoutMs: HOSTED_LINQ_CHAT_CLASSIFICATION_TIMEOUT_MS,
-      ...(input.signal ? { signal: input.signal } : {}),
-    });
-    canonicalIsGroup = summary.isGroup;
-  } catch (error) {
-    logHostedLinqChatClassification("canonical-unavailable");
-    if (input.signal?.aborted) {
-      throw error;
+  const threadRoute = await readHostedThreadRouteByThreadIdentity({
+    channel: "linq",
+    prisma: input.prisma,
+    threadId: messageEvent.data.chat_id,
+  });
+  let resolvedIsGroup: boolean;
+  if (threadRoute) {
+    logHostedLinqChatClassification("thread-route-group");
+    resolvedIsGroup = true;
+  } else {
+    let canonicalIsGroup: boolean | null;
+    try {
+      const summary = await getHostedLinqChatSummary({
+        chatId: messageEvent.data.chat_id,
+        timeoutMs: HOSTED_LINQ_CHAT_CLASSIFICATION_TIMEOUT_MS,
+        ...(input.signal ? { signal: input.signal } : {}),
+      });
+      canonicalIsGroup = summary.isGroup;
+    } catch (error) {
+      logHostedLinqChatClassification("canonical-unavailable");
+      if (input.signal?.aborted) {
+        throw error;
+      }
+      throw hostedOnboardingError({
+        cause: error,
+        code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+        httpStatus: 502,
+        message: "Linq chat classification is unavailable.",
+        retryable: true,
+      });
     }
-    throw hostedOnboardingError({
-      cause: error,
-      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
-      httpStatus: 502,
-      message: "Linq chat classification is unavailable.",
-      retryable: true,
-    });
+
+    if (canonicalIsGroup === null) {
+      logHostedLinqChatClassification("canonical-unavailable");
+      throw hostedOnboardingError({
+        code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+        httpStatus: 502,
+        message: "Linq chat classification is unavailable.",
+        retryable: true,
+      });
+    }
+
+    logHostedLinqChatClassification(canonicalIsGroup ? "canonical-group" : "canonical-direct");
+    resolvedIsGroup = canonicalIsGroup;
   }
 
-  if (canonicalIsGroup === null) {
-    logHostedLinqChatClassification("canonical-unavailable");
-    throw hostedOnboardingError({
-      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
-      httpStatus: 502,
-      message: "Linq chat classification is unavailable.",
-      retryable: true,
-    });
-  }
-
-  logHostedLinqChatClassification(canonicalIsGroup ? "canonical-group" : "canonical-direct");
   return {
     ...messageEvent,
     data: {
@@ -502,7 +513,7 @@ async function resolveHostedLinqPlanningEvent(input: {
       chat: {
         id: messageEvent.data.chat_id,
         ...(messageEvent.data.chat ?? {}),
-        is_group: canonicalIsGroup,
+        is_group: resolvedIsGroup,
       },
     },
   };
@@ -513,6 +524,7 @@ function logHostedLinqChatClassification(
     | "canonical-direct"
     | "canonical-group"
     | "canonical-unavailable"
+    | "thread-route-group"
     | "webhook-direct"
     | "webhook-group",
 ): void {

--- a/apps/web/src/lib/linq/api.ts
+++ b/apps/web/src/lib/linq/api.ts
@@ -7,7 +7,7 @@ export class LinqApiTimeoutError extends Error {
 
 const DEFAULT_LINQ_API_TIMEOUT_MS = 10_000;
 
-export async function fetchLinqApi(input: {
+type LinqApiRequestInput = {
   apiBaseUrl: string;
   apiToken: string;
   body?: BodyInit | null;
@@ -15,14 +15,47 @@ export async function fetchLinqApi(input: {
   path: string;
   signal?: AbortSignal;
   timeoutMs?: number;
-}): Promise<Response> {
+};
+
+export async function fetchLinqApi(input: LinqApiRequestInput): Promise<Response> {
+  return runLinqApiRequest(input, (response) => response);
+}
+
+export async function fetchLinqApiJson(input: LinqApiRequestInput): Promise<{
+  ok: boolean;
+  payload: unknown | null;
+  status: number;
+}> {
+  return runLinqApiRequest(input, async (response) => {
+    const text = await response.text();
+    let payload: unknown | null = null;
+    if (text.trim()) {
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        payload = null;
+      }
+    }
+
+    return {
+      ok: response.ok,
+      payload,
+      status: response.status,
+    };
+  });
+}
+
+async function runLinqApiRequest<T>(
+  input: LinqApiRequestInput,
+  consumeResponse: (response: Response) => Promise<T> | T,
+): Promise<T> {
   const { didTimeout, signal, clearTimeout } = createTimedAbortSignal({
     signal: input.signal,
     timeoutMs: input.timeoutMs ?? DEFAULT_LINQ_API_TIMEOUT_MS,
   });
 
   try {
-    return await fetch(new URL(input.path, `${input.apiBaseUrl}/`), {
+    const response = await fetch(new URL(input.path, `${input.apiBaseUrl}/`), {
       method: input.method ?? "GET",
       headers: {
         authorization: `Bearer ${input.apiToken}`,
@@ -35,7 +68,12 @@ export async function fetchLinqApi(input: {
       body: input.body ?? undefined,
       signal,
     });
+    return await consumeResponse(response);
   } catch (error) {
+    if (input.signal?.aborted) {
+      throw input.signal.reason ?? error;
+    }
+
     if (didTimeout() && !input.signal?.aborted) {
       throw new LinqApiTimeoutError("Linq API request timed out.");
     }

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -119,6 +119,11 @@ const mocks = vi.hoisted(() => {
       remainingUsdMicros: 100_000n,
       spentUsdMicros: 0n,
     })),
+    getHostedLinqChatSummary: vi.fn(async () => ({
+      handles: [],
+      isGroup: false,
+    })),
+    logHostedOnboardingDiagnostic: vi.fn(),
     sendHostedLinqChatMessage: vi.fn(),
     createHostedLinqChat: vi.fn(),
     sendHostedLinqReadReceipt: vi.fn(),
@@ -269,6 +274,7 @@ vi.mock("../src/lib/hosted-onboarding/linq-client", async () => {
   return {
     ...actual,
     createHostedLinqChat: mocks.createHostedLinqChat,
+    getHostedLinqChatSummary: mocks.getHostedLinqChatSummary,
     sendHostedLinqChatMessage: mocks.sendHostedLinqChatMessage,
     sendHostedLinqReadReceipt: mocks.sendHostedLinqReadReceipt,
   };
@@ -345,6 +351,7 @@ vi.mock("@/src/lib/hosted-onboarding/logging", async () => {
     ...actual,
     deriveHostedOnboardingTimingErrorName: mocks.deriveHostedOnboardingTimingErrorName,
     finishHostedOnboardingTiming: mocks.finishHostedOnboardingTiming,
+    logHostedOnboardingDiagnostic: mocks.logHostedOnboardingDiagnostic,
     startHostedOnboardingTiming: mocks.startHostedOnboardingTiming,
   };
 });
@@ -757,7 +764,11 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     },
   );
 
-  it("does not add synthetic route authority to active-member direct iMessage wakes", async () => {
+  it("keeps active-member iMessage ingress direct when canonical classification is direct", async () => {
+    mocks.getHostedLinqChatSummary.mockResolvedValueOnce({
+      handles: [],
+      isGroup: false,
+    });
     const prisma = asPrismaTransactionClient({
       hostedWebhookReceipt: {
         create: vi.fn().mockResolvedValue({}),
@@ -796,6 +807,14 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       ok: true,
       reason: "wake-appended-active-member",
     });
+    expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+      chatId: "chat_123",
+      timeoutMs: 1_500,
+    });
+    expect(mocks.logHostedOnboardingDiagnostic).toHaveBeenCalledWith(
+      "hosted-onboarding.webhook.linq.chat-classification",
+      { outcome: "canonical-direct" },
+    );
     expect(mocks.enqueueHostedExecutionOutbox).toHaveBeenCalledWith(
       expect.objectContaining({
         envelope: expect.objectContaining({
@@ -812,6 +831,88 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     const outboxCall = mocks.enqueueHostedExecutionOutbox.mock.calls[0]?.[0];
     expect(outboxCall?.envelope.message).not.toHaveProperty("accountLookupKey");
     expect(outboxCall?.envelope.message).not.toHaveProperty("routeAuthority");
+  });
+
+  it.each([
+    {
+      lookupError: new TypeError("Linq chat read unavailable"),
+      summary: null,
+    },
+    {
+      lookupError: null,
+      summary: {
+        handles: [],
+        isGroup: null,
+      },
+    },
+  ])("fails before planning when canonical classification is unavailable", async ({
+    lookupError,
+    summary,
+  }) => {
+    if (summary) {
+      mocks.getHostedLinqChatSummary.mockResolvedValueOnce(summary);
+    } else {
+      mocks.getHostedLinqChatSummary.mockRejectedValueOnce(lookupError as Error);
+    }
+    const prisma = asPrismaTransactionClient({
+      hostedMember: {
+        findUnique: vi.fn(),
+      },
+      hostedWebhookReceipt: {
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        updateMany: vi.fn(),
+      },
+    });
+
+    await expect(handleHostedOnboardingLinqWebhook({
+      prisma,
+      rawBody: buildHostedLinqWebhookBody({
+        chatIsGroup: false,
+        service: "iMessage",
+      }),
+      signature: null,
+      timestamp: null,
+    })).rejects.toMatchObject({
+      ...(lookupError ? { cause: lookupError } : {}),
+      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      httpStatus: 502,
+      retryable: true,
+    });
+
+    expect(mocks.logHostedOnboardingDiagnostic).toHaveBeenCalledWith(
+      "hosted-onboarding.webhook.linq.chat-classification",
+      { outcome: "canonical-unavailable" },
+    );
+    expect(prisma.hostedWebhookReceipt?.create).not.toHaveBeenCalled();
+    expect(prisma.hostedMember?.findUnique).not.toHaveBeenCalled();
+    expect(mocks.enqueueHostedExecutionOutbox).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+  });
+
+  it("propagates caller cancellation before Linq planning", async () => {
+    const controller = new AbortController();
+    const abortReason = new Error("caller cancelled");
+    controller.abort(abortReason);
+    mocks.getHostedLinqChatSummary.mockRejectedValueOnce(abortReason);
+
+    await expect(handleHostedOnboardingLinqWebhook({
+      rawBody: buildHostedLinqWebhookBody({
+        chatIsGroup: false,
+        service: "iMessage",
+      }),
+      signal: controller.signal,
+      signature: null,
+      timestamp: null,
+    })).rejects.toBe(abortReason);
+
+    expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+      chatId: "chat_123",
+      signal: controller.signal,
+      timeoutMs: 1_500,
+    });
+    expect(mocks.enqueueHostedExecutionOutbox).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
   });
 
   it("marks Linq reaction eligibility from raw parts before mailbox text compaction", async () => {
@@ -2960,7 +3061,9 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     }));
   });
 
-  it("does not accept a Family invite token that would rebind an unattested active home chat", async () => {
+  it("does not accept a Family invite token when canonical chat classification is unavailable", async () => {
+    const classificationError = new Error("Linq chat read unavailable");
+    mocks.getHostedLinqChatSummary.mockRejectedValueOnce(classificationError);
     const homeLinePhone = "+15550100001";
     const hostedMemberRouting = createStatefulHostedMemberRoutingMock({
       linqChatIdEncrypted: await encryptHostedWebNullableString({
@@ -3008,7 +3111,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       },
     });
 
-    const response = await handleHostedOnboardingLinqWebhook({
+    await expect(handleHostedOnboardingLinqWebhook({
       prisma,
       rawBody: buildHostedLinqWebhookBody({
         data: {
@@ -3033,12 +3136,11 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       }),
       signature: null,
       timestamp: null,
-    });
-
-    expect(response).toMatchObject({
-      ignored: true,
-      ok: true,
-      reason: "unattested-direct-chat",
+    })).rejects.toMatchObject({
+      cause: classificationError,
+      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      httpStatus: 502,
+      retryable: true,
     });
     expect(mocks.acceptHostedFamilyInviteFromPhoneTx).not.toHaveBeenCalled();
     expect(hostedMemberRouting.upsert).not.toHaveBeenCalled();
@@ -7132,7 +7234,9 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(readHostedMemberRoutingUpsertMock(prisma)).not.toHaveBeenCalled();
   });
 
-  it("refuses to rebind a member's home chat to a new chat id when the payload does not attest the chat is direct", async () => {
+  it("refuses to rebind a member's home chat when canonical chat classification is unavailable", async () => {
+    const classificationError = new Error("Linq chat read unavailable");
+    mocks.getHostedLinqChatSummary.mockRejectedValueOnce(classificationError);
     const prisma = asPrismaTransactionClient({
       hostedWebhookReceipt: {
         create: vi.fn().mockResolvedValue({}),
@@ -7191,7 +7295,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
 
     // Same recipient line as the bound home, NEW chat id, and no is_group flag at all —
     // exactly what a group message would look like if the provider's flag went missing.
-    const response = await handleHostedOnboardingLinqWebhook({
+    await expect(handleHostedOnboardingLinqWebhook({
       prisma,
       rawBody: buildHostedLinqWebhookBody({
         data: {
@@ -7210,12 +7314,11 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       }),
       signature: null,
       timestamp: null,
-    });
-
-    expect(response).toMatchObject({
-      ignored: true,
-      ok: true,
-      reason: "unattested-direct-chat",
+    })).rejects.toMatchObject({
+      cause: classificationError,
+      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      httpStatus: 502,
+      retryable: true,
     });
     expect(readHostedMemberRoutingUpsertMock(prisma)).not.toHaveBeenCalled();
     expect(mocks.incrementHostedLinqInboundDailyState).not.toHaveBeenCalled();
@@ -7225,7 +7328,9 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.enqueueHostedExecutionOutbox).not.toHaveBeenCalled();
   });
 
-  it("rechecks the current home route under lock before binding an active Linq chat", async () => {
+  it("does not change a current home route when canonical chat classification is unavailable", async () => {
+    const classificationError = new Error("Linq chat read unavailable");
+    mocks.getHostedLinqChatSummary.mockRejectedValueOnce(classificationError);
     const homeLinePhone = "+15550100001";
     const currentRoute = {
       linqChatIdEncrypted: await encryptHostedWebNullableString({
@@ -7276,7 +7381,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       hostedMemberRouting,
     });
 
-    const response = await handleHostedOnboardingLinqWebhook({
+    await expect(handleHostedOnboardingLinqWebhook({
       prisma,
       rawBody: buildHostedLinqWebhookBody({
         data: {
@@ -7295,12 +7400,11 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       }),
       signature: null,
       timestamp: null,
-    });
-
-    expect(response).toMatchObject({
-      ignored: true,
-      ok: true,
-      reason: "unattested-direct-chat",
+    })).rejects.toMatchObject({
+      cause: classificationError,
+      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      httpStatus: 502,
+      retryable: true,
     });
     expect(hostedMemberRouting.upsert).not.toHaveBeenCalled();
     expect(mocks.incrementHostedLinqInboundDailyState).not.toHaveBeenCalled();

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -683,12 +683,14 @@ describe("handleHostedOnboardingLinqWebhook", () => {
                 messageId: "msg_123",
                 reactionEligible: false,
                 service,
+                threadIsDirect: null,
               }),
             }),
             userId: "member_123",
           }),
         }),
       );
+      expect(mocks.getHostedLinqChatSummary).not.toHaveBeenCalled();
       expect(mocks.nudgeHostedRunnerUserBestEffort).not.toHaveBeenCalled();
       expect(mocks.nudgeHostedRunnerUserBestEffortResult).not.toHaveBeenCalled();
       expectHostedLinqPointerSignalAccepted();

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -629,8 +629,12 @@ describe("handleHostedOnboardingLinqWebhook", () => {
   });
 
   it.each(["sms", "RCS"] as const)(
-    "uses parser-owned Linq %s service when preferred-service metadata conflicts",
+    "canonically classifies route-less inbound Linq %s direct chats despite conflicting preferred-service metadata",
     async (service) => {
+      mocks.getHostedLinqChatSummary.mockResolvedValueOnce({
+        handles: [],
+        isGroup: false,
+      });
       const prisma = asPrismaTransactionClient({
         hostedWebhookReceipt: {
           create: vi.fn().mockResolvedValue({}),
@@ -684,14 +688,21 @@ describe("handleHostedOnboardingLinqWebhook", () => {
                 messageId: "msg_123",
                 reactionEligible: false,
                 service,
-                threadIsDirect: null,
+                threadIsDirect: true,
               }),
             }),
             userId: "member_123",
           }),
         }),
       );
-      expect(mocks.getHostedLinqChatSummary).not.toHaveBeenCalled();
+      expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+        chatId: "chat_123",
+        timeoutMs: 1_500,
+      });
+      expect(mocks.logHostedOnboardingDiagnostic).toHaveBeenCalledWith(
+        "hosted-onboarding.webhook.linq.chat-classification",
+        { outcome: "canonical-direct" },
+      );
       expect(mocks.nudgeHostedRunnerUserBestEffort).not.toHaveBeenCalled();
       expect(mocks.nudgeHostedRunnerUserBestEffortResult).not.toHaveBeenCalled();
       expectHostedLinqPointerSignalAccepted();
@@ -896,11 +907,58 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
   });
 
+  it.each(["sms", "RCS"] as const)(
+    "fails before planning when canonical %s classification is unavailable",
+    async (service) => {
+      const lookupError = new TypeError("Linq chat read unavailable");
+      mocks.getHostedLinqChatSummary.mockRejectedValueOnce(lookupError);
+      const prisma = asPrismaTransactionClient({
+        $transaction: vi.fn(),
+        hostedMember: {
+          findUnique: vi.fn(),
+        },
+        hostedWebhookReceipt: {
+          create: vi.fn(),
+          findUnique: vi.fn(),
+          updateMany: vi.fn(),
+        },
+      });
+
+      await expect(handleHostedOnboardingLinqWebhook({
+        prisma,
+        rawBody: buildHostedLinqWebhookBody({
+          chatIsGroup: false,
+          service,
+        }),
+        signature: null,
+        timestamp: null,
+      })).rejects.toMatchObject({
+        cause: lookupError,
+        code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+        httpStatus: 502,
+        retryable: true,
+      });
+
+      expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+        chatId: "chat_123",
+        timeoutMs: 1_500,
+      });
+      expect(prisma.hostedThreadRoute?.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(prisma.hostedWebhookReceipt?.create).not.toHaveBeenCalled();
+      expect(prisma.hostedMember?.findUnique).not.toHaveBeenCalled();
+      expect(mocks.incrementHostedLinqInboundDailyState).not.toHaveBeenCalled();
+      expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+      expect(mocks.enqueueHostedExecutionOutbox).not.toHaveBeenCalled();
+      expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+      expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
+    },
+  );
+
   it("propagates caller cancellation before Linq planning", async () => {
     const controller = new AbortController();
     const abortReason = new Error("caller cancelled");
     controller.abort(abortReason);
-    mocks.getHostedLinqChatSummary.mockRejectedValueOnce(abortReason);
 
     await expect(handleHostedOnboardingLinqWebhook({
       rawBody: buildHostedLinqWebhookBody({
@@ -912,11 +970,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       timestamp: null,
     })).rejects.toBe(abortReason);
 
-    expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
-      chatId: "chat_123",
-      signal: controller.signal,
-      timeoutMs: 1_500,
-    });
+    expect(mocks.getHostedLinqChatSummary).not.toHaveBeenCalled();
     expect(mocks.enqueueHostedExecutionOutbox).not.toHaveBeenCalled();
     expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
   });
@@ -1912,6 +1966,23 @@ describe("handleHostedOnboardingLinqWebhook", () => {
               threadLookupKey: routeLookupKey,
             },
           ])
+          .mockResolvedValueOnce([
+            {
+              channel: "linq",
+              container: {
+                member: {
+                  billingStatus: HostedBillingStatus.active,
+                  createdAt: new Date("2026-03-26T00:00:00.000Z"),
+                  id: "member_thread_container_123",
+                  suspendedAt: null,
+                  updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+                },
+                owner: ownerAccessRecord,
+              },
+              containerMemberId: "member_thread_container_123",
+              threadLookupKey: routeLookupKey,
+            },
+          ])
           .mockResolvedValue([]),
       },
       hostedMember: {
@@ -1955,7 +2026,8 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       mailboxItemId: "mailbox_evt_routed_read_receipt_stale",
     });
     expect(mocks.sendHostedLinqReadReceipt).not.toHaveBeenCalled();
-    expect(prisma.hostedThreadRoute?.findMany).toHaveBeenCalledTimes(2);
+    expect(mocks.getHostedLinqChatSummary).not.toHaveBeenCalled();
+    expect(prisma.hostedThreadRoute?.findMany).toHaveBeenCalledTimes(3);
     expect(prisma.hostedThreadRoute?.findMany).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -1968,6 +2040,16 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     );
     expect(prisma.hostedThreadRoute?.findMany).toHaveBeenNthCalledWith(
       2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          threadIdentityLookupKey: {
+            in: expect.arrayContaining([routeIdentityLookupKey]),
+          },
+        }),
+      }),
+    );
+    expect(prisma.hostedThreadRoute?.findMany).toHaveBeenNthCalledWith(
+      3,
       expect.objectContaining({
         where: expect.objectContaining({
           threadIdentityLookupKey: {

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -629,7 +629,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
   });
 
   it.each(["sms", "RCS"] as const)(
-    "reuses an existing transaction when dispatching active-member Linq %s messages",
+    "uses parser-owned Linq %s service when preferred-service metadata conflicts",
     async (service) => {
       const prisma = asPrismaTransactionClient({
         hostedWebhookReceipt: {
@@ -661,6 +661,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
           data: {
             extra_field: "discard-me",
             extra_message_field: "discard-me-too",
+            preferred_service: "iMessage",
           },
           service,
         }),

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -119,7 +119,10 @@ const mocks = vi.hoisted(() => {
       remainingUsdMicros: 100_000n,
       spentUsdMicros: 0n,
     })),
-    getHostedLinqChatSummary: vi.fn(async () => ({
+    getHostedLinqChatSummary: vi.fn(async (): Promise<{
+      handles: string[];
+      isGroup: boolean | null;
+    }> => ({
       handles: [],
       isGroup: false,
     })),

--- a/apps/web/test/hosted-onboarding-linq-http.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-http.test.ts
@@ -14,6 +14,9 @@ import {
   updateHostedLinqChatAvatar,
   updateHostedLinqChatDisplayName,
 } from "@/src/lib/hosted-onboarding/linq";
+import {
+  getHostedLinqChatSummary,
+} from "@/src/lib/hosted-onboarding/linq-client";
 
 const originalFetch = globalThis.fetch;
 const describe = baseDescribe.sequential;
@@ -48,6 +51,56 @@ function readJsonRequestBody(init: RequestInit | undefined): unknown {
 
   return JSON.parse(body);
 }
+
+describe("getHostedLinqChatSummary", () => {
+  afterEach(() => {
+    if (originalFetch) {
+      vi.stubGlobal("fetch", originalFetch);
+      return;
+    }
+
+    Reflect.deleteProperty(globalThis, "fetch");
+  });
+
+  it("reads top-level canonical group directness from the chat endpoint", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      void _input;
+      void _init;
+      return createJsonResponse({
+        handles: [
+          {
+            handle: "+15550000000",
+            is_me: true,
+            status: "active",
+          },
+        ],
+        is_group: true,
+      }, 200);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getHostedLinqChatSummary({
+      chatId: "chat_123",
+      timeoutMs: 1_500,
+    })).resolves.toEqual({
+      handles: [
+        {
+          handle: "+15550000000",
+          isMe: true,
+          status: "active",
+        },
+      ],
+      isGroup: true,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("chats/chat_123", "https://linq.example.test/api/partner/v3/"),
+      expect.objectContaining({
+        method: "GET",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});
 
 describe("sendHostedLinqChatMessage", () => {
   beforeEach(() => {

--- a/apps/web/test/hosted-onboarding-linq-http.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-http.test.ts
@@ -1,10 +1,16 @@
+import { createServer, type Server } from "node:http";
+
+import type { Chat } from "@linqapp/sdk/resources/chats";
 import { afterEach, beforeEach, describe as baseDescribe, expect, it, vi } from "vitest";
 
+const DEFAULT_LINQ_API_BASE_URL = "https://linq.example.test/api/partner/v3";
+const linqRuntimeConfig = vi.hoisted(() => ({
+  apiBaseUrl: "https://linq.example.test/api/partner/v3",
+  apiToken: "linq-token",
+}));
+
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
-  requireHostedOnboardingLinqConfig: () => ({
-    apiBaseUrl: "https://linq.example.test/api/partner/v3",
-    apiToken: "linq-token",
-  }),
+  requireHostedOnboardingLinqConfig: () => linqRuntimeConfig,
 }));
 
 import {
@@ -20,6 +26,10 @@ import {
 
 const originalFetch = globalThis.fetch;
 const describe = baseDescribe.sequential;
+
+beforeEach(() => {
+  linqRuntimeConfig.apiBaseUrl = DEFAULT_LINQ_API_BASE_URL;
+});
 
 function createJsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
@@ -52,6 +62,57 @@ function readJsonRequestBody(init: RequestInit | undefined): unknown {
   return JSON.parse(body);
 }
 
+function createCanonicalLinqChat(isGroup: boolean): Chat {
+  return {
+    created_at: "2026-07-10T00:00:00.000Z",
+    display_name: null,
+    handles: [
+      {
+        handle: "+15550000000",
+        id: "handle_me",
+        is_me: true,
+        joined_at: "2026-07-10T00:00:00.000Z",
+        service: "iMessage",
+        status: "active",
+      },
+    ],
+    health_status: {
+      doc_url: "https://docs.linqapp.com/guides/chats/chat-health",
+      status: "HEALTHY",
+      updated_at: "2026-07-10T00:00:00.000Z",
+    },
+    id: "chat_123",
+    is_archived: false,
+    is_group: isGroup,
+    service: "iMessage",
+    updated_at: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+async function listenOnLoopback(server: Server): Promise<string> {
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected a loopback TCP server address.");
+  }
+  return `http://127.0.0.1:${address.port}/api/partner/v3`;
+}
+
+async function closeTestServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 describe("getHostedLinqChatSummary", () => {
   afterEach(() => {
     if (originalFetch) {
@@ -66,16 +127,7 @@ describe("getHostedLinqChatSummary", () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
       void _input;
       void _init;
-      return createJsonResponse({
-        handles: [
-          {
-            handle: "+15550000000",
-            is_me: true,
-            status: "active",
-          },
-        ],
-        is_group: true,
-      }, 200);
+      return createJsonResponse(createCanonicalLinqChat(true), 200);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -99,6 +151,110 @@ describe("getHostedLinqChatSummary", () => {
         signal: expect.any(AbortSignal),
       }),
     );
+  });
+
+  it("reads top-level canonical direct-chat directness from the chat endpoint", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      createJsonResponse(createCanonicalLinqChat(false), 200)
+    ));
+
+    await expect(getHostedLinqChatSummary({
+      chatId: "chat_123",
+      timeoutMs: 1_500,
+    })).resolves.toMatchObject({
+      isGroup: false,
+    });
+  });
+
+  it.each([
+    {
+      label: "nested webhook-style truth",
+      payload: {
+        chat: createCanonicalLinqChat(true),
+      },
+    },
+    {
+      label: "malformed top-level truth",
+      payload: {
+        ...createCanonicalLinqChat(true),
+        is_group: "true",
+      },
+    },
+  ])("rejects $label as a canonical chat-read response", async ({ payload }) => {
+    vi.stubGlobal("fetch", vi.fn(async () => createJsonResponse(payload, 200)));
+
+    await expect(getHostedLinqChatSummary({
+      chatId: "chat_123",
+      timeoutMs: 1_500,
+    })).resolves.toEqual({
+      handles: [],
+      isGroup: null,
+    });
+  });
+
+  it("keeps the chat-read deadline active through a stalled response body", async () => {
+    let connectionClosed = false;
+    const server = createServer((_request, response) => {
+      response.on("close", () => {
+        connectionClosed = true;
+      });
+      response.writeHead(200, {
+        "content-type": "application/json",
+      });
+      response.flushHeaders();
+      response.write('{"is_group":');
+    });
+    linqRuntimeConfig.apiBaseUrl = await listenOnLoopback(server);
+
+    try {
+      const startedAt = performance.now();
+      await expect(getHostedLinqChatSummary({
+        chatId: "chat_123",
+        timeoutMs: 75,
+      })).rejects.toMatchObject({
+        code: "LINQ_SEND_FAILED",
+        httpStatus: 502,
+        message: "Linq chat read timed out.",
+        retryable: true,
+      });
+      expect(performance.now() - startedAt).toBeLessThan(1_500);
+      await vi.waitFor(() => {
+        expect(connectionClosed).toBe(true);
+      });
+    } finally {
+      await closeTestServer(server);
+    }
+  });
+
+  it("preserves caller cancellation while reading a stalled response body", async () => {
+    let headersFlushed: (() => void) | null = null;
+    const didFlushHeaders = new Promise<void>((resolve) => {
+      headersFlushed = resolve;
+    });
+    const server = createServer((_request, response) => {
+      response.writeHead(200, {
+        "content-type": "application/json",
+      });
+      response.flushHeaders();
+      response.write('{"is_group":');
+      headersFlushed?.();
+    });
+    linqRuntimeConfig.apiBaseUrl = await listenOnLoopback(server);
+    const controller = new AbortController();
+    const abortReason = new Error("caller cancelled chat read");
+
+    try {
+      const result = getHostedLinqChatSummary({
+        chatId: "chat_123",
+        signal: controller.signal,
+        timeoutMs: 5_000,
+      });
+      await didFlushHeaders;
+      controller.abort(abortReason);
+      await expect(result).rejects.toBe(abortReason);
+    } finally {
+      await closeTestServer(server);
+    }
   });
 });
 

--- a/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getHostedLinqChatSummary: vi.fn(),
   maybeHandoffHostedExecutionWebhookWake: vi.fn(),
   planHostedOnboardingLinqWebhook: vi.fn(),
+  readHostedThreadRouteByThreadIdentity: vi.fn(),
   requireHostedLinqMessageReceivedEvent: vi.fn(),
   resolveHostedLinqRecipientPhoneNumber: vi.fn(() => "+15555550123"),
   sendHostedLinqReadReceipt: vi.fn(),
@@ -39,6 +40,7 @@ vi.mock("@/src/lib/hosted-onboarding/webhook-service-wake", () => ({
 
 vi.mock("@/src/lib/hosted-routing/thread-route-store", () => ({
   assertHostedLinqRouteEgressAuthority: mocks.assertHostedLinqRouteEgressAuthority,
+  readHostedThreadRouteByThreadIdentity: mocks.readHostedThreadRouteByThreadIdentity,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/logging", () => ({
@@ -81,6 +83,7 @@ describe("hosted Linq read receipt route authority", () => {
       handles: [],
       isGroup: false,
     });
+    mocks.readHostedThreadRouteByThreadIdentity.mockResolvedValue(null);
     mocks.verifyAndParseHostedLinqWebhookRequest.mockReturnValue({
       event_id: "evt_read_receipt_mismatch",
       event_type: "message.received",
@@ -150,6 +153,15 @@ describe("hosted Linq read receipt route authority", () => {
     });
 
     expect(mocks.assertHostedLinqRouteEgressAuthority).not.toHaveBeenCalled();
+    expect(mocks.readHostedThreadRouteByThreadIdentity).toHaveBeenCalledWith({
+      channel: "linq",
+      prisma: {},
+      threadId: "chat_123",
+    });
+    expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+      chatId: "chat_123",
+      timeoutMs: 1_500,
+    });
     expect(mocks.sendHostedLinqReadReceipt).not.toHaveBeenCalled();
     expect(mocks.finishHostedOnboardingTiming).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-read-receipt-authority.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   assertHostedLinqRouteEgressAuthority: vi.fn(),
   deriveHostedOnboardingTimingErrorName: vi.fn(() => "Error"),
   finishHostedOnboardingTiming: vi.fn(),
+  getHostedLinqChatSummary: vi.fn(),
   maybeHandoffHostedExecutionWebhookWake: vi.fn(),
   planHostedOnboardingLinqWebhook: vi.fn(),
   requireHostedLinqMessageReceivedEvent: vi.fn(),
@@ -22,6 +23,10 @@ vi.mock("@/src/lib/hosted-onboarding/linq", () => ({
   resolveHostedLinqRecipientPhoneNumber: mocks.resolveHostedLinqRecipientPhoneNumber,
   sendHostedLinqReadReceipt: mocks.sendHostedLinqReadReceipt,
   verifyAndParseHostedLinqWebhookRequest: mocks.verifyAndParseHostedLinqWebhookRequest,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/linq-client", () => ({
+  getHostedLinqChatSummary: mocks.getHostedLinqChatSummary,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/webhook-provider-linq", () => ({
@@ -72,6 +77,10 @@ import {
 describe("hosted Linq read receipt route authority", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getHostedLinqChatSummary.mockResolvedValue({
+      handles: [],
+      isGroup: false,
+    });
     mocks.verifyAndParseHostedLinqWebhookRequest.mockReturnValue({
       event_id: "evt_read_receipt_mismatch",
       event_type: "message.received",

--- a/apps/web/test/hosted-onboarding-linq-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-route.test.ts
@@ -128,6 +128,29 @@ describe("hosted onboarding Linq webhook route", () => {
     );
   });
 
+  it("returns a retryable server response when Linq chat classification is unavailable", async () => {
+    mocks.handleHostedOnboardingLinqWebhook.mockRejectedValueOnce(hostedOnboardingError({
+      code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      httpStatus: 502,
+      message: "Linq chat classification is unavailable.",
+      retryable: true,
+    }));
+
+    const response = await hostedOnboardingLinqRoute.POST(
+      new Request("https://join.example.test/api/hosted-onboarding/linq/webhook", {
+        body: JSON.stringify({ ok: true }),
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "LINQ_CHAT_CLASSIFICATION_UNAVAILABLE",
+      },
+    });
+  });
+
   it("logs redacted Linq ingress timing deltas for message webhooks", async () => {
     const routeStartedAtMs = Date.parse("2026-06-24T18:46:10.522Z");
     vi.spyOn(Date, "now").mockReturnValue(routeStartedAtMs);

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -1144,7 +1144,16 @@ describe("Linq explicit external-thread routing", () => {
     });
   });
 
-  it("does not treat routed Linq traffic as direct when directness is not attested", async () => {
+  it.each([
+    {
+      description: "provider directness is omitted",
+      isGroup: null,
+    },
+    {
+      description: "the provider reports a direct chat",
+      isGroup: false,
+    },
+  ] as const)("keeps a routed Linq thread non-direct when $description", async ({ isGroup }) => {
     const prisma = createPrisma({
       routeContainerMemberId: "member_thread_container_123",
     });
@@ -1171,14 +1180,14 @@ describe("Linq explicit external-thread routing", () => {
       duplicate: false,
       inserted: true,
       item: buildHostedMailboxItem({
-        id: "mailbox_unknown_directness_123",
+        id: "mailbox_routed_directness_123",
         userId: "member_thread_container_123",
       }),
     });
 
     const plan = await planHostedOnboardingLinqWebhook({
       event: buildLinqMessageReceivedEvent({
-        isGroup: null,
+        isGroup,
       }),
       prisma: prisma as never,
     });
@@ -1193,64 +1202,7 @@ describe("Linq explicit external-thread routing", () => {
         message: expect.objectContaining({
           linqMessage: expect.objectContaining({
             chatId: "chat_group_123",
-            threadIsDirect: null,
-          }),
-        }),
-      }),
-      tx: prisma,
-    });
-  });
-
-  it("preserves routed Linq directness when the provider attests direct chat", async () => {
-    const prisma = createPrisma({
-      routeContainerMemberId: "member_thread_container_123",
-    });
-    vi.mocked(mailboxStore.readHostedMailboxItemByDedupeKey).mockResolvedValueOnce(null);
-    vi.mocked(linqDailyState.incrementHostedLinqInboundDailyState).mockResolvedValueOnce({
-      dayUtc: new Date("2026-06-24T00:00:00.000Z"),
-      inboundCount: 1,
-      memberId: "member_thread_container_123",
-      outboundCount: 0,
-      quotaReplySentAt: null,
-    } as Awaited<ReturnType<typeof linqDailyState.incrementHostedLinqInboundDailyState>>);
-    vi.mocked(usageAllowance.checkHostedAiUsageGate).mockResolvedValueOnce({
-      allowed: true,
-      billingPlanCode: "launch_monthly",
-      limitUsdMicros: 4_500_000n,
-      memberId: "member_thread_container_123",
-      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
-      periodStart: new Date("2026-06-01T00:00:00.000Z"),
-      remainingUsdMicros: 4_500_000n,
-      spentUsdMicros: 0n,
-    });
-    vi.mocked(mailboxStore.appendHostedMailboxEnvelopeTx).mockResolvedValueOnce({
-      dedupeConflict: false,
-      duplicate: false,
-      inserted: true,
-      item: buildHostedMailboxItem({
-        id: "mailbox_direct_123",
-        userId: "member_thread_container_123",
-      }),
-    });
-
-    const plan = await planHostedOnboardingLinqWebhook({
-      event: buildLinqMessageReceivedEvent({
-        isGroup: false,
-      }),
-      prisma: prisma as never,
-    });
-
-    expect(plan.response).toMatchObject({
-      ignored: false,
-      ok: true,
-      reason: "wake-appended-thread-route",
-    });
-    expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
-      envelope: expect.objectContaining({
-        message: expect.objectContaining({
-          linqMessage: expect.objectContaining({
-            chatId: "chat_group_123",
-            threadIsDirect: true,
+            threadIsDirect: false,
           }),
         }),
       }),

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -102,6 +102,7 @@ vi.mock("../src/lib/hosted-onboarding/linq-client", async (importOriginal) => {
   return {
     ...actual,
     getHostedLinqChatHandles: vi.fn(),
+    getHostedLinqChatSummary: vi.fn(),
   };
 });
 
@@ -148,6 +149,11 @@ beforeEach(() => {
   vi.mocked(prismaModule.getPrisma).mockReset();
   vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest).mockReset();
   vi.mocked(linqClient.getHostedLinqChatHandles).mockReset();
+  vi.mocked(linqClient.getHostedLinqChatSummary).mockReset();
+  vi.mocked(linqClient.getHostedLinqChatSummary).mockResolvedValue({
+    handles: [],
+    isGroup: null,
+  });
   vi.mocked(mailboxStore.readHostedMailboxItemByDedupeKey).mockReset();
   vi.mocked(mailboxStore.appendHostedMailboxEnvelopeTx).mockReset();
   vi.mocked(linqDailyState.incrementHostedLinqInboundDailyState).mockReset();
@@ -1640,6 +1646,72 @@ describe("Linq group chat auto-provision", () => {
 
   it.each([
     {
+      description: "incorrectly says direct",
+      webhookIsGroup: false,
+    },
+    {
+      description: "omits group directness",
+      webhookIsGroup: null,
+    },
+  ] as const)("uses canonical chat metadata when an iMessage webhook $description", async ({
+    webhookIsGroup,
+  }) => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const prisma = createStatefulThreadRoutePrisma();
+    vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
+    vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
+      .mockReturnValue(buildLinqMessageReceivedEvent({ isGroup: webhookIsGroup }) as never);
+    mockSenderLookup(senderCore);
+    mockSuccessfulGroupProvision({ prisma, senderCore });
+    vi.mocked(linqClient.getHostedLinqChatSummary).mockResolvedValue({
+      handles: [],
+      isGroup: true,
+    });
+    vi.mocked(linqClient.getHostedLinqChatHandles).mockResolvedValue([]);
+
+    try {
+      const response = await handleHostedOnboardingLinqWebhook({
+        rawBody: "{}",
+        signature: null,
+        timestamp: null,
+      });
+
+      expect(response).toMatchObject({
+        ignored: false,
+        ok: true,
+        reason: "wake-appended-thread-route",
+      });
+      expect(linqClient.getHostedLinqChatSummary).toHaveBeenCalledWith({
+        chatId: "chat_group_123",
+        timeoutMs: 1_500,
+      });
+      expect(prisma.hostedThreadContainer.create).toHaveBeenCalledTimes(1);
+      expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenLastCalledWith({
+        envelope: expect.objectContaining({
+          kind: "conversation.message",
+          message: expect.objectContaining({
+            linqMessage: expect.objectContaining({
+              chatId: "chat_group_123",
+              threadIsDirect: false,
+            }),
+          }),
+        }),
+        tx: prisma,
+      });
+      expect(info).toHaveBeenCalledWith(
+        "Hosted onboarding diagnostic: hosted-onboarding.webhook.linq.chat-classification.",
+        {
+          diagnostic: "hosted-onboarding.webhook.linq.chat-classification",
+          outcome: "canonical-group",
+        },
+      );
+    } finally {
+      info.mockRestore();
+    }
+  });
+
+  it.each([
+    {
       kind: "direct-paid",
       senderAccess: {
         accountGroupMemberships: [],
@@ -1833,6 +1905,7 @@ describe("Linq group chat auto-provision", () => {
     expect(linqClient.getHostedLinqChatHandles).toHaveBeenCalledWith({
       chatId: "chat_group_123",
     });
+    expect(linqClient.getHostedLinqChatSummary).not.toHaveBeenCalled();
     expect(prisma.hostedThreadContainerParticipant.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         create: expect.objectContaining({

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -193,9 +193,11 @@ function buildLinqMessageReceivedEvent(input: {
   messageId?: string;
   recipient?: string;
   sender?: string;
+  service?: string;
   text?: string;
 }) {
   const recipient = input.recipient ?? "+15550000000";
+  const service = input.service ?? "iMessage";
   return {
     api_version: "2026-01-01",
     created_at: "2026-06-24T12:00:00.000Z",
@@ -207,7 +209,7 @@ function buildLinqMessageReceivedEvent(input: {
           handle: recipient,
           id: "owner_handle_123",
           is_me: true,
-          service: "iMessage",
+          service,
         },
       },
       chat_id: input.chatId ?? "chat_group_123",
@@ -225,16 +227,16 @@ function buildLinqMessageReceivedEvent(input: {
               },
             ],
       },
-      preferred_service: "iMessage",
+      preferred_service: service,
       recipient_phone: recipient,
       received_at: "2026-06-24T12:00:00.000Z",
       sender_handle: {
         handle: input.sender ?? "+15551112222",
         id: "sender_handle_123",
         is_me: false,
-        service: "iMessage",
+        service,
       },
-      service: "iMessage",
+      service,
     },
     event_id: input.eventId ?? "evt_group_123",
     event_type: "message.received",
@@ -1545,6 +1547,44 @@ describe("Linq group chat auto-provision", () => {
     );
   }
 
+  function mockAllowedThreadUsage(): void {
+    vi.mocked(usageAllowance.checkHostedAiUsageGate).mockResolvedValue({
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: 4_500_000n,
+      memberId: "member_thread_container_123",
+      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+      periodStart: new Date("2026-06-01T00:00:00.000Z"),
+      remainingUsdMicros: 4_500_000n,
+      spentUsdMicros: 0n,
+    });
+  }
+
+  function seedExistingGroupRoute(
+    prisma: ReturnType<typeof createStatefulThreadRoutePrisma>,
+  ): void {
+    const accountLookupKey = createHostedPhoneLookupKey("+15550000000");
+    const threadLookupKey = createHostedExternalThreadLookupKey({
+      accountLookupKey,
+      channel: "linq",
+      threadId: "chat_group_123",
+    });
+    const threadIdentityLookupKey = createHostedExternalThreadIdentityLookupKey({
+      channel: "linq",
+      threadId: "chat_group_123",
+    });
+    if (!accountLookupKey || !threadLookupKey || !threadIdentityLookupKey) {
+      throw new Error("Expected test route lookup keys.");
+    }
+    prisma.seedThreadRoute({
+      channel: "linq",
+      containerMemberId: "member_thread_container_123",
+      ownerMemberId: "member_owner_123",
+      threadIdentityLookupKey,
+      threadLookupKey,
+    });
+  }
+
   function mockSuccessfulGroupProvision(input: {
     prisma: ReturnType<typeof createStatefulThreadRoutePrisma>;
     senderCore: typeof senderCore;
@@ -1584,35 +1624,196 @@ describe("Linq group chat auto-provision", () => {
       outboundCount: 0,
       quotaReplySentAt: null,
     } as Awaited<ReturnType<typeof linqDailyState.incrementHostedLinqInboundDailyState>>);
-    vi.mocked(usageAllowance.checkHostedAiUsageGate).mockResolvedValue({
-      allowed: true,
-      billingPlanCode: "launch_monthly",
-      limitUsdMicros: 4_500_000n,
-      memberId: "member_thread_container_123",
-      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
-      periodStart: new Date("2026-06-01T00:00:00.000Z"),
-      remainingUsdMicros: 4_500_000n,
-      spentUsdMicros: 0n,
-    });
+    mockAllowedThreadUsage();
   }
 
   it.each([
     {
+      description: "reported direct",
+      webhookIsGroup: false,
+    },
+    {
+      description: "omitted",
+      webhookIsGroup: null,
+    },
+  ] as const)(
+    "routes an existing durable thread as group when webhook directness is $description",
+    async ({ webhookIsGroup }) => {
+      const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+      const prisma = createStatefulThreadRoutePrisma();
+      seedExistingGroupRoute(prisma);
+      mockAllowedThreadUsage();
+      vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
+      vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
+        .mockReturnValue(buildLinqMessageReceivedEvent({ isGroup: webhookIsGroup }) as never);
+      vi.mocked(linqClient.getHostedLinqChatSummary)
+        .mockRejectedValue(new Error("Linq chat read unavailable"));
+      vi.mocked(linqClient.getHostedLinqChatHandles).mockResolvedValue([]);
+
+      try {
+        const response = await handleHostedOnboardingLinqWebhook({
+          rawBody: "{}",
+          signature: null,
+          timestamp: null,
+        });
+
+        expect(response).toMatchObject({
+          ignored: false,
+          ok: true,
+          reason: "wake-appended-thread-route",
+        });
+        expect(linqClient.getHostedLinqChatSummary).not.toHaveBeenCalled();
+        expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+          envelope: expect.objectContaining({
+            message: expect.objectContaining({
+              linqMessage: expect.objectContaining({
+                chatId: "chat_group_123",
+                threadIsDirect: false,
+              }),
+            }),
+          }),
+          tx: prisma,
+        });
+        expect(prisma.hostedThreadContainer.create).not.toHaveBeenCalled();
+        expect(memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber).not.toHaveBeenCalled();
+        expect(info).toHaveBeenCalledWith(
+          "Hosted onboarding diagnostic: hosted-onboarding.webhook.linq.chat-classification.",
+          {
+            diagnostic: "hosted-onboarding.webhook.linq.chat-classification",
+            outcome: "thread-route-group",
+          },
+        );
+      } finally {
+        info.mockRestore();
+      }
+    },
+  );
+
+  it("fails closed as group when the pre-read route disappears before planning", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    seedExistingGroupRoute(prisma);
+    const seededFindMany = prisma.hostedThreadRoute.findMany.getMockImplementation();
+    if (!seededFindMany) {
+      throw new Error("Expected the stateful route lookup implementation.");
+    }
+    let routeReadCount = 0;
+    prisma.hostedThreadRoute.findMany.mockImplementation(async (args: never) => {
+      routeReadCount += 1;
+      return routeReadCount === 1 ? seededFindMany(args) : [];
+    });
+    mockSenderLookup(null);
+    vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
+    vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
+      .mockReturnValue(buildLinqMessageReceivedEvent({ isGroup: false }) as never);
+    vi.mocked(linqClient.getHostedLinqChatSummary)
+      .mockRejectedValue(new Error("Linq chat read unavailable"));
+
+    const response = await handleHostedOnboardingLinqWebhook({
+      rawBody: "{}",
+      signature: null,
+      timestamp: null,
+    });
+
+    expect(response).toMatchObject({
+      ignored: true,
+      ok: true,
+      reason: "group-chat",
+    });
+    expect(linqClient.getHostedLinqChatSummary).not.toHaveBeenCalled();
+    expect(memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber).toHaveBeenCalled();
+    expect(prisma.hostedMemberRouting.upsert).not.toHaveBeenCalled();
+    expect(prisma.hostedMemberRouting.updateMany).not.toHaveBeenCalled();
+    expect(prisma.hostedThreadContainer.create).not.toHaveBeenCalled();
+    expect(hostedMemberStore.createHostedMember).not.toHaveBeenCalled();
+    expect(linqDailyState.incrementHostedLinqInboundDailyState).not.toHaveBeenCalled();
+    expect(mailboxStore.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(signalRuntime.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+  });
+
+  it("uses a route created after the pre-read instead of personal direct planning", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    seedExistingGroupRoute(prisma);
+    const seededFindMany = prisma.hostedThreadRoute.findMany.getMockImplementation();
+    if (!seededFindMany) {
+      throw new Error("Expected the stateful route lookup implementation.");
+    }
+    let routeReadCount = 0;
+    prisma.hostedThreadRoute.findMany.mockImplementation(async (args: never) => {
+      routeReadCount += 1;
+      return routeReadCount === 1 ? [] : seededFindMany(args);
+    });
+    mockAllowedThreadUsage();
+    vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
+    vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
+      .mockReturnValue(buildLinqMessageReceivedEvent({ isGroup: false }) as never);
+    vi.mocked(linqClient.getHostedLinqChatSummary).mockResolvedValue({
+      handles: [],
+      isGroup: false,
+    });
+    vi.mocked(linqClient.getHostedLinqChatHandles).mockResolvedValue([]);
+
+    const response = await handleHostedOnboardingLinqWebhook({
+      rawBody: "{}",
+      signature: null,
+      timestamp: null,
+    });
+
+    expect(response).toMatchObject({
+      ignored: false,
+      ok: true,
+      reason: "wake-appended-thread-route",
+    });
+    expect(linqClient.getHostedLinqChatSummary).toHaveBeenCalledWith({
+      chatId: "chat_group_123",
+      timeoutMs: 1_500,
+    });
+    expect(mailboxStore.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: expect.objectContaining({
+        message: expect.objectContaining({
+          linqMessage: expect.objectContaining({
+            chatId: "chat_group_123",
+            threadIsDirect: false,
+          }),
+        }),
+      }),
+      tx: prisma,
+    });
+    expect(memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
       description: "incorrectly says direct",
+      service: "iMessage",
       webhookIsGroup: false,
     },
     {
       description: "omits group directness",
+      service: "iMessage",
       webhookIsGroup: null,
     },
-  ] as const)("uses canonical chat metadata when an iMessage webhook $description", async ({
+    {
+      description: "incorrectly says direct",
+      service: "sms",
+      webhookIsGroup: false,
+    },
+    {
+      description: "omits group directness",
+      service: "RCS",
+      webhookIsGroup: null,
+    },
+  ] as const)("uses canonical chat metadata when a $service webhook $description", async ({
+    service,
     webhookIsGroup,
   }) => {
     const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const prisma = createStatefulThreadRoutePrisma();
     vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
     vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
-      .mockReturnValue(buildLinqMessageReceivedEvent({ isGroup: webhookIsGroup }) as never);
+      .mockReturnValue(buildLinqMessageReceivedEvent({
+        isGroup: webhookIsGroup,
+        service,
+      }) as never);
     mockSenderLookup(senderCore);
     mockSuccessfulGroupProvision({ prisma, senderCore });
     vi.mocked(linqClient.getHostedLinqChatSummary).mockResolvedValue({

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -1193,7 +1193,7 @@ describe("Linq explicit external-thread routing", () => {
         message: expect.objectContaining({
           linqMessage: expect.objectContaining({
             chatId: "chat_group_123",
-            threadIsDirect: false,
+            threadIsDirect: null,
           }),
         }),
       }),

--- a/apps/web/test/hosted-onboarding-linq-usage-reset-e2e.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-usage-reset-e2e.test.ts
@@ -43,6 +43,7 @@ const mocks = vi.hoisted(() => {
     }),
     deriveHostedOnboardingTimingErrorName: vi.fn(() => "Error"),
     finishHostedOnboardingTiming: vi.fn(),
+    getHostedLinqChatSummary: vi.fn(),
     hostedOnboardingEnvironment: {
       contactPrivacyKeyring: {
         currentVersion: "v1",
@@ -214,6 +215,17 @@ vi.mock("../src/lib/hosted-onboarding/linq", async () => {
   };
 });
 
+vi.mock("@/src/lib/hosted-onboarding/linq-client", async () => {
+  const actual = await vi.importActual<typeof import("@/src/lib/hosted-onboarding/linq-client")>(
+    "@/src/lib/hosted-onboarding/linq-client",
+  );
+
+  return {
+    ...actual,
+    getHostedLinqChatSummary: mocks.getHostedLinqChatSummary,
+  };
+});
+
 vi.mock("@/src/lib/hosted-onboarding/runtime", async () => {
   const actual = await vi.importActual<typeof import("@/src/lib/hosted-onboarding/runtime")>(
     "@/src/lib/hosted-onboarding/runtime",
@@ -340,6 +352,11 @@ describe("hosted Linq usage reset e2e", () => {
     vi.setSystemTime(new Date("2026-04-30T12:00:00.000Z"));
     vi.clearAllMocks();
 
+    mocks.getHostedLinqChatSummary.mockResolvedValue({
+      handles: [],
+      isGroup: false,
+    });
+
     mocks.lookupHostedMemberByVerifiedEmailAddress.mockResolvedValue(null);
     mocks.lookupHostedMemberIdentityByPhoneNumber.mockResolvedValue({
       core: activeMember,
@@ -462,6 +479,7 @@ describe("hosted Linq usage reset e2e", () => {
                 value: "Can you answer before the reset?",
               },
             ],
+            threadIsDirect: true,
           }),
         }),
         userId: MEMBER_ID,
@@ -474,6 +492,10 @@ describe("hosted Linq usage reset e2e", () => {
       mailboxItemId: "mailbox_evt_before_reset",
     });
     expectHostedLinqReadReceiptSent();
+    expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+      chatId: CHAT_ID,
+      timeoutMs: 1_500,
+    });
     expect(usage.getPeriod("2026-04-01T00:00:00.000Z")).toMatchObject({
       limitNoticeSentAt: null,
       spentUsdMicros: monthlyLimit,
@@ -536,6 +558,7 @@ describe("hosted Linq usage reset e2e", () => {
                 value: "Can you answer after the reset?",
               },
             ],
+            threadIsDirect: true,
           }),
         }),
         userId: MEMBER_ID,
@@ -549,6 +572,10 @@ describe("hosted Linq usage reset e2e", () => {
       mailboxItemId: "mailbox_evt_after_reset",
     });
     expectHostedLinqReadReceiptSent();
+    expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+      chatId: CHAT_ID,
+      timeoutMs: 1_500,
+    });
   });
 
   it("preserves exhausted-period messages when the usage-limit notice was already claimed", async () => {
@@ -603,6 +630,7 @@ describe("hosted Linq usage reset e2e", () => {
           linqMessage: expect.objectContaining({
             chatId: CHAT_ID,
             messageId: "msg_after_notice_claimed",
+            threadIsDirect: true,
           }),
         }),
         userId: MEMBER_ID,
@@ -615,6 +643,10 @@ describe("hosted Linq usage reset e2e", () => {
       mailboxItemId: "mailbox_evt_after_notice_claimed",
     });
     expectHostedLinqReadReceiptSent();
+    expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledWith({
+      chatId: CHAT_ID,
+      timeoutMs: 1_500,
+    });
   });
 });
 

--- a/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   releaseHostedLinqQuotaReplyNoticeClaim: vi.fn(),
   claimHostedLinqDeliveryProviderDispatchTx: vi.fn(),
   ensureHostedMemberForPhoneTx: vi.fn(),
+  getHostedLinqChatSummary: vi.fn(),
   getPrisma: vi.fn(),
   handleHostedGroupJoinOfferReaction: vi.fn(),
   incrementHostedLinqInboundDailyState: vi.fn(),
@@ -147,6 +148,10 @@ vi.mock("@/src/lib/hosted-onboarding/linq", async () => {
   };
 });
 
+vi.mock("@/src/lib/hosted-onboarding/linq-client", () => ({
+  getHostedLinqChatSummary: mocks.getHostedLinqChatSummary,
+}));
+
 vi.mock("@/src/lib/hosted-onboarding/linq-delivery-store", async () => {
   const actual = await vi.importActual<
     typeof import("@/src/lib/hosted-onboarding/linq-delivery-store")
@@ -178,6 +183,10 @@ import { handleHostedOnboardingLinqWebhook } from "@/src/lib/hosted-onboarding/w
 describe("hosted onboarding Linq webhook hard-cut flows", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    mocks.getHostedLinqChatSummary.mockResolvedValue({
+      handles: [],
+      isGroup: false,
+    });
     const linq = await vi.importActual<typeof import("@/src/lib/hosted-onboarding/linq")>(
       "@/src/lib/hosted-onboarding/linq",
     );

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -457,7 +457,8 @@ export async function resolveAssistantRouteTurnPlan(input: {
   })
   const shouldInjectOnboardingGuidance =
     input.profile.promptProfile === 'conversation' &&
-    input.sharedPlan.onboardingGuidanceOpen
+    input.sharedPlan.onboardingGuidanceOpen &&
+    input.sharedPlan.conversationPolicy.audience.effectiveThreadIsDirect !== false
   const assistantToolNameAliases = null
   // Maintenance turns consume only the engine-supplied conversation evidence
   // plus canonical memory; the context snapshot (which carries health

--- a/packages/assistant-engine/test/assistant-protocol-index-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-protocol-index-planning.test.ts
@@ -255,7 +255,18 @@ describe('assistant protocol index planning', () => {
     expect(plan.systemPrompt).not.toContain('Supported experiment protocols:')
   })
 
-  it('injects Murph onboarding skill activation through route planning', async () => {
+  it.each([
+    {
+      effectiveThreadIsDirect: true,
+      label: 'direct',
+    },
+    {
+      effectiveThreadIsDirect: null,
+      label: 'unknown-directness',
+    },
+  ] as const)('injects Murph onboarding skill activation for a $label conversation through route planning', async ({
+    effectiveThreadIsDirect,
+  }) => {
     planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
     planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(null)
     planningMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
@@ -267,6 +278,11 @@ describe('assistant protocol index planning', () => {
       toolProfile: 'provider-turn',
     }
 
+    const sharedPlan = createSharedPlan({
+      onboardingGuidanceOpen: true,
+    })
+    sharedPlan.conversationPolicy.audience.effectiveThreadIsDirect = effectiveThreadIsDirect
+
     const plan = await resolveAssistantRouteTurnPlan({
       executionContext: null,
       input: createMessageInput(),
@@ -277,9 +293,7 @@ describe('assistant protocol index planning', () => {
       },
       route: createRoute(),
       session: createSession(),
-      sharedPlan: createSharedPlan({
-        onboardingGuidanceOpen: true,
-      }),
+      sharedPlan,
     })
 
     const skillRef = buildAssistantSkillFileRef('murph-onboarding')
@@ -298,6 +312,45 @@ describe('assistant protocol index planning', () => {
       'roughly 5-6 short assistant messages',
     )
     expect(plan.turnContextPrompt).not.toContain('Natural first-run flow')
+  })
+
+  it('does not inject personal onboarding guidance into a group conversation', async () => {
+    planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(null)
+    planningMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
+      supportsNativeResume: false,
+    })
+    const executionProfile: AssistantCodexTurnResolvedExecutionProfile = {
+      promptProfile: 'conversation',
+      threadScope: 'session-thread',
+      toolProfile: 'provider-turn',
+    }
+    const sharedPlan = createSharedPlan({
+      onboardingGuidanceOpen: true,
+    })
+    sharedPlan.conversationPolicy.audience.effectiveThreadIsDirect = false
+
+    const plan = await resolveAssistantRouteTurnPlan({
+      executionContext: null,
+      input: createMessageInput(),
+      profile: executionProfile,
+      promptTimeContext: {
+        currentLocalDate: '2026-05-04',
+        currentTimeZone: 'Asia/Kuala_Lumpur',
+      },
+      route: createRoute(),
+      session: createSession(),
+      sharedPlan,
+    })
+
+    const skillRef = buildAssistantSkillFileRef('murph-onboarding')
+
+    expect(plan.onboardingGuidanceInjected).toBe(false)
+    expect(plan.systemPrompt).not.toContain(skillRef)
+    expect(plan.developerInstructions).not.toContain('Murph onboarding:')
+    expect(plan.developerInstructions).not.toContain(
+      'Before ending a normal reply while onboarding is open, keep onboarding moving unless a skip condition applies',
+    )
   })
 
   it('resolves assistant voice preferences into ElevenLabs planning ids', async () => {

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -1319,9 +1319,9 @@ function createHostedConversationAssistantInputConversation(
         identifierBlind,
         wake.message.linqMessage.chatId,
       ),
-      threadIsDirect: typeof wake.message.linqMessage.threadIsDirect === "boolean"
-        ? wake.message.linqMessage.threadIsDirect
-        : true,
+      threadIsDirect: wake.message.linqMessage.threadIsDirect === undefined
+        ? true
+        : wake.message.linqMessage.threadIsDirect,
     };
   }
 

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -120,6 +120,7 @@ describe("hosted mailbox conversation import adapter", () => {
               url: "redacted-attachment-url-sentinel",
             },
           ],
+          threadIsDirect: null,
         },
         phoneLookupKey: "redacted-contact-sentinel",
       },
@@ -182,6 +183,7 @@ describe("hosted mailbox conversation import adapter", () => {
     assert.match(event.conversation?.accountId ?? "", HASHED_IDENTIFIER_PATTERN);
     assert.match(event.conversation?.actorId ?? "", HASHED_IDENTIFIER_PATTERN);
     assert.match(event.conversation?.threadId ?? "", HASHED_IDENTIFIER_PATTERN);
+    assert.equal(event.conversation?.threadIsDirect, null);
     const replyTarget = event.replyTarget;
     assert.deepEqual(replyTarget, {
       channel: "linq",

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -213,6 +213,7 @@ export async function startHostedLocalDevStack(input: {
   pipeOutput?: boolean;
   stderrTarget?: NodeJS.WritableStream;
   stdoutTarget?: NodeJS.WritableStream;
+  webProcessEnvOverrides?: NodeJS.ProcessEnv;
 }): Promise<HostedLocalDevStack> {
   throwIfAbortSignalAborted(input.abortSignal);
   const initialEnv = { ...input.env } satisfies NodeJS.ProcessEnv;
@@ -862,7 +863,10 @@ export async function startHostedLocalDevStack(input: {
       : spawnChildProcess("web", "pnpm", buildHostedWebProcessArgs({
         config,
         shouldUseProductionStart: shouldUseWebProductionStart,
-      }), buildHostedWebProcessEnv(runtimeEnv, shouldUseWebProductionStart), {
+      }), buildHostedWebProcessEnv({
+        ...runtimeEnv,
+        ...(input.webProcessEnvOverrides ?? {}),
+      }, shouldUseWebProductionStart), {
         pipeOutput: input.pipeOutput,
         stderrTarget: input.stderrTarget,
         stdoutTarget: input.stdoutTarget,

--- a/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
@@ -566,7 +566,7 @@ describe("hosted local dev stack", () => {
     vi.unstubAllGlobals();
   });
 
-  it("starts Cloudflare through the prepared app-owned dev entrypoint", async () => {
+  it("starts Cloudflare with web-only process environment overrides", async () => {
     vi.stubEnv("OPENAI_API_KEY", "local-openai-key");
     spawnChildProcess
       .mockReturnValueOnce(createBufferedChild({ exitCode: null, name: "cloudflare", pid: 101 }))
@@ -589,10 +589,27 @@ describe("hosted local dev stack", () => {
     const { startHostedLocalDevStack } = await import("../../src/dev-hosted-local/stack.ts");
 
     const stack = await startHostedLocalDevStack({
-      env: process.env,
+      env: {
+        ...process.env,
+        LINQ_API_BASE_URL: "http://host.docker.internal:4011",
+      },
+      webProcessEnvOverrides: {
+        LINQ_API_BASE_URL: "http://127.0.0.1:4011",
+      },
     });
     await stack.ready;
     await stack.stop();
+
+    expect(stack.runtimeEnv.LINQ_API_BASE_URL).toBe(
+      "http://host.docker.internal:4011",
+    );
+    expect(startHostedLocalTemporalRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          LINQ_API_BASE_URL: "http://host.docker.internal:4011",
+        }),
+      }),
+    );
 
     expect(spawnChildProcess).toHaveBeenCalledWith(
       "cloudflare",
@@ -628,6 +645,7 @@ describe("hosted local dev stack", () => {
         MURPH_DEV_SKIP_RUNNER_BUNDLE: "1",
         NODE_ENV: "development",
         TSX_TSCONFIG_PATH: expect.stringMatching(/tsconfig\.base\.json$/),
+        LINQ_API_BASE_URL: "http://host.docker.internal:4011",
         OPENAI_API_KEY: "local-openai-key",
         VERCEL_OIDC_TOKEN: "oidc-token",
       }),
@@ -645,6 +663,7 @@ describe("hosted local dev stack", () => {
         "3000",
       ]),
       expect.objectContaining({
+        LINQ_API_BASE_URL: "http://127.0.0.1:4011",
         MURPH_HOSTED_WEB_DEV_OWNER_PID: String(process.pid),
       }),
       expect.any(Object),


### PR DESCRIPTION
## Why

When Murph was added to an iMessage group, a participant's message could be routed into that person's direct assistant runtime. Murph then asked personal onboarding questions inside the group. The ingress path did not carry authoritative direct-vs-group context far enough to prevent personal onboarding.

## User-visible goal

Murph must treat group conversations as group conversations and must never personally onboard an individual from a group message. Existing direct iMessage, SMS, and RCS conversations must continue normally.

## What changed

- Parse and preserve Linq's webhook group metadata, and canonically retrieve chat metadata when the webhook is not already authoritative.
- Classify route-less inbound iMessage, SMS, and RCS chats before any receipt, identity, onboarding, mailbox, outbox, or reply mutation.
- Let an existing durable thread route establish conservative group handling without depending on Linq API availability; the planner still re-reads that route inside its transaction.
- Preserve tri-state directness through mailbox import and suppress onboarding prompts only for explicit group audiences.
- Make every durable Linq thread-route envelope non-direct, independent of conflicting provider metadata.
- Keep classification failures retryable and fail closed before planning.
- Keep the hosted-local Linq provider stub production-shaped for canonical chat reads and reachable by both the host web process and the container runner.

## Invariants preserved

- Webhook verification precedes classification.
- Provider network calls remain outside database transactions.
- Durable thread routes remain the authoritative group-container primitive.
- If a pre-read route disappears, the event remains group-only and cannot fall into personal onboarding.
- If a route appears concurrently, transactional planning routes to the group container.
- Legacy ambiguous directness remains fail closed in the runner.
- Direct current-inbound replies, onboarding, mailbox handoff, billing/access, and read-receipt behavior remain enabled.
- The CI harness does not bypass or weaken production classification; runner environment construction still owns loopback-to-container host rewriting.

## Verification

- Focused Linq dispatch and thread-route suites: 156 passed.
- Focused usage-reset and read-receipt harnesses: 3 passed.
- Focused hosted-local Linq helper and runner-env suites: 53 passed.
- Web and Cloudflare typechecks: passed.
- Scoped ESLint: passed.
- Web `pnpm test:diff`: passed, including 4,056 web tests (9 skipped), production build, dev smoke, dependency/workspace/runtime guards, and lint with 0 errors (9 unrelated existing warnings).
- Cloudflare `pnpm test:diff`: passed, including 93 test files and 1,680 tests plus dependency/workspace/runtime guards.
- Security/privacy completion audit: no medium-or-higher findings.
- Coverage-write completion audits: existing full-handler and harness proof is sufficient; no additional test changes requested.

## Deployment contract

This change spans hosted web ingress and the Cloudflare runner bundle. Do not allow corrected web ingress to send group directness to an older runner that lacks the onboarding guard.

1. Hold or cancel Vercel production promotion so production web remains on the old commit.
2. Merge the protected-main commit.
3. Deploy Cloudflare with `container_rollout=immediate`.
4. Require the managed smoke check to report the exact expected bundle and source fingerprints.
5. Do not treat that smoke alone as fleet convergence. Wait for old per-user runner instances to drain: conservatively, the configured 5-minute active grace plus Cloudflare's possible 15-minute shutdown window, unless equivalent fleet-wide evidence proves convergence earlier. See [Cloudflare container rollouts](https://developers.cloudflare.com/containers/platform-details/rollouts/).
6. Promote hosted web only after runner convergence.
7. Verify one real group turn routes to the thread container with `threadIsDirect: false` and does not emit personal onboarding.

Rollback web first while retaining the guarded runner. Never roll the runner below the onboarding guard while corrected web remains live. If the runner must be rolled back, first hold or roll back web and drain corrected-web executions, then roll back the runner. If production web cannot be reliably held for this sequence, split the runner guard into a predecessor PR and deploy/drain it before landing the web correction.
