### PR TITLE
Reconcile ambiguous hosted receipt checkpoints

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-10-pr475-ambiguous-receipt-checkpoint.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-pr475-ambiguous-receipt-checkpoint.md
@@ -1,0 +1,34 @@
+# PR 475 Ambiguous Receipt Checkpoint Reconciliation
+
+## Goal
+
+Make hosted canonical receipt publication converge when the workspace checkpoint commits but its acknowledgement is lost, without accepting unrelated workspace progress or weakening the active invocation fence.
+
+## Constraints
+
+- Keep the correction inside the existing canonical checkpoint CAS boundary; add no new persisted state, queue, or generic retry subsystem.
+- Retry only the identical `canonical_runtime_commit` request and accept a version conflict only when the returned workspace is the exact requested successor.
+- Preserve rollback for unmatched, rejected, or repeatedly ambiguous outcomes.
+- Preserve unrelated working-tree changes and redact local identifiers from committed artifacts.
+
+## Plan
+
+1. Add a production-faithful regression for a remotely committed checkpoint whose first acknowledgement is lost.
+2. Add one bounded identical-CAS retry and exact successor-state reconciliation in the Cloudflare workspace-port owner.
+3. Document the ambiguous-acknowledgement contract and run focused plus owner verification.
+4. Run required completion audits and close the scoped fix; the PR lane then continues with base integration and exact-head Mountain and Phlebas rounds.
+
+## Verification
+
+- Assistant-runtime focused receipt/checkpoint tests and typecheck
+- Cloudflare hosted control tests and typecheck
+- Core focused receipt tests and typecheck
+- Repo diff verification required by the workflow router
+- Required local audits and exact-head ReviewGPT rounds
+
+## State
+
+Complete. The identical CAS retry and exact successor reconciliation are implemented and documented. Cloudflare typecheck, all 115 workspace-port owner tests, the 1,709-test Cloudflare verification lane, `test:diff`, privacy scanning, security/privacy review, coverage-write review, and local deep review passed with no remaining medium-or-higher finding.
+Status: completed
+Updated: 2026-07-10
+Completed: 2026-07-10

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -753,7 +753,12 @@ snapshot producer. `canonical_runtime_commit` instead uploads exact canonical
 write receipts and publishes a receipt-log ref, bounded to 64 pending entries
 and 64 KiB, through a status-only workspace checkpoint that retains the prior
 snapshot ref. Capacity and log shape are validated before referenced payloads
-are uploaded. Cold restore replays that log over the prior snapshot and marks
+are uploaded. If that checkpoint has an ambiguous transport outcome, the
+Cloudflare workspace port retries the identical expected-version CAS once. It
+accepts a version-conflict response only when the active invocation fence still
+matches and the returned workspace is the exact requested successor, including
+the receipt fingerprint, snapshot ref, wake fields, and retention wake. Cold
+restore replays that log over the prior snapshot and marks
 affected context domains dirty; when the restored log is at the hard entry
 bound, the runtime consolidates it through an idle snapshot before foreground
 mailbox or assistant work. That recovery snapshot publishes an immediate

--- a/apps/cloudflare/src/runtime-platform/workspace-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-port.ts
@@ -1,17 +1,33 @@
 import type { HostedRuntimePlatform } from "@murphai/assistant-runtime/hosted-runtime-contracts";
-import { checkpointHostedRuntimeBridgeWebWorkspace } from "@murphai/assistant-runtime/hosted-checkpoint-bridge";
+import {
+  checkpointHostedRuntimeBridgeWebWorkspace,
+  HostedRuntimeBridgeCheckpointLeaseError,
+} from "@murphai/assistant-runtime/hosted-checkpoint-bridge";
 import {
   parseHostedWorkspaceCheckpointResponse,
   parseHostedWorkspaceReadResponse,
 } from "@murphai/hosted-execution/parsers";
+import {
+  HOSTED_CANONICAL_WRITE_RECEIPT_LOG_BYTE_SIZE_STATUS_KEY,
+  HOSTED_CANONICAL_WRITE_RECEIPT_LOG_SHA_STATUS_KEY,
+  type HostedWorkspaceCheckpointRequest,
+  type HostedWorkspaceCheckpointResponse,
+} from "@murphai/hosted-execution/runtime-control";
 import {
   HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH,
   HOSTED_RUNTIME_WORKSPACE_PATH,
 } from "@murphai/hosted-execution/routes";
 
 import type { HostedWorkspaceCheckpointBridgeAuthority } from "./authority-headers.ts";
-import { requireHostedRuntimeWriteFenceHeaders } from "./authority-headers.ts";
-import { fetchHostedWebControlPlaneJson, type HostedWebControlTransport } from "./web-control-transport.ts";
+import {
+  isHostedRuntimeInternalAuthorityRejectedError,
+  requireHostedRuntimeWriteFenceHeaders,
+} from "./authority-headers.ts";
+import {
+  fetchHostedWebControlPlaneJson,
+  HostedWebControlPlaneResponseError,
+  type HostedWebControlTransport,
+} from "./web-control-transport.ts";
 
 export function createHostedWebWorkspacePort(input: {
   boundUserId: string;
@@ -74,19 +90,156 @@ export function createHostedWebWorkspacePort(input: {
       if (!input.workspaceCheckpointBridge) {
         return await checkpointWorkspace(request);
       }
+      const workspaceCheckpointBridge = input.workspaceCheckpointBridge;
 
-      const response = await checkpointHostedRuntimeBridgeWebWorkspace({
-        checkpointWorkspace,
-        readCurrentLease: input.workspaceCheckpointBridge.readCurrentLease,
-        request,
-        userId: input.boundUserId,
-      });
+      const checkpointThroughBridge = async () =>
+        await checkpointHostedRuntimeBridgeWebWorkspace({
+          checkpointWorkspace,
+          readCurrentLease: workspaceCheckpointBridge.readCurrentLease,
+          request,
+          userId: input.boundUserId,
+        });
+      let response: HostedWorkspaceCheckpointResponse;
+      try {
+        response = await checkpointThroughBridge();
+      } catch (error) {
+        if (
+          request.reason !== "canonical_runtime_commit"
+          || !isAmbiguousHostedWorkspaceCheckpointError(error)
+        ) {
+          throw error;
+        }
+
+        let retried: HostedWorkspaceCheckpointResponse;
+        try {
+          retried = await checkpointThroughBridge();
+        } catch {
+          throw error;
+        }
+        if (retried.checkpointed) {
+          response = retried;
+        } else if (isExactCanonicalCheckpointSuccessor({
+          boundUserId: input.boundUserId,
+          request,
+          response: retried,
+        })) {
+          response = {
+            checkpointed: true,
+            workspace: retried.workspace,
+          };
+        } else {
+          throw error;
+        }
+      }
       if (response.checkpointed) {
-        await input.workspaceCheckpointBridge.recordCheckpoint?.({
+        await workspaceCheckpointBridge.recordCheckpoint?.({
           workspaceVersion: response.workspace.version,
         });
       }
       return response;
     },
   };
+}
+
+function isAmbiguousHostedWorkspaceCheckpointError(error: unknown): boolean {
+  if (
+    error instanceof HostedRuntimeBridgeCheckpointLeaseError
+    || isHostedRuntimeInternalAuthorityRejectedError(error)
+  ) {
+    return false;
+  }
+  if (error instanceof HostedWebControlPlaneResponseError) {
+    return error.status === 408 || error.status >= 500;
+  }
+  return true;
+}
+
+function isExactCanonicalCheckpointSuccessor(input: {
+  boundUserId: string;
+  request: HostedWorkspaceCheckpointRequest;
+  response: HostedWorkspaceCheckpointResponse;
+}): boolean {
+  if (
+    input.request.reason !== "canonical_runtime_commit"
+    || input.response.checkpointed
+    || input.response.checkpointConflictReason !== "workspace_version"
+    || !hasExplicitCanonicalCheckpointState(input.request)
+  ) {
+    return false;
+  }
+
+  const receiptLogSha256 = input.request.redactedStatus?.[
+    HOSTED_CANONICAL_WRITE_RECEIPT_LOG_SHA_STATUS_KEY
+  ];
+  const receiptLogByteSize = input.request.redactedStatus?.[
+    HOSTED_CANONICAL_WRITE_RECEIPT_LOG_BYTE_SIZE_STATUS_KEY
+  ];
+  if (
+    typeof receiptLogSha256 !== "string"
+    || !/^[a-f0-9]{64}$/u.test(receiptLogSha256)
+    || typeof receiptLogByteSize !== "number"
+    || !Number.isSafeInteger(receiptLogByteSize)
+    || receiptLogByteSize <= 0
+  ) {
+    return false;
+  }
+
+  const successorVersion = incrementWorkspaceVersion(
+    input.request.expectedWorkspaceVersion,
+  );
+  const workspace = input.response.workspace;
+  return successorVersion !== null
+    && workspace.userId === input.boundUserId
+    && workspace.version === successorVersion
+    && (workspace.inboxMediaRetentionWakeAt ?? null)
+      === (input.request.inboxMediaRetentionWakeAt ?? null)
+    && (workspace.nextWakeAt ?? null) === (input.request.nextWakeAt ?? null)
+    && (workspace.nextWakeReason ?? null) === (input.request.nextWakeReason ?? null)
+    && areJsonValuesEqual(workspace.snapshotRef, input.request.snapshotRef)
+    && areJsonValuesEqual(
+      workspace.redactedStatus ?? null,
+      input.request.redactedStatus ?? null,
+    );
+}
+
+function hasExplicitCanonicalCheckpointState(
+  request: HostedWorkspaceCheckpointRequest,
+): boolean {
+  return Object.hasOwn(request, "inboxMediaRetentionWakeAt")
+    && Object.hasOwn(request, "nextWakeAt")
+    && Object.hasOwn(request, "nextWakeReason")
+    && Object.hasOwn(request, "redactedStatus");
+}
+
+function incrementWorkspaceVersion(version: string): string | null {
+  if (!/^[0-9]+$/u.test(version)) {
+    return null;
+  }
+  return (BigInt(version) + 1n).toString();
+}
+
+function areJsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return Array.isArray(left)
+      && Array.isArray(right)
+      && left.length === right.length
+      && left.every((value, index) => areJsonValuesEqual(value, right[index]));
+  }
+  if (!isRecord(left) || !isRecord(right)) {
+    return false;
+  }
+
+  const leftKeys = Object.keys(left);
+  return leftKeys.length === Object.keys(right).length
+    && leftKeys.every((key) =>
+      Object.hasOwn(right, key)
+      && areJsonValuesEqual(left[key], right[key])
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -21,6 +21,10 @@ import {
   type HostedWorkspaceSnapshotV2Aad,
   type HostedWorkspaceSnapshotV2Ref,
 } from "@murphai/hosted-execution/workspace-snapshot-v2";
+import type {
+  HostedWorkspaceCheckpointRequest,
+  HostedWorkspaceState,
+} from "@murphai/hosted-execution/runtime-control";
 import {
   HostedRuntimeBridgeCheckpointLeaseError,
 } from "@murphai/assistant-runtime/hosted-checkpoint-bridge";
@@ -5210,6 +5214,432 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect(artifactRequest.headers.get("x-hosted-runtime-attempt-id")).toBe("attempt_1");
     expect(artifactRequest.headers.get("x-hosted-runtime-lease-generation")).toBe("9");
     expect(artifactRequest.headers.get("x-hosted-runtime-workspace-version")).toBe("5");
+  });
+
+  it("reconciles a canonical checkpoint whose committed response is lost", async () => {
+    const redactedStatus = {
+      hostedCanonicalWriteReceiptLogByteSize: 512,
+      hostedCanonicalWriteReceiptLogSha256: "b".repeat(64),
+    };
+    const committedWorkspace = {
+      checkpointedAt: "2026-04-26T00:00:04.000Z",
+      createdAt: "2026-04-26T00:00:00.000Z",
+      inboxMediaRetentionWakeAt: "2026-04-30T00:00:00.000Z",
+      nextWakeAt: "2026-04-27T00:10:00.000Z",
+      nextWakeReason: "assistant",
+      redactedStatus,
+      snapshotRef: null,
+      updatedAt: "2026-04-26T00:00:04.000Z",
+      userId: "member_123",
+      version: "5",
+    };
+    let currentLease = {
+      attemptId: "attempt_1",
+      leaseGeneration: "9",
+      userId: "member_123",
+      workspaceVersion: "4",
+    };
+    const recordCheckpoint = vi.fn(({ workspaceVersion }: { workspaceVersion: string }) => {
+      currentLease = {
+        ...currentLease,
+        workspaceVersion,
+      };
+    });
+    let checkpointCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url === "http://web-control.worker/api/internal/hosted-workspace/checkpoint") {
+        checkpointCalls += 1;
+        if (checkpointCalls === 1) {
+          throw new Error("Synthetic response loss after the workspace CAS committed.");
+        }
+        return new Response(JSON.stringify({
+          checkpointConflictReason: "workspace_version",
+          checkpointed: false,
+          workspace: committedWorkspace,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      return new Response(null, { status: 200 });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => currentLease,
+        recordCheckpoint,
+      },
+    });
+    const checkpointRequest = {
+      attemptId: "attempt_1",
+      expectedWorkspaceVersion: "4",
+      inboxMediaRetentionWakeAt: committedWorkspace.inboxMediaRetentionWakeAt,
+      leaseGeneration: "9",
+      nextWakeAt: committedWorkspace.nextWakeAt,
+      nextWakeReason: committedWorkspace.nextWakeReason,
+      reason: "canonical_runtime_commit" as const,
+      redactedStatus,
+      snapshotRef: null,
+    };
+
+    const result = await platform.workspacePort!.checkpoint(checkpointRequest);
+
+    expect(result).toEqual({
+      checkpointed: true,
+      workspace: committedWorkspace,
+    });
+    expect(recordCheckpoint).toHaveBeenCalledOnce();
+    expect(recordCheckpoint).toHaveBeenCalledWith({ workspaceVersion: "5" });
+    expect(checkpointCalls).toBe(2);
+    expect(currentLease.workspaceVersion).toBe("5");
+    const firstRequest = requireFetchRequest(fetchMock.mock.calls[0], "initial checkpoint");
+    const retryRequest = requireFetchRequest(fetchMock.mock.calls[1], "retried checkpoint");
+    await expect(firstRequest.json()).resolves.toEqual(checkpointRequest);
+    await expect(retryRequest.json()).resolves.toEqual(checkpointRequest);
+  });
+
+  it("rejects ambiguous canonical checkpoints without exact successor proof", async () => {
+    const rejectionCases: Array<{
+      label: string;
+      mutate(input: {
+        request: HostedWorkspaceCheckpointRequest;
+        workspace: HostedWorkspaceState;
+      }): void;
+    }> = [
+      {
+        label: "receipt state mismatch",
+        mutate({ workspace }) {
+          workspace.redactedStatus = {
+            ...workspace.redactedStatus,
+            hostedCanonicalWriteReceiptLogByteSize: 513,
+          };
+        },
+      },
+      {
+        label: "non-successor version",
+        mutate({ workspace }) {
+          workspace.version = "6";
+        },
+      },
+      {
+        label: "invalid receipt authority",
+        mutate({ request, workspace }) {
+          request.redactedStatus = {
+            hostedCanonicalWriteReceiptLogByteSize: 512,
+            hostedCanonicalWriteReceiptLogSha256: "invalid",
+          };
+          workspace.redactedStatus = request.redactedStatus;
+        },
+      },
+      {
+        label: "implicit retention wake",
+        mutate({ request }) {
+          delete request.inboxMediaRetentionWakeAt;
+        },
+      },
+    ];
+
+    for (const rejectionCase of rejectionCases) {
+      const redactedStatus = {
+        hostedCanonicalWriteReceiptLogByteSize: 512,
+        hostedCanonicalWriteReceiptLogSha256: "d".repeat(64),
+      };
+      const request: HostedWorkspaceCheckpointRequest = {
+        attemptId: "attempt_1",
+        expectedWorkspaceVersion: "4",
+        inboxMediaRetentionWakeAt: null,
+        leaseGeneration: "9",
+        nextWakeAt: null,
+        nextWakeReason: null,
+        reason: "canonical_runtime_commit",
+        redactedStatus,
+        snapshotRef: null,
+      };
+      const workspace: HostedWorkspaceState = {
+        checkpointedAt: "2026-04-26T00:00:04.000Z",
+        createdAt: "2026-04-26T00:00:00.000Z",
+        inboxMediaRetentionWakeAt: null,
+        nextWakeAt: null,
+        nextWakeReason: null,
+        redactedStatus,
+        snapshotRef: null,
+        updatedAt: "2026-04-26T00:00:04.000Z",
+        userId: "member_123",
+        version: "5",
+      };
+      rejectionCase.mutate({ request, workspace });
+      const recordCheckpoint = vi.fn();
+      const fetchMock = vi.fn(async () => {
+        if (fetchMock.mock.calls.length === 1) {
+          throw new Error(`Synthetic ambiguous failure: ${rejectionCase.label}.`);
+        }
+        return new Response(JSON.stringify({
+          checkpointConflictReason: "workspace_version",
+          checkpointed: false,
+          workspace,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      });
+      const platform = buildTestHostedExecutionRuntimePlatform({
+        boundUserId: "member_123",
+        fetchImpl: fetchMock as typeof fetch,
+        workspaceCheckpointBridge: {
+          readCurrentLease: () => ({
+            attemptId: "attempt_1",
+            leaseGeneration: "9",
+            userId: "member_123",
+            workspaceVersion: "4",
+          }),
+          recordCheckpoint,
+        },
+      });
+
+      await expect(platform.workspacePort!.checkpoint(request)).rejects.toThrow(
+        "Hosted workspace checkpoint request failed.",
+      );
+      expect(fetchMock, rejectionCase.label).toHaveBeenCalledTimes(2);
+      expect(recordCheckpoint, rejectionCase.label).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rethrows the first error when canonical checkpoint reconciliation stays ambiguous", async () => {
+    const firstFailure = new Error("Synthetic first ambiguous checkpoint failure.");
+    const retryFailure = new Error("Synthetic retry checkpoint failure.");
+    const recordCheckpoint = vi.fn();
+    const fetchMock = vi.fn(async () => {
+      throw fetchMock.mock.calls.length === 1 ? firstFailure : retryFailure;
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "4",
+        }),
+        recordCheckpoint,
+      },
+    });
+
+    let rejected: unknown = null;
+    try {
+      await platform.workspacePort!.checkpoint({
+        attemptId: "attempt_1",
+        expectedWorkspaceVersion: "4",
+        inboxMediaRetentionWakeAt: null,
+        leaseGeneration: "9",
+        nextWakeAt: null,
+        nextWakeReason: null,
+        reason: "canonical_runtime_commit",
+        redactedStatus: {
+          hostedCanonicalWriteReceiptLogByteSize: 512,
+          hostedCanonicalWriteReceiptLogSha256: "e".repeat(64),
+        },
+        snapshotRef: null,
+      });
+    } catch (error) {
+      rejected = error;
+    }
+
+    expect(rejected).toBeInstanceOf(Error);
+    if (!(rejected instanceof Error)) {
+      throw new Error("Expected canonical checkpoint failure.");
+    }
+    expect(rejected.cause).toBe(firstFailure);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(recordCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a canonical checkpoint after its active lease changes", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("Synthetic ambiguous checkpoint failure.");
+    });
+    const recordCheckpoint = vi.fn();
+    let leaseReads = 0;
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => {
+          leaseReads += 1;
+          return {
+            attemptId: "attempt_1",
+            leaseGeneration: "9",
+            userId: "member_123",
+            workspaceVersion: leaseReads <= 2 ? "4" : "5",
+          };
+        },
+        recordCheckpoint,
+      },
+    });
+
+    await expect(platform.workspacePort!.checkpoint({
+      attemptId: "attempt_1",
+      expectedWorkspaceVersion: "4",
+      inboxMediaRetentionWakeAt: null,
+      leaseGeneration: "9",
+      nextWakeAt: null,
+      nextWakeReason: null,
+      reason: "canonical_runtime_commit",
+      redactedStatus: {
+        hostedCanonicalWriteReceiptLogByteSize: 512,
+        hostedCanonicalWriteReceiptLogSha256: "1".repeat(64),
+      },
+      snapshotRef: null,
+    })).rejects.toThrow("Hosted workspace checkpoint request failed.");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(recordCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("does not retry deterministic canonical checkpoint rejection responses", async () => {
+    const fetchMock = vi.fn(async () => new Response("Unauthorized", { status: 401 }));
+    const recordCheckpoint = vi.fn();
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "4",
+        }),
+        recordCheckpoint,
+      },
+    });
+
+    await expect(platform.workspacePort!.checkpoint({
+      attemptId: "attempt_1",
+      expectedWorkspaceVersion: "4",
+      inboxMediaRetentionWakeAt: null,
+      leaseGeneration: "9",
+      nextWakeAt: null,
+      nextWakeReason: null,
+      reason: "canonical_runtime_commit",
+      redactedStatus: {
+        hostedCanonicalWriteReceiptLogByteSize: 512,
+        hostedCanonicalWriteReceiptLogSha256: "f".repeat(64),
+      },
+      snapshotRef: null,
+    })).rejects.toMatchObject({ status: 401 });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(recordCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("does not retry ambiguous non-canonical checkpoints", async () => {
+    const transportFailure = new Error("Synthetic import checkpoint transport failure.");
+    const fetchMock = vi.fn(async () => {
+      throw transportFailure;
+    });
+    const recordCheckpoint = vi.fn();
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "4",
+        }),
+        recordCheckpoint,
+      },
+    });
+
+    let rejected: unknown = null;
+    try {
+      await platform.workspacePort!.checkpoint({
+        attemptId: "attempt_1",
+        expectedWorkspaceVersion: "4",
+        leaseGeneration: "9",
+        reason: "import",
+        snapshotRef: null,
+      });
+    } catch (error) {
+      rejected = error;
+    }
+
+    expect(rejected).toBeInstanceOf(Error);
+    if (!(rejected instanceof Error)) {
+      throw new Error("Expected non-canonical checkpoint failure.");
+    }
+    expect(rejected.cause).toBe(transportFailure);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(recordCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("retries a server-error canonical checkpoint response once", async () => {
+    const redactedStatus = {
+      hostedCanonicalWriteReceiptLogByteSize: 512,
+      hostedCanonicalWriteReceiptLogSha256: "0".repeat(64),
+    };
+    const recordCheckpoint = vi.fn();
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        return new Response("Temporarily unavailable", { status: 503 });
+      }
+      return new Response(JSON.stringify({
+        checkpointed: true,
+        workspace: {
+          checkpointedAt: "2026-04-26T00:00:04.000Z",
+          createdAt: "2026-04-26T00:00:00.000Z",
+          inboxMediaRetentionWakeAt: null,
+          nextWakeAt: null,
+          nextWakeReason: null,
+          redactedStatus,
+          snapshotRef: null,
+          updatedAt: "2026-04-26T00:00:04.000Z",
+          userId: "member_123",
+          version: "5",
+        },
+      }), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        status: 200,
+      });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "4",
+        }),
+        recordCheckpoint,
+      },
+    });
+
+    const result = await platform.workspacePort!.checkpoint({
+      attemptId: "attempt_1",
+      expectedWorkspaceVersion: "4",
+      inboxMediaRetentionWakeAt: null,
+      leaseGeneration: "9",
+      nextWakeAt: null,
+      nextWakeReason: null,
+      reason: "canonical_runtime_commit",
+      redactedStatus,
+      snapshotRef: null,
+    });
+
+    expect(result.checkpointed).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(recordCheckpoint).toHaveBeenCalledOnce();
   });
 
   it("uses the advanced checkpoint version for direct-R2 snapshot start and complete", async () => {


### PR DESCRIPTION
## Why

PR #475 made hosted canonical writes crash-durable through receipt-log checkpoints. If the web checkpoint committed but its response was lost, the runtime could still report failure and roll the local write back while the durable receipt remained eligible for replay.

## User-visible goal

A hosted canonical write must not appear after being reported as failed or be duplicated by a retry when its receipt checkpoint already committed.

## Invariants

- Retry only the identical `canonical_runtime_commit` expected-version CAS, once.
- Keep the active attempt, lease generation, and workspace-version fence valid across both attempts.
- Accept a version conflict only when the returned workspace is the exact requested successor, including receipt authority, snapshot ref, wakes, retention wake, and full redacted status.
- Preserve existing rollback behavior for mismatches, deterministic rejection, stale authority, non-canonical checkpoints, and repeated ambiguity.

## Verification

- `pnpm --dir apps/cloudflare typecheck`
- `runner-platform.test.ts` (115/115)
- `pnpm test:diff ...` (Cloudflare verification: 1,709/1,709)
- security/privacy, coverage-write, and deep-review audits: no remaining medium-or-higher findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786288700&installation_id=127572939&pr_number=532&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F532&signature=f9308aa26f37c7da8232d44ca6e79ff8fbe64ffd55c9864b2590b8214c3c9dd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->