### PR TITLE
Harden reply path against observability and maintenance stalls

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-10-hosted-latency-review-followups.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-hosted-latency-review-followups.md
@@ -1,0 +1,51 @@
+# Hosted latency review follow-ups (post-PR #519)
+
+## Goal
+
+Fix the four material gaps a deep review found in merged PR #519 ("Reduce
+hosted reply hot-path latency") without adding schedulers, managers, or new
+lifecycle machinery:
+
+1. Attempt telemetry could delay Codex start and discard a successful reply:
+   `recordCodexAttemptStarted` was awaited before the provider ran and
+   `recordCodexAttemptSucceeded` was awaited inside the success try block, so
+   a failed receipt write reclassified a successful turn as a provider
+   failure. Both events were write-only (no reader anywhere).
+2. An optional diagnostics write in `finalizeAssistantTurnFromDeliveryOutcome`
+   ran after authoritative receipt finalization but before first-contact
+   state; its failure entered notification commit-error handling and marked
+   an already-pending queued outbox intent abandoned.
+3. PR #519 removed the maintenance owner from `sendAssistantMessageLocal`, so
+   direct ask/chat/assistantd modes could grow runtime state (transcripts,
+   event logs) without bound; the regression test covering this was deleted.
+4. The automation pass checked foreground availability once, then ran the
+   whole maintenance pass under the runtime write lock with no way to yield
+   when a foreground wake arrived mid-pass.
+
+## Approach
+
+- Delete the write-only start/success attempt events (keep
+  `recordCodexAttemptFailed`, which feeds diagnostics). Keep the contract enum
+  values so persisted receipts still parse.
+- Make the terminal delivery diagnostic last and best-effort; receipt
+  finalization stays the commit, first-contact marking stays awaited.
+- Restore a post-turn maintenance owner in `sendAssistantMessageLocal` for
+  `turnTrigger !== 'automation-auto-reply'` (try/finally around the locked
+  turn), keeping maintenance off the foreground reply path.
+- Thread the existing `shouldYieldBackgroundMaintenance` predicate and abort
+  signal into `maybeRunAssistantRuntimeMaintenance`; check between bounded
+  units, note a yielded pass, and preserve the previous `lastRunAt` so the
+  next idle pass retries promptly.
+
+## Verification
+
+- Full `assistant-engine` (2017), `assistant-runtime` (1497), and
+  `assistant-cli` (128) suites pass; workspace build and typecheck pass.
+- New regression tests: diagnostic-rejection on model and exact-text
+  queue-only notifications (bite-checked against the reverted fix), post-turn
+  maintenance ownership and ordering, restored oversized-event-log compaction
+  in direct mode, mid-pass yield and aborted-signal skip, run-loop threading
+  of the yield predicate.
+Status: completed
+Updated: 2026-07-10
+Completed: 2026-07-10

--- a/packages/assistant-engine/src/assistant/automation/run-loop.ts
+++ b/packages/assistant-engine/src/assistant/automation/run-loop.ts
@@ -952,6 +952,8 @@ export async function runAssistantAutomationPass(
     && input.shouldYieldBackgroundMaintenance?.() !== true
   ) {
     await maybeRunAssistantRuntimeMaintenance({
+      shouldYield: input.shouldYieldBackgroundMaintenance ?? null,
+      signal: input.signal ?? null,
       vault: input.vault,
     }).catch((error) => {
       warnAssistantBestEffortFailure({

--- a/packages/assistant-engine/src/assistant/codex-turn-runner.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn-runner.ts
@@ -74,8 +74,6 @@ import type { AssistantUserMessageContentPart } from './content-types.js'
 import type { AssistantProviderTraceEvent } from './provider-traces.js'
 import {
   recordCodexAttemptFailed,
-  recordCodexAttemptStarted,
-  recordCodexAttemptSucceeded,
 } from './codex-turn/attempt-observability.js'
 import {
   buildCodexTurnExecutionPlan,
@@ -357,7 +355,6 @@ async function executeAssistantCodexAttempt(input: {
     runtimeIssueInputs: [] as readonly AssistantRuntimeIssueInput[],
   }
 
-  const attemptAt = new Date().toISOString()
   emitCodexPlanTraceEvent({
     onTraceEvent: executionPlan.input.onTraceEvent,
     codexContinuation: attemptPlan.routePlan.codexContinuation.kind,
@@ -365,13 +362,6 @@ async function executeAssistantCodexAttempt(input: {
     routePlanningDiagnostics: attemptPlan.routePlan.planningDiagnostics,
     resumeCodexThreadIdPresent: attemptPlan.routePlan.resume !== null,
     workingDirectory: attemptPlan.routePlan.workingDirectory,
-  })
-  await recordCodexAttemptStarted({
-    attemptCount: attemptPlan.attemptCount,
-    at: attemptAt,
-    route: attemptPlan.route,
-    turnId: executionPlan.turnId,
-    vault: executionPlan.input.vault,
   })
   let effectiveCodexContinuation = attemptPlan.routePlan.codexContinuation
   let usageAttribution: AssistantUsageAttribution | null = null
@@ -530,14 +520,6 @@ async function executeAssistantCodexAttempt(input: {
       throw attemptResult.error
     }
     const result = attemptResult.result
-
-    await recordCodexAttemptSucceeded({
-      activityLabels: attemptMetadata.activityLabels,
-      attemptCount: attemptPlan.attemptCount,
-      route: attemptPlan.route,
-      turnId: executionPlan.turnId,
-      vault: executionPlan.input.vault,
-    })
     return {
       kind: 'succeeded',
       result: {

--- a/packages/assistant-engine/src/assistant/codex-turn/attempt-observability.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/attempt-observability.ts
@@ -3,62 +3,14 @@ import {
   type CodexThreadIdentity,
 } from '../codex-thread-route.js'
 import { recordAssistantDiagnosticEvent } from '../diagnostics.js'
+import { warnAssistantBestEffortFailure } from '../shared.js'
 import {
   appendAssistantTurnReceiptEvent,
 } from '../turns.js'
 
-export async function recordCodexAttemptStarted(input: {
-  attemptCount: number
-  at: string
-  route: CodexThreadIdentity
-  turnId: string
-  vault: string
-}): Promise<void> {
-  const routeFingerprint = readCodexThreadRouteFingerprint(input.route)
-  await appendAssistantTurnReceiptEvent({
-    vault: input.vault,
-    turnId: input.turnId,
-    kind: 'provider.attempt.started',
-    detail: input.route.label,
-    metadata: {
-      attempt: String(input.attemptCount),
-      provider: input.route.provider,
-      model: input.route.providerOptions.model ?? 'default',
-      routeFingerprint,
-    },
-    at: input.at,
-  })
-}
-
-export async function recordCodexAttemptSucceeded(input: {
-  activityLabels?: readonly string[]
-  attemptCount: number
-  route: CodexThreadIdentity
-  turnId: string
-  vault: string
-}): Promise<void> {
-  const activityLabels = input.activityLabels ?? []
-  const routeFingerprint = readCodexThreadRouteFingerprint(input.route)
-  const metadata: Record<string, string> = {
-    attempt: String(input.attemptCount),
-    provider: input.route.provider,
-    model: input.route.providerOptions.model ?? 'default',
-    routeFingerprint,
-  }
-  if (activityLabels.length > 0) {
-    metadata.activityCount = String(activityLabels.length)
-    metadata.activities = activityLabels.join(', ')
-  }
-
-  await appendAssistantTurnReceiptEvent({
-    vault: input.vault,
-    turnId: input.turnId,
-    kind: 'provider.attempt.succeeded',
-    detail: input.route.label,
-    metadata,
-  })
-}
-
+// Only failed attempts are recorded: the start/success receipt events were
+// write-only (no reader), and awaiting them let an observability write delay
+// provider start or reclassify a successful turn as a provider failure.
 export async function recordCodexAttemptFailed(input: {
   activityLabels?: readonly string[]
   attemptCount: number
@@ -83,30 +35,48 @@ export async function recordCodexAttemptFailed(input: {
     metadata.activities = activityLabels.join(', ')
   }
 
-  await appendAssistantTurnReceiptEvent({
-    vault: input.vault,
-    turnId: input.turnId,
-    kind: 'provider.attempt.failed',
-    detail: input.detail,
-    metadata,
-  })
-  await recordAssistantDiagnosticEvent({
-    vault: input.vault,
-    component: 'provider',
-    kind: 'provider.attempt.failed',
-    level: 'warn',
-    message: input.detail,
-    code: input.errorCode,
-    sessionId: input.sessionId,
-    turnId: input.turnId,
-    data: {
-      attempt: input.attemptCount,
-      routeFingerprint,
-      provider: input.route.provider,
-      model: input.route.providerOptions.model,
-    },
-    counterDeltas: {
-      providerFailures: 1,
-    },
-  })
+  // Both writes are best-effort: this runs inside the provider failure
+  // classification, and a thrown observability error here would replace the
+  // structured failed-attempt outcome (thread id, usage, delivered-context
+  // ordinals) with an unclassified error.
+  try {
+    await appendAssistantTurnReceiptEvent({
+      vault: input.vault,
+      turnId: input.turnId,
+      kind: 'provider.attempt.failed',
+      detail: input.detail,
+      metadata,
+    })
+  } catch (error) {
+    warnAssistantBestEffortFailure({
+      error,
+      operation: 'provider attempt receipt event',
+    })
+  }
+  try {
+    await recordAssistantDiagnosticEvent({
+      vault: input.vault,
+      component: 'provider',
+      kind: 'provider.attempt.failed',
+      level: 'warn',
+      message: input.detail,
+      code: input.errorCode,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      data: {
+        attempt: input.attemptCount,
+        routeFingerprint,
+        provider: input.route.provider,
+        model: input.route.providerOptions.model,
+      },
+      counterDeltas: {
+        providerFailures: 1,
+      },
+    })
+  } catch (error) {
+    warnAssistantBestEffortFailure({
+      error,
+      operation: 'provider attempt diagnostic',
+    })
+  }
 }

--- a/packages/assistant-engine/src/assistant/delivery-service.ts
+++ b/packages/assistant-engine/src/assistant/delivery-service.ts
@@ -30,7 +30,10 @@ import type {
 import type {
   AssistantMessageReaction,
 } from '@murphai/operator-config/assistant-cli-contracts'
-import { normalizeNullableString } from './shared.js'
+import {
+  normalizeNullableString,
+  warnAssistantBestEffortFailure,
+} from './shared.js'
 import {
   normalizeAssistantResponseMediaList,
 } from './response-media.js'
@@ -992,7 +995,6 @@ export async function finalizeAssistantTurnFromDeliveryOutcome(input: {
   })
   const state = createAssistantRuntimeStateService(input.vault)
   await state.turns.finalizeReceipt(plan.receipt)
-  await state.diagnostics.recordEvent(plan.diagnostic)
   // Any accepted reply on a first-contact-scoped route is first contact, not
   // just the canned welcome text: once the user has heard from the assistant
   // here, a queued signup welcome for this route is stale and must skip.
@@ -1007,6 +1009,15 @@ export async function finalizeAssistantTurnFromDeliveryOutcome(input: {
       vault: input.vault,
     })
   }
+  // The receipt finalization above is the commit; the terminal diagnostic is
+  // observability only and must never fail an already-accepted delivery (a
+  // thrown error here would abandon a queued outbox intent upstream).
+  await state.diagnostics.recordEvent(plan.diagnostic).catch((error) => {
+    warnAssistantBestEffortFailure({
+      error,
+      operation: 'turn delivery diagnostic',
+    })
+  })
 }
 
 // The first-contact marker's only reader is the hosted signup-welcome skip,

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -94,6 +94,7 @@ import {
   recordAdditionalAssistantUsageEvents,
   recordAssistantUsageEvent,
 } from './service-usage.js'
+import { maybeRunAssistantRuntimeMaintenance } from './runtime-budgets.js'
 import {
   type AssistantActiveTurnInputAdmissionResult,
 } from './turn-input.js'
@@ -368,7 +369,7 @@ export async function sendAssistantMessageLocal(
     executionContext,
   })
   const turnLockWaitStartedAt = Date.now()
-  return withAssistantTurnLock({
+  const runLockedTurn = () => withAssistantTurnLock({
     abortSignal: input.abortSignal,
     vault: input.vault,
     run: async () => {
@@ -1709,6 +1710,23 @@ export async function sendAssistantMessageLocal(
       }
     },
   })
+
+  try {
+    return await runLockedTurn()
+  } finally {
+    // The automation pass owns maintenance for auto-reply turns; every
+    // independently-started turn keeps a post-turn owner so direct ask/chat/
+    // assistantd use cannot grow runtime state (transcripts, event logs)
+    // without bound. Post-turn keeps it off the foreground reply path.
+    if (input.turnTrigger !== 'automation-auto-reply') {
+      await runAssistantTurnBestEffort(() =>
+        maybeRunAssistantRuntimeMaintenance({
+          signal: input.abortSignal ?? null,
+          vault: input.vault,
+        })
+      )
+    }
+  }
 }
 
 function assistantDeliveryOutcomeSupersedesTypingIndicatorForTarget(input: {

--- a/packages/assistant-engine/src/assistant/runtime-budgets.ts
+++ b/packages/assistant-engine/src/assistant/runtime-budgets.ts
@@ -41,6 +41,8 @@ const QUARANTINE_METADATA_SUFFIX = '.meta.json'
 
 export async function maybeRunAssistantRuntimeMaintenance(input: {
   now?: Date
+  shouldYield?: (() => boolean) | null
+  signal?: AbortSignal | null
   vault: string
 }): Promise<AssistantRuntimeBudgetSnapshot> {
   const now = input.now ?? new Date()
@@ -58,10 +60,17 @@ export async function maybeRunAssistantRuntimeMaintenance(input: {
     ) {
       return current
     }
+    // Foreground work may have arrived while waiting for the runtime lock.
+    if (assistantRuntimeMaintenanceYieldRequested(input)) {
+      return current
+    }
 
     return await runAssistantRuntimeMaintenanceAtPaths({
       now,
       paths,
+      previousLastRunAt: lastRunAt,
+      shouldYield: input.shouldYield ?? null,
+      signal: input.signal ?? null,
       vault: input.vault,
     })
   })
@@ -93,64 +102,116 @@ export async function readAssistantRuntimeBudgetStatus(
   })
 }
 
+function assistantRuntimeMaintenanceYieldRequested(input: {
+  shouldYield?: (() => boolean) | null
+  signal?: AbortSignal | null
+}): boolean {
+  return input.signal?.aborted === true || input.shouldYield?.() === true
+}
+
 async function runAssistantRuntimeMaintenanceAtPaths(input: {
   now: Date
   paths: AssistantStatePaths
+  previousLastRunAt?: string | null
+  shouldYield?: (() => boolean) | null
+  signal?: AbortSignal | null
   vault: string
 }): Promise<AssistantRuntimeBudgetSnapshot> {
   const nowIso = input.now.toISOString()
   const notes: string[] = []
+  let staleQuarantinePruned = 0
+  let transcriptRetention = {
+    entriesTrimmed: 0,
+    transcriptsTrimmed: 0,
+  }
+  let terminalOutboxPruned = 0
+  let cronHistory = {
+    responsesRedacted: 0,
+    runsPruned: 0,
+  }
+  let staleLocksCleared = 0
+
   const expiredCacheEntries = pruneAssistantRuntimeCaches(input.now.getTime())
   if (expiredCacheEntries > 0) {
     notes.push(
       `${expiredCacheEntries} expired runtime cache entr${expiredCacheEntries === 1 ? 'y was' : 'ies were'} pruned.`,
     )
   }
-  const staleQuarantinePruned = await pruneAssistantQuarantineFiles(
-    input.paths,
-    input.now,
-  )
-  if (staleQuarantinePruned > 0) {
-    notes.push(
-      `${staleQuarantinePruned} expired quarantine artifact(s) were removed.`,
-    )
+
+  const units: Array<() => Promise<void>> = [
+    async () => {
+      staleQuarantinePruned = await pruneAssistantQuarantineFiles(
+        input.paths,
+        input.now,
+      )
+      if (staleQuarantinePruned > 0) {
+        notes.push(
+          `${staleQuarantinePruned} expired quarantine artifact(s) were removed.`,
+        )
+      }
+    },
+    async () => {
+      transcriptRetention = await pruneAssistantTranscriptRetention(input.paths)
+      if (transcriptRetention.entriesTrimmed > 0) {
+        notes.push(
+          `${transcriptRetention.entriesTrimmed} transcript entr${transcriptRetention.entriesTrimmed === 1 ? 'y was' : 'ies were'} trimmed across ${transcriptRetention.transcriptsTrimmed} session transcript(s).`,
+        )
+      }
+    },
+    async () => {
+      terminalOutboxPruned = await pruneAssistantTerminalOutboxIntents({
+        now: input.now,
+        paths: input.paths,
+        vault: input.vault,
+      })
+      if (terminalOutboxPruned > 0) {
+        notes.push(
+          `${terminalOutboxPruned} terminal outbox intent(s) were pruned.`,
+        )
+      }
+    },
+    async () => {
+      cronHistory = await pruneAssistantCronRunHistory({
+        now: input.now,
+        paths: input.paths,
+      })
+      if (cronHistory.responsesRedacted > 0) {
+        notes.push(
+          `${cronHistory.responsesRedacted} older cron response(s) were redacted.`,
+        )
+      }
+      if (cronHistory.runsPruned > 0) {
+        notes.push(
+          `${cronHistory.runsPruned} stale cron run record(s) were pruned.`,
+        )
+      }
+    },
+    async () => {
+      staleLocksCleared = await clearStaleAssistantLocks({
+        paths: input.paths,
+        vault: input.vault,
+      })
+      if (staleLocksCleared > 0) {
+        notes.push(`${staleLocksCleared} stale runtime lock(s) were cleared.`)
+      }
+    },
+  ]
+
+  // Maintenance holds the runtime write lock through workspace-wide file
+  // traversals. Yield between bounded units so foreground work arriving
+  // mid-pass only ever waits for the unit already in flight.
+  let yielded = false
+  for (const unit of units) {
+    if (assistantRuntimeMaintenanceYieldRequested(input)) {
+      yielded = true
+      break
+    }
+    await unit()
   }
-  const transcriptRetention = await pruneAssistantTranscriptRetention(input.paths)
-  if (transcriptRetention.entriesTrimmed > 0) {
+  if (yielded) {
     notes.push(
-      `${transcriptRetention.entriesTrimmed} transcript entr${transcriptRetention.entriesTrimmed === 1 ? 'y was' : 'ies were'} trimmed across ${transcriptRetention.transcriptsTrimmed} session transcript(s).`,
+      'Runtime maintenance yielded to foreground work and will finish in a later pass.',
     )
-  }
-  const terminalOutboxPruned = await pruneAssistantTerminalOutboxIntents({
-    now: input.now,
-    paths: input.paths,
-    vault: input.vault,
-  })
-  if (terminalOutboxPruned > 0) {
-    notes.push(
-      `${terminalOutboxPruned} terminal outbox intent(s) were pruned.`,
-    )
-  }
-  const cronHistory = await pruneAssistantCronRunHistory({
-    now: input.now,
-    paths: input.paths,
-  })
-  if (cronHistory.responsesRedacted > 0) {
-    notes.push(
-      `${cronHistory.responsesRedacted} older cron response(s) were redacted.`,
-    )
-  }
-  if (cronHistory.runsPruned > 0) {
-    notes.push(
-      `${cronHistory.runsPruned} stale cron run record(s) were pruned.`,
-    )
-  }
-  const staleLocksCleared = await clearStaleAssistantLocks({
-    paths: input.paths,
-    vault: input.vault,
-  })
-  if (staleLocksCleared > 0) {
-    notes.push(`${staleLocksCleared} stale runtime lock(s) were cleared.`)
   }
 
   await appendAssistantRuntimeEventAtPaths(input.paths, {
@@ -170,17 +231,20 @@ async function runAssistantRuntimeMaintenanceAtPaths(input: {
       terminalOutboxPruned,
       transcriptEntriesTrimmed: transcriptRetention.entriesTrimmed,
       transcriptFilesTrimmed: transcriptRetention.transcriptsTrimmed,
+      yielded,
     },
   }).catch(() => undefined)
-  try {
-    await compactAssistantEventLogsAtPaths({
-      now: input.now,
-      paths: input.paths,
-    })
-  } catch {
-    notes.push(
-      'Assistant event log compaction failed and will be retried by a later maintenance pass.',
-    )
+  if (!yielded && !assistantRuntimeMaintenanceYieldRequested(input)) {
+    try {
+      await compactAssistantEventLogsAtPaths({
+        now: input.now,
+        paths: input.paths,
+      })
+    } catch {
+      notes.push(
+        'Assistant event log compaction failed and will be retried by a later maintenance pass.',
+      )
+    }
   }
 
   const snapshot = assistantRuntimeBudgetSnapshotSchema.parse({
@@ -188,7 +252,9 @@ async function runAssistantRuntimeMaintenanceAtPaths(input: {
     updatedAt: nowIso,
     caches: listAssistantRuntimeCacheSnapshots(),
     maintenance: {
-      lastRunAt: nowIso,
+      // A yielded pass is unfinished: keep the previous run marker so the
+      // next idle pass retries promptly instead of waiting a full interval.
+      lastRunAt: yielded ? input.previousLastRunAt ?? null : nowIso,
       staleQuarantinePruned,
       staleLocksCleared,
       notes,

--- a/packages/assistant-engine/test/assistant-automation-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-runtime.test.ts
@@ -9490,6 +9490,54 @@ describe('assistant automation run loop', () => {
     expect(runLoopMocks.maybeRunAssistantRuntimeMaintenance).not.toHaveBeenCalled()
   })
 
+  it('threads the foreground yield check into an in-flight maintenance pass', async () => {
+    const inboxServices = createInboxServices({
+      run: vi.fn().mockResolvedValue(undefined),
+    })
+    runLoopMocks.scanAssistantAutomationOnce.mockResolvedValueOnce({
+      currentTurnDeliveryIntentIds: [],
+      routing: {
+        considered: 0,
+        failed: 0,
+        nextWakeAt: null,
+        noAction: 0,
+        routed: 0,
+        skipped: 0,
+      },
+      replies: {
+        considered: 0,
+        failed: 0,
+        nextWakeAt: null,
+        replied: 0,
+        skipped: 0,
+      },
+    })
+    const runLoop = await vi.importActual<typeof import('../src/assistant/automation/run-loop.ts')>(
+      '../src/assistant/automation/run-loop.ts',
+    )
+    const shouldYieldBackgroundMaintenance = vi.fn(() => false)
+
+    await runLoop.runAssistantAutomation({
+      drainOutbox: true,
+      inboxServices,
+      once: true,
+      shouldYieldBackgroundMaintenance,
+      startDaemon: false,
+      vault: '/tmp/assistant-automation-vault',
+    })
+
+    // A wake arriving after maintenance starts must be able to stop it: the
+    // pass receives the same yield predicate the pre-start gate consulted,
+    // plus the run's abort signal.
+    expect(runLoopMocks.maybeRunAssistantRuntimeMaintenance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldYield: shouldYieldBackgroundMaintenance,
+        signal: expect.any(AbortSignal),
+        vault: '/tmp/assistant-automation-vault',
+      }),
+    )
+  })
+
   it('passes hosted turn environment into due cron processing', async () => {
     const inboxServices = createInboxServices({
       run: vi.fn().mockResolvedValue(undefined),

--- a/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
@@ -42,8 +42,6 @@ const providerTurnRunnerMocks = vi.hoisted(() => ({
   buildCodexTurnAttemptPlan: vi.fn(),
   recordAssistantRuntimeIssueInputsBestEffort: vi.fn(),
   recordCodexAttemptFailed: vi.fn(),
-  recordCodexAttemptStarted: vi.fn(),
-  recordCodexAttemptSucceeded: vi.fn(),
 }))
 
 const storeMocks = vi.hoisted(() => ({
@@ -75,9 +73,6 @@ vi.mock('../src/assistant/codex-turn/planning.js', () => ({
 
 vi.mock('../src/assistant/codex-turn/attempt-observability.js', () => ({
   recordCodexAttemptFailed: providerTurnRunnerMocks.recordCodexAttemptFailed,
-  recordCodexAttemptStarted: providerTurnRunnerMocks.recordCodexAttemptStarted,
-  recordCodexAttemptSucceeded:
-    providerTurnRunnerMocks.recordCodexAttemptSucceeded,
 }))
 
 vi.mock('../src/assistant/issue-reporting.js', () => ({
@@ -135,8 +130,6 @@ afterEach(() => {
   providerTurnRunnerMocks.buildCodexTurnAttemptPlan.mockReset()
   providerTurnRunnerMocks.recordAssistantRuntimeIssueInputsBestEffort.mockReset()
   providerTurnRunnerMocks.recordCodexAttemptFailed.mockReset()
-  providerTurnRunnerMocks.recordCodexAttemptStarted.mockReset()
-  providerTurnRunnerMocks.recordCodexAttemptSucceeded.mockReset()
   storeMocks.appendAssistantTranscriptEntries
     .mockReset()
     .mockImplementation(() => Promise.resolve([]))
@@ -1651,10 +1644,9 @@ describe('Codex model catalog', () => {
         userPrompt: 'Please connect my WHOOP',
       }),
     )
-    expect(
-      providerTurnRunnerMocks.recordCodexAttemptSucceeded,
-    ).toHaveBeenCalledWith(expect.objectContaining({
-      activityLabels: [],
-    }))
+    // Attempt observability is the runner's only receipt-writing seam, and it
+    // records failures exclusively: a successful attempt must make no receipt
+    // timeline write between provider success and the reply return.
+    expect(providerTurnRunnerMocks.recordCodexAttemptFailed).not.toHaveBeenCalled()
   })
 })

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -1,4 +1,4 @@
-import { readFile, rm } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import assert from 'node:assert/strict'
 
 import { afterEach, expect, test, vi } from 'vitest'
@@ -76,6 +76,7 @@ afterEach(async () => {
   vi.doUnmock('../src/assistant/prompt-attempts.js')
   vi.doUnmock('../src/assistant/service-turn-routes.js')
   vi.doUnmock('../src/assistant/service-usage.js')
+  vi.doUnmock('../src/assistant/runtime-budgets.js')
   vi.doUnmock('../src/assistant/channel-adapters.js')
   vi.doUnmock('../src/assistant/runtime-state-service.js')
   vi.doUnmock('../src/assistant/turn-lock.js')
@@ -141,6 +142,16 @@ test('sendAssistantMessageLocal completes a successful turn, persists usage, and
   assert.equal(mocks.getAssistantChannelAdapter.mock.calls[0]?.[0], 'telegram')
   assert.equal(stopTyping.mock.calls.length, 1)
   assert.deepEqual(stopTyping.mock.calls[0], [{ providerStop: false }])
+  assert.deepEqual(mocks.maybeRunAssistantRuntimeMaintenance.mock.calls[0]?.[0], {
+    signal: null,
+    vault: '/vaults/test',
+  })
+  // Maintenance is a post-turn owner: it must run after the reply is
+  // committed and delivered, never on the foreground path before it.
+  assert.ok(
+    (mocks.maybeRunAssistantRuntimeMaintenance.mock.invocationCallOrder[0] ?? 0) >
+      (mocks.finalizeDeliveredAssistantTurn.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY),
+  )
 })
 
 test('sendAssistantMessageLocal gives hosted manual phone-call turns a real accepted input id', async () => {
@@ -204,6 +215,46 @@ test('sendAssistantMessageLocal gives hosted manual phone-call turns a real acce
   expect(phoneCallScope).toMatchObject({
     acceptedInputIds: ['manual-phone-call:turn-1'],
   })
+})
+
+test('sendAssistantMessageLocal compacts oversized runtime logs after the turn commits', async () => {
+  const { parentRoot, vaultRoot } = await createTempVaultContext(
+    'assistant-local-service-runtime-maintenance-',
+  )
+  tempRoots.push(parentRoot)
+  const paths = resolveAssistantStatePaths(vaultRoot)
+  await mkdir(paths.journalsDirectory, {
+    recursive: true,
+  })
+  await writeFile(
+    paths.runtimeEventsPath,
+    Array.from({ length: 2050 }, (_value, index) =>
+      JSON.stringify(makeRuntimeEvent(index)),
+    ).join('\n') + '\n',
+    'utf8',
+  )
+
+  const { sendAssistantMessageLocal } = await loadLocalServiceModule({
+    useRealRuntimeMaintenance: true,
+  })
+
+  await sendAssistantMessageLocal({
+    deliverResponse: false,
+    executionContext: {
+      hosted: null,
+    },
+    prompt: 'Summarize my inbox',
+    vault: vaultRoot,
+  })
+
+  const compactedRuntimeEvents = await readFile(paths.runtimeEventsPath, 'utf8')
+  const compactedRuntimeEventCount = compactedRuntimeEvents
+    .trim()
+    .split('\n')
+    .filter(Boolean).length
+
+  assert.ok(compactedRuntimeEventCount <= 2000)
+  assert.match(compactedRuntimeEvents, /runtime\.maintenance/)
 })
 
 test('sendAssistantMessageLocal delivers media-only provider replies', async () => {
@@ -1347,6 +1398,8 @@ test('sendAssistantMessageLocal keeps auto-reply turns on the session Codex thre
       ?.providerResumeStateAction,
     'persist-from-provider-turn',
   )
+  // The automation pass owns maintenance for auto-reply turns.
+  assert.equal(mocks.maybeRunAssistantRuntimeMaintenance.mock.calls.length, 0)
 })
 
 test('sendAssistantMessageLocal runs automation cron turns on isolated Codex threads', async () => {
@@ -1370,6 +1423,7 @@ test('sendAssistantMessageLocal runs automation cron turns on isolated Codex thr
       ?.providerResumeStateAction,
     'preserve-existing',
   )
+  assert.equal(mocks.maybeRunAssistantRuntimeMaintenance.mock.calls.length, 1)
 })
 
 test('sendAssistantMessageLocal prefers the hosted execution default target when resolving the session', async () => {
@@ -5936,6 +5990,9 @@ test('sendAssistantMessageLocal runs best-effort failure cleanup and rethrows te
   mocks.refreshAssistantStatusSnapshotLocal.mockRejectedValueOnce(
     new Error('ignore failed status refresh'),
   )
+  mocks.maybeRunAssistantRuntimeMaintenance.mockRejectedValueOnce(
+    new Error('ignore failed post-turn maintenance'),
+  )
 
   await assert.rejects(
     () =>
@@ -5951,6 +6008,10 @@ test('sendAssistantMessageLocal runs best-effort failure cleanup and rethrows te
   )
 
   assert.equal(mocks.appendAssistantTranscriptEntries.mock.calls.length, 0)
+  // The post-turn maintenance owner still runs when the turn fails, and its
+  // own rejection above must not mask the original provider error asserted
+  // by assert.rejects.
+  assert.equal(mocks.maybeRunAssistantRuntimeMaintenance.mock.calls.length, 1)
   assert.equal(mocks.persistFailedAssistantPromptAttempt.mock.calls.length, 1)
   assert.equal(
     mocks.persistFailedAssistantPromptAttempt.mock.calls[0]?.[0]?.persistUserPromptOnFailure,
@@ -8208,6 +8269,7 @@ async function loadLocalServiceModule(input?: {
     startTypingIndicator?: NonNullable<AssistantChannelAdapter['startTypingIndicator']>
   } | null
   realAcceptedInputPersistence?: boolean
+  useRealRuntimeMaintenance?: boolean
   plan?: ReturnType<typeof createSharedPlan>
   providerOutcome?:
     | {
@@ -8294,6 +8356,7 @@ async function loadLocalServiceModule(input?: {
   const session = input?.session ?? createAssistantSession()
   const sharedPlan = input?.plan ?? createSharedPlan()
   const useRealAcceptedInputPersistence = input?.realAcceptedInputPersistence === true
+  const useRealRuntimeMaintenance = input?.useRealRuntimeMaintenance === true
   const realStore = await vi.importActual<typeof import('../src/assistant/store.js')>(
     '../src/assistant/store.js',
   )
@@ -8583,6 +8646,13 @@ async function loadLocalServiceModule(input?: {
         >[0],
       ) => undefined,
     ),
+    maybeRunAssistantRuntimeMaintenance: vi.fn(
+      async (
+        _input: Parameters<
+          typeof import('../src/assistant/runtime-budgets.js').maybeRunAssistantRuntimeMaintenance
+        >[0],
+      ) => undefined,
+    ),
     redactAssistantDisplayPath: vi.fn(() => '<redacted-vault>'),
     refreshAssistantStatusSnapshotLocal: vi.fn(async () => undefined),
     saveAssistantSession: vi.fn(),
@@ -8814,6 +8884,12 @@ async function loadLocalServiceModule(input?: {
     recordAdditionalAssistantUsageEvents: mocks.recordAdditionalAssistantUsageEvents,
     recordAssistantUsageEvent: mocks.recordAssistantUsageEvent,
   }))
+  if (!useRealRuntimeMaintenance) {
+    vi.doMock('../src/assistant/runtime-budgets.js', () => ({
+      maybeRunAssistantRuntimeMaintenance:
+        mocks.maybeRunAssistantRuntimeMaintenance,
+    }))
+  }
   if (!useRealAcceptedInputPersistence) {
     vi.doMock('../src/assistant/runtime-state-service.js', () => ({
       createAssistantRuntimeStateService: vi.fn(() => mocks.runtimeState),
@@ -9026,5 +9102,21 @@ function createDeferred<T>(): Deferred<T> {
     promise,
     reject,
     resolve,
+  }
+}
+
+function makeRuntimeEvent(index: number) {
+  return {
+    at: `2026-04-08T10:${String(Math.floor(index / 60)).padStart(2, '0')}:${String(
+      index % 60,
+    ).padStart(2, '0')}.000Z`,
+    component: 'test',
+    dataJson: null,
+    entityId: `entity-${index}`,
+    entityType: 'session',
+    kind: 'runtime.maintenance' as const,
+    level: 'info' as const,
+    message: `event-${index}`,
+    schema: 'murph.assistant-runtime-event.v1' as const,
   }
 }

--- a/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
@@ -921,6 +921,188 @@ test('sendAssistantNotificationLocal rejects deferred immediate exact-text deliv
   })
 })
 
+test('sendAssistantNotificationLocal keeps a queued exact-text welcome when the terminal diagnostic write fails', async () => {
+  const initialSession = createAssistantSession({
+    binding: {
+      actorId: 'actor-exact',
+      channel: 'telegram',
+      conversationKey: null,
+      delivery: {
+        kind: 'thread',
+        target: 'thread-exact',
+      },
+      identityId: 'identity-exact',
+      threadId: 'thread-exact',
+      threadIsDirect: true,
+    },
+  })
+  const sharedPlan = createSharedPlan()
+  sharedPlan.conversationPolicy.audience.channel = 'telegram'
+  sharedPlan.conversationPolicy.audience.threadId = 'thread-exact'
+  sharedPlan.conversationPolicy.audience.threadIsDirect = true
+  const deliverMessage = vi.fn(async () => ({
+    delivery: null,
+    deliveryError: null,
+    intent: {
+      intentId: 'intent-exact-diagnostic-failure',
+    },
+    kind: 'queued',
+    session: null,
+  }))
+  const runtimeState = {
+    outbox: {
+      deliverMessage,
+    },
+    status: {
+      refreshSnapshot: vi.fn(async () => undefined),
+    },
+    transcripts: {
+      append: vi.fn(async () => []),
+    },
+    sessions: {
+      save: vi.fn(async () => initialSession),
+    },
+    turns: {
+      createReceipt: vi.fn(async () => undefined),
+      finalizeReceipt: vi.fn(async () => undefined),
+    },
+    diagnostics: {
+      recordEvent: vi.fn(async () => {
+        throw new Error('diagnostic sink unavailable')
+      }),
+    },
+  }
+  const mocks = {
+    createAssistantRuntimeStateService: vi.fn(() => runtimeState),
+    executeCodexTurnWithRecovery: vi.fn(async () => {
+      throw new Error('provider should not run for exact text')
+    }),
+    hasAssistantSeenFirstContact: vi.fn(async () => false),
+    markAssistantFirstContactSeen: vi.fn(async () => undefined),
+    markAssistantOutboxIntentMirrorTerminalById: vi.fn(async () => null),
+    normalizeAssistantExecutionContext: vi.fn((value) => value),
+    resolveAssistantExecutionDefaultTarget: vi.fn((input) => input.fallbackTarget),
+    resolveAssistantExecutionOperatorDefaults: vi.fn((input) => input.defaults ?? null),
+    persistAssistantTurnAndSession: vi.fn(async () => {
+      throw new Error('provider finalizer should not run for exact text')
+    }),
+    recordAdditionalAssistantUsageEvents: vi.fn(async () => undefined),
+    recordAssistantUsageEvent: vi.fn(async () => undefined),
+    resolveAssistantOperatorDefaults: vi.fn(async () => null),
+    resolveAssistantSessionForMessage: vi.fn(async () => ({
+      created: false,
+      session: initialSession,
+    })),
+    resolveAssistantTurnRoute: vi.fn(() => createRoute()),
+    resolveAssistantTurnSharedPlan: vi.fn(async () => sharedPlan),
+    withAssistantTurnLock: vi.fn(async (input: { run(): Promise<unknown> }) => await input.run()),
+  }
+
+  vi.doMock('@murphai/operator-config/operator-config', () => ({
+    resolveAssistantOperatorDefaults: mocks.resolveAssistantOperatorDefaults,
+  }))
+  vi.doMock('@murphai/operator-config/assistant-backend', () => ({
+    createDefaultLocalAssistantModelTarget: () => createCodexTarget(),
+  }))
+  vi.doMock('../src/assistant/runtime-state-service.js', () => ({
+    createAssistantRuntimeStateService: mocks.createAssistantRuntimeStateService,
+  }))
+  vi.doMock('../src/assistant/outbox.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../src/assistant/outbox.js')>()
+    return {
+      ...actual,
+      markAssistantOutboxIntentMirrorTerminalById:
+        mocks.markAssistantOutboxIntentMirrorTerminalById,
+    }
+  })
+  vi.doMock('../src/assistant/execution-context.js', () => ({
+    normalizeAssistantExecutionContext: mocks.normalizeAssistantExecutionContext,
+    resolveAssistantExecutionDefaultTarget:
+      mocks.resolveAssistantExecutionDefaultTarget,
+    resolveAssistantExecutionOperatorDefaults:
+      mocks.resolveAssistantExecutionOperatorDefaults,
+  }))
+  vi.doMock('../src/assistant/session-resolution.js', () => ({
+    resolveAssistantSessionForMessage: mocks.resolveAssistantSessionForMessage,
+    resolveAssistantSessionTarget: vi.fn(() => createCodexTarget()),
+  }))
+  vi.doMock('../src/assistant/turn-plan.js', () => ({
+    resolveAssistantTurnSharedPlan: mocks.resolveAssistantTurnSharedPlan,
+  }))
+  vi.doMock('../src/assistant/codex-turn-runner.js', () => ({
+    executeCodexTurnWithRecovery: mocks.executeCodexTurnWithRecovery,
+  }))
+  vi.doMock('../src/assistant/service-usage.js', () => ({
+    recordAdditionalAssistantUsageEvents: mocks.recordAdditionalAssistantUsageEvents,
+    recordAssistantUsageEvent: mocks.recordAssistantUsageEvent,
+  }))
+  vi.doMock('../src/assistant/turn-finalizer.js', () => ({
+    clearAssistantSessionCodexResumeState: vi.fn(async (input: { session: AssistantSession }) => input.session),
+    persistAssistantTurnAndSession: mocks.persistAssistantTurnAndSession,
+  }))
+  vi.doMock('../src/assistant/service-turn-routes.js', () => ({
+    resolveAssistantTurnRoute: mocks.resolveAssistantTurnRoute,
+  }))
+  vi.doMock('../src/assistant/turns.js', () => ({
+    createAssistantTurnId: () => 'turn-exact-diagnostic-failure',
+  }))
+  vi.doMock('../src/assistant/channel-adapters.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/assistant/channel-adapters.ts')
+    >('../src/assistant/channel-adapters.js')
+
+    return {
+      ...actual,
+      getAssistantChannelAdapter: vi.fn(() => null),
+    }
+  })
+  vi.doMock('../src/assistant/turn-lock.js', () => ({
+    withAssistantTurnLock: mocks.withAssistantTurnLock,
+  }))
+  vi.doMock('../src/assistant/first-contact.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/assistant/first-contact.ts')
+    >('../src/assistant/first-contact.js')
+
+    return {
+      ...actual,
+      hasAssistantSeenFirstContact: mocks.hasAssistantSeenFirstContact,
+      markAssistantFirstContactSeen: mocks.markAssistantFirstContactSeen,
+    }
+  })
+
+  const { sendAssistantNotificationLocal } = await import(
+    '../src/assistant/notification-turn.ts'
+  )
+
+  const result = await sendAssistantNotificationLocal({
+    deferCommitUntilDeliveryAccepted: true,
+    deliveryDedupeToken: 'signup-welcome:member_exact_diag',
+    deliveryDispatchMode: 'queue-only',
+    deliveryIdempotencyKey: 'signup-welcome:member_exact_diag',
+    firstContactPolicy: {
+      markSeenOnDeliveryAccepted: true,
+    },
+    instructions: 'Send the fixed hosted signup welcome.',
+    responsePolicy: {
+      kind: 'require_send_exact_text',
+      text: 'Fixed welcome text',
+    },
+    vault: '/vaults/exact-diagnostic-failure',
+  })
+
+  // Receipt finalization is the commit; a failed diagnostic write afterwards
+  // must not abandon the already-pending outbox intent or fail the turn.
+  expect(result.deliveryOutcome).toEqual(expect.objectContaining({
+    intentId: 'intent-exact-diagnostic-failure',
+    kind: 'queued',
+  }))
+  expect(runtimeState.turns.finalizeReceipt).toHaveBeenCalledOnce()
+  expect(runtimeState.diagnostics.recordEvent).toHaveBeenCalledOnce()
+  expect(runtimeState.sessions.save).toHaveBeenCalledOnce()
+  expect(mocks.markAssistantOutboxIntentMirrorTerminalById).not.toHaveBeenCalled()
+})
+
 test('an organic same-route reply supersedes the exact-text signup welcome through the real first-contact state', async () => {
   const vault = await mkdtemp(path.join(tmpdir(), 'murph-first-contact-supersede-'))
   const routeBinding = {
@@ -2128,6 +2310,71 @@ test('sendAssistantNotificationLocal abandons queued delivery when deferred comm
       providerStop: true,
     },
   )
+})
+
+test('sendAssistantNotificationLocal keeps a queued model reply when the terminal diagnostic write fails', async () => {
+  const providerSession = createAssistantSession()
+  const providerResult = createProviderResult({
+    response: JSON.stringify({
+      kind: 'send_message',
+      privateSummary: 'Queued scheduled reminder.',
+      text: 'Remember to sleep.',
+    }),
+    session: providerSession,
+  })
+  const { deliverMessage, mocks, sendAssistantNotificationLocal } =
+    await loadNotificationTurnHarness({
+      providerResult,
+      turnId: 'turn-notification-diagnostic-failure',
+    })
+  deliverMessage.mockResolvedValueOnce({
+    delivery: null,
+    deliveryError: null,
+    intent: {
+      intentId: 'intent-queued-diagnostic-failure',
+    },
+    kind: 'queued',
+    session: providerSession,
+  })
+  const finalizeReceipt = vi.fn(async () => undefined)
+  const recordEvent = vi.fn(async () => {
+    throw new Error('diagnostic sink unavailable')
+  })
+  mocks.createAssistantRuntimeStateService.mockImplementation(() => ({
+    outbox: {
+      deliverMessage,
+    },
+    status: {
+      refreshSnapshot: vi.fn(async () => undefined),
+    },
+    turns: {
+      createReceipt: vi.fn(async () => undefined),
+      finalizeReceipt,
+    },
+    diagnostics: {
+      recordEvent,
+    },
+  }))
+
+  const result = await sendAssistantNotificationLocal({
+    deferCommitUntilDeliveryAccepted: true,
+    deliveryDispatchMode: 'queue-only',
+    executionContext: {
+      hosted: null,
+    },
+    instructions: 'Queue this scheduled reminder.',
+    vault: '/vaults/deferred-queue-diagnostic-failure',
+  })
+
+  // Receipt finalization is the commit; a failed diagnostic write afterwards
+  // must not abandon the already-pending outbox intent or fail the turn.
+  expect(result.deliveryOutcome).toEqual(expect.objectContaining({
+    intentId: 'intent-queued-diagnostic-failure',
+    kind: 'queued',
+  }))
+  expect(finalizeReceipt).toHaveBeenCalledOnce()
+  expect(recordEvent).toHaveBeenCalledOnce()
+  expect(mocks.markAssistantOutboxIntentMirrorTerminalById).not.toHaveBeenCalled()
 })
 
 test('sendAssistantNotificationLocal preserves queued typing continuity when first-contact marking throws after commit', async () => {

--- a/packages/assistant-engine/test/assistant-runtime-thresholds.test.ts
+++ b/packages/assistant-engine/test/assistant-runtime-thresholds.test.ts
@@ -1,4 +1,4 @@
-import { readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -665,6 +665,119 @@ describe('assistant runtime thresholds', () => {
         staleQuarantinePruned: 1,
       },
     })
+  })
+
+  it('stops between maintenance units when foreground work asks the pass to yield', async () => {
+    const paths = createMockAssistantPaths('assistant-runtime-thresholds-maintenance-yield')
+    mockRuntimeBudgetDependencies(paths)
+
+    const runtimeBudgets = await import('../src/assistant/runtime-budgets.ts')
+    const persistence = await import('../src/assistant/store/persistence.js')
+    const outboxStore = await import('../src/assistant/outbox/store.js')
+
+    // First check happens after the runtime lock is acquired, the second
+    // before the first unit; the third (before transcript retention) yields.
+    const shouldYield = vi.fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true)
+
+    const yieldedSnapshot = await runtimeBudgets.maybeRunAssistantRuntimeMaintenance({
+      now: new Date('2026-03-12T00:00:00.000Z'),
+      shouldYield,
+      vault: 'ignored-by-mock',
+    })
+
+    expect(persistence.pruneAssistantTranscriptRetention).not.toHaveBeenCalled()
+    expect(outboxStore.pruneAssistantTerminalOutboxIntents).not.toHaveBeenCalled()
+    // A yielded pass is unfinished: the run marker must stay unset so the
+    // next idle pass retries promptly instead of waiting a full interval.
+    expect(yieldedSnapshot.maintenance.lastRunAt).toBeNull()
+    expect(yieldedSnapshot.maintenance.notes).toContain(
+      'Runtime maintenance yielded to foreground work and will finish in a later pass.',
+    )
+
+    const completedSnapshot = await runtimeBudgets.maybeRunAssistantRuntimeMaintenance({
+      now: new Date('2026-03-12T00:01:00.000Z'),
+      shouldYield: () => false,
+      vault: 'ignored-by-mock',
+    })
+
+    expect(persistence.pruneAssistantTranscriptRetention).toHaveBeenCalledOnce()
+    expect(outboxStore.pruneAssistantTerminalOutboxIntents).toHaveBeenCalledOnce()
+    expect(completedSnapshot.maintenance.lastRunAt).toBe('2026-03-12T00:01:00.000Z')
+  })
+
+  it('preserves the previous non-null run marker when a due pass yields mid-run', async () => {
+    const paths = createMockAssistantPaths(
+      'assistant-runtime-thresholds-maintenance-yield-marker',
+    )
+    mockRuntimeBudgetDependencies(paths)
+    tempRoots.push(paths.assistantStateRoot)
+    await mkdir(paths.assistantStateRoot, {
+      recursive: true,
+    })
+    await writeFile(
+      paths.resourceBudgetPath,
+      JSON.stringify({
+        schema: 'murph.assistant-runtime-budget.v1',
+        updatedAt: '2026-03-12T00:00:00.000Z',
+        caches: [],
+        maintenance: {
+          lastRunAt: '2026-03-12T00:00:00.000Z',
+          staleQuarantinePruned: 0,
+          staleLocksCleared: 0,
+          notes: [],
+        },
+      }),
+      'utf8',
+    )
+
+    const runtimeBudgets = await import('../src/assistant/runtime-budgets.ts')
+    const persistence = await import('../src/assistant/store/persistence.js')
+
+    const shouldYield = vi.fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true)
+
+    const snapshot = await runtimeBudgets.maybeRunAssistantRuntimeMaintenance({
+      now: new Date('2026-03-12T00:06:00.000Z'),
+      shouldYield,
+      vault: 'ignored-by-mock',
+    })
+
+    expect(persistence.pruneAssistantTranscriptRetention).not.toHaveBeenCalled()
+    // The pass was due (previous completed run six minutes earlier) and
+    // started, then yielded: the previous non-null marker must survive, not
+    // reset to null or advance to now, so retry timing stays anchored to the
+    // last completed run.
+    expect(snapshot.maintenance.lastRunAt).toBe('2026-03-12T00:00:00.000Z')
+    expect(snapshot.maintenance.notes).toContain(
+      'Runtime maintenance yielded to foreground work and will finish in a later pass.',
+    )
+  })
+
+  it('skips the maintenance pass entirely when the automation signal is already aborted', async () => {
+    const paths = createMockAssistantPaths('assistant-runtime-thresholds-maintenance-abort')
+    mockRuntimeBudgetDependencies(paths)
+
+    const runtimeBudgets = await import('../src/assistant/runtime-budgets.ts')
+    const persistence = await import('../src/assistant/store/persistence.js')
+    const shared = await import('../src/assistant/shared.js')
+
+    const abortController = new AbortController()
+    abortController.abort()
+
+    const snapshot = await runtimeBudgets.maybeRunAssistantRuntimeMaintenance({
+      now: new Date('2026-03-12T00:00:00.000Z'),
+      signal: abortController.signal,
+      vault: 'ignored-by-mock',
+    })
+
+    expect(snapshot.maintenance.lastRunAt).toBeNull()
+    expect(persistence.pruneAssistantTranscriptRetention).not.toHaveBeenCalled()
+    expect(shared.writeJsonFileAtomic).not.toHaveBeenCalled()
   })
 
   it('skips quarantine errors when a malformed outbox inventory file disappears mid-race', async () => {

--- a/packages/assistant-engine/test/codex-runtime-helpers.test.ts
+++ b/packages/assistant-engine/test/codex-runtime-helpers.test.ts
@@ -50,7 +50,6 @@ import {
 } from '../src/assistant/providers/helpers.ts'
 import {
   recordCodexAttemptFailed,
-  recordCodexAttemptStarted,
 } from '../src/assistant/codex-turn/attempt-observability.ts'
 import {
   executeCodexAssistantTurnFromInput,
@@ -732,45 +731,6 @@ describe('Codex assistant registry helpers', () => {
     ])
   })
 
-  it('records provider-attempt-started receipt evidence', async () => {
-    const providerConfig = normalizeAssistantProviderConfig({
-      provider: 'codex-cli',
-      model: 'gpt-5.4',
-      modelProvider: 'vercel-ai-gateway',
-      oss: false,
-      profile: 'prod',
-      reasoningEffort: 'high',
-    })
-    const route: CodexThreadIdentity = {
-      codexCommand: '/opt/murph/bin/codex',
-      label: 'primary:Codex app-server:gpt-5.4:prod',
-      provider: 'codex-cli',
-      providerOptions: serializeAssistantProviderSessionOptions(providerConfig),
-      routeId: 'route-1',
-    }
-
-    await recordCodexAttemptStarted({
-      attemptCount: 2,
-      at: '2026-05-04T00:00:00.000Z',
-      route,
-      turnId: 'turn-1',
-      vault: '/vaults/test',
-    })
-
-    expect(turnsMocks.appendAssistantTurnReceiptEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: 'provider.attempt.started',
-        metadata: {
-          attempt: '2',
-          model: 'gpt-5.4',
-          provider: 'codex-cli',
-          routeFingerprint: 'route-1',
-        },
-      }),
-    )
-    expect(diagnosticsMocks.recordAssistantDiagnosticEvent).not.toHaveBeenCalled()
-  })
-
   it('counts a failed provider attempt in its terminal diagnostic', async () => {
     const route: CodexThreadIdentity = {
       codexCommand: null,
@@ -803,6 +763,41 @@ describe('Codex assistant registry helpers', () => {
         kind: 'provider.attempt.failed',
       }),
     )
+  })
+
+  it('keeps failed-attempt recording best-effort when observability writes reject', async () => {
+    const route: CodexThreadIdentity = {
+      codexCommand: null,
+      label: 'primary:Codex app-server:gpt-5.4',
+      provider: 'codex-cli',
+      providerOptions: serializeAssistantProviderSessionOptions(
+        normalizeAssistantProviderConfig({
+          model: 'gpt-5.4',
+          provider: 'codex-cli',
+        }),
+      ),
+      routeId: 'route-failed',
+    }
+    turnsMocks.appendAssistantTurnReceiptEvent.mockRejectedValueOnce(
+      new Error('receipt store unavailable'),
+    )
+    diagnosticsMocks.recordAssistantDiagnosticEvent.mockRejectedValueOnce(
+      new Error('diagnostic sink unavailable'),
+    )
+
+    // A thrown observability write here would replace the structured
+    // failed-attempt outcome in the provider catch with an unclassified error.
+    await expect(
+      recordCodexAttemptFailed({
+        attemptCount: 1,
+        detail: 'Provider attempt failed.',
+        errorCode: 'PROVIDER_FAILED',
+        route,
+        sessionId: 'session-failed',
+        turnId: 'turn-failed',
+        vault: '/vaults/test',
+      }),
+    ).resolves.toBeUndefined()
   })
 
   it.each([


### PR DESCRIPTION
## Why this PR exists

A deep review of merged PR #519 (hosted reply hot-path latency) found four material gaps where observability or maintenance work could delay, fail, or silently drop user replies. This PR fixes all four.

## User goal / user-visible behavior

Users always receive a reply the assistant successfully produced, and replies stay fast: no receipt or diagnostics write can delay provider start, discard a successful turn, or strand a queued reply; background maintenance can never block a foreground message for more than one bounded unit of work.

## What changed

1. **Attempt telemetry off the provider hot path.** `provider.attempt.started`/`provider.attempt.succeeded` receipt events were write-only (no reader anywhere) yet awaited around provider execution; a failed success-write reclassified a successful turn as a provider failure and suppressed its reply. Both writers are deleted. `recordCodexAttemptFailed` stays (feeds diagnostics/counters) but is now best-effort so a thrown observability write cannot replace the structured failed-attempt outcome (thread id, usage, delivered-context ordinals). Contract enum values stay so persisted receipts keep parsing.
2. **Terminal delivery diagnostic is last and best-effort.** In `finalizeAssistantTurnFromDeliveryOutcome`, receipt finalization is the commit; the diagnostics write now runs after first-contact state and cannot throw into notification commit-error handling, which abandoned an already-pending queued outbox intent.
3. **Direct modes get their maintenance owner back — post-turn.** #519 removed the pre-turn maintenance call from `sendAssistantMessageLocal`, leaving ask/chat/assistantd with unbounded runtime-state growth (whole-transcript reads happen pre-provider). A try/finally now runs throttled maintenance after the turn for non-auto-reply triggers, honoring the turn's abort signal. The deleted oversized-event-log regression test is restored (post-turn semantics).
4. **Maintenance yields to foreground work mid-pass.** `maybeRunAssistantRuntimeMaintenance` accepts the existing `shouldYieldBackgroundMaintenance` predicate plus abort signal, checks between bounded units, and preserves the previous `lastRunAt` on a yielded pass so the next idle pass retries promptly. The automation run-loop threads both through.

## Invariants to preserve

- Observability writes never gate provider start, success classification, or delivery finalization.
- An accepted queued outbox intent is never abandoned by a post-commit best-effort failure.
- Every mode has a maintenance owner; maintenance stays off the foreground reply path.
- A foreground wake arriving after maintenance starts waits at most one bounded unit (in-process).
- Persisted receipts containing the retired timeline kinds still parse.

## Verification

- Full `assistant-engine` (2019), `assistant-runtime` (1497), and `assistant-cli` (128) suites pass; workspace build + typecheck pass.
- New regression tests bite: diagnostic-rejection tests fail with the fix reverted; the yield test seeds a real prior `lastRunAt` and detects both wrong stamping and vacuous passes; the failure-path test proves post-turn maintenance runs on a thrown turn without masking the original error.
- Local audit passes (`coverage-write`, `deep-review`) ran on the parent model because the local Codex CLI is at its usage limit until this afternoon and ReviewGPT is rate-limited per AGENTS.md; both reports reconciled, accepted findings fixed (abort-signal threading, best-effort failed-attempt recording, run-loop signal-threading test).

## Known deferred items (from deep review, pre-existing or low)

- Cross-process runtime write-lock contention can still fail a concurrent daemon turn hard while another process runs maintenance (pre-#519 behavior, restored not introduced; in-process yield cannot mitigate it).
- Exact-text deferred notifications persist the session after finalize inside the abandon-catch; a persist failure after commit still abandons the intent (pre-existing; model path already orders persist first).
- A first-contact marking failure now skips the terminal diagnostic counters (observability-only, rare).
- Hosted manual turns do not yet thread the hosted wake predicate into post-turn maintenance (abort signal is threaded).

## Deployment skew / compatibility

`packages/assistant-engine` ships inside the hosted runner bundle. During gradual container rollout, warm containers on the old bundle keep writing the retired receipt events — harmless, since the contract enum still includes them and no reader consumes them. No web/Worker ordering constraint; no schema or persisted-state migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786290499&installation_id=127572939&pr_number=534&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F534&signature=936678cdfb1de1f1f14b2b358dd1b138f5fa72468ed5f62d8a6f512f729ad85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->