### PR TITLE
fix(cloudflare): serialize pointerless abort recovery

### DIFF
--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -263,9 +263,13 @@ inactive-fence replacement path. An inactive liveness proof must still send the
 identity-checked abort first so any queued exact retention invocation is
 canceled before the fence is cleared; an inactive result or queued matching
 abort is replacement-safe. Missing-pointer abort delivery without inactive
-proof is only an abort request and preserves the fence until a later liveness
-pass proves the old child inactive. Stale or failed status preserves the fence
-and retries.
+proof owns the container lifecycle while it delivers the identity-checked abort.
+A stale result preserves the fence and retries. An accepted or queued result, or
+an ambiguous delivery failure, recycles the old shell fail-closed before the
+container returns `accepted`; only that settled stop allows the controller to
+clear the exact fence and start a replacement. A deploy-skewed request-only
+`requested` result remains non-authoritative without inactive proof and
+preserves the fence for retry.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -1298,14 +1298,21 @@ export class RunnerContainer extends Container {
     leaseGeneration: string;
     userId: string;
   }): Promise<RunnerWorkspaceInvocationAbortStatus> {
-    const status = await readRunnerContainerStatus(this);
-    if (isRunnerContainerStopped(status)) {
-      return "inactive";
-    }
-    const abortStatus = await this.postWorkspaceInvocationAbort(input);
-    return abortStatus === "accepted" || abortStatus === "queued"
-      ? "requested"
-      : abortStatus;
+    return await this.withLifecycleLock(async () => {
+      const status = await readRunnerContainerStatus(this);
+      if (isRunnerContainerStopped(status)) {
+        return "inactive";
+      }
+      const abortStatus = await this.postWorkspaceInvocationAbort(input);
+      if (abortStatus === "stale") {
+        return "stale";
+      }
+      await this.stopWarmContainer({
+        failClosed: true,
+        reason: "invoke-failure",
+      });
+      return "accepted";
+    });
   }
 
   private async postWorkspaceInvocationAbort(input: {

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3728,25 +3728,58 @@ describe("RunnerContainer", () => {
     );
   });
 
-  it("posts workspace abort when the local active pointer is missing but the child is running", async () => {
-    const request = createRunnerRequest("evt_missing_pointer_abort");
-    const containerFetch = vi.fn(async (url: string, init?: RequestInit) => {
+  it.each(["accepted", "queued", "failed"] as const)(
+    "destroys the child after a %s no-pointer abort result",
+    async (abortStatus) => {
+      const request = createRunnerRequest(`evt_missing_pointer_${abortStatus}_abort`);
+      const containerFetch = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.endsWith("/internal/workspace-invocation/abort")) {
+          expect(JSON.parse(String(init?.body))).toEqual({
+            attemptId: request.attemptId,
+            leaseGeneration: request.leaseGeneration,
+            userId: "member_123",
+          });
+          if (abortStatus === "failed") {
+            return new Response(null, { status: 503 });
+          }
+          return new Response(null, {
+            headers: {
+              "x-workspace-invocation-abort-status": abortStatus,
+            },
+            status: 204,
+          });
+        }
+        throw new Error(`Unexpected runner request URL: ${url}`);
+      });
+      const { container, destroy } = createContainerDouble({
+        containerFetch,
+        initialStatus: "running",
+      });
+
+      await expect(container.abortWorkspaceInvocation({
+        attemptId: request.attemptId,
+        leaseGeneration: request.leaseGeneration,
+        userId: "member_123",
+      })).resolves.toBe("accepted");
+      expect(containerFetch).toHaveBeenCalledOnce();
+      expect(destroy).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("preserves a newer child when a no-pointer abort is stale", async () => {
+    const request = createRunnerRequest("evt_missing_pointer_stale_abort");
+    const containerFetch = vi.fn(async (url: string) => {
       if (url.endsWith("/internal/workspace-invocation/abort")) {
-        expect(JSON.parse(String(init?.body))).toEqual({
-          attemptId: request.attemptId,
-          leaseGeneration: request.leaseGeneration,
-          userId: "member_123",
-        });
         return new Response(null, {
           headers: {
-            "x-workspace-invocation-abort-status": "accepted",
+            "x-workspace-invocation-abort-status": "stale",
           },
           status: 204,
         });
       }
       throw new Error(`Unexpected runner request URL: ${url}`);
     });
-    const { container } = createContainerDouble({
+    const { container, destroy } = createContainerDouble({
       containerFetch,
       initialStatus: "running",
     });
@@ -3755,8 +3788,88 @@ describe("RunnerContainer", () => {
       attemptId: request.attemptId,
       leaseGeneration: request.leaseGeneration,
       userId: "member_123",
-    })).resolves.toBe("requested");
-    expect(containerFetch).toHaveBeenCalledOnce();
+    })).resolves.toBe("stale");
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  it("serializes no-pointer abort recovery before starting a replacement", async () => {
+    const firstAbortStarted = createDeferred<void>();
+    const firstAbortResponse = createDeferred<Response>();
+    let status: "running" | "stopped" = "running";
+    const containerFetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/internal/workspace-invocation/abort")) {
+        firstAbortStarted.resolve();
+        return await firstAbortResponse.promise;
+      }
+      if (url.endsWith("/health")) {
+        return new Response(JSON.stringify(createRunnerHealthResult()), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      if (url.endsWith("/internal/workspace-invocation")) {
+        return new Response(JSON.stringify(createRunnerResult()), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected runner request URL: ${url}`);
+    });
+    const destroy = vi.fn(async () => {
+      status = "stopped";
+    });
+    const getState = vi.fn(async () => ({
+      lastChange: Date.now(),
+      status,
+    }));
+    const startAndWaitForPorts = vi.fn(async () => {
+      status = "running";
+    });
+    const { container } = createContainerDouble({
+      containerFetch,
+      destroy,
+      getState,
+      initialStatus: "running",
+      startAndWaitForPorts,
+    });
+    const staleRequest = createRunnerRequest("evt_missing_pointer_serialized_abort");
+    const replacementRequest = createRunnerRequest("evt_replacement_after_abort");
+
+    const firstAbort = container.abortWorkspaceInvocation({
+      attemptId: staleRequest.attemptId,
+      leaseGeneration: staleRequest.leaseGeneration,
+      userId: "member_123",
+    });
+    await firstAbortStarted.promise;
+    const secondAbort = container.abortWorkspaceInvocation({
+      attemptId: staleRequest.attemptId,
+      leaseGeneration: staleRequest.leaseGeneration,
+      userId: "member_123",
+    });
+    const replacement = container.invoke({
+      job: {
+        kind: "workspace-invocation",
+        request: replacementRequest,
+      },
+      timeoutMs: 30_000,
+      userId: "member_123",
+    });
+
+    await Promise.resolve();
+    expect(containerFetch).toHaveBeenCalledTimes(1);
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+
+    firstAbortResponse.resolve(new Response(null, { status: 503 }));
+
+    await expect(firstAbort).resolves.toBe("accepted");
+    await expect(secondAbort).resolves.toBe("inactive");
+    await expect(replacement).resolves.toEqual(createRunnerResult());
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(startAndWaitForPorts).toHaveBeenCalledOnce();
   });
 
   it("reports inactive liveness from a missing local pointer only after running health is idle", async () => {


### PR DESCRIPTION
## Why this PR exists

PR #494 was merged before its final deep-review reconciliation completed. That review proved a pointerless abort could let the old child keep unwinding after fence replacement, and a lock-free cleanup could race with and destroy a newer replacement.

## User goal / user-visible behavior

Foreground processing can safely preempt stale retention work: replacement begins only after the old runner shell is stopped, so delayed old-child writes cannot overlap the new invocation.

## Invariants

- Abort identity remains exact across user, attempt, and lease generation; `stale` never destroys a newer child.
- Accepted, queued, or ambiguous failed pointerless abort delivery stops the old shell fail-closed before returning `accepted`.
- Pointerless recovery and successor startup share lifecycle serialization, while an active local invocation remains synchronously preemptable.
- Legacy request-only `requested` results remain non-authoritative without prior inactive proof.

## Verification

- `pnpm test:diff agent-docs/references/hosted-runtime-protocol.md apps/cloudflare/src/runner-container.ts apps/cloudflare/test/runner-container.test.ts`
- Repository policy/architecture guards and tooling typecheck passed.
- Cloudflare typecheck passed.
- Cloudflare suite: 94 files, 1,710 tests passed.
- Three independent deep-review reconciliations found no remaining code or contract blocker.

## Deployment skew / compatibility

This is a Cloudflare Worker/Durable Object ownership fix and does not change the runner child protocol or bundle shape. It is backward compatible with warm runner containers, requires no web tandem deploy and no immediate container-image rollout, and can deploy as a normal Cloudflare Worker version. After deploy, verify pointerless preemption records a fail-closed container destroy before exact-fence replacement and that no stale child remains active.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786299262&installation_id=127572939&pr_number=540&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F540&signature=8eae0d9cf90a59d1cc10374ab62817d039c9cdee6dd9467bd382a1156d56ae43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->