### PR TITLE
Fix Junction historical evidence integrity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-10-junction-historical-evidence-window.md
+++ b/agent-docs/exec-plans/completed/2026-07-10-junction-historical-evidence-window.md
@@ -1,0 +1,77 @@
+# Correct Junction historical evidence integrity
+
+Status: completed
+Created: 2026-07-10
+Updated: 2026-07-10
+
+## Goal
+
+- Prevent current connection-day Garmin records from being mistaken for proof
+  that an older historical export arrived.
+- Prevent the same-epoch Link callback from erasing historical evidence that
+  arrived while the connection was still pending.
+
+## Success criteria
+
+- A signed current-day activity or sleep webhook still imports normally but
+  cannot satisfy an older connect-window historical obligation.
+- A genuinely historical signed webhook can still satisfy its matching source
+  and resource obligation.
+- A guarded same-epoch callback atomically preserves only Junction historical
+  progress/evidence while provider completion metadata remains authoritative
+  for ordinary keys.
+- Existing bounded retries and exact-window verification remain the sole
+  recovery owner.
+- No new table, queue, service, lifecycle state, or compatibility layer is
+  added.
+- Focused regressions, affected-workspace verification, required audits,
+  ReviewGPT, and final CI are green before merge.
+
+## Scope
+
+- Junction direct-webhook temporal attribution, guarded account-upsert metadata
+  preservation, and focused provider/store parity tests.
+- No changes to retry policy, reset UX, provider credentials, storage schema,
+  or unrelated wearable ingestion.
+
+## Decisions
+
+- Prove the bug through the signed webhook parser and normal job executor,
+  rather than constructing a synthetic job window in the test.
+- Fail closed when deciding whether an inline record proves historical
+  coverage: import success may preserve current data without closing an older
+  recovery obligation.
+- Perform callback preservation inside the existing guarded store transaction;
+  an ingress pre-read would retain a webhook/callback race.
+- Filter the seeded metadata to the six existing Junction historical keys
+  before applying the existing version-aware merge, so ordinary callback
+  metadata remains replacement-authoritative.
+- Reuse existing timestamps and windows; do not add persisted evidence state.
+
+## Tasks
+
+1. Add a failing signed connection-day regression for activity and sleep.
+2. Correct evidence attribution at the smallest existing ownership boundary.
+3. Preserve same-epoch historical metadata atomically in SQLite and Prisma
+   guarded upserts, with callback and store parity regressions.
+4. Run focused checks, required completion audits, affected-workspace
+   verification, scoped commit, PR ReviewGPT, and final merge checks.
+
+## Verification
+
+- `packages/device-syncd`: 775 tests passed and typecheck passed.
+- Hosted Prisma connection-store regression: 33 tests passed; hosted web
+  typecheck passed.
+- Hosted-local harness: 382 tests passed, 1 skipped.
+- Affected-workspace dependency, boundary, hosted-runtime, crypto, raw-log,
+  and all 14 package typecheck lanes passed. The package-test fan-out is
+  locally blocked by the untouched assistant-engine test `prunes terminal
+  outbox intents by instant when timestamp offsets differ`, which timed out at
+  60.23 seconds under the constrained package run but passed alone in 55.54
+  seconds. The modified device-sync suite remained 775/775 in the same gate.
+- Security/privacy, coverage-write, and the explicitly requested post-fix deep
+  review found no medium-or-higher blocker.
+- `git diff --check` and the scoped identifier/secret scan passed.
+- ReviewGPT against the final pushed head and final remote CI remain required
+  before merge.
+Completed: 2026-07-10

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -1,6 +1,9 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 import { deviceSyncError } from "@murphai/device-syncd/errors";
 import {
+  mergeGuardedJunctionHistoricalBackfillMetadata,
+} from "@murphai/device-syncd/hosted-runtime";
+import {
   isEstablishedDeviceSyncConnection,
   toRedactedPublicDeviceSyncAccount,
 } from "@murphai/device-syncd/public-account";
@@ -137,7 +140,7 @@ export class PrismaHostedConnectionStore {
   ): Promise<UpsertPublicDeviceSyncConnectionResult> {
     const ownerId = normalizeNullableString(input.ownerId);
     const displayName = normalizeNullableString(input.displayName);
-    const metadata = sanitizeHostedDeviceSyncConnectionMetadata(input.metadata ?? {});
+    const replacementMetadata = sanitizeHostedDeviceSyncConnectionMetadata(input.metadata ?? {});
     const scopes = normalizeStoredScopes(input.scopes);
     const connectedAt = new Date(input.connectedAt);
     const requestedStatus = input.status === undefined
@@ -196,6 +199,15 @@ export class PrismaHostedConnectionStore {
         }
 
         assertNoActiveHostedConnectionRefreshLease(existing, connectedAt);
+
+        const metadata = input.provider === "junction" && input.existingAccountGuard
+          ? sanitizeHostedDeviceSyncConnectionMetadata(
+              mergeGuardedJunctionHistoricalBackfillMetadata({
+                existingMetadata: mapHostedConnectionRecord(existing).metadata,
+                replacementMetadata,
+              }),
+            )
+          : replacementMetadata;
 
         const credentialWrite = await buildHostedConnectionCredentialWrite({
           connectionId: existing.id,
@@ -284,7 +296,7 @@ export class PrismaHostedConnectionStore {
             value: input.externalAccountId,
           }),
           id: connectionId,
-          metadataJson: toPrismaJsonObject(metadata),
+          metadataJson: toPrismaJsonObject(replacementMetadata),
           nextReconcileAt: maybeDate(input.nextReconcileAt),
           provider: input.provider,
           providerAccountBlindIndex,

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -570,26 +570,40 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(createCalled).toBe(false);
   });
 
-  it("accepts a guarded callback after mutable connection observations change", async () => {
-    const existing = createConnection({
+  it("atomically preserves Junction historical progress during a guarded callback", async () => {
+    let stored = createConnection({
+      credentialKind: "provider_config",
+      externalAccountIdEncrypted: "enc:junction-user-123",
       id: "dsc_123",
-      provider: "oura",
+      metadataJson: {
+        callbackOutcome: "seeded",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+        junctionHistoricalBackfillEmptyAttempts: 2,
+        junctionHistoricalBackfillLastEmptyAt: "2026-03-25T00:30:00.000Z",
+        junctionHistoricalBackfillWindowStart: "2026-03-23T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-03-25T00:00:00.000Z",
+        junctionHistoricalBackfillEvidence:
+          "e1|2026-03-23T00:00:00.000Z|2026-03-25T00:00:00.000Z|garmin:1",
+        seedOnlyState: "discard",
+      },
+      provider: "junction",
+      providerConfigKey: "junction",
+      setupPhase: "pending_link",
       status: "active",
       updatedAt: new Date("2026-03-25T00:30:00.000Z"),
       userId: "user-123",
     });
-    const updated = createConnection({
-      id: "dsc_123",
-      nextReconcileAt: new Date("2026-03-25T05:00:00.000Z"),
-      provider: "oura",
-      status: "active",
-      updatedAt: new Date("2026-03-26T04:00:00.000Z"),
-      userId: "user-123",
-    });
 
     const lockConnectionMutation = vi.fn(async () => 0);
-    const findConnection = vi.fn(async () => cloneConnection(existing));
-    const updateConnection = vi.fn(async () => cloneConnection(updated));
+    const findConnection = vi.fn(async () => cloneConnection(stored));
+    const updateConnection = vi.fn(async ({ data }: { data: Partial<MutableConnectionRecord> }) => {
+      stored = {
+        ...stored,
+        ...data,
+        updatedAt: new Date("2026-03-26T04:00:00.000Z"),
+      };
+      return cloneConnection(stored);
+    });
     const tx = {
       $executeRaw: lockConnectionMutation,
       deviceConnection: {
@@ -613,17 +627,16 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
 
     await expect(store.upsertConnection({
       ownerId: "user-123",
-      provider: "oura",
-      externalAccountId: "acct_456",
-      displayName: "Updated Oura ring",
-      scopes: ["daily"],
-      tokens: {
-        accessToken: "new-access-token",
-        refreshToken: "new-refresh-token",
-        accessTokenExpiresAt: "2026-03-26T04:00:00.000Z",
+      provider: "junction",
+      externalAccountId: "junction-user-123",
+      displayName: "Junction",
+      scopes: [],
+      credential: {
+        kind: "provider_config",
+        providerConfigKey: "junction",
       },
       metadata: {
-        region: "ca",
+        callbackOutcome: "complete",
       },
       existingAccountGuard: {
         expectedAccountId: "dsc_123",
@@ -644,6 +657,20 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(lockConnectionMutation.mock.invocationCallOrder[0]).toBeLessThan(
       updateConnection.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
+    expect(updateConnection).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        metadataJson: {
+          junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+          junctionHistoricalBackfillEmptyAttempts: 2,
+          junctionHistoricalBackfillLastEmptyAt: "2026-03-25T00:30:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-03-23T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-03-25T00:00:00.000Z",
+          junctionHistoricalBackfillEvidence:
+            "e1|2026-03-23T00:00:00.000Z|2026-03-25T00:00:00.000Z|garmin:1",
+          callbackOutcome: "complete",
+        },
+      }),
+    }));
     expect(tx.deviceConnectionSecret.upsert).not.toHaveBeenCalled();
   });
 

--- a/packages/device-syncd/src/hosted-runtime.ts
+++ b/packages/device-syncd/src/hosted-runtime.ts
@@ -2,6 +2,7 @@ import { sanitizeStoredDeviceSyncMetadata } from "./metadata.ts";
 import {
   canCurrentRuntimeMutateJunctionHistoricalBackfillProgress,
   JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
+  mergeGuardedJunctionHistoricalBackfillMetadata,
   mergeHostedJunctionHistoricalBackfillMetadata,
   readJunctionHistoricalBackfillProgress,
   readJunctionHistoricalBackfillStatus,
@@ -14,6 +15,7 @@ import type {
 export {
   canCurrentRuntimeMutateJunctionHistoricalBackfillProgress,
   JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS,
+  mergeGuardedJunctionHistoricalBackfillMetadata,
   readJunctionHistoricalBackfillProgress,
   readJunctionHistoricalBackfillStatus,
 };

--- a/packages/device-syncd/src/junction-historical-backfill-progress.ts
+++ b/packages/device-syncd/src/junction-historical-backfill-progress.ts
@@ -229,6 +229,39 @@ export function mergeHostedJunctionHistoricalBackfillMetadata(input: {
   return { metadata, preservedLocalProgress };
 }
 
+/** Preserve provider-owned progress during a guarded replacement inside the store transaction. */
+export function mergeGuardedJunctionHistoricalBackfillMetadata(input: {
+  existingMetadata: Record<string, unknown>;
+  replacementMetadata: Record<string, unknown>;
+}): Record<string, unknown> {
+  const existingHistoricalMetadata: Record<string, unknown> = {};
+  for (const key of Object.values(JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS)) {
+    if (Object.prototype.hasOwnProperty.call(input.existingMetadata, key)) {
+      existingHistoricalMetadata[key] = input.existingMetadata[key];
+    }
+  }
+
+  const mergedMetadata = mergeHostedJunctionHistoricalBackfillMetadata({
+    hostedMetadata: input.replacementMetadata,
+    localConnectionStateUnpublished: true,
+    localMetadata: existingHistoricalMetadata,
+  }).metadata;
+  const metadata: Record<string, unknown> = {};
+
+  for (const key of Object.values(JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS)) {
+    if (Object.prototype.hasOwnProperty.call(mergedMetadata, key)) {
+      metadata[key] = mergedMetadata[key];
+    }
+  }
+  for (const [key, value] of Object.entries(input.replacementMetadata)) {
+    if (!Object.prototype.hasOwnProperty.call(metadata, key)) {
+      metadata[key] = value;
+    }
+  }
+
+  return metadata;
+}
+
 export function encodeJunctionHistoricalBackfillStatus(
   status: JunctionHistoricalBackfillStatus,
 ): string {

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -190,6 +190,39 @@ const JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCES = Object.freeze([
 const JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCE_SET = new Set<string>(
   JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCES,
 );
+const JUNCTION_HISTORICAL_EVIDENCE_ACTIVITY_TIMESTAMP_PATHS = Object.freeze([
+  "observedAtRaw",
+  "observed_at_raw",
+  "observedAt",
+  "observed_at",
+  "timestamp",
+  "time",
+  "date",
+  "day",
+  "calendarDate",
+  "calendar_date",
+  "localDate",
+  "local_date",
+  "end",
+  "endAt",
+  "end_at",
+  "timeEnd",
+  "time_end",
+  "start",
+  "startAt",
+  "start_at",
+  "timeStart",
+  "time_start",
+] as const);
+const JUNCTION_HISTORICAL_EVIDENCE_SLEEP_TIMESTAMP_PATHS = Object.freeze([
+  "sessionEnd",
+  "session_end",
+  ...JUNCTION_SLEEP_END_TIMESTAMP_PATHS,
+  ...JUNCTION_SLEEP_START_TIMESTAMP_PATHS,
+  "sessionStart",
+  "session_start",
+  ...JUNCTION_HISTORICAL_EVIDENCE_ACTIVITY_TIMESTAMP_PATHS,
+] as const);
 
 type JunctionOptionalResourceFailureReason = "not_found" | "unavailable" | "unsupported" | "ambiguous";
 
@@ -1489,6 +1522,14 @@ export function createJunctionDeviceSyncProvider(
 
       const directInput = readJunctionDirectResourceJobInput(job, window);
       if (directInput) {
+        const directHistoricalWindow = isJunctionHistoricalBackfillRequiredSummaryResource(
+          directInput.resource,
+        )
+          ? readJunctionDirectHistoricalEvidenceWindow(
+              directInput,
+              buildConnectHistoricalBackfillWindow(context.account, summaryBackfillDays),
+            )
+          : window;
         const sourceProviders = shouldLoadJunctionDirectResourceSourceProviders(directInput)
           ? await loadSourceProviders()
           : [];
@@ -1503,11 +1544,12 @@ export function createJunctionDeviceSyncProvider(
         return withJunctionHistoricalCoverageVerification(
           context,
           job,
-          window,
+          directHistoricalWindow,
           withJunctionDirectHistoricalBackfillEvidence(
             context,
             job,
             directInput,
+            directHistoricalWindow,
             canonicalEventCount,
             { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
           ),
@@ -1651,13 +1693,14 @@ export function createJunctionDeviceSyncProvider(
   function withJunctionHistoricalCoverageVerification(
     context: ProviderJobContext,
     job: DeviceSyncJobRecord,
-    resourceWindow: { windowEnd: string; windowStart: string },
+    resourceWindow: { windowEnd: string; windowStart: string } | null,
     result: ProviderJobResult,
   ): ProviderJobResult {
     const historicalState = readHistoricalBackfillStatus(context.account.metadata);
     const eventType = normalizeString(job.payload.eventType);
     if (
       !historicalState
+      || !resourceWindow
       || historicalState.coverageVersion > JUNCTION_HISTORICAL_BACKFILL_COVERAGE_VERSION
       || historicalState.status !== "exhausted"
       || !eventType
@@ -1696,12 +1739,14 @@ export function createJunctionDeviceSyncProvider(
     context: ProviderJobContext,
     job: DeviceSyncJobRecord,
     directInput: JunctionDirectResourceJobInput,
+    directHistoricalWindow: { windowEnd: string; windowStart: string } | null,
     canonicalEventCount: number,
     result: ProviderJobResult,
   ): ProviderJobResult {
     const eventType = normalizeString(job.payload.eventType);
     if (
       !canCurrentRuntimeMutateJunctionHistoricalBackfillProgress(context.account.metadata)
+      || !directHistoricalWindow
       || canonicalEventCount <= 0
       || !eventType
       || !isJunctionDataEvent(eventType)
@@ -1715,13 +1760,6 @@ export function createJunctionDeviceSyncProvider(
       context.account,
       summaryBackfillDays,
     );
-    if (
-      Date.parse(directInput.windowStart) >= Date.parse(connectWindow.windowEnd)
-      || Date.parse(directInput.windowEnd) <= Date.parse(connectWindow.windowStart)
-    ) {
-      return result;
-    }
-
     const evidence = addJunctionHistoricalBackfillEvidence({
       existingValue:
         context.account.metadata[JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS.evidence],
@@ -4365,6 +4403,74 @@ function isJunctionHistoricalBackfillRequiredSummaryResource(
   resource: string,
 ): resource is JunctionHistoricalBackfillEvidenceResource {
   return JUNCTION_HISTORICAL_BACKFILL_REQUIRED_SUMMARY_RESOURCE_SET.has(resource);
+}
+
+function readJunctionDirectHistoricalEvidenceWindow(
+  input: JunctionDirectResourceJobInput,
+  connectWindow: { windowEnd: string; windowStart: string },
+): { windowEnd: string; windowStart: string } | null {
+  if (!isJunctionHistoricalBackfillRequiredSummaryResource(input.resource)) {
+    return null;
+  }
+
+  const connectWindowStartMs = Date.parse(connectWindow.windowStart);
+  const connectWindowEndMs = Date.parse(connectWindow.windowEnd);
+  if (
+    !Number.isFinite(connectWindowStartMs)
+    || !Number.isFinite(connectWindowEndMs)
+    || connectWindowStartMs >= connectWindowEndMs
+  ) {
+    return null;
+  }
+
+  for (const { entry, originFallback } of expandJunctionHistoricalBackfillSummaryRecord(input.record)) {
+    const record = originFallback ? { ...originFallback, ...entry } : entry;
+    if (!hasUsefulJunctionHistoricalBackfillSummaryRecord(
+      input.resource,
+      record,
+      input.sourceProviderSlug,
+    )) {
+      continue;
+    }
+
+    const timestampPaths = input.resource === "activity"
+      ? JUNCTION_HISTORICAL_EVIDENCE_ACTIVITY_TIMESTAMP_PATHS
+      : JUNCTION_HISTORICAL_EVIDENCE_SLEEP_TIMESTAMP_PATHS;
+
+    for (const path of timestampPaths) {
+      const timestampMs = junctionHistoricalEvidenceTimestampMillis(
+        readJunctionRecordPath(record, path),
+        input.sourceProviderSlug,
+      );
+      if (timestampMs === null) {
+        continue;
+      }
+      if (timestampMs >= connectWindowStartMs && timestampMs < connectWindowEndMs) {
+        const windowStart = new Date(timestampMs).toISOString();
+        return {
+          windowStart,
+          windowEnd: addMilliseconds(windowStart, 1),
+        };
+      }
+
+      break;
+    }
+  }
+
+  return null;
+}
+
+function junctionHistoricalEvidenceTimestampMillis(
+  value: unknown,
+  sourceProviderSlug: string,
+): number | null {
+  const normalized = normalizeString(value);
+  if (normalized && /^\d{4}-\d{2}-\d{2}$/u.test(normalized)) {
+    const timestamp = toJunctionWebhookWindowBoundaryTimestampIfValid(normalized, "start");
+    return timestamp ? Date.parse(timestamp) : null;
+  }
+
+  return junctionTimestampMillis(value, sourceProviderSlug);
 }
 
 function isJunctionResourceAdvertisedAvailable(value: unknown): boolean {

--- a/packages/device-syncd/src/store/accounts.ts
+++ b/packages/device-syncd/src/store/accounts.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { withImmediateTransaction } from "@murphai/runtime-state/node";
 
 import { deviceSyncError } from "../errors.ts";
+import { mergeGuardedJunctionHistoricalBackfillMetadata } from "../junction-historical-backfill-progress.ts";
 import { resolveDeviceProviderMatchKeys } from "../provider-match.ts";
 import {
   generatePrefixedId,
@@ -796,11 +797,18 @@ export function upsertAccount(
       ? input.setupExpiresAt ?? null
       : existing?.setupExpiresAt ?? null;
     const scopesJson = stringifyJson(input.scopes ?? []);
-    const metadataJson = stringifyJson(sanitizeStoredDeviceSyncAccountMetadata(input.metadata ?? {}));
+    const replacementMetadata = sanitizeStoredDeviceSyncAccountMetadata(input.metadata ?? {});
 
     if (existing) {
       assertAccountUpsertExistingGuard(existing, input.existingAccountGuard ?? null);
       const credential = resolveAccountCredentialInput(input);
+      const metadata = input.provider === "junction" && input.existingAccountGuard
+        ? mergeGuardedJunctionHistoricalBackfillMetadata({
+            existingMetadata: existing.metadata,
+            replacementMetadata,
+          })
+        : replacementMetadata;
+      const metadataJson = stringifyJson(sanitizeStoredDeviceSyncAccountMetadata(metadata));
 
       database.prepare(`
         update device_connection
@@ -869,6 +877,7 @@ export function upsertAccount(
 
     assertAccountUpsertExistingGuard(null, input.existingAccountGuard ?? null);
     const credential = resolveAccountCredentialInput(input);
+    const metadataJson = stringifyJson(replacementMetadata);
 
     const id = generatePrefixedId("dsa");
     database.prepare(`

--- a/packages/device-syncd/test/hosted-runtime.test.ts
+++ b/packages/device-syncd/test/hosted-runtime.test.ts
@@ -9,6 +9,7 @@ import { DEVICE_SYNC_METADATA_MAX_STRING_LENGTH } from "../src/metadata.ts";
 import {
   buildHostedExecutionDeviceSyncConnectLinkPath,
   isHostedRuntimeIdShapedDiagnosticToken,
+  mergeGuardedJunctionHistoricalBackfillMetadata,
   mergeHostedDeviceSyncConnectionMetadata,
   normalizeHostedDeviceSyncJobHints,
   parseHostedExecutionDeviceSyncConnectLinkResponse,
@@ -457,6 +458,26 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
         windowEnd: "2026-03-20T00:00:00.000Z",
       })).toBeNull();
     }
+  });
+});
+
+describe("mergeGuardedJunctionHistoricalBackfillMetadata", () => {
+  it("preserves opaque future historical state without retaining ordinary seed metadata", () => {
+    expect(mergeGuardedJunctionHistoricalBackfillMetadata({
+      existingMetadata: {
+        junctionHistoricalBackfillEvidence: "e2|opaque-future-evidence",
+        junctionHistoricalBackfillStatus: "coverage_v3_deferred",
+        seedOnlyState: "discard",
+      },
+      replacementMetadata: {
+        callbackOutcome: "complete",
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      },
+    })).toEqual({
+      callbackOutcome: "complete",
+      junctionHistoricalBackfillEvidence: "e2|opaque-future-evidence",
+      junctionHistoricalBackfillStatus: "coverage_v3_deferred",
+    });
   });
 });
 

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -3429,6 +3429,148 @@ test("Junction late historical data queues one connect-window verification after
   assert.equal(currentResult.metadataPatch, undefined);
 });
 
+test("Junction connection-day direct pushes do not prove older historical coverage", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    throw new Error(`Unexpected request: ${readUrl(input)}`);
+  }, {
+    providerFilter: ["garmin"],
+    webhookSecret: "whsec_d2ViaG9vay10ZXN0LXNlY3JldA==",
+  });
+  const webhook = createJunctionSvixWebhook({
+    body: {
+      event_type: "daily.data.activity.created",
+      user_id: "junction-user-1",
+      data: {
+        date: "2026-04-03",
+        id: "connection-day-activity",
+        source: {
+          provider: "garmin",
+          type: "watch",
+        },
+        steps: 1234,
+      },
+    },
+    messageId: "msg_connection_day_activity_1",
+    timestamp: "1775174400",
+  });
+  const parsed = await requireJunctionWebhookHandler(provider).verifyAndParseWebhook({
+    headers: webhook.headers,
+    rawBody: webhook.rawBody,
+    now: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.equal(parsed.jobs.length, 1);
+
+  let importCount = 0;
+  const result = await executeJunctionJob(
+    provider,
+    createJunctionJobContext({
+      account: createAccount({
+        metadata: {
+          junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+          junctionHistoricalBackfillEmptyAttempts: 5,
+          junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
+          junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+          junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        },
+      }),
+      importSnapshot: async () => {
+        importCount += 1;
+        return { canonicalEventCount: 1 };
+      },
+    }),
+    createJob("resource", parsed.jobs[0]?.payload ?? {}),
+  );
+
+  assert.equal(importCount, 1);
+  assert.equal(result.metadataPatch, undefined);
+  assert.equal(result.scheduledJobs, undefined);
+});
+
+test("Junction connection-day sleep records do not prove older historical coverage", async () => {
+  const provider = createJunctionProvider(async (input) => {
+    throw new Error(`Unexpected request: ${readUrl(input)}`);
+  }, {
+    providerFilter: ["garmin"],
+    summaryResources: ["sleep", "sleep_cycle"],
+    webhookSecret: "whsec_d2ViaG9vay10ZXN0LXNlY3JldA==",
+  });
+  const cases = [
+    {
+      eventType: "daily.data.sleep.created",
+      messageId: "msg_connection_day_sleep_1",
+      data: {
+        bedtime_start: "2026-04-03T01:00:00.000Z",
+        bedtime_stop: "2026-04-03T08:00:00.000Z",
+        date: "2026-04-03",
+        id: "connection-day-sleep",
+        score: 88,
+        sourceProviderSlug: "garmin",
+      },
+    },
+    {
+      eventType: "daily.data.sleep_cycle.created",
+      messageId: "msg_connection_day_sleep_cycle_1",
+      data: {
+        id: "connection-day-sleep-cycle",
+        sessionEnd: "2026-04-03T08:00:00.000Z",
+        sessionStart: "2026-04-02T23:00:00.000Z",
+        sourceProviderSlug: "garmin",
+        stages: [{
+          endAt: "2026-04-03T08:00:00.000Z",
+          stage: "light",
+          startAt: "2026-04-02T23:00:00.000Z",
+        }],
+      },
+    },
+  ] as const;
+  let importCount = 0;
+
+  for (const fixture of cases) {
+    const webhook = createJunctionSvixWebhook({
+      body: {
+        event_type: fixture.eventType,
+        user_id: "junction-user-1",
+        data: fixture.data,
+      },
+      messageId: fixture.messageId,
+      timestamp: "1775217600",
+    });
+    const parsed = await requireJunctionWebhookHandler(provider).verifyAndParseWebhook({
+      headers: webhook.headers,
+      rawBody: webhook.rawBody,
+      now: "2026-04-03T12:00:00.000Z",
+    });
+    assert.equal(parsed.jobs.length, 1);
+
+    const result = await executeJunctionJob(
+      provider,
+      createJunctionJobContext({
+        account: createAccount({
+          metadata: {
+            junctionHistoricalBackfillStatus: "coverage_v2_exhausted",
+            junctionHistoricalBackfillEmptyAttempts: 5,
+            junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:00:00.000Z",
+            junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+            junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+          },
+        }),
+        now: "2026-04-03T12:00:00.000Z",
+        importSnapshot: async () => {
+          importCount += 1;
+          return { canonicalEventCount: 1 };
+        },
+      }),
+      createJob("resource", parsed.jobs[0]?.payload ?? {}),
+    );
+
+    assert.equal(result.metadataPatch, undefined);
+    assert.equal(result.scheduledJobs, undefined);
+  }
+
+  assert.equal(importCount, cases.length);
+});
+
 test("Junction direct pushes without canonical events or from another source do not become history evidence", async () => {
   const provider = createJunctionProvider(async (input) => {
     throw new Error(`Unexpected request: ${readUrl(input)}`);

--- a/packages/device-syncd/test/public-ingress.test.ts
+++ b/packages/device-syncd/test/public-ingress.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test, vi } from "vitest";
 
 import { DeviceSyncError, deviceSyncError } from "../src/errors.ts";
+import { mergeGuardedJunctionHistoricalBackfillMetadata } from "../src/junction-historical-backfill-progress.ts";
 import { createDeviceSyncPublicIngress } from "../src/public-ingress.ts";
 import { createDeviceSyncRegistry } from "../src/registry.ts";
 import { scopeWebhookTraceId, sha256Text } from "../src/shared.ts";
@@ -163,6 +164,12 @@ class InMemoryPublicIngressStore implements DeviceSyncPublicIngressStore {
     const setupExpiresAt = Object.prototype.hasOwnProperty.call(input, "setupExpiresAt")
       ? input.setupExpiresAt ?? null
       : existing?.setupExpiresAt ?? null;
+    const metadata = existing && input.provider === "junction" && input.existingAccountGuard
+      ? mergeGuardedJunctionHistoricalBackfillMetadata({
+          existingMetadata: existing.metadata,
+          replacementMetadata: input.metadata ?? {},
+        })
+      : input.metadata ?? {};
 
     const record: PublicDeviceSyncAccount = {
       id,
@@ -174,7 +181,7 @@ class InMemoryPublicIngressStore implements DeviceSyncPublicIngressStore {
       setupExpiresAt,
       scopes: [...(input.scopes ?? [])],
       accessTokenExpiresAt: tokens?.accessTokenExpiresAt ?? null,
-      metadata: { ...(input.metadata ?? {}) },
+      metadata: { ...metadata },
       connectedAt: input.connectedAt,
       lastWebhookAt: existing?.lastWebhookAt ?? null,
       lastSyncStartedAt: existing?.lastSyncStartedAt ?? null,
@@ -986,7 +993,9 @@ test("public ingress completes seeded external-link callbacks after mutable webh
           kind: "provider_config",
           providerConfigKey: "junction",
         },
-        metadata: { ...input.stateMetadata },
+        metadata: {
+          callbackOutcome: "complete",
+        },
       };
     },
   });
@@ -1003,6 +1012,33 @@ test("public ingress completes seeded external-link callbacks after mutable webh
   });
   const seeded = store.getConnectionByExternalAccount("junction", "external-account-1");
   assert.ok(seeded?.setupExpiresAt);
+  store.upsertConnection({
+    ownerId: "<REDACTED_OWNER_ID>",
+    provider: "junction",
+    externalAccountId: "external-account-1",
+    displayName: "Junction",
+    status: "active",
+    setupPhase: "pending_link",
+    setupExpiresAt: seeded.setupExpiresAt,
+    scopes: [],
+    credential: {
+      kind: "provider_config",
+      providerConfigKey: "junction",
+    },
+    metadata: {
+      callbackOutcome: "seeded",
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      junctionHistoricalBackfillEmptyAttempts: 2,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:30:00.000Z",
+      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+      junctionHistoricalBackfillEvidence:
+        "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:1",
+      seedOnlyState: "discard",
+    },
+    connectedAt: seeded.connectedAt,
+    nextReconcileAt: seeded.nextReconcileAt,
+  });
   const stateRecord = store.peekOAuthState(begin.state);
   assert.ok(stateRecord);
   store.createOAuthState({
@@ -1041,6 +1077,16 @@ test("public ingress completes seeded external-link callbacks after mutable webh
   assert.equal(completed.account.setupExpiresAt, null);
   assert.equal(completed.account.externalAccountId, "external-account-1");
   assert.equal(completed.account.id, seeded.id);
+  assert.deepEqual(completed.account.metadata, {
+    callbackOutcome: "complete",
+    junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+    junctionHistoricalBackfillEmptyAttempts: 2,
+    junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:30:00.000Z",
+    junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+    junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+    junctionHistoricalBackfillEvidence:
+      "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:1",
+  });
   assert.equal(
     Object.prototype.hasOwnProperty.call(
       completed.account.metadata,

--- a/packages/device-syncd/test/store.test.ts
+++ b/packages/device-syncd/test/store.test.ts
@@ -3379,6 +3379,84 @@ test("device sync store clears tokens and requires reauthorization after connect
   }
 });
 
+test("device sync store preserves guarded Junction historical progress across callback replacement", async () => {
+  const tempDir = await makeTempDirectory("murph-device-syncd-store-junction-callback-metadata");
+  const store = new SqliteDeviceSyncStore(path.join(tempDir, "state.sqlite"));
+
+  try {
+    const seeded = store.upsertAccount({
+      provider: "junction",
+      externalAccountId: "junction-guarded-callback",
+      displayName: "Junction",
+      status: "active",
+      setupPhase: "pending_link",
+      scopes: [],
+      credential: {
+        kind: "provider_config",
+        providerConfigKey: "junction",
+      },
+      metadata: {
+        callbackOutcome: "seeded",
+        seedOnlyState: "discard",
+      },
+      connectedAt: "2026-04-03T00:00:00.000Z",
+      nextReconcileAt: null,
+    });
+    store.patchAccount(seeded.id, {
+      metadata: {
+        junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+        junctionHistoricalBackfillEmptyAttempts: 2,
+        junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:30:00.000Z",
+        junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+        junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+        junctionHistoricalBackfillEvidence:
+          "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:1",
+      },
+    });
+
+    const completed = store.upsertAccount({
+      provider: "junction",
+      externalAccountId: "junction-guarded-callback",
+      displayName: "Junction",
+      status: "active",
+      setupPhase: "link_returned",
+      scopes: [],
+      credential: {
+        kind: "provider_config",
+        providerConfigKey: "junction",
+      },
+      metadata: {
+        callbackOutcome: "complete",
+      },
+      existingAccountGuard: {
+        expectedAccountId: seeded.id,
+        expectedConnectedAt: seeded.connectedAt,
+        rejectIfDisconnected: true,
+      },
+      connectedAt: seeded.connectedAt,
+      nextReconcileAt: null,
+    });
+
+    assert.equal(completed.id, seeded.id);
+    assert.deepEqual(completed.metadata, {
+      junctionHistoricalBackfillStatus: "coverage_v2_retrying",
+      junctionHistoricalBackfillEmptyAttempts: 2,
+      junctionHistoricalBackfillLastEmptyAt: "2026-04-03T00:30:00.000Z",
+      junctionHistoricalBackfillWindowStart: "2026-04-01T00:00:00.000Z",
+      junctionHistoricalBackfillWindowEnd: "2026-04-03T00:00:00.000Z",
+      junctionHistoricalBackfillEvidence:
+        "e1|2026-04-01T00:00:00.000Z|2026-04-03T00:00:00.000Z|garmin:1",
+      callbackOutcome: "complete",
+    });
+  } finally {
+    store.close();
+    await rm(tempDir, {
+      force: true,
+      recursive: true,
+    });
+  }
+});
+
 test("device sync store updates existing accounts and rejects stale success writes", async () => {
   const tempDir = await makeTempDirectory("murph-device-syncd-store-update-existing");
   const store = new SqliteDeviceSyncStore(path.join(tempDir, "state.sqlite"));


### PR DESCRIPTION
## Why

Follow-up to #516. The required post-merge deep review found two production integrity gaps in Garmin/Junction historical recovery:

- Signed connection-day activity or sleep records inherited the webhook parser's coarse daily window and could be mistaken for older historical evidence, prematurely ending retries.
- Genuine historical evidence could arrive while Link was pending, then be erased when the same-epoch browser callback replaced the seeded connection metadata.

## User-visible goal

Garmin history recovery must keep working until genuine historical records arrive, retain accepted evidence through connection completion, and continue importing current wearable data normally.

## Changes

- Attribute required-summary evidence and exact-window verification to the first importer-aligned timestamp on the accepted record, inside the exact half-open connect window.
- Preserve exactly the six provider-owned Junction historical keys during a same-account, same-epoch guarded callback replacement. The merge runs atomically inside the existing SQLite transaction or Prisma advisory-lock transaction.
- Keep callback metadata authoritative for ordinary keys and keep public hosted metadata redacted.
- Add signed activity/sleep/sleep-cycle regressions plus public-ingress, SQLite, Prisma, future-version, and replacement-semantics coverage.

## Invariants preserved

- Current records still import even when they cannot prove historical coverage.
- Only signed, successfully normalized canonical records can become inline evidence.
- Unguarded upserts and non-Junction providers retain replacement semantics.
- No schema, table, queue, service, lifecycle state, or retry-policy expansion.
- Stale or disconnected epochs remain rejected by the existing account guard.

## Verification

- `packages/device-syncd`: typecheck passed; 775/775 tests passed.
- Hosted Prisma connection-store regression: 33/33 tests passed; hosted web typecheck passed.
- Hosted-local harness: 382 passed, 1 skipped.
- Affected dependency, boundary, hosted-runtime, crypto, raw-log, and all 14 package typecheck lanes passed.
- Security/privacy, coverage-write, and fresh post-fix deep review found no medium-or-higher blocker.
- Diff integrity and identifier/secret scans passed.
- Local affected package fan-out is blocked only by an untouched assistant-engine timeout test: it exceeded its 60-second suite threshold by 0.23 seconds and passed alone in 55.54 seconds. Remote CI remains the merge authority.

## Deployment

No migration is required. Deploy the hosted web/control-plane callback path first, then the hosted device-sync runtime, or deploy both together. The compatibility window is non-crashing, but the complete integrity guarantee requires both versions. After rollout, confirm a connection-day webhook does not close an older history obligation and a same-epoch Link callback retains existing historical progress.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786306557&installation_id=127572939&pr_number=545&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F545&signature=999a3c4fd495f9f18e1acb54d3bd3f42b49856c9da7e5b49455a41d62222e5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->