### PR TITLE
docs: add Fable ↔ Sol model complementarity routing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,15 @@ Always read these before repo code/docs/test/config work:
 - Document architecture-significant changes in the matching durable docs, and update `agent-docs/index.md` when durable docs are added, removed, moved, or materially repurposed.
 - If a completed task could break or degrade production when Vercel (`apps/web`) and Cloudflare (`apps/cloudflare`) deploy out of sync, add a final-response section labeled `DEPLOYMENT CONCERNS:` with the recommended safe deployment order, required tandem deploy or compatibility window, and any post-deploy checks.
 
+## Model Complementarity (Fable ↔ Sol)
+
+Working hypothesis from a single collaboration (not a proven law): Fable and Sol (`gpt-5.6-sol`) tend to fail in opposite directions, so bounce a sub-problem to the other whenever you hit its apparent strength or your own known weakness, and reach for a second-model pass more as stakes rise. Detail: `agent-docs/operations/agent-workflow-routing.md` § Model Complementarity (Fable ↔ Sol).
+
+- Sol is the builder: strongest at concrete work — implementations, specific fixes, reproductions, failing tests, cases that settle a question. Apparent failure: overclaiming scope (code is sound, but "this handles X" exceeds what it covers). Lean on its concrete work, double-check its scope claims.
+- Fable is the architect: strongest at structure — reframing, root cause, the right abstraction, simplification, plus process hygiene. Apparent failure: overreach at polish (adds speculative refactors/abstractions/generalizations past the verified core). Lean on its framing, double-check its finishing extras.
+- Route by need: hand to Sol to build or verify something concrete; hand to Fable for reframing, root cause, the right abstraction, or scope discipline.
+- Referee across model when it's worth it: Fable checks Sol's scope, Sol checks Fable's added polish. Same-model self-review shares the blind spot.
+
 ## Notes
 
 - When debugging Codex CLI issues, check for a sibling checkout at `../codex`; if it is missing, clone the Codex CLI repo there so future debugging can reuse that location.

--- a/agent-docs/operations/agent-workflow-routing.md
+++ b/agent-docs/operations/agent-workflow-routing.md
@@ -63,6 +63,29 @@ Then load only the task-relevant docs listed below.
 - Do not use `scripts/committer` or raw `git commit` as the final task commit for work that has an active plan unless the user explicitly asks to leave the plan active.
 - If a plan-bearing task cannot safely create a scoped commit because overlapping dirty files would force an unsafe partial stage, do not leave the plan under `active/`; clear the matching ledger row and archive it with `scripts/close-exec-plan.sh` before handoff.
 
+## Model Complementarity (Fable ↔ Sol)
+
+This is a working hypothesis from a single observed collaboration, not a proven law — treat it as a prompt to reach for the other model, not a fixed claim about either one's ability. In that session Fable and Sol (`gpt-5.6-sol`, the Codex model this repo pins) showed distinct working styles whose failure modes leaned in opposite directions, so a cross-model pass caught real mistakes in both directions. Bounce a sub-problem to the other model whenever you hit its apparent strength or your own known weakness, and lean on a second-model pass more as the stakes rise.
+
+**Sol — the builder.** Tends to produce concrete artifacts: working implementations, specific fixes, reproductions, failing tests, and concrete cases that settle a question. It tends to make progress by building or running something specific, and even when reviewing it often objects by producing a concrete counterexample rather than an abstract concern.
+- Apparent failure mode: overclaiming scope. The code it writes is often sound, but the claim about *what it covers* can exceed it — "this handles X" when it handles only part of X. Its own caveats often already flag the gap; the caution just doesn't always propagate into the summary.
+- So: lean on Sol's concrete work, double-check its scope claims, and read its self-flagged caveats as real.
+
+**Fable — the architect.** Tends to produce structure: reframing the problem, finding the root cause or the real obstruction, choosing the right abstraction and placement, and simplifying. It also tends toward process hygiene — flagging shaky steps and documenting what it could not verify.
+- Apparent failure mode: overreach at the polish layer. At finishing time it can add "nice" extras beyond the verified core — a speculative refactor, an extra abstraction, or a claimed generalization — that weren't actually checked. It also leans on concrete artifacts as raw material more than it originates them.
+- So: lean on Fable's framing and simplifications, double-check any extra it adds after the core change, and re-verify claimed generalizations.
+
+**Route by need — hand the sub-problem to whichever model's zone it is.**
+- Hand to Sol when you need something concrete built or verified: an implementation, a specific fix, a reproduction, a failing test, or a case that settles whether a claim holds. If Fable is stuck for raw material or needs its structure grounded in something concrete, that is Sol's zone.
+- Hand to Fable when you need structure: a reframing, the root cause or obstruction, the right abstraction/placement, a simplification, or scope and process discipline. If Sol has working code but is unsure what it means or how far it reaches, that is Fable's zone.
+
+**Referee across model when it's worth it.** A cross-model pass tends to catch what a same-model self-review misses, because a model's blind spot and its self-review share the same bias:
+- Fable checking Sol's scope: does the change actually cover the cases it claims? did an assumption slip in?
+- Sol checking Fable's added polish: is each extra refactor or generalization actually verified? build the concrete case that tests it.
+- A workable rhythm is alternation: Sol builds something concrete → Fable reframes or simplifies it → Sol re-grounds the next step in something concrete.
+
+In that session the styles seemed to persist even when the models swapped roles (the builder still built while reviewing, the architect still reframed while attacking), a hint the tendency is model-level rather than just prompt-driven. Either way, when a task hits one model's weak spot, routing that piece to the other is usually cheaper than trying to prompt the same model out of its default mode.
+
 ## Quick Path
 
 For tiny repo-internal workflow/tooling changes:


### PR DESCRIPTION
## Why

Agents working in this repo (Fable and the pinned Codex model, `gpt-5.6-sol`) had no shared, written understanding of how the two tend to complement each other, or when to hand a sub-problem to the other model. A single observed collaboration surfaced a consistent, useful pattern; capturing it lets agents route work to the right model and cross-referee before trusting results.

## What ships

- New **Model Complementarity (Fable ↔ Sol)** section in the always-read `agent-docs/operations/agent-workflow-routing.md`: Sol tends to be the builder (concrete implementations, fixes, repros, tests) with an apparent failure mode of overclaiming scope; Fable tends to be the architect (reframing, root cause, abstraction, simplification) with an apparent failure mode of overreach at the polish layer. Includes route-by-need guidance and cross-model refereeing.
- A tight gist plus pointer under the same heading in `AGENTS.md`.

Framed explicitly as a working hypothesis from one anecdote (not a law), stated as tendencies, and generalized to coding rather than the math session it came from.

## Invariants to preserve

- Docs-only, text change; no runtime, schema, auth, or behavior touched.
- Keeps `AGENTS.md` route-oriented (gist + pointer), with durable detail in `agent-docs/`.
- Neutral attribution only — no personal names.

DEPLOYMENT CONCERNS: none (docs only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786322480&installation_id=127572939&pr_number=552&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F552&signature=f0414fc5acb3b489589c6b25eec891d2b9cdc9dcd545b8d32e5c09f0aa8c5a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->