### PR TITLE
Soften homepage tagline to "Almost no one gets there alone."

### DIFF
--- a/apps/web/src/lib/site-metadata.ts
+++ b/apps/web/src/lib/site-metadata.ts
@@ -7,7 +7,7 @@ type TwitterMetadata = NonNullable<Metadata["twitter"]>;
 // the default OG image), the metadata title, and both descriptions. Edit the
 // copy here, nowhere else.
 export const MURPH_TAGLINE_LINE_1 = "Everyone has a health goal.";
-export const MURPH_TAGLINE_LINE_2 = "Nobody gets there alone.";
+export const MURPH_TAGLINE_LINE_2 = "Almost no one gets there alone.";
 
 export const MURPH_DEFAULT_METADATA_TITLE =
   "Murph — Get healthier with your group chat";

--- a/apps/web/test/browser-vault-dashboard-pages.test.tsx
+++ b/apps/web/test/browser-vault-dashboard-pages.test.tsx
@@ -78,7 +78,7 @@ test("dashboard routes define page-specific metadata with the shared preview ima
   ]) {
     assert.deepEqual(routeMetadata.openGraph?.images, [
       {
-        alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+        alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
         height: 630,
         type: "image/png",
         url: "/opengraph-image",
@@ -87,7 +87,7 @@ test("dashboard routes define page-specific metadata with the shared preview ima
     ]);
     assert.deepEqual(routeMetadata.twitter?.images, [
       {
-        alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+        alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
         height: 630,
         type: "image/png",
         url: "/opengraph-image",

--- a/apps/web/test/layout.test.ts
+++ b/apps/web/test/layout.test.ts
@@ -128,7 +128,7 @@ test("RootLayout provides default title, description, and preview image metadata
   );
   assert.deepEqual(metadata.openGraph?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",
@@ -137,7 +137,7 @@ test("RootLayout provides default title, description, and preview image metadata
   ]);
   assert.deepEqual(metadata.twitter?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",

--- a/apps/web/test/opengraph-image.test.ts
+++ b/apps/web/test/opengraph-image.test.ts
@@ -66,7 +66,7 @@ test("OGImage reads bundled font assets without fetching Google Fonts", async ()
   ];
   const serializedImageTree = JSON.stringify(imageTree);
   expect(serializedImageTree).toContain("Everyone has a health goal.");
-  expect(serializedImageTree).toContain("Nobody gets there alone.");
+  expect(serializedImageTree).toContain("Almost no one gets there alone.");
   expect(serializedImageTree).not.toContain("Health experiments with friends.");
 
   expect(init.fonts.map((font) => [font.name, font.weight])).toEqual([

--- a/apps/web/test/page.test.ts
+++ b/apps/web/test/page.test.ts
@@ -183,11 +183,11 @@ test("HomePage renders the canonical landing page at the root route", async () =
     /font-serif text-\[clamp\(2rem,4vw,3\.25rem\)\][^"]* text-black/,
   );
   assert.match(markup, /<span class="block">Everyone has a health goal\.<\/span>/);
-  assert.match(markup, /Nobody gets there alone\./);
+  assert.match(markup, /Almost no one gets there alone\./);
   assert.equal((markup.match(/<h1\b/g) ?? []).length, 1);
   assert.match(
     markup,
-    /<h1 class="sr-only">Everyone has a health goal\. Nobody gets there alone\.<\/h1>/,
+    /<h1 class="sr-only">Everyone has a health goal\. Almost no one gets there alone\.<\/h1>/,
   );
   assert.match(
     markup,

--- a/apps/web/test/pitch-and-biomarkers-pages.test.tsx
+++ b/apps/web/test/pitch-and-biomarkers-pages.test.tsx
@@ -146,7 +146,7 @@ test("BiomarkersPage metadata and route entrypoint filter generated biomarkers",
   );
   assert.deepEqual(biomarkersMetadata.twitter?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",

--- a/apps/web/test/route-metadata-pages.test.ts
+++ b/apps/web/test/route-metadata-pages.test.ts
@@ -17,7 +17,7 @@ test("DesignPage metadata keeps the shared preview image and product copy", () =
   );
   assert.deepEqual(designMetadata.openGraph?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",
@@ -26,7 +26,7 @@ test("DesignPage metadata keeps the shared preview image and product copy", () =
   ]);
   assert.deepEqual(designMetadata.twitter?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",
@@ -70,7 +70,7 @@ test("SubprocessorsPage metadata and table expose the provider list", () => {
   assert.equal(subprocessorsMetadata.alternates?.canonical, "/subprocessors");
   assert.deepEqual(subprocessorsMetadata.openGraph?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",

--- a/apps/web/test/settings-page.test.ts
+++ b/apps/web/test/settings-page.test.ts
@@ -246,7 +246,7 @@ test("SettingsPage metadata uses the shared preview image", async () => {
   assert.equal(metadata.description, "Manage your Murph account settings.");
   assert.deepEqual(metadata.openGraph?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",
@@ -255,7 +255,7 @@ test("SettingsPage metadata uses the shared preview image", async () => {
   ]);
   assert.deepEqual(metadata.twitter?.images, [
     {
-      alt: "Murph — Everyone has a health goal. Nobody gets there alone.",
+      alt: "Murph — Everyone has a health goal. Almost no one gets there alone.",
       height: 630,
       type: "image/png",
       url: "/opengraph-image",


### PR DESCRIPTION
## What

Changes the second homepage tagline line from the absolute **"Nobody gets there alone."** to **"Almost no one gets there alone."**

The hedge reads as truer and less preachy than the absolute claim, and it leaves room for the reader instead of stating a flat rule. Line 1 ("Everyone has a health goal.") is unchanged. This keeps the "gets there" verb (journey/arrival framing) over alternatives like "hits it."

## Where

Edited the single source of truth, `apps/web/src/lib/site-metadata.ts` (`MURPH_TAGLINE_LINE_2`). That constant feeds:

- the homepage hero headline (`hero-clocks-in.tsx`)
- the default OG image and the join-invite OG image
- the shared OG `alt` text

Test assertions that pin the rendered string are updated to match.

## Verification

Ran the affected suites (opengraph-image, page, layout, route-metadata-pages, settings-page, browser-vault-dashboard-pages, pitch-and-biomarkers-pages) — all green (26 tests). Hero line 2 is its own `block` span with `text-wrap:balance`, so the slightly longer string wraps naturally with no layout change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786382057&installation_id=127572939&pr_number=564&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F564&signature=8aacd68c70298217ac0ebf2f294a0781f2b4270e12b91bb66ebb7592417dd928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->