### PR TITLE
fix(web): fit "just you and Murph" cards on small phones

### DIFF
--- a/apps/web/src/components/homepage/asks-section.tsx
+++ b/apps/web/src/components/homepage/asks-section.tsx
@@ -144,7 +144,7 @@ function CompactCard({
   artifact: React.ReactNode;
 }) {
   return (
-    <article className="flex flex-col gap-6 rounded-[1.75rem] bg-[#fffcf6] p-7 ring-1 ring-black/[0.04] shadow-[0_1px_2px_rgba(45,52,54,0.04),0_16px_50px_-30px_rgba(45,52,54,0.1)] sm:p-9">
+    <article className="flex min-w-0 flex-col gap-6 rounded-[1.75rem] bg-[#fffcf6] p-7 ring-1 ring-black/[0.04] shadow-[0_1px_2px_rgba(45,52,54,0.04),0_16px_50px_-30px_rgba(45,52,54,0.1)] sm:p-9">
       <div className="flex flex-col gap-3">
         <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[#736a58]">
           {eyebrow}
@@ -361,7 +361,7 @@ function BloodworkArtifact() {
                   : "bg-[#a04f30]/12 text-[#a04f30]"
               }`}
             >
-              {m.delta} {m.unit}
+              {m.delta}
             </span>
           </li>
         ))}
@@ -482,7 +482,7 @@ function HabitArtifact() {
 
       <div className="mt-4">
         <VoiceMemoPlayer
-          bars={56}
+          bars={32}
           src="/audio/one-foot-two-foot.mp3"
           caption="Murph sent a hype track. Press play."
         />


### PR DESCRIPTION
## Why

On phones at iPhone-mini width (375px) and below, the "Just you and Murph" section (the asks grid) ran off the right edge of the screen. The Labs and Habits demo cards contain artifact content (a bloodwork table and a voice-memo waveform) whose intrinsic min-width is wider than the viewport, so the shared grid column stretched to ~398px. Body copy, the flag badges, and the waveform timer were clipped, and the page scrolled horizontally.

## User-visible goal

The homepage reads cleanly on small phones — no horizontal scroll, nothing clipped — while the layout is unchanged on tablet and desktop.

## What changed (`apps/web/src/components/homepage/asks-section.tsx`)

- **Cap the compact cards** with `min-w-0` so a rich demo artifact can never force the grid column past the viewport (the standard grid/flex `min-width: auto` overflow guard).
- **Habits waveform 56 → 32 bars.** 56 fixed-width bars set a 168px hard floor that could not shrink; 32 is the component default and the appropriate density for a compact card.
- **Bloodwork flag badge shows the delta only.** The value column already states the unit (`108 → 122 mg/dL`), so `+14 mg/dL` was redundant and forced the badge to wrap into a tall pill on mobile. It now reads `+14`.

## Verification

Measured horizontal overflow with a headless browser at mobile widths and screenshotted the cards before/after:

- 375px (iPhone mini): document scrollWidth 414 → 375, no overflow.
- 320px: no horizontal overflow.
- 1280px desktop: unchanged, no overflow.

## Invariants to preserve

- Desktop `lg:grid-cols-2` layout and all other sections unchanged.
- No content meaning lost (the measurement unit is still shown in the value column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786411304&installation_id=127572939&pr_number=576&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F576&signature=2aa5d700733a9f001c0e8e2f9b765c9c51f5dfafb77afccd5623856346510e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->