### PR TITLE
fix(web): stack coming-soon connect cards on phone widths

### DIFF
--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -38,6 +38,14 @@ export function SourceCard({
   const unavailableMessage = !source.requiresReconnect && !requiresConnectionReset && !isAvailable
     ? source.unavailableMessage
     : undefined;
+  // Any of these branches renders a wide (max-w-[22rem]) message beside the
+  // source details. That message is too wide to share the base-breakpoint row,
+  // so the card stacks vertically on phone widths to keep the text from
+  // overlapping the description.
+  const showsSideMessage = requiresConnectionReset
+    || source.requiresReconnect
+    || historicalResetIncomplete
+    || Boolean(unavailableMessage);
 
   return (
     <div className="relative box-border flex min-w-0 w-full max-w-full flex-col justify-between overflow-hidden rounded-xl border border-border/50 bg-[rgba(255,252,246,0.9)] p-4 sm:p-5">
@@ -55,11 +63,9 @@ export function SourceCard({
         <SourceLogo source={source} />
       </div>
 
-      {/* The reset messages are too wide to share the base-breakpoint row with the
-          source details, so those cards stack vertically on phone widths. */}
       <div
         className={
-          requiresConnectionReset || historicalResetIncomplete
+          showsSideMessage
             ? "flex flex-1 flex-col items-stretch gap-3 sm:gap-0"
             : "flex flex-1 items-center gap-4 sm:flex-col sm:items-stretch sm:gap-0"
         }

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -1611,6 +1611,40 @@ test("SourceCard stacks connection-reset content vertically at the base breakpoi
   );
 });
 
+test("SourceCard stacks coming-soon content vertically at the base breakpoint", async () => {
+  const { SourceCard } = await import("../app/(dashboard)/connect/connect-source-card");
+  const logo = { className: "size-11 object-contain", height: 44, src: "/logo.png", width: 44 };
+
+  const comingSoonMarkup = renderToStaticMarkup(createElement(SourceCard, {
+    authenticated: true,
+    errorMessage: null,
+    onDisconnectTargetChange: () => {},
+    onStartConnection: async () => {},
+    pending: false,
+    pendingDisconnect: false,
+    source: {
+      description: "iPhone and Apple Watch activity, sleep, vitals, and workouts.",
+      id: "apple-health",
+      logo,
+      name: "Apple Health",
+      unavailableActionLabel: "Coming soon",
+      unavailableMessage:
+        "Apple Health web setup is coming soon. Connect from the Murph iOS app for now.",
+    },
+  }));
+
+  assert.match(
+    comingSoonMarkup,
+    /Apple Health web setup is coming soon\. Connect from the Murph iOS app for now\./u,
+  );
+  assert.match(comingSoonMarkup, />Coming soon<\/button>/u);
+  // The coming-soon message can be up to 22rem wide, so the card content must
+  // stack at the base breakpoint instead of overlapping the source details in
+  // the shared horizontal row under the card's overflow-hidden.
+  assert.match(comingSoonMarkup, /class="flex flex-1 flex-col items-stretch gap-3 sm:gap-0"/u);
+  assert.doesNotMatch(comingSoonMarkup, /items-center gap-4/u);
+});
+
 test("ConnectPage lets active reconnect rows win over stale reconnectable rows", async () => {
   const { resolveConnectSourceConnectionStates } = await import("../app/(dashboard)/connect/page");
 


### PR DESCRIPTION
## Problem

On `/connect`, the **Apple Health** card overlapped its own text on narrow phones: the description ("iPhone and Apple Watch activity, sleep, vitals, and workouts.") collapsed to one word per line while the "Apple Health web setup is coming soon…" message and the "Coming soon" pill rendered on top of it.

**Root cause:** the "coming soon" card renders a wide (`max-w-[22rem]`) message plus a pill in its action column. At the base breakpoint the card lays its two columns out as a `shrink-0` horizontal row (`flex items-center gap-4`), so that column overflowed the card's `overflow-hidden` box and overlapped the collapsed (`flex-1 min-w-0`) description. The connection-reset and historical-reset cards already dodge this by stacking vertically on phones, but the stacking condition never covered the unavailable-message (coming soon) or reconnect cases, which render the same wide message.

## Fix

Extend the existing vertical-stacking seam to cover any card that shows a wide side message (`showsSideMessage`). Desktop (`sm:`) layout is unchanged — only the phone-width layout for these message cards flips from a horizontal row to a vertical stack, exactly like the reset cards already do.

## Tests

- Added a regression test asserting the coming-soon card stacks vertically at the base breakpoint (the gap that let this ship).
- Full `connect-page.test.ts` suite passes (69 tests); the existing assertions that pin the ordinary card to the horizontal row and the reset card to the vertical stack still hold.
- ESLint clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786419345&installation_id=127572939&pr_number=577&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F577&signature=71021370d321f5e3c6ba1579e47626205cff36fd384a33294489bfb61b94b5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->