### PR TITLE
fix(web): trim AI model settings copy

### DIFF
--- a/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
+++ b/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
@@ -25,14 +25,12 @@ const SOL_REQUIRES_EDGE_ERROR_CODE = "ASSISTANT_MODEL_SOL_REQUIRES_EDGE";
 
 const MODEL_OPTIONS = [
   {
-    description:
-      "For everyday check-ins, questions, planning, and follow-through with Murph.",
+    description: "Everyday check-ins, questions, and planning.",
     model: HOSTED_ASSISTANT_TERRA_MODEL,
     name: "GPT-5.6 Terra",
   },
   {
-    description:
-      "When you want Murph to dig deeper on complex questions, research, and demanding tasks. Counts more toward your Edge usage limit.",
+    description: "Deeper research and harder tasks. Uses more of your Edge limit.",
     model: HOSTED_ASSISTANT_SOL_MODEL,
     name: "GPT-5.6 Sol",
   },
@@ -203,9 +201,8 @@ function HostedAssistantModelSettingsForm(
       }}
     >
       <p className="text-sm text-pretty text-muted-foreground">
-        Choose Murph’s default model. You can switch back at any time. New work
-        uses the change after the current run closes. An idle run can take up
-        to three minutes to close.
+        Choose Murph’s default model. Changes apply to new work and can take a
+        few minutes.
       </p>
 
       <fieldset

--- a/apps/web/test/hosted-assistant-model-settings.test.tsx
+++ b/apps/web/test/hosted-assistant-model-settings.test.tsx
@@ -110,7 +110,7 @@ test("Edge members can explicitly save Sol as their default model", async () => 
   );
   assert.match(
     view.container.textContent ?? "",
-    /An idle run can take up to three minutes to close\./,
+    /Changes apply to new work and can take a few minutes\./,
   );
   const terraInput = view.container.querySelector<HTMLInputElement>(
     `input[value="${HOSTED_ASSISTANT_TERRA_MODEL}"]`,
@@ -226,14 +226,12 @@ test("model radios stay labeled and the form becomes busy while saving", async (
   );
   const options = [
     {
-      description:
-        "For everyday check-ins, questions, planning, and follow-through with Murph.",
+      description: "Everyday check-ins, questions, and planning.",
       model: HOSTED_ASSISTANT_TERRA_MODEL,
       name: "GPT-5.6 Terra",
     },
     {
-      description:
-        "When you want Murph to dig deeper on complex questions, research, and demanding tasks. Counts more toward your Edge usage limit.",
+      description: "Deeper research and harder tasks. Uses more of your Edge limit.",
       model: HOSTED_ASSISTANT_SOL_MODEL,
       name: "GPT-5.6 Sol",
     },


### PR DESCRIPTION
The AI model section on the settings page was too wordy. This tightens it without changing behavior.

- Intro paragraph: four sentences collapsed to one ("Choose Murph's default model. Changes apply to new work and can take a few minutes.").
- Terra description: "Everyday check-ins, questions, and planning."
- Sol description: "Deeper research and harder tasks. Uses more of your Edge limit."

Verbatim test assertions in `hosted-assistant-model-settings.test.tsx` updated to match.

**Verification:** focused settings test suite passes (8/8); web typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786474816&installation_id=127572939&pr_number=584&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F584&signature=8edf165d94e5311d3e4a7f1853a9213087be0d054841654045c4169ae4a561bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->