### PR TITLE
Match FAQ and security-teaser headers to canonical section scale

### DIFF
--- a/apps/web/src/components/homepage/faq-section.tsx
+++ b/apps/web/src/components/homepage/faq-section.tsx
@@ -74,7 +74,7 @@ export function FaqSection() {
             <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-[#736a58]">
               FAQ
             </span>
-            <h2 className="mt-4 font-serif text-[clamp(1.5rem,2.5vw,2rem)] font-semibold leading-[1.15] tracking-[-0.02em] text-[#2d3436]">
+            <h2 className="mt-4 font-serif text-[clamp(2rem,4vw,3.25rem)] font-semibold leading-[1.1] tracking-[-0.03em] text-[#2d3436]">
               Common questions
             </h2>
           </div>

--- a/apps/web/src/components/homepage/security-teaser-section.tsx
+++ b/apps/web/src/components/homepage/security-teaser-section.tsx
@@ -18,7 +18,7 @@ export function SecurityTeaserSection() {
               Security &amp; privacy
             </span>
           </div>
-          <h2 className="mt-6 max-w-[18ch] font-serif text-[clamp(1.875rem,4vw,2.75rem)] font-semibold leading-[1.05] tracking-[-0.03em] text-balance text-[#2d3436]">
+          <h2 className="mt-6 max-w-[18ch] font-serif text-[clamp(2rem,4vw,3.25rem)] font-semibold leading-[1.05] tracking-[-0.03em] text-balance text-[#2d3436]">
             Your health data{" "}
             <span className="italic text-[#8a6a3a]">stays</span> yours.
           </h2>


### PR DESCRIPTION
## What

The **"Common questions"** (FAQ) and **"Your health data stays yours."** (security teaser) homepage headers used smaller `clamp()` font sizes than the other section headers. Sitting in a run right after the Assistant section, the shrinking steps made both stand out.

Bump both to the canonical `clamp(2rem,4vw,3.25rem)` scale shared by the Together, Asks, Personas, Integrations, and Assistant section headers.

| Header | Before (max) | After (max) |
|---|---|---|
| "Your health data stays yours." | `clamp(1.875rem,4vw,2.75rem)` (44px) | `clamp(2rem,4vw,3.25rem)` (52px) |
| "Common questions" | `clamp(1.5rem,2.5vw,2rem)` (32px) | `clamp(2rem,4vw,3.25rem)` (52px) |

The FAQ header sits in a 280px sidebar column, so it keeps a slightly looser `leading-[1.1]` (it wraps to two lines at desktop) with tracking aligned to the canonical `-0.03em`.

## Files
- `apps/web/src/components/homepage/faq-section.tsx`
- `apps/web/src/components/homepage/security-teaser-section.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786552165&installation_id=127572939&pr_number=598&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F598&signature=839e988645c4f27bd07f5fe9c00591270fe97e670c520b08cc4f5e5143a3994f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->