### PR TITLE
fix: reach hosted Codex HTTPS fallback

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-13-hosted-codex-https-fallback.md
+++ b/agent-docs/exec-plans/completed/2026-07-13-hosted-codex-https-fallback.md
@@ -1,0 +1,51 @@
+# Hosted Codex HTTPS fallback reachability
+
+## Goal
+
+Make Codex's native WebSocket-to-HTTPS fallback reachable within one hosted
+assistant attempt when the provider stream stalls or disconnects retryably.
+
+Success criteria:
+
+- Hosted Codex config permits one WebSocket attempt and then native HTTPS
+  fallback.
+- The existing 90-second stream idle timeout and HTTP request retry budget stay
+  unchanged.
+- Focused tests protect the generated config and safe transport diagnostics.
+- Required reliability, security/privacy, and coverage checks pass.
+
+## Root-cause evidence
+
+- The affected hosted attempts opened WebSockets but emitted neither an HTTPS
+  request nor the existing structured `transport-fallback` diagnostic.
+- Codex exhausts `stream_max_retries` before switching transport. The hosted
+  value of five made fallback unreachable inside the enclosing hosted attempt
+  budget, and each new orchestration attempt reset Codex's turn-local counter.
+- Runtime resource telemetry showed no matching CPU, memory, OOM, eviction, or
+  process-limit failure.
+- The currently pinned Codex release already implements native HTTPS fallback;
+  later patch releases do not change that mechanism.
+
+## Constraints
+
+- Keep the change hosted-only; do not alter Codex CLI source or global defaults.
+- Reuse Codex's native fallback and retry machinery without adding another
+  retry loop or state owner.
+- Preserve secret-safe structured transport diagnostics.
+- Preserve unrelated worktree and coordination-ledger edits.
+
+## Approach
+
+1. Set hosted provider stream retries to zero while keeping WebSockets enabled.
+2. Update focused config and diagnostics expectations for the one-attempt policy.
+3. Document the hosted transport policy at the package owner boundary.
+4. Run focused tests, typecheck, and direct generated-config proof.
+5. Run required security/privacy and coverage audits.
+6. Commit the scoped change, open a PR, and complete CI plus ReviewGPT gates.
+
+## State
+
+Active.
+Status: completed
+Updated: 2026-07-13
+Completed: 2026-07-13

--- a/packages/assistant-runtime/README.md
+++ b/packages/assistant-runtime/README.md
@@ -90,6 +90,11 @@ membership is owned by `@murphai/hosted-execution/assistant-capabilities`, so
 runtime launch/profile contracts do not re-export lower owner packages through
 legacy shims. Concrete Codex app-server process lifecycle hooks remain owned by
 `@murphai/assistant-engine/codex-lifecycle`.
+Hosted Codex keeps WebSockets enabled for the first provider attempt and sets
+`stream_max_retries = 0`, so a retryable stream failure activates Codex's native
+HTTPS fallback instead of spending another full stream-idle window on the same
+transport. The stream idle timeout remains 90 seconds, and HTTPS requests retain
+their separate request retry budget.
 Host apps may still decide which env profiles are enabled and how
 transport-specific URL rewriting works, but the profile key sets and runtime
 manifest shape come from this package.

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -68,8 +68,10 @@ const DEFAULT_HOSTED_CODEX_SANDBOX = "danger-full-access";
 const DEFAULT_HOSTED_CODEX_AUTO_COMPACT_TOKEN_LIMIT = 164_000;
 const DEFAULT_HOSTED_CODEX_LOG_DIR = "/tmp/murph-codex-log";
 const HOSTED_CODEX_PROVIDER_REQUEST_MAX_RETRIES = 4;
-// Match Codex's native default so hosted runs keep provider stream reconnects.
-const HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES = 5;
+// Hosted runs get one WebSocket attempt, then Codex replays the request over
+// HTTPS. Repeating the full idle window here can outlive the enclosing hosted
+// attempt and make Codex's native transport fallback unreachable.
+const HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES = 0;
 const HOSTED_CODEX_PROVIDER_STREAM_IDLE_TIMEOUT_MS = 90_000;
 const HOSTED_CODEX_OPERATOR_MEMORY_CONFIG = {
   disableOnExternalContext: false,

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -85,9 +85,29 @@ test("hosted Codex provider transport diagnostics expose only safe config metada
   assert.deepEqual(HOSTED_CODEX_PROVIDER_TRANSPORT_DIAGNOSTICS, {
     codexProviderRequestMaxRetries: 4,
     codexProviderStreamIdleTimeoutMs: 90_000,
-    codexProviderStreamMaxRetries: 5,
+    codexProviderStreamMaxRetries: 0,
     codexProviderTransportMode: "codex-native-provider-transport",
   });
+});
+
+test("hosted Codex uses one WebSocket attempt before native HTTPS fallback", () => {
+  const config = buildHostedCodexConfigToml({
+    model: "gpt-5.2",
+    provider: {
+      id: "hosted-openai",
+      name: "OpenAI",
+      baseUrl: "https://api.openai.com/v1",
+      envKey: "OPENAI_API_KEY",
+      wireApi: "responses",
+      supportsWebSockets: true,
+    },
+    reasoningEffort: "low",
+  });
+
+  assert.match(config, /^supports_websockets = true$/mu);
+  assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
+  assert.match(config, /^stream_max_retries = 0$/mu);
+  assert.match(config, /^request_max_retries = 4$/mu);
 });
 
 function executeCodexAppServerTurn(
@@ -174,7 +194,7 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
   assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
   assert.match(config, /^requires_openai_auth = false$/mu);
   assert.match(config, /^request_max_retries = 4$/mu);
-  assert.match(config, /^stream_max_retries = 5$/mu);
+  assert.match(config, /^stream_max_retries = 0$/mu);
   assert.doesNotMatch(config, /^requires_openai_auth = true$/mu);
   assert.match(config, /\[features\]\nplugins = false\nmulti_agent_v2 = true\nmemories = true/u);
   assert.doesNotMatch(config, /root_agent_usage_hint_text/u);
@@ -402,7 +422,7 @@ test("hosted Codex runtime config accepts a local test-only model provider base 
   assert.doesNotMatch(config, /^supports_websockets = true$/mu);
   assert.match(config, /stream_idle_timeout_ms = 90000/u);
   assert.match(config, /request_max_retries = 4/u);
-  assert.match(config, /stream_max_retries = 5/u);
+  assert.match(config, /stream_max_retries = 0/u);
   assert.doesNotMatch(config, /https:\/\/api\.openai\.com\/v1/u);
 });
 
@@ -460,7 +480,7 @@ test("hosted Codex runtime config uses ChatGPT subscription auth in local dev", 
   assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
   assert.match(config, /^requires_openai_auth = true$/mu);
   assert.match(config, /^request_max_retries = 4$/mu);
-  assert.match(config, /^stream_max_retries = 5$/mu);
+  assert.match(config, /^stream_max_retries = 0$/mu);
   assert.doesNotMatch(config, /chatgpt-access-token/u);
   assert.match(config, /model_reasoning_effort = "low"/u);
   assert.match(config, /\[history\]\npersistence = "none"/u);
@@ -639,7 +659,7 @@ test("hosted Codex runtime config preserves managed ChatGPT auth", async () => {
   assert.match(config, /^requires_openai_auth = true$/mu);
   assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
   assert.match(config, /^request_max_retries = 4$/mu);
-  assert.match(config, /^stream_max_retries = 5$/mu);
+  assert.match(config, /^stream_max_retries = 0$/mu);
   assert.doesNotMatch(config, /chatgpt-refresh-token/u);
   assertHostedCodexConfigDisablesLoginShellAtTopLevel(config);
   assertHostedCodexAutoCompactTokenLimit(config);
@@ -1315,7 +1335,7 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
       "stream_idle_timeout_ms = 90000",
       "requires_openai_auth = false",
       "request_max_retries = 4",
-      "stream_max_retries = 5",
+      "stream_max_retries = 0",
       "",
       "# Hosted runs should not perform Codex plugin marketplace or remote plugin",
       "# sync work on cold wake; Murph owns the hosted runtime tool surface.",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -768,7 +768,7 @@ describe("hosted workspace runtime entrypoint", () => {
       expect(codexPrepareDoneLog?.details).toEqual(expect.objectContaining({
         codexProviderRequestMaxRetries: 4,
         codexProviderStreamIdleTimeoutMs: 90_000,
-        codexProviderStreamMaxRetries: 5,
+        codexProviderStreamMaxRetries: 0,
         codexProviderTransportMode: "codex-native-provider-transport",
       }));
       expect(phaseLogs.every((entry) =>


### PR DESCRIPTION
## Why

Hosted assistant turns could exhaust their enclosing attempt while Codex repeated 90-second WebSocket waits, so Codex's existing HTTPS fallback never became reachable and a group-chat message could receive no reply.

## User-visible goal and flow

A hosted turn still starts on WebSockets. If that stream fails retryably or reaches the existing idle timeout, Codex immediately activates its native HTTPS Responses transport within the same turn. HTTPS keeps its independent request retry budget so the assistant can complete the reply.

## Invariants

- Keep WebSockets enabled for the first attempt.
- Preserve the 90-second stream idle timeout.
- Preserve four HTTPS request retries.
- Reuse Codex-native fallback; add no retry loop or persisted state.
- Keep provider transport diagnostics metadata-only and secret-safe.
- Do not alter provider endpoints, credentials, payloads, or authorization boundaries.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 2 |
| Tests | 27 | 7 |
| Docs / plan | 56 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

## Verification

- Focused generated-config regression coverage for WebSocket enablement, zero stream retries, the 90-second idle timeout, and four request retries.
- Hosted runtime phase diagnostic expectation updated to the effective policy.
- Security/privacy audit: zero medium-or-higher findings.
- Coverage audit: no missing proof identified.
- Immediate production rollout workflow: https://github.com/cobuildwithus/murph/actions/runs/29295154699

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786579815&installation_id=127572939&pr_number=612&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F612&signature=f1e4d864fc9dcceb339236122375ae62eb32e439adbe62db19419693db3dec04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->