### PR TITLE
fix(hosted-runtime): preserve checkpoint liveness across wake nudges

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-13-hosted-wake-checkpoint-liveness.md
+++ b/agent-docs/exec-plans/completed/2026-07-13-hosted-wake-checkpoint-liveness.md
@@ -1,0 +1,72 @@
+# Hosted wake checkpoint liveness
+
+## Goal
+
+Stop repeated non-conversation runtime wakes from starving hosted background
+maintenance and the runtime-owned idle checkpoint.
+
+Success criteria:
+
+- Reproduce the production interaction between a pending device-sync wake,
+  repeated source-less/system wake signals, and the idle checkpoint boundary.
+- Preserve immediate preemption for newly imported conversation work.
+- Let already-imported or non-advancing system wake hints coexist with bounded
+  device-sync maintenance and checkpoint progress.
+- Keep durable mailbox, device-sync, checkpoint, and scheduling ownership
+  unchanged.
+- Land the smallest maintainable correction with focused regression coverage,
+  required verification, an open PR, green CI, and a zero-accepted-finding
+  ReviewGPT round.
+
+## Constraints
+
+- Preserve foreground conversation priority and fail-closed authority checks.
+- A wake remains a droppable latency hint; imported and handling progress stay
+  distinct.
+- Do not add persisted state, a scheduler, queue, retry owner, signal kind, or
+  cross-plane protocol.
+- Preserve unrelated checkout and ledger work.
+- Do not expose private identifiers, payloads, local paths, or secrets in
+  committed artifacts or review material.
+
+## Approach
+
+1. Trace the current wake-consumption and background-yield call paths from the
+   production incident evidence.
+2. Add a focused failing test for repeated non-conversation wake hints while a
+   due device-sync wake and dirty checkpoint are pending.
+3. Resume the existing foreground mailbox watcher after the pre-delivery
+   system barrier and drain only the wake already delivered to it, so actual
+   conversation progress preempts maintenance while no-progress nudges do not.
+4. Run package coverage/diff verification and direct scenario proof.
+5. Complete the required security/privacy and coverage audits, parent review,
+   scoped commit, PR, CI, and ReviewGPT loop.
+
+## State
+
+Complete. The implementation, focused lifecycle proof, owner-level diff lane,
+security/privacy audit, coverage-write audit, and parent final review are green.
+
+## Evidence
+
+- Production showed the same already-imported system pointer re-signalled each
+  minute while a device-sync reconcile wake remained overdue.
+- The pre-delivery system barrier permanently stopped the foreground mailbox
+  watcher, so later source-less wakes bypassed mailbox classification and were
+  converted directly into foreground pressure.
+- Focused runner and entrypoint scenarios prove that a wake already pending at
+  the barrier and one delivered immediately afterward are drained before the
+  watcher stops; conversation progress still preempts, while no-progress wakes
+  leave background maintenance eligible.
+- The long-lived invocation then encountered a bounded runtime-wake timeout and
+  later an outer transport timeout around checkpoint completion.
+- Focused runner and entrypoint verification passed all six watcher lifecycle
+  scenarios, including both projection-stall abort paths.
+- The canonical diff lane passed assistant-runtime (1,580 passed, 2 skipped)
+  and the reverse-dependent Cloudflare app (1,759 passed), together with all
+  required typechecks and repository guards.
+- The independent security/privacy audit found no medium-or-higher issue; the
+  coverage-write audit found no missing stable-boundary proof and made no edit.
+Status: completed
+Updated: 2026-07-13
+Completed: 2026-07-13

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -817,6 +817,11 @@ supported by the hosted foreground mailbox import loop plus the store-backed
 assistant input spine: a payloadless runtime wake causes the active child to
 import conversation mailbox rows, stage any new `AssistantInputEvent` records,
 run prompt-preparation effects best-effort, and notify active-turn admission.
+The pre-delivery system-mailbox consistency barrier may pause that loop, but it
+must resume before post-checkpoint delivery or background drains continue. A
+source-less wake preempts those drains only after the resumed import proves new
+conversation work; a no-progress or system-only nudge must not starve bounded
+maintenance or the idle checkpoint.
 The assistant engine then admits the persisted input through live steering or
 pre-provider admission without using hosted-specific mailbox
 refresh/checkpoint ports. While a Codex turn is live, same-conversation input is

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -820,35 +820,46 @@ export async function runHostedWorkspaceUntilIdleOrBudget(
   }
   const runnerStartedAtEpochMs = Date.now();
   let foregroundConversationWorkObserved = false;
-  const foregroundMailboxImportLoop = await withHostedCanonicalWritePort(
-    hostedCanonicalMailboxWritePort,
-    async () => startHostedForegroundConversationMailboxImportLoop({
-      checkpointRequestBuilder: checkpointRequestSession,
-      input,
-      onForegroundConversationWorkObserved: () => {
-        foregroundConversationWorkObserved = true;
-      },
-      checkpointCanonicalMailboxImportProgress,
-    }),
-  );
-  input.trackLocalWorkspaceMutationCompletion?.(foregroundMailboxImportLoop.completion);
-  let foregroundMailboxImportLoopStopped = false;
-  const stopForegroundMailboxImportLoop = async (): Promise<void> => {
-    if (foregroundMailboxImportLoopStopped) {
+  let foregroundRuntimeWakeObservedAfterStop = false;
+  let foregroundMailboxImportLoop:
+    ReturnType<typeof startHostedForegroundConversationMailboxImportLoop> | null = null;
+  const startForegroundMailboxImportLoop = async (): Promise<void> => {
+    if (foregroundMailboxImportLoop) {
       return;
     }
-    await foregroundMailboxImportLoop.stop({
+    foregroundRuntimeWakeObservedAfterStop = false;
+    foregroundMailboxImportLoop = await withHostedCanonicalWritePort(
+      hostedCanonicalMailboxWritePort,
+      async () => startHostedForegroundConversationMailboxImportLoop({
+        checkpointRequestBuilder: checkpointRequestSession,
+        input,
+        onForegroundConversationWorkObserved: () => {
+          foregroundConversationWorkObserved = true;
+        },
+        checkpointCanonicalMailboxImportProgress,
+      }),
+    );
+    input.trackLocalWorkspaceMutationCompletion?.(foregroundMailboxImportLoop.completion);
+  };
+  await startForegroundMailboxImportLoop();
+  const stopForegroundMailboxImportLoop = async (): Promise<void> => {
+    const activeLoop = foregroundMailboxImportLoop;
+    if (!activeLoop) {
+      return;
+    }
+    await activeLoop.stop({
       shouldAbortInFlightImport: () => foregroundConversationWorkObserved,
     });
-    foregroundMailboxImportLoopStopped = true;
+    if (foregroundMailboxImportLoop === activeLoop) {
+      foregroundMailboxImportLoop = null;
+    }
   };
-  let foregroundRuntimeWakeObservedAfterStop = false;
   const shouldYieldBackgroundMaintenance = (): boolean => {
     if (foregroundConversationWorkObserved || foregroundRuntimeWakeObservedAfterStop) {
       return true;
     }
 
-    if (!foregroundMailboxImportLoopStopped) {
+    if (foregroundMailboxImportLoop) {
       return false;
     }
 
@@ -901,14 +912,24 @@ export async function runHostedWorkspaceUntilIdleOrBudget(
     materializeWorkspaceArtifacts: input.materializeWorkspaceArtifacts ?? null,
     now: input.now,
     platform: input.platform,
-    prepareAutoReplyDelivery: async () =>
-      await prepareHostedAutoReplyDeliveryForWorkspaceRunner({
+    prepareAutoReplyDelivery: async () => {
+      const barrier = await prepareHostedAutoReplyDeliveryForWorkspaceRunner({
         checkpointRequestBuilder: checkpointRequestSession,
         checkpointCanonicalMailboxImportProgress,
         hostedCanonicalMailboxWritePort,
         input,
         stopForegroundMailboxImportLoop,
-      }),
+      });
+      if (!foregroundConversationWorkObserved && !input.signal?.aborted) {
+        // The delivery barrier needs a stable system-mailbox prefix, but it is
+        // not the end of foreground admission. Resume the existing
+        // conversation watcher so source-less system nudges are classified by
+        // actual mailbox progress instead of starving later maintenance.
+        await startForegroundMailboxImportLoop();
+        await foregroundMailboxImportLoop?.drainPendingWake();
+      }
+      return barrier;
+    },
     recordDeferredUsage(
       record: AssistantUsageRecord,
       noticeDeliveryTarget?: HostedRuntimeUsageNoticeDeliveryTarget | null,
@@ -1104,6 +1125,7 @@ function startHostedForegroundConversationMailboxImportLoop(input: {
   onForegroundConversationWorkObserved?: (() => void) | null;
 }): {
   completion: Promise<void>;
+  drainPendingWake(): Promise<void>;
   stop(options?: {
     shouldAbortInFlightImport?: (() => boolean) | null;
   }): Promise<void>;
@@ -1112,6 +1134,7 @@ function startHostedForegroundConversationMailboxImportLoop(input: {
   if (!runtimeWakeSignal) {
     return {
       completion: Promise.resolve(),
+      drainPendingWake: async () => undefined,
       stop: async () => undefined,
     };
   }
@@ -1128,6 +1151,7 @@ function startHostedForegroundConversationMailboxImportLoop(input: {
   }
   let wakeOrdinal = 0;
   let stopRequested = false;
+  let activeWakeCompletion: Promise<void> | null = null;
   let shouldAbortInFlightImportOnStop: (() => boolean) | null = null;
   const inFlightImportController = new AbortController();
   const abortInFlightImportAfterObservedWork = (): void => {
@@ -1169,6 +1193,11 @@ function startHostedForegroundConversationMailboxImportLoop(input: {
         continue;
       }
       wakeOrdinal += 1;
+      let resolveActiveWake = (): void => undefined;
+      const currentWakeCompletion = new Promise<void>((resolve) => {
+        resolveActiveWake = resolve;
+      });
+      activeWakeCompletion = currentWakeCompletion;
       const requestId = `${input.input.requestId}:runtime-wake:${wakeOrdinal}`;
       const waitResolvedAtEpochMs = Date.now();
       const latencyMilestones = createHostedForegroundMailboxImportLatencyMilestones({
@@ -1283,21 +1312,38 @@ function startHostedForegroundConversationMailboxImportLoop(input: {
           error,
           input: input.input,
         });
+      } finally {
+        resolveActiveWake();
+        if (activeWakeCompletion === currentWakeCompletion) {
+          activeWakeCompletion = null;
+        }
+      }
+      if (stopRequested) {
+        break;
       }
     }
   })();
   const completion = loop.catch(() => undefined);
+  const drainPendingWake = async (): Promise<void> => {
+    // A coalesced notification is delivered on a microtask. Let a wake that
+    // already exists enter the import loop before deciding whether there is
+    // anything to drain.
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    await activeWakeCompletion;
+  };
 
   return {
     completion,
+    drainPendingWake,
     async stop(options) {
       stopRequested = true;
       shouldAbortInFlightImportOnStop = options?.shouldAbortInFlightImport ?? null;
       outerSignal?.removeEventListener("abort", abort);
+      abortInFlightImportAfterObservedWork();
+      await drainPendingWake();
       if (!waitController.signal.aborted) {
         waitController.abort(new DOMException("Foreground mailbox import loop stopped.", "AbortError"));
       }
-      abortInFlightImportAfterObservedWork();
       await completion;
     },
   };

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -8667,7 +8667,7 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
-  test("late runtime wake imports conversation input after foreground loop stop", async () => {
+  test("late runtime wake imports conversation input after the delivery barrier", async () => {
     const vaultRoot = await mkdtemp(
       path.join(tmpdir(), "murph-runtime-late-foreground-direct-"),
     );
@@ -8757,7 +8757,7 @@ describe("hosted workspace runtime entrypoint", () => {
         },
       );
 
-      assert.equal(assistantPhaseCalls, 2);
+      assert.equal(assistantPhaseCalls, 1);
       assert.deepEqual(
         importedSeqs,
         Array.from({ length: 14 }, (_, index) => String(index + 1)),
@@ -8768,7 +8768,7 @@ describe("hosted workspace runtime entrypoint", () => {
           && request.limitPerLane === 13
         ),
       );
-      assert.ok(events.includes("assistant:2:14"));
+      assert.ok(events.includes("assistant:1:12"));
       assert.ok(events.includes("snapshot:idle_shutdown:14"));
       assert.equal(
         checkpointRequests[0]?.redactedStatus?.hostedMailboxConversationImportedSeq,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -191,11 +191,12 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
     }
   });
 
-  test("stale pending runtime wakes do not yield background maintenance after foreground stop", async () => {
+  test("delivery barrier drains repeated no-progress wakes without yielding background maintenance", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-stale-runtime-wake-"));
     const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const fetchRequests: HostedMailboxFetchRequest[] = [];
     const yieldStates: boolean[] = [];
 
     try {
@@ -217,7 +218,7 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
         },
         limitPerLane: 10,
         platform: createPlatform({
-          mailboxPort: createMailboxPort({ items: [] }).mailboxPort,
+          mailboxPort: createMailboxPort({ fetchRequests, items: [] }).mailboxPort,
           workspacePort: createWorkspacePort({ checkpointRequests }),
         }),
         requestId: "request_synthetic_runner_stale_runtime_wake",
@@ -226,10 +227,18 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
           yieldStates.push(input.shouldYieldBackgroundMaintenance?.() ?? false);
           await input.prepareAutoReplyDelivery?.();
 
+          const fetchCountBeforeStaleWake = fetchRequests.length;
           runtimeWakeSignal.notify(Date.parse(TEST_NOW) - 1);
+          await waitForCondition(() =>
+            fetchRequests.length >= fetchCountBeforeStaleWake + 2
+          );
           yieldStates.push(input.shouldYieldBackgroundMaintenance?.() ?? false);
 
+          const fetchCountBeforeFreshWake = fetchRequests.length;
           runtimeWakeSignal.notify(Date.parse(TEST_NOW) + 1);
+          await waitForCondition(() =>
+            fetchRequests.length >= fetchCountBeforeFreshWake + 2
+          );
           yieldStates.push(input.shouldYieldBackgroundMaintenance?.() ?? false);
 
           return { progressed: false };
@@ -239,10 +248,8 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
         now: () => TEST_NOW,
       });
 
-      assert.deepEqual(yieldStates, [false, false, true]);
-      assert.deepEqual(runtimeWakeSignal.consumePending(), {
-        notifiedAtEpochMs: Date.parse(TEST_NOW) + 1,
-      });
+      assert.deepEqual(yieldStates, [false, false, false]);
+      assert.equal(runtimeWakeSignal.consumePending(), null);
     } finally {
       vi.useRealTimers();
       await rm(vaultRoot, { force: true, recursive: true });
@@ -482,11 +489,14 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
     }
   });
 
-  test("fresh coalesced runtime wake yields background maintenance after foreground stop", async () => {
+  test("delivery barrier still yields background maintenance after fresh conversation import", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-coalesced-runtime-wake-"));
     const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const fetchRequests: HostedMailboxFetchRequest[] = [];
+    const items: HostedMailboxItem[] = [];
+    const importedSeqs: string[] = [];
     const yieldStates: boolean[] = [];
 
     try {
@@ -503,12 +513,13 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
           snapshotRef: null,
         }),
         expectedUserId: TEST_USER_ID,
-        async importItem() {
+        async importItem(item) {
+          importedSeqs.push(item.item.laneSeq);
           return { status: "imported" };
         },
         limitPerLane: 10,
         platform: createPlatform({
-          mailboxPort: createMailboxPort({ items: [] }).mailboxPort,
+          mailboxPort: createMailboxPort({ fetchRequests, items }).mailboxPort,
           workspacePort: createWorkspacePort({ checkpointRequests }),
         }),
         requestId: "request_synthetic_runner_coalesced_runtime_wake",
@@ -517,8 +528,24 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
           yieldStates.push(input.shouldYieldBackgroundMaintenance?.() ?? false);
           await input.prepareAutoReplyDelivery?.();
 
+          const fetchCountBeforeNoProgressWake = fetchRequests.length;
           runtimeWakeSignal.notify(Date.parse(TEST_NOW) - 1);
           runtimeWakeSignal.notify(Date.parse(TEST_NOW) + 1);
+          await waitForCondition(() =>
+            fetchRequests.length >= fetchCountBeforeNoProgressWake + 2
+          );
+          yieldStates.push(input.shouldYieldBackgroundMaintenance?.() ?? false);
+
+          items.push(createMailboxItem({
+            id: "mailbox_item_runner_delivery_barrier_late_conversation",
+            laneSeq: "1",
+            occurredAt: "2026-04-26T00:00:02.000Z",
+          }));
+          runtimeWakeSignal.notify(Date.parse(TEST_NOW) + 2);
+          await waitForCondition(() => importedSeqs.includes("1"));
+          await waitForCondition(() =>
+            input.shouldYieldBackgroundMaintenance?.() === true
+          );
           yieldStates.push(input.shouldYieldBackgroundMaintenance?.() ?? false);
 
           return { progressed: false };
@@ -528,11 +555,8 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
         now: () => TEST_NOW,
       });
 
-      assert.deepEqual(yieldStates, [false, true]);
-      assert.deepEqual(runtimeWakeSignal.consumePending(), {
-        latestNotifiedAtEpochMs: Date.parse(TEST_NOW) + 1,
-        notifiedAtEpochMs: Date.parse(TEST_NOW) - 1,
-      });
+      assert.deepEqual(importedSeqs, ["1"]);
+      assert.deepEqual(yieldStates, [false, false, true]);
     } finally {
       vi.useRealTimers();
       await rm(vaultRoot, { force: true, recursive: true });
@@ -1380,6 +1404,9 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
         ],
         [
           { importedSeq: "0", lane: "system" },
+        ],
+        [
+          { importedSeq: "0", lane: "conversation" },
         ],
       ]);
       assert.deepEqual(checkpointRequests, []);


### PR DESCRIPTION
## Why

The pre-auto-reply system-mailbox barrier permanently stopped the foreground conversation watcher. After that point, every fresh source-less wake was treated as foreground pressure even when mailbox progress did not advance, so repeated system nudges could starve bounded device-sync maintenance and the idle checkpoint.

## User-visible goal and UX

Keep replies responsive to genuinely new conversation input while allowing background device reconciliation and checkpoint progress to complete under repeated no-progress wake traffic. There is no new UI; the visible effect is fewer delayed replies and sync results after wake churn.

## What changed

- resume the existing foreground mailbox watcher after the system consistency barrier
- drain only a wake already delivered to that watcher before stopping it
- preserve the existing immediate abort/yield path once conversation work is staged
- update runner and entrypoint proof plus the hosted runtime protocol

## Invariants

- fresh conversation work still preempts background maintenance immediately
- source-less wakes remain droppable latency hints, not durable product truth
- mailbox, pending-input, device-sync, checkpoint, and scheduling ownership do not move
- no new persisted state, queue, scheduler, wake kind, dependency, auth surface, or cross-plane protocol
- existing user, attempt, lease, write-fence, and expected-user checks remain unchanged

## Verification

- focused watcher lifecycle proof: 6 passed
- assistant-runtime: 73 files, 1,580 passed, 2 skipped
- Cloudflare reverse-dependent verification: 102 files, 1,759 passed
- package typechecks and repository architecture, dependency, boundary, cycle, crypto, and sensitive-log guards passed
- security/privacy completion audit: zero medium-or-higher findings
- coverage-write audit: no missing stable-boundary proof; no edits
- rebased-head focused proof and assistant-runtime typecheck passed

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 68 | 22 |
| Tests / fixtures | 44 | 17 |
| Docs | 77 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **189** | **39** |

## Deployment concerns

Deploy the Cloudflare runner bundle/container path so new containers receive the updated assistant-runtime bundle. No `apps/web` or Temporal tandem deploy is required and the protocol remains compatible during rollout. Warm containers on the prior bundle retain the old wake behavior until replaced; after rollout, confirm repeated no-progress wakes no longer defer device-sync reconciliation or the idle checkpoint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786582117&installation_id=127572939&pr_number=615&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F615&signature=f8bbf1a4418ef8032b8cbdeb3ae5efbb81ce6b3cbc63d7759b5c2513eca94724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->