### PR TITLE
chore(web): disable Vercel PR preview deployments

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-disable-vercel-pr-previews.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-disable-vercel-pr-previews.md
@@ -1,0 +1,52 @@
+# Disable Vercel pull request preview deployments
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+- Stop Vercel's Git integration from automatically creating preview deployments for pull-request and other non-production branches while preserving automatic production deployments from `main`.
+
+## Success criteria
+
+- `apps/web/vercel.json` disables Git deployments for every branch except `main` using Vercel's supported `git.deploymentEnabled` configuration.
+- The checked-in configuration remains valid against Vercel's published schema.
+- Direct config and diff validation pass; heavyweight completion reviews are skipped per explicit user instruction for this simple change.
+
+## Scope
+
+- In scope: automatic Git-triggered Vercel deployments for the hosted web project.
+- Out of scope: production deployments from `main`, manual Vercel CLI/API deployments, deploy hooks, existing preview deployments, and Cloudflare or Render deployment behavior.
+
+## Constraints
+
+- Technical constraints: the Vercel project is GitHub-connected, uses `main` as its production branch, and has `apps/web` as its project root.
+- Product/process constraints: keep the control checked in at the owning Vercel project root and avoid a custom ignore script or dashboard-only state.
+
+## Risks and mitigations
+
+1. Risk: a catch-all rule could also suppress production deployments.
+   Mitigation: explicitly enable `main`; Vercel deploys when any matching rule is `true`, so `main` remains enabled even though it also matches `*`.
+2. Risk: the change could be mistaken for disabling every preview mechanism.
+   Mitigation: document that it disables automatic Git deployments only; manual preview deployments and existing deployments remain unchanged.
+
+## Tasks
+
+1. Confirm Vercel's current documented branch-deployment configuration and the linked project's production branch/root directory.
+2. Add the minimal branch rules to `apps/web/vercel.json`.
+3. Validate the JSON and published Vercel schema and inspect the final diff.
+4. Finish the plan, commit, push, and open the PR without heavyweight review gates per user instruction.
+
+## Decisions
+
+- Use `git.deploymentEnabled` instead of `ignoreCommand`: the former prevents the automatic Git deployment itself rather than creating and then skipping a build.
+- Use `{ "main": true, "*": false }` instead of `false` so automatic production deploys continue.
+
+## Verification
+
+- Passed: read-only Vercel API confirmation that the linked GitHub project uses `main` as its production branch and `apps/web` as its root directory.
+- Passed: JSON parse plus validation of the exact branch map against Vercel's published schema at `https://openapi.vercel.sh/vercel.json`.
+- Passed: `git diff --check`.
+- Not required per explicit user instruction: completion audit subagents, ReviewGPT, and the full acceptance suite. A started acceptance run was intentionally interrupted after that instruction; its interrupted subprocess results are not treated as verification evidence.
+Completed: 2026-07-14

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm release:production:migrate && pnpm build",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "*": false
+    }
+  },
   "crons": [
     {
       "path": "/api/internal/hosted-onboarding/stripe/cron",


### PR DESCRIPTION
## Why this PR exists

Automatic Vercel preview deployments on pull requests are unnecessary for this project and should be disabled at the project-owned configuration boundary.

## User goal / user-visible behavior

Pushes to pull-request and other non-production branches no longer trigger automatic Vercel Git deployments. Pushes to main continue to trigger production deployments.

## User experience

No product UI changes. This only changes deployment automation for contributors.

## Invariants

- Automatic production deployments from main remain enabled.
- Manual Vercel CLI/API deployments and deploy hooks remain available.
- Existing preview deployments are not deleted or modified.
- Cloudflare and Render deployment behavior is unchanged.

## Change shape

Classification rule: authored deployment configuration is config/tooling; the closed execution plan is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 52 | 0 |
| Config/tooling | 6 | 0 |
| Generated/other | 0 | 0 |
| Total | 58 | 0 |

## Verification

- Confirmed the linked Vercel project uses main as its production branch and apps/web as its root directory.
- Parsed apps/web/vercel.json and validated the branch-rule shape against Vercel published schema.
- Confirmed the exact policy is main enabled and catch-all disabled.
- git diff --check passed.

Heavyweight completion reviews and the full acceptance suite were intentionally skipped per explicit user instruction for this simple configuration change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786595831&installation_id=127572939&pr_number=617&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F617&signature=d97d4590d55e92aad5c8d63becb91a83ba732ff0d8caa3b14c21389ae0e11b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->