### PR TITLE
Add secret-safe Linq upstream diagnostics

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-linq-upstream-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-linq-upstream-diagnostics.md
@@ -1,0 +1,69 @@
+# Add secret-safe Linq upstream diagnostics
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+- Make future Linq upstream failures distinguishable as provider API responses versus Cloudflare challenge-like responses without changing message delivery behavior.
+
+## Success criteria
+
+- Linq provider-egress completion logs identify the fixed allowlisted operation.
+- Non-success Linq responses add only bounded, header-derived diagnostics: content kind, Cloudflare challenge signal, and a strictly validated optional Ray correlation value.
+- The original upstream response body remains unread and unmodified by diagnostics.
+- Focused tests prove useful fields and the absence of route identifiers, bodies, credentials, member identifiers, phone numbers, and arbitrary header values.
+- Required verification, security/privacy review, coverage review, and PR review gates pass.
+
+## Scope
+
+- In scope: `apps/cloudflare/src/runner-egress-intercept.ts`, its focused test, this plan, and the coordination ledger.
+- Out of scope: retries, fallback delivery, route authority changes, container lifecycle, mailbox ordering, response-body inspection, provider configuration, and deployment.
+
+## Constraints
+
+- Technical constraints: preserve the current route allowlist as the single source of truth; keep diagnostics synchronous and header-only; return the exact upstream `Response`.
+- Product/process constraints: production is currently recovered, so this is observability-only and must not alter user-visible behavior.
+
+## Risks and mitigations
+
+1. Risk: diagnostics leak provider paths, message content, or user identifiers.
+   Mitigation: emit fixed enums, one boolean, and a bounded validated correlation value only; assert negative privacy cases in tests.
+2. Risk: diagnostics consume the response body or add latency.
+   Mitigation: inspect headers only and test that the caller can still read the unchanged body.
+3. Risk: concurrent PR #511 modifies the same source and test files.
+   Mitigation: keep this patch narrow, avoid its replay/usage-authority symbols, and rebase before push.
+
+## Tasks
+
+1. [x] Replace the Linq boolean route matcher with a fixed operation classifier so authorization and diagnostics share one route decision.
+2. [x] Add bounded header-only metadata to failed Linq upstream completion logs.
+3. [x] Add focused behavior and privacy regression tests.
+4. [x] Run focused verification, required local audits, and parent diff review.
+5. [ ] Run CI and ReviewGPT on the exact pushed PR head before merge.
+
+## Decisions
+
+- Do not use the existing response-body metadata helper because it buffers the response and is unnecessary for this diagnosis.
+- Treat `cf-mitigated: challenge` as the definitive Cloudflare challenge signal; treat content kind and a valid `cf-ray` only as correlation context.
+- Do not deploy this observability patch as part of the recovered incident unless separately requested.
+
+## Verification
+
+- Commands to run:
+  - `pnpm --dir apps/cloudflare test:node test/runner-egress-intercept.test.ts`
+  - `pnpm test:diff apps/cloudflare/src/runner-egress-intercept.ts apps/cloudflare/test/runner-egress-intercept.test.ts`
+  - Required `security-privacy-review` and `coverage-write` audit passes.
+  - CI and ReviewGPT on the exact pushed PR head.
+- Expected outcomes: all checks pass; failed Linq logs contain only the documented bounded metadata; upstream responses remain unchanged.
+
+## Verification results
+
+- `pnpm --dir apps/cloudflare test:node test/runner-egress-intercept.test.ts`: 216 tests passed.
+- `pnpm --dir apps/cloudflare typecheck`: passed.
+- `pnpm test:diff apps/cloudflare/src/runner-egress-intercept.ts apps/cloudflare/test/runner-egress-intercept.test.ts`: dependency, boundary, architecture, crypto, and raw-log guards passed; Cloudflare typecheck passed; 103 test files and 1,779 tests passed.
+- `security-privacy-review`: no evidence-backed medium-or-higher findings.
+- `coverage-write`: added one synthetic phone exclusion assertion; no unresolved coverage findings.
+- Parent final review: response metadata is limited to actual upstream responses, and the rebased source/test patch remained byte-for-byte unchanged through ledger conflict resolution.
+Completed: 2026-07-14

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -2743,7 +2743,11 @@ async function maybeHandleLinqRequest(input: {
     return null;
   }
 
-  if (!isAllowedLinqRequest(input.request.method, pathMatch.pathnameSuffix)) {
+  const providerOperation = readAllowedLinqOperation(
+    input.request.method,
+    pathMatch.pathnameSuffix,
+  );
+  if (!providerOperation) {
     return disallowedProviderEgress();
   }
   if (!hasBearerCredentialSentinel(input.request.headers)) {
@@ -2771,6 +2775,7 @@ async function maybeHandleLinqRequest(input: {
   return await fetchAuthorizedProviderUpstream({
     authorization,
     providerKind: "linq",
+    providerOperation,
     request: input.request,
     startedAt,
     upstreamRequest: await createHostedRunnerUpstreamRequest(
@@ -3019,35 +3024,57 @@ function hasHeaderCredentialSentinel(headers: Headers, name: string): boolean {
   return headers.get(name)?.trim() === HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL;
 }
 
-function isAllowedLinqRequest(method: string, pathnameSuffix: string): boolean {
+type HostedLinqProviderOperation =
+  | "attachment_create"
+  | "attachment_read"
+  | "chat_create"
+  | "message_delete"
+  | "message_send"
+  | "phone_numbers_list"
+  | "reaction_create"
+  | "read_receipt_send"
+  | "typing_start"
+  | "typing_stop"
+  | "voice_memo_send";
+
+function readAllowedLinqOperation(
+  method: string,
+  pathnameSuffix: string,
+): HostedLinqProviderOperation | null {
   if (method === "GET" && pathnameSuffix === "/phone_numbers") {
-    return true;
+    return "phone_numbers_list";
   }
   if (method === "GET" && /^\/attachments\/[^/]+$/u.test(pathnameSuffix)) {
-    return true;
+    return "attachment_read";
   }
   if (method === "POST" && pathnameSuffix === "/attachments") {
-    return true;
+    return "attachment_create";
   }
   if (method === "POST" && pathnameSuffix === "/chats") {
-    return true;
+    return "chat_create";
   }
   if (method === "POST" && /^\/messages\/[^/]+\/reactions$/u.test(pathnameSuffix)) {
-    return true;
+    return "reaction_create";
   }
   if (method === "POST" && /^\/chats\/[^/]+\/voicememo$/u.test(pathnameSuffix)) {
-    return true;
+    return "voice_memo_send";
   }
-  if (
-    method === "POST"
-    && /^\/chats\/[^/]+\/(?:messages|typing|read)$/u.test(pathnameSuffix)
-  ) {
-    return true;
+  if (method === "POST" && /^\/chats\/[^/]+\/messages$/u.test(pathnameSuffix)) {
+    return "message_send";
+  }
+  if (method === "POST" && /^\/chats\/[^/]+\/typing$/u.test(pathnameSuffix)) {
+    return "typing_start";
+  }
+  if (method === "POST" && /^\/chats\/[^/]+\/read$/u.test(pathnameSuffix)) {
+    return "read_receipt_send";
   }
   if (method === "DELETE" && /^\/chats\/[^/]+\/typing$/u.test(pathnameSuffix)) {
-    return true;
+    return "typing_stop";
   }
-  return method === "DELETE" && /^\/messages\/[^/]+$/u.test(pathnameSuffix);
+  if (method === "DELETE" && /^\/messages\/[^/]+$/u.test(pathnameSuffix)) {
+    return "message_delete";
+  }
+  return null;
 }
 
 function readTelegramSentinelOperation(pathname: string): string | null {
@@ -3643,6 +3670,7 @@ function unauthorizedProviderEgress(input: {
 async function fetchAuthorizedProviderUpstream(input: {
   authorization: HostedProviderEgressAuthorization;
   providerKind: string;
+  providerOperation?: HostedLinqProviderOperation;
   request: Request;
   startedAt: number;
   upstreamRequest: Request;
@@ -3655,6 +3683,7 @@ async function fetchAuthorizedProviderUpstream(input: {
     emitHostedProviderEgressDiagnostic({
       authorization: input.authorization,
       providerKind: input.providerKind,
+      ...(input.providerOperation ? { providerOperation: input.providerOperation } : {}),
       request: input.request,
       response,
       startedAt: input.startedAt,
@@ -3667,6 +3696,7 @@ async function fetchAuthorizedProviderUpstream(input: {
       authorization: input.authorization,
       error,
       providerKind: input.providerKind,
+      ...(input.providerOperation ? { providerOperation: input.providerOperation } : {}),
       request: input.request,
       startedAt: input.startedAt,
       upstreamDurationMs: Date.now() - upstreamStartedAt,
@@ -3681,6 +3711,7 @@ function emitHostedProviderEgressDiagnostic(input: {
   audioBytes?: number;
   error?: unknown;
   providerKind: string;
+  providerOperation?: HostedLinqProviderOperation;
   request: Request;
   response?: Response;
   startedAt: number;
@@ -3694,6 +3725,12 @@ function emitHostedProviderEgressDiagnostic(input: {
   const providerBearerCredentialKind = input.providerKind === "openai"
     ? readHostedProviderCredentialDiagnosticKind(readBearerCredential(input.request.headers))
     : null;
+  const linqFailureResponseMetadata = input.providerKind === "linq"
+      && input.providerOperation
+      && input.response
+      && !input.response.ok
+    ? readLinqFailureResponseMetadata(input.response)
+    : {};
   emitHostedExecutionStructuredLog({
     component: "runner",
     details: {
@@ -3705,8 +3742,10 @@ function emitHostedProviderEgressDiagnostic(input: {
       providerUpstreamDurationMs: input.upstreamDurationMs,
       providerEgressAuthDurationMs: input.authorization.durationMs,
       providerEgressAuthMode: input.authorization.mode,
+      ...(input.providerOperation ? { providerOperation: input.providerOperation } : {}),
       responseOk: input.response?.ok ?? null,
       responseStatus: input.response?.status ?? null,
+      ...linqFailureResponseMetadata,
       ...(providerBearerCredentialKind
         ? { providerBearerCredentialKind }
         : {}),
@@ -3748,6 +3787,48 @@ function emitHostedProviderEgressDiagnostic(input: {
     message: "Hosted runner provider egress completed.",
     phase: "wake.running",
   });
+}
+
+type HostedLinqResponseContentKind = "html" | "json" | "missing" | "other" | "text";
+
+function readLinqFailureResponseMetadata(response: Response): {
+  providerResponseCloudflareChallenge: boolean;
+  providerResponseCloudflareRay?: string;
+  providerResponseContentKind: HostedLinqResponseContentKind;
+} {
+  const cloudflareRay = readSafeCloudflareRay(response.headers.get("cf-ray"));
+  return {
+    providerResponseCloudflareChallenge:
+      response.headers.get("cf-mitigated")?.trim().toLowerCase() === "challenge",
+    ...(cloudflareRay ? { providerResponseCloudflareRay: cloudflareRay } : {}),
+    providerResponseContentKind: readResponseContentKind(
+      response.headers.get("content-type"),
+    ),
+  };
+}
+
+function readResponseContentKind(value: string | null): HostedLinqResponseContentKind {
+  const mediaType = value?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  if (!mediaType) {
+    return "missing";
+  }
+  if (mediaType === "application/json" || mediaType.endsWith("+json")) {
+    return "json";
+  }
+  if (mediaType === "text/html") {
+    return "html";
+  }
+  if (mediaType.startsWith("text/")) {
+    return "text";
+  }
+  return "other";
+}
+
+function readSafeCloudflareRay(value: string | null): string | null {
+  const normalized = value?.trim() ?? "";
+  return /^[0-9A-Fa-f]{16,32}(?:-[A-Z]{3})?$/u.test(normalized)
+    ? normalized
+    : null;
 }
 
 function stripHostedRuntimeAuthorityHeaders(headers: Headers): Headers {

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -2251,6 +2251,9 @@ describe("hostedRunnerIntercept", () => {
         message: "Hosted runner provider egress completed.",
       }),
     );
+    expect(JSON.stringify(mocks.emitHostedExecutionStructuredLog.mock.calls)).not.toContain(
+      "providerResponse",
+    );
   });
 
   async function expectTokenlessDeliveryProviderRejected(
@@ -4823,6 +4826,116 @@ describe("hostedRunnerIntercept", () => {
     );
   });
 
+  it("logs bounded Cloudflare challenge metadata for a failed Linq response without reading it", async () => {
+    const responseBody = "<html>private upstream challenge body</html>";
+    const privatePhoneNumber = "+15555550123";
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      new Response(responseBody, {
+        headers: {
+          "cf-mitigated": "challenge",
+          "cf-ray": "230b030023ae2822-SJC",
+          "content-type": "text/html; charset=UTF-8",
+          "x-provider-debug": "private arbitrary header value",
+        },
+        status: 403,
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const requestBody = JSON.stringify({
+      text: `private outbound message body ${privatePhoneNumber}`,
+    });
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.linqapp.com/api/partner/v3/chats/private_chat_id/messages", {
+        body: requestBody,
+        headers: {
+          ...BOUND_USER_WRITE_FENCE_HEADERS,
+          authorization: `Bearer ${HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL}`,
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        LINQ_API_TOKEN: "linq-worker-secret",
+        validateRuntimeWriteFence: vi.fn(async () => true),
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe(responseBody);
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          providerKind: "linq",
+          providerOperation: "message_send",
+          providerResponseCloudflareChallenge: true,
+          providerResponseCloudflareRay: "230b030023ae2822-SJC",
+          providerResponseContentKind: "html",
+          responseStatus: 403,
+        }),
+        message: "Hosted runner provider egress completed.",
+      }),
+    );
+    const serializedLogs = JSON.stringify(mocks.emitHostedExecutionStructuredLog.mock.calls);
+    expect(serializedLogs).not.toContain(responseBody);
+    expect(serializedLogs).not.toContain(requestBody);
+    expect(serializedLogs).not.toContain("private_chat_id");
+    expect(serializedLogs).not.toContain("linq-worker-secret");
+    expect(serializedLogs).not.toContain("member_123");
+    expect(serializedLogs).not.toContain(privatePhoneNumber);
+    expect(serializedLogs).not.toContain("private arbitrary header value");
+  });
+
+  it("classifies a failed Linq API response without logging invalid correlation values", async () => {
+    const responseBody = '{"error":"private upstream API body"}';
+    const responseBytes = TEST_TEXT_ENCODER.encode(responseBody);
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      new Response(responseBytes, {
+        headers: {
+          "cf-mitigated": "not-a-challenge",
+          "cf-ray": "private invalid correlation value",
+          "content-type": "application/problem+json; charset=utf-8",
+        },
+        status: 403,
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.linqapp.com/api/partner/v3/phone_numbers", {
+        headers: {
+          ...BOUND_USER_WRITE_FENCE_HEADERS,
+          authorization: `Bearer ${HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL}`,
+        },
+        method: "GET",
+      }),
+      createInterceptEnv({
+        LINQ_API_TOKEN: "linq-worker-secret",
+        validateRuntimeWriteFence: vi.fn(async () => true),
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(403);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(responseBytes);
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          providerKind: "linq",
+          providerOperation: "phone_numbers_list",
+          providerResponseCloudflareChallenge: false,
+          providerResponseContentKind: "json",
+          responseStatus: 403,
+        }),
+      }),
+    );
+    const serializedLogs = JSON.stringify(mocks.emitHostedExecutionStructuredLog.mock.calls);
+    expect(serializedLogs).not.toContain("providerResponseCloudflareRay");
+    expect(serializedLogs).not.toContain("private invalid correlation value");
+    expect(serializedLogs).not.toContain(responseBody);
+  });
+
   it("requires the active write fence before injecting Linq credentials for reads", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
       phone_numbers: [],
@@ -4907,12 +5020,14 @@ describe("hostedRunnerIntercept", () => {
     {
       name: "phone number probe",
       method: "GET",
+      operation: "phone_numbers_list",
       path: "/phone_numbers",
       responseBody: JSON.stringify({ phone_numbers: [] }),
     },
     {
       name: "attachment metadata",
       method: "GET",
+      operation: "attachment_read",
       path: "/attachments/attachment_metadata_1",
       responseBody: "{}",
     },
@@ -4924,6 +5039,7 @@ describe("hostedRunnerIntercept", () => {
       },
       method: "POST",
       name: "attachment upload creation",
+      operation: "attachment_create",
       path: "/attachments",
     },
     {
@@ -4934,6 +5050,7 @@ describe("hostedRunnerIntercept", () => {
       },
       method: "POST",
       name: "chat creation",
+      operation: "chat_create",
       path: "/chats",
     },
     {
@@ -4942,6 +5059,7 @@ describe("hostedRunnerIntercept", () => {
       },
       method: "POST",
       name: "chat message send",
+      operation: "message_send",
       path: "/chats/chat_1/messages",
     },
     {
@@ -4950,6 +5068,7 @@ describe("hostedRunnerIntercept", () => {
       },
       method: "POST",
       name: "voice memo send",
+      operation: "voice_memo_send",
       path: "/chats/chat_1/voicememo",
     },
     {
@@ -4959,26 +5078,31 @@ describe("hostedRunnerIntercept", () => {
       },
       method: "POST",
       name: "message reaction",
+      operation: "reaction_create",
       path: "/messages/message_1/reactions",
     },
     {
       method: "POST",
       name: "typing start",
+      operation: "typing_start",
       path: "/chats/chat_1/typing",
     },
     {
       method: "POST",
       name: "read receipt",
+      operation: "read_receipt_send",
       path: "/chats/chat_1/read",
     },
     {
       method: "DELETE",
       name: "typing stop",
+      operation: "typing_stop",
       path: "/chats/chat_1/typing",
     },
     {
       method: "DELETE",
       name: "message cleanup",
+      operation: "message_delete",
       path: "/messages/message_1",
     },
   ] as const)("allows required Linq runtime route: $name", async (route) => {
@@ -5023,6 +5147,13 @@ describe("hostedRunnerIntercept", () => {
     expect(forwarded.headers.get("authorization")).toBe("Bearer linq-worker-secret");
     expect(forwarded.headers.has("x-hosted-runtime-attempt-id")).toBe(false);
     expect(forwarded.headers.has(HOSTED_RUNNER_BOUND_USER_ID_HEADER)).toBe(false);
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          providerOperation: route.operation,
+        }),
+      }),
+    );
   });
 
   it("honors configured Linq base URL pathname prefixes before validating allowed suffixes", async () => {


### PR DESCRIPTION
## Why

During the production no-reply incident, hosted-runner telemetry proved that Linq egress was authorized and received an HTTP 403, but the existing log could not distinguish a Linq API response from a Cloudflare challenge-like response. That made provider escalation and root-cause confirmation unnecessarily ambiguous.

## User-visible goal and UX

There is no user-visible behavior change. Future Linq failures should be diagnosable from one secret-safe provider-egress record while message delivery, authorization, route admission, and the returned upstream response remain unchanged.

## What changed

- Replaced the Linq route allowlist's boolean result with a fixed operation classifier, keeping one route decision for both admission and diagnostics.
- For failed, authorized Linq upstream responses only, records:
  - a fixed content-kind enum
  - whether `cf-mitigated` is exactly `challenge`
  - an optional strictly validated, bounded `cf-ray` correlation value
- Added focused proof for all 11 allowed operations, challenge and non-challenge 403s, valid and invalid Ray values, unchanged response bodies, and exclusion of paths, content, credentials, member/contact identifiers, phone-shaped values, and arbitrary headers.

Cloudflare references: [challenge response detection](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/) and [CF-Ray](https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-ray).

## Invariants preserved

- Linq paths remain allowlisted by the existing worker-owned policy; no route was added or removed.
- Runtime/provider authorization and credential injection are unchanged.
- Internal authorization failures are not labeled as upstream responses.
- Diagnostics never read or buffer the request or response body.
- The exact upstream `Response` is returned to the caller.
- No retry, fallback, mailbox, route-authority, container-lifecycle, database, or deployment behavior changed.

## Verification

- `pnpm --dir apps/cloudflare test:node test/runner-egress-intercept.test.ts` — 216 passed
- `pnpm --dir apps/cloudflare typecheck` — passed
- `pnpm test:diff apps/cloudflare/src/runner-egress-intercept.ts apps/cloudflare/test/runner-egress-intercept.test.ts` — dependency/boundary/architecture/crypto/log guards passed; 103 test files and 1,779 tests passed
- Security/privacy audit — zero medium-or-higher findings
- Coverage audit — zero unresolved findings after one phone-exclusion assertion

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 96 | 15 |
| Tests | 131 | 0 |
| Docs / execution plan | 69 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

## Deployment skew

Cloudflare Worker-only observability change. It has no web, database, container-image, or protocol dependency and can deploy independently. No deployment is included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786603062&installation_id=127572939&pr_number=622&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F622&signature=351d40a1312eacc3d20cda602094e55457a4c9ab6fd2fb095620378f448059ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->