### PR TITLE
Use balanced ReviewGPT browser scheduling

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-review-gpt-cpu-balanced.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-review-gpt-cpu-balanced.md
@@ -1,0 +1,77 @@
+# Reduce ReviewGPT managed-browser CPU
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+- Reduce CPU contention from shared ReviewGPT browser lanes without interrupting active reviews, Codex sessions, or their child agents.
+
+## Success criteria
+
+- ReviewGPT keeps waited background response capture reliable while allowing occluded windows and unrelated renderers to use Chromium's normal background scheduling.
+- Murph opts into the balanced browser policy through its repo configuration and consumes a released ReviewGPT patch.
+- Existing browser lanes are not stopped or restarted by this task; the new launch policy takes effect on their next normal restart.
+- ReviewGPT typecheck/tests/release checks and Murph's focused configuration checks pass.
+
+## Scope
+
+- In scope: ReviewGPT managed-browser launch flags and configuration, matching tests/docs, package patch release, Murph ReviewGPT configuration/docs, dependency lockfile update.
+- Out of scope: terminating or reprioritizing live processes, closing browser targets, changing Codex sessions, deleting caches, or changing system startup/network settings.
+
+## Constraints
+
+- Preserve exact owned-target cleanup: waited runs close only the target they created, while draft-only and send-without-wait runs retain their user-facing target.
+- Preserve a documented fully unthrottled fallback for browser versions that cannot capture reliably under the balanced policy.
+- Never expose credentials, account identifiers, personal identifiers, or local home-directory paths.
+- Keep the change small: one configuration value, one launch-argument decision, focused coverage, and the Murph opt-in.
+
+## Risks and mitigations
+
+1. Risk: background response DOM capture stalls on a browser that needs all legacy flags.
+   Mitigation: keep background timer throttling disabled in balanced mode, retain active lifecycle/focus emulation for the owned page, and provide an explicit `unthrottled` fallback.
+2. Risk: current pending reviews are interrupted while changing lane behavior.
+   Mitigation: do not touch live lanes; launch arguments change only after a normal future restart.
+3. Risk: Murph references an unreleased or mismatched package contract.
+   Mitigation: release the verified ReviewGPT patch first, then update the dependency and lockfile to the published version.
+
+## Tasks
+
+1. Add and validate ReviewGPT's balanced/unthrottled managed-browser background policy.
+2. Update ReviewGPT tests and browser behavior documentation.
+3. Run required ReviewGPT verification, commit, and publish a patch release.
+4. Configure Murph for balanced mode and update the dependency/lockfile and lifecycle documentation.
+5. Run focused Murph verification, privacy checks, completion audit, and create the scoped commit.
+6. Remeasure after the lanes next restart normally; do not force that restart while reviews are pending.
+
+## Decisions
+
+- Balanced mode retains `--disable-background-timer-throttling` for response polling but removes process-wide opt-outs from renderer background scheduling and occluded-window throttling.
+- The old three-flag behavior remains available as `unthrottled` for targeted rollback.
+
+## Progress
+
+- Confirmed the sustained CPU load comes from three shared ReviewGPT lane processes launched with all Chromium background-throttling opt-outs, not from orphaned review targets.
+- Confirmed pending reviews survived the browser-lane restart and the active lanes must remain untouched.
+- Confirmed waited runs already pin their owned page lifecycle active and use exact target ownership cleanup.
+- Added a balanced managed-browser background mode to ReviewGPT, retained the legacy fully unthrottled fallback, and released the verified change as `@cobuild/review-gpt@0.5.107`.
+- Updated Murph's lane configuration, dependency lock, lifecycle documentation, and focused release/config assertions for the published package.
+- Preserved every live Codex and ReviewGPT process; the new launch flags remain intentionally deferred until each lane's next normal restart.
+- Completed the required coverage-write audit with no edits and no actionable coverage finding; existing focused assertions and direct dry-run proof were sufficient.
+
+## Now
+
+- Close the plan and create the scoped Murph commit.
+
+## Next
+
+- Open the low-risk tooling PR without running ReviewGPT against its own lane configuration change.
+
+## Verification
+
+- ReviewGPT: `pnpm typecheck`, 168 tests, and `pnpm release:check` passed; the v0.5.107 release workflow and npm publication succeeded.
+- Murph: frozen lockfile install, shell and Node syntax, dependency policy, workspace boundaries, hosted runtime/Temporal/crypto/log guards, all three CLI typechecks, prepared runtime artifacts, Health Commons generation, and CLI package-shape verification passed.
+- Murph direct proof: the installed ReviewGPT CLI dry run loaded `scripts/review-gpt.config.sh`, reported `Managed browser background mode: balanced`, and skipped browser launch.
+- Murph scoped CLI suite: 18 of 19 files and 366 of 367 tests passed. The only failure was the unrelated release-tarball assistant manifest probe timing out while another lane ran the same expensive test under severe host contention. A single-worker retry hit the test's 120-second timeout after 615 seconds of wall time; no ReviewGPT assertion failed.
+Completed: 2026-07-14

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -39,10 +39,19 @@ the prepared draft or conversation is the user-facing result. Never implement
 this cleanup as a profile-wide tab sweep or close a target that the current run
 did not create.
 
-This ownership rule is required because the managed browser lanes disable
-background throttling and ReviewGPT pins the capture page lifecycle active.
-Leaving completed waited targets open accumulates active renderers across
-rounds even when ordinary browser history and site data have been cleared.
+This ownership rule is required because the managed browser lanes keep
+background response-polling timers reliable and ReviewGPT pins only the owned
+capture page lifecycle active. The Murph lanes use balanced background mode so
+Chromium can still deprioritize unrelated renderers and occluded windows; use
+the fully unthrottled fallback only for a browser version with a proven capture
+stall. Leaving completed waited targets open still accumulates active renderers
+across rounds even when ordinary browser history and site data have been
+cleared.
+
+Changing the launch mode does not reconfigure a browser process that is already
+running. Never restart a shared lane merely to apply this setting while it has
+pending reviews; let the new flags take effect on the lane's next normal
+restart.
 
 ## When It Runs
 

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -41,12 +41,12 @@ did not create.
 
 This ownership rule is required because the managed browser lanes keep
 background response-polling timers reliable and ReviewGPT pins only the owned
-capture page lifecycle active. The Murph lanes use balanced background mode so
-Chromium can still deprioritize unrelated renderers and occluded windows; use
-the fully unthrottled fallback only for a browser version with a proven capture
-stall. Leaving completed waited targets open still accumulates active renderers
-across rounds even when ordinary browser history and site data have been
-cleared.
+capture page lifecycle active, then releases emulated focus before retaining or
+closing that target. The Murph lanes use balanced background mode so Chromium
+can still deprioritize unrelated renderers and occluded windows; use the fully
+unthrottled fallback only for a browser version with a proven capture stall.
+Leaving completed waited targets open still accumulates active renderers across
+rounds even when ordinary browser history and site data have been cleared.
 
 Changing the launch mode does not reconfigure a browser process that is already
 running. Never restart a shared lane merely to apply this setting while it has

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.106",
+    "@cobuild/review-gpt": "^0.5.107",
     "@murphai/hosted-local-harness": "workspace:*",
     "@murphai/health-metrics": "workspace:*",
     "@types/node": "^25.6.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.107",
+    "@cobuild/review-gpt": "^0.5.108",
     "@murphai/hosted-local-harness": "workspace:*",
     "@murphai/health-metrics": "workspace:*",
     "@types/node": "^25.6.2",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -918,8 +918,8 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.107')
-    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.107')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.108')
+    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.108')
     expect(pnpmWorkspace.match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]?.trim()).toBe(
       'incur@0.4.5: patches/incur@0.4.5.patch',
     )

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -918,8 +918,8 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.106')
-    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.106')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.107')
+    expect(pnpmWorkspace).toContain('@cobuild/review-gpt@0.5.107')
     expect(pnpmWorkspace.match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]?.trim()).toBe(
       'incur@0.4.5: patches/incur@0.4.5.patch',
     )
@@ -1077,6 +1077,9 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptConfig).toContain('app_connector="current"')
     expect(reviewGptConfig).toContain('model="gpt-5.6-sol"')
     expect(reviewGptConfig).toContain('thinking="current"')
+    expect(reviewGptConfig).toContain(
+      'managed_browser_background_mode="${managed_browser_background_mode:-balanced}"',
+    )
     expect(reviewGptConfig).toContain('codebase.zip')
     expect(reviewGptConfig).not.toContain('snapshot_attachment_name=')
     expect(reviewGptConfig).not.toContain('repomix_attachment_format=')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15
       '@cobuild/review-gpt':
-        specifier: ^0.5.107
-        version: 0.5.107(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
+        specifier: ^0.5.108
+        version: 0.5.108(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
       '@murphai/health-metrics':
         specifier: workspace:*
         version: link:packages/health-metrics
@@ -1317,8 +1317,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.107':
-    resolution: {integrity: sha512-T7W7T51TGSOPTTfu0xzSaRW94PgdhFcVLevUr+bwZcmzgQfy2GyaxVgfW3elh3Op+Gwln/Xh5Jszu+5QM+tnRw==}
+  '@cobuild/review-gpt@0.5.108':
+    resolution: {integrity: sha512-e7oxBQpnlAmvM6jMc+3s1NvMDXJN4KeSTO3ZMEWRmSYMvHhL05lRRsgsjJ+MfPUOWrpLuJkcDXivxBapFzCz0g==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10475,7 +10475,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15': {}
 
-  '@cobuild/review-gpt@0.5.107(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
+  '@cobuild/review-gpt@0.5.108(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15
       '@cobuild/review-gpt':
-        specifier: ^0.5.106
-        version: 0.5.106(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
+        specifier: ^0.5.107
+        version: 0.5.107(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
       '@murphai/health-metrics':
         specifier: workspace:*
         version: link:packages/health-metrics
@@ -1317,8 +1317,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.106':
-    resolution: {integrity: sha512-Vqn1NsVowcRnR5f70TUnxKzfZTBTCp/u/4Y9ytbpWUrppfVwsf3yO2fBxpHh1oKbzz3/kUFXQY6iEtU+8TkABA==}
+  '@cobuild/review-gpt@0.5.107':
+    resolution: {integrity: sha512-T7W7T51TGSOPTTfu0xzSaRW94PgdhFcVLevUr+bwZcmzgQfy2GyaxVgfW3elh3Op+Gwln/Xh5Jszu+5QM+tnRw==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10475,7 +10475,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15': {}
 
-  '@cobuild/review-gpt@0.5.106(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
+  '@cobuild/review-gpt@0.5.107(@cfworker/json-schema@4.1.1)(typescript@5.9.3)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.107'
+  - '@cobuild/review-gpt@0.5.108'
   - '@onkernel/sdk@0.76.0'
   - '@openai/codex@0.144.0||0.144.0-darwin-arm64||0.144.0-darwin-x64||0.144.0-linux-arm64||0.144.0-linux-x64||0.144.0-win32-arm64||0.144.0-win32-x64'
   - '@temporalio/activity@1.16.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.106'
+  - '@cobuild/review-gpt@0.5.107'
   - '@onkernel/sdk@0.76.0'
   - '@openai/codex@0.144.0||0.144.0-darwin-arm64||0.144.0-darwin-x64||0.144.0-linux-arm64||0.144.0-linux-x64||0.144.0-win32-arm64||0.144.0-win32-x64'
   - '@temporalio/activity@1.16.3'

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -122,6 +122,10 @@ fi
 managed_browser_user_data_dir="${managed_browser_user_data_dir:-$(review_gpt_browser_lane_data_dir "$review_gpt_selected_browser_lane")}"
 managed_browser_profile="${managed_browser_profile:-Default}"
 managed_browser_port="${managed_browser_port:-$review_gpt_selected_browser_port}"
+# Keep response-polling timers reliable without forcing every renderer and
+# occluded lane window to run at foreground priority. Set this to unthrottled
+# only when a specific browser version has a proven background-capture stall.
+managed_browser_background_mode="${managed_browser_background_mode:-balanced}"
 export REVIEW_GPT_SELECTED_BROWSER_LANE="$review_gpt_selected_browser_lane"
 
 name_prefix="murph-$review_gpt_selected_browser_lane-chatgpt-audit"


### PR DESCRIPTION
## Why

Shared ReviewGPT lanes accumulated preserved ChatGPT pages that stayed at foreground-like scheduling. Two mechanisms contributed: process-wide Chromium anti-throttling flags and CDP focus emulation that was not released from retained draft or send-without-wait targets.

## Goal and behavior

- Consume the released @cobuild/review-gpt 0.5.108 patch.
- Set Murph lanes to balanced mode: keep response-polling timers reliable while restoring normal renderer and occluded-window scheduling.
- Release emulated focus before ReviewGPT retains or closes its owned page; later capture re-enables it only while polling.
- Document that launch flags apply only on the next normal lane restart; never restart a lane merely to apply this setting while reviews are pending.

## Invariants

- Preserve exact owned-target cleanup and pending review tabs.
- Preserve the explicit fully unthrottled rollback for a browser version with a proven capture stall.
- Do not change product runtime, persisted state, auth, data flow, or deploy behavior.

## Verification

- Upstream ReviewGPT 0.5.108: typecheck, 168 of 168 tests, release check, GitHub release workflow, and npm trusted publication passed.
- Murph: frozen lockfile install; syntax, dependency, workspace-boundary, hosted-runtime, Temporal, crypto, privacy-log, CLI typechecks, runtime artifact, and package-shape checks passed for the original integration head.
- Installed package proof confirms 0.5.108 contains the focus-release cleanup. Direct dry run reports balanced background mode and skips browser launch.
- Exact Murph package/config contract test passes. The broader file passed 33 assertions but an unrelated audit-ZIP size test timed out under severe host contention. The earlier broad CLI lane passed 18 of 19 files and 366 of 367 tests; its only failure was another unrelated fixed-timeout assistant-manifest subprocess under the same contention.
- Required coverage-write audit found existing integration proof sufficient and made no edits. Upstream focus-release behavior is covered by the 168-test ReviewGPT suite.
- ReviewGPT PR gate skipped under the low-risk developer-tooling exemption so this fix does not create more browser-lane load.

## Diff breakdown

- Source: +0 / -0
- Tests: +5 / -2
- Docs and plan: +89 / -3
- Config and tooling: +11 / -7
- Generated or other: +0 / -0