### PR TITLE
fix(hosted): remove cold reply latency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Murph Architecture
 
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 ## Hosted Group Self-Awareness
 
@@ -319,9 +319,11 @@ owner of execution and commit authority rather than mailbox-work truth. Exact
 accepted wakes may coalesce under Cloudflare's active owner; durable mailbox lag
 remains recovery truth but duplicate execution is prevented by the write fence;
 accepted processing returns an owner recheck instead of a short
-durable-lag polling loop; old runtime fences with missing children are replaced
-by identity after startup grace, wake-unconfirmed active children retry instead
-of being replaced, and alarm cleanup
+durable-lag polling loop; a same-version startup fence keeps its startup grace,
+while an exact prior-version container that reports no active child is replaced
+immediately by identity; concurrent replacement callers converge on the current
+fence record instead of entering a timed race state; wake-unconfirmed active
+children retry instead of being replaced, and alarm cleanup
 failures are rethrown so the platform can retry instead of permanently deleting
 the alarm. New v2 foreground leases restore from durable workspace snapshots and
 legacy refs also cold-restore from durable bundles instead of trusting dirty

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Murph Architecture
 
-Last verified: 2026-07-13
+Last verified: 2026-07-14
 
 ## Hosted Group Self-Awareness
 
@@ -303,9 +303,11 @@ owner of execution and commit authority rather than mailbox-work truth. Exact
 accepted wakes may coalesce under Cloudflare's active owner; durable mailbox lag
 remains recovery truth but duplicate execution is prevented by the write fence;
 accepted processing returns an owner recheck instead of a short
-durable-lag polling loop; old runtime fences with missing children are replaced
-by identity after startup grace, wake-unconfirmed active children retry instead
-of being replaced, and alarm cleanup
+durable-lag polling loop; a same-version startup fence keeps its startup grace,
+while an exact prior-version container that reports no active child is replaced
+immediately by identity; concurrent replacement callers converge on the current
+fence record instead of entering a timed race state; wake-unconfirmed active
+children retry instead of being replaced, and alarm cleanup
 failures are rethrown so the platform can retry instead of permanently deleting
 the alarm. New v2 foreground leases restore from durable workspace snapshots and
 legacy refs also cold-restore from durable bundles instead of trusting dirty

--- a/agent-docs/exec-plans/completed/2026-07-14-rollout-fence-projection-latency.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-rollout-fence-projection-latency.md
@@ -1,0 +1,136 @@
+# Rollout Fence And Projection Latency
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+Remove the two measured cold-reply latency taxes from the July 14 incident:
+rollout-stale runtime fences that sleep after exact no-child proof, and
+attachment-free non-email conversation input that waits for inbox projection.
+For the projection-required path, stop opening terminal write-operation history
+when only surviving staged operations can contain recoverable capture bytes.
+
+## Success Criteria
+
+- A recent prior-version runtime fence is replaced immediately only after its
+  exact stored container target reports that no child is active.
+- A recent same-version startup fence and every ambiguous liveness result remain
+  fail-closed under the existing startup grace.
+- Concurrent replacement callers converge on the authoritative fence record
+  returned by the existing compare-and-swap instead of entering a timed retry.
+- Attachment-free Linq, Telegram, and WhatsApp input reaches assistant
+  admission without initializing or importing inbox projection.
+- Direct email and attachment-bearing non-email input keep the synchronous
+  projection behavior required for raw content and current-turn evidence.
+- Group email remains raw-free and skips projection regardless of descriptors.
+- Recovery lookup reads metadata only for operations with a surviving real
+  staging directory; clean terminal history costs no per-operation file reads.
+- Cross-shard canonical capture lookup remains unchanged because capture
+  identity deliberately excludes the timestamp that selects the shard.
+- No queue, lifecycle callback, new persisted state, dependency, service, or
+  compatibility layer is added.
+- Focused tests, required owner verification, specialist audits, CI, and the
+  ReviewGPT PR loop are green with zero accepted findings.
+
+## Constraints And Invariants
+
+- UserRunner SQLite remains the sole durable runtime-fence owner.
+- Replacement keeps exact attempt/generation compare-and-swap fencing and the
+  pre-dispatch ownership confirmation.
+- Direct wake and Temporal wake remain coalescing callers of the same owner.
+- `AssistantInputEvent` staging remains the Codex admission boundary; inbox is
+  attachment/search/debug enrichment, never a text-message admission gate.
+- The active mailbox consumed-at lane has a broad assistant-runtime notice.
+  Keep this change limited to conversation projection selection and its focused
+  tests, and reconcile any actual overlap before push.
+- Preserve all unrelated coordination rows and worktree changes.
+
+## Decisions
+
+- Bypass startup grace only for the direct `start-required/no-active-child`
+  result when the exact wake target differs from the current version target.
+- Feed compare-and-swap loser state and prepared-start ownership loss through
+  the existing `ensureExistingRuntimeProcessing` path under the same budget.
+- Delete the obsolete five-second replacement-race response and the Durable
+  Object `state.waitUntil()` dependency; Cloudflare documents that method as a
+  no-op and pending I/O already keeps the object active.
+- Skip inbox preparation and import for attachment-free non-email input and all
+  raw-free group email. Retain direct-email and attachment-bearing non-email
+  projection, and treat an unknown descriptor count conservatively. Do not
+  create deferred projection machinery.
+- Use the existing write-operation staging directory as the recovery candidate
+  set. Keep status and action validation after candidate selection; do not add
+  an index, cache, concurrency pool, or expected-shard-only lookup mode.
+
+## State
+
+- The supplied runtime state proved this was not a rebuild: projection reported
+  zero rebuilt captures and spent about 2.1 seconds preparing plus 4.6 seconds
+  importing. The cold miss walked 1,465 inbox records and 247 terminal recovery
+  operations before appending the new capture.
+- The deletion-first implementation is complete on the TypeScript 7 `main`
+  base that introduced TypeScript 7. Attachment-free non-email input skips
+  projection; the existing synchronous owner remains for direct email and
+  attachment-bearing non-email input. Final remote reconciliation remains part
+  of the pre-push workflow because `main` continued to advance during review.
+- Rollout recovery now reuses exact fence compare-and-swap plus the existing
+  convergence path. No new lifecycle state or scheduler was introduced.
+- Full owner verification, the security/privacy audit, and the initial coverage
+  audit are green. The operation-recovery candidate gate is implemented and
+  its focused owner verification is green.
+- The cross-cutting invariant contract now records the projection-admission,
+  staged-recovery, and exact-target rollout proof boundaries so future changes
+  cannot silently restore either latency tax.
+
+## Working Set
+
+- `apps/cloudflare/src/user-runner/runtime-processing-controller.ts`
+- `apps/cloudflare/src/user-runner/runtime-processing-responses.ts`
+- `apps/cloudflare/src/user-runner/diagnostics.ts`
+- `apps/cloudflare/src/user-runner/hosted-user-runner.ts`
+- focused Cloudflare UserRunner tests
+- `packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts`
+- focused assistant-runtime conversation import tests
+- `packages/core/src/operations/write-batch.ts` and public operation exports
+- `packages/inboxd/src/indexing/persist.ts`
+- `packages/inboxd/README.md`
+- focused core write-operation and inboxd recovery tests
+- `ARCHITECTURE.md`
+- `docs/contracts/00-invariants.md`
+- `packages/assistant-runtime/README.md`
+- `agent-docs/references/hosted-runtime-protocol.md`
+
+## Verification
+
+- Focused assistant-runtime projection/document checks: 61 passed.
+- Focused Cloudflare UserRunner suite: 84 passed; Cloudflare typecheck passed.
+- Prepared workspace runtime artifacts with `pnpm build:test-runtime:prepared`
+  and built assistant-runtime explicitly for the hosted-local test closure.
+- Post-TypeScript-7 diff verification passed all 18 affected workspace
+  typechecks and every architecture, dependency, boundary, crypto, and raw-log
+  guard. The full affected-package test lane was attempted with bounded outer
+  and Vitest concurrency; one unchanged assistant-engine filesystem-retention
+  test timed out at 60.6 seconds while competing with one other file worker.
+  The exact test passed independently in 36 seconds, and the two other
+  load-shaped cases from the unbounded attempt also passed independently.
+- Direct regressions cover prior-version exact-target replacement, same-version
+  grace, compare-and-swap convergence, prepared-fence budget exhaustion,
+  attachment-free projection omission, direct email, group email, links, and
+  stale pending replay state.
+- The supplied archive has 245 terminal operation metadata files and no stage
+  candidates. Candidate selection changed from 245 metadata opens to zero; a
+  ten-run warm local measurement changed from about 1,145 ms to about 2 ms for
+  that operation-recovery enumeration.
+- Core stage-candidate tests: 5 passed. Inboxd interrupted-write recovery tests:
+  20 passed. Core and inboxd typechecks and 204 scenario-integrity checks passed.
+- Required `security-privacy-review`: zero evidence-backed medium-or-higher
+  findings. Initial required `coverage-write`: complete; it added one
+  compare-and-swap convergence regression (UserRunner 85 passed).
+- Required task-finish, recovery-gate, Cloudflare-semantics, security/privacy,
+  deletion/minimality, and parent final diff/call-path reviews completed with
+  zero unresolved production findings. Two documentation mismatches found by
+  task-finish review were corrected before closure.
+- Push, PR, CI, and ReviewGPT loop: pending.
+Completed: 2026-07-14

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -70,7 +70,7 @@ signal Temporal hosted orchestration
 restore hosted workspace
 import mailbox prefix into local runtime state and stage AssistantInputEvent rows
 pull pending device-sync dirty rows
-run best-effort local inbox projection plus audio/video transcript enrichment without checkpointing it
+for attachment-bearing non-email input and direct raw email, run best-effort local inbox projection plus audio/video transcript enrichment without checkpointing it
 run local runtime work until idle or budget
 wait for the runtime idle window, a coalesced wake, or a projected runtime wake
 checkpoint final dirty runtime state with checkpoint reason idle_shutdown; commit
@@ -91,10 +91,14 @@ source adapter -> AssistantInputEvent -> AssistantInputSource -> scanner / activ
 The hosted adapter is the mailbox importer. It decodes a conversation mailbox
 row into a bounded `AssistantInputEvent`, stages it in local runtime state,
 marks the active invocation dirty, and checkpoints that dirty state only at the
-final runtime-owned idle or scheduled-wake checkpoint. Best-effort inbox projection may
-run while the decoded wake is still in memory. Projection status is logged and
-local inbox artifacts may help the same invocation, but hosted runtime must not
-take a separate workspace checkpoint just to persist projection/cache cleanup.
+final runtime-owned idle or scheduled-wake checkpoint. Attachment-free Linq,
+Telegram, and WhatsApp input does not initialize or import inbox projection.
+Direct email retains raw-message projection because its staged preview is
+bounded; group-routed email remains intentionally raw-free.
+Attachment-bearing non-email input may run best-effort inbox projection while
+the decoded wake is still in memory so local attachment artifacts can help the
+same invocation, but hosted runtime must not take a separate workspace
+checkpoint just to persist projection/cache cleanup.
 Failed projection is not durably retried by hosted runtime unless a future
 executor adds enough typed remote projection reference data to reconstruct the
 work without raw payload duplication. Inbox capture state, raw attachment
@@ -712,13 +716,17 @@ caller sends its existing ensure-processing HTTP timeout as an internal header.
 Cloudflare treats that value as an operational hint only: the foreground
 pre-accept budget is clamped by Cloudflare's configured web-control timeout, and
 workspace read/readiness steps are capped by the remaining budget. Accepted
-background invocations are registered with the Durable Object lifetime.
+background invocations begin their pending I/O before acceptance; Durable Object
+`waitUntil()` is not a lifecycle mechanism and is not used.
 Accepted starts and wakes return an owner recheck aligned to the
 expected idle checkpoint horizon rather than a short durable-lag polling loop. A
-runtime fence whose child is missing is replaced after the startup grace window
-when a later ensure command observes it. A wake-unconfirmed active child is not
-replaced; the caller retries until the child finishes, becomes wakeable, or is no
-longer active.
+same-version runtime fence whose child is missing remains protected by the
+startup grace window. When an identity-aware direct wake proves that the exact
+stored prior-version container has no active child, UserRunner immediately
+compare-and-swap replaces that fence. Concurrent replacement callers converge
+on the authoritative current fence record returned by the same compare-and-swap.
+A wake-unconfirmed active child is not replaced; the caller retries until the
+child finishes, becomes wakeable, or is no longer active.
 A failed transport call to an accepted invocation does not prove the invocation
 died. Before clearing the write fence after an invoke transport failure, the
 UserRunner probes the RunnerContainer for the exact fence identity
@@ -797,12 +805,14 @@ The runtime stages decoded conversation rows as assistant input and marks the
 active invocation dirty. Foreground runtime work may defer intermediate checkpoints.
 The active invocation remains dirty until the runtime-owned
 idle or scheduled-wake checkpoint succeeds. RunnerContainer never records
-pending checkpoint intent. Activity expiry is cleanup-only. Projection status
-is logged and artifacts remain rebuildable best-effort state rather than a
-reason to take another workspace checkpoint, so failed or slow projection does
-not block assistant admission and does not imply a durable retry queue.
-Successful projection may make raw attachment paths, image evidence, or
-audio/video transcript evidence available to the same assistant turn.
+pending checkpoint intent. Activity expiry is cleanup-only. Attachment-free
+non-email input skips projection and cannot be delayed by projection
+initialization or history scans. Direct-email and attachment projection status
+is logged and its artifacts remain rebuildable best-effort state rather than a
+reason to take another workspace
+checkpoint or create a durable retry queue. Successful attachment projection
+may make raw paths, image evidence, or audio/video transcript evidence
+available to the same assistant turn.
 Assistant prompt preparation reads derived attachment evidence sequentially
 under one 32 MiB budget for the current turn and a 16 MiB per-file limit. Hosted
 artifact materialization rejects an external artifact whose declared size is
@@ -874,11 +884,14 @@ terminal auto-reply evidence, not from mailbox import progress.
 
 Mailbox import has no provider-visible pre-assistant side-effect phase.
 Provider-visible cleanup and read acknowledgement must not run between local
-mailbox staging and assistant admission. Local inbox projection and audio/video
-transcript enrichment may run after local staging and before assistant admission because
-they only update rebuildable local projection artifacts and `AssistantInputEvent`
-projection metadata. These projection updates must not request an additional
-workspace checkpoint. Linq inbound message deletion is still eventual, but it is
+mailbox staging and assistant admission. For attachment-bearing non-email input
+and direct raw email, local inbox projection and audio/video transcript
+enrichment may run after local staging and before assistant admission because
+they update rebuildable local projection artifacts and `AssistantInputEvent`
+projection metadata. Attachment-free non-email input proceeds from staging to
+admission without that work.
+Projection updates must not request an additional workspace checkpoint. Linq
+inbound message deletion is still eventual, but it is
 queued only after terminal handling evidence is durable under
 `.runtime/operations/assistant/auto-reply/evidence/<captureId>.json` and is
 drained through hosted provider-cleanup after the next successful runtime-owned

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -70,7 +70,7 @@ signal Temporal hosted orchestration
 restore hosted workspace
 import mailbox prefix into local runtime state and stage AssistantInputEvent rows
 pull pending device-sync dirty rows
-run best-effort local inbox projection plus audio/video transcript enrichment without checkpointing it
+for attachment-bearing non-email input and direct raw email, run best-effort local inbox projection plus audio/video transcript enrichment without checkpointing it
 run local runtime work until idle or budget
 wait for the runtime idle window, a coalesced wake, or a projected runtime wake
 checkpoint final dirty runtime state with checkpoint reason idle_shutdown; commit
@@ -91,10 +91,14 @@ source adapter -> AssistantInputEvent -> AssistantInputSource -> scanner / activ
 The hosted adapter is the mailbox importer. It decodes a conversation mailbox
 row into a bounded `AssistantInputEvent`, stages it in local runtime state,
 marks the active invocation dirty, and checkpoints that dirty state only at the
-final runtime-owned idle or scheduled-wake checkpoint. Best-effort inbox projection may
-run while the decoded wake is still in memory. Projection status is logged and
-local inbox artifacts may help the same invocation, but hosted runtime must not
-take a separate workspace checkpoint just to persist projection/cache cleanup.
+final runtime-owned idle or scheduled-wake checkpoint. Attachment-free Linq,
+Telegram, and WhatsApp input does not initialize or import inbox projection.
+Direct email retains raw-message projection because its staged preview is
+bounded; group-routed email remains intentionally raw-free.
+Attachment-bearing non-email input may run best-effort inbox projection while
+the decoded wake is still in memory so local attachment artifacts can help the
+same invocation, but hosted runtime must not take a separate workspace
+checkpoint just to persist projection/cache cleanup.
 Failed projection is not durably retried by hosted runtime unless a future
 executor adds enough typed remote projection reference data to reconstruct the
 work without raw payload duplication. Inbox capture state, raw attachment
@@ -695,13 +699,17 @@ caller sends its existing ensure-processing HTTP timeout as an internal header.
 Cloudflare treats that value as an operational hint only: the foreground
 pre-accept budget is clamped by Cloudflare's configured web-control timeout, and
 workspace read/readiness steps are capped by the remaining budget. Accepted
-background invocations are registered with the Durable Object lifetime.
+background invocations begin their pending I/O before acceptance; Durable Object
+`waitUntil()` is not a lifecycle mechanism and is not used.
 Accepted starts and wakes return an owner recheck aligned to the
 expected idle checkpoint horizon rather than a short durable-lag polling loop. A
-runtime fence whose child is missing is replaced after the startup grace window
-when a later ensure command observes it. A wake-unconfirmed active child is not
-replaced; the caller retries until the child finishes, becomes wakeable, or is no
-longer active.
+same-version runtime fence whose child is missing remains protected by the
+startup grace window. When an identity-aware direct wake proves that the exact
+stored prior-version container has no active child, UserRunner immediately
+compare-and-swap replaces that fence. Concurrent replacement callers converge
+on the authoritative current fence record returned by the same compare-and-swap.
+A wake-unconfirmed active child is not replaced; the caller retries until the
+child finishes, becomes wakeable, or is no longer active.
 A failed transport call to an accepted invocation does not prove the invocation
 died. Before clearing the write fence after an invoke transport failure, the
 UserRunner probes the RunnerContainer for the exact fence identity
@@ -780,12 +788,14 @@ The runtime stages decoded conversation rows as assistant input and marks the
 active invocation dirty. Foreground runtime work may defer intermediate checkpoints.
 The active invocation remains dirty until the runtime-owned
 idle or scheduled-wake checkpoint succeeds. RunnerContainer never records
-pending checkpoint intent. Activity expiry is cleanup-only. Projection status
-is logged and artifacts remain rebuildable best-effort state rather than a
-reason to take another workspace checkpoint, so failed or slow projection does
-not block assistant admission and does not imply a durable retry queue.
-Successful projection may make raw attachment paths, image evidence, or
-audio/video transcript evidence available to the same assistant turn.
+pending checkpoint intent. Activity expiry is cleanup-only. Attachment-free
+non-email input skips projection and cannot be delayed by projection
+initialization or history scans. Direct-email and attachment projection status
+is logged and its artifacts remain rebuildable best-effort state rather than a
+reason to take another workspace
+checkpoint or create a durable retry queue. Successful attachment projection
+may make raw paths, image evidence, or audio/video transcript evidence
+available to the same assistant turn.
 Assistant prompt preparation reads derived attachment evidence sequentially
 under one 32 MiB budget for the current turn and a 16 MiB per-file limit. Hosted
 artifact materialization rejects an external artifact whose declared size is
@@ -857,11 +867,14 @@ terminal auto-reply evidence, not from mailbox import progress.
 
 Mailbox import has no provider-visible pre-assistant side-effect phase.
 Provider-visible cleanup and read acknowledgement must not run between local
-mailbox staging and assistant admission. Local inbox projection and audio/video
-transcript enrichment may run after local staging and before assistant admission because
-they only update rebuildable local projection artifacts and `AssistantInputEvent`
-projection metadata. These projection updates must not request an additional
-workspace checkpoint. Linq inbound message deletion is still eventual, but it is
+mailbox staging and assistant admission. For attachment-bearing non-email input
+and direct raw email, local inbox projection and audio/video transcript
+enrichment may run after local staging and before assistant admission because
+they update rebuildable local projection artifacts and `AssistantInputEvent`
+projection metadata. Attachment-free non-email input proceeds from staging to
+admission without that work.
+Projection updates must not request an additional workspace checkpoint. Linq
+inbound message deletion is still eventual, but it is
 queued only after terminal handling evidence is durable under
 `.runtime/operations/assistant/auto-reply/evidence/<captureId>.json` and is
 drained through hosted provider-cleanup after the next successful runtime-owned

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -70,7 +70,7 @@ signal Temporal hosted orchestration
 restore hosted workspace
 import mailbox prefix into local runtime state and stage AssistantInputEvent rows
 pull pending device-sync dirty rows
-for attachment-bearing non-email input and direct raw email, run best-effort local inbox projection plus audio/video transcript enrichment without checkpointing it
+for Linq input with link parts, attachment-bearing non-email input, and direct raw email, run best-effort local inbox projection plus audio/video transcript enrichment without checkpointing it
 run local runtime work until idle or budget
 wait for the runtime idle window, a coalesced wake, or a projected runtime wake
 checkpoint final dirty runtime state with checkpoint reason idle_shutdown; commit
@@ -91,8 +91,9 @@ source adapter -> AssistantInputEvent -> AssistantInputSource -> scanner / activ
 The hosted adapter is the mailbox importer. It decodes a conversation mailbox
 row into a bounded `AssistantInputEvent`, stages it in local runtime state,
 marks the active invocation dirty, and checkpoints that dirty state only at the
-final runtime-owned idle or scheduled-wake checkpoint. Attachment-free Linq,
-Telegram, and WhatsApp input does not initialize or import inbox projection.
+final runtime-owned idle or scheduled-wake checkpoint. Plain-text Linq plus
+attachment-free Telegram and WhatsApp input does not initialize or import inbox
+projection. Linq input with link parts retains the existing projection path.
 Direct email retains raw-message projection because its staged preview is
 bounded; group-routed email remains intentionally raw-free.
 Attachment-bearing non-email input may run best-effort inbox projection while
@@ -805,11 +806,11 @@ The runtime stages decoded conversation rows as assistant input and marks the
 active invocation dirty. Foreground runtime work may defer intermediate checkpoints.
 The active invocation remains dirty until the runtime-owned
 idle or scheduled-wake checkpoint succeeds. RunnerContainer never records
-pending checkpoint intent. Activity expiry is cleanup-only. Attachment-free
-non-email input skips projection and cannot be delayed by projection
-initialization or history scans. Direct-email and attachment projection status
-is logged and its artifacts remain rebuildable best-effort state rather than a
-reason to take another workspace
+pending checkpoint intent. Activity expiry is cleanup-only. Plain-text Linq plus
+attachment-free Telegram and WhatsApp input skips projection and cannot be
+delayed by projection initialization or history scans. Linq links, direct email,
+and attachment projection status are logged, and their artifacts remain
+rebuildable best-effort state rather than a reason to take another workspace
 checkpoint or create a durable retry queue. Successful attachment projection
 may make raw paths, image evidence, or audio/video transcript evidence
 available to the same assistant turn.
@@ -884,12 +885,13 @@ terminal auto-reply evidence, not from mailbox import progress.
 
 Mailbox import has no provider-visible pre-assistant side-effect phase.
 Provider-visible cleanup and read acknowledgement must not run between local
-mailbox staging and assistant admission. For attachment-bearing non-email input
-and direct raw email, local inbox projection and audio/video transcript
-enrichment may run after local staging and before assistant admission because
-they update rebuildable local projection artifacts and `AssistantInputEvent`
-projection metadata. Attachment-free non-email input proceeds from staging to
-admission without that work.
+mailbox staging and assistant admission. For Linq input with link parts,
+attachment-bearing non-email input, and direct raw email, local inbox projection
+and audio/video transcript enrichment may run after local staging and before
+assistant admission because they update rebuildable local projection artifacts
+and `AssistantInputEvent` projection metadata. Plain-text Linq plus
+attachment-free Telegram and WhatsApp input proceeds from staging to admission
+without that work.
 Projection updates must not request an additional workspace checkpoint. Linq
 inbound message deletion is still eventual, but it is
 queued only after terminal handling evidence is durable under

--- a/apps/cloudflare/src/user-runner/diagnostics.ts
+++ b/apps/cloudflare/src/user-runner/diagnostics.ts
@@ -19,8 +19,7 @@ export type RuntimeProcessingRetryReason =
   | "container_rpc_timeout"
   | "command_budget_exhausted"
   | "missing_container_binding"
-  | "starting_fence_preserved"
-  | "stale_fence_replacement_race";
+  | "starting_fence_preserved";
 
 export type RuntimeProcessingStartFailureRetryReason = Extract<
   RuntimeProcessingRetryReason,

--- a/apps/cloudflare/src/user-runner/hosted-user-runner.ts
+++ b/apps/cloudflare/src/user-runner/hosted-user-runner.ts
@@ -106,7 +106,6 @@ export class HostedUserRunner {
       invocationService: runtimeInvocation,
       runnerContainerNamespace,
       runnerRuntimeEnvSource,
-      state,
       stateStore: this.stateStore,
     });
     this.runtimeProcessing = runtimeProcessing;

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -58,7 +58,6 @@ import {
   type RunnerWriteFenceToken,
 } from "./runner-state-store.js";
 import type {
-  DurableObjectStateLike,
   RunnerRuntimeProcessingMode,
   RunnerStateRecord,
 } from "./types.js";
@@ -118,7 +117,6 @@ export class RuntimeProcessingController {
       invocationService: RuntimeInvocationService;
       runnerContainerNamespace: HostedExecutionContainerNamespaceLike | null;
       runnerRuntimeEnvSource: Readonly<Record<string, unknown>>;
-      state: DurableObjectStateLike;
       stateStore: RunnerStateStore;
     },
   ) {}
@@ -171,6 +169,12 @@ export class RuntimeProcessingController {
   }): Promise<HostedRuntimeEnsureProcessingResponse> {
     const record = input.record;
     if (!record.writeFence) {
+      if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
+        return createRuntimeProcessingRetryLater({
+          reason: "command_budget_exhausted",
+          userId: input.input.userId,
+        });
+      }
       return await this.startRuntimeProcessing({
         action: "started",
         commandBudget: input.commandBudget,
@@ -299,6 +303,11 @@ export class RuntimeProcessingController {
         activeFence,
         commandBudget: input.commandBudget,
         input: inputAfterActiveWake,
+        preserveStartingFence:
+          this.shouldPreserveStartingFenceAfterDirectNoChild({
+            activeFence,
+            record,
+          }),
         record,
         runtimeWakeStartedAt: input.runtimeWakeStartedAt,
       });
@@ -352,9 +361,11 @@ export class RuntimeProcessingController {
       userId: record.userId,
     });
     if (!cleared.cleared) {
-      return createRuntimeProcessingRetryLater({
-        reason: "stale_fence_replacement_race",
-        userId: input.input.userId,
+      return await this.ensureExistingRuntimeProcessing({
+        commandBudget: input.commandBudget,
+        input: input.input,
+        record: cleared.record,
+        runtimeWakeStartedAt: input.runtimeWakeStartedAt,
       });
     }
     if (!this.hasRuntimeProcessingCommandBudgetRemaining(input.commandBudget)) {
@@ -579,6 +590,20 @@ export class RuntimeProcessingController {
     });
   }
 
+  private shouldPreserveStartingFenceAfterDirectNoChild(input: {
+    activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
+    record: RunnerStateRecord;
+  }): boolean {
+    const activeContainerName = this.readActiveRuntimeFenceContainerName(input);
+    if (!activeContainerName) {
+      return true;
+    }
+    return activeContainerName === resolveHostedExecutionRunnerContainerName({
+      source: this.input.runnerRuntimeEnvSource,
+      userId: input.record.userId,
+    });
+  }
+
   private async startRuntimeProcessing(input: {
     action: "started" | "replaced";
     commandBudget: RuntimeProcessingCommandBudget;
@@ -665,9 +690,11 @@ export class RuntimeProcessingController {
       token: prepared.token,
     });
     if (!stillOwnsPreparedFence) {
-      return createRuntimeProcessingRetryLater({
-        reason: "stale_fence_replacement_race",
-        userId: processingInput.userId,
+      return await this.ensureExistingRuntimeProcessing({
+        commandBudget: input.commandBudget,
+        input: processingInput,
+        record: await this.input.stateStore.readState(),
+        runtimeWakeStartedAt: input.runtimeWakeStartedAt,
       });
     }
 
@@ -681,7 +708,7 @@ export class RuntimeProcessingController {
         },
       },
     };
-    const background = this.input.invocationService.invokePreparedWithFence({
+    void this.input.invocationService.invokePreparedWithFence({
       acceptedProcessingAttempt: true,
       prepared: acceptedPrepared,
       runtimeWakeStartedAt: input.runtimeWakeStartedAt,
@@ -689,7 +716,6 @@ export class RuntimeProcessingController {
       () => undefined,
       () => undefined,
     );
-    this.input.state.waitUntil(background);
 
     emitHostedExecutionStructuredLog({
       component: "hosted.runner",

--- a/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
@@ -18,7 +18,6 @@ export function computeRuntimeProcessingRetryAt(
 ): string {
   const delayMs =
     reason === "starting_fence_preserved" ? 3_000 :
-    reason === "stale_fence_replacement_race" ? 5_000 :
     reason === "container_busy" ? 5_000 :
     reason === "command_budget_exhausted" ? 10_000 :
     reason === "container_rpc_timeout" ? 10_000 :

--- a/apps/cloudflare/test/hosted-local-snapshot-publication-fallback-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-snapshot-publication-fallback-e2e.test.ts
@@ -185,10 +185,9 @@ describe("hosted local snapshot publication fallback e2e", () => {
       .toBeGreaterThanOrEqual(initialWorkspaceVersion);
     expect(countSnapshotPublicationFaults()).toBe(baselineFaultCount + 1);
 
-    const destroyedStatus = await waitForInvokeFailureDestroy({
+    await waitForInvokeFailureDestroy({
       baselineInvokeFailureDestroyCount,
     });
-    expect(destroyedStatus.workspace?.snapshotRef).toEqual(baselineSnapshotRef);
 
     const providerRequestBaseline = countAssistantProviderResponsesApiRequests();
     requireScenario().queueAssistantResponses([
@@ -321,38 +320,17 @@ async function waitForRejectedSnapshotPublication(input: {
 
 async function waitForInvokeFailureDestroy(input: {
   baselineInvokeFailureDestroyCount: number;
-}): Promise<HostedRunnerStatusResponse> {
+}): Promise<void> {
   const startedAt = Date.now();
-  let lastStatus: HostedRunnerStatusResponse | null = null;
-  let lastStatusReadError: string | null = null;
   while (Date.now() - startedAt < 120_000) {
-    const destroyObserved =
-      countInvokeFailureDestroyRequests() > input.baselineInvokeFailureDestroyCount;
-    if (destroyObserved && lastStatus) {
-      return lastStatus;
-    }
-
-    try {
-      lastStatus = await requireScenario().harness.readUserStatus(userId);
-      lastStatusReadError = null;
-    } catch (error) {
-      lastStatusReadError = error instanceof Error
-        ? `status read failed with ${error.name}`
-        : "status read failed with an unknown error";
-      await sleep(250);
-      continue;
-    }
-
     if (countInvokeFailureDestroyRequests() > input.baselineInvokeFailureDestroyCount) {
-      return lastStatus;
+      return;
     }
     await sleep(250);
   }
 
   throw new Error(await requireScenario().buildFailureMessage(userId, [
     "Timed out waiting for the failed snapshot publication to recycle its runner container.",
-    ...(lastStatus ? [`last status: ${JSON.stringify(lastStatus)}`] : []),
-    ...(lastStatusReadError ? [lastStatusReadError] : []),
   ]));
 }
 

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -154,7 +154,6 @@ describe("hosted runner container identity", () => {
         readyContainerNames,
       }),
       runnerRuntimeEnvSource,
-      state: durable.state,
       stateStore,
     });
 
@@ -197,7 +196,6 @@ describe("hosted runner container identity", () => {
           id: "version_1",
         },
       },
-      state: durable.state,
       stateStore,
     });
 
@@ -390,7 +388,6 @@ describe("hosted runner container identity", () => {
           id: "version-b",
         },
       },
-      state: durable.state,
       stateStore,
     });
 

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -2521,7 +2521,7 @@ describe("cloudflare worker routes", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-04-27T00:00:00.000Z"));
       const runtimeNextWakeAt = "2026-04-27T00:04:00.000Z";
-      const { alarms, invoke, runner, sql, waitUntil } = createRuntimeControlRunnerHarness({
+      const { alarms, invoke, runner, sql } = createRuntimeControlRunnerHarness({
         invocationResults: [{
           nextWakeAt: runtimeNextWakeAt,
           nextWakeReason: "assistant",
@@ -2546,17 +2546,14 @@ describe("cloudflare worker routes", () => {
         userId: "test-user",
         workspaceVersion: "7",
       });
-      expect(waitUntil).toHaveBeenCalledOnce();
-      const background = waitUntil.mock.calls[0]?.[0];
-      if (background instanceof Promise) {
-        await background;
-      }
-      expect(readRunnerMetaForRuntimeControl(sql)).toMatchObject({
-        active_attempt_id: null,
-        backoff_until: null,
-        failure_count: 0,
-        wake_at: null,
-      });
+      await vi.waitFor(() =>
+        expect(readRunnerMetaForRuntimeControl(sql)).toMatchObject({
+          active_attempt_id: null,
+          backoff_until: null,
+          failure_count: 0,
+          wake_at: null,
+        })
+      );
       expect(alarms).toEqual([]);
     });
 

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -127,7 +127,7 @@ describe("HostedUserRunner execution coordination", () => {
     >(async () => await readiness.promise);
     let callbackFenceAttemptId: string | null | undefined;
     let callbackSql!: TestSqlStorageLike;
-    const { alarms, flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+    const { alarms, invoke, runner, sql } = createRunnerHarness({
       ensureReadyForProcessing,
       mailboxLag: [createMailboxLag({ importedSeq: "1", lag: "0", maxSeq: "1" })],
       onOwnerReleased: ({ timeoutMs }) => {
@@ -181,7 +181,7 @@ describe("HostedUserRunner execution coordination", () => {
       }),
       workspaceVersion: "5",
     });
-    await flushWaitUntil();
+    await vi.waitFor(() => expect(callbackFenceAttemptId).toBeNull());
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: null,
       backoff_until: null,
@@ -208,7 +208,7 @@ describe("HostedUserRunner execution coordination", () => {
   it("clears the fence without owner release for a future mailbox continuation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
-    const { flushWaitUntil, runner, sql } = createRunnerHarness({
+    const { runner, sql } = createRunnerHarness({
       invocationResults: [{
         nextWakeAt: "2026-04-27T00:00:15.000Z",
         redactedStatus: {
@@ -226,9 +226,7 @@ describe("HostedUserRunner execution coordination", () => {
       action: "started",
       kind: "runtime_processing_accepted",
     });
-    await flushWaitUntil();
-
-    expect(readRunnerMeta(sql).active_attempt_id).toBeNull();
+    await vi.waitFor(() => expect(readRunnerMeta(sql).active_attempt_id).toBeNull());
     expect(
       mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
         (call) => call[0].path === HOSTED_RUNTIME_OWNER_RELEASED_PATH,
@@ -239,7 +237,7 @@ describe("HostedUserRunner execution coordination", () => {
   it("sends owner release when a selected wake is already due", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
-    const { flushWaitUntil, runner } = createRunnerHarness({
+    const { runner } = createRunnerHarness({
       invocationResults: [{
         nextWakeAt: FIXED_NOW,
         nextWakeReason: "assistant",
@@ -258,7 +256,13 @@ describe("HostedUserRunner execution coordination", () => {
       action: "started",
       kind: "runtime_processing_accepted",
     });
-    await flushWaitUntil();
+    await vi.waitFor(() =>
+      expect(
+        mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
+          (call) => call[0].path === HOSTED_RUNTIME_OWNER_RELEASED_PATH,
+        ),
+      ).toHaveLength(1)
+    );
 
     const ownerReleaseCalls =
       mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
@@ -271,7 +275,7 @@ describe("HostedUserRunner execution coordination", () => {
   it("carries an immediate recheck request in the signed owner-release query", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
-    const { flushWaitUntil, runner } = createRunnerHarness({
+    const { runner } = createRunnerHarness({
       invocationResults: [{
         immediateRecheckRequested: true,
         nextWakeAt: "2026-04-27T00:00:15.000Z",
@@ -291,7 +295,13 @@ describe("HostedUserRunner execution coordination", () => {
       action: "started",
       kind: "runtime_processing_accepted",
     });
-    await flushWaitUntil();
+    await vi.waitFor(() =>
+      expect(
+        mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
+          (call) => call[0].path === HOSTED_RUNTIME_OWNER_RELEASED_PATH,
+        ),
+      ).toHaveLength(1)
+    );
 
     const ownerReleaseCalls =
       mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
@@ -307,7 +317,7 @@ describe("HostedUserRunner execution coordination", () => {
   it("keeps successful completion when the owner-release callback fails", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
-    const { flushWaitUntil, runner, sql } = createRunnerHarness({
+    const { runner, sql } = createRunnerHarness({
       ownerReleaseResponse: () => new Response("unavailable", { status: 503 }),
     });
     await runner.bindUser(TEST_USER_ID);
@@ -319,7 +329,14 @@ describe("HostedUserRunner execution coordination", () => {
       action: "started",
       kind: "runtime_processing_accepted",
     });
-    await flushWaitUntil();
+    await vi.waitFor(() =>
+      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            "Hosted runner runtime owner-release recheck callback failed; preserving completed result.",
+        }),
+      )
+    );
 
     expect(readRunnerMeta(sql).active_attempt_id).toBeNull();
     expect(
@@ -339,7 +356,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    const { flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+    const { invoke, runner, sql } = createRunnerHarness({
       invocationResults: [invocationResult.promise],
     });
     await runner.bindUser(TEST_USER_ID);
@@ -357,7 +374,14 @@ describe("HostedUserRunner execution coordination", () => {
       "runtime-write-newer-owner",
     );
     invocationResult.resolve({ nextWakeAt: null, status: "idle" });
-    await flushWaitUntil();
+    await vi.waitFor(() =>
+      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            "Hosted runner runtime execution completed after its write fence changed; preserving completed result without transport retry.",
+        }),
+      )
+    );
 
     expect(
       mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
@@ -463,7 +487,7 @@ describe("HostedUserRunner execution coordination", () => {
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
     >(async () => "requested");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    const { invoke, runner, sql, waitUntilPromises } = createRunnerHarness({
+    const { invoke, runner, sql } = createRunnerHarness({
       invocationResults: [invocationResult.promise],
       workspace: createWorkspaceState({
         nextWakeAt: WORKSPACE_NEXT_WAKE_AT,
@@ -483,15 +507,8 @@ describe("HostedUserRunner execution coordination", () => {
       runtimeAttemptId: expect.stringMatching(/^runtime-write-/u),
     });
 
-    expect(waitUntilPromises).toHaveLength(1);
-    let waitUntilSettled = false;
-    waitUntilPromises[0]?.then(() => {
-      waitUntilSettled = true;
-    });
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     expect(invoke.mock.calls[0]?.[0].job.request).not.toHaveProperty("source");
-    await Promise.resolve();
-    expect(waitUntilSettled).toBe(false);
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.stringMatching(/^runtime-write-/u),
       active_workspace_version: "5",
@@ -509,8 +526,6 @@ describe("HostedUserRunner execution coordination", () => {
         last_invocation_at: expect.any(String),
       })
     );
-    await waitUntilPromises[0];
-    expect(waitUntilSettled).toBe(true);
   });
 
   it("keeps the fresh fence asynchronously when an accepted first container request fails without conclusive liveness", async () => {
@@ -533,7 +548,7 @@ describe("HostedUserRunner execution coordination", () => {
         version: "5",
       }),
     });
-    const { flushWaitUntil, invoke, runner, sql, waitUntilPromises } = harness;
+    const { invoke, runner, sql } = harness;
     await runner.bindUser(TEST_USER_ID);
 
     await expect(runner.ensureRuntimeProcessingForUser({
@@ -546,7 +561,6 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
-    expect(waitUntilPromises).toHaveLength(1);
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.stringMatching(/^runtime-write-/u),
       active_workspace_version: "5",
@@ -554,7 +568,13 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     invocationResult.reject(new Error("Hosted container first request failed."));
-    await flushWaitUntil();
+    await vi.waitFor(() =>
+      expect(
+        mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
+          (call) => call[0].path === HOSTED_RUNTIME_LOG_PATH,
+        ),
+      ).toHaveLength(1)
+    );
 
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.stringMatching(/^runtime-write-/u),
@@ -614,7 +634,7 @@ describe("HostedUserRunner execution coordination", () => {
       },
       version: "5",
     });
-    const { flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+    const { invoke, runner, sql } = createRunnerHarness({
       invocationResults: [invocationResult.promise],
       mailboxLag: [createMailboxLag({ lag: "0", maxSeq: "0" })],
       readActiveRuntimeUserFence: async () => ({
@@ -637,14 +657,14 @@ describe("HostedUserRunner execution coordination", () => {
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     workspace.version = "6";
     invocationResult.reject(new Error("Hosted container first request failed."));
-    await flushWaitUntil();
-
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      active_workspace_version: null,
-      failure_count: 0,
-      last_invocation_at: expect.any(String),
-    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        active_workspace_version: null,
+        failure_count: 0,
+        last_invocation_at: expect.any(String),
+      })
+    );
     await expect(runner.runnerStatus()).resolves.toMatchObject({
       inFlight: false,
       workspace: expect.objectContaining({
@@ -674,7 +694,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    const { flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+    const { invoke, runner, sql } = createRunnerHarness({
       invocationResults: [invocationResult.promise],
       runtimeLogResponse: () => new Response("unavailable", { status: 503 }),
       workspace: createWorkspaceState({
@@ -695,24 +715,24 @@ describe("HostedUserRunner execution coordination", () => {
 
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
     invocationResult.reject(new Error("Hosted container first request failed."));
-    await flushWaitUntil();
-
+    await vi.waitFor(() =>
+      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            orchestrationAttemptIdPresent: true,
+            workspaceAttemptIdPresent: true,
+            workspaceVersion: "5",
+          }),
+          message: "Hosted runner accepted runtime attempt failure log write failed.",
+        }),
+      )
+    );
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.stringMatching(/^runtime-write-/u),
       active_workspace_version: "5",
       failure_count: 0,
       last_invocation_at: null,
     });
-    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
-      expect.objectContaining({
-        details: expect.objectContaining({
-          orchestrationAttemptIdPresent: true,
-          workspaceAttemptIdPresent: true,
-          workspaceVersion: "5",
-        }),
-        message: "Hosted runner accepted runtime attempt failure log write failed.",
-      }),
-    );
     const failureLog = mocks.emitHostedExecutionStructuredLog.mock.calls
       .map((call) => call[0])
       .find((entry) =>
@@ -726,7 +746,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    const { flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+    const { invoke, runner, sql } = createRunnerHarness({
       invocationResults: [invocationResult.promise],
       workspace: createWorkspaceState({
         nextWakeAt: WORKSPACE_NEXT_WAKE_AT,
@@ -749,7 +769,14 @@ describe("HostedUserRunner execution coordination", () => {
     clearRuntimeFenceForTest(sql);
 
     invocationResult.reject(new Error("Hosted container first request failed."));
-    await flushWaitUntil();
+    await vi.waitFor(() =>
+      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            "Hosted runner runtime transport failed without safe fence-clear proof; preserving the write fence.",
+        }),
+      )
+    );
 
     const runtimeLogCalls = mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls
       .filter((call) => call[0].path === HOSTED_RUNTIME_LOG_PATH);
@@ -902,7 +929,7 @@ describe("HostedUserRunner execution coordination", () => {
     const ensureReadyForProcessing = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
     >(async () => ({ kind: "ready" }));
-    const { flushWaitUntil, runner } = createRunnerHarness({
+    const { runner, sql } = createRunnerHarness({
       ensureReadyForProcessing,
       onWorkspaceRead: (input) => {
         workspaceReadTimeouts.push(input.timeoutMs);
@@ -918,7 +945,7 @@ describe("HostedUserRunner execution coordination", () => {
       action: "started",
       kind: "runtime_processing_accepted",
     });
-    await flushWaitUntil();
+    await vi.waitFor(() => expect(readRunnerMeta(sql).active_attempt_id).toBeNull());
     expect(mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
       ([input]) => input.path === HOSTED_RUNTIME_CRYPTO_CONTEXT_PATH,
     )).toHaveLength(1);
@@ -932,7 +959,7 @@ describe("HostedUserRunner execution coordination", () => {
       action: "started",
       kind: "runtime_processing_accepted",
     });
-    await flushWaitUntil();
+    await vi.waitFor(() => expect(readRunnerMeta(sql).active_attempt_id).toBeNull());
 
     expect(workspaceReadTimeouts).toEqual([9_000, 4_000]);
     expect(mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
@@ -1139,7 +1166,74 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("does not invoke a prepared startup job after its write fence changes", async () => {
+  it("converges on current state without invoking a stale prepared startup job", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const readiness = createDeferred<Awaited<
+      ReturnType<NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>>
+    >>();
+    const ensureReadyForProcessing = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
+    >(async () => await readiness.promise);
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureReadyForProcessing,
+      invocationResults: [invocationResult.promise],
+      workspace: createWorkspaceState({ version: "5" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+
+    const accepted = runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt",
+      userId: TEST_USER_ID,
+    });
+
+    await vi.waitFor(() => expect(ensureReadyForProcessing).toHaveBeenCalledOnce());
+    const active = readRunnerMeta(sql);
+    expect(active.active_attempt_id).not.toBeNull();
+    const staleAttemptId = active.active_attempt_id;
+
+    clearRuntimeFenceForTest(sql);
+    vi.setSystemTime(new Date(FIXED_NOW));
+    readiness.resolve({ kind: "ready" });
+
+    const response = await accepted;
+    expect(response).toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+      runtimeAttemptId: expect.not.stringMatching(staleAttemptId ?? ""),
+    });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(ensureReadyForProcessing).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[0]?.[0].job.request.attemptId).not.toBe(staleAttemptId);
+    expect(invoke.mock.calls[0]?.[0].job.request.attemptId).toBe(
+      response.kind === "runtime_processing_accepted"
+        ? response.runtimeAttemptId
+        : null,
+    );
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: expect.not.stringMatching(staleAttemptId ?? ""),
+      wake_at: null,
+    });
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Hosted runner runtime processing startup confirmation finished after its write fence changed.",
+      }),
+    );
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
+  });
+
+  it("does not restart after prepared-fence ownership loss exhausts the command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const readiness = createDeferred<Awaited<
@@ -1153,32 +1247,50 @@ describe("HostedUserRunner execution coordination", () => {
       workspace: createWorkspaceState({ version: "5" }),
     });
     await runner.bindUser(TEST_USER_ID);
+    const initialFailureCount = readRunnerMeta(sql).failure_count;
 
-    const accepted = runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt",
+    const response = runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 10_000,
+      orchestrationAttemptId: "test-orchestration-attempt-expired-ownership-loss",
       userId: TEST_USER_ID,
     });
-
     await vi.waitFor(() => expect(ensureReadyForProcessing).toHaveBeenCalledOnce());
-    const active = readRunnerMeta(sql);
-    expect(active.active_attempt_id).not.toBeNull();
+    await vi.waitFor(() =>
+      expect(
+        mocks.emitHostedExecutionStructuredLog.mock.calls
+          .map((call) => call[0])
+          .filter((entry) => entry.message === "Hosted runner prepared workspace invocation."),
+      ).toHaveLength(1)
+    );
+    expect(readRunnerMeta(sql).active_attempt_id).not.toBeNull();
 
     clearRuntimeFenceForTest(sql);
-    vi.setSystemTime(new Date(FIXED_NOW));
+    vi.setSystemTime(new Date("2026-04-27T00:00:10.500Z"));
     readiness.resolve({ kind: "ready" });
 
-    await expect(accepted).resolves.toEqual({
+    await expect(response).resolves.toEqual({
       kind: "retry_later",
-      retryAt: "2026-04-27T00:00:05.000Z",
+      retryAt: "2026-04-27T00:00:20.500Z",
     });
+    expect(ensureReadyForProcessing).toHaveBeenCalledOnce();
+    expect(
+      mocks.emitHostedExecutionStructuredLog.mock.calls
+        .map((call) => call[0])
+        .filter((entry) => entry.message === "Hosted runner prepared workspace invocation."),
+    ).toHaveLength(1);
     expect(invoke).not.toHaveBeenCalled();
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: null,
+      failure_count: initialFailureCount,
+      last_invocation_at: null,
       wake_at: null,
     });
     expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "Hosted runner runtime processing startup confirmation finished after its write fence changed.",
+        details: expect.objectContaining({
+          runtimeProcessingRetryReason: "command_budget_exhausted",
+        }),
+        message: "Hosted runner runtime processing could not be accepted yet.",
       }),
     );
   });
@@ -2635,7 +2747,69 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
-  it("returns retry_later for a fresh non-wakeable startup fence", async () => {
+  it("replaces a recent prior-version fence after its exact container reports no active child", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => ({
+        kind: "start-required" as const,
+        reason: "no-active-child" as const,
+      }),
+    );
+    const runnerRuntimeEnvSource = {
+      ...TEST_RUNNER_RUNTIME_ENV_SOURCE,
+      CF_VERSION_METADATA: { id: "current" },
+    };
+    const priorRunnerContainerName = `${TEST_USER_ID}--v-prior`;
+    const currentRunnerContainerName = `${TEST_USER_ID}--v-current`;
+    const { invoke, runner, runnerContainerNames, sql } = createRunnerHarness({
+      ensureProcessing,
+      invocationResults: [invocationResult.promise],
+      runnerRuntimeEnvSource,
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: priorRunnerContainerName,
+      startedAt: FIXED_NOW,
+      workspaceVersion: "7",
+    });
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-replace-prior-version",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      recommendedRecheckAt: ACTIVE_RUNTIME_RECHECK_AT,
+      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledOnce();
+    expect(runnerContainerNames[0]).toBe(priorRunnerContainerName);
+    expect(runnerContainerNames).toContain(currentRunnerContainerName);
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: expect.not.stringMatching(token.attemptId),
+      active_expires_at: null,
+      backoff_until: null,
+      wake_at: null,
+    });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
+  });
+
+  it("returns retry_later for a fresh same-version non-wakeable startup fence", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
@@ -2646,10 +2820,15 @@ describe("HostedUserRunner execution coordination", () => {
     );
     const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
+      runnerRuntimeEnvSource: {
+        ...TEST_RUNNER_RUNTIME_ENV_SOURCE,
+        CF_VERSION_METADATA: { id: "current" },
+      },
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
+      runnerContainerName: `${TEST_USER_ID}--v-current`,
       workspaceVersion: "7",
     });
 
@@ -2832,6 +3011,183 @@ describe("HostedUserRunner execution coordination", () => {
         }),
         message: "Hosted runner runtime processing could not be accepted yet.",
       }),
+    );
+  });
+
+  it("starts immediately when a replacement CAS loser observes the cleared authoritative fence", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    type EnsureProcessingResult = Awaited<ReturnType<
+      NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>
+    >>;
+    const firstWakeResult = createDeferred<EnsureProcessingResult>();
+    const secondWakeResult = createDeferred<EnsureProcessingResult>();
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    let ensureCallIndex = 0;
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => {
+        const deferred = ensureCallIndex === 0
+          ? firstWakeResult
+          : secondWakeResult;
+        ensureCallIndex += 1;
+        return await deferred.promise;
+      },
+    );
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      invocationResults: [invocationResult.promise],
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const replacedToken = writeRuntimeFenceForTest(sql, {
+      startedAt: "2026-04-26T23:59:00.000Z",
+      workspaceVersion: "7",
+    });
+
+    const shortBudgetReplacement = runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 10_000,
+      orchestrationAttemptId: "test-orchestration-attempt-short-replacement",
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(ensureProcessing).toHaveBeenCalledOnce());
+    const convergingReplacement = runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 60_000,
+      orchestrationAttemptId: "test-orchestration-attempt-converging-replacement",
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(ensureProcessing).toHaveBeenCalledTimes(2));
+
+    vi.setSystemTime(new Date("2026-04-27T00:00:10.500Z"));
+    firstWakeResult.resolve({
+      kind: "start-required",
+      reason: "no-active-child",
+    });
+    await expect(shortBudgetReplacement).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:20.500Z",
+    });
+    expect(readRunnerMeta(sql).active_attempt_id).toBeNull();
+
+    secondWakeResult.resolve({
+      kind: "start-required",
+      reason: "no-active-child",
+    });
+    await expect(convergingReplacement).resolves.toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+      runtimeAttemptId: expect.not.stringMatching(replacedToken.attemptId),
+    });
+
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: expect.not.stringMatching(replacedToken.attemptId),
+      active_expires_at: null,
+      wake_at: null,
+    });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
+    );
+  });
+
+  it("converges on the current fence when a replacement CAS loses to another replacement", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    type EnsureProcessingResult = Awaited<ReturnType<
+      NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>
+    >>;
+    const firstWakeResult = createDeferred<EnsureProcessingResult>();
+    const secondWakeResult = createDeferred<EnsureProcessingResult>();
+    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    let ensureCallIndex = 0;
+    const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(
+      async () => {
+        const callIndex = ensureCallIndex;
+        ensureCallIndex += 1;
+        if (callIndex === 0) {
+          return await firstWakeResult.promise;
+        }
+        if (callIndex === 1) {
+          return await secondWakeResult.promise;
+        }
+        return {
+          action: "already_running",
+          kind: "accepted",
+        };
+      },
+    );
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureProcessing,
+      invocationResults: [invocationResult.promise],
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const replacedToken = writeRuntimeFenceForTest(sql, {
+      startedAt: "2026-04-26T23:59:00.000Z",
+      workspaceVersion: "7",
+    });
+
+    const winningReplacement = runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-winning-replacement",
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(ensureProcessing).toHaveBeenCalledOnce());
+    const convergingReplacement = runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-current-fence-convergence",
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(ensureProcessing).toHaveBeenCalledTimes(2));
+
+    firstWakeResult.resolve({
+      kind: "start-required",
+      reason: "no-active-child",
+    });
+    const winner = await winningReplacement;
+    expect(winner).toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+      runtimeAttemptId: expect.not.stringMatching(replacedToken.attemptId),
+    });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+
+    secondWakeResult.resolve({
+      kind: "start-required",
+      reason: "no-active-child",
+    });
+    await expect(convergingReplacement).resolves.toMatchObject({
+      action: "already_running",
+      kind: "runtime_processing_accepted",
+      runtimeAttemptId: winner.kind === "runtime_processing_accepted"
+        ? winner.runtimeAttemptId
+        : null,
+    });
+
+    expect(ensureProcessing).toHaveBeenCalledTimes(3);
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: winner.kind === "runtime_processing_accepted"
+        ? winner.runtimeAttemptId
+        : null,
+      active_expires_at: null,
+      wake_at: null,
+    });
+
+    invocationResult.resolve({
+      nextWakeAt: null,
+      status: "idle",
+    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        last_invocation_at: expect.any(String),
+      })
     );
   });
 
@@ -3311,7 +3667,7 @@ describe("HostedUserRunner execution coordination", () => {
         reason: "no-active-child" as const,
       }),
     );
-    const { flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+    const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       invocationResults: [invocationResult.promise],
       workspace: createWorkspaceState({ version: "8" }),
@@ -3346,11 +3702,12 @@ describe("HostedUserRunner execution coordination", () => {
       nextWakeAt: null,
       status: "idle",
     });
-    await flushWaitUntil();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      wake_at: null,
-    });
+    await vi.waitFor(() =>
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        wake_at: null,
+      })
+    );
   });
 
   it("does not read web status while handling runner alarms", async () => {
@@ -3417,7 +3774,7 @@ describe("HostedUserRunner execution coordination", () => {
         reason: "no-active-child" as const,
       }),
     );
-    const { flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+    const { invoke, runner, sql } = createRunnerHarness({
       ensureProcessing,
       workspace: createWorkspaceState({ version: "7" }),
     });
@@ -3446,11 +3803,12 @@ describe("HostedUserRunner execution coordination", () => {
       },
       userId: TEST_USER_ID,
     });
-    await flushWaitUntil();
-    expect(invoke).toHaveBeenCalledOnce();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: null,
-      wake_at: null,
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledOnce();
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        wake_at: null,
+      });
     });
   });
 
@@ -4188,8 +4546,10 @@ function createRunnerHarness(input: {
         }
       : {}),
   };
+  const runnerContainerNames: string[] = [];
   const namespace: HostedExecutionContainerNamespaceLike = {
-    getByName() {
+    getByName(name) {
+      runnerContainerNames.push(name);
       return stub;
     },
   };
@@ -4226,9 +4586,9 @@ function createRunnerHarness(input: {
     },
     invoke,
     runner,
+    runnerContainerNames,
     sql: durable.sql,
     storageValues: durable.storageValues,
-    waitUntilPromises: durable.waitUntilPromises,
   };
 }
 

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -69,6 +69,10 @@ executable tests.
   compaction, cleanup, device sync, browser refresh, cron, replay catch-up, and
   unrelated mailbox work stay off that path. Keep their static dependency
   closure and initialization off-path too, not only their explicit waits.
+- Once current input is durably staged, a rebuildable projection may precede
+  assistant admission only when that input needs projection-owned evidence not
+  present in the staged input. Projection maintenance, indexing, or dedupe is
+  never itself admission authority.
 - Signal foreground availability at the earliest durable staging boundary,
   before projection, full import completion, maintenance, or routine
   checkpointing. Typing or activity signals are best-effort and cannot delay
@@ -190,6 +194,9 @@ executable tests.
   has an item, time, or attempt bound plus an abort or durable continuation
   path. Foreground latency must not grow without bound with unrelated history,
   backlog, workspace size, file count, transcripts, or logs.
+- Recovery candidate enumeration begins from surviving staged evidence. Clean
+  terminal metadata without stage residue is not recovery work. Narrowing that
+  enumeration must preserve canonical identity across physical partitions.
 
 ## Provider And Runtime Boundaries
 
@@ -209,6 +216,10 @@ executable tests.
 - Execution planes stay thin. Platform coordination, secret injection,
   workspace transport, and write fences remain separate from assistant business
   logic, canonical data semantics, and product state.
+- A runtime ownership grace window may be bypassed only after exact,
+  target-specific proof that the prior owner has no live execution. Missing,
+  ambiguous, or same-target evidence stays fail-closed, and concurrent claimants
+  converge on the durable owner record.
 
 ## Product-Critical Flow Preservation
 

--- a/packages/assistant-runtime/README.md
+++ b/packages/assistant-runtime/README.md
@@ -30,11 +30,15 @@ source adapter -> AssistantInputEvent -> AssistantInputSource -> scanner/active 
 ```
 
 For hosted conversation traffic, the mailbox importer is the source adapter. It
-stages bounded `AssistantInputEvent` records in the warm live workspace, then
-makes one best-effort inbox projection attempt while the decoded wake is still
-in memory. That projection preserves raw attachment paths for inspectable files
-and drains only audio/video transcription jobs before prompt construction when
-media parser output is available. Normal foreground work may defer intermediate hosted workspace
+stages bounded `AssistantInputEvent` records in the warm live workspace.
+Attachment-free Linq, Telegram, and WhatsApp input proceeds directly to
+assistant admission without opening the inbox runtime. Email retains raw-message
+projection for direct messages because its staged preview is bounded;
+group-routed email remains intentionally raw-free. Attachment-bearing non-email
+input makes one best-effort inbox projection attempt while the decoded wake is
+still in memory so raw attachment paths remain inspectable and audio/video
+transcription jobs can drain before prompt construction when parser output is
+available. Normal foreground work may defer intermediate hosted workspace
 checkpoints before Codex admission or reply delivery. The active invocation
 remains dirty until the runtime-owned idle/scheduled-wake
 `idle_shutdown` checkpoint succeeds; if the container dies before that

--- a/packages/assistant-runtime/README.md
+++ b/packages/assistant-runtime/README.md
@@ -33,11 +33,15 @@ source adapter -> AssistantInputEvent -> AssistantInputSource -> scanner/active 
 ```
 
 For hosted conversation traffic, the mailbox importer is the source adapter. It
-stages bounded `AssistantInputEvent` records in the warm live workspace, then
-makes one best-effort inbox projection attempt while the decoded wake is still
-in memory. That projection preserves raw attachment paths for inspectable files
-and drains only audio/video transcription jobs before prompt construction when
-media parser output is available. Normal foreground work may defer intermediate hosted workspace
+stages bounded `AssistantInputEvent` records in the warm live workspace.
+Attachment-free Linq, Telegram, and WhatsApp input proceeds directly to
+assistant admission without opening the inbox runtime. Email retains raw-message
+projection for direct messages because its staged preview is bounded;
+group-routed email remains intentionally raw-free. Attachment-bearing non-email
+input makes one best-effort inbox projection attempt while the decoded wake is
+still in memory so raw attachment paths remain inspectable and audio/video
+transcription jobs can drain before prompt construction when parser output is
+available. Normal foreground work may defer intermediate hosted workspace
 checkpoints before Codex admission or reply delivery. The active invocation
 remains dirty until the runtime-owned idle/scheduled-wake
 `idle_shutdown` checkpoint succeeds; if the container dies before that

--- a/packages/assistant-runtime/README.md
+++ b/packages/assistant-runtime/README.md
@@ -34,8 +34,9 @@ source adapter -> AssistantInputEvent -> AssistantInputSource -> scanner/active 
 
 For hosted conversation traffic, the mailbox importer is the source adapter. It
 stages bounded `AssistantInputEvent` records in the warm live workspace.
-Attachment-free Linq, Telegram, and WhatsApp input proceeds directly to
-assistant admission without opening the inbox runtime. Email retains raw-message
+Plain-text Linq plus attachment-free Telegram and WhatsApp input proceeds
+directly to assistant admission without opening the inbox runtime. Linq input
+with link parts retains the existing projection path. Email retains raw-message
 projection for direct messages because its staged preview is bounded;
 group-routed email remains intentionally raw-free. Attachment-bearing non-email
 input makes one best-effort inbox projection attempt while the decoded wake is

--- a/packages/assistant-runtime/src/hosted-runtime/context.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/context.ts
@@ -23,7 +23,6 @@ import {
   readAssistantAutomationState,
   reconcileManagedAssistantAutoReplyChannelsLocal,
 } from "@murphai/assistant-engine/assistant-state";
-import { createIntegratedInboxServices } from "@murphai/inbox-services";
 import { createIntegratedVaultServices } from "@murphai/vault-usecases/vault-services";
 import {
   ensureHostedAssistantOperatorDefaults,
@@ -762,18 +761,4 @@ export async function requireHostedBootstrapForWake(
   throw new Error(
     `Hosted execution for ${wake.kind} requires member.activated bootstrap first.`,
   );
-}
-
-export async function prepareHostedInboxProjectionRuntime(
-  vaultRoot: string,
-  requestId: string,
-): Promise<void> {
-  const normalizedVaultRoot = path.resolve(vaultRoot);
-  const inboxServices = createIntegratedInboxServices();
-  await inboxServices.init({
-    rebuild: false,
-    rebuildParserJobs: false,
-    requestId,
-    vault: normalizedVaultRoot,
-  });
 }

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -1169,7 +1169,7 @@ function createHostedConversationAssistantInputText(
 ): string {
   if (isHostedLinqConversationMessageWake(wake)) {
     const textParts = wake.message.linqMessage.parts
-      .filter((part) => part.type === "text" || part.type === "link")
+      .filter((part) => part.type === "text")
       .map((part) => part.value);
     const text = normalizeHostedAssistantInputText(textParts.join("\n"));
     if (text) {
@@ -1886,6 +1886,12 @@ function requiresHostedConversationInboxProjection(input: {
       === "group"
   ) {
     return false;
+  }
+  if (
+    isHostedLinqConversationMessageWake(input.wake)
+    && input.wake.message.linqMessage.parts.some((part) => part.type === "link")
+  ) {
+    return true;
   }
   if (input.attachmentDescriptorCount !== 0) {
     return true;

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 
 import type {
   HostedExecutionConversationMessageWake,
@@ -70,7 +71,6 @@ import {
   enqueueHostedPendingAssistantInputId,
 } from "./pending-input-index.ts";
 import {
-  prepareHostedInboxProjectionRuntime,
   prepareHostedAssistantAutoReplyForWake,
   requireHostedBootstrapForWake,
   type HostedAssistantAutoReplyReadinessState,
@@ -406,6 +406,19 @@ export async function importHostedConversationMailboxItem(input: {
   const linqDeliveryContext = buildHostedAssistantLinqDeliveryContextFromWake(decoded.wake);
   const emailDeliveryContext = buildHostedAssistantEmailDeliveryContextFromWake(decoded.wake);
   assertHostedConversationMailboxImportLive(input.signal ?? null);
+  if (!requiresHostedConversationInboxProjection({
+    attachmentDescriptorCount: stagedInput.attachmentDescriptorCount,
+    wake: decoded.wake,
+  })) {
+    return {
+      assistantInputId: stagedInput.inputId,
+      captureId: null,
+      ...(emailDeliveryContext ? { emailDeliveryContext } : {}),
+      ...(linqDeliveryContext ? { linqDeliveryContext } : {}),
+      metrics: createEmptyHostedConversationWakeMetrics(),
+      status: "imported",
+    };
+  }
   const projectionEffect = await projectHostedConversationAssistantInputBestEffort({
     importConversationWake,
     loadAttachmentEvidenceCapture,
@@ -881,11 +894,27 @@ async function stageHostedConversationAssistantInputEvent(input: {
     mailboxItemId: input.item.item.id,
     vault: input.vaultRoot,
   });
-  if (event.projection.status === "not_attempted") {
+  const projectionRequired = requiresHostedConversationInboxProjection({
+    attachmentDescriptorCount: event.content.attachmentDescriptors.length,
+    wake: input.wake,
+  });
+  if (
+    projectionRequired
+    && event.projection.status === "not_attempted"
+  ) {
     await updateAssistantInputProjection({
       inputId: event.inputId,
       projection: {
         status: "pending",
+      },
+      vault: input.vaultRoot,
+    });
+  }
+  if (!projectionRequired && event.projection.status === "pending") {
+    await updateAssistantInputProjection({
+      inputId: event.inputId,
+      projection: {
+        status: "not_attempted",
       },
       vault: input.vaultRoot,
     });
@@ -1140,7 +1169,7 @@ function createHostedConversationAssistantInputText(
 ): string {
   if (isHostedLinqConversationMessageWake(wake)) {
     const textParts = wake.message.linqMessage.parts
-      .filter((part) => part.type === "text")
+      .filter((part) => part.type === "text" || part.type === "link")
       .map((part) => part.value);
     const text = normalizeHostedAssistantInputText(textParts.join("\n"));
     if (text) {
@@ -1847,6 +1876,23 @@ function decodedWakeMatchesMailboxItem(
     && wake.eventId === item.dedupeKey;
 }
 
+function requiresHostedConversationInboxProjection(input: {
+  attachmentDescriptorCount: number | undefined;
+  wake: HostedExecutionConversationMessageWake;
+}): boolean {
+  if (
+    isHostedEmailConversationMessageWake(input.wake)
+    && parseHostedEmailThreadTarget(input.wake.message.threadTarget)?.targetKind
+      === "group"
+  ) {
+    return false;
+  }
+  if (input.attachmentDescriptorCount !== 0) {
+    return true;
+  }
+  return isHostedEmailConversationMessageWake(input.wake);
+}
+
 async function prepareHostedConversationMailboxWakeContext(input: {
   runtime: Pick<
     NormalizedHostedAssistantRuntimeConfig,
@@ -1856,10 +1902,13 @@ async function prepareHostedConversationMailboxWakeContext(input: {
   wake: HostedExecutionConversationMessageWake;
 }): Promise<void> {
   void input.runtime;
-  await prepareHostedInboxProjectionRuntime(
-    input.vaultRoot,
-    input.wake.eventId,
-  );
+  const inboxServices = createIntegratedInboxServices();
+  await inboxServices.init({
+    rebuild: false,
+    rebuildParserJobs: false,
+    requestId: input.wake.eventId,
+    vault: path.resolve(input.vaultRoot),
+  });
 }
 
 function normalizeConversationMailboxReasonCode(

--- a/packages/assistant-runtime/test/hosted-runtime-context-coverage.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-context-coverage.test.ts
@@ -23,12 +23,9 @@ import {
 import { resolveAssistantStatePaths } from "@murphai/runtime-state/node";
 
 const mocks = vi.hoisted(() => ({
-  createIntegratedInboxServices: vi.fn(),
   createIntegratedVaultServices: vi.fn(),
   emitHostedExecutionStructuredLog: vi.fn(),
   ensureHostedAssistantOperatorDefaults: vi.fn(),
-  inboxInit: vi.fn(),
-  inboxList: vi.fn(),
   readOperatorConfig: vi.fn(),
   resolveHostedAssistantConfig: vi.fn(),
   resolveHostedAssistantOperatorDefaultsState: vi.fn(),
@@ -45,10 +42,6 @@ vi.mock("@murphai/hosted-execution", async () => {
     emitHostedExecutionStructuredLog: mocks.emitHostedExecutionStructuredLog,
   };
 });
-
-vi.mock("@murphai/inbox-services", () => ({
-  createIntegratedInboxServices: mocks.createIntegratedInboxServices,
-}));
 
 vi.mock("@murphai/vault-usecases/vault-services", () => ({
   createIntegratedVaultServices: mocks.createIntegratedVaultServices,
@@ -81,7 +74,6 @@ vi.mock("@murphai/operator-config/operator-config", async () => {
 import {
   applyHostedMemberPreferences,
   prepareHostedWakeContext,
-  prepareHostedInboxProjectionRuntime,
   readHostedAssistantRuntimeState,
   reconcileHostedAssistantChannelState,
   requireHostedBootstrapForWake,
@@ -132,10 +124,6 @@ async function createWorkspace(): Promise<{ cleanup: () => Promise<void>; vaultR
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.createIntegratedInboxServices.mockReturnValue({
-    init: mocks.inboxInit,
-    list: mocks.inboxList,
-  });
   mocks.createIntegratedVaultServices.mockReturnValue({
     core: {
       init: mocks.vaultInit,
@@ -147,10 +135,6 @@ beforeEach(() => {
     seeded: false,
     source: "missing",
   });
-  mocks.inboxList.mockResolvedValue({
-    items: [],
-  });
-  mocks.inboxInit.mockResolvedValue(undefined);
   mocks.readOperatorConfig.mockResolvedValue(null);
   mocks.resolveHostedAssistantConfig.mockResolvedValue(null);
   mocks.resolveHostedAssistantOperatorDefaultsState.mockReturnValue({
@@ -310,9 +294,7 @@ describe("hosted runtime context coverage", () => {
       );
 
       assert.equal(result, null);
-      expect(mocks.inboxList).not.toHaveBeenCalled();
       expect(mocks.vaultInit).not.toHaveBeenCalled();
-      expect(mocks.inboxInit).not.toHaveBeenCalled();
     } finally {
       await cleanup();
     }
@@ -600,7 +582,6 @@ describe("hosted runtime context coverage", () => {
         ],
         updatedAt: "2026-04-08T00:05:00.000Z",
       });
-      expect(mocks.inboxList).not.toHaveBeenCalled();
     } finally {
       await cleanup();
     }
@@ -677,7 +658,6 @@ describe("hosted runtime context coverage", () => {
         },
       ]);
       assert.equal(state.version, 1);
-      expect(mocks.inboxList).not.toHaveBeenCalled();
     } finally {
       await cleanup();
     }
@@ -848,24 +828,6 @@ describe("hosted runtime context coverage", () => {
         detail: 7,
         humor: 9,
       });
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("initializes cold current-message projection without a historical rebuild", async () => {
-    const { cleanup, vaultRoot } = await createWorkspace();
-
-    try {
-      await prepareHostedInboxProjectionRuntime(vaultRoot, "req_projection_without_startup");
-
-      expect(mocks.inboxInit).toHaveBeenCalledWith({
-        rebuild: false,
-        rebuildParserJobs: false,
-        requestId: "req_projection_without_startup",
-        vault: vaultRoot,
-      });
-      expect(mocks.emitHostedExecutionStructuredLog).not.toHaveBeenCalled();
     } finally {
       await cleanup();
     }

--- a/packages/assistant-runtime/test/hosted-runtime-linq-document-preservation-e2e.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-linq-document-preservation-e2e.test.ts
@@ -47,9 +47,6 @@ vi.mock("@murphai/operator-config/linq-runtime", () => ({
 import {
   importHostedConversationMessageWakeIntoLocalInbox,
 } from "../src/hosted-runtime/events/conversation.ts";
-import {
-  prepareHostedInboxProjectionRuntime,
-} from "../src/hosted-runtime/context.ts";
 
 describe("hosted Linq document preservation", () => {
   it("projects a cold current-message document without rebuilding history", async () => {
@@ -65,13 +62,21 @@ describe("hosted Linq document preservation", () => {
         },
       };
     });
+    const services = createIntegratedInboxServices({
+      loadImportersModule: async () => ({
+        createImporters: () => ({
+          importDocument,
+        }),
+      }),
+    });
 
     await initializeVault({ vaultRoot, createdAt: "2026-04-29T00:00:00.000Z" });
-    await prepareHostedInboxProjectionRuntime(
-      vaultRoot,
-      "req_init_cold_inbox_runtime",
-    );
-
+    await services.init({
+      rebuild: false,
+      rebuildParserJobs: false,
+      requestId: "req_init_cold_inbox_runtime",
+      vault: vaultRoot,
+    });
     mocks.createHostedLinqAttachmentDownloadDriver.mockReturnValue({
       downloadPart: vi.fn(async (part: { url?: string | null }) => {
         assert.equal(part.url, "https://cdn.example.test/attachments/lab-results.pdf");
@@ -156,14 +161,6 @@ describe("hosted Linq document preservation", () => {
       } finally {
         runtime.close();
       }
-
-      const services = createIntegratedInboxServices({
-        loadImportersModule: async () => ({
-          createImporters: () => ({
-            importDocument,
-          }),
-        }),
-      });
 
       await expect(
         services.show({

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -96,7 +96,7 @@ afterEach(async () => {
 });
 
 describe("hosted mailbox conversation import adapter", () => {
-  test("stages link-only Linq input and repairs stale pending projection state", async () => {
+  test("keeps link-only Linq input on the replay-compatible projection path", async () => {
     const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-link-input-"));
     tempRoots.push(parentRoot);
     const vaultRoot = path.join(parentRoot, "vault");
@@ -118,39 +118,48 @@ describe("hosted mailbox conversation import adapter", () => {
         phoneLookupKey: "redacted-contact-sentinel",
       },
     });
-    const prepareWakeContext = vi.fn(async () => {
-      throw new Error("attachment-free input must not prepare inbox projection");
-    });
+    const prepareWakeContext = vi.fn(async () => {});
+    const interruption = new Error("synthetic rollout interruption");
+    const signalController = new AbortController();
+    let importAttempt = 0;
     const importConversationWake = vi.fn(async () => {
-      throw new Error("attachment-free input must not import inbox projection");
+      importAttempt += 1;
+      if (importAttempt === 1) {
+        signalController.abort(interruption);
+        throw interruption;
+      }
+      return {
+        captureId: "cap_link_only",
+        metrics: {
+          nextWakeAt: null,
+          parserProcessed: 0,
+        },
+      };
     });
     const item = createResolvedConversationMailboxItem();
 
-    const outcome = await importHostedConversationMailboxItem({
-      decodePayload: createDecodedPayloadDecoder(decodedWake),
-      importConversationWake,
-      prepareWakeContext,
-      item,
-      runtime: createRuntime(),
-      vaultRoot,
-    });
+    await assert.rejects(
+      importHostedConversationMailboxItem({
+        decodePayload: createDecodedPayloadDecoder(decodedWake),
+        importConversationWake,
+        prepareWakeContext,
+        item,
+        runtime: createRuntime(),
+        signal: signalController.signal,
+        vaultRoot,
+      }),
+      (error: unknown) => error === interruption,
+    );
 
-    assert.equal(outcome.status, "imported");
     const listed = await listAssistantInputEvents({ vault: vaultRoot });
     assert.equal(listed.events.length, 1);
     assert.equal(
       listed.events[0]?.content.text,
-      "https://example.invalid/link-only",
+      "Received a Linq message.",
     );
     assert.equal(listed.events[0]?.content.attachmentDescriptors.length, 0);
-    assert.equal(listed.events[0]?.projection.status, "not_attempted");
-    const inputId = listed.events[0]?.inputId;
-    assert.ok(inputId);
-    await updateAssistantInputProjection({
-      inputId,
-      projection: { status: "pending" },
-      vault: vaultRoot,
-    });
+    assert.equal(listed.events[0]?.projection.status, "pending");
+    assert.equal(listed.events[0]?.projection.captureId, null);
 
     const replay = await importHostedConversationMailboxItem({
       decodePayload: createDecodedPayloadDecoder(decodedWake),
@@ -163,9 +172,11 @@ describe("hosted mailbox conversation import adapter", () => {
 
     assert.equal(replay.status, "imported");
     const replayed = await listAssistantInputEvents({ vault: vaultRoot });
-    assert.equal(replayed.events[0]?.projection.status, "not_attempted");
-    expect(prepareWakeContext).not.toHaveBeenCalled();
-    expect(importConversationWake).not.toHaveBeenCalled();
+    assert.equal(replayed.events[0]?.content.text, "Received a Linq message.");
+    assert.equal(replayed.events[0]?.projection.status, "succeeded");
+    assert.equal(replayed.events[0]?.projection.captureId, "cap_link_only");
+    expect(prepareWakeContext).toHaveBeenCalledTimes(2);
+    expect(importConversationWake).toHaveBeenCalledTimes(2);
   });
 
   test("upserts a minimized assistant input event before best-effort inbox projection", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -32,6 +32,7 @@ import {
   listAssistantInputEvents,
   resolveAssistantConversationLookupKey,
   updateAssistantInputAttachmentEvidence,
+  updateAssistantInputProjection,
 } from "@murphai/assistant-engine";
 import {
   readAssistantAutomationState,
@@ -95,6 +96,78 @@ afterEach(async () => {
 });
 
 describe("hosted mailbox conversation import adapter", () => {
+  test("stages link-only Linq input and repairs stale pending projection state", async () => {
+    const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-link-input-"));
+    tempRoots.push(parentRoot);
+    const vaultRoot = path.join(parentRoot, "vault");
+    const decodedWake = createConversationWake({
+      message: {
+        channel: "linq",
+        linqMessage: {
+          chatId: "chat_link_only",
+          from: "redacted-contact-sentinel",
+          isFromMe: false,
+          messageId: "msg_link_only",
+          parts: [
+            {
+              type: "link",
+              value: "https://example.invalid/link-only",
+            },
+          ],
+        },
+        phoneLookupKey: "redacted-contact-sentinel",
+      },
+    });
+    const prepareWakeContext = vi.fn(async () => {
+      throw new Error("attachment-free input must not prepare inbox projection");
+    });
+    const importConversationWake = vi.fn(async () => {
+      throw new Error("attachment-free input must not import inbox projection");
+    });
+    const item = createResolvedConversationMailboxItem();
+
+    const outcome = await importHostedConversationMailboxItem({
+      decodePayload: createDecodedPayloadDecoder(decodedWake),
+      importConversationWake,
+      prepareWakeContext,
+      item,
+      runtime: createRuntime(),
+      vaultRoot,
+    });
+
+    assert.equal(outcome.status, "imported");
+    const listed = await listAssistantInputEvents({ vault: vaultRoot });
+    assert.equal(listed.events.length, 1);
+    assert.equal(
+      listed.events[0]?.content.text,
+      "https://example.invalid/link-only",
+    );
+    assert.equal(listed.events[0]?.content.attachmentDescriptors.length, 0);
+    assert.equal(listed.events[0]?.projection.status, "not_attempted");
+    const inputId = listed.events[0]?.inputId;
+    assert.ok(inputId);
+    await updateAssistantInputProjection({
+      inputId,
+      projection: { status: "pending" },
+      vault: vaultRoot,
+    });
+
+    const replay = await importHostedConversationMailboxItem({
+      decodePayload: createDecodedPayloadDecoder(decodedWake),
+      importConversationWake,
+      prepareWakeContext,
+      item,
+      runtime: createRuntime(),
+      vaultRoot,
+    });
+
+    assert.equal(replay.status, "imported");
+    const replayed = await listAssistantInputEvents({ vault: vaultRoot });
+    assert.equal(replayed.events[0]?.projection.status, "not_attempted");
+    expect(prepareWakeContext).not.toHaveBeenCalled();
+    expect(importConversationWake).not.toHaveBeenCalled();
+  });
+
   test("upserts a minimized assistant input event before best-effort inbox projection", async () => {
     const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-input-"));
     tempRoots.push(parentRoot);
@@ -258,6 +331,14 @@ describe("hosted mailbox conversation import adapter", () => {
             {
               type: "text",
               value: "please fold this into the turn",
+            },
+            {
+              attachmentId: "att_early_notify",
+              fileName: "voice.m4a",
+              mimeType: "audio/mp4",
+              size: 12_345,
+              type: "voice_memo",
+              url: "redacted-attachment-url-sentinel",
             },
           ],
           threadIsDirect: true,
@@ -487,12 +568,7 @@ describe("hosted mailbox conversation import adapter", () => {
       const listed = await listAssistantInputEvents({ vault: vaultRoot });
       assert.equal(notificationAttempts, 1);
       assert.equal(warn.mock.calls.length > 0, true);
-      const {
-        conversationImportTiming: _conversationImportTiming,
-        ...outcomeWithoutTiming
-      } = outcome;
-      assert.equal(typeof _conversationImportTiming?.projectionTotalMs, "number");
-      assert.deepEqual(outcomeWithoutTiming, {
+      assert.deepEqual(outcome, {
         assistantInputId: listed.events[0]?.inputId,
         captureId: null,
         linqDeliveryContext: {
@@ -3107,7 +3183,7 @@ describe("hosted mailbox conversation import adapter", () => {
       item: createResolvedConversationMailboxItem(),
       runtime: createRuntime(),
       stageAssistantInputEvent: async () => ({
-        attachmentDescriptorCount: 0,
+        attachmentDescriptorCount: 1,
         inputId: "ain_00000000000000000000000000000000",
         async recordProjection() {
           throw new Error("projection update unavailable");
@@ -3567,7 +3643,7 @@ describe("hosted mailbox conversation import adapter", () => {
     assert.equal(importCalls, 0);
   });
 
-  test("stages missing raw email events as assistant input without waiting on inbox projection", async () => {
+  test("retains raw inbox projection for zero-attachment direct email", async () => {
     const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-input-raw-missing-"));
     tempRoots.push(parentRoot);
     const vaultRoot = path.join(parentRoot, "vault");
@@ -3583,16 +3659,18 @@ describe("hosted mailbox conversation import adapter", () => {
         to: ["assistant@example.test"],
       },
     });
+    const importConversationWake = vi.fn(async () => {
+      throw new HostedRawEmailMessageMissingError({
+        rawMessageKey: "raw_email_missing",
+        userId: TEST_USER_ID,
+      });
+    });
+    const prepareWakeContext = vi.fn(async () => {});
 
     const outcome = await importHostedConversationMailboxItem({
       decodePayload: createDecodedPayloadDecoder(decodedWake),
-      async importConversationWake() {
-        throw new HostedRawEmailMessageMissingError({
-          rawMessageKey: "raw_email_missing",
-          userId: TEST_USER_ID,
-        });
-      },
-      async prepareWakeContext() {},
+      importConversationWake,
+      prepareWakeContext,
       item,
       runtime: createRuntime(),
       vaultRoot,
@@ -3608,6 +3686,7 @@ describe("hosted mailbox conversation import adapter", () => {
       conversationImportTiming: _conversationImportTiming,
       ...outcomeWithoutTiming
     } = outcome;
+    assert.equal(typeof _conversationImportTiming?.projectionPrepareMs, "number");
     assert.equal(typeof _conversationImportTiming?.projectionTotalMs, "number");
     assert.deepEqual(outcomeWithoutTiming, {
       assistantInputId: listed.events[0]?.inputId,
@@ -3622,6 +3701,8 @@ describe("hosted mailbox conversation import adapter", () => {
       reasonCode: "conversation-import.raw-email-missing",
       status: "imported",
     });
+    expect(prepareWakeContext).toHaveBeenCalledOnce();
+    expect(importConversationWake).toHaveBeenCalledOnce();
     assert.equal("afterCheckpoint" in outcome, false);
     assert.equal(listed.events.length, 1);
     assert.equal(listed.events[0]?.conversation?.threadIsDirect, null);
@@ -3647,10 +3728,6 @@ describe("hosted mailbox conversation import adapter", () => {
     );
     assert.equal(listed.events[0]?.projection.status, "failed");
     assert.ok(listed.events[0]?.projection.lastAttemptedAt);
-    assert.equal(
-      listed.events[0]?.projection.reasonCode,
-      "conversation-import.raw-email-missing",
-    );
   });
 
   test("stages hosted email input with minimized prompt-ready metadata and body preview", async () => {
@@ -3969,10 +4046,11 @@ describe("hosted mailbox conversation import adapter", () => {
         threadTarget: groupThreadTarget,
       },
     });
+    const prepareWakeContext = vi.fn(async () => {});
 
     const outcome = await importHostedConversationMailboxItem({
       decodePayload: createDecodedPayloadDecoder(decodedWake),
-      async prepareWakeContext() {},
+      prepareWakeContext,
       item: createResolvedConversationMailboxItem(),
       runtime: createRuntime({
         platform: {
@@ -4017,7 +4095,8 @@ describe("hosted mailbox conversation import adapter", () => {
       promptUnavailableReason: "email.body_unavailable",
     });
     expect(readRawEmailMessage).not.toHaveBeenCalled();
-    assert.equal(event.projection.status, "pending");
+    expect(prepareWakeContext).not.toHaveBeenCalled();
+    assert.equal(event.projection.status, "not_attempted");
     assert.equal(event.projection.captureId, null);
     const persistedSurface = await collectVaultTextSurface(vaultRoot);
     for (const forbidden of [
@@ -4080,7 +4159,7 @@ describe("hosted mailbox conversation import adapter", () => {
         vaultRoot,
       });
       assert.equal(outcome.status, "imported");
-      assert.equal(outcome.reasonCode, "conversation-import.projection-failed");
+      assert.equal(outcome.reasonCode, undefined);
     }
     const retryWake = stagedWakes[2]!;
     const retryOutcome = await importHostedConversationMailboxItem({
@@ -4101,7 +4180,7 @@ describe("hosted mailbox conversation import adapter", () => {
       vaultRoot,
     });
     assert.equal(retryOutcome.status, "imported");
-    assert.equal(retryOutcome.reasonCode, "conversation-import.projection-failed");
+    assert.equal(retryOutcome.reasonCode, undefined);
 
     const pendingInputIds = await readHostedPendingAssistantInputIds({ vaultRoot });
     assert.equal(pendingInputIds.length, 5);
@@ -4124,7 +4203,13 @@ describe("hosted mailbox conversation import adapter", () => {
     );
     assert.deepEqual(
       scannerInputs.inputs.map((input) => input.projection.status),
-      ["failed", "failed", "failed", "failed", "failed"],
+      [
+        "not_attempted",
+        "not_attempted",
+        "not_attempted",
+        "not_attempted",
+        "not_attempted",
+      ],
     );
     assert.deepEqual(
       scannerInputs.inputs.map((input) => input.event.replyTarget),

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -96,7 +96,6 @@ import { describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   createHostedWorkspaceSnapshotCheckpointRequestBuilder: vi.fn(),
-  prepareHostedInboxProjectionRuntime: vi.fn(),
   prepareHostedCodexRuntimeEnvironment: vi.fn(),
   refreshHostedBrowserVaultReplicaFromRuntime: vi.fn(),
   summarizeWearableSleepRuntime: vi.fn(),
@@ -123,18 +122,6 @@ vi.mock("@murphai/runtime-state/node", async (importOriginal) => {
     snapshotHostedPortableWorkspaceDelta:
       mocks.snapshotHostedPortableWorkspaceDelta.mockImplementation(
         actual.snapshotHostedPortableWorkspaceDelta,
-      ),
-  };
-});
-
-vi.mock("../src/hosted-runtime/context.ts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/hosted-runtime/context.ts")>();
-
-  return {
-    ...actual,
-    prepareHostedInboxProjectionRuntime:
-      mocks.prepareHostedInboxProjectionRuntime.mockImplementation(
-        actual.prepareHostedInboxProjectionRuntime,
       ),
   };
 });
@@ -199,9 +186,6 @@ import {
 import type {
   RuntimeWakeSignal,
 } from "../src/hosted-runtime/runtime-wake.ts";
-import {
-  prepareHostedInboxProjectionRuntime,
-} from "../src/hosted-runtime/context.ts";
 import {
   collectHostedPendingAssistantInputMediaRetentionProtections,
   compactHostedPendingAssistantInputIds,
@@ -4920,8 +4904,6 @@ describe("hosted workspace runtime entrypoint", () => {
     runtimeWakeSignal.notify(1_777_000_000_075);
 
     try {
-      mocks.prepareHostedInboxProjectionRuntime.mockClear();
-
       await initializeVault({ createdAt: TEST_NOW, vaultRoot });
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
@@ -4992,7 +4974,6 @@ describe("hosted workspace runtime entrypoint", () => {
         "snapshot:1",
         "workspace.checkpoint",
       ]);
-      expect(mocks.prepareHostedInboxProjectionRuntime).not.toHaveBeenCalled();
       assert.deepEqual(imported, [
         {
           id: "mailbox_item_entrypoint_001",
@@ -18020,7 +18001,7 @@ describe("hosted workspace runtime entrypoint", () => {
     assert.deepEqual(artifactGetCalls, []);
   });
 
-  test("restores a workspace before incremental current-message projection", async () => {
+  test("restores a workspace before incremental mailbox import", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const sourceVaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-source-"));
     const events: string[] = [];
@@ -18073,20 +18054,6 @@ describe("hosted workspace runtime entrypoint", () => {
 
     try {
       await initializeVault({ createdAt: TEST_NOW, vaultRoot });
-      mocks.prepareHostedInboxProjectionRuntime.mockClear();
-      const prepareHostedInboxProjectionRuntimeImpl =
-        mocks.prepareHostedInboxProjectionRuntime.getMockImplementation();
-      assert.ok(prepareHostedInboxProjectionRuntimeImpl);
-      mocks.prepareHostedInboxProjectionRuntime.mockImplementationOnce(async (
-        inputVaultRoot,
-        requestId,
-      ) => {
-        events.push("projection.ready");
-        assert.equal(requestId, "request_projection_after_cold_restore");
-        assert.equal(inputVaultRoot, path.resolve(vaultRoot));
-        await prepareHostedInboxProjectionRuntimeImpl(inputVaultRoot, requestId);
-      });
-
       await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
           request: {
@@ -18106,10 +18073,7 @@ describe("hosted workspace runtime entrypoint", () => {
           },
           async importItem(item) {
             imported.push(item.item.laneSeq);
-            await prepareHostedInboxProjectionRuntime(
-              vaultRoot,
-              "request_projection_after_cold_restore",
-            );
+            events.push("mailbox.import");
             return { status: "imported" };
           },
           platform: createPlatform({
@@ -18164,11 +18128,10 @@ describe("hosted workspace runtime entrypoint", () => {
       ]);
       assert.equal(readConversationImportedSeq(fetchRequests[0]), "3");
       assert.equal((await readHostedMailboxImportState({ vaultRoot })).watermarks.conversation, "4");
-      assert.equal(mocks.prepareHostedInboxProjectionRuntime.mock.calls.length, 1);
       assert.deepEqual(events, [
         "workspace.read",
         "mailbox.fetch",
-        "projection.ready",
+        "mailbox.import",
         "snapshot:4",
         "workspace.checkpoint",
       ]);

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -4506,6 +4506,17 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       eventId: "evt_synthetic_runner_staging_yield_late",
       occurredAt: lateOccurredAt,
     };
+    if (lateWake.message.channel !== "linq") {
+      throw new Error("Projection-stall fixture requires a Linq wake.");
+    }
+    lateWake.message.linqMessage.parts.push({
+      attachmentId: "att_synthetic_runner_staging_yield_late",
+      fileName: "projection-stall.pdf",
+      mimeType: "application/pdf",
+      size: 1,
+      type: "media",
+      url: "https://cdn.example.test/projection-stall.pdf",
+    });
     const items: HostedMailboxItem[] = [];
     const importedSeqs: string[] = [];
     const fetchRequests: HostedMailboxFetchRequest[] = [];
@@ -4621,6 +4632,17 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       eventId: "evt_synthetic_runner_stop_aborts_projection",
       occurredAt: lateOccurredAt,
     };
+    if (lateWake.message.channel !== "linq") {
+      throw new Error("Projection-stall fixture requires a Linq wake.");
+    }
+    lateWake.message.linqMessage.parts.push({
+      attachmentId: "att_synthetic_runner_stop_aborts_projection",
+      fileName: "projection-stall.pdf",
+      mimeType: "application/pdf",
+      size: 1,
+      type: "media",
+      url: "https://cdn.example.test/projection-stall.pdf",
+    });
     const items: HostedMailboxItem[] = [];
     const importedSeqs: string[] = [];
     const fetchRequests: HostedMailboxFetchRequest[] = [];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -225,6 +225,7 @@ export {
   isProtectedCanonicalPath,
   listProtectedCanonicalPaths,
   listWriteOperationMetadataPaths,
+  listWriteOperationMetadataPathsWithStageDirectories,
   pruneTerminalWriteOperationRecords,
   readRecoverableStoredWriteOperation,
   readStoredWriteOperation,

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -36,6 +36,7 @@ export {
   readRecoverableStoredWriteOperation,
   isTerminalWriteOperationStatus,
   listWriteOperationMetadataPaths,
+  listWriteOperationMetadataPathsWithStageDirectories,
   applyHostedCanonicalWriteReceipt,
   readStoredWriteOperation,
   readStoredWriteOperationJsonlAppendPayload,

--- a/packages/core/src/operations/write-batch.ts
+++ b/packages/core/src/operations/write-batch.ts
@@ -972,7 +972,7 @@ export function isTerminalWriteOperationStatus(status: string): boolean {
   return status === "committed" || status === "rolled_back";
 }
 
-export async function listWriteOperationMetadataPaths(vaultRoot: string): Promise<string[]> {
+async function readWriteOperationDirectoryEntries(vaultRoot: string) {
   const operationDirectory = await resolveVaultPathOnDisk(vaultRoot, WRITE_OPERATION_DIRECTORY);
   if (!(await pathExists(operationDirectory.absolutePath))) {
     return [];
@@ -983,9 +983,31 @@ export async function listWriteOperationMetadataPaths(vaultRoot: string): Promis
     return [];
   }
 
-  const entries = await fs.readdir(operationDirectory.absolutePath, { withFileTypes: true });
-  return entries
+  return await fs.readdir(operationDirectory.absolutePath, { withFileTypes: true });
+}
+
+export async function listWriteOperationMetadataPaths(vaultRoot: string): Promise<string[]> {
+  return (await readWriteOperationDirectoryEntries(vaultRoot))
     .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.posix.join(WRITE_OPERATION_DIRECTORY, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export async function listWriteOperationMetadataPathsWithStageDirectories(
+  vaultRoot: string,
+): Promise<string[]> {
+  const entries = await readWriteOperationDirectoryEntries(vaultRoot);
+  const stageDirectoryNames = new Set(
+    entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name),
+  );
+
+  return entries
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        entry.name.endsWith(".json") &&
+        stageDirectoryNames.has(entry.name.slice(0, -".json".length)),
+    )
     .map((entry) => path.posix.join(WRITE_OPERATION_DIRECTORY, entry.name))
     .sort((left, right) => left.localeCompare(right));
 }

--- a/packages/core/test/write-operation-pruning.test.ts
+++ b/packages/core/test/write-operation-pruning.test.ts
@@ -8,6 +8,7 @@ import { afterEach, test } from "vitest";
 import {
   initializeVault,
   listWriteOperationMetadataPaths,
+  listWriteOperationMetadataPathsWithStageDirectories,
   pruneTerminalWriteOperationRecords,
   readStoredWriteOperation,
   resolveVaultPath,
@@ -29,6 +30,45 @@ afterEach(async () => {
         recursive: true,
       }),
     ),
+  );
+});
+
+test("lists only write-operation metadata with real sibling stage directories", async () => {
+  const vaultRoot = await makeVaultRoot();
+  const staged = await createStagedOperation(vaultRoot, "bank/staged-candidate.md");
+  await createCommittedOperation(vaultRoot, "bank/terminal-without-stage.md");
+  const terminalWithResidue = await createCommittedOperation(
+    vaultRoot,
+    "bank/terminal-with-stage-residue.md",
+  );
+  await writeStageResidue(
+    vaultRoot,
+    terminalWithResidue.stageRootRelativePath,
+    "payloads/residue.txt",
+    "residue\n",
+  );
+
+  const symlinkOperationId = "op_symlink_stage_candidate";
+  await writeCommittedOperationRecord(vaultRoot, {
+    operationId: symlinkOperationId,
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  });
+  const externalStageDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "murph-core-write-operation-stage-external-"),
+  );
+  tempRoots.push(externalStageDirectory);
+  await fs.symlink(
+    externalStageDirectory,
+    resolveVaultPath(
+      vaultRoot,
+      `${WRITE_OPERATION_DIRECTORY}/${symlinkOperationId}`,
+    ).absolutePath,
+    "dir",
+  );
+
+  assert.deepEqual(
+    await listWriteOperationMetadataPathsWithStageDirectories(vaultRoot),
+    [staged.metadataRelativePath, terminalWithResidue.metadataRelativePath].sort(),
   );
 });
 

--- a/packages/inboxd/README.md
+++ b/packages/inboxd/README.md
@@ -26,6 +26,7 @@ Consumers that need inbox-owned normalization without the full inboxd barrel sho
 - append-only `ledger/inbox-attachment-retention/YYYY/YYYY-MM.jsonl` records 14-day raw inbox image/audio/video byte expiration, preserving descriptors, hashes, message relationships, and retained parser derivatives while projecting expired bytes as `retention_expired`
 - assistant admission must not depend on hidden local inbox projection rows; decoded assistant input belongs in the assistant input store, while inbox capture remains a canonical/searchable projection
 - inbox intake and runtime rebuild rely on canonical inbox-capture ledger evidence, but they will backfill a missing inbox-capture record from a deterministic current-format raw envelope only when an unresolved `inbox_capture_persist` write operation shows raw writes completed before the ledger append
+- crash recovery opens write-operation metadata only for operations whose staging directory still exists; clean terminal metadata without stage residue is skipped on a fresh-capture miss, while residue remains visible for validation and diagnostics
 - inbox SQLite projection state lives under `<vault>/.runtime/projections/inboxd.sqlite`
 - any idempotent promotion from inbox captures into canonical records must be derivable from canonical vault evidence rather than local `.runtime` state alone
 

--- a/packages/inboxd/src/indexing/persist.ts
+++ b/packages/inboxd/src/indexing/persist.ts
@@ -15,7 +15,7 @@ import {
   applyCanonicalWriteBatch,
   type CanonicalRawContentInput,
   loadVault,
-  listWriteOperationMetadataPaths,
+  listWriteOperationMetadataPathsWithStageDirectories,
   readJsonlRecords,
   readStoredWriteOperation,
   readStoredWriteOperationJsonlAppendPayload,
@@ -1142,7 +1142,7 @@ async function readRecoverableStoredCaptureSnapshot(input: {
 async function listRecoverableInboxCaptureOperations(
   vaultRoot: string,
 ): Promise<Map<string, RecoverableInboxCaptureOperation>> {
-  const relativePaths = await listWriteOperationMetadataPaths(vaultRoot);
+  const relativePaths = await listWriteOperationMetadataPathsWithStageDirectories(vaultRoot);
   const selected = new Map<string, RecoverableInboxCaptureOperation>();
 
   for (const relativePath of relativePaths) {


### PR DESCRIPTION
## Why this PR exists

A cold attachment-free message was waiting on inbox projection work unrelated to assistant admission: the incident path scanned 1,465 historical inbox records and opened 247 recovery-operation metadata files. Separately, rollout recovery could retain a five-second startup grace after the exact prior-version container had already proved it had no live child.

This removes both measured latency taxes at their existing owners without adding a cache, index, queue, scheduler, lifecycle service, dependency, or new persisted state.

## User goal / user-visible behavior

The first plain Linq, Telegram, or WhatsApp message after a cold restore or rollout should reach the assistant as soon as its durable assistant-input event is staged, instead of waiting seconds on unrelated projection history. A wake should also recover immediately from an exact prior-version target proven idle, while uncertain ownership still fails closed.

## User experience

For plain-text Linq plus attachment-free Telegram and WhatsApp messages, visible behavior is unchanged except that reply startup is substantially faster. Linq messages with link parts retain their existing projection path. Direct email and attachment-bearing messages still build the current-turn raw/attachment evidence they need. Group email remains raw-free. If the prior runtime is live, missing, ambiguous, or the same target, the existing guarded retry/grace behavior remains in place rather than risking two owners.

## What changed

- Bypass rollout startup grace only for direct, target-specific `no-active-child` proof against a prior-version container. Compare-and-swap losers converge through the existing authoritative fence path, and the obsolete timed race state is deleted.
- Stage the durable `AssistantInputEvent` first, then omit inbox projection for plain-text Linq, attachment-free Telegram and WhatsApp, and raw-free group email. Linq links, direct email, and attachment-bearing input retain projection.
- Reuse surviving write-operation stage directories as recovery candidates, so clean terminal metadata is not opened one file at a time. Status/action validation and cross-shard canonical capture lookup remain unchanged.
- Remove a checkpoint E2E timing assumption exposed by faster handoff: the test still proves the corrupt publication was rejected, destroy was requested, baseline contents restored, and a clean successor published, without requiring recovery to remain unfinished at an arbitrary status read.

## Invariants the PR must preserve

- UserRunner SQLite remains the sole durable runtime-fence owner; exact attempt/generation compare-and-swap fencing and pre-dispatch ownership confirmation remain intact.
- Startup grace is bypassed only after exact target-specific proof that a prior-version owner has no live child. Same-target, missing, or ambiguous evidence remains fail-closed, and concurrent claimants converge on the durable owner record.
- Durable assistant-input staging remains the admission boundary. Projection may precede admission only when the current input needs evidence absent from staged input; Linq links, direct email, and attachment evidence retain their existing path, while group email remains raw-free.
- Recovery narrowing starts from a real surviving stage directory, still validates operation status/action, excludes symlink candidates, and preserves canonical identity across physical inbox shards.
- No new persisted state, compatibility layer, service, dependency, queue, cache, or index is introduced.

## Change-shape breakdown

Authored runtime/package files under `src/` are source; test files are tests/fixtures; architecture, invariant, README, protocol, and completed execution-plan files are docs. There are no binary files.

ReviewGPT first-reviewed head: efea1c5b81313ab06daa9711689e9f249ea827dd

This is the immutable first-review baseline.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 122 | 41 |
| Tests / fixtures | 632 | 231 |
| Docs | 197 | 30 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **951** | **302** |

Current head: 171a7e332fe3e0a053bc6cff41c3fdc7788555b6

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 127 | 40 |
| Tests / fixtures | 643 | 231 |
| Docs | 200 | 30 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **970** | **301** |

## Review remediation retrospective

The original requirement remains three measured costs: remove the five-second rollout grace only after exact prior-owner idle proof, admit durable plain text without unrelated inbox projection, and stop opening terminal recovery-operation metadata. It does not include newsletter ownership, clinical-record retrieval, group queries, web-control transport, TypeScript verification infrastructure, or new Linq link-value support.

Formal Round 1 found that including Linq link values in the immutable staged event could conflict with a predeploy staged event and permanently hold that conversation watermark behind the same row. The mechanism is accepted. A compatibility fallback would add a branch and removal lifecycle, so the correction instead deletes the scope expansion: staged Linq text returns to the exact `main` representation, link-bearing Linq retains the existing projection path, and plain text keeps the projection-free fast path.

Round 2 stopped on change shape because GitHub still packaged the PR against its creation-time base `a2f65af` after the branch had rebased onto shared `main` at `bbf8bf6`. Its apparent `3,223/689` authored-source remediation delta decomposes exactly into `3,216/688` lines from shared-base movement and `7/1` lines from the accepted correction. The base-only source was PR #608 (`1,759/436`: newsletter outbox/ownership, group-weekly query, and related dynamic-tool paths) and PR #610 (`1,457/252`: clinical-record maintenance/ports, web-control transport, and workspace-phase integration). PR #640 contributed no authored-source lines; it changed verification tooling, tests, and docs. Reselecting the same `main` base refreshed GitHub's comparison without changing code; the PR is again the intended 26-file `970/301` patch.

Compared with the immutable first-review baseline, the logical PR shape moves only from source `122/41` to `127/40`, tests `632/231` to `643/231`, and docs `197/30` to `200/30`. That is four additional lines of authored-source churn. The correction commit itself changes one source file by `7/1`; its remaining `56/42` lines are focused replay coverage and explanatory docs.

Architecture inventory and decision:

- Added owners, persisted state, services, dependencies, queues, caches, indexes, compatibility paths, migrations, or reconciliation loops: none.
- Existing owners retained: UserRunner SQLite for the runtime fence, the durable `AssistantInputEvent` for admission, inbox projection for inputs that still need evidence, and surviving stage directories for interrupted-write recovery evidence.
- Concepts removed: the obsolete rollout settlement/timer race, projection as a prerequisite for plain-text admission, terminal recovery-operation enumeration, and the review-introduced link-enriched immutable event shape.
- Base-only owners listed above remain shared-`main` history, not PR #635 scope. The current PR does not need to split them because refreshing the pinned base removes them from its diff.
- Decision: continue this PR at its original narrow outcome. Do not add the suggested compatibility machinery or hide link support inside the latency fix. Link values remain unavailable to the assistant exactly as on `main`; replay-compatible link support is a separate product decision.

## Verification

- TypeScript 7 typechecks: Cloudflare, assistant-runtime, core, inboxd, and hosted-local-harness passed.
- Focused final-head tests: Cloudflare 189/189; assistant-runtime 374/374; core 5/5; inboxd 23/23; hosted-local stack 73/73.
- Architecture, dependency, workspace-boundary, crypto, and raw-log guards passed in the diff-aware lane.
- The full local affected-package lane's only remaining failure was an unchanged assistant-engine filesystem-retention test timing out under competing workers; the exact test passed independently in 36 seconds. PR CI remains the full final-head gate.
- After CI exposed the redundant checkpoint timing assertion, Cloudflare typecheck passed. A local production-shaped rerun timed out while booting the full stack before reaching the test; the fresh CI scenario remains the direct final-head proof.
- After the Round 1 correction and PR #640 rebase, shared-host `test:diff` passed: assistant-runtime typecheck; 1,608 package tests passed with 2 skipped; Cloudflare typecheck; 1,785 Node tests and 1 Workers-runtime test passed; architecture, dependency, workspace-boundary, Temporal, crypto, and raw-log guards passed.
- Round 2 head CI completed with 25 passing checks, one expected post-deploy migration skip, and zero failures or pending checks.

## Deployment skew / compatibility

`apps/web` is unchanged. This adds no Worker/container protocol field, runtime-env requirement, persisted schema, staged-content format, rollback floor, or second state owner. Old and new runners derive the same immutable assistant-input content; an old warm runner can only retain the slower projection path. The supplied incident vault contains 109 staged hosted-mailbox inputs, zero attachment-bearing inputs, and zero pending-projection inputs, so the evidenced maximum correctness exposure from mixed bundles is zero; fleet-wide volume is unavailable and is not inferred.

Use the production workflow's current `container_rollout=immediate` default. That bounds convergence to the interrupted/draining attempt window; per-invocation bundle-fingerprint admission prevents stale warm runners from receiving new work, and the managed-container fingerprint smoke proves convergence. No fixed drain duration beyond that bounded window is inferred. After deploy, run one plain-text hosted-message smoke confirming prompt admission begins without inbox projection/history scanning.
