### PR TITLE
Clean up inactive legacy Family subscriptions exactly

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-pr606-billing-simplification.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-pr606-billing-simplification.md
@@ -1,0 +1,61 @@
+# PR 606 Billing Simplification
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+Replace the billing portion of PR 606 with one independently deployable patch
+built from current `main`, preserving only the proven legacy synthetic-owned
+Family reconciliation repair.
+
+## Success criteria
+
+- An inactive legacy Family Stripe event owned by a synthetic group container
+  converges instead of retrying to poison; active legacy groups remain visibly
+  failed for one-time operator repair.
+- Cleanup cancels the exact subscription and refunds only the exact causal paid
+  invoice, with idempotent retry behavior.
+- No owner migration, checkout fence, account-deletion scanner, new receipt
+  schema, or generic compensation framework.
+- The final diff excludes PR history artifacts and unrelated automation/runtime
+  changes.
+- Target no more than 220 production additions and 260 focused test additions;
+  stop and cut scope before exceeding either cap.
+
+## Constraints
+
+- Rebuild manually from current `main`; do not cherry-pick mixed PR 606 commits.
+- Reuse the existing Stripe event receipt and immutable event/provider ids.
+- Keep this Family-only; do not add Pulse cleanup, a lifecycle manager, queue,
+  migration, or state owner.
+- Prefer removal of compatibility paths that current data and deployment facts
+  no longer require.
+
+## Decisions
+
+- Scope is limited to exact retryable cleanup for inactive synthetic-owned
+  Family billing. Already-active legacy groups require a proven, one-time
+  operator repair and are explicitly outside this PR.
+
+## Tasks
+
+1. Re-prove the legacy synthetic-owned Family event failure on current `main`.
+2. Implement the smallest exact-owner correction and focused regressions.
+3. Re-read the diff against the line caps and delete redundant compatibility.
+4. Run required verification, coverage, security/privacy, and final review.
+5. Finish, push, open a draft PR, and run exact-head ReviewGPT with CI.
+
+## Progress
+
+Now:
+
+- Implementation, focused verification, coverage, security/privacy, and
+  simplification audits complete: inactive synthetic-owned events converge,
+  while active legacy groups remain visibly failed for operator repair.
+
+Next:
+
+- Parent-agent handoff, scoped commit/PR, CI, and exact-head ReviewGPT.
+Completed: 2026-07-14

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -62,6 +62,7 @@ import {
   type HostedOnboardingReadClient,
 } from "./shared";
 import {
+  coerceStripeInvoiceSubscriptionId,
   coerceStripeObjectId,
   coerceStripeSubscriptionId,
   mapStripeSubscriptionStatusToHostedBillingStatus,
@@ -1028,6 +1029,55 @@ export async function findHostedAccountGroupForStripeSubscription(input: {
     subscriptionId: input.subscription.id,
   });
   return match?.group ?? null;
+}
+
+export async function prepareHostedLegacySyntheticFamilyCleanupTx(input: {
+  event: Stripe.Event;
+  tx: Prisma.TransactionClient;
+}): Promise<string | null> {
+  const binding = readHostedLegacySyntheticFamilyStripeBinding(input.event);
+  if (!binding) {
+    return null;
+  }
+
+  const findMatch = () => findHostedAccountGroupForStripeObject({
+    ...binding,
+    customerLookupAllowed: false,
+    prisma: input.tx,
+  });
+  const initialMatch = await findMatch();
+  if (!initialMatch) {
+    return null;
+  }
+
+  await lockHostedMemberRow(input.tx, initialMatch.group.ownerMemberId);
+  const match = await findMatch();
+  if (
+    !match ||
+    match.group.id !== initialMatch.group.id ||
+    match.group.ownerMemberId !== initialMatch.group.ownerMemberId
+  ) {
+    return null;
+  }
+
+  const threadContainer = await input.tx.hostedThreadContainer.findUnique({
+    select: { memberId: true },
+    where: { memberId: match.group.ownerMemberId },
+  });
+  if (!threadContainer || match.group.billingStatus === HostedBillingStatus.active) {
+    return null;
+  }
+
+  await writeHostedAccountGroupStripeBillingTx({
+    billingStatus: HostedBillingStatus.canceled,
+    groupId: match.group.id,
+    stripeEventCreatedAt: match.billingRef?.lastStripeEventCreatedAt ?? null,
+    stripeCustomerId: binding.customerId ?? match.billingRef?.stripeCustomerId ?? null,
+    stripeSubscriptionId: binding.subscriptionId,
+    tx: input.tx,
+  });
+
+  return binding.subscriptionId;
 }
 
 export async function applyHostedFamilyStripeCheckoutCompletedTx(input: {
@@ -4159,6 +4209,54 @@ async function findHostedAccountGroupForStripeObject(input: {
         group: lookup.group,
       };
     }
+  }
+
+  return null;
+}
+
+function readHostedLegacySyntheticFamilyStripeBinding(event: Stripe.Event): {
+  accountGroupId: string | null;
+  checkoutAttemptId?: string | null;
+  checkoutSessionId?: string | null;
+  customerId: string | null;
+  subscriptionId: string;
+} | null {
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const subscriptionId = coerceStripeSubscriptionId(session.subscription);
+    return session.metadata?.kind === HOSTED_FAMILY_STRIPE_METADATA_KIND && subscriptionId
+      ? {
+          accountGroupId: normalizeNullableString(session.metadata.accountGroupId),
+          checkoutAttemptId: normalizeNullableString(session.metadata.checkoutAttemptId),
+          checkoutSessionId: session.id,
+          customerId: coerceStripeObjectId(session.customer),
+          subscriptionId,
+        }
+      : null;
+  }
+
+  if (event.type.startsWith("customer.subscription.")) {
+    const subscription = event.data.object as Stripe.Subscription;
+    return isHostedFamilyStripeSubscriptionMetadata(subscription)
+      ? {
+          accountGroupId: normalizeNullableString(subscription.metadata.accountGroupId),
+          checkoutAttemptId: normalizeNullableString(subscription.metadata.checkoutAttemptId),
+          customerId: coerceStripeObjectId(subscription.customer),
+          subscriptionId: subscription.id,
+        }
+      : null;
+  }
+
+  if (event.type === "invoice.paid" || event.type === "invoice.payment_failed") {
+    const invoice = event.data.object as Stripe.Invoice;
+    const subscriptionId = coerceStripeInvoiceSubscriptionId(invoice);
+    return subscriptionId
+      ? {
+          accountGroupId: null,
+          customerId: coerceStripeObjectId(invoice.customer),
+          subscriptionId,
+        }
+      : null;
   }
 
   return null;

--- a/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
@@ -620,16 +620,12 @@ async function processClaimedHostedStripeEvent(
         );
     const { memberId: processingMemberId, result } = processing;
     if (legacyFamilySubscriptionId) {
-      try {
-        await executeHostedLegacySyntheticFamilyCleanup({
-          invoice: stripeEvent.type === "invoice.paid"
-            ? stripeEvent.data.object as Stripe.Invoice
-            : null,
-          subscriptionId: legacyFamilySubscriptionId,
-        });
-      } catch {
-        throw new HostedLegacyFamilyCleanupPendingError("Legacy Family Stripe cleanup is still pending.");
-      }
+      await executeHostedLegacySyntheticFamilyCleanup({
+        invoice: stripeEvent.type === "invoice.paid"
+          ? stripeEvent.data.object as Stripe.Invoice
+          : null,
+        subscriptionId: legacyFamilySubscriptionId,
+      });
     }
     if (result.cleanupPulseTrialStripeSubscriptionId) {
       if (!processingMemberId) {
@@ -991,26 +987,26 @@ async function executeHostedLegacySyntheticFamilyCleanup(input: {
   if (matchingRefunds.some((refund) => refund.status === "succeeded")) {
     return;
   }
-  if (matchingRefunds.some((refund) =>
-    refund.status === "pending" || refund.status === "requires_action"
-  )) {
-    throw new Error("Legacy Family refund is pending.");
+  if (matchingRefunds.some((refund) => refund.status === "pending")) {
+    throw new HostedLegacyFamilyCleanupPendingError("Legacy Family refund is pending.");
+  }
+  if (matchingRefunds.length > 0) {
+    throw new Error("Legacy Family refund previously failed.");
   }
 
-  const previousTerminalRefund = matchingRefunds[0] ?? null;
   const refund = await stripe.refunds.create({
     ...payment,
     metadata: {
       [HOSTED_LEGACY_FAMILY_REFUND_INVOICE_METADATA_KEY]: input.invoice.id,
     },
   }, {
-    idempotencyKey: [
-      `hosted-family-legacy-refund:${input.invoice.id}`,
-      ...(previousTerminalRefund ? [`after:${previousTerminalRefund.id}`] : []),
-    ].join(":"),
+    idempotencyKey: `hosted-family-legacy-refund:${input.invoice.id}`,
   });
+  if (refund.status === "pending") {
+    throw new HostedLegacyFamilyCleanupPendingError("Legacy Family refund is pending.");
+  }
   if (refund.status !== "succeeded") {
-    throw new Error("Legacy Family refund is pending.");
+    throw new Error("Legacy Family refund failed.");
   }
 }
 

--- a/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
@@ -24,6 +24,7 @@ import {
 } from "./stripe-billing-events";
 import {
   HOSTED_FAMILY_STRIPE_METADATA_KIND,
+  prepareHostedLegacySyntheticFamilyCleanupTx,
 } from "./family-plan";
 import {
   findMemberForStripeInvoice,
@@ -90,6 +91,11 @@ const STRIPE_EVENT_SAFE_PRISMA_META_KEYS = new Set([
   "table",
   "target",
 ]);
+const HOSTED_LEGACY_FAMILY_REFUND_INVOICE_METADATA_KEY = "hosted_family_legacy_invoice_id";
+
+class HostedLegacyFamilyCleanupPendingError extends Error {
+  readonly code = "HOSTED_LEGACY_FAMILY_CLEANUP_PENDING";
+}
 
 export type HostedStripeEventReconcileResult = {
   activatedMemberId: string | null;
@@ -594,7 +600,15 @@ async function processClaimedHostedStripeEvent(
       stripeEvent,
       prisma,
     );
-    const processing = directBillingMemberId
+    const legacyFamilySubscriptionId = directBillingMemberId
+      ? null
+      : await prisma.$transaction(
+          (tx) => prepareHostedLegacySyntheticFamilyCleanupTx({ event: stripeEvent, tx }),
+          HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+        );
+    const processing = legacyFamilySubscriptionId
+      ? { memberId: null, result: buildEmptyHostedStripeEventProcessingResult() }
+      : directBillingMemberId
       ? await processHostedStripeEventWithVerifiedMemberLock({
           memberId: directBillingMemberId,
           prisma,
@@ -605,6 +619,18 @@ async function processClaimedHostedStripeEvent(
           prisma,
         );
     const { memberId: processingMemberId, result } = processing;
+    if (legacyFamilySubscriptionId) {
+      try {
+        await executeHostedLegacySyntheticFamilyCleanup({
+          invoice: stripeEvent.type === "invoice.paid"
+            ? stripeEvent.data.object as Stripe.Invoice
+            : null,
+          subscriptionId: legacyFamilySubscriptionId,
+        });
+      } catch {
+        throw new HostedLegacyFamilyCleanupPendingError("Legacy Family Stripe cleanup is still pending.");
+      }
+    }
     if (result.cleanupPulseTrialStripeSubscriptionId) {
       if (!processingMemberId) {
         throw new Error("Pulse Trial cleanup requires a direct billing member.");
@@ -677,12 +703,14 @@ async function processClaimedHostedStripeEvent(
       status: "completed",
     };
   } catch (error) {
+    const poisoned = claimed.attemptCount >= STRIPE_EVENT_MAX_ATTEMPTS &&
+      !(error instanceof HostedLegacyFamilyCleanupPendingError);
     logHostedStripeEventReconciliationFailure({
       attemptCount: claimed.attemptCount,
       error,
       eventId: claimed.eventId,
       eventType: claimed.type,
-      poisoned: claimed.attemptCount >= STRIPE_EVENT_MAX_ATTEMPTS,
+      poisoned,
     });
     await prisma.hostedStripeEvent.updateMany({
       where: {
@@ -700,15 +728,14 @@ async function processClaimedHostedStripeEvent(
         ),
         nextAttemptAt: computeHostedStripeEventNextAttemptAt(claimed.attemptCount),
         status:
-          claimed.attemptCount >= STRIPE_EVENT_MAX_ATTEMPTS
+          poisoned
             ? HostedStripeEventStatus.poisoned
             : HostedStripeEventStatus.failed,
       },
     });
     finishHostedOnboardingTiming(timing, "failed", {
       errorName: deriveHostedOnboardingTimingErrorName(error),
-      poisoned:
-        claimed.attemptCount >= STRIPE_EVENT_MAX_ATTEMPTS,
+      poisoned,
     });
 
     return {
@@ -925,6 +952,90 @@ function sanitizeHostedStripeEventPrismaMetaValue(value: unknown): unknown {
   }
 
   return null;
+}
+
+async function executeHostedLegacySyntheticFamilyCleanup(input: {
+  invoice: Stripe.Invoice | null;
+  subscriptionId: string;
+}): Promise<void> {
+  const stripe = requireHostedStripeApi();
+  try {
+    const subscription = await stripe.subscriptions.retrieve(input.subscriptionId);
+    if (subscription.status !== "canceled" && subscription.status !== "incomplete_expired") {
+      await stripe.subscriptions.cancel(input.subscriptionId, {}, {
+        idempotencyKey: `hosted-family-legacy-cancel:${input.subscriptionId}`,
+      });
+    }
+  } catch (error) {
+    if (!error || typeof error !== "object" || !("code" in error) || error.code !== "resource_missing") {
+      throw error;
+    }
+  }
+
+  if (!input.invoice) {
+    return;
+  }
+  const amountPaid = (input.invoice as Stripe.Invoice & { amount_paid?: unknown }).amount_paid;
+  if (amountPaid === 0) {
+    return;
+  }
+
+  const payment = await resolveHostedStripeInvoicePayment(input.invoice, stripe);
+  if (!payment) {
+    throw new Error("Legacy Family refund requires an exact paid invoice payment.");
+  }
+  const refunds = await stripe.refunds.list({ ...payment, limit: 100 });
+  const matchingRefunds = refunds.data.filter((refund) =>
+    refund.metadata?.[HOSTED_LEGACY_FAMILY_REFUND_INVOICE_METADATA_KEY] === input.invoice?.id
+  );
+  if (matchingRefunds.some((refund) => refund.status === "succeeded")) {
+    return;
+  }
+  if (matchingRefunds.some((refund) =>
+    refund.status === "pending" || refund.status === "requires_action"
+  )) {
+    throw new Error("Legacy Family refund is pending.");
+  }
+
+  const previousTerminalRefund = matchingRefunds[0] ?? null;
+  const refund = await stripe.refunds.create({
+    ...payment,
+    metadata: {
+      [HOSTED_LEGACY_FAMILY_REFUND_INVOICE_METADATA_KEY]: input.invoice.id,
+    },
+  }, {
+    idempotencyKey: [
+      `hosted-family-legacy-refund:${input.invoice.id}`,
+      ...(previousTerminalRefund ? [`after:${previousTerminalRefund.id}`] : []),
+    ].join(":"),
+  });
+  if (refund.status !== "succeeded") {
+    throw new Error("Legacy Family refund is pending.");
+  }
+}
+
+async function resolveHostedStripeInvoicePayment(
+  invoice: Stripe.Invoice,
+  stripe: Stripe,
+): Promise<{ charge: string } | { payment_intent: string } | null> {
+  const payment = (await stripe.invoicePayments.list({
+    invoice: invoice.id,
+    limit: 100,
+    status: "paid",
+    expand: ["data.payment.charge", "data.payment.payment_intent"],
+  })).data[0];
+  const paymentIntentId = coerceStripeObjectId(
+    payment?.payment.payment_intent ??
+      (invoice as Stripe.Invoice & { payment_intent?: string | null }).payment_intent,
+  );
+  if (paymentIntentId) {
+    return { payment_intent: paymentIntentId };
+  }
+  const chargeId = coerceStripeObjectId(
+    payment?.payment.charge ??
+      (invoice as Stripe.Invoice & { charge?: string | null }).charge,
+  );
+  return chargeId ? { charge: chargeId } : null;
 }
 
 async function fetchHostedStripeEventForReconciliation(eventId: string): Promise<Stripe.Event> {

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -98,6 +98,7 @@ import {
   hostedFamilyInviteHasReusableTarget,
   issueHostedFamilyInviteFromOwnerTx,
   issueHostedFamilyInviteTx,
+  prepareHostedLegacySyntheticFamilyCleanupTx,
   readHostedFamilyCheckoutSessionIdFromUrl,
   resolveHostedFamilyChatNotificationRouteTx,
   resolveHostedFamilyCheckoutRedirectUrl,
@@ -2143,6 +2144,88 @@ describe("hosted Family plan", () => {
     expect(activationMocks.activateHostedMemberForFamilySponsorshipTx).not.toHaveBeenCalled();
   });
 
+  it("prepares consistent cleanup for a legacy Family invoice without a customer", async () => {
+    const lastStripeEventCreatedAt = new Date("2026-06-18T12:00:00.000Z");
+    const event = makeFamilyStripeSubscriptionEvent();
+    Object.assign(event, { id: "evt_family_invoice", type: "invoice.paid" });
+    Object.assign(event.data.object, {
+      customer: null,
+      id: "in_family",
+      object: "invoice",
+      subscription: "sub_family",
+    });
+    const group = {
+      billingStatus: HostedBillingStatus.not_started,
+      id: "hbag_family",
+      ownerMemberId: "member_owner",
+      suspendedAt: null,
+    };
+    const tx = createTxMock({
+      group,
+    });
+    const billingRef = createBillingRefMock({ group, lastStripeEventCreatedAt });
+    tx.hostedAccountGroupBillingRef.findMany.mockResolvedValue([billingRef]);
+    tx.hostedAccountGroupBillingRef.findUnique.mockResolvedValue(billingRef);
+    tx.hostedThreadContainer.findUnique.mockResolvedValue({ memberId: "member_owner" });
+
+    await expect(prepareHostedLegacySyntheticFamilyCleanupTx({
+      event,
+      tx,
+    })).resolves.toBe("sub_family");
+
+    expect(tx.$queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.hostedAccountGroupBillingRef.findMany.mock.invocationCallOrder[1],
+    );
+    expect(tx.hostedAccountGroupBillingRef.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      update: expect.objectContaining({
+        billedSeatCount: null,
+        currentBillingPhase: null,
+        currentBillingPlanCode: "launch_family_monthly",
+        currentPeriodEnd: null,
+        currentPeriodStart: null,
+        lastStripeEventCreatedAt,
+        stripeCustomerLookupKey: expect.stringMatching(/^hbidx:stripe-customer:v1:/u),
+        stripeSubscriptionItemLookupKey: null,
+        stripeSubscriptionLookupKey: expect.stringMatching(/^hbidx:stripe-subscription:v1:/u),
+      }),
+    }));
+    expect(tx.hostedAccountGroup.update).toHaveBeenCalledWith({
+      data: { billingStatus: HostedBillingStatus.canceled },
+      where: { id: "hbag_family" },
+    });
+  });
+
+  it("leaves already-active legacy Family billing for explicit operator repair", async () => {
+    const tx = createTxMock();
+    tx.hostedThreadContainer.findUnique.mockResolvedValue({ memberId: "member_owner" });
+
+    await expect(prepareHostedLegacySyntheticFamilyCleanupTx({
+      event: makeFamilyStripeSubscriptionEvent(),
+      tx,
+    })).resolves.toBeNull();
+
+    expect(tx.hostedAccountGroupBillingRef.upsert).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroup.update).not.toHaveBeenCalled();
+  });
+
+  it("does not clean up a legacy event after its Family binding changes under lock", async () => {
+    const tx = createTxMock();
+    tx.hostedAccountGroupBillingRef.findUnique
+      .mockResolvedValueOnce(createBillingRefMock())
+      .mockResolvedValueOnce(createBillingRefMock({
+        stripeSubscriptionIdEncrypted: "encrypted:sub_newer",
+      }));
+
+    await expect(prepareHostedLegacySyntheticFamilyCleanupTx({
+      event: makeFamilyStripeSubscriptionEvent(),
+      tx,
+    })).resolves.toBeNull();
+
+    expect(tx.hostedThreadContainer.findUnique).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroupBillingRef.upsert).not.toHaveBeenCalled();
+    expect(tx.hostedAccountGroup.update).not.toHaveBeenCalled();
+  });
+
   it("reconciles active Family billing while skipping direct-paid members during activation", async () => {
     const tx = createTxMock();
     const eventCreatedAt = new Date("2026-06-18T12:30:00.000Z");
@@ -3629,6 +3712,16 @@ function makeFamilyStripeCheckoutSession(input: {
   };
 
   return session as Stripe.Checkout.Session;
+}
+
+function makeFamilyStripeSubscriptionEvent(): Stripe.Event {
+  return {
+    created: 1_771_948_800,
+    data: { object: makeFamilyStripeSubscription() },
+    id: "evt_family_subscription",
+    object: "event",
+    type: "customer.subscription.updated",
+  } as Stripe.Event;
 }
 
 function makeFamilyStripeSubscription(input: {

--- a/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
@@ -522,7 +522,7 @@ describe("hosted Stripe event reconciliation", () => {
     );
   });
 
-  it("keeps legacy Family cleanup retryable after the ordinary poison limit", async () => {
+  it("keeps a transient legacy Family cleanup failure within the ordinary poison bound", async () => {
     const prisma = createStripeEventPrismaHarness();
     const event = makeSubscriptionUpdatedEvent();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -534,15 +534,23 @@ describe("hosted Stripe event reconciliation", () => {
       .mockResolvedValueOnce(makeCanonicalSubscription({ status: "canceled" }));
 
     await recordHostedStripeEvent({ event, prisma: prisma.client });
-    prisma.rows[0]!.attemptCount = 5;
     await expect(reconcileHostedStripeEventById({
       eventId: event.id,
       prisma: prisma.client,
     })).resolves.toMatchObject({ status: "failed" });
     expect(prisma.rows[0]).toEqual(expect.objectContaining({
-      attemptCount: 6,
+      attemptCount: 1,
+      lastErrorCode: "Error",
+      lastErrorMessage: "[redacted]",
       status: HostedStripeEventStatus.failed,
     }));
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Hosted Stripe event reconciliation failed.",
+      expect.objectContaining({
+        errorMessage: "Stripe unavailable",
+        poisoned: false,
+      }),
+    );
 
     prisma.rows[0]!.nextAttemptAt = new Date(0);
     await expect(reconcileHostedStripeEventById({
@@ -592,10 +600,17 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.stripe.refunds.create.mockResolvedValue({ status: "pending" });
 
     await recordHostedStripeEvent({ event, prisma: prisma.client });
+    prisma.rows[0]!.attemptCount = 5;
     await expect(reconcileHostedStripeEventById({
       eventId: event.id,
       prisma: prisma.client,
     })).resolves.toMatchObject({ status: "failed" });
+    expect(prisma.rows[0]).toEqual(expect.objectContaining({
+      attemptCount: 6,
+      lastErrorCode: "HOSTED_LEGACY_FAMILY_CLEANUP_PENDING",
+      lastErrorMessage: "[redacted]",
+      status: HostedStripeEventStatus.failed,
+    }));
     prisma.rows[0]!.nextAttemptAt = new Date(0);
     await expect(reconcileHostedStripeEventById({
       eventId: event.id,
@@ -613,6 +628,54 @@ describe("hosted Stripe event reconciliation", () => {
     }, {
       idempotencyKey: "hosted-family-legacy-refund:in_123",
     });
+    errorSpy.mockRestore();
+  });
+
+  it("poisons a terminal legacy Family refund without issuing another refund", async () => {
+    const prisma = createStripeEventPrismaHarness();
+    const event = makeInvoicePaidEvent();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.stripe.events.retrieve.mockResolvedValue(event);
+    mocks.findMemberForStripeInvoice.mockResolvedValue(null);
+    mocks.prepareHostedLegacySyntheticFamilyCleanupTx.mockResolvedValue("sub_123");
+    mocks.stripe.subscriptions.retrieve.mockResolvedValue(makeCanonicalSubscription({
+      status: "canceled",
+    }));
+    mocks.stripe.refunds.list.mockResolvedValue({
+      data: [{
+        id: "re_failed",
+        metadata: { hosted_family_legacy_invoice_id: "in_123" },
+        status: "failed",
+      }],
+    });
+
+    await recordHostedStripeEvent({ event, prisma: prisma.client });
+    prisma.rows[0]!.attemptCount = 5;
+    await expect(reconcileHostedStripeEventById({
+      eventId: event.id,
+      prisma: prisma.client,
+    })).resolves.toMatchObject({ status: "failed" });
+
+    expect(prisma.rows[0]).toEqual(expect.objectContaining({
+      attemptCount: 6,
+      lastErrorCode: "Error",
+      lastErrorMessage: "[redacted]",
+      status: HostedStripeEventStatus.poisoned,
+    }));
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Hosted Stripe event reconciliation failed.",
+      expect.objectContaining({
+        errorMessage: "Legacy Family refund previously failed.",
+        poisoned: true,
+      }),
+    );
+    expect(mocks.stripe.refunds.create).not.toHaveBeenCalled();
+    prisma.rows[0]!.nextAttemptAt = new Date(0);
+    await expect(reconcileHostedStripeEventById({
+      eventId: event.id,
+      prisma: prisma.client,
+    })).resolves.toBeNull();
+    expect(mocks.stripe.refunds.list).toHaveBeenCalledOnce();
     errorSpy.mockRestore();
   });
 

--- a/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   findMemberForStripeInvoice: vi.fn(),
   findMemberForStripeSubscription: vi.fn(),
   listHostedStripeCheckoutSessionMemberIds: vi.fn(),
+  prepareHostedLegacySyntheticFamilyCleanupTx: vi.fn(),
   readHostedMemberBillingSnapshot: vi.fn(),
   refreshHostedBillingPlanSwitchToPulsePendingFieldsFromScheduleTx: vi.fn(),
   resolveStripeCustomerContext: vi.fn(),
@@ -27,6 +28,13 @@ const mocks = vi.hoisted(() => ({
   stripe: {
     events: {
       retrieve: vi.fn(),
+    },
+    invoicePayments: {
+      list: vi.fn(),
+    },
+    refunds: {
+      create: vi.fn(),
+      list: vi.fn(),
     },
     subscriptions: {
       cancel: vi.fn(),
@@ -51,6 +59,8 @@ vi.mock("@/src/lib/hosted-onboarding/family-plan", async () => {
       activations: [],
       groupId: null,
     })),
+    prepareHostedLegacySyntheticFamilyCleanupTx:
+      mocks.prepareHostedLegacySyntheticFamilyCleanupTx,
   };
 });
 
@@ -236,6 +246,7 @@ describe("hosted Stripe event reconciliation", () => {
       core: { id: "member_123" },
     });
     mocks.listHostedStripeCheckoutSessionMemberIds.mockResolvedValue(["member_123"]);
+    mocks.prepareHostedLegacySyntheticFamilyCleanupTx.mockResolvedValue(null);
     mocks.readHostedMemberBillingSnapshot.mockResolvedValue(null);
     mocks.refreshHostedBillingPlanSwitchToPulsePendingFieldsFromScheduleTx.mockResolvedValue(undefined);
     mocks.resolveStripeCustomerContext.mockResolvedValue({
@@ -250,6 +261,12 @@ describe("hosted Stripe event reconciliation", () => {
       status: "sent",
     });
     mocks.stripe.subscriptions.retrieve.mockResolvedValue(makeCanonicalSubscription());
+    mocks.stripe.invoicePayments.list.mockResolvedValue({ data: [] });
+    mocks.stripe.refunds.create.mockResolvedValue({ status: "succeeded" });
+    mocks.stripe.refunds.list.mockResolvedValue({ data: [] });
+    mocks.stripe.subscriptions.cancel.mockResolvedValue(makeCanonicalSubscription({
+      status: "canceled",
+    }));
     mocks.writeHostedMemberStripeBillingTx.mockResolvedValue(null);
   });
 
@@ -503,6 +520,100 @@ describe("hosted Stripe event reconciliation", () => {
       HostedBillingStatus.active,
       canonicalSubscription,
     );
+  });
+
+  it("keeps legacy Family cleanup retryable after the ordinary poison limit", async () => {
+    const prisma = createStripeEventPrismaHarness();
+    const event = makeSubscriptionUpdatedEvent();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.stripe.events.retrieve.mockResolvedValue(event);
+    mocks.findMemberForStripeSubscription.mockResolvedValue(null);
+    mocks.prepareHostedLegacySyntheticFamilyCleanupTx.mockResolvedValue("sub_123");
+    mocks.stripe.subscriptions.cancel
+      .mockRejectedValueOnce(new Error("Stripe unavailable"))
+      .mockResolvedValueOnce(makeCanonicalSubscription({ status: "canceled" }));
+
+    await recordHostedStripeEvent({ event, prisma: prisma.client });
+    prisma.rows[0]!.attemptCount = 5;
+    await expect(reconcileHostedStripeEventById({
+      eventId: event.id,
+      prisma: prisma.client,
+    })).resolves.toMatchObject({ status: "failed" });
+    expect(prisma.rows[0]).toEqual(expect.objectContaining({
+      attemptCount: 6,
+      status: HostedStripeEventStatus.failed,
+    }));
+
+    prisma.rows[0]!.nextAttemptAt = new Date(0);
+    await expect(reconcileHostedStripeEventById({
+      eventId: event.id,
+      prisma: prisma.client,
+    })).resolves.toMatchObject({ status: "completed" });
+    expect(mocks.stripe.subscriptions.cancel).toHaveBeenCalledTimes(2);
+    expect(mocks.stripe.subscriptions.cancel).toHaveBeenCalledWith(
+      "sub_123",
+      {},
+      { idempotencyKey: "hosted-family-legacy-cancel:sub_123" },
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("retries the exact legacy Family invoice refund without duplicating it", async () => {
+    const prisma = createStripeEventPrismaHarness();
+    const event = makeInvoicePaidEvent();
+    const invoice = event.data.object as Stripe.Invoice & {
+      charge?: string | null;
+      payment_intent?: string | null;
+    };
+    invoice.charge = null;
+    invoice.payment_intent = null;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.stripe.events.retrieve.mockResolvedValue(event);
+    mocks.findMemberForStripeInvoice.mockResolvedValue(null);
+    mocks.prepareHostedLegacySyntheticFamilyCleanupTx.mockResolvedValue("sub_123");
+    mocks.stripe.subscriptions.retrieve.mockResolvedValue(makeCanonicalSubscription({
+      status: "canceled",
+    }));
+    mocks.stripe.invoicePayments.list.mockResolvedValue({
+      data: [{
+        payment: { charge: null, payment_intent: "pi_exact" },
+        status: "paid",
+      }],
+    });
+    mocks.stripe.refunds.list
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({
+        data: [{
+          id: "re_legacy",
+          metadata: { hosted_family_legacy_invoice_id: "in_123" },
+          status: "succeeded",
+        }],
+      });
+    mocks.stripe.refunds.create.mockResolvedValue({ status: "pending" });
+
+    await recordHostedStripeEvent({ event, prisma: prisma.client });
+    await expect(reconcileHostedStripeEventById({
+      eventId: event.id,
+      prisma: prisma.client,
+    })).resolves.toMatchObject({ status: "failed" });
+    prisma.rows[0]!.nextAttemptAt = new Date(0);
+    await expect(reconcileHostedStripeEventById({
+      eventId: event.id,
+      prisma: prisma.client,
+    })).resolves.toMatchObject({ status: "completed" });
+
+    expect(mocks.stripe.invoicePayments.list).toHaveBeenCalledWith(expect.objectContaining({
+      invoice: "in_123",
+      status: "paid",
+    }));
+    expect(mocks.stripe.refunds.create).toHaveBeenCalledOnce();
+    expect(mocks.stripe.refunds.create).toHaveBeenCalledWith({
+      metadata: { hosted_family_legacy_invoice_id: "in_123" },
+      payment_intent: "pi_exact",
+    }, {
+      idempotencyKey: "hosted-family-legacy-refund:in_123",
+    });
+    errorSpy.mockRestore();
   });
 
   it("does not send the Resend welcome when a later paid invoice has no new activation", async () => {


### PR DESCRIPTION
## Why

PR #606 combined unrelated repairs into a ~12k-line patch. Its first billing replacement, #638, kept the correct five-file implementation but GitHub pinned that PR to an old base and displayed 181 files / 13k additions. This fresh replacement starts from current `main`, so the visible PR is the real five-file billing patch.

## User-visible goal

An inactive legacy Family subscription owned by a synthetic thread container should reconcile against its exact Stripe objects instead of failing the direct-member path. When Stripe succeeds, the exact subscription is canceled, the exact paid invoice is refunded once, and the local group becomes canceled.

Already-active legacy groups and genuine terminal cleanup failures remain visibly failed for operator repair, so this patch cannot revoke paid access or retry a failed financial operation forever.

## How it works

- Parse the exact Family subscription binding from the causal Stripe event.
- Find the group by subscription only, lock its owner row, then re-read and revalidate the same binding.
- Proceed only for a synthetic-owned, non-active Family group.
- Clear the canceled billing fields while preserving the Stripe customer and event watermark.
- Cancel the exact subscription and refund the exact invoice payment with stable idempotency keys.
- Let only an actual Stripe refund with `pending` status remain retryable past the ordinary poison threshold.
- Send failed, canceled, action-required, transient, and permanent outcomes through the existing bounded failure path with their sanitized cause preserved.

## Invariants

- No customer-only lookup or cross-group fallback.
- No owner migration, checkout fence, account-deletion scan, schema change, queue, replay route, or generic compensation framework.
- Active paid access is not silently revoked.
- Existing direct-member and non-Family reconciliation paths are unchanged.
- Already-poisoned historical receipts are not automatically reclaimed; production inspection found none.

## Validation

- Focused Family and Stripe reconciliation suite: 143/143 tests passed.
- Shared-host hosted-Web typecheck passed.
- Shared-host `pnpm test:diff` passed on this exact tree, including focused tests, typecheck, and the production Next.js build.
- Coverage-write, security/privacy, and simplification audits completed with no unresolved findings.
- `git diff --check`, privacy scan, and unsafe-cast scan passed.

## Historical ReviewGPT disposition from #638

Round 1 found two issues. A proposed poisoned-receipt re-admission path was rejected after production proof found zero poisoned or nonterminal receipts, and that compatibility path was deleted. The blanket failure catch was accepted and replaced by preserved sanitized causes, existing bounded poisoning, and retry only for an actual Stripe `pending` refund. That production remediation was net deletion (`+16/-20`) with no new state.

Round 2 returned `RETROSPECTIVE_REQUIRED` because #638's stale pinned base made unrelated adopted `main` history appear in its audit package. The decision was to continue the actual isolated five-file patch; no product code or complexity was added by that retrospective.

The already-running #638 Round 3 was allowed to finish without cancellation or duplication and passed. #645's own Round 1 later completed on exact head `9667888b92` with PASS and no Critical, High, or Complexity Collapse findings. It verified the exact binding under the existing lock, inactive-only repair, existing billing writer, durable receipt and stable idempotency keys, bounded poisoning, and pending-refund-only continuation. No review-driven fix or complexity was added.

## Change shape

Classification: authored hosted-Web files are source; test files are tests/fixtures; the completed execution plan is docs/process. No binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 210 | 5 |
| Tests/fixtures | 267 | 0 |
| Docs/process | 61 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **538** | **5** |

ReviewGPT first-reviewed head: 9667888b920a375d61a61edc953e3a423646cd7b

## Supersedes

This draft replaces the billing slice of #606 and the stale-base presentation of #638.
