### PR TITLE
fix: remove shared-host admission deadline

### DIFF
--- a/agent-docs/operations/typescript-verification-performance.md
+++ b/agent-docs/operations/typescript-verification-performance.md
@@ -60,7 +60,9 @@ pnpm verify:acceptance
 Each admitted command atomically claims one directory beneath the operating
 system's temporary directory. Nested commands inherit the claim and do not
 queue again. Dead claims can be reclaimed from process-liveness evidence. The
-state is disposable and contains no product data or command output.
+state is disposable and contains no product data or command output. Admission
+has no deadline: a waiting command runs when capacity becomes available or
+exits when its own caller cancels it.
 
 Commands that also need the per-worktree artifact lock acquire that lock first,
 then acquire the host slot. The two controls have separate jobs:

--- a/scripts/run-with-host-verification-slot.mjs
+++ b/scripts/run-with-host-verification-slot.mjs
@@ -22,9 +22,8 @@ const HELD_ENV = "MURPH_VERIFY_HOST_SLOT_HELD";
 const SLOT_COUNT_ENV = "MURPH_VERIFY_HOST_CONCURRENCY";
 const TEST_STATE_ROOT_ENV = "MURPH_VERIFY_SHARED_HOST_TEST_STATE_ROOT";
 const DEFAULT_POLL_INTERVAL_MS = 250;
-const DEFAULT_TIMEOUT_MS = 30 * 60 * 1_000;
 const DEFAULT_STALE_METADATA_GRACE_MS = 10_000;
-const WAIT_LOG_INTERVAL_MS = 5_000;
+const WAIT_LOG_INTERVAL_MS = 60_000;
 const OWNER_FILE_NAME = "owner.json";
 const invocationCwd = process.cwd();
 const invocation = parseInvocation(process.argv.slice(2));
@@ -60,15 +59,10 @@ async function acquireSlot(label) {
     process.env.MURPH_VERIFY_SHARED_HOST_POLL_INTERVAL_MS,
     DEFAULT_POLL_INTERVAL_MS,
   );
-  const timeoutMs = readPositiveInteger(
-    process.env.MURPH_VERIFY_SHARED_HOST_TIMEOUT_MS,
-    DEFAULT_TIMEOUT_MS,
-  );
   const staleMetadataGraceMs = readNonNegativeInteger(
     process.env.MURPH_VERIFY_SHARED_HOST_STALE_METADATA_GRACE_MS,
     DEFAULT_STALE_METADATA_GRACE_MS,
   );
-  const startedAtMs = Date.now();
   const owner = {
     childPid: null,
     claimId: randomUUID(),
@@ -116,16 +110,9 @@ async function acquireSlot(label) {
       continue;
     }
 
-    const elapsedMs = Date.now() - startedAtMs;
-    if (elapsedMs >= timeoutMs) {
-      throw new Error(
-        `Timed out after ${timeoutMs}ms waiting for one of ${slotCount} shared-host verification slot(s).${formatOwners(owners)}`,
-      );
-    }
-
     if (Date.now() - lastWaitLogAtMs >= WAIT_LOG_INTERVAL_MS) {
       console.error(
-        `[host-verification] waiting for one of ${slotCount} shared-host slot(s).${formatOwners(owners)}`,
+        `[host-verification] waiting for one of ${slotCount} shared-host slot(s).${formatOwners(owners)} Waiting continues until a slot is available or this command is cancelled.`,
       );
       lastWaitLogAtMs = Date.now();
     }
@@ -412,9 +399,6 @@ function formatOwners(owners) {
 }
 
 function formatError(error) {
-  if (error instanceof Error && error.message.startsWith("Timed out after ")) {
-    return error.message;
-  }
   if (error instanceof Error && error.message.startsWith(`${SLOT_COUNT_ENV} `)) {
     return error.message;
   }

--- a/scripts/run-with-host-verification-slot.test.ts
+++ b/scripts/run-with-host-verification-slot.test.ts
@@ -73,13 +73,21 @@ describe("shared-host verification slots", () => {
     );
   });
 
-  it("serializes commands when one slot is configured", async () => {
+  it("waits without a deadline when one slot is configured", async () => {
     const stateRoot = makeTempRoot();
     const first = startHolder("first", stateRoot, 1);
     await waitForLine(first, "ready");
 
-    const second = startCommand("second", stateRoot, 1, "process.stdout.write('started\\n')");
+    const second = startCommand(
+      "second",
+      stateRoot,
+      1,
+      "process.stdout.write('started\\n')",
+      { MURPH_VERIFY_SHARED_HOST_TIMEOUT_MS: "40" },
+    );
+    await waitForStderrLine(second, "Waiting continues until a slot is available");
     await expectNoLine(second, "started", 120);
+    expect(second.exitCode).toBeNull();
 
     first.stdin?.end();
     await waitForExit(first);
@@ -131,32 +139,12 @@ describe("shared-host verification slots", () => {
     expect(readdirSync(stateRoot)).toEqual([]);
   });
 
-  it("times out cleanly without exposing absolute working paths", async () => {
+  it("does not expose absolute working paths in owner metadata", async () => {
     const stateRoot = makeTempRoot();
-    const privateCwd = path.join(makeTempRoot(), "private-cwd");
-    mkdirSync(privateCwd);
-    const holder = startHolder("holder", stateRoot, 1);
+    const holder = startHolder(repoRoot, stateRoot, 1);
     await waitForLine(holder, "ready");
 
-    const result = spawnSync(
-      process.execPath,
-      [wrapperPath, "waiting command", "--", process.execPath, "-e", ""],
-      {
-        cwd: privateCwd,
-        encoding: "utf8",
-        env: slotEnv(stateRoot, 1, {
-          MURPH_VERIFY_SHARED_HOST_TIMEOUT_MS: "80",
-        }),
-      },
-    );
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Timed out after 80ms");
-    expect(result.stderr).not.toContain(privateCwd);
-    expect(result.stderr).not.toContain(os.homedir());
-
     const ownerText = readFileSync(path.join(stateRoot, "slot-1", "owner.json"), "utf8");
-    expect(ownerText).not.toContain(privateCwd);
     expect(ownerText).not.toContain(repoRoot);
     expect(ownerText).not.toContain(os.homedir());
 
@@ -312,7 +300,6 @@ function slotEnv(
     MURPH_VERIFY_HOST_CONCURRENCY: String(slots),
     MURPH_VERIFY_SHARED_HOST_STALE_METADATA_GRACE_MS: "0",
     MURPH_VERIFY_SHARED_HOST_TEST_STATE_ROOT: stateRoot,
-    MURPH_VERIFY_SHARED_HOST_TIMEOUT_MS: "2000",
     ...overrides,
   };
 }
@@ -339,6 +326,7 @@ function startCommand(
   stateRoot: string,
   slots: number,
   source: string,
+  overrides: NodeJS.ProcessEnv = {},
 ): ChildProcess {
   const child = spawn(
     process.execPath,
@@ -353,7 +341,7 @@ function startCommand(
     ],
     {
       cwd: repoRoot,
-      env: slotEnv(stateRoot, slots),
+      env: slotEnv(stateRoot, slots, overrides),
       stdio: ["pipe", "pipe", "pipe"],
     },
   );


### PR DESCRIPTION
## Why

The opt-in shared-host verifier imposed a fixed 30-minute admission timeout. With many worktrees sharing one intentionally conservative slot, healthy waiters could turn red even though the live owner was still running. The timeout did not recover or stop a hung owner; it only failed unrelated callers behind it.

## Outcome

Waiting commands now remain queued until capacity becomes available or their own caller cancels them. Wait diagnostics are emitted once per minute instead of every five seconds.

There is no product-facing behavior change.

## Invariants

- Shared-host admission remains opt-in and defaults to one slot.
- Live owners are never signaled or reaped by another worktree.
- Dead-owner reclamation, caller cancellation, child-process isolation, and multi-slot behavior remain unchanged.
- No daemon, database, persistent coordinator, FIFO scheduler, dynamic hardware policy, or cross-worktree config file is added.

## Validation

- `node --check scripts/run-with-host-verification-slot.mjs`
- Focused repo-tools Vitest: 10/10 passed with one worker.
- `git diff --check`
- Identifier/path privacy scan passed.
- Required coverage-write audit found no remaining proof gap after adding a regression assertion that the retired timeout variable no longer ends a waiter.
- The local truthful `test:diff` was queued behind a different worktree's live owner and cancelled before rebase; CI is the broader gate for this draft head.

## Diff shape

- Product source: +0 / -0
- Tests: +14 / -26
- Docs: +3 / -1
- Config/tooling: +2 / -18
- Generated/other: +0 / -0
- Total: +19 / -45

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786660996&installation_id=127572939&pr_number=647&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F647&signature=67e462db30599a276044d746008ca6db5e64b1ed3d4d7d13373c0295b5378ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->