### PR TITLE
fix(web): restore simple Telegram signup welcome

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-telegram-signup-welcome-simple.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-telegram-signup-welcome-simple.md
@@ -1,0 +1,58 @@
+# Simple Telegram Signup Welcome
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+- Restore the immediate activation welcome for a Telegram-only signup with the
+  smallest architecture that satisfies the current product requirement.
+- Treat the Privy-verified Telegram user id as the direct delivery target when
+  no inbound Telegram thread exists.
+
+## Constraints
+
+- Prefer `telegramThreadId ?? telegramUserId`; inbound-observed routes remain
+  preferred.
+- Reuse the existing encrypted member routing record, activation event,
+  assistant notification route, mailbox, outbox, and Telegram sender.
+- Add no provider probe, bot-bound target grammar, configuration flag, callback,
+  queue, state owner, compatibility layer, replay, or cleanup protocol.
+- Keep semantic conversation identity and delivery target identical for the
+  direct-user-id fallback.
+- Preserve unrelated work and the hosted signup timezone lane's changes when
+  reconciling with `main`.
+
+## Method
+
+1. Start from current `origin/main` and inspect the original pre-review patch.
+2. Make the routing resolver prefer an inbound thread and otherwise use the
+   verified Telegram user id.
+3. Prevent activation from performing an unnecessary Linq lookup when either
+   Telegram target is available.
+4. Add only focused tests proving Telegram-only signup readiness and welcome
+   delivery-route construction.
+5. Run truthful Web verification, required coverage review, parent final review,
+   close the plan, commit, push, and open a replacement PR.
+
+## Verification Plan
+
+- Focused hosted onboarding messaging, activation, and Privy service tests.
+- `pnpm test:diff` for the exact changed source and test files under the shared
+  host profile.
+- Required `coverage-write` audit with test-only write scope.
+- ReviewGPT and CI on the exact pushed replacement PR head.
+
+## Verification Log
+
+- Shared-host `pnpm test:diff` selected only `apps/web` and passed dependency,
+  workspace-boundary, hosted-runtime, Temporal, crypto, and logging guards.
+- TypeScript 7 passed with the shared profile.
+- Web verification passed 5,047 tests with 139 intentional skips, lint with zero
+  errors and 12 unrelated warnings, dev smoke, and the production Next build.
+- Required coverage-write audit found no material proof gap and made no edits.
+- Parent scope review confirmed the production change is limited to the existing
+  routing resolver and activation decision; no new runtime or persisted concept
+  was introduced.
+Completed: 2026-07-14

--- a/apps/web/src/lib/hosted-onboarding/member-activation.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-activation.ts
@@ -307,7 +307,8 @@ async function resolveHostedMemberActivationWelcomeLinqRoute(input: {
     || input.member.routing?.pendingLinqChatId,
   );
   const hasTelegramRoute = Boolean(
-    input.member.routing?.telegramThreadId,
+    input.member.routing?.telegramThreadId
+    || input.member.routing?.telegramUserId,
   );
 
   if (

--- a/apps/web/src/lib/hosted-onboarding/messaging-state.ts
+++ b/apps/web/src/lib/hosted-onboarding/messaging-state.ts
@@ -32,7 +32,7 @@ export interface HostedMemberMessagingState {
   linqContactLookupKey: string | null;
   linqThreadId: string | null;
   phoneLookupKey: string | null;
-  telegramThreadId: string | null;
+  telegramTarget: string | null;
 }
 
 export type HostedMemberAssistantNotificationRoute =
@@ -59,10 +59,12 @@ export function resolveHostedMemberMessagingState(input: {
   const linqContactLookupKey =
     phoneLookupKey
     ?? normalizeMessagingIdentity(input.routing?.pendingLinqParticipantContact?.lookupKey);
-  const telegramThreadId = normalizeMessagingIdentity(input.routing?.telegramThreadId);
+  const telegramTarget =
+    normalizeMessagingIdentity(input.routing?.telegramThreadId)
+    ?? normalizeMessagingIdentity(input.routing?.telegramUserId);
   const hasPhone = phoneLookupKey !== null;
   const hasLinq = hasPhone || (linqThreadId !== null && linqContactLookupKey !== null);
-  const hasTelegram = telegramThreadId !== null;
+  const hasTelegram = telegramTarget !== null;
 
   return {
     hasDirectMessagingChannel: hasLinq || hasTelegram,
@@ -72,7 +74,7 @@ export function resolveHostedMemberMessagingState(input: {
     linqContactLookupKey,
     linqThreadId,
     phoneLookupKey,
-    telegramThreadId,
+    telegramTarget,
   };
 }
 
@@ -166,9 +168,9 @@ export function resolveHostedMemberAssistantNotificationRoute(
     };
   }
 
-  if (input.messaging.telegramThreadId) {
+  if (input.messaging.telegramTarget) {
     const identifierBlind = createHostedAssistantConversationIdentifierBlind({
-      secret: input.messaging.telegramThreadId,
+      secret: input.messaging.telegramTarget,
       userId: input.memberId,
     });
     return {
@@ -176,12 +178,12 @@ export function resolveHostedMemberAssistantNotificationRoute(
       channel: "telegram",
       delivery: {
         kind: "thread",
-        target: input.messaging.telegramThreadId,
+        target: input.messaging.telegramTarget,
       },
       identityId: null,
       threadId: hashHostedAssistantConversationIdentifier(
         identifierBlind,
-        input.messaging.telegramThreadId,
+        input.messaging.telegramTarget,
       ),
       threadIsDirect: true,
     };

--- a/apps/web/test/hosted-onboarding-member-activation.test.ts
+++ b/apps/web/test/hosted-onboarding-member-activation.test.ts
@@ -458,7 +458,7 @@ describe("hosted onboarding member activation", () => {
     });
   });
 
-  it("emits Telegram first-contact without a Linq lookup for phone-less members", async () => {
+  it("emits Telegram first-contact from the verified user id before the first inbound message", async () => {
     const member = makeMemberSnapshot({
       identity: {
         phoneLookupKey: null,
@@ -472,8 +472,8 @@ describe("hosted onboarding member activation", () => {
         pendingLinqChatId: null,
         pendingLinqParticipantContact: null,
         pendingLinqRecipientPhone: null,
-        telegramThreadId: "telegram_user_123:business:biz-42:dm-topic:9",
-        telegramUserId: "telegram_user_123",
+        telegramThreadId: null,
+        telegramUserId: "456",
         telegramUserLookupKey: "telegram_lookup_123",
       },
     });
@@ -506,12 +506,12 @@ describe("hosted onboarding member activation", () => {
             channel: "telegram",
             delivery: {
               kind: "thread",
-              target: "telegram_user_123:business:biz-42:dm-topic:9",
+              target: "456",
             },
             identityId: null,
             threadId: expectedTelegramAssistantThreadId({
               memberId: "member_123",
-              threadId: "telegram_user_123:business:biz-42:dm-topic:9",
+              threadId: "456",
             }),
             threadIsDirect: true,
           },
@@ -527,12 +527,12 @@ describe("hosted onboarding member activation", () => {
         channel: "telegram",
         delivery: {
           kind: "thread",
-          target: "telegram_user_123:business:biz-42:dm-topic:9",
+          target: "456",
         },
         identityId: null,
         threadId: expectedTelegramAssistantThreadId({
           memberId: "member_123",
-          threadId: "telegram_user_123:business:biz-42:dm-topic:9",
+          threadId: "456",
         }),
         threadIsDirect: true,
       },

--- a/apps/web/test/hosted-onboarding-messaging-state.test.ts
+++ b/apps/web/test/hosted-onboarding-messaging-state.test.ts
@@ -135,4 +135,31 @@ describe("hosted member messaging authority", () => {
       },
     });
   });
+
+  it("prefers an inbound Telegram thread and otherwise uses the verified user id", () => {
+    const resolveRoute = (telegramThreadId: string | null) => {
+      const messaging = resolveHostedMemberMessagingState({
+        identity: null,
+        routing: {
+          telegramThreadId,
+          telegramUserId: "456",
+        },
+      });
+
+      return resolveHostedMemberAssistantNotificationRoute({
+        linqChatId: null,
+        memberId: "member_telegram",
+        messaging,
+      });
+    };
+
+    expect(resolveRoute("456:business:connection:dm-topic:9")?.delivery).toEqual({
+      kind: "thread",
+      target: "456:business:connection:dm-topic:9",
+    });
+    expect(resolveRoute(null)?.delivery).toEqual({
+      kind: "thread",
+      target: "456",
+    });
+  });
 });

--- a/apps/web/test/hosted-onboarding-privy-service.test.ts
+++ b/apps/web/test/hosted-onboarding-privy-service.test.ts
@@ -1162,7 +1162,7 @@ describe("completeHostedPrivyVerification", () => {
     expect(prisma.hostedMember.create).toHaveBeenCalledTimes(1);
   });
 
-  it("creates a hosted member and a web invite for a new Telegram-only signup without treating identity as messaging setup", async () => {
+  it("creates a hosted member and a web invite for a messaging-ready Telegram-only signup", async () => {
     const identityUpsert = vi.fn(async ({
       create,
       update,
@@ -1228,7 +1228,7 @@ describe("completeHostedPrivyVerification", () => {
       inviteCode: "public-telegram-invite",
       joinUrl: "https://join.example.test/join/public-telegram-invite",
       memberId: "member_telegram_only",
-      messagingSetupRequired: true,
+      messagingSetupRequired: false,
       stage: "checkout",
     });
 
@@ -1246,7 +1246,7 @@ describe("completeHostedPrivyVerification", () => {
     }));
   });
 
-  it("allows invite-bound Telegram-only verification while still requiring a direct messaging route", async () => {
+  it("allows invite-bound Telegram-only verification with messaging ready", async () => {
     const inviteMember = makeMember({
       maskedPhoneNumberHint: null,
       phoneLookupKey: null,
@@ -1305,7 +1305,7 @@ describe("completeHostedPrivyVerification", () => {
       inviteCode: "invite-code",
       joinUrl: "https://join.example.test/join/invite-code",
       memberId: inviteMember.id,
-      messagingSetupRequired: true,
+      messagingSetupRequired: false,
       stage: "checkout",
     });
 


### PR DESCRIPTION
## Why this PR exists

A Telegram-only signup already has a server-verified Telegram user ID, but before the first inbound message it has no stored Telegram thread. The existing resolver therefore treated the member as having no messaging route and withheld the activation welcome.

This replaces closed PR #603 with the smallest change that satisfies the requirement: use the verified user ID as the direct Telegram target until an inbound thread exists.

## User goal / visible behavior

A member who signs up with Telegram can receive Murph's normal activation welcome in Telegram immediately, without first messaging the bot or configuring a second channel.

## User experience

The signup and checkout flow does not change. On activation, the existing welcome event, mailbox, outbox, and Telegram sender deliver to the verified Telegram user ID. If an inbound Telegram thread is already known, that more specific route still wins. The actual send remains the definitive delivery attempt and existing failure handling remains unchanged.

## Invariants

- Prefer the observed inbound Telegram thread over the verified user ID.
- Use only the Telegram identity already accepted and stored by the existing Privy verification path.
- Do not perform a Linq lookup when either Telegram route is available.
- Preserve the existing activation, notification, mailbox, outbox, and sender ownership boundaries.
- Add no provider probe, callback protocol, rollout flag, queue, replay path, or new persisted state.

## Change shape

Classification: runtime TypeScript under `apps/web/src` is source; files under `apps/web/test` are tests; the completed execution plan is docs; no binary files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 12 | 9 |
| Tests / fixtures | 38 | 11 |
| Docs | 58 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **108** | **20** |

ReviewGPT first-reviewed head: 156a66460d7811dc365cfa936dbfa1166737cdc0

### ReviewGPT current head

| Head | Source added | Source deleted |
| --- | ---: | ---: |
| `156a66460d7811dc365cfa936dbfa1166737cdc0` | 12 | 9 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786661552&installation_id=127572939&pr_number=649&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F649&signature=d70bd161d2889d88e671987b894dd774a74dc1f9d616f45d798f8e35ba451e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->