### PR TITLE
fix(hosted): admit only reply-eligible fresh input

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-reply-eligible-fresh-input.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-reply-eligible-fresh-input.md
@@ -1,0 +1,102 @@
+# Admit only reply-eligible fresh input
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+- Ensure a durably staged hosted conversation message enters foreground assistant work only when the existing reply-eligibility decision says it can produce a reply.
+- Prevent an earlier reply-ineligible mailbox row from occupying the single fresh-input slot and stranding a later replyable message.
+
+## Success criteria
+
+- Reply-ineligible messages remain durably staged and projected as today, but do not notify the active turn or return a foreground `assistantInputId`.
+- Foreground freshness is derived only from returned assistant input ids, never from a raw conversation import count.
+- Focused regressions prove reply-ineligible and consumed rows return no foreground id, while existing batch aggregation continues to retain every later returned eligible id.
+- The scoped assistant-runtime verification lane, required coverage audit, parent final review, PR CI, and exact-head ReviewGPT loop complete with no accepted findings.
+- The production diff adds no persisted state, owner, queue, scheduler, retry loop, compatibility path, dependency, configuration, or media-parser lifecycle.
+
+## Scope
+
+- In scope:
+  - `packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts`
+  - `packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts`
+  - Focused assistant-runtime regression tests for eligibility-aware foreground admission.
+- Out of scope:
+  - Asynchronous parser maintenance, media parser recovery, SQLite restoration, or media-before-text lane decoupling.
+  - Linq route fallback or scheduled-route changes.
+  - WhatsApp support.
+  - New storage, schemas, lifecycle state, compatibility machinery, or deployment.
+
+## Constraints
+
+- Technical constraints:
+  - Preserve durable mailbox staging, mapping, projection, watermark, replay, and terminal handling behavior.
+  - Use the existing optional `assistantInputId` as the sole foreground-admission capability instead of adding another boolean or abstraction.
+  - Preserve reply-eligible media behavior; this PR does not redesign parser ownership.
+- Product/process constraints:
+  - Default to deletion and the smallest owner-bound correction.
+  - Preserve the old oversized PR and its conflicted worktree for audit history; do not copy or repair it in place.
+  - Open a draft replacement PR only. Do not merge or deploy.
+  - Do not cancel, duplicate, or interfere with another ReviewGPT/browser run.
+
+## Risks and mitigations
+
+1. Risk: suppressing `assistantInputId` could accidentally suppress durable message storage.
+   Mitigation: keep staging, mapping, projection, and imported status unchanged; assert them directly in focused tests.
+2. Risk: consumed replay or active-turn behavior could change unintentionally.
+   Mitigation: trace both return paths and retain existing consumed guards; add only eligibility predicates at the foreground capability boundary.
+3. Risk: adjacent hosted-runtime work overlaps these files.
+   Mitigation: stay on current `main`, touch only named symbols and focused tests, inspect the coordination ledger, and rebase before final handoff if the base moves.
+4. Risk: review feedback could recreate the oversized architecture.
+   Mitigation: require production-path proof for every finding and reject fixes that add owners, queues, state machines, or compatibility machinery without a demonstrated current need.
+
+## Tasks
+
+1. Trace current-main eligibility, staging, import aggregation, and fresh-work selection end to end.
+2. Add the smallest production predicates at the existing capability boundaries.
+3. Add focused regression coverage for durable-but-ineligible input, consumed replay, and pending-work discovery after count-only imports.
+4. Run scoped verification, the required coverage-write audit, and the parent final review.
+5. Close the plan with a scoped commit, push the branch, and open a draft PR with the intent and change-shape contract.
+6. Run PR CI and the exact-head ReviewGPT loop to its repository-defined terminal outcome.
+
+## Decisions
+
+- Use optional `assistantInputId` as the existing foreground capability; do not add `assistantReplyEligible` or another state field.
+- Keep inbox projection unchanged for reply-ineligible messages because it remains durable conversation evidence and is not foreground authority.
+- Defer the distinct media-parser lane-blocking edge; solving it requires a separate product/architecture decision and is not needed for the proven mixed-eligibility bug.
+
+## Progress
+
+- Traced durable staging through mailbox aggregation, workspace-runner control signals, assistant-phase freshness, and foreground selection on current `main`.
+- Reproduced both defects before changing production code: an unconfigured staged input still notified the active turn and returned an id, and a count-only conversation import suppressed pending-index discovery.
+- Added one effective foreground predicate in the conversation importer and removed the raw-count freshness fallback in the assistant phase. Production scope is 17 added and 10 deleted lines across the two owner files.
+- Kept staging, mailbox mapping, projection, latency tracing, pending indexing, watermarks, replay, runner control-loop counts, and media-parser behavior unchanged.
+
+## Now
+
+- The focused projected-ineligible, consumed-replay, and count-only pending-discovery regressions pass.
+- Full scoped diff verification, the required coverage-write audit, and the independent parent-level static review pass.
+- The final commit, draft PR, CI, and ReviewGPT remain.
+
+## Verification
+
+- Commands to run:
+  - `MURPH_VERIFY_SHARED_HOST=1 pnpm test:diff <touched assistant-runtime paths>` with `MURPH_VERIFY_HOST_CONCURRENCY` unset.
+  - Focused direct scenario tests selected from the existing assistant-runtime test files.
+  - `git diff --check` and a base-to-head scope/change-shape inspection.
+  - PR CI plus the exact-head `pnpm review:gpt pr-review` loop after the draft PR opens.
+- Expected outcomes:
+  - All touched-owner and reverse-dependent typechecks/tests pass.
+  - The focused regression shows durable import without foreground admission for an ineligible row and admission of the later eligible row.
+  - No unrelated source, docs, config, schema, dependency, generated file, or deployment change appears in the final patch.
+- Completed focused checks:
+  - Pre-fix focused run reproduced both failures; its exact owned Vitest session was stopped with Ctrl-C after the failure evidence was captured.
+  - Unconfigured projected input: 1 passed, 58 skipped.
+  - Consumed replay plus count-only pending discovery: 2 passed, 277 skipped.
+  - `pnpm test:diff` for the four touched assistant-runtime source/test paths passed with the shared-host profile: dependency policy, workspace boundaries, hosted-runtime guards, affected typechecks, 73 assistant-runtime test files with 1,635 passing tests and 2 skips, 104 Cloudflare Node test files with 1,789 passing tests, and 1 Cloudflare Workers test with 1 passing test.
+  - `git diff --check` passed.
+  - The required coverage-write audit found the current regressions sufficient and made no edits: both importer return branches, durable projection, foreground callback/notification suppression, eligible positive behavior, and count-only pending discovery are covered. It rejected a new mocked mixed-batch test because that test would also pass before the fix and would duplicate existing aggregation proof.
+  - Independent final static review found no critical, high, or medium defect and confirmed that the diff adds no state owner, queue, service, retry mechanism, or compatibility path.
+Completed: 2026-07-14

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -379,6 +379,10 @@ export async function importHostedConversationMailboxItem(input: {
     vaultRoot: input.vaultRoot,
     wake: decoded.wake,
   });
+  const foregroundAssistantInputId =
+    pendingReplyEligible && input.item.durablyConsumed !== true
+      ? stagedInput.inputId
+      : null;
   if (input.item.durablyConsumed !== true) {
     const latencyMilestones = withHostedConversationImportLatencyMilestones({
       autoReplyPreparedAtEpochMs,
@@ -388,7 +392,9 @@ export async function importHostedConversationMailboxItem(input: {
       pendingIndexEnsuredAtEpochMs,
       stagedAtEpochMs: Date.now(),
     });
-    notifyConversationInputStagedBestEffort(input.onConversationInputStaged ?? null);
+    if (foregroundAssistantInputId) {
+      notifyConversationInputStagedBestEffort(input.onConversationInputStaged ?? null);
+    }
     recordHostedConversationLatencyTraceAssistantInputStagedBestEffort({
       inputId: stagedInput.inputId,
       item: input.item,
@@ -397,11 +403,13 @@ export async function importHostedConversationMailboxItem(input: {
       runtimeAttemptId: input.runtimeAttemptId ?? null,
       wake: decoded.wake,
     });
-    await notifyAssistantActiveTurnInputAvailableForInputIds({
-      inputIds: [stagedInput.inputId],
-      ...(input.signal ? { signal: input.signal } : {}),
-      vault: input.vaultRoot,
-    });
+    if (foregroundAssistantInputId) {
+      await notifyAssistantActiveTurnInputAvailableForInputIds({
+        inputIds: [foregroundAssistantInputId],
+        ...(input.signal ? { signal: input.signal } : {}),
+        vault: input.vaultRoot,
+      });
+    }
   }
 
   const linqDeliveryContext = buildHostedAssistantLinqDeliveryContextFromWake(decoded.wake);
@@ -412,7 +420,7 @@ export async function importHostedConversationMailboxItem(input: {
     wake: decoded.wake,
   })) {
     return {
-      assistantInputId: stagedInput.inputId,
+      ...(foregroundAssistantInputId ? { assistantInputId: foregroundAssistantInputId } : {}),
       captureId: null,
       ...(emailDeliveryContext ? { emailDeliveryContext } : {}),
       ...(linqDeliveryContext ? { linqDeliveryContext } : {}),
@@ -438,7 +446,7 @@ export async function importHostedConversationMailboxItem(input: {
     };
   }
   return {
-    assistantInputId: stagedInput.inputId,
+    ...(foregroundAssistantInputId ? { assistantInputId: foregroundAssistantInputId } : {}),
     captureId: null,
     ...(emailDeliveryContext ? { emailDeliveryContext } : {}),
     ...(linqDeliveryContext ? { linqDeliveryContext } : {}),

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -1448,8 +1448,7 @@ export async function runHostedWorkspaceAssistantPhase(
 function hasFreshHostedConversationInput(
   input: HostedWorkspaceRuntimeAssistantPhaseInput,
 ): boolean {
-  return readHostedInitialAssistantInputIds(input).length > 0
-    || (input.initialMailboxImport.importResult.conversationImportedCount ?? 0) > 0;
+  return readHostedInitialAssistantInputIds(input).length > 0;
 }
 
 function hasFreshHostedMailboxInput(

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -672,6 +672,7 @@ describe("hosted mailbox conversation import adapter", () => {
     });
 
     assert.equal(outcome.status, "imported");
+    assert.equal("assistantInputId" in outcome, false);
     if (outcome.status === "imported") {
       assert.equal(outcome.reasonCode ?? null, null);
     }
@@ -1322,40 +1323,60 @@ describe("hosted mailbox conversation import adapter", () => {
               type: "text",
               value: "assistant is unavailable",
             },
+            {
+              type: "link",
+              value: "https://example.invalid/context",
+            },
           ],
         },
         phoneLookupKey: "redacted-contact-sentinel",
       },
     });
-
-    const outcome = await withOperatorHomeRoot(operatorHomeRoot, () =>
-      importHostedConversationMailboxItem({
-        decodePayload: createDecodedPayloadDecoder(decodedWake),
-        async importConversationWake() {
-          return {
-            captureId: null,
-            metrics: {
-              nextWakeAt: null,
-              parserProcessed: 0,
-            },
-          };
-        },
-        item,
-        runtime: createRuntime(),
-        vaultRoot,
-      })
-    );
-
-    assert.equal(outcome.status, "imported");
-    const listed = await listAssistantInputEvents({
+    let activeTurnAdmissionCount = 0;
+    const controller = createAssistantActiveTurnInputController({
+      admissionHook: async () => {
+        activeTurnAdmissionCount += 1;
+        return {
+          kind: "no-new-input",
+        };
+      },
+      conversationKeys: [createLinqConversationLookupKey({ item, wake: decodedWake })],
+      sessionId: "session_unconfigured",
+      turnId: "turn_unconfigured",
       vault: vaultRoot,
     });
-    assert.deepEqual(listed.events[0]?.replyTarget, {
-      channel: "linq",
-      messageId: "msg_unconfigured",
-      threadId: "chat_unconfigured",
-    });
-    assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), []);
+    let stagedCallbackCount = 0;
+
+    try {
+      const outcome = await withOperatorHomeRoot(operatorHomeRoot, () =>
+        importHostedConversationMailboxItem({
+          decodePayload: createDecodedPayloadDecoder(decodedWake),
+          item,
+          onConversationInputStaged() {
+            stagedCallbackCount += 1;
+          },
+          runtime: createRuntime(),
+          vaultRoot,
+        })
+      );
+
+      assert.equal(outcome.status, "imported");
+      assert.equal("assistantInputId" in outcome, false);
+      assert.equal(activeTurnAdmissionCount, 0);
+      assert.equal(stagedCallbackCount, 0);
+      const listed = await listAssistantInputEvents({
+        vault: vaultRoot,
+      });
+      assert.notEqual(listed.events[0]?.projection.status, "not_attempted");
+      assert.deepEqual(listed.events[0]?.replyTarget, {
+        channel: "linq",
+        messageId: "msg_unconfigured",
+        threadId: "chat_unconfigured",
+      });
+      assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), []);
+    } finally {
+      controller.close();
+    }
   });
 
   test("does not enqueue pending email input when the assistant is configured but email is unavailable", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -11189,13 +11189,15 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     ).toBe("2026-04-27T00:10:00.000Z");
   });
 
-  it("runs the automation lane when pending assistant input exists before background work", async () => {
+  it("probes pending input when imported conversations have no eligible foreground ids", async () => {
     mocks.resolveHostedPendingAssistantInputWakeAt.mockResolvedValueOnce(
       "2026-04-27T00:10:00.000Z",
     );
 
     const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
-      importedCount: 0,
+      assistantInputIds: [],
+      conversationImportedCount: 1,
+      importedCount: 1,
       now: () => "2026-04-27T00:10:00.000Z",
     }));
 


### PR DESCRIPTION
ReviewGPT first-reviewed head: 5c06dee28e3584ac313a79701f71bf3c54e43d49

## Why this PR exists

A durably imported hosted conversation row was being treated as foreground assistant work even when the existing reply-eligibility check said Murph could not reply. An earlier ineligible row could occupy the only fresh-input slot, suppress pending-input discovery, and leave a later replyable message waiting for an unrelated wake.

## User goal and experience

Murph should reach the next valid inbound message even when an older mailbox row is intentionally not replyable. There is no UI change: reply-ineligible messages remain durably staged and projected, while only reply-eligible, unconsumed messages enter the foreground turn.

## What changes

- Derive the existing optional `assistantInputId` from reply eligibility and durable-consumption state once, then use it consistently for the staged callback, active-turn notification, and importer result.
- Decide whether the assistant phase has fresh conversation work from returned input IDs only, not the raw imported-row count.
- Strengthen focused regressions for the projected and non-projected importer branches and for pending-input discovery after a count-only import.

## Invariants

- Preserve durable mailbox staging, item-to-input mapping, inbox projection, latency tracing, pending indexing, watermarks, and replay behavior.
- Preserve the positive callback, active-turn notification, and foreground-ID path for eligible input.
- Keep the optional input ID as the single foreground-admission capability; add no state, queue, scheduler, service, schema, dependency, configuration, or compatibility layer.
- Do not change parser ownership, media scheduling, Linq route fallback, or supported-channel scope.

## Verification

- `pnpm test:diff` passed for the four touched source/test paths with the shared-host profile.
- Assistant runtime: 73 test files passed; 1,635 tests passed and 2 skipped.
- Cloudflare Node: 104 test files and 1,789 tests passed.
- Cloudflare Workers: 1 test file and 1 test passed.
- Dependency policy, workspace boundaries, hosted-runtime guards, affected typechecks, and `git diff --check` passed.
- Required coverage-write audit passed with no edits or unresolved findings.
- Independent final static review found no critical, high, or medium defect.

## Scope

This is the narrow replacement for #625; that larger draft remains untouched for audit history. The distinct media-parser lane-blocking edge is deliberately deferred because it is not needed to fix this proven admission bug.

## Change shape

Classification: production TypeScript is source, test files are tests/fixtures, and the completed execution plan is docs. Generated output is reported separately.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 17 | 10 |
| Tests/fixtures | 52 | 29 |
| Docs | 102 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **171** | **39** |

Binary files: none.

## Deployment compatibility

No schema, persisted-data shape, API, configuration, dependency, or cross-component contract changes. Old warm runner containers can continue exhibiting the existing admission bug until replaced, while new containers read the same mailbox and workspace state safely; no tandem or immediate rollout is required. This PR does not deploy anything.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786669753&installation_id=127572939&pr_number=656&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F656&signature=e95f63892e958697f1334d95092f3dff8745cd6d1b774fc12f5a7a02f4d8df3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->