### PR TITLE
Improve new-member group join handoff

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-group-join-onboarding-handoff.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-group-join-onboarding-handoff.md
@@ -1,0 +1,48 @@
+Goal (incl. success criteria):
+- Keep a new member's group invite as the primary journey through authentication, explicit sharing consent, and membership acceptance.
+- Automatically open the join authentication dialog for an unauthenticated visitor on a valid group link, matching the intent-driven `/connect` behavior while retaining the visible page CTA as a recovery action.
+- After a successful join, route a new accessible member through the normal initial-visit Murph handoff, an existing accessible member to home, and a member who still needs account setup to the hosted setup flow.
+- Success means focused routing and component coverage, required frontend/coverage review, exact-head ReviewGPT, green required CI, and no new auth or membership authority derived from client-controlled state.
+
+Constraints/Assumptions:
+- Preserve the existing group preview, auth dialog, launch-consent gate, and explicit sharing choice before membership is created.
+- Keep post-auth state presentational only. It may choose among fixed internal destinations but must never grant access, join membership, or carry an arbitrary redirect.
+- Reuse the existing hosted onboarding destinations and group acceptance route; add no persisted product state, session table, or compatibility layer.
+- Preserve unrelated worktrees, ledger rows, processes, and active reviews.
+
+Key decisions:
+- Return to the same group join page immediately after auth rather than detouring through generic onboarding.
+- Open the auth dialog once on mount for the valid anonymous join state; closing it leaves the group preview and `Continue to join` action available without reopening automatically.
+- Carry one bounded query marker through the server-rendered join page so the successful join action can choose a fixed next step.
+- Use intent-first copy, `Continue to join`, because the action supports both account creation and sign-in.
+- Keep the join itself explicit because the member's name is shared and optional health projections require a deliberate choice.
+
+State:
+- Local implementation and completion checks are done; ready for the scoped commit and PR gates.
+
+Done:
+- Traced the current anonymous preview, auth, launch-consent, sharing, membership, and homepage routing paths.
+- Confirmed the current group flow returns to the invite after auth but discards the normal new-member `initialVisitEligible` result.
+- Confirmed group membership acceptance does not derive authority from the proposed presentation marker.
+- Added a bounded, presentation-only post-auth marker that selects only fixed internal destinations after the existing membership POST succeeds.
+- Made the valid anonymous join page open the existing auth dialog on first render while preserving dismiss and fallback reopen behavior.
+- Added direct coverage for auth return paths, marker sanitization, explicit membership-before-navigation, and new-versus-existing member destinations.
+- Passed focused tests, lint, prepared typecheck, the full diff-aware web verification suite, frontend review, coverage review, and parent final review.
+
+Now:
+- Close the active plan and create the scoped task commit.
+
+Next:
+- Push the exact head, open the PR, and run ReviewGPT concurrently with required CI.
+
+Open questions (UNCONFIRMED if needed):
+- None. The approved behavior is group first, then the appropriate private Murph handoff after membership succeeds.
+
+Working set (initial; narrow as implementation resolves ownership):
+- apps/web/app/groups/join/[joinCode]/page.tsx
+- apps/web/src/components/hosted-groups/group-join-client.tsx
+- apps/web/src/lib/hosted-groups/group-join-handoff.ts
+- apps/web/test/hosted-group-join-*.test.ts*
+Status: completed
+Updated: 2026-07-14
+Completed: 2026-07-14

--- a/apps/web/app/groups/join/[joinCode]/page.tsx
+++ b/apps/web/app/groups/join/[joinCode]/page.tsx
@@ -7,6 +7,11 @@ import {
   GroupJoinSignInButton,
 } from "@/src/components/hosted-groups/group-join-client";
 import { Button } from "@/src/components/ui/button";
+import {
+  readGroupJoinPostAuthHandoff,
+  resolveGroupJoinPostJoinDestination,
+  type GroupJoinPostJoinDestination,
+} from "@/src/lib/hosted-groups/group-join-handoff";
 import { readHostedGroupJoinView } from "@/src/lib/hosted-groups/group-store";
 import { getHostedPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
 import { resolveDecodedRouteParam } from "@/src/lib/http";
@@ -20,6 +25,10 @@ import { createMurphPageMetadata } from "@/src/lib/site-metadata";
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 export const revalidate = 0;
+
+type GroupJoinSearchParams = {
+  postJoin?: string | string[] | undefined;
+};
 
 export async function generateMetadata({
   params,
@@ -48,10 +57,18 @@ export async function generateMetadata({
 
 export default async function GroupJoinPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ joinCode: string }>;
+  searchParams?: Promise<GroupJoinSearchParams>;
 }) {
-  const joinCode = await resolveDecodedRouteParam(params, "joinCode");
+  const [joinCode, resolvedSearchParams]: [string, GroupJoinSearchParams] = await Promise.all([
+    resolveDecodedRouteParam(params, "joinCode"),
+    searchParams ?? Promise.resolve<GroupJoinSearchParams>({}),
+  ]);
+  const postJoinDestination = resolveGroupJoinPostJoinDestination(
+    readGroupJoinPostAuthHandoff(resolvedSearchParams.postJoin),
+  );
   const auth = await getHostedPageAuthSnapshot();
   const prisma = getPrisma();
   const view = await readHostedGroupJoinView({
@@ -72,6 +89,7 @@ export default async function GroupJoinPage({
         authenticated: auth.authenticated,
         joinCode,
         launchConsentStatus,
+        postJoinDestination,
         view,
       })}
     </main>
@@ -82,6 +100,7 @@ function renderGroupJoin(input: {
   authenticated: boolean;
   joinCode: string;
   launchConsentStatus: HostedConsentStatus | null;
+  postJoinDestination: GroupJoinPostJoinDestination;
   view: Awaited<ReturnType<typeof readHostedGroupJoinView>>;
 }) {
   const { view } = input;
@@ -142,12 +161,13 @@ function renderGroupJoin(input: {
             groupName={groupName}
             joinCode={input.joinCode}
             permissions={view.requestedVaultShareProjections}
+            postJoinDestination={alreadyActiveMember ? "/home" : input.postJoinDestination}
           />
         ) : (
           <div className="flex flex-col gap-2">
             <GroupJoinSignInButton />
             <p className="text-center text-xs leading-5 text-muted-foreground">
-              Sign in or create a private Murph account, and we&apos;ll bring you back here.
+              Create or open your private Murph account, and we&apos;ll bring you back here.
             </p>
           </div>
         )}

--- a/apps/web/src/components/hosted-groups/group-join-client.tsx
+++ b/apps/web/src/components/hosted-groups/group-join-client.tsx
@@ -15,7 +15,12 @@ import { requestHostedOnboardingJson } from "@/src/components/hosted-onboarding/
 import { navigateHostedAuthRedirect } from "@/src/components/hosted-onboarding/hosted-auth-navigation";
 import { toErrorMessage } from "@/src/components/settings/hosted-settings-sync-helpers";
 import { Button } from "@/src/components/ui/button";
+import {
+  buildGroupJoinPostAuthReturnPath,
+  type GroupJoinPostJoinDestination,
+} from "@/src/lib/hosted-groups/group-join-handoff";
 import type { HostedConsentStatus } from "@/src/lib/legal/consent";
+import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
 import { cn } from "@/src/lib/utils";
 
 export interface GroupJoinPermissionDisplay {
@@ -26,23 +31,26 @@ export interface GroupJoinPermissionDisplay {
 }
 
 export function GroupJoinSignInButton() {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
 
-  function handleCompleted() {
-    navigateHostedAuthRedirect(readCurrentGroupJoinPath());
+  function handleCompleted(payload: HostedPrivyCompletionPayload) {
+    navigateHostedAuthRedirect(buildGroupJoinPostAuthReturnPath({
+      currentPath: readCurrentGroupJoinPath(),
+      payload,
+    }));
   }
 
   return (
     <>
       <Button type="button" size="xl" onClick={() => setOpen(true)}>
-        Sign in to join
+        Continue to join
       </Button>
       <AuthDialog
         open={open}
         onCompleted={handleCompleted}
         onOpenChange={setOpen}
         requireLaunchConsentOnCompletion
-        title="Sign in to join this Murph group"
+        title="Continue to join this Murph group"
         description="Create or open your private Murph account, then we'll bring you back here."
       />
     </>
@@ -91,6 +99,7 @@ export function GroupJoinAcceptForm(props: {
   groupName: string;
   joinCode: string;
   permissions: readonly GroupJoinPermissionDisplay[];
+  postJoinDestination: GroupJoinPostJoinDestination;
 }) {
   const router = useRouter();
   const [selected, setSelected] = useState<Set<string>>(
@@ -146,7 +155,12 @@ export function GroupJoinAcceptForm(props: {
         <p className="text-base font-medium text-foreground">
           {props.alreadyActiveMember ? "Your sharing is updated." : `You're in ${props.groupName}.`}
         </p>
-        <Button type="button" size="xl" onClick={() => router.push("/home")} className="w-full">
+        <Button
+          type="button"
+          size="xl"
+          onClick={() => router.push(props.postJoinDestination)}
+          className="w-full"
+        >
           Open Murph
         </Button>
       </div>

--- a/apps/web/src/lib/hosted-groups/group-join-handoff.ts
+++ b/apps/web/src/lib/hosted-groups/group-join-handoff.ts
@@ -1,0 +1,66 @@
+import {
+  HOSTED_APP_HOME_PATH,
+  HOSTED_APP_INITIAL_VISIT_HOME_PATH,
+} from "@/src/lib/hosted-onboarding/app-routes";
+import { isHostedOnboardingAccessibleStage } from "@/src/lib/hosted-onboarding/stage";
+import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
+
+export const GROUP_JOIN_POST_AUTH_QUERY_KEY = "postJoin";
+
+const GROUP_JOIN_POST_AUTH_HANDOFFS = ["initial-visit", "setup"] as const;
+
+export type GroupJoinPostAuthHandoff = (typeof GROUP_JOIN_POST_AUTH_HANDOFFS)[number];
+export type GroupJoinPostJoinDestination =
+  | typeof HOSTED_APP_HOME_PATH
+  | typeof HOSTED_APP_INITIAL_VISIT_HOME_PATH
+  | "/join";
+type GroupJoinAuthCompletionHandoff = Pick<
+  HostedPrivyCompletionPayload,
+  "initialVisitEligible" | "stage"
+>;
+
+export function buildGroupJoinPostAuthReturnPath(input: {
+  currentPath: string;
+  payload: GroupJoinAuthCompletionHandoff;
+}): string {
+  const url = new URL(input.currentPath, "https://murph.invalid");
+  const handoff = resolveGroupJoinPostAuthHandoff(input.payload);
+
+  if (handoff) {
+    url.searchParams.set(GROUP_JOIN_POST_AUTH_QUERY_KEY, handoff);
+  } else {
+    url.searchParams.delete(GROUP_JOIN_POST_AUTH_QUERY_KEY);
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function readGroupJoinPostAuthHandoff(
+  value: string | string[] | undefined,
+): GroupJoinPostAuthHandoff | null {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  return GROUP_JOIN_POST_AUTH_HANDOFFS.find((handoff) => handoff === candidate) ?? null;
+}
+
+export function resolveGroupJoinPostJoinDestination(
+  handoff: GroupJoinPostAuthHandoff | null,
+): GroupJoinPostJoinDestination {
+  switch (handoff) {
+    case "initial-visit":
+      return HOSTED_APP_INITIAL_VISIT_HOME_PATH;
+    case "setup":
+      return "/join";
+    default:
+      return HOSTED_APP_HOME_PATH;
+  }
+}
+
+function resolveGroupJoinPostAuthHandoff(
+  payload: GroupJoinAuthCompletionHandoff,
+): GroupJoinPostAuthHandoff | null {
+  if (!isHostedOnboardingAccessibleStage(payload.stage)) {
+    return "setup";
+  }
+
+  return payload.initialVisitEligible === true ? "initial-visit" : null;
+}

--- a/apps/web/test/hosted-group-join-client.test.tsx
+++ b/apps/web/test/hosted-group-join-client.test.tsx
@@ -1,11 +1,60 @@
-import { createElement } from "react";
+import { act, createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { expect, test, vi } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { renderClientComponent } from "./render-client-component";
+
+const mocks = vi.hoisted(() => ({
+  authDialogProps: null as {
+    description: string;
+    onCompleted?: (payload: {
+      initialVisitEligible?: boolean;
+      stage: "active" | "activating" | "blocked" | "checkout";
+    }) => Promise<void> | void;
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+    title: string;
+  } | null,
+  navigateHostedAuthRedirect: vi.fn(),
+  requestHostedOnboardingJson: vi.fn(),
+  routerPush: vi.fn(),
+  routerRefresh: vi.fn(),
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    refresh: vi.fn(),
+    push: mocks.routerPush,
+    refresh: mocks.routerRefresh,
   }),
+}));
+
+vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
+  AuthDialog(props: {
+    description: string;
+    onCompleted?: (payload: {
+      initialVisitEligible?: boolean;
+      stage: "active" | "activating" | "blocked" | "checkout";
+    }) => Promise<void> | void;
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+    title: string;
+  }) {
+    mocks.authDialogProps = props;
+    return props.open
+      ? createElement("div", {
+          "data-auth-description": props.description,
+          "data-auth-title": props.title,
+        })
+      : null;
+  },
+}));
+
+vi.mock("@/src/components/hosted-onboarding/client-api", () => ({
+  requestHostedOnboardingJson: mocks.requestHostedOnboardingJson,
+}));
+
+vi.mock("@/src/components/hosted-onboarding/hosted-auth-navigation", () => ({
+  navigateHostedAuthRedirect: mocks.navigateHostedAuthRedirect,
 }));
 
 vi.mock("@/src/components/legal/hosted-legal-consent-card", () => ({
@@ -13,6 +62,17 @@ vi.mock("@/src/components/legal/hosted-legal-consent-card", () => ({
     return createElement("div", { "data-consent-card": "true" }, "Consent card");
   },
 }));
+
+let cleanupRender: (() => Promise<void>) | null = null;
+
+afterEach(async () => {
+  if (cleanupRender) {
+    await cleanupRender();
+    cleanupRender = null;
+  }
+  mocks.authDialogProps = null;
+  vi.clearAllMocks();
+});
 
 test("renders a not-now escape link with the group join legal consent gate", async () => {
   const { GroupJoinLegalConsentGate } = await import(
@@ -26,4 +86,123 @@ test("renders a not-now escape link with the group join legal consent gate", asy
   expect(markup).toContain('data-consent-card="true"');
   expect(markup).toContain('href="/home"');
   expect(markup).toContain("Not now");
+});
+
+test("automatically opens the intent-first auth prompt on a valid group join page", async () => {
+  const { GroupJoinSignInButton } = await import(
+    "@/src/components/hosted-groups/group-join-client"
+  );
+  const { cleanup, container } = await renderClientComponent(
+    createElement(GroupJoinSignInButton),
+    {
+      location: {
+        hash: "",
+        href: "https://join.example.test/groups/join/JOIN123",
+        pathname: "/groups/join/JOIN123",
+        search: "",
+      },
+    },
+  );
+  cleanupRender = cleanup;
+
+  await vi.waitFor(() => {
+    expect(mocks.authDialogProps?.open).toBe(true);
+  });
+
+  expect(container.textContent).toContain("Continue to join");
+  expect(container.querySelector(
+    '[data-auth-title="Continue to join this Murph group"]',
+  )).toBeTruthy();
+  expect(container.textContent).not.toContain("Sign in to join");
+
+  await act(async () => {
+    mocks.authDialogProps?.onOpenChange(false);
+  });
+
+  expect(mocks.authDialogProps?.open).toBe(false);
+  expect(container.textContent).toContain("Continue to join");
+
+  const continueButton = container.querySelector("button");
+  expect(continueButton).toBeTruthy();
+
+  await act(async () => {
+    continueButton?.dispatchEvent(new Event("click", { bubbles: true }));
+  });
+
+  expect(mocks.authDialogProps?.open).toBe(true);
+});
+
+test("returns an authenticated new member to the same group intent", async () => {
+  const { GroupJoinSignInButton } = await import(
+    "@/src/components/hosted-groups/group-join-client"
+  );
+  const { cleanup } = await renderClientComponent(
+    createElement(GroupJoinSignInButton),
+    {
+      location: {
+        hash: "#sharing",
+        href: "https://join.example.test/groups/join/JOIN123?source=text#sharing",
+        pathname: "/groups/join/JOIN123",
+        search: "?source=text",
+      },
+    },
+  );
+  cleanupRender = cleanup;
+
+  await vi.waitFor(() => {
+    expect(mocks.authDialogProps?.open).toBe(true);
+  });
+
+  await act(async () => {
+    await mocks.authDialogProps?.onCompleted?.({
+      initialVisitEligible: true,
+      stage: "active",
+    });
+  });
+
+  expect(mocks.navigateHostedAuthRedirect).toHaveBeenCalledWith(
+    "/groups/join/JOIN123?source=text&postJoin=initial-visit#sharing",
+  );
+});
+
+test("opens the post-auth destination only after membership succeeds", async () => {
+  mocks.requestHostedOnboardingJson.mockResolvedValueOnce({ ok: true });
+  const { GroupJoinAcceptForm } = await import(
+    "@/src/components/hosted-groups/group-join-client"
+  );
+  const { button, cleanup, container, window } = await renderClientComponent(
+    createElement(GroupJoinAcceptForm, {
+      activeVaultShareProjectionScopes: [],
+      alreadyActiveMember: false,
+      groupName: "Sunday Sleep Crew",
+      joinCode: "JOIN123",
+      permissions: [],
+      postJoinDestination: "/home?initialVisit=true",
+    }),
+  );
+  cleanupRender = cleanup;
+
+  await act(async () => {
+    button.dispatchEvent(new window.Event("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+
+  expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledWith({
+    method: "POST",
+    payload: { selectedVaultShareProjectionScopes: [] },
+    url: "/api/groups/join/JOIN123/accept",
+  });
+  expect(mocks.routerPush).not.toHaveBeenCalled();
+  expect(container.textContent).toContain("You're in Sunday Sleep Crew.");
+
+  const openMurphButton = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent === "Open Murph",
+  );
+  expect(openMurphButton).toBeTruthy();
+
+  await act(async () => {
+    openMurphButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
+  });
+
+  expect(mocks.routerPush).toHaveBeenCalledWith("/home?initialVisit=true");
 });

--- a/apps/web/test/hosted-group-join-handoff.test.ts
+++ b/apps/web/test/hosted-group-join-handoff.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+
+import {
+  buildGroupJoinPostAuthReturnPath,
+  readGroupJoinPostAuthHandoff,
+  resolveGroupJoinPostJoinDestination,
+} from "@/src/lib/hosted-groups/group-join-handoff";
+
+test("keeps a new accessible member on the group link with an initial-visit handoff", () => {
+  expect(buildGroupJoinPostAuthReturnPath({
+    currentPath: "/groups/join/JOIN123?source=text#sharing",
+    payload: {
+      initialVisitEligible: true,
+      stage: "active",
+    },
+  })).toBe("/groups/join/JOIN123?source=text&postJoin=initial-visit#sharing");
+});
+
+test("removes a stale post-join marker for an existing accessible member", () => {
+  expect(buildGroupJoinPostAuthReturnPath({
+    currentPath: "/groups/join/JOIN123?postJoin=setup&source=text",
+    payload: {
+      initialVisitEligible: false,
+      stage: "activating",
+    },
+  })).toBe("/groups/join/JOIN123?source=text");
+});
+
+test.each(["checkout", "blocked"] as const)(
+  "keeps a %s member on the group link with a setup handoff",
+  (stage) => {
+    expect(buildGroupJoinPostAuthReturnPath({
+      currentPath: "/groups/join/JOIN123",
+      payload: { stage },
+    })).toBe("/groups/join/JOIN123?postJoin=setup");
+  },
+);
+
+test("maps only bounded handoff markers to fixed internal destinations", () => {
+  expect(resolveGroupJoinPostJoinDestination(
+    readGroupJoinPostAuthHandoff("initial-visit"),
+  )).toBe("/home?initialVisit=true");
+  expect(resolveGroupJoinPostJoinDestination(
+    readGroupJoinPostAuthHandoff(["setup", "initial-visit"]),
+  )).toBe("/join");
+  expect(resolveGroupJoinPostJoinDestination(
+    readGroupJoinPostAuthHandoff("https://example.test"),
+  )).toBe("/home");
+});

--- a/apps/web/test/hosted-group-join-page.test.ts
+++ b/apps/web/test/hosted-group-join-page.test.ts
@@ -12,10 +12,16 @@ const mocks = vi.hoisted(() => ({
 vi.mock("server-only", () => ({}));
 
 vi.mock("@/src/components/hosted-groups/group-join-client", () => ({
-  GroupJoinAcceptForm(props: { groupName: string }) {
+  GroupJoinAcceptForm(props: {
+    groupName: string;
+    postJoinDestination: string;
+  }) {
     return createElement(
       "form",
-      { "data-group-name": props.groupName },
+      {
+        "data-group-name": props.groupName,
+        "data-post-join-destination": props.postJoinDestination,
+      },
       "Accept group invite",
     );
   },
@@ -38,7 +44,7 @@ vi.mock("@/src/components/hosted-groups/group-join-client", () => ({
     );
   },
   GroupJoinSignInButton() {
-    return createElement("button", null, "Sign in to join");
+    return createElement("button", null, "Continue to join");
   },
 }));
 
@@ -164,12 +170,62 @@ test("renders the join form for authenticated viewers with current launch consen
   expect(markup).not.toContain('data-legal-consent-gate="true"');
 });
 
-async function renderGroupJoinPage(joinCode: string): Promise<string> {
+test.each([
+  ["initial-visit", "/home?initialVisit=true"],
+  ["setup", "/join"],
+  ["untrusted", "/home"],
+] as const)(
+  "passes the bounded %s post-auth handoff to the join form",
+  async (postJoin, destination) => {
+    mocks.getHostedPageAuthSnapshot.mockResolvedValueOnce({
+      authenticated: true,
+      authenticatedMember: { id: "member_123" },
+    });
+    mocks.readHostedConsentStatus.mockResolvedValueOnce(createConsentStatus({
+      launchGranted: true,
+    }));
+
+    const markup = await renderGroupJoinPage("JOIN123", { postJoin });
+
+    expect(markup).toContain(`data-post-join-destination="${destination.replaceAll("&", "&amp;")}"`);
+  },
+);
+
+test("does not send an existing group member through the new-member handoff", async () => {
+  mocks.getHostedPageAuthSnapshot.mockResolvedValueOnce({
+    authenticated: true,
+    authenticatedMember: { id: "member_123" },
+  });
+  mocks.readHostedConsentStatus.mockResolvedValueOnce(createConsentStatus({
+    launchGranted: true,
+  }));
+  mocks.readHostedGroupJoinView.mockResolvedValueOnce({
+    activeVaultShareProjectionKinds: [],
+    activeVaultShareProjectionScopes: [],
+    displayName: "Sunday Sleep Crew",
+    id: "hgrp_123",
+    kind: "family",
+    memberCount: 2,
+    requestedVaultShareProjections: [],
+    status: "active",
+    viewerMembershipStatus: "active",
+  });
+
+  const markup = await renderGroupJoinPage("JOIN123", { postJoin: "initial-visit" });
+
+  expect(markup).toContain('data-post-join-destination="/home"');
+});
+
+async function renderGroupJoinPage(
+  joinCode: string,
+  searchParams?: { postJoin?: string | string[] | undefined },
+): Promise<string> {
   const { default: GroupJoinPage } = await import("../app/groups/join/[joinCode]/page");
 
   return renderToStaticMarkup(
     await GroupJoinPage({
       params: Promise.resolve({ joinCode }),
+      ...(searchParams ? { searchParams: Promise.resolve(searchParams) } : {}),
     }),
   );
 }


### PR DESCRIPTION
## Why this PR exists

An invitee who opens a Murph group link should stay in the group-join journey through account creation or sign-in. The existing flow returned to the invite after auth, but it did not preserve the new-account initial-visit handoff, and the auth dialog required a second click.

## User goal and experience

- A signed-out invitee opens a valid group link and immediately sees the existing create-account/sign-in dialog over the group preview.
- They can dismiss it and reopen it with **Continue to join**.
- After auth, Murph returns to the exact invite and still requires the existing explicit sharing choice before creating membership.
- After the membership request succeeds, a newly created accessible account gets the normal initial-visit welcome, an existing accessible account goes home, and an account that still needs setup goes to the existing hosted setup flow.

## Invariants

- Keep the group preview, launch-consent gate, explicit sharing choice, and membership POST as the authority for joining.
- Treat the query marker as presentation state only: accept two bounded values, map them to fixed internal destinations, and never derive access or membership from it.
- Existing members always go home regardless of query input.
- Add no persisted state, arbitrary redirect, auth owner, or compatibility layer.

## Validation

- Focused Vitest coverage: 3 files, 18 tests passed.
- Targeted ESLint passed.
- Prepared web typecheck passed.
- Full diff-aware web verification passed: production build, lint, dependency/boundary guards, and 5,145 tests passed with 139 skipped.
- Frontend review and coverage review returned zero findings.

## Change shape

Classification is by file ownership in the base-to-head diff; all files are authored text and there are no binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 108 | 8 |
| Tests/fixtures | 291 | 7 |
| Docs | 48 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **447** | **15** |

ReviewGPT first-reviewed head: db6ca52972ec1d5ddf8b21070778b281cabf808f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786673651&installation_id=127572939&pr_number=659&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F659&signature=b7de084693358e8614841d1bdb4762ece17226bfed99d1003345963f88e1f223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->