### PR TITLE
replace campaign trial extension flow

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-member-trial-extension.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-member-trial-extension.md
@@ -1,0 +1,100 @@
+# Single-member Pulse Trial extension
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+- Replace the expired July Pulse Trial campaign workflow with one operator tool
+  that previews and adds seven trial days for an explicitly entered member ID.
+
+## Success criteria
+
+- `/ops/trials` contains one member-ID form and one result table, with no fixed
+  cohort, provider sweep, batch pagination, cutoff, campaign key, or cleanup
+  action.
+- Preview reads the member's current local and Stripe subscription state and
+  shows the exact seven-day change before Apply is enabled.
+- Apply rejects stale previews, serializes against other billing mutations, and
+  extends either a live Pulse Trial from its current end or a lapsed paused
+  Pulse Trial for seven days from Preview without charging the member.
+- Paid, canceled, incomplete, mismatched, or non-Pulse subscriptions are shown
+  as ineligible and never mutated.
+- Provider and local trial windows reconcile in the same locked operation, and
+  a retried Apply does not add another seven days.
+
+## Scope
+
+- In scope: the hosted ops trial extension service and route, the `/ops/trials`
+  client, focused route/service/UI tests, and current ops documentation.
+- Out of scope: automatic cohort processing, provider-wide subscription search
+  or cleanup, changing trial enrollment/conversion policy, bulk extension, and
+  database schema changes.
+
+## Constraints
+
+- Stripe remains authoritative for subscription identity, status, price, and
+  trial end.
+- Preserve current paid billing and the one-subscription owner invariant.
+- Reuse the existing hosted member Stripe mutation lock and contact-privacy
+  keyring; add no new database state, scheduler, queue, dependency, or config.
+- Keep provider identifiers out of the client-visible preview payload and logs.
+
+## Risks and mitigations
+
+1. Risk: reviving a paused subscription could create an invoice.
+   Mitigation: use Stripe's existing-subscription trial update with
+   `proration_behavior: none`; require the returned state to be `trialing` at
+   the exact target end before local access is restored.
+2. Risk: an operator could Apply after billing changed since Preview.
+   Mitigation: carry one short-lived signed preview proof and re-read both
+   local and Stripe state under the member billing mutation lock.
+3. Risk: a timeout after Stripe succeeds could add seven more days on retry.
+   Mitigation: derive one idempotent operation key from the previewed state,
+   mark the resulting subscription with that key, and reconcile an already
+   applied provider result instead of extending it again.
+
+## Tasks
+
+1. Replace the campaign service with member-scoped eligibility, signed
+   preview proof, locked provider mutation, and local reconciliation.
+2. Narrow the route body and response to one member ID and one Preview/Apply.
+3. Replace both campaign cards with one existing-component form and result
+   table.
+4. Replace campaign tests and documentation with lapsed/live/paid/stale/retry
+   coverage and single-member operator instructions.
+5. Run focused and routed verification, required frontend and coverage audits,
+   then finish the plan with a scoped commit and exact-head PR gates.
+
+## Decisions
+
+- A live `trialing` subscription extends from its current provider trial end.
+- A lapsed `paused` subscription receives seven days from Preview time, because
+  extending its historical end would not restore seven usable days. The proof
+  expires after 15 minutes so the displayed window remains accurate.
+- Other provider statuses are ineligible. In particular, `active` is not
+  converted back to a trial because it may represent paid billing.
+- Keep Preview as a required safety step, but reduce its proof to one opaque
+  member-scoped token rather than campaign snapshots and continuation tokens.
+
+## Verification
+
+- Focused service, route, and client Vitest: 3 files and 26 tests passed.
+- `pnpm test:diff` selected the complete hosted-web verifier: dependency and
+  architecture guards, TypeScript, dev smoke, lint, 5,032 tests, and the
+  production Next build passed. Lint retained 13 unrelated warnings and no
+  errors.
+- `git diff --check`, stale campaign-surface search, and identifier scan passed.
+- Required `coverage-write` completed with added live/lapsed, non-mutation,
+  proof, lock, provider-failure, reconciliation, and route coverage.
+- Required `frontend-review` findings were fixed and re-reviewed to closure:
+  pending member identity is locked, stale results are rejected, result updates
+  are announced, and unchecked provider state is labeled accurately.
+- Isolated frontend startup and hosted-local worktree doctor passed. Desktop and
+  mobile screenshots were unavailable because the browser controller reported
+  no connected browser backend. Full hosted-local startup was independently
+  blocked by the assistant-engine CLI-manifest timeout before the web app began.
+- After the exact pushed PR head exists, start ReviewGPT concurrently with CI
+  and resolve every substantive finding.
+Completed: 2026-07-14

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1109,73 +1109,20 @@ Current hosted billing assumptions:
   `HOSTED_AUTO_PULSE_TRIAL_ENABLED=0` only to force card checkout fallback.
 - Card-based Pulse Trial checkout fallback is gated by
   `HOSTED_PULSE_TRIAL_CHECKOUT_ENABLED=1`.
-- `/ops/trials` is the only Pulse Trial beta-extension surface. It runs the
-  fixed `pulse-beta-extension-2026-07` campaign in-process through
-  `POST /api/ops/pulse-trial-extension` (operator allowlist + mutation-origin
-  gated), so operators do not need production secrets on a local machine. The
-  route extends each Stripe-authoritative current trial by exactly seven days
-  from its existing end and reconciles only the matching local billing and
-  usage-period end timestamps under the shared hosted-member Stripe mutation
-  lock. Preview is aggregate-only and does not mutate; Apply requires echoing
-  the exact fixed campaign key plus the opaque batch and per-target
-  provider proof returned by a complete Preview. Apply rejects a changed local
-  batch before provider work and refuses to mutate a target whose locked Stripe
-  state differs from Preview. A Preview with any provider failure cannot be
-  applied. The Stripe metadata marker makes every Apply retry safe: an already
-  marked subscription cannot receive a second extension, while a
-  Stripe-success/local-failure retry can still repair local reconciliation.
-  Foreign campaign markers fail closed.
-- The deployed route has an 800-second duration and processes one ordered batch
-  of at most four candidates per request. The authoritative finalized cohort is
-  every locally redeemed Pulse Trial with `pulseTrialRedeemedAt` before
-  `2026-07-14T00:00:00.000Z`. Before local keyset traversal, each run performs
-  a bounded, resumable Stripe subscription phase for exact, still-trialing
-  Pulse subscriptions whose provider `trial_start` predates that cutoff. This
-  discovers both missing billing owners and billing rows written after the
-  cutoff; billing-ref creation time otherwise retains only pre-cutoff
-  provider-only reservations whose local finalization may have failed. Preview
-  asks the auto-trial owner to classify those provider-only subscriptions.
-  Apply can extend and recover an exact live pre-cutoff trial in one locked
-  terminal operation, clean up an
-  obsolete exact provider trial while preserving current paid billing, or
-  record a paused trial as ended so it cannot block later members. Trials that
-  actually start after the cutoff remain outside this one-time extension.
-  The all-member UI advances with an encrypted, authenticated keyset
-  continuation in Stripe subscription order during provider reconciliation,
-  then member-id order during local traversal. The continuation exposes neither
-  identifier, and deleting an earlier local candidate cannot shift or skip
-  later candidates. The July 14 cohort expansion versions that continuation
-  namespace so a pre-expansion batch token fails closed and resets the operator
-  to Batch 1 for a complete fresh pass.
-  Each Preview/Apply pair stays on the same batch; the local-batch digest
-  prevents a changed batch from reaching Stripe, and each
-  opaque target proof is checked under that member's mutation lock before its
-  Stripe update. Trial-extension Stripe reads and writes use one 80-second
-  attempt, and the minimum remaining trial runway is derived from that timeout
-  as 81 seconds. Obsolete-provider cleanup carries its final in-lock read
-  directly into one cancellation, keeping the two 80-second provider attempts
-  inside the candidate budget. Apply gives each member lock at most 25 seconds
-  to acquire and each candidate transaction at most 190 seconds. It stops
-  starting candidates once less than 190 seconds remains in the route's
-  780-second work budget. A committed recovery then gives its optional
-  immediate activation wake at most five seconds inside the route margin; the durable
-  `member.activated` mailbox item remains the continuation, and wake/email
-  failures cannot relabel committed campaign work. A lock-busy or
-  route-runway result performs no further Stripe work.
-  The fixed idempotency key and operator-driven retry preserve safe recovery
-  while keeping each page inside the route budget.
-  Before the first production Apply, keep a deployment containing the
-  shared Start-paid-Pulse mutation lock live for at least 1,140 seconds (19
-  minutes) so any older unlocked invocation drains; do not roll back below that
-  lock-capable version during the campaign. Preview immediately before Apply,
-  investigate every unexpected skip/failure, Apply the returned key and proof,
-  and continue through the final batch. Only after the July 14 UTC cutoff has
-  passed, restart without a continuation, Preview every batch again, and require
-  `wouldRecoverProviderTrial = 0`,
-  `wouldCleanupProviderTrial = 0`, `wouldExtend = 0`, and
-  `wouldReconcile = 0` throughout before calling the campaign done. This
-  final pass is the cohort-closing preflight: do not remove the surface while
-  any provider-only pre-cutoff trial remains. The PR owner owns the immediate follow-up
-  removal after that production proof: delete the Ops link, page/client, route,
-  campaign service, focused tests, and this runbook entry. Do not retain or
-  repurpose this fixed one-time campaign surface for a later occasion.
+- `/ops/trials` is the operator-only manual Pulse Trial extension surface. Enter
+  exactly one hosted member ID and Preview before Apply. Preview reads the
+  member's current local billing record and exact Stripe subscription without
+  mutation. Apply checks the same short-lived opaque proof under the shared
+  hosted-member Stripe mutation lock, adds exactly seven days, and reconciles
+  the local trial and usage-period window in that operation.
+- A live `trialing` Pulse Trial extends from its current Stripe trial end. A
+  lapsed `paused` no-card Pulse Trial restarts for seven days from Preview time.
+  The proof expires after 15 minutes. Paid, scheduled, canceling, canceled,
+  incomplete, past-due, unpaid, foreign, or otherwise mismatched billing is
+  displayed as ineligible and is never mutated. The route does not search for
+  members, process cohorts or batches, or clean up provider subscriptions.
+- Stripe reads and writes use one 80-second attempt. Apply gives the member lock
+  at most 25 seconds to acquire and the locked transaction at most 190 seconds.
+  The provider update uses no proration and carries a proof-derived idempotency
+  key and metadata marker. A retry after Stripe success reconciles local billing
+  instead of adding another seven days.

--- a/apps/web/app/(dashboard)/ops/page.tsx
+++ b/apps/web/app/(dashboard)/ops/page.tsx
@@ -34,7 +34,7 @@ const OPS_TOOLS = [
   },
   {
     description:
-      "Recover and extend the fixed Pulse Trial cohort started or redeemed before July 14 UTC, or handle one eligible member.",
+      "Preview and add seven days to one member's active or lapsed paused Pulse Trial without changing paid billing.",
     href: "/ops/trials",
     label: "Trials",
   },

--- a/apps/web/app/(dashboard)/ops/trials/trial-extension-client.tsx
+++ b/apps/web/app/(dashboard)/ops/trials/trial-extension-client.tsx
@@ -1,25 +1,81 @@
 "use client";
 
-import { AlertCircleIcon, CalendarPlusIcon, SearchIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { CalendarPlusIcon, SearchIcon } from "lucide-react";
+import { useRef, useState } from "react";
 
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
-import type { HostedPulseTrialExtensionSummary } from "@/src/lib/hosted-ops/pulse-trial-extension";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
+import type {
+  HostedPulseTrialExtensionPreviewProof,
+  HostedPulseTrialExtensionResult,
+} from "@/src/lib/hosted-ops/pulse-trial-extension";
 
-type TrialExtensionScope = "all" | "member";
-type TrialExtensionPendingAction = "apply" | "preview" | null;
-type TrialExtensionPreview = {
-  summary: HostedPulseTrialExtensionSummary;
-  targetBatchIndex: number;
-  targetContinuationToken: string | null;
-  targetMemberId: string | null;
-};
+type PendingAction = "apply" | "preview" | null;
 
 export function TrialExtensionClient() {
+  const [memberId, setMemberId] = useState("");
+  const [result, setResult] = useState<HostedPulseTrialExtensionResult | null>(
+    null,
+  );
+  const [pending, setPending] = useState<PendingAction>(null);
+  const [error, setError] = useState<string | null>(null);
+  const memberIdRef = useRef(memberId);
+  const normalizedMemberId = memberId.trim();
+
+  async function previewExtension(): Promise<void> {
+    if (!normalizedMemberId) {
+      return;
+    }
+    setPending("preview");
+    setError(null);
+    setResult(null);
+    try {
+      const preview = await requestTrialExtension({
+        memberId: normalizedMemberId,
+        mode: "preview",
+        previewProof: null,
+      });
+      if (memberIdRef.current.trim() === normalizedMemberId) {
+        setResult(preview);
+      }
+    } catch (requestError) {
+      setError(readRequestErrorMessage(requestError));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function applyExtension(): Promise<void> {
+    if (!result?.eligible || !result.previewProof) {
+      return;
+    }
+    setPending("apply");
+    setError(null);
+    try {
+      setResult(await requestTrialExtension({
+        memberId: result.memberId,
+        mode: "apply",
+        previewProof: result.previewProof,
+      }));
+    } catch (requestError) {
+      setResult(null);
+      setError(readRequestErrorMessage(requestError));
+    } finally {
+      setPending(null);
+    }
+  }
+
   return (
     <div className="flex flex-col gap-8">
       <header className="border-b border-border/70 pb-6">
@@ -31,660 +87,285 @@ export function TrialExtensionClient() {
             Trials
           </h1>
           <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Recover unfinished provider trials, reconcile local records, and give
-            eligible Pulse Trial members 7 more days. Preview shows what would
-            change without touching anything; applying asks you to type the run
-            key from the preview. Retries are safe: already extended trials are
-            not extended again.
+            Enter one member ID, check the current Stripe trial, then add seven
+            days. Lapsed paused trials restart from Preview time. Active trials
+            extend from their current end. Paid billing is never changed.
           </p>
         </div>
       </header>
 
-      <TrialExtensionSection
-        description="Closes the fixed Pulse Trial cohort started or redeemed before July 14 UTC, recovers and extends unfinished provider trials in one Apply, and cleans up obsolete provider trials without disturbing paid billing. Process the bounded provider phase and ordered batches of up to four members. After the July 14 UTC cutoff has passed, restart at Batch 1 and Preview every batch again. Retire the campaign only when that full pass shows zero trials to recover, clean up, extend, or reconcile."
-        scope="all"
-        title="Fixed campaign cohort"
-      />
-      <TrialExtensionSection
-        description="Recovers and extends an unfinished provider trial in one Apply, or cleans up an obsolete one while preserving current billing."
-        scope="member"
-        title="One member"
-      />
-    </div>
-  );
-}
-
-function TrialExtensionSection({
-  description,
-  scope,
-  title,
-}: {
-  description: string;
-  scope: TrialExtensionScope;
-  title: string;
-}) {
-  const [memberId, setMemberId] = useState("");
-  const [preview, setPreview] = useState<TrialExtensionPreview | null>(null);
-  const [applied, setApplied] = useState<HostedPulseTrialExtensionSummary | null>(null);
-  const [confirmation, setConfirmation] = useState("");
-  const [pending, setPending] = useState<TrialExtensionPendingAction>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [batchIndex, setBatchIndex] = useState(0);
-  const [continuationHistory, setContinuationHistory] = useState<Array<string | null>>([
-    null,
-  ]);
-  const previewResultRef = useRef<HTMLDivElement>(null);
-  const appliedResultRef = useRef<HTMLDivElement>(null);
-
-  const targetMemberId = scope === "member" ? memberId.trim() : null;
-  const missingMemberId = scope === "member" && targetMemberId === "";
-  const confirmationMatches =
-    preview !== null &&
-    preview.summary.candidateSnapshotDigest !== null &&
-    hasCompleteTrialExtensionPreviewProof(preview.summary) &&
-    confirmation.trim() === preview.summary.campaign;
-  const sectionId = `trial-extension-${scope}`;
-  const displayedSummary = applied ?? preview?.summary ?? null;
-
-  function resetToFirstBatch(): void {
-    setBatchIndex(0);
-    setContinuationHistory([null]);
-    setPreview(null);
-    setApplied(null);
-    setConfirmation("");
-  }
-
-  useEffect(() => {
-    if (applied) {
-      appliedResultRef.current?.focus();
-    }
-  }, [applied]);
-
-  useEffect(() => {
-    if (preview) {
-      previewResultRef.current?.focus();
-    }
-  }, [preview]);
-
-  async function previewExtension(
-    requestedContinuationToken = continuationHistory[batchIndex] ?? null,
-    requestedBatchIndex = batchIndex,
-  ): Promise<void> {
-    const requestedMemberId = scope === "member" ? memberId.trim() : null;
-    if (scope === "member" && !requestedMemberId) {
-      return;
-    }
-
-    setPending("preview");
-    setError(null);
-    setPreview(null);
-    setApplied(null);
-    setConfirmation("");
-    try {
-      const summary = await requestTrialExtension({
-        campaign: null,
-        candidatePreviewTokens: null,
-        candidateSnapshotDigest: null,
-        continuationToken: requestedContinuationToken,
-        memberId: requestedMemberId,
-        mode: "dry-run",
-      });
-      if (!summary.candidateSnapshotDigest) {
-        throw new Error("Preview could not be verified. Preview again.");
-      }
-      setBatchIndex(requestedBatchIndex);
-      setPreview({
-        summary,
-        targetBatchIndex: requestedBatchIndex,
-        targetContinuationToken: requestedContinuationToken,
-        targetMemberId: requestedMemberId,
-      });
-    } catch (requestError) {
-      if (isTrialExtensionContinuationInvalidError(requestError)) {
-        resetToFirstBatch();
-        setError(`${readRequestErrorMessage(requestError)} Batch 1 is ready to Preview.`);
-      } else {
-        setError(readRequestErrorMessage(requestError));
-      }
-    } finally {
-      setPending(null);
-    }
-  }
-
-  async function applyExtension(): Promise<void> {
-    if (
-      !preview?.summary.candidateSnapshotDigest ||
-      !hasCompleteTrialExtensionPreviewProof(preview.summary) ||
-      confirmation.trim() !== preview.summary.campaign
-    ) {
-      return;
-    }
-
-    setPending("apply");
-    setError(null);
-    try {
-      const summary = await requestTrialExtension({
-        campaign: preview.summary.campaign,
-        candidatePreviewTokens: preview.summary.candidatePreviewTokens,
-        candidateSnapshotDigest: preview.summary.candidateSnapshotDigest,
-        continuationToken: preview.targetContinuationToken,
-        memberId: preview.targetMemberId,
-        mode: "apply",
-      });
-      setApplied(summary);
-      if (
-        !hasTrialExtensionFailures(summary) ||
-        summary.localWindowsReconciled > 0 ||
-        summary.failures.preview_state_changed > 0 ||
-        summary.providerTrialsCleanedUp > 0 ||
-        summary.providerTrialsRecovered > 0 ||
-        summary.stripeTrialsExtended > 0 ||
-        summary.skipped.local_candidate_changed > 0
-      ) {
-        setPreview(null);
-        setConfirmation("");
-      }
-    } catch (requestError) {
-      if (isTrialExtensionContinuationInvalidError(requestError)) {
-        resetToFirstBatch();
-        setError(`${readRequestErrorMessage(requestError)} Batch 1 is ready to Preview.`);
-      } else {
-        if (isTrialExtensionPreviewStaleError(requestError)) {
-          setPreview(null);
-          setConfirmation("");
-        }
-        setError(readRequestErrorMessage(requestError));
-      }
-    } finally {
-      setPending(null);
-    }
-  }
-
-  return (
-    <section
-      aria-busy={pending !== null}
-      aria-labelledby={`${sectionId}-title`}
-      className="rounded-xl border border-border/70 bg-card/90 p-5"
-    >
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div>
+      <section
+        aria-busy={pending !== null}
+        aria-labelledby="member-trial-extension-title"
+      >
+        <div className="flex flex-col gap-1">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-chart-5">
             7 more days
           </span>
           <h2
-            className="mt-1 font-serif text-xl font-semibold tracking-tight text-foreground"
-            id={`${sectionId}-title`}
+            className="font-serif text-xl font-semibold tracking-tight text-foreground"
+            id="member-trial-extension-title"
           >
-            {title}
+            Extend one member
           </h2>
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
-            {description}
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            Preview is required before Apply so you can verify the exact member
+            and trial window.
           </p>
         </div>
-      </div>
 
-      <div className="mt-5 flex flex-col gap-4">
-        {scope === "member" ? (
-          <div className="flex max-w-sm flex-col gap-2">
-            <Label
-              className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
-              htmlFor={`${sectionId}-member-id`}
-            >
-              Member id
-            </Label>
+        <form
+          className="mt-5 flex max-w-2xl flex-col gap-3 sm:flex-row sm:items-end"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void previewExtension();
+          }}
+        >
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <Label htmlFor="trial-extension-member-id">Member ID</Label>
             <Input
               autoComplete="off"
-              id={`${sectionId}-member-id`}
-              onChange={(event) => {
-                setMemberId(event.target.value);
-                setPreview(null);
-                setApplied(null);
-                setConfirmation("");
-                setError(null);
-                setBatchIndex(0);
-                setContinuationHistory([null]);
-              }}
               disabled={pending !== null}
-              placeholder="member_..."
+              id="trial-extension-member-id"
+              onChange={(event) => {
+                memberIdRef.current = event.target.value;
+                setMemberId(event.target.value);
+                setResult(null);
+                setError(null);
+              }}
+              placeholder="hbm_..."
               spellCheck={false}
               value={memberId}
             />
           </div>
-        ) : null}
-
-        <div className="flex flex-wrap items-center gap-2">
           <Button
-            disabled={pending !== null || missingMemberId}
+            disabled={!normalizedMemberId || pending !== null}
             onClick={() => void previewExtension()}
-            size="sm"
             type="button"
             variant="outline"
           >
             <SearchIcon data-icon="inline-start" />
             {pending === "preview" ? "Previewing..." : "Preview"}
           </Button>
-        </div>
-
-        {preview ? (
-          <div
-            className="flex flex-col gap-3 rounded-lg border border-border/70 bg-muted/20 p-4"
-            ref={previewResultRef}
-            tabIndex={-1}
-          >
-            <div aria-live="polite" role="status">
-              <TrialExtensionSummaryPanel
-                batchNumber={preview.targetBatchIndex + 1}
-                scope={scope}
-                summary={preview.summary}
-              />
-            </div>
-            {!hasCompleteTrialExtensionPreviewProof(preview.summary) ? (
-              <p className="border-t border-border/70 pt-4 text-sm text-muted-foreground">
-                Apply is unavailable until Preview completes without failures.
-              </p>
-            ) : preview.summary.wouldExtend > 0 ||
-              preview.summary.wouldRecoverProviderTrial > 0 ||
-              preview.summary.wouldCleanupProviderTrial > 0 ||
-              preview.summary.wouldReconcile > 0 ? (
-              <div className="flex flex-col gap-3 border-t border-border/70 pt-4">
-                <div className="flex max-w-sm flex-col gap-2">
-                  <Label
-                    className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
-                    htmlFor={`${sectionId}-confirmation`}
-                  >
-                    Type {preview.summary.campaign} to confirm
-                  </Label>
-                  <Input
-                    autoComplete="off"
-                    disabled={pending !== null}
-                    id={`${sectionId}-confirmation`}
-                    onChange={(event) => setConfirmation(event.target.value)}
-                    placeholder={preview.summary.campaign}
-                    spellCheck={false}
-                    value={confirmation}
-                  />
-                </div>
-                <div>
-                  <Button
-                    disabled={pending !== null || !confirmationMatches}
-                    onClick={() => void applyExtension()}
-                    size="sm"
-                    type="button"
-                  >
-                    <CalendarPlusIcon data-icon="inline-start" />
-                    {pending === "apply" ? "Applying..." : "Apply batch"}
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <p className="border-t border-border/70 pt-4 text-sm text-muted-foreground">
-                {scope === "all"
-                  ? "Nothing to change in this batch. This is complete only after every batch in a fresh pass shows zero provider trials to recover or clean up, zero trials to extend, and zero records to reconcile."
-                  : hasTrialExtensionFailures(preview.summary)
-                    ? "Retry this batch before continuing the member search."
-                  : preview.summary.hasMoreCandidates
-                    ? "Nothing to change in this batch. Preview the next batch to continue the member search."
-                  : "Nothing to change right now."}
-              </p>
-            )}
-          </div>
-        ) : null}
-
-        {applied ? (
-          <div
-            aria-live="polite"
-            className="flex flex-col gap-3 rounded-lg border border-border/70 bg-muted/20 p-4"
-            ref={appliedResultRef}
-            role="status"
-            tabIndex={-1}
-          >
-            <TrialExtensionSummaryPanel
-              batchNumber={batchIndex + 1}
-              scope={scope}
-              summary={applied}
-            />
-            {applied.providerTrialsCleanedUp > 0 ? (
-              <p className="border-t border-border/70 pt-4 text-sm text-muted-foreground">
-                Obsolete provider trial cleaned up. Current billing was left unchanged.
-              </p>
-            ) : null}
-          </div>
-        ) : null}
-
-        {displayedSummary || batchIndex > 0 ? (
-          <div className="flex flex-wrap items-center gap-2 border-t border-border/70 pt-4">
-            {batchIndex > 0 ? (
-              <Button
-                disabled={pending !== null}
-                onClick={() => {
-                  resetToFirstBatch();
-                  void previewExtension(null, 0);
-                }}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                Restart at Batch 1
-              </Button>
-            ) : null}
-            <Button
-              disabled={pending !== null || batchIndex === 0}
-              onClick={() => {
-                const previousBatchIndex = batchIndex - 1;
-                void previewExtension(
-                  continuationHistory[previousBatchIndex] ?? null,
-                  previousBatchIndex,
-                );
-              }}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              Previous batch
-            </Button>
-            {displayedSummary ? (
-              <Button
-                disabled={
-                  pending !== null ||
-                  hasTrialExtensionFailures(displayedSummary) ||
-                  !displayedSummary.hasMoreCandidates ||
-                  !displayedSummary.nextContinuationToken
-                }
-                onClick={() => {
-                  const nextContinuationToken = displayedSummary.nextContinuationToken;
-                  if (!nextContinuationToken) {
-                    return;
-                  }
-                  const nextBatchIndex = batchIndex + 1;
-                  setContinuationHistory((current) => [
-                    ...current.slice(0, nextBatchIndex),
-                    nextContinuationToken,
-                  ]);
-                  void previewExtension(nextContinuationToken, nextBatchIndex);
-                }}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                Preview next batch
-              </Button>
-            ) : null}
-          </div>
-        ) : null}
+        </form>
 
         {error ? (
-          <Alert variant="destructive">
-            <AlertCircleIcon data-icon="inline-start" />
-            <AlertDescription className="min-w-0 break-words">{error}</AlertDescription>
+          <Alert className="mt-5 max-w-3xl" variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
           </Alert>
         ) : null}
-      </div>
-    </section>
-  );
-}
 
-function TrialExtensionSummaryPanel({
-  batchNumber,
-  scope,
-  summary,
-}: {
-  batchNumber: number;
-  scope: TrialExtensionScope;
-  summary: HostedPulseTrialExtensionSummary;
-}) {
-  const isPreview = summary.mode === "dry-run";
-  const skippedEntries = Object.entries(summary.skipped).filter(([, count]) => count > 0);
-  const failureEntries = Object.entries(summary.failures).filter(([, count]) => count > 0);
-  const hasFailures = failureEntries.length > 0;
-  const defaultBadgeLabel = isPreview ? "Preview" : "Applied";
-  const defaultBadgeVariant = isPreview ? "outline" : "secondary";
-  const failureBadgeLabel = isPreview ? "Preview incomplete" : "Needs retry";
-  const badgeLabel = hasFailures ? failureBadgeLabel : defaultBadgeLabel;
-  const badgeVariant = hasFailures ? "destructive" : defaultBadgeVariant;
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant={badgeVariant}>{badgeLabel}</Badge>
-        <span className="font-mono text-[11px] text-muted-foreground">
-          Run key {summary.campaign}
-        </span>
-        {scope === "all" || summary.hasMoreCandidates || batchNumber > 1 ? (
-          <span className="font-mono text-[11px] text-muted-foreground">
-            Batch {batchNumber}
-            {summary.hasMoreCandidates ? " · more batches" : " · final batch"}
-          </span>
-        ) : null}
-      </div>
-
-      {scope === "member" && summary.candidates === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          {hasFailures
-            ? "Retry this batch before continuing the member search."
-            : summary.hasMoreCandidates
-            ? "No eligible campaign trial in this batch. Preview the next batch to continue the member search."
-            : batchNumber > 1
-              ? "Member search complete. No additional eligible campaign trial was found."
-              : "No eligible campaign trial found for that member id."}
+        <p aria-live="polite" className="sr-only">
+          {readAnnouncedStatus({ error, pending, result })}
         </p>
-      ) : (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <TrialExtensionMetricTile label="Trials checked" value={summary.candidates} />
-          {isPreview ? (
-            <>
-              <TrialExtensionMetricTile label="Would get 7 days" value={summary.wouldExtend} />
-              <TrialExtensionMetricTile
-                label="Would recover trial"
-                value={summary.wouldRecoverProviderTrial}
-              />
-              <TrialExtensionMetricTile
-                label="Would clean up trial"
-                value={summary.wouldCleanupProviderTrial}
-              />
-              <TrialExtensionMetricTile label="Would fix records" value={summary.wouldReconcile} />
-            </>
-          ) : (
-            <>
-              <TrialExtensionMetricTile
-                label="Got 7 days"
-                value={summary.stripeTrialsExtended}
-              />
-              <TrialExtensionMetricTile
-                label="Records updated"
-                value={summary.localWindowsReconciled}
-              />
-              <TrialExtensionMetricTile
-                label="Provider trials recovered"
-                value={summary.providerTrialsRecovered}
-              />
-              <TrialExtensionMetricTile
-                label="Provider trials cleaned up"
-                value={summary.providerTrialsCleanedUp}
-              />
-            </>
-          )}
-          <TrialExtensionMetricTile
-            label="Already extended"
-            value={summary.alreadyExtended}
-          />
+
+        <div className="mt-6 overflow-hidden rounded-lg border border-border/70">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Member</TableHead>
+                <TableHead>Local</TableHead>
+                <TableHead>Stripe</TableHead>
+                <TableHead>Current end</TableHead>
+                <TableHead>New end</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {result ? (
+                <TableRow>
+                  <TableCell className="font-mono text-xs">
+                    {result.memberId}
+                  </TableCell>
+                  <TableCell>
+                    <BillingStateBadge
+                      phase={result.localBillingPhase}
+                      status={result.localBillingStatus}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">
+                      {result.providerStatus ?? "Not checked"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                    {formatTrialDate(result.currentTrialEndsAt)}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-sm">
+                    {formatTrialDate(result.targetTrialEndsAt)}
+                  </TableCell>
+                  <TableCell className="min-w-64">
+                    <div className="flex flex-col gap-1">
+                      <Badge variant={result.eligible ? "secondary" : "outline"}>
+                        {readResultLabel(result)}
+                      </Badge>
+                      <span className="text-xs leading-5 text-muted-foreground">
+                        {result.message}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {result.outcome === "preview" && result.eligible &&
+                        result.previewProof ? (
+                      <Button
+                        disabled={pending !== null}
+                        onClick={() => void applyExtension()}
+                        size="sm"
+                        type="button"
+                      >
+                        <CalendarPlusIcon data-icon="inline-start" />
+                        {pending === "apply" ? "Applying..." : "Apply +7 days"}
+                      </Button>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">
+                        {result.outcome === "preview" ? "No action" : "Done"}
+                      </span>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ) : pending === "preview" ? (
+                <TableRow>
+                  <TableCell
+                    className="h-24 text-center text-sm text-muted-foreground"
+                    colSpan={7}
+                  >
+                    Checking member trial...
+                  </TableCell>
+                </TableRow>
+              ) : (
+                <TableRow>
+                  <TableCell
+                    className="h-24 text-center text-sm text-muted-foreground"
+                    colSpan={7}
+                  >
+                    Enter a member ID to preview the trial.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         </div>
-      )}
-
-      {skippedEntries.length > 0 ? (
-        <TrialExtensionReasonList label="Skipped" entries={skippedEntries} />
-      ) : null}
-      {failureEntries.length > 0 ? (
-        <Alert variant="destructive">
-          <AlertCircleIcon data-icon="inline-start" />
-          <AlertDescription className="min-w-0 break-words">
-            {failureEntries
-              .map(([reason, count]) => `${reason}: ${count}`)
-              .join(", ")}
-          </AlertDescription>
-        </Alert>
-      ) : null}
+      </section>
     </div>
   );
 }
 
-function TrialExtensionMetricTile({
-  label,
-  value,
-}: {
-  label: string;
-  value: number;
-}) {
-  return (
-    <div className="rounded-lg border border-border/70 bg-card/90 px-4 py-3">
-      <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
-        {label}
-      </div>
-      <div className="mt-2 font-serif text-2xl font-semibold leading-none tracking-tight text-foreground tabular-nums">
-        {new Intl.NumberFormat("en-US").format(value)}
-      </div>
-    </div>
-  );
-}
-
-function TrialExtensionReasonList({
-  entries,
-  label,
-}: {
-  entries: Array<[string, number]>;
-  label: string;
-}) {
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
-        {label}
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {entries.map(([reason, count]) => (
-          <span
-            className="rounded-md border border-border/70 bg-muted/30 px-2 py-1 font-mono text-[11px] text-muted-foreground"
-            key={reason}
-          >
-            {formatTrialExtensionReason(reason)} ({count})
-          </span>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function hasTrialExtensionFailures(
-  summary: HostedPulseTrialExtensionSummary,
-): boolean {
-  return Object.values(summary.failures).some((count) => count > 0);
-}
-
-function hasCompleteTrialExtensionPreviewProof(
-  summary: HostedPulseTrialExtensionSummary,
-): boolean {
-  return (
-    summary.mode === "dry-run" &&
-    summary.candidatePreviewTokens !== null &&
-    summary.candidatePreviewTokens.length === summary.candidates &&
-    summary.candidatePreviewTokens.every((token) => token.length > 0) &&
-    !hasTrialExtensionFailures(summary)
-  );
-}
-
-function readRequestErrorMessage(requestError: unknown): string {
-  return requestError instanceof Error
-    ? requestError.message
-    : "The trial extension request failed.";
-}
-
-class TrialExtensionRequestError extends Error {
-  readonly code: string | null;
-
-  constructor(input: { code: string | null; message: string }) {
-    super(input.message);
-    this.name = "TrialExtensionRequestError";
-    this.code = input.code;
+function readAnnouncedStatus(input: {
+  error: string | null;
+  pending: PendingAction;
+  result: HostedPulseTrialExtensionResult | null;
+}): string {
+  if (input.pending === "preview") {
+    return "Checking member trial.";
   }
+  if (input.pending === "apply") {
+    return "Applying seven-day trial extension.";
+  }
+  if (input.error) {
+    return "";
+  }
+  if (!input.result) {
+    return "";
+  }
+  return input.result.outcome === "preview"
+    ? `Preview complete. ${input.result.message}`
+    : input.result.message;
 }
 
-function isTrialExtensionPreviewStaleError(requestError: unknown): boolean {
-  return (
-    requestError instanceof TrialExtensionRequestError &&
-    requestError.code === "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_STALE"
-  );
+function BillingStateBadge(input: {
+  phase: string | null;
+  status: string | null;
+}) {
+  const label = [input.status, input.phase].filter(Boolean).join(" · ");
+  return <Badge variant="outline">{label || "Not found"}</Badge>;
 }
 
-function isTrialExtensionContinuationInvalidError(requestError: unknown): boolean {
-  return (
-    requestError instanceof TrialExtensionRequestError &&
-    requestError.code === "HOSTED_OPS_PULSE_TRIAL_EXTENSION_CONTINUATION_INVALID"
-  );
+function readResultLabel(result: HostedPulseTrialExtensionResult): string {
+  if (result.outcome === "extended") {
+    return "Extended";
+  }
+  if (result.outcome === "reconciled") {
+    return "Reconciled";
+  }
+  return result.eligible ? "Ready" : "No change";
 }
 
-function formatTrialExtensionReason(reason: string): string {
-  return reason === "provider_trial_ended"
-    ? "Provider trial already ended — no action needed"
-    : reason;
+function formatTrialDate(value: string | null): string {
+  if (!value) {
+    return "Not set";
+  }
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    return "Not set";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 
 async function requestTrialExtension(input: {
-  campaign: string | null;
-  candidatePreviewTokens: readonly string[] | null;
-  candidateSnapshotDigest: string | null;
-  continuationToken: string | null;
-  memberId: string | null;
-  mode: "apply" | "dry-run";
-}): Promise<HostedPulseTrialExtensionSummary> {
+  memberId: string;
+  mode: "apply" | "preview";
+  previewProof: HostedPulseTrialExtensionPreviewProof | null;
+}): Promise<HostedPulseTrialExtensionResult> {
   const response = await fetch("/api/ops/pulse-trial-extension", {
     body: JSON.stringify({
-      ...(input.campaign ? { campaign: input.campaign } : {}),
-      ...(input.candidatePreviewTokens
-        ? { candidatePreviewTokens: input.candidatePreviewTokens }
-        : {}),
-      ...(input.candidateSnapshotDigest
-        ? { candidateSnapshotDigest: input.candidateSnapshotDigest }
-        : {}),
-      ...(input.continuationToken
-        ? { continuationToken: input.continuationToken }
-        : {}),
-      ...(input.memberId ? { memberId: input.memberId } : {}),
+      memberId: input.memberId,
       mode: input.mode,
+      ...(input.previewProof ? { previewProof: input.previewProof } : {}),
     }),
     cache: "no-store",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
     method: "POST",
   });
-  const payload: unknown = await response.json().catch(() => null);
+  const payload: unknown = await response.json();
   if (!response.ok) {
-    throw new TrialExtensionRequestError({
-      code: readJsonErrorCode(payload),
-      message:
-        readJsonErrorMessage(payload) ?? `Request failed with status ${response.status}.`,
-    });
+    throw new Error(readResponseErrorMessage(payload));
   }
-
-  return payload as HostedPulseTrialExtensionSummary;
+  if (!isHostedPulseTrialExtensionResult(payload)) {
+    throw new Error("Trial extension returned an invalid response.");
+  }
+  return payload;
 }
 
-function readJsonErrorCode(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object" || !("error" in payload)) {
-    return null;
-  }
-  const error = payload.error;
-  if (!error || typeof error !== "object" || !("code" in error)) {
-    return null;
-  }
-  return typeof error.code === "string" ? error.code : null;
+function isHostedPulseTrialExtensionResult(
+  value: unknown,
+): value is HostedPulseTrialExtensionResult {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      typeof Reflect.get(value, "memberId") === "string" &&
+      typeof Reflect.get(value, "eligible") === "boolean" &&
+      typeof Reflect.get(value, "message") === "string" &&
+      typeof Reflect.get(value, "outcome") === "string",
+  );
 }
 
-function readJsonErrorMessage(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object" || !("error" in payload)) {
-    return null;
+function readResponseErrorMessage(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
+    return "Trial extension failed. Try again.";
   }
-  const error = payload.error;
-  if (!error || typeof error !== "object" || !("message" in error)) {
-    return null;
+  const error = Reflect.get(payload, "error");
+  if (typeof error === "string" && error.trim()) {
+    return error;
   }
-  return typeof error.message === "string" ? error.message : null;
+  if (error && typeof error === "object") {
+    const message = Reflect.get(error, "message");
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+  const message = Reflect.get(payload, "message");
+  return typeof message === "string" && message.trim()
+    ? message
+    : "Trial extension failed. Try again.";
+}
+
+function readRequestErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Trial extension failed. Try again.";
 }

--- a/apps/web/app/api/ops/pulse-trial-extension/route.ts
+++ b/apps/web/app/api/ops/pulse-trial-extension/route.ts
@@ -1,12 +1,11 @@
 import { requireHostedOpsRequestAccess } from "@/src/lib/hosted-ops/access";
 import {
-  extendHostedPulseTrialsForCampaign,
-  HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-  HostedPulseTrialExtensionContinuationError,
-  HostedPulseTrialExtensionPreviewMismatchError,
-  isHostedPulseTrialExtensionContinuationTokenShape,
-  type HostedPulseTrialExtensionMode,
-  type HostedPulseTrialExtensionSummary,
+  applyHostedPulseTrialExtension,
+  HostedPulseTrialExtensionLockBusyError,
+  HostedPulseTrialExtensionPreviewStaleError,
+  HostedPulseTrialExtensionProviderError,
+  previewHostedPulseTrialExtension,
+  type HostedPulseTrialExtensionPreviewProof,
 } from "@/src/lib/hosted-ops/pulse-trial-extension";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import {
@@ -17,190 +16,125 @@ import {
 
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
-export const maxDuration = 800;
+export const maxDuration = 220;
 export const revalidate = 0;
 
-const HOSTED_OPS_PULSE_TRIAL_EXTENSION_BODY_LIMIT_BYTES = 4 * 1024;
-const HOSTED_OPS_PULSE_TRIAL_EXTENSION_MAX_CANDIDATES = 4;
+const REQUEST_BODY_LIMIT_BYTES = 4 * 1024;
+const MEMBER_ID_MAX_LENGTH = 128;
 
 export const POST = withJsonError(async (request: Request) => {
   await requireHostedOpsRequestAccess(request, {
     requireMutationOrigin: true,
   });
   const body = await readHostedOnboardingJsonObject(request, {
-    limitBytes: HOSTED_OPS_PULSE_TRIAL_EXTENSION_BODY_LIMIT_BYTES,
+    limitBytes: REQUEST_BODY_LIMIT_BYTES,
     tooLargeErrorCode: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_REQUEST_TOO_LARGE",
     tooLargeErrorMessage: "Hosted ops trial extension request body is too large.",
   });
+  const memberId = readMemberId(body.memberId);
+  const mode = readMode(body.mode);
 
-  const mode = readMode(body);
-  const memberId = readMemberId(body);
-  const continuationToken = readContinuationToken(body);
-  if (
-    mode === "apply" &&
-    readOptionalString(body.campaign) !== HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN
-  ) {
-    throw hostedOnboardingError({
-      code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_CAMPAIGN_CONFIRMATION_INVALID",
-      httpStatus: 400,
-      message:
-        "Applying a trial extension requires the exact campaign key from a fresh preview.",
-      retryable: false,
-    });
-  }
-  const previewProof = mode === "apply"
-    ? {
-        candidatePreviewTokens: readRequiredCandidatePreviewTokens(body),
-        candidateSnapshotDigest: readRequiredCandidateSnapshotDigest(body),
-      }
-    : null;
-
-  let summary: HostedPulseTrialExtensionSummary;
   try {
-    const commonInput = {
-      maxCandidates: HOSTED_OPS_PULSE_TRIAL_EXTENSION_MAX_CANDIDATES,
-      memberId,
-      continuationToken,
-    };
-    summary = previewProof
-      ? await extendHostedPulseTrialsForCampaign({
-          ...commonInput,
-          expectedCandidatePreviewTokens: previewProof.candidatePreviewTokens,
-          expectedCandidateSnapshotDigest: previewProof.candidateSnapshotDigest,
-          mode: "apply",
+    const result = mode === "apply"
+      ? await applyHostedPulseTrialExtension({
+          memberId,
+          previewProof: readPreviewProof(body.previewProof),
         })
-      : await extendHostedPulseTrialsForCampaign({
-          ...commonInput,
-          mode: "dry-run",
-        });
+      : await previewHostedPulseTrialExtension({ memberId });
+
+    if (mode === "apply") {
+      console.info("Hosted ops member Pulse Trial extension completed.", {
+        outcome: result.outcome,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    return jsonOk(result);
   } catch (error) {
-    if (error instanceof HostedPulseTrialExtensionPreviewMismatchError) {
+    if (error instanceof HostedPulseTrialExtensionPreviewStaleError) {
       throw hostedOnboardingError({
         code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_STALE",
         httpStatus: 409,
-        message: "Eligible trials changed since Preview. Preview again before applying.",
+        message: error.message,
         retryable: false,
       });
     }
-    if (error instanceof HostedPulseTrialExtensionContinuationError) {
+    if (error instanceof HostedPulseTrialExtensionLockBusyError) {
       throw hostedOnboardingError({
-        code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_CONTINUATION_INVALID",
-        httpStatus: 400,
-        message: "Trial extension continuation is invalid. Restart at Batch 1.",
-        retryable: false,
+        code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_LOCK_BUSY",
+        httpStatus: 409,
+        message: error.message,
+        retryable: true,
+      });
+    }
+    if (error instanceof HostedPulseTrialExtensionProviderError) {
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PROVIDER_UNAVAILABLE",
+        httpStatus: 502,
+        message: error.message,
+        retryable: true,
       });
     }
     throw error;
   }
-  if (mode === "apply") {
-    console.info("Hosted ops Pulse Trial extension applied.", {
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      localWindowsReconciled: summary.localWindowsReconciled,
-      providerTrialsCleanedUp: summary.providerTrialsCleanedUp,
-      providerTrialsRecovered: summary.providerTrialsRecovered,
-      scope: memberId ? "member" : "all",
-      stripeTrialsExtended: summary.stripeTrialsExtended,
-      timestamp: new Date().toISOString(),
-    });
-  }
-
-  return jsonOk(summary);
 });
 
-function readMode(body: Record<string, unknown>): HostedPulseTrialExtensionMode {
-  const value = body.mode;
-  if (value === undefined || value === null || value === "" || value === "dry-run") {
-    return "dry-run";
+function readMode(value: unknown): "apply" | "preview" {
+  if (value === undefined || value === null || value === "" || value === "preview") {
+    return "preview";
   }
   if (value === "apply") {
     return "apply";
   }
-
   throw hostedOnboardingError({
     code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_MODE_INVALID",
     httpStatus: 400,
-    message: "Trial extension mode must be dry-run or apply.",
+    message: "Trial extension mode must be preview or apply.",
     retryable: false,
   });
 }
 
-function readMemberId(body: Record<string, unknown>): string | undefined {
-  if (!Object.hasOwn(body, "memberId")) {
-    return undefined;
-  }
-  const memberId = readOptionalString(body.memberId);
-  if (memberId) {
+function readMemberId(value: unknown): string {
+  const memberId = typeof value === "string" ? value.trim() : "";
+  if (
+    memberId.length > 0 &&
+    memberId.length <= MEMBER_ID_MAX_LENGTH &&
+    /^hbm_[A-Za-z0-9_-]+$/u.test(memberId)
+  ) {
     return memberId;
   }
-
   throw hostedOnboardingError({
     code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_MEMBER_ID_INVALID",
     httpStatus: 400,
-    message: "Member id must be a non-empty string when provided.",
+    message: "Enter a valid hosted member ID.",
     retryable: false,
   });
 }
 
-function readRequiredCandidateSnapshotDigest(body: Record<string, unknown>): string {
-  const value = body.candidateSnapshotDigest;
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value;
+function readPreviewProof(value: unknown): HostedPulseTrialExtensionPreviewProof {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidPreviewProofError();
   }
-
-  throw hostedOnboardingError({
-    code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_DIGEST_INVALID",
-    httpStatus: 400,
-    message: "Applying a trial extension requires a candidate snapshot from Preview.",
-    retryable: false,
-  });
-}
-
-function readRequiredCandidatePreviewTokens(body: Record<string, unknown>): readonly string[] {
-  const value = body.candidatePreviewTokens;
+  const previewedAt = Reflect.get(value, "previewedAt");
+  const targetTrialEndsAt = Reflect.get(value, "targetTrialEndsAt");
+  const token = Reflect.get(value, "token");
   if (
-    Array.isArray(value) &&
-    value.length <= HOSTED_OPS_PULSE_TRIAL_EXTENSION_MAX_CANDIDATES &&
-    value.every((token): token is string =>
-      typeof token === "string" && token.trim().length > 0
-    )
+    typeof previewedAt !== "string" ||
+    typeof targetTrialEndsAt !== "string" ||
+    typeof token !== "string" ||
+    previewedAt.length > 64 ||
+    targetTrialEndsAt.length > 64 ||
+    token.length > 256
   ) {
-    return value;
+    throw invalidPreviewProofError();
   }
+  return { previewedAt, targetTrialEndsAt, token };
+}
 
-  throw hostedOnboardingError({
+function invalidPreviewProofError(): Error {
+  return hostedOnboardingError({
     code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_PROOF_INVALID",
     httpStatus: 400,
-    message: "Applying a trial extension requires a complete successful Preview.",
+    message: "Preview this member before applying the extension.",
     retryable: false,
   });
-}
-
-function readContinuationToken(
-  body: Record<string, unknown>,
-): string | null {
-  if (!Object.hasOwn(body, "continuationToken") || body.continuationToken === null) {
-    return null;
-  }
-  const token = readOptionalString(body.continuationToken);
-  if (
-    token &&
-    isHostedPulseTrialExtensionContinuationTokenShape(token)
-  ) {
-    return token;
-  }
-
-  throw hostedOnboardingError({
-    code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_CONTINUATION_INVALID",
-    httpStatus: 400,
-    message: "Trial extension continuation is invalid. Restart at Batch 1.",
-    retryable: false,
-  });
-}
-
-function readOptionalString(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : null;
 }

--- a/apps/web/src/lib/hosted-onboarding/hosted-member-billing-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/hosted-member-billing-store.ts
@@ -87,9 +87,10 @@ export interface HostedMemberStripeBillingRefWriteInput {
 }
 
 // Stripe's pinned SDK permits three 80-second attempts plus two Retry-After
-// waits of up to 60 seconds per call. Extension performs one retrieve and one
-// update under this lock, so 13 minutes covers both 6-minute provider budgets
-// plus one minute for lock acquisition and local database reconciliation.
+// waits of up to 60 seconds per call. A serialized billing transition can
+// perform one retrieve and one update under this lock, so 13 minutes covers
+// both 6-minute provider budgets plus one minute for lock acquisition and local
+// database reconciliation.
 const HOSTED_MEMBER_STRIPE_MUTATION_TRANSACTION_OPTIONS = {
   ...HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
   timeout: 780_000,

--- a/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
+++ b/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
@@ -1,13 +1,7 @@
-import {
-  createCipheriv,
-  createDecipheriv,
-  createHash,
-  randomBytes,
-} from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 
 import {
   HostedBillingStatus,
-  type HostedMemberBillingRef,
   type Prisma,
   type PrismaClient,
 } from "@prisma/client";
@@ -15,1213 +9,898 @@ import type Stripe from "stripe";
 
 import {
   HOSTED_PULSE_TRIAL_OFFER,
-  HOSTED_PULSE_TRIAL_POLICY_VERSION,
 } from "../hosted-onboarding/billing-plans";
-import {
-  applyHostedAutoPulseTrialCampaignDispositionTx,
-  inspectHostedAutoPulseTrialCampaignDisposition,
-  runHostedAutoPulseTrialCampaignPostCommitEffects,
-  type HostedAutoPulseTrialCampaignApplyTxResult,
-  type HostedAutoPulseTrialCampaignDisposition,
-  type HostedAutoPulseTrialCampaignSubscription,
-} from "../hosted-onboarding/auto-trial-enrollment-service";
-import {
-  createHostedStripeCustomerLookupKeyReadCandidates,
-  createHostedStripeSubscriptionLookupKeyReadCandidates,
-} from "../hosted-onboarding/contact-privacy";
 import { readHostedContactPrivacyKeyring } from "../hosted-onboarding/env";
 import {
   HostedMemberStripeMutationLockBusyError,
-  projectHostedMemberStripeBillingRefSnapshot,
   withHostedMemberStripeMutationLockForOps,
+  writeHostedMemberStripeBillingRefTx,
 } from "../hosted-onboarding/hosted-member-billing-store";
-import { readHostedMemberBillingSnapshot } from "../hosted-onboarding/hosted-member-store";
 import {
-  HOSTED_STRIPE_LEGACY_AI_USAGE_PRICE_METADATA_KEY,
-} from "../hosted-onboarding/legacy-usage-price";
-import { requiresHostedBillingCheckout } from "../hosted-onboarding/lifecycle";
+  readHostedMemberBillingSnapshot,
+  updateHostedMemberCoreState,
+  type HostedMemberBillingSnapshot,
+} from "../hosted-onboarding/hosted-member-store";
 import {
   isHostedPulseTrialSubscriptionForKnownPolicy,
 } from "../hosted-onboarding/pulse-trial-subscription-cleanup";
 import { requireHostedStripeBillingPlanConfig } from "../hosted-onboarding/runtime";
-import type { HostedOnboardingReadClient } from "../hosted-onboarding/shared";
 import {
   reconcileHostedAiUsageAllowancePeriodForMemberTx,
 } from "../hosted-execution/usage-allowance";
 import { getPrisma } from "../prisma";
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
-const STRIPE_REQUEST_MAX_NETWORK_RETRIES = 0;
+const PREVIEW_PROOF_TTL_MS = 15 * 60_000;
 const STRIPE_REQUEST_TIMEOUT_MS = 80_000;
-const HOSTED_OPS_ROUTE_WORK_BUDGET_MS = 780_000;
-const HOSTED_OPS_MEMBER_LOCK_ACQUISITION_TIMEOUT_MS = 25_000;
-const HOSTED_OPS_CANDIDATE_TRANSACTION_TIMEOUT_MS = 190_000;
-const HOSTED_OPS_POST_COMMIT_EFFECT_TIMEOUT_MS = 5_000;
-const STRIPE_UPDATE_MINIMUM_RUNWAY_SECONDS =
-  Math.ceil(STRIPE_REQUEST_TIMEOUT_MS / 1000) + 1;
-const HOSTED_PULSE_TRIAL_EXTENSION_CURSOR_PREFIX = "pulse-cursor-v4";
-const HOSTED_PULSE_TRIAL_EXTENSION_CURSOR_AAD =
-  "pulse-beta-extension-2026-07:provider-and-member-keyset-v4";
+const STRIPE_REQUEST_MAX_NETWORK_RETRIES = 0;
+const MEMBER_LOCK_ACQUISITION_TIMEOUT_MS = 25_000;
+const MEMBER_TRANSACTION_TIMEOUT_MS = 190_000;
+const PREVIEW_TOKEN_PREFIX = "pulse-member-preview-v1";
+const PREVIEW_HMAC_CONTEXT = "hosted-member-pulse-trial-extension-preview-v1";
+const EXTENSION_OPERATION_METADATA_KEY = "murphTrialExtensionOperation";
+const EXTENSION_DAYS_METADATA_KEY = "murphTrialExtensionDays";
 
-export const HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN =
-  "pulse-beta-extension-2026-07" as const;
-export const HOSTED_PULSE_TRIAL_EXTENSION_DAYS = 7;
-export const HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO =
-  "2026-07-14T00:00:00.000Z" as const;
-export const HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY =
-  "murphTrialExtensionCampaign" as const;
-export const HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY =
-  "murphTrialExtensionDays" as const;
+export const HOSTED_PULSE_TRIAL_EXTENSION_DAYS = 7 as const;
 
-export type HostedPulseTrialExtensionMode = "apply" | "dry-run";
+export type HostedPulseTrialExtensionEligibilityCode =
+  | "eligible"
+  | "member_not_found"
+  | "member_suspended"
+  | "missing_billing_reference"
+  | "not_a_redeemed_pulse_trial"
+  | "paid_billing"
+  | "scheduled_billing_change"
+  | "missing_stripe_reference"
+  | "provider_identity_mismatch"
+  | "provider_subscription_canceling"
+  | "provider_subscription_not_extendable"
+  | "provider_trial_end_invalid";
 
-export interface HostedPulseTrialExtensionCandidate {
-  billingRefCreatedAt: Date;
-  currentBillingPhase: string | null;
-  currentBillingPlanCode: string | null;
-  currentCheckoutOffer: string | null;
-  currentPeriodEnd: Date | null;
-  currentTrialEndsAt: Date | null;
-  currentTrialStartedAt: Date | null;
-  lastStripeEventCreatedAt: Date | null;
-  memberBillingStatus: HostedBillingStatus;
+export type HostedPulseTrialExtensionOutcome =
+  | "preview"
+  | "extended"
+  | "reconciled";
+
+export interface HostedPulseTrialExtensionPreviewProof {
+  previewedAt: string;
+  targetTrialEndsAt: string;
+  token: string;
+}
+
+export interface HostedPulseTrialExtensionResult {
+  currentTrialEndsAt: string | null;
+  eligibilityCode: HostedPulseTrialExtensionEligibilityCode;
+  eligible: boolean;
+  extensionDays: typeof HOSTED_PULSE_TRIAL_EXTENSION_DAYS;
+  localBillingPhase: string | null;
+  localBillingStatus: string | null;
   memberId: string;
-  memberSuspendedAt: Date | null;
-  providerCustomerId: string | null;
-  providerSubscriptionId: string | null;
-  pulseTrialRedeemedAt: Date | null;
-  stripeCustomerId: string | null;
-  stripeSubscriptionId: string | null;
+  message: string;
+  outcome: HostedPulseTrialExtensionOutcome;
+  previewProof: HostedPulseTrialExtensionPreviewProof | null;
+  providerStatus: string | null;
+  targetTrialEndsAt: string | null;
 }
 
-export interface HostedPulseTrialExtensionLockedCandidate {
-  applyProviderOnlyDisposition(
-    disposition: Exclude<HostedAutoPulseTrialCampaignDisposition, { kind: "not-applicable" }>,
-    now: Date,
-  ): Promise<HostedAutoPulseTrialCampaignApplyTxResult["kind"]>;
-  candidate: HostedPulseTrialExtensionCandidate | null;
-  updateTrialEnd(trialEndsAt: Date, now: Date): Promise<void>;
+export interface HostedPulseTrialExtensionSubscription {
+  cancel_at: number | null;
+  cancel_at_period_end: boolean;
+  customer: string | { id: string } | null;
+  id: string;
+  items: {
+    data: Array<{
+      id: string;
+      price: {
+        id: string;
+        metadata?: Record<string, string> | null;
+        recurring?: {
+          interval?: string;
+          interval_count?: number;
+          usage_type?: string;
+        } | null;
+      };
+      quantity?: number | null;
+    }>;
+    has_more: boolean;
+  };
+  metadata: Record<string, string>;
+  status: Stripe.Subscription.Status;
+  trial_end: number | null;
+  trial_settings?: {
+    end_behavior: {
+      missing_payment_method: "cancel" | "create_invoice" | "pause";
+    };
+  } | null;
+  trial_start: number | null;
 }
 
-export interface HostedPulseTrialExtensionCandidateSource {
-  listCandidates(input: {
-    continuationToken: string | null;
-    limit: number;
-  }): Promise<{
-    candidates: readonly HostedPulseTrialExtensionCandidate[];
-    nextContinuationToken: string | null;
-  }>;
-  inspectProviderOnlyTrial(input: {
-    candidate: HostedPulseTrialExtensionCandidate;
-    now: Date;
-  }): Promise<HostedAutoPulseTrialCampaignDisposition>;
-  withStripeMutationLock<TResult>(input: {
-    acquisitionTimeoutMs: number;
-    candidate: HostedPulseTrialExtensionCandidate;
-    run: (locked: HostedPulseTrialExtensionLockedCandidate) => Promise<TResult>;
-    transactionTimeoutMs: number;
-  }): Promise<TResult>;
-}
-
-export interface HostedPulseTrialExtensionStripeRequestOptions {
-  maxNetworkRetries: typeof STRIPE_REQUEST_MAX_NETWORK_RETRIES;
-  timeout: typeof STRIPE_REQUEST_TIMEOUT_MS;
-}
-
-export type HostedPulseTrialExtensionStripeSubscription =
-  HostedAutoPulseTrialCampaignSubscription;
-
-export interface HostedPulseTrialExtensionStripeUpdateParams {
+interface HostedPulseTrialExtensionStripeUpdateParams {
   metadata: Record<string, string>;
   proration_behavior: "none";
   trial_end: number;
 }
 
-export interface HostedPulseTrialExtensionStripeClient {
+interface HostedPulseTrialExtensionStripeClient {
   retrieveSubscription(
     subscriptionId: string,
-    options: HostedPulseTrialExtensionStripeRequestOptions,
-  ): Promise<HostedPulseTrialExtensionStripeSubscription>;
+    options: Stripe.RequestOptions,
+  ): Promise<HostedPulseTrialExtensionSubscription>;
   updateSubscription(
     subscriptionId: string,
     params: HostedPulseTrialExtensionStripeUpdateParams,
-    options: {
-      idempotencyKey: string;
-    } & HostedPulseTrialExtensionStripeRequestOptions,
-  ): Promise<HostedAutoPulseTrialCampaignSubscription>;
+    options: Stripe.RequestOptions,
+  ): Promise<HostedPulseTrialExtensionSubscription>;
 }
 
-export type HostedPulseTrialExtensionSkipReason =
-  | "local_candidate_changed"
-  | "local_trial_window_invalid"
-  | "missing_stripe_refs"
-  | "outside_campaign_cohort"
-  | "provider_recovery_not_found"
-  | "provider_trial_ended"
-  | "stripe_billing_plan_mismatch"
-  | "stripe_campaign_marker_conflict"
-  | "stripe_checkout_offer_mismatch"
-  | "stripe_customer_mismatch"
-  | "stripe_price_mismatch"
-  | "stripe_subscription_canceling"
-  | "stripe_subscription_id_mismatch"
-  | "stripe_subscription_not_trialing"
-  | "stripe_trial_end_invalid";
-
-export type HostedPulseTrialExtensionFailureReason =
-  | "db_update_failed"
-  | "member_lock_busy"
-  | "preview_state_changed"
-  | "provider_recovery_failed"
-  | "provider_recovery_lookup_failed"
-  | "route_runway_exhausted"
-  | "stripe_retrieve_failed"
-  | "stripe_update_failed"
-  | "stripe_update_result_invalid";
-
-export interface HostedPulseTrialExtensionSummary {
-  alreadyExtended: number;
-  campaign: typeof HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN;
-  candidatePreviewTokens: readonly string[] | null;
-  candidateSnapshotDigest: string | null;
-  candidates: number;
-  extensionDays: typeof HOSTED_PULSE_TRIAL_EXTENSION_DAYS;
-  failures: Record<HostedPulseTrialExtensionFailureReason, number>;
-  hasMoreCandidates: boolean;
-  localWindowsReconciled: number;
-  mode: HostedPulseTrialExtensionMode;
-  nextContinuationToken: string | null;
-  providerTrialsCleanedUp: number;
-  providerTrialsRecovered: number;
-  skipped: Record<HostedPulseTrialExtensionSkipReason, number>;
-  stripeTrialsExtended: number;
-  wouldExtend: number;
-  wouldCleanupProviderTrial: number;
-  wouldRecoverProviderTrial: number;
-  wouldReconcile: number;
-}
-
-type HostedPulseTrialExtensionClassification =
-  | {
-      alreadyMarked: boolean;
-      ok: true;
-      stripeTrialEnd: number;
-    }
-  | {
-      ok: false;
-      reason: HostedPulseTrialExtensionSkipReason;
-    };
-
-type HostedPulseTrialExtensionPreviewAction =
-  | {
-      kind: "already-marked";
-      locallyReconciled: boolean;
-      stripeTrialEnd: number;
-    }
-  | {
-      kind: "extend";
-      stripeTrialEnd: number;
-      targetTrialEnd: number;
-    }
-  | {
-      kind: "cleanup-provider-trial";
-      stripeSubscriptionId: string;
-    }
-  | {
-      kind: "skipped";
-      reason: HostedPulseTrialExtensionSkipReason;
-    };
-
-type HostedPulseTrialLockedApplyResult =
-  | {
-      kind: "already-marked";
-      stripeTrialEnd: number;
-      subscription: HostedPulseTrialExtensionStripeSubscription;
-    }
-  | {
-      kind: "extended";
-      stripeTrialEnd: number;
-      subscription: HostedPulseTrialExtensionStripeSubscription;
-    }
-  | {
-      kind: "failure";
-      reason: Exclude<
-        HostedPulseTrialExtensionFailureReason,
-        "db_update_failed" | "preview_state_changed"
-      >;
-    }
-  | {
-      kind: "preview-stale";
-    }
-  | {
-      kind: "skipped";
-      reason: HostedPulseTrialExtensionSkipReason;
-    };
-
-type HostedPulseTrialLockedOutcome = {
-  localReconciliation: "already-current" | "reconciled" | null;
-  result: HostedPulseTrialLockedApplyResult;
-};
-
-export class HostedPulseTrialExtensionPreviewMismatchError extends Error {
-  constructor() {
-    super("Pulse Trial extension candidates changed since Preview.");
-    this.name = "HostedPulseTrialExtensionPreviewMismatchError";
-  }
-}
-
-export class HostedPulseTrialExtensionContinuationError extends Error {
-  constructor() {
-    super("Pulse Trial extension continuation token is invalid.");
-    this.name = "HostedPulseTrialExtensionContinuationError";
-  }
-}
-
-export function isHostedPulseTrialExtensionContinuationTokenShape(
-  value: unknown,
-): value is string {
-  return typeof value === "string" &&
-    /^pulse-cursor-v4\.v[0-9]+\.[A-Za-z0-9_-]{16}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]{22}$/u
-      .test(value);
-}
-
-type HostedPulseTrialExtensionContinuation =
-  | { afterMemberId: string | null; memberId: string | null; phase: "members" }
-  | { afterSubscriptionId: string | null; memberId: string | null; phase: "provider" };
-
-function encryptHostedPulseTrialExtensionContinuationToken(
-  continuation: HostedPulseTrialExtensionContinuation,
-): string {
-  const keyring = readHostedContactPrivacyKeyring(process.env);
-  const version = keyring.currentVersion;
-  const sourceKey = keyring.keysByVersion[version];
-  if (!sourceKey) {
-    throw new HostedPulseTrialExtensionContinuationError();
-  }
-  const iv = randomBytes(12);
-  const cipher = createCipheriv(
-    "aes-256-gcm",
-    deriveHostedPulseTrialExtensionContinuationKey(sourceKey),
-    iv,
-  );
-  cipher.setAAD(Buffer.from(HOSTED_PULSE_TRIAL_EXTENSION_CURSOR_AAD, "utf8"));
-  const ciphertext = Buffer.concat([
-    cipher.update(JSON.stringify(continuation), "utf8"),
-    cipher.final(),
-  ]);
-  return [
-    HOSTED_PULSE_TRIAL_EXTENSION_CURSOR_PREFIX,
-    version,
-    iv.toString("base64url"),
-    ciphertext.toString("base64url"),
-    cipher.getAuthTag().toString("base64url"),
-  ].join(".");
-}
-
-function decryptHostedPulseTrialExtensionContinuationToken(
-  token: string,
-): HostedPulseTrialExtensionContinuation {
-  const parts = token.split(".");
-  if (
-    parts.length !== 5 ||
-    parts[0] !== HOSTED_PULSE_TRIAL_EXTENSION_CURSOR_PREFIX ||
-    !/^v[0-9]+$/u.test(parts[1] ?? "")
-  ) {
-    throw new HostedPulseTrialExtensionContinuationError();
-  }
-  const version = parts[1];
-  const keyring = readHostedContactPrivacyKeyring(process.env);
-  const sourceKey = version ? keyring.keysByVersion[version] : undefined;
-  if (!sourceKey) {
-    throw new HostedPulseTrialExtensionContinuationError();
-  }
-
-  try {
-    const iv = Buffer.from(parts[2] ?? "", "base64url");
-    const ciphertext = Buffer.from(parts[3] ?? "", "base64url");
-    const authTag = Buffer.from(parts[4] ?? "", "base64url");
-    if (iv.length !== 12 || ciphertext.length === 0 || authTag.length !== 16) {
-      throw new HostedPulseTrialExtensionContinuationError();
-    }
-    const decipher = createDecipheriv(
-      "aes-256-gcm",
-      deriveHostedPulseTrialExtensionContinuationKey(sourceKey),
-      iv,
-    );
-    decipher.setAAD(Buffer.from(HOSTED_PULSE_TRIAL_EXTENSION_CURSOR_AAD, "utf8"));
-    decipher.setAuthTag(authTag);
-    const plaintext = Buffer.concat([
-      decipher.update(ciphertext),
-      decipher.final(),
-    ]).toString("utf8");
-    if (!plaintext) {
-      throw new HostedPulseTrialExtensionContinuationError();
-    }
-    if (!plaintext.startsWith("{")) {
-      throw new HostedPulseTrialExtensionContinuationError();
-    }
-    const parsed: unknown = JSON.parse(plaintext);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      Reflect.get(parsed, "phase") === "members" &&
-      (
-        Reflect.get(parsed, "afterMemberId") === null ||
-        typeof Reflect.get(parsed, "afterMemberId") === "string"
-      )
-    ) {
-      return {
-        afterMemberId: Reflect.get(parsed, "afterMemberId") as string | null,
-        memberId: typeof Reflect.get(parsed, "memberId") === "string"
-          ? Reflect.get(parsed, "memberId") as string
-          : null,
-        phase: "members",
-      };
-    }
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      Reflect.get(parsed, "phase") === "provider" &&
-      (
-        Reflect.get(parsed, "afterSubscriptionId") === null ||
-        typeof Reflect.get(parsed, "afterSubscriptionId") === "string"
-      )
-    ) {
-      return {
-        afterSubscriptionId: Reflect.get(parsed, "afterSubscriptionId") as string | null,
-        memberId: typeof Reflect.get(parsed, "memberId") === "string"
-          ? Reflect.get(parsed, "memberId") as string
-          : null,
-        phase: "provider",
-      };
-    }
-    throw new HostedPulseTrialExtensionContinuationError();
-  } catch (error) {
-    if (error instanceof HostedPulseTrialExtensionContinuationError) {
-      throw error;
-    }
-    throw new HostedPulseTrialExtensionContinuationError();
-  }
-}
-
-function deriveHostedPulseTrialExtensionContinuationKey(sourceKey: Buffer): Buffer {
-  return createHash("sha256")
-    .update("hosted-pulse-trial-extension-continuation-v1", "utf8")
-    .update("\0", "utf8")
-    .update(sourceKey)
-    .digest();
-}
-
-type HostedPulseTrialExtensionCommonInput = {
-  candidateSource: HostedPulseTrialExtensionCandidateSource;
-  continuationToken?: string | null;
-  currentTime?: () => Date;
-  maxCandidates: number;
-  now?: Date;
-  priceId: string;
-  stripe: HostedPulseTrialExtensionStripeClient;
-};
-
-export type HostedPulseTrialExtensionInput = HostedPulseTrialExtensionCommonInput & (
-  | {
-      mode: "dry-run";
-    }
-  | {
-      expectedCandidatePreviewTokens: readonly string[];
-      expectedCandidateSnapshotDigest: string;
-      mode: "apply";
-    }
-);
-
-export async function extendHostedPulseTrials(
-  input: HostedPulseTrialExtensionInput,
-): Promise<HostedPulseTrialExtensionSummary> {
-  const operationDeadlineMs = Date.now() + HOSTED_OPS_ROUTE_WORK_BUDGET_MS;
-  const readCurrentTime = input.currentTime ?? (() => input.now ?? new Date());
-  const mode = input.mode;
-  const continuationToken = input.continuationToken ?? null;
-  if (!Number.isSafeInteger(input.maxCandidates) || input.maxCandidates < 1) {
-    throw new Error("Pulse Trial extension candidate limit must be a positive integer.");
-  }
-  const candidatePage = await readHostedPulseTrialExtensionCandidatePage({
-    candidateSource: input.candidateSource,
-    continuationToken,
-    maxCandidates: input.maxCandidates,
-  });
-  const candidates = candidatePage.candidates;
-
-  const candidateSnapshotDigest = buildHostedPulseTrialExtensionCandidateSnapshotDigest(
-    candidates,
-    continuationToken,
-  );
-  if (
-    input.mode === "apply" &&
-    input.expectedCandidateSnapshotDigest !== candidateSnapshotDigest
-  ) {
-    throw new HostedPulseTrialExtensionPreviewMismatchError();
-  }
-  if (
-    input.mode === "apply" &&
-    input.expectedCandidatePreviewTokens.length !== candidates.length
-  ) {
-    throw new HostedPulseTrialExtensionPreviewMismatchError();
-  }
-
-  const summary = buildEmptyHostedPulseTrialExtensionSummary(
-    mode,
-    mode === "dry-run" ? candidateSnapshotDigest : null,
-    candidatePage.hasMoreCandidates,
-    candidatePage.nextContinuationToken,
-  );
-
-  for (const [candidateIndex, candidate] of candidates.entries()) {
-      summary.candidates += 1;
-
-      const providerOrigin = candidate.providerSubscriptionId !== null;
-      const localSkipReason = providerOrigin
-        ? null
-        : classifyHostedPulseTrialExtensionCandidate(candidate);
-      if (localSkipReason) {
-        const previewToken = buildHostedPulseTrialExtensionCandidatePreviewToken({
-          action: { kind: "skipped", reason: localSkipReason },
-          candidate,
-          subscription: null,
-        });
-        if (mode === "dry-run") {
-          appendHostedPulseTrialExtensionCandidatePreviewToken(summary, previewToken);
-        } else if (
-          input.expectedCandidatePreviewTokens[candidateIndex] !== previewToken
-        ) {
-          summary.failures.preview_state_changed += 1;
-          return suppressHostedPulseTrialExtensionContinuationOnFailure(summary);
-        }
-        summary.skipped[localSkipReason] += 1;
-        continue;
-      }
-
-      if (providerOrigin || candidate.pulseTrialRedeemedAt === null) {
-        if (mode === "dry-run") {
-          appendHostedPulseTrialExtensionCandidatePreviewToken(
-            summary,
-            await previewHostedPulseTrialProviderRecoveryCandidate({
-              candidate,
-              candidateSource: input.candidateSource,
-              now: readCurrentTime(),
-              priceId: input.priceId,
-              stripe: input.stripe,
-              summary,
-            }),
-          );
-          continue;
-        }
-
-        if (
-          operationDeadlineMs - Date.now() <
-            HOSTED_OPS_CANDIDATE_TRANSACTION_TIMEOUT_MS
-        ) {
-          summary.failures.route_runway_exhausted += 1;
-          return suppressHostedPulseTrialExtensionContinuationOnFailure(summary);
-        }
-
-        const providerRecoveryResult = await applyHostedPulseTrialProviderRecoveryCandidate({
-          candidate,
-          candidateSource: input.candidateSource,
-          expectedPreviewToken: input.expectedCandidatePreviewTokens[candidateIndex],
-          now: readCurrentTime(),
-          priceId: input.priceId,
-          readCurrentTime,
-          stripe: input.stripe,
-          summary,
-        });
-        if (providerRecoveryResult === "preview-stale") {
-          summary.failures.preview_state_changed += 1;
-          return suppressHostedPulseTrialExtensionContinuationOnFailure(summary);
-        }
-        continue;
-      }
-
-      if (mode === "dry-run") {
-        appendHostedPulseTrialExtensionCandidatePreviewToken(
-          summary,
-          await previewHostedPulseTrialExtensionCandidate({
-            candidate,
-            now: input.now,
-            priceId: input.priceId,
-            stripe: input.stripe,
-            summary,
-          }),
-        );
-        continue;
-      }
-
-      if (
-        operationDeadlineMs - Date.now() <
-          HOSTED_OPS_CANDIDATE_TRANSACTION_TIMEOUT_MS
-      ) {
-        summary.failures.route_runway_exhausted += 1;
-        return suppressHostedPulseTrialExtensionContinuationOnFailure(summary);
-      }
-
-      const providerState: { result: HostedPulseTrialLockedApplyResult | null } = {
-        result: null,
-      };
-      let lockedOutcome: HostedPulseTrialLockedOutcome;
-      try {
-        lockedOutcome = await input.candidateSource.withStripeMutationLock({
-          acquisitionTimeoutMs: HOSTED_OPS_MEMBER_LOCK_ACQUISITION_TIMEOUT_MS,
-          candidate,
-          run: async (locked) => {
-            if (!locked.candidate) {
-              return {
-                localReconciliation: null,
-                result: { kind: "preview-stale" },
-              };
-            }
-
-            const lockedLocalSkipReason = classifyHostedPulseTrialExtensionCandidate(
-              locked.candidate,
-            );
-            if (lockedLocalSkipReason) {
-              const lockedPreviewToken = buildHostedPulseTrialExtensionCandidatePreviewToken({
-                action: { kind: "skipped", reason: lockedLocalSkipReason },
-                candidate: locked.candidate,
-                subscription: null,
-              });
-              return {
-                localReconciliation: null,
-                result: input.expectedCandidatePreviewTokens[candidateIndex] ===
-                    lockedPreviewToken
-                  ? { kind: "skipped", reason: lockedLocalSkipReason }
-                  : { kind: "preview-stale" },
-              };
-            }
-
-            const providerResult = await applyHostedPulseTrialExtensionUnderLock({
-              candidate: locked.candidate,
-              expectedPreviewToken: input.expectedCandidatePreviewTokens[candidateIndex],
-              now: input.now,
-              priceId: input.priceId,
-              stripe: input.stripe,
-            });
-            providerState.result = providerResult;
-            if (
-              providerResult.kind !== "already-marked" &&
-              providerResult.kind !== "extended"
-            ) {
-              return {
-                localReconciliation: null,
-                result: providerResult,
-              };
-            }
-
-            const trialEndsAt = stripeUnixSecondsToDate(providerResult.stripeTrialEnd);
-            const localAlreadyCurrent = isHostedPulseTrialExtensionLocallyReconciled({
-              candidate: locked.candidate,
-              trialEndsAt,
-            });
-            await locked.updateTrialEnd(trialEndsAt, input.now ?? new Date());
-            return {
-              localReconciliation: localAlreadyCurrent
-                ? "already-current"
-                : "reconciled",
-              result: providerResult,
-            };
-          },
-          transactionTimeoutMs: HOSTED_OPS_CANDIDATE_TRANSACTION_TIMEOUT_MS,
-        });
-      } catch (error) {
-        if (error instanceof HostedMemberStripeMutationLockBusyError) {
-          summary.failures.member_lock_busy += 1;
-          continue;
-        }
-        if (providerState.result?.kind === "extended") {
-          summary.stripeTrialsExtended += 1;
-        }
-        summary.failures.db_update_failed += 1;
-        continue;
-      }
-
-      if (lockedOutcome.result.kind === "failure") {
-        summary.failures[lockedOutcome.result.reason] += 1;
-        continue;
-      }
-      if (lockedOutcome.result.kind === "preview-stale") {
-        summary.failures.preview_state_changed += 1;
-        return suppressHostedPulseTrialExtensionContinuationOnFailure(summary);
-      }
-      if (lockedOutcome.result.kind === "skipped") {
-        summary.skipped[lockedOutcome.result.reason] += 1;
-        continue;
-      }
-
-      if (lockedOutcome.result.kind === "extended") {
-        summary.stripeTrialsExtended += 1;
-      }
-      if (lockedOutcome.localReconciliation === "reconciled") {
-        summary.localWindowsReconciled += 1;
-      }
-      if (
-        lockedOutcome.result.kind === "already-marked" &&
-        lockedOutcome.localReconciliation === "already-current"
-      ) {
-        summary.alreadyExtended += 1;
-      }
-  }
-
-  return suppressHostedPulseTrialExtensionContinuationOnFailure(summary);
-}
-
-function suppressHostedPulseTrialExtensionContinuationOnFailure(
-  summary: HostedPulseTrialExtensionSummary,
-): HostedPulseTrialExtensionSummary {
-  if (Object.values(summary.failures).some((count) => count > 0)) {
-    summary.nextContinuationToken = null;
-  }
-  return summary;
-}
-
-type HostedPulseTrialExtensionCampaignInput = {
-  continuationToken?: string | null;
-  maxCandidates: number;
-  memberId?: string;
-  now?: Date;
+interface HostedPulseTrialExtensionDependencies {
   priceId?: string;
   prisma?: PrismaClient;
   stripe?: HostedPulseTrialExtensionStripeClient;
-} & (
-  | {
-      mode: "dry-run";
-    }
-  | {
-      expectedCandidatePreviewTokens: readonly string[];
-      expectedCandidateSnapshotDigest: string;
-      mode: "apply";
-    }
-);
+}
 
-export async function extendHostedPulseTrialsForCampaign(
-  input: HostedPulseTrialExtensionCampaignInput,
-): Promise<HostedPulseTrialExtensionSummary> {
+type HostedPulseTrialExtensionState = {
+  currentTrialEnd: number | null;
+  eligibilityCode: HostedPulseTrialExtensionEligibilityCode;
+  eligible: boolean;
+  member: HostedMemberBillingSnapshot | null;
+  message: string;
+  providerStatus: string | null;
+  subscription: HostedPulseTrialExtensionSubscription | null;
+  targetTrialEnd: number | null;
+};
+
+export class HostedPulseTrialExtensionPreviewStaleError extends Error {
+  constructor() {
+    super("Billing changed since Preview. Preview this member again before applying.");
+    this.name = "HostedPulseTrialExtensionPreviewStaleError";
+  }
+}
+
+export class HostedPulseTrialExtensionProviderError extends Error {
+  constructor() {
+    super("Stripe could not be checked for this member. Try Preview again.");
+    this.name = "HostedPulseTrialExtensionProviderError";
+  }
+}
+
+export class HostedPulseTrialExtensionLockBusyError extends Error {
+  constructor() {
+    super("Another billing change is running for this member. Try again shortly.");
+    this.name = "HostedPulseTrialExtensionLockBusyError";
+  }
+}
+
+export async function previewHostedPulseTrialExtension(
+  input: {
+    memberId: string;
+    now?: Date;
+  } & HostedPulseTrialExtensionDependencies,
+): Promise<HostedPulseTrialExtensionResult> {
+  const dependencies = resolveHostedPulseTrialExtensionDependencies(input);
+  const now = input.now ?? new Date();
+  const member = await readHostedMemberBillingSnapshot({
+    memberId: input.memberId,
+    prisma: dependencies.prisma,
+  });
+  const state = await inspectHostedPulseTrialExtensionState({
+    member,
+    memberId: input.memberId,
+    now,
+    priceId: dependencies.priceId,
+    stripe: dependencies.stripe,
+  });
+
+  if (!state.eligible || !state.subscription || state.targetTrialEnd === null) {
+    return buildHostedPulseTrialExtensionResult({
+      memberId: input.memberId,
+      outcome: "preview",
+      previewProof: null,
+      state,
+    });
+  }
+
+  const proof = buildHostedPulseTrialExtensionPreviewProof({
+    member: state.member,
+    memberId: input.memberId,
+    previewedAt: now,
+    subscription: state.subscription,
+    targetTrialEnd: state.targetTrialEnd,
+  });
+  return buildHostedPulseTrialExtensionResult({
+    memberId: input.memberId,
+    outcome: "preview",
+    previewProof: proof,
+    state,
+  });
+}
+
+export async function applyHostedPulseTrialExtension(
+  input: {
+    memberId: string;
+    now?: Date;
+    previewProof: HostedPulseTrialExtensionPreviewProof;
+  } & HostedPulseTrialExtensionDependencies,
+): Promise<HostedPulseTrialExtensionResult> {
+  const dependencies = resolveHostedPulseTrialExtensionDependencies(input);
+  const now = input.now ?? new Date();
+  const proofDates = parseHostedPulseTrialExtensionPreviewProofDates({
+    now,
+    previewProof: input.previewProof,
+  });
+  const operationId = readHostedPulseTrialExtensionOperationId(
+    input.previewProof.token,
+  );
+
+  try {
+    return await withHostedMemberStripeMutationLockForOps({
+      acquisitionTimeoutMs: MEMBER_LOCK_ACQUISITION_TIMEOUT_MS,
+      memberId: input.memberId,
+      prisma: dependencies.prisma,
+      run: async (tx) => {
+        const member = await readHostedMemberBillingSnapshot({
+          memberId: input.memberId,
+          prisma: tx,
+        });
+        const state = await inspectHostedPulseTrialExtensionState({
+          member,
+          memberId: input.memberId,
+          now: proofDates.previewedAt,
+          priceId: dependencies.priceId,
+          stripe: dependencies.stripe,
+        });
+        const subscription = state.subscription;
+
+        if (
+          subscription &&
+          isHostedPulseTrialExtensionAlreadyApplied({
+            memberId: input.memberId,
+            operationId,
+            priceId: dependencies.priceId,
+            subscription,
+            targetTrialEnd: proofDates.targetTrialEndUnix,
+          })
+        ) {
+          const reconciledMember = await reconcileHostedPulseTrialExtensionLocalState({
+            member,
+            now,
+            subscription,
+            targetTrialEndsAt: proofDates.targetTrialEndsAt,
+            tx,
+          });
+          return buildHostedPulseTrialExtensionResult({
+            memberId: input.memberId,
+            outcome: "reconciled",
+            previewProof: null,
+            state: {
+              ...state,
+              currentTrialEnd: proofDates.targetTrialEndUnix,
+              eligibilityCode: "eligible",
+              eligible: true,
+              member: reconciledMember,
+              message: "The seven-day extension was already in Stripe and local billing is reconciled.",
+              providerStatus: subscription.status,
+              targetTrialEnd: proofDates.targetTrialEndUnix,
+            },
+          });
+        }
+
+        if (
+          !state.eligible ||
+          !member ||
+          !subscription ||
+          state.targetTrialEnd !== proofDates.targetTrialEndUnix ||
+          !verifyHostedPulseTrialExtensionPreviewProof({
+            member,
+            memberId: input.memberId,
+            previewProof: input.previewProof,
+            subscription,
+            targetTrialEnd: proofDates.targetTrialEndUnix,
+          })
+        ) {
+          throw new HostedPulseTrialExtensionPreviewStaleError();
+        }
+
+        let updatedSubscription: HostedPulseTrialExtensionSubscription;
+        try {
+          updatedSubscription = await dependencies.stripe.updateSubscription(
+            subscription.id,
+            {
+              metadata: {
+                [EXTENSION_DAYS_METADATA_KEY]:
+                  HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString(),
+                [EXTENSION_OPERATION_METADATA_KEY]: operationId,
+              },
+              proration_behavior: "none",
+              trial_end: proofDates.targetTrialEndUnix,
+            },
+            {
+              idempotencyKey: `hosted-member-trial-extension:${operationId}`,
+              ...buildHostedPulseTrialExtensionStripeRequestOptions(),
+            },
+          );
+        } catch {
+          throw new HostedPulseTrialExtensionProviderError();
+        }
+
+        if (!isHostedPulseTrialExtensionAlreadyApplied({
+          memberId: input.memberId,
+          operationId,
+          priceId: dependencies.priceId,
+          subscription: updatedSubscription,
+          targetTrialEnd: proofDates.targetTrialEndUnix,
+        })) {
+          throw new HostedPulseTrialExtensionProviderError();
+        }
+
+        const reconciledMember = await reconcileHostedPulseTrialExtensionLocalState({
+          member,
+          now,
+          subscription: updatedSubscription,
+          targetTrialEndsAt: proofDates.targetTrialEndsAt,
+          tx,
+        });
+        return buildHostedPulseTrialExtensionResult({
+          memberId: input.memberId,
+          outcome: "extended",
+          previewProof: null,
+          state: {
+            ...state,
+            currentTrialEnd: proofDates.targetTrialEndUnix,
+            member: reconciledMember,
+            message: "The member's Pulse Trial now ends seven days later.",
+            providerStatus: updatedSubscription.status,
+          },
+        });
+      },
+      transactionTimeoutMs: MEMBER_TRANSACTION_TIMEOUT_MS,
+    });
+  } catch (error) {
+    if (error instanceof HostedMemberStripeMutationLockBusyError) {
+      throw new HostedPulseTrialExtensionLockBusyError();
+    }
+    throw error;
+  }
+}
+
+function resolveHostedPulseTrialExtensionDependencies(
+  input: HostedPulseTrialExtensionDependencies,
+): Required<HostedPulseTrialExtensionDependencies> {
   const prisma = input.prisma ?? getPrisma();
   const billingConfig = input.priceId && input.stripe
     ? null
     : requireHostedStripeBillingPlanConfig({ billingPlanCode: "launch_monthly" });
   const priceId = input.priceId ?? billingConfig?.priceId;
-  if (!priceId) {
-    throw new Error("Stripe price configuration is required for Pulse Trial extension.");
+  const stripe = input.stripe ?? (billingConfig
+    ? createHostedPulseTrialExtensionStripeClient(billingConfig.stripe)
+    : null);
+  if (!priceId || !stripe) {
+    throw new Error("Stripe Pulse billing configuration is required for trial extension.");
   }
-
-  const commonInput = {
-    candidateSource: createPrismaHostedPulseTrialExtensionCandidateSource(prisma, {
-      ...(billingConfig?.stripe
-        ? {
-            campaignRecovery: {
-              priceId,
-              stripe: billingConfig.stripe,
-            },
-          }
-        : {}),
-      memberId: input.memberId,
-    }),
-    maxCandidates: input.maxCandidates,
-    now: input.now,
-    continuationToken: input.continuationToken,
-    priceId,
-    stripe: input.stripe ?? createHostedPulseTrialExtensionStripeClient(billingConfig?.stripe),
-  };
-  if (input.mode === "dry-run") {
-    return extendHostedPulseTrials({
-      ...commonInput,
-      mode: "dry-run",
-    });
-  }
-  return extendHostedPulseTrials({
-    ...commonInput,
-    expectedCandidatePreviewTokens: input.expectedCandidatePreviewTokens,
-    expectedCandidateSnapshotDigest: input.expectedCandidateSnapshotDigest,
-    mode: "apply",
-  });
+  return { priceId, prisma, stripe };
 }
 
-export function classifyHostedPulseTrialExtensionSubscription(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  nowUnixSeconds: number;
+async function inspectHostedPulseTrialExtensionState(input: {
+  member: HostedMemberBillingSnapshot | null;
+  memberId: string;
+  now: Date;
   priceId: string;
-  stripeCustomerId?: string;
-  stripeSubscriptionId?: string;
-  subscription: HostedPulseTrialExtensionStripeSubscription;
-}): HostedPulseTrialExtensionClassification {
+  stripe: HostedPulseTrialExtensionStripeClient;
+}): Promise<HostedPulseTrialExtensionState> {
+  const localReason = classifyHostedPulseTrialExtensionLocalState(input.member);
+  if (localReason) {
+    return buildIneligibleHostedPulseTrialExtensionState({
+      code: localReason,
+      member: input.member,
+    });
+  }
+
+  const billingRef = input.member?.billingRef;
+  if (!billingRef?.stripeSubscriptionId) {
+    return buildIneligibleHostedPulseTrialExtensionState({
+      code: "missing_stripe_reference",
+      member: input.member,
+    });
+  }
+
+  let subscription: HostedPulseTrialExtensionSubscription;
+  try {
+    subscription = await input.stripe.retrieveSubscription(
+      billingRef.stripeSubscriptionId,
+      buildHostedPulseTrialExtensionStripeRequestOptions(),
+    );
+  } catch {
+    throw new HostedPulseTrialExtensionProviderError();
+  }
+
+  const providerReason = classifyHostedPulseTrialExtensionProviderState({
+    memberId: input.memberId,
+    now: input.now,
+    priceId: input.priceId,
+    stripeCustomerId: billingRef.stripeCustomerId,
+    stripeSubscriptionId: billingRef.stripeSubscriptionId,
+    subscription,
+  });
+  if (providerReason) {
+    return buildIneligibleHostedPulseTrialExtensionState({
+      code: providerReason,
+      member: input.member,
+      subscription,
+    });
+  }
+
+  const currentTrialEnd = readSafeUnixSecond(subscription.trial_end);
+  const targetTrialEnd = subscription.status === "trialing"
+    ? requireSafeUnixSecond(currentTrialEnd) +
+      HOSTED_PULSE_TRIAL_EXTENSION_DAYS * SECONDS_PER_DAY
+    : Math.floor(input.now.getTime() / 1000) +
+      HOSTED_PULSE_TRIAL_EXTENSION_DAYS * SECONDS_PER_DAY;
+  return {
+    currentTrialEnd,
+    eligibilityCode: "eligible",
+    eligible: true,
+    member: input.member,
+    message: subscription.status === "paused"
+      ? "This lapsed Pulse Trial can be restored for seven days."
+      : "This active Pulse Trial can be extended by seven days.",
+    providerStatus: subscription.status,
+    subscription,
+    targetTrialEnd,
+  };
+}
+
+function classifyHostedPulseTrialExtensionLocalState(
+  member: HostedMemberBillingSnapshot | null,
+): Exclude<HostedPulseTrialExtensionEligibilityCode, "eligible"> | null {
+  if (!member) {
+    return "member_not_found";
+  }
+  if (member.core.suspendedAt) {
+    return "member_suspended";
+  }
+  const billingRef = member.billingRef;
+  if (!billingRef) {
+    return "missing_billing_reference";
+  }
   if (
-    input.subscription.id !==
-      (input.stripeSubscriptionId ?? input.candidate.stripeSubscriptionId)
+    billingRef.currentBillingPhase === "paid" ||
+    (
+      member.core.billingStatus === HostedBillingStatus.active &&
+      billingRef.currentBillingPhase !== "trial"
+    )
   ) {
-    return { ok: false, reason: "stripe_subscription_id_mismatch" };
-  }
-  if (input.subscription.status !== "trialing") {
-    return { ok: false, reason: "stripe_subscription_not_trialing" };
-  }
-  if (input.subscription.cancel_at_period_end || input.subscription.cancel_at !== null) {
-    return { ok: false, reason: "stripe_subscription_canceling" };
+    return "paid_billing";
   }
   if (
-    coerceStripeCustomerId(input.subscription.customer) !==
-      (input.stripeCustomerId ?? input.candidate.stripeCustomerId)
+    !billingRef.pulseTrialRedeemedAt ||
+    billingRef.currentBillingPlanCode !== "launch_monthly" ||
+    billingRef.currentCheckoutOffer !== HOSTED_PULSE_TRIAL_OFFER
   ) {
-    return { ok: false, reason: "stripe_customer_mismatch" };
-  }
-  if (input.subscription.metadata?.checkoutOffer !== HOSTED_PULSE_TRIAL_OFFER) {
-    return { ok: false, reason: "stripe_checkout_offer_mismatch" };
-  }
-  if (input.subscription.metadata?.billingPlanCode !== "launch_monthly") {
-    return { ok: false, reason: "stripe_billing_plan_mismatch" };
+    return "not_a_redeemed_pulse_trial";
   }
   if (
-    input.subscription.metadata?.trialPolicyVersion !==
-      HOSTED_PULSE_TRIAL_POLICY_VERSION ||
+    billingRef.stripeSubscriptionScheduleId ||
+    billingRef.scheduledBillingPlanCode ||
+    billingRef.scheduledBillingEffectiveAt
+  ) {
+    return "scheduled_billing_change";
+  }
+  if (!billingRef.stripeCustomerId || !billingRef.stripeSubscriptionId) {
+    return "missing_stripe_reference";
+  }
+  return null;
+}
+
+export function classifyHostedPulseTrialExtensionProviderState(input: {
+  memberId: string;
+  now: Date;
+  priceId: string;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string;
+  subscription: HostedPulseTrialExtensionSubscription;
+}): Exclude<HostedPulseTrialExtensionEligibilityCode, "eligible"> | null {
+  if (
+    input.subscription.id !== input.stripeSubscriptionId ||
+    coerceStripeCustomerId(input.subscription.customer) !== input.stripeCustomerId ||
     !isHostedPulseTrialSubscriptionForKnownPolicy({
-      memberId: input.candidate.memberId,
+      memberId: input.memberId,
       priceId: input.priceId,
       subscription: input.subscription,
     })
   ) {
-    return { ok: false, reason: "stripe_price_mismatch" };
+    return "provider_identity_mismatch";
   }
   if (
-    !Number.isSafeInteger(input.subscription.trial_end) ||
-    input.subscription.trial_end === null ||
-    input.subscription.trial_end <= input.nowUnixSeconds
+    input.subscription.cancel_at_period_end ||
+    input.subscription.cancel_at !== null
   ) {
-    return { ok: false, reason: "stripe_trial_end_invalid" };
+    return "provider_subscription_canceling";
   }
-
-  const campaignMarker = input.subscription.metadata?.[
-    HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY
-  ];
-  if (campaignMarker && campaignMarker !== HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN) {
-    return { ok: false, reason: "stripe_campaign_marker_conflict" };
+  if (input.subscription.status === "trialing") {
+    const trialEnd = readSafeUnixSecond(input.subscription.trial_end);
+    return trialEnd && trialEnd > Math.floor(input.now.getTime() / 1000)
+      ? null
+      : "provider_trial_end_invalid";
   }
-
-  const alreadyMarked = campaignMarker === HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN;
   if (
-    alreadyMarked &&
-    input.subscription.metadata?.[HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY] !==
-      HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString()
+    input.subscription.status === "paused" &&
+    input.subscription.trial_settings?.end_behavior.missing_payment_method === "pause"
   ) {
-    return { ok: false, reason: "stripe_campaign_marker_conflict" };
+    return null;
   }
+  return "provider_subscription_not_extendable";
+}
 
+function buildIneligibleHostedPulseTrialExtensionState(input: {
+  code: Exclude<HostedPulseTrialExtensionEligibilityCode, "eligible">;
+  member: HostedMemberBillingSnapshot | null;
+  subscription?: HostedPulseTrialExtensionSubscription;
+}): HostedPulseTrialExtensionState {
   return {
-    alreadyMarked,
-    ok: true,
-    stripeTrialEnd: input.subscription.trial_end,
+    currentTrialEnd: readSafeUnixSecond(input.subscription?.trial_end),
+    eligibilityCode: input.code,
+    eligible: false,
+    member: input.member,
+    message: readHostedPulseTrialExtensionEligibilityMessage(input.code),
+    providerStatus: input.subscription?.status ?? null,
+    subscription: input.subscription ?? null,
+    targetTrialEnd: null,
   };
 }
 
-function buildHostedPulseTrialExtensionStripeUpdateParams(input: {
-  subscription: HostedPulseTrialExtensionStripeSubscription;
+function readHostedPulseTrialExtensionEligibilityMessage(
+  code: Exclude<HostedPulseTrialExtensionEligibilityCode, "eligible">,
+): string {
+  switch (code) {
+    case "member_not_found":
+      return "No hosted member exists with this ID.";
+    case "member_suspended":
+      return "This member is suspended, so billing was left unchanged.";
+    case "missing_billing_reference":
+      return "This member has no Stripe billing record.";
+    case "not_a_redeemed_pulse_trial":
+      return "This member does not have a redeemed Pulse Trial.";
+    case "paid_billing":
+      return "This member has paid billing, so the subscription was left unchanged.";
+    case "scheduled_billing_change":
+      return "This member has a scheduled billing change, so the subscription was left unchanged.";
+    case "missing_stripe_reference":
+      return "This trial is missing its Stripe customer or subscription reference.";
+    case "provider_identity_mismatch":
+      return "Stripe no longer matches this member's Pulse Trial billing record.";
+    case "provider_subscription_canceling":
+      return "This Stripe subscription is scheduled to cancel.";
+    case "provider_subscription_not_extendable":
+      return "Only active or lapsed paused Pulse Trials can be extended.";
+    case "provider_trial_end_invalid":
+      return "Stripe returned an invalid active trial end.";
+  }
+}
+
+function buildHostedPulseTrialExtensionPreviewProof(input: {
+  member: HostedMemberBillingSnapshot | null;
+  memberId: string;
+  previewedAt: Date;
+  subscription: HostedPulseTrialExtensionSubscription;
   targetTrialEnd: number;
-}): HostedPulseTrialExtensionStripeUpdateParams {
-  return {
-    metadata: {
-      ...(input.subscription.metadata ?? {}),
-      [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]:
-        HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      [HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY]:
-        HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString(),
-    },
-    proration_behavior: "none",
-    trial_end: input.targetTrialEnd,
-  };
-}
-
-export function createPrismaHostedPulseTrialExtensionCandidateSource(
-  prisma: PrismaClient,
-  options: {
-    campaignRecovery?: {
-      priceId: string;
-      stripe: Stripe;
-    };
-    memberId?: string;
-  } = {},
-): HostedPulseTrialExtensionCandidateSource {
-  const where = buildPrismaHostedPulseTrialExtensionCandidateWhere(options.memberId);
-  return {
-    async listCandidates(input) {
-      const continuation = input.continuationToken
-        ? decryptHostedPulseTrialExtensionContinuationToken(input.continuationToken)
-        : options.campaignRecovery
-          ? {
-              afterSubscriptionId: null,
-              memberId: options.memberId ?? null,
-              phase: "provider",
-            } as const
-          : {
-              afterMemberId: null,
-              memberId: options.memberId ?? null,
-              phase: "members",
-            } as const;
-      if (continuation.memberId !== (options.memberId ?? null)) {
-        throw new HostedPulseTrialExtensionContinuationError();
-      }
-      if (continuation.phase === "provider") {
-        if (!options.campaignRecovery) {
-          throw new HostedPulseTrialExtensionContinuationError();
-        }
-        const providerPage = await listHostedPulseTrialProviderCandidates({
-          afterSubscriptionId: continuation.afterSubscriptionId,
-          limit: input.limit,
-          memberId: options.memberId,
-          priceId: options.campaignRecovery.priceId,
-          prisma,
-          stripe: options.campaignRecovery.stripe,
-        });
-        if (providerPage.hasMore) {
-          return {
-            candidates: providerPage.candidates,
-            nextContinuationToken: encryptHostedPulseTrialExtensionContinuationToken({
-              afterSubscriptionId: providerPage.lastSubscriptionId,
-              memberId: options.memberId ?? null,
-              phase: "provider",
-            }),
-          };
-        }
-        if (providerPage.candidates.length > 0) {
-          return {
-            candidates: providerPage.candidates,
-            nextContinuationToken: encryptHostedPulseTrialExtensionContinuationToken({
-              afterMemberId: null,
-              memberId: options.memberId ?? null,
-              phase: "members",
-            }),
-          };
-        }
-        return listHostedPulseTrialMemberCandidates({
-          afterMemberId: null,
-          limit: input.limit,
-          memberId: options.memberId ?? null,
-          prisma,
-          where,
-        });
-      }
-      return listHostedPulseTrialMemberCandidates({
-        afterMemberId: continuation.afterMemberId,
-        limit: input.limit,
-        memberId: options.memberId ?? null,
-        prisma,
-        where,
-      });
-    },
-    async inspectProviderOnlyTrial(input) {
-      if (!options.campaignRecovery) {
-        throw new Error("Pulse Trial provider recovery configuration is required.");
-      }
-      const stripeCustomerId = input.candidate.providerCustomerId ??
-        input.candidate.stripeCustomerId;
-      if (!stripeCustomerId) {
-        return {
-          kind: "not-applicable",
-          reason: "provider-trial-not-found",
-          subscription: null,
-        };
-      }
-      return inspectHostedAutoPulseTrialCampaignDisposition({
-        candidate: buildHostedAutoPulseTrialCampaignCandidateState(input.candidate),
-        priceId: options.campaignRecovery.priceId,
-        requestOptions: buildHostedPulseTrialExtensionStripeRequestOptions(),
-        stripe: options.campaignRecovery.stripe,
-        stripeCustomerId,
-        ...(input.candidate.providerSubscriptionId
-          ? { targetStripeSubscriptionId: input.candidate.providerSubscriptionId }
-          : {}),
-        trialStartedBefore: new Date(
-          HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO,
-        ),
-      });
-    },
-    async withStripeMutationLock(input) {
-      let postCommitEffects:
-        | HostedAutoPulseTrialCampaignApplyTxResult["postCommitEffects"]
-        | null = null;
-      const result = await withHostedMemberStripeMutationLockForOps({
-        acquisitionTimeoutMs: input.acquisitionTimeoutMs,
-        memberId: input.candidate.memberId,
-        prisma,
-        run: async (tx) => {
-          const candidate = await readLockedPrismaHostedPulseTrialExtensionCandidate({
-            expectedCandidate: input.candidate,
-            tx,
-          });
-          return input.run({
-            applyProviderOnlyDisposition: async (disposition, now) => {
-              const providerCustomerId = candidate?.providerCustomerId ??
-                candidate?.stripeCustomerId;
-              if (!options.campaignRecovery || !candidate || !providerCustomerId) {
-                throw new Error(
-                  "Pulse Trial provider recovery configuration changed before Apply.",
-                );
-              }
-              const currentMember = await readHostedMemberBillingSnapshot({
-                memberId: input.candidate.memberId,
-                prisma: tx,
-              });
-              if (!currentMember) {
-                throw new Error("Pulse Trial provider recovery member no longer exists.");
-              }
-              const applied = await applyHostedAutoPulseTrialCampaignDispositionTx({
-                campaignPolicy: {
-                  minimumTrialRunwaySeconds: STRIPE_UPDATE_MINIMUM_RUNWAY_SECONDS,
-                  priceId: options.campaignRecovery.priceId,
-                  trialStartedBefore: new Date(
-                    HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO,
-                  ),
-                },
-                currentMember,
-                disposition,
-                now,
-                requestOptions: buildHostedPulseTrialExtensionStripeRequestOptions(),
-                stripe: options.campaignRecovery.stripe,
-                stripeCustomerId: providerCustomerId,
-                tx,
-              });
-              postCommitEffects = applied.postCommitEffects;
-              return applied.kind;
-            },
-            candidate,
-            updateTrialEnd: async (trialEndsAt, now) => {
-              if (!candidate) {
-                throw new Error("Pulse Trial extension candidate changed before apply.");
-              }
-              await updatePrismaHostedPulseTrialExtensionCandidateTrialEnd({
-                candidate,
-                now,
-                trialEndsAt,
-                tx,
-              });
-            },
-          });
-        },
-        transactionTimeoutMs: input.transactionTimeoutMs,
-      });
-      if (postCommitEffects) {
-        await runHostedAutoPulseTrialCampaignPostCommitEffects({
-          effects: postCommitEffects,
-          prisma,
-          timeoutMs: HOSTED_OPS_POST_COMMIT_EFFECT_TIMEOUT_MS,
-        });
-      }
-      return result;
-    },
-  };
-}
-
-async function listHostedPulseTrialMemberCandidates(input: {
-  afterMemberId: string | null;
-  limit: number;
-  memberId: string | null;
-  prisma: PrismaClient;
-  where: Prisma.HostedMemberBillingRefWhereInput;
-}): Promise<{
-  candidates: readonly HostedPulseTrialExtensionCandidate[];
-  nextContinuationToken: string | null;
-}> {
-  const records = await input.prisma.hostedMemberBillingRef.findMany({
-    include: {
-      member: {
-        select: {
-          billingStatus: true,
-          suspendedAt: true,
-        },
-      },
-    },
-    orderBy: { memberId: "asc" },
-    take: input.limit + 1,
-    where: {
-      ...input.where,
-      ...(input.afterMemberId ? { memberId: { gt: input.afterMemberId } } : {}),
-    },
-  });
-  const pageRecords = records.slice(0, input.limit);
-  const candidates = await Promise.all(pageRecords.map((record) =>
-    projectHostedPulseTrialExtensionCandidate(record, input.prisma)
-  ));
-  const lastRecord = pageRecords.at(-1);
-  return {
-    candidates,
-    nextContinuationToken:
-      records.length > input.limit && lastRecord
-        ? encryptHostedPulseTrialExtensionContinuationToken({
-            afterMemberId: lastRecord.memberId,
-            memberId: input.memberId,
-            phase: "members",
-          })
-        : null,
-  };
-}
-
-async function listHostedPulseTrialProviderCandidates(input: {
-  afterSubscriptionId: string | null;
-  limit: number;
-  memberId?: string;
-  priceId: string;
-  prisma: PrismaClient;
-  stripe: Stripe;
-}): Promise<{
-  candidates: readonly HostedPulseTrialExtensionCandidate[];
-  hasMore: boolean;
-  lastSubscriptionId: string;
-}> {
-  const page = await input.stripe.subscriptions.list({
-    limit: input.limit,
-    ...(input.afterSubscriptionId
-      ? { starting_after: input.afterSubscriptionId }
-      : {}),
-    status: "all",
-  }, buildHostedPulseTrialExtensionStripeRequestOptions());
-  const lastSubscription = page.data.at(-1);
-  if (!lastSubscription && page.has_more) {
-    throw new Error("Stripe returned an incomplete Pulse Trial provider page.");
+}): HostedPulseTrialExtensionPreviewProof {
+  const previewedAt = input.previewedAt.toISOString();
+  const targetTrialEndsAt = unixSecondsToIso(input.targetTrialEnd);
+  if (!targetTrialEndsAt) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
   }
-  const projected = await Promise.all(page.data.map(async (subscription) => {
-    if (!isHistoricalHostedPulseTrialProviderSubscription({
-      memberId: input.memberId,
-      priceId: input.priceId,
-      subscription,
-    })) {
-      return null;
-    }
-    return projectHistoricalHostedPulseTrialProviderCandidate({
-      prisma: input.prisma,
-      subscription,
-    });
-  }));
   return {
-    candidates: projected.filter(
-      (candidate): candidate is HostedPulseTrialExtensionCandidate => candidate !== null,
-    ),
-    hasMore: page.has_more,
-    lastSubscriptionId: lastSubscription?.id ?? input.afterSubscriptionId ?? "complete",
+    previewedAt,
+    targetTrialEndsAt,
+    token: signHostedPulseTrialExtensionPreview({
+      member: input.member,
+      memberId: input.memberId,
+      previewedAt,
+      subscription: input.subscription,
+      targetTrialEnd: input.targetTrialEnd,
+    }),
   };
 }
 
-function isHistoricalHostedPulseTrialProviderSubscription(input: {
-  memberId?: string;
-  priceId: string;
-  subscription: Stripe.Subscription;
+function verifyHostedPulseTrialExtensionPreviewProof(input: {
+  member: HostedMemberBillingSnapshot;
+  memberId: string;
+  previewProof: HostedPulseTrialExtensionPreviewProof;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEnd: number;
 }): boolean {
-  const trialStart = input.subscription.trial_start;
-  return input.subscription.status !== "canceled" &&
-    input.subscription.status !== "incomplete_expired" &&
-    typeof input.subscription.metadata.memberId === "string" &&
-    (!input.memberId || input.subscription.metadata.memberId === input.memberId) &&
-    input.subscription.metadata.trialPolicyVersion ===
-      HOSTED_PULSE_TRIAL_POLICY_VERSION &&
-    Number.isSafeInteger(trialStart) &&
-    trialStart !== null &&
-    trialStart < Date.parse(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO) / 1000 &&
+  const tokenParts = readHostedPulseTrialExtensionTokenParts(input.previewProof.token);
+  const expected = signHostedPulseTrialExtensionPreview({
+    keyVersion: tokenParts.keyVersion,
+    member: input.member,
+    memberId: input.memberId,
+    previewedAt: input.previewProof.previewedAt,
+    subscription: input.subscription,
+    targetTrialEnd: input.targetTrialEnd,
+  });
+  const actualBuffer = Buffer.from(input.previewProof.token);
+  const expectedBuffer = Buffer.from(expected);
+  return actualBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function signHostedPulseTrialExtensionPreview(input: {
+  keyVersion?: string;
+  member: HostedMemberBillingSnapshot | null;
+  memberId: string;
+  previewedAt: string;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEnd: number;
+}): string {
+  const keyring = readHostedContactPrivacyKeyring(process.env);
+  const keyVersion = input.keyVersion ?? keyring.currentVersion;
+  const sourceKey = keyring.keysByVersion[keyVersion];
+  if (!sourceKey) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
+  }
+  const digest = createHmac(
+    "sha256",
+    createHash("sha256")
+      .update(PREVIEW_HMAC_CONTEXT, "utf8")
+      .update("\0", "utf8")
+      .update(sourceKey)
+      .digest(),
+  )
+    .update(JSON.stringify({
+      local: projectHostedPulseTrialExtensionLocalProofState(input.member),
+      memberId: input.memberId,
+      previewedAt: input.previewedAt,
+      provider: projectHostedPulseTrialExtensionProviderProofState(
+        input.subscription,
+      ),
+      targetTrialEnd: input.targetTrialEnd,
+    }), "utf8")
+    .digest("base64url");
+  return `${PREVIEW_TOKEN_PREFIX}.${keyVersion}.${digest}`;
+}
+
+function projectHostedPulseTrialExtensionLocalProofState(
+  member: HostedMemberBillingSnapshot | null,
+): object | null {
+  if (!member) {
+    return null;
+  }
+  const ref = member.billingRef;
+  return {
+    billingStatus: member.core.billingStatus,
+    currentBillingPhase: ref?.currentBillingPhase ?? null,
+    currentBillingPlanCode: ref?.currentBillingPlanCode ?? null,
+    currentCheckoutOffer: ref?.currentCheckoutOffer ?? null,
+    currentPeriodEnd: ref?.currentPeriodEnd?.toISOString() ?? null,
+    currentTrialEndsAt: ref?.currentTrialEndsAt?.toISOString() ?? null,
+    currentTrialStartedAt: ref?.currentTrialStartedAt?.toISOString() ?? null,
+    pulseTrialPolicyVersion: ref?.pulseTrialPolicyVersion ?? null,
+    pulseTrialRedeemedAt: ref?.pulseTrialRedeemedAt?.toISOString() ?? null,
+    scheduledBillingEffectiveAt:
+      ref?.scheduledBillingEffectiveAt?.toISOString() ?? null,
+    scheduledBillingPlanCode: ref?.scheduledBillingPlanCode ?? null,
+    stripeCustomerId: ref?.stripeCustomerId ?? null,
+    stripeSubscriptionId: ref?.stripeSubscriptionId ?? null,
+    stripeSubscriptionScheduleId: ref?.stripeSubscriptionScheduleId ?? null,
+    suspendedAt: member.core.suspendedAt?.toISOString() ?? null,
+  };
+}
+
+function projectHostedPulseTrialExtensionProviderProofState(
+  subscription: HostedPulseTrialExtensionSubscription,
+): object {
+  return {
+    cancelAt: subscription.cancel_at,
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    customerId: coerceStripeCustomerId(subscription.customer),
+    extensionOperation:
+      subscription.metadata[EXTENSION_OPERATION_METADATA_KEY] ?? null,
+    id: subscription.id,
+    items: subscription.items.data.map((item) => ({
+      id: item.id,
+      priceId: item.price.id,
+      quantity: item.quantity ?? null,
+    })),
+    metadata: {
+      billingPlanCode: subscription.metadata.billingPlanCode ?? null,
+      checkoutOffer: subscription.metadata.checkoutOffer ?? null,
+      memberId: subscription.metadata.memberId ?? null,
+      trialDurationDays: subscription.metadata.trialDurationDays ?? null,
+      trialPolicyVersion: subscription.metadata.trialPolicyVersion ?? null,
+      trialUsageLimitUsdMicros:
+        subscription.metadata.trialUsageLimitUsdMicros ?? null,
+    },
+    status: subscription.status,
+    trialEnd: subscription.trial_end,
+    trialStart: subscription.trial_start,
+  };
+}
+
+function parseHostedPulseTrialExtensionPreviewProofDates(input: {
+  now: Date;
+  previewProof: HostedPulseTrialExtensionPreviewProof;
+}): {
+  previewedAt: Date;
+  targetTrialEndsAt: Date;
+  targetTrialEndUnix: number;
+} {
+  const previewedAt = new Date(input.previewProof.previewedAt);
+  const targetTrialEndsAt = new Date(input.previewProof.targetTrialEndsAt);
+  if (
+    !Number.isFinite(previewedAt.getTime()) ||
+    !Number.isFinite(targetTrialEndsAt.getTime()) ||
+    input.now.getTime() < previewedAt.getTime() - 60_000 ||
+    input.now.getTime() > previewedAt.getTime() + PREVIEW_PROOF_TTL_MS
+  ) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
+  }
+  const targetTrialEndUnix = Math.floor(targetTrialEndsAt.getTime() / 1000);
+  const canonicalTargetTrialEndsAt = unixSecondsToDate(targetTrialEndUnix);
+  if (
+    !canonicalTargetTrialEndsAt ||
+    input.previewProof.targetTrialEndsAt !==
+      canonicalTargetTrialEndsAt.toISOString() ||
+    targetTrialEndUnix <= Math.floor(input.now.getTime() / 1000)
+  ) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
+  }
+  return {
+    previewedAt,
+    targetTrialEndsAt: canonicalTargetTrialEndsAt,
+    targetTrialEndUnix,
+  };
+}
+
+function readHostedPulseTrialExtensionTokenParts(token: string): {
+  digest: string;
+  keyVersion: string;
+} {
+  const parts = token.split(".");
+  const digest = parts[2];
+  const keyVersion = parts[1];
+  if (
+    parts.length !== 3 ||
+    parts[0] !== PREVIEW_TOKEN_PREFIX ||
+    !keyVersion ||
+    !/^v[0-9]+$/u.test(keyVersion) ||
+    !digest ||
+    !/^[A-Za-z0-9_-]{43}$/u.test(digest)
+  ) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
+  }
+  return { digest, keyVersion };
+}
+
+function readHostedPulseTrialExtensionOperationId(token: string): string {
+  return readHostedPulseTrialExtensionTokenParts(token).digest;
+}
+
+function isHostedPulseTrialExtensionAlreadyApplied(input: {
+  memberId: string;
+  operationId: string;
+  priceId: string;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEnd: number;
+}): boolean {
+  return input.subscription.status === "trialing" &&
+    input.subscription.trial_end === input.targetTrialEnd &&
+    input.subscription.metadata[EXTENSION_OPERATION_METADATA_KEY] ===
+      input.operationId &&
+    input.subscription.metadata[EXTENSION_DAYS_METADATA_KEY] ===
+      HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString() &&
     isHostedPulseTrialSubscriptionForKnownPolicy({
-      memberId: input.subscription.metadata.memberId,
+      memberId: input.memberId,
       priceId: input.priceId,
       subscription: input.subscription,
     });
 }
 
-async function projectHistoricalHostedPulseTrialProviderCandidate(input: {
-  prisma: PrismaClient;
-  subscription: Stripe.Subscription;
-}): Promise<HostedPulseTrialExtensionCandidate | null> {
-  const memberId = input.subscription.metadata.memberId;
-  const stripeCustomerId = coerceStripeCustomerId(input.subscription.customer);
-  const trialStart = input.subscription.trial_start;
-  if (!memberId || !stripeCustomerId || trialStart === null) {
-    return null;
+async function reconcileHostedPulseTrialExtensionLocalState(input: {
+  member: HostedMemberBillingSnapshot | null;
+  now: Date;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEndsAt: Date;
+  tx: Prisma.TransactionClient;
+}): Promise<HostedMemberBillingSnapshot> {
+  const member = input.member;
+  const billingRef = member?.billingRef;
+  if (!member || !billingRef?.stripeCustomerId || !billingRef.stripeSubscriptionId) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
   }
-  const record = await input.prisma.hostedMemberBillingRef.findUnique({
-    include: {
-      member: {
-        select: {
-          billingStatus: true,
-          suspendedAt: true,
-        },
-      },
-    },
-    where: { memberId },
+  const providerTrialStartedAt = unixSecondsToDate(input.subscription.trial_start);
+  const currentTrialStartedAt = billingRef.currentTrialStartedAt ??
+    providerTrialStartedAt ?? billingRef.pulseTrialRedeemedAt;
+  if (!currentTrialStartedAt) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
+  }
+  const providerPeriod = readHostedPulseTrialExtensionProviderPeriod(
+    input.subscription,
+  );
+
+  const core = await updateHostedMemberCoreState({
+    billingStatus: HostedBillingStatus.active,
+    memberId: member.core.id,
+    prisma: input.tx,
   });
-  const cutoff = new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO);
-  const trialStartedAt = stripeUnixSecondsToDate(trialStart);
-  if (record) {
-    const candidate = await projectHostedPulseTrialExtensionCandidate(record, input.prisma);
-    const belongsToLocalCohort =
-      (record.pulseTrialRedeemedAt && record.pulseTrialRedeemedAt < cutoff) ||
-      (!record.pulseTrialRedeemedAt && record.createdAt < cutoff);
-    if (
-      belongsToLocalCohort &&
-      candidate.stripeSubscriptionId === input.subscription.id
-    ) {
-      return null;
-    }
-    return {
-      ...candidate,
-      providerCustomerId: stripeCustomerId,
-      providerSubscriptionId: input.subscription.id,
-    };
-  }
-  const member = await readHostedMemberBillingSnapshot({
-    memberId,
-    prisma: input.prisma,
+  const updatedBillingRef = await writeHostedMemberStripeBillingRefTx({
+    currentBillingPhase: "trial",
+    currentBillingPlanCode: "launch_monthly",
+    currentCheckoutOffer: HOSTED_PULSE_TRIAL_OFFER,
+    currentPeriodEnd: providerPeriod?.currentPeriodEnd ??
+      input.targetTrialEndsAt,
+    currentPeriodStart: providerPeriod?.currentPeriodStart ??
+      billingRef.currentPeriodStart ?? currentTrialStartedAt,
+    currentTrialEndsAt: input.targetTrialEndsAt,
+    currentTrialStartedAt,
+    memberId: member.core.id,
+    pulseTrialPolicyVersion: billingRef.pulseTrialPolicyVersion,
+    pulseTrialRedeemedAt: billingRef.pulseTrialRedeemedAt,
+    stripeCustomerId: billingRef.stripeCustomerId,
+    stripeSubscriptionId: billingRef.stripeSubscriptionId,
+    tx: input.tx,
   });
-  if (!member) {
-    return null;
-  }
+  await reconcileHostedAiUsageAllowancePeriodForMemberTx({
+    memberId: member.core.id,
+    now: input.now,
+    tx: input.tx,
+  });
   return {
-    billingRefCreatedAt: trialStartedAt,
-    currentBillingPhase: null,
-    currentBillingPlanCode: null,
-    currentCheckoutOffer: null,
-    currentPeriodEnd: null,
-    currentTrialEndsAt: null,
-    currentTrialStartedAt: null,
-    lastStripeEventCreatedAt: null,
-    memberBillingStatus: member.core.billingStatus,
-    memberId,
-    memberSuspendedAt: member.core.suspendedAt,
-    providerCustomerId: stripeCustomerId,
-    providerSubscriptionId: input.subscription.id,
-    pulseTrialRedeemedAt: null,
-    stripeCustomerId: null,
-    stripeSubscriptionId: null,
+    billingRef: updatedBillingRef,
+    core,
   };
 }
 
-function buildPrismaHostedPulseTrialExtensionCandidateWhere(
-  memberId?: string,
-): Prisma.HostedMemberBillingRefWhereInput {
+function readHostedPulseTrialExtensionProviderPeriod(
+  subscription: HostedPulseTrialExtensionSubscription,
+): { currentPeriodEnd: Date; currentPeriodStart: Date } | null {
+  const candidates: object[] = [subscription, ...subscription.items.data];
+  for (const candidate of candidates) {
+    const currentPeriodStart = unixSecondsToDate(
+      readSafeUnixSecond(Reflect.get(candidate, "current_period_start")),
+    );
+    const currentPeriodEnd = unixSecondsToDate(
+      readSafeUnixSecond(Reflect.get(candidate, "current_period_end")),
+    );
+    if (
+      currentPeriodStart &&
+      currentPeriodEnd &&
+      currentPeriodStart.getTime() < currentPeriodEnd.getTime()
+    ) {
+      return { currentPeriodEnd, currentPeriodStart };
+    }
+  }
+  return null;
+}
+
+function buildHostedPulseTrialExtensionResult(input: {
+  memberId: string;
+  outcome: HostedPulseTrialExtensionOutcome;
+  previewProof: HostedPulseTrialExtensionPreviewProof | null;
+  state: HostedPulseTrialExtensionState;
+}): HostedPulseTrialExtensionResult {
   return {
-    OR: [
-      {
-        pulseTrialRedeemedAt: {
-          lt: new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO),
-        },
-      },
-      {
-        createdAt: {
-          lt: new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO),
-        },
-        pulseTrialRedeemedAt: null,
-      },
-    ],
-    ...(memberId ? { memberId } : {}),
+    currentTrialEndsAt: unixSecondsToIso(input.state.currentTrialEnd),
+    eligibilityCode: input.state.eligibilityCode,
+    eligible: input.state.eligible,
+    extensionDays: HOSTED_PULSE_TRIAL_EXTENSION_DAYS,
+    localBillingPhase:
+      input.state.member?.billingRef?.currentBillingPhase ?? null,
+    localBillingStatus: input.state.member?.core.billingStatus ?? null,
+    memberId: input.memberId,
+    message: input.state.message,
+    outcome: input.outcome,
+    previewProof: input.previewProof,
+    providerStatus: input.state.providerStatus,
+    targetTrialEndsAt: unixSecondsToIso(input.state.targetTrialEnd),
   };
 }
 
 function createHostedPulseTrialExtensionStripeClient(
-  stripe: Pick<Stripe, "subscriptions"> | undefined,
+  stripe: Pick<Stripe, "subscriptions">,
 ): HostedPulseTrialExtensionStripeClient {
-  if (!stripe) {
-    throw new Error("Stripe billing configuration is required for Pulse Trial extension.");
-  }
   return {
     retrieveSubscription(subscriptionId, options) {
-      return stripe.subscriptions.retrieve(subscriptionId, undefined, options);
+      return stripe.subscriptions.retrieve(subscriptionId, {}, options);
     },
     updateSubscription(subscriptionId, params, options) {
       return stripe.subscriptions.update(subscriptionId, params, options);
@@ -1229,921 +908,36 @@ function createHostedPulseTrialExtensionStripeClient(
   };
 }
 
-function classifyHostedPulseTrialExtensionCandidate(
-  candidate: HostedPulseTrialExtensionCandidate,
-): HostedPulseTrialExtensionSkipReason | null {
-  if (
-    candidate.pulseTrialRedeemedAt !== null &&
-    candidate.pulseTrialRedeemedAt >=
-      new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO)
-  ) {
-    return "outside_campaign_cohort";
-  }
-  if (candidate.pulseTrialRedeemedAt === null) {
-    if (candidate.memberSuspendedAt !== null) {
-      return "local_candidate_changed";
-    }
-    return candidate.stripeCustomerId ? null : "missing_stripe_refs";
-  }
-  if (
-    candidate.memberBillingStatus !== HostedBillingStatus.active ||
-    candidate.memberSuspendedAt !== null ||
-    candidate.currentBillingPhase !== "trial" ||
-    candidate.currentBillingPlanCode !== "launch_monthly" ||
-    candidate.currentCheckoutOffer !== HOSTED_PULSE_TRIAL_OFFER
-  ) {
-    return "local_candidate_changed";
-  }
-  if (!candidate.stripeCustomerId || !candidate.stripeSubscriptionId) {
-    return "missing_stripe_refs";
-  }
-  if (
-    !candidate.currentTrialStartedAt ||
-    !candidate.currentTrialEndsAt ||
-    !candidate.currentPeriodEnd ||
-    candidate.currentTrialStartedAt >= candidate.currentTrialEndsAt
-  ) {
-    return "local_trial_window_invalid";
-  }
-  return null;
-}
-
-function buildHostedAutoPulseTrialCampaignCandidateState(
-  candidate: HostedPulseTrialExtensionCandidate,
-) {
-  return {
-    billingStatus: candidate.memberBillingStatus,
-    currentBillingPhase: candidate.currentBillingPhase,
-    currentStripeSubscriptionId: candidate.stripeSubscriptionId,
-    memberId: candidate.memberId,
-    pulseTrialRedeemedAt: candidate.pulseTrialRedeemedAt,
-  };
-}
-
-function buildEmptyHostedPulseTrialExtensionSummary(
-  mode: HostedPulseTrialExtensionMode,
-  candidateSnapshotDigest: string | null,
-  hasMoreCandidates: boolean,
-  nextContinuationToken: string | null,
-): HostedPulseTrialExtensionSummary {
-  return {
-    alreadyExtended: 0,
-    campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    candidatePreviewTokens: mode === "dry-run" ? [] : null,
-    candidateSnapshotDigest,
-    candidates: 0,
-    extensionDays: HOSTED_PULSE_TRIAL_EXTENSION_DAYS,
-    failures: {
-      db_update_failed: 0,
-      member_lock_busy: 0,
-      preview_state_changed: 0,
-      provider_recovery_failed: 0,
-      provider_recovery_lookup_failed: 0,
-      route_runway_exhausted: 0,
-      stripe_retrieve_failed: 0,
-      stripe_update_failed: 0,
-      stripe_update_result_invalid: 0,
-    },
-    hasMoreCandidates,
-    localWindowsReconciled: 0,
-    mode,
-    nextContinuationToken,
-    providerTrialsCleanedUp: 0,
-    providerTrialsRecovered: 0,
-    skipped: {
-      local_candidate_changed: 0,
-      local_trial_window_invalid: 0,
-      missing_stripe_refs: 0,
-      outside_campaign_cohort: 0,
-      provider_recovery_not_found: 0,
-      provider_trial_ended: 0,
-      stripe_billing_plan_mismatch: 0,
-      stripe_campaign_marker_conflict: 0,
-      stripe_checkout_offer_mismatch: 0,
-      stripe_customer_mismatch: 0,
-      stripe_price_mismatch: 0,
-      stripe_subscription_canceling: 0,
-      stripe_subscription_id_mismatch: 0,
-      stripe_subscription_not_trialing: 0,
-      stripe_trial_end_invalid: 0,
-    },
-    stripeTrialsExtended: 0,
-    wouldExtend: 0,
-    wouldCleanupProviderTrial: 0,
-    wouldRecoverProviderTrial: 0,
-    wouldReconcile: 0,
-  };
-}
-
-function buildHostedPulseTrialExtensionIdempotencyKey(subscriptionId: string): string {
-  return [
-    "hosted-pulse-trial-extension",
-    HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    subscriptionId,
-  ].join(":");
-}
-
-function isHostedPulseTrialExtensionLocallyReconciled(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  trialEndsAt: Date;
-}): boolean {
-  const targetTime = input.trialEndsAt.getTime();
-  return input.candidate.currentTrialEndsAt?.getTime() === targetTime &&
-    input.candidate.currentPeriodEnd?.getTime() === targetTime;
-}
-
-function isValidHostedPulseTrialExtensionUpdateResult(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  priceId: string;
-  stripeCustomerId?: string;
-  stripeSubscriptionId?: string;
-  subscription: HostedPulseTrialExtensionStripeSubscription;
-  targetTrialEnd: number;
-}): boolean {
-  const classification = classifyHostedPulseTrialExtensionSubscription({
-    candidate: input.candidate,
-    nowUnixSeconds: input.targetTrialEnd - 1,
-    priceId: input.priceId,
-    stripeCustomerId: input.stripeCustomerId,
-    stripeSubscriptionId: input.stripeSubscriptionId,
-    subscription: input.subscription,
-  });
-  return classification.ok &&
-    classification.alreadyMarked &&
-    classification.stripeTrialEnd === input.targetTrialEnd;
-}
-
-async function applyHostedPulseTrialExtensionUnderLock(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  expectedPreviewToken: string;
-  now?: Date;
-  priceId: string;
-  stripe: HostedPulseTrialExtensionStripeClient;
-}): Promise<HostedPulseTrialLockedApplyResult> {
-  const stripeSubscriptionId = requireStripeSubscriptionId(input.candidate);
-  let subscription: HostedPulseTrialExtensionStripeSubscription;
-  try {
-    subscription = await input.stripe.retrieveSubscription(
-      stripeSubscriptionId,
-      buildHostedPulseTrialExtensionStripeRequestOptions(),
-    );
-  } catch {
-    return { kind: "failure", reason: "stripe_retrieve_failed" };
-  }
-
-  const nowUnixSeconds = resolveHostedPulseTrialExtensionNowUnixSeconds(input.now);
-  const classification = classifyHostedPulseTrialExtensionSubscription({
-    candidate: input.candidate,
-    nowUnixSeconds,
-    priceId: input.priceId,
-    subscription,
-  });
-  const action = classifyHostedPulseTrialExtensionPreviewAction({
-    candidate: input.candidate,
-    classification,
-    nowUnixSeconds,
-  });
-  const previewToken = buildHostedPulseTrialExtensionCandidatePreviewToken({
-    action,
-    candidate: input.candidate,
-    subscription,
-  });
-  if (
-    input.expectedPreviewToken !== previewToken
-  ) {
-    return { kind: "preview-stale" };
-  }
-
-  if (action.kind === "skipped") {
-    return { kind: "skipped", reason: action.reason };
-  }
-  if (action.kind === "already-marked") {
-    return {
-      kind: "already-marked",
-      stripeTrialEnd: action.stripeTrialEnd,
-      subscription,
-    };
-  }
-  if (action.kind !== "extend") {
-    throw new Error("Provider recovery action cannot mutate a redeemed trial.");
-  }
-  let updatedSubscription: HostedPulseTrialExtensionStripeSubscription;
-  try {
-    updatedSubscription = await input.stripe.updateSubscription(
-      stripeSubscriptionId,
-      buildHostedPulseTrialExtensionStripeUpdateParams({
-        subscription,
-        targetTrialEnd: action.targetTrialEnd,
-      }),
-      {
-        idempotencyKey: buildHostedPulseTrialExtensionIdempotencyKey(
-          stripeSubscriptionId,
-        ),
-        ...buildHostedPulseTrialExtensionStripeRequestOptions(),
-      },
-    );
-  } catch {
-    return { kind: "failure", reason: "stripe_update_failed" };
-  }
-
-  if (!isValidHostedPulseTrialExtensionUpdateResult({
-    candidate: input.candidate,
-    priceId: input.priceId,
-    subscription: updatedSubscription,
-    targetTrialEnd: action.targetTrialEnd,
-  })) {
-    return { kind: "failure", reason: "stripe_update_result_invalid" };
-  }
-
-  return {
-    kind: "extended",
-    stripeTrialEnd: action.targetTrialEnd,
-    subscription: updatedSubscription,
-  };
-}
-
-async function projectHostedPulseTrialExtensionCandidate(
-  record: HostedMemberBillingRef & {
-    member: {
-      billingStatus: HostedBillingStatus;
-      suspendedAt: Date | null;
-    };
-  },
-  prisma: HostedOnboardingReadClient,
-): Promise<HostedPulseTrialExtensionCandidate> {
-  const snapshot = await projectHostedMemberStripeBillingRefSnapshot(record, prisma);
-
-  return {
-    billingRefCreatedAt: record.createdAt,
-    currentBillingPhase: snapshot.currentBillingPhase ?? null,
-    currentBillingPlanCode: snapshot.currentBillingPlanCode ?? null,
-    currentCheckoutOffer: snapshot.currentCheckoutOffer ?? null,
-    currentPeriodEnd: snapshot.currentPeriodEnd ?? null,
-    currentTrialEndsAt: snapshot.currentTrialEndsAt ?? null,
-    currentTrialStartedAt: snapshot.currentTrialStartedAt ?? null,
-    lastStripeEventCreatedAt: snapshot.lastStripeEventCreatedAt ?? null,
-    memberBillingStatus: record.member.billingStatus,
-    memberId: snapshot.memberId,
-    memberSuspendedAt: record.member.suspendedAt,
-    providerCustomerId: null,
-    providerSubscriptionId: null,
-    pulseTrialRedeemedAt: snapshot.pulseTrialRedeemedAt ?? null,
-    stripeCustomerId: snapshot.stripeCustomerId,
-    stripeSubscriptionId: snapshot.stripeSubscriptionId,
-  };
-}
-
-async function previewHostedPulseTrialExtensionCandidate(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  now?: Date;
-  priceId: string;
-  stripe: HostedPulseTrialExtensionStripeClient;
-  summary: HostedPulseTrialExtensionSummary;
-}): Promise<string | null> {
-  let subscription: HostedPulseTrialExtensionStripeSubscription;
-  try {
-    subscription = await input.stripe.retrieveSubscription(
-      requireStripeSubscriptionId(input.candidate),
-      buildHostedPulseTrialExtensionStripeRequestOptions(),
-    );
-  } catch {
-    input.summary.failures.stripe_retrieve_failed += 1;
-    return null;
-  }
-
-  const nowUnixSeconds = resolveHostedPulseTrialExtensionNowUnixSeconds(input.now);
-  const classification = classifyHostedPulseTrialExtensionSubscription({
-    candidate: input.candidate,
-    nowUnixSeconds,
-    priceId: input.priceId,
-    subscription,
-  });
-  const action = classifyHostedPulseTrialExtensionPreviewAction({
-    candidate: input.candidate,
-    classification,
-    nowUnixSeconds,
-  });
-  if (action.kind === "skipped") {
-    input.summary.skipped[action.reason] += 1;
-  } else if (action.kind === "extend") {
-    input.summary.wouldExtend += 1;
-  } else if (action.kind === "already-marked" && action.locallyReconciled) {
-    input.summary.alreadyExtended += 1;
-  } else if (action.kind === "already-marked") {
-    input.summary.wouldReconcile += 1;
-  } else {
-    throw new Error("Provider recovery action cannot classify a redeemed trial.");
-  }
-
-  return buildHostedPulseTrialExtensionCandidatePreviewToken({
-    action,
-    candidate: input.candidate,
-    subscription,
-  });
-}
-
-async function previewHostedPulseTrialProviderRecoveryCandidate(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  candidateSource: HostedPulseTrialExtensionCandidateSource;
-  now?: Date;
-  priceId: string;
-  stripe: HostedPulseTrialExtensionStripeClient;
-  summary: HostedPulseTrialExtensionSummary;
-}): Promise<string | null> {
-  let disposition: HostedAutoPulseTrialCampaignDisposition;
-  const now = input.now ?? new Date();
-  try {
-    disposition = await input.candidateSource.inspectProviderOnlyTrial({
-      candidate: input.candidate,
-      now,
-    });
-  } catch {
-    input.summary.failures.provider_recovery_lookup_failed += 1;
-    return null;
-  }
-  const proof = classifyHostedPulseTrialProviderDisposition({
-    candidate: input.candidate,
-    disposition,
-    now,
-    priceId: input.priceId,
-  });
-  if (disposition.kind === "recoverable" && proof.action.kind === "extend") {
-    input.summary.wouldRecoverProviderTrial += 1;
-    input.summary.wouldExtend += 1;
-  } else if (
-    disposition.kind === "recoverable" &&
-    proof.action.kind === "already-marked"
-  ) {
-    input.summary.wouldRecoverProviderTrial += 1;
-    input.summary.wouldReconcile += 1;
-  } else if (proof.action.kind === "cleanup-provider-trial") {
-    input.summary.wouldCleanupProviderTrial += 1;
-  } else if (proof.action.kind === "skipped") {
-    input.summary.skipped[proof.action.reason] += 1;
-  } else {
-    throw new Error("Provider recovery produced an unsupported Preview action.");
-  }
-  return buildHostedPulseTrialExtensionCandidatePreviewToken({
-    action: proof.action,
-    candidate: proof.candidate,
-    subscription: disposition.subscription,
-  });
-}
-
-async function applyHostedPulseTrialProviderRecoveryCandidate(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  candidateSource: HostedPulseTrialExtensionCandidateSource;
-  expectedPreviewToken: string;
-  now: Date;
-  priceId: string;
-  readCurrentTime: () => Date;
-  stripe: HostedPulseTrialExtensionStripeClient;
-  summary: HostedPulseTrialExtensionSummary;
-}): Promise<"complete" | "preview-stale"> {
-  let inspectionCompleted = false;
-  try {
-    const result = await input.candidateSource.withStripeMutationLock({
-      acquisitionTimeoutMs: HOSTED_OPS_MEMBER_LOCK_ACQUISITION_TIMEOUT_MS,
-      candidate: input.candidate,
-      run: async (locked) => {
-        if (
-          !locked.candidate ||
-          locked.candidate.providerSubscriptionId !==
-            input.candidate.providerSubscriptionId
-        ) {
-          return { kind: "preview-stale" } as const;
-        }
-
-        const disposition = await input.candidateSource.inspectProviderOnlyTrial({
-          candidate: locked.candidate,
-          now: input.now,
-        });
-        inspectionCompleted = true;
-        const decisionNow = input.readCurrentTime();
-        const proof = classifyHostedPulseTrialProviderDisposition({
-          candidate: locked.candidate,
-          disposition,
-          now: decisionNow,
-          priceId: input.priceId,
-        });
-        const lockedToken = buildHostedPulseTrialExtensionCandidatePreviewToken({
-          action: proof.action,
-          candidate: proof.candidate,
-          subscription: disposition.subscription,
-        });
-        if (lockedToken !== input.expectedPreviewToken) {
-          return { kind: "preview-stale" } as const;
-        }
-        if (proof.action.kind === "skipped") {
-          return { kind: "skipped", reason: proof.action.reason } as const;
-        }
-        if (disposition.kind === "not-applicable") {
-          throw new Error("Provider disposition action did not match its source state.");
-        }
-
-        if (disposition.kind === "recoverable") {
-          let finalizedSubscription = disposition.subscription;
-          let providerExtended = false;
-          if (proof.action.kind === "extend") {
-            try {
-              finalizedSubscription = await input.stripe.updateSubscription(
-                disposition.subscription.id,
-                buildHostedPulseTrialExtensionStripeUpdateParams({
-                  subscription: disposition.subscription,
-                  targetTrialEnd: proof.action.targetTrialEnd,
-                }),
-                {
-                  idempotencyKey: buildHostedPulseTrialExtensionIdempotencyKey(
-                    disposition.subscription.id,
-                  ),
-                  ...buildHostedPulseTrialExtensionStripeRequestOptions(),
-                },
-              );
-            } catch {
-              return { kind: "failure", reason: "stripe_update_failed" } as const;
-            }
-            if (!isValidHostedPulseTrialExtensionUpdateResult({
-              candidate: proof.candidate,
-              priceId: input.priceId,
-              stripeCustomerId: proof.candidate.providerCustomerId ?? undefined,
-              stripeSubscriptionId: disposition.subscription.id,
-              subscription: finalizedSubscription,
-              targetTrialEnd: proof.action.targetTrialEnd,
-            })) {
-              return {
-                kind: "failure",
-                reason: "stripe_update_result_invalid",
-              } as const;
-            }
-            providerExtended = true;
-          } else if (proof.action.kind !== "already-marked") {
-            throw new Error("Recoverable provider disposition was not extendable.");
-          }
-          const kind = await locked.applyProviderOnlyDisposition({
-            ...disposition,
-            subscription: finalizedSubscription,
-          }, decisionNow);
-          return {
-            kind,
-            providerExtended,
-          } as const;
-        }
-
-        return {
-          kind: await locked.applyProviderOnlyDisposition(disposition, decisionNow),
-          providerExtended: false,
-        } as const;
-      },
-      transactionTimeoutMs: HOSTED_OPS_CANDIDATE_TRANSACTION_TIMEOUT_MS,
-    });
-    if (result.kind === "preview-stale") {
-      return "preview-stale";
-    }
-    if (result.kind === "failure") {
-      input.summary.failures[result.reason] += 1;
-    } else if (result.kind === "skipped") {
-      input.summary.skipped[result.reason] += 1;
-    } else if (result.kind === "recovered") {
-      input.summary.providerTrialsRecovered += 1;
-      if (result.providerExtended) {
-        input.summary.stripeTrialsExtended += 1;
-      }
-    } else {
-      input.summary.providerTrialsCleanedUp += 1;
-    }
-  } catch (error) {
-    if (error instanceof HostedMemberStripeMutationLockBusyError) {
-      input.summary.failures.member_lock_busy += 1;
-      return "complete";
-    }
-    if (!inspectionCompleted) {
-      input.summary.failures.provider_recovery_lookup_failed += 1;
-      return "complete";
-    }
-    input.summary.failures.provider_recovery_failed += 1;
-  }
-  return "complete";
-}
-
-function classifyHostedPulseTrialProviderDisposition(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  disposition: HostedAutoPulseTrialCampaignDisposition;
-  now: Date;
-  priceId: string;
-}): {
-  action: HostedPulseTrialExtensionPreviewAction;
-  candidate: HostedPulseTrialExtensionCandidate;
-} {
-  const disposition = input.disposition;
-  if (disposition.kind === "recoverable") {
-    if (
-      input.candidate.memberSuspendedAt !== null ||
-      input.candidate.pulseTrialRedeemedAt !== null ||
-      !requiresHostedBillingCheckout(input.candidate.memberBillingStatus)
-    ) {
-      return {
-        action: { kind: "skipped", reason: "local_candidate_changed" },
-        candidate: input.candidate,
-      };
-    }
-    if (
-      input.candidate.stripeCustomerId &&
-      input.candidate.providerCustomerId &&
-      input.candidate.stripeCustomerId !== input.candidate.providerCustomerId
-    ) {
-      return {
-        action: { kind: "skipped", reason: "stripe_customer_mismatch" },
-        candidate: input.candidate,
-      };
-    }
-    const nowUnixSeconds = resolveHostedPulseTrialExtensionNowUnixSeconds(input.now);
-    return {
-      action: classifyHostedPulseTrialExtensionPreviewAction({
-        candidate: input.candidate,
-        classification: classifyHostedPulseTrialExtensionSubscription({
-          candidate: input.candidate,
-          nowUnixSeconds,
-          priceId: input.priceId,
-          stripeCustomerId: input.candidate.providerCustomerId ?? undefined,
-          stripeSubscriptionId: disposition.subscription.id,
-          subscription: disposition.subscription,
-        }),
-        nowUnixSeconds,
-      }),
-      candidate: input.candidate,
-    };
-  }
-  if (disposition.kind === "cleanup-obsolete") {
-    const campaignMarker = disposition.subscription.metadata?.[
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY
-    ];
-    if (
-      campaignMarker &&
-      campaignMarker !== HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN
-    ) {
-      return {
-        action: { kind: "skipped", reason: "stripe_campaign_marker_conflict" },
-        candidate: input.candidate,
-      };
-    }
-    return {
-      action: {
-        kind: "cleanup-provider-trial",
-        stripeSubscriptionId: disposition.subscription.id,
-      },
-      candidate: input.candidate,
-    };
-  }
-  return {
-    action: {
-      kind: "skipped",
-      reason: disposition.reason === "provider-trial-ended"
-        ? "provider_trial_ended"
-        : "provider_recovery_not_found",
-    },
-    candidate: input.candidate,
-  };
-}
-
-async function readLockedPrismaHostedPulseTrialExtensionCandidate(input: {
-  expectedCandidate: HostedPulseTrialExtensionCandidate;
-  tx: Prisma.TransactionClient;
-}): Promise<HostedPulseTrialExtensionCandidate | null> {
-  const stripeCustomerLookupKeys = createHostedStripeCustomerLookupKeyReadCandidates(
-    input.expectedCandidate.stripeCustomerId ??
-      input.expectedCandidate.providerCustomerId,
-  );
-  const stripeSubscriptionLookupKeys = createHostedStripeSubscriptionLookupKeyReadCandidates(
-    input.expectedCandidate.stripeSubscriptionId,
-  );
-  if (stripeCustomerLookupKeys.length === 0) {
-    return null;
-  }
-
-  let record = await input.tx.hostedMemberBillingRef.findFirst({
-    include: {
-      member: {
-        select: {
-          billingStatus: true,
-          suspendedAt: true,
-        },
-      },
-    },
-    where: {
-      memberId: input.expectedCandidate.memberId,
-      stripeCustomerLookupKey: { in: stripeCustomerLookupKeys },
-      stripeSubscriptionLookupKey:
-        stripeSubscriptionLookupKeys.length > 0
-          ? { in: stripeSubscriptionLookupKeys }
-          : null,
-    },
-  });
-  if (!record && input.expectedCandidate.pulseTrialRedeemedAt === null) {
-    record = await input.tx.hostedMemberBillingRef.findFirst({
-      include: {
-        member: {
-          select: {
-            billingStatus: true,
-            suspendedAt: true,
-          },
-        },
-      },
-      where: { memberId: input.expectedCandidate.memberId },
-    });
-  }
-
-  if (!record) {
-    if (input.expectedCandidate.pulseTrialRedeemedAt !== null) {
-      return null;
-    }
-    const member = await input.tx.hostedMember.findUnique({
-      select: {
-        billingStatus: true,
-        suspendedAt: true,
-      },
-      where: { id: input.expectedCandidate.memberId },
-    });
-    return member
-      ? {
-          ...input.expectedCandidate,
-          memberBillingStatus: member.billingStatus,
-          memberSuspendedAt: member.suspendedAt,
-        }
-      : null;
-  }
-
-  if (
-    input.expectedCandidate.pulseTrialRedeemedAt === null &&
-    record.stripeCustomerLookupKey &&
-    !stripeCustomerLookupKeys.includes(record.stripeCustomerLookupKey)
-  ) {
-    return null;
-  }
-
-  const lockedCandidate = await projectHostedPulseTrialExtensionCandidate(record, input.tx);
-  return {
-    ...lockedCandidate,
-    providerCustomerId: input.expectedCandidate.providerCustomerId,
-    providerSubscriptionId: input.expectedCandidate.providerSubscriptionId,
-    pulseTrialRedeemedAt:
-      input.expectedCandidate.pulseTrialRedeemedAt &&
-        record.pulseTrialRedeemedAt &&
-        record.pulseTrialRedeemedAt >=
-          new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO)
-        ? input.expectedCandidate.pulseTrialRedeemedAt
-        : record.pulseTrialRedeemedAt,
-  };
-}
-
-async function updatePrismaHostedPulseTrialExtensionCandidateTrialEnd(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  now: Date;
-  trialEndsAt: Date;
-  tx: Prisma.TransactionClient;
-}): Promise<void> {
-  const currentTrialStartedAt = input.candidate.currentTrialStartedAt;
-  if (!currentTrialStartedAt) {
-    throw new Error("Pulse Trial extension candidate is missing its local window.");
-  }
-
-  const billingUpdate = await input.tx.hostedMemberBillingRef.updateMany({
-    data: {
-      currentPeriodEnd: input.trialEndsAt,
-      currentTrialEndsAt: input.trialEndsAt,
-    },
-    where: {
-      currentBillingPhase: "trial",
-      currentBillingPlanCode: "launch_monthly",
-      currentCheckoutOffer: HOSTED_PULSE_TRIAL_OFFER,
-      currentPeriodEnd: input.candidate.currentPeriodEnd,
-      currentTrialEndsAt: input.candidate.currentTrialEndsAt,
-      currentTrialStartedAt,
-      lastStripeEventCreatedAt: input.candidate.lastStripeEventCreatedAt,
-      memberId: input.candidate.memberId,
-      member: {
-        billingStatus: HostedBillingStatus.active,
-        suspendedAt: null,
-      },
-    },
-  });
-  if (billingUpdate.count !== 1) {
-    throw new Error("Pulse Trial billing state changed during extension.");
-  }
-
-  await reconcileHostedAiUsageAllowancePeriodForMemberTx({
-    memberId: input.candidate.memberId,
-    now: input.now,
-    tx: input.tx,
-  });
-}
-
-function requireStripeSubscriptionId(candidate: HostedPulseTrialExtensionCandidate): string {
-  if (!candidate.stripeSubscriptionId) {
-    throw new Error("Pulse Trial extension candidate is missing its Stripe subscription.");
-  }
-  return candidate.stripeSubscriptionId;
-}
-
-function coerceStripeCustomerId(
-  value: HostedPulseTrialExtensionStripeSubscription["customer"],
-): string | null {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (value && typeof value === "object") {
-    const id = Reflect.get(value, "id");
-    return typeof id === "string" ? id : null;
-  }
-  return null;
-}
-
-function stripeUnixSecondsToDate(value: number): Date {
-  return new Date(value * 1000);
-}
-
-function resolveHostedPulseTrialExtensionNowUnixSeconds(now?: Date): number {
-  return Math.floor((now ?? new Date()).getTime() / 1000);
-}
-
-async function readHostedPulseTrialExtensionCandidatePage(input: {
-  candidateSource: HostedPulseTrialExtensionCandidateSource;
-  continuationToken: string | null;
-  maxCandidates: number;
-}): Promise<{
-  candidates: readonly HostedPulseTrialExtensionCandidate[];
-  hasMoreCandidates: boolean;
-  nextContinuationToken: string | null;
-}> {
-  const page = await input.candidateSource.listCandidates({
-    continuationToken: input.continuationToken,
-    limit: input.maxCandidates,
-  });
-
-  return {
-    candidates: page.candidates,
-    hasMoreCandidates: page.nextContinuationToken !== null,
-    nextContinuationToken: page.nextContinuationToken,
-  };
-}
-
-function classifyHostedPulseTrialExtensionPreviewAction(input: {
-  candidate: HostedPulseTrialExtensionCandidate;
-  classification: HostedPulseTrialExtensionClassification;
-  nowUnixSeconds: number;
-}): HostedPulseTrialExtensionPreviewAction {
-  if (!input.classification.ok) {
-    return { kind: "skipped", reason: input.classification.reason };
-  }
-  if (input.classification.alreadyMarked) {
-    return {
-      kind: "already-marked",
-      locallyReconciled: isHostedPulseTrialExtensionLocallyReconciled({
-        candidate: input.candidate,
-        trialEndsAt: stripeUnixSecondsToDate(input.classification.stripeTrialEnd),
-      }),
-      stripeTrialEnd: input.classification.stripeTrialEnd,
-    };
-  }
-  if (
-    input.classification.stripeTrialEnd <=
-      input.nowUnixSeconds + STRIPE_UPDATE_MINIMUM_RUNWAY_SECONDS
-  ) {
-    return { kind: "skipped", reason: "stripe_trial_end_invalid" };
-  }
-  return {
-    kind: "extend",
-    stripeTrialEnd: input.classification.stripeTrialEnd,
-    targetTrialEnd: input.classification.stripeTrialEnd +
-      HOSTED_PULSE_TRIAL_EXTENSION_DAYS * SECONDS_PER_DAY,
-  };
-}
-
-function appendHostedPulseTrialExtensionCandidatePreviewToken(
-  summary: HostedPulseTrialExtensionSummary,
-  token: string | null,
-): void {
-  if (summary.candidatePreviewTokens === null) {
-    throw new Error("Pulse Trial extension Apply cannot collect preview proof.");
-  }
-  summary.candidatePreviewTokens = [...summary.candidatePreviewTokens, token ?? ""];
-}
-
-function buildHostedPulseTrialExtensionStripeRequestOptions():
-  HostedPulseTrialExtensionStripeRequestOptions {
+function buildHostedPulseTrialExtensionStripeRequestOptions(): Stripe.RequestOptions {
   return {
     maxNetworkRetries: STRIPE_REQUEST_MAX_NETWORK_RETRIES,
     timeout: STRIPE_REQUEST_TIMEOUT_MS,
   };
 }
 
-function buildHostedPulseTrialExtensionCandidateSnapshotDigest(
-  candidates: readonly HostedPulseTrialExtensionCandidate[],
-  continuationToken: string | null,
-): string {
-  const snapshot = [...candidates]
-    .sort((left, right) => {
-      if (left.memberId < right.memberId) {
-        return -1;
-      }
-      return left.memberId > right.memberId ? 1 : 0;
-    })
-    .map((candidate) => [
-      candidate.memberId,
-      candidate.billingRefCreatedAt.toISOString(),
-      candidate.memberBillingStatus,
-      candidate.memberSuspendedAt?.toISOString() ?? null,
-      candidate.providerCustomerId,
-      candidate.providerSubscriptionId,
-      candidate.pulseTrialRedeemedAt?.toISOString() ?? null,
-      candidate.currentBillingPhase,
-      candidate.currentBillingPlanCode,
-      candidate.currentCheckoutOffer,
-      candidate.stripeCustomerId,
-      candidate.stripeSubscriptionId,
-      candidate.currentTrialStartedAt?.toISOString() ?? null,
-      candidate.currentTrialEndsAt?.toISOString() ?? null,
-      candidate.currentPeriodEnd?.toISOString() ?? null,
-      candidate.lastStripeEventCreatedAt?.toISOString() ?? null,
-    ]);
-
-  return `pulse-candidates-v4.${createHash("sha256")
-    .update(HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN, "utf8")
-    .update("\0", "utf8")
-    .update(continuationToken ?? "first", "utf8")
-    .update("\0", "utf8")
-    .update(JSON.stringify(snapshot), "utf8")
-    .digest("base64url")}`;
+function coerceStripeCustomerId(
+  customer: HostedPulseTrialExtensionSubscription["customer"],
+): string | null {
+  return typeof customer === "string" ? customer : customer?.id ?? null;
 }
 
-function buildHostedPulseTrialExtensionCandidatePreviewToken(input: {
-  action: HostedPulseTrialExtensionPreviewAction;
-  candidate: HostedPulseTrialExtensionCandidate;
-  subscription: HostedPulseTrialExtensionStripeSubscription | null;
-}): string {
-  const subscriptionItems = [...(input.subscription?.items?.data ?? [])]
-    .sort((left, right) => left.id.localeCompare(right.id))
-    .map((item) => ({
-      id: item.id,
-      legacyUsagePrice: item.price?.metadata?.[
-        HOSTED_STRIPE_LEGACY_AI_USAGE_PRICE_METADATA_KEY
-      ] ?? null,
-      priceId: item.price?.id ?? null,
-      quantity: item.quantity ?? null,
-      recurringInterval: item.price?.recurring?.interval ?? null,
-      recurringIntervalCount: item.price?.recurring?.interval_count ?? null,
-      recurringUsageType: item.price?.recurring?.usage_type ?? null,
-    }));
-  const snapshot = {
-    action: input.action,
-    candidate: {
-      billingRefCreatedAt: input.candidate.billingRefCreatedAt.toISOString(),
-      currentBillingPhase: input.candidate.currentBillingPhase,
-      currentBillingPlanCode: input.candidate.currentBillingPlanCode,
-      currentCheckoutOffer: input.candidate.currentCheckoutOffer,
-      currentPeriodEnd: input.candidate.currentPeriodEnd?.toISOString() ?? null,
-      currentTrialEndsAt: input.candidate.currentTrialEndsAt?.toISOString() ?? null,
-      currentTrialStartedAt: input.candidate.currentTrialStartedAt?.toISOString() ?? null,
-      lastStripeEventCreatedAt: input.candidate.lastStripeEventCreatedAt?.toISOString() ?? null,
-      memberBillingStatus: input.candidate.memberBillingStatus,
-      memberId: input.candidate.memberId,
-      memberSuspendedAt: input.candidate.memberSuspendedAt?.toISOString() ?? null,
-      providerCustomerId: input.candidate.providerCustomerId,
-      providerSubscriptionId: input.candidate.providerSubscriptionId,
-      pulseTrialRedeemedAt: input.candidate.pulseTrialRedeemedAt?.toISOString() ?? null,
-      stripeCustomerId: input.candidate.stripeCustomerId,
-      stripeSubscriptionId: input.candidate.stripeSubscriptionId,
-    },
-    subscription: input.subscription
-      ? {
-          billingPlanCode: input.subscription.metadata?.billingPlanCode ?? null,
-          campaign: input.subscription.metadata?.[
-            HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY
-          ] ?? null,
-          campaignDays: input.subscription.metadata?.[
-            HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY
-          ] ?? null,
-          cancelAt: input.subscription.cancel_at,
-          cancelAtPeriodEnd: input.subscription.cancel_at_period_end,
-          checkoutOffer: input.subscription.metadata?.checkoutOffer ?? null,
-          customerId: coerceStripeCustomerId(input.subscription.customer),
-          id: input.subscription.id,
-          itemsHasMore: input.subscription.items?.has_more ?? null,
-          items: subscriptionItems,
-          memberId: input.subscription.metadata?.memberId ?? null,
-          trialDurationDays: input.subscription.metadata?.trialDurationDays ?? null,
-          status: input.subscription.status,
-          trialEnd: input.subscription.trial_end,
-          trialPolicyVersion: input.subscription.metadata?.trialPolicyVersion ?? null,
-          trialStart: input.subscription.trial_start,
-          trialUsageLimitUsdMicros:
-            input.subscription.metadata?.trialUsageLimitUsdMicros ?? null,
-        }
-      : null,
-  };
+function readSafeUnixSecond(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : null;
+}
 
-  return `pulse-target-v4.${createHash("sha256")
-    .update(HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN, "utf8")
-    .update("\0", "utf8")
-    .update(JSON.stringify(snapshot), "utf8")
-    .digest("base64url")}`;
+function requireSafeUnixSecond(value: number | null): number {
+  if (value === null) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
+  }
+  return value;
+}
+
+function unixSecondsToDate(value: number | null | undefined): Date | null {
+  return value === null || value === undefined ? null : new Date(value * 1000);
+}
+
+function unixSecondsToIso(value: number | null): string | null {
+  return unixSecondsToDate(value)?.toISOString() ?? null;
 }

--- a/apps/web/test/hosted-ops-pulse-trial-extension-route.test.ts
+++ b/apps/web/test/hosted-ops-pulse-trial-extension-route.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
-import { HostedBillingStatus } from "@prisma/client";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
+  applyHostedPulseTrialExtension: vi.fn(),
   assertHostedOnboardingMutationOrigin: vi.fn(),
-  extendHostedPulseTrialsForCampaign: vi.fn(),
+  previewHostedPulseTrialExtension: vi.fn(),
   requireActiveHostedAppSessionFromRequest: vi.fn(),
 }));
 
@@ -25,37 +25,35 @@ vi.mock("@/src/lib/hosted-ops/pulse-trial-extension", async () => {
   >("@/src/lib/hosted-ops/pulse-trial-extension");
   return {
     ...actual,
-    extendHostedPulseTrialsForCampaign: mocks.extendHostedPulseTrialsForCampaign,
+    applyHostedPulseTrialExtension: mocks.applyHostedPulseTrialExtension,
+    previewHostedPulseTrialExtension: mocks.previewHostedPulseTrialExtension,
   };
 });
 
 import {
-  extendHostedPulseTrials,
-  HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-  HostedPulseTrialExtensionPreviewMismatchError,
-  type HostedPulseTrialExtensionCandidateSource,
-  type HostedPulseTrialExtensionStripeClient,
-  type HostedPulseTrialExtensionSummary,
+  HostedPulseTrialExtensionLockBusyError,
+  HostedPulseTrialExtensionPreviewStaleError,
+  HostedPulseTrialExtensionProviderError,
+  type HostedPulseTrialExtensionPreviewProof,
+  type HostedPulseTrialExtensionResult,
 } from "@/src/lib/hosted-ops/pulse-trial-extension";
 
-type PulseTrialExtensionRouteModule =
-  typeof import("../app/api/ops/pulse-trial-extension/route");
+type RouteModule = typeof import("../app/api/ops/pulse-trial-extension/route");
 
-let route: PulseTrialExtensionRouteModule;
-
-const originalHostedOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
-const NOW = new Date("2026-07-10T12:00:00.000Z");
+const NOW = new Date("2026-07-14T16:00:00.000Z");
 const OPERATOR_MEMBER_ID = "member_operator";
-const CANDIDATE_SNAPSHOT_DIGEST = `pulse-candidates-v4.${"a".repeat(43)}`;
-const CANDIDATE_PREVIEW_TOKEN = `pulse-target-v4.${"b".repeat(43)}`;
-const CONTINUATION_TOKEN =
-  `pulse-cursor-v4.v1.${"a".repeat(16)}.${"b".repeat(8)}.${"c".repeat(22)}`;
-const PRE_EXPANSION_CONTINUATION_TOKEN =
-  `pulse-cursor-v3.v1.${"a".repeat(16)}.${"b".repeat(8)}.${"c".repeat(22)}`;
+const TARGET_MEMBER_ID = "hbm_target_1";
+const PREVIEW_PROOF: HostedPulseTrialExtensionPreviewProof = {
+  previewedAt: NOW.toISOString(),
+  targetTrialEndsAt: "2026-07-21T16:00:00.000Z",
+  token: `pulse-member-preview-v1.v1.${"a".repeat(43)}`,
+};
 
+let route: RouteModule;
 let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+const originalOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
 
-describe("hosted ops Pulse Trial extension route", () => {
+describe("hosted ops member Pulse Trial extension route", () => {
   beforeAll(async () => {
     route = await import("../app/api/ops/pulse-trial-extension/route");
   });
@@ -69,18 +67,19 @@ describe("hosted ops Pulse Trial extension route", () => {
     mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
       member: { id: OPERATOR_MEMBER_ID },
     });
-    mocks.extendHostedPulseTrialsForCampaign.mockResolvedValue(
-      makeSummary({}),
+    mocks.previewHostedPulseTrialExtension.mockResolvedValue(makeResult());
+    mocks.applyHostedPulseTrialExtension.mockResolvedValue(
+      makeResult({ outcome: "extended", previewProof: null }),
     );
   });
 
   afterEach(() => {
     vi.useRealTimers();
     consoleInfoSpy.mockRestore();
-    if (originalHostedOpsMemberIds === undefined) {
+    if (originalOpsMemberIds === undefined) {
       delete process.env.HOSTED_OPS_MEMBER_IDS;
     } else {
-      process.env.HOSTED_OPS_MEMBER_IDS = originalHostedOpsMemberIds;
+      process.env.HOSTED_OPS_MEMBER_IDS = originalOpsMemberIds;
     }
   });
 
@@ -89,356 +88,139 @@ describe("hosted ops Pulse Trial extension route", () => {
       member: { id: "member_other" },
     });
 
-    const response = await route.POST(makeRequest({}));
+    const response = await route.POST(makeRequest({
+      memberId: TARGET_MEMBER_ID,
+      mode: "preview",
+    }));
 
     assert.equal(response.status, 404);
-    assert.equal(mocks.extendHostedPulseTrialsForCampaign.mock.calls.length, 0);
+    expect(mocks.previewHostedPulseTrialExtension).not.toHaveBeenCalled();
   });
 
-  test("defaults to a bounded preview with the fixed campaign and no member filter", async () => {
-    const response = await route.POST(makeRequest({}));
+  test("previews exactly one trimmed member", async () => {
+    const response = await route.POST(makeRequest({
+      memberId: `  ${TARGET_MEMBER_ID}  `,
+    }));
 
     assert.equal(response.status, 200);
-    assert.equal(route.maxDuration, 800);
-    assert.equal(mocks.assertHostedOnboardingMutationOrigin.mock.calls.length, 1);
-    expect(mocks.extendHostedPulseTrialsForCampaign).toHaveBeenCalledWith({
-      continuationToken: null,
-      maxCandidates: 4,
-      memberId: undefined,
-      mode: "dry-run",
+    assert.equal(route.maxDuration, 220);
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledTimes(1);
+    expect(mocks.previewHostedPulseTrialExtension).toHaveBeenCalledWith({
+      memberId: TARGET_MEMBER_ID,
     });
-    const payload = await response.json() as HostedPulseTrialExtensionSummary;
-    assert.equal(payload.campaign, HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN);
+    expect(mocks.applyHostedPulseTrialExtension).not.toHaveBeenCalled();
     assert.equal(consoleInfoSpy.mock.calls.length, 0);
   });
 
-  test("passes a trimmed member filter through to the campaign", async () => {
-    await route.POST(makeRequest({ memberId: "  member_target  " }));
-
-    expect(mocks.extendHostedPulseTrialsForCampaign).toHaveBeenCalledWith({
-      continuationToken: null,
-      maxCandidates: 4,
-      memberId: "member_target",
-      mode: "dry-run",
-    });
-  });
-
   test.each([
+    ["missing", undefined],
     ["blank", "   "],
-    ["null", null],
-    ["number", 42],
-    ["object", { id: "member_target" }],
-  ])("rejects a present invalid %s member scope instead of widening to all", async (
-    _label,
-    memberId,
-  ) => {
+    ["wrong prefix", "member_target"],
+    ["object", { id: TARGET_MEMBER_ID }],
+  ])("rejects an invalid %s member ID", async (_label, memberId) => {
     const response = await route.POST(makeRequest({ memberId }));
 
     assert.equal(response.status, 400);
-    assert.equal(mocks.extendHostedPulseTrialsForCampaign.mock.calls.length, 0);
+    expect(mocks.previewHostedPulseTrialExtension).not.toHaveBeenCalled();
+    expect(mocks.applyHostedPulseTrialExtension).not.toHaveBeenCalled();
   });
 
-  test("refuses to apply without the exact current campaign key", async () => {
-    const missing = await route.POST(makeRequest({ mode: "apply" }));
-    const stale = await route.POST(makeRequest({
-      campaign: "pulse-beta-extension-another-occasion",
-      mode: "apply",
-    }));
-
-    assert.equal(missing.status, 400);
-    assert.equal(stale.status, 400);
-    assert.equal(mocks.extendHostedPulseTrialsForCampaign.mock.calls.length, 0);
-  });
-
-  test("applies with the exact campaign key and logs only aggregate results", async () => {
+  test("applies only the supplied member-scoped preview proof", async () => {
     const response = await route.POST(makeRequest({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      candidatePreviewTokens: [CANDIDATE_PREVIEW_TOKEN],
-      candidateSnapshotDigest: CANDIDATE_SNAPSHOT_DIGEST,
-      memberId: "member_target",
+      memberId: TARGET_MEMBER_ID,
       mode: "apply",
+      previewProof: PREVIEW_PROOF,
     }));
 
     assert.equal(response.status, 200);
-    expect(mocks.extendHostedPulseTrialsForCampaign).toHaveBeenCalledWith({
-      expectedCandidatePreviewTokens: [CANDIDATE_PREVIEW_TOKEN],
-      expectedCandidateSnapshotDigest: CANDIDATE_SNAPSHOT_DIGEST,
-      continuationToken: null,
-      maxCandidates: 4,
-      memberId: "member_target",
-      mode: "apply",
+    expect(mocks.applyHostedPulseTrialExtension).toHaveBeenCalledWith({
+      memberId: TARGET_MEMBER_ID,
+      previewProof: PREVIEW_PROOF,
     });
-    assert.equal(consoleInfoSpy.mock.calls.length, 1);
+    expect(mocks.previewHostedPulseTrialExtension).not.toHaveBeenCalled();
     assert.deepEqual(consoleInfoSpy.mock.calls[0]?.[1], {
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      localWindowsReconciled: 0,
-      providerTrialsCleanedUp: 0,
-      providerTrialsRecovered: 0,
-      scope: "member",
-      stripeTrialsExtended: 0,
+      outcome: "extended",
       timestamp: NOW.toISOString(),
     });
   });
 
-  test("passes a production Preview v4 proof unchanged into Apply", async () => {
-    const preview = await buildProductionPreviewProof();
-    const candidatePreviewToken = preview.candidatePreviewTokens?.[0];
-    const candidateSnapshotDigest = preview.candidateSnapshotDigest;
-    assert.ok(candidatePreviewToken);
-    assert.ok(candidateSnapshotDigest);
-    assert.match(candidatePreviewToken, /^pulse-target-v4\./u);
-
+  test("rejects Apply without a complete Preview proof", async () => {
     const response = await route.POST(makeRequest({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      candidatePreviewTokens: [candidatePreviewToken],
-      candidateSnapshotDigest,
-      mode: "apply",
-    }));
-
-    assert.equal(response.status, 200);
-    expect(mocks.extendHostedPulseTrialsForCampaign).toHaveBeenCalledWith({
-      expectedCandidatePreviewTokens: [candidatePreviewToken],
-      expectedCandidateSnapshotDigest: candidateSnapshotDigest,
-      continuationToken: null,
-      maxCandidates: 4,
-      memberId: undefined,
-      mode: "apply",
-    });
-  });
-
-  test("passes an opaque snapshot digest unchanged to its semantic owner", async () => {
-    const opaqueSnapshotDigest = "pulse-candidates-future.opaque-proof";
-    const response = await route.POST(makeRequest({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      candidatePreviewTokens: [CANDIDATE_PREVIEW_TOKEN],
-      candidateSnapshotDigest: opaqueSnapshotDigest,
-      mode: "apply",
-    }));
-
-    assert.equal(response.status, 200);
-    expect(mocks.extendHostedPulseTrialsForCampaign).toHaveBeenCalledWith({
-      expectedCandidatePreviewTokens: [CANDIDATE_PREVIEW_TOKEN],
-      expectedCandidateSnapshotDigest: opaqueSnapshotDigest,
-      continuationToken: null,
-      maxCandidates: 4,
-      memberId: undefined,
-      mode: "apply",
-    });
-  });
-
-  test.each([
-    ["non-array", CANDIDATE_PREVIEW_TOKEN],
-    ["blank", ["   "]],
-    ["non-string", [42]],
-    ["too many", Array.from({ length: 5 }, () => CANDIDATE_PREVIEW_TOKEN)],
-  ])("rejects %s candidate Preview proof input at the body boundary", async (
-    _label,
-    candidatePreviewTokens,
-  ) => {
-    const response = await route.POST(makeRequest({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      candidatePreviewTokens,
-      candidateSnapshotDigest: CANDIDATE_SNAPSHOT_DIGEST,
+      memberId: TARGET_MEMBER_ID,
       mode: "apply",
     }));
 
     assert.equal(response.status, 400);
-    expect(mocks.extendHostedPulseTrialsForCampaign).not.toHaveBeenCalled();
+    expect(mocks.applyHostedPulseTrialExtension).not.toHaveBeenCalled();
   });
 
-  test("refuses to apply without a candidate snapshot from Preview", async () => {
-    const response = await route.POST(makeRequest({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
+  test("maps stale, busy, and unavailable results without widening scope", async () => {
+    mocks.applyHostedPulseTrialExtension
+      .mockRejectedValueOnce(new HostedPulseTrialExtensionPreviewStaleError())
+      .mockRejectedValueOnce(new HostedPulseTrialExtensionLockBusyError())
+      .mockRejectedValueOnce(new HostedPulseTrialExtensionProviderError());
+
+    const stale = await route.POST(makeRequest({
+      memberId: TARGET_MEMBER_ID,
       mode: "apply",
+      previewProof: PREVIEW_PROOF,
     }));
-
-    assert.equal(response.status, 400);
-    assert.equal(mocks.extendHostedPulseTrialsForCampaign.mock.calls.length, 0);
-  });
-
-  test("refuses to apply with a snapshot but without complete provider preview proof", async () => {
-    const response = await route.POST(makeRequest({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      candidateSnapshotDigest: CANDIDATE_SNAPSHOT_DIGEST,
+    const busy = await route.POST(makeRequest({
+      memberId: TARGET_MEMBER_ID,
       mode: "apply",
+      previewProof: PREVIEW_PROOF,
     }));
-
-    assert.equal(response.status, 400);
-    assert.equal(mocks.extendHostedPulseTrialsForCampaign.mock.calls.length, 0);
-  });
-
-  test("rejects a changed candidate snapshot before applying", async () => {
-    mocks.extendHostedPulseTrialsForCampaign.mockRejectedValueOnce(
-      new HostedPulseTrialExtensionPreviewMismatchError(),
-    );
-
-    const response = await route.POST(makeRequest({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      candidatePreviewTokens: [CANDIDATE_PREVIEW_TOKEN],
-      candidateSnapshotDigest: CANDIDATE_SNAPSHOT_DIGEST,
+    const unavailable = await route.POST(makeRequest({
+      memberId: TARGET_MEMBER_ID,
       mode: "apply",
+      previewProof: PREVIEW_PROOF,
     }));
-    const payload = await response.json() as {
-      error?: { code?: string; message?: string };
-    };
 
-    assert.equal(response.status, 409);
-    assert.equal(payload.error?.code, "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_STALE");
-    assert.match(payload.error?.message ?? "", /Preview again/u);
-    assert.equal(consoleInfoSpy.mock.calls.length, 0);
+    assert.equal(stale.status, 409);
+    assert.equal(busy.status, 409);
+    assert.equal(unavailable.status, 502);
+    expect(mocks.applyHostedPulseTrialExtension).toHaveBeenCalledTimes(3);
   });
 
-  test("passes opaque continuations for all-member and member-scoped traversal", async () => {
-    const continuationResponse = await route.POST(makeRequest({
-      continuationToken: CONTINUATION_TOKEN,
-    }));
-    const memberContinuationResponse = await route.POST(makeRequest({
-      continuationToken: CONTINUATION_TOKEN,
-      memberId: "member_target",
-    }));
-    const malformedContinuationResponse = await route.POST(makeRequest({
-      continuationToken: "member_secret",
-    }));
-    const preExpansionContinuationResponse = await route.POST(makeRequest({
-      continuationToken: PRE_EXPANSION_CONTINUATION_TOKEN,
-    }));
-
-    assert.equal(continuationResponse.status, 200);
-    expect(mocks.extendHostedPulseTrialsForCampaign).toHaveBeenCalledWith({
-      continuationToken: CONTINUATION_TOKEN,
-      maxCandidates: 4,
-      memberId: undefined,
-      mode: "dry-run",
-    });
-    assert.equal(memberContinuationResponse.status, 200);
-    expect(mocks.extendHostedPulseTrialsForCampaign).toHaveBeenCalledWith({
-      continuationToken: CONTINUATION_TOKEN,
-      maxCandidates: 4,
-      memberId: "member_target",
-      mode: "dry-run",
-    });
-    assert.equal(malformedContinuationResponse.status, 400);
-    assert.equal(preExpansionContinuationResponse.status, 400);
-  });
-
-  test("rejects unknown modes", async () => {
-    const response = await route.POST(makeRequest({ mode: "extend-everything" }));
-
-    assert.equal(response.status, 400);
-    assert.equal(mocks.extendHostedPulseTrialsForCampaign.mock.calls.length, 0);
+  test("rejects retired campaign and batch modes", async () => {
+    for (const mode of ["dry-run", "campaign", "all"]) {
+      const response = await route.POST(makeRequest({
+        memberId: TARGET_MEMBER_ID,
+        mode,
+      }));
+      assert.equal(response.status, 400);
+    }
+    expect(mocks.previewHostedPulseTrialExtension).not.toHaveBeenCalled();
   });
 });
+
+function makeResult(
+  overrides: Partial<HostedPulseTrialExtensionResult> = {},
+): HostedPulseTrialExtensionResult {
+  return {
+    currentTrialEndsAt: "2026-07-12T16:00:00.000Z",
+    eligibilityCode: "eligible",
+    eligible: true,
+    extensionDays: 7,
+    localBillingPhase: null,
+    localBillingStatus: "paused",
+    memberId: TARGET_MEMBER_ID,
+    message: "This lapsed Pulse Trial can be restored for seven days.",
+    outcome: "preview",
+    previewProof: PREVIEW_PROOF,
+    providerStatus: "paused",
+    targetTrialEndsAt: PREVIEW_PROOF.targetTrialEndsAt,
+    ...overrides,
+  };
+}
 
 function makeRequest(body: Record<string, unknown>): Request {
   return new Request("http://localhost/api/ops/pulse-trial-extension", {
     body: JSON.stringify(body),
     headers: {
-      "Content-Type": "application/json",
+      "content-type": "application/json",
+      origin: "http://localhost",
     },
     method: "POST",
   });
-}
-
-async function buildProductionPreviewProof(): Promise<HostedPulseTrialExtensionSummary> {
-  const candidateSource: HostedPulseTrialExtensionCandidateSource = {
-    async inspectProviderOnlyTrial() {
-      throw new Error("A suspended local candidate must not inspect Stripe.");
-    },
-    async listCandidates() {
-      return {
-        candidates: [{
-          billingRefCreatedAt: new Date("2026-07-01T12:00:00.000Z"),
-          currentBillingPhase: "trial",
-          currentBillingPlanCode: "launch_monthly",
-          currentCheckoutOffer: "pulse_trial_7d",
-          currentPeriodEnd: new Date("2026-07-09T12:00:00.000Z"),
-          currentTrialEndsAt: new Date("2026-07-09T12:00:00.000Z"),
-          currentTrialStartedAt: new Date("2026-07-02T12:00:00.000Z"),
-          lastStripeEventCreatedAt: null,
-          memberBillingStatus: HostedBillingStatus.active,
-          memberId: "member_preview_contract",
-          memberSuspendedAt: new Date("2026-07-08T12:00:00.000Z"),
-          providerCustomerId: null,
-          providerSubscriptionId: null,
-          pulseTrialRedeemedAt: new Date("2026-07-02T12:00:00.000Z"),
-          stripeCustomerId: "cus_preview_contract",
-          stripeSubscriptionId: "sub_preview_contract",
-        }],
-        nextContinuationToken: null,
-      };
-    },
-    async withStripeMutationLock<TResult>(): Promise<TResult> {
-      throw new Error("Preview must not acquire the member mutation lock.");
-    },
-  };
-  const stripe: HostedPulseTrialExtensionStripeClient = {
-    async retrieveSubscription() {
-      throw new Error("A suspended local candidate must not retrieve Stripe.");
-    },
-    async updateSubscription() {
-      throw new Error("Preview must not update Stripe.");
-    },
-  };
-
-  return extendHostedPulseTrials({
-    candidateSource,
-    maxCandidates: 4,
-    mode: "dry-run",
-    now: NOW,
-    priceId: "price_pulse_monthly_123",
-    stripe,
-  });
-}
-
-function makeSummary(
-  overrides: Partial<HostedPulseTrialExtensionSummary>,
-): HostedPulseTrialExtensionSummary {
-  return {
-    alreadyExtended: 0,
-    campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    candidatePreviewTokens: [],
-    candidateSnapshotDigest: CANDIDATE_SNAPSHOT_DIGEST,
-    candidates: 0,
-    extensionDays: 7,
-    failures: {
-      db_update_failed: 0,
-      member_lock_busy: 0,
-      preview_state_changed: 0,
-      provider_recovery_failed: 0,
-      provider_recovery_lookup_failed: 0,
-      route_runway_exhausted: 0,
-      stripe_retrieve_failed: 0,
-      stripe_update_failed: 0,
-      stripe_update_result_invalid: 0,
-    },
-    hasMoreCandidates: false,
-    localWindowsReconciled: 0,
-    mode: "dry-run",
-    nextContinuationToken: null,
-    providerTrialsCleanedUp: 0,
-    providerTrialsRecovered: 0,
-    skipped: {
-      local_candidate_changed: 0,
-      local_trial_window_invalid: 0,
-      missing_stripe_refs: 0,
-      outside_campaign_cohort: 0,
-      provider_recovery_not_found: 0,
-      provider_trial_ended: 0,
-      stripe_billing_plan_mismatch: 0,
-      stripe_campaign_marker_conflict: 0,
-      stripe_checkout_offer_mismatch: 0,
-      stripe_customer_mismatch: 0,
-      stripe_price_mismatch: 0,
-      stripe_subscription_id_mismatch: 0,
-      stripe_subscription_canceling: 0,
-      stripe_subscription_not_trialing: 0,
-      stripe_trial_end_invalid: 0,
-    },
-    stripeTrialsExtended: 0,
-    wouldExtend: 0,
-    wouldCleanupProviderTrial: 0,
-    wouldRecoverProviderTrial: 0,
-    wouldReconcile: 0,
-    ...overrides,
-  };
 }

--- a/apps/web/test/hosted-pulse-trial-extension.test.ts
+++ b/apps/web/test/hosted-pulse-trial-extension.test.ts
@@ -1,4023 +1,665 @@
-import assert from "node:assert/strict";
-import { Prisma } from "@prisma/client";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { HostedBillingStatus } from "@prisma/client";
+import type Stripe from "stripe";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  reconcileHostedAiUsageAllowancePeriodForMemberTx: vi.fn(async () => {}),
+  readHostedMemberBillingSnapshot: vi.fn(),
+  reconcileHostedAiUsageAllowancePeriodForMemberTx: vi.fn(),
+  updateHostedMemberCoreState: vi.fn(),
+  withHostedMemberStripeMutationLockForOps: vi.fn(),
+  writeHostedMemberStripeBillingRefTx: vi.fn(),
 }));
+
+vi.mock("../src/lib/hosted-onboarding/hosted-member-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/hosted-onboarding/hosted-member-store")
+  >("../src/lib/hosted-onboarding/hosted-member-store");
+  return {
+    ...actual,
+    readHostedMemberBillingSnapshot: mocks.readHostedMemberBillingSnapshot,
+    updateHostedMemberCoreState: mocks.updateHostedMemberCoreState,
+  };
+});
+
+vi.mock("../src/lib/hosted-onboarding/hosted-member-billing-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/hosted-onboarding/hosted-member-billing-store")
+  >("../src/lib/hosted-onboarding/hosted-member-billing-store");
+  return {
+    ...actual,
+    withHostedMemberStripeMutationLockForOps:
+      mocks.withHostedMemberStripeMutationLockForOps,
+    writeHostedMemberStripeBillingRefTx:
+      mocks.writeHostedMemberStripeBillingRefTx,
+  };
+});
 
 vi.mock("../src/lib/hosted-execution/usage-allowance", () => ({
   reconcileHostedAiUsageAllowancePeriodForMemberTx:
     mocks.reconcileHostedAiUsageAllowancePeriodForMemberTx,
 }));
 
-import type {
-  HostedAutoPulseTrialCampaignDisposition,
-} from "../src/lib/hosted-onboarding/auto-trial-enrollment-service";
+import type { HostedMemberBillingSnapshot } from "../src/lib/hosted-onboarding/hosted-member-store";
+import { HostedMemberStripeMutationLockBusyError } from "../src/lib/hosted-onboarding/hosted-member-billing-store";
 import {
-  HostedMemberStripeMutationLockBusyError,
-  withHostedMemberStripeMutationLock,
-  withHostedMemberStripeMutationLockForOps,
-} from "../src/lib/hosted-onboarding/hosted-member-billing-store";
-import { buildHostedMemberBillingPrivateColumns } from "../src/lib/hosted-onboarding/member-private-codecs";
-import {
-  classifyHostedPulseTrialExtensionSubscription as classifyHostedPulseTrialExtensionSubscriptionWithPrice,
-  createPrismaHostedPulseTrialExtensionCandidateSource,
-  extendHostedPulseTrials as extendHostedPulseTrialsWithPrice,
-  HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-  HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY,
-  HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO,
-  HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY,
-  HostedPulseTrialExtensionContinuationError,
-  HostedPulseTrialExtensionPreviewMismatchError,
-  type HostedPulseTrialExtensionCandidate,
-  type HostedPulseTrialExtensionCandidateSource,
-  type HostedPulseTrialExtensionStripeClient,
-  type HostedPulseTrialExtensionStripeRequestOptions,
-  type HostedPulseTrialExtensionStripeSubscription,
-  type HostedPulseTrialExtensionStripeUpdateParams,
+  applyHostedPulseTrialExtension,
+  classifyHostedPulseTrialExtensionProviderState,
+  HostedPulseTrialExtensionLockBusyError,
+  HostedPulseTrialExtensionPreviewStaleError,
+  HostedPulseTrialExtensionProviderError,
+  previewHostedPulseTrialExtension,
+  type HostedPulseTrialExtensionSubscription,
 } from "../src/lib/hosted-ops/pulse-trial-extension";
 
-const NOW = new Date("2026-07-09T12:00:00.000Z");
-const PRICE_ID = "price_pulse_recurring";
-const ORIGINAL_TRIAL_END = new Date("2026-07-12T12:00:00.000Z");
-const EXTENDED_TRIAL_END = new Date("2026-07-19T12:00:00.000Z");
+const NOW = new Date("2026-07-14T16:00:00.000Z");
+const MEMBER_ID = "hbm_target_1";
+const CUSTOMER_ID = "cus_target";
+const SUBSCRIPTION_ID = "sub_target";
+const PRICE_ID = "price_pulse";
+const ORIGINAL_TRIAL_END = Math.floor(
+  new Date("2026-07-18T16:00:00.000Z").getTime() / 1000,
+);
+const TARGET_FROM_PAUSED = Math.floor(
+  new Date("2026-07-21T16:00:00.000Z").getTime() / 1000,
+);
+const TARGET_FROM_LIVE = Math.floor(
+  new Date("2026-07-25T16:00:00.000Z").getTime() / 1000,
+);
+const CONTACT_PRIVACY_KEY = Buffer.alloc(32, 7).toString("base64");
+const originalContactPrivacyKeys = process.env.HOSTED_CONTACT_PRIVACY_KEYS;
+const originalContactPrivacyVersion =
+  process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION;
 
-describe("Pulse Trial beta extension", () => {
+describe("single-member Pulse Trial extension", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  test("holds the member row lock for the serialized Stripe mutation", async () => {
-    const events: string[] = [];
-    const tx = {
-      $queryRaw: vi.fn(async () => {
-        events.push("lock");
-        return [];
-      }),
-    };
-    const prisma = {
-      $transaction: vi.fn(async (
-        callback: (transaction: typeof tx) => Promise<string>,
-        options?: unknown,
-      ) => {
-        void options;
-        events.push("transaction");
-        const result = await callback(tx);
-        events.push("commit");
-        return result;
-      }),
-    };
-
-    const result = await withHostedMemberStripeMutationLock({
-      memberId: "member_test",
-      prisma: prisma as never,
-      run: async (lockedTx) => {
-        assert.equal(lockedTx, tx);
-        events.push("stripe");
-        return "done";
-      },
+    process.env.HOSTED_CONTACT_PRIVACY_KEYS = `v1:${CONTACT_PRIVACY_KEY}`;
+    process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = "v1";
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValue(makeMember());
+    mocks.withHostedMemberStripeMutationLockForOps.mockImplementation(
+      async (input: { run: (tx: object) => Promise<unknown> }) => input.run({}),
+    );
+    mocks.updateHostedMemberCoreState.mockResolvedValue({
+      ...makeMember().core,
+      billingStatus: HostedBillingStatus.active,
     });
-
-    assert.equal(result, "done");
-    assert.deepEqual(events, ["transaction", "lock", "stripe", "commit"]);
-    assert.equal(tx.$queryRaw.mock.calls.length, 1);
-    assert.deepEqual(prisma.$transaction.mock.calls[0]?.[1], {
-      maxWait: 5_000,
-      timeout: 780_000,
-    });
-  });
-
-  test("maps the Ops PostgreSQL lock timeout to a typed busy result", async () => {
-    const lockTimeoutError = new Prisma.PrismaClientKnownRequestError(
-      "canceling statement due to lock timeout",
-      {
-        clientVersion: "test",
-        code: "P2010",
-        meta: { code: "55P03" },
-      },
+    mocks.writeHostedMemberStripeBillingRefTx.mockImplementation(
+      async (input: { currentTrialEndsAt: Date }) => ({
+        ...makeMember().billingRef,
+        currentBillingPhase: "trial",
+        currentPeriodEnd: input.currentTrialEndsAt,
+        currentTrialEndsAt: input.currentTrialEndsAt,
+      }),
     );
-    const tx = {
-      $queryRaw: vi.fn()
-        .mockResolvedValueOnce([])
-        .mockRejectedValueOnce(lockTimeoutError),
-    };
-    const prisma = {
-      $transaction: vi.fn(async (
-        callback: (transaction: typeof tx) => Promise<unknown>,
-        options: unknown,
-      ) => {
-        void options;
-        return callback(tx);
-      }),
-    };
-
-    await expect(withHostedMemberStripeMutationLockForOps({
-      acquisitionTimeoutMs: 25_000,
-      memberId: "member_test",
-      prisma: prisma as never,
-      run: async () => "unreachable",
-      transactionTimeoutMs: 190_000,
-    })).rejects.toBeInstanceOf(HostedMemberStripeMutationLockBusyError);
-
-    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
-      maxWait: 5_000,
-      timeout: 190_000,
-    });
-    assert.equal(tx.$queryRaw.mock.calls.length, 2);
-  });
-
-  test("validates current Stripe trial ownership and campaign state", () => {
-    const candidate = makeCandidate();
-    assert.deepEqual(
-      classifyHostedPulseTrialExtensionSubscription({
-        candidate,
-        nowUnixSeconds: toUnixSeconds(NOW),
-        subscription: makeSubscription(),
-      }),
-      {
-        alreadyMarked: false,
-        ok: true,
-        stripeTrialEnd: toUnixSeconds(ORIGINAL_TRIAL_END),
-      },
-    );
-
-    assert.deepEqual(
-      classifyHostedPulseTrialExtensionSubscription({
-        candidate,
-        nowUnixSeconds: toUnixSeconds(NOW),
-        subscription: makeSubscription({ customer: "cus_other" }),
-      }),
-      { ok: false, reason: "stripe_customer_mismatch" },
-    );
-    assert.deepEqual(
-      classifyHostedPulseTrialExtensionSubscription({
-        candidate,
-        nowUnixSeconds: toUnixSeconds(NOW),
-        subscription: makeSubscription({
-          metadata: {
-            billingPlanCode: "launch_monthly",
-            checkoutOffer: "pulse_trial_7d",
-            [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]: "another-campaign",
-          },
-        }),
-      }),
-      { ok: false, reason: "stripe_campaign_marker_conflict" },
+    mocks.reconcileHostedAiUsageAllowancePeriodForMemberTx.mockResolvedValue(
+      undefined,
     );
   });
 
-  test("rejects mismatched Stripe subscription, offer, and plan facts", () => {
-    const candidate = makeCandidate();
-    const cases: Array<{
-      expectedReason:
-        | "stripe_billing_plan_mismatch"
-        | "stripe_checkout_offer_mismatch"
-        | "stripe_price_mismatch"
-        | "stripe_subscription_id_mismatch";
-      subscription: HostedPulseTrialExtensionStripeSubscription;
-    }> = [
-      {
-        expectedReason: "stripe_subscription_id_mismatch",
-        subscription: makeSubscription({ id: "sub_other" }),
-      },
-      {
-        expectedReason: "stripe_checkout_offer_mismatch",
-        subscription: makeSubscription({
-          metadata: {
-            billingPlanCode: "launch_monthly",
-            checkoutOffer: "another_offer",
-          },
-        }),
-      },
-      {
-        expectedReason: "stripe_billing_plan_mismatch",
-        subscription: makeSubscription({
-          metadata: {
-            billingPlanCode: "edge_monthly",
-            checkoutOffer: "pulse_trial_7d",
-          },
-        }),
-      },
-      {
-        expectedReason: "stripe_price_mismatch",
-        subscription: makeSubscription({
-          items: {
-            data: [makeSubscriptionItem({ priceId: "price_other" })],
-          },
-        }),
-      },
-      {
-        expectedReason: "stripe_price_mismatch",
-        subscription: makeSubscription({
-          items: {
-            data: [makeSubscriptionItem()],
-            has_more: true,
-          },
-        }),
-      },
-      {
-        expectedReason: "stripe_price_mismatch",
-        subscription: makeSubscription({
-          metadata: { memberId: "member_other" },
-        }),
-      },
-      {
-        expectedReason: "stripe_price_mismatch",
-        subscription: makeSubscription({
-          metadata: {
-            trialDurationDays: "7",
-            trialPolicyVersion: "pulse-trial-2026-05-05-v1",
-          },
-        }),
-      },
-    ];
-
-    for (const entry of cases) {
-      assert.deepEqual(
-        classifyHostedPulseTrialExtensionSubscription({
-          candidate,
-          nowUnixSeconds: toUnixSeconds(NOW),
-          subscription: entry.subscription,
-        }),
-        { ok: false, reason: entry.expectedReason },
-      );
-    }
+  afterEach(() => {
+    restoreEnv("HOSTED_CONTACT_PRIVACY_KEYS", originalContactPrivacyKeys);
+    restoreEnv(
+      "HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION",
+      originalContactPrivacyVersion,
+    );
   });
 
-  test("canceled, expired, mismatched, and foreign-campaign subscriptions remain untouched", async () => {
-    const cases: Array<{
-      expectedReason:
-        | "stripe_campaign_marker_conflict"
-        | "stripe_price_mismatch"
-        | "stripe_subscription_not_trialing";
-      label: string;
-      subscription: HostedPulseTrialExtensionStripeSubscription;
-    }> = [
-      {
-        expectedReason: "stripe_subscription_not_trialing",
-        label: "canceled",
-        subscription: makeSubscription({ status: "canceled" }),
-      },
-      {
-        expectedReason: "stripe_subscription_not_trialing",
-        label: "expired",
-        subscription: makeSubscription({ status: "incomplete_expired" }),
-      },
-      {
-        expectedReason: "stripe_price_mismatch",
-        label: "mismatched",
-        subscription: makeSubscription({
-          items: {
-            data: [makeSubscriptionItem({ priceId: "price_other" })],
-          },
-        }),
-      },
-      {
-        expectedReason: "stripe_campaign_marker_conflict",
-        label: "foreign campaign",
-        subscription: makeSubscription({
-          metadata: {
-            [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]:
-              "pulse-beta-extension-another-occasion",
-          },
-        }),
-      },
-    ];
-
-    for (const entry of cases) {
-      const source = makeCandidateSource([makeCandidate()]);
-      const stripe = makeStripeClient(entry.subscription);
-
-      const summary = await extendHostedPulseTrials({
-        candidateSource: source,
-        mode: "apply",
-        now: NOW,
-        stripe,
-      });
-
-      assert.equal(summary.skipped[entry.expectedReason], 1, entry.label);
-      assert.equal(summary.stripeTrialsExtended, 0, entry.label);
-      assert.equal(summary.localWindowsReconciled, 0, entry.label);
-      assert.equal(stripe.updateCalls.length, 0, entry.label);
-      assert.equal(source.updateCalls.length, 0, entry.label);
-    }
-  });
-
-  test.each([
-    ["period end", { cancel_at_period_end: true }],
-    ["explicit time", { cancel_at: toUnixSeconds(ORIGINAL_TRIAL_END) }],
-  ] as const)("skips a trial scheduled to cancel at %s", async (_label, cancellation) => {
-    const source = makeCandidateSource([makeCandidate()]);
-    const stripe = makeStripeClient(makeSubscription(cancellation));
-
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
+  test("accepts only owned live or lapsed paused Pulse Trials", () => {
+    expect(classifyHostedPulseTrialExtensionProviderState({
+      memberId: MEMBER_ID,
       now: NOW,
-      stripe,
-    });
-
-    assert.equal(summary.skipped.stripe_subscription_canceling, 1);
-    assert.equal(summary.stripeTrialsExtended, 0);
-    assert.equal(summary.localWindowsReconciled, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(source.updateCalls.length, 0);
-    expect(mocks.reconcileHostedAiUsageAllowancePeriodForMemberTx).not.toHaveBeenCalled();
+      priceId: PRICE_ID,
+      stripeCustomerId: CUSTOMER_ID,
+      stripeSubscriptionId: SUBSCRIPTION_ID,
+      subscription: makeSubscription({ status: "trialing" }),
+    })).toBeNull();
+    expect(classifyHostedPulseTrialExtensionProviderState({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      stripeCustomerId: CUSTOMER_ID,
+      stripeSubscriptionId: SUBSCRIPTION_ID,
+      subscription: makeSubscription({ status: "paused", trialEnd: 1_700_000_000 }),
+    })).toBeNull();
+    expect(classifyHostedPulseTrialExtensionProviderState({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      stripeCustomerId: CUSTOMER_ID,
+      stripeSubscriptionId: SUBSCRIPTION_ID,
+      subscription: makeSubscription({ status: "active", trialEnd: null }),
+    })).toBe("provider_subscription_not_extendable");
+    expect(classifyHostedPulseTrialExtensionProviderState({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      stripeCustomerId: CUSTOMER_ID,
+      stripeSubscriptionId: SUBSCRIPTION_ID,
+      subscription: makeSubscription({ customerId: "cus_other" }),
+    })).toBe("provider_identity_mismatch");
   });
 
-  test.each([
-    ["period end", { cancel_at_period_end: true }],
-    ["explicit time", { cancel_at: toUnixSeconds(ORIGINAL_TRIAL_END) }],
-  ] as const)("does not locally reconcile a marked trial canceled at %s", async (
-    _label,
-    cancellation,
-  ) => {
-    const source = makeCandidateSource([makeCandidate()]);
+  test("previews a lapsed paused trial for seven days from Preview", async () => {
     const stripe = makeStripeClient(makeSubscription({
-      ...cancellation,
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]:
-          HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-        [HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY]: "7",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-      trial_end: toUnixSeconds(EXTENDED_TRIAL_END),
+      status: "paused",
+      trialEnd: 1_700_000_000,
     }));
 
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
+    const result = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
       now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
       stripe,
     });
 
-    assert.equal(summary.skipped.stripe_subscription_canceling, 1);
-    assert.equal(summary.localWindowsReconciled, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(source.updateCalls.length, 0);
-  });
-
-  test("dry-run reports eligible trials without mutating Stripe or local state", async () => {
-    const source = makeCandidateSource([makeCandidate()]);
-    const stripe = makeStripeClient();
-
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      now: NOW,
-      stripe,
+    expect(result).toMatchObject({
+      currentTrialEndsAt: new Date(1_700_000_000 * 1000).toISOString(),
+      eligibilityCode: "eligible",
+      eligible: true,
+      localBillingStatus: "paused",
+      memberId: MEMBER_ID,
+      outcome: "preview",
+      providerStatus: "paused",
+      targetTrialEndsAt: new Date(TARGET_FROM_PAUSED * 1000).toISOString(),
     });
-
-    assert.equal(summary.candidates, 1);
-    assert.equal(summary.wouldExtend, 1);
-    assert.equal(summary.stripeTrialsExtended, 0);
-    assert.equal(summary.localWindowsReconciled, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(source.updateCalls.length, 0);
-  });
-
-  test("apply extends from the existing Stripe end by exactly seven days before local reconciliation", async () => {
-    const events: string[] = [];
-    const source = makeCandidateSource([makeCandidate()], { events });
-    const stripe = makeStripeClient(makeSubscription(), events);
-
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(summary.stripeTrialsExtended, 1);
-    assert.equal(summary.localWindowsReconciled, 1);
-    assert.deepEqual(events, ["stripe", "database"]);
-    assert.deepEqual(stripe.updateCalls[0]?.params, {
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]:
-          HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-        [HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY]: "7",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-      proration_behavior: "none",
-      trial_end: toUnixSeconds(EXTENDED_TRIAL_END),
-    });
-    assert.match(
-      stripe.updateCalls[0]?.options.idempotencyKey ?? "",
-      /pulse-beta-extension-2026-07/u,
+    expect(result.previewProof?.token).toMatch(
+      /^pulse-member-preview-v1\.v1\.[A-Za-z0-9_-]{43}$/u,
     );
-    assert.deepEqual(stripe.retrieveOptions[0], {
-      maxNetworkRetries: 0,
-      timeout: 80_000,
-    });
-    assert.equal(stripe.updateCalls[0]?.options.maxNetworkRetries, 0);
-    assert.equal(stripe.updateCalls[0]?.options.timeout, 80_000);
-    assert.deepEqual(source.candidates[0], {
-      ...makeCandidate(),
-      currentPeriodEnd: EXTENDED_TRIAL_END,
-      currentTrialEndsAt: EXTENDED_TRIAL_END,
-    });
+    expect(JSON.stringify(result)).not.toContain(CUSTOMER_ID);
+    expect(JSON.stringify(result)).not.toContain(SUBSCRIPTION_ID);
   });
 
-  test("a repeated apply does not extend Stripe twice", async () => {
-    const source = makeCandidateSource([makeCandidate()]);
-    const stripe = makeStripeClient();
-
-    const first = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
+  test("extends a paused trial once and reconciles local billing under the lock", async () => {
+    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
+    const stripe = makeStripeClient(paused);
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
       now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
       stripe,
     });
-    const second = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(first.stripeTrialsExtended, 1);
-    assert.equal(second.stripeTrialsExtended, 0);
-    assert.equal(second.alreadyExtended, 1);
-    assert.equal(stripe.updateCalls.length, 1);
-    assert.equal(source.updateCalls.length, 2);
-  });
-
-  test("a retry repairs local state after Stripe succeeded without extending Stripe again", async () => {
-    const source = makeCandidateSource([makeCandidate()], { failUpdates: 1 });
-    const stripe = makeStripeClient();
-
-    const first = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-    const second = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(first.stripeTrialsExtended, 1);
-    assert.equal(first.failures.db_update_failed, 1);
-    assert.equal(second.stripeTrialsExtended, 0);
-    assert.equal(second.localWindowsReconciled, 1);
-    assert.equal(stripe.updateCalls.length, 1);
-    assert.equal(source.lockCalls, 2);
-    assert.equal(source.updateCalls.length, 2);
-    assert.equal(source.candidates[0]?.currentTrialEndsAt?.getTime(), EXTENDED_TRIAL_END.getTime());
-  });
-
-  test("does not reconcile local windows when the Stripe extension fails", async () => {
-    const source = makeCandidateSource([makeCandidate()]);
-    const updateSubscription = vi.fn(async () => {
-      throw new Error("Synthetic Stripe update failure.");
-    });
-    const stripe: HostedPulseTrialExtensionStripeClient = {
-      async retrieveSubscription() {
-        return makeSubscription();
-      },
-      updateSubscription,
-    };
-
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(summary.failures.stripe_update_failed, 1);
-    assert.equal(summary.stripeTrialsExtended, 0);
-    assert.equal(summary.localWindowsReconciled, 0);
-    assert.equal(updateSubscription.mock.calls.length, 1);
-    assert.equal(source.updateCalls.length, 0);
-  });
-
-  test("uses current Stripe trial status when local end timestamps are stale", async () => {
-    const staleLocalEnd = new Date("2026-07-08T12:00:00.000Z");
-    const source = makeCandidateSource([makeCandidate({
-      currentPeriodEnd: staleLocalEnd,
-      currentTrialEndsAt: staleLocalEnd,
-    })]);
-    const stripe = makeStripeClient();
-
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(summary.stripeTrialsExtended, 1);
-    assert.equal(summary.localWindowsReconciled, 1);
-    assert.equal(source.candidates[0]?.currentTrialEndsAt?.getTime(), EXTENDED_TRIAL_END.getTime());
-  });
-
-  test("does not restore a trial when paid conversion wins the shared mutation lock", async () => {
-    const source = makeCandidateSource([makeCandidate()]);
-    const convertedSubscription = makeSubscription({
-      status: "active",
-      trial_end: null,
-    });
-    let retrieveCalls = 0;
-    const updateSubscription = vi.fn();
-    const stripe: HostedPulseTrialExtensionStripeClient = {
-      async retrieveSubscription() {
-        retrieveCalls += 1;
-        return convertedSubscription;
-      },
-      updateSubscription,
-    };
-
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(retrieveCalls, 2);
-    assert.equal(summary.skipped.stripe_subscription_not_trialing, 1);
-    assert.equal(summary.stripeTrialsExtended, 0);
-    assert.equal(source.updateCalls.length, 0);
-    assert.equal(updateSubscription.mock.calls.length, 0);
-  });
-
-  test("does not update a trial without the derived one-attempt provider runway", async () => {
-    vi.useFakeTimers();
-    try {
-      const safeClock = new Date("2026-07-09T12:01:20.000Z");
-      const nearTrialEnd = new Date(safeClock.getTime() + 81_000);
-      vi.setSystemTime(new Date("2026-07-09T12:00:00.000Z"));
-      const source = makeCandidateSource([makeCandidate({
-        currentPeriodEnd: nearTrialEnd,
-        currentTrialEndsAt: nearTrialEnd,
-      })]);
-      const updateSubscription = vi.fn();
-      const stripe: HostedPulseTrialExtensionStripeClient = {
-        async retrieveSubscription() {
-          vi.setSystemTime(safeClock);
-          return makeSubscription({ trial_end: toUnixSeconds(nearTrialEnd) });
-        },
-        updateSubscription,
-      };
-
-      const summary = await extendHostedPulseTrials({
-        candidateSource: source,
-        mode: "apply",
-        stripe,
-      });
-
-      assert.equal(summary.skipped.stripe_trial_end_invalid, 1);
-      assert.equal(summary.stripeTrialsExtended, 0);
-      assert.equal(summary.localWindowsReconciled, 0);
-      assert.equal(updateSubscription.mock.calls.length, 0);
-      assert.equal(source.updateCalls.length, 0);
-    } finally {
-      vi.useRealTimers();
+    if (!preview.previewProof) {
+      throw new Error("Expected an eligible preview.");
     }
-  });
-
-  test("dry-run does not report an extension at the derived runway boundary", async () => {
-    vi.useFakeTimers();
-    try {
-      const safeClock = new Date("2026-07-09T12:01:20.000Z");
-      const nearTrialEnd = new Date(safeClock.getTime() + 81_000);
-      vi.setSystemTime(new Date("2026-07-09T12:00:00.000Z"));
-      const source = makeCandidateSource([makeCandidate({
-        currentPeriodEnd: nearTrialEnd,
-        currentTrialEndsAt: nearTrialEnd,
-      })]);
-      const updateSubscription = vi.fn();
-      const stripe: HostedPulseTrialExtensionStripeClient = {
-        async retrieveSubscription() {
-          vi.setSystemTime(safeClock);
-          return makeSubscription({ trial_end: toUnixSeconds(nearTrialEnd) });
-        },
-        updateSubscription,
-      };
-
-      const summary = await extendHostedPulseTrials({
-        candidateSource: source,
-        mode: "dry-run",
-        stripe,
-      });
-
-      assert.equal(summary.skipped.stripe_trial_end_invalid, 1);
-      assert.equal(summary.wouldExtend, 0);
-      assert.equal(updateSubscription.mock.calls.length, 0);
-      assert.equal(source.updateCalls.length, 0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("dry-run reports an extension above the derived runway boundary", async () => {
-    vi.useFakeTimers();
-    try {
-      const safeClock = new Date("2026-07-09T12:01:20.000Z");
-      const safeTrialEnd = new Date(safeClock.getTime() + 82_000);
-      vi.setSystemTime(new Date("2026-07-09T12:00:00.000Z"));
-      const source = makeCandidateSource([makeCandidate({
-        currentPeriodEnd: safeTrialEnd,
-        currentTrialEndsAt: safeTrialEnd,
-      })]);
-      const updateSubscription = vi.fn();
-      const stripe: HostedPulseTrialExtensionStripeClient = {
-        async retrieveSubscription() {
-          vi.setSystemTime(safeClock);
-          return makeSubscription({ trial_end: toUnixSeconds(safeTrialEnd) });
-        },
-        updateSubscription,
-      };
-
-      const summary = await extendHostedPulseTrials({
-        candidateSource: source,
-        mode: "dry-run",
-        stripe,
-      });
-
-      assert.equal(summary.skipped.stripe_trial_end_invalid, 0);
-      assert.equal(summary.wouldExtend, 1);
-      assert.equal(updateSubscription.mock.calls.length, 0);
-      assert.equal(source.updateCalls.length, 0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("updates a trial with five minutes left using one bounded provider attempt", async () => {
-    vi.useFakeTimers();
-    try {
-      const safeClock = new Date("2026-07-09T12:01:20.000Z");
-      const safeTrialEnd = new Date(safeClock.getTime() + 300_000);
-      vi.setSystemTime(new Date("2026-07-09T12:00:00.000Z"));
-      const source = makeCandidateSource([makeCandidate({
-        currentPeriodEnd: safeTrialEnd,
-        currentTrialEndsAt: safeTrialEnd,
-      })]);
-      const stripe = makeStripeClient(makeSubscription({
-        trial_end: toUnixSeconds(safeTrialEnd),
-      }));
-      const retrieveSubscription = vi.spyOn(stripe, "retrieveSubscription")
-        .mockImplementationOnce(async () => {
-          vi.setSystemTime(safeClock);
-          return makeSubscription({ trial_end: toUnixSeconds(safeTrialEnd) });
-        });
-
-      const summary = await extendHostedPulseTrials({
-        candidateSource: source,
-        mode: "apply",
-        stripe,
-      });
-
-      assert.equal(retrieveSubscription.mock.calls.length, 2);
-      assert.equal(summary.stripeTrialsExtended, 1);
-      assert.equal(summary.localWindowsReconciled, 1);
-      assert.equal(stripe.updateCalls.length, 1);
-      assert.equal(stripe.updateCalls[0]?.options.maxNetworkRetries, 0);
-      assert.equal(stripe.updateCalls[0]?.options.timeout, 80_000);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("does not touch Stripe when the locked local re-read is no longer eligible", async () => {
-    const source = makeCandidateSource([makeCandidate()]);
-    source.withStripeMutationLock = (input) => input.run({
-      async applyProviderOnlyDisposition() {
-        return "recovered";
-      },
-      candidate: null,
-      async updateTrialEnd() {
-        throw new Error("A changed candidate must not be reconciled.");
-      },
-    });
-    const stripe = makeStripeClient();
-
-    const summary = await extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(summary.failures.preview_state_changed, 1);
-    assert.equal(summary.stripeTrialsExtended, 0);
-    assert.equal(summary.localWindowsReconciled, 0);
-    assert.equal(stripe.retrieveCalls, 1);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(source.updateCalls.length, 0);
-  });
-
-  test("stable local ineligibility skips without blocking the next page member", async () => {
-    const source = makeCandidateSource([
-      makeCandidate({
-        memberId: "member_suspended",
-        memberSuspendedAt: new Date("2026-07-09T10:00:00.000Z"),
-        stripeCustomerId: "cus_suspended",
-        stripeSubscriptionId: "sub_suspended",
-      }),
-      makeCandidate({ memberId: "member_eligible" }),
-    ]);
-    const previewStripe = makeStripeClient(
-      makeSubscription(),
-      undefined,
-      makeCandidateSubscriptionResolver(source.candidates),
-    );
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: previewStripe,
-    });
-
-    assert.equal(preview.skipped.local_candidate_changed, 1);
-    assert.equal(preview.wouldExtend, 1);
-    assert.equal(previewStripe.retrieveCalls, 1);
-
-    const applyStripe = makeStripeClient(
-      makeSubscription(),
-      undefined,
-      makeCandidateSubscriptionResolver(source.candidates),
-    );
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: applyStripe,
-    });
-
-    assert.equal(applied.skipped.local_candidate_changed, 1);
-    assert.equal(applied.failures.preview_state_changed, 0);
-    assert.equal(applied.stripeTrialsExtended, 1);
-    assert.equal(applyStripe.retrieveCalls, 1);
-    assert.equal(applyStripe.updateCalls.length, 1);
-  });
-
-  test("an active-to-suspended race after Preview rejects before Stripe", async () => {
-    const previewSource = makeCandidateSource([makeCandidate()]);
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: previewSource,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-    const source = makeCandidateSource([makeCandidate()]);
-    source.withStripeMutationLock = async (input) => {
-      const candidate = source.candidates[0];
-      assert.ok(candidate);
-      candidate.memberSuspendedAt = new Date("2026-07-09T12:00:01.000Z");
-      return input.run({
-        async applyProviderOnlyDisposition() {
-          return "recovered";
-        },
-        candidate,
-        async updateTrialEnd() {
-          throw new Error("A stale local candidate must not be reconciled.");
-        },
-      });
-    };
-    const stripe = makeStripeClient();
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(stripe.retrieveCalls, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-  });
-
-  test("a busy member lock returns a bounded retry result without Stripe work", async () => {
-    const candidates = [
-      makeCandidate({ memberId: "member_1" }),
-      makeCandidate({ memberId: "member_2" }),
-    ];
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: makeCandidateSource(candidates),
-      maxCandidates: 1,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-    const source = makeCandidateSource(candidates);
-    let acquisitionTimeoutMs = 0;
-    let transactionTimeoutMs = 0;
-    source.withStripeMutationLock = async (input) => {
-      acquisitionTimeoutMs = input.acquisitionTimeoutMs;
-      transactionTimeoutMs = input.transactionTimeoutMs;
-      throw new HostedMemberStripeMutationLockBusyError();
-    };
-    const stripe = makeStripeClient();
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 1,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-
-    assert.equal(acquisitionTimeoutMs, 25_000);
-    assert.equal(transactionTimeoutMs, 190_000);
-    assert.equal(applied.failures.member_lock_busy, 1);
-    assert.equal(applied.hasMoreCandidates, true);
-    assert.equal(applied.nextContinuationToken, null);
-    assert.equal(stripe.retrieveCalls, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-  });
-
-  test("the operation deadline prevents a later candidate from crossing the route budget", async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(NOW);
-      const candidates = [
-        makeCandidate({
-          memberId: "member_1",
-          stripeCustomerId: "cus_1",
-          stripeSubscriptionId: "sub_1",
-        }),
-        makeCandidate({
-          memberId: "member_2",
-          stripeCustomerId: "cus_2",
-          stripeSubscriptionId: "sub_2",
-        }),
-      ];
-      const preview = await extendHostedPulseTrialsWithPrice({
-        candidateSource: makeCandidateSource(candidates),
-        maxCandidates: 4,
-        mode: "dry-run",
-        now: NOW,
-        priceId: PRICE_ID,
-        stripe: makeStripeClient(
-          makeSubscription(),
-          undefined,
-          makeCandidateSubscriptionResolver(candidates),
-        ),
-      });
-      const source = makeCandidateSource(candidates);
-      const baseLock = source.withStripeMutationLock.bind(source);
-      source.withStripeMutationLock = async (input) => {
-        const result = await baseLock(input);
-        vi.setSystemTime(new Date(Date.now() + 600_001));
-        return result;
-      };
-      const stripe = makeStripeClient(
-        makeSubscription(),
-        undefined,
-        makeCandidateSubscriptionResolver(candidates),
-      );
-
-      const applied = await extendHostedPulseTrialsWithPrice({
-        candidateSource: source,
-        expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-        expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-        maxCandidates: 4,
-        mode: "apply",
-        now: NOW,
-        priceId: PRICE_ID,
-        stripe,
-      });
-
-      assert.equal(applied.stripeTrialsExtended, 1);
-      assert.equal(applied.failures.route_runway_exhausted, 1);
-      assert.equal(source.lockCalls, 1);
-      assert.equal(stripe.retrieveCalls, 1);
-      assert.equal(stripe.updateCalls.length, 1);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("extends and recovers a provider-only pre-cutoff trial in one Apply", async () => {
-    const providerOnlyCandidate = makeCandidate({
-      currentBillingPhase: null,
-      currentBillingPlanCode: null,
-      currentCheckoutOffer: null,
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "not_started",
-      providerCustomerId: "cus_test",
-      providerSubscriptionId: "sub_test",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: null,
-    });
-    const providerSubscription = makeSubscription({
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const recovery = vi.fn(async (
-      disposition: Exclude<
-        HostedAutoPulseTrialCampaignDisposition,
-        { kind: "not-applicable" }
-      >,
-    ) => {
-      void disposition;
-      return "recovered" as const;
-    });
-    const source = makeCandidateSource([providerOnlyCandidate], {
-      applyProviderOnlyDisposition: recovery,
-      inspectProviderOnlyTrial: async () => ({
-        kind: "recoverable",
-        subscription: providerSubscription as never,
-      }),
-    });
-    const previewStripe = makeStripeClient(providerSubscription);
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: previewStripe,
-    });
-
-    assert.equal(preview.wouldRecoverProviderTrial, 1);
-    assert.equal(preview.wouldExtend, 1);
-
-    const updatedSubscription = {
-      ...providerSubscription,
-      metadata: {
-        ...providerSubscription.metadata,
-        [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]:
-          HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-        [HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY]: "7",
-      },
-      trial_end: toUnixSeconds(EXTENDED_TRIAL_END),
-    };
-    const retrieveSubscription = vi.fn(async () => providerSubscription);
-    const updateSubscription = vi.fn(async (...input: [
-      string,
-      HostedPulseTrialExtensionStripeUpdateParams,
-      {
-        idempotencyKey: string;
-      } & HostedPulseTrialExtensionStripeRequestOptions,
-    ]) => {
-      void input;
-      return updatedSubscription;
-    });
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: { retrieveSubscription, updateSubscription },
-    });
-
-    assert.equal(applied.providerTrialsRecovered, 1);
-    assert.equal(applied.stripeTrialsExtended, 1);
-    assert.equal(recovery.mock.calls.length, 1);
-    assert.equal(retrieveSubscription.mock.calls.length, 0);
-    assert.equal(updateSubscription.mock.calls.length, 1);
-    assert.equal(recovery.mock.calls[0]?.[0].subscription, updatedSubscription);
-    expect(updateSubscription.mock.calls[0]?.[2]).toEqual({
-      idempotencyKey:
-        "hosted-pulse-trial-extension:pulse-beta-extension-2026-07:sub_test",
-      maxNetworkRetries: 0,
-      timeout: 80_000,
-    });
-  });
-
-  test("replays provider-only finalization without extending Stripe twice", async () => {
-    const providerOnlyCandidate = makeCandidate({
-      currentBillingPhase: null,
-      currentBillingPlanCode: null,
-      currentCheckoutOffer: null,
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "not_started",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: null,
-    });
-    let providerSubscription = makeSubscription({
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const updateSubscription = vi.fn(async (
-      _subscriptionId: string,
-      params: HostedPulseTrialExtensionStripeUpdateParams,
-    ) => {
-      providerSubscription = {
-        ...providerSubscription,
-        metadata: { ...params.metadata },
-        trial_end: params.trial_end,
-      };
-      return providerSubscription;
-    });
-    const stripe: HostedPulseTrialExtensionStripeClient = {
-      async retrieveSubscription() {
-        return providerSubscription;
-      },
-      updateSubscription,
-    };
-    const finalize = vi.fn()
-      .mockRejectedValueOnce(new Error("synthetic local finalization failure"))
-      .mockResolvedValueOnce("recovered" as const);
-    const source = makeCandidateSource([providerOnlyCandidate], {
-      applyProviderOnlyDisposition: finalize,
-      inspectProviderOnlyTrial: async () => ({
-        kind: "recoverable",
-        subscription: providerSubscription as never,
-      }),
-    });
-
-    const firstPreview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-    const firstApply = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: firstPreview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: firstPreview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-
-    assert.equal(firstApply.failures.provider_recovery_failed, 1);
-    assert.equal(updateSubscription.mock.calls.length, 1);
-
-    const retryPreview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-    assert.equal(retryPreview.wouldRecoverProviderTrial, 1);
-    assert.equal(retryPreview.wouldReconcile, 1);
-    assert.equal(retryPreview.wouldExtend, 0);
-
-    const retryApply = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: retryPreview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: retryPreview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-
-    assert.equal(retryApply.providerTrialsRecovered, 1);
-    assert.equal(retryApply.stripeTrialsExtended, 0);
-    assert.equal(updateSubscription.mock.calls.length, 1);
-    assert.equal(finalize.mock.calls.length, 2);
-  });
-
-  test("member-scoped service recovers one exact provider trial and retries its failed sibling as cleanup", async () => {
-    const buildProviderCandidate = (subscriptionId: string) => makeCandidate({
-      currentBillingPhase: null,
-      currentBillingPlanCode: null,
-      currentCheckoutOffer: null,
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "not_started",
-      memberId: "member_target",
-      providerCustomerId: "cus_target",
-      providerSubscriptionId: subscriptionId,
-      pulseTrialRedeemedAt: null,
-      stripeCustomerId: "cus_target",
-      stripeSubscriptionId: null,
-    });
-    const providerCandidates = [
-      buildProviderCandidate("sub_provider_a"),
-      buildProviderCandidate("sub_provider_b"),
-    ];
-    const subscriptions = new Map(providerCandidates.map((candidate) => [
-      candidate.providerSubscriptionId!,
+    stripe.retrieveSubscription.mockResolvedValue(paused);
+    stripe.updateSubscription.mockImplementation(async (_id, params) =>
       makeSubscription({
-        customer: "cus_target",
-        id: candidate.providerSubscriptionId!,
-        metadata: {
-          billingPlanCode: "launch_monthly",
-          checkoutOffer: "pulse_trial_7d",
-          memberId: "member_target",
-          trialDurationDays: "10",
-          trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-          trialUsageLimitUsdMicros: "4500000",
-        },
-      }),
-    ]));
-    let currentSubscriptionId: string | null = null;
-    let firstCandidateFailed = false;
-    const cleanedSubscriptionIds: string[] = [];
-    const buildLockedCandidate = (
-      candidate: HostedPulseTrialExtensionCandidate,
-    ): HostedPulseTrialExtensionCandidate => currentSubscriptionId
-      ? makeCandidate({
-          currentBillingPhase: "trial",
-          currentBillingPlanCode: "launch_monthly",
-          currentCheckoutOffer: "pulse_trial_7d",
-          currentPeriodEnd: EXTENDED_TRIAL_END,
-          currentTrialEndsAt: EXTENDED_TRIAL_END,
-          currentTrialStartedAt: new Date("2026-07-02T12:00:00.000Z"),
-          memberId: "member_target",
-          providerCustomerId: candidate.providerCustomerId,
-          providerSubscriptionId: candidate.providerSubscriptionId,
-          pulseTrialRedeemedAt: new Date("2026-07-02T12:00:00.000Z"),
-          stripeCustomerId: "cus_target",
-          stripeSubscriptionId: currentSubscriptionId,
-        })
-      : candidate;
-    const source: HostedPulseTrialExtensionCandidateSource = {
-      async listCandidates() {
-        if (!currentSubscriptionId) {
-          return {
-            candidates: providerCandidates,
-            nextContinuationToken: "member-provider-page",
-          };
-        }
-        const remainingProviderCandidates = providerCandidates
-          .filter((candidate) =>
-            candidate.providerSubscriptionId !== currentSubscriptionId &&
-            !cleanedSubscriptionIds.includes(candidate.providerSubscriptionId!)
-          )
-          .map(buildLockedCandidate);
-        if (remainingProviderCandidates.length > 0) {
-          return {
-            candidates: remainingProviderCandidates,
-            nextContinuationToken: "member-provider-page",
-          };
-        }
-        return {
-          candidates: [makeCandidate({
-            currentBillingPhase: "trial",
-            currentBillingPlanCode: "launch_monthly",
-            currentCheckoutOffer: "pulse_trial_7d",
-            currentPeriodEnd: EXTENDED_TRIAL_END,
-            currentTrialEndsAt: EXTENDED_TRIAL_END,
-            currentTrialStartedAt: new Date("2026-07-02T12:00:00.000Z"),
-            memberId: "member_target",
-            providerCustomerId: null,
-            providerSubscriptionId: null,
-            pulseTrialRedeemedAt: new Date("2026-07-02T12:00:00.000Z"),
-            stripeCustomerId: "cus_target",
-            stripeSubscriptionId: currentSubscriptionId,
-          })],
-          nextContinuationToken: null,
-        };
-      },
-      async inspectProviderOnlyTrial({ candidate }) {
-        const subscription = subscriptions.get(candidate.providerSubscriptionId!);
-        if (!subscription) {
-          return {
-            kind: "not-applicable",
-            reason: "provider-trial-not-found",
-            subscription: null,
-          };
-        }
-        return currentSubscriptionId && currentSubscriptionId !== subscription.id
-          ? { kind: "cleanup-obsolete", subscription }
-          : { kind: "recoverable", subscription };
-      },
-      async withStripeMutationLock(input) {
-        const lockedCandidate = buildLockedCandidate(input.candidate);
-        return input.run({
-          async applyProviderOnlyDisposition(disposition) {
-            if (
-              disposition.kind === "recoverable" &&
-              disposition.subscription.id === "sub_provider_a" &&
-              !firstCandidateFailed
-            ) {
-              firstCandidateFailed = true;
-              throw new Error("synthetic local finalization failure");
-            }
-            if (disposition.kind === "recoverable") {
-              currentSubscriptionId = disposition.subscription.id;
-              return "recovered";
-            }
-            cleanedSubscriptionIds.push(disposition.subscription.id);
-            return "cleaned-up";
-          },
-          candidate: lockedCandidate,
-          async updateTrialEnd() {
-            throw new Error("Provider-only candidates must not use local trial updates.");
-          },
-        });
-      },
-    };
-    const stripe: HostedPulseTrialExtensionStripeClient = {
-      async retrieveSubscription(subscriptionId) {
-        const subscription = subscriptions.get(subscriptionId);
-        if (!subscription) {
-          throw new Error("Synthetic subscription was not found.");
-        }
-        return subscription;
-      },
-      async updateSubscription(subscriptionId, params) {
-        const subscription = subscriptions.get(subscriptionId);
-        if (!subscription) {
-          throw new Error("Synthetic subscription was not found.");
-        }
-        const updated = {
-          ...subscription,
-          metadata: { ...params.metadata },
-          trial_end: params.trial_end,
-        };
-        subscriptions.set(subscriptionId, updated);
-        return updated;
-      },
-    };
-
-    const firstPreview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-    assert.equal(firstPreview.wouldRecoverProviderTrial, 2);
-    const firstApply = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: firstPreview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: firstPreview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-    assert.equal(firstApply.failures.provider_recovery_failed, 1);
-    assert.equal(firstApply.providerTrialsRecovered, 1);
-    assert.equal(firstApply.nextContinuationToken, null);
-    assert.equal(currentSubscriptionId, "sub_provider_b");
-
-    const cleanupPreview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-    assert.equal(cleanupPreview.wouldCleanupProviderTrial, 1);
-    const cleanupApply = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: cleanupPreview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: cleanupPreview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-    assert.equal(cleanupApply.providerTrialsCleanedUp, 1);
-    expect(cleanedSubscriptionIds).toEqual(["sub_provider_a"]);
-
-    const localClosure = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-    assert.equal(localClosure.alreadyExtended, 1);
-    assert.equal(localClosure.wouldCleanupProviderTrial, 0);
-    assert.equal(localClosure.wouldRecoverProviderTrial, 0);
-  });
-
-  test.each([
-    [81, 0, 1],
-    [82, 1, 0],
-  ] as const)(
-    "provider-only trial with %i seconds remaining applies the shared runway rule",
-    async (secondsRemaining, wouldRecover, invalidSkips) => {
-      const providerOnlyCandidate = makeCandidate({
-        currentBillingPhase: null,
-        currentBillingPlanCode: null,
-        currentCheckoutOffer: null,
-        currentPeriodEnd: null,
-        currentTrialEndsAt: null,
-        currentTrialStartedAt: null,
-        memberBillingStatus: "not_started",
-        pulseTrialRedeemedAt: null,
-        stripeSubscriptionId: null,
-      });
-      const providerSubscription = makeSubscription({
-        metadata: {
-          billingPlanCode: "launch_monthly",
-          checkoutOffer: "pulse_trial_7d",
-          memberId: "member_test",
-          trialDurationDays: "10",
-          trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-          trialUsageLimitUsdMicros: "4500000",
-        },
-        trial_end: toUnixSeconds(NOW) + secondsRemaining,
-      });
-      const source = makeCandidateSource([providerOnlyCandidate], {
-        inspectProviderOnlyTrial: async () => ({
-          kind: "recoverable",
-          subscription: providerSubscription as never,
-        }),
-      });
-
-      const preview = await extendHostedPulseTrialsWithPrice({
-        candidateSource: source,
-        maxCandidates: 4,
-        mode: "dry-run",
-        now: NOW,
-        priceId: PRICE_ID,
-        stripe: makeStripeClient(providerSubscription),
-      });
-
-      assert.equal(preview.wouldRecoverProviderTrial, wouldRecover);
-      assert.equal(preview.wouldExtend, wouldRecover);
-      assert.equal(preview.skipped.stripe_trial_end_invalid, invalidSkips);
-    },
-  );
-
-  test("provider-only Apply rechecks runway after its owner lookup", async () => {
-    const providerOnlyCandidate = makeCandidate({
-      currentBillingPhase: null,
-      currentBillingPlanCode: null,
-      currentCheckoutOffer: null,
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "not_started",
-      providerCustomerId: "cus_test",
-      providerSubscriptionId: "sub_test",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: null,
-    });
-    const providerSubscription = makeSubscription({
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-      trial_end: toUnixSeconds(NOW) + 82,
-    });
-    const recovery = vi.fn(async () => "recovered" as const);
-    const source = makeCandidateSource([providerOnlyCandidate], {
-      applyProviderOnlyDisposition: recovery,
-      inspectProviderOnlyTrial: async () => ({
-        kind: "recoverable",
-        subscription: providerSubscription as never,
-      }),
-    });
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(providerSubscription),
-    });
-    const stripe = makeStripeClient(providerSubscription);
-    let clockReads = 0;
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      currentTime: () => {
-        clockReads += 1;
-        return clockReads === 1
-          ? NOW
-          : new Date(NOW.getTime() + 2_000);
-      },
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      priceId: PRICE_ID,
-      stripe,
-    });
-
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(stripe.retrieveCalls, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(recovery.mock.calls.length, 0);
-    assert.equal(clockReads, 2);
-  });
-
-  test("provider-origin recovery never mutates Stripe for a suspended member", async () => {
-    const providerOnlyCandidate = makeCandidate({
-      currentBillingPhase: null,
-      currentBillingPlanCode: null,
-      currentCheckoutOffer: null,
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "not_started",
-      memberSuspendedAt: NOW,
-      providerCustomerId: "cus_test",
-      providerSubscriptionId: "sub_test",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: null,
-    });
-    const providerSubscription = makeSubscription({
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const finalize = vi.fn(async () => "recovered" as const);
-    const source = makeCandidateSource([providerOnlyCandidate], {
-      applyProviderOnlyDisposition: finalize,
-      inspectProviderOnlyTrial: async () => ({
-        kind: "recoverable",
-        subscription: providerSubscription as never,
-      }),
-    });
-    const stripe = makeStripeClient(providerSubscription);
-
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-
-    assert.equal(preview.skipped.local_candidate_changed, 1);
-    assert.equal(preview.wouldRecoverProviderTrial, 0);
-    assert.equal(preview.wouldExtend, 0);
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe,
-    });
-
-    assert.equal(applied.skipped.local_candidate_changed, 1);
-    assert.equal(stripe.retrieveCalls, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(finalize.mock.calls.length, 0);
-  });
-
-  test.each([
-    [
-      "cancellation flag",
-      { cancel_at_period_end: true },
-      "stripe_subscription_canceling",
-    ],
-    [
-      "non-unit quantity",
-      {
-        items: {
-          data: [{ ...makeSubscriptionItem(), quantity: 2 }],
-        },
-      },
-      "stripe_price_mismatch",
-    ],
-    [
-      "unsupported extra recurring item",
-      {
-        items: {
-          data: [
-            makeSubscriptionItem(),
-            {
-              ...makeSubscriptionItem({ priceId: "price_other" }),
-              id: "si_other",
-            },
-          ],
-        },
-      },
-      "stripe_price_mismatch",
-    ],
-    [
-      "mismatched price",
-      {
-        items: {
-          data: [makeSubscriptionItem({ priceId: "price_other" })],
-        },
-      },
-      "stripe_price_mismatch",
-    ],
-  ] as const)(
-    "provider-only trial rejects %s before recovery",
-    async (_label, overrides, expectedReason) => {
-      const candidate = makeCandidate({
-        currentBillingPhase: null,
-        currentBillingPlanCode: null,
-        currentCheckoutOffer: null,
-        currentPeriodEnd: null,
-        currentTrialEndsAt: null,
-        currentTrialStartedAt: null,
-        memberBillingStatus: "not_started",
-        pulseTrialRedeemedAt: null,
-        stripeSubscriptionId: null,
-      });
-      const subscription = makeSubscription({
-        metadata: {
-          billingPlanCode: "launch_monthly",
-          checkoutOffer: "pulse_trial_7d",
-          memberId: "member_test",
-          trialDurationDays: "10",
-          trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-          trialUsageLimitUsdMicros: "4500000",
-        },
-        ...overrides,
-      });
-      const source = makeCandidateSource([candidate], {
-        inspectProviderOnlyTrial: async () => ({
-          kind: "recoverable",
-          subscription: subscription as never,
-        }),
-      });
-
-      const preview = await extendHostedPulseTrialsWithPrice({
-        candidateSource: source,
-        maxCandidates: 4,
-        mode: "dry-run",
-        now: NOW,
-        priceId: PRICE_ID,
-        stripe: makeStripeClient(subscription),
-      });
-
-      assert.equal(preview.wouldRecoverProviderTrial, 0);
-      assert.equal(preview.wouldExtend, 0);
-      assert.equal(preview.skipped[expectedReason], 1);
-    },
-  );
-
-  test("a provider-only race after Preview rejects Apply as stale", async () => {
-    const providerOnlyCandidate = makeCandidate({
-      currentBillingPhase: null,
-      currentBillingPlanCode: null,
-      currentCheckoutOffer: null,
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "not_started",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: null,
-    });
-    const providerSubscription = makeSubscription({
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const recovery = vi.fn(async () => "recovered" as const);
-    const source = makeCandidateSource([providerOnlyCandidate], {
-      applyProviderOnlyDisposition: recovery,
-      beforeLock(candidates) {
-        const candidate = candidates[0];
-        if (!candidate) {
-          throw new Error("Synthetic candidate was not found.");
-        }
-        candidate.memberBillingStatus = "active";
-        candidate.pulseTrialRedeemedAt = new Date("2026-07-09T12:00:00.000Z");
-      },
-      inspectProviderOnlyTrial: async () => ({
-        kind: "recoverable",
-        subscription: providerSubscription as never,
-      }),
-    });
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(providerSubscription),
-    });
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(providerSubscription),
-    });
-
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(applied.providerTrialsCleanedUp, 0);
-    assert.equal(applied.providerTrialsRecovered, 0);
-    assert.equal(applied.stripeTrialsExtended, 0);
-    assert.equal(recovery.mock.calls.length, 0);
-  });
-
-  test("applies an active-paid provider cleanup only from the exact Preview proof", async () => {
-    const paidCandidate = makeCandidate({
-      currentBillingPhase: "paid",
-      currentBillingPlanCode: "launch_monthly",
-      currentCheckoutOffer: "standard",
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "active",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: "sub_paid",
-    });
-    const obsoleteTrial = makeSubscription({ id: "sub_obsolete_trial" });
-    const cleanup = vi.fn(async () => "cleaned-up" as const);
-    const source = makeCandidateSource([paidCandidate], {
-      applyProviderOnlyDisposition: cleanup,
-      inspectProviderOnlyTrial: async () => ({
-        kind: "cleanup-obsolete",
-        subscription: obsoleteTrial as never,
-      }),
-    });
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-
-    assert.equal(preview.wouldCleanupProviderTrial, 1);
-    assert.equal(preview.wouldExtend, 0);
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-
-    assert.equal(applied.providerTrialsCleanedUp, 1);
-    assert.equal(applied.providerTrialsRecovered, 0);
-    assert.equal(applied.stripeTrialsExtended, 0);
-    assert.equal(cleanup.mock.calls.length, 1);
-  });
-
-  test("does not clean up an obsolete provider trial owned by another campaign", async () => {
-    const paidCandidate = makeCandidate({
-      currentBillingPhase: "paid",
-      currentBillingPlanCode: "launch_monthly",
-      currentCheckoutOffer: "standard",
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "active",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: "sub_paid",
-    });
-    const obsoleteTrial = makeSubscription({
-      id: "sub_obsolete_trial",
-      metadata: {
-        [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]: "another-campaign",
-      },
-    });
-    const cleanup = vi.fn(async () => "cleaned-up" as const);
-    const source = makeCandidateSource([paidCandidate], {
-      applyProviderOnlyDisposition: cleanup,
-      inspectProviderOnlyTrial: async () => ({
-        kind: "cleanup-obsolete",
-        subscription: obsoleteTrial as never,
-      }),
-    });
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-
-    assert.equal(preview.wouldCleanupProviderTrial, 0);
-    assert.equal(preview.skipped.stripe_campaign_marker_conflict, 1);
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-
-    assert.equal(applied.providerTrialsCleanedUp, 0);
-    assert.equal(applied.skipped.stripe_campaign_marker_conflict, 1);
-    assert.equal(cleanup.mock.calls.length, 0);
-  });
-
-  test("rejects a changed provider-only cleanup target under the member lock", async () => {
-    const paidCandidate = makeCandidate({
-      currentBillingPhase: "paid",
-      currentBillingPlanCode: "launch_monthly",
-      currentCheckoutOffer: "standard",
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "active",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: "sub_paid",
-    });
-    const inspectProviderOnlyTrial = vi.fn()
-      .mockResolvedValueOnce({
-        kind: "cleanup-obsolete" as const,
-        subscription: makeSubscription({ id: "sub_obsolete_preview" }) as never,
-      })
-      .mockResolvedValueOnce({
-        kind: "cleanup-obsolete" as const,
-        subscription: makeSubscription({ id: "sub_obsolete_apply" }) as never,
-      });
-    const cleanup = vi.fn(async () => "cleaned-up" as const);
-    const source = makeCandidateSource([paidCandidate], {
-      applyProviderOnlyDisposition: cleanup,
-      inspectProviderOnlyTrial,
-    });
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(applied.providerTrialsCleanedUp, 0);
-    assert.equal(cleanup.mock.calls.length, 0);
-    assert.equal(inspectProviderOnlyTrial.mock.calls.length, 2);
-  });
-
-  test("provider traversal excludes a trial that starts at the fixed cutoff", async () => {
-    const providerSubscription = makeSubscription({
-      trial_end: toUnixSeconds(new Date("2026-07-24T00:00:00.000Z")),
-      trial_start: toUnixSeconds(new Date("2026-07-14T00:00:00.000Z")),
-    });
-    const findMany = vi.fn(async () => []);
-    const list = vi.fn(async () => ({
-      data: [providerSubscription],
-      has_more: false,
-    }));
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: { findMany },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { list } } as never,
-      },
-    });
-
-    const page = await source.listCandidates({
-      continuationToken: null,
-      limit: 4,
-    });
-
-    assert.deepEqual(page.candidates, []);
-    assert.equal(page.nextContinuationToken, null);
-    assert.equal(findMany.mock.calls.length, 1);
-    assert.equal(list.mock.calls.length, 1);
-  });
-
-  test("an ended provider trial does not block the other candidates in its batch", async () => {
-    const candidates = [
-      makeCandidate({
-        currentBillingPhase: null,
-        currentBillingPlanCode: null,
-        currentCheckoutOffer: null,
-        currentPeriodEnd: null,
-        currentTrialEndsAt: null,
-        currentTrialStartedAt: null,
-        memberBillingStatus: "not_started",
-        memberId: "member_a",
-        pulseTrialRedeemedAt: null,
-        stripeSubscriptionId: null,
-      }),
-      makeCandidate({
-        memberId: "member_b",
-        stripeCustomerId: "cus_b",
-        stripeSubscriptionId: "sub_b",
-      }),
-      makeCandidate({
-        memberId: "member_c",
-        stripeCustomerId: "cus_c",
-        stripeSubscriptionId: "sub_c",
-      }),
-      makeCandidate({
-        memberId: "member_d",
-        stripeCustomerId: "cus_d",
-        stripeSubscriptionId: "sub_d",
-      }),
-    ];
-    const source = makeCandidateSource(candidates, {
-      inspectProviderOnlyTrial: async () => ({
-        kind: "not-applicable",
-        reason: "provider-trial-ended",
-        subscription: makeSubscription({ status: "paused" }) as never,
-      }),
-    });
-
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(
-        makeSubscription(),
-        undefined,
-        makeCandidateSubscriptionResolver(candidates),
-      ),
-    });
-
-    assert.equal(preview.candidates, 4);
-    assert.equal(preview.candidatePreviewTokens?.length, 4);
-    assert.equal(preview.skipped.provider_trial_ended, 1);
-    assert.equal(preview.wouldExtend, 3);
-    assert.equal(
-      Object.values(preview.failures).reduce((total, count) => total + count, 0),
-      0,
-    );
-  });
-
-  test("provider-only verification fails closed when one customer exceeds one bounded page", async () => {
-    const candidate = makeCandidate({
-      currentBillingPhase: null,
-      currentBillingPlanCode: null,
-      currentCheckoutOffer: null,
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "not_started",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: null,
-    });
-    const source = makeCandidateSource([candidate], {
-      inspectProviderOnlyTrial: async () => {
-        throw new Error("bounded provider lookup incomplete");
-      },
-    });
-
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: makeStripeClient(),
-    });
-
-    assert.equal(preview.failures.provider_recovery_lookup_failed, 1);
-    assert.deepEqual(preview.candidatePreviewTokens, [""]);
-  });
-
-  test("keeps local reconciliation inside the lock when paid conversion starts after Stripe extension", async () => {
-    const source = makeCandidateSource([makeCandidate()]);
-    const withMemberLock = makeAsyncMutex();
-    const providerUpdated = makeDeferred();
-    const allowProviderReturn = makeDeferred();
-    const events: string[] = [];
-    let subscription = makeSubscription();
-
-    source.withStripeMutationLock = (input) => withMemberLock(async () =>
-      input.run({
-        async applyProviderOnlyDisposition() {
-          return "recovered";
-        },
-        candidate: source.candidates[0] ?? null,
-        async updateTrialEnd(trialEndsAt) {
-          events.push("extension-local");
-          const candidate = source.candidates[0];
-          if (!candidate) {
-            throw new Error("Synthetic candidate was not found.");
-          }
-          source.updateCalls.push({ candidate, trialEndsAt });
-          candidate.currentPeriodEnd = trialEndsAt;
-          candidate.currentTrialEndsAt = trialEndsAt;
-        },
+        extensionDays: params.metadata.murphTrialExtensionDays,
+        extensionOperation:
+          params.metadata.murphTrialExtensionOperation,
+        status: "trialing",
+        trialEnd: params.trial_end,
       })
     );
 
-    const stripe: HostedPulseTrialExtensionStripeClient = {
-      async retrieveSubscription() {
-        return subscription;
-      },
-      async updateSubscription(_subscriptionId, params) {
-        events.push("extension-stripe");
-        subscription = {
-          ...subscription,
-          metadata: params.metadata,
-          trial_end: params.trial_end,
-        };
-        providerUpdated.resolve();
-        await allowProviderReturn.promise;
-        return subscription;
-      },
-    };
-
-    const extension = extendHostedPulseTrials({
-      candidateSource: source,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-    await providerUpdated.promise;
-
-    events.push("paid-attempt");
-    const paidConversion = withMemberLock(async () => {
-      events.push("paid-wins");
-      subscription = makeSubscription({ status: "active", trial_end: null });
-      const candidate = source.candidates[0];
-      if (candidate) {
-        candidate.currentPeriodEnd = null;
-        candidate.currentTrialEndsAt = null;
-      }
-    });
-    allowProviderReturn.resolve();
-
-    const [summary] = await Promise.all([extension, paidConversion]);
-    assert.equal(summary.stripeTrialsExtended, 1);
-    assert.equal(summary.localWindowsReconciled, 1);
-    assert.deepEqual(events, [
-      "extension-stripe",
-      "paid-attempt",
-      "extension-local",
-      "paid-wins",
-    ]);
-    assert.equal(subscription.status, "active");
-    assert.equal(source.candidates[0]?.currentTrialEndsAt, null);
-  });
-
-  test("Prisma reconciliation updates billing then delegates the usage projection to its owner", async () => {
-    const billingUpdate = vi.fn(async (input: unknown) => {
-      void input;
-      return { count: 1 };
-    });
-    const candidate = makeCandidate();
-    const findFirst = vi.fn(async (input: unknown) => {
-      void input;
-      return {
-        createdAt: candidate.billingRefCreatedAt,
-        currentPeriodEnd: ORIGINAL_TRIAL_END,
-        currentBillingPhase: "trial",
-        currentBillingPlanCode: "launch_monthly",
-        currentCheckoutOffer: "pulse_trial_7d",
-        currentTrialEndsAt: ORIGINAL_TRIAL_END,
-        currentTrialStartedAt: candidate.currentTrialStartedAt,
-        lastStripeEventCreatedAt: candidate.lastStripeEventCreatedAt,
-        member: {
-          billingStatus: "active",
-          suspendedAt: null,
-        },
-        memberId: candidate.memberId,
-        pulseTrialRedeemedAt: candidate.pulseTrialRedeemedAt,
-      };
-    });
-    const tx = {
-      $queryRaw: vi.fn(async () => []),
-      hostedMemberBillingRef: { findFirst, updateMany: billingUpdate },
-    };
-    const prisma = {
-      $transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
-        callback(tx),
-      ),
-    };
-
-    await createPrismaHostedPulseTrialExtensionCandidateSource(prisma as never)
-      .withStripeMutationLock({
-        acquisitionTimeoutMs: 25_000,
-        candidate,
-        run: async (locked) => {
-          assert.ok(locked.candidate);
-          await locked.updateTrialEnd(EXTENDED_TRIAL_END, NOW);
-        },
-        transactionTimeoutMs: 190_000,
-      });
-
-    assert.equal(tx.$queryRaw.mock.calls.length, 2);
-    assert.equal(findFirst.mock.calls.length, 1);
-    assert.deepEqual(billingUpdate.mock.calls[0]?.[0], {
-      data: {
-        currentPeriodEnd: EXTENDED_TRIAL_END,
-        currentTrialEndsAt: EXTENDED_TRIAL_END,
-      },
-      where: {
-        currentBillingPhase: "trial",
-        currentBillingPlanCode: "launch_monthly",
-        currentCheckoutOffer: "pulse_trial_7d",
-        currentPeriodEnd: ORIGINAL_TRIAL_END,
-        currentTrialEndsAt: ORIGINAL_TRIAL_END,
-        currentTrialStartedAt: new Date("2026-07-02T12:00:00.000Z"),
-        lastStripeEventCreatedAt: new Date("2026-07-02T12:00:00.000Z"),
-        memberId: "member_test",
-        member: {
-          billingStatus: "active",
-          suspendedAt: null,
-        },
-      },
-    });
-    expect(mocks.reconcileHostedAiUsageAllowancePeriodForMemberTx).toHaveBeenCalledWith({
-      memberId: "member_test",
-      now: NOW,
-      tx,
-    });
-  });
-
-  test("Prisma candidate scan uses redemption for finalized trials and reservation time only for provider-only rows", async () => {
-    assert.equal(
-      HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO,
-      "2026-07-14T00:00:00.000Z",
-    );
-    const findMany = vi.fn(async (input: unknown) => {
-      void input;
-      return [];
-    });
-    const prisma = {
-      hostedMemberBillingRef: { findMany },
-    };
-
-    await createPrismaHostedPulseTrialExtensionCandidateSource(
-      prisma as never,
-    ).listCandidates({
-      continuationToken: null,
-      limit: 100,
-    });
-
-    assert.deepEqual(findMany.mock.calls[0]?.[0], {
-      include: {
-        member: {
-          select: {
-            billingStatus: true,
-            suspendedAt: true,
-          },
-        },
-      },
-      orderBy: { memberId: "asc" },
-      take: 101,
-      where: {
-        OR: [
-          {
-            pulseTrialRedeemedAt: {
-              lt: new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO),
-            },
-          },
-          {
-            createdAt: {
-              lt: new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO),
-            },
-            pulseTrialRedeemedAt: null,
-          },
-        ],
-      },
-    });
-  });
-
-  test("local cohort includes a July 13 redemption and excludes the cutoff instant", async () => {
-    const now = new Date("2026-07-13T12:00:00.000Z");
-    const stripeSubscription = makeSubscription({
-      trial_end: toUnixSeconds(new Date("2026-07-20T12:00:00.000Z")),
-    });
-    const eligibleSource = makeCandidateSource([makeCandidate({
-      pulseTrialRedeemedAt: new Date("2026-07-13T11:59:59.999Z"),
-    })]);
-    const excludedSource = makeCandidateSource([makeCandidate({
-      pulseTrialRedeemedAt: new Date("2026-07-14T00:00:00.000Z"),
-    })]);
-
-    const eligible = await extendHostedPulseTrials({
-      candidateSource: eligibleSource,
-      now,
-      stripe: makeStripeClient(stripeSubscription),
-    });
-    const excludedStripe = makeStripeClient(stripeSubscription);
-    const excluded = await extendHostedPulseTrials({
-      candidateSource: excludedSource,
-      now,
-      stripe: excludedStripe,
-    });
-
-    assert.equal(eligible.wouldExtend, 1);
-    assert.equal(eligible.skipped.outside_campaign_cohort, 0);
-    assert.equal(excluded.wouldExtend, 0);
-    assert.equal(excluded.skipped.outside_campaign_cohort, 1);
-    assert.equal(excludedStripe.retrieveCalls, 0);
-    assert.equal(excludedStripe.updateCalls.length, 0);
-  });
-
-  test("provider phase discovers a pre-cutoff trial whose billing row arrived after the cutoff", async () => {
-    const providerSubscription = makeSubscription({
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_late_event",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-      trial_end: toUnixSeconds(new Date("2026-07-23T12:00:00.000Z")),
-      trial_start: toUnixSeconds(new Date("2026-07-13T12:00:00.000Z")),
-    });
-    const lateRecord = {
-      ...makePrismaCandidateRecord("member_late_event"),
-      createdAt: new Date("2026-07-15T12:00:00.000Z"),
-      pulseTrialRedeemedAt: null,
-    };
-    const findMany = vi.fn(async () => []);
-    const list = vi.fn(async () => ({
-      data: [providerSubscription],
-      has_more: false,
-    }));
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: {
-        findMany,
-        findUnique: vi.fn(async () => lateRecord),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { list } } as never,
-      },
-    });
-
-    const page = await source.listCandidates({
-      continuationToken: null,
-      limit: 4,
-    });
-
-    assert.equal(page.candidates.length, 1);
-    assert.equal(page.candidates[0]?.memberId, "member_late_event");
-    assert.equal(page.candidates[0]?.pulseTrialRedeemedAt, null);
-    assert.equal(page.candidates[0]?.providerCustomerId, "cus_test");
-    assert.equal(page.candidates[0]?.stripeCustomerId, null);
-    assert.ok(page.nextContinuationToken);
-    assert.equal(page.nextContinuationToken.includes("member_late_event"), false);
-    assert.equal(findMany.mock.calls.length, 0);
-    expect(list).toHaveBeenCalledWith({
-      limit: 4,
-      status: "all",
-    }, {
-      maxNetworkRetries: 0,
-      timeout: 80_000,
-    });
-  });
-
-  test.each<[
-    string,
-    Date,
-    Date | null,
-    "active" | "not_started",
-    "cleanup" | "stripe_customer_mismatch" | "local_candidate_changed",
-  ]>([
-    [
-      "post-cutoff local row",
-      new Date("2026-07-15T12:00:00.000Z"),
-      null,
-      "not_started",
-      "stripe_customer_mismatch",
-    ],
-    [
-      "pre-cutoff redeemed local row",
-      new Date("2026-07-02T12:00:00.000Z"),
-      new Date("2026-07-02T12:00:00.000Z"),
-      "not_started",
-      "cleanup",
-    ],
-    [
-      "active row with no durable subscription winner",
-      new Date("2026-07-15T12:00:00.000Z"),
-      null,
-      "active",
-      "local_candidate_changed",
-    ],
-  ])("provider phase skips cross-customer recovery without a durable winner on a %s", async (
-    _case,
-    createdAt,
-    pulseTrialRedeemedAt,
-    billingStatus,
-    expectedSkipReason,
-  ) => {
-    const providerSubscription = makeSubscription({
-      customer: "cus_provider_owner",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_customer_conflict",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const conflictingRecord = {
-      ...makePrismaCandidateRecord("member_customer_conflict"),
-      ...(await buildHostedMemberBillingPrivateColumns({
-        memberId: "member_customer_conflict",
-        stripeCustomerId: "cus_durable_owner",
-        stripeSubscriptionId: null,
-      })),
-      createdAt,
-      member: {
-        billingStatus,
-        suspendedAt: null,
-      },
-      pulseTrialRedeemedAt,
-    };
-    const findMany = vi.fn(async () => []);
-    const list = vi.fn(async () => ({
-      data: [providerSubscription],
-      has_more: false,
-    }));
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: {
-        findMany,
-        findUnique: vi.fn(async () => conflictingRecord),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { list } } as never,
-      },
-    });
-
-    const page = await source.listCandidates({
-      continuationToken: null,
-      limit: 4,
-    });
-
-    expect(page.candidates).toHaveLength(1);
-    const stripe = makeStripeClient(providerSubscription);
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
+    const result = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preview.previewProof,
       priceId: PRICE_ID,
+      prisma: {} as never,
       stripe,
     });
 
-    if (expectedSkipReason !== "cleanup") {
-      expect(preview.skipped).toMatchObject({ [expectedSkipReason]: 1 });
-    }
-    assert.equal(preview.wouldRecoverProviderTrial, 0);
-    assert.equal(preview.wouldCleanupProviderTrial, expectedSkipReason === "cleanup" ? 1 : 0);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(findMany.mock.calls.length, 0);
-    expect(list).toHaveBeenCalledTimes(3);
-  });
-
-  test("provider phase discovers a pre-cutoff trial with no local billing owner", async () => {
-    const providerSubscription = makeSubscription({
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_unowned",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMember: {
-        findUnique: vi.fn(async () => ({
-          billingRef: null,
-          billingStatus: "not_started",
-          createdAt: new Date("2026-07-01T12:00:00.000Z"),
-          id: "member_unowned",
-          suspendedAt: null,
-          updatedAt: new Date("2026-07-01T12:00:00.000Z"),
-        })),
-      },
-      hostedMemberBillingRef: {
-        findMany: vi.fn(async () => []),
-        findUnique: vi.fn(async () => null),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: {
-          subscriptions: {
-            list: vi.fn(async () => ({
-              data: [providerSubscription],
-              has_more: false,
-            })),
-          },
-        } as never,
-      },
-    });
-
-    const page = await source.listCandidates({
-      continuationToken: null,
-      limit: 4,
-    });
-
-    expect(page.candidates[0]).toMatchObject({
-      memberBillingStatus: "not_started",
-      memberId: "member_unowned",
-      providerCustomerId: "cus_test",
-      providerSubscriptionId: "sub_test",
-      pulseTrialRedeemedAt: null,
-      stripeCustomerId: null,
-      stripeSubscriptionId: null,
-    });
-    assert.ok(page.nextContinuationToken);
-  });
-
-  test.each([
-    [
-      "pre-cutoff local redemption",
-      new Date("2026-07-02T12:00:00.000Z"),
-      new Date("2026-07-02T12:00:00.000Z"),
-    ],
-    [
-      "post-cutoff local row",
-      new Date("2026-07-15T12:00:00.000Z"),
-      null,
-    ],
-  ])("provider phase keeps an obsolete exact subscription beside the durable winner for %s", async (
-    _case,
-    createdAt,
-    pulseTrialRedeemedAt,
-  ) => {
-    const obsoleteSubscription = makeSubscription({
-      id: "sub_obsolete",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const durableSubscription = makeSubscription({
-      id: "sub_durable",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const record = {
-      ...makePrismaCandidateRecord("member_test"),
-      ...(await buildHostedMemberBillingPrivateColumns({
-        memberId: "member_test",
-        stripeCustomerId: "cus_test",
-        stripeSubscriptionId: "sub_durable",
-      })),
-      createdAt,
-      pulseTrialRedeemedAt,
-    };
-    const list = vi.fn()
-      .mockResolvedValueOnce({
-        data: [obsoleteSubscription, durableSubscription],
-        has_more: false,
-      })
-      .mockResolvedValueOnce({
-        data: [obsoleteSubscription, durableSubscription],
-        has_more: false,
-      });
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: {
-        findMany: vi.fn(async () => []),
-        findUnique: vi.fn(async () => record),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { list } } as never,
-      },
-    });
-
-    const page = await source.listCandidates({
-      continuationToken: null,
-      limit: 4,
-    });
-
-    expect(page.candidates.map((candidate) => candidate.providerSubscriptionId)).toEqual(
-      pulseTrialRedeemedAt
-        ? ["sub_obsolete"]
-        : ["sub_obsolete", "sub_durable"],
-    );
-    expect(page.candidates[0]).toMatchObject({
-      providerSubscriptionId: "sub_obsolete",
-      stripeSubscriptionId: "sub_durable",
-    });
-    await expect(source.inspectProviderOnlyTrial({
-      candidate: page.candidates[0]!,
-      now: NOW,
-    })).resolves.toEqual({
-      kind: "cleanup-obsolete",
-      subscription: obsoleteSubscription,
-    });
-    expect(list).toHaveBeenNthCalledWith(2, {
-      customer: "cus_test",
-      limit: 100,
-      status: "all",
-    }, {
-      maxNetworkRetries: 0,
-      timeout: 80_000,
-    });
-  });
-
-  test.each(["active", "paused"] as const)(
-    "provider phase discovers an exact %s obsolete campaign subscription",
-    async (status) => {
-      const obsoleteSubscription = makeSubscription({
-        id: "sub_obsolete",
-        metadata: {
-          billingPlanCode: "launch_monthly",
-          checkoutOffer: "pulse_trial_7d",
-          memberId: "member_test",
-          trialDurationDays: "10",
-          trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-          trialUsageLimitUsdMicros: "4500000",
-        },
-        status,
-      });
-      const record = {
-        ...makePrismaCandidateRecord("member_test"),
-        ...(await buildHostedMemberBillingPrivateColumns({
-          memberId: "member_test",
-          stripeCustomerId: "cus_test",
-          stripeSubscriptionId: "sub_durable",
-        })),
-        currentBillingPhase: "paid",
-        currentCheckoutOffer: "standard",
-        pulseTrialRedeemedAt: new Date("2026-07-02T12:00:00.000Z"),
-      };
-      const list = vi.fn(async () => ({
-        data: [obsoleteSubscription],
-        has_more: false,
-      }));
-      const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-        hostedMemberBillingRef: {
-          findMany: vi.fn(async () => []),
-          findUnique: vi.fn(async () => record),
-        },
-      } as never, {
-        campaignRecovery: {
-          priceId: PRICE_ID,
-          stripe: { subscriptions: { list } } as never,
-        },
-      });
-
-      const page = await source.listCandidates({
-        continuationToken: null,
-        limit: 4,
-      });
-
-      expect(page.candidates).toHaveLength(1);
-      expect(page.candidates[0]).toMatchObject({
-        providerSubscriptionId: "sub_obsolete",
-        stripeSubscriptionId: "sub_durable",
-      });
-      await expect(source.inspectProviderOnlyTrial({
-        candidate: page.candidates[0]!,
-        now: NOW,
-      })).resolves.toEqual({
-        kind: "cleanup-obsolete",
-        subscription: obsoleteSubscription,
-      });
-    },
-  );
-
-  test("locked provider cleanup proof uses the current durable subscription owner", async () => {
-    const providerSubscription = makeSubscription({
-      id: "sub_provider",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const previewCandidate = makeCandidate({
-      currentBillingPhase: "paid",
-      currentBillingPlanCode: "launch_monthly",
-      currentCheckoutOffer: "standard",
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      memberBillingStatus: "active",
-      providerCustomerId: "cus_test",
-      providerSubscriptionId: "sub_provider",
-      pulseTrialRedeemedAt: null,
-      stripeSubscriptionId: "sub_previous",
-    });
-    const lockedRecord = {
-      ...makePrismaCandidateRecord("member_test"),
-      ...(await buildHostedMemberBillingPrivateColumns({
-        memberId: "member_test",
-        stripeCustomerId: "cus_test",
-        stripeSubscriptionId: "sub_provider",
-      })),
-      createdAt: previewCandidate.billingRefCreatedAt,
-      currentBillingPhase: "paid",
-      currentBillingPlanCode: "launch_monthly",
-      currentCheckoutOffer: "standard",
-      currentPeriodEnd: null,
-      currentTrialEndsAt: null,
-      currentTrialStartedAt: null,
-      pulseTrialRedeemedAt: null,
-    };
-    const list = vi.fn(async () => ({
-      data: [providerSubscription],
-      has_more: false,
-    }));
-    const cancel = vi.fn();
-    const tx = {
-      $queryRaw: vi.fn(async () => []),
-      hostedMemberBillingRef: {
-        findFirst: vi.fn(async () => lockedRecord),
-      },
-    };
-    const prismaSource = createPrismaHostedPulseTrialExtensionCandidateSource({
-      $transaction: vi.fn(async (
-        run: (transaction: typeof tx) => Promise<unknown>,
-      ) => run(tx)),
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { cancel, list } } as never,
-      },
-    });
-    const source: HostedPulseTrialExtensionCandidateSource = {
-      ...prismaSource,
-      async listCandidates() {
-        return {
-          candidates: [previewCandidate],
-          nextContinuationToken: null,
-        };
-      },
-    };
-    const extensionStripe = makeStripeClient(providerSubscription);
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: extensionStripe,
-    });
-    assert.equal(preview.wouldCleanupProviderTrial, 1);
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: extensionStripe,
-    });
-
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(applied.providerTrialsCleanedUp, 0);
-    assert.equal(cancel.mock.calls.length, 0);
-    assert.equal(extensionStripe.updateCalls.length, 0);
-  });
-
-  test("production source cleans cross-customer provider A beside durable B before closure", async () => {
-    let obsoleteStatus: HostedPulseTrialExtensionStripeSubscription["status"] = "trialing";
-    const buildObsoleteSubscription = () => makeSubscription({
-      customer: "cus_provider_owner",
-      id: "sub_obsolete",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-      status: obsoleteStatus,
-    });
-    const durableSubscription = makeSubscription({
-      customer: "cus_durable_owner",
-      id: "sub_durable",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_test",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-        [HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN_METADATA_KEY]:
-          HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-        [HOSTED_PULSE_TRIAL_EXTENSION_DAYS_METADATA_KEY]: "7",
-      },
-      trial_end: toUnixSeconds(EXTENDED_TRIAL_END),
-    });
-    const record = {
-      ...makePrismaCandidateRecord("member_test"),
-      ...(await buildHostedMemberBillingPrivateColumns({
-        memberId: "member_test",
-        stripeCustomerId: "cus_durable_owner",
-        stripeSubscriptionId: "sub_durable",
-      })),
-      currentPeriodEnd: EXTENDED_TRIAL_END,
-      currentTrialEndsAt: EXTENDED_TRIAL_END,
-      pulseTrialRedeemedAt: new Date("2026-07-02T12:00:00.000Z"),
-    };
-    const memberRecord = {
-      billingRef: record,
-      billingStatus: "active",
-      createdAt: new Date("2026-07-01T12:00:00.000Z"),
-      id: "member_test",
-      suspendedAt: null,
-      updatedAt: new Date("2026-07-02T12:00:00.000Z"),
-    };
-    const list = vi.fn(async (params: { customer?: string }) => ({
-      data: params.customer === "cus_provider_owner"
-        ? [buildObsoleteSubscription()]
-        : params.customer === "cus_durable_owner"
-          ? [durableSubscription]
-          : [buildObsoleteSubscription(), durableSubscription],
-      has_more: false,
-    }));
-    const cancel = vi.fn(async (subscriptionId: string) => {
-      assert.equal(subscriptionId, "sub_obsolete");
-      obsoleteStatus = "canceled";
-      return buildObsoleteSubscription();
-    });
-    const findMany = vi.fn(async () => [record]);
-    const tx = {
-      $queryRaw: vi.fn(async () => []),
-      hostedMember: {
-        findUnique: vi.fn(async () => memberRecord),
-      },
-      hostedMemberBillingRef: {
-        findFirst: vi.fn(async () => record),
-      },
-    };
-    const prisma = {
-      $transaction: vi.fn(async (
-        run: (transaction: typeof tx) => Promise<unknown>,
-      ) => run(tx)),
-      hostedMemberBillingRef: {
-        findMany,
-        findUnique: vi.fn(async () => record),
-      },
-    };
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource(
-      prisma as never,
-      {
-        campaignRecovery: {
-          priceId: PRICE_ID,
-          stripe: {
-            subscriptions: { cancel, list },
-          } as never,
-        },
-      },
-    );
-    const extensionStripe = {
-      retrieveSubscription: vi.fn(async () => durableSubscription),
-      updateSubscription: vi.fn(),
-    };
-
-    const preview = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: extensionStripe,
-    });
-    assert.equal(preview.wouldCleanupProviderTrial, 1);
-    assert.equal(preview.hasMoreCandidates, true);
-
-    const applied = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      priceId: PRICE_ID,
-      stripe: extensionStripe,
-    });
-    assert.equal(applied.providerTrialsCleanedUp, 1);
-    assert.equal(cancel.mock.calls.length, 1);
-    expect(list.mock.invocationCallOrder.at(-1) ?? 0).toBeLessThan(
-      cancel.mock.invocationCallOrder[0] ?? 0,
-    );
-    expect(cancel).toHaveBeenCalledWith(
-      "sub_obsolete",
-      {},
-      {
+    expect(stripe.updateSubscription).toHaveBeenCalledWith(
+      SUBSCRIPTION_ID,
+      expect.objectContaining({
+        proration_behavior: "none",
+        trial_end: TARGET_FROM_PAUSED,
+      }),
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^hosted-member-trial-extension:[A-Za-z0-9_-]{43}$/u,
+        ),
         maxNetworkRetries: 0,
         timeout: 80_000,
-      },
+      }),
     );
-    assert.equal(extensionStripe.retrieveSubscription.mock.calls.length, 0);
-    assert.equal(extensionStripe.updateSubscription.mock.calls.length, 0);
+    expect(mocks.withHostedMemberStripeMutationLockForOps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        acquisitionTimeoutMs: 25_000,
+        memberId: MEMBER_ID,
+        transactionTimeoutMs: 190_000,
+      }),
+    );
+    expect(mocks.updateHostedMemberCoreState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingStatus: HostedBillingStatus.active,
+        memberId: MEMBER_ID,
+      }),
+    );
+    expect(mocks.writeHostedMemberStripeBillingRefTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentBillingPhase: "trial",
+        currentTrialEndsAt: new Date(TARGET_FROM_PAUSED * 1000),
+        memberId: MEMBER_ID,
+      }),
+    );
+    expect(
+      mocks.reconcileHostedAiUsageAllowancePeriodForMemberTx,
+    ).toHaveBeenCalledWith(expect.objectContaining({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+    }));
+    expect(result).toMatchObject({
+      currentTrialEndsAt: new Date(TARGET_FROM_PAUSED * 1000).toISOString(),
+      localBillingPhase: "trial",
+      localBillingStatus: "active",
+      outcome: "extended",
+      providerStatus: "trialing",
+    });
+  });
 
-    const closure = await extendHostedPulseTrialsWithPrice({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
+  test("extends a live trial from its existing provider end", async () => {
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValue(makeMember({
+      billingPhase: "trial",
+      billingStatus: HostedBillingStatus.active,
+      trialEndsAt: new Date(ORIGINAL_TRIAL_END * 1000),
+    }));
+    const live = makeSubscription({ status: "trialing" });
+    const stripe = makeStripeClient(live);
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
       now: NOW,
       priceId: PRICE_ID,
-      stripe: extensionStripe,
-    });
-    assert.equal(closure.wouldCleanupProviderTrial, 0);
-    assert.equal(closure.wouldRecoverProviderTrial, 0);
-    assert.equal(closure.wouldExtend, 0);
-    assert.equal(closure.wouldReconcile, 0);
-    assert.equal(closure.alreadyExtended, 1);
-    assert.equal(cancel.mock.calls.length, 1);
-  });
-
-  test("provider discovery resumes across bounded Stripe pages before entering member traversal", async () => {
-    const unrelatedSubscription = makeSubscription({
-      id: "sub_unrelated",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "standard",
-        memberId: "member_unrelated",
-      },
-    });
-    const historicalSubscription = makeSubscription({
-      id: "sub_historical",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_historical",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const list = vi.fn()
-      .mockResolvedValueOnce({
-        data: [unrelatedSubscription],
-        has_more: true,
-      })
-      .mockResolvedValueOnce({
-        data: [historicalSubscription],
-        has_more: false,
-      });
-    const memberFindMany = vi.fn(async () => []);
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMember: {
-        findUnique: vi.fn(async () => ({
-          billingRef: null,
-          billingStatus: "not_started",
-          createdAt: new Date("2026-07-01T12:00:00.000Z"),
-          id: "member_historical",
-          suspendedAt: null,
-          updatedAt: new Date("2026-07-01T12:00:00.000Z"),
-        })),
-      },
-      hostedMemberBillingRef: {
-        findMany: memberFindMany,
-        findUnique: vi.fn(async () => null),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: {
-          subscriptions: { list },
-        } as never,
-      },
-    });
-
-    const firstPage = await source.listCandidates({
-      continuationToken: null,
-      limit: 1,
-    });
-    assert.equal(firstPage.candidates.length, 0);
-    assert.ok(firstPage.nextContinuationToken);
-    assert.equal(memberFindMany.mock.calls.length, 0);
-
-    const secondPage = await source.listCandidates({
-      continuationToken: firstPage.nextContinuationToken,
-      limit: 1,
-    });
-    assert.equal(secondPage.candidates[0]?.memberId, "member_historical");
-    assert.ok(secondPage.nextContinuationToken);
-    assert.equal(memberFindMany.mock.calls.length, 0);
-    expect(list).toHaveBeenNthCalledWith(2, {
-      limit: 1,
-      starting_after: "sub_unrelated",
-      status: "all",
-    }, {
-      maxNetworkRetries: 0,
-      timeout: 80_000,
-    });
-
-    const memberPage = await source.listCandidates({
-      continuationToken: secondPage.nextContinuationToken,
-      limit: 1,
-    });
-    assert.equal(memberPage.candidates.length, 0);
-    assert.equal(memberPage.nextContinuationToken, null);
-    assert.equal(list.mock.calls.length, 2);
-    assert.equal(memberFindMany.mock.calls.length, 1);
-  });
-
-  test("member-scoped traversal reaches its provider trial beyond unrelated raw pages", async () => {
-    const unrelatedSubscription = makeSubscription({
-      id: "sub_unrelated",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_unrelated",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const targetSubscription = makeSubscription({
-      id: "sub_target",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_target",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const list = vi.fn()
-      .mockResolvedValueOnce({ data: [unrelatedSubscription], has_more: true })
-      .mockResolvedValueOnce({ data: [targetSubscription], has_more: false });
-    const findMany = vi.fn(async () => []);
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMember: {
-        findUnique: vi.fn(async () => ({
-          billingRef: null,
-          billingStatus: "not_started",
-          createdAt: new Date("2026-07-01T12:00:00.000Z"),
-          id: "member_target",
-          suspendedAt: null,
-          updatedAt: new Date("2026-07-01T12:00:00.000Z"),
-        })),
-      },
-      hostedMemberBillingRef: {
-        findMany,
-        findUnique: vi.fn(async () => null),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { list } } as never,
-      },
-      memberId: "member_target",
-    });
-
-    const memberPage = await source.listCandidates({
-      continuationToken: null,
-      limit: 1,
-    });
-    assert.equal(memberPage.candidates.length, 0);
-    assert.ok(memberPage.nextContinuationToken);
-    assert.equal(findMany.mock.calls.length, 0);
-
-    const allMembersSource = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: { findMany },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { list } } as never,
-      },
-    });
-    await expect(allMembersSource.listCandidates({
-      continuationToken: memberPage.nextContinuationToken,
-      limit: 1,
-    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionContinuationError);
-
-    const targetProviderPage = await source.listCandidates({
-      continuationToken: memberPage.nextContinuationToken,
-      limit: 1,
-    });
-    expect(targetProviderPage.candidates).toHaveLength(1);
-    expect(targetProviderPage.candidates[0]).toMatchObject({
-      memberId: "member_target",
-      providerSubscriptionId: "sub_target",
-    });
-    assert.ok(targetProviderPage.nextContinuationToken);
-    expect(list).toHaveBeenNthCalledWith(2, {
-      limit: 1,
-      starting_after: "sub_unrelated",
-      status: "all",
-    }, {
-      maxNetworkRetries: 0,
-      timeout: 80_000,
-    });
-
-    const localPage = await source.listCandidates({
-      continuationToken: targetProviderPage.nextContinuationToken,
-      limit: 1,
-    });
-    expect(localPage.candidates).toHaveLength(0);
-    expect(localPage.nextContinuationToken).toBeNull();
-    expect(findMany).toHaveBeenCalledOnce();
-  });
-
-  test("member-scoped traversal returns every exact provider obligation before its local candidate", async () => {
-    const firstProviderSubscription = makeSubscription({
-      id: "sub_provider_a",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_target",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const secondProviderSubscription = {
-      ...firstProviderSubscription,
-      id: "sub_provider_b",
-    };
-    const localRecord = makePrismaCandidateRecord("member_target");
-    const findMany = vi.fn(async () => [localRecord]);
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: {
-        findMany,
-        findUnique: vi.fn(async () => localRecord),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: {
-          subscriptions: {
-            list: vi.fn(async () => ({
-              data: [firstProviderSubscription, secondProviderSubscription],
-              has_more: false,
-            })),
-          },
-        } as never,
-      },
-      memberId: "member_target",
-    });
-
-    const providerPage = await source.listCandidates({
-      continuationToken: null,
-      limit: 10,
-    });
-    expect(providerPage.candidates.map((candidate) => candidate.providerSubscriptionId))
-      .toEqual(["sub_provider_a", "sub_provider_b"]);
-    expect(findMany).not.toHaveBeenCalled();
-    expect(providerPage.nextContinuationToken).not.toBeNull();
-
-    const localPage = await source.listCandidates({
-      continuationToken: providerPage.nextContinuationToken,
-      limit: 10,
-    });
-    expect(localPage.candidates).toHaveLength(1);
-    expect(localPage.candidates[0]?.memberId).toBe("member_target");
-    expect(findMany).toHaveBeenCalledOnce();
-  });
-
-  test("member-scoped provider traversal retries the same first page after a provider failure", async () => {
-    const providerSubscription = makeSubscription({
-      id: "sub_provider_retry",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "pulse_trial_7d",
-        memberId: "member_target",
-        trialDurationDays: "10",
-        trialPolicyVersion: "pulse-trial-2026-06-30-v2",
-        trialUsageLimitUsdMicros: "4500000",
-      },
-    });
-    const list = vi.fn()
-      .mockRejectedValueOnce(new Error("temporary provider failure"))
-      .mockResolvedValueOnce({ data: [providerSubscription], has_more: false });
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: {
-        findMany: vi.fn(async () => []),
-        findUnique: vi.fn(async () => null),
-      },
-      hostedMember: {
-        findUnique: vi.fn(async () => ({
-          billingRef: null,
-          billingStatus: "not_started",
-          createdAt: new Date("2026-07-01T12:00:00.000Z"),
-          id: "member_target",
-          suspendedAt: null,
-          updatedAt: new Date("2026-07-01T12:00:00.000Z"),
-        })),
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: { subscriptions: { list } } as never,
-      },
-      memberId: "member_target",
-    });
-
-    await expect(source.listCandidates({ continuationToken: null, limit: 10 }))
-      .rejects.toThrow("temporary provider failure");
-    await expect(source.listCandidates({ continuationToken: null, limit: 10 }))
-      .resolves.toMatchObject({
-        candidates: [expect.objectContaining({
-          providerSubscriptionId: "sub_provider_retry",
-        })],
-      });
-    expect(list).toHaveBeenNthCalledWith(1, {
-      limit: 10,
-      status: "all",
-    }, expect.anything());
-    expect(list).toHaveBeenNthCalledWith(2, {
-      limit: 10,
-      status: "all",
-    }, expect.anything());
-  });
-
-  test("member-scoped traversal moves from an empty provider phase to its finalized local trial", async () => {
-    const localRecord = makePrismaCandidateRecord("member_target");
-    const findMany = vi.fn(async () => [localRecord]);
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource({
-      hostedMemberBillingRef: {
-        findMany,
-      },
-    } as never, {
-      campaignRecovery: {
-        priceId: PRICE_ID,
-        stripe: {
-          subscriptions: {
-            list: vi.fn(async () => ({ data: [], has_more: false })),
-          },
-        } as never,
-      },
-      memberId: "member_target",
-    });
-
-    const page = await source.listCandidates({
-      continuationToken: null,
-      limit: 10,
-    });
-
-    expect(page.candidates).toHaveLength(1);
-    expect(page.candidates[0]?.memberId).toBe("member_target");
-    expect(page.candidates[0]?.providerSubscriptionId).toBeNull();
-    expect(findMany).toHaveBeenCalledOnce();
-  });
-
-  test("continuations cannot cross all-member or member-specific scopes", async () => {
-    const unrelatedSubscription = makeSubscription({
-      id: "sub_unrelated",
-      metadata: {
-        billingPlanCode: "launch_monthly",
-        checkoutOffer: "standard",
-        memberId: "member_unrelated",
-      },
-    });
-    const allList = vi.fn(async () => ({
-      data: [unrelatedSubscription],
-      has_more: true,
-    }));
-    const prisma = {
-      hostedMemberBillingRef: {
-        findMany: vi.fn(async () => []),
-      },
-    };
-    const allMembersSource = createPrismaHostedPulseTrialExtensionCandidateSource(
-      prisma as never,
-      {
-        campaignRecovery: {
-          priceId: PRICE_ID,
-          stripe: { subscriptions: { list: allList } } as never,
-        },
-      },
-    );
-    const allMembersPage = await allMembersSource.listCandidates({
-      continuationToken: null,
-      limit: 1,
-    });
-    assert.ok(allMembersPage.nextContinuationToken);
-
-    const memberASource = createPrismaHostedPulseTrialExtensionCandidateSource(
-      prisma as never,
-      {
-        campaignRecovery: {
-          priceId: PRICE_ID,
-          stripe: {
-            subscriptions: {
-              list: vi.fn(async () => ({
-                data: [unrelatedSubscription],
-                has_more: true,
-              })),
-            },
-          } as never,
-        },
-        memberId: "member_a",
-      },
-    );
-    await expect(memberASource.listCandidates({
-      continuationToken: allMembersPage.nextContinuationToken,
-      limit: 1,
-    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionContinuationError);
-
-    const memberAPage = await memberASource.listCandidates({
-      continuationToken: null,
-      limit: 1,
-    });
-    assert.ok(memberAPage.nextContinuationToken);
-    const memberBSource = createPrismaHostedPulseTrialExtensionCandidateSource(
-      prisma as never,
-      {
-        campaignRecovery: {
-          priceId: PRICE_ID,
-          stripe: {
-            subscriptions: {
-              list: vi.fn(async () => ({
-                data: [unrelatedSubscription],
-                has_more: true,
-              })),
-            },
-          } as never,
-        },
-        memberId: "member_b",
-      },
-    );
-    await expect(memberBSource.listCandidates({
-      continuationToken: memberAPage.nextContinuationToken,
-      limit: 1,
-    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionContinuationError);
-  });
-
-  test("Prisma candidate continuation is opaque, deletion-safe keyset state", async () => {
-    const firstRecord = makePrismaCandidateRecord("member_a");
-    const findMany = vi.fn()
-      .mockResolvedValueOnce([firstRecord, makePrismaCandidateRecord("member_b")])
-      .mockResolvedValueOnce([]);
-    const prisma = {
-      hostedMemberBillingRef: { findMany },
-    };
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource(prisma as never);
-
-    const firstPage = await source.listCandidates({
-      continuationToken: null,
-      limit: 1,
-    });
-    assert.equal(firstPage.candidates[0]?.memberId, "member_a");
-    assert.ok(firstPage.nextContinuationToken);
-    assert.equal(firstPage.nextContinuationToken.includes("member_a"), false);
-
-    await source.listCandidates({
-      continuationToken: firstPage.nextContinuationToken,
-      limit: 1,
-    });
-    expect(findMany.mock.calls[1]?.[0]).toMatchObject({
-      orderBy: { memberId: "asc" },
-      take: 2,
-      where: {
-        memberId: { gt: "member_a" },
-      },
-    });
-
-    await expect(source.listCandidates({
-      continuationToken: `${firstPage.nextContinuationToken}tampered`,
-      limit: 1,
-    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionContinuationError);
-
-    await expect(source.listCandidates({
-      continuationToken:
-        `pulse-cursor-v3.v1.${"a".repeat(16)}.${"b".repeat(8)}.${"c".repeat(22)}`,
-      limit: 1,
-    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionContinuationError);
-  });
-
-  test("Prisma candidate scan narrows to one member when a member filter is set", async () => {
-    const findMany = vi.fn(async (input: unknown) => {
-      void input;
-      return [];
-    });
-    const prisma = {
-      hostedMemberBillingRef: { findMany },
-    };
-
-    const source = createPrismaHostedPulseTrialExtensionCandidateSource(
-      prisma as never,
-      { memberId: "member_only" },
-    );
-    await source.listCandidates({
-      continuationToken: null,
-      limit: 100,
-    });
-
-    assert.deepEqual(findMany.mock.calls[0]?.[0], {
-      include: {
-        member: {
-          select: {
-            billingStatus: true,
-            suspendedAt: true,
-          },
-        },
-      },
-      orderBy: { memberId: "asc" },
-      take: 101,
-      where: {
-        memberId: "member_only",
-        OR: [
-          {
-            pulseTrialRedeemedAt: {
-              lt: new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO),
-            },
-          },
-          {
-            createdAt: {
-              lt: new Date(HOSTED_PULSE_TRIAL_EXTENSION_COHORT_END_EXCLUSIVE_ISO),
-            },
-            pulseTrialRedeemedAt: null,
-          },
-        ],
-      },
-    });
-  });
-
-  test("candidate pages keep every request bounded and reach candidates above four", async () => {
-    const source = makeCandidateSource([
-      makeCandidate({ memberId: "member_1" }),
-      makeCandidate({ memberId: "member_2" }),
-      makeCandidate({ memberId: "member_3" }),
-      makeCandidate({ memberId: "member_4" }),
-      makeCandidate({ memberId: "member_5" }),
-    ]);
-    const stripe = makeStripeClient();
-
-    const firstPage = await extendHostedPulseTrials({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe,
-    });
-    const secondPage = await extendHostedPulseTrials({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      continuationToken: firstPage.nextContinuationToken,
+      prisma: {} as never,
       stripe,
     });
 
-    assert.equal(firstPage.candidates, 4);
-    assert.equal(firstPage.hasMoreCandidates, true);
-    assert.equal(secondPage.candidates, 1);
-    assert.equal(secondPage.hasMoreCandidates, false);
-    assert.deepEqual(source.listInputs, [
-      { continuationToken: null, limit: 4 },
-      { continuationToken: "cursor:member_4", limit: 4 },
-    ]);
-    assert.equal(source.lockCalls, 0);
-    assert.equal(stripe.retrieveCalls, 5);
-    assert.equal(stripe.updateCalls.length, 0);
-  });
-
-  test("keyset continuation reaches an unvisited member after an earlier account deletion", async () => {
-    const source = makeCandidateSource([
-      makeCandidate({ memberId: "member_a" }),
-      makeCandidate({ memberId: "member_b" }),
-      makeCandidate({ memberId: "member_c" }),
-      makeCandidate({ memberId: "member_d" }),
-      makeCandidate({ memberId: "member_e" }),
-    ]);
-    const stripe = makeStripeClient();
-
-    const firstBatch = await extendHostedPulseTrials({
-      candidateSource: source,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe,
-    });
-    source.candidates.splice(1, 1);
-    const terminalBatch = await extendHostedPulseTrials({
-      candidateSource: source,
-      continuationToken: firstBatch.nextContinuationToken,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(terminalBatch.candidates, 1);
-    assert.equal(terminalBatch.hasMoreCandidates, false);
-    assert.deepEqual(source.listInputs, [
-      { continuationToken: null, limit: 4 },
-      { continuationToken: "cursor:member_d", limit: 4 },
-    ]);
-    assert.equal(stripe.retrieveCalls, 5);
-  });
-
-  test("candidate snapshot digest rejects a changed bounded set before provider work", async () => {
-    const previewSource = makeCandidateSource([makeCandidate()]);
-    const previewStripe = makeStripeClient();
-    const preview = await extendHostedPulseTrials({
-      candidateSource: previewSource,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe: previewStripe,
-    });
-
-    assert.match(preview.candidateSnapshotDigest ?? "", /^pulse-candidates-v4\./u);
-    assert.equal(preview.candidatePreviewTokens?.length, 1);
-    assert.match(preview.candidatePreviewTokens?.[0] ?? "", /^pulse-target-v4\./u);
-    assert.doesNotMatch(preview.candidateSnapshotDigest ?? "", /member_test/u);
-
-    const changedSource = makeCandidateSource([
-      makeCandidate(),
-      makeCandidate({ memberId: "member_new" }),
-    ]);
-    const changedStripe = makeStripeClient();
-    await assert.rejects(
-      extendHostedPulseTrials({
-        candidateSource: changedSource,
-        expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-        maxCandidates: 4,
-        mode: "apply",
-        now: NOW,
-        stripe: changedStripe,
-      }),
-      HostedPulseTrialExtensionPreviewMismatchError,
+    expect(preview.targetTrialEndsAt).toBe(
+      new Date(TARGET_FROM_LIVE * 1000).toISOString(),
     );
-    assert.equal(changedSource.lockCalls, 0);
-    assert.equal(changedStripe.retrieveCalls, 0);
-    assert.equal(changedStripe.updateCalls.length, 0);
-
-    const changedReferenceSource = makeCandidateSource([
-      makeCandidate({ stripeSubscriptionId: "sub_replaced" }),
-    ]);
-    const changedReferenceStripe = makeStripeClient();
-    await assert.rejects(
-      extendHostedPulseTrials({
-        candidateSource: changedReferenceSource,
-        expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-        maxCandidates: 4,
-        mode: "apply",
-        now: NOW,
-        stripe: changedReferenceStripe,
-      }),
-      HostedPulseTrialExtensionPreviewMismatchError,
-    );
-    assert.equal(changedReferenceSource.lockCalls, 0);
-    assert.equal(changedReferenceStripe.retrieveCalls, 0);
-    assert.equal(changedReferenceStripe.updateCalls.length, 0);
-
-    const changedContinuationSource = makeCandidateSource([makeCandidate()]);
-    const changedContinuationStripe = makeStripeClient();
-    await assert.rejects(
-      extendHostedPulseTrials({
-        candidateSource: changedContinuationSource,
-        continuationToken: "cursor:member_before",
-        expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? undefined,
-        expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-        maxCandidates: 4,
-        mode: "apply",
-        now: NOW,
-        stripe: changedContinuationStripe,
-      }),
-      HostedPulseTrialExtensionPreviewMismatchError,
-    );
-    assert.equal(changedContinuationSource.lockCalls, 0);
-    assert.equal(changedContinuationStripe.retrieveCalls, 0);
-    assert.equal(changedContinuationStripe.updateCalls.length, 0);
-
-    const matchingSource = makeCandidateSource([makeCandidate()]);
-    const matchingStripe = makeStripeClient();
-    const applied = await extendHostedPulseTrials({
-      candidateSource: matchingSource,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? undefined,
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      stripe: matchingStripe,
-    });
-    assert.equal(applied.stripeTrialsExtended, 1);
-    assert.equal(applied.candidateSnapshotDigest, null);
-  });
-
-  test("provider state proof blocks a changed target before its Stripe update", async () => {
-    const previewSource = makeCandidateSource([makeCandidate()]);
-    const preview = await extendHostedPulseTrials({
-      candidateSource: previewSource,
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe: makeStripeClient(),
-    });
-    const changedStripe = makeStripeClient(makeSubscription({
-      trial_end: toUnixSeconds(EXTENDED_TRIAL_END),
-    }));
-
-    const applied = await extendHostedPulseTrials({
-      candidateSource: makeCandidateSource([makeCandidate()]),
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? undefined,
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      stripe: changedStripe,
-    });
-
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(applied.stripeTrialsExtended, 0);
-    assert.equal(changedStripe.retrieveCalls, 1);
-    assert.equal(changedStripe.updateCalls.length, 0);
-  });
-
-  test.each([
-    [
-      "an incomplete item page",
+    if (!preview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    stripe.retrieveSubscription.mockResolvedValue(live);
+    stripe.updateSubscription.mockImplementation(async (_id, params) =>
       makeSubscription({
-        items: {
-          data: [makeSubscriptionItem()],
-          has_more: true,
-        },
-      }),
-    ],
-    [
-      "different member ownership",
-      makeSubscription({ metadata: { memberId: "member_other" } }),
-    ],
-    [
-      "a different trial policy",
-      makeSubscription({
-        metadata: {
-          trialDurationDays: "7",
-          trialPolicyVersion: "pulse-trial-2026-05-05-v1",
-        },
-      }),
-    ],
-  ])("provider state proof binds %s before its Stripe update", async (
-    _label,
-    changedSubscription,
-  ) => {
-    const preview = await extendHostedPulseTrials({
-      candidateSource: makeCandidateSource([makeCandidate()]),
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe: makeStripeClient(),
-    });
-    const source = makeCandidateSource([makeCandidate()]);
-    const stripe = makeStripeClient(changedSubscription);
-
-    const applied = await extendHostedPulseTrials({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? undefined,
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
-      stripe,
-    });
-
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(applied.stripeTrialsExtended, 0);
-    assert.equal(stripe.updateCalls.length, 0);
-    assert.equal(source.updateCalls.length, 0);
-  });
-
-  test("rejects an incomplete Stripe update result before local reconciliation", async () => {
-    const preview = await extendHostedPulseTrials({
-      candidateSource: makeCandidateSource([makeCandidate()]),
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe: makeStripeClient(),
-    });
-    const source = makeCandidateSource([makeCandidate()]);
-    const stripe = makeStripeClient();
-    stripe.updateSubscription = vi.fn(async (_subscriptionId, params) =>
-      makeSubscription({
-        items: {
-          data: [makeSubscriptionItem()],
-          has_more: true,
-        },
-        metadata: params.metadata,
-        trial_end: params.trial_end,
+        extensionDays: params.metadata.murphTrialExtensionDays,
+        extensionOperation: params.metadata.murphTrialExtensionOperation,
+        status: "trialing",
+        trialEnd: params.trial_end,
       })
     );
 
-    const applied = await extendHostedPulseTrials({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? undefined,
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-      maxCandidates: 4,
-      mode: "apply",
-      now: NOW,
+    const result = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
       stripe,
     });
 
-    assert.equal(applied.failures.stripe_update_result_invalid, 1);
-    assert.equal(applied.stripeTrialsExtended, 0);
-    assert.equal(source.updateCalls.length, 0);
+    expect(stripe.updateSubscription).toHaveBeenCalledWith(
+      SUBSCRIPTION_ID,
+      expect.objectContaining({ trial_end: TARGET_FROM_LIVE }),
+      expect.any(Object),
+    );
+    expect(result).toMatchObject({
+      currentTrialEndsAt: new Date(TARGET_FROM_LIVE * 1000).toISOString(),
+      outcome: "extended",
+      providerStatus: "trialing",
+    });
   });
 
-  test("rechecks provider preview proof while the member mutation lock is held", async () => {
-    const preview = await extendHostedPulseTrials({
-      candidateSource: makeCandidateSource([makeCandidate()]),
-      maxCandidates: 4,
-      mode: "dry-run",
-      now: NOW,
-      stripe: makeStripeClient(),
-    });
-    const source = makeCandidateSource([makeCandidate()]);
-    const events: string[] = [];
-    source.withStripeMutationLock = async (input) => {
-      events.push("lock-enter");
-      try {
-        return await input.run({
-          async applyProviderOnlyDisposition() {
-            return "recovered";
-          },
-          candidate: source.candidates[0] ?? null,
-          async updateTrialEnd() {
-            throw new Error("A stale provider target must not be reconciled.");
-          },
-        });
-      } finally {
-        events.push("lock-exit");
-      }
-    };
-    const updateSubscription = vi.fn();
-    const stripe: HostedPulseTrialExtensionStripeClient = {
-      async retrieveSubscription() {
-        events.push("provider-retrieve");
-        return makeSubscription({
-          trial_end: toUnixSeconds(EXTENDED_TRIAL_END),
-        });
-      },
-      updateSubscription,
-    };
+  test("never retrieves or mutates Stripe for paid billing", async () => {
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValue(makeMember({
+      billingPhase: "paid",
+      billingStatus: HostedBillingStatus.active,
+    }));
+    const stripe = makeStripeClient(makeSubscription({ status: "active" }));
 
-    const applied = await extendHostedPulseTrials({
-      candidateSource: source,
-      expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? undefined,
-      expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? undefined,
-      maxCandidates: 4,
-      mode: "apply",
+    const result = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
       now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
       stripe,
     });
 
-    assert.deepEqual(events, ["lock-enter", "provider-retrieve", "lock-exit"]);
-    assert.equal(applied.failures.preview_state_changed, 1);
-    assert.equal(applied.stripeTrialsExtended, 0);
-    assert.equal(updateSubscription.mock.calls.length, 0);
-    assert.equal(source.updateCalls.length, 0);
+    expect(result).toMatchObject({
+      eligibilityCode: "paid_billing",
+      eligible: false,
+      previewProof: null,
+    });
+    expect(stripe.retrieveSubscription).not.toHaveBeenCalled();
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+  });
+
+  test("leaves scheduled, canceling, terminal, and mismatched billing unchanged", async () => {
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValueOnce(makeMember({
+      scheduledBillingPlanCode: "edge_monthly",
+    }));
+    const scheduledStripe = makeStripeClient(makeSubscription());
+    const scheduled = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe: scheduledStripe,
+    });
+
+    expect(scheduled.eligibilityCode).toBe("scheduled_billing_change");
+    expect(scheduledStripe.retrieveSubscription).not.toHaveBeenCalled();
+    expect(scheduledStripe.updateSubscription).not.toHaveBeenCalled();
+
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValue(makeMember());
+    for (const [subscription, eligibilityCode] of [
+      [
+        makeSubscription({ cancelAtPeriodEnd: true }),
+        "provider_subscription_canceling",
+      ],
+      [
+        makeSubscription({ status: "canceled" }),
+        "provider_subscription_not_extendable",
+      ],
+      [
+        makeSubscription({ customerId: "cus_other" }),
+        "provider_identity_mismatch",
+      ],
+    ] as const) {
+      const stripe = makeStripeClient(subscription);
+      const result = await previewHostedPulseTrialExtension({
+        memberId: MEMBER_ID,
+        now: NOW,
+        priceId: PRICE_ID,
+        prisma: {} as never,
+        stripe,
+      });
+
+      expect(result.eligibilityCode).toBe(eligibilityCode);
+      expect(result.previewProof).toBeNull();
+      expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    }
+  });
+
+  test("rejects Apply when local billing changed after Preview", async () => {
+    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
+    const stripe = makeStripeClient(paused);
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!preview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValueOnce(makeMember({
+      trialEndsAt: new Date("2026-07-13T16:00:00.000Z"),
+    }));
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+  });
+
+  test("rejects expired and tampered Preview proofs before Stripe mutation", async () => {
+    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
+    const stripe = makeStripeClient(paused);
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!preview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:15:00.001Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+
+    const originalDigest = preview.previewProof.token.at(-1);
+    const tamperedToken = `${preview.previewProof.token.slice(0, -1)}${
+      originalDigest === "a" ? "b" : "a"
+    }`;
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: {
+        ...preview.previewProof,
+        token: tamperedToken,
+      },
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: {
+        ...preview.previewProof,
+        targetTrialEndsAt: preview.previewProof.targetTrialEndsAt.replace(
+          ".000Z",
+          ".999Z",
+        ),
+      },
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    expect(mocks.updateHostedMemberCoreState).not.toHaveBeenCalled();
+  });
+
+  test("reports lock contention and Stripe failures without local reconciliation", async () => {
+    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
+    const stripe = makeStripeClient(paused);
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!preview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+
+    mocks.withHostedMemberStripeMutationLockForOps.mockRejectedValueOnce(
+      new HostedMemberStripeMutationLockBusyError(),
+    );
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionLockBusyError);
+
+    mocks.withHostedMemberStripeMutationLockForOps.mockImplementation(
+      async (input: { run: (tx: object) => Promise<unknown> }) => input.run({}),
+    );
+    stripe.retrieveSubscription.mockResolvedValue(paused);
+    stripe.updateSubscription.mockRejectedValueOnce(new Error("provider unavailable"));
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+
+    expect(mocks.updateHostedMemberCoreState).not.toHaveBeenCalled();
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+    expect(
+      mocks.reconcileHostedAiUsageAllowancePeriodForMemberTx,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("retries reconcile an already applied provider result without adding days", async () => {
+    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
+    const stripe = makeStripeClient(paused);
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!preview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    const operationId = preview.previewProof.token.split(".")[2];
+    if (!operationId) {
+      throw new Error("Expected an operation ID.");
+    }
+    stripe.retrieveSubscription.mockResolvedValue(makeSubscription({
+      extensionDays: "7",
+      extensionOperation: operationId,
+      status: "trialing",
+      trialEnd: TARGET_FROM_PAUSED,
+    }));
+
+    const result = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:03:00.000Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+
+    expect(result.outcome).toBe("reconciled");
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    expect(mocks.writeHostedMemberStripeBillingRefTx).toHaveBeenCalledTimes(1);
   });
 });
 
-async function extendHostedPulseTrials(input: {
-  candidateSource: HostedPulseTrialExtensionCandidateSource;
-  continuationToken?: string | null;
-  expectedCandidatePreviewTokens?: readonly string[];
-  expectedCandidateSnapshotDigest?: string;
-  maxCandidates?: number;
-  mode?: "apply" | "dry-run";
-  now?: Date;
-  stripe: HostedPulseTrialExtensionStripeClient;
-}) {
-  const commonInput = {
-    candidateSource: input.candidateSource,
-    continuationToken: input.continuationToken,
-    maxCandidates: input.maxCandidates ?? 4,
-    now: input.now,
-    priceId: PRICE_ID,
-    stripe: input.stripe,
-  };
-  if (input.mode !== "apply") {
-    return extendHostedPulseTrialsWithPrice({
-      ...commonInput,
-      mode: "dry-run",
-    });
-  }
-  if (
-    input.expectedCandidatePreviewTokens !== undefined ||
-    input.expectedCandidateSnapshotDigest !== undefined
-  ) {
-    return extendHostedPulseTrialsWithPrice({
-      ...commonInput,
-      expectedCandidatePreviewTokens: input.expectedCandidatePreviewTokens ?? [],
-      expectedCandidateSnapshotDigest: input.expectedCandidateSnapshotDigest ?? "",
-      mode: "apply",
-    });
-  }
-  const preview = await extendHostedPulseTrialsWithPrice({
-    ...commonInput,
-    mode: "dry-run",
-  });
-  return extendHostedPulseTrialsWithPrice({
-    ...commonInput,
-    expectedCandidatePreviewTokens: preview.candidatePreviewTokens ?? [],
-    expectedCandidateSnapshotDigest: preview.candidateSnapshotDigest ?? "",
-    mode: "apply",
-  });
-}
-
-function classifyHostedPulseTrialExtensionSubscription(
-  input: Omit<
-    Parameters<typeof classifyHostedPulseTrialExtensionSubscriptionWithPrice>[0],
-    "priceId"
-  >,
-) {
-  return classifyHostedPulseTrialExtensionSubscriptionWithPrice({
-    ...input,
-    priceId: PRICE_ID,
-  });
-}
-
-function makeCandidate(
-  overrides: Partial<HostedPulseTrialExtensionCandidate> = {},
-): HostedPulseTrialExtensionCandidate {
+function makeMember(input: {
+  billingPhase?: string | null;
+  billingStatus?: HostedBillingStatus;
+  scheduledBillingPlanCode?: string;
+  trialEndsAt?: Date;
+} = {}): HostedMemberBillingSnapshot {
+  const trialStartedAt = new Date("2026-07-01T16:00:00.000Z");
+  const trialEndsAt = input.trialEndsAt ??
+    new Date("2026-07-11T16:00:00.000Z");
   return {
-    billingRefCreatedAt: new Date("2026-07-01T12:00:00.000Z"),
-    currentBillingPhase: "trial",
-    currentBillingPlanCode: "launch_monthly",
-    currentCheckoutOffer: "pulse_trial_7d",
-    currentPeriodEnd: ORIGINAL_TRIAL_END,
-    currentTrialEndsAt: ORIGINAL_TRIAL_END,
-    currentTrialStartedAt: new Date("2026-07-02T12:00:00.000Z"),
-    lastStripeEventCreatedAt: new Date("2026-07-02T12:00:00.000Z"),
-    memberBillingStatus: "active",
-    memberId: "member_test",
-    memberSuspendedAt: null,
-    providerCustomerId: null,
-    providerSubscriptionId: null,
-    pulseTrialRedeemedAt: new Date("2026-07-02T12:00:00.000Z"),
-    stripeCustomerId: "cus_test",
-    stripeSubscriptionId: "sub_test",
-    ...overrides,
-  };
-}
-
-function makePrismaCandidateRecord(memberId: string) {
-  const candidate = makeCandidate({ memberId });
-  return {
-    createdAt: candidate.billingRefCreatedAt,
-    currentBillingPhase: candidate.currentBillingPhase,
-    currentBillingPlanCode: candidate.currentBillingPlanCode,
-    currentCheckoutOffer: candidate.currentCheckoutOffer,
-    currentPeriodEnd: candidate.currentPeriodEnd,
-    currentPeriodStart: candidate.currentTrialStartedAt,
-    currentTrialEndsAt: candidate.currentTrialEndsAt,
-    currentTrialStartedAt: candidate.currentTrialStartedAt,
-    lastStripeEventCreatedAt: candidate.lastStripeEventCreatedAt,
-    member: {
-      billingStatus: candidate.memberBillingStatus,
-      suspendedAt: candidate.memberSuspendedAt,
+    billingRef: {
+      currentBillingPhase: input.billingPhase ?? null,
+      currentBillingPlanCode: "launch_monthly",
+      currentCheckoutOffer: "pulse_trial_7d",
+      currentPeriodEnd: trialEndsAt,
+      currentPeriodStart: trialStartedAt,
+      currentTrialEndsAt: trialEndsAt,
+      currentTrialStartedAt: trialStartedAt,
+      memberId: MEMBER_ID,
+      pulseTrialPolicyVersion: "pulse-trial-2026-06-30-v2",
+      pulseTrialRedeemedAt: trialStartedAt,
+      scheduledBillingPlanCode: input.scheduledBillingPlanCode ?? null,
+      stripeCustomerId: CUSTOMER_ID,
+      stripeSubscriptionId: SUBSCRIPTION_ID,
     },
-    memberId,
-    pulseTrialPolicyVersion: "pulse-trial-2026-06-30-v2",
-    pulseTrialRedeemedAt: candidate.pulseTrialRedeemedAt,
-    scheduledBillingEffectiveAt: null,
-    scheduledBillingPlanCode: null,
-    stripeCustomerIdEncrypted: null,
-    stripeSubscriptionIdEncrypted: null,
-    stripeSubscriptionScheduleIdEncrypted: null,
+    core: {
+      billingStatus: input.billingStatus ?? HostedBillingStatus.paused,
+      createdAt: new Date("2026-06-01T16:00:00.000Z"),
+      id: MEMBER_ID,
+      suspendedAt: null,
+      updatedAt: NOW,
+    },
   };
 }
 
-function makeSubscription(
-  overrides: Partial<HostedPulseTrialExtensionStripeSubscription> = {},
-): HostedPulseTrialExtensionStripeSubscription {
-  const { items, metadata, ...rest } = overrides;
+function makeSubscription(input: {
+  cancelAtPeriodEnd?: boolean;
+  customerId?: string;
+  extensionDays?: string;
+  extensionOperation?: string;
+  status?: Stripe.Subscription.Status;
+  trialEnd?: number | null;
+} = {}): HostedPulseTrialExtensionSubscription {
   return {
     cancel_at: null,
-    cancel_at_period_end: false,
-    customer: "cus_test",
-    id: "sub_test",
+    cancel_at_period_end: input.cancelAtPeriodEnd ?? false,
+    customer: input.customerId ?? CUSTOMER_ID,
+    id: SUBSCRIPTION_ID,
     items: {
-      data: items?.data ?? [makeSubscriptionItem()],
-      has_more: items?.has_more ?? false,
+      data: [{
+        id: "si_base",
+        price: {
+          id: PRICE_ID,
+          metadata: {},
+          recurring: {
+            interval: "month",
+            interval_count: 1,
+            usage_type: "licensed",
+          },
+        },
+        quantity: 1,
+      }],
+      has_more: false,
     },
     metadata: {
       billingPlanCode: "launch_monthly",
       checkoutOffer: "pulse_trial_7d",
-      memberId: "member_test",
+      memberId: MEMBER_ID,
       trialDurationDays: "10",
       trialPolicyVersion: "pulse-trial-2026-06-30-v2",
       trialUsageLimitUsdMicros: "4500000",
-      ...metadata,
+      ...(input.extensionDays
+        ? { murphTrialExtensionDays: input.extensionDays }
+        : {}),
+      ...(input.extensionOperation
+        ? { murphTrialExtensionOperation: input.extensionOperation }
+        : {}),
     },
-    status: "trialing",
-    trial_end: toUnixSeconds(ORIGINAL_TRIAL_END),
-    trial_start: toUnixSeconds(new Date("2026-07-02T12:00:00.000Z")),
-    ...rest,
+    status: input.status ?? "trialing",
+    trial_end: input.trialEnd === undefined
+      ? ORIGINAL_TRIAL_END
+      : input.trialEnd,
+    trial_settings: {
+      end_behavior: { missing_payment_method: "pause" },
+    },
+    trial_start: Math.floor(
+      new Date("2026-07-01T16:00:00.000Z").getTime() / 1000,
+    ),
   };
 }
 
-function makeSubscriptionItem(input: { priceId?: string } = {}) {
+function makeStripeClient(subscription: HostedPulseTrialExtensionSubscription) {
   return {
-    id: "si_recurring",
-    price: {
-      id: input.priceId ?? PRICE_ID,
-      metadata: {},
-      recurring: {
-        interval: "month",
-        interval_count: 1,
-        usage_type: "licensed",
-      },
-    },
-    quantity: 1,
-  };
-}
-
-function makeCandidateSource(
-  initialCandidates: readonly HostedPulseTrialExtensionCandidate[],
-  options: {
-    applyProviderOnlyDisposition?: (
-      disposition: Exclude<
-        Awaited<ReturnType<HostedPulseTrialExtensionCandidateSource["inspectProviderOnlyTrial"]>>,
-        { kind: "not-applicable" }
-      >,
-      now: Date,
-    ) => Promise<"cleaned-up" | "recovered">;
-    beforeLock?: (candidates: HostedPulseTrialExtensionCandidate[]) => void;
-    events?: string[];
-    failUpdates?: number;
-    inspectProviderOnlyTrial?: HostedPulseTrialExtensionCandidateSource[
-      "inspectProviderOnlyTrial"
-    ];
-  } = {},
-): HostedPulseTrialExtensionCandidateSource & {
-  candidates: HostedPulseTrialExtensionCandidate[];
-  listInputs: Array<{
-    continuationToken: string | null;
-    limit: number;
-  }>;
-  readonly lockCalls: number;
-  updateCalls: Array<{
-    candidate: HostedPulseTrialExtensionCandidate;
-    trialEndsAt: Date;
-  }>;
-} {
-  const candidates = initialCandidates.map((candidate) => ({ ...candidate }));
-  const updateCalls: Array<{
-    candidate: HostedPulseTrialExtensionCandidate;
-    trialEndsAt: Date;
-  }> = [];
-  const listInputs: Array<{
-    continuationToken: string | null;
-    limit: number;
-  }> = [];
-  let lockCalls = 0;
-  let remainingFailures = options.failUpdates ?? 0;
-
-  return {
-    candidates,
-    get lockCalls() {
-      return lockCalls;
-    },
-    listInputs,
-    async listCandidates(input) {
-      listInputs.push(input);
-      const afterMemberId = input.continuationToken?.replace(/^cursor:/u, "") ?? null;
-      const startIndex = afterMemberId
-        ? candidates.findIndex((candidate) => candidate.memberId > afterMemberId)
-        : 0;
-      const normalizedStartIndex = startIndex < 0 ? candidates.length : startIndex;
-      const pageCandidates = candidates.slice(
-        normalizedStartIndex,
-        normalizedStartIndex + input.limit,
-      );
-      const hasMore = normalizedStartIndex + pageCandidates.length < candidates.length;
-      return {
-        candidates: pageCandidates,
-        nextContinuationToken: hasMore
-          ? `cursor:${pageCandidates.at(-1)?.memberId ?? ""}`
-          : null,
-      };
-    },
-    updateCalls,
-    inspectProviderOnlyTrial: options.inspectProviderOnlyTrial ??
-      (async () => ({
-        kind: "not-applicable",
-        reason: "provider-trial-not-found",
-        subscription: null,
-      })),
-    async withStripeMutationLock(input) {
-      lockCalls += 1;
-      options.beforeLock?.(candidates);
-      const candidate = candidates.find(
-        (entry) => entry.memberId === input.candidate.memberId,
-      ) ?? null;
-      return input.run({
-        applyProviderOnlyDisposition: options.applyProviderOnlyDisposition ??
-          (async () => "recovered"),
-        candidate,
-        async updateTrialEnd(trialEndsAt) {
-          options.events?.push("database");
-          if (!candidate) {
-            throw new Error("Synthetic candidate was not found.");
-          }
-          updateCalls.push({ candidate, trialEndsAt });
-          if (remainingFailures > 0) {
-            remainingFailures -= 1;
-            throw new Error("Synthetic local write failure.");
-          }
-          candidate.currentPeriodEnd = trialEndsAt;
-          candidate.currentTrialEndsAt = trialEndsAt;
+    retrieveSubscription: vi.fn(async () => subscription),
+    updateSubscription: vi.fn<
+      (
+        id: string,
+        params: {
+          metadata: Record<string, string>;
+          proration_behavior: "none";
+          trial_end: number;
         },
-      });
-    },
+        options: Stripe.RequestOptions,
+      ) => Promise<HostedPulseTrialExtensionSubscription>
+    >(async () => subscription),
   };
 }
 
-function makeStripeClient(
-  initialSubscription = makeSubscription(),
-  events?: string[],
-  resolveSubscription?: (
-    subscriptionId: string,
-  ) => HostedPulseTrialExtensionStripeSubscription,
-): HostedPulseTrialExtensionStripeClient & {
-  retrieveCalls: number;
-  retrieveOptions: HostedPulseTrialExtensionStripeRequestOptions[];
-  updateCalls: Array<{
-    options: {
-      idempotencyKey: string;
-      maxNetworkRetries: 0;
-      timeout: 80_000;
-    };
-    params: HostedPulseTrialExtensionStripeUpdateParams;
-    subscriptionId: string;
-  }>;
-} {
-  let subscription = {
-    ...initialSubscription,
-    metadata: { ...(initialSubscription.metadata ?? {}) },
-  };
-  const client = {
-    retrieveCalls: 0,
-    retrieveOptions: [] as HostedPulseTrialExtensionStripeRequestOptions[],
-    updateCalls: [] as Array<{
-      options: {
-        idempotencyKey: string;
-        maxNetworkRetries: 0;
-        timeout: 80_000;
-      };
-      params: HostedPulseTrialExtensionStripeUpdateParams;
-      subscriptionId: string;
-    }>,
-    async retrieveSubscription(
-      subscriptionId: string,
-      options: HostedPulseTrialExtensionStripeRequestOptions,
-    ) {
-      client.retrieveCalls += 1;
-      client.retrieveOptions.push(options);
-      if (resolveSubscription) {
-        const resolvedSubscription = resolveSubscription(subscriptionId);
-        subscription = {
-          ...resolvedSubscription,
-          metadata: { ...(resolvedSubscription.metadata ?? {}) },
-        };
-      }
-      return subscription;
-    },
-    async updateSubscription(
-      subscriptionId: string,
-      params: HostedPulseTrialExtensionStripeUpdateParams,
-      options: {
-        idempotencyKey: string;
-        maxNetworkRetries: 0;
-        timeout: 80_000;
-      },
-    ) {
-      events?.push("stripe");
-      client.updateCalls.push({ options, params, subscriptionId });
-      subscription = {
-        ...subscription,
-        metadata: { ...params.metadata },
-        trial_end: params.trial_end,
-      };
-      return subscription;
-    },
-  };
-  return client;
-}
-
-function makeCandidateSubscriptionResolver(
-  candidates: readonly HostedPulseTrialExtensionCandidate[],
-) {
-  return (subscriptionId: string): HostedPulseTrialExtensionStripeSubscription => {
-    const candidate = candidates.find(
-      (current) => current.stripeSubscriptionId === subscriptionId,
-    );
-    return makeSubscription({
-      customer: candidate?.stripeCustomerId ?? "cus_test",
-      id: subscriptionId,
-      metadata: {
-        memberId: candidate?.memberId ?? "member_test",
-      },
-    });
-  };
-}
-
-function makeAsyncMutex() {
-  let tail = Promise.resolve();
-
-  return async function withLock<TResult>(run: () => Promise<TResult>): Promise<TResult> {
-    const previous = tail;
-    let release = () => {};
-    tail = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    await previous;
-    try {
-      return await run();
-    } finally {
-      release();
-    }
-  };
-}
-
-function makeDeferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
-function toUnixSeconds(value: Date): number {
-  return Math.floor(value.getTime() / 1000);
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
 }

--- a/apps/web/test/ops-trial-extension-client.test.tsx
+++ b/apps/web/test/ops-trial-extension-client.test.tsx
@@ -2,7 +2,6 @@ import { act, createElement, type ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("lucide-react", () => ({
-  AlertCircleIcon: () => createElement("svg"),
   CalendarPlusIcon: () => createElement("svg"),
   SearchIcon: () => createElement("svg"),
 }));
@@ -23,11 +22,10 @@ vi.mock("@/src/components/ui/badge", () => ({
 }));
 
 vi.mock("@/src/components/ui/button", () => ({
-  Button: ({
-    size,
-    variant,
-    ...props
-  }: ComponentProps<"button"> & { size?: string; variant?: string }) => {
+  Button: ({ size, variant, ...props }: ComponentProps<"button"> & {
+    size?: string;
+    variant?: string;
+  }) => {
     void size;
     void variant;
     return createElement("button", props);
@@ -43,29 +41,23 @@ vi.mock("@/src/components/ui/label", () => ({
   Label: (props: ComponentProps<"label">) => createElement("label", props),
 }));
 
+vi.mock("@/src/components/ui/table", () => ({
+  Table: (props: ComponentProps<"table">) => createElement("table", props),
+  TableBody: (props: ComponentProps<"tbody">) => createElement("tbody", props),
+  TableCell: (props: ComponentProps<"td">) => createElement("td", props),
+  TableHead: (props: ComponentProps<"th">) => createElement("th", props),
+  TableHeader: (props: ComponentProps<"thead">) => createElement("thead", props),
+  TableRow: (props: ComponentProps<"tr">) => createElement("tr", props),
+}));
+
 import { TrialExtensionClient } from "../app/(dashboard)/ops/trials/trial-extension-client";
-import {
-  HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-  type HostedPulseTrialExtensionSummary,
+import type {
+  HostedPulseTrialExtensionResult,
 } from "../src/lib/hosted-ops/pulse-trial-extension";
 import { renderClientComponent } from "./render-client-component";
 
 const fetchMock = vi.fn<typeof fetch>();
-const CANDIDATE_SNAPSHOT_DIGEST = `pulse-candidates-v4.${"a".repeat(43)}`;
-const CANDIDATE_PREVIEW_TOKEN = `pulse-target-v4.${"b".repeat(43)}`;
-const CONTINUATION_TOKEN =
-  `pulse-cursor-v4.v1.${"a".repeat(16)}.${"b".repeat(8)}.${"c".repeat(22)}`;
-const TRIAL_EXTENSION_FAILURE_TYPES = [
-  "db_update_failed",
-  "member_lock_busy",
-  "preview_state_changed",
-  "provider_recovery_failed",
-  "provider_recovery_lookup_failed",
-  "route_runway_exhausted",
-  "stripe_retrieve_failed",
-  "stripe_update_failed",
-  "stripe_update_result_invalid",
-] as const satisfies ReadonlyArray<keyof HostedPulseTrialExtensionSummary["failures"]>;
+const MEMBER_ID = "hbm_target_1";
 let cleanupRender: (() => Promise<void>) | null = null;
 
 beforeEach(() => {
@@ -82,768 +74,217 @@ afterEach(async () => {
 });
 
 describe("TrialExtensionClient", () => {
-  test("describes the expanded fixed cohort and fresh-pass requirement", async () => {
+  test("shows one member workflow and no campaign controls", async () => {
     const rendered = await renderClientComponent(createElement(TrialExtensionClient));
     cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
 
-    expect(allSection.textContent).toContain(
-      "started or redeemed before July 14 UTC",
-    );
-    expect(allSection.textContent).toContain(
-      "After the July 14 UTC cutoff has passed, restart at Batch 1 and Preview every batch again",
-    );
-    expect(allSection.textContent).toContain(
-      "without disturbing paid billing",
-    );
+    expect(rendered.container.textContent).toContain("Extend one member");
+    expect(rendered.container.textContent).toContain("Paid billing is never changed");
+    expect(rendered.container.textContent).not.toContain("Fixed campaign cohort");
+    expect(rendered.container.textContent).not.toContain("Batch 1");
+    expect(rendered.container.querySelectorAll("table")).toHaveLength(1);
+    expect(rendered.container.querySelectorAll("input")).toHaveLength(1);
   });
 
-  test("disables changing inputs while requests are pending and applies the previewed target", async () => {
-    const previewRequest = createDeferred<Response>();
-    const applyRequest = createDeferred<Response>();
+  test("previews the entered member and applies the same proof from its row", async () => {
     fetchMock
-      .mockReturnValueOnce(previewRequest.promise)
-      .mockReturnValueOnce(applyRequest.promise);
-
+      .mockResolvedValueOnce(jsonResponse(makeResult()))
+      .mockResolvedValueOnce(jsonResponse(makeResult({
+        currentTrialEndsAt: "2026-07-21T16:00:00.000Z",
+        localBillingPhase: "trial",
+        localBillingStatus: "active",
+        message: "The member's Pulse Trial now ends seven days later.",
+        outcome: "extended",
+        previewProof: null,
+        providerStatus: "trialing",
+      })));
     const rendered = await renderClientComponent(createElement(TrialExtensionClient));
     cleanupRender = rendered.cleanup;
-    const focusMock = vi.fn();
-    Object.defineProperty(rendered.window.HTMLElement.prototype, "focus", {
-      configurable: true,
-      value: focusMock,
-    });
-    const memberSection = getSection(rendered.container, 1);
-    const memberInput = getInput(memberSection, 0);
+    const input = rendered.container.querySelector("input");
+    if (!input) {
+      throw new Error("Member input was not rendered.");
+    }
 
-    await changeInput(rendered.window, memberInput, "  member_one  ");
-    expect(memberInput.value).toBe("  member_one  ");
-    expect(getButton(memberSection, "Preview").disabled).toBe(false);
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
+    await changeInput(rendered.window, input, `  ${MEMBER_ID}  `);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview"));
 
-    expect(memberInput.disabled).toBe(true);
-    expect(getButton(memberSection, "Previewing...").disabled).toBe(true);
     expect(readRequestBody(0)).toEqual({
-      memberId: "member_one",
-      mode: "dry-run",
+      memberId: MEMBER_ID,
+      mode: "preview",
     });
+    expect(rendered.container.textContent).toContain("Ready");
+    expect(rendered.container.textContent).toContain("paused");
 
-    // A disabled control cannot change through normal interaction. Force the
-    // state transition to prove a late preview still owns its captured target.
-    memberInput.disabled = false;
-    await changeInput(rendered.window, memberInput, "member_two");
-
-    await act(async () => {
-      previewRequest.resolve(jsonResponse(buildSummary("dry-run", { wouldExtend: 1 })));
-      await previewRequest.promise;
-    });
-
-    const confirmationInput = getInput(memberSection, 1);
-    await changeInput(
+    await clickButton(
       rendered.window,
-      confirmationInput,
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
+      getButton(rendered.container, "Apply +7 days"),
     );
-    await clickButton(rendered.window, getButton(memberSection, "Apply batch"));
 
     expect(readRequestBody(1)).toEqual({
-      campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-      candidatePreviewTokens: [CANDIDATE_PREVIEW_TOKEN],
-      candidateSnapshotDigest: CANDIDATE_SNAPSHOT_DIGEST,
-      memberId: "member_one",
+      memberId: MEMBER_ID,
       mode: "apply",
+      previewProof: makeResult().previewProof,
     });
-    expect(memberInput.disabled).toBe(true);
-    expect(confirmationInput.disabled).toBe(true);
+    expect(rendered.container.textContent).toContain("Extended");
+    expect(rendered.container.textContent).toContain("active · trial");
+    expect(rendered.container.textContent).not.toContain("Apply +7 days");
+  });
+
+  test("shows an ineligible paid member without an Apply action", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(makeResult({
+      currentTrialEndsAt: null,
+      eligibilityCode: "paid_billing",
+      eligible: false,
+      localBillingPhase: "paid",
+      localBillingStatus: "active",
+      message: "This member has paid billing, so the subscription was left unchanged.",
+      previewProof: null,
+      providerStatus: null,
+      targetTrialEndsAt: null,
+    })));
+    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
+    cleanupRender = rendered.cleanup;
+    const input = rendered.container.querySelector("input");
+    if (!input) {
+      throw new Error("Member input was not rendered.");
+    }
+
+    await changeInput(rendered.window, input, MEMBER_ID);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview"));
+
+    expect(rendered.container.textContent).toContain("No change");
+    expect(rendered.container.textContent).toContain("paid billing");
+    expect(rendered.container.textContent).toContain("Not checked");
+    expect(rendered.container.textContent).not.toContain("Not found");
+    expect(rendered.container.textContent).not.toContain("Apply +7 days");
+  });
+
+  test("locks the member input and announces progress while Preview is pending", async () => {
+    const preview = createDeferred<Response>();
+    fetchMock.mockReturnValueOnce(preview.promise);
+    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
+    cleanupRender = rendered.cleanup;
+    const input = rendered.container.querySelector("input");
+    if (!input) {
+      throw new Error("Member input was not rendered.");
+    }
+
+    await changeInput(rendered.window, input, MEMBER_ID);
+    await clickButtonWithoutWaiting(
+      rendered.window,
+      getButton(rendered.container, "Preview"),
+    );
+
+    expect(input.disabled).toBe(true);
+    expect(
+      rendered.container.querySelector("section")?.getAttribute("aria-busy"),
+    ).toBe("true");
+    expect(rendered.container.textContent).toContain("Checking member trial...");
 
     await act(async () => {
-      applyRequest.resolve(jsonResponse(buildSummary("apply")));
-      await applyRequest.promise;
+      preview.resolve(jsonResponse(makeResult()));
+      await preview.promise;
     });
 
-    const appliedStatus = memberSection.querySelector('[role="status"]');
-    expect(appliedStatus?.textContent).toContain("Applied");
-    expect(focusMock).toHaveBeenCalledTimes(2);
+    expect(input.disabled).toBe(false);
+    expect(rendered.container.textContent).toContain("Preview complete.");
+    expect(rendered.container.textContent).toContain("Apply +7 days");
   });
 
-  test("changing a member after preview removes the confirmation and apply action", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(buildSummary("dry-run", { wouldExtend: 1 })),
-    );
-
+  test("clears a preview when the member ID changes", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(makeResult()));
     const rendered = await renderClientComponent(createElement(TrialExtensionClient));
     cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-    const memberInput = getInput(memberSection, 0);
-
-    await changeInput(rendered.window, memberInput, "member_one");
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    expect(getButton(memberSection, "Apply batch")).toBeDefined();
-
-    await changeInput(rendered.window, memberInput, "member_two");
-
-    expect(findButton(memberSection, "Apply batch")).toBeUndefined();
-    expect(memberSection.querySelectorAll("input")).toHaveLength(1);
-    expect(memberSection.textContent).not.toContain("Run key");
-  });
-
-  test("a failed preview refresh cannot leave a stale apply action", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", { wouldExtend: 1 })))
-      .mockResolvedValueOnce(
-        jsonResponse(
-          { error: { message: "Preview could not be refreshed." } },
-          409,
-        ),
-      );
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_one");
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    await changeInput(
-      rendered.window,
-      getInput(memberSection, 1),
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    expect(getButton(memberSection, "Apply batch")).toBeDefined();
-
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-
-    expect(memberSection.textContent).toContain("Preview could not be refreshed.");
-    expect(findButton(memberSection, "Apply batch")).toBeUndefined();
-    expect(memberSection.querySelectorAll("input")).toHaveLength(1);
-  });
-
-  test("an unverifiable preview cannot expose an apply action", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(buildSummary("dry-run", {
-        candidateSnapshotDigest: null,
-        wouldExtend: 1,
-      })),
-    );
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-
-    expect(allSection.textContent).toContain("Preview could not be verified");
-    expect(findButton(allSection, "Apply batch")).toBeUndefined();
-    expect(allSection.textContent).not.toContain("Type pulse-beta-extension");
-  });
-
-  test("an incomplete provider preview cannot expose an apply action", async () => {
-    const incompletePreview = buildSummary("dry-run", { wouldExtend: 1 });
-    incompletePreview.failures.stripe_retrieve_failed = 1;
-    incompletePreview.candidatePreviewTokens = [""];
-    fetchMock.mockResolvedValueOnce(jsonResponse(incompletePreview));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-
-    expect(allSection.textContent).toContain("Preview incomplete");
-    expect(allSection.textContent).toContain("stripe_retrieve_failed: 1");
-    expect(allSection.textContent).toContain("Apply is unavailable");
-    expect(findButton(allSection, "Apply batch")).toBeUndefined();
-  });
-
-  test.each(TRIAL_EXTENSION_FAILURE_TYPES)(
-    "a page with %s cannot navigate through its continuation",
-    async (failureType) => {
-      const failedPage = buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      });
-      failedPage.failures[failureType] = 1;
-      fetchMock.mockResolvedValueOnce(jsonResponse(failedPage));
-
-      const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-      cleanupRender = rendered.cleanup;
-      const allSection = getSection(rendered.container, 0);
-
-      await clickButton(rendered.window, getButton(allSection, "Preview"));
-
-      expect(getButton(allSection, "Preview next batch").disabled).toBe(true);
-      expect(fetchMock).toHaveBeenCalledOnce();
-    },
-  );
-
-  test("a failed member page asks for a retry instead of impossible navigation", async () => {
-    const failedPage = buildSummary("dry-run", {
-      candidatePreviewTokens: [],
-      candidates: 0,
-      hasMoreCandidates: true,
-      nextContinuationToken: CONTINUATION_TOKEN,
-    });
-    failedPage.failures.provider_recovery_lookup_failed = 1;
-    fetchMock.mockResolvedValueOnce(jsonResponse(failedPage));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_target");
-
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-
-    expect(memberSection.textContent).toContain(
-      "Retry this batch before continuing the member search.",
-    );
-    expect(memberSection.textContent).not.toContain(
-      "Preview the next batch to continue the member search",
-    );
-    expect(getButton(memberSection, "Preview next batch").disabled).toBe(true);
-  });
-
-  test("navigates bounded all-member batches with opaque continuation", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      })))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run")))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      })));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const focusMock = vi.fn();
-    Object.defineProperty(rendered.window.HTMLElement.prototype, "focus", {
-      configurable: true,
-      value: focusMock,
-    });
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    expect(allSection.textContent).toContain("Batch 1 · more batches");
-    expect(focusMock).toHaveBeenCalledTimes(1);
-    await clickButton(rendered.window, getButton(allSection, "Preview next batch"));
-
-    expect(readRequestBody(1)).toEqual({
-      continuationToken: CONTINUATION_TOKEN,
-      mode: "dry-run",
-    });
-    expect(allSection.textContent).toContain("Batch 2 · final batch");
-    expect(focusMock).toHaveBeenCalledTimes(2);
-    await clickButton(rendered.window, getButton(allSection, "Previous batch"));
-
-    expect(readRequestBody(2)).toEqual({ mode: "dry-run" });
-    expect(allSection.textContent).toContain("Batch 1 · more batches");
-    expect(focusMock).toHaveBeenCalledTimes(3);
-  });
-
-  test("continues member-scoped Preview through an empty provider batch", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        candidatePreviewTokens: [],
-        candidates: 0,
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      })))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        wouldExtend: 1,
-      })));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_target");
-
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    expect(memberSection.textContent).toContain("Batch 1 · more batches");
-    expect(memberSection.textContent).toContain(
-      "Preview the next batch to continue the member search",
-    );
-    await clickButton(rendered.window, getButton(memberSection, "Preview next batch"));
-
-    expect(readRequestBody(1)).toEqual({
-      continuationToken: CONTINUATION_TOKEN,
-      memberId: "member_target",
-      mode: "dry-run",
-    });
-    expect(memberSection.textContent).toContain("Batch 2 · final batch");
-    expect(memberSection.textContent).toContain("Would get 7 days1");
-  });
-
-  test("keeps a non-actionable member batch non-terminal while more pages remain", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-      hasMoreCandidates: true,
-      nextContinuationToken: CONTINUATION_TOKEN,
-    })));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_target");
-
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-
-    expect(memberSection.textContent).toContain(
-      "Nothing to change in this batch. Preview the next batch to continue the member search.",
-    );
-    expect(memberSection.textContent).not.toContain("Nothing to change right now.");
-  });
-
-  test("describes a later empty member batch as no additional match", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-        wouldExtend: 1,
-      })))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        candidatePreviewTokens: [],
-        candidates: 0,
-      })));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_target");
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    await clickButton(rendered.window, getButton(memberSection, "Preview next batch"));
-
-    expect(memberSection.textContent).toContain(
-      "Member search complete. No additional eligible campaign trial was found.",
-    );
-    expect(memberSection.textContent).not.toContain(
-      "No eligible campaign trial found for that member id.",
-    );
-  });
-
-  test("restarts a later batch at Batch 1 without replaying its continuation", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      })))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run")))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      })));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    await clickButton(rendered.window, getButton(allSection, "Preview next batch"));
-    expect(allSection.textContent).toContain("Batch 2 · final batch");
-    await clickButton(rendered.window, getButton(allSection, "Restart at Batch 1"));
-
-    expect(readRequestBody(2)).toEqual({ mode: "dry-run" });
-    expect(allSection.textContent).toContain("Batch 1 · more batches");
-  });
-
-  test("an invalid continuation resets the next Preview to Batch 1", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      })))
-      .mockResolvedValueOnce(jsonResponse({
-        error: {
-          code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_CONTINUATION_INVALID",
-          message: "Trial extension continuation is invalid. Restart at Batch 1.",
-        },
-      }, 400))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run")));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    await clickButton(rendered.window, getButton(allSection, "Preview next batch"));
-    expect(allSection.textContent).toContain("Batch 1 is ready to Preview.");
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-
-    expect(readRequestBody(2)).toEqual({ mode: "dry-run" });
-    expect(allSection.textContent).toContain("Batch 1 · final batch");
-  });
-
-  test("an apply failure retains the matching preview and confirmation for retry", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", { wouldExtend: 1 })))
-      .mockResolvedValueOnce(
-        jsonResponse({ error: { message: "Apply failed safely." } }, 500),
-      );
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_one");
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    const confirmationInput = getInput(memberSection, 1);
-    await changeInput(
-      rendered.window,
-      confirmationInput,
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(memberSection, "Apply batch"));
-
-    expect(memberSection.textContent).toContain("Apply failed safely.");
-    expect(getButton(memberSection, "Apply batch")).toBeDefined();
-    expect(confirmationInput.value).toBe(HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN);
-  });
-
-  test("a stale apply response clears the obsolete preview", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", { wouldExtend: 1 })))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          error: {
-            code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_STALE",
-            message: "Eligible trials changed since Preview. Preview again before applying.",
-          },
-        }, 409),
-      );
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    await changeInput(
-      rendered.window,
-      getInput(allSection, 0),
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(allSection, "Apply batch"));
-
-    expect(allSection.textContent).toContain("Eligible trials changed since Preview");
-    expect(findButton(allSection, "Apply batch")).toBeUndefined();
-    expect(allSection.querySelectorAll("input")).toHaveLength(0);
-  });
-
-  test("an invalid continuation during Apply resets the next Preview to Batch 1", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        hasMoreCandidates: true,
-        nextContinuationToken: CONTINUATION_TOKEN,
-      })))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", { wouldExtend: 1 })))
-      .mockResolvedValueOnce(jsonResponse({
-        error: {
-          code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_CONTINUATION_INVALID",
-          message: "Trial extension continuation is invalid. Restart at Batch 1.",
-        },
-      }, 400))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run")));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    await clickButton(rendered.window, getButton(allSection, "Preview next batch"));
-    await changeInput(
-      rendered.window,
-      getInput(allSection, 0),
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(allSection, "Apply batch"));
-
-    expect(allSection.textContent).toContain("Batch 1 is ready to Preview.");
-    expect(findButton(allSection, "Apply batch")).toBeUndefined();
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    expect(readRequestBody(3)).toEqual({ mode: "dry-run" });
-  });
-
-  test("a partial apply result stays confirmed and available for an idempotent retry", async () => {
-    const partialApply = buildSummary("apply");
-    partialApply.failures.stripe_update_failed = 1;
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", { wouldExtend: 1 })))
-      .mockResolvedValueOnce(jsonResponse(partialApply));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_one");
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    const confirmationInput = getInput(memberSection, 1);
-    await changeInput(
-      rendered.window,
-      confirmationInput,
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(memberSection, "Apply batch"));
-
-    expect(memberSection.textContent).toContain("Needs retry");
-    expect(memberSection.textContent).toContain("stripe_update_failed: 1");
-    expect(getButton(memberSection, "Apply batch")).toBeDefined();
-    expect(confirmationInput.value).toBe(HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN);
-  });
-
-  test("a partial apply that reconciles local state requires a new preview", async () => {
-    const partialApply = buildSummary("apply", { localWindowsReconciled: 1 });
-    partialApply.failures.stripe_update_failed = 1;
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", { wouldExtend: 2 })))
-      .mockResolvedValueOnce(jsonResponse(partialApply));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    await changeInput(
-      rendered.window,
-      getInput(allSection, 0),
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(allSection, "Apply batch"));
-
-    expect(allSection.textContent).toContain("Needs retry");
-    expect(findButton(allSection, "Apply batch")).toBeUndefined();
-    expect(allSection.querySelectorAll("input")).toHaveLength(0);
-  });
-
-  test("a partial apply with changed local eligibility requires a new preview", async () => {
-    const partialApply = buildSummary("apply");
-    partialApply.failures.stripe_update_failed = 1;
-    partialApply.skipped.local_candidate_changed = 1;
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", { wouldExtend: 2 })))
-      .mockResolvedValueOnce(jsonResponse(partialApply));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-    await changeInput(
-      rendered.window,
-      getInput(allSection, 0),
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(allSection, "Apply batch"));
-
-    expect(allSection.textContent).toContain("Needs retry");
-    expect(allSection.textContent).toContain("local_candidate_changed (1)");
-    expect(findButton(allSection, "Apply batch")).toBeUndefined();
-    expect(allSection.querySelectorAll("input")).toHaveLength(0);
-  });
-
-  test("a targeted provider-only trial is recovered and extended in one Apply", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        wouldRecoverProviderTrial: 1,
-        wouldExtend: 1,
-      })))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("apply", {
-        providerTrialsRecovered: 1,
-        stripeTrialsExtended: 1,
-      })));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-
-    expect(memberSection.textContent).toContain("one Apply");
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_one");
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    expect(memberSection.textContent).toContain("Would recover trial");
-    await changeInput(
-      rendered.window,
-      getInput(memberSection, 1),
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(memberSection, "Apply batch"));
-
-    expect(memberSection.textContent).toContain("Provider trials recovered");
-    expect(memberSection.textContent).toContain("Got 7 days");
-    expect(memberSection.textContent).not.toContain("Preview this member again");
-    expect(findButton(memberSection, "Apply batch")).toBeUndefined();
-    expect(memberSection.querySelectorAll("input")).toHaveLength(1);
-  });
-
-  test("provider-only cleanup explains that current billing was preserved", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(buildSummary("dry-run", {
-        wouldCleanupProviderTrial: 1,
-      })))
-      .mockResolvedValueOnce(jsonResponse(buildSummary("apply", {
-        providerTrialsCleanedUp: 1,
-      })));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const memberSection = getSection(rendered.container, 1);
-
-    await changeInput(rendered.window, getInput(memberSection, 0), "member_one");
-    await clickButton(rendered.window, getButton(memberSection, "Preview"));
-    expect(memberSection.textContent).toContain("Would clean up trial");
-    await changeInput(
-      rendered.window,
-      getInput(memberSection, 1),
-      HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    );
-    await clickButton(rendered.window, getButton(memberSection, "Apply batch"));
-
-    expect(memberSection.textContent).toContain("Provider trials cleaned up");
-    expect(memberSection.textContent).toContain(
-      "Obsolete provider trial cleaned up. Current billing was left unchanged.",
-    );
-  });
-
-  test("renders an ended provider trial as a stable no-action skip", async () => {
-    const summary = buildSummary("dry-run");
-    summary.skipped.provider_trial_ended = 1;
-    fetchMock.mockResolvedValueOnce(jsonResponse(summary));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-
-    expect(allSection.textContent).toContain(
-      "Provider trial already ended — no action needed (1)",
-    );
-    expect(allSection.textContent).not.toContain("provider_trial_ended");
-  });
-
-  test("the all-member preview omits memberId and explains bounded batches", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(buildSummary("dry-run")));
-
-    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
-    cleanupRender = rendered.cleanup;
-    const allSection = getSection(rendered.container, 0);
-
-    expect(allSection.textContent).toContain("ordered batches of up to four");
-    expect(allSection.textContent).toContain(
-      "After the July 14 UTC cutoff has passed, restart at Batch 1 and Preview every batch again",
-    );
-    await clickButton(rendered.window, getButton(allSection, "Preview"));
-
-    expect(readRequestBody(0)).toEqual({ mode: "dry-run" });
+    const input = rendered.container.querySelector("input");
+    if (!input) {
+      throw new Error("Member input was not rendered.");
+    }
+
+    await changeInput(rendered.window, input, MEMBER_ID);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview"));
+    expect(rendered.container.textContent).toContain("Apply +7 days");
+
+    await changeInput(rendered.window, input, "hbm_another");
+    expect(rendered.container.textContent).not.toContain("Apply +7 days");
     expect(rendered.container.textContent).toContain(
-      "already extended trials are not extended again",
+      "Enter a member ID to preview the trial",
     );
-    expect(rendered.container.textContent).not.toContain("Already done today");
+  });
+
+  test("shows a route error and removes stale preview state", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(makeResult()))
+      .mockResolvedValueOnce(jsonResponse({
+        error: { message: "Billing changed since Preview. Preview this member again." },
+      }, 409));
+    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
+    cleanupRender = rendered.cleanup;
+    const input = rendered.container.querySelector("input");
+    if (!input) {
+      throw new Error("Member input was not rendered.");
+    }
+
+    await changeInput(rendered.window, input, MEMBER_ID);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview"));
+    await clickButton(
+      rendered.window,
+      getButton(rendered.container, "Apply +7 days"),
+    );
+
+    expect(rendered.container.querySelector('[role="alert"]')?.textContent).toContain(
+      "Billing changed since Preview",
+    );
+    expect(rendered.container.textContent).not.toContain("Apply +7 days");
   });
 });
 
-function buildSummary(
-  mode: HostedPulseTrialExtensionSummary["mode"],
-  overrides: Partial<HostedPulseTrialExtensionSummary> = {},
-): HostedPulseTrialExtensionSummary {
+function makeResult(
+  overrides: Partial<HostedPulseTrialExtensionResult> = {},
+): HostedPulseTrialExtensionResult {
   return {
-    alreadyExtended: 0,
-    campaign: HOSTED_PULSE_TRIAL_EXTENSION_CAMPAIGN,
-    candidatePreviewTokens: mode === "dry-run" ? [CANDIDATE_PREVIEW_TOKEN] : null,
-    candidateSnapshotDigest: mode === "dry-run" ? CANDIDATE_SNAPSHOT_DIGEST : null,
-    candidates: 1,
+    currentTrialEndsAt: "2026-07-12T16:00:00.000Z",
+    eligibilityCode: "eligible",
+    eligible: true,
     extensionDays: 7,
-    failures: {
-      db_update_failed: 0,
-      member_lock_busy: 0,
-      preview_state_changed: 0,
-      provider_recovery_failed: 0,
-      provider_recovery_lookup_failed: 0,
-      route_runway_exhausted: 0,
-      stripe_retrieve_failed: 0,
-      stripe_update_failed: 0,
-      stripe_update_result_invalid: 0,
+    localBillingPhase: null,
+    localBillingStatus: "paused",
+    memberId: MEMBER_ID,
+    message: "This lapsed Pulse Trial can be restored for seven days.",
+    outcome: "preview",
+    previewProof: {
+      previewedAt: "2026-07-14T16:00:00.000Z",
+      targetTrialEndsAt: "2026-07-21T16:00:00.000Z",
+      token: `pulse-member-preview-v1.v1.${"a".repeat(43)}`,
     },
-    hasMoreCandidates: false,
-    localWindowsReconciled: 0,
-    mode,
-    nextContinuationToken: null,
-    providerTrialsCleanedUp: 0,
-    providerTrialsRecovered: 0,
-    skipped: {
-      local_candidate_changed: 0,
-      local_trial_window_invalid: 0,
-      missing_stripe_refs: 0,
-      outside_campaign_cohort: 0,
-      provider_recovery_not_found: 0,
-      provider_trial_ended: 0,
-      stripe_billing_plan_mismatch: 0,
-      stripe_campaign_marker_conflict: 0,
-      stripe_checkout_offer_mismatch: 0,
-      stripe_customer_mismatch: 0,
-      stripe_price_mismatch: 0,
-      stripe_subscription_canceling: 0,
-      stripe_subscription_id_mismatch: 0,
-      stripe_subscription_not_trialing: 0,
-      stripe_trial_end_invalid: 0,
-    },
-    stripeTrialsExtended: 0,
-    wouldExtend: 0,
-    wouldCleanupProviderTrial: 0,
-    wouldRecoverProviderTrial: 0,
-    wouldReconcile: 0,
+    providerStatus: "paused",
+    targetTrialEndsAt: "2026-07-21T16:00:00.000Z",
     ...overrides,
   };
 }
 
-function jsonResponse(payload: unknown, status = 200): Response {
-  return new Response(JSON.stringify(payload), {
-    headers: { "Content-Type": "application/json" },
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
     status,
   });
 }
 
-function getSection(container: HTMLElement, index: number): HTMLElement {
-  const section = container.querySelectorAll("section").item(index);
-  if (!section) {
-    throw new Error(`Missing trial extension section ${index}.`);
+function readRequestBody(index: number): unknown {
+  const init = fetchMock.mock.calls[index]?.[1];
+  if (!init || typeof init.body !== "string") {
+    throw new Error("Expected a JSON request body.");
   }
-  return section;
+  return JSON.parse(init.body) as unknown;
 }
 
-function getInput(section: HTMLElement, index: number): HTMLInputElement {
-  const input = section.querySelectorAll("input").item(index);
-  if (!input) {
-    throw new Error(`Missing trial extension input ${index}.`);
-  }
-  return input;
-}
-
-function getButton(section: HTMLElement, label: string): HTMLButtonElement {
-  const button = findButton(section, label);
+function getButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
   if (!button) {
-    throw new Error(`Missing trial extension button ${label}.`);
+    throw new Error(`Button not found: ${label}`);
   }
   return button;
-}
-
-function findButton(
-  section: HTMLElement,
-  label: string,
-): HTMLButtonElement | undefined {
-  return Array.from(section.querySelectorAll("button")).find(
-    (button) => button.textContent?.trim() === label,
-  );
-}
-
-async function changeInput(
-  window: Window & typeof globalThis,
-  input: HTMLInputElement,
-  value: string,
-): Promise<void> {
-  await act(async () => {
-    const descriptor = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype,
-      "value",
-    );
-    descriptor?.set?.call(input, value);
-    input.dispatchEvent(new window.Event("input", { bubbles: true }));
-    input.dispatchEvent(new window.Event("change", { bubbles: true }));
-  });
 }
 
 async function clickButton(
@@ -856,31 +297,41 @@ async function clickButton(
   });
 }
 
-function readRequestBody(callIndex: number): unknown {
-  const call = fetchMock.mock.calls[callIndex];
-  const body = call?.[1]?.body;
-  if (typeof body !== "string") {
-    throw new Error(`Missing JSON body for request ${callIndex}.`);
-  }
-  const parsed: unknown = JSON.parse(body);
-  return parsed;
+async function clickButtonWithoutWaiting(
+  window: Window & typeof globalThis,
+  button: HTMLButtonElement,
+): Promise<void> {
+  await act(async () => {
+    button.dispatchEvent(new window.Event("click", { bubbles: true }));
+  });
 }
 
 function createDeferred<T>(): {
   promise: Promise<T>;
   resolve: (value: T) => void;
 } {
-  let resolvePromise: ((value: T) => void) | null = null;
-  const promise = new Promise<T>((resolve) => {
-    resolvePromise = resolve;
+  let resolve: ((value: T) => void) | null = null;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
   });
-  return {
-    promise,
-    resolve: (value) => {
-      if (!resolvePromise) {
-        throw new Error("Deferred promise resolver is unavailable.");
-      }
-      resolvePromise(value);
-    },
-  };
+  if (!resolve) {
+    throw new Error("Deferred promise was not initialized.");
+  }
+  return { promise, resolve };
+}
+
+async function changeInput(
+  window: Window & typeof globalThis,
+  input: HTMLInputElement,
+  value: string,
+): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    await Promise.resolve();
+  });
 }


### PR DESCRIPTION
## Why

The ops trial page was still tied to a fixed July campaign, provider-wide batch scans, and a cutoff. Entering one member ID could therefore return “no eligible campaign trial in this batch” instead of checking that member's current trial directly.

## User-visible goal and flow

`/ops/trials` now has one member-ID field and one result table:

1. Enter a hosted member ID and Preview its current local and Stripe trial state.
2. Review the current end, exact new end, and eligibility reason.
3. Apply seven more days from the same row.

An active Pulse Trial extends from its current Stripe end. A lapsed no-card trial in Stripe's paused state restarts for seven days from Preview time. The fixed cohort, cutoff, run key, provider sweep, ordered batches, and cleanup controls are deleted.

## Invariants

- Paid billing, scheduled billing changes, canceling subscriptions, terminal subscriptions, suspended members, and mismatched member/customer/subscription/price state are never mutated.
- Only the member's current, locally owned, redeemed Pulse Trial subscription is eligible.
- Apply re-reads local and Stripe state under the existing member billing mutation lock and requires a 15-minute signed Preview proof.
- Stripe receives an exact `trial_end`, `proration_behavior: none`, and a proof-derived idempotency key. A retry after provider success reconciles local billing instead of adding another seven days.
- Provider identifiers stay out of the browser payload and logs.

## Change shape

ReviewGPT first-reviewed head: 45183b89049e06e005f4332ab40d7328d74933b5

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1,093 | 2,683 |
| Tests | 817 | 4,942 |
| Docs | 117 | 70 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Current head: `45183b89049e06e005f4332ab40d7328d74933b5`

## Verification

- `pnpm test:diff <touched apps/web paths>`
  - dependency, workspace-boundary, crypto, log-payload, and hosted architecture guards passed
  - hosted-web TypeScript passed
  - dev smoke passed
  - lint passed with 13 unrelated existing warnings and no errors
  - 423 test files passed; 5,046 tests passed; 2 files / 139 tests skipped
  - production Next build passed
- Focused service, route, and client Vitest: 3 files, 26 tests passed
- Required `coverage-write` and `frontend-review` passes completed; frontend findings were fixed and re-reviewed to closure
- `git diff --check` and stale campaign-string/identifier scans passed

Visual browser capture remains unavailable because the browser controller reported no connected backend. The isolated frontend and repo dev smoke both started successfully; full hosted-local startup separately stopped in the assistant-engine CLI-manifest build before web startup.

## Architecture retrospective

ReviewGPT round 1 stopped at the mandatory authored-source churn threshold: 1,093 additions plus 2,683 deletions (3,776 changed lines). This is original implementation churn, not review remediation. The change removes the fixed campaign's cohort key/cutoff, provider-wide and local enumeration, encrypted batch continuations, aggregate campaign summaries, per-candidate batch proofs, provider-only cleanup/recovery, work budgets, and multi-candidate scheduling. The replacement is a net deletion of 1,590 source lines and collapses the operational model to one explicit member and one locked mutation.

Decision: continue the current replacement as one indivisible product change.

- The irreducible outcome is both behaviors the operator requested: extend an active Pulse Trial from its current provider end and restore a lapsed no-card Pulse Trial from Stripe's paused state. Shipping only the live case would leave the reported lapsed-member failure unresolved.
- Preview is a safety/authorization boundary, not cosmetic feedback. Its short-lived signature binds the exact member, local billing ownership/status/phase/plan/offer/schedule/suspension/redeemed state, provider customer/subscription/policy/items/status/cancel/trial state, preview time, and displayed target. Apply re-reads those facts under the existing member billing lock and rejects a mismatch. The signature avoids adding server-side Preview state while proving Apply corresponds to what the operator reviewed.
- Mutation ownership remains unchanged: Stripe owns provider subscription identity/status/window; the hosted billing store owns local billing/access state. The member-scoped ops service is one application use case that orchestrates those existing owners under their existing lock. It adds no schema, queue, scheduler, lifecycle owner, dependency, or background reconciliation path.
- The proof-derived Stripe idempotency key and subscription metadata marker are retained because provider success followed by local failure is an unavoidable cross-store ambiguity. They let the same Apply reconcile local state without adding another seven days or introducing persisted operation state.
- Eligibility stays in the member-scoped use case because paid, scheduled, canceling, terminal, mismatched, and non-Pulse subscriptions must fail closed before mutation. The route remains validation/auth only, and local writes continue through the existing billing-store owner.
- Splitting campaign deletion from the member operation would create a transient ops page with no usable extension path and make the behavioral replacement harder to review as one outcome. No campaign-era runtime machinery remains to delete; only negative UI assertions retain old labels as regression guards.

Review remediation authored-source growth: 0 lines. No repeated finding mechanism exists; this is the first full-patch audit prerequisite.
