### PR TITLE
preserve trial extension retry identity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-pr660-ambiguous-apply-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-pr660-ambiguous-apply-recovery.md
@@ -1,0 +1,47 @@
+# PR 660 ambiguous Apply recovery
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-14
+
+## Goal
+
+- Preserve the exact trial-extension operation identity across an ambiguous
+  Apply response so retrying one intended extension cannot authorize another
+  seven days.
+
+## Success criteria
+
+- The client retains the current Preview proof after transport, malformed
+  response, provider, or other ambiguous Apply failures and retries byte-for-byte
+  with the same proof.
+- A server-confirmed stale Preview clears the unusable proof and requires a new
+  Preview.
+- Apply can reconcile an exact already-applied Stripe operation after the
+  Preview TTL, while an expired proof can never start a new Stripe mutation.
+- Focused regression tests prove ambiguous client failure, confirmed stale,
+  provider-success retry, expired exact-marker recovery, and expired unmarked
+  non-mutation.
+
+## Constraints
+
+- Reorder checks inside the existing client/service owners; add no database
+  state, browser persistence, queue, scheduler, or retry abstraction.
+- Preserve the existing member billing mutation lock, signed proof, Stripe
+  idempotency key, and exact provider marker.
+- Keep paid and other ineligible billing non-mutation guarantees unchanged.
+
+## Verification
+
+- Focused client/service/route tests passed with 28/28 tests; the remediation
+  subset passed with 18/18 tests after coverage review.
+- Hosted-web typecheck and scoped lint passed.
+- `pnpm test:diff` selected the complete hosted-web verifier: architecture and
+  privacy guards, dev smoke, lint, 5,048 tests, and the production Next build
+  passed. Lint retained 13 unrelated warnings and no errors.
+- Required coverage review added byte-identical request proof and exact
+  provider call-count assertions; required frontend re-review returned zero
+  findings.
+- Push the remediation and run ReviewGPT correction round 2 concurrently with
+  CI until PASS.
+Completed: 2026-07-14

--- a/apps/web/app/(dashboard)/ops/trials/trial-extension-client.tsx
+++ b/apps/web/app/(dashboard)/ops/trials/trial-extension-client.tsx
@@ -22,6 +22,8 @@ import type {
 } from "@/src/lib/hosted-ops/pulse-trial-extension";
 
 type PendingAction = "apply" | "preview" | null;
+const PREVIEW_STALE_ERROR_CODE =
+  "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_STALE";
 
 export function TrialExtensionClient() {
   const [memberId, setMemberId] = useState("");
@@ -39,7 +41,6 @@ export function TrialExtensionClient() {
     }
     setPending("preview");
     setError(null);
-    setResult(null);
     try {
       const preview = await requestTrialExtension({
         memberId: normalizedMemberId,
@@ -69,8 +70,14 @@ export function TrialExtensionClient() {
         previewProof: result.previewProof,
       }));
     } catch (requestError) {
-      setResult(null);
-      setError(readRequestErrorMessage(requestError));
+      if (isPreviewStaleRequestError(requestError)) {
+        setResult(null);
+        setError(readRequestErrorMessage(requestError));
+      } else {
+        setError(
+          "The trial extension could not be confirmed. Retry Apply with the same Preview.",
+        );
+      }
     } finally {
       setPending(null);
     }
@@ -321,14 +328,55 @@ async function requestTrialExtension(input: {
     headers: { "content-type": "application/json" },
     method: "POST",
   });
-  const payload: unknown = await response.json();
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new TrialExtensionRequestError(
+      "Trial extension returned an unreadable response.",
+      null,
+    );
+  }
   if (!response.ok) {
-    throw new Error(readResponseErrorMessage(payload));
+    throw new TrialExtensionRequestError(
+      readResponseErrorMessage(payload),
+      readResponseErrorCode(payload),
+    );
   }
   if (!isHostedPulseTrialExtensionResult(payload)) {
-    throw new Error("Trial extension returned an invalid response.");
+    throw new TrialExtensionRequestError(
+      "Trial extension returned an invalid response.",
+      null,
+    );
   }
   return payload;
+}
+
+class TrialExtensionRequestError extends Error {
+  readonly code: string | null;
+
+  constructor(message: string, code: string | null) {
+    super(message);
+    this.code = code;
+    this.name = "TrialExtensionRequestError";
+  }
+}
+
+function readResponseErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const error = Reflect.get(payload, "error");
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
+}
+
+function isPreviewStaleRequestError(error: unknown): boolean {
+  return error instanceof TrialExtensionRequestError &&
+    error.code === PREVIEW_STALE_ERROR_CODE;
 }
 
 function isHostedPulseTrialExtensionResult(

--- a/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
+++ b/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
@@ -159,7 +159,7 @@ export class HostedPulseTrialExtensionPreviewStaleError extends Error {
 
 export class HostedPulseTrialExtensionProviderError extends Error {
   constructor() {
-    super("Stripe could not be checked for this member. Try Preview again.");
+    super("Stripe could not confirm this trial extension request.");
     this.name = "HostedPulseTrialExtensionProviderError";
   }
 }
@@ -284,6 +284,11 @@ export async function applyHostedPulseTrialExtension(
             },
           });
         }
+
+        requireHostedPulseTrialExtensionPreviewFresh({
+          now,
+          previewedAt: proofDates.previewedAt,
+        });
 
         if (
           !state.eligible ||
@@ -729,8 +734,7 @@ function parseHostedPulseTrialExtensionPreviewProofDates(input: {
   if (
     !Number.isFinite(previewedAt.getTime()) ||
     !Number.isFinite(targetTrialEndsAt.getTime()) ||
-    input.now.getTime() < previewedAt.getTime() - 60_000 ||
-    input.now.getTime() > previewedAt.getTime() + PREVIEW_PROOF_TTL_MS
+    input.now.getTime() < previewedAt.getTime() - 60_000
   ) {
     throw new HostedPulseTrialExtensionPreviewStaleError();
   }
@@ -749,6 +753,18 @@ function parseHostedPulseTrialExtensionPreviewProofDates(input: {
     targetTrialEndsAt: canonicalTargetTrialEndsAt,
     targetTrialEndUnix,
   };
+}
+
+function requireHostedPulseTrialExtensionPreviewFresh(input: {
+  now: Date;
+  previewedAt: Date;
+}): void {
+  if (
+    input.now.getTime() >
+      input.previewedAt.getTime() + PREVIEW_PROOF_TTL_MS
+  ) {
+    throw new HostedPulseTrialExtensionPreviewStaleError();
+  }
 }
 
 function readHostedPulseTrialExtensionTokenParts(token: string): {

--- a/apps/web/test/hosted-pulse-trial-extension.test.ts
+++ b/apps/web/test/hosted-pulse-trial-extension.test.ts
@@ -426,6 +426,9 @@ describe("single-member Pulse Trial extension", () => {
       prisma: {} as never,
       stripe,
     })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+    expect(stripe.retrieveSubscription).toHaveBeenCalledTimes(2);
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    expect(mocks.updateHostedMemberCoreState).not.toHaveBeenCalled();
 
     const originalDigest = preview.previewProof.token.at(-1);
     const tamperedToken = `${preview.previewProof.token.slice(0, -1)}${
@@ -509,7 +512,7 @@ describe("single-member Pulse Trial extension", () => {
     ).not.toHaveBeenCalled();
   });
 
-  test("retries reconcile an already applied provider result without adding days", async () => {
+  test("reconciles an expired exact marker after an ambiguous provider success", async () => {
     const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
     const stripe = makeStripeClient(paused);
     const preview = await previewHostedPulseTrialExtension({
@@ -526,16 +529,32 @@ describe("single-member Pulse Trial extension", () => {
     if (!operationId) {
       throw new Error("Expected an operation ID.");
     }
-    stripe.retrieveSubscription.mockResolvedValue(makeSubscription({
-      extensionDays: "7",
-      extensionOperation: operationId,
-      status: "trialing",
-      trialEnd: TARGET_FROM_PAUSED,
-    }));
+    let providerSubscription = paused;
+    stripe.retrieveSubscription.mockImplementation(
+      async () => providerSubscription,
+    );
+    stripe.updateSubscription.mockImplementationOnce(async () => {
+      providerSubscription = makeSubscription({
+        extensionDays: "7",
+        extensionOperation: operationId,
+        status: "trialing",
+        trialEnd: TARGET_FROM_PAUSED,
+      });
+      throw new Error("response lost after provider success");
+    });
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:03:00.000Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionProviderError);
 
     const result = await applyHostedPulseTrialExtension({
       memberId: MEMBER_ID,
-      now: new Date("2026-07-14T16:03:00.000Z"),
+      now: new Date("2026-07-14T16:16:00.000Z"),
       previewProof: preview.previewProof,
       priceId: PRICE_ID,
       prisma: {} as never,
@@ -543,7 +562,8 @@ describe("single-member Pulse Trial extension", () => {
     });
 
     expect(result.outcome).toBe("reconciled");
-    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(1);
+    expect(stripe.retrieveSubscription).toHaveBeenCalledTimes(3);
     expect(mocks.writeHostedMemberStripeBillingRefTx).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/test/ops-trial-extension-client.test.tsx
+++ b/apps/web/test/ops-trial-extension-client.test.tsx
@@ -215,7 +215,10 @@ describe("TrialExtensionClient", () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(makeResult()))
       .mockResolvedValueOnce(jsonResponse({
-        error: { message: "Billing changed since Preview. Preview this member again." },
+        error: {
+          code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PREVIEW_STALE",
+          message: "Billing changed since Preview. Preview this member again.",
+        },
       }, 409));
     const rendered = await renderClientComponent(createElement(TrialExtensionClient));
     cleanupRender = rendered.cleanup;
@@ -235,6 +238,84 @@ describe("TrialExtensionClient", () => {
       "Billing changed since Preview",
     );
     expect(rendered.container.textContent).not.toContain("Apply +7 days");
+  });
+
+  test("retries an ambiguous Apply with the byte-identical Preview proof", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(makeResult()))
+      .mockRejectedValueOnce(new TypeError("connection lost"))
+      .mockResolvedValueOnce(jsonResponse(makeResult({
+        currentTrialEndsAt: "2026-07-21T16:00:00.000Z",
+        localBillingPhase: "trial",
+        localBillingStatus: "active",
+        message: "The seven-day extension was already in Stripe and local billing is reconciled.",
+        outcome: "reconciled",
+        previewProof: null,
+        providerStatus: "trialing",
+      })));
+    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
+    cleanupRender = rendered.cleanup;
+    const input = rendered.container.querySelector("input");
+    if (!input) {
+      throw new Error("Member input was not rendered.");
+    }
+
+    await changeInput(rendered.window, input, MEMBER_ID);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview"));
+    await clickButton(
+      rendered.window,
+      getButton(rendered.container, "Apply +7 days"),
+    );
+
+    expect(rendered.container.textContent).toContain(
+      "Retry Apply with the same Preview",
+    );
+    expect(rendered.container.textContent).toContain("Apply +7 days");
+
+    await clickButton(
+      rendered.window,
+      getButton(rendered.container, "Apply +7 days"),
+    );
+
+    expect(readRequestBodyText(2)).toBe(readRequestBodyText(1));
+    expect(rendered.container.textContent).toContain("Reconciled");
+  });
+
+  test("keeps an existing proof when a replacement Preview fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(makeResult()))
+      .mockRejectedValueOnce(new TypeError("connection lost"))
+      .mockResolvedValueOnce(jsonResponse(makeResult({
+        currentTrialEndsAt: "2026-07-21T16:00:00.000Z",
+        localBillingPhase: "trial",
+        localBillingStatus: "active",
+        outcome: "extended",
+        previewProof: null,
+        providerStatus: "trialing",
+      })));
+    const rendered = await renderClientComponent(createElement(TrialExtensionClient));
+    cleanupRender = rendered.cleanup;
+    const input = rendered.container.querySelector("input");
+    if (!input) {
+      throw new Error("Member input was not rendered.");
+    }
+
+    await changeInput(rendered.window, input, MEMBER_ID);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview"));
+    await clickButton(rendered.window, getButton(rendered.container, "Preview"));
+
+    expect(rendered.container.textContent).toContain("Apply +7 days");
+
+    await clickButton(
+      rendered.window,
+      getButton(rendered.container, "Apply +7 days"),
+    );
+
+    expect(readRequestBody(2)).toEqual({
+      memberId: MEMBER_ID,
+      mode: "apply",
+      previewProof: makeResult().previewProof,
+    });
   });
 });
 
@@ -270,11 +351,15 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 function readRequestBody(index: number): unknown {
+  return JSON.parse(readRequestBodyText(index)) as unknown;
+}
+
+function readRequestBodyText(index: number): string {
   const init = fetchMock.mock.calls[index]?.[1];
   if (!init || typeof init.body !== "string") {
     throw new Error("Expected a JSON request body.");
   }
-  return JSON.parse(init.body) as unknown;
+  return init.body;
 }
 
 function getButton(container: HTMLElement, label: string): HTMLButtonElement {


### PR DESCRIPTION
## Why

PR #660 replaced the fixed trial campaign with the direct member workflow, but it was merged while its required ReviewGPT audit was still running. That audit found an ambiguous-provider-response bug: if Stripe accepted Apply and the response was lost, the browser discarded the only proof and directed the operator to Preview again. The new Preview represented a new Stripe operation and could grant a second seven-day extension.

## User-visible goal and flow

Keep the exact Preview row and “Apply +7 days” action after transport, malformed-response, provider, lock, or other unconfirmed Apply failures. Retrying Apply sends the byte-identical proof. Only a server-confirmed stale Preview removes the action and requires a new Preview.

If Stripe already carries that proof's exact operation marker and target, the server may reconcile local billing after the 15-minute Preview TTL. The same expired proof without the marker remains stale and can never start a provider mutation.

## Invariants

- One intended Apply can produce at most one seven-day provider extension.
- Ambiguous provider success is retried under the same Stripe idempotency key and operation marker.
- Expired proofs can only reconcile an exact already-applied provider result; they cannot mutate Stripe.
- Member changes and typed stale responses still clear unusable proofs.
- The fix reorders checks inside the existing client/service owners and adds no state, queue, scheduler, persistence, or retry abstraction.

## Change shape

ReviewGPT first-reviewed head: 33bf2efb1c979c072d0481490a1dc04fc557ce1a

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 73 | 9 |
| Tests | 116 | 11 |
| Docs | 47 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Current head: `33bf2efb1c979c072d0481490a1dc04fc557ce1a`

## Review finding disposition

- PR #660 ReviewGPT round 1: one High original-PR ambiguous Apply finding, accepted.
- Root mechanism: the client destroyed the only operation identity on any failure, and the service enforced TTL before checking the exact provider marker.
- Landed correction: retain the proof for ambiguous failures, parse typed stale errors, and check exact already-applied provider state before applying freshness to any new mutation.
- Required coverage and frontend re-reviews completed with zero remaining findings.

## Verification

- `pnpm test:diff <remediation paths>` on current `main`
  - dependency, workspace-boundary, crypto, log-payload, and hosted architecture guards passed
  - hosted-web TypeScript passed
  - dev smoke passed
  - lint passed with 13 unrelated existing warnings and no errors
  - 424 test files passed; 5,060 tests passed; 2 files / 139 tests skipped
  - production Next build passed
- Focused service, route, and client Vitest: 3 files, 28 tests passed
- Coverage remediation subset: 2 files, 18 tests passed
- `git diff --check`, privacy scan, coverage review, and frontend re-review passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786678915&installation_id=127572939&pr_number=662&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F662&signature=4ffeee3ca610e631a3ef54203f847087ed1b4dea72fbb3dd54977680c828e2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->