### PR TITLE
Add safe Pulse Trial Stripe diagnostics

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-14-trial-extension-provider-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-trial-extension-provider-diagnostics.md
@@ -1,0 +1,78 @@
+# Pulse Trial provider diagnostics
+
+Status: completed
+Created: 2026-07-14
+Updated: 2026-07-15
+
+## Goal
+
+- Make a failed single-member Pulse Trial Stripe lookup diagnosable from
+  production logs without exposing member or provider identifiers, then use
+  that evidence to fix and verify the production failure.
+
+## Success criteria
+
+- Stripe retrieve and update failures emit one bounded structured error log with
+  the operation and safe provider metadata only.
+- Logs never include member, customer, subscription, request, credential, or
+  provider-message values.
+- Focused tests prove the safe field projection and both failure call paths.
+- The exact pushed head passes routed verification, required audits,
+  ReviewGPT, and CI before production deployment.
+- A production Preview for the affected member either succeeds or yields the
+  safe diagnostic needed for a follow-up root-cause fix.
+
+## Scope
+
+- In scope: `apps/web` Pulse Trial extension provider-error projection,
+  structured error logging, focused tests, PR/deploy proof, and the smallest
+  evidence-backed follow-up fix if the new log identifies one.
+- Out of scope: changing trial eligibility, bulk campaign behavior, billing
+  schema, Stripe credentials, or unrelated hosted billing flows.
+
+## Constraints
+
+- Stripe remains authoritative and member billing behavior must not change in
+  the diagnostics-only patch.
+- Keep logs content-free and identifier-free; provider messages and raw errors
+  are forbidden.
+- Reuse the existing single-member extension owner and add no dependency,
+  persisted state, queue, retry loop, or compatibility path.
+
+## Risks and mitigations
+
+1. Risk: provider errors can contain billing identifiers or request context.
+   Mitigation: project only bounded allowlisted type/code, numeric HTTP status,
+   and request-id presence; never log the raw error or message.
+2. Risk: logging changes accidentally alter failure behavior.
+   Mitigation: retain the existing typed provider error and assert the same
+   caller-visible result in focused tests.
+3. Risk: deployment backlog obscures which code handled the retry.
+   Mitigation: record and verify the production alias deployment SHA before
+   interpreting the post-deploy log.
+
+## Tasks
+
+1. Add the narrow safe Stripe error projector and error logs at retrieve/update.
+2. Add focused regression coverage for allowed and forbidden log fields.
+3. Run scoped verification, coverage audit, and parent final review.
+4. Finish the plan-bearing commit, open the PR, start ReviewGPT concurrently
+   with CI, and resolve all findings.
+5. Merge/deploy, verify the production alias head, retry Preview, and use the
+   resulting evidence for the smallest root-cause fix if needed.
+
+## Verification
+
+- Focused provider and route tests pass with 23 tests.
+- Focused ESLint and TypeScript checks pass.
+- `pnpm test:diff` passes, including 5,098 hosted-web tests and the production
+  Next.js build; its 13 lint warnings are unrelated pre-existing warnings.
+- The required `coverage-write` audit and parent final review found no
+  unresolved actionable gaps.
+
+## State
+
+The diagnostics-only implementation, focused verification, required coverage
+audit, full routed verification, and parent final review are complete. Exact-head
+PR CI, ReviewGPT, deployment, and the production Preview remain.
+Completed: 2026-07-15

--- a/apps/web/app/api/ops/pulse-trial-extension/route.ts
+++ b/apps/web/app/api/ops/pulse-trial-extension/route.ts
@@ -67,6 +67,10 @@ export const POST = withJsonError(async (request: Request) => {
       });
     }
     if (error instanceof HostedPulseTrialExtensionProviderError) {
+      console.error(
+        "Hosted ops member Pulse Trial Stripe request failed.",
+        error.logDetails,
+      );
       throw hostedOnboardingError({
         code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PROVIDER_UNAVAILABLE",
         httpStatus: 502,

--- a/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
+++ b/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
@@ -40,6 +40,8 @@ const PREVIEW_TOKEN_PREFIX = "pulse-member-preview-v1";
 const PREVIEW_HMAC_CONTEXT = "hosted-member-pulse-trial-extension-preview-v1";
 const EXTENSION_OPERATION_METADATA_KEY = "murphTrialExtensionOperation";
 const EXTENSION_DAYS_METADATA_KEY = "murphTrialExtensionDays";
+const STRIPE_ERROR_IDENTIFIER_PREFIX =
+  /^(?:acct|ch|cus|hbm|pi|pk|pm|price|req|rk|seti|sk|src|sub|whsec)_/iu;
 
 export const HOSTED_PULSE_TRIAL_EXTENSION_DAYS = 7 as const;
 
@@ -158,9 +160,23 @@ export class HostedPulseTrialExtensionPreviewStaleError extends Error {
 }
 
 export class HostedPulseTrialExtensionProviderError extends Error {
-  constructor() {
+  readonly logDetails: Record<string, unknown>;
+
+  constructor(input: {
+    error?: unknown;
+    operationName:
+      | "retrieve_subscription"
+      | "update_subscription"
+      | "validate_updated_subscription";
+  }) {
     super("Stripe could not confirm this trial extension request.");
     this.name = "HostedPulseTrialExtensionProviderError";
+    this.logDetails = {
+      operationName: input.operationName,
+      ...(Object.prototype.hasOwnProperty.call(input, "error")
+        ? describeSafeHostedPulseTrialExtensionStripeError(input.error)
+        : {}),
+    };
   }
 }
 
@@ -324,8 +340,11 @@ export async function applyHostedPulseTrialExtension(
               ...buildHostedPulseTrialExtensionStripeRequestOptions(),
             },
           );
-        } catch {
-          throw new HostedPulseTrialExtensionProviderError();
+        } catch (error) {
+          throw new HostedPulseTrialExtensionProviderError({
+            error,
+            operationName: "update_subscription",
+          });
         }
 
         if (!isHostedPulseTrialExtensionAlreadyApplied({
@@ -335,7 +354,9 @@ export async function applyHostedPulseTrialExtension(
           subscription: updatedSubscription,
           targetTrialEnd: proofDates.targetTrialEndUnix,
         })) {
-          throw new HostedPulseTrialExtensionProviderError();
+          throw new HostedPulseTrialExtensionProviderError({
+            operationName: "validate_updated_subscription",
+          });
         }
 
         const reconciledMember = await reconcileHostedPulseTrialExtensionLocalState({
@@ -414,8 +435,11 @@ async function inspectHostedPulseTrialExtensionState(input: {
       billingRef.stripeSubscriptionId,
       buildHostedPulseTrialExtensionStripeRequestOptions(),
     );
-  } catch {
-    throw new HostedPulseTrialExtensionProviderError();
+  } catch (error) {
+    throw new HostedPulseTrialExtensionProviderError({
+      error,
+      operationName: "retrieve_subscription",
+    });
   }
 
   const providerReason = classifyHostedPulseTrialExtensionProviderState({
@@ -929,6 +953,64 @@ function buildHostedPulseTrialExtensionStripeRequestOptions(): Stripe.RequestOpt
     maxNetworkRetries: STRIPE_REQUEST_MAX_NETWORK_RETRIES,
     timeout: STRIPE_REQUEST_TIMEOUT_MS,
   };
+}
+
+function describeSafeHostedPulseTrialExtensionStripeError(
+  error: unknown,
+): Record<string, unknown> {
+  if (!error || typeof error !== "object") {
+    return { type: typeof error };
+  }
+
+  const code = readSafeHostedPulseTrialExtensionStripeErrorToken(
+    readHostedPulseTrialExtensionStripeErrorField(error, "code"),
+  );
+  const type = readSafeHostedPulseTrialExtensionStripeErrorToken(
+    readHostedPulseTrialExtensionStripeErrorField(error, "type"),
+  ) ?? readSafeHostedPulseTrialExtensionStripeErrorToken(
+    readHostedPulseTrialExtensionStripeErrorField(error, "rawType"),
+  );
+  const statusCode = readHostedPulseTrialExtensionStripeErrorField(
+    error,
+    "statusCode",
+  );
+  const requestId = readHostedPulseTrialExtensionStripeErrorField(
+    error,
+    "requestId",
+  );
+
+  return {
+    ...(code ? { code } : {}),
+    ...(type ? { type } : {}),
+    ...(typeof statusCode === "number" &&
+        Number.isInteger(statusCode) &&
+        statusCode >= 100 &&
+        statusCode <= 599
+      ? { statusCode }
+      : {}),
+    requestIdPresent: typeof requestId === "string" && requestId.length > 0,
+  };
+}
+
+function readSafeHostedPulseTrialExtensionStripeErrorToken(
+  value: unknown,
+): string | null {
+  return typeof value === "string" &&
+      /^[A-Za-z0-9_.-]{1,120}$/u.test(value) &&
+      !STRIPE_ERROR_IDENTIFIER_PREFIX.test(value)
+    ? value
+    : null;
+}
+
+function readHostedPulseTrialExtensionStripeErrorField(
+  error: object,
+  field: "code" | "rawType" | "requestId" | "statusCode" | "type",
+): unknown {
+  try {
+    return Reflect.get(error, field);
+  } catch {
+    return undefined;
+  }
 }
 
 function coerceStripeCustomerId(

--- a/apps/web/test/hosted-ops-pulse-trial-extension-route.test.ts
+++ b/apps/web/test/hosted-ops-pulse-trial-extension-route.test.ts
@@ -50,6 +50,7 @@ const PREVIEW_PROOF: HostedPulseTrialExtensionPreviewProof = {
 };
 
 let route: RouteModule;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
 const originalOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
 
@@ -63,6 +64,7 @@ describe("hosted ops member Pulse Trial extension route", () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(NOW);
     process.env.HOSTED_OPS_MEMBER_IDS = OPERATOR_MEMBER_ID;
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
       member: { id: OPERATOR_MEMBER_ID },
@@ -75,6 +77,7 @@ describe("hosted ops member Pulse Trial extension route", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    consoleErrorSpy.mockRestore();
     consoleInfoSpy.mockRestore();
     if (originalOpsMemberIds === undefined) {
       delete process.env.HOSTED_OPS_MEMBER_IDS;
@@ -158,7 +161,16 @@ describe("hosted ops member Pulse Trial extension route", () => {
     mocks.applyHostedPulseTrialExtension
       .mockRejectedValueOnce(new HostedPulseTrialExtensionPreviewStaleError())
       .mockRejectedValueOnce(new HostedPulseTrialExtensionLockBusyError())
-      .mockRejectedValueOnce(new HostedPulseTrialExtensionProviderError());
+      .mockRejectedValueOnce(new HostedPulseTrialExtensionProviderError({
+        error: {
+          code: "resource_missing",
+          message: `sensitive ${TARGET_MEMBER_ID}`,
+          requestId: "req_private",
+          statusCode: 404,
+          type: "StripeInvalidRequestError",
+        },
+        operationName: "retrieve_subscription",
+      }));
 
     const stale = await route.POST(makeRequest({
       memberId: TARGET_MEMBER_ID,
@@ -180,6 +192,27 @@ describe("hosted ops member Pulse Trial extension route", () => {
     assert.equal(busy.status, 409);
     assert.equal(unavailable.status, 502);
     expect(mocks.applyHostedPulseTrialExtension).toHaveBeenCalledTimes(3);
+    assert.deepEqual(await unavailable.json(), {
+      error: {
+        code: "HOSTED_OPS_PULSE_TRIAL_EXTENSION_PROVIDER_UNAVAILABLE",
+        message: "Stripe could not confirm this trial extension request.",
+        retryable: true,
+      },
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy.mock.calls[0]).toEqual([
+      "Hosted ops member Pulse Trial Stripe request failed.",
+      {
+        code: "resource_missing",
+        operationName: "retrieve_subscription",
+        requestIdPresent: true,
+        statusCode: 404,
+        type: "StripeInvalidRequestError",
+      },
+    ]);
+    expect(JSON.stringify(consoleErrorSpy.mock.calls[0])).not.toMatch(
+      /hbm_|req_|sensitive/u,
+    );
   });
 
   test("rejects retired campaign and batch modes", async () => {

--- a/apps/web/test/hosted-pulse-trial-extension.test.ts
+++ b/apps/web/test/hosted-pulse-trial-extension.test.ts
@@ -495,16 +495,174 @@ describe("single-member Pulse Trial extension", () => {
       async (input: { run: (tx: object) => Promise<unknown> }) => input.run({}),
     );
     stripe.retrieveSubscription.mockResolvedValue(paused);
-    stripe.updateSubscription.mockRejectedValueOnce(new Error("provider unavailable"));
-    await expect(applyHostedPulseTrialExtension({
+    stripe.updateSubscription.mockRejectedValueOnce({
+      code: "api_connection_error",
+      message: `sensitive ${MEMBER_ID} ${CUSTOMER_ID} ${SUBSCRIPTION_ID}`,
+      requestId: "req_private",
+      statusCode: 503,
+      type: "StripeConnectionError",
+    });
+    const updateError = await applyHostedPulseTrialExtension({
       memberId: MEMBER_ID,
       now: new Date("2026-07-14T16:02:00.000Z"),
       previewProof: preview.previewProof,
       priceId: PRICE_ID,
       prisma: {} as never,
       stripe,
-    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+    }).catch((error: unknown) => error);
 
+    expect(updateError).toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+    expect((updateError as HostedPulseTrialExtensionProviderError).logDetails)
+      .toEqual({
+        code: "api_connection_error",
+        operationName: "update_subscription",
+        requestIdPresent: true,
+        statusCode: 503,
+        type: "StripeConnectionError",
+      });
+    expect(JSON.stringify(
+      (updateError as HostedPulseTrialExtensionProviderError).logDetails,
+    )).not.toMatch(/hbm_|cus_|sub_|req_|sensitive/u);
+
+    expect(mocks.updateHostedMemberCoreState).not.toHaveBeenCalled();
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+    expect(
+      mocks.reconcileHostedAiUsageAllowancePeriodForMemberTx,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("projects a failed Stripe lookup into identifier-free diagnostics", async () => {
+    const stripe = makeStripeClient(makeSubscription());
+    stripe.retrieveSubscription.mockRejectedValueOnce({
+      code: "resource_missing",
+      message: `No such subscription: ${SUBSCRIPTION_ID}`,
+      param: "subscription",
+      rawType: "invalid_request_error",
+      requestId: "req_private",
+      statusCode: 404,
+    });
+
+    const lookupError = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    }).catch((error: unknown) => error);
+
+    expect(lookupError).toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+    expect((lookupError as HostedPulseTrialExtensionProviderError).logDetails)
+      .toEqual({
+        code: "resource_missing",
+        operationName: "retrieve_subscription",
+        requestIdPresent: true,
+        statusCode: 404,
+        type: "invalid_request_error",
+      });
+    expect(JSON.stringify(
+      (lookupError as HostedPulseTrialExtensionProviderError).logDetails,
+    )).not.toMatch(/hbm_|cus_|sub_|req_|message|param/u);
+  });
+
+  test("rejects identifier-shaped metadata and tolerates throwing provider getters", async () => {
+    const stripe = makeStripeClient(makeSubscription());
+    stripe.retrieveSubscription
+      .mockRejectedValueOnce({
+        code: "whsec_private",
+        rawType: SUBSCRIPTION_ID,
+        requestId: "req_private",
+        statusCode: 600,
+        type: "sk_private",
+      })
+      .mockRejectedValueOnce(Object.defineProperties({}, {
+        code: {
+          get: () => {
+            throw new Error(`sensitive ${MEMBER_ID}`);
+          },
+        },
+        rawType: { get: () => "invalid_request_error" },
+        requestId: {
+          get: () => {
+            throw new Error("sensitive request ID");
+          },
+        },
+        statusCode: {
+          get: () => {
+            throw new Error("sensitive status");
+          },
+        },
+        type: {
+          get: () => {
+            throw new Error("sensitive type");
+          },
+        },
+      }));
+
+    const identifierError = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    }).catch((error: unknown) => error);
+    const getterError = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    }).catch((error: unknown) => error);
+
+    expect(identifierError).toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+    expect((identifierError as HostedPulseTrialExtensionProviderError).logDetails)
+      .toEqual({
+        operationName: "retrieve_subscription",
+        requestIdPresent: true,
+      });
+    expect(getterError).toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+    expect((getterError as HostedPulseTrialExtensionProviderError).logDetails)
+      .toEqual({
+        operationName: "retrieve_subscription",
+        requestIdPresent: false,
+        type: "invalid_request_error",
+      });
+    expect(JSON.stringify([
+      (identifierError as HostedPulseTrialExtensionProviderError).logDetails,
+      (getterError as HostedPulseTrialExtensionProviderError).logDetails,
+    ])).not.toMatch(/cus_|hbm_|req_|sensitive|sk_|sub_|whsec_/u);
+  });
+
+  test("identifies post-update validation failure without local reconciliation", async () => {
+    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
+    const stripe = makeStripeClient(paused);
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!preview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    stripe.retrieveSubscription.mockResolvedValue(paused);
+    stripe.updateSubscription.mockResolvedValue(makeSubscription({
+      status: "trialing",
+      trialEnd: TARGET_FROM_PAUSED,
+    }));
+
+    const validationError = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    }).catch((error: unknown) => error);
+
+    expect(validationError).toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+    expect((validationError as HostedPulseTrialExtensionProviderError).logDetails)
+      .toEqual({ operationName: "validate_updated_subscription" });
     expect(mocks.updateHostedMemberCoreState).not.toHaveBeenCalled();
     expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
     expect(


### PR DESCRIPTION
## Why

The single-member Pulse Trial Preview converted every Stripe retrieve/update failure into the same generic 502 and discarded all provider category metadata. The production failure therefore could not be distinguished as missing provider state, authentication, transport, or validation without exposing raw Stripe errors.

## User-visible goal and UX

Ops members keep the existing Preview and Apply behavior. Successful requests are unchanged, and failed Stripe checks still return the same generic retryable 502 with no provider details. Production logs now identify the failing operation and only bounded, identifier-free provider category fields so the underlying incident can be diagnosed safely.

## Invariants

- Stripe remains authoritative; trial eligibility, billing mutation order, idempotency, and local reconciliation are unchanged.
- Raw Stripe errors, messages, params, member/customer/subscription/request values, and credentials are never logged.
- The caller-visible 502 status and JSON body are unchanged.
- No schema, dependency, persisted-state, queue, or cross-runtime protocol changes.

## Verification

- Focused provider and route tests: 23 passed.
- Focused ESLint and TypeScript checks passed.
- `pnpm test:diff` passed, including 5,098 hosted-web tests and the production Next.js build; 13 unrelated pre-existing lint warnings remain.
- Required coverage-write audit and parent final review found no unresolved actionable gaps.

## Change shape

Classification rule: runtime implementation is source; regression suites are tests; the archived execution plan is docs; no file is counted twice.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 92 | 6 |
| Tests | 195 | 4 |
| Docs | 78 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **365** | **10** |

No binary or generated artifacts are included.

## Deployment

Vercel-only additive logging change. No coordinated Cloudflare deployment, compatibility window, migration, or special ordering is required. Old and new functions both preserve the same generic 502 contract.

ReviewGPT first-reviewed head: 37888d8d8990fbca40fee278820104e4d524cb13

| ReviewGPT baseline | Commit |
| --- | --- |
| Round 1 full patch | `37888d8d8990fbca40fee278820104e4d524cb13` |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786680974&installation_id=127572939&pr_number=663&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F663&signature=6abaf61cac93e66ee166f8c1ecf6a9b3364ecd8a734a058361b2ae11f98c621f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->