### PR TITLE
Bind affirmative reactions to exact Murph targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -388,7 +388,8 @@ delivery on the same route before the synthetic `Yes.` can reach reply
 generation. Synthetic reactions stay in one-input automation groups, so an
 adjacent ordinary reply cannot lend them trust or be suppressed with them.
 This keeps the path independent of Linq's short provider-message retention
-while recovering cross-session target context from existing truth.
+while rendering the exact same- or cross-session target from existing outbox
+truth.
 Unmatched targets are terminally silent, and synthetic reaction identities are
 excluded from message read receipts and provider-message cleanup. The reaction
 path adds no mailbox kind, state, or lifecycle. Existing group join-offer

--- a/agent-docs/exec-plans/completed/2026-07-14-pr655-exact-reaction-target.md
+++ b/agent-docs/exec-plans/completed/2026-07-14-pr655-exact-reaction-target.md
@@ -1,0 +1,45 @@
+Goal (incl. success criteria):
+- Resolve PR #655 ReviewGPT round 2 without adding state or rollout machinery.
+- An affirmative reaction always carries the exact attested sent Murph target into model-visible context, including same-session delayed reactions.
+- The durable deploy guide records the marker-aware runner-first order and rollback floor for independent Web/Cloudflare deployment.
+- Success means focused proof, required coverage audit, green exact-head CI, and a passing ReviewGPT correction round.
+
+Constraints/Assumptions:
+- Reuse the outbox deliveries already loaded for attestation; add no provider read, query, schema, queue, state, or lifecycle.
+- Preserve cross-session fallback semantics for ordinary inputs.
+- Preserve the existing immediate rollout, runner fingerprint admission, and managed-container smoke controls; document rather than duplicate them.
+- Preserve private and group reaction behavior and unrelated working-tree/ledger work.
+
+Key decisions:
+- Return the exact reply-target delivery separately from the cross-session-only context candidate.
+- Render a narrow affirmative-reaction target context from the exact stored outbox message for both same- and cross-session matches.
+- Keep the marker-aware runner as a rollback floor once Web can emit synthetic reaction wakes.
+
+State:
+- ReviewGPT round 2 findings accepted; implementation and focused proof complete.
+
+Done:
+- Confirmed the same-session filter discards the exact target message after attestation.
+- Confirmed the existing cross-session context wording is inaccurate for a same-session reaction target.
+- Confirmed deploy fingerprint admission and immediate rollout already exist; only the reaction-specific order/floor is missing from the durable deploy guide.
+- Reused the already-loaded exact reply-target delivery for same- and cross-session affirmative-reaction context without adding a query or state.
+- Documented the marker-aware runner-first rollout and rollback floor using the existing immediate-rollout and fingerprint-smoke controls.
+- Added direct same-session older-target proof; the fresh coverage-write audit found no unresolved actionable gap after one test-only assertion improvement.
+- Passed focused assistant-engine proof, assistant-engine typecheck/build, diff checks, and diff-aware affected package/app verification.
+
+Now:
+- Close the scoped plan and commit.
+
+Next:
+- Merge current main without rewriting the first-reviewed ancestor, push, then run ReviewGPT round 3 concurrently with exact-head CI.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set:
+- packages/assistant-engine/src/assistant/automation/reply.ts
+- packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
+- apps/cloudflare/DEPLOY.md
+Status: completed
+Updated: 2026-07-15
+Completed: 2026-07-15

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -96,6 +96,32 @@ after a new web producer consumes it. Runner-first deployment avoids that
 feature-only loss. Either side may otherwise roll back independently because
 the strict persisted assistant-input schema is unchanged.
 
+## Linq Affirmative-Reaction Rollout
+
+The affirmative-reaction adapter transfers target authorship from a live Linq
+message read to an optional wake marker plus exact same-route sent-outbox
+attestation in the runner. Old Web with a marker-aware runner is safe; new Web
+with an old runner is unsafe because the old tolerant parser drops the marker
+and imports the synthetic `Yes.` as an ordinary message.
+
+Roll out the first marker-aware release in this order:
+
+1. Deploy the Cloudflare Worker and runner bundle with
+   `container_rollout=immediate`. Require the predeploy parser/importer tests
+   for that exact commit and managed-container smoke reporting its runner-bundle
+   fingerprint before processing the new wake shape.
+2. Deploy `apps/web` only after the runner fleet has converged.
+3. Smoke an affirmative reaction to an exact Murph delivery in both a private
+   and group chat, then verify that a reaction to a participant-authored target
+   is terminally suppressed before model execution.
+
+Once Web can emit a synthetic affirmative-reaction wake, that marker-aware
+runner bundle is a rollback floor while any such mailbox item or imported input
+can remain. Do not independently restore an older runner; roll Web back first,
+prove no synthetic reaction work remains, and otherwise use a forward fix on
+the marker-aware bundle or newer. Existing runner fingerprint admission rejects
+stale warm containers, but it does not make an old deployed parser compatible.
+
 ## Linq Provider-Claim Protocol
 
 Every Linq provider entry uses one Web-owned authorization and atomic dispatch

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -1268,10 +1268,12 @@ async function evaluateAssistantAutoReplyGroup(input: {
       ),
       session: existingSession,
     })
-  if (
+  const affirmativeReaction =
     primaryReplyInput.sourceMetadata?.kind === 'linq' &&
-    primaryReplyInput.sourceMetadata.affirmativeReaction === true &&
-    !outboxContext.replyTargetAttested
+    primaryReplyInput.sourceMetadata.affirmativeReaction === true
+  if (
+    affirmativeReaction &&
+    outboxContext.replyTargetDelivery === null
   ) {
     return createAdvancingSkipDecision(
       'affirmative Linq reaction target is not an attested assistant delivery',
@@ -1308,9 +1310,13 @@ async function evaluateAssistantAutoReplyGroup(input: {
     operatorAuthority: 'direct-operator',
     primaryInput: primaryReplyInput,
     prompt: preparedInput.prompt,
-    turnContext: buildAssistantAutoReplyCrossSessionTurnContext(
-      latestCrossSessionDelivery?.message ?? null,
-    ),
+    turnContext: affirmativeReaction
+      ? buildAssistantAutoReplyAffirmativeReactionTurnContext(
+          outboxContext.replyTargetDelivery?.message ?? null,
+        )
+      : buildAssistantAutoReplyCrossSessionTurnContext(
+          latestCrossSessionDelivery?.message ?? null,
+        ),
     userMessageContent: preparedInput.userMessageContent,
   }
 }
@@ -3552,14 +3558,14 @@ async function resolveAssistantAutoReplyLatestCrossSessionDelivery(input: {
   session: AssistantSession | null
 }): Promise<{
   delivery: AssistantAutoReplyMatchingOutboxDelivery | null
-  replyTargetAttested: boolean
+  replyTargetDelivery: AssistantAutoReplyMatchingOutboxDelivery | null
 }> {
   const channel = normalizeNullableString(input.input.source)
   const deliveryTarget = normalizeNullableString(input.deliveryTarget)
   if (!channel || !deliveryTarget) {
     return {
       delivery: null,
-      replyTargetAttested: false,
+      replyTargetDelivery: null,
     }
   }
 
@@ -3569,10 +3575,12 @@ async function resolveAssistantAutoReplyLatestCrossSessionDelivery(input: {
       historyReader: input.historyReader,
       input: input.input,
     })
-  const replyTargetAttested = input.replyToMessageId !== null &&
-    matchingDeliveries.some((delivery) =>
-      delivery.providerMessageIds.includes(input.replyToMessageId!),
-    )
+  const replyToMessageId = input.replyToMessageId
+  const replyTargetDelivery = replyToMessageId === null
+    ? null
+    : matchingDeliveries.find((delivery) =>
+        delivery.providerMessageIds.includes(replyToMessageId),
+      ) ?? null
   const sessionEligible = matchingDeliveries
     .filter((delivery) =>
       input.session === null || delivery.sessionId !== input.session.sessionId,
@@ -3590,12 +3598,12 @@ async function resolveAssistantAutoReplyLatestCrossSessionDelivery(input: {
   // stale deliveries; an exact provider-id match across the same route can't
   // be either. The send-ack/inbound-webhook race that records sentAt after
   // the inbound input's receivedAt is the realistic case this protects.
-  if (input.replyToMessageId) {
+  if (replyToMessageId) {
     return {
       delivery: sessionEligible.find((delivery) =>
-        delivery.providerMessageIds.includes(input.replyToMessageId!),
+        delivery.providerMessageIds.includes(replyToMessageId),
       ) ?? null,
-      replyTargetAttested,
+      replyTargetDelivery,
     }
   }
 
@@ -3605,7 +3613,7 @@ async function resolveAssistantAutoReplyLatestCrossSessionDelivery(input: {
   if (causalUpperBoundMs === null) {
     return {
       delivery: null,
-      replyTargetAttested,
+      replyTargetDelivery,
     }
   }
 
@@ -3615,7 +3623,7 @@ async function resolveAssistantAutoReplyLatestCrossSessionDelivery(input: {
   if (fresh.length === 0) {
     return {
       delivery: null,
-      replyTargetAttested,
+      replyTargetDelivery,
     }
   }
 
@@ -3632,7 +3640,7 @@ async function resolveAssistantAutoReplyLatestCrossSessionDelivery(input: {
   }
   return {
     delivery: fresh.slice(firstFreshIndex).at(-1) ?? null,
-    replyTargetAttested,
+    replyTargetDelivery,
   }
 }
 
@@ -3885,6 +3893,24 @@ function buildAssistantAutoReplyCrossSessionTurnContext(
     normalized.slice(0, ASSISTANT_AUTO_REPLY_PRIOR_MESSAGE_MAX_LENGTH),
     '',
     'Use it only to interpret the current user message.',
+  ].join('\n')
+}
+
+function buildAssistantAutoReplyAffirmativeReactionTurnContext(
+  message: string | null,
+): string | null {
+  const normalized = normalizeNullableString(message)
+  if (!normalized) {
+    return null
+  }
+
+  return [
+    'Affirmative reaction target:',
+    'The user reacted affirmatively to this exact assistant message:',
+    '',
+    normalized.slice(0, ASSISTANT_AUTO_REPLY_PRIOR_MESSAGE_MAX_LENGTH),
+    '',
+    'Bind the affirmative response only to this message.',
   ].join('\n')
 }
 

--- a/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
@@ -1127,7 +1127,7 @@ describe('assistant auto-reply event-first path', () => {
     expect(result.terminalLinqCleanup).toBeUndefined()
   })
 
-  it('admits an attested same-session affirmative Linq reaction without duplicating turn context', async () => {
+  it('binds an attested same-session affirmative Linq reaction to the exact older target', async () => {
     const vault = await createTempVault()
     replyEventPathMocks.resolveAssistantSession.mockResolvedValue({
       created: false,
@@ -1143,6 +1143,14 @@ describe('assistant auto-reply event-first path', () => {
         message: 'Would you like me to continue?',
         providerMessageId: 'linq-msg-same-session-target',
         sentAt: '2026-04-08T00:05:00.000Z',
+        sessionId: 'session-chat',
+      }),
+      createOutboxMessage({
+        channel: 'linq',
+        intentId: 'intent-newer-same-session-message',
+        message: 'Should I send the newer message?',
+        providerMessageId: 'linq-msg-newer-same-session',
+        sentAt: '2026-04-08T00:06:00.000Z',
         sessionId: 'session-chat',
       }),
     ])
@@ -1184,8 +1192,15 @@ describe('assistant auto-reply event-first path', () => {
     })
     expect(result.terminalLinqCleanup).toBeUndefined()
     expect(replyEventPathMocks.sendAssistantMessage).toHaveBeenCalledTimes(1)
-    expect(replyEventPathMocks.sendAssistantMessage.mock.calls[0]?.[0].turnContext)
-      .toBeUndefined()
+    const sendInput = replyEventPathMocks.sendAssistantMessage.mock.calls[0]?.[0]
+    const turnContext = sendInput?.turnContext
+    expect(turnContext).toContain('Affirmative reaction target:')
+    expect(turnContext).toContain('Would you like me to continue?')
+    expect(turnContext).not.toContain('Should I send the newer message?')
+    expect(turnContext).not.toContain('another assistant run')
+    expect(sendInput?.receiptMetadata).not.toHaveProperty(
+      AUTO_REPLY_RECEIPT_CROSS_SESSION_CONTEXT_INTENT_ID_KEY,
+    )
   })
 
   it('terminally suppresses an affirmative Linq reaction without an exact same-route sent target', async () => {


### PR DESCRIPTION
## Why

PR #655 validates that an affirmative Linq reaction targets a sent Murph delivery. A delayed same-session reaction could still reach the model without the exact reacted-to message in turn context, allowing a newer Murph question to capture the synthetic `Yes.`.

## User-visible goal

When someone reacts affirmatively to an older Murph message, Murph responds to that exact message in both private and group chats.

## What changed

- Reuse the exact same-route outbox delivery already loaded for target attestation.
- Render that exact target as affirmative-reaction context for same- and cross-session reactions.
- Keep ordinary cross-session context behavior unchanged.
- Add a regression proving a newer same-session message cannot steal the reaction.
- Document the existing Cloudflare-first immediate rollout and marker-aware rollback floor.

## Invariants

- Reactions to participant-authored or unmatched targets remain terminally suppressed before model execution.
- No provider message fetch, new query, schema, state, queue, dependency, feature flag, or lifecycle is added.
- Private and group behavior share the same adapter and existing reply planner.
- Synthetic reactions remain isolated from ordinary-input grouping, read receipts, and provider cleanup.

## Verification

- Assistant-engine typecheck passed.
- Focused reaction/grouping tests passed: 38/38.
- Fresh coverage-write audit completed with no unresolved actionable findings.
- Diff-aware affected package and Cloudflare verification passed on the identical source tree.
- Exact-head GitHub CI passed completely, including release coverage and both aggregate hosted gates.
- `git diff --check` and privacy/scope scans passed.
- ReviewGPT artifact attempts were invalid because two routed contracts were absent from the generated ZIP; they issued no substantive merge disposition.

## Deployment concerns

Deploy the marker-aware Cloudflare Worker and runner first with immediate rollout. Require exact-commit parser/importer proof and the managed-container bundle fingerprint smoke before deploying Web. Keep that runner version as the rollback floor while synthetic reaction work can remain, then smoke private, group, and participant-authored-target suppression paths.

ReviewGPT first-reviewed head: 3d3da512cec8a71757a7017b5c676efbc006786e