### PR TITLE
fix: persist safe hosted runtime failure diagnostics

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-hosted-runtime-safe-error-detail.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-hosted-runtime-safe-error-detail.md
@@ -1,0 +1,99 @@
+# Persist privacy-safe hosted runtime failure diagnostics
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Make accepted hosted-runtime attempt failures operationally diagnosable by
+  persisting the bounded detail and cause already produced by the shared safe
+  error-diagnostics owner.
+
+## Success criteria
+
+- `runner.accepted_attempt_failed` retains `safeErrorDetail` and
+  `safeErrorCause` when present, alongside the stable summary and code.
+- Hosted member IDs, workflow IDs, paths, URLs, credentials, contact details,
+  and tokens remain redacted before the diagnostic crosses the runtime-log
+  boundary.
+- The shared runtime-log parser accepts the new values and focused tests prove
+  the failure record contains useful sanitized detail without raw identifiers.
+- Required Cloudflare/shared-package verification, coverage review, CI, and
+  exact-head ReviewGPT complete before the production deploy.
+
+## Scope
+
+- In scope: the shared hosted-execution text redactor and matching persisted-log
+  parser contract, Cloudflare runner diagnostic projection, and focused
+  regression tests.
+- Out of scope: runtime repair operations, runner lifecycle or retry behavior,
+  mailbox semantics, database schema, and user-facing Web behavior.
+
+## Constraints
+
+- Reuse the existing bounded safe-error diagnostics rather than introducing a
+  second sanitizer, persisted state owner, or raw exception channel.
+- Persist no stack preview, nested error object, payload, workspace path, or
+  direct member identifier.
+- Avoid files owned by active runner lifecycle and container-entrypoint lanes.
+
+## Risks and mitigations
+
+1. Risk: diagnostic text can contain a hosted opaque identifier not covered by
+   the existing `member_` and `user_` patterns.
+   Mitigation: redact the canonical hosted prefixed-ID shape in the shared
+   sanitizer and cover it with a synthetic identifier regression test.
+2. Risk: an otherwise safe diagnostic key can make Web reject the complete log
+   request.
+   Mitigation: use the already allowlisted `safeErrorDetail` and
+   `safeErrorCause` keys, keep the parser fail-closed for raw secret-shaped
+   values while accepting exact redaction sentinels, and parse the resulting
+   request in focused coverage. Deploy the backward-compatible Web parser
+   before the Cloudflare producer starts sending the enriched values.
+3. Risk: widening observability changes the runtime behavior or retry loop.
+   Mitigation: change only metadata projection; leave invocation, fence,
+   checkpoint, and retry control flow untouched.
+
+## Tasks
+
+1. Add hosted opaque-ID redaction coverage to the shared sanitizer.
+2. Project shared sanitized error detail and cause into persisted runner logs.
+3. Run focused and owner verification, required coverage review, and parent
+   final review.
+4. Finish the scoped commit, push and open the PR, then run ReviewGPT and CI in
+   parallel, merge, and deploy the exact merged main revision immediately.
+
+## Verification
+
+- Focused hosted-execution observability test.
+- Focused Cloudflare accepted-attempt transport-failure test.
+- Cloudflare/shared-owner typecheck and acceptance verification routed by the
+  repository verification map.
+- `git diff --check`, required `coverage-write` pass, exact-head ReviewGPT, PR
+  CI, and clean merge proof against current `main`.
+
+Completed locally:
+
+- Focused hosted-execution tests: 53 passed.
+- Focused Cloudflare transport-failure tests: 22 passed.
+- Hosted-execution and Cloudflare typechecks passed.
+- Cloudflare owner verification: 105 files and 1,806 tests passed.
+- A full acceptance run passed before the final parser hardening. The repeated
+  acceptance run passed all changed owners, Cloudflare verification, Web tests,
+  lint, and production build; one unrelated CLI expansion test timed out under
+  concurrent coverage load, and the command was stopped after its remaining
+  workspace tail produced no output for more than 90 seconds.
+- `git diff --check` passed.
+
+## Audit outcomes
+
+- Coverage-write added production-path proof at the accepted-attempt harness.
+  It exposed a shared sanitizer/parser mismatch where exact `[redacted]`
+  credential sentinels were rejected as secret-shaped content. The parser now
+  accepts only bounded exact sentinels while continuing to reject raw and
+  suffix-adjacent secret values.
+- The enriched harness serializes and reparses the real runtime-log request and
+  proves hosted IDs, paths, URLs, email, phone, tokens, and bearer credentials
+  do not survive into persisted diagnostics. No coverage finding remains.
+Completed: 2026-07-15

--- a/apps/cloudflare/src/user-runner/diagnostics.ts
+++ b/apps/cloudflare/src/user-runner/diagnostics.ts
@@ -110,17 +110,18 @@ export function readRunnerWriteFenceValidationRejectReason(input: {
 }
 
 /**
- * Same metadata-only picks as `buildHostedRunnerMetadataOnlyErrorDetails`, but
- * narrowed to the persisted runtime-log `redactedJson` value shape. Keys must
- * pass the hosted runtime-log redacted-key gate; the sanitized error summary is
- * emitted under the allowlisted `safeErrorMessage` key because bare
- * `errorMessage` is rejected by that gate.
+ * Same metadata-only picks as `buildHostedRunnerMetadataOnlyErrorDetails`, plus
+ * the shared sanitizer's bounded error detail and cause, narrowed to the
+ * persisted runtime-log `redactedJson` value shape. Keys must pass the hosted
+ * runtime-log redacted-key gate; sanitized error text uses the allowlisted
+ * `safeError*` keys because the bare diagnostic keys are rejected by that gate.
  */
 const SAFE_REDACTED_ERROR_CODE_DETAIL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$/u;
 
 export function buildHostedRunnerRedactedErrorJson(
   error: unknown,
 ): HostedRuntimeRedactedJson {
+  const diagnostics = buildHostedExecutionSafeErrorDiagnostics(error);
   const details = buildHostedRunnerMetadataOnlyErrorDetails(error);
   const redacted: HostedRuntimeRedactedJson = {};
   for (const [key, value] of Object.entries(details)) {
@@ -151,6 +152,12 @@ export function buildHostedRunnerRedactedErrorJson(
     ) {
       redacted[redactedKey] = value;
     }
+  }
+  if (typeof diagnostics?.errorDetail === "string") {
+    redacted.safeErrorDetail = diagnostics.errorDetail;
+  }
+  if (typeof diagnostics?.errorCause === "string") {
+    redacted.safeErrorCause = diagnostics.errorCause;
   }
   return redacted;
 }

--- a/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
+++ b/apps/cloudflare/test/runtime-invocation-transport-failure.test.ts
@@ -74,7 +74,25 @@ describe("runtime invocation transport failure fence handling", () => {
   });
 
   it("keeps the write fence when the invocation is still active in the container", async () => {
+    const rawHostedId = "hbm_abcdefghijklmnop-";
+    const rawPath = "/tmp/runtime.log";
+    const rawUrl = "https://internal.example.test/private?token=url-secret";
+    const rawEmail = "operator@example.test";
+    const rawPhone = "+15551234567";
+    const rawToken = "raw-token";
+    const safeDetailPrefix =
+      "container transport failed for hbm_<redacted-id> at <REDACTED_PATH> "
+      + "via <REDACTED_URL> contact [redacted-email] [redacted-phone] token=[redacted] ";
+    const safeCausePrefix = "authorization=Bearer [redacted] ";
+    const invocationError = new Error(
+      `container transport failed for ${rawHostedId} at ${rawPath} via ${rawUrl} `
+      + `contact ${rawEmail} ${rawPhone} token=${rawToken} ${"x".repeat(400)}`,
+      {
+        cause: new Error(`authorization=Bearer cause-secret ${"y".repeat(400)}`),
+      },
+    );
     const harness = await createTransportFailureHarness({
+      invocationError,
       readActiveRuntimeUserFence: async (token) => ({
         active: true,
         attemptId: token.attemptId,
@@ -98,9 +116,25 @@ describe("runtime invocation transport failure fence handling", () => {
         redactedJson: expect.objectContaining({
           attemptStillActive: true,
           fenceCleared: false,
+          safeErrorCause:
+            `${safeCausePrefix}${"y".repeat(319 - safeCausePrefix.length)}…`,
+          safeErrorDetail:
+            `${safeDetailPrefix}${"x".repeat(319 - safeDetailPrefix.length)}…`,
         }),
       }),
     ]);
+    const serializedEntries = JSON.stringify(harness.loggedFailureEntries());
+    for (const rawSensitiveValue of [
+      rawHostedId,
+      rawPath,
+      rawUrl,
+      rawEmail,
+      rawPhone,
+      rawToken,
+      "cause-secret",
+    ]) {
+      expect(serializedEntries).not.toContain(rawSensitiveValue);
+    }
   });
 
   it("keeps the accepted write fence when the local active pointer is missing but progress is not durable yet", async () => {
@@ -591,22 +625,26 @@ describe("runtime invocation transport failure fence handling", () => {
 });
 
 describe("buildHostedRunnerRedactedErrorJson", () => {
-  it("keeps scalar diagnostics and the string-array details keys in the persisted redacted shape", () => {
-    const redacted = buildHostedRunnerRedactedErrorJson(
-      new Error("container transport failed"),
+  it("keeps scalar diagnostics plus bounded sanitized detail and cause in the persisted redacted shape", () => {
+    const error = new Error(
+      "container transport failed for hbm_abcdefghijklmnop- at /tmp/runtime.log",
+      { cause: new Error("authorization=Bearer secret-token") },
     );
+    const redacted = buildHostedRunnerRedactedErrorJson(error);
 
     expect(redacted).toEqual({
-      detailsKeys: ["errorCode", "errorDetail", "errorMessage", "errorName"],
+      detailsKeys: ["errorCause", "errorCode", "errorDetail", "errorMessage", "errorName"],
       errorCode: "runtime_error",
       errorDetailPresent: true,
       errorName: "Error",
-      // The sanitized summary moves to the runtime-log allowlisted key.
+      safeErrorCause: "authorization=Bearer [redacted]",
+      safeErrorDetail:
+        "container transport failed for hbm_<redacted-id> at <REDACTED_PATH>",
       safeErrorMessage: "Hosted execution runtime failed.",
     });
-    // The raw error text stays out of the persisted redacted JSON; only the
-    // presence flag survives.
-    expect(JSON.stringify(redacted)).not.toContain("container transport failed");
+    expect(JSON.stringify(redacted)).not.toContain("abcdefghijklmnop-");
+    expect(JSON.stringify(redacted)).not.toContain("/tmp/runtime.log");
+    expect(JSON.stringify(redacted)).not.toContain("secret-token");
   });
 
   it("returns an empty redacted object for undefined errors", () => {
@@ -634,6 +672,7 @@ describe("buildHostedRunnerRedactedErrorJson", () => {
 });
 
 async function createTransportFailureHarness(input: {
+  invocationError?: Error;
   /** `null` omits the probe method from the container stub entirely. */
   readActiveRuntimeUserFence:
     | ((
@@ -695,6 +734,7 @@ async function createTransportFailureHarness(input: {
       workspace: null,
     }),
     runnerContainerNamespace: createFailingInvokeContainerNamespace({
+      invocationError: input.invocationError,
       readActiveRuntimeUserFence: readActiveRuntimeUserFenceInput
         ? (() => readActiveRuntimeUserFenceInput(token))
         : null,
@@ -735,6 +775,7 @@ async function createTransportFailureHarness(input: {
 }
 
 function createFailingInvokeContainerNamespace(input: {
+  invocationError?: Error;
   readActiveRuntimeUserFence:
     | (() => Promise<WorkerActiveRuntimeUserFenceResult>)
     | null;
@@ -743,7 +784,7 @@ function createFailingInvokeContainerNamespace(input: {
   const stub: HostedExecutionContainerStubLike = {
     destroyInstance: async () => {},
     invoke: async () => {
-      throw new Error("container transport failed");
+      throw input.invocationError ?? new Error("container transport failed");
     },
     ...(readActiveRuntimeUserFenceInput
       ? {

--- a/packages/hosted-execution/src/observability.ts
+++ b/packages/hosted-execution/src/observability.ts
@@ -64,6 +64,8 @@ const HOSTED_EXECUTION_LOCAL_WINDOWS_PATH_PATTERN = /[A-Za-z]:\\[^\s)"']+/gu;
 const HOSTED_EXECUTION_WORKFLOW_ID_PATTERN = /\bhosted-user-runtime:[A-Za-z0-9._:-]+/gu;
 const HOSTED_EXECUTION_DIRECT_ID_PATTERN =
   /\b(member|user)_[A-Za-z0-9._:-]*\d[A-Za-z0-9._:-]*/gu;
+const HOSTED_EXECUTION_HOSTED_ID_PATTERN =
+  /\b(haa|hbag|hbagi|hbagm|hbce|hbdi|hbfca|hbi|hbid|hbidx|hbm|hbpc|hbvs|hccv|hch|hcp|hcr|hgrp|hgrpjo|hgrpm|hid|hla|hld|hpc|hsn)_[A-Za-z0-9_-]{8,}(?=$|[^A-Za-z0-9_-])/gu;
 const HOSTED_EXECUTION_SENSITIVE_ID_PRESENT_DETAIL_KEYS = {
   boundUserId: "boundUserIdPresent",
   codexThreadId: "codexThreadIdPresent",
@@ -932,6 +934,7 @@ function redactHostedExecutionText(value: string): string {
     .replace(/\bhttps?:\/\/[^\s)"'<>]+/giu, "<REDACTED_URL>")
     .replace(HOSTED_EXECUTION_WORKFLOW_ID_PATTERN, "hosted-user-runtime:<redacted-id>")
     .replace(HOSTED_EXECUTION_DIRECT_ID_PATTERN, "$1_<redacted-id>")
+    .replace(HOSTED_EXECUTION_HOSTED_ID_PATTERN, "$1_<redacted-id>")
     .replace(
       /\b(authorization)\b\s*:\s*Bearer\s+[A-Za-z0-9._~+/=-]+\b/giu,
       (_match, key: string) => `${key}=Bearer [redacted]`,

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -4805,7 +4805,7 @@ function assertSafeRedactedString(value: string, label: string): void {
     throw new TypeError(`${label} must not contain a direct identifier.`);
   }
   if (
-    /(["']?(?:authorization|secret|token|password|cookie|set-cookie|api[-_]?key)["']?\s*[:=]\s*["']?)([^"',\s}]+)/iu
+    /(["']?(?:authorization|secret|token|password|cookie|set-cookie|api[-_]?key)["']?\s*[:=]\s*)(?!(?:(?:Basic|Bearer)\s+)?\[redacted\](?=$|\s|[,.;:)}\]](?=$|\s)))["']?([^"',\s}]+)/iu
       .test(value)
     || /\b(Basic|Bearer)\s+[A-Z0-9._~+/=-]+\b/iu.test(value)
     || /\b(?:sk|pk|rk)_(?:live|test)_[A-Z0-9]+\b/iu.test(value)

--- a/packages/hosted-execution/test/hosted-execution-observability-side-effects.test.ts
+++ b/packages/hosted-execution/test/hosted-execution-observability-side-effects.test.ts
@@ -166,6 +166,11 @@ describe("hosted execution observability", () => {
     ).toBe(
       "safe message for hosted-user-runtime:<redacted-id> and member_<redacted-id>",
     );
+    expect(
+      sanitizeHostedExecutionStructuredLogText(
+        "accepted attempt failed for hbm_abcdefghijklmnop-",
+      ),
+    ).toBe("accepted attempt failed for hbm_<redacted-id>");
 
     const repeated = "x".repeat(260);
     const normalized = normalizeHostedExecutionOperatorMessage(repeated);

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -2255,6 +2255,30 @@ describe("hosted runtime control contracts", () => {
         safeErrorDetail: "retrying member_abc123",
       },
     })).toThrow(/direct identifier/u);
+    expect(parseHostedRuntimeLogEntry({
+      ...entry,
+      redactedJson: {
+        safeErrorCause: "authorization=Bearer [redacted].",
+        safeErrorDetail: "request failed with token=[redacted]",
+      },
+    })).toMatchObject({
+      redactedJson: {
+        safeErrorCause: "authorization=Bearer [redacted].",
+        safeErrorDetail: "request failed with token=[redacted]",
+      },
+    });
+    expect(() => parseHostedRuntimeLogEntry({
+      ...entry,
+      redactedJson: {
+        safeErrorDetail: "request failed with token=[redacted]suffix",
+      },
+    })).toThrow(/secret-shaped content/u);
+    expect(() => parseHostedRuntimeLogEntry({
+      ...entry,
+      redactedJson: {
+        safeErrorDetail: "request failed with token=[redacted].suffix",
+      },
+    })).toThrow(/secret-shaped content/u);
     expect(() => parseHostedRuntimeLogEntry({
       ...entry,
       outboxIntentRef: "<HOME_DIR>/intent.json",


### PR DESCRIPTION
## Why

Accepted hosted-runtime failures currently persist only a generic summary and presence flag, which hides the sanitized detail needed to diagnose repeated production failures.

## User-visible goal

Operators can identify the safe cause of future accepted-attempt failures without exposing member identifiers, credentials, paths, URLs, or contact details. There is no user-facing UX change.

## Invariants

- Reuses the shared bounded safe-error sanitizer; no raw exception or stack is persisted.
- Invocation, write-fence, checkpoint, retry, and mailbox behavior are unchanged.
- The runtime-log parser remains fail-closed for raw and suffix-adjacent secret-shaped values.
- Hosted IDs, paths, URLs, credentials, email addresses, and phone numbers are redacted before the logging boundary.

## Verification

- Focused hosted-execution tests: 53 passed.
- Focused Cloudflare transport-failure tests: 22 passed.
- Hosted-execution and Cloudflare typechecks passed.
- Cloudflare owner verification: 105 files / 1,806 tests passed.
- Full acceptance passed before final parser hardening; the post-hardening rerun passed all changed owners plus Cloudflare/Web verification, with one unrelated CLI coverage timeout under concurrent load.
- Required coverage-write audit completed with no unresolved finding.

## Deployment compatibility

Deploy Web first so the parser accepts exact redaction sentinels, then deploy the Cloudflare runtime producer. New Web with old Cloudflare is backward compatible.

## Diff shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 16 | 6 |
| Tests | 79 | 9 |
| Docs/process | 99 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 23b34c36c02f7d8e68663af2c620dc1ada4590c3

| Review round | Head | Scope |
| --- | --- | --- |
| 1 | 23b34c36c02f7d8e68663af2c620dc1ada4590c3 | Full PR patch |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786684408&installation_id=127572939&pr_number=665&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F665&signature=4fcc04386fb1e4376c0278279120f26a60068ab601bf78eeacf11888e023e20d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->