### PR TITLE
Fix paused Pulse Trial extension recovery

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-trial-extension-paused-resume.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-trial-extension-paused-resume.md
@@ -1,0 +1,103 @@
+# Paused Pulse Trial resume recovery
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Make single-member Apply safely recover and extend a lapsed Stripe Pulse
+  Trial that has entered Stripe's `paused` status.
+
+## Root-cause evidence
+
+- The deployed diagnostic recorded `update_subscription`,
+  `StripeInvalidRequestError`, and HTTP 400 for the affected Apply.
+- Preview had already retrieved and accepted the subscription as a lapsed
+  paused Pulse Trial; only the update path failed.
+- Stripe's current trial contract requires a paused subscription to be resumed
+  before a new trial is configured. The implementation directly set
+  `trial_end` while the subscription was paused.
+
+## Success criteria
+
+- Paused subscriptions are prepared, resumed with the billing anchor unchanged
+  and no proration (so the resume creates no billable invoice), and placed into
+  the exact target trial under the existing shared member mutation lock.
+- A response loss or deterministic failure after any provider mutation leaves
+  a bounded provider-side marker that a later Preview and Apply can recover.
+- Trialing subscriptions retain the existing one-call extension behavior.
+- Local billing is written only after Stripe proves the final trialing shape;
+  ambiguous provider success and local-write failure reconcile without adding
+  another seven days.
+- Provider diagnostics remain identifier-free and distinguish prepare,
+  resume, update, and validation failures.
+- Focused tests, state-consistency audit, routed verification, coverage audit,
+  ReviewGPT, CI, deployment, and production Preview/Apply proof are complete.
+
+## Constraints
+
+- Stripe remains authoritative for subscription status and trial dates.
+- Do not create an invoice, collect payment, or expose provider identifiers.
+- Preserve the existing preview proof, mutation lock, local reconciliation,
+  and exact-marker idempotency boundaries.
+- Add no schema, dependency, queue, retry service, or second billing owner.
+
+## Risks and mitigations
+
+1. Resume can succeed before the trial update fails.
+   Mitigation: write an operation/target marker while still paused, use stable
+   per-step idempotency keys, and recognize only that exact marker as a
+   recoverable active intermediate state.
+2. A final Stripe update can commit while its response is lost.
+   Mitigation: bind the marker to the exact target and reconcile a fresh
+   Preview when provider state matches but local billing does not.
+3. Stripe webhooks can observe intermediate provider states.
+   Mitigation: retain the Pulse Trial offer marker and reconcile local billing
+   only from canonical Stripe events or the final proven trialing response;
+   test partial paths and event-owned state assumptions.
+4. Resetting the billing anchor while resuming can immediately start a billed
+   period.
+   Mitigation: resume with `billing_cycle_anchor=unchanged` and
+   `proration_behavior=none`; Stripe documents that combination as creating no
+   debit proration or new invoice. The final trial update owns the next anchor.
+5. Multiple network calls can approach the transaction timeout.
+   Mitigation: keep network retries disabled, skip already completed steps,
+   and make every completed provider step recoverable on the next request.
+
+## Tasks
+
+1. Map provider/local coupled state and every prepare/resume/update failure
+   boundary using the state-consistency audit.
+2. Add the narrow recoverable marker and paused prepare/resume transition.
+3. Add focused coverage for success, response loss after each step, fresh
+   Preview recovery, exact idempotency, validation, and unchanged live trials.
+4. Run focused and routed verification, required completion audits, and parent
+   final review.
+5. Finish the scoped commit, open the PR, run ReviewGPT with CI, merge/deploy,
+   and verify the affected member from production without applying twice.
+
+## Verification
+
+- Production diagnostics reproduced the failure twice as
+  `update_subscription`, `StripeInvalidRequestError`, HTTP 400, with no
+  provider or member identifiers emitted.
+- State-consistency audit verified and resolved the recoverability gaps after
+  prepare, resume, final provider update, and local-write failure. No
+  unresolved coupled-state finding remains.
+- Required coverage-write audit added local-write-loss reconciliation proof and
+  found no remaining material coverage gap; the focused four-file billing
+  suite passed 72 tests.
+- `pnpm test:diff` passed all workspace guards, hosted-web TypeScript, dev
+  smoke, 5,110 tests (139 skipped), lint with zero errors and 12 unrelated
+  pre-existing warnings, and the optimized Next production build.
+- Parent final review corrected the resume anchor to `unchanged` with no
+  proration so the intermediate provider transition does not start a billable
+  period or create a new invoice.
+
+## State
+
+Implementation, local verification, coverage audit, state-consistency audit,
+and parent review are complete. PR ReviewGPT, CI, deployment, and the final
+production Preview/Apply proof remain external release gates.
+Completed: 2026-07-15

--- a/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
+++ b/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
@@ -40,6 +40,8 @@ const PREVIEW_TOKEN_PREFIX = "pulse-member-preview-v1";
 const PREVIEW_HMAC_CONTEXT = "hosted-member-pulse-trial-extension-preview-v1";
 const EXTENSION_OPERATION_METADATA_KEY = "murphTrialExtensionOperation";
 const EXTENSION_DAYS_METADATA_KEY = "murphTrialExtensionDays";
+const EXTENSION_TARGET_METADATA_KEY = "murphTrialExtensionTargetTrialEnd";
+const EXTENSION_OPERATION_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
 const STRIPE_ERROR_IDENTIFIER_PREFIX =
   /^(?:acct|ch|cus|hbm|pi|pk|pm|price|req|rk|seti|sk|src|sub|whsec)_/iu;
 
@@ -117,15 +119,31 @@ export interface HostedPulseTrialExtensionSubscription {
   trial_start: number | null;
 }
 
-interface HostedPulseTrialExtensionStripeUpdateParams {
-  metadata: Record<string, string>;
+type HostedPulseTrialExtensionStripeUpdateParams =
+  | {
+      metadata: Record<string, string>;
+      proration_behavior?: never;
+      trial_end?: never;
+    }
+  | {
+      metadata: Record<string, string>;
+      proration_behavior: "none";
+      trial_end: number;
+    };
+
+interface HostedPulseTrialExtensionStripeResumeParams {
+  billing_cycle_anchor: "unchanged";
   proration_behavior: "none";
-  trial_end: number;
 }
 
 interface HostedPulseTrialExtensionStripeClient {
   retrieveSubscription(
     subscriptionId: string,
+    options: Stripe.RequestOptions,
+  ): Promise<HostedPulseTrialExtensionSubscription>;
+  resumeSubscription(
+    subscriptionId: string,
+    params: HostedPulseTrialExtensionStripeResumeParams,
     options: Stripe.RequestOptions,
   ): Promise<HostedPulseTrialExtensionSubscription>;
   updateSubscription(
@@ -148,6 +166,10 @@ type HostedPulseTrialExtensionState = {
   member: HostedMemberBillingSnapshot | null;
   message: string;
   providerStatus: string | null;
+  recoverableOperation: {
+    operationId: string;
+    targetTrialEnd: number;
+  } | null;
   subscription: HostedPulseTrialExtensionSubscription | null;
   targetTrialEnd: number | null;
 };
@@ -165,8 +187,12 @@ export class HostedPulseTrialExtensionProviderError extends Error {
   constructor(input: {
     error?: unknown;
     operationName:
+      | "prepare_subscription"
       | "retrieve_subscription"
+      | "resume_subscription"
       | "update_subscription"
+      | "validate_prepared_subscription"
+      | "validate_resumed_subscription"
       | "validate_updated_subscription";
   }) {
     super("Stripe could not confirm this trial extension request.");
@@ -244,7 +270,7 @@ export async function applyHostedPulseTrialExtension(
     now,
     previewProof: input.previewProof,
   });
-  const operationId = readHostedPulseTrialExtensionOperationId(
+  const previewOperationId = readHostedPulseTrialExtensionOperationId(
     input.previewProof.token,
   );
 
@@ -271,33 +297,21 @@ export async function applyHostedPulseTrialExtension(
           subscription &&
           isHostedPulseTrialExtensionAlreadyApplied({
             memberId: input.memberId,
-            operationId,
+            operationId: previewOperationId,
             priceId: dependencies.priceId,
             subscription,
             targetTrialEnd: proofDates.targetTrialEndUnix,
           })
         ) {
-          const reconciledMember = await reconcileHostedPulseTrialExtensionLocalState({
+          return reconcileAlreadyAppliedHostedPulseTrialExtension({
             member,
+            memberId: input.memberId,
             now,
+            state,
             subscription,
             targetTrialEndsAt: proofDates.targetTrialEndsAt,
+            targetTrialEndUnix: proofDates.targetTrialEndUnix,
             tx,
-          });
-          return buildHostedPulseTrialExtensionResult({
-            memberId: input.memberId,
-            outcome: "reconciled",
-            previewProof: null,
-            state: {
-              ...state,
-              currentTrialEnd: proofDates.targetTrialEndUnix,
-              eligibilityCode: "eligible",
-              eligible: true,
-              member: reconciledMember,
-              message: "The seven-day extension was already in Stripe and local billing is reconciled.",
-              providerStatus: subscription.status,
-              targetTrialEnd: proofDates.targetTrialEndUnix,
-            },
           });
         }
 
@@ -322,30 +336,55 @@ export async function applyHostedPulseTrialExtension(
           throw new HostedPulseTrialExtensionPreviewStaleError();
         }
 
-        let updatedSubscription: HostedPulseTrialExtensionSubscription;
-        try {
-          updatedSubscription = await dependencies.stripe.updateSubscription(
-            subscription.id,
-            {
-              metadata: {
-                [EXTENSION_DAYS_METADATA_KEY]:
-                  HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString(),
-                [EXTENSION_OPERATION_METADATA_KEY]: operationId,
-              },
-              proration_behavior: "none",
-              trial_end: proofDates.targetTrialEndUnix,
-            },
-            {
-              idempotencyKey: `hosted-member-trial-extension:${operationId}`,
-              ...buildHostedPulseTrialExtensionStripeRequestOptions(),
-            },
-          );
-        } catch (error) {
-          throw new HostedPulseTrialExtensionProviderError({
-            error,
-            operationName: "update_subscription",
+        const operationId = state.recoverableOperation?.operationId ??
+          previewOperationId;
+        if (isHostedPulseTrialExtensionAlreadyApplied({
+          memberId: input.memberId,
+          operationId,
+          priceId: dependencies.priceId,
+          subscription,
+          targetTrialEnd: proofDates.targetTrialEndUnix,
+        })) {
+          return reconcileAlreadyAppliedHostedPulseTrialExtension({
+            member,
+            memberId: input.memberId,
+            now,
+            state,
+            subscription,
+            targetTrialEndsAt: proofDates.targetTrialEndsAt,
+            targetTrialEndUnix: proofDates.targetTrialEndUnix,
+            tx,
           });
         }
+
+        let providerSubscription = subscription;
+        if (providerSubscription.status === "paused") {
+          if (!isHostedPulseTrialExtensionPrepared({
+            operationId,
+            subscription: providerSubscription,
+            targetTrialEnd: proofDates.targetTrialEndUnix,
+          })) {
+            providerSubscription = await prepareHostedPulseTrialExtension({
+              operationId,
+              stripe: dependencies.stripe,
+              subscription: providerSubscription,
+              targetTrialEnd: proofDates.targetTrialEndUnix,
+            });
+          }
+          providerSubscription = await resumeHostedPulseTrialExtension({
+            operationId,
+            stripe: dependencies.stripe,
+            subscription: providerSubscription,
+            targetTrialEnd: proofDates.targetTrialEndUnix,
+          });
+        }
+
+        const updatedSubscription = await updateHostedPulseTrialExtension({
+          operationId,
+          stripe: dependencies.stripe,
+          subscription: providerSubscription,
+          targetTrialEnd: proofDates.targetTrialEndUnix,
+        });
 
         if (!isHostedPulseTrialExtensionAlreadyApplied({
           memberId: input.memberId,
@@ -387,6 +426,177 @@ export async function applyHostedPulseTrialExtension(
     }
     throw error;
   }
+}
+
+async function reconcileAlreadyAppliedHostedPulseTrialExtension(input: {
+  member: HostedMemberBillingSnapshot | null;
+  memberId: string;
+  now: Date;
+  state: HostedPulseTrialExtensionState;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEndsAt: Date;
+  targetTrialEndUnix: number;
+  tx: Prisma.TransactionClient;
+}): Promise<HostedPulseTrialExtensionResult> {
+  const reconciledMember = await reconcileHostedPulseTrialExtensionLocalState({
+    member: input.member,
+    now: input.now,
+    subscription: input.subscription,
+    targetTrialEndsAt: input.targetTrialEndsAt,
+    tx: input.tx,
+  });
+  return buildHostedPulseTrialExtensionResult({
+    memberId: input.memberId,
+    outcome: "reconciled",
+    previewProof: null,
+    state: {
+      ...input.state,
+      currentTrialEnd: input.targetTrialEndUnix,
+      eligibilityCode: "eligible",
+      eligible: true,
+      member: reconciledMember,
+      message:
+        "The seven-day extension was already in Stripe and local billing is reconciled.",
+      providerStatus: input.subscription.status,
+      targetTrialEnd: input.targetTrialEndUnix,
+    },
+  });
+}
+
+async function prepareHostedPulseTrialExtension(input: {
+  operationId: string;
+  stripe: HostedPulseTrialExtensionStripeClient;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEnd: number;
+}): Promise<HostedPulseTrialExtensionSubscription> {
+  let preparedSubscription: HostedPulseTrialExtensionSubscription;
+  try {
+    preparedSubscription = await input.stripe.updateSubscription(
+      input.subscription.id,
+      {
+        metadata: buildHostedPulseTrialExtensionMetadata(input),
+      },
+      {
+        idempotencyKey: buildHostedPulseTrialExtensionIdempotencyKey({
+          operationId: input.operationId,
+          step: "prepare",
+        }),
+        ...buildHostedPulseTrialExtensionStripeRequestOptions(),
+      },
+    );
+  } catch (error) {
+    throw new HostedPulseTrialExtensionProviderError({
+      error,
+      operationName: "prepare_subscription",
+    });
+  }
+
+  if (
+    preparedSubscription.status !== "paused" ||
+    !isHostedPulseTrialExtensionPrepared({
+      operationId: input.operationId,
+      subscription: preparedSubscription,
+      targetTrialEnd: input.targetTrialEnd,
+    })
+  ) {
+    throw new HostedPulseTrialExtensionProviderError({
+      operationName: "validate_prepared_subscription",
+    });
+  }
+  return preparedSubscription;
+}
+
+async function resumeHostedPulseTrialExtension(input: {
+  operationId: string;
+  stripe: HostedPulseTrialExtensionStripeClient;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEnd: number;
+}): Promise<HostedPulseTrialExtensionSubscription> {
+  let resumedSubscription: HostedPulseTrialExtensionSubscription;
+  try {
+    resumedSubscription = await input.stripe.resumeSubscription(
+      input.subscription.id,
+      {
+        billing_cycle_anchor: "unchanged",
+        proration_behavior: "none",
+      },
+      {
+        idempotencyKey: buildHostedPulseTrialExtensionIdempotencyKey({
+          operationId: input.operationId,
+          step: "resume",
+        }),
+        ...buildHostedPulseTrialExtensionStripeRequestOptions(),
+      },
+    );
+  } catch (error) {
+    throw new HostedPulseTrialExtensionProviderError({
+      error,
+      operationName: "resume_subscription",
+    });
+  }
+
+  if (
+    resumedSubscription.status !== "active" ||
+    !isHostedPulseTrialExtensionPrepared({
+      operationId: input.operationId,
+      subscription: resumedSubscription,
+      targetTrialEnd: input.targetTrialEnd,
+    })
+  ) {
+    throw new HostedPulseTrialExtensionProviderError({
+      operationName: "validate_resumed_subscription",
+    });
+  }
+  return resumedSubscription;
+}
+
+async function updateHostedPulseTrialExtension(input: {
+  operationId: string;
+  stripe: HostedPulseTrialExtensionStripeClient;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEnd: number;
+}): Promise<HostedPulseTrialExtensionSubscription> {
+  try {
+    return await input.stripe.updateSubscription(
+      input.subscription.id,
+      {
+        metadata: buildHostedPulseTrialExtensionMetadata(input),
+        proration_behavior: "none",
+        trial_end: input.targetTrialEnd,
+      },
+      {
+        idempotencyKey: buildHostedPulseTrialExtensionIdempotencyKey({
+          operationId: input.operationId,
+          step: "update",
+        }),
+        ...buildHostedPulseTrialExtensionStripeRequestOptions(),
+      },
+    );
+  } catch (error) {
+    throw new HostedPulseTrialExtensionProviderError({
+      error,
+      operationName: "update_subscription",
+    });
+  }
+}
+
+function buildHostedPulseTrialExtensionMetadata(input: {
+  operationId: string;
+  targetTrialEnd: number;
+}): Record<string, string> {
+  return {
+    [EXTENSION_DAYS_METADATA_KEY]:
+      HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString(),
+    [EXTENSION_OPERATION_METADATA_KEY]: input.operationId,
+    [EXTENSION_TARGET_METADATA_KEY]: input.targetTrialEnd.toString(),
+  };
+}
+
+function buildHostedPulseTrialExtensionIdempotencyKey(input: {
+  operationId: string;
+  step: "prepare" | "resume" | "update";
+}): string {
+  return `hosted-member-trial-extension:${input.step}:${input.operationId}`;
 }
 
 function resolveHostedPulseTrialExtensionDependencies(
@@ -459,20 +669,29 @@ async function inspectHostedPulseTrialExtensionState(input: {
   }
 
   const currentTrialEnd = readSafeUnixSecond(subscription.trial_end);
-  const targetTrialEnd = subscription.status === "trialing"
-    ? requireSafeUnixSecond(currentTrialEnd) +
-      HOSTED_PULSE_TRIAL_EXTENSION_DAYS * SECONDS_PER_DAY
-    : Math.floor(input.now.getTime() / 1000) +
-      HOSTED_PULSE_TRIAL_EXTENSION_DAYS * SECONDS_PER_DAY;
+  const recoverableOperation = readHostedPulseTrialExtensionRecoverableOperation({
+    member: input.member,
+    now: input.now,
+    subscription,
+  });
+  const targetTrialEnd = recoverableOperation?.targetTrialEnd ??
+    (subscription.status === "trialing"
+      ? requireSafeUnixSecond(currentTrialEnd) +
+        HOSTED_PULSE_TRIAL_EXTENSION_DAYS * SECONDS_PER_DAY
+      : Math.floor(input.now.getTime() / 1000) +
+        HOSTED_PULSE_TRIAL_EXTENSION_DAYS * SECONDS_PER_DAY);
   return {
     currentTrialEnd,
     eligibilityCode: "eligible",
     eligible: true,
     member: input.member,
-    message: subscription.status === "paused"
+    message: recoverableOperation
+      ? "This unfinished Pulse Trial extension can be completed."
+      : subscription.status === "paused"
       ? "This lapsed Pulse Trial can be restored for seven days."
       : "This active Pulse Trial can be extended by seven days.",
     providerStatus: subscription.status,
+    recoverableOperation,
     subscription,
     targetTrialEnd,
   };
@@ -557,6 +776,15 @@ export function classifyHostedPulseTrialExtensionProviderState(input: {
   ) {
     return null;
   }
+  if (
+    input.subscription.status === "active" &&
+    hasHostedPulseTrialExtensionMarker(input.subscription) &&
+    (
+      readHostedPulseTrialExtensionMetadataTarget(input.subscription) ?? 0
+    ) > Math.floor(input.now.getTime() / 1000)
+  ) {
+    return null;
+  }
   return "provider_subscription_not_extendable";
 }
 
@@ -572,6 +800,7 @@ function buildIneligibleHostedPulseTrialExtensionState(input: {
     member: input.member,
     message: readHostedPulseTrialExtensionEligibilityMessage(input.code),
     providerStatus: input.subscription?.status ?? null,
+    recoverableOperation: null,
     subscription: input.subscription ?? null,
     targetTrialEnd: null,
   };
@@ -722,8 +951,12 @@ function projectHostedPulseTrialExtensionProviderProofState(
     cancelAt: subscription.cancel_at,
     cancelAtPeriodEnd: subscription.cancel_at_period_end,
     customerId: coerceStripeCustomerId(subscription.customer),
+    extensionDays:
+      subscription.metadata[EXTENSION_DAYS_METADATA_KEY] ?? null,
     extensionOperation:
       subscription.metadata[EXTENSION_OPERATION_METADATA_KEY] ?? null,
+    extensionTargetTrialEnd:
+      subscription.metadata[EXTENSION_TARGET_METADATA_KEY] ?? null,
     id: subscription.id,
     items: subscription.items.data.map((item) => ({
       id: item.id,
@@ -815,6 +1048,82 @@ function readHostedPulseTrialExtensionOperationId(token: string): string {
   return readHostedPulseTrialExtensionTokenParts(token).digest;
 }
 
+function readHostedPulseTrialExtensionRecoverableOperation(input: {
+  member: HostedMemberBillingSnapshot | null;
+  now: Date;
+  subscription: HostedPulseTrialExtensionSubscription;
+}): { operationId: string; targetTrialEnd: number } | null {
+  if (!hasHostedPulseTrialExtensionMarker(input.subscription)) {
+    return null;
+  }
+  const operationId = input.subscription.metadata[EXTENSION_OPERATION_METADATA_KEY];
+  if (!operationId) {
+    return null;
+  }
+  const nowUnix = Math.floor(input.now.getTime() / 1000);
+  const metadataTarget = readHostedPulseTrialExtensionMetadataTarget(
+    input.subscription,
+  );
+
+  if (
+    (input.subscription.status === "paused" ||
+      input.subscription.status === "active") &&
+    metadataTarget !== null &&
+    metadataTarget > nowUnix
+  ) {
+    return { operationId, targetTrialEnd: metadataTarget };
+  }
+
+  const trialEnd = readSafeUnixSecond(input.subscription.trial_end);
+  const trialingTarget = metadataTarget ?? trialEnd;
+  const localTrialEnd = input.member?.billingRef?.currentTrialEndsAt
+    ? Math.floor(input.member.billingRef.currentTrialEndsAt.getTime() / 1000)
+    : null;
+  if (
+    input.subscription.status === "trialing" &&
+    trialEnd !== null &&
+    trialingTarget === trialEnd &&
+    trialEnd > nowUnix &&
+    localTrialEnd !== trialEnd
+  ) {
+    return { operationId, targetTrialEnd: trialEnd };
+  }
+  return null;
+}
+
+function hasHostedPulseTrialExtensionMarker(
+  subscription: HostedPulseTrialExtensionSubscription,
+): boolean {
+  const operationId = subscription.metadata[EXTENSION_OPERATION_METADATA_KEY];
+  return typeof operationId === "string" &&
+    EXTENSION_OPERATION_PATTERN.test(operationId) &&
+    subscription.metadata[EXTENSION_DAYS_METADATA_KEY] ===
+      HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString();
+}
+
+function readHostedPulseTrialExtensionMetadataTarget(
+  subscription: HostedPulseTrialExtensionSubscription,
+): number | null {
+  const value = subscription.metadata[EXTENSION_TARGET_METADATA_KEY];
+  if (!value || !/^[1-9][0-9]{0,11}$/u.test(value)) {
+    return null;
+  }
+  return readSafeUnixSecond(Number.parseInt(value, 10));
+}
+
+function isHostedPulseTrialExtensionPrepared(input: {
+  operationId: string;
+  subscription: HostedPulseTrialExtensionSubscription;
+  targetTrialEnd: number;
+}): boolean {
+  return input.subscription.metadata[EXTENSION_OPERATION_METADATA_KEY] ===
+      input.operationId &&
+    input.subscription.metadata[EXTENSION_DAYS_METADATA_KEY] ===
+      HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString() &&
+    readHostedPulseTrialExtensionMetadataTarget(input.subscription) ===
+      input.targetTrialEnd;
+}
+
 function isHostedPulseTrialExtensionAlreadyApplied(input: {
   memberId: string;
   operationId: string;
@@ -828,6 +1137,11 @@ function isHostedPulseTrialExtensionAlreadyApplied(input: {
       input.operationId &&
     input.subscription.metadata[EXTENSION_DAYS_METADATA_KEY] ===
       HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString() &&
+    (
+      readHostedPulseTrialExtensionMetadataTarget(input.subscription) === null ||
+      readHostedPulseTrialExtensionMetadataTarget(input.subscription) ===
+        input.targetTrialEnd
+    ) &&
     isHostedPulseTrialSubscriptionForKnownPolicy({
       memberId: input.memberId,
       priceId: input.priceId,
@@ -941,6 +1255,9 @@ function createHostedPulseTrialExtensionStripeClient(
   return {
     retrieveSubscription(subscriptionId, options) {
       return stripe.subscriptions.retrieve(subscriptionId, {}, options);
+    },
+    resumeSubscription(subscriptionId, params, options) {
+      return stripe.subscriptions.resume(subscriptionId, params, options);
     },
     updateSubscription(subscriptionId, params, options) {
       return stripe.subscriptions.update(subscriptionId, params, options);

--- a/apps/web/test/hosted-pulse-trial-extension.test.ts
+++ b/apps/web/test/hosted-pulse-trial-extension.test.ts
@@ -65,6 +65,7 @@ const TARGET_FROM_PAUSED = Math.floor(
 const TARGET_FROM_LIVE = Math.floor(
   new Date("2026-07-25T16:00:00.000Z").getTime() / 1000,
 );
+const RECOVERABLE_OPERATION_ID = "a".repeat(43);
 const CONTACT_PRIVACY_KEY = Buffer.alloc(32, 7).toString("base64");
 const originalContactPrivacyKeys = process.env.HOSTED_CONTACT_PRIVACY_KEYS;
 const originalContactPrivacyVersion =
@@ -135,6 +136,34 @@ describe("single-member Pulse Trial extension", () => {
       priceId: PRICE_ID,
       stripeCustomerId: CUSTOMER_ID,
       stripeSubscriptionId: SUBSCRIPTION_ID,
+      subscription: makeSubscription({
+        extensionDays: "7",
+        extensionOperation: RECOVERABLE_OPERATION_ID,
+        extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+        status: "active",
+        trialEnd: 1_700_000_000,
+      }),
+    })).toBeNull();
+    expect(classifyHostedPulseTrialExtensionProviderState({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      stripeCustomerId: CUSTOMER_ID,
+      stripeSubscriptionId: SUBSCRIPTION_ID,
+      subscription: makeSubscription({
+        extensionDays: "7",
+        extensionOperation: RECOVERABLE_OPERATION_ID,
+        extensionTargetTrialEnd: Math.floor(NOW.getTime() / 1000) - 1,
+        status: "active",
+        trialEnd: 1_700_000_000,
+      }),
+    })).toBe("provider_subscription_not_extendable");
+    expect(classifyHostedPulseTrialExtensionProviderState({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      stripeCustomerId: CUSTOMER_ID,
+      stripeSubscriptionId: SUBSCRIPTION_ID,
       subscription: makeSubscription({ customerId: "cus_other" }),
     })).toBe("provider_identity_mismatch");
   });
@@ -183,16 +212,37 @@ describe("single-member Pulse Trial extension", () => {
     if (!preview.previewProof) {
       throw new Error("Expected an eligible preview.");
     }
-    stripe.retrieveSubscription.mockResolvedValue(paused);
-    stripe.updateSubscription.mockImplementation(async (_id, params) =>
-      makeSubscription({
+    const operationId = preview.previewProof.token.split(".")[2];
+    if (!operationId) {
+      throw new Error("Expected an operation ID.");
+    }
+    let providerSubscription = paused;
+    stripe.retrieveSubscription.mockImplementation(
+      async () => providerSubscription,
+    );
+    stripe.updateSubscription.mockImplementation(async (_id, params) => {
+      providerSubscription = makeSubscription({
         extensionDays: params.metadata.murphTrialExtensionDays,
         extensionOperation:
           params.metadata.murphTrialExtensionOperation,
-        status: "trialing",
-        trialEnd: params.trial_end,
-      })
-    );
+        extensionTargetTrialEnd: Number(
+          params.metadata.murphTrialExtensionTargetTrialEnd,
+        ),
+        status: params.trial_end === undefined ? "paused" : "trialing",
+        trialEnd: params.trial_end ?? 1_700_000_000,
+      });
+      return providerSubscription;
+    });
+    stripe.resumeSubscription.mockImplementation(async () => {
+      providerSubscription = makeSubscription({
+        extensionDays: "7",
+        extensionOperation: operationId,
+        extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+        status: "active",
+        trialEnd: 1_700_000_000,
+      });
+      return providerSubscription;
+    });
 
     const result = await applyHostedPulseTrialExtension({
       memberId: MEMBER_ID,
@@ -203,20 +253,62 @@ describe("single-member Pulse Trial extension", () => {
       stripe,
     });
 
-    expect(stripe.updateSubscription).toHaveBeenCalledWith(
+    expect(stripe.updateSubscription).toHaveBeenNthCalledWith(
+      1,
+      SUBSCRIPTION_ID,
+      {
+        metadata: {
+          murphTrialExtensionDays: "7",
+          murphTrialExtensionOperation: operationId,
+          murphTrialExtensionTargetTrialEnd: TARGET_FROM_PAUSED.toString(),
+        },
+      },
+      expect.objectContaining({
+        idempotencyKey:
+          `hosted-member-trial-extension:prepare:${operationId}`,
+        maxNetworkRetries: 0,
+        timeout: 80_000,
+      }),
+    );
+    expect(stripe.resumeSubscription).toHaveBeenCalledWith(
+      SUBSCRIPTION_ID,
+      {
+        billing_cycle_anchor: "unchanged",
+        proration_behavior: "none",
+      },
+      expect.objectContaining({
+        idempotencyKey:
+          `hosted-member-trial-extension:resume:${operationId}`,
+        maxNetworkRetries: 0,
+        timeout: 80_000,
+      }),
+    );
+    expect(stripe.updateSubscription).toHaveBeenNthCalledWith(
+      2,
       SUBSCRIPTION_ID,
       expect.objectContaining({
         proration_behavior: "none",
         trial_end: TARGET_FROM_PAUSED,
       }),
       expect.objectContaining({
-        idempotencyKey: expect.stringMatching(
-          /^hosted-member-trial-extension:[A-Za-z0-9_-]{43}$/u,
-        ),
+        idempotencyKey:
+          `hosted-member-trial-extension:update:${operationId}`,
         maxNetworkRetries: 0,
         timeout: 80_000,
       }),
     );
+    const prepareOrder = stripe.updateSubscription.mock.invocationCallOrder[0];
+    const resumeOrder = stripe.resumeSubscription.mock.invocationCallOrder[0];
+    const updateOrder = stripe.updateSubscription.mock.invocationCallOrder[1];
+    if (
+      prepareOrder === undefined ||
+      resumeOrder === undefined ||
+      updateOrder === undefined
+    ) {
+      throw new Error("Expected all three Stripe mutation steps.");
+    }
+    expect(prepareOrder).toBeLessThan(resumeOrder);
+    expect(resumeOrder).toBeLessThan(updateOrder);
     expect(mocks.withHostedMemberStripeMutationLockForOps).toHaveBeenCalledWith(
       expect.objectContaining({
         acquisitionTimeoutMs: 25_000,
@@ -295,9 +387,20 @@ describe("single-member Pulse Trial extension", () => {
 
     expect(stripe.updateSubscription).toHaveBeenCalledWith(
       SUBSCRIPTION_ID,
-      expect.objectContaining({ trial_end: TARGET_FROM_LIVE }),
-      expect.any(Object),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          murphTrialExtensionTargetTrialEnd: TARGET_FROM_LIVE.toString(),
+        }),
+        trial_end: TARGET_FROM_LIVE,
+      }),
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^hosted-member-trial-extension:update:[A-Za-z0-9_-]{43}$/u,
+        ),
+      }),
     );
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(1);
+    expect(stripe.resumeSubscription).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       currentTrialEndsAt: new Date(TARGET_FROM_LIVE * 1000).toISOString(),
       outcome: "extended",
@@ -466,8 +569,8 @@ describe("single-member Pulse Trial extension", () => {
   });
 
   test("reports lock contention and Stripe failures without local reconciliation", async () => {
-    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
-    const stripe = makeStripeClient(paused);
+    const live = makeSubscription({ status: "trialing" });
+    const stripe = makeStripeClient(live);
     const preview = await previewHostedPulseTrialExtension({
       memberId: MEMBER_ID,
       now: NOW,
@@ -494,7 +597,7 @@ describe("single-member Pulse Trial extension", () => {
     mocks.withHostedMemberStripeMutationLockForOps.mockImplementation(
       async (input: { run: (tx: object) => Promise<unknown> }) => input.run({}),
     );
-    stripe.retrieveSubscription.mockResolvedValue(paused);
+    stripe.retrieveSubscription.mockResolvedValue(live);
     stripe.updateSubscription.mockRejectedValueOnce({
       code: "api_connection_error",
       message: `sensitive ${MEMBER_ID} ${CUSTOMER_ID} ${SUBSCRIPTION_ID}`,
@@ -633,8 +736,8 @@ describe("single-member Pulse Trial extension", () => {
   });
 
   test("identifies post-update validation failure without local reconciliation", async () => {
-    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
-    const stripe = makeStripeClient(paused);
+    const live = makeSubscription({ status: "trialing" });
+    const stripe = makeStripeClient(live);
     const preview = await previewHostedPulseTrialExtension({
       memberId: MEMBER_ID,
       now: NOW,
@@ -645,10 +748,10 @@ describe("single-member Pulse Trial extension", () => {
     if (!preview.previewProof) {
       throw new Error("Expected an eligible preview.");
     }
-    stripe.retrieveSubscription.mockResolvedValue(paused);
+    stripe.retrieveSubscription.mockResolvedValue(live);
     stripe.updateSubscription.mockResolvedValue(makeSubscription({
       status: "trialing",
-      trialEnd: TARGET_FROM_PAUSED,
+      trialEnd: TARGET_FROM_LIVE,
     }));
 
     const validationError = await applyHostedPulseTrialExtension({
@@ -670,9 +773,494 @@ describe("single-member Pulse Trial extension", () => {
     ).not.toHaveBeenCalled();
   });
 
+  test("validates prepared and resumed paused states before local reconciliation", async () => {
+    const paused = makeSubscription({
+      status: "paused",
+      trialEnd: 1_700_000_000,
+    });
+    const prepareStripe = makeStripeClient(paused);
+    const preparePreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe: prepareStripe,
+    });
+    if (!preparePreview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    prepareStripe.retrieveSubscription.mockResolvedValue(paused);
+    prepareStripe.updateSubscription.mockResolvedValue(paused);
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preparePreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe: prepareStripe,
+    })).rejects.toMatchObject({
+      logDetails: { operationName: "validate_prepared_subscription" },
+    });
+    expect(prepareStripe.resumeSubscription).not.toHaveBeenCalled();
+
+    const resumeStripe = makeStripeClient(paused);
+    const resumePreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe: resumeStripe,
+    });
+    if (!resumePreview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    const operationId = resumePreview.previewProof.token.split(".")[2];
+    if (!operationId) {
+      throw new Error("Expected an operation ID.");
+    }
+    const prepared = makeSubscription({
+      extensionDays: "7",
+      extensionOperation: operationId,
+      extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+      status: "paused",
+      trialEnd: 1_700_000_000,
+    });
+    resumeStripe.retrieveSubscription.mockResolvedValue(paused);
+    resumeStripe.updateSubscription.mockResolvedValue(prepared);
+    resumeStripe.resumeSubscription.mockResolvedValue(prepared);
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: resumePreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe: resumeStripe,
+    })).rejects.toMatchObject({
+      logDetails: { operationName: "validate_resumed_subscription" },
+    });
+    expect(resumeStripe.updateSubscription).toHaveBeenCalledTimes(1);
+    expect(mocks.updateHostedMemberCoreState).not.toHaveBeenCalled();
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+  });
+
+  test("recovers a prepared paused trial through a fresh Preview after response loss", async () => {
+    let providerSubscription = makeSubscription({
+      status: "paused",
+      trialEnd: 1_700_000_000,
+    });
+    const stripe = makeStripeClient(providerSubscription);
+    stripe.retrieveSubscription.mockImplementation(
+      async () => providerSubscription,
+    );
+    const initialPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!initialPreview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    const operationId = initialPreview.previewProof.token.split(".")[2];
+    if (!operationId) {
+      throw new Error("Expected an operation ID.");
+    }
+    let losePrepareResponse = true;
+    stripe.updateSubscription.mockImplementation(async (_id, params) => {
+      providerSubscription = makeSubscription({
+        extensionDays: params.metadata.murphTrialExtensionDays,
+        extensionOperation: params.metadata.murphTrialExtensionOperation,
+        extensionTargetTrialEnd: Number(
+          params.metadata.murphTrialExtensionTargetTrialEnd,
+        ),
+        status: params.trial_end === undefined ? "paused" : "trialing",
+        trialEnd: params.trial_end ?? 1_700_000_000,
+      });
+      if (params.trial_end === undefined && losePrepareResponse) {
+        losePrepareResponse = false;
+        throw new Error("response lost after prepare");
+      }
+      return providerSubscription;
+    });
+    stripe.resumeSubscription.mockImplementation(async () => {
+      providerSubscription = makeSubscription({
+        extensionDays: "7",
+        extensionOperation: operationId,
+        extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+        status: "active",
+        trialEnd: 1_700_000_000,
+      });
+      return providerSubscription;
+    });
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: initialPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toMatchObject({
+      logDetails: expect.objectContaining({
+        operationName: "prepare_subscription",
+      }),
+    });
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+
+    const recoveryPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:03:00.000Z"),
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    expect(recoveryPreview).toMatchObject({
+      eligible: true,
+      message: "This unfinished Pulse Trial extension can be completed.",
+      providerStatus: "paused",
+      targetTrialEndsAt: new Date(TARGET_FROM_PAUSED * 1000).toISOString(),
+    });
+    if (!recoveryPreview.previewProof) {
+      throw new Error("Expected a recovery preview proof.");
+    }
+
+    const recoveryDigestEnd = recoveryPreview.previewProof.token.at(-1);
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:04:00.000Z"),
+      previewProof: {
+        ...recoveryPreview.previewProof,
+        token: `${recoveryPreview.previewProof.token.slice(0, -1)}${
+          recoveryDigestEnd === "a" ? "b" : "a"
+        }`,
+      },
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(1);
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+
+    const result = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:04:00.000Z"),
+      previewProof: recoveryPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+
+    expect(result.outcome).toBe("extended");
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(2);
+    expect(stripe.resumeSubscription).toHaveBeenCalledTimes(1);
+    expect(stripe.updateSubscription.mock.calls[1]?.[1].metadata)
+      .toMatchObject({ murphTrialExtensionOperation: operationId });
+  });
+
+  test("recovers an active intermediate through a fresh Preview after resume response loss", async () => {
+    let providerSubscription = makeSubscription({
+      status: "paused",
+      trialEnd: 1_700_000_000,
+    });
+    const stripe = makeStripeClient(providerSubscription);
+    stripe.retrieveSubscription.mockImplementation(
+      async () => providerSubscription,
+    );
+    const initialPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!initialPreview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    const operationId = initialPreview.previewProof.token.split(".")[2];
+    if (!operationId) {
+      throw new Error("Expected an operation ID.");
+    }
+    stripe.updateSubscription.mockImplementation(async (_id, params) => {
+      providerSubscription = makeSubscription({
+        extensionDays: params.metadata.murphTrialExtensionDays,
+        extensionOperation: params.metadata.murphTrialExtensionOperation,
+        extensionTargetTrialEnd: Number(
+          params.metadata.murphTrialExtensionTargetTrialEnd,
+        ),
+        status: params.trial_end === undefined ? "paused" : "trialing",
+        trialEnd: params.trial_end ?? 1_700_000_000,
+      });
+      return providerSubscription;
+    });
+    stripe.resumeSubscription.mockImplementationOnce(async () => {
+      providerSubscription = makeSubscription({
+        extensionDays: "7",
+        extensionOperation: operationId,
+        extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+        status: "active",
+        trialEnd: 1_700_000_000,
+      });
+      throw new Error("response lost after resume");
+    });
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: initialPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toMatchObject({
+      logDetails: expect.objectContaining({
+        operationName: "resume_subscription",
+      }),
+    });
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+
+    const recoveryPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:03:00.000Z"),
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    expect(recoveryPreview).toMatchObject({
+      eligible: true,
+      message: "This unfinished Pulse Trial extension can be completed.",
+      providerStatus: "active",
+      targetTrialEndsAt: new Date(TARGET_FROM_PAUSED * 1000).toISOString(),
+    });
+    if (!recoveryPreview.previewProof) {
+      throw new Error("Expected a recovery preview proof.");
+    }
+
+    const finalRecoveryDigestEnd = recoveryPreview.previewProof.token.at(-1);
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:04:00.000Z"),
+      previewProof: {
+        ...recoveryPreview.previewProof,
+        token: `${recoveryPreview.previewProof.token.slice(0, -1)}${
+          finalRecoveryDigestEnd === "a" ? "b" : "a"
+        }`,
+      },
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(1);
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+
+    const result = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:04:00.000Z"),
+      previewProof: recoveryPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+
+    expect(result.outcome).toBe("extended");
+    expect(stripe.resumeSubscription).toHaveBeenCalledTimes(1);
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(2);
+    expect(stripe.updateSubscription.mock.calls[1]?.[1].metadata)
+      .toMatchObject({ murphTrialExtensionOperation: operationId });
+  });
+
+  test("fresh Preview reconciles the exact target after final update response loss", async () => {
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValue(makeMember({
+      billingPhase: "trial",
+      billingStatus: HostedBillingStatus.active,
+      trialEndsAt: new Date(ORIGINAL_TRIAL_END * 1000),
+    }));
+    let providerSubscription = makeSubscription({ status: "trialing" });
+    const stripe = makeStripeClient(providerSubscription);
+    stripe.retrieveSubscription.mockImplementation(
+      async () => providerSubscription,
+    );
+    const initialPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!initialPreview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    const operationId = initialPreview.previewProof.token.split(".")[2];
+    if (!operationId) {
+      throw new Error("Expected an operation ID.");
+    }
+    stripe.updateSubscription.mockImplementationOnce(async (_id, params) => {
+      providerSubscription = makeSubscription({
+        extensionDays: params.metadata.murphTrialExtensionDays,
+        extensionOperation: params.metadata.murphTrialExtensionOperation,
+        extensionTargetTrialEnd: Number(
+          params.metadata.murphTrialExtensionTargetTrialEnd,
+        ),
+        status: "trialing",
+        trialEnd: params.trial_end,
+      });
+      throw new Error("response lost after final update");
+    });
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: initialPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionProviderError);
+
+    const recoveryPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:03:00.000Z"),
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    expect(recoveryPreview).toMatchObject({
+      message: "This unfinished Pulse Trial extension can be completed.",
+      targetTrialEndsAt: new Date(TARGET_FROM_LIVE * 1000).toISOString(),
+    });
+    if (!recoveryPreview.previewProof) {
+      throw new Error("Expected a recovery preview proof.");
+    }
+
+    const reconciledRecoveryDigestEnd = recoveryPreview.previewProof.token.at(-1);
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:04:00.000Z"),
+      previewProof: {
+        ...recoveryPreview.previewProof,
+        token: `${recoveryPreview.previewProof.token.slice(0, -1)}${
+          reconciledRecoveryDigestEnd === "a" ? "b" : "a"
+        }`,
+      },
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(1);
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+
+    const result = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:04:00.000Z"),
+      previewProof: recoveryPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+
+    expect(result.outcome).toBe("reconciled");
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(1);
+    expect(stripe.resumeSubscription).not.toHaveBeenCalled();
+    expect(mocks.writeHostedMemberStripeBillingRefTx).toHaveBeenCalledTimes(1);
+  });
+
+  test("reconciles a completed paused extension after the local write fails", async () => {
+    let providerSubscription = makeSubscription({
+      status: "paused",
+      trialEnd: 1_700_000_000,
+    });
+    const stripe = makeStripeClient(providerSubscription);
+    stripe.retrieveSubscription.mockImplementation(
+      async () => providerSubscription,
+    );
+    const initialPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!initialPreview.previewProof) {
+      throw new Error("Expected an eligible preview.");
+    }
+    const operationId = initialPreview.previewProof.token.split(".")[2];
+    if (!operationId) {
+      throw new Error("Expected an operation ID.");
+    }
+    stripe.updateSubscription.mockImplementation(async (_id, params) => {
+      providerSubscription = makeSubscription({
+        extensionDays: params.metadata.murphTrialExtensionDays,
+        extensionOperation: params.metadata.murphTrialExtensionOperation,
+        extensionTargetTrialEnd: Number(
+          params.metadata.murphTrialExtensionTargetTrialEnd,
+        ),
+        status: params.trial_end === undefined ? "paused" : "trialing",
+        trialEnd: params.trial_end ?? 1_700_000_000,
+      });
+      return providerSubscription;
+    });
+    stripe.resumeSubscription.mockImplementation(async () => {
+      providerSubscription = makeSubscription({
+        extensionDays: "7",
+        extensionOperation: operationId,
+        extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+        status: "active",
+        trialEnd: 1_700_000_000,
+      });
+      return providerSubscription;
+    });
+    mocks.writeHostedMemberStripeBillingRefTx.mockRejectedValueOnce(
+      new Error("local billing write failed"),
+    );
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: initialPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toThrow("local billing write failed");
+    expect(providerSubscription).toMatchObject({
+      status: "trialing",
+      trial_end: TARGET_FROM_PAUSED,
+    });
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(2);
+    expect(stripe.resumeSubscription).toHaveBeenCalledTimes(1);
+
+    const recoveryPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:03:00.000Z"),
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    expect(recoveryPreview).toMatchObject({
+      message: "This unfinished Pulse Trial extension can be completed.",
+      targetTrialEndsAt: new Date(TARGET_FROM_PAUSED * 1000).toISOString(),
+    });
+    if (!recoveryPreview.previewProof) {
+      throw new Error("Expected a recovery preview proof.");
+    }
+
+    const result = await applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:04:00.000Z"),
+      previewProof: recoveryPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+
+    expect(result.outcome).toBe("reconciled");
+    expect(stripe.updateSubscription).toHaveBeenCalledTimes(2);
+    expect(stripe.resumeSubscription).toHaveBeenCalledTimes(1);
+    expect(mocks.writeHostedMemberStripeBillingRefTx).toHaveBeenCalledTimes(2);
+  });
+
   test("reconciles an expired exact marker after an ambiguous provider success", async () => {
-    const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
-    const stripe = makeStripeClient(paused);
+    const live = makeSubscription({ status: "trialing" });
+    const stripe = makeStripeClient(live);
     const preview = await previewHostedPulseTrialExtension({
       memberId: MEMBER_ID,
       now: NOW,
@@ -687,7 +1275,7 @@ describe("single-member Pulse Trial extension", () => {
     if (!operationId) {
       throw new Error("Expected an operation ID.");
     }
-    let providerSubscription = paused;
+    let providerSubscription = live;
     stripe.retrieveSubscription.mockImplementation(
       async () => providerSubscription,
     );
@@ -696,7 +1284,7 @@ describe("single-member Pulse Trial extension", () => {
         extensionDays: "7",
         extensionOperation: operationId,
         status: "trialing",
-        trialEnd: TARGET_FROM_PAUSED,
+        trialEnd: TARGET_FROM_LIVE,
       });
       throw new Error("response lost after provider success");
     });
@@ -766,6 +1354,7 @@ function makeSubscription(input: {
   customerId?: string;
   extensionDays?: string;
   extensionOperation?: string;
+  extensionTargetTrialEnd?: number;
   status?: Stripe.Subscription.Status;
   trialEnd?: number | null;
 } = {}): HostedPulseTrialExtensionSubscription {
@@ -803,6 +1392,12 @@ function makeSubscription(input: {
       ...(input.extensionOperation
         ? { murphTrialExtensionOperation: input.extensionOperation }
         : {}),
+      ...(input.extensionTargetTrialEnd
+        ? {
+            murphTrialExtensionTargetTrialEnd:
+              input.extensionTargetTrialEnd.toString(),
+          }
+        : {}),
     },
     status: input.status ?? "trialing",
     trial_end: input.trialEnd === undefined
@@ -820,13 +1415,23 @@ function makeSubscription(input: {
 function makeStripeClient(subscription: HostedPulseTrialExtensionSubscription) {
   return {
     retrieveSubscription: vi.fn(async () => subscription),
+    resumeSubscription: vi.fn<
+      (
+        id: string,
+        params: {
+          billing_cycle_anchor: "unchanged";
+          proration_behavior: "none";
+        },
+        options: Stripe.RequestOptions,
+      ) => Promise<HostedPulseTrialExtensionSubscription>
+    >(async () => subscription),
     updateSubscription: vi.fn<
       (
         id: string,
         params: {
           metadata: Record<string, string>;
-          proration_behavior: "none";
-          trial_end: number;
+          proration_behavior?: "none";
+          trial_end?: number;
         },
         options: Stripe.RequestOptions,
       ) => Promise<HostedPulseTrialExtensionSubscription>


### PR DESCRIPTION
## Why this PR exists

Production Apply retrieves a valid lapsed Pulse Trial but Stripe rejects setting trial_end while the subscription is paused. Stripe requires the subscription to be resumed before a new trial is configured.

## User goal and experience

An operator can Preview one member and Apply the seven-day recovery once. A paused trial is prepared, resumed without an invoice, and moved to the exact trial target; if any provider response or the local write is lost, a fresh signed Preview offers completion of that same operation rather than adding another seven days. Existing live trials keep the one-update extension path, and failures retain the generic identifier-free response.

## Invariants

- Stripe remains authoritative for subscription status and trial dates.
- Resume keeps the billing anchor unchanged with no proration, so it creates no debit proration or new invoice before the trial update.
- Provider steps use distinct stable idempotency keys and one operation marker bound to one exact target.
- Local billing changes only after the final trialing provider shape is proven; partial success is recoverable.
- Paid, canceling, identity-mismatched, unmarked active, and tampered/stale Preview states remain ineligible.
- Logs and caller-visible failures contain no member, customer, subscription, request, credential, or raw provider-message identifiers.

## Verification

- Required state-consistency audit: both partial-state findings resolved; no unresolved finding.
- Required coverage-write audit: added local-write-loss recovery proof; no unresolved material gap.
- Focused four-file billing suite: 72 tests passed after rebase.
- pnpm test:diff: all workspace guards, hosted-web TypeScript, dev smoke, 5,110 tests, lint with zero errors, and optimized Next production build passed.

## Change shape

Classification: authored runtime TypeScript is source; Vitest is tests/fixtures; the archived execution plan is docs; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 366 | 49 |
| Tests/fixtures | 631 | 26 |
| Docs | 103 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 1100 | 75 |

ReviewGPT first-reviewed head: 10b185a186ebca05613a8b4d6f1d4a702d68c16e

## Deployment compatibility

Vercel web only; no schema, environment, Cloudflare Worker, container, or persisted-state contract changes. Old and new web instances remain compatible during rollout because the route and local billing schema are unchanged. The exposed operation is one bounded manual member action, reversible through the same exact-target reconciliation path. Post-deploy proof is one fresh Preview, one Apply, and safe operation-level Vercel log inspection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786685517&installation_id=127572939&pr_number=666&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F666&signature=fd26256446f29c156b11b667ca0d3d623cfb6f5012192b72195b6c66670408e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->