### PR TITLE
Delete Linq invite delivery identifiers on account removal

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-linq-invite-delivery-deletion.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-linq-invite-delivery-deletion.md
@@ -1,0 +1,96 @@
+# Delete Linq invite-delivery identifiers with hosted accounts
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Ensure permanent hosted-account deletion removes Linq signup-link delivery
+  records that carry the deleted member's raw identifier, including historical
+  orphan rows left by earlier deletions.
+
+## Success criteria
+
+- Account deletion removes every `invite_signup` and `invite_signup_fallback`
+  delivery row whose raw source reference belongs to the deleted personal or
+  owned thread-container member.
+- A side effect that resumes after the account-deletion suspension fence cannot
+  recreate an invite-delivery row for that member.
+- A migration removes historical invite-delivery rows whose referenced member
+  no longer exists without touching live-member delivery state.
+- The account-data store inventory, durable deletion documentation, focused
+  tests, scoped verification, required coverage audit, ReviewGPT, and PR CI all
+  confirm the privacy fix with no unresolved accepted finding.
+
+## Scope
+
+- In scope: the Linq signup-link effect-id owner; Linq side-effect dispatch
+  preparation; hosted account deletion counts and transaction; one bounded
+  orphan-row cleanup migration; focused tests and current deletion docs.
+- Out of scope: general Linq observability retention, provider-side message
+  deletion, invite retry semantics, unrelated account-deletion stores, and any
+  new persisted ownership model.
+
+## Invariants
+
+- Live signup-link receipts can still reopen or restore the same member/day
+  notice claim before account deletion.
+- Account suspension remains the first local deletion fence, and deletion keeps
+  its existing fail-closed provider cleanup and transaction ordering.
+- Late or duplicate Linq work cannot recreate account-linked operational rows
+  after the suspension fence.
+- Historical cleanup targets only recognized signup-link rows whose parsed raw
+  member identifier has no matching hosted member.
+- No provider credential, raw contact value, invite code, or message content is
+  added to storage, logs, tests, docs, or review artifacts.
+
+## Implementation steps
+
+1. Add one shared builder for the canonical per-member signup-link effect-id
+   prefix and use it to select account-owned delivery rows.
+2. Fence signup-link delivery claiming on the existing hosted-member row lock
+   plus an unsuspended matching invite/member check.
+3. Count and delete the selected rows in the account-deletion transaction.
+4. Add a data-only migration that deletes recognized orphan rows from previous
+   account deletions.
+5. Update focused tests and the account-data deletion store matrix/docs.
+6. Run the routed verification, coverage audit, parent final review, scoped
+   commit, PR, ReviewGPT loop, CI, and mergeability proof.
+
+## Verification
+
+- Focused Vitest for hosted account deletion, Linq transport, Linq observability,
+  and privacy migration guards.
+- `pnpm test:diff` over the touched web owner, tests, migration, and docs when it
+  truthfully selects the hosted-web lane.
+- Direct readback of the migration predicate and account-deletion `deleteMany`
+  predicate proving live-member rows are preserved while deleted-member rows are
+  removed.
+- Required `coverage-write` audit; ReviewGPT is the sole cross-cutting gate for
+  the PR lane.
+
+## Risks and mitigations
+
+- Risk: deleting a live member's delivery row breaks receipt-driven retry state.
+  Mitigation: transactional deletion selects only the exact deleting member ids;
+  migration cleanup requires that the parsed member id no longer exists.
+- Risk: a delayed side effect recreates a row after the deletion transaction.
+  Mitigation: claim under the existing member row lock and require the member to
+  remain unsuspended with the matching invite before writing.
+- Risk: an over-broad string predicate deletes unrelated observability rows.
+  Mitigation: require the two signup templates, the canonical prefix, and an
+  exact parsed member-id match; cover personal and owned runtime member ids.
+
+## Progress
+
+- [x] Traced the audit finding to raw signup-link `sourceRef` persistence and the
+  missing deletion coverage.
+- [x] Implemented account-linked delivery deletion, the late-dispatch fence,
+  historical cleanup, store inventory/docs, and focused regression proof.
+- [x] Completed the required `coverage-write` pass, web typecheck, lint, build,
+  smoke, focused suites, and disposable PostgreSQL migration scenario. The full
+  web test lane passed 5,244 of 5,245 tests; its sole unrelated connection-close
+  timing failure passed immediately in isolation.
+- [ ] Commit, PR, ReviewGPT, CI, and mergeability proof.
+Completed: 2026-07-15

--- a/apps/web/prisma/migrations/20260715120000_delete_orphaned_linq_invite_deliveries/migration.sql
+++ b/apps/web/prisma/migrations/20260715120000_delete_orphaned_linq_invite_deliveries/migration.sql
@@ -1,0 +1,9 @@
+DELETE FROM "hosted_linq_delivery" AS "delivery"
+WHERE "delivery"."template" IN ('invite_signup', 'invite_signup_fallback')
+  AND "delivery"."source_ref" LIKE 'linq-invite-signup:%'
+  AND split_part("delivery"."source_ref", ':', 2) <> ''
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "hosted_member" AS "member"
+    WHERE "member"."id" = split_part("delivery"."source_ref", ':', 2)
+  );

--- a/apps/web/src/lib/hosted-onboarding/linq-invite-signup-effect-id.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-invite-signup-effect-id.ts
@@ -16,10 +16,16 @@ export function buildHostedLinqInviteSignupEffectId(input: {
   occurredAt: Date | string;
 }): string {
   const dayUtc = resolveHostedLinqDayUtc(input.occurredAt).toISOString();
-  const base = `${HOSTED_LINQ_INVITE_SIGNUP_EFFECT_ID_PREFIX}${input.memberId}:${dayUtc}`;
+  const base = `${buildHostedLinqInviteSignupEffectIdMemberPrefix(input.memberId)}${dayUtc}`;
   return typeof input.attempt === "number" && input.attempt > 1
     ? `${base}:a${input.attempt}`
     : base;
+}
+
+export function buildHostedLinqInviteSignupEffectIdMemberPrefix(
+  memberId: string,
+): string {
+  return `${HOSTED_LINQ_INVITE_SIGNUP_EFFECT_ID_PREFIX}${memberId}:`;
 }
 
 export function parseHostedLinqInviteSignupEffectId(

--- a/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
@@ -57,6 +57,7 @@ import {
   toHostedOnboardingLogIdSuffix,
 } from "./logging";
 import { requireHostedOnboardingLinqConfig } from "./runtime";
+import { lockHostedMemberRow } from "./shared";
 
 type HostedLinqTransportPersistenceClient = PrismaClient | Prisma.TransactionClient;
 type HostedLinqTransportPostResponseScheduler = (task: () => Promise<void>) => void;
@@ -312,6 +313,11 @@ type HostedLinqSideEffectDrainSkipReason =
   | "notice_in_flight"
   | "notice_target_unauthorized";
 
+type HostedLinqProviderDispatchPreparation =
+  | "claimed"
+  | "in_flight"
+  | "target_unauthorized";
+
 export type HostedLinqSideEffectDrainResult = {
   sentCount: number;
   skipped: readonly {
@@ -437,7 +443,7 @@ async function sendHostedLinqSideEffect(
       ? effect.payload
       : null;
   const deliveryAttemptTask = usageLimitPayload
-    ? Promise.resolve(true)
+    ? Promise.resolve<HostedLinqProviderDispatchPreparation>("claimed")
     : prepareHostedLinqSideEffectProviderDispatch({
         effect,
         prisma: options.prisma,
@@ -446,7 +452,11 @@ async function sendHostedLinqSideEffect(
   let deliveryEffect = effect;
 
   try {
-    if (!await deliveryAttemptTask) {
+    const preparation = await deliveryAttemptTask;
+    if (preparation === "target_unauthorized") {
+      return "notice_target_unauthorized";
+    }
+    if (preparation === "in_flight") {
       return "notice_in_flight";
     }
 
@@ -694,34 +704,42 @@ async function prepareHostedLinqSideEffectProviderDispatch(input: {
   effect: HostedLinqMessageSideEffect;
   prisma: HostedLinqTransportPersistenceClient;
   startedAtMs: number;
-}): Promise<boolean> {
+}): Promise<HostedLinqProviderDispatchPreparation> {
   const template = input.effect.payload.template;
   const target = readHostedLinqSideEffectDeliveryTarget(input.effect.payload);
-  if (!target.linqChatId) {
-    const claim = await claimHostedLinqDeliveryProviderDispatchTx({
-      attemptedAt: new Date(input.startedAtMs),
-      idempotencyKey: input.effect.effectId,
-      phoneNumber: target.phoneNumber,
-      prisma: input.prisma,
-      source: "hosted_webhook_side_effect",
-      sourceRef: input.effect.effectId,
-      status: "provider_dispatch_started",
-      targetKind: target.targetKind,
-      template,
-    });
-    return claim.claimed;
-  }
 
   return await runHostedLinqTransportTransaction(input.prisma, async (prisma) => {
-    await acquireHostedLinqChatOwnershipLockTx({
-      chatId: target.linqChatId,
-      tx: prisma,
-    });
-    await assertHostedLinqSideEffectRouteAuthority(input.effect, prisma);
+    if (
+      input.effect.payload.template === "invite_signup"
+      || input.effect.payload.template === "invite_signup_fallback"
+    ) {
+      await lockHostedMemberRow(prisma, input.effect.payload.memberId);
+      const invite = await prisma.hostedInvite.findUnique({
+        select: { id: true },
+        where: {
+          id: input.effect.payload.inviteId,
+          member: { suspendedAt: null },
+          memberId: input.effect.payload.memberId,
+        },
+      });
+      if (!invite) {
+        return "target_unauthorized";
+      }
+    }
+
+    if (target.linqChatId) {
+      await acquireHostedLinqChatOwnershipLockTx({
+        chatId: target.linqChatId,
+        tx: prisma,
+      });
+      await assertHostedLinqSideEffectRouteAuthority(input.effect, prisma);
+    }
     const claim = await claimHostedLinqDeliveryProviderDispatchTx({
       attemptedAt: new Date(input.startedAtMs),
       idempotencyKey: input.effect.effectId,
-      linqChatId: target.linqChatId,
+      ...(target.linqChatId
+        ? { linqChatId: target.linqChatId }
+        : { phoneNumber: target.phoneNumber }),
       prisma,
       source: "hosted_webhook_side_effect",
       sourceRef: input.effect.effectId,
@@ -729,7 +747,7 @@ async function prepareHostedLinqSideEffectProviderDispatch(input: {
       targetKind: target.targetKind,
       template,
     });
-    return claim.claimed;
+    return claim.claimed ? "claimed" : "in_flight";
   });
 }
 

--- a/apps/web/src/lib/hosted-privacy/account-data-service.ts
+++ b/apps/web/src/lib/hosted-privacy/account-data-service.ts
@@ -31,6 +31,7 @@ import { readHostedMemberStripeBillingRef } from "../hosted-onboarding/hosted-me
 import { readHostedMemberIdentity } from "../hosted-onboarding/hosted-member-identity-store";
 import { readHostedAccountGroupStripeBillingRef } from "../hosted-onboarding/family-plan";
 import { deleteHostedPrivyUser } from "../hosted-onboarding/privy";
+import { buildHostedLinqInviteSignupEffectIdMemberPrefix } from "../hosted-onboarding/linq-invite-signup-effect-id";
 import { getHostedOnboardingStripe } from "../hosted-onboarding/runtime";
 import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from "../hosted-onboarding/shared";
 import {
@@ -243,6 +244,12 @@ export const HOSTED_ACCOUNT_DATA_STORE_COVERAGE = [
     label: "Linq daily message counters",
     deletion: "live-delete",
     note: "Deletes member-scoped Linq daily inbound/outbound quota counters.",
+  },
+  {
+    slug: "prisma.hosted_linq_invite_delivery",
+    label: "Linq signup-link delivery records",
+    deletion: "live-delete",
+    note: "Deletes signup-link delivery records whose delivery identity contains the member id. Unrelated operational delivery records remain under their normal retention policy.",
   },
   {
     slug: "prisma.hosted_invite",
@@ -900,6 +907,21 @@ function buildStringInFilter(values: readonly string[]): string | { in: string[]
   return { in: uniqueValues };
 }
 
+function buildHostedLinqInviteSignupDeliveryWhere(
+  memberIds: readonly string[],
+): Prisma.HostedLinqDeliveryWhereInput {
+  return {
+    OR: uniqueStrings(memberIds).map((memberId) => ({
+      sourceRef: {
+        startsWith: buildHostedLinqInviteSignupEffectIdMemberPrefix(memberId),
+      },
+    })),
+    template: {
+      in: ["invite_signup", "invite_signup_fallback"],
+    },
+  };
+}
+
 async function assertNoConnectedAppWritesAfterProviderCleanupTx(input: {
   memberId: string;
   prisma: Prisma.TransactionClient;
@@ -1178,6 +1200,7 @@ async function countHostedAccountData(input: {
     hostedAiUsagePeriod,
     hostedProductFeedback,
     hostedLinqDailyState,
+    hostedLinqInviteDelivery,
     deviceConnection,
     deviceSyncCompanionCaptureReceipt,
     deviceSyncDirtyConnection,
@@ -1289,6 +1312,9 @@ async function countHostedAccountData(input: {
     input.prisma.hostedAiUsagePeriod.count({ where: { memberId: memberIdFilter } }),
     input.prisma.hostedProductFeedback.count({ where: { memberId: memberIdFilter } }),
     input.prisma.hostedLinqDailyState.count({ where: { memberId: memberIdFilter } }),
+    input.prisma.hostedLinqDelivery.count({
+      where: buildHostedLinqInviteSignupDeliveryWhere(memberIds),
+    }),
     input.prisma.deviceConnection.count({ where: { userId: memberIdFilter } }),
     input.prisma.deviceSyncCompanionCaptureReceipt.count({ where: { userId: memberIdFilter } }),
     input.prisma.deviceSyncDirtyConnection.count({ where: { userId: memberIdFilter } }),
@@ -1331,6 +1357,7 @@ async function countHostedAccountData(input: {
     "prisma.hosted_invite": hostedInvite,
     "prisma.hosted_ingress_latency_trace": hostedIngressLatencyTrace,
     "prisma.hosted_linq_daily_state": hostedLinqDailyState,
+    "prisma.hosted_linq_invite_delivery": hostedLinqInviteDelivery,
     "prisma.hosted_mailbox_item": hostedMailboxItem,
     "prisma.hosted_mailbox_lane_counter": hostedMailboxLaneCounter,
     "prisma.hosted_mailbox_payload": hostedMailboxPayload,
@@ -1391,6 +1418,9 @@ async function deleteHostedAccountPrismaRows(input: {
   record("prisma.hosted_product_feedback", await input.prisma.hostedProductFeedback.deleteMany({ where: { memberId: memberIdFilter } }));
   record("prisma.hosted_codex_auth_connection", await input.prisma.hostedCodexAuthConnection.deleteMany({ where: { memberId: memberIdFilter } }));
   record("prisma.hosted_linq_daily_state", await input.prisma.hostedLinqDailyState.deleteMany({ where: { memberId: memberIdFilter } }));
+  record("prisma.hosted_linq_invite_delivery", await input.prisma.hostedLinqDelivery.deleteMany({
+    where: buildHostedLinqInviteSignupDeliveryWhere(input.memberIds),
+  }));
   record("prisma.hosted_invite", await input.prisma.hostedInvite.deleteMany({ where: { memberId: memberIdFilter } }));
   record("prisma.hosted_consent_event", await input.prisma.hostedConsentEvent.deleteMany({ where: { memberId: memberIdFilter } }));
   record("prisma.hosted_consent_grant", await input.prisma.hostedConsentGrant.deleteMany({ where: { memberId: memberIdFilter } }));

--- a/apps/web/test/hosted-account-data-service.test.ts
+++ b/apps/web/test/hosted-account-data-service.test.ts
@@ -123,6 +123,7 @@ const REQUIRED_STORE_SLUGS = [
   "prisma.hosted_ai_usage_period",
   "prisma.hosted_product_feedback",
   "prisma.hosted_linq_daily_state",
+  "prisma.hosted_linq_invite_delivery",
   "prisma.hosted_invite",
   "prisma.hosted_consent_event",
   "prisma.hosted_consent_grant",
@@ -397,6 +398,26 @@ describe("deleteHostedAccountData", () => {
     });
     expect(deleteCalls).toEqual(expect.arrayContaining([
       {
+        model: "hostedLinqDelivery",
+        where: {
+          OR: [
+            {
+              sourceRef: {
+                startsWith: "linq-invite-signup:member_123:",
+              },
+            },
+            {
+              sourceRef: {
+                startsWith: "linq-invite-signup:member_thread_container_123:",
+              },
+            },
+          ],
+          template: {
+            in: ["invite_signup", "invite_signup_fallback"],
+          },
+        },
+      },
+      {
         model: "hostedThreadRoute",
         where: {
           OR: [
@@ -441,6 +462,7 @@ describe("deleteHostedAccountData", () => {
         },
       },
     ]));
+    expect(result.deletedCounts["prisma.hosted_linq_invite_delivery"]).toBe(1);
   });
 
   it("deletes delivery-time consume stamps with hosted mailbox item rows", async () => {

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -8753,12 +8753,15 @@ function asPrismaTransactionClient<T extends PrismaFixtureBase>(
   }
 
   if (hostedInvite && !hostedInvite.findUnique && hostedInvite.findFirst) {
-    hostedInvite.findUnique = vi.fn(async (input: { where?: Record<string, unknown>; select?: Record<string, unknown> }) =>
-      hostedInvite.findFirst?.({
+    hostedInvite.findUnique = vi.fn(async (input: { where?: Record<string, unknown>; select?: Record<string, unknown> }) => {
+      if (input.select?.id === true && typeof input.where?.id === "string") {
+        return { id: input.where.id };
+      }
+      return hostedInvite.findFirst?.({
         select: input.select,
         where: input.where,
-      }),
-    );
+      });
+    });
   }
 
   if (hostedMember && !hostedMember.updateMany) {

--- a/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@/src/lib/hosted-onboarding/linq-delivery-store";
 import {
   buildHostedLinqInviteSignupEffectId,
+  buildHostedLinqInviteSignupEffectIdMemberPrefix,
   parseHostedLinqInviteSignupEffectId,
 } from "@/src/lib/hosted-onboarding/linq-invite-signup-effect-id";
 import { ingestHostedLinqProviderEventTx } from "@/src/lib/hosted-onboarding/linq-provider-event-store";
@@ -3540,6 +3541,8 @@ describe("hosted Linq signup-link delivery attempts", () => {
   });
 
   it("round-trips attempt ordinals through the invite effect id", () => {
+    expect(buildHostedLinqInviteSignupEffectIdMemberPrefix("member_123"))
+      .toBe("linq-invite-signup:member_123:");
     expect(buildHostedLinqInviteSignupEffectId({
       memberId: "member_123",
       occurredAt: "2026-03-26T12:34:56.000Z",

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -260,6 +260,89 @@ describe("hosted Linq webhook transport", () => {
     });
   });
 
+  it("does not dispatch a signup link when its exact active invite is absent", async () => {
+    const effect = createHostedWebhookLinqMessageSideEffect({
+      chatId: "chat-1",
+      inviteId: "invite-1",
+      memberId: "member-1",
+      occurredAt: "2026-03-26T12:00:00.000Z",
+      sourceEventId: "event-deleted-member",
+      template: "invite_signup",
+    });
+    const prisma = createInviteSignupPrismaFixture({ inviteAuthorized: false });
+
+    await expect(
+      drainHostedLinqSideEffectsDirect({
+        prisma: prisma as never,
+        sideEffects: [effect],
+      }),
+    ).resolves.toEqual({
+      sentCount: 0,
+      skipped: [{
+        effectId: effect.effectId,
+        reason: "notice_target_unauthorized",
+        template: "invite_signup",
+      }],
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRaw).toHaveBeenCalledWith(expect.any(Array), "member-1");
+    expect(prisma.hostedInvite.findUnique).toHaveBeenCalledWith({
+      select: { id: true },
+      where: {
+        id: "invite-1",
+        member: { suspendedAt: null },
+        memberId: "member-1",
+      },
+    });
+    expect(prisma.$queryRaw.mock.invocationCallOrder[0])
+      .toBeLessThan(prisma.hostedInvite.findUnique.mock.invocationCallOrder[0] ?? 0);
+    expect(claimHostedLinqDeliveryProviderDispatchTx).not.toHaveBeenCalled();
+    expect(sendHostedLinqChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not create a fallback signup chat when its exact active invite is absent", async () => {
+    const effect = createHostedWebhookLinqMessageSideEffect({
+      assignedRecipientPhone: "+15550100001",
+      inviteId: "invite-1",
+      memberId: "member-1",
+      memberPhone: "+15551234567",
+      occurredAt: "2026-03-26T12:00:00.000Z",
+      sourceEventId: "event-deleted-member-fallback",
+      template: "invite_signup_fallback",
+    });
+    const prisma = createInviteSignupPrismaFixture({ inviteAuthorized: false });
+
+    await expect(
+      drainHostedLinqSideEffectsDirect({
+        prisma: prisma as never,
+        sideEffects: [effect],
+      }),
+    ).resolves.toEqual({
+      sentCount: 0,
+      skipped: [{
+        effectId: effect.effectId,
+        reason: "notice_target_unauthorized",
+        template: "invite_signup_fallback",
+      }],
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRaw).toHaveBeenCalledWith(expect.any(Array), "member-1");
+    expect(prisma.hostedInvite.findUnique).toHaveBeenCalledWith({
+      select: { id: true },
+      where: {
+        id: "invite-1",
+        member: { suspendedAt: null },
+        memberId: "member-1",
+      },
+    });
+    expect(prisma.$queryRaw.mock.invocationCallOrder[0])
+      .toBeLessThan(prisma.hostedInvite.findUnique.mock.invocationCallOrder[0] ?? 0);
+    expect(claimHostedLinqDeliveryProviderDispatchTx).not.toHaveBeenCalled();
+    expect(createHostedLinqChat).not.toHaveBeenCalled();
+  });
+
   it("does not share the contact card after a quota side effect with validated route authority", async () => {
     const route = buildAuthorizedLinqRouteFixture({
       memberId: "member-1",
@@ -1225,6 +1308,7 @@ describe("hosted Linq webhook transport", () => {
 
   it("creates fallback signup chats without thread-authority delivery", async () => {
     const prisma = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "member-1" }]),
       hostedInvite: {
         findUnique: vi.fn().mockResolvedValue({
           inviteCode: "invite-code",
@@ -1688,6 +1772,7 @@ describe("hosted Linq webhook transport", () => {
   it("does not mark invite signup notices sent when delivery fails", async () => {
     vi.mocked(sendHostedLinqChatMessage).mockRejectedValueOnce(new Error("send failed"));
     const prisma = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "member-1" }]),
       hostedInvite: {
         findUnique: vi.fn().mockResolvedValue({
           inviteCode: "invite-code",
@@ -1756,6 +1841,7 @@ describe("hosted Linq webhook transport", () => {
       });
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const prisma = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "member-1" }]),
       hostedInvite: {
         findUnique: vi.fn().mockResolvedValue({
           inviteCode: "invite-code",
@@ -1909,14 +1995,25 @@ function buildAuthorizedLinqRouteFixture(input: {
   };
 }
 
-function createInviteSignupPrismaFixture() {
-  return {
+function createInviteSignupPrismaFixture(
+  input: { inviteAuthorized?: boolean } = {},
+) {
+  const transactionClient = {
+    $queryRaw: vi.fn().mockResolvedValue([{ id: "member-1" }]),
     hostedInvite: {
-      findUnique: vi.fn().mockResolvedValue({
-        inviteCode: "invite-code",
-      }),
+      findUnique: vi.fn(async (query: { select?: { id?: boolean } }) =>
+        query.select?.id
+          ? input.inviteAuthorized === false ? null : { id: "invite-1" }
+          : { inviteCode: "invite-code" }
+      ),
       update: vi.fn().mockResolvedValue({}),
     },
+  };
+  return {
+    ...transactionClient,
+    $transaction: vi.fn(async (
+      operation: (prisma: typeof transactionClient) => Promise<unknown>,
+    ) => operation(transactionClient)),
   };
 }
 

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -572,6 +572,13 @@ describe("hosted Prisma baseline migration", () => {
       ),
       "utf8",
     );
+    const orphanedHostedLinqInviteDeliveryDeletionMigrationSql = readFileSync(
+      new URL(
+        "../prisma/migrations/20260715120000_delete_orphaned_linq_invite_deliveries/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     const hostedMemberAssistantModelPreferenceMigrationSql = readFileSync(
       new URL(
         "../prisma/migrations/20260709120000_hosted_member_assistant_model_preference/migration.sql",
@@ -789,6 +796,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260714090000_hosted_family_mixed_tier_capacity",
       "20260714120000_hosted_group_reaction_context",
       "20260714130000_hosted_mailbox_assistant_input_lookup",
+      "20260715120000_delete_orphaned_linq_invite_deliveries",
       "migration_lock.toml",
     ]);
     expect(hostedFamilyMixedTierCapacityMigrationSql).toContain(
@@ -1045,6 +1053,21 @@ describe("hosted Prisma baseline migration", () => {
       'hosted_linq_line_phone_number_key',
     );
     expect(hostedLinqObservabilityMigrationSql).not.toContain("raw_payload");
+    expect(orphanedHostedLinqInviteDeliveryDeletionMigrationSql).toContain(
+      'DELETE FROM "hosted_linq_delivery"',
+    );
+    expect(orphanedHostedLinqInviteDeliveryDeletionMigrationSql).toContain(
+      "'invite_signup', 'invite_signup_fallback'",
+    );
+    expect(orphanedHostedLinqInviteDeliveryDeletionMigrationSql).toContain(
+      'split_part("delivery"."source_ref", \':\', 2)',
+    );
+    expect(orphanedHostedLinqInviteDeliveryDeletionMigrationSql).toContain(
+      "NOT EXISTS",
+    );
+    expect(orphanedHostedLinqInviteDeliveryDeletionMigrationSql).toContain(
+      'FROM "hosted_member"',
+    );
     expect(hostedLinqEgressEngagementMigrationSql).toContain('"linq_last_inbound_at" TIMESTAMP(3)');
     expect(hostedLinqEgressEngagementMigrationSql).toContain('"pending_linq_last_inbound_at" TIMESTAMP(3)');
     expect(hostedLinqEgressEngagementMigrationSql).toContain('"last_inbound_at" TIMESTAMP(3)');

--- a/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
@@ -1630,6 +1630,7 @@ function buildLinqProviderWebhookBody(input: {
 function createPrismaStub() {
   const prisma = {
     $executeRaw: vi.fn().mockResolvedValue([]),
+    $queryRaw: vi.fn().mockResolvedValue([{ id: "member_123" }]),
     $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(prisma)),
     hostedLinqAlert: {
       createMany: vi.fn().mockResolvedValue({ count: 1 }),

--- a/docs/hosted-account-data-deletion-export.md
+++ b/docs/hosted-account-data-deletion-export.md
@@ -96,6 +96,7 @@ The Settings vault export does not include:
 | `prisma.hosted_ai_usage_period` | Live delete | Metadata/counts | Deletes local allowance-period snapshots. Export includes period windows, allowance totals, and billing-state metadata while omitting internal reconciliation identifiers. |
 | `prisma.hosted_product_feedback` | Live delete | Confirmed data export | Deletes assistant-captured product feedback rows. Confirmed export includes safe kind/summary metadata and optional published changelog item ids while omitting internal feedback ids. |
 | `prisma.hosted_linq_daily_state` | Live delete | Metadata/counts | Deletes Linq daily inbound/outbound quota counters. |
+| `prisma.hosted_linq_invite_delivery` | Live delete | Metadata/counts | Deletes signup-link delivery records whose delivery identity contains the member id; unrelated operational delivery records remain under their normal retention policy. |
 | `prisma.hosted_invite` | Live delete | Metadata/counts | Deletes invite codes and channel metadata owned by the member. |
 | `prisma.hosted_consent_event` | Live delete | Confirmed data export | Deletes member-scoped consent event history. Confirmed export includes event scope/source/action and document metadata. |
 | `prisma.hosted_consent_grant` | Live delete | Confirmed data export | Deletes member-scoped consent grant state. Confirmed export includes grant scope/source/status and document metadata. |


### PR DESCRIPTION
## Why

The hosted account-deletion flow removed invite records but left Linq signup-link delivery rows whose raw `sourceRef` embedded the deleted member identifier. Historical deletions therefore retained an account-linked identifier indefinitely, and delayed side-effect work could recreate the row after deletion began.

## User-visible goal and flow

There is no new UI. When a member confirms permanent account deletion, the existing deletion flow now also removes signup-link delivery records for the personal member and any owned thread-container members. Delayed direct or fallback signup-link work must prove that the exact invite still belongs to an unsuspended member before it may claim delivery. A bounded migration removes historical orphan rows.

## Invariants

- Account suspension remains the first local deletion fence.
- Live-member signup delivery and receipt state remains intact.
- Cleanup is limited to `invite_signup` and `invite_signup_fallback` rows with the canonical raw member prefix.
- The historical migration deletes a recognized raw signup row only when its parsed member no longer exists.
- No new persisted owner, dependency, provider credential, raw contact value, invite code, or message content is introduced.

## Verification

- Focused privacy/transport/observability/migration proof: 182/182 tests passed.
- Rebased affected onboarding/privacy suites: 328/328 tests passed.
- Required `coverage-write` audit: passed; added fallback late-deletion proof.
- Web typecheck: passed.
- Web lint: 0 errors (existing warnings only).
- Production Next build and dev smoke: passed.
- Disposable PostgreSQL migration scenario: deleted both orphaned signup templates and preserved the live-member row, unrelated template, and hashed source reference.
- Full web suite: 5,244/5,245 passed; the sole unrelated connection-close timing test passed immediately in isolation.

ReviewGPT first-reviewed head: d40a047ad030ed21cd6a2edb203053ca30634d0a

## Change shape

Immutable round-1 baseline and current head: `d40a047ad030ed21cd6a2edb203053ca30634d0a`

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 79 | 25 |
| Tests | 158 | 9 |
| Docs | 97 | 0 |
| Config/tooling | 9 | 0 |
| Generated/other | 0 | 0 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786687604&installation_id=127572939&pr_number=668&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F668&signature=79600bb8edae5961d119f1c09ddbe0a8ce57f2cf56a3634ca96b45e7a9fedc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->