### PR TITLE
Recover hosted audit receipt replay after append drift

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-hosted-audit-receipt-replay.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-hosted-audit-receipt-replay.md
@@ -1,0 +1,113 @@
+# Hosted audit receipt replay recovery
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Recover a hosted member runtime whose committed preference writes cannot be
+  restored because an append-only audit shard advanced beyond the byte-prefix
+  recorded by two durable canonical-write receipts.
+
+## Success criteria
+
+- Replaying a valid single-record audit append succeeds when that audit ID is
+  already present with identical content or is absent from an otherwise valid
+  audit shard.
+- An existing audit ID with different content still fails closed, and no
+  conflicting bytes are written.
+- Invalid, multi-record, malformed-existing-file, and non-audit JSONL replay
+  retain the existing byte-prefix guard.
+- Reconciliation is unavailable unless the recorded base prefix is still
+  present byte-for-byte and only later audit appends caused the drift.
+- The affected hosted runtime restores, processes its pending mailbox, and the
+  post-deploy hosted contract migration completes.
+
+## Scope
+
+- In scope: hosted canonical receipt replay for append-only audit shards,
+  focused core tests, Cloudflare runner deployment, runtime recovery proof, and
+  rerunning the blocked hosted contract migration.
+- Out of scope: arbitrary JSONL conflict resolution, direct production database
+  mutation, mailbox deletion, or weakening canonical-write guards generally.
+
+## Constraints
+
+- Reconcile only one schema-valid audit record at a time, using its immutable
+  audit ID as the identity boundary.
+- Append only when every existing non-empty audit line is schema-valid and the
+  current file has a valid JSONL boundary.
+- Preserve fail-closed behavior for duplicate IDs with different record content
+  and every non-audit append target.
+- Do not expose the affected member identifier or production payload contents in
+  code, tests, commits, logs, or review artifacts.
+
+## Root-cause evidence
+
+- Production diagnostics repeatedly report
+  `HOSTED_CANONICAL_WRITE_APPEND_BASE_MISMATCH` during cold restore.
+- The affected runtime has two durable canonical-write receipts and two legacy
+  preference mailbox events; its workspace checkpoint and consumed sequence do
+  not advance.
+- Preference mutation writes commit their text targets before appending an audit
+  record. Replaying the older receipt after a later committed audit append makes
+  the earlier byte-prefix guard permanently unsatisfiable even though audit
+  records have immutable IDs and readers order by `occurredAt`.
+- The operations page can only wake the runtime, and container SSH is not
+  authenticated, so recovery must occur in the supported restore path.
+
+## Tasks
+
+1. Add the smallest audit-only reconciliation path at hosted receipt replay.
+2. Prove identical replay, missing-record recovery, conflict rejection, and
+   unchanged non-audit guarding with focused tests.
+3. Run core owner verification, required coverage audit, and parent final review.
+4. Commit through `scripts/finish-task`, push a PR, and run CI plus ReviewGPT on
+   the exact pushed head.
+5. Merge, deploy Cloudflare with immediate container rollout, prove the runtime
+   drains safely, and rerun the blocked hosted contract migration.
+
+## Verification
+
+- Focused Vitest coverage for hosted canonical JSONL receipt replay.
+- `pnpm --filter @murphai/core typecheck`.
+- Truthful owner coverage through `pnpm test:diff` or the core coverage command
+  selected by the verification map.
+- `git diff --check`, required `coverage-write`, parent final review, exact-head
+  ReviewGPT `PASS`, green PR CI, production runtime progress, and green hosted
+  contract migration.
+
+## Audit outcomes
+
+- `coverage-write` found that the first implementation detected duplicate IDs
+  only when they matched the incoming record. Accepted and fixed by validating
+  uniqueness across the current audit shard before extending it.
+- The audit added direct strict-guard proofs for unrelated duplicate IDs, an
+  invalid single-record payload, and a current audit file shorter than the
+  recorded base. No unresolved actionable findings remain.
+- Parent final review narrowed reconciliation to the proven advanced-file case:
+  base hash drift remains fail-closed even when the current file happens to
+  contain schema-valid audit records.
+
+## Verification outcomes
+
+- Focused core operation suite: 43/43 passed.
+- Core package typecheck: passed.
+- Core package coverage: 705/705 passed; repository coverage thresholds passed.
+- `git diff --check`: passed.
+- Diff-aware reverse-dependent verification passed global guards and all 18
+  affected package typechecks. Its parallel test phase hit one unrelated
+  clinical-record preemption assertion (`AbortError` instead of the expected
+  custom code); the exact test passed 1/1 when rerun alone. PR CI remains the
+  clean full-graph proof.
+
+## Deployment concerns
+
+- The repair is runner-bundle behavior. Deploy Cloudflare with immediate
+  container rollout so a retry does not land on an old warm runner lacking the
+  recovery path.
+- Web is backward compatible and does not need a tandem code change. After the
+  runner converges, watch the anonymized runtime for checkpoint/mailbox progress
+  before rerunning the post-deploy migration.
+Completed: 2026-07-15

--- a/packages/core/src/operations/write-batch.ts
+++ b/packages/core/src/operations/write-batch.ts
@@ -3,6 +3,8 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, promises as fs, type Stats } from "node:fs";
 
+import { auditRecordSchema } from "@murphai/contracts";
+
 import {
   copyFileAtomic,
   copyFileAtomicExclusive,
@@ -757,6 +759,14 @@ async function applyHostedCanonicalJsonlAppendReceiptAction(input: {
   }
 
   if (existing.byteLength !== originalSize) {
+    if (await tryReconcileHostedCanonicalAuditAppend({
+      bytes: input.bytes,
+      comparisonOptions,
+      existing,
+      target,
+    })) {
+      return;
+    }
     throw new VaultError(
       "HOSTED_CANONICAL_WRITE_APPEND_BASE_MISMATCH",
       "Hosted canonical JSONL append base content does not match the receipt.",
@@ -764,6 +774,92 @@ async function applyHostedCanonicalJsonlAppendReceiptAction(input: {
   }
 
   await fs.appendFile(target.absolutePath, input.bytes);
+}
+
+async function tryReconcileHostedCanonicalAuditAppend(input: {
+  bytes: Uint8Array;
+  comparisonOptions: VaultPathComparisonOptions;
+  existing: Uint8Array;
+  target: ResolvedVaultPath;
+}): Promise<boolean> {
+  const comparisonRelativePath = normalizeRelativeVaultPathForComparison(
+    input.target.relativePath,
+    input.comparisonOptions,
+  );
+  const auditDirectory = normalizeRelativeVaultPathForComparison(
+    VAULT_LAYOUT.auditDirectory,
+    input.comparisonOptions,
+  );
+  if (
+    !comparisonRelativePath.startsWith(`${auditDirectory}/`) ||
+    !isJsonlRelativePath(input.target.relativePath, input.comparisonOptions)
+  ) {
+    return false;
+  }
+
+  const payload = Buffer.from(input.bytes).toString("utf8");
+  if (!payload.endsWith("\n")) {
+    return false;
+  }
+  const payloadLines = payload.slice(0, -1).split("\n");
+  if (payloadLines.length !== 1 || payloadLines[0]?.length === 0) {
+    return false;
+  }
+  const incomingRecord = parseHostedAuditRecordLine(payloadLines[0]);
+  if (!incomingRecord) {
+    return false;
+  }
+
+  const existingText = Buffer.from(input.existing).toString("utf8");
+  if (existingText.length > 0 && !existingText.endsWith("\n")) {
+    return false;
+  }
+  const existingLines = existingText.length === 0 ? [] : existingText.slice(0, -1).split("\n");
+  const existingRecordIds = new Set<string>();
+  let matchingRecord: typeof incomingRecord | null = null;
+  for (const line of existingLines) {
+    if (line.length === 0) {
+      return false;
+    }
+    const record = parseHostedAuditRecordLine(line);
+    if (!record) {
+      return false;
+    }
+    if (existingRecordIds.has(record.id)) {
+      throw new VaultError(
+        "HOSTED_CANONICAL_WRITE_APPEND_BASE_MISMATCH",
+        "Hosted canonical audit replay found a duplicate existing audit record ID.",
+      );
+    }
+    existingRecordIds.add(record.id);
+    if (record.id === incomingRecord.id) {
+      matchingRecord = record;
+    }
+  }
+
+  if (matchingRecord) {
+    if (JSON.stringify(matchingRecord) !== JSON.stringify(incomingRecord)) {
+      throw new VaultError(
+        "HOSTED_CANONICAL_WRITE_APPEND_BASE_MISMATCH",
+        "Hosted canonical audit replay found conflicting content for an existing audit record ID.",
+      );
+    }
+    return true;
+  }
+
+  await fs.appendFile(input.target.absolutePath, input.bytes);
+  return true;
+}
+
+function parseHostedAuditRecordLine(line: string) {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  const result = auditRecordSchema.safeParse(value);
+  return result.success ? result.data : null;
 }
 
 function isArchivedIntegrationIngestAppendError(

--- a/packages/core/test/operations-thresholds.test.ts
+++ b/packages/core/test/operations-thresholds.test.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { CONTRACT_SCHEMA_VERSION } from "@murphai/contracts";
+import { CONTRACT_SCHEMA_VERSION, type AuditRecord } from "@murphai/contracts";
 import { afterEach, test, vi } from "vitest";
 
 import {
@@ -55,6 +55,7 @@ import {
   applyHostedCanonicalWriteReceipt,
   HOSTED_CANONICAL_WRITE_RECEIPT_SCHEMA_VERSION,
   resolveHostedCanonicalWritePayloadFilePath,
+  type HostedCanonicalWriteReceipt,
   WriteBatch,
   WRITE_OPERATION_SCHEMA_VERSION,
 } from "../src/operations/write-batch.ts";
@@ -89,6 +90,54 @@ async function assertHostedPayloadFile(input: {
     }), "utf8"),
     input.content,
   );
+}
+
+function buildHostedJsonlAppendReceipt(input: {
+  appendContent: string;
+  baseContent: string;
+  operationId: string;
+  targetRelativePath: string;
+}): HostedCanonicalWriteReceipt {
+  return {
+    schema: HOSTED_CANONICAL_WRITE_RECEIPT_SCHEMA_VERSION,
+    operationId: input.operationId,
+    operationType: "hosted_jsonl_replay",
+    summary: "Replay a hosted JSONL append.",
+    createdAt: FIXED_TIME,
+    updatedAt: FIXED_TIME,
+    occurredAt: FIXED_TIME,
+    committedAt: FIXED_TIME,
+    actions: [{
+      kind: "jsonl_append",
+      targetRelativePath: input.targetRelativePath,
+      appendSha256: createHash("sha256").update(input.appendContent).digest("hex"),
+      appendByteLength: Buffer.byteLength(input.appendContent),
+      baseSha256: createHash("sha256").update(input.baseContent).digest("hex"),
+      baseByteLength: Buffer.byteLength(input.baseContent),
+      originalSize: Buffer.byteLength(input.baseContent),
+      contentRef: {
+        sha256: createHash("sha256").update(input.appendContent).digest("hex"),
+        byteSize: Buffer.byteLength(input.appendContent),
+      },
+    }],
+  };
+}
+
+function buildAuditRecord(id: string, summary: string): AuditRecord {
+  return {
+    schemaVersion: CONTRACT_SCHEMA_VERSION.audit,
+    id,
+    action: "preferences_update",
+    status: "success",
+    occurredAt: FIXED_TIME,
+    actor: "core",
+    commandName: "preferences.update",
+    summary,
+    changes: [{
+      path: "preferences.md",
+      op: "update",
+    }],
+  };
 }
 
 afterEach(async () => {
@@ -870,6 +919,294 @@ test("hosted JSONL replay rejects matching-size base content drift", async () =>
     /base content does not match/u,
   );
   assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), "other\n");
+});
+
+test("hosted audit replay accepts an identical record after another audit append", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-identical-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AC",
+    "Base audit record.",
+  ))}\n`;
+  const interveningContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AD",
+    "Intervening audit record.",
+  ))}\n`;
+  const appendContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AE",
+    "Replayed audit record.",
+  ))}\n`;
+  const existingContent = `${baseContent}${interveningContent}${appendContent}`;
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, existingContent, "utf8");
+
+  await applyHostedCanonicalWriteReceipt({
+    vaultRoot,
+    readPayload: async () => Buffer.from(appendContent, "utf8"),
+    receipt: buildHostedJsonlAppendReceipt({
+      appendContent,
+      baseContent,
+      operationId: "op_hosted_audit_identical_replay",
+      targetRelativePath,
+    }),
+  });
+
+  assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), existingContent);
+});
+
+test("hosted audit replay appends a missing record after another audit append", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-missing-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AF",
+    "Base audit record.",
+  ))}\n`;
+  const interveningContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AG",
+    "Intervening audit record.",
+  ))}\n`;
+  const appendContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AH",
+    "Missing audit record.",
+  ))}\n`;
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, `${baseContent}${interveningContent}`, "utf8");
+  const receipt = buildHostedJsonlAppendReceipt({
+    appendContent,
+    baseContent,
+    operationId: "op_hosted_audit_missing_replay",
+    targetRelativePath,
+  });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await applyHostedCanonicalWriteReceipt({
+      vaultRoot,
+      readPayload: async () => Buffer.from(appendContent, "utf8"),
+      receipt,
+    });
+  }
+
+  assert.equal(
+    await fs.readFile(targetAbsolutePath, "utf8"),
+    `${baseContent}${interveningContent}${appendContent}`,
+  );
+});
+
+test("hosted audit replay rejects conflicting content for an existing audit ID", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-conflicting-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AJ",
+    "Base audit record.",
+  ))}\n`;
+  const appendRecordId = "aud_01JQ9R7WF97M1WAB2B4QF2Q1AK";
+  const existingContent = `${baseContent}${JSON.stringify(buildAuditRecord(
+    appendRecordId,
+    "Conflicting audit record.",
+  ))}\n`;
+  const appendContent = `${JSON.stringify(buildAuditRecord(
+    appendRecordId,
+    "Expected audit record.",
+  ))}\n`;
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, existingContent, "utf8");
+
+  await assert.rejects(
+    applyHostedCanonicalWriteReceipt({
+      vaultRoot,
+      readPayload: async () => Buffer.from(appendContent, "utf8"),
+      receipt: buildHostedJsonlAppendReceipt({
+        appendContent,
+        baseContent,
+        operationId: "op_hosted_audit_conflicting_replay",
+        targetRelativePath,
+      }),
+    }),
+    /conflicting content for an existing audit record ID/u,
+  );
+  assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), existingContent);
+});
+
+test("hosted audit replay rejects duplicate existing audit IDs before appending", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-duplicate-id-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AT",
+    "Base audit record.",
+  ))}\n`;
+  const duplicateRecordId = "aud_01JQ9R7WF97M1WAB2B4QF2Q1AV";
+  const existingContent = [
+    baseContent,
+    `${JSON.stringify(buildAuditRecord(duplicateRecordId, "First duplicate record."))}\n`,
+    `${JSON.stringify(buildAuditRecord(duplicateRecordId, "Second duplicate record."))}\n`,
+  ].join("");
+  const appendContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AW",
+    "Missing audit record.",
+  ))}\n`;
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, existingContent, "utf8");
+
+  await assert.rejects(
+    applyHostedCanonicalWriteReceipt({
+      vaultRoot,
+      readPayload: async () => Buffer.from(appendContent, "utf8"),
+      receipt: buildHostedJsonlAppendReceipt({
+        appendContent,
+        baseContent,
+        operationId: "op_hosted_audit_duplicate_id_replay",
+        targetRelativePath,
+      }),
+    }),
+    /duplicate existing audit record ID/u,
+  );
+  assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), existingContent);
+});
+
+test("hosted audit replay preserves the base guard for malformed audit shards", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-malformed-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AM",
+    "Base audit record.",
+  ))}\n`;
+  const appendContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AN",
+    "Missing audit record.",
+  ))}\n`;
+  const existingContent = `${baseContent}{"not":"an audit record"}\n`;
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, existingContent, "utf8");
+
+  await assert.rejects(
+    applyHostedCanonicalWriteReceipt({
+      vaultRoot,
+      readPayload: async () => Buffer.from(appendContent, "utf8"),
+      receipt: buildHostedJsonlAppendReceipt({
+        appendContent,
+        baseContent,
+        operationId: "op_hosted_audit_malformed_replay",
+        targetRelativePath,
+      }),
+    }),
+    /base content does not match/u,
+  );
+  assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), existingContent);
+});
+
+test("hosted audit replay does not reconcile a schema-invalid append record", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-invalid-record-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AX",
+    "Base audit record.",
+  ))}\n`;
+  const existingContent = `${baseContent}${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AY",
+    "Intervening audit record.",
+  ))}\n`;
+  const appendContent = `${JSON.stringify({
+    schemaVersion: CONTRACT_SCHEMA_VERSION.audit,
+    id: "aud_01JQ9R7WF97M1WAB2B4QF2Q1AZ",
+  })}\n`;
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, existingContent, "utf8");
+
+  await assert.rejects(
+    applyHostedCanonicalWriteReceipt({
+      vaultRoot,
+      readPayload: async () => Buffer.from(appendContent, "utf8"),
+      receipt: buildHostedJsonlAppendReceipt({
+        appendContent,
+        baseContent,
+        operationId: "op_hosted_audit_invalid_record_replay",
+        targetRelativePath,
+      }),
+    }),
+    /base content does not match/u,
+  );
+  assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), existingContent);
+});
+
+test("hosted audit replay preserves the short-base guard", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-short-base-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1B0",
+    "Base audit record.",
+  ))}\n`;
+  const existingContent = "";
+  const appendContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1B1",
+    "Missing audit record.",
+  ))}\n`;
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, existingContent, "utf8");
+
+  await assert.rejects(
+    applyHostedCanonicalWriteReceipt({
+      vaultRoot,
+      readPayload: async () => Buffer.from(appendContent, "utf8"),
+      receipt: buildHostedJsonlAppendReceipt({
+        appendContent,
+        baseContent,
+        operationId: "op_hosted_audit_short_base_replay",
+        targetRelativePath,
+      }),
+    }),
+    /base size is not present/u,
+  );
+  assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), existingContent);
+});
+
+test("hosted audit replay does not reconcile a multi-record append payload", async () => {
+  const vaultRoot = await makeTempDirectory("murph-core-hosted-audit-multi-record-replay");
+  await initializeVault({ vaultRoot });
+  const targetRelativePath = "audit/2026/2026-04.jsonl";
+  const targetAbsolutePath = path.join(vaultRoot, targetRelativePath);
+  const baseContent = `${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AP",
+    "Base audit record.",
+  ))}\n`;
+  const existingContent = `${baseContent}${JSON.stringify(buildAuditRecord(
+    "aud_01JQ9R7WF97M1WAB2B4QF2Q1AQ",
+    "Intervening audit record.",
+  ))}\n`;
+  const appendContent = [
+    buildAuditRecord("aud_01JQ9R7WF97M1WAB2B4QF2Q1AR", "First append record."),
+    buildAuditRecord("aud_01JQ9R7WF97M1WAB2B4QF2Q1AS", "Second append record."),
+  ].map((record) => `${JSON.stringify(record)}\n`).join("");
+  await fs.mkdir(path.dirname(targetAbsolutePath), { recursive: true });
+  await fs.writeFile(targetAbsolutePath, existingContent, "utf8");
+
+  await assert.rejects(
+    applyHostedCanonicalWriteReceipt({
+      vaultRoot,
+      readPayload: async () => Buffer.from(appendContent, "utf8"),
+      receipt: buildHostedJsonlAppendReceipt({
+        appendContent,
+        baseContent,
+        operationId: "op_hosted_audit_multi_record_replay",
+        targetRelativePath,
+      }),
+    }),
+    /base content does not match/u,
+  );
+  assert.equal(await fs.readFile(targetAbsolutePath, "utf8"), existingContent);
 });
 
 test("hosted canonical receipt replay allows raw manifest text writes idempotently", async () => {


### PR DESCRIPTION
## Why this PR exists

One hosted runtime is stuck in cold restore because two durable preference-write receipts contain audit appends from the same valid base. Replaying one append advances the audit shard, so the next receipt permanently fails the byte-position guard even though the audit records are independently valid.

## User goal / user-visible behavior

The affected member runtime can restore, process its pending conversation and system mailbox normally, and stop retrying every roughly 30 seconds. There is no new user-facing UI.

## Root cause and change

Hosted canonical JSONL replay previously used byte offset as the only append identity. Audit records already have immutable IDs, so this adds an audit-only reconciliation path when the recorded base prefix still matches but later audit records have advanced the file:

- identical ID and content is already applied;
- a missing schema-valid single audit record is appended once;
- duplicate IDs, conflicting content, malformed shards, invalid or multi-record payloads, short or changed bases, and every non-audit JSONL target remain fail-closed.

## Invariants

- Never reconcile a changed, missing, or short receipt base.
- Never overwrite audit content or accept conflicting immutable IDs.
- Reconcile only one current-schema audit record under the audit directory.
- Preserve strict byte-prefix replay for all non-audit JSONL.
- Preserve the mailbox as authoritative; no production rows or events are edited or deleted.

## Verification

- Focused core operation suite: 43/43 passed.
- Core package typecheck: passed.
- Core package coverage: 705/705 passed; thresholds passed.
- Required coverage-write audit: one duplicate-ID gap found, fixed, and reverified; zero unresolved findings.
- Diff-aware lane: global guards and all 18 affected package typechecks passed. Its parallel test fanout hit one unrelated clinical-record preemption assertion; that exact test passed 1/1 alone.
- git diff check and privacy/secret scan: passed.

## Change shape

Classification: authored runtime TypeScript is source; Vitest is tests; the completed execution plan is docs; no generated artifacts or binaries.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 96 | 0 |
| Tests / fixtures | 338 | 1 |
| Docs | 113 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **547** | **1** |

## Deployment skew / compatibility

This changes the Cloudflare runner bundle only; Web is unchanged and compatible. Deploy with immediate container rollout so retries cannot land on an old warm runner. Current evidence shows one affected runtime and two blocked preference events, so the bounded exposed volume is one runtime restore. The code is rollbackable; a successfully reconciled audit record is the original immutable committed record, not synthetic repair state. Monitor the anonymized runtime for disappearance of the append-mismatch failure, workspace checkpoint progress, receipt-log clearance, and mailbox consumption before rerunning the blocked hosted contract migration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786687698&installation_id=127572939&pr_number=669&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F669&signature=d1563c7756802f75b51469fba3a0ffac5b75be18c4626a0124b87b103f72147b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

ReviewGPT first-reviewed head: 657aafa1ce57bc335e80e95ab88106d306fb9737