### PR TITLE
Fix canonical Settings email sync

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-pr592-email-sync-minimal.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-pr592-email-sync-minimal.md
@@ -1,0 +1,94 @@
+# Replace PR 592 with canonical email sync fix
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Replace PR #592 with the smallest durable fix for the observed Settings email
+  incident: never report a linked or verified email until the canonical server
+  sync succeeds, and never substitute a stale initial display value for the
+  email returned by Privy's link callback.
+
+## Success criteria
+
+- A phone-only/stale Privy callback still syncs the exact email account returned
+  by the link callback instead of reusing the initial unverified display hint.
+- Missing callback email data remains an error and cannot become terminal
+  success or trigger addressless server-side credential selection.
+- A failed canonical sync returns no success message.
+- A failed first-link canonical sync can retry the same exact callback address
+  without reopening Privy's already-completed link flow.
+- A successful sync updates presentation state only from the server response.
+- Focused tests, the routed acceptance suite, required specialist audits, CI,
+  and ReviewGPT complete for the replacement PR head.
+
+## Scope
+
+- In scope: the hosted Settings email controller, its sync presentation helper,
+  the email-to-Privy handoff, and focused Settings email regression coverage.
+- Out of scope: generalized onboarding auth intents, link-intent cookies,
+  provider credential baselines, phone/Telegram/passkey flows, deploy-skew
+  compatibility, non-email authentication promotion, and unrelated principal
+  mutation hardening.
+
+## Constraints
+
+- Technical constraints: preserve `/api/settings/email/sync` as the sole
+  canonical persistence boundary; treat the callback address only as an exact
+  selector; fail closed when it is unavailable; add no persisted state,
+  endpoint, cookie, dependency, queue, or compatibility layer.
+- Product/process constraints: preserve unrelated work, keep sensitive identity
+  values out of artifacts, use the isolated PR lane, and do not close PR #592
+  without explicit user direction.
+
+## Risks and mitigations
+
+1. Risk: Privy's callback user snapshot can lag the newly linked account.
+   Mitigation: ignore that snapshot and consume the callback's explicit linked
+   email address, which is guaranteed by the pinned SDK contract.
+2. Risk: an unexpected addressless runtime callback could tempt a broad
+   server-side credential-selection protocol.
+   Mitigation: surface a retryable error and keep the state nonterminal.
+3. Risk: valid but separate auth hardening findings could re-expand the patch.
+   Mitigation: document them as follow-up scope and keep this PR tied to the
+   reproduced incident invariant.
+
+## Tasks
+
+1. Add a focused regression for the observed stale phone-only callback shape.
+2. Delete stale callback-user/initial-email fallback from the link flow while
+   preserving the existing OTP update recovery state.
+3. Preserve the callback address only as retryable, non-authoritative state so
+   canonical saving can retry without reopening the provider flow.
+4. Make all terminal success and successful address state derive from canonical
+   sync results.
+5. Run focused verification, specialist audits, full acceptance, CI, and
+   ReviewGPT, then open the replacement PR.
+
+## Decisions
+
+- Use the exact callback email rather than addressless server resolution. The
+  pinned Privy SDK types require an email link callback to include an email
+  account with an address; an absent address therefore fails closed.
+- Keep exact-principal pre-mutation gating and non-email secondary-email
+  promotion as separate security follow-ups because neither caused the
+  reproduced Settings false-success incident.
+
+## Verification
+
+- Focused rebased Vitest: 33 tests passed across the Settings controller and
+  canonical sync route suites.
+- Exact final-scope `pnpm test:diff`: 5,107 tests passed and 139 skipped;
+  dependency/security guards, TypeScript, dev smoke, lint, and production build
+  passed. Lint reported 12 existing warnings and zero errors.
+- Required `frontend-review` and `coverage-write` passes found no unresolved
+  issue. Live Privy/browser behavior remains mocked.
+- `pnpm verify:acceptance` cleared all email-relevant checks, package typechecks,
+  app builds, lint, dev smoke, and package coverage, but current main's unrelated
+  CLI release-tarball test exceeded its hardcoded 120-second timeout. A serial
+  rerun also timed out with 35 of 36 tests passing. A separate Health Commons
+  generated-file race from the parallel run passed 18 of 18 when rerun serially.
+- Replacement PR CI and ReviewGPT remain required on the exact pushed head.
+Completed: 2026-07-15

--- a/apps/web/src/components/settings/hosted-email-privy-link-hand-off.tsx
+++ b/apps/web/src/components/settings/hosted-email-privy-link-hand-off.tsx
@@ -58,16 +58,6 @@ export function HostedEmailPrivyLinkHandOff(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready]);
 
-  // Defensive: if linking finished without a route sync (no verified email in
-  // the linked payload), there is nothing further to show — close the flow.
-  const completedWithoutSync =
-    Boolean(controller.successMessage) && !controller.isSyncingEmailRoute;
-  useEffect(() => {
-    if (completedWithoutSync) {
-      onAborted();
-    }
-  }, [completedWithoutSync, onAborted]);
-
   if (controller.errorMessage) {
     return (
       <Dialog
@@ -92,9 +82,13 @@ export function HostedEmailPrivyLinkHandOff(props: {
             size="xl"
             className="w-full"
             disabled={controller.isBusy || controller.isPrivyLinkModalActive}
-            onClick={controller.handleLinkEmail}
+            onClick={
+              controller.hasPendingEmailSync
+                ? controller.handleRetryEmailSync
+                : controller.handleLinkEmail
+            }
           >
-            Try again
+            {controller.hasPendingEmailSync ? "Retry saving" : "Try again"}
           </Button>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/settings/hosted-email-settings-controller.ts
+++ b/apps/web/src/components/settings/hosted-email-settings-controller.ts
@@ -46,6 +46,7 @@ export function useHostedEmailSettingsController(input: {
   const [isSyncingEmailRoute, setIsSyncingEmailRoute] = useState(false);
   const [noticeMessage, setNoticeMessage] = useState<string | null>(null);
   const [pendingEmailAddress, setPendingEmailAddress] = useState<string | null>(null);
+  const [pendingEmailSyncAddress, setPendingEmailSyncAddress] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [verifiedEmailOverride, setVerifiedEmailOverride] = useState<HostedPrivyEmailAccount | null>(null);
   const updateEmailErrorRef = useRef(false);
@@ -70,13 +71,10 @@ export function useHostedEmailSettingsController(input: {
 
       setErrorMessage("We could not link that email address.");
     },
-    onSuccess: (params) => {
+    onSuccess: async (params) => {
       setIsPrivyLinkModalActive(false);
       if (params.linkMethod === "email") {
-        void handleLinkedEmailAccount({
-          linkedUser: params.user,
-          preferredEmailAddress: readLinkedEmailAddress(params.linkedAccount),
-        });
+        await handleLinkedEmailAccount(params.linkedAccount);
       }
     },
   });
@@ -192,6 +190,7 @@ export function useHostedEmailSettingsController(input: {
     setSuccessMessage(null);
     setCode("");
     setPendingEmailAddress(null);
+    setPendingEmailSyncAddress(null);
   }
 
   async function handleVerifyCode(rawCode?: string) {
@@ -244,7 +243,7 @@ export function useHostedEmailSettingsController(input: {
     }
 
     if (!verifiedEmailAddress) {
-      setSuccessMessage("Email verified.");
+      setErrorMessage("We could not confirm the email address you verified. Try again.");
       return;
     }
 
@@ -272,34 +271,30 @@ export function useHostedEmailSettingsController(input: {
     linkEmail();
   }
 
-  async function handleLinkedEmailAccount(input: {
-    linkedUser: HostedEmailPrivyUser;
-    preferredEmailAddress: string | null;
-  }) {
-    const { linkedUser } = input;
-    const refreshedUser = await refreshUser().catch(() => linkedUser);
-    const displayState = resolveHostedEmailSettingsDisplayStateFromUsers({
-      fallbackUser: linkedUser,
-      initialLinkedAccounts: linkedAccounts,
-      preferredEmailAddress: input.preferredEmailAddress,
-      refreshedUser,
-    });
-    const linkedEmail = displayState.currentVerifiedEmail ?? displayState.currentEmail;
+  async function handleLinkedEmailAccount(linkedAccount: unknown) {
+    const linkedEmailAddress = readLinkedEmailAddress(linkedAccount);
 
-    if (!linkedEmail?.address) {
-      setSuccessMessage("Email linked.");
+    if (!linkedEmailAddress) {
+      setErrorMessage("We could not confirm the email address you linked. Try again.");
       return;
     }
 
-    setEmailAddress(linkedEmail.address);
+    setPendingEmailSyncAddress(linkedEmailAddress);
+    setEmailAddress(linkedEmailAddress);
+    await syncVerifiedEmailAddress(linkedEmailAddress, "verify");
+  }
 
-    if (!displayState.currentVerifiedEmail) {
-      setSuccessMessage(`Email linked: ${linkedEmail.address}`);
+  async function handleRetryEmailSync() {
+    setErrorMessage(null);
+    setNoticeMessage(null);
+    setSuccessMessage(null);
+
+    if (!pendingEmailSyncAddress) {
+      setErrorMessage("Link your email before trying to save it again.");
       return;
     }
 
-    setVerifiedEmailOverride(displayState.currentVerifiedEmail);
-    await syncVerifiedEmailAddress(displayState.currentVerifiedEmail.address, "verify");
+    await syncVerifiedEmailAddress(pendingEmailSyncAddress, "verify");
   }
 
   async function handleSyncVerifiedEmail() {
@@ -327,6 +322,13 @@ export function useHostedEmailSettingsController(input: {
       setErrorMessage(syncPresentation.errorMessage);
 
       if (syncPresentation.syncResult) {
+        setPendingEmailSyncAddress(null);
+        setEmailAddress(syncPresentation.syncResult.emailAddress);
+        setVerifiedEmailOverride({
+          address: syncPresentation.syncResult.emailAddress,
+          verifiedAt: readVerifiedAtTimestamp(syncPresentation.syncResult.verifiedAt),
+        });
+
         try {
           await input.onSynced?.(syncPresentation.syncResult);
         } catch (error) {
@@ -352,6 +354,7 @@ export function useHostedEmailSettingsController(input: {
     isSendingCode,
     isSubmittingCode,
     isSyncingEmailRoute,
+    hasPendingEmailSync: pendingEmailSyncAddress !== null,
     canSendEmailUpdateCode,
     noticeMessage,
     pendingEmailAddress,
@@ -359,6 +362,7 @@ export function useHostedEmailSettingsController(input: {
     setCode,
     setEmailAddress,
     handleLinkEmail,
+    handleRetryEmailSync,
     handleClientAuthRequired,
     handleResendCode,
     handleSendCode,
@@ -430,6 +434,13 @@ function readCurrentUnixTimestamp(): number {
   return Math.trunc(Date.now() / 1000);
 }
 
+function readVerifiedAtTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp)
+    ? Math.trunc(timestamp / 1000)
+    : readCurrentUnixTimestamp();
+}
+
 function readPrivyLinkedAccounts(input: HostedEmailPrivyUser): readonly PrivyLinkedAccountLike[] | null {
   if (!Array.isArray(input?.linkedAccounts)) {
     return null;
@@ -439,11 +450,13 @@ function readPrivyLinkedAccounts(input: HostedEmailPrivyUser): readonly PrivyLin
 }
 
 function readLinkedEmailAddress(input: unknown): string | null {
-  if (!isPrivyLinkedAccountLike(input)) {
+  if (!isPrivyLinkedAccountLike(input) || input.type !== "email") {
     return null;
   }
 
-  return typeof input.address === "string" ? input.address : null;
+  return normalizeEmailAddress(
+    typeof input.address === "string" ? input.address : null,
+  );
 }
 
 function isPrivyLinkedAccountLike(value: unknown): value is PrivyLinkedAccountLike {

--- a/apps/web/src/components/settings/hosted-email-settings-helpers.ts
+++ b/apps/web/src/components/settings/hosted-email-settings-helpers.ts
@@ -74,7 +74,7 @@ export async function syncHostedVerifiedEmailAddress(input: {
   } catch (error) {
     return {
       errorMessage: toHostedEmailSyncErrorMessage(error),
-      successMessage: input.mode === "verify" ? `Email verified: ${input.verifiedEmailAddress}` : null,
+      successMessage: null,
       syncResult: null,
     };
   }

--- a/apps/web/src/components/settings/hosted-email-settings-sections.tsx
+++ b/apps/web/src/components/settings/hosted-email-settings-sections.tsx
@@ -23,6 +23,7 @@ export function HostedEmailSettingsContent(props: {
   murphEmailAddress?: string | null;
   authSatisfied: boolean;
   canSendEmailUpdateCode: boolean;
+  hasPendingEmailSync: boolean;
   isBusy: boolean;
   isSendingCode: boolean;
   isSubmittingCode: boolean;
@@ -32,6 +33,7 @@ export function HostedEmailSettingsContent(props: {
   onChangeEmailAddress: (value: string) => void;
   onAuthRequired: () => void;
   onResendCode: () => Promise<void>;
+  onRetryEmailSync: () => Promise<void>;
   onSendCode: (emailAddress?: string) => Promise<void>;
   onSyncVerifiedEmail: () => Promise<void>;
   onUseAnotherEmail: () => void;
@@ -45,6 +47,7 @@ export function HostedEmailSettingsContent(props: {
     murphEmailAddress,
     authSatisfied,
     canSendEmailUpdateCode,
+    hasPendingEmailSync,
     isBusy,
     isSendingCode,
     isSubmittingCode,
@@ -54,6 +57,7 @@ export function HostedEmailSettingsContent(props: {
     onChangeEmailAddress,
     onAuthRequired,
     onResendCode,
+    onRetryEmailSync,
     onSendCode,
     onSyncVerifiedEmail,
     onUseAnotherEmail,
@@ -134,11 +138,17 @@ export function HostedEmailSettingsContent(props: {
                 authSatisfied={authSatisfied}
                 type="button"
                 onAuthRequired={onAuthRequired}
-                onClick={() => void onSendCode()}
+                onClick={() => {
+                  void (hasPendingEmailSync ? onRetryEmailSync() : onSendCode());
+                }}
                 disabled={isBusy}
                 size="sm"
               >
-                Link email
+                {isSyncingEmailRoute
+                  ? "Saving..."
+                  : hasPendingEmailSync
+                    ? "Retry saving"
+                    : "Link email"}
               </AuthButton>
             ) : null
           }
@@ -158,6 +168,7 @@ export function HostedEmailSettingsContent(props: {
           <Input
             id="settings-email-address"
             autoComplete="email"
+            disabled={hasPendingEmailSync}
             inputMode="email"
             inputSize="xl"
             placeholder="user@example.com"
@@ -170,16 +181,22 @@ export function HostedEmailSettingsContent(props: {
             authSatisfied={authSatisfied}
             type="button"
             onAuthRequired={onAuthRequired}
-            onClick={() => void onSendCode(emailInputRef.current?.value ?? emailAddress)}
+            onClick={() => {
+              void (hasPendingEmailSync
+                ? onRetryEmailSync()
+                : onSendCode(emailInputRef.current?.value ?? emailAddress));
+            }}
             disabled={isBusy}
             size="xl"
             className="w-full"
           >
             {isSyncingEmailRoute
               ? "Saving..."
-              : isSendingCode
-                ? "Sending..."
-                : "Send verification code"}
+              : hasPendingEmailSync
+                ? "Retry saving"
+                : isSendingCode
+                  ? "Sending..."
+                  : "Send verification code"}
           </AuthButton>
         </div>
       ) : null}

--- a/apps/web/src/components/settings/hosted-email-settings.tsx
+++ b/apps/web/src/components/settings/hosted-email-settings.tsx
@@ -64,6 +64,7 @@ export function HostedEmailSettings(props: {
         murphEmailAddress={props.murphEmailAddress ?? null}
         authSatisfied={controller.authenticated && controller.clientAuthenticated}
         canSendEmailUpdateCode={controller.canSendEmailUpdateCode}
+        hasPendingEmailSync={controller.hasPendingEmailSync}
         isBusy={controller.isBusy}
         isSendingCode={controller.isSendingCode}
         isSubmittingCode={controller.isSubmittingCode}
@@ -73,6 +74,7 @@ export function HostedEmailSettings(props: {
         onChangeEmailAddress={controller.setEmailAddress}
         onAuthRequired={controller.handleClientAuthRequired}
         onResendCode={controller.handleResendCode}
+        onRetryEmailSync={controller.handleRetryEmailSync}
         onSendCode={controller.handleSendCode}
         onSyncVerifiedEmail={controller.handleSyncVerifiedEmail}
         onUseAnotherEmail={controller.handleUseAnotherEmail}

--- a/apps/web/test/settings-email-settings.test.ts
+++ b/apps/web/test/settings-email-settings.test.ts
@@ -12,7 +12,7 @@ type LinkAccountCallbacks = {
     linkedAccount: unknown;
     linkMethod: string;
     user: { linkedAccounts?: unknown };
-  }) => void;
+  }) => Promise<void> | void;
 };
 
 type UpdateEmailCallbacks = {
@@ -37,6 +37,14 @@ vi.mock("@privy-io/react-auth", () => ({
   usePrivy: mocks.usePrivy,
   useUpdateEmail: mocks.useUpdateEmail,
   useUser: mocks.useUser,
+}));
+
+vi.mock("@/src/components/ui/dialog", () => ({
+  Dialog: "div",
+  DialogContent: "div",
+  DialogDescription: "p",
+  DialogHeader: "div",
+  DialogTitle: "h2",
 }));
 
 let cleanupRender: (() => Promise<void>) | null = null;
@@ -323,6 +331,93 @@ describe("HostedEmailSettings", () => {
 
       expect(onAborted).toHaveBeenCalledTimes(1);
     });
+
+    it("retries canonical saving without reopening Privy's link flow", async () => {
+      mocks.useUser.mockReturnValue({
+        refreshUser: mocks.refreshUser,
+        user: {
+          email: null,
+          linkedAccounts: [],
+        },
+      });
+      const syncFetch = vi.fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response(JSON.stringify({
+          error: {
+            code: "HOSTED_SYNC_UNAVAILABLE",
+            message: "Hosted sync unavailable right now.",
+          },
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 503,
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({
+          emailAddress: "linked@example.com",
+          ok: true,
+          runTriggered: true,
+          verifiedAt: "2026-04-25T00:00:00.000Z",
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        }));
+      vi.stubGlobal("fetch", syncFetch);
+      const onSynced = vi.fn();
+      const { HostedEmailPrivyLinkHandOff } = await import(
+        "@/src/components/settings/hosted-email-privy-link-hand-off"
+      );
+      const { cleanup, window } = await renderClientComponent(
+        createElement(HostedEmailPrivyLinkHandOff, {
+          onAborted: vi.fn(),
+          onSynced,
+        }),
+        { requireButton: false },
+      );
+      cleanupRender = cleanup;
+
+      await vi.waitFor(() => {
+        expect(mocks.linkEmail).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await mocks.linkAccountCallbacks?.onSuccess?.({
+          linkedAccount: {
+            address: "linked@example.com",
+            latest_verified_at: 1771977600,
+            type: "email",
+          },
+          linkMethod: "email",
+          user: {
+            linkedAccounts: [],
+          },
+        });
+      });
+
+      await vi.waitFor(() => {
+        expect(syncFetch).toHaveBeenCalledTimes(1);
+        expect(window.document.body.textContent).toContain("Hosted sync unavailable right now.");
+      });
+      const retryButton = Array.from(window.document.body.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.includes("Retry saving"),
+      );
+      expect(retryButton).toBeTruthy();
+
+      await act(async () => {
+        retryButton?.dispatchEvent(new Event("click", { bubbles: true }));
+      });
+
+      await vi.waitFor(() => {
+        expect(onSynced).toHaveBeenCalledTimes(1);
+      });
+      expect(syncFetch).toHaveBeenCalledTimes(2);
+      expect(syncFetch.mock.calls.map((call) => JSON.parse(String(call[1]?.body)))).toEqual([
+        { expectedEmailAddress: "linked@example.com" },
+        { expectedEmailAddress: "linked@example.com" },
+      ]);
+      expect(mocks.linkEmail).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("prefills an unverified server-provided email and lets the member send a verification code", async () => {
@@ -431,7 +526,7 @@ describe("HostedEmailSettings", () => {
     const linkedUser = {
       linkedAccounts: [
         {
-          address: "linked@example.com",
+          address: "Linked@example.com",
           latest_verified_at: 1771977600,
           type: "email",
         },
@@ -463,7 +558,7 @@ describe("HostedEmailSettings", () => {
     await act(async () => {
       mocks.linkAccountCallbacks?.onSuccess?.({
         linkedAccount: {
-          address: "linked@example.com",
+          address: "Linked@example.com",
           latest_verified_at: 1771977600,
           type: "email",
         },
@@ -486,25 +581,30 @@ describe("HostedEmailSettings", () => {
       runTriggered: true,
       verifiedAt: "2026-04-25T00:00:00.000Z",
     });
+    expect(container.querySelector<HTMLInputElement>(
+      'input[id="settings-email-address"]',
+    )?.value).toBe("linked@example.com");
   });
 
-  it("prefers Privy's email link payload over a stale refreshed email", async () => {
+  it("syncs the newly linked callback account when callback users are still phone-only", async () => {
+    mocks.useUser.mockReturnValue({
+      refreshUser: mocks.refreshUser,
+      user: {
+        email: null,
+        linkedAccounts: [
+          {
+            phone_number: "+15555550100",
+            type: "phone",
+          },
+        ],
+      },
+    });
     const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
-    const linkedUser = {
-      linkedAccounts: [
-        {
-          address: "linked@example.com",
-          latest_verified_at: 1771977600,
-          type: "email",
-        },
-      ],
-    };
     mocks.refreshUser.mockResolvedValueOnce({
       linkedAccounts: [
         {
-          address: "old@example.com",
-          latest_verified_at: 1771891200,
-          type: "email",
+          phone_number: "+15555550100",
+          type: "phone",
         },
       ],
     });
@@ -524,18 +624,23 @@ describe("HostedEmailSettings", () => {
     const { cleanup, container } = await renderClientComponent(
       createElement(HostedEmailSettings, {
         authenticated: true,
-        initialEmail: null,
+        initialEmail: {
+          address: "payer-hint@example.com",
+          verifiedAt: null,
+        },
       }),
     );
     cleanupRender = cleanup;
 
     const linkButton = Array.from(container.querySelectorAll("button")).find(
-      (candidate) => candidate.textContent?.includes("Link email"),
+      (candidate) => candidate.textContent?.includes("Send verification code"),
     );
+    expect(linkButton).toBeTruthy();
 
     await act(async () => {
       linkButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
+    expect(mocks.linkEmail).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       mocks.linkAccountCallbacks?.onSuccess?.({
@@ -545,7 +650,14 @@ describe("HostedEmailSettings", () => {
           type: "email",
         },
         linkMethod: "email",
-        user: linkedUser,
+        user: {
+          linkedAccounts: [
+            {
+              phone_number: "+15555550100",
+              type: "phone",
+            },
+          ],
+        },
       });
     });
 
@@ -560,6 +672,64 @@ describe("HostedEmailSettings", () => {
     expect(JSON.parse(String(syncFetch.mock.calls[0]?.[1]?.body))).toEqual({
       expectedEmailAddress: "linked@example.com",
     });
+    expect(container.textContent).not.toContain("Email linked: payer-hint@example.com");
+    expect(container.querySelector<HTMLInputElement>(
+      'input[id="settings-email-address"]',
+    )?.value).toBe("linked@example.com");
+  });
+
+  it("keeps an addressless email link callback nonterminal", async () => {
+    mocks.useUser.mockReturnValue({
+      refreshUser: mocks.refreshUser,
+      user: {
+        email: null,
+        linkedAccounts: [],
+      },
+    });
+    mocks.refreshUser.mockResolvedValueOnce({
+      linkedAccounts: [
+        {
+          address: "refreshed-hint@example.com",
+          latest_verified_at: 1771891200,
+          type: "email",
+        },
+      ],
+    });
+    const syncFetch = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", syncFetch);
+    const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
+    const { cleanup, container } = await renderClientComponent(
+      createElement(HostedEmailSettings, {
+        authenticated: true,
+        initialEmail: {
+          address: "payer-hint@example.com",
+          verifiedAt: null,
+        },
+      }),
+    );
+    cleanupRender = cleanup;
+
+    await act(async () => {
+      mocks.linkAccountCallbacks?.onSuccess?.({
+        linkedAccount: {
+          type: "email",
+        },
+        linkMethod: "email",
+        user: {
+          linkedAccounts: [
+            {
+              address: "callback-user-hint@example.com",
+              latest_verified_at: 1771891200,
+              type: "email",
+            },
+          ],
+        },
+      });
+    });
+
+    expect(syncFetch).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("We could not confirm the email address you linked.");
+    expect(container.textContent).not.toContain("Email linked");
   });
 
   it("sends an update-email code and verifies it from the inline code step", async () => {
@@ -1018,7 +1188,7 @@ describe("hosted email settings sync helpers", () => {
 
     expect(firstAttempt).toEqual({
       errorMessage: "Hosted sync unavailable right now.",
-      successMessage: "Email verified: verified@example.com",
+      successMessage: null,
       syncResult: null,
     });
     expect(secondAttempt).toEqual({

--- a/apps/web/test/settings-email-settings.test.ts
+++ b/apps/web/test/settings-email-settings.test.ts
@@ -420,6 +420,143 @@ describe("HostedEmailSettings", () => {
     });
   });
 
+  it.each([
+    {
+      editedEmailBeforeRetry: "edited-after-callback@example.com",
+      initialActionLabel: "Send verification code",
+      initialEmail: {
+        address: "payer-hint@example.com",
+        verifiedAt: null,
+      },
+      scenario: "a stale Settings email hint",
+    },
+    {
+      editedEmailBeforeRetry: null,
+      initialActionLabel: "Link email",
+      initialEmail: null,
+      scenario: "no initial email",
+    },
+  ])("retries canonical saving inline with $scenario", async ({
+    editedEmailBeforeRetry,
+    initialActionLabel,
+    initialEmail,
+  }) => {
+    mocks.useUser.mockReturnValue({
+      refreshUser: mocks.refreshUser,
+      user: {
+        email: null,
+        linkedAccounts: [
+          {
+            phone_number: "+15555550100",
+            type: "phone",
+          },
+        ],
+      },
+    });
+    const syncFetch = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: {
+          code: "HOSTED_SYNC_UNAVAILABLE",
+          message: "Hosted sync unavailable right now.",
+        },
+      }), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        status: 503,
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        emailAddress: "linked@example.com",
+        ok: true,
+        runTriggered: true,
+        verifiedAt: "2026-04-25T00:00:00.000Z",
+      }), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        status: 200,
+      }));
+    vi.stubGlobal("fetch", syncFetch);
+    const onSynced = vi.fn();
+    const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
+    const { cleanup, container, window } = await renderClientComponent(
+      createElement(HostedEmailSettings, {
+        authenticated: true,
+        initialEmail,
+        onSynced,
+      }),
+    );
+    cleanupRender = cleanup;
+
+    const initialAction = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes(initialActionLabel),
+    );
+    expect(initialAction).toBeTruthy();
+
+    await act(async () => {
+      initialAction?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+    expect(mocks.linkEmail).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await mocks.linkAccountCallbacks?.onSuccess?.({
+        linkedAccount: {
+          address: "linked@example.com",
+          latest_verified_at: 1771977600,
+          type: "email",
+        },
+        linkMethod: "email",
+        user: {
+          linkedAccounts: [
+            {
+              phone_number: "+15555550100",
+              type: "phone",
+            },
+          ],
+        },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(syncFetch).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Hosted sync unavailable right now.");
+    });
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes("Retry saving"),
+    );
+    expect(retryButton).toBeTruthy();
+
+    if (editedEmailBeforeRetry) {
+      const emailInput = container.querySelector<HTMLInputElement>(
+        'input[id="settings-email-address"]',
+      );
+      expect(emailInput?.value).toBe("linked@example.com");
+      expect(emailInput?.disabled).toBe(true);
+
+      await act(async () => {
+        if (emailInput) {
+          setInputValue(window, emailInput, editedEmailBeforeRetry);
+        }
+      });
+      expect(emailInput?.value).toBe(editedEmailBeforeRetry);
+    }
+
+    await act(async () => {
+      retryButton?.dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(onSynced).toHaveBeenCalledTimes(1);
+    });
+    expect(syncFetch).toHaveBeenCalledTimes(2);
+    expect(syncFetch.mock.calls.map((call) => JSON.parse(String(call[1]?.body)))).toEqual([
+      { expectedEmailAddress: "linked@example.com" },
+      { expectedEmailAddress: "linked@example.com" },
+    ]);
+    expect(mocks.linkEmail).toHaveBeenCalledTimes(1);
+    expect(mocks.sendCode).not.toHaveBeenCalled();
+  });
+
   it("prefills an unverified server-provided email and lets the member send a verification code", async () => {
     const { HostedEmailSettings } = await import("@/src/components/settings/hosted-email-settings");
 


### PR DESCRIPTION
## Why this exists

Settings could finish Privy's email-link flow while its callback user snapshot was still phone-only. The client then fell back to the initial Settings email (including an unverified Stripe billing hint), displayed `Email linked`, and returned without calling the canonical `/api/settings/email/sync` route. The sync presentation helper could also retain an `Email verified` success message when that route failed.

This is the small replacement for #592. It fixes the reproduced Settings bug without introducing auth intents, cookies, credential baselines, compatibility machinery, or changes to phone, Telegram, passkey, or onboarding flows.

## User-visible goal and flow

1. The member links an email in Privy's existing modal.
2. Settings uses the callback's exact email address only as a selector for the existing canonical sync route.
3. The handoff stays nonterminal while Murph saves the canonical connection.
4. A transient save failure shows `Retry saving` on both Settings email surfaces; retry reuses the exact address without reopening Privy or sending another code.
5. The editable email field is disabled while that exact-address retry is pending so the UI cannot imply a different address will be saved.
6. Success and the displayed address come only from the server response.
7. An unexpected addressless callback fails closed and cannot reuse a stale Settings, callback-user, or refreshed-user hint.

## Invariants

- `/api/settings/email/sync` remains the sole persistence and authorization boundary.
- Browser callback data selects an exact address; it is never canonical product truth.
- No terminal success is rendered before canonical sync succeeds.
- A failed sync returns no success message.
- No addressless or stale fallback can choose a different provider credential.
- No new persisted state, endpoint, cookie, dependency, or cross-channel auth abstraction is added.

Deliberate follow-up scope: exact app-session/Privy principal gating before provider mutation and preventing non-email authentication from promoting a secondary email are separate hardening issues. Neither caused the reproduced Settings false-success path, so they are not folded into this replacement.

## Change shape (immutable round-1 baseline)

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 49 | 42 |
| Tests | 190 | 20 |
| Docs | 94 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 9986da271a17168415734ace9cbbad3b0510e6c8

## Current change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 74 | 48 |
| Tests | 327 | 20 |
| Docs | 94 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

## Review findings and corrections

- ReviewGPT round 1: accepted the missing inline canonical-retry path. A production-shaped regression failed in both stale-hint and no-initial-email variants before the fix. The existing pending selector and retry handler now drive each existing inline primary action.
- Frontend review: accepted that an editable stale-hint field could imply retry would save a later edit. The existing field is now disabled only while the exact-address retry is pending; coverage proved this red before the one-line correction and green afterward.
- ReviewGPT correction round 2 on `f475813a46f5ba909411e95d801f0c99dd68ea24`: `PASS` with no qualifying findings; the prior accepted finding is resolved.
- No new owner, state machine, endpoint, fallback credential source, or compatibility path was added.

## Verification

- Focused Settings controller + canonical sync route: 35/35 passed on the current head.
- Exact final-scope `pnpm test:diff`: 5,121 passed, 139 skipped; dependency/security guards, TypeScript, dev smoke, lint, and production build passed (12 existing lint warnings, 0 errors).
- Required coverage audit strengthened the exact-selector and disabled-input proof. The final frontend re-review found no unresolved issues; live Privy/provider browser inspection remains unavailable.
- All PR CI checks passed on the current head, including hosted E2Es, app verification, package coverage, release checks, and viewport overflow.
- Full `pnpm verify:acceptance` on the round-1 head passed all email-relevant checks, package/app typechecks, builds, lint, dev smoke, and package coverage. Its parallel run hit an unrelated generated Health Commons file race (serial rerun: 18/18 passed) and current main's CLI release-tarball test exceeded its hardcoded 120-second timeout both in the suite and serially (the other 35/36 tests passed; this patch changes no CLI/release files).

Live Privy/provider behavior remains mocked; the patch is covered through callback-level rendered DOM tests and the existing canonical route tests.
