### PR TITLE
fix(web): preserve Family usage during billing projection gaps

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-family-usage-projection-gap.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-family-usage-projection-gap.md
@@ -1,0 +1,79 @@
+# Keep Family usage available during billing period projection gaps
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Preserve active Family members' sponsored access and assigned-tier usage
+  attribution when the local Stripe billing-period projection is temporarily
+  absent or does not contain the usage timestamp.
+- Replace PR #605's cross-plane attribution protocol with the smallest
+  web-owned correction that matches the advisory usage contract.
+
+## Success criteria
+
+- Active Family membership remains the sponsorship authority while the local
+  Family billing projection is absent, invalid, or its period timestamps lag.
+- Usage is attributed to the member's Family tier and a UTC calendar-month
+  allowance period during the projection gap; a stale personal trial is not
+  used instead.
+- Valid Stripe periods remain preferred; invalid or non-Family billing
+  projections cannot determine the allowance period; and no schema, retry
+  queue, runtime protocol, or cross-plane state is added.
+- Focused regression tests and diff-aware verification pass; the required
+  high-risk acceptance/review gates complete with unrelated blockers recorded.
+
+## Scope
+
+- In scope: Family-sponsored allowance resolution, focused hosted-web tests,
+  and the durable plan-usage contract describing the fallback.
+- Out of scope: historical exact-period reattribution, runtime admission,
+  Cloudflare/Temporal/assistant changes, schema changes, and PR #605 cleanup.
+
+## Constraints
+
+- Technical constraints: reuse the allowance resolver's existing calendar
+  fallback and keep Family billing validation at the web owner.
+- Product/process constraints: included usage is advisory; sponsored access is
+  derived from active membership/group state; preserve unrelated ledger work.
+
+## Risks and mitigations
+
+1. Risk: Reusing period bounds from a malformed non-Family billing projection.
+   Mitigation: active membership still supplies sponsorship, but only a paid
+   Family projection is eligible and the shared resolver validates its bounds.
+2. Risk: Split advisory usage across a calendar fallback and a later Stripe
+   period.
+   Mitigation: document the bounded fallback explicitly; do not add a second
+   ledger or retry state machine for a non-billing, advisory meter.
+
+## Tasks
+
+1. Prove PR #605's originating failure and classify its later scope growth.
+2. Add focused failing regression coverage for gate and accounting behavior.
+3. Reuse the existing UTC calendar-period fallback for active Family usage.
+4. Update the durable usage contract and run required verification/review.
+
+## Decisions
+
+- Active Family membership owns sponsorship identity; local billing projection
+  validity controls only whether its period bounds can be reused.
+- Exact historical Stripe-period reattribution is intentionally excluded
+  because this meter is advisory and the repo forbids a second usage owner.
+
+## Verification
+
+- Focused hosted usage Vitest passes 84/84 tests, including the accounting,
+  Family-source, missing-period, and invalid-projection regressions.
+- `pnpm test:diff` passes: web typecheck, dev smoke, lint (zero errors), 5,106
+  tests with 139 skipped, and the production build.
+- Low-concurrency `pnpm verify:acceptance` passes the changed hosted-execution
+  owner (344/344 tests) and all completed guards/owners. The overall command is
+  blocked outside this diff by a CLI release-tarball timeout, an
+  assistant-engine worker-shutdown timeout, and an assistant-runtime
+  preemption assertion.
+- The required coverage-write pass added only the missing Family-source
+  assertion. ReviewGPT and PR CI run against the exact pushed head.
+Completed: 2026-07-15

--- a/agent-docs/product-specs/hosted-plan-usage.md
+++ b/agent-docs/product-specs/hosted-plan-usage.md
@@ -32,6 +32,14 @@ The available projection keeps these access states distinct:
 | Direct paid Edge | Edge | Monthly | None |
 | Sponsored member | Family | Monthly | None |
 
+An active sponsored member keeps their assigned Family tier when the local
+Family billing projection is absent, invalid, or lacks a period containing the
+usage timestamp. Only a valid paid Family projection supplies period bounds;
+otherwise the shared allowance resolver uses its existing UTC calendar-month
+fallback, just as it does for direct paid plans. Because included usage is
+advisory rather than an exact prepaid meter, already-accounted fallback usage
+is not moved between periods later.
+
 Synthetic group-thread allowance is not personal plan usage. It returns the
 unavailable reason `group_not_supported` before exposing personal usage facts.
 Inactive hosted access and a trial awaiting conversion also return explicit

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -254,7 +254,6 @@ type HostedAiUsageAllowancePricingDecision =
   };
 
 async function resolveHostedAiUsageAllowanceBillingRefForMember(input: {
-  at: Date;
   billingRef: HostedAiUsageAllowanceBillingRef | null;
   billingStatus: HostedBillingStatus;
   memberId: string;
@@ -274,7 +273,6 @@ async function resolveHostedAiUsageAllowanceBillingRefForMember(input: {
   }
 
   const familyBillingRef = await readHostedFamilySponsoredBillingRefForMember({
-    at: input.at,
     memberId: input.memberId,
     tx: input.tx,
   });
@@ -292,7 +290,6 @@ async function resolveHostedAiUsageAllowanceBillingRefForMember(input: {
 }
 
 async function readHostedFamilySponsoredBillingRefForMember(input: {
-  at: Date;
   memberId: string;
   tx: Prisma.TransactionClient;
 }): Promise<HostedAiUsageAllowanceBillingRef | null> {
@@ -319,25 +316,17 @@ async function readHostedFamilySponsoredBillingRefForMember(input: {
       groupId: familyAccess.groupId,
     },
   });
-  if (
-    billingRef?.currentBillingPlanCode !== HOSTED_FAMILY_BILLING_PLAN_CODE ||
-    billingRef.currentBillingPhase !== "paid"
-  ) {
-    return null;
-  }
+  const periodBillingRef =
+    billingRef?.currentBillingPlanCode === HOSTED_FAMILY_BILLING_PLAN_CODE &&
+    billingRef.currentBillingPhase === "paid"
+      ? billingRef
+      : null;
+  const currentPeriodStart = periodBillingRef?.currentPeriodStart ?? null;
+  const currentPeriodEnd = periodBillingRef?.currentPeriodEnd ?? null;
 
-  const currentPeriodStart = billingRef.currentPeriodStart;
-  const currentPeriodEnd = billingRef.currentPeriodEnd;
-  if (
-    !currentPeriodStart ||
-    !currentPeriodEnd ||
-    currentPeriodStart.getTime() >= currentPeriodEnd.getTime() ||
-    input.at.getTime() < currentPeriodStart.getTime() ||
-    input.at.getTime() >= currentPeriodEnd.getTime()
-  ) {
-    return null;
-  }
-
+  // Family sponsorship owns the plan, tier, and allowance. Only a paid Family
+  // projection is eligible to define the billing period; the shared resolver
+  // validates its bounds and falls back to a UTC month when they lag.
   return {
     allowanceSource: "family_sponsored_plan",
     currentBillingPhase: "paid",
@@ -795,7 +784,6 @@ export async function accountHostedAiUsageForAllowanceTx(input: {
   }
   const allowanceAccess = memberState.suspendedAt === null
     ? await resolveHostedAiUsageAllowanceBillingRefForMember({
-        at,
         billingRef: memberState.billingRef,
         billingStatus: memberState.billingStatus,
         memberId: input.memberId,
@@ -1015,7 +1003,6 @@ export async function resolveHostedAiUsageGate(input: {
 
     const allowanceAccess = memberState.suspendedAt === null
       ? await resolveHostedAiUsageAllowanceBillingRefForMember({
-          at: now,
           billingRef: memberState.billingRef,
           billingStatus: memberState.billingStatus,
           memberId: input.memberId,
@@ -1126,7 +1113,6 @@ export async function readHostedAiUsageGate(input: {
 
     const allowanceAccess = memberState.suspendedAt === null
       ? await resolveHostedAiUsageAllowanceBillingRefForMember({
-          at: now,
           billingRef: memberState.billingRef,
           billingStatus: memberState.billingStatus,
           memberId: input.memberId,

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -1422,6 +1422,56 @@ describe("accountHostedAiUsageForAllowanceTx", () => {
     expect(countPeriodMetadataUpdateCalls(tx)).toBe(1);
   });
 
+  it("uses a Family calendar period while the sponsor period projection is missing", async () => {
+    const updateMany = vi.fn(async () => ({ count: 1 }));
+    const executeRaw = vi.fn<AllowanceExecuteRaw>(async () => 1);
+    const tx = createAllowanceTx({
+      billingPhase: "trial",
+      checkoutOffer: "pulse_trial_7d",
+      executeRaw,
+      familyAccessActive: true,
+      familyPeriodEnd: null,
+      familyPeriodStart: null,
+      hostedAiUsageUpdateMany: updateMany,
+      periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+      periodStart: new Date("2026-04-01T00:00:00.000Z"),
+      pulseTrialPolicyVersion: "pulse-trial-2026-05-05-v1",
+      trialEndsAt: new Date("2026-04-08T12:00:00.000Z"),
+      trialStartedAt: new Date("2026-04-01T12:00:00.000Z"),
+    });
+
+    await accountHostedAiUsageForAllowanceTx({
+      memberId: "member_123",
+      now: new Date("2026-04-09T12:00:05.000Z"),
+      record: {
+        ...BASE_USAGE_RECORD,
+        occurredAt: "2026-04-09T12:00:01.000Z",
+      },
+      tx: tx as never,
+    });
+
+    expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        allowanceAccountedAt: new Date("2026-04-09T12:00:05.000Z"),
+        allowanceCostUsdMicros: 1896n,
+        allowanceCounted: true,
+        allowancePeriodEnd: new Date("2026-05-01T00:00:00.000Z"),
+        allowancePeriodStart: new Date("2026-04-01T00:00:00.000Z"),
+        allowancePricingVersion: "openai-api-pricing-2026-05-05-standard",
+      }),
+    }));
+    expect(tx.hostedAiUsagePeriod.createMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        billingPlanCode: "launch_monthly",
+        limitUsdMicros: 10_000_000n,
+        memberId: "member_123",
+        periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+        periodStart: new Date("2026-04-01T00:00:00.000Z"),
+      }),
+    }));
+    expect(countPeriodMetadataUpdateCalls(tx)).toBe(1);
+  });
+
   it("validates OpenAI flex evidence before marking stale-trial usage denied", async () => {
     const updateMany = vi.fn(async () => ({ count: 1 }));
     const executeRaw = vi.fn<AllowanceExecuteRaw>(async () => 1);
@@ -1966,13 +2016,15 @@ describe("resolveHostedAiUsageGate", () => {
     });
   });
 
-  it("denies Family-sponsored members when the group billing period is missing", async () => {
+  it("uses a calendar period for Family-sponsored members when the group period is missing", async () => {
     const prisma = createGatePrisma({
       billingStatus: HostedBillingStatus.not_started,
       familyAccessActive: true,
       familyPeriodEnd: null,
       familyPeriodStart: null,
       findUniquePeriod: null,
+      periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+      periodStart: new Date("2026-04-01T00:00:00.000Z"),
       spentUsdMicros: 0n,
     });
 
@@ -1981,14 +2033,18 @@ describe("resolveHostedAiUsageGate", () => {
       now: "2026-04-09T12:00:00.000Z",
       prisma: prisma as never,
     })).resolves.toMatchObject({
-      allowed: false,
-      reason: "hosted_access_inactive",
-      userNotice: null,
+      allowed: true,
+      allowanceSource: "family_sponsored_plan",
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: 10_000_000n,
+      periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+      periodStart: new Date("2026-04-01T00:00:00.000Z"),
+      remainingUsdMicros: 10_000_000n,
+      spentUsdMicros: 0n,
     });
-    expect(prisma.hostedAiUsagePeriod.createMany).not.toHaveBeenCalled();
   });
 
-  it("does not treat non-Family group billing as sponsored access", async () => {
+  it("keeps Family sponsorship when the group billing projection is invalid", async () => {
     const prisma = createGatePrisma({
       billingPhase: "trial",
       billingStatus: HostedBillingStatus.canceled,
@@ -2009,11 +2065,14 @@ describe("resolveHostedAiUsageGate", () => {
       now: "2026-04-09T12:00:00.000Z",
       prisma: prisma as never,
     })).resolves.toMatchObject({
-      allowed: false,
-      reason: "hosted_access_inactive",
-      userNotice: null,
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: 10_000_000n,
+      periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+      periodStart: new Date("2026-04-01T00:00:00.000Z"),
+      remainingUsdMicros: 10_000_000n,
+      spentUsdMicros: 0n,
     });
-    expect(prisma.hostedAiUsagePeriod.createMany).not.toHaveBeenCalled();
   });
 
   it("keeps pending Pulse Trial billing notices stable when no trial start exists", async () => {
@@ -2925,6 +2984,8 @@ function createAllowanceTx(input: {
   familyAccessActive?: boolean;
   familyBillingPlanCode?: string | null;
   familyPlanCode?: "edge" | "pulse";
+  familyPeriodEnd?: Date | null;
+  familyPeriodStart?: Date | null;
   hostedAiUsageAggregate?: ReturnType<typeof vi.fn>;
   hostedAiUsageUpdateMany: ReturnType<typeof vi.fn>;
   limitNoticeSentAt?: Date | null;
@@ -2938,6 +2999,12 @@ function createAllowanceTx(input: {
   trialEndsAt?: Date | null;
   trialStartedAt?: Date | null;
 }) {
+  const familyPeriodStart = input.familyPeriodStart === undefined
+    ? input.periodStart ?? new Date("2026-03-01T00:00:00.000Z")
+    : input.familyPeriodStart;
+  const familyPeriodEnd = input.familyPeriodEnd === undefined
+    ? input.periodEnd ?? new Date("2026-04-01T00:00:00.000Z")
+    : input.familyPeriodEnd;
   const defaultAggregate = vi.fn()
     .mockResolvedValueOnce({
       _max: {
@@ -3020,8 +3087,8 @@ function createAllowanceTx(input: {
             billedSeatCount: 2,
             currentBillingPlanCode: input.familyBillingPlanCode ?? "launch_family_monthly",
             currentBillingPhase: "paid",
-            currentPeriodEnd: input.periodEnd ?? new Date("2026-04-01T00:00:00.000Z"),
-            currentPeriodStart: input.periodStart ?? new Date("2026-03-01T00:00:00.000Z"),
+            currentPeriodEnd: familyPeriodEnd,
+            currentPeriodStart: familyPeriodStart,
           }
         : null),
     },


### PR DESCRIPTION
## Why

Active Family membership is the authority for sponsored access. The usage projection path incorrectly treated a missing, invalid, or out-of-window local billing-period projection as if sponsorship itself had disappeared.

That could fall through to stale member billing and produce incorrect advisory usage accounting or plan-usage status. This supersedes #605 with a web-only correction; it does not close #605.

## User-visible goal and flow

Keep an active Family member attributed to their assigned Family tier and allowance when the local Stripe period projection is temporarily incomplete or stale. Existing plan-usage surfaces continue to show Family usage; there is no new UI or runtime admission protocol.

## Root cause

`readHostedFamilySponsoredBillingRefForMember` coupled two separate facts:

1. Whether active group membership currently sponsors the member.
2. Whether the rebuildable local billing projection currently has usable Stripe period bounds.

When the second fact was unavailable, the helper returned no Family reference and discarded the first. A stale personal trial could then produce a terminal denied accounting row, or an absent personal reference could attribute usage to the default direct plan.

## Approach

- Keep active membership in an active, unsuspended group as the sponsorship authority.
- Preserve the member's assigned Family tier, allowance source, and limit.
- Allow only a paid Family projection to be considered for period bounds.
- Let the existing shared resolver validate containment and use its UTC calendar-month fallback when bounds are missing, malformed, or stale.

## Invariants

- Family sponsorship comes from active membership and active group state.
- Projection readiness does not determine sponsorship identity.
- Invalid or non-Family projection data cannot determine the allowance period.
- Included usage remains advisory and does not become a second billing system.
- Already-accounted fallback usage is not moved retroactively.
- No schema, migration, retry state machine, rehydration path, queue, or cross-runtime protocol is introduced.
- Direct active billing keeps its existing precedence.

## Deliberate tradeoff

For a non-calendar Stripe cycle, usage recorded before the projection becomes usable can remain in a UTC-month bucket while later usage uses the Stripe period. That can split advisory usage or produce an extra advisory notice. Exact historical continuity would require the durable state and reconciliation machinery this replacement intentionally avoids.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 11 | 25 |
| Tests | 79 | 12 |
| Docs | 87 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Total: 4 files, +177/-37. Production source is a net deletion.

ReviewGPT first-reviewed head: 703dbfe4e26441ddb060c65dde1f17b16fa46622

## Review heads

| Round | Head | Scope | Authored-source growth from first head | Result |
| --- | --- | --- | ---: | --- |
| 1 | `703dbfe4e26441ddb060c65dde1f17b16fa46622` | Full PR patch | baseline | PASS |

## Verification

- Focused usage-allowance regression: 84/84 passed.
- Explicit-path `pnpm test:diff`: passed.
  - Web tests: 5,118 passed, 139 skipped.
  - TypeScript, dev smoke, lint, and production build passed.
  - Lint: 0 errors, 12 existing warnings.
- Low-concurrency `pnpm verify:acceptance`: the changed hosted-execution owner passed 344/344, as did every completed guard/owner. The overall command stopped on unrelated failures in the CLI release-tarball timeout, assistant-engine worker shutdown, and assistant-runtime preemption lanes.
- ReviewGPT round 1: PASS; zero qualifying Critical, High, or Complexity Collapse findings.
- PR CI: green on the reviewed head; one unrelated localhost port-collision E2E passed on job-level rerun.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786687995&installation_id=127572939&pr_number=672&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F672&signature=70e72735f22ba4f29d07babd826091647aa0aba604863c74d8c7b2c38c2a1359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->