### PR TITLE
Bound hosted device-sync apply fan-out

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-device-sync-apply-bounds.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-device-sync-apply-bounds.md
@@ -1,0 +1,89 @@
+# Bound hosted device-sync runtime apply work
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Close security finding `cand-R0097-01` by preventing one authenticated hosted
+  device-sync apply request from amplifying into unbounded concurrent database
+  transactions, without changing device-sync ownership or adding infrastructure.
+
+## Success criteria
+
+- The shared runtime-apply contract rejects an oversized update batch before web
+  opens any connection mutation transaction.
+- The trusted runtime splits legitimate larger results into bounded sequential
+  requests.
+- Web applies accepted updates sequentially while preserving the current
+  per-connection lock, version checks, response order, and independent transaction
+  semantics.
+- Focused tests, truthful diff-aware verification, required completion audits,
+  parent final review, ReviewGPT, and CI have no unresolved actionable findings.
+
+## Scope
+
+- In scope: the shared device-sync apply contract, hosted runtime reconciliation
+  producer, web-owned apply implementation, focused tests, and the narrow durable
+  device-sync owner documentation needed to record the bound.
+- Out of scope: bulk SQL, queues, leases, schema changes, provider behavior,
+  connection ownership, and unrelated device-sync resource-window findings.
+
+## Constraints
+
+- Keep `apps/web` as the canonical hosted device-sync control-plane owner.
+- Preserve each connection's existing transaction and stale-version handling.
+- Do not introduce a concurrency helper, dependency, persisted state, or new
+  retry/reconciliation mechanism.
+- Preserve unrelated work in every checkout and do not interrupt other sessions.
+
+## Risks and mitigations
+
+1. Risk: a hard admission limit rejects a legitimate member with many connections.
+   Mitigation: share the limit with the runtime producer and split its output into
+   sequential bounded requests.
+2. Risk: sequential application changes atomicity or result ordering.
+   Mitigation: the current path already uses one independent transaction per
+   connection; retain input-order output and prove it directly.
+3. Risk: a new protocol assumption breaks during web/runner deploy skew.
+   Mitigation: new runners remain compatible with old web, and new web accepts all
+   batches emitted by the new runner; document and use runner-before-web rollout.
+
+## Tasks
+
+1. Define and enforce the shared update-count bound.
+2. Split runtime write-back into sequential bounded requests.
+3. Replace the web apply `Promise.all` fan-out with sequential application.
+4. Add focused contract, runtime, and web concurrency proof.
+5. Run verification, completion audits, final review, commit, PR, ReviewGPT, and CI.
+
+## Decisions
+
+- Use a shared numeric admission constant rather than deriving authority from
+  request size or adding a second state owner.
+- Apply web updates sequentially because normal batches are one entry per changed
+  connection and are expected to be small; optimize only if measured later.
+
+## Verification
+
+- `pnpm --dir packages/device-syncd test -- hosted-runtime.test.ts` passed
+  package-wide: 42 files, 822 tests.
+- `pnpm --dir packages/assistant-runtime test
+  test/hosted-device-sync-runtime.test.ts` passed: 1 file, 72 tests.
+- `pnpm --dir apps/web test:prepared
+  apps/web/test/device-sync-hosted-runtime-authority.test.ts` passed: 1 file,
+  38 tests.
+- `pnpm --dir apps/web typecheck` passed, including generated health-commons and
+  Prisma artifacts and the shared-host TypeScript checker lane.
+- Diff-aware verification passed syntax, architecture, security/logging, dependency,
+  workspace-boundary, cycle, and all affected package typechecks. Its broad
+  reverse-dependent test graph was stopped after the unrelated
+  `assistant-engine` warm-Codex suite entered shared-state contention and reported
+  144 failures; no changed file is in that package, and all three owner-level
+  suites pass independently.
+- Required coverage-write audit made no edits and independently reran the three
+  focused suites. It found the proof sufficient at the shared contract, runtime
+  batching, and web mutation boundaries.
+- `git diff --check` passed.
+Completed: 2026-07-15

--- a/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
+++ b/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
@@ -187,9 +187,11 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
     }
   }
 
-  const updates = await Promise.all(
-    parsed.updates.map(async (update) => {
-      const result = await controlPlane.store.withConnectionMutationLock(update.connectionId, async (tx) => {
+  const updates: HostedExecutionDeviceSyncRuntimeApplyEntry[] = [];
+  for (const update of parsed.updates) {
+    const result = await controlPlane.store.withConnectionMutationLock(
+      update.connectionId,
+      async (tx) => {
         const record = await tx.deviceConnection.findFirst({
           where: {
             id: update.connectionId,
@@ -469,11 +471,10 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
           tokenUpdate,
           writeUpdate,
         } satisfies HostedExecutionDeviceSyncRuntimeApplyEntry;
-      });
-
-      return result;
-    }),
-  );
+      },
+    );
+    updates.push(result);
+  }
 
   return {
     appliedAt,

--- a/apps/web/test/device-sync-hosted-runtime-authority.test.ts
+++ b/apps/web/test/device-sync-hosted-runtime-authority.test.ts
@@ -510,6 +510,70 @@ describe("applyHostedDeviceSyncRuntimeResult", () => {
     vi.clearAllMocks();
   });
 
+  it("applies accepted connection updates sequentially in request order", async () => {
+    let activeLocks = 0;
+    let maxActiveLocks = 0;
+    const withConnectionMutationLock = vi.fn(async (
+      _connectionId: string,
+      callback: (tx: {
+        deviceConnection: {
+          findFirst: () => Promise<null>;
+        };
+      }) => Promise<unknown>,
+    ) => {
+      activeLocks += 1;
+      maxActiveLocks = Math.max(maxActiveLocks, activeLocks);
+      await Promise.resolve();
+      try {
+        return await callback({
+          deviceConnection: {
+            findFirst: vi.fn(async () => null),
+          },
+        });
+      } finally {
+        activeLocks -= 1;
+      }
+    });
+    mocks.createHostedDeviceSyncControlPlane.mockReturnValue({
+      store: {
+        withConnectionMutationLock,
+      },
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [
+            { connectionId: "conn_first" },
+            { connectionId: "conn_second" },
+          ],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(maxActiveLocks).toBe(1);
+    expect(withConnectionMutationLock).toHaveBeenNthCalledWith(
+      1,
+      "conn_first",
+      expect.any(Function),
+    );
+    expect(withConnectionMutationLock).toHaveBeenNthCalledWith(
+      2,
+      "conn_second",
+      expect.any(Function),
+    );
+    expect(response.updates.map((update) => update.connectionId)).toEqual([
+      "conn_first",
+      "conn_second",
+    ]);
+  });
+
   it("rejects omitted observedUpdatedAt fences for connection and local-state mutations", async () => {
     const { applyHostedDeviceSyncRuntimeResult } = await import(
       "@/src/lib/device-sync/hosted-runtime-authority"

--- a/docs/device-sync-hosted-control-plane.md
+++ b/docs/device-sync-hosted-control-plane.md
@@ -217,6 +217,14 @@ These are authenticated by local-agent credentials, not browser cookies.
 
 These routes are authenticated by signed server-to-server traffic that never reaches the browser. `:connectTarget` is resolved through the same connect-target registry used by `/connect`; the target carries the manifest provider plus optional Junction `sourceProviderSlug` such as Garmin, Oura, or Strava. The connect-link route creates a short-lived first-party connect intent and returns `connectUrl` plus a compatibility `authorizationUrl` copy of the same first-party URL; it does not start provider OAuth or return raw provider/Junction URLs to hosted execution. `apps/web` remains the canonical device-sync control plane while `apps/cloudflare` invokes only the narrow runtime callbacks it needs during hosted execution. Dirty-state callbacks are device-sync-specific; they are not a generic mailbox wake broker.
 
+Runtime apply write-back is bounded to 100 distinct connection updates per
+request. The hosted runtime splits larger legitimate results into sequential
+batches, and web applies each accepted connection update sequentially through
+its existing per-connection mutation lock and transaction. This bound prevents
+one signed runtime callback from amplifying into unbounded concurrent database
+transactions without introducing a queue, bulk mutation owner, or second retry
+path.
+
 ## Runtime access strategy
 
 The current hosted runtime strategy is:

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -20,6 +20,7 @@ import type {
   StoredDeviceSyncAccount,
 } from "@murphai/device-syncd/types";
 import {
+  HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT,
   mergeHostedDeviceSyncConnectionMetadata,
   normalizeHostedDeviceSyncJobHints,
   resolveHostedDeviceSyncWakeContext,
@@ -366,11 +367,18 @@ export async function reconcileHostedDeviceSyncControlPlaneState(input: {
     }
   }
 
-  await client.applyUpdates({
-    occurredAt: input.wake.occurredAt,
-    ...(input.signal ? { signal: input.signal } : {}),
-    updates,
-  });
+  let offset = 0;
+  do {
+    await client.applyUpdates({
+      occurredAt: input.wake.occurredAt,
+      ...(input.signal ? { signal: input.signal } : {}),
+      updates: updates.slice(
+        offset,
+        offset + HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT,
+      ),
+    });
+    offset += HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT;
+  } while (offset < updates.length);
 }
 
 function createEmptyHostedDeviceSyncRuntimeSyncState(

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -18,6 +18,7 @@ import { buildJunctionProviderSourceInstanceKey } from "@murphai/device-syncd/co
 import { JUNCTION_COMPANION_HRV_OBSERVATION_INVALID_CODE } from "@murphai/device-syncd/junction-resources";
 import { buildDeviceSyncTokenCipherOptions, createSecretCodec } from "@murphai/device-syncd/local-secret-codec";
 import { deviceSyncError } from "@murphai/device-syncd/errors";
+import { HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT } from "@murphai/device-syncd/hosted-runtime";
 import {
   type DeviceSyncAccount,
   type DeviceSyncJobRecord,
@@ -521,6 +522,97 @@ function clearAccountCredentialForTesting(service: DeviceSyncService, accountId:
 }
 
 describe("hosted device-sync runtime", () => {
+  test("reconciliation sends oversized legitimate updates as sequential bounded batches", async () => {
+    const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
+      "hosted-device-sync-runtime-",
+    );
+    await mkdir(vaultRoot, { recursive: true });
+
+    const service = createDeviceSyncServiceForVault(vaultRoot);
+
+    try {
+      const store = getStore(service);
+      const updateCount = HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT + 1;
+      const localToHostedAccountIds = new Map<string, string>();
+      const hostedToLocalAccountIds = new Map<string, string>();
+      const observedTokenVersions = new Map<string, number | null>();
+
+      for (let index = 0; index < updateCount; index += 1) {
+        const account = store.upsertAccount({
+          connectedAt: "2026-04-06T09:00:00.000Z",
+          credential: {
+            credentialMetadata: {},
+            kind: "none",
+          },
+          displayName: `Device ${index}`,
+          externalAccountId: `external_${index}`,
+          provider: "demo",
+          scopes: [],
+          status: "active",
+        });
+        const hostedConnectionId = `hosted_conn_${index}`;
+        localToHostedAccountIds.set(account.id, hostedConnectionId);
+        hostedToLocalAccountIds.set(hostedConnectionId, account.id);
+        observedTokenVersions.set(hostedConnectionId, null);
+      }
+
+      let activeApplyCalls = 0;
+      let maxActiveApplyCalls = 0;
+      const appliedRequests: ApplyUpdatesRequest[] = [];
+      const deviceSyncPort: HostedRuntimeDeviceSyncPort = {
+        ...createNoDirtyStateDeviceSyncPortMethods(),
+        async applyUpdates(input): Promise<HostedExecutionDeviceSyncRuntimeApplyResponse> {
+          activeApplyCalls += 1;
+          maxActiveApplyCalls = Math.max(maxActiveApplyCalls, activeApplyCalls);
+          await Promise.resolve();
+          appliedRequests.push(input);
+          activeApplyCalls -= 1;
+          return {
+            appliedAt: "2026-04-06T09:11:00.000Z",
+            updates: [],
+            userId: "member_123",
+          };
+        },
+        async createConnectLink() {
+          throw new Error("createConnectLink should not be called during reconciliation");
+        },
+        async fetchSnapshot() {
+          throw new Error("fetchSnapshot should not be called during reconciliation");
+        },
+      };
+
+      await reconcileHostedDeviceSyncControlPlaneState({
+        deviceSyncPort,
+        secret: DEVICE_SYNC_SECRET,
+        service,
+        state: {
+          hostedToLocalAccountIds,
+          localToHostedAccountIds,
+          observedTokenVersions,
+          pendingDirtyAcks: [],
+          pendingDirtyPayloadJobs: [],
+          snapshot: buildEmptyRuntimeSnapshot(),
+        },
+        wake: buildCronWake("2026-04-06T09:10:00.000Z"),
+      });
+
+      assert.equal(appliedRequests.length, 2);
+      assert.equal(
+        appliedRequests[0]?.updates.length,
+        HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT,
+      );
+      assert.equal(appliedRequests[1]?.updates.length, 1);
+      assert.equal(maxActiveApplyCalls, 1);
+      assert.deepEqual(
+        appliedRequests.flatMap((request) => request.updates.map((update) => update.connectionId)),
+        Array.from({ length: updateCount }, (_, index) => `hosted_conn_${index}`),
+      );
+    } finally {
+      closeHostedRuntimeDeviceSyncService(service);
+      await cleanup();
+    }
+  });
+
   test("sync fails closed when no device-sync client is available", async () => {
     const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
       "hosted-device-sync-runtime-",

--- a/packages/device-syncd/src/hosted-runtime.ts
+++ b/packages/device-syncd/src/hosted-runtime.ts
@@ -33,6 +33,7 @@ export const HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_DIRTY_PENDING_PATH =
   "/api/internal/device-sync/runtime/dirty-pending";
 export const HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_DIRTY_ACK_PATH =
   "/api/internal/device-sync/runtime/dirty-ack";
+export const HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT = 100;
 export const HOSTED_EXECUTION_DEVICE_SYNC_STAGED_DIRTY_ACK_RECORD_LIMIT = 200;
 export const HOSTED_EXECUTION_DEVICE_SYNC_STAGED_DIRTY_ACK_PAYLOAD_ID_LIMIT = 5_000;
 
@@ -676,9 +677,10 @@ export function parseHostedExecutionDeviceSyncRuntimeApplyRequest(
   trustedUserId: string | null = null,
 ): HostedExecutionDeviceSyncRuntimeApplyRequest {
   const record = requireObject(value, "Hosted device-sync runtime apply request");
-  const updates = requireArray(
+  const updates = requireBoundedArray(
     record.updates,
     "Hosted device-sync runtime apply request updates",
+    HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT,
   ).map((entry, index) => parseHostedExecutionDeviceSyncRuntimeConnectionUpdate(entry, index));
 
   assertUniqueHostedExecutionDeviceSyncRuntimeApplyConnectionIds(updates);
@@ -708,9 +710,10 @@ export function parseHostedExecutionDeviceSyncRuntimeApplyResponse(
 
   return {
     appliedAt,
-    updates: requireArray(
+    updates: requireBoundedArray(
       record.updates,
       "Hosted device-sync runtime apply response updates",
+      HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT,
     ).map((entry, index) => parseHostedExecutionDeviceSyncRuntimeApplyEntry(entry, index)),
     userId: requireString(record.userId, "Hosted device-sync runtime apply response userId"),
   };

--- a/packages/device-syncd/test/hosted-runtime.test.ts
+++ b/packages/device-syncd/test/hosted-runtime.test.ts
@@ -519,6 +519,37 @@ describe("mergeGuardedJunctionHistoricalBackfillMetadata", () => {
 });
 
 describe("parseHostedExecutionDeviceSyncRuntimeApplyRequest", () => {
+  it("rejects runtime apply request and response batches above the shared limit", () => {
+    const connectionIds = Array.from(
+      {
+        length:
+          hostedRuntime.HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_APPLY_UPDATE_LIMIT + 1,
+      },
+      (_, index) => `conn_${index}`,
+    );
+
+    expect(() =>
+      parseHostedExecutionDeviceSyncRuntimeApplyRequest({
+        updates: connectionIds.map((connectionId) => ({ connectionId })),
+        userId: "user_123",
+      })
+    ).toThrowError(/runtime apply request updates must include no more than 100 entries/u);
+
+    expect(() =>
+      parseHostedExecutionDeviceSyncRuntimeApplyResponse({
+        appliedAt: "2026-04-07T02:00:00.000Z",
+        updates: connectionIds.map((connectionId) => ({
+          connection: null,
+          connectionId,
+          status: "missing",
+          tokenUpdate: "missing",
+          writeUpdate: "missing",
+        })),
+        userId: "user_123",
+      })
+    ).toThrowError(/runtime apply response updates must include no more than 100 entries/u);
+  });
+
   it("parses staged dirty ack overlays on dirty-pending requests", () => {
     expect(
       parseHostedExecutionDeviceSyncDirtyPendingRequest(


### PR DESCRIPTION
## Why

The security audit found that one authenticated hosted device-sync runtime result could contain an unbounded update array. Web fanned that array out with Promise.all, allowing one callback to open thousands of concurrent per-connection database transactions.

The user-visible goal is unchanged device-sync persistence with bounded server work and predictable database load.

## How

- Enforce one shared 100-update request and response limit at the device-sync runtime contract.
- Split legitimate larger runtime results into ordered sequential batches of at most 100.
- Apply accepted web updates sequentially through the existing per-connection mutation lock and transaction.
- Keep the existing empty reconciliation callback, stale-version checks, independent transaction semantics, and response order.

No queue, lease, bulk mutation owner, persisted state, retry path, dependency, or schema was added.

## Invariants

- Apps/web remains the canonical hosted device-sync control-plane owner.
- Oversized requests fail before any mutation transaction opens.
- Existing per-connection locking and optimistic-version behavior remain authoritative.
- Legitimate results larger than the wire bound are preserved by runtime batching rather than dropped.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Production source | 27 | 15 |
| Tests | 187 | 0 |
| Durable docs | 8 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 89 | 0 |

ReviewGPT first-reviewed head: 02c24905e79b04dbb88a451aea00cdd9a573e44f

| ReviewGPT round | Current head | Scope | Review remediation source growth |
| --- | --- | --- | ---: |
| 1 | 02c24905e79b04dbb88a451aea00cdd9a573e44f | Full patch | +0 / -0 |

## Validation

- Device-syncd: 42 files, 822 tests passed.
- Assistant runtime: 1 file, 72 tests passed.
- Web authority: 1 file, 38 tests passed.
- Web TypeScript 7 typecheck passed.
- Diff-aware syntax, architecture, security/logging, dependency, workspace-boundary, cycle, and affected-owner typechecks passed.
- Required coverage-write audit found no missing proof and made no edits.
- The broad reverse-dependent assistant-engine test suite encountered shared warm-Codex state contention and reported unrelated failures; all changed owners pass independently.

## Deployment

Deploy the hosted runner/container before, or atomically with, apps/web. Then smoke-test a representative hosted device-sync result and confirm sequential multi-batch apply behavior for more than 100 updates.