### PR TITLE
fix(web): harden trial extension recovery and eligibility

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-trial-extension-completed-marker-hotfix.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-trial-extension-completed-marker-hotfix.md
@@ -1,0 +1,95 @@
+# Trial extension completed-marker hotfix
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Prevent a completed Pulse Trial extension marker from being interpreted as a
+  pending recovery after the member has moved into paid billing.
+
+## Success criteria
+
+- The pending target marker remains present through paused prepare and resume
+  recovery, but is cleared by the final update that proves `trialing` at the
+  target end.
+- Final-update response loss and local-write failure remain recoverable from
+  the provider trial end plus completed operation/day markers.
+- A completed extension followed by an active paid conversion is ineligible for
+  a fresh trial extension even if local paid invoice reconciliation is delayed.
+- Paid conversion clears any legacy pending target marker in the same Stripe
+  mutation that ends the trial.
+- The known successfully extended production subscriptions have their legacy
+  target marker cleared without changing billing status or trial end.
+- No paid subscription is moved back to trialing by the ops recovery path.
+
+## Scope
+
+- In scope: the Pulse Trial extension provider metadata transition, clearing the
+  marker during paid conversion, bounded cleanup of the known successful
+  production cohort, and focused regressions across recovery and conversion.
+- Out of scope: changing trial duration, invoice policy, plan selection, Stripe
+  subscription structure, or database schema.
+
+## Constraints
+
+- Preserve the current paused prepare/resume recovery protocol and exact-target
+  idempotency.
+- Preserve successful final-update and local-write recovery without a new state
+  owner, provider read, queue, or persisted field.
+- Keep provider and member identifiers out of logs and committed examples.
+
+## Risks and mitigations
+
+1. Risk: clearing the target marker breaks ambiguous-success recovery.
+   Mitigation: retain operation/day markers and recover completed `trialing`
+   state from the exact provider `trial_end`, which the existing resolver
+   already supports.
+2. Risk: clearing the marker too early breaks paused or active intermediate
+   recovery.
+   Mitigation: keep the target only on prepare/resume state and clear it only in
+   the final update that sets the exact trial end.
+3. Risk: a paid transition is still eligible through another predicate.
+   Mitigation: add a focused active-provider regression with local trial state
+   and completed markers, and prove no provider mutation occurs.
+
+## Tasks
+
+1. Add a failing regression that distinguishes pending active recovery from a
+   completed active paid conversion.
+2. Make the final provider update clear the pending target marker while keeping
+   operation/day markers.
+3. Update recovery assertions for final response loss and local write loss.
+4. Clear legacy target metadata during paid conversion and reject already-local
+   completed targets as active recovery.
+5. Run focused and routed verification, required coverage and billing-state
+   audits, then ship a reviewed follow-up PR and verify deployment.
+6. Clear the target marker on the known successful production cohort after
+   canonical Stripe identity/state rechecks; do not mutate `trial_end`.
+
+## Decisions
+
+- The target marker is a pending predicate, not historical completion metadata.
+- Operation and extension-day markers remain as completion identity, while the
+  canonical provider `trial_end` is sufficient for completed-state recovery.
+- The state audit proved already-persisted targets from the deployed run need a
+  bounded provider cleanup; future paid conversion also clears the marker.
+
+## Verification
+
+- Focused billing and route suites: 78 tests passed.
+- Routed `pnpm test:diff`: 5,123 tests passed, 139 skipped; typecheck,
+  lint, production build, dev smoke, and workspace guards passed.
+- Coverage-write review: no unresolved material coverage gap.
+- State-inconsistency audit: no remaining Critical, High, or Medium finding.
+- `git diff --check` and identifier/privacy scan passed.
+
+## Post-deploy action
+
+- After the reviewed deployment is Ready, clear only
+  `murphTrialExtensionTargetTrialEnd` on the known successful production
+  extension cohort after canonical member/subscription/operation rechecks.
+  Preserve operation/day metadata, billing status, and `trial_end`, then verify
+  that no matching subscription retains the target marker.
+Completed: 2026-07-15

--- a/agent-docs/exec-plans/completed/2026-07-15-trial-extension-family-sponsorship-guard.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-trial-extension-family-sponsorship-guard.md
@@ -1,0 +1,54 @@
+# Trial extension Family sponsorship guard
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Prevent the manual Pulse Trial extension flow from mutating a direct Stripe
+  subscription when the member already has active Family-sponsored access.
+
+## Production proof
+
+- The manual extension reconciled nine local trial rows.
+- Seven subscriptions remained trialing.
+- The other two were canceled immediately by the existing canonical Family
+  sponsorship cleanup path.
+- A one-time salted comparison proved those two rows were exactly the two
+  members with active, unsuspended Family sponsorship.
+
+## Success criteria
+
+- Preview returns an explicit ineligible result for active Family-sponsored
+  members without reading or mutating Stripe.
+- Apply rechecks Family sponsorship under the existing member billing lock and
+  fails stale if sponsorship changed after Preview.
+- Ordinary eligible trial extension and recovery behavior remains unchanged.
+- Post-deploy marker cleanup targets only the seven subscriptions that remain
+  canonical trialing subscriptions.
+
+## Constraints
+
+- Reuse canonical Family sponsorship derivation from member access.
+- Do not add persisted state or a second billing owner.
+- Keep member, customer, subscription, and provider request identifiers out of
+  logs and committed artifacts.
+
+## Tasks
+
+1. Add the Family-sponsored eligibility code and canonical access check.
+2. Add focused no-provider Preview and stale-Apply regressions.
+3. Run routed verification and required coverage/state audits.
+4. Prepare the corrected PR head and a bounded counts-only post-deploy cleanup.
+
+## Outcome
+
+- Preview rejects active Family sponsorship before any Stripe read.
+- Apply repeats that check inside the existing member billing lock and treats a
+  newly active sponsorship as stale Preview state.
+- Focused regressions, the full diff verification suite, coverage review, and
+  billing state-consistency review all passed.
+- The post-deploy cleanup remains bounded to the seven canonical subscriptions
+  that are still trialing and will clear only the obsolete target marker.
+Completed: 2026-07-15

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1117,10 +1117,11 @@ Current hosted billing assumptions:
   the local trial and usage-period window in that operation.
 - A live `trialing` Pulse Trial extends from its current Stripe trial end. A
   lapsed `paused` no-card Pulse Trial restarts for seven days from Preview time.
-  The proof expires after 15 minutes. Paid, scheduled, canceling, canceled,
-  incomplete, past-due, unpaid, foreign, or otherwise mismatched billing is
-  displayed as ineligible and is never mutated. The route does not search for
-  members, process cohorts or batches, or clean up provider subscriptions.
+  The proof expires after 15 minutes. Active Family sponsorship and paid,
+  scheduled, canceling, canceled, incomplete, past-due, unpaid, foreign, or
+  otherwise mismatched direct billing are displayed as ineligible and are never
+  mutated. The route does not search for members, process cohorts or batches,
+  or clean up provider subscriptions.
 - Stripe reads and writes use one 80-second attempt. Apply gives the member lock
   at most 25 seconds to acquire and the locked transaction at most 190 seconds.
   The provider update uses no proration and carries a proof-derived idempotency

--- a/apps/web/src/lib/hosted-onboarding/billing-start-paid-pulse-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/billing-start-paid-pulse-service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import {
   HostedBillingStatus,
   type PrismaClient,
@@ -76,9 +78,11 @@ const START_PAID_PULSE_RECOVERABLE_STRIPE_SUBSCRIPTION_STATUSES = new Set([
   "trialing",
   "unpaid",
 ]);
+const PULSE_TRIAL_EXTENSION_TARGET_METADATA_KEY =
+  "murphTrialExtensionTargetTrialEnd";
 
 type HostedPulseTrialStartPaidIdempotencyOperation =
-  | "paused-legacy-metered-cleanup-v1"
+  | "active-trial-end-now-v2"
   | "paused-resume-v1";
 
 export type HostedPulseTrialStartPaidResult =
@@ -669,11 +673,13 @@ async function updateHostedPulseTrialStartPaidSubscription(input: {
           () => input.stripe.subscriptions.update(input.stripeSubscriptionId, {
             expand: [...START_PAID_PULSE_STRIPE_UPDATE_EXPANSIONS],
             ...(input.legacyMeteredItems.length > 0 ? { items: input.legacyMeteredItems } : {}),
+            metadata: { murphTrialExtensionTargetTrialEnd: "" },
             payment_behavior: "allow_incomplete",
             trial_end: "now",
           }, {
             idempotencyKey: buildHostedPulseTrialStartPaidIdempotencyKey({
               memberId: input.memberId,
+              operation: "active-trial-end-now-v2",
               priceId: input.priceId,
               stripeSubscriptionId: input.stripeSubscriptionId,
               trialEnd: input.trialEnd,
@@ -794,55 +800,35 @@ async function resumeHostedPulseTrialStartPaidPausedSubscription(input: {
   let stripeMutationCompleted = false;
 
   try {
-    if (input.legacyMeteredItems.length > 0) {
-      const cleanedSubscription = await withHostedMemberStripeMutationLock({
-        memberId: input.memberId,
-        prisma: input.prisma,
-        run: async () => {
-          const subscription = await callHostedStripeStartPaidPulseOperation(
-            "subscription.update.paused-legacy-metered-cleanup",
-            () => input.stripe.subscriptions.update(input.stripeSubscriptionId, {
-              expand: [...START_PAID_PULSE_STRIPE_UPDATE_EXPANSIONS],
-              items: input.legacyMeteredItems,
-              proration_behavior: "none",
-            }, {
-              idempotencyKey: buildHostedPulseTrialStartPaidIdempotencyKey({
-                memberId: input.memberId,
-                operation: "paused-legacy-metered-cleanup-v1",
-                priceId: input.priceId,
-                stripeSubscriptionId: input.stripeSubscriptionId,
-                trialEnd: input.trialEnd,
-              }),
-            }),
-          );
-          stripeMutationCompleted = true;
-          return subscription;
-        },
-      });
-      assertHostedStripePulseTrialStartPaidPostMutationSubscriptionShape({
-        priceId: input.priceId,
-        subscription: cleanedSubscription,
-      });
-      const cleanedInvoiceResult = await maybeResolveHostedPulseTrialStartPaidPostMutationInvoiceResult({
-        invoice: readExpandedLatestInvoice(cleanedSubscription),
-        memberId: input.memberId,
-        now: input.now,
-        priceId: input.priceId,
-        prisma: input.prisma,
-        stripeCustomerId: input.stripeCustomerId,
-        stripeSubscriptionId: input.stripeSubscriptionId,
-        subscription: cleanedSubscription,
-      });
-
-      if (cleanedInvoiceResult) {
-        return cleanedInvoiceResult;
-      }
-    }
-
     const resumedSubscription = await withHostedMemberStripeMutationLock({
       memberId: input.memberId,
       prisma: input.prisma,
       run: async () => {
+        const cleanedSubscription = await callHostedStripeStartPaidPulseOperation(
+          "subscription.update.paused-pre-resume-cleanup",
+          () => input.stripe.subscriptions.update(input.stripeSubscriptionId, {
+            expand: [...START_PAID_PULSE_STRIPE_UPDATE_EXPANSIONS],
+            ...(input.legacyMeteredItems.length > 0
+              ? { items: input.legacyMeteredItems }
+              : {}),
+            metadata: {
+              [PULSE_TRIAL_EXTENSION_TARGET_METADATA_KEY]: "",
+            },
+            proration_behavior: "none",
+          }, {
+            idempotencyKey:
+              buildHostedPulseTrialStartPaidCleanupIdempotencyKey(),
+          }),
+        );
+        stripeMutationCompleted = true;
+        assertHostedStripePulseTrialStartPaidPostMutationSubscriptionShape({
+          priceId: input.priceId,
+          subscription: cleanedSubscription,
+        });
+        if (cleanedSubscription.status !== "paused") {
+          return cleanedSubscription;
+        }
+
         const subscription = await callHostedStripeStartPaidPulseOperation(
           "subscription.resume.paused-trial",
           () => input.stripe.subscriptions.resume(input.stripeSubscriptionId, {
@@ -1099,4 +1085,11 @@ function buildHostedPulseTrialStartPaidIdempotencyKey(input: {
         operation: input.operation,
       }
     : keyPayload))}`;
+}
+
+function buildHostedPulseTrialStartPaidCleanupIdempotencyKey(): string {
+  // Clearing metadata and deleting already-selected legacy items are
+  // convergent operations. A fresh key per top-level attempt prevents Stripe
+  // from replaying a cached cleanup response after provider state changes.
+  return `hosted-billing-start-paid-pulse:paused-cleanup:${randomUUID()}`;
 }

--- a/apps/web/src/lib/hosted-onboarding/billing-start-paid-pulse-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/billing-start-paid-pulse-service.ts
@@ -820,7 +820,6 @@ async function resumeHostedPulseTrialStartPaidPausedSubscription(input: {
               buildHostedPulseTrialStartPaidCleanupIdempotencyKey(),
           }),
         );
-        stripeMutationCompleted = true;
         assertHostedStripePulseTrialStartPaidPostMutationSubscriptionShape({
           priceId: input.priceId,
           subscription: cleanedSubscription,

--- a/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
+++ b/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
@@ -474,7 +474,7 @@ async function prepareHostedPulseTrialExtension(input: {
     preparedSubscription = await input.stripe.updateSubscription(
       input.subscription.id,
       {
-        metadata: buildHostedPulseTrialExtensionMetadata(input),
+        metadata: buildHostedPulseTrialExtensionPendingMetadata(input),
       },
       {
         idempotencyKey: buildHostedPulseTrialExtensionIdempotencyKey({
@@ -560,7 +560,7 @@ async function updateHostedPulseTrialExtension(input: {
     return await input.stripe.updateSubscription(
       input.subscription.id,
       {
-        metadata: buildHostedPulseTrialExtensionMetadata(input),
+        metadata: buildHostedPulseTrialExtensionCompletedMetadata(input),
         proration_behavior: "none",
         trial_end: input.targetTrialEnd,
       },
@@ -580,7 +580,7 @@ async function updateHostedPulseTrialExtension(input: {
   }
 }
 
-function buildHostedPulseTrialExtensionMetadata(input: {
+function buildHostedPulseTrialExtensionPendingMetadata(input: {
   operationId: string;
   targetTrialEnd: number;
 }): Record<string, string> {
@@ -589,6 +589,17 @@ function buildHostedPulseTrialExtensionMetadata(input: {
       HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString(),
     [EXTENSION_OPERATION_METADATA_KEY]: input.operationId,
     [EXTENSION_TARGET_METADATA_KEY]: input.targetTrialEnd.toString(),
+  };
+}
+
+function buildHostedPulseTrialExtensionCompletedMetadata(input: {
+  operationId: string;
+}): Record<string, string> {
+  return {
+    [EXTENSION_DAYS_METADATA_KEY]:
+      HOSTED_PULSE_TRIAL_EXTENSION_DAYS.toString(),
+    [EXTENSION_OPERATION_METADATA_KEY]: input.operationId,
+    [EXTENSION_TARGET_METADATA_KEY]: "",
   };
 }
 
@@ -674,6 +685,13 @@ async function inspectHostedPulseTrialExtensionState(input: {
     now: input.now,
     subscription,
   });
+  if (subscription.status === "active" && !recoverableOperation) {
+    return buildIneligibleHostedPulseTrialExtensionState({
+      code: "provider_subscription_not_extendable",
+      member: input.member,
+      subscription,
+    });
+  }
   const targetTrialEnd = recoverableOperation?.targetTrialEnd ??
     (subscription.status === "trialing"
       ? requireSafeUnixSecond(currentTrialEnd) +
@@ -1064,21 +1082,25 @@ function readHostedPulseTrialExtensionRecoverableOperation(input: {
   const metadataTarget = readHostedPulseTrialExtensionMetadataTarget(
     input.subscription,
   );
+  const localTrialEnd = input.member?.billingRef?.currentTrialEndsAt
+    ? Math.floor(input.member.billingRef.currentTrialEndsAt.getTime() / 1000)
+    : null;
 
   if (
     (input.subscription.status === "paused" ||
       input.subscription.status === "active") &&
     metadataTarget !== null &&
-    metadataTarget > nowUnix
+    metadataTarget > nowUnix &&
+    (
+      input.subscription.status !== "active" ||
+      localTrialEnd !== metadataTarget
+    )
   ) {
     return { operationId, targetTrialEnd: metadataTarget };
   }
 
   const trialEnd = readSafeUnixSecond(input.subscription.trial_end);
   const trialingTarget = metadataTarget ?? trialEnd;
-  const localTrialEnd = input.member?.billingRef?.currentTrialEndsAt
-    ? Math.floor(input.member.billingRef.currentTrialEndsAt.getTime() / 1000)
-    : null;
   if (
     input.subscription.status === "trialing" &&
     trialEnd !== null &&

--- a/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
+++ b/apps/web/src/lib/hosted-ops/pulse-trial-extension.ts
@@ -21,6 +21,7 @@ import {
   updateHostedMemberCoreState,
   type HostedMemberBillingSnapshot,
 } from "../hosted-onboarding/hosted-member-store";
+import { readActiveHostedFamilySponsorship } from "../hosted-onboarding/member-access";
 import {
   isHostedPulseTrialSubscriptionForKnownPolicy,
 } from "../hosted-onboarding/pulse-trial-subscription-cleanup";
@@ -51,6 +52,7 @@ export type HostedPulseTrialExtensionEligibilityCode =
   | "eligible"
   | "member_not_found"
   | "member_suspended"
+  | "family_sponsored"
   | "missing_billing_reference"
   | "not_a_redeemed_pulse_trial"
   | "paid_billing"
@@ -230,6 +232,7 @@ export async function previewHostedPulseTrialExtension(
     memberId: input.memberId,
     now,
     priceId: dependencies.priceId,
+    prisma: dependencies.prisma,
     stripe: dependencies.stripe,
   });
 
@@ -289,6 +292,7 @@ export async function applyHostedPulseTrialExtension(
           memberId: input.memberId,
           now: proofDates.previewedAt,
           priceId: dependencies.priceId,
+          prisma: tx,
           stripe: dependencies.stripe,
         });
         const subscription = state.subscription;
@@ -632,12 +636,23 @@ async function inspectHostedPulseTrialExtensionState(input: {
   memberId: string;
   now: Date;
   priceId: string;
+  prisma: PrismaClient | Prisma.TransactionClient;
   stripe: HostedPulseTrialExtensionStripeClient;
 }): Promise<HostedPulseTrialExtensionState> {
   const localReason = classifyHostedPulseTrialExtensionLocalState(input.member);
   if (localReason) {
     return buildIneligibleHostedPulseTrialExtensionState({
       code: localReason,
+      member: input.member,
+    });
+  }
+
+  if (await readActiveHostedFamilySponsorship({
+    memberId: input.memberId,
+    prisma: input.prisma,
+  })) {
+    return buildIneligibleHostedPulseTrialExtensionState({
+      code: "family_sponsored",
       member: input.member,
     });
   }
@@ -832,6 +847,8 @@ function readHostedPulseTrialExtensionEligibilityMessage(
       return "No hosted member exists with this ID.";
     case "member_suspended":
       return "This member is suspended, so billing was left unchanged.";
+    case "family_sponsored":
+      return "This member already has access through an active Family plan.";
     case "missing_billing_reference":
       return "This member has no Stripe billing record.";
     case "not_a_redeemed_pulse_trial":

--- a/apps/web/test/hosted-onboarding-billing-start-paid-pulse-service.test.ts
+++ b/apps/web/test/hosted-onboarding-billing-start-paid-pulse-service.test.ts
@@ -100,13 +100,20 @@ describe("startHostedPulseTrialPaidPlan", () => {
       status: "active",
       trialEnd: null,
     }));
-    mocks.stripe.subscriptions.update.mockResolvedValue(makeSubscription({
-      latestInvoice: makeInvoice({
-        status: "draft",
-      }),
-      status: "active",
-      trialEnd: null,
-    }));
+    mocks.stripe.subscriptions.update.mockImplementation(
+      async (_subscriptionId: string, params: Stripe.SubscriptionUpdateParams) =>
+        params.trial_end === "now"
+          ? makeSubscription({
+            latestInvoice: makeInvoice({ status: "draft" }),
+            status: "active",
+            trialEnd: null,
+          })
+          : makeSubscription({
+            latestInvoice: null,
+            status: "paused",
+            trialEnd: null,
+          }),
+    );
   });
 
   test("ends an active Pulse trial with allow_incomplete and returns billing_pending while Stripe is settling", async () => {
@@ -125,11 +132,14 @@ describe("startHostedPulseTrialPaidPlan", () => {
       "sub_123",
       {
         expand: ["items.data.price", "latest_invoice", "latest_invoice.payment_intent"],
+        metadata: { murphTrialExtensionTargetTrialEnd: "" },
         payment_behavior: "allow_incomplete",
         trial_end: "now",
       },
       {
-        idempotencyKey: buildExpectedStartPaidPulseIdempotencyKey(),
+        idempotencyKey: buildExpectedStartPaidPulseIdempotencyKey(
+          "active-trial-end-now-v2",
+        ),
       },
     );
     expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledWith({
@@ -257,9 +267,12 @@ describe("startHostedPulseTrialPaidPlan", () => {
     expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(2);
     expect(mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
     const firstKey = mocks.stripe.subscriptions.update.mock.calls[0]?.[2]?.idempotencyKey;
-    expect(firstKey).toBe(buildExpectedStartPaidPulseIdempotencyKey());
+    expect(firstKey).toBe(buildExpectedStartPaidPulseIdempotencyKey(
+      "active-trial-end-now-v2",
+    ));
     expect(mocks.stripe.subscriptions.update.mock.calls[0]?.[1]).toEqual({
       expand: ["items.data.price", "latest_invoice", "latest_invoice.payment_intent"],
+      metadata: { murphTrialExtensionTargetTrialEnd: "" },
       payment_behavior: "allow_incomplete",
       trial_end: "now",
     });
@@ -443,6 +456,7 @@ describe("startHostedPulseTrialPaidPlan", () => {
         deleted: true,
         id: "si_price_pulse_usage",
       }],
+      metadata: { murphTrialExtensionTargetTrialEnd: "" },
       payment_behavior: "allow_incomplete",
       trial_end: "now",
     });
@@ -674,7 +688,7 @@ describe("startHostedPulseTrialPaidPlan", () => {
     });
 
     expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(2);
-    expect(mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
+    expect(mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledTimes(1);
     expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(1);
     expect(mocks.applyStripeInvoicePaid).toHaveBeenCalledWith(
@@ -740,7 +754,7 @@ describe("startHostedPulseTrialPaidPlan", () => {
     expect(mocks.applyStripeInvoicePaid).toHaveBeenCalledTimes(2);
   });
 
-  test("holds paused cleanup and resume mutations behind the shared member lock", async () => {
+  test("holds paused cleanup and resume mutations behind one shared member lock", async () => {
     let releaseFirstLock: (() => void) | undefined;
     let signalFirstLock: (() => void) | undefined;
     const firstLockEntered = new Promise<void>((resolve) => {
@@ -784,13 +798,13 @@ describe("startHostedPulseTrialPaidPlan", () => {
       status: "paused",
       trialEnd: null,
     }));
-    mocks.withHostedMemberStripeMutationLock
-      .mockImplementationOnce(async (input: { run: () => Promise<unknown> }) => {
+    mocks.withHostedMemberStripeMutationLock.mockImplementationOnce(
+      async (input: { run: () => Promise<unknown> }) => {
         signalFirstLock?.();
         await firstLockRelease;
         return input.run();
-      })
-      .mockImplementationOnce(async (input: { run: () => Promise<unknown> }) => input.run());
+      },
+    );
 
     const startPromise = startHostedPulseTrialPaidPlan({
       memberId: "member_123",
@@ -807,9 +821,142 @@ describe("startHostedPulseTrialPaidPlan", () => {
       status: "billing_pending",
     });
 
-    expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(2);
+    expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledTimes(1);
+    expect(mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      "sub_123",
+      {
+        expand: ["items.data.price", "latest_invoice", "latest_invoice.payment_intent"],
+        items: [{
+          deleted: true,
+          id: "si_price_pulse_usage",
+        }],
+        metadata: { murphTrialExtensionTargetTrialEnd: "" },
+        proration_behavior: "none",
+      },
+      {
+        idempotencyKey: expect.stringMatching(
+          /^hosted-billing-start-paid-pulse:paused-cleanup:[0-9a-f-]{36}$/u,
+        ),
+      },
+    );
+    expect(
+      mocks.stripe.subscriptions.update.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.stripe.subscriptions.resume.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  test("clears a prepared extension target before resuming paused paid billing", async () => {
+    mocks.readHostedMemberCoreState.mockResolvedValueOnce({
+      billingStatus: HostedBillingStatus.paused,
+      createdAt: new Date("2026-05-01T00:00:00.000Z"),
+      id: "member_123",
+      suspendedAt: null,
+      updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    mocks.readHostedMemberStripeBillingRef.mockResolvedValueOnce(makeBillingRef({
+      currentBillingPhase: null,
+    }));
+    const preparedPausedSubscription = makeSubscription({
+      customer: makeCustomer({
+        defaultPaymentMethod: "pm_customer_123",
+        defaultSource: null,
+      }),
+      metadata: {
+        murphTrialExtensionDays: "7",
+        murphTrialExtensionOperation: "a".repeat(43),
+        murphTrialExtensionTargetTrialEnd: "1779024000",
+      },
+      status: "paused",
+      trialEnd: null,
+    });
+    mocks.stripe.subscriptions.retrieve.mockResolvedValueOnce(
+      preparedPausedSubscription,
+    );
+    mocks.stripe.subscriptions.update.mockResolvedValueOnce(makeSubscription({
+      latestInvoice: null,
+      metadata: {
+        murphTrialExtensionDays: "7",
+        murphTrialExtensionOperation: "a".repeat(43),
+      },
+      status: "paused",
+      trialEnd: null,
+    }));
+
+    await expect(startHostedPulseTrialPaidPlan({
+      memberId: "member_123",
+      now: new Date("2026-05-06T00:00:00.000Z"),
+    })).resolves.toEqual({
+      billingPlanCode: "launch_monthly",
+      status: "billing_pending",
+    });
+
+    expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(1);
+    expect(mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      "sub_123",
+      {
+        expand: ["items.data.price", "latest_invoice", "latest_invoice.payment_intent"],
+        metadata: { murphTrialExtensionTargetTrialEnd: "" },
+        proration_behavior: "none",
+      },
+      {
+        idempotencyKey: expect.stringMatching(
+          /^hosted-billing-start-paid-pulse:paused-cleanup:[0-9a-f-]{36}$/u,
+        ),
+      },
+    );
+    expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.stripe.subscriptions.update.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.stripe.subscriptions.resume.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  test("uses a fresh cleanup key when paused paid conversion is retried", async () => {
+    mocks.readHostedMemberCoreState.mockResolvedValue({
+      billingStatus: HostedBillingStatus.paused,
+      createdAt: new Date("2026-05-01T00:00:00.000Z"),
+      id: "member_123",
+      suspendedAt: null,
+      updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    mocks.readHostedMemberStripeBillingRef.mockResolvedValue(makeBillingRef({
+      currentBillingPhase: null,
+    }));
+    mocks.stripe.subscriptions.retrieve.mockResolvedValue(makeSubscription({
+      customer: makeCustomer({
+        defaultPaymentMethod: "pm_customer_123",
+        defaultSource: null,
+      }),
+      status: "paused",
+      trialEnd: null,
+    }));
+
+    await startHostedPulseTrialPaidPlan({
+      memberId: "member_123",
+      now: new Date("2026-05-06T00:00:00.000Z"),
+    });
+    await startHostedPulseTrialPaidPlan({
+      memberId: "member_123",
+      now: new Date("2026-05-06T00:00:00.000Z"),
+    });
+
+    const firstCleanupKey =
+      mocks.stripe.subscriptions.update.mock.calls[0]?.[2]?.idempotencyKey;
+    const secondCleanupKey =
+      mocks.stripe.subscriptions.update.mock.calls[1]?.[2]?.idempotencyKey;
+    expect(firstCleanupKey).toMatch(
+      /^hosted-billing-start-paid-pulse:paused-cleanup:[0-9a-f-]{36}$/u,
+    );
+    expect(secondCleanupKey).toMatch(
+      /^hosted-billing-start-paid-pulse:paused-cleanup:[0-9a-f-]{36}$/u,
+    );
+    expect(secondCleanupKey).not.toBe(firstCleanupKey);
+    expect(mocks.stripe.subscriptions.resume.mock.calls[0]?.[2]?.idempotencyKey)
+      .toBe(mocks.stripe.subscriptions.resume.mock.calls[1]?.[2]?.idempotencyKey);
   });
 
   test("canonical-reconciles an ambiguous paused cleanup without resuming", async () => {
@@ -919,13 +1066,13 @@ describe("startHostedPulseTrialPaidPlan", () => {
     });
 
     expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(2);
-    expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(2);
+    expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledTimes(1);
     expect(mocks.applyStripeInvoicePaid).not.toHaveBeenCalled();
   });
 
-  test("propagates deterministic paused resume failures without canonical reconciliation", async () => {
+  test("canonical-reconciles deterministic resume failures after ordinary paused cleanup", async () => {
     mocks.readHostedMemberCoreState.mockResolvedValueOnce({
       billingStatus: HostedBillingStatus.paused,
       createdAt: new Date("2026-05-01T00:00:00.000Z"),
@@ -952,13 +1099,15 @@ describe("startHostedPulseTrialPaidPlan", () => {
     await expect(startHostedPulseTrialPaidPlan({
       memberId: "member_123",
       now: new Date("2026-05-06T00:00:00.000Z"),
-    })).rejects.toMatchObject({
-      code: "HOSTED_PULSE_TRIAL_START_PAID_STRIPE_UNAVAILABLE",
-      httpStatus: 502,
+    })).resolves.toEqual({
+      billingPlanCode: "launch_monthly",
+      status: "billing_pending",
     });
 
-    expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
+    expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(2);
+    expect(mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledTimes(1);
+    expect(mocks.applyStripeInvoicePaid).not.toHaveBeenCalled();
   });
 
   test("keeps a follow-up status check pending when Stripe already left trialing without invoice proof", async () => {
@@ -1096,7 +1245,20 @@ describe("startHostedPulseTrialPaidPlan", () => {
       status: "payment_required",
     });
 
-    expect(mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
+    expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(1);
+    expect(mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      "sub_123",
+      {
+        expand: ["items.data.price", "latest_invoice", "latest_invoice.payment_intent"],
+        metadata: { murphTrialExtensionTargetTrialEnd: "" },
+        proration_behavior: "none",
+      },
+      {
+        idempotencyKey: expect.stringMatching(
+          /^hosted-billing-start-paid-pulse:paused-cleanup:[0-9a-f-]{36}$/u,
+        ),
+      },
+    );
     expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledWith(
       "sub_123",
       {
@@ -1104,8 +1266,15 @@ describe("startHostedPulseTrialPaidPlan", () => {
         expand: ["items.data.price", "latest_invoice", "latest_invoice.payment_intent"],
       },
       {
-        idempotencyKey: expect.stringMatching(/^hosted-billing-start-paid-pulse:[a-f0-9]{64}$/u),
+        idempotencyKey: buildExpectedStartPaidPulseIdempotencyKey(
+          "paused-resume-v1",
+        ),
       },
+    );
+    expect(
+      mocks.stripe.subscriptions.update.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.stripe.subscriptions.resume.mock.invocationCallOrder[0] ?? 0,
     );
   });
 
@@ -1576,16 +1745,19 @@ function makeBillingRef(input: {
   };
 }
 
-function buildExpectedStartPaidPulseIdempotencyKey(): string {
+function buildExpectedStartPaidPulseIdempotencyKey(
+  operation?: "active-trial-end-now-v2" | "paused-resume-v1",
+): string {
   const payload = {
     memberId: "member_123",
     priceId: "price_pulse_recurring",
     stripeSubscriptionId: "sub_123",
     trialEnd: "2026-05-13T00:00:00.000Z",
   };
+  const keyPayload = operation ? { ...payload, operation } : payload;
 
   return `hosted-billing-start-paid-pulse:${
-    createHash("sha256").update(JSON.stringify(payload)).digest("hex")
+    createHash("sha256").update(JSON.stringify(keyPayload)).digest("hex")
   }`;
 }
 
@@ -1596,6 +1768,7 @@ function makeSubscription(input: {
   defaultSource?: string | null;
   items?: Stripe.SubscriptionItem[];
   latestInvoice?: Stripe.Invoice | null;
+  metadata?: Record<string, string>;
   pauseCollection?: Stripe.Subscription["pause_collection"];
   status?: Stripe.Subscription.Status;
   trialEnd?: number | null;
@@ -1619,6 +1792,7 @@ function makeSubscription(input: {
       ],
     },
     latest_invoice: input.latestInvoice ?? null,
+    metadata: input.metadata ?? {},
     object: "subscription",
     pause_collection: input.pauseCollection ?? null,
     pending_update: null,

--- a/apps/web/test/hosted-onboarding-billing-start-paid-pulse-service.test.ts
+++ b/apps/web/test/hosted-onboarding-billing-start-paid-pulse-service.test.ts
@@ -1012,7 +1012,7 @@ describe("startHostedPulseTrialPaidPlan", () => {
     expect(mocks.stripe.subscriptions.resume).not.toHaveBeenCalled();
   });
 
-  test("canonical-reconciles a deterministic resume failure after paused cleanup succeeds", async () => {
+  test("surfaces a deterministic resume failure after paused cleanup succeeds", async () => {
     mocks.readHostedMemberCoreState.mockResolvedValueOnce({
       billingStatus: HostedBillingStatus.paused,
       createdAt: new Date("2026-05-01T00:00:00.000Z"),
@@ -1049,8 +1049,7 @@ describe("startHostedPulseTrialPaidPlan", () => {
       trialEnd: null,
     });
     mocks.stripe.subscriptions.retrieve
-      .mockResolvedValueOnce(pausedLegacySubscription)
-      .mockResolvedValueOnce(cleanedPausedSubscription);
+      .mockResolvedValueOnce(pausedLegacySubscription);
     mocks.stripe.subscriptions.update.mockResolvedValueOnce(cleanedPausedSubscription);
     mocks.stripe.subscriptions.resume.mockRejectedValueOnce({
       statusCode: 400,
@@ -1060,19 +1059,25 @@ describe("startHostedPulseTrialPaidPlan", () => {
     await expect(startHostedPulseTrialPaidPlan({
       memberId: "member_123",
       now: new Date("2026-05-06T00:00:00.000Z"),
-    })).resolves.toEqual({
-      billingPlanCode: "launch_monthly",
-      status: "billing_pending",
+    })).rejects.toMatchObject({
+      code: "HOSTED_PULSE_TRIAL_START_PAID_STRIPE_UNAVAILABLE",
+      details: {
+        operationName: "subscription.resume.paused-trial",
+        statusCode: 400,
+        type: "StripeInvalidRequestError",
+      },
+      httpStatus: 502,
+      retryable: true,
     });
 
-    expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(2);
+    expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
     expect(mocks.withHostedMemberStripeMutationLock).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledTimes(1);
     expect(mocks.applyStripeInvoicePaid).not.toHaveBeenCalled();
   });
 
-  test("canonical-reconciles deterministic resume failures after ordinary paused cleanup", async () => {
+  test("surfaces deterministic resume failures after ordinary paused cleanup", async () => {
     mocks.readHostedMemberCoreState.mockResolvedValueOnce({
       billingStatus: HostedBillingStatus.paused,
       createdAt: new Date("2026-05-01T00:00:00.000Z"),
@@ -1099,12 +1104,18 @@ describe("startHostedPulseTrialPaidPlan", () => {
     await expect(startHostedPulseTrialPaidPlan({
       memberId: "member_123",
       now: new Date("2026-05-06T00:00:00.000Z"),
-    })).resolves.toEqual({
-      billingPlanCode: "launch_monthly",
-      status: "billing_pending",
+    })).rejects.toMatchObject({
+      code: "HOSTED_PULSE_TRIAL_START_PAID_STRIPE_UNAVAILABLE",
+      details: {
+        operationName: "subscription.resume.paused-trial",
+        statusCode: 400,
+        type: "StripeInvalidRequestError",
+      },
+      httpStatus: 502,
+      retryable: true,
     });
 
-    expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(2);
+    expect(mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
     expect(mocks.stripe.subscriptions.resume).toHaveBeenCalledTimes(1);
     expect(mocks.applyStripeInvoicePaid).not.toHaveBeenCalled();

--- a/apps/web/test/hosted-pulse-trial-extension.test.ts
+++ b/apps/web/test/hosted-pulse-trial-extension.test.ts
@@ -3,12 +3,24 @@ import type Stripe from "stripe";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  readActiveHostedFamilySponsorship: vi.fn(),
   readHostedMemberBillingSnapshot: vi.fn(),
   reconcileHostedAiUsageAllowancePeriodForMemberTx: vi.fn(),
   updateHostedMemberCoreState: vi.fn(),
   withHostedMemberStripeMutationLockForOps: vi.fn(),
   writeHostedMemberStripeBillingRefTx: vi.fn(),
 }));
+
+vi.mock("../src/lib/hosted-onboarding/member-access", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/hosted-onboarding/member-access")
+  >("../src/lib/hosted-onboarding/member-access");
+  return {
+    ...actual,
+    readActiveHostedFamilySponsorship:
+      mocks.readActiveHostedFamilySponsorship,
+  };
+});
 
 vi.mock("../src/lib/hosted-onboarding/hosted-member-store", async () => {
   const actual = await vi.importActual<
@@ -76,6 +88,7 @@ describe("single-member Pulse Trial extension", () => {
     vi.clearAllMocks();
     process.env.HOSTED_CONTACT_PRIVACY_KEYS = `v1:${CONTACT_PRIVACY_KEY}`;
     process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = "v1";
+    mocks.readActiveHostedFamilySponsorship.mockResolvedValue(false);
     mocks.readHostedMemberBillingSnapshot.mockResolvedValue(makeMember());
     mocks.withHostedMemberStripeMutationLockForOps.mockImplementation(
       async (input: { run: (tx: object) => Promise<unknown> }) => input.run({}),
@@ -197,6 +210,84 @@ describe("single-member Pulse Trial extension", () => {
     );
     expect(JSON.stringify(result)).not.toContain(CUSTOMER_ID);
     expect(JSON.stringify(result)).not.toContain(SUBSCRIPTION_ID);
+  });
+
+  test("rejects active Family sponsorship before reading Stripe", async () => {
+    mocks.readActiveHostedFamilySponsorship.mockResolvedValue(true);
+    const stripe = makeStripeClient(makeSubscription({ status: "paused" }));
+
+    const result = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+
+    expect(result).toMatchObject({
+      eligibilityCode: "family_sponsored",
+      eligible: false,
+      message: "This member already has access through an active Family plan.",
+      providerStatus: null,
+      targetTrialEndsAt: null,
+    });
+    expect(stripe.retrieveSubscription).not.toHaveBeenCalled();
+    expect(stripe.resumeSubscription).not.toHaveBeenCalled();
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+  });
+
+  test("rejects Apply if Family sponsorship became active after Preview", async () => {
+    mocks.readActiveHostedFamilySponsorship
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const prisma = {};
+    const lockTx = {};
+    mocks.withHostedMemberStripeMutationLockForOps.mockImplementationOnce(
+      async (input: { run: (tx: object) => Promise<unknown> }) =>
+        input.run(lockTx),
+    );
+    const stripe = makeStripeClient(makeSubscription({
+      status: "paused",
+      trialEnd: 1_700_000_000,
+    }));
+    const preview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: prisma as never,
+      stripe,
+    });
+    if (!preview.previewProof) {
+      throw new Error("Expected a preview proof.");
+    }
+    stripe.retrieveSubscription.mockClear();
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date(NOW.getTime() + 60_000),
+      previewProof: preview.previewProof,
+      priceId: PRICE_ID,
+      prisma: prisma as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+    expect(mocks.readActiveHostedFamilySponsorship).toHaveBeenNthCalledWith(
+      1,
+      { memberId: MEMBER_ID, prisma },
+    );
+    expect(mocks.readActiveHostedFamilySponsorship).toHaveBeenNthCalledWith(
+      2,
+      { memberId: MEMBER_ID, prisma: lockTx },
+    );
+    expect(
+      mocks.withHostedMemberStripeMutationLockForOps.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.readActiveHostedFamilySponsorship.mock.invocationCallOrder[1] ?? 0,
+    );
+    expect(stripe.retrieveSubscription).not.toHaveBeenCalled();
+    expect(stripe.resumeSubscription).not.toHaveBeenCalled();
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    expect(mocks.updateHostedMemberCoreState).not.toHaveBeenCalled();
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
   });
 
   test("does not recover a completed extension after the provider becomes paid active", async () => {

--- a/apps/web/test/hosted-pulse-trial-extension.test.ts
+++ b/apps/web/test/hosted-pulse-trial-extension.test.ts
@@ -199,6 +199,75 @@ describe("single-member Pulse Trial extension", () => {
     expect(JSON.stringify(result)).not.toContain(SUBSCRIPTION_ID);
   });
 
+  test("does not recover a completed extension after the provider becomes paid active", async () => {
+    mocks.readHostedMemberBillingSnapshot.mockResolvedValue(makeMember({
+      billingPhase: "trial",
+      billingStatus: HostedBillingStatus.active,
+      trialEndsAt: new Date(TARGET_FROM_PAUSED * 1000),
+    }));
+    let providerSubscription = makeSubscription({
+      extensionDays: "7",
+      extensionOperation: RECOVERABLE_OPERATION_ID,
+      extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+      status: "trialing",
+      trialEnd: TARGET_FROM_PAUSED,
+    });
+    const stripe = makeStripeClient(providerSubscription);
+    stripe.retrieveSubscription.mockImplementation(
+      async () => providerSubscription,
+    );
+    const preConversionPreview = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+    if (!preConversionPreview.previewProof) {
+      throw new Error("Expected an eligible pre-conversion preview.");
+    }
+
+    providerSubscription = makeSubscription({
+      extensionDays: "7",
+      extensionOperation: RECOVERABLE_OPERATION_ID,
+      extensionTargetTrialEnd: TARGET_FROM_PAUSED,
+      status: "active",
+      trialEnd: TARGET_FROM_PAUSED,
+    });
+
+    const result = await previewHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: NOW,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    });
+
+    expect(result).toMatchObject({
+      eligibilityCode: "provider_subscription_not_extendable",
+      eligible: false,
+      localBillingPhase: "trial",
+      localBillingStatus: "active",
+      outcome: "preview",
+      providerStatus: "active",
+    });
+    expect(result.previewProof).toBeNull();
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    expect(stripe.resumeSubscription).not.toHaveBeenCalled();
+
+    await expect(applyHostedPulseTrialExtension({
+      memberId: MEMBER_ID,
+      now: new Date("2026-07-14T16:02:00.000Z"),
+      previewProof: preConversionPreview.previewProof,
+      priceId: PRICE_ID,
+      prisma: {} as never,
+      stripe,
+    })).rejects.toBeInstanceOf(HostedPulseTrialExtensionPreviewStaleError);
+    expect(stripe.updateSubscription).not.toHaveBeenCalled();
+    expect(stripe.resumeSubscription).not.toHaveBeenCalled();
+    expect(mocks.writeHostedMemberStripeBillingRefTx).not.toHaveBeenCalled();
+  });
+
   test("extends a paused trial once and reconciles local billing under the lock", async () => {
     const paused = makeSubscription({ status: "paused", trialEnd: 1_700_000_000 });
     const stripe = makeStripeClient(paused);
@@ -270,6 +339,9 @@ describe("single-member Pulse Trial extension", () => {
         timeout: 80_000,
       }),
     );
+    expect(providerSubscription.metadata).not.toHaveProperty(
+      "murphTrialExtensionTargetTrialEnd",
+    );
     expect(stripe.resumeSubscription).toHaveBeenCalledWith(
       SUBSCRIPTION_ID,
       {
@@ -286,10 +358,15 @@ describe("single-member Pulse Trial extension", () => {
     expect(stripe.updateSubscription).toHaveBeenNthCalledWith(
       2,
       SUBSCRIPTION_ID,
-      expect.objectContaining({
+      {
+        metadata: {
+          murphTrialExtensionDays: "7",
+          murphTrialExtensionOperation: operationId,
+          murphTrialExtensionTargetTrialEnd: "",
+        },
         proration_behavior: "none",
         trial_end: TARGET_FROM_PAUSED,
-      }),
+      },
       expect.objectContaining({
         idempotencyKey:
           `hosted-member-trial-extension:update:${operationId}`,
@@ -389,7 +466,7 @@ describe("single-member Pulse Trial extension", () => {
       SUBSCRIPTION_ID,
       expect.objectContaining({
         metadata: expect.objectContaining({
-          murphTrialExtensionTargetTrialEnd: TARGET_FROM_LIVE.toString(),
+          murphTrialExtensionTargetTrialEnd: "",
         }),
         trial_end: TARGET_FROM_LIVE,
       }),


### PR DESCRIPTION
## Why this PR exists

A completed Pulse Trial extension retained the metadata marker used to recover an unfinished provider mutation. After a member converted to paid billing, that stale marker could make Ops treat the paid subscription as recoverable and move it back into trialing. Production reconciliation also proved that active Family-sponsored members could enter the direct-trial extension path even though the canonical Family cleanup immediately cancels their redundant direct subscription.

The same paused-trial paid-conversion seam also treated successful metadata cleanup as evidence that paid conversion started. A deterministic Stripe resume rejection could therefore be mislabeled as billing pending indefinitely.

## User goal / user-visible behavior

Members can extend or restore a direct Pulse Trial and later start paid billing without a fresh Ops action rolling the paid subscription back into trial. Ambiguous provider responses remain recoverable. Members who already have active Family access are explicitly ineligible before Stripe is read or mutated. Deterministic paid-resume failures surface through the existing retryable provider error instead of presenting false progress.

## User experience

There is no new UI. Trial extension Preview and Apply continue to behave the same for eligible direct trials. Completed or paid states fail closed, paid conversion clears extension-only pending state, and active Family sponsorship displays a clear ineligible result. Apply repeats the Family check under the existing member billing lock so a sponsorship activated after Preview cannot race a provider mutation.

For paid conversion, ambiguous cleanup or resume failures still reconcile from a canonical Stripe reread. A deterministic resume rejection now reaches the existing error UI instead of leaving the member on an indefinite Check status loop.

## Invariants

- The target marker exists only while prepare or resume recovery is pending.
- Final trial extension atomically clears the target while retaining operation and day identity.
- Final-update response loss and local-write failure recover from the provider trial end without another extension.
- Live and paused paid conversion clear the target before paid state can coexist with it.
- Paused cleanup and resume stay under one member mutation lock; cleanup retries converge without cached-response or changed-body collisions.
- Cleanup success alone never proves that paid conversion started; only a returned resume mutation sets that evidence flag.
- Ambiguous cleanup or resume failures canonical-reread, while deterministic resume failures propagate through the existing typed provider error.
- Active Family sponsorship is derived from the canonical access query and blocks direct-trial provider reads and mutations.
- Apply rechecks Family sponsorship inside the existing member mutation lock.
- No cleanup path changes trial end, billing status, operation metadata, or extension-day metadata.

## Change-shape breakdown

Classification is by path: runtime TypeScript is source, Vitest files are tests, README plus completed execution plans are docs, and no generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 84 | 53 |
| Tests / fixtures | 385 | 32 |
| Docs | 154 | 4 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **623** | **89** |

ReviewGPT first-reviewed head: 19d6ac8664a1f8e7d9ff3406d8a22185cc76e011

## Rollout and compatibility

This is a web-only deploy with no schema or environment change. During rollout, an old web instance can still retain the legacy target, so bounded provider cleanup must run only after the new deployment is Ready. Production proof found nine locally reconciled trial rows: seven subscriptions remain canonical trialing subscriptions, while two Family-sponsored redundant subscriptions were canceled by the existing cleanup. Post-deploy cleanup is limited to the seven current trialing subscriptions. It will recheck provider status, target, trial end, operation, and extension-day identity; unset only the obsolete target marker; preserve trial end and billing state; and verify aggregate results without exposing provider or member identifiers.
