### PR TITLE
Fix Linq invite cleanup after Vercel drain

### DIFF
--- a/.github/workflows/cloudflare-hosted-e2e.yml
+++ b/.github/workflows/cloudflare-hosted-e2e.yml
@@ -249,13 +249,14 @@ jobs:
           pnpm hosted-local e2e "${scenarios[@]}" --no-bundle 2>&1 \
             | tee ".artifacts/cloudflare-hosted-e2e/${{ matrix.slug }}.log"
 
-      - name: Prove Linq participant-addition lock ordering
+      - name: Prove Linq PostgreSQL ordering and cleanup
         if: ${{ matrix.slug == 'linq-route-authority-admission' }}
         env:
           MURPH_TEST_POSTGRES_CONCURRENCY: "1"
         run: >-
           pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage
           apps/web/test/hosted-onboarding-linq-participant-addition-concurrency.test.ts
+          apps/web/test/hosted-linq-invite-deletion-contract-migration-postgres.test.ts
 
       - name: Upload hosted E2E logs
         if: always()

--- a/agent-docs/exec-plans/completed/2026-07-15-linq-invite-deletion-contract-cleanup.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-linq-invite-deletion-contract-cleanup.md
@@ -1,0 +1,92 @@
+# Move Linq invite orphan cleanup behind Vercel drain
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Close ReviewGPT's accepted rollout finding for PR #668 by ensuring the final
+  orphaned Linq signup-delivery scrub runs only after the replacement Vercel
+  deployment is promoted and prior functions have drained.
+
+## Success criteria
+
+- Preserve the already-merged Prisma migration as immutable deployment history.
+- Add an idempotent contract migration with the same narrow orphan predicate so
+  rows created by warm old functions after the predeploy pass are removed.
+- Prove with PostgreSQL that a predeploy pass can preserve a then-live row, an
+  old-bundle deletion can orphan it, and the post-drain pass removes it while
+  preserving live-member and unrelated delivery rows.
+- Keep the existing live account-deletion and delayed-dispatch fences unchanged.
+- Complete scoped verification, the required coverage audit, parent final
+  review, a follow-up PR, ReviewGPT, CI, and mergeability proof.
+
+## Scope
+
+- In scope: one post-drain contract migration, migration inventory/static proof,
+  one focused PostgreSQL rollout regression, the existing CI PostgreSQL proof
+  command, and concise deployment/deletion documentation.
+- Out of scope: changing the live account-deletion implementation, changing
+  signup dispatch behavior, rewriting the merged Prisma migration, adding a new
+  migration runner, or broad Linq retention changes.
+
+## Constraints
+
+- Technical constraints: the contract SQL must remain idempotent and use the
+  existing `Hosted Web Contract Migrations` owner, advisory lock, drain wait,
+  and production-alias proof.
+- Product/process constraints: account deletion must continue to complete for
+  authorized members while raw member identifiers do not survive indefinitely;
+  preserve unrelated working-tree and migration history.
+
+## Risks and mitigations
+
+1. Risk: deleting or editing the merged Prisma migration creates migration-history
+   drift if the pending production deploy already applied it.
+   Mitigation: leave that migration byte-for-byte intact and add a separately
+   tracked contract migration for the authoritative post-drain pass.
+2. Risk: the final scrub deletes live-member or unrelated delivery state.
+   Mitigation: retain the exact two-template, canonical-prefix, parsed-member-id,
+   and missing-member predicate and cover positive controls in PostgreSQL.
+3. Risk: the contract migration runs against a stale deployment.
+   Mitigation: reuse the existing workflow's deployed-commit ancestry check,
+   bounded old-function drain, final alias recheck, and advisory lock.
+
+## Tasks
+
+1. Revalidate the ReviewGPT finding against Vercel predeploy and contract-lane
+   repository evidence.
+2. Add the post-drain contract migration without mutating Prisma history.
+3. Add static inventory and production-faithful PostgreSQL rollout proof.
+4. Update durable deletion/deployment docs with the two-pass ownership and
+   rollback/deploy implication.
+5. Run focused and routed verification, required audits, parent final review,
+   commit/plan closure, follow-up PR, ReviewGPT, CI, and merge proof.
+
+## Decisions
+
+- ReviewGPT's High rollout finding is accepted. The old bundle remains live
+  while `pnpm release:production:migrate && pnpm build` runs, so the predeploy
+  scrub cannot be the final deletion authority.
+- PR #668 merged and its main deployment entered `pending` before the review
+  returned. Preserve the merged Prisma migration; a second idempotent scrub in
+  the existing post-drain contract lane is the smallest production-safe fix.
+
+## Verification
+
+- Focused migration inventory: 37 tests passed.
+- Direct PostgreSQL 17 proof passed: the predeploy pass preserved a then-live
+  row, deletion orphaned it, the post-drain pass removed exactly that row while
+  preserving live and unrelated controls, and a repeated pass removed nothing.
+- `pnpm test:diff` passed twice, including the dedicated `coverage-write` pass:
+  hosted web typecheck, lint, build, 425 files, and 5,121 tests passed.
+- Required `coverage-write` audit completed with no edits or findings; parent
+  final review found no remaining patch-specific proof gap.
+- `pnpm verify:acceptance` completed the workspace/app checks but its unrelated
+  package-coverage fanout was red: one CLI test timed out under load and the
+  assistant-engine coverage worker exhausted its heap. The CLI test passed in
+  3.7 seconds in isolation; assistant-engine's no-coverage lane passed 154 files
+  and 2,208 tests, while its standalone coverage lane reproduced the heap limit.
+- Follow-up PR CI, ReviewGPT, and mergeability remain as post-commit gates.
+Completed: 2026-07-15

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -783,6 +783,14 @@ without letting stale events replace valid pending runs. After those gates, it c
 The shared production migration URL resolver strips Prisma-style
 `sslcert=system`, `sslkey=system`, and `sslrootcert=system` markers before
 handing Postgres URLs to raw `pg` clients, while preserving real SSL file paths.
+The merged
+`20260715120000_delete_orphaned_linq_invite_deliveries` Prisma migration is an
+unchanged historical first pass because production may already have recorded
+it. The
+`20260715150000_delete_orphaned_linq_invite_deliveries_after_drain` contract
+migration repeats the same narrow orphan predicate after promotion and the
+prior-function drain; that post-drain pass is the final historical-cleanup
+authority.
 Rollback floor: after contract cleanup drops an old schema shape, the oldest
 safe Vercel rollback target is the first deployed commit that no longer reads or
 writes that dropped shape. Rolling back below that floor requires restoring or

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -791,6 +791,19 @@ it. The
 migration repeats the same narrow orphan predicate after promotion and the
 prior-function drain; that post-drain pass is the final historical-cleanup
 authority.
+The permanent Linq invite-delivery data-producer rollback floor is
+`e67aedb61fd021f50cadae147b92006fef43b97e`, the merge of PR #668 and the
+first `main` commit with both the live account-deletion cleanup and the delayed
+invite-dispatch fence. Freeze deploys and rollbacks before promoting the
+cleanup deployment, then record that deployed commit, this floor SHA, both
+production-alias proofs, the elapsed drain, and the contract-migration outcome
+before ending the freeze. After the contract migration is recorded, do not
+roll Vercel below this floor. Rerunning the existing workflow is not a repair
+for rows recreated by a below-floor rollback because the recorded migration ID
+and checksum make its SQL skip. A below-floor emergency rollback therefore
+requires a roll-forward, a fresh promotion-and-drain proof, and either a new
+timestamped cleanup migration or explicit operator SQL before the deletion
+guarantee is restored.
 Rollback floor: after contract cleanup drops an old schema shape, the oldest
 safe Vercel rollback target is the first deployed commit that no longer reads or
 writes that dropped shape. Rolling back below that floor requires restoring or

--- a/apps/web/prisma/contract-migrations/20260715150000_delete_orphaned_linq_invite_deliveries_after_drain/migration.sql
+++ b/apps/web/prisma/contract-migrations/20260715150000_delete_orphaned_linq_invite_deliveries_after_drain/migration.sql
@@ -1,0 +1,9 @@
+DELETE FROM "hosted_linq_delivery" AS "delivery"
+WHERE "delivery"."template" IN ('invite_signup', 'invite_signup_fallback')
+  AND "delivery"."source_ref" LIKE 'linq-invite-signup:%'
+  AND split_part("delivery"."source_ref", ':', 2) <> ''
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "hosted_member" AS "member"
+    WHERE "member"."id" = split_part("delivery"."source_ref", ':', 2)
+  );

--- a/apps/web/test/hosted-linq-invite-deletion-contract-migration-postgres.test.ts
+++ b/apps/web/test/hosted-linq-invite-deletion-contract-migration-postgres.test.ts
@@ -1,0 +1,91 @@
+import { readFile } from "node:fs/promises";
+
+import pg from "pg";
+import { describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
+const runPostgresMigrationProof =
+  process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+
+const predeployMigrationUrl = new URL(
+  "../prisma/migrations/20260715120000_delete_orphaned_linq_invite_deliveries/migration.sql",
+  import.meta.url,
+);
+const contractMigrationUrl = new URL(
+  "../prisma/contract-migrations/20260715150000_delete_orphaned_linq_invite_deliveries_after_drain/migration.sql",
+  import.meta.url,
+);
+
+describe.skipIf(!runPostgresMigrationProof)(
+  "Linq invite deletion post-drain contract migration",
+  () => {
+    it("removes rows orphaned after predeploy while preserving scoped controls", async () => {
+      if (!databaseUrl) {
+        throw new Error("DATABASE_URL is required for the PostgreSQL migration proof.");
+      }
+
+      const [predeploySql, contractSql] = await Promise.all([
+        readFile(predeployMigrationUrl, "utf8"),
+        readFile(contractMigrationUrl, "utf8"),
+      ]);
+      expect(contractSql).toBe(predeploySql);
+
+      const client = new pg.Client({ connectionString: databaseUrl });
+      await client.connect();
+
+      try {
+        await client.query(`
+          CREATE TEMP TABLE "hosted_member" (
+            "id" TEXT PRIMARY KEY
+          );
+          CREATE TEMP TABLE "hosted_linq_delivery" (
+            "id" TEXT PRIMARY KEY,
+            "source_ref" TEXT NOT NULL,
+            "template" TEXT NOT NULL
+          );
+        `);
+        await client.query(`
+          INSERT INTO "hosted_member" ("id")
+          VALUES ('member_live'), ('member_deleted_after_predeploy');
+
+          INSERT INTO "hosted_linq_delivery" ("id", "source_ref", "template")
+          VALUES
+            ('live', 'linq-invite-signup:member_live', 'invite_signup'),
+            (
+              'deleted-after-predeploy',
+              'linq-invite-signup:member_deleted_after_predeploy',
+              'invite_signup_fallback'
+            ),
+            ('unrelated-template', 'linq-invite-signup:member_missing', 'reply'),
+            ('opaque-source', 'provider-delivery:member_missing', 'invite_signup');
+        `);
+
+        const predeployResult = await client.query(predeploySql);
+        expect(predeployResult.rowCount).toBe(0);
+
+        await client.query(
+          `DELETE FROM "hosted_member" WHERE "id" = 'member_deleted_after_predeploy'`,
+        );
+
+        const contractResult = await client.query(contractSql);
+        expect(contractResult.rowCount).toBe(1);
+
+        const remaining = await client.query<{ id: string }>(`
+          SELECT "id"
+          FROM "hosted_linq_delivery"
+          ORDER BY "id"
+        `);
+        expect(remaining.rows.map(({ id }) => id)).toEqual([
+          "live",
+          "opaque-source",
+          "unrelated-template",
+        ]);
+
+        const idempotentResult = await client.query(contractSql);
+        expect(idempotentResult.rowCount).toBe(0);
+      } finally {
+        await client.end();
+      }
+    });
+  },
+);

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -579,6 +579,13 @@ describe("hosted Prisma baseline migration", () => {
       ),
       "utf8",
     );
+    const orphanedHostedLinqInviteDeliveryContractMigrationSql = readFileSync(
+      new URL(
+        "../prisma/contract-migrations/20260715150000_delete_orphaned_linq_invite_deliveries_after_drain/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     const hostedMemberAssistantModelPreferenceMigrationSql = readFileSync(
       new URL(
         "../prisma/migrations/20260709120000_hosted_member_assistant_model_preference/migration.sql",
@@ -1067,6 +1074,9 @@ describe("hosted Prisma baseline migration", () => {
     );
     expect(orphanedHostedLinqInviteDeliveryDeletionMigrationSql).toContain(
       'FROM "hosted_member"',
+    );
+    expect(orphanedHostedLinqInviteDeliveryContractMigrationSql).toBe(
+      orphanedHostedLinqInviteDeliveryDeletionMigrationSql,
     );
     expect(hostedLinqEgressEngagementMigrationSql).toContain('"linq_last_inbound_at" TIMESTAMP(3)');
     expect(hostedLinqEgressEngagementMigrationSql).toContain('"pending_linq_last_inbound_at" TIMESTAMP(3)');

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -533,6 +533,26 @@ describe("hosted web production migration guard", () => {
     assert.match(sql, /DROP FUNCTION IF EXISTS clear_orphaned_hosted_linq_home_participant\(\)/u);
   });
 
+  test("repeats the Linq invite orphan scrub in the post-drain contract lane", async () => {
+    const migrationId =
+      "20260715150000_delete_orphaned_linq_invite_deliveries_after_drain";
+    const migrations = await listHostedWebContractMigrations();
+    const migration = migrations.find(({ id }) => id === migrationId);
+    const predeploySql = await readFile(
+      path.join(
+        appRoot,
+        "prisma",
+        "migrations",
+        "20260715120000_delete_orphaned_linq_invite_deliveries",
+        "migration.sql",
+      ),
+      "utf8",
+    );
+
+    assert.ok(migration, `Expected contract migration ${migrationId}`);
+    assert.equal(migration.sql, predeploySql);
+  });
+
   test("applies hosted web contract migrations idempotently and rejects checksum drift", async () => {
     const database = new FakeContractMigrationDatabase();
     const migration: HostedWebContractMigration = {

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -553,6 +553,24 @@ describe("hosted web production migration guard", () => {
     assert.equal(migration.sql, predeploySql);
   });
 
+  test("pins the Linq invite deletion producer rollback floor in operator docs", async () => {
+    const readme = await readFile(path.join(appRoot, "README.md"), "utf8");
+
+    assert.match(
+      readme,
+      /Linq invite-delivery data-producer rollback floor is\s+`e67aedb61fd021f50cadae147b92006fef43b97e`/u,
+    );
+    assert.match(readme, /do not\s+roll Vercel below this floor/iu);
+    assert.match(
+      readme,
+      /Rerunning the existing workflow is not a repair[\s\S]*recorded migration ID[\s\S]*make its SQL skip/u,
+    );
+    assert.match(
+      readme,
+      /new\s+timestamped cleanup migration or explicit operator SQL/u,
+    );
+  });
+
   test("applies hosted web contract migrations idempotently and rejects checksum drift", async () => {
     const database = new FakeContractMigrationDatabase();
     const migration: HostedWebContractMigration = {

--- a/docs/hosted-account-data-deletion-export.md
+++ b/docs/hosted-account-data-deletion-export.md
@@ -96,7 +96,7 @@ The Settings vault export does not include:
 | `prisma.hosted_ai_usage_period` | Live delete | Metadata/counts | Deletes local allowance-period snapshots. Export includes period windows, allowance totals, and billing-state metadata while omitting internal reconciliation identifiers. |
 | `prisma.hosted_product_feedback` | Live delete | Confirmed data export | Deletes assistant-captured product feedback rows. Confirmed export includes safe kind/summary metadata and optional published changelog item ids while omitting internal feedback ids. |
 | `prisma.hosted_linq_daily_state` | Live delete | Metadata/counts | Deletes Linq daily inbound/outbound quota counters. |
-| `prisma.hosted_linq_invite_delivery` | Live delete | Metadata/counts | Deletes signup-link delivery records whose delivery identity contains the member id; unrelated operational delivery records remain under their normal retention policy. |
+| `prisma.hosted_linq_invite_delivery` | Live delete | Metadata/counts | Deletes signup-link delivery records whose delivery identity contains the member id; unrelated operational delivery records remain under their normal retention policy. Historical orphan cleanup is finalized after production promotion and the prior-function drain. |
 | `prisma.hosted_invite` | Live delete | Metadata/counts | Deletes invite codes and channel metadata owned by the member. |
 | `prisma.hosted_consent_event` | Live delete | Confirmed data export | Deletes member-scoped consent event history. Confirmed export includes event scope/source/action and document metadata. |
 | `prisma.hosted_consent_grant` | Live delete | Confirmed data export | Deletes member-scoped consent grant state. Confirmed export includes grant scope/source/status and document metadata. |


### PR DESCRIPTION
## Why

PR #668 fixed live account deletion and delayed Linq invite dispatch, but its historical orphan scrub runs during the Vercel predeploy migration. ReviewGPT found that the prior production bundle remains live during that window, so an old function can delete a member after the one-time scrub and recreate the orphan condition before promotion.

This follow-up makes the existing post-promotion contract-migration lane the final historical cleanup authority.

## User-visible goal

There is no new UI or message copy. Deleted members' identifiers must not remain in signup-delivery rows after the replacement deployment is live, while authorized account deletion and current inbound/onboarding behavior remain unchanged.

## What changed

- Preserved the merged Prisma migration byte-for-byte as immutable deployment history.
- Added an idempotent contract migration with the same narrow orphan predicate.
- Added PostgreSQL rollout proof for the predeploy → old-bundle deletion → post-drain cleanup sequence.
- Wired that proof into the existing PostgreSQL CI leg and documented the two-pass ownership.
- Pinned the permanent producer rollback floor at the PR #668 merge commit and guarded that operator contract with a focused test.

## Invariants

- Cleanup is limited to `invite_signup` and `invite_signup_fallback` rows with the canonical `linq-invite-signup:` source identity and no matching hosted member.
- Live-member rows, unrelated templates, and opaque provider source references remain untouched.
- The final pass reuses the existing production-alias proof, bounded prior-function drain, and advisory lock.
- Live account deletion and delayed-dispatch fences from #668 are unchanged.
- After cleanup is recorded, Vercel must not roll below the PR #668 producer-fence commit; a below-floor emergency rollback requires a new cleanup operation after roll-forward.

## Deployment and compatibility

Deploy the Vercel web head first. Freeze deploys and rollbacks through promotion, both production-alias proofs, the prior-function drain, contract migration completion, and recording of the deployed cleanup SHA plus the permanent producer floor. The existing Hosted Web Contract Migrations workflow then applies the final scrub. No Cloudflare runtime deploy is required for behavior compatibility; its hosted E2E workflow only gains the PostgreSQL proof.

## Verification

- Focused migration inventory tests: 37 passed.
- PostgreSQL 17 rollout proof: passed, including scope controls and idempotency.
- Initial `pnpm test:diff`: passed twice, including the required coverage-write pass; hosted web typecheck, lint, build, 425 test files, and 5,121 tests passed.
- ReviewGPT remediation: focused migration guard 33/33 passed; routed `pnpm test:diff` passed web typecheck, lint, build, 425 test files, and 5,122 tests.
- Coverage-write audit: no edits or findings.
- `pnpm verify:acceptance`: workspace/app checks passed, but unrelated package coverage fanout was red from a CLI timeout under load and an assistant-engine coverage-worker heap exhaustion. The CLI test passed in 3.7 seconds in isolation; assistant-engine's no-coverage lane passed 154 files and 2,208 tests, while its standalone coverage lane reproduced the existing heap limit. GitHub's clean runners passed both package-coverage lanes; all final-head GitHub checks passed.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 9 | 0 |
| Tests | 121 | 0 |
| Docs | 101 | 1 |
| Config/tooling | 2 | 1 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 413d8089438b99788c26eb3aba0cd4649075597b

## ReviewGPT rounds

| Round | Head | Scope | Outcome |
| --- | --- | --- | --- |
| 1 | `413d8089438b99788c26eb3aba0cd4649075597b` | Full patch | One accepted rollback-floor finding |
| 2 | `756670f197e1190ee874b443ff2ba2b12fa1b959` | Correction | Pass — no qualifying findings |

Round 2 remediation delta from the first-reviewed head: source +0/-0, tests +18/-0, docs +13/-0, config/tooling +0/-0, generated/other +0/-0. The correction adds no runtime owner or repeatable-migration machinery.
