### PR TITLE
Add ops member email composer

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-ops-member-email.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-ops-member-email.md
@@ -1,0 +1,125 @@
+# Ops member email composer
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Add an authenticated ops tool that resolves one or more explicit member IDs
+  to existing authorized email records, previews the send, and delivers a
+  plain-text message through the existing Resend configuration.
+
+## Success criteria
+
+- `/ops/email` accepts up to 100 member IDs plus a subject and plain-text body.
+- Preview shows each supplied member ID as ready or skipped without returning
+  or rendering any email address.
+- Send requires the exact signed Preview, rechecks member and recipient state,
+  and submits one separate email per ready member in a single Resend batch.
+- Account-deletion-suspended members, unknown members, and members without an
+  authorized recipient are never sent email.
+- A lost or ambiguous Send response can be retried with the same Preview
+  without duplicate delivery.
+- Logs contain aggregate outcome and provider status only, never member IDs,
+  addresses, subject text, or body text.
+
+## Scope
+
+- In scope: the hosted ops landing page, a new email composer page and client,
+  a member-email ops route/service, a reusable strict Resend plain-text batch
+  sender, shadcn Field/Textarea components, focused tests, and operator docs if
+  an existing durable ops guide owns this surface.
+- Out of scope: campaigns, audience discovery, scheduled delivery, HTML email,
+  attachments, templates, contact-list storage, database schema changes, and
+  sending any real email during verification.
+
+## Constraints
+
+- Reuse the current ops allowlist and same-origin mutation boundary.
+- Reuse encrypted member email authorization records, preferring verified
+  email and falling back to the Stripe checkout email already permitted by
+  existing transactional email flows.
+- Reuse the contact-privacy keyring for a short-lived signed preview; add no
+  new secret, dependency, database state, queue, or scheduler.
+- Keep member IDs only in the authenticated operator response and UI, not in
+  server logs or committed examples.
+- Use Resend's strict batch endpoint so invalid provider input cannot produce a
+  partial send, and bind one provider idempotency key to the signed Preview.
+
+## Risks and mitigations
+
+1. Risk: the operator sends to a different recipient set or draft than shown.
+   Mitigation: sign the normalized IDs, exact subject/body, recipient state,
+   and preview timestamp; re-read and verify all inputs before Send.
+2. Risk: a timeout causes duplicate email delivery on retry.
+   Mitigation: derive one stable Resend idempotency key from the Preview token
+   and retain the same proof after an ambiguous response.
+3. Risk: private email data leaks through the API, UI, or logs.
+   Mitigation: return only member-scoped eligibility labels, keep recipient
+   addresses server-side, and log aggregate counts plus safe provider status.
+4. Risk: an account-deletion privacy fence changes after Preview.
+   Mitigation: include suspension and recipient state in the proof and reject a
+   stale Send before contacting Resend.
+
+## Tasks
+
+1. Add bounded member/draft validation, recipient resolution, and signed
+   Preview/Send behavior.
+2. Add strict plain-text Resend batch submission with safe error projection and
+   retry-stable idempotency.
+3. Add the ops page, composer, preview summary, per-member status list, and an
+   explicit irreversible Send action using existing design-system primitives.
+4. Add service, route, Resend boundary, and client interaction coverage,
+   including privacy, staleness, suspension, fallback, and retry behavior.
+5. Run focused and routed verification, browser proof, required security,
+   frontend, and coverage audits, then finish the plan with a scoped commit and
+   exact-head PR gates.
+
+## Decisions
+
+- The batch is operator-selected, never query-derived. This tool does not infer
+  an audience from billing or activity state.
+- Billing status does not block a send because the tool must support active and
+  lapsed-trial members. The account-deletion suspension fence always blocks it.
+- Each Resend batch item has exactly one recipient, so recipients cannot see
+  one another's addresses.
+- The provider call uses strict validation. A provider-level rejection fails
+  the whole batch and leaves the same Preview available for a safe retry.
+
+## Verification
+
+- Focused hosted-web tests: 5 files, 111 tests passed. Coverage includes
+  mixed eligible/skipped batches, verified-email precedence, address privacy,
+  stable retry idempotency, independent recipient-state staleness, exact draft
+  preservation, client response validation, and form accessibility.
+- `pnpm --dir apps/web typecheck`: passed.
+- `pnpm --dir apps/web lint`: passed with 0 errors and the 12 pre-existing
+  warnings.
+- `pnpm test:diff`: passed. The routed web lane ran 428 passing test files plus
+  2 skipped, 5,163 passing tests plus 139 skipped, the production Next build,
+  dev smoke, typecheck, lint, and workspace guards.
+- Coverage-write audit: passed after adding five focused proof cases; no
+  material gap remains.
+- Frontend audit: the first pass found exact-draft, long-ID, assistive-text,
+  failure-label, and design-gallery gaps. All five were remediated and the
+  remediation re-audit was clean; its focused client suite passed 10 tests.
+- The local app compiled and reached Ready on the isolated worktree port, but
+  the in-app browser runtime exposed no browser instance. Desktop/mobile
+  rendered inspection and screenshots could not be captured. No real email
+  was sent during verification.
+
+## Outcome
+
+- Added `/ops/email`, where an authenticated operator can enter up to 100
+  explicit member IDs, compose one plain-text draft, Preview eligibility, and
+  deliberately Send only to ready recipients.
+- Recipient addresses remain server-side. Unknown, suspended, and no-email
+  members are visibly skipped by member ID.
+- Send rechecks current member/recipient/sender state against a short-lived
+  HMAC-bound Preview and uses one stable Resend batch idempotency key for safe
+  ambiguous-response retries.
+- Reused the existing ops boundary, encrypted email authorization records,
+  contact-privacy keyring, and Resend configuration without a schema,
+  dependency, queue, or scheduler.
+Completed: 2026-07-15

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1127,3 +1127,14 @@ Current hosted billing assumptions:
   The provider update uses no proration and carries a proof-derived idempotency
   key and metadata marker. A retry after Stripe success reconciles local billing
   instead of adding another seven days.
+- `/ops/email` is the operator-only member email composer. It accepts up to 100
+  explicit hosted member IDs plus one plain-text subject and body. Preview
+  resolves verified email first and falls back to the stored Stripe checkout
+  email, while returning member eligibility only and never returning an email
+  address.
+- Send re-reads current member suspension and recipient state and requires the
+  exact 24-hour signed Preview. Unknown members, account-deletion-suspended
+  members, and members without a recipient stay skipped. Ready recipients are
+  submitted as separate emails in one strict Resend batch with a Preview-bound
+  idempotency key, so an ambiguous response can be retried without duplicate
+  delivery. Logs contain aggregate counts and safe provider status only.

--- a/apps/web/app/(dashboard)/ops/email/member-email-client.tsx
+++ b/apps/web/app/(dashboard)/ops/email/member-email-client.tsx
@@ -1,0 +1,652 @@
+"use client";
+
+import { SearchIcon, SendIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/src/components/ui/alert";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/src/components/ui/field";
+import { Input } from "@/src/components/ui/input";
+import { Textarea } from "@/src/components/ui/textarea";
+import type {
+  HostedOpsMemberEmailPreviewProof,
+  HostedOpsMemberEmailRecipientStatus,
+  HostedOpsMemberEmailResult,
+} from "@/src/lib/hosted-ops/member-email";
+
+type PendingAction = "preview" | "send" | null;
+type FailedAction = Exclude<PendingAction, null>;
+
+const MEMBER_EMAIL_MAX_RECIPIENTS = 100;
+const MEMBER_EMAIL_MAX_SUBJECT_LENGTH = 200;
+const MEMBER_EMAIL_MAX_TEXT_LENGTH = 20_000;
+const MEMBER_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/u;
+const PREVIEW_STALE_ERROR_CODE = "HOSTED_OPS_MEMBER_EMAIL_PREVIEW_STALE";
+const RECIPIENT_STATUSES = new Set<unknown>([
+  "member_not_found",
+  "member_suspended",
+  "no_email",
+  "ready",
+  "sent",
+]);
+
+export function MemberEmailClient() {
+  const [memberIdsText, setMemberIdsText] = useState("");
+  const [subject, setSubject] = useState("");
+  const [text, setText] = useState("");
+  const [result, setResult] = useState<HostedOpsMemberEmailResult | null>(null);
+  const [pending, setPending] = useState<PendingAction>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [failedAction, setFailedAction] = useState<FailedAction | null>(null);
+  const memberIds = useMemo(
+    () => parseHostedOpsMemberIds(memberIdsText),
+    [memberIdsText],
+  );
+  const memberIdsError = readMemberIdsError({ memberIds, memberIdsText });
+  const draftIsValid = !memberIdsError &&
+    memberIds.length > 0 &&
+    subject.trim().length > 0 &&
+    subject.length <= MEMBER_EMAIL_MAX_SUBJECT_LENGTH &&
+    text.trim().length > 0 &&
+    text.length <= MEMBER_EMAIL_MAX_TEXT_LENGTH;
+  const sendableCount = result?.outcome === "preview"
+    ? result.summary.readyCount
+    : 0;
+
+  function updateDraft(update: () => void): void {
+    update();
+    setResult(null);
+    setError(null);
+    setFailedAction(null);
+  }
+
+  async function previewEmail(): Promise<void> {
+    if (!draftIsValid) {
+      return;
+    }
+    setPending("preview");
+    setError(null);
+    setFailedAction(null);
+    try {
+      setResult(await requestMemberEmail({
+        memberIds,
+        mode: "preview",
+        previewProof: null,
+        subject,
+        text,
+      }));
+    } catch (requestError) {
+      setFailedAction("preview");
+      setError(readRequestErrorMessage(requestError));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function sendEmail(): Promise<void> {
+    if (
+      !result?.previewProof ||
+      result.outcome !== "preview" ||
+      result.summary.readyCount === 0
+    ) {
+      return;
+    }
+    setPending("send");
+    setError(null);
+    setFailedAction(null);
+    try {
+      setResult(await requestMemberEmail({
+        memberIds,
+        mode: "send",
+        previewProof: result.previewProof,
+        subject,
+        text,
+      }));
+    } catch (requestError) {
+      setFailedAction("send");
+      if (isPreviewStaleRequestError(requestError)) {
+        setResult(null);
+        setError(readRequestErrorMessage(requestError));
+      } else {
+        setError(
+          "The send could not be confirmed. Retry Send with the same Preview; Resend will reuse the same idempotency key.",
+        );
+      }
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="border-b border-border/70 pb-6">
+        <div className="max-w-3xl">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-chart-5">
+            Ops notebook
+          </span>
+          <h1 className="mt-2 font-serif text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+            Member email
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Draft one plain-text email for an explicit list of members. Preview
+            resolves the current recipients before anything is sent.
+          </p>
+        </div>
+      </header>
+
+      <section
+        aria-busy={pending !== null}
+        aria-labelledby="member-email-composer-title"
+        className="grid items-start gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)] lg:gap-10"
+      >
+        <div>
+          <div className="flex flex-col gap-1">
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-chart-5">
+              Plain text
+            </span>
+            <h2
+              className="font-serif text-xl font-semibold tracking-tight text-foreground"
+              id="member-email-composer-title"
+            >
+              Compose
+            </h2>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              Verified email is used first, with the Stripe checkout email as
+              fallback. Recipient addresses stay server-side.
+            </p>
+          </div>
+
+          <form
+            className="mt-6"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void previewEmail();
+            }}
+          >
+            <FieldGroup>
+              <Field data-invalid={Boolean(memberIdsError)}>
+                <FieldLabel htmlFor="member-email-member-ids">
+                  Member IDs
+                </FieldLabel>
+                <Textarea
+                  aria-describedby="member-email-member-ids-description"
+                  aria-errormessage={memberIdsError
+                    ? "member-email-member-ids-error"
+                    : undefined}
+                  aria-invalid={Boolean(memberIdsError)}
+                  autoComplete="off"
+                  className="min-h-32 resize-y font-mono text-xs leading-5"
+                  disabled={pending !== null}
+                  id="member-email-member-ids"
+                  onChange={(event) => updateDraft(() => {
+                    setMemberIdsText(event.target.value);
+                  })}
+                  placeholder={"hbm_member_1\nhbm_member_2"}
+                  required
+                  spellCheck={false}
+                  value={memberIdsText}
+                />
+                <FieldDescription id="member-email-member-ids-description">
+                  One per line, or separated by spaces or commas. Up to 100
+                  unique members.
+                </FieldDescription>
+                {memberIdsError ? (
+                  <FieldError id="member-email-member-ids-error">
+                    {memberIdsError}
+                  </FieldError>
+                ) : null}
+              </Field>
+
+              <Field
+                data-invalid={subject.length > MEMBER_EMAIL_MAX_SUBJECT_LENGTH}
+              >
+                <div className="flex items-baseline justify-between gap-4">
+                  <FieldLabel htmlFor="member-email-subject">Subject</FieldLabel>
+                  <CharacterCount
+                    current={subject.length}
+                    id="member-email-subject-count"
+                    maximum={MEMBER_EMAIL_MAX_SUBJECT_LENGTH}
+                  />
+                </div>
+                <Input
+                  aria-describedby="member-email-subject-count"
+                  aria-errormessage={subject.length > MEMBER_EMAIL_MAX_SUBJECT_LENGTH
+                    ? "member-email-subject-error"
+                    : undefined}
+                  aria-invalid={subject.length > MEMBER_EMAIL_MAX_SUBJECT_LENGTH}
+                  autoComplete="off"
+                  disabled={pending !== null}
+                  id="member-email-subject"
+                  onChange={(event) => updateDraft(() => {
+                    setSubject(event.target.value);
+                  })}
+                  placeholder="Your Murph trial is ready again"
+                  required
+                  value={subject}
+                />
+                {subject.length > MEMBER_EMAIL_MAX_SUBJECT_LENGTH ? (
+                  <FieldError id="member-email-subject-error">
+                    Subject must be 200 characters or fewer.
+                  </FieldError>
+                ) : null}
+              </Field>
+
+              <Field data-invalid={text.length > MEMBER_EMAIL_MAX_TEXT_LENGTH}>
+                <div className="flex items-baseline justify-between gap-4">
+                  <FieldLabel htmlFor="member-email-text">Message</FieldLabel>
+                  <CharacterCount
+                    current={text.length}
+                    id="member-email-text-count"
+                    maximum={MEMBER_EMAIL_MAX_TEXT_LENGTH}
+                  />
+                </div>
+                <Textarea
+                  aria-describedby="member-email-text-count member-email-text-description"
+                  aria-errormessage={text.length > MEMBER_EMAIL_MAX_TEXT_LENGTH
+                    ? "member-email-text-error"
+                    : undefined}
+                  aria-invalid={text.length > MEMBER_EMAIL_MAX_TEXT_LENGTH}
+                  className="min-h-72 resize-y leading-6"
+                  disabled={pending !== null}
+                  id="member-email-text"
+                  onChange={(event) => updateDraft(() => {
+                    setText(event.target.value);
+                  })}
+                  placeholder={"Hey,\n\nI added more trial time to your Murph account..."}
+                  required
+                  value={text}
+                />
+                <FieldDescription id="member-email-text-description">
+                  The message is sent exactly as plain text.
+                </FieldDescription>
+                {text.length > MEMBER_EMAIL_MAX_TEXT_LENGTH ? (
+                  <FieldError id="member-email-text-error">
+                    Message must be 20,000 characters or fewer.
+                  </FieldError>
+                ) : null}
+              </Field>
+            </FieldGroup>
+
+            <div className="mt-6 flex items-center justify-between gap-4 border-t border-border/70 pt-5">
+              <span className="text-xs text-muted-foreground">
+                {memberIds.length > 0
+                  ? `${memberIds.length} unique member${memberIds.length === 1 ? "" : "s"}`
+                  : "No members entered"}
+              </span>
+              {result?.outcome === "sent" ? (
+                <Badge variant="secondary">Batch complete</Badge>
+              ) : (
+                <Button
+                  disabled={!draftIsValid || pending !== null}
+                  onClick={() => void previewEmail()}
+                  type="button"
+                  variant="outline"
+                >
+                  <SearchIcon data-icon="inline-start" />
+                  {pending === "preview" ? "Previewing..." : "Preview recipients"}
+                </Button>
+              )}
+            </div>
+          </form>
+        </div>
+
+        <aside className="border-t border-border/70 pt-6 lg:sticky lg:top-6 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-chart-5">
+            Send check
+          </span>
+          <h2 className="mt-1 font-serif text-xl font-semibold tracking-tight text-foreground">
+            Recipients
+          </h2>
+
+          {error ? (
+            <Alert className="mt-5" variant="destructive">
+              <AlertTitle>
+                {failedAction === "preview" ? "Preview failed" : "Send not confirmed"}
+              </AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {!result ? (
+            <div className="mt-5 rounded-xl border border-dashed border-border px-5 py-10 text-center">
+              <p className="font-serif text-base font-medium text-foreground">
+                Nothing ready yet
+              </p>
+              <p className="mx-auto mt-2 max-w-xs text-sm leading-6 text-muted-foreground">
+                Complete the draft and preview it to check who can receive the
+                email. No addresses will be shown.
+              </p>
+            </div>
+          ) : (
+            <>
+              <ResultSummary result={result} />
+
+              <div className="mt-5 overflow-hidden rounded-xl border border-border/70">
+                <div className="divide-y divide-border/70">
+                  {result.recipients.map((recipient) => (
+                    <div
+                      className="flex items-center justify-between gap-4 px-4 py-3"
+                      key={recipient.memberId}
+                    >
+                      <span className="min-w-0 flex-1 break-all font-mono text-xs text-foreground">
+                        {recipient.memberId}
+                      </span>
+                      <RecipientStatusBadge status={recipient.status} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {result.outcome === "preview" && sendableCount > 0 &&
+                  result.previewProof ? (
+                <div className="mt-5">
+                  <Alert>
+                    <AlertTitle>Sends immediately</AlertTitle>
+                    <AlertDescription>
+                      Each member receives a separate email. Unknown,
+                      suspended, and no-email members stay skipped.
+                    </AlertDescription>
+                  </Alert>
+                  <Button
+                    className="mt-4 w-full"
+                    disabled={pending !== null}
+                    onClick={() => void sendEmail()}
+                    size="lg"
+                    type="button"
+                  >
+                    <SendIcon data-icon="inline-start" />
+                    {pending === "send"
+                      ? "Sending..."
+                      : `Send to ${sendableCount} member${sendableCount === 1 ? "" : "s"}`}
+                  </Button>
+                </div>
+              ) : null}
+            </>
+          )}
+
+          <p aria-live="polite" className="sr-only">
+            {readAnnouncedStatus({ error, pending, result })}
+          </p>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function CharacterCount(input: {
+  current: number;
+  id?: string;
+  maximum: number;
+}) {
+  return (
+    <span
+      className={input.current > input.maximum
+        ? "font-mono text-[10px] text-destructive"
+        : "font-mono text-[10px] text-muted-foreground"}
+      id={input.id}
+    >
+      {input.current.toLocaleString("en-US")} / {input.maximum.toLocaleString("en-US")}
+    </span>
+  );
+}
+
+function ResultSummary({ result }: { result: HostedOpsMemberEmailResult }) {
+  const columns = result.outcome === "sent"
+    ? [
+        ["Requested", result.summary.requestedCount],
+        ["Sent", result.summary.sentCount],
+        ["Skipped", result.summary.skippedCount],
+      ] as const
+    : [
+        ["Requested", result.summary.requestedCount],
+        ["Ready", result.summary.readyCount],
+        ["Skipped", result.summary.skippedCount],
+      ] as const;
+
+  return (
+    <div className="mt-5">
+      <div className="grid grid-cols-3 divide-x divide-border/70 rounded-xl border border-border/70 bg-card">
+        {columns.map(([label, value]) => (
+          <div className="px-3 py-4 text-center" key={label}>
+            <div className="font-serif text-2xl font-semibold text-foreground">
+              {value}
+            </div>
+            <div className="mt-1 font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+              {label}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="mt-3 text-sm leading-6 text-muted-foreground">
+        {result.message}
+      </p>
+    </div>
+  );
+}
+
+function RecipientStatusBadge({
+  status,
+}: {
+  status: HostedOpsMemberEmailRecipientStatus;
+}) {
+  const label = {
+    member_not_found: "Not found",
+    member_suspended: "Suspended",
+    no_email: "No email",
+    ready: "Ready",
+    sent: "Sent",
+  }[status];
+  return (
+    <Badge variant={status === "ready" || status === "sent" ? "secondary" : "outline"}>
+      {label}
+    </Badge>
+  );
+}
+
+export function parseHostedOpsMemberIds(value: string): string[] {
+  const memberIds: string[] = [];
+  for (const candidate of value.split(/[\s,]+/u)) {
+    const memberId = candidate.trim();
+    if (memberId && !memberIds.includes(memberId)) {
+      memberIds.push(memberId);
+    }
+  }
+  return memberIds;
+}
+
+function readMemberIdsError(input: {
+  memberIds: string[];
+  memberIdsText: string;
+}): string | null {
+  if (!input.memberIdsText.trim()) {
+    return null;
+  }
+  if (input.memberIds.length > MEMBER_EMAIL_MAX_RECIPIENTS) {
+    return `Enter no more than ${MEMBER_EMAIL_MAX_RECIPIENTS} unique member IDs.`;
+  }
+  if (input.memberIds.some((memberId) => !MEMBER_ID_PATTERN.test(memberId))) {
+    return "One or more member IDs has an invalid format.";
+  }
+  return null;
+}
+
+async function requestMemberEmail(input: {
+  memberIds: string[];
+  mode: "preview" | "send";
+  previewProof: HostedOpsMemberEmailPreviewProof | null;
+  subject: string;
+  text: string;
+}): Promise<HostedOpsMemberEmailResult> {
+  const response = await fetch("/api/ops/member-email", {
+    body: JSON.stringify({
+      memberIds: input.memberIds,
+      mode: input.mode,
+      ...(input.previewProof ? { previewProof: input.previewProof } : {}),
+      subject: input.subject,
+      text: input.text,
+    }),
+    cache: "no-store",
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new MemberEmailRequestError(
+      "Member email returned an unreadable response.",
+      null,
+    );
+  }
+  if (!response.ok) {
+    throw new MemberEmailRequestError(
+      readResponseErrorMessage(payload),
+      readResponseErrorCode(payload),
+    );
+  }
+  if (!isHostedOpsMemberEmailResult(payload)) {
+    throw new MemberEmailRequestError(
+      "Member email returned an invalid response.",
+      null,
+    );
+  }
+  return payload;
+}
+
+class MemberEmailRequestError extends Error {
+  readonly code: string | null;
+
+  constructor(message: string, code: string | null) {
+    super(message);
+    this.code = code;
+    this.name = "MemberEmailRequestError";
+  }
+}
+
+function isPreviewStaleRequestError(error: unknown): boolean {
+  return error instanceof MemberEmailRequestError &&
+    error.code === PREVIEW_STALE_ERROR_CODE;
+}
+
+function isHostedOpsMemberEmailResult(
+  value: unknown,
+): value is HostedOpsMemberEmailResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const recipients = Reflect.get(value, "recipients");
+  const summary = Reflect.get(value, "summary");
+  const previewProof = Reflect.get(value, "previewProof");
+  return (
+    (Reflect.get(value, "outcome") === "preview" ||
+      Reflect.get(value, "outcome") === "sent") &&
+    typeof Reflect.get(value, "message") === "string" &&
+    Array.isArray(recipients) &&
+    recipients.every(isHostedOpsMemberEmailRecipientResult) &&
+    isHostedOpsMemberEmailSummary(summary) &&
+    (
+      previewProof === null ||
+      isHostedOpsMemberEmailPreviewProof(previewProof)
+    )
+  );
+}
+
+function isHostedOpsMemberEmailRecipientResult(value: unknown): boolean {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      typeof Reflect.get(value, "memberId") === "string" &&
+      RECIPIENT_STATUSES.has(Reflect.get(value, "status")),
+  );
+}
+
+function isHostedOpsMemberEmailSummary(value: unknown): boolean {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      ["readyCount", "requestedCount", "sentCount", "skippedCount"].every(
+        (key) => {
+          const count = Reflect.get(value, key);
+          return typeof count === "number" &&
+            Number.isSafeInteger(count) &&
+            count >= 0;
+        },
+      ),
+  );
+}
+
+function isHostedOpsMemberEmailPreviewProof(value: unknown): boolean {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      typeof Reflect.get(value, "previewedAt") === "string" &&
+      typeof Reflect.get(value, "token") === "string",
+  );
+}
+
+function readResponseErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const error = Reflect.get(payload, "error");
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
+}
+
+function readResponseErrorMessage(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
+    return "Member email failed. Try again.";
+  }
+  const error = Reflect.get(payload, "error");
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    const message = Reflect.get(error, "message");
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+  return "Member email failed. Try again.";
+}
+
+function readRequestErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Member email failed. Try again.";
+}
+
+function readAnnouncedStatus(input: {
+  error: string | null;
+  pending: PendingAction;
+  result: HostedOpsMemberEmailResult | null;
+}): string {
+  if (input.pending === "preview") {
+    return "Checking member email recipients.";
+  }
+  if (input.pending === "send") {
+    return "Sending member email batch.";
+  }
+  if (input.error || !input.result) {
+    return "";
+  }
+  return input.result.message;
+}

--- a/apps/web/app/(dashboard)/ops/email/page.tsx
+++ b/apps/web/app/(dashboard)/ops/email/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+
+import { requireHostedOpsPageAccess } from "@/src/lib/hosted-ops/access";
+import { getHostedDashboardPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
+
+import { MemberEmailClient } from "./member-email-client";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  robots: {
+    follow: false,
+    index: false,
+  },
+  title: "Member email - Murph",
+};
+
+export default async function HostedOpsMemberEmailPage() {
+  await getHostedDashboardPageAuthSnapshot();
+  await requireHostedOpsPageAccess();
+
+  return <MemberEmailClient />;
+}

--- a/apps/web/app/(dashboard)/ops/page.tsx
+++ b/apps/web/app/(dashboard)/ops/page.tsx
@@ -38,6 +38,12 @@ const OPS_TOOLS = [
     href: "/ops/trials",
     label: "Trials",
   },
+  {
+    description:
+      "Preview recipients and send one plain-text email to an explicit list of member IDs.",
+    href: "/ops/email",
+    label: "Member email",
+  },
 ] as const;
 
 export default async function HostedOpsPage() {

--- a/apps/web/app/api/ops/member-email/route.ts
+++ b/apps/web/app/api/ops/member-email/route.ts
@@ -1,0 +1,200 @@
+import { requireHostedOpsRequestAccess } from "@/src/lib/hosted-ops/access";
+import {
+  HOSTED_OPS_MEMBER_EMAIL_MAX_RECIPIENTS,
+  HOSTED_OPS_MEMBER_EMAIL_MAX_SUBJECT_LENGTH,
+  HOSTED_OPS_MEMBER_EMAIL_MAX_TEXT_LENGTH,
+  HostedOpsMemberEmailNotConfiguredError,
+  HostedOpsMemberEmailPreviewStaleError,
+  previewHostedOpsMemberEmail,
+  sendHostedOpsMemberEmail,
+  type HostedOpsMemberEmailPreviewProof,
+} from "@/src/lib/hosted-ops/member-email";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import {
+  jsonOk,
+  readHostedOnboardingJsonObject,
+  withJsonError,
+} from "@/src/lib/hosted-onboarding/http";
+import { HostedResendPlainTextEmailError } from "@/src/lib/hosted-onboarding/resend-plain-text-email";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const maxDuration = 60;
+export const revalidate = 0;
+
+const REQUEST_BODY_LIMIT_BYTES = 64 * 1024;
+const MEMBER_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/u;
+
+export const POST = withJsonError(async (request: Request) => {
+  await requireHostedOpsRequestAccess(request, {
+    requireMutationOrigin: true,
+  });
+  const body = await readHostedOnboardingJsonObject(request, {
+    limitBytes: REQUEST_BODY_LIMIT_BYTES,
+    tooLargeErrorCode: "HOSTED_OPS_MEMBER_EMAIL_REQUEST_TOO_LARGE",
+    tooLargeErrorMessage: "Hosted ops member email request body is too large.",
+  });
+  const memberIds = readMemberIds(body.memberIds);
+  const subject = readDraftString({
+    emptyMessage: "Email subject is required.",
+    invalidCode: "HOSTED_OPS_MEMBER_EMAIL_SUBJECT_INVALID",
+    maxLength: HOSTED_OPS_MEMBER_EMAIL_MAX_SUBJECT_LENGTH,
+    tooLongMessage: `Email subject must be ${HOSTED_OPS_MEMBER_EMAIL_MAX_SUBJECT_LENGTH} characters or fewer.`,
+    value: body.subject,
+  });
+  const text = readDraftString({
+    emptyMessage: "Email body is required.",
+    invalidCode: "HOSTED_OPS_MEMBER_EMAIL_TEXT_INVALID",
+    maxLength: HOSTED_OPS_MEMBER_EMAIL_MAX_TEXT_LENGTH,
+    tooLongMessage: `Email body must be ${HOSTED_OPS_MEMBER_EMAIL_MAX_TEXT_LENGTH.toLocaleString("en-US")} characters or fewer.`,
+    value: body.text,
+  });
+  const mode = readMode(body.mode);
+
+  try {
+    const result = mode === "send"
+      ? await sendHostedOpsMemberEmail({
+          memberIds,
+          previewProof: readPreviewProof(body.previewProof),
+          subject,
+          text,
+        })
+      : await previewHostedOpsMemberEmail({ memberIds, subject, text });
+
+    if (mode === "send") {
+      console.info("Hosted ops member email batch completed.", {
+        requestedCount: result.summary.requestedCount,
+        sentCount: result.summary.sentCount,
+        skippedCount: result.summary.skippedCount,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    return jsonOk(result);
+  } catch (error) {
+    if (error instanceof HostedOpsMemberEmailPreviewStaleError) {
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_MEMBER_EMAIL_PREVIEW_STALE",
+        httpStatus: 409,
+        message: error.message,
+      });
+    }
+    if (error instanceof HostedOpsMemberEmailNotConfiguredError) {
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_MEMBER_EMAIL_NOT_CONFIGURED",
+        httpStatus: 503,
+        message: error.message,
+        retryable: false,
+      });
+    }
+    if (error instanceof HostedResendPlainTextEmailError) {
+      console.error("Hosted ops member email Resend batch failed.", {
+        providerErrorCode: error.code,
+        providerStatus: error.providerStatus,
+      });
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_MEMBER_EMAIL_PROVIDER_UNAVAILABLE",
+        httpStatus: 502,
+        message: "Resend could not confirm this email batch.",
+        retryable: true,
+      });
+    }
+    throw error;
+  }
+});
+
+function readMode(value: unknown): "preview" | "send" {
+  if (value === "preview" || value === "send") {
+    return value;
+  }
+  throw hostedOnboardingError({
+    code: "HOSTED_OPS_MEMBER_EMAIL_MODE_INVALID",
+    httpStatus: 400,
+    message: "Member email mode must be preview or send.",
+  });
+}
+
+function readMemberIds(value: unknown): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > HOSTED_OPS_MEMBER_EMAIL_MAX_RECIPIENTS
+  ) {
+    throw hostedOnboardingError({
+      code: "HOSTED_OPS_MEMBER_EMAIL_MEMBER_IDS_INVALID",
+      httpStatus: 400,
+      message: `Provide between 1 and ${HOSTED_OPS_MEMBER_EMAIL_MAX_RECIPIENTS} member IDs.`,
+    });
+  }
+
+  const normalized: string[] = [];
+  for (const candidate of value) {
+    const memberId = typeof candidate === "string" ? candidate.trim() : "";
+    if (!MEMBER_ID_PATTERN.test(memberId)) {
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_MEMBER_EMAIL_MEMBER_IDS_INVALID",
+        httpStatus: 400,
+        message: "Every member ID must be a valid hosted member identifier.",
+      });
+    }
+    if (!normalized.includes(memberId)) {
+      normalized.push(memberId);
+    }
+  }
+  return normalized;
+}
+
+function readDraftString(input: {
+  emptyMessage: string;
+  invalidCode: string;
+  maxLength: number;
+  tooLongMessage: string;
+  value: unknown;
+}): string {
+  if (typeof input.value !== "string") {
+    throw hostedOnboardingError({
+      code: input.invalidCode,
+      httpStatus: 400,
+      message: input.emptyMessage,
+    });
+  }
+  if (!input.value.trim()) {
+    throw hostedOnboardingError({
+      code: input.invalidCode,
+      httpStatus: 400,
+      message: input.emptyMessage,
+    });
+  }
+  if (input.value.length > input.maxLength) {
+    throw hostedOnboardingError({
+      code: input.invalidCode,
+      httpStatus: 400,
+      message: input.tooLongMessage,
+    });
+  }
+  return input.value;
+}
+
+function readPreviewProof(value: unknown): HostedOpsMemberEmailPreviewProof {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidPreviewProofError();
+  }
+  const previewedAt = Reflect.get(value, "previewedAt");
+  const token = Reflect.get(value, "token");
+  if (
+    typeof previewedAt !== "string" ||
+    previewedAt.length > 64 ||
+    typeof token !== "string" ||
+    token.length > 160
+  ) {
+    throw invalidPreviewProofError();
+  }
+  return { previewedAt, token };
+}
+
+function invalidPreviewProofError() {
+  return hostedOnboardingError({
+    code: "HOSTED_OPS_MEMBER_EMAIL_PREVIEW_PROOF_INVALID",
+    httpStatus: 400,
+    message: "Send requires the signed member email Preview.",
+  });
+}

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -28,6 +28,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/src/components/ui/ta
 import { Progress } from "@/src/components/ui/progress";
 import { Separator } from "@/src/components/ui/separator";
 import { Input } from "@/src/components/ui/input";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/src/components/ui/field";
+import { Textarea } from "@/src/components/ui/textarea";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/src/components/ui/input-otp";
 import { Label } from "@/src/components/ui/label";
 import { PhoneNumberInput } from "@/src/components/ui/phone-number-input";
@@ -213,11 +221,40 @@ export function ComponentsContent() {
         <Separator />
 
         <Section title="Input & Label">
-          <div className="grid max-w-sm gap-4">
+          <div className="grid max-w-sm gap-6">
             <div className="grid gap-2">
               <Label htmlFor="email-ds">Email</Label>
               <Input id="email-ds" type="email" placeholder="you@example.com" />
             </div>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="notes-ds">Notes</FieldLabel>
+                <Textarea
+                  id="notes-ds"
+                  placeholder="Add a plain-text note"
+                />
+                <FieldDescription>
+                  A multiline field with supporting help text.
+                </FieldDescription>
+              </Field>
+              <Field data-invalid="true">
+                <FieldLabel htmlFor="invalid-notes-ds">Invalid notes</FieldLabel>
+                <Textarea
+                  aria-invalid="true"
+                  defaultValue="This example needs attention."
+                  id="invalid-notes-ds"
+                />
+                <FieldError>Review this value before continuing.</FieldError>
+              </Field>
+              <Field data-disabled="true">
+                <FieldLabel htmlFor="disabled-notes-ds">Disabled notes</FieldLabel>
+                <Textarea
+                  defaultValue="Locked value"
+                  disabled
+                  id="disabled-notes-ds"
+                />
+              </Field>
+            </FieldGroup>
             <div className="grid gap-2">
               <Label htmlFor="disabled-ds">Disabled</Label>
               <Input id="disabled-ds" placeholder="Can't edit this" disabled />

--- a/apps/web/src/components/ui/field.tsx
+++ b/apps/web/src/components/ui/field.tsx
@@ -1,0 +1,238 @@
+"use client"
+
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/src/lib/utils"
+import { Label } from "@/src/components/ui/label"
+import { Separator } from "@/src/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-2 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+        horizontal:
+          "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        responsive:
+          "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-0.5 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/src/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/apps/web/src/lib/hosted-onboarding/hosted-member-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/hosted-member-store.ts
@@ -120,6 +120,11 @@ export interface HostedMemberEmailAuthorizationLookup {
   matchedBy: "verifiedEmail";
 }
 
+export interface HostedMemberEmailSnapshot {
+  core: HostedMemberCoreState;
+  emailAuthorization: HostedMemberEmailAuthorizationState | null;
+}
+
 export interface HostedMemberEmailAuthorizationWriteInput {
   directPublicSender?: {
     address: string;
@@ -208,6 +213,39 @@ export async function readHostedMemberCoreState(input: {
     },
     select: hostedMemberCoreStateSelect,
   });
+}
+
+export async function readHostedMemberEmailSnapshots(input: {
+  memberIds: readonly string[];
+  prisma: HostedOnboardingReadClient;
+}): Promise<HostedMemberEmailSnapshot[]> {
+  if (input.memberIds.length === 0) {
+    return [];
+  }
+
+  const records = await input.prisma.hostedMember.findMany({
+    where: {
+      id: {
+        in: [...input.memberIds],
+      },
+    },
+    select: {
+      ...hostedMemberCoreStateSelect,
+      emailAuthorization: {
+        select: hostedMemberEmailAuthorizationStateSelect,
+      },
+    },
+  });
+
+  return Promise.all(records.map(async (record) => ({
+    core: projectHostedMemberCoreState(record),
+    emailAuthorization: record.emailAuthorization
+      ? await projectHostedMemberEmailAuthorizationState(
+          record.emailAuthorization,
+          input.prisma,
+        )
+      : null,
+  })));
 }
 
 export async function claimHostedMemberSignupWelcomeEmailAttempt(input: {

--- a/apps/web/src/lib/hosted-onboarding/resend-plain-text-email.ts
+++ b/apps/web/src/lib/hosted-onboarding/resend-plain-text-email.ts
@@ -1,6 +1,7 @@
 import { normalizeNullableString, parseInteger } from "../primitives";
 
 const RESEND_EMAILS_ENDPOINT = "https://api.resend.com/emails";
+const RESEND_BATCH_EMAILS_ENDPOINT = "https://api.resend.com/emails/batch";
 const HOSTED_RESEND_EMAIL_DEFAULT_TIMEOUT_MS = 10_000;
 const HOSTED_RESEND_EMAIL_MIN_TIMEOUT_MS = 1_000;
 const HOSTED_RESEND_EMAIL_MAX_TIMEOUT_MS = 30_000;
@@ -15,6 +16,10 @@ export type HostedResendPlainTextEmailConfig = {
 
 export type HostedResendPlainTextEmailResult = {
   providerMessageId: string | null;
+};
+
+export type HostedResendPlainTextEmailBatchResult = {
+  providerMessageIds: string[];
 };
 
 export class HostedResendPlainTextEmailError extends Error {
@@ -84,6 +89,49 @@ export async function sendHostedResendPlainTextEmail(input: {
   };
 }
 
+export async function sendHostedResendPlainTextEmailBatch(input: {
+  config: HostedResendPlainTextEmailConfig;
+  emails: Array<{
+    subject: string;
+    text: string;
+    to: string[];
+  }>;
+  fetchImpl?: typeof fetch;
+  idempotencyKey: string;
+}): Promise<HostedResendPlainTextEmailBatchResult> {
+  const response = await (input.fetchImpl ?? fetch)(RESEND_BATCH_EMAILS_ENDPOINT, {
+    body: JSON.stringify(input.emails.map((email) => ({
+      from: input.config.from,
+      subject: email.subject,
+      text: email.text,
+      to: email.to,
+    }))),
+    headers: {
+      Authorization: `Bearer ${input.config.apiKey}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": input.idempotencyKey,
+    },
+    method: "POST",
+    signal: AbortSignal.timeout(input.config.timeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new HostedResendPlainTextEmailError(
+      "Hosted Resend email batch send failed.",
+      {
+        code: "RESEND_BATCH_SEND_FAILED",
+        providerStatus: response.status,
+      },
+    );
+  }
+
+  return {
+    providerMessageIds: readResendBatchMessageIds(
+      await readResendJsonPayload(response),
+    ),
+  };
+}
+
 function readHostedResendPlainTextEmailTimeoutMs(
   source: HostedResendPlainTextEmailEnv,
 ): number {
@@ -114,4 +162,20 @@ function readResendMessageId(value: unknown): string | null {
 
   const id = "id" in value ? value.id : null;
   return typeof id === "string" && id ? id : null;
+}
+
+function readResendBatchMessageIds(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  const data = "data" in value ? value.data : null;
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.flatMap((entry) => {
+    const id = readResendMessageId(entry);
+    return id ? [id] : [];
+  });
 }

--- a/apps/web/src/lib/hosted-ops/member-email.ts
+++ b/apps/web/src/lib/hosted-ops/member-email.ts
@@ -1,0 +1,430 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+import { readHostedContactPrivacyKeyring } from "../hosted-onboarding/env";
+import {
+  readHostedMemberEmailSnapshots,
+  type HostedMemberEmailSnapshot,
+} from "../hosted-onboarding/hosted-member-store";
+import {
+  readHostedResendPlainTextEmailConfig,
+  sendHostedResendPlainTextEmailBatch,
+} from "../hosted-onboarding/resend-plain-text-email";
+import { getPrisma } from "../prisma";
+
+const PREVIEW_TOKEN_PREFIX = "ops-member-email-preview-v1";
+const PREVIEW_HMAC_CONTEXT = "hosted-ops-member-email-preview-v1";
+const PREVIEW_PROOF_TTL_MS = 24 * 60 * 60_000;
+const PREVIEW_CLOCK_SKEW_MS = 60_000;
+
+export const HOSTED_OPS_MEMBER_EMAIL_MAX_RECIPIENTS = 100;
+export const HOSTED_OPS_MEMBER_EMAIL_MAX_SUBJECT_LENGTH = 200;
+export const HOSTED_OPS_MEMBER_EMAIL_MAX_TEXT_LENGTH = 20_000;
+
+export type HostedOpsMemberEmailRecipientStatus =
+  | "member_not_found"
+  | "member_suspended"
+  | "no_email"
+  | "ready"
+  | "sent";
+
+export interface HostedOpsMemberEmailRecipientResult {
+  memberId: string;
+  status: HostedOpsMemberEmailRecipientStatus;
+}
+
+export interface HostedOpsMemberEmailPreviewProof {
+  previewedAt: string;
+  token: string;
+}
+
+export interface HostedOpsMemberEmailResult {
+  message: string;
+  outcome: "preview" | "sent";
+  previewProof: HostedOpsMemberEmailPreviewProof | null;
+  recipients: HostedOpsMemberEmailRecipientResult[];
+  summary: {
+    readyCount: number;
+    requestedCount: number;
+    sentCount: number;
+    skippedCount: number;
+  };
+}
+
+type HostedOpsMemberEmailEnvironment = Readonly<
+  Record<string, string | undefined>
+>;
+
+type HostedOpsMemberEmailDependencies = {
+  env?: HostedOpsMemberEmailEnvironment;
+  fetchImpl?: typeof fetch;
+  prisma?: Parameters<typeof readHostedMemberEmailSnapshots>[0]["prisma"];
+};
+
+type HostedOpsMemberEmailDraft = {
+  memberIds: readonly string[];
+  subject: string;
+  text: string;
+};
+
+type HostedOpsMemberEmailInspection = {
+  recipient: string | null;
+  result: HostedOpsMemberEmailRecipientResult;
+};
+
+export class HostedOpsMemberEmailPreviewStaleError extends Error {
+  constructor() {
+    super("The member or draft changed since Preview. Preview this email again.");
+    this.name = "HostedOpsMemberEmailPreviewStaleError";
+  }
+}
+
+export class HostedOpsMemberEmailNotConfiguredError extends Error {
+  constructor() {
+    super("Member email sending is not configured.");
+    this.name = "HostedOpsMemberEmailNotConfiguredError";
+  }
+}
+
+export async function previewHostedOpsMemberEmail(
+  input: HostedOpsMemberEmailDraft &
+    HostedOpsMemberEmailDependencies & {
+      now?: Date;
+    },
+): Promise<HostedOpsMemberEmailResult> {
+  const dependencies = resolveHostedOpsMemberEmailDependencies(input);
+  const inspections = await inspectHostedOpsMemberEmailRecipients({
+    memberIds: input.memberIds,
+    prisma: dependencies.prisma,
+  });
+  const readyCount = countReadyHostedOpsMemberEmailRecipients(inspections);
+  const previewProof = readyCount > 0
+    ? buildHostedOpsMemberEmailPreviewProof({
+        env: dependencies.env,
+        from: dependencies.from,
+        inspections,
+        memberIds: input.memberIds,
+        previewedAt: input.now ?? new Date(),
+        subject: input.subject,
+        text: input.text,
+      })
+    : null;
+
+  return buildHostedOpsMemberEmailResult({
+    inspections,
+    outcome: "preview",
+    previewProof,
+  });
+}
+
+export async function sendHostedOpsMemberEmail(
+  input: HostedOpsMemberEmailDraft &
+    HostedOpsMemberEmailDependencies & {
+      now?: Date;
+      previewProof: HostedOpsMemberEmailPreviewProof;
+    },
+): Promise<HostedOpsMemberEmailResult> {
+  const dependencies = resolveHostedOpsMemberEmailDependencies(input);
+  requireHostedOpsMemberEmailPreviewFresh({
+    now: input.now ?? new Date(),
+    previewProof: input.previewProof,
+  });
+  const inspections = await inspectHostedOpsMemberEmailRecipients({
+    memberIds: input.memberIds,
+    prisma: dependencies.prisma,
+  });
+
+  if (
+    countReadyHostedOpsMemberEmailRecipients(inspections) === 0 ||
+    !verifyHostedOpsMemberEmailPreviewProof({
+      env: dependencies.env,
+      from: dependencies.from,
+      inspections,
+      memberIds: input.memberIds,
+      previewProof: input.previewProof,
+      subject: input.subject,
+      text: input.text,
+    })
+  ) {
+    throw new HostedOpsMemberEmailPreviewStaleError();
+  }
+
+  const readyRecipients = inspections.flatMap((inspection) =>
+    inspection.result.status === "ready" && inspection.recipient
+      ? [inspection.recipient]
+      : []
+  );
+  const tokenParts = readHostedOpsMemberEmailPreviewTokenParts(
+    input.previewProof.token,
+  );
+
+  await sendHostedResendPlainTextEmailBatch({
+    config: dependencies.resend,
+    emails: readyRecipients.map((recipient) => ({
+      subject: input.subject,
+      text: input.text,
+      to: [recipient],
+    })),
+    fetchImpl: dependencies.fetchImpl,
+    idempotencyKey: `hosted-ops-member-email/${tokenParts.digest}`,
+  });
+
+  return buildHostedOpsMemberEmailResult({
+    inspections,
+    outcome: "sent",
+    previewProof: null,
+  });
+}
+
+function resolveHostedOpsMemberEmailDependencies(
+  input: HostedOpsMemberEmailDependencies,
+) {
+  const env = input.env ?? process.env;
+  const resend = readHostedResendPlainTextEmailConfig(env);
+  if (!resend) {
+    throw new HostedOpsMemberEmailNotConfiguredError();
+  }
+
+  return {
+    env,
+    fetchImpl: input.fetchImpl,
+    from: resend.from,
+    prisma: input.prisma ?? getPrisma(),
+    resend,
+  };
+}
+
+async function inspectHostedOpsMemberEmailRecipients(input: {
+  memberIds: readonly string[];
+  prisma: Parameters<typeof readHostedMemberEmailSnapshots>[0]["prisma"];
+}): Promise<HostedOpsMemberEmailInspection[]> {
+  const snapshots = await readHostedMemberEmailSnapshots(input);
+  const snapshotByMemberId = new Map(
+    snapshots.map((snapshot) => [snapshot.core.id, snapshot]),
+  );
+
+  return input.memberIds.map((memberId) =>
+    inspectHostedOpsMemberEmailRecipient({
+      memberId,
+      snapshot: snapshotByMemberId.get(memberId) ?? null,
+    })
+  );
+}
+
+function inspectHostedOpsMemberEmailRecipient(input: {
+  memberId: string;
+  snapshot: HostedMemberEmailSnapshot | null;
+}): HostedOpsMemberEmailInspection {
+  if (!input.snapshot) {
+    return buildSkippedHostedOpsMemberEmailInspection(
+      input.memberId,
+      "member_not_found",
+    );
+  }
+  if (input.snapshot.core.suspendedAt) {
+    return buildSkippedHostedOpsMemberEmailInspection(
+      input.memberId,
+      "member_suspended",
+    );
+  }
+
+  const recipient = input.snapshot.emailAuthorization?.verifiedEmail?.address
+    ?? input.snapshot.emailAuthorization?.stripeCheckoutEmail?.address
+    ?? null;
+  if (!recipient) {
+    return buildSkippedHostedOpsMemberEmailInspection(
+      input.memberId,
+      "no_email",
+    );
+  }
+
+  return {
+    recipient,
+    result: {
+      memberId: input.memberId,
+      status: "ready",
+    },
+  };
+}
+
+function buildSkippedHostedOpsMemberEmailInspection(
+  memberId: string,
+  status: Exclude<
+    HostedOpsMemberEmailRecipientStatus,
+    "ready" | "sent"
+  >,
+): HostedOpsMemberEmailInspection {
+  return {
+    recipient: null,
+    result: { memberId, status },
+  };
+}
+
+function buildHostedOpsMemberEmailResult(input: {
+  inspections: HostedOpsMemberEmailInspection[];
+  outcome: HostedOpsMemberEmailResult["outcome"];
+  previewProof: HostedOpsMemberEmailPreviewProof | null;
+}): HostedOpsMemberEmailResult {
+  const readyCount = countReadyHostedOpsMemberEmailRecipients(
+    input.inspections,
+  );
+  const sentCount = input.outcome === "sent" ? readyCount : 0;
+  const recipients = input.inspections.map(({ result }) => ({
+    ...result,
+    status: input.outcome === "sent" && result.status === "ready"
+      ? "sent" as const
+      : result.status,
+  }));
+  const requestedCount = recipients.length;
+  const skippedCount = requestedCount - readyCount;
+
+  return {
+    message: input.outcome === "sent"
+      ? `${sentCount} member email${sentCount === 1 ? " was" : "s were"} sent.`
+      : readyCount > 0
+      ? `${readyCount} of ${requestedCount} member${requestedCount === 1 ? " is" : "s are"} ready to receive this email.`
+      : "No supplied member can receive this email.",
+    outcome: input.outcome,
+    previewProof: input.previewProof,
+    recipients,
+    summary: {
+      readyCount: input.outcome === "preview" ? readyCount : 0,
+      requestedCount,
+      sentCount,
+      skippedCount,
+    },
+  };
+}
+
+function countReadyHostedOpsMemberEmailRecipients(
+  inspections: HostedOpsMemberEmailInspection[],
+): number {
+  return inspections.filter(
+    ({ result }) => result.status === "ready",
+  ).length;
+}
+
+function buildHostedOpsMemberEmailPreviewProof(input: {
+  env: HostedOpsMemberEmailEnvironment;
+  from: string;
+  inspections: HostedOpsMemberEmailInspection[];
+  memberIds: readonly string[];
+  previewedAt: Date;
+  subject: string;
+  text: string;
+}): HostedOpsMemberEmailPreviewProof {
+  const previewedAt = input.previewedAt.toISOString();
+  return {
+    previewedAt,
+    token: signHostedOpsMemberEmailPreview({
+      ...input,
+      previewedAt,
+    }),
+  };
+}
+
+function verifyHostedOpsMemberEmailPreviewProof(input: {
+  env: HostedOpsMemberEmailEnvironment;
+  from: string;
+  inspections: HostedOpsMemberEmailInspection[];
+  memberIds: readonly string[];
+  previewProof: HostedOpsMemberEmailPreviewProof;
+  subject: string;
+  text: string;
+}): boolean {
+  let tokenParts: ReturnType<typeof readHostedOpsMemberEmailPreviewTokenParts>;
+  try {
+    tokenParts = readHostedOpsMemberEmailPreviewTokenParts(
+      input.previewProof.token,
+    );
+  } catch {
+    return false;
+  }
+
+  const expected = signHostedOpsMemberEmailPreview({
+    env: input.env,
+    from: input.from,
+    inspections: input.inspections,
+    keyVersion: tokenParts.keyVersion,
+    memberIds: input.memberIds,
+    previewedAt: input.previewProof.previewedAt,
+    subject: input.subject,
+    text: input.text,
+  });
+  const actualBuffer = Buffer.from(input.previewProof.token);
+  const expectedBuffer = Buffer.from(expected);
+  return actualBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function signHostedOpsMemberEmailPreview(input: {
+  env: HostedOpsMemberEmailEnvironment;
+  from: string;
+  inspections: HostedOpsMemberEmailInspection[];
+  keyVersion?: string;
+  memberIds: readonly string[];
+  previewedAt: string;
+  subject: string;
+  text: string;
+}): string {
+  const keyring = readHostedContactPrivacyKeyring(input.env);
+  const keyVersion = input.keyVersion ?? keyring.currentVersion;
+  const sourceKey = keyring.keysByVersion[keyVersion];
+  if (!sourceKey) {
+    throw new HostedOpsMemberEmailPreviewStaleError();
+  }
+  const digest = createHmac(
+    "sha256",
+    createHash("sha256")
+      .update(PREVIEW_HMAC_CONTEXT, "utf8")
+      .update("\0", "utf8")
+      .update(sourceKey)
+      .digest(),
+  )
+    .update(JSON.stringify({
+      from: input.from,
+      memberIds: input.memberIds,
+      previewedAt: input.previewedAt,
+      recipients: input.inspections.map((inspection) => ({
+        memberId: inspection.result.memberId,
+        recipient: inspection.recipient,
+        status: inspection.result.status,
+      })),
+      subject: input.subject,
+      text: input.text,
+    }), "utf8")
+    .digest("base64url");
+
+  return `${PREVIEW_TOKEN_PREFIX}.${keyVersion}.${digest}`;
+}
+
+function readHostedOpsMemberEmailPreviewTokenParts(token: string): {
+  digest: string;
+  keyVersion: string;
+} {
+  const match = new RegExp(
+    `^${PREVIEW_TOKEN_PREFIX}\\.(v[0-9]+)\\.([A-Za-z0-9_-]{43})$`,
+    "u",
+  ).exec(token);
+  if (!match?.[1] || !match[2]) {
+    throw new HostedOpsMemberEmailPreviewStaleError();
+  }
+  return {
+    digest: match[2],
+    keyVersion: match[1],
+  };
+}
+
+function requireHostedOpsMemberEmailPreviewFresh(input: {
+  now: Date;
+  previewProof: HostedOpsMemberEmailPreviewProof;
+}): void {
+  const previewedAt = new Date(input.previewProof.previewedAt);
+  if (
+    !Number.isFinite(previewedAt.getTime()) ||
+    previewedAt.toISOString() !== input.previewProof.previewedAt ||
+    input.now.getTime() < previewedAt.getTime() - PREVIEW_CLOCK_SKEW_MS ||
+    input.now.getTime() - previewedAt.getTime() > PREVIEW_PROOF_TTL_MS
+  ) {
+    throw new HostedOpsMemberEmailPreviewStaleError();
+  }
+}

--- a/apps/web/test/hosted-onboarding-member-store.test.ts
+++ b/apps/web/test/hosted-onboarding-member-store.test.ts
@@ -24,6 +24,7 @@ import {
   composeHostedMemberSnapshot,
   lookupHostedMemberByVerifiedEmailAddress,
   readHostedMemberAssistantNotificationState,
+  readHostedMemberEmailSnapshots,
   readHostedMemberMessagingSetupState,
   readHostedMemberSnapshot,
   type HostedMemberCoreState,
@@ -232,6 +233,62 @@ describe("hosted-member-store", () => {
         },
         verifiedEmailVerifiedAt: {
           not: null,
+        },
+      },
+    }));
+  });
+
+  it("reads bounded member email snapshots in one query and decrypts recipients", async () => {
+    const member = createHostedMember({ id: "member_email_snapshot" });
+    const address = "member@example.test";
+    const findMany = vi.fn().mockResolvedValue([{
+      ...member,
+      emailAuthorization: {
+        directPublicSenderAddressEncrypted: null,
+        directPublicSenderAuthorizedAt: null,
+        directPublicSenderLookupKey: null,
+        memberId: member.id,
+        stripeCheckoutEmailAddressEncrypted: null,
+        stripeCheckoutEmailCollectedAt: null,
+        verifiedEmailAddressEncrypted: await encryptHostedWebNullableString({
+          field: "hosted-member-email-authorization.verified-email",
+          memberId: member.id,
+          value: address,
+        }),
+        verifiedEmailLookupKey: "hbidx:email:v1:snapshot",
+        verifiedEmailVerifiedAt: new Date("2026-07-15T12:00:00.000Z"),
+      },
+    }]);
+    const prisma = {
+      hostedMember: { findMany },
+    } as never;
+
+    await expect(readHostedMemberEmailSnapshots({
+      memberIds: [member.id, "member_missing"],
+      prisma,
+    })).resolves.toEqual([{
+      core: {
+        billingStatus: member.billingStatus,
+        createdAt: member.createdAt,
+        id: member.id,
+        suspendedAt: member.suspendedAt,
+        updatedAt: member.updatedAt,
+      },
+      emailAuthorization: {
+        directPublicSender: null,
+        memberId: member.id,
+        stripeCheckoutEmail: null,
+        verifiedEmail: {
+          address,
+          lookupKey: "hbidx:email:v1:snapshot",
+          verifiedAt: new Date("2026-07-15T12:00:00.000Z"),
+        },
+      },
+    }]);
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        id: {
+          in: [member.id, "member_missing"],
         },
       },
     }));

--- a/apps/web/test/hosted-ops-member-email-route.test.ts
+++ b/apps/web/test/hosted-ops-member-email-route.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  assertHostedOnboardingMutationOrigin: vi.fn(),
+  previewHostedOpsMemberEmail: vi.fn(),
+  requireActiveHostedAppSessionFromRequest: vi.fn(),
+  sendHostedOpsMemberEmail: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
+  requireActiveHostedAppSessionFromRequest:
+    mocks.requireActiveHostedAppSessionFromRequest,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/csrf", () => ({
+  assertHostedOnboardingMutationOrigin: mocks.assertHostedOnboardingMutationOrigin,
+}));
+
+vi.mock("@/src/lib/hosted-ops/member-email", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-ops/member-email")
+  >("@/src/lib/hosted-ops/member-email");
+  return {
+    ...actual,
+    previewHostedOpsMemberEmail: mocks.previewHostedOpsMemberEmail,
+    sendHostedOpsMemberEmail: mocks.sendHostedOpsMemberEmail,
+  };
+});
+
+import {
+  HostedOpsMemberEmailNotConfiguredError,
+  HostedOpsMemberEmailPreviewStaleError,
+  type HostedOpsMemberEmailPreviewProof,
+  type HostedOpsMemberEmailResult,
+} from "@/src/lib/hosted-ops/member-email";
+import { HostedResendPlainTextEmailError } from "@/src/lib/hosted-onboarding/resend-plain-text-email";
+
+type RouteModule = typeof import("../app/api/ops/member-email/route");
+
+const NOW = new Date("2026-07-15T16:00:00.000Z");
+const OPERATOR_MEMBER_ID = "member_operator";
+const TARGET_MEMBER_ID = "hbm_target_1";
+const SUBJECT = "Subject";
+const TEXT = "Plain text body.";
+const PREVIEW_PROOF: HostedOpsMemberEmailPreviewProof = {
+  previewedAt: NOW.toISOString(),
+  token: `ops-member-email-preview-v1.v1.${"a".repeat(43)}`,
+};
+
+let route: RouteModule;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+const originalOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
+
+describe("hosted ops member email route", () => {
+  beforeAll(async () => {
+    route = await import("../app/api/ops/member-email/route");
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
+    process.env.HOSTED_OPS_MEMBER_IDS = OPERATOR_MEMBER_ID;
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
+      member: { id: OPERATOR_MEMBER_ID },
+    });
+    mocks.previewHostedOpsMemberEmail.mockResolvedValue(makeResult());
+    mocks.sendHostedOpsMemberEmail.mockResolvedValue(makeResult({
+      outcome: "sent",
+      previewProof: null,
+      recipients: [{ memberId: TARGET_MEMBER_ID, status: "sent" }],
+      summary: {
+        readyCount: 0,
+        requestedCount: 1,
+        sentCount: 1,
+        skippedCount: 0,
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    consoleErrorSpy.mockRestore();
+    consoleInfoSpy.mockRestore();
+    if (originalOpsMemberIds === undefined) {
+      delete process.env.HOSTED_OPS_MEMBER_IDS;
+    } else {
+      process.env.HOSTED_OPS_MEMBER_IDS = originalOpsMemberIds;
+    }
+  });
+
+  test("hides the route from members outside the ops allowlist", async () => {
+    mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
+      member: { id: "member_other" },
+    });
+
+    const response = await route.POST(makeRequest({
+      memberIds: [TARGET_MEMBER_ID],
+      mode: "preview",
+      subject: SUBJECT,
+      text: TEXT,
+    }));
+
+    assert.equal(response.status, 404);
+    expect(mocks.previewHostedOpsMemberEmail).not.toHaveBeenCalled();
+  });
+
+  test("normalizes unique member IDs while preserving the exact draft", async () => {
+    const subject = `  ${SUBJECT}  `;
+    const text = `\n${TEXT}\n`;
+    const response = await route.POST(makeRequest({
+      memberIds: [`  ${TARGET_MEMBER_ID}  `, TARGET_MEMBER_ID],
+      mode: "preview",
+      subject,
+      text,
+    }));
+
+    assert.equal(response.status, 200);
+    assert.equal(route.maxDuration, 60);
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledTimes(1);
+    expect(mocks.previewHostedOpsMemberEmail).toHaveBeenCalledWith({
+      memberIds: [TARGET_MEMBER_ID],
+      subject,
+      text,
+    });
+    expect(mocks.sendHostedOpsMemberEmail).not.toHaveBeenCalled();
+    expect(consoleInfoSpy).not.toHaveBeenCalled();
+  });
+
+  test("sends only with the supplied Preview and logs aggregate counts", async () => {
+    const response = await route.POST(makeRequest({
+      memberIds: [TARGET_MEMBER_ID],
+      mode: "send",
+      previewProof: PREVIEW_PROOF,
+      subject: SUBJECT,
+      text: TEXT,
+    }));
+
+    assert.equal(response.status, 200);
+    expect(mocks.sendHostedOpsMemberEmail).toHaveBeenCalledWith({
+      memberIds: [TARGET_MEMBER_ID],
+      previewProof: PREVIEW_PROOF,
+      subject: SUBJECT,
+      text: TEXT,
+    });
+    expect(consoleInfoSpy.mock.calls[0]).toEqual([
+      "Hosted ops member email batch completed.",
+      {
+        requestedCount: 1,
+        sentCount: 1,
+        skippedCount: 0,
+        timestamp: NOW.toISOString(),
+      },
+    ]);
+    expect(JSON.stringify(consoleInfoSpy.mock.calls)).not.toMatch(/hbm_|Subject|Plain text/u);
+  });
+
+  test.each([
+    ["empty member list", { memberIds: [] }],
+    ["invalid member", { memberIds: ["bad member"] }],
+    ["missing subject", { subject: " " }],
+    ["long subject", { subject: "s".repeat(201) }],
+    ["missing body", { text: " " }],
+    ["long body", { text: "t".repeat(20_001) }],
+    ["invalid mode", { mode: "apply" }],
+  ])("rejects %s", async (_label, override) => {
+    const response = await route.POST(makeRequest({
+      memberIds: [TARGET_MEMBER_ID],
+      mode: "preview",
+      subject: SUBJECT,
+      text: TEXT,
+      ...override,
+    }));
+
+    assert.equal(response.status, 400);
+    expect(mocks.previewHostedOpsMemberEmail).not.toHaveBeenCalled();
+    expect(mocks.sendHostedOpsMemberEmail).not.toHaveBeenCalled();
+  });
+
+  test("rejects more than 100 member IDs and Send without a proof", async () => {
+    const tooMany = await route.POST(makeRequest({
+      memberIds: Array.from({ length: 101 }, (_, index) => `hbm_${index}`),
+      mode: "preview",
+      subject: SUBJECT,
+      text: TEXT,
+    }));
+    const noProof = await route.POST(makeRequest({
+      memberIds: [TARGET_MEMBER_ID],
+      mode: "send",
+      subject: SUBJECT,
+      text: TEXT,
+    }));
+
+    assert.equal(tooMany.status, 400);
+    assert.equal(noProof.status, 400);
+    expect(mocks.previewHostedOpsMemberEmail).not.toHaveBeenCalled();
+    expect(mocks.sendHostedOpsMemberEmail).not.toHaveBeenCalled();
+  });
+
+  test("maps stale, unconfigured, and provider errors without logging private data", async () => {
+    mocks.sendHostedOpsMemberEmail
+      .mockRejectedValueOnce(new HostedOpsMemberEmailPreviewStaleError())
+      .mockRejectedValueOnce(new HostedOpsMemberEmailNotConfiguredError())
+      .mockRejectedValueOnce(new HostedResendPlainTextEmailError(
+        "Hosted Resend email batch send failed.",
+        { code: "RESEND_BATCH_SEND_FAILED", providerStatus: 429 },
+      ));
+    const requestBody = {
+      memberIds: [TARGET_MEMBER_ID],
+      mode: "send",
+      previewProof: PREVIEW_PROOF,
+      subject: SUBJECT,
+      text: TEXT,
+    };
+
+    const stale = await route.POST(makeRequest(requestBody));
+    const unconfigured = await route.POST(makeRequest(requestBody));
+    const unavailable = await route.POST(makeRequest(requestBody));
+
+    assert.equal(stale.status, 409);
+    assert.equal(unconfigured.status, 503);
+    assert.equal(unavailable.status, 502);
+    assert.deepEqual(await unavailable.json(), {
+      error: {
+        code: "HOSTED_OPS_MEMBER_EMAIL_PROVIDER_UNAVAILABLE",
+        message: "Resend could not confirm this email batch.",
+        retryable: true,
+      },
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Hosted ops member email Resend batch failed.",
+      {
+        providerErrorCode: "RESEND_BATCH_SEND_FAILED",
+        providerStatus: 429,
+      },
+    );
+    expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toMatch(
+      /hbm_|Subject|Plain text|@/u,
+    );
+  });
+});
+
+function makeResult(
+  overrides: Partial<HostedOpsMemberEmailResult> = {},
+): HostedOpsMemberEmailResult {
+  return {
+    message: "1 of 1 member is ready to receive this email.",
+    outcome: "preview",
+    previewProof: PREVIEW_PROOF,
+    recipients: [{ memberId: TARGET_MEMBER_ID, status: "ready" }],
+    summary: {
+      readyCount: 1,
+      requestedCount: 1,
+      sentCount: 0,
+      skippedCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/ops/member-email", {
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+      origin: "http://localhost",
+    },
+    method: "POST",
+  });
+}

--- a/apps/web/test/hosted-ops-member-email.test.ts
+++ b/apps/web/test/hosted-ops-member-email.test.ts
@@ -1,0 +1,369 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPrisma: vi.fn(),
+  prisma: { readonly: true },
+  readHostedMemberEmailSnapshots: vi.fn(),
+  sendHostedResendPlainTextEmailBatch: vi.fn(),
+}));
+
+vi.mock("@/src/lib/prisma", async () => {
+  const actual = await vi.importActual<typeof import("@/src/lib/prisma")>(
+    "@/src/lib/prisma",
+  );
+  return {
+    ...actual,
+    getPrisma: mocks.getPrisma,
+  };
+});
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/hosted-member-store")
+  >("@/src/lib/hosted-onboarding/hosted-member-store");
+  return {
+    ...actual,
+    readHostedMemberEmailSnapshots: mocks.readHostedMemberEmailSnapshots,
+  };
+});
+
+vi.mock("@/src/lib/hosted-onboarding/resend-plain-text-email", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/resend-plain-text-email")
+  >("@/src/lib/hosted-onboarding/resend-plain-text-email");
+  return {
+    ...actual,
+    sendHostedResendPlainTextEmailBatch:
+      mocks.sendHostedResendPlainTextEmailBatch,
+  };
+});
+
+import {
+  HostedOpsMemberEmailNotConfiguredError,
+  HostedOpsMemberEmailPreviewStaleError,
+  previewHostedOpsMemberEmail,
+  sendHostedOpsMemberEmail,
+} from "@/src/lib/hosted-ops/member-email";
+
+const NOW = new Date("2026-07-15T16:00:00.000Z");
+const MEMBER_ONE = "hbm_member_1";
+const MEMBER_TWO = "hbm_member_2";
+const MEMBER_THREE = "hbm_member_3";
+const MEMBER_FOUR = "hbm_member_4";
+const SUBJECT = "Your Murph trial is ready again";
+const TEXT = "Hey,\n\nI added more time to your trial.";
+const ENV = {
+  HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION: "v1",
+  HOSTED_CONTACT_PRIVACY_KEYS: `v1:${Buffer.alloc(32, 7).toString("base64")}`,
+  HOSTED_SIGNUP_WELCOME_EMAIL_FROM: "Murph <hello@example.com>",
+  RESEND_API_KEY: "re_test",
+};
+
+describe("hosted ops member email", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPrisma.mockReturnValue(mocks.prisma);
+    mocks.sendHostedResendPlainTextEmailBatch.mockResolvedValue({
+      providerMessageIds: ["email_1"],
+    });
+  });
+
+  it("previews ready and skipped members without exposing email addresses", async () => {
+    mocks.readHostedMemberEmailSnapshots.mockResolvedValue([
+      makeSnapshot(MEMBER_ONE, { verifiedEmail: "verified@example.com" }),
+      makeSnapshot(MEMBER_TWO),
+      makeSnapshot(MEMBER_THREE, {
+        suspendedAt: new Date("2026-07-14T00:00:00.000Z"),
+        verifiedEmail: "private@example.com",
+      }),
+    ]);
+
+    const result = await previewHostedOpsMemberEmail({
+      env: ENV,
+      memberIds: [MEMBER_ONE, MEMBER_TWO, MEMBER_THREE, "hbm_missing"],
+      now: NOW,
+      subject: SUBJECT,
+      text: TEXT,
+    });
+
+    expect(result).toMatchObject({
+      outcome: "preview",
+      recipients: [
+        { memberId: MEMBER_ONE, status: "ready" },
+        { memberId: MEMBER_TWO, status: "no_email" },
+        { memberId: MEMBER_THREE, status: "member_suspended" },
+        { memberId: "hbm_missing", status: "member_not_found" },
+      ],
+      summary: {
+        readyCount: 1,
+        requestedCount: 4,
+        sentCount: 0,
+        skippedCount: 3,
+      },
+    });
+    expect(result.previewProof).toMatchObject({
+      previewedAt: NOW.toISOString(),
+      token: expect.stringMatching(/^ops-member-email-preview-v1\.v1\./u),
+    });
+    expect(JSON.stringify(result)).not.toContain("@");
+    expect(mocks.sendHostedResendPlainTextEmailBatch).not.toHaveBeenCalled();
+  });
+
+  it("sends one separate batch item per ready member with stable idempotency", async () => {
+    mocks.readHostedMemberEmailSnapshots.mockResolvedValue([
+      makeSnapshot(MEMBER_ONE, {
+        stripeCheckoutEmail: "older-payer@example.com",
+        verifiedEmail: "verified@example.com",
+      }),
+      makeSnapshot(MEMBER_TWO, { stripeCheckoutEmail: "payer@example.com" }),
+      makeSnapshot(MEMBER_THREE),
+      makeSnapshot(MEMBER_FOUR, {
+        suspendedAt: new Date("2026-07-14T00:00:00.000Z"),
+        verifiedEmail: "suspended@example.com",
+      }),
+    ]);
+    const draft = {
+      env: ENV,
+      memberIds: [
+        MEMBER_ONE,
+        MEMBER_TWO,
+        MEMBER_THREE,
+        MEMBER_FOUR,
+        "hbm_missing",
+      ],
+      subject: SUBJECT,
+      text: TEXT,
+    };
+    const preview = await previewHostedOpsMemberEmail({ ...draft, now: NOW });
+    if (!preview.previewProof) {
+      throw new Error("Expected a preview proof.");
+    }
+
+    const first = await sendHostedOpsMemberEmail({
+      ...draft,
+      now: new Date(NOW.getTime() + 60_000),
+      previewProof: preview.previewProof,
+    });
+    await sendHostedOpsMemberEmail({
+      ...draft,
+      now: new Date(NOW.getTime() + 120_000),
+      previewProof: preview.previewProof,
+    });
+
+    expect(first).toEqual({
+      message: "2 member emails were sent.",
+      outcome: "sent",
+      previewProof: null,
+      recipients: [
+        { memberId: MEMBER_ONE, status: "sent" },
+        { memberId: MEMBER_TWO, status: "sent" },
+        { memberId: MEMBER_THREE, status: "no_email" },
+        { memberId: MEMBER_FOUR, status: "member_suspended" },
+        { memberId: "hbm_missing", status: "member_not_found" },
+      ],
+      summary: {
+        readyCount: 0,
+        requestedCount: 5,
+        sentCount: 2,
+        skippedCount: 3,
+      },
+    });
+    expect(mocks.sendHostedResendPlainTextEmailBatch).toHaveBeenCalledTimes(2);
+    const firstCall = mocks.sendHostedResendPlainTextEmailBatch.mock.calls[0]?.[0];
+    const secondCall = mocks.sendHostedResendPlainTextEmailBatch.mock.calls[1]?.[0];
+    expect(firstCall).toMatchObject({
+      emails: [
+        { subject: SUBJECT, text: TEXT, to: ["verified@example.com"] },
+        { subject: SUBJECT, text: TEXT, to: ["payer@example.com"] },
+      ],
+      idempotencyKey: expect.stringMatching(/^hosted-ops-member-email\//u),
+    });
+    expect(JSON.stringify(first)).not.toContain("@");
+    expect(secondCall.idempotencyKey).toBe(firstCall.idempotencyKey);
+  });
+
+  it.each([
+    ["subject", { subject: `${SUBJECT}!` }],
+    ["body", { text: `${TEXT}\nChanged` }],
+    ["member order", { memberIds: [MEMBER_TWO, MEMBER_ONE] }],
+  ])("rejects Send when the %s changed after Preview", async (_label, change) => {
+    mocks.readHostedMemberEmailSnapshots.mockResolvedValue([
+      makeSnapshot(MEMBER_ONE, { verifiedEmail: "verified@example.com" }),
+      makeSnapshot(MEMBER_TWO, { verifiedEmail: "second@example.com" }),
+    ]);
+    const draft = {
+      env: ENV,
+      memberIds: [MEMBER_ONE, MEMBER_TWO],
+      subject: SUBJECT,
+      text: TEXT,
+    };
+    const preview = await previewHostedOpsMemberEmail({ ...draft, now: NOW });
+    if (!preview.previewProof) {
+      throw new Error("Expected a preview proof.");
+    }
+
+    await expect(sendHostedOpsMemberEmail({
+      ...draft,
+      ...change,
+      now: new Date(NOW.getTime() + 60_000),
+      previewProof: preview.previewProof,
+    })).rejects.toBeInstanceOf(HostedOpsMemberEmailPreviewStaleError);
+    expect(mocks.sendHostedResendPlainTextEmailBatch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "recipient changed",
+      [makeSnapshot(MEMBER_ONE, { verifiedEmail: "second@example.com" })],
+    ],
+    [
+      "member became suspended",
+      [makeSnapshot(MEMBER_ONE, {
+        suspendedAt: new Date("2026-07-15T16:00:30.000Z"),
+        verifiedEmail: "first@example.com",
+      })],
+    ],
+    ["recipient disappeared", [makeSnapshot(MEMBER_ONE)]],
+    ["member disappeared", []],
+  ])("rejects Send when the %s after Preview", async (_label, sendSnapshots) => {
+    mocks.readHostedMemberEmailSnapshots.mockResolvedValueOnce([
+      makeSnapshot(MEMBER_ONE, { verifiedEmail: "first@example.com" }),
+    ]).mockResolvedValueOnce(sendSnapshots);
+    const draft = {
+      env: ENV,
+      memberIds: [MEMBER_ONE],
+      subject: SUBJECT,
+      text: TEXT,
+    };
+    const preview = await previewHostedOpsMemberEmail({ ...draft, now: NOW });
+    if (!preview.previewProof) {
+      throw new Error("Expected a preview proof.");
+    }
+
+    await expect(sendHostedOpsMemberEmail({
+      ...draft,
+      now: new Date(NOW.getTime() + 60_000),
+      previewProof: preview.previewProof,
+    })).rejects.toBeInstanceOf(HostedOpsMemberEmailPreviewStaleError);
+    expect(mocks.sendHostedResendPlainTextEmailBatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects Send if the configured sender changed after Preview", async () => {
+    mocks.readHostedMemberEmailSnapshots.mockResolvedValue([
+      makeSnapshot(MEMBER_ONE, { verifiedEmail: "verified@example.com" }),
+    ]);
+    const draft = {
+      env: ENV,
+      memberIds: [MEMBER_ONE],
+      subject: SUBJECT,
+      text: TEXT,
+    };
+    const preview = await previewHostedOpsMemberEmail({ ...draft, now: NOW });
+    if (!preview.previewProof) {
+      throw new Error("Expected a preview proof.");
+    }
+
+    await expect(sendHostedOpsMemberEmail({
+      ...draft,
+      env: {
+        ...ENV,
+        HOSTED_SIGNUP_WELCOME_EMAIL_FROM: "Murph <other@example.com>",
+      },
+      now: new Date(NOW.getTime() + 60_000),
+      previewProof: preview.previewProof,
+    })).rejects.toBeInstanceOf(HostedOpsMemberEmailPreviewStaleError);
+    expect(mocks.sendHostedResendPlainTextEmailBatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an expired Preview before contacting Resend", async () => {
+    mocks.readHostedMemberEmailSnapshots.mockResolvedValue([
+      makeSnapshot(MEMBER_ONE, { verifiedEmail: "verified@example.com" }),
+    ]);
+    const draft = {
+      env: ENV,
+      memberIds: [MEMBER_ONE],
+      subject: SUBJECT,
+      text: TEXT,
+    };
+    const preview = await previewHostedOpsMemberEmail({ ...draft, now: NOW });
+    if (!preview.previewProof) {
+      throw new Error("Expected a preview proof.");
+    }
+
+    await expect(sendHostedOpsMemberEmail({
+      ...draft,
+      now: new Date(NOW.getTime() + 24 * 60 * 60_000 + 1),
+      previewProof: preview.previewProof,
+    })).rejects.toBeInstanceOf(HostedOpsMemberEmailPreviewStaleError);
+    expect(mocks.readHostedMemberEmailSnapshots).toHaveBeenCalledTimes(1);
+    expect(mocks.sendHostedResendPlainTextEmailBatch).not.toHaveBeenCalled();
+  });
+
+  it("returns no proof when every supplied member is skipped", async () => {
+    mocks.readHostedMemberEmailSnapshots.mockResolvedValue([]);
+
+    await expect(previewHostedOpsMemberEmail({
+      env: ENV,
+      memberIds: [MEMBER_ONE],
+      now: NOW,
+      subject: SUBJECT,
+      text: TEXT,
+    })).resolves.toMatchObject({
+      message: "No supplied member can receive this email.",
+      previewProof: null,
+      summary: { readyCount: 0, skippedCount: 1 },
+    });
+  });
+
+  it("fails closed when the existing Resend configuration is absent", async () => {
+    await expect(previewHostedOpsMemberEmail({
+      env: {
+        HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION: "v1",
+        HOSTED_CONTACT_PRIVACY_KEYS: ENV.HOSTED_CONTACT_PRIVACY_KEYS,
+      },
+      memberIds: [MEMBER_ONE],
+      now: NOW,
+      subject: SUBJECT,
+      text: TEXT,
+    })).rejects.toBeInstanceOf(HostedOpsMemberEmailNotConfiguredError);
+    expect(mocks.readHostedMemberEmailSnapshots).not.toHaveBeenCalled();
+  });
+});
+
+function makeSnapshot(
+  memberId: string,
+  input: {
+    stripeCheckoutEmail?: string;
+    suspendedAt?: Date | null;
+    verifiedEmail?: string;
+  } = {},
+) {
+  return {
+    core: {
+      billingStatus: "paused",
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      id: memberId,
+      suspendedAt: input.suspendedAt ?? null,
+      updatedAt: new Date("2026-07-15T00:00:00.000Z"),
+    },
+    emailAuthorization: input.verifiedEmail || input.stripeCheckoutEmail
+      ? {
+          directPublicSender: null,
+          memberId,
+          stripeCheckoutEmail: input.stripeCheckoutEmail
+            ? {
+                address: input.stripeCheckoutEmail,
+                collectedAt: new Date("2026-07-01T00:00:00.000Z"),
+              }
+            : null,
+          verifiedEmail: input.verifiedEmail
+            ? {
+                address: input.verifiedEmail,
+                lookupKey: "lookup_key",
+                verifiedAt: new Date("2026-07-01T00:00:00.000Z"),
+              }
+            : null,
+        }
+      : null,
+  };
+}

--- a/apps/web/test/hosted-resend-plain-text-email.test.ts
+++ b/apps/web/test/hosted-resend-plain-text-email.test.ts
@@ -4,6 +4,7 @@ import {
   HostedResendPlainTextEmailError,
   readHostedResendPlainTextEmailConfig,
   sendHostedResendPlainTextEmail,
+  sendHostedResendPlainTextEmailBatch,
 } from "@/src/lib/hosted-onboarding/resend-plain-text-email";
 
 describe("hosted Resend plain-text email sender", () => {
@@ -108,6 +109,71 @@ describe("hosted Resend plain-text email sender", () => {
     })).rejects.toMatchObject({
       code: "RESEND_SEND_FAILED",
       providerStatus: 401,
+    } satisfies Partial<HostedResendPlainTextEmailError>);
+  });
+
+  it("sends separate plain-text emails through one idempotent batch request", async () => {
+    const fetchMock: typeof fetch = async (input, init) => {
+      expect(input).toBe("https://api.resend.com/emails/batch");
+      expect(init?.method).toBe("POST");
+      expect(init?.headers).toMatchObject({
+        Authorization: expect.stringMatching(/^Bearer\s+\S+$/u),
+        "Content-Type": "application/json",
+        "Idempotency-Key": "batch/idempotency-key",
+      });
+      expect(JSON.parse(String(init?.body))).toEqual([
+        {
+          from: "Murph <founder@example.com>",
+          subject: "Subject",
+          text: "Plain text only.",
+          to: ["first@example.com"],
+        },
+        {
+          from: "Murph <founder@example.com>",
+          subject: "Subject",
+          text: "Plain text only.",
+          to: ["second@example.com"],
+        },
+      ]);
+
+      return new Response(JSON.stringify({
+        data: [{ id: "email_1" }, { id: "email_2" }],
+      }), { status: 200 });
+    };
+
+    await expect(sendHostedResendPlainTextEmailBatch({
+      config: {
+        apiKey: "re_test",
+        from: "Murph <founder@example.com>",
+        timeoutMs: 1_000,
+      },
+      emails: [
+        { subject: "Subject", text: "Plain text only.", to: ["first@example.com"] },
+        { subject: "Subject", text: "Plain text only.", to: ["second@example.com"] },
+      ],
+      fetchImpl: fetchMock,
+      idempotencyKey: "batch/idempotency-key",
+    })).resolves.toEqual({
+      providerMessageIds: ["email_1", "email_2"],
+    });
+  });
+
+  it("returns only sanitized metadata when a batch is rejected", async () => {
+    await expect(sendHostedResendPlainTextEmailBatch({
+      config: {
+        apiKey: "re_sensitive_test",
+        from: "Murph <founder@example.com>",
+        timeoutMs: 1_000,
+      },
+      emails: [
+        { subject: "Private subject", text: "Private text", to: ["private@example.com"] },
+      ],
+      fetchImpl: async () => new Response("private failure", { status: 429 }),
+      idempotencyKey: "batch/idempotency-key",
+    })).rejects.toMatchObject({
+      code: "RESEND_BATCH_SEND_FAILED",
+      message: "Hosted Resend email batch send failed.",
+      providerStatus: 429,
     } satisfies Partial<HostedResendPlainTextEmailError>);
   });
 });

--- a/apps/web/test/ops-member-email-client.test.tsx
+++ b/apps/web/test/ops-member-email-client.test.tsx
@@ -1,0 +1,416 @@
+import { act, createElement, type ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("lucide-react", () => ({
+  SearchIcon: () => createElement("svg"),
+  SendIcon: () => createElement("svg"),
+}));
+
+vi.mock("@/src/components/ui/alert", () => ({
+  Alert: ({ variant, ...props }: ComponentProps<"div"> & { variant?: string }) => {
+    void variant;
+    return createElement("div", { role: "alert", ...props });
+  },
+  AlertDescription: (props: ComponentProps<"div">) => createElement("div", props),
+  AlertTitle: (props: ComponentProps<"div">) => createElement("div", props),
+}));
+
+vi.mock("@/src/components/ui/badge", () => ({
+  Badge: ({ variant, ...props }: ComponentProps<"span"> & { variant?: string }) => {
+    void variant;
+    return createElement("span", props);
+  },
+}));
+
+vi.mock("@/src/components/ui/button", () => ({
+  Button: ({ size, variant, ...props }: ComponentProps<"button"> & {
+    size?: string;
+    variant?: string;
+  }) => {
+    void size;
+    void variant;
+    return createElement("button", props);
+  },
+}));
+
+vi.mock("@/src/components/ui/field", () => ({
+  Field: ({ "data-invalid": dataInvalid, ...props }: ComponentProps<"div"> & {
+    "data-invalid"?: boolean;
+  }) => {
+    void dataInvalid;
+    return createElement("div", props);
+  },
+  FieldDescription: (props: ComponentProps<"p">) => createElement("p", props),
+  FieldError: (props: ComponentProps<"div">) => createElement("div", props),
+  FieldGroup: (props: ComponentProps<"div">) => createElement("div", props),
+  FieldLabel: (props: ComponentProps<"label">) => createElement("label", props),
+}));
+
+vi.mock("@/src/components/ui/input", () => ({
+  Input: ({ onChange, ...props }: ComponentProps<"input">) =>
+    createElement("input", { ...props, onInput: onChange }),
+}));
+
+vi.mock("@/src/components/ui/textarea", () => ({
+  Textarea: ({ onChange, ...props }: ComponentProps<"textarea">) =>
+    createElement("textarea", { ...props, onInput: onChange }),
+}));
+
+import {
+  MemberEmailClient,
+  parseHostedOpsMemberIds,
+} from "../app/(dashboard)/ops/email/member-email-client";
+import type {
+  HostedOpsMemberEmailResult,
+} from "../src/lib/hosted-ops/member-email";
+import { renderClientComponent } from "./render-client-component";
+
+const fetchMock = vi.fn<typeof fetch>();
+const MEMBER_ONE = "hbm_member_1";
+const MEMBER_TWO = "hbm_member_2";
+const PREVIEW_PROOF = {
+  previewedAt: "2026-07-15T16:00:00.000Z",
+  token: `ops-member-email-preview-v1.v1.${"a".repeat(43)}`,
+};
+let cleanupRender: (() => Promise<void>) | null = null;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(async () => {
+  if (cleanupRender) {
+    await cleanupRender();
+    cleanupRender = null;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("MemberEmailClient", () => {
+  test("parses newline, comma, and whitespace-separated IDs without duplicates", () => {
+    expect(parseHostedOpsMemberIds(
+      ` ${MEMBER_ONE}\n${MEMBER_TWO}, ${MEMBER_ONE} `,
+    )).toEqual([MEMBER_ONE, MEMBER_TWO]);
+  });
+
+  test("previews recipient eligibility and sends the exact signed draft", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(makePreviewResult()))
+      .mockResolvedValueOnce(jsonResponse(makeSentResult()));
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+
+    await fillDraft(rendered, {
+      memberIds: `${MEMBER_ONE}\n${MEMBER_TWO}, ${MEMBER_ONE}`,
+      subject: " Trial update ",
+      text: "\nHey,\n\nYour trial is ready again.\n",
+    });
+    await clickButton(rendered.window, getButton(rendered.container, "Preview recipients"));
+
+    expect(readRequestBody(0)).toEqual({
+      memberIds: [MEMBER_ONE, MEMBER_TWO],
+      mode: "preview",
+      subject: " Trial update ",
+      text: "\nHey,\n\nYour trial is ready again.\n",
+    });
+    expect(rendered.container.textContent).toContain("1 of 2 members are ready");
+    expect(rendered.container.textContent).toContain(MEMBER_ONE);
+    expect(rendered.container.textContent).toContain("No email");
+    expect(rendered.container.textContent).not.toContain("member@example.com");
+    expect(rendered.container.textContent).toContain("Send to 1 member");
+
+    await clickButton(rendered.window, getButton(rendered.container, "Send to 1 member"));
+
+    expect(readRequestBody(1)).toEqual({
+      memberIds: [MEMBER_ONE, MEMBER_TWO],
+      mode: "send",
+      previewProof: PREVIEW_PROOF,
+      subject: " Trial update ",
+      text: "\nHey,\n\nYour trial is ready again.\n",
+    });
+    expect(rendered.container.textContent).toContain("Batch complete");
+    expect(rendered.container.textContent).toContain("1 member email was sent");
+    expect(rendered.container.textContent).not.toContain("Send to 1 member");
+  });
+
+  test("keeps the same Preview for a retry after an ambiguous Send", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(makePreviewResult()))
+      .mockRejectedValueOnce(new TypeError("connection lost"))
+      .mockResolvedValueOnce(jsonResponse(makeSentResult()));
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+    await fillDraft(rendered);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview recipients"));
+    await clickButton(rendered.window, getButton(rendered.container, "Send to 1 member"));
+
+    expect(rendered.container.textContent).toContain(
+      "Retry Send with the same Preview",
+    );
+    expect(rendered.container.textContent).toContain("Send not confirmed");
+    expect(rendered.container.textContent).toContain("Send to 1 member");
+
+    await clickButton(rendered.window, getButton(rendered.container, "Send to 1 member"));
+
+    expect(readRequestBodyText(2)).toBe(readRequestBodyText(1));
+    expect(rendered.container.textContent).toContain("Batch complete");
+  });
+
+  test("clears a stale Preview and requires another Preview", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(makePreviewResult()))
+      .mockResolvedValueOnce(jsonResponse({
+        error: {
+          code: "HOSTED_OPS_MEMBER_EMAIL_PREVIEW_STALE",
+          message: "The member or draft changed since Preview. Preview this email again.",
+        },
+      }, 409));
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+    await fillDraft(rendered);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview recipients"));
+    await clickButton(rendered.window, getButton(rendered.container, "Send to 1 member"));
+
+    expect(rendered.container.textContent).toContain("changed since Preview");
+    expect(rendered.container.textContent).toContain("Nothing ready yet");
+    expect(rendered.container.textContent).not.toContain("Send to 1 member");
+  });
+
+  test("shows complete member IDs in the recipient review", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(makePreviewResult()));
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+    await fillDraft(rendered);
+
+    await clickButton(rendered.window, getButton(rendered.container, "Preview recipients"));
+
+    const memberId = Array.from(rendered.container.querySelectorAll("span")).find(
+      (candidate) => candidate.textContent === MEMBER_ONE,
+    );
+    expect(memberId?.className).toContain("break-all");
+    expect(memberId?.className).not.toContain("truncate");
+  });
+
+  test("changing any draft field clears an existing Preview", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(makePreviewResult()));
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+    await fillDraft(rendered);
+    await clickButton(rendered.window, getButton(rendered.container, "Preview recipients"));
+    expect(rendered.container.textContent).toContain("Send to 1 member");
+
+    await changeValue(
+      rendered.window,
+      requireElement<HTMLInputElement>(rendered.container, "#member-email-subject"),
+      "Changed subject",
+    );
+
+    expect(rendered.container.textContent).toContain("Nothing ready yet");
+    expect(rendered.container.textContent).not.toContain("Send to 1 member");
+  });
+
+  test("blocks Preview when more than 100 unique member IDs are entered", async () => {
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+    await fillDraft(rendered, {
+      memberIds: Array.from({ length: 101 }, (_, index) => `hbm_${index}`).join("\n"),
+    });
+
+    expect(rendered.container.textContent).toContain("no more than 100");
+    expect(getButton(rendered.container, "Preview recipients").disabled).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects a malformed successful Preview response", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      message: "Preview ready.",
+      outcome: "preview",
+      previewProof: PREVIEW_PROOF,
+      recipients: [],
+      summary: {},
+    }));
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+    await fillDraft(rendered);
+
+    await clickButton(rendered.window, getButton(rendered.container, "Preview recipients"));
+
+    expect(rendered.container.textContent).toContain(
+      "Member email returned an invalid response.",
+    );
+    expect(rendered.container.textContent).toContain("Nothing ready yet");
+    expect(rendered.container.textContent).not.toContain("Send to 1 member");
+  });
+
+  test("associates required field help and errors with each draft control", async () => {
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+
+    const memberIds = requireElement<HTMLTextAreaElement>(
+      rendered.container,
+      "#member-email-member-ids",
+    );
+    const subject = requireElement<HTMLInputElement>(
+      rendered.container,
+      "#member-email-subject",
+    );
+    const text = requireElement<HTMLTextAreaElement>(
+      rendered.container,
+      "#member-email-text",
+    );
+
+    expect(memberIds.hasAttribute("required")).toBe(true);
+    expect(memberIds.getAttribute("aria-describedby")).toBe(
+      "member-email-member-ids-description",
+    );
+    expect(subject.hasAttribute("required")).toBe(true);
+    expect(subject.getAttribute("aria-describedby")).toBe(
+      "member-email-subject-count",
+    );
+    expect(text.hasAttribute("required")).toBe(true);
+    expect(text.getAttribute("aria-describedby")).toBe(
+      "member-email-text-count member-email-text-description",
+    );
+
+    await changeValue(rendered.window, subject, "s".repeat(201));
+    expect(subject.getAttribute("aria-errormessage")).toBe(
+      "member-email-subject-error",
+    );
+    expect(getButton(rendered.container, "Preview recipients").disabled).toBe(true);
+  });
+
+  test("labels Preview failures without implying that Send was attempted", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("connection lost"));
+    const rendered = await renderClientComponent(createElement(MemberEmailClient));
+    cleanupRender = rendered.cleanup;
+    await fillDraft(rendered);
+
+    await clickButton(rendered.window, getButton(rendered.container, "Preview recipients"));
+
+    expect(rendered.container.textContent).toContain("Preview failed");
+    expect(rendered.container.textContent).not.toContain("Send not confirmed");
+  });
+});
+
+function makePreviewResult(): HostedOpsMemberEmailResult {
+  return {
+    message: "1 of 2 members are ready to receive this email.",
+    outcome: "preview",
+    previewProof: PREVIEW_PROOF,
+    recipients: [
+      { memberId: MEMBER_ONE, status: "ready" },
+      { memberId: MEMBER_TWO, status: "no_email" },
+    ],
+    summary: {
+      readyCount: 1,
+      requestedCount: 2,
+      sentCount: 0,
+      skippedCount: 1,
+    },
+  };
+}
+
+function makeSentResult(): HostedOpsMemberEmailResult {
+  return {
+    message: "1 member email was sent.",
+    outcome: "sent",
+    previewProof: null,
+    recipients: [
+      { memberId: MEMBER_ONE, status: "sent" },
+      { memberId: MEMBER_TWO, status: "no_email" },
+    ],
+    summary: {
+      readyCount: 0,
+      requestedCount: 2,
+      sentCount: 1,
+      skippedCount: 1,
+    },
+  };
+}
+
+async function fillDraft(
+  rendered: Awaited<ReturnType<typeof renderClientComponent>>,
+  overrides: Partial<{
+    memberIds: string;
+    subject: string;
+    text: string;
+  }> = {},
+): Promise<void> {
+  await changeValue(
+    rendered.window,
+    requireElement<HTMLTextAreaElement>(rendered.container, "#member-email-member-ids"),
+    overrides.memberIds ?? `${MEMBER_ONE}\n${MEMBER_TWO}`,
+  );
+  await changeValue(
+    rendered.window,
+    requireElement<HTMLInputElement>(rendered.container, "#member-email-subject"),
+    overrides.subject ?? "Trial update",
+  );
+  await changeValue(
+    rendered.window,
+    requireElement<HTMLTextAreaElement>(rendered.container, "#member-email-text"),
+    overrides.text ?? "Hey,\n\nYour trial is ready again.",
+  );
+}
+
+function requireElement<T extends Element>(
+  container: HTMLElement,
+  selector: string,
+): T {
+  const element = container.querySelector(selector);
+  if (!element) {
+    throw new Error(`Expected element ${selector}.`);
+  }
+  return element as T;
+}
+
+async function changeValue(
+  window: Window & typeof globalThis,
+  element: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+): Promise<void> {
+  await act(async () => {
+    element.value = value;
+    element.dispatchEvent(new window.Event("input", { bubbles: true }));
+  });
+}
+
+async function clickButton(
+  window: Window & typeof globalThis,
+  button: HTMLButtonElement,
+): Promise<void> {
+  await act(async () => {
+    button.dispatchEvent(new window.Event("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+function getButton(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.includes(text),
+  );
+  if (!button) {
+    throw new Error(`Expected button containing ${text}.`);
+  }
+  return button;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function readRequestBody(index: number): unknown {
+  return JSON.parse(readRequestBodyText(index)) as unknown;
+}
+
+function readRequestBodyText(index: number): string {
+  const init = fetchMock.mock.calls[index]?.[1];
+  if (!init || typeof init.body !== "string") {
+    throw new Error("Expected a JSON request body.");
+  }
+  return init.body;
+}


### PR DESCRIPTION
## Why this exists

Operators need a bounded way to contact an explicit set of known members after support or billing remediation without exporting addresses, building an audience system, or using a separate email tool.

## User-visible goal and UX

- Add `/ops/email` to the authenticated Ops notebook.
- Accept up to 100 explicit member IDs plus one subject and plain-text message.
- Preview each member as ready, unknown, suspended, or missing email without returning or rendering an address.
- Require a deliberate immediate Send action after Preview and show per-member sent/skipped outcomes.

## Invariants

- Reuse the existing ops allowlist and same-origin mutation boundary.
- Prefer the member's verified email and use the existing Stripe checkout-email fallback; keep all addresses server-side.
- Re-read current member, recipient, suspension, sender, and exact-draft state before Send using a short-lived HMAC-bound Preview.
- Send one separate email per ready member through Resend's strict batch endpoint with a stable idempotency key for ambiguous retries.
- Never send to unknown, suspended, or no-email members, and never log IDs, addresses, subject text, or body text.
- Add no schema, dependency, queue, scheduler, campaign discovery, HTML template, or stored contact list.

## Verification

- Focused hosted-web lane: 5 files, 111 tests passed.
- `pnpm --dir apps/web typecheck`: passed.
- `pnpm --dir apps/web lint`: 0 errors; 12 pre-existing warnings.
- `pnpm test:diff`: passed with 428 test files plus 2 skipped, 5,163 tests plus 139 skipped, production build, dev smoke, typecheck, lint, and workspace guards.
- Coverage-write audit: clean after added mixed-batch, privacy, precedence, staleness, sender-state, and idempotency proof.
- Frontend remediation re-audit: clean; focused client suite 10/10.
- Rendered desktop/mobile proof was unavailable because the in-app browser runtime exposed no browser instance. The isolated local app compiled and reached Ready. No real email was sent.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1,709 | 1 |
| Tests | 1,184 | 0 |
| Docs | 136 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Total: 3,029 added / 1 deleted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786696565&installation_id=127572939&pr_number=680&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F680&signature=44e5129e479fcbcf43fcdf5738bf9aaae0e6c03172ddff62048dd4cb242896b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

ReviewGPT first-reviewed head: cb982572b81d19718a9ffd984b57db7460518843


