### PR TITLE
fix(parsers): requeue jobs aborted during shutdown

### DIFF
--- a/packages/parsers/src/pipelines/worker.ts
+++ b/packages/parsers/src/pipelines/worker.ts
@@ -142,6 +142,15 @@ async function runAttachmentParseJobAttempt(
       resultPath: published.resultPath,
     };
   } catch (error) {
+    if (input.signal?.aborted) {
+      input.runtime.requeueAttachmentParseJobs({
+        attachmentId: job.attachmentId,
+        captureId: job.captureId,
+        state: "running",
+      });
+      return null;
+    }
+
     const errorMessage = redactSensitiveText(error instanceof Error ? error.message : String(error));
     const errorCode = classifyParseError(errorMessage);
     const failedJob = input.runtime.failAttachmentParseJob({

--- a/packages/parsers/test/parsers.test.ts
+++ b/packages/parsers/test/parsers.test.ts
@@ -2666,6 +2666,105 @@ test("attachment parse worker consumes inbox jobs, writes derived artifacts, and
   pipeline.close();
 });
 
+test("attachment parse worker requeues its claimed job when provider parsing aborts", async () => {
+  const vaultRoot = await makeTempDirectory("murph-parser-worker-aborted-provider-vault");
+  const sourceRoot = await makeTempDirectory("murph-parser-worker-aborted-provider-source");
+  await initializeVault({ vaultRoot, createdAt: "2026-03-12T12:00:00.000Z" });
+
+  const audioPath = await writeExternalFile(
+    sourceRoot,
+    "aborted-provider.wav",
+    "wav-bytes-placeholder",
+  );
+  const runtime = await openInboxRuntime({ vaultRoot });
+  const pipeline = await createInboxPipeline({ vaultRoot, runtime });
+
+  const capture = await pipeline.processCapture({
+    source: "telegram",
+    externalId: "aborted-provider-1",
+    accountId: "self",
+    thread: {
+      id: "chat-aborted-provider-1",
+    },
+    actor: {
+      isSelf: false,
+    },
+    occurredAt: "2026-03-13T11:04:00.000Z",
+    text: null,
+    attachments: [
+      {
+        kind: "audio",
+        mime: "audio/wav",
+        originalPath: audioPath,
+        fileName: "aborted-provider.wav",
+      },
+    ],
+    raw: {},
+  });
+  const storedCapture = runtime.getCapture(capture.captureId);
+  assert.ok(storedCapture);
+  const attachmentId = storedCapture.attachments[0]?.attachmentId;
+  assert.ok(attachmentId);
+
+  const requeueFilters: RequeueAttachmentParseJobsInput[] = [];
+  const requeueAttachmentParseJobs = runtime.requeueAttachmentParseJobs.bind(runtime);
+  runtime.requeueAttachmentParseJobs = (filters) => {
+    assert.ok(filters);
+    requeueFilters.push(filters);
+    return requeueAttachmentParseJobs(filters);
+  };
+
+  const controller = new AbortController();
+  const results = await runAttachmentParseWorker({
+    vaultRoot,
+    runtime,
+    registry: createParserRegistry([
+      {
+        id: "aborted-provider",
+        locality: "remote",
+        openness: "closed",
+        runtime: "remote_api",
+        priority: 500,
+        async discover() {
+          return {
+            available: true,
+            reason: "available for provider abort test",
+          };
+        },
+        supports(request) {
+          return (request.preparedKind ?? request.artifact.kind) === "audio";
+        },
+        async run(request) {
+          assert.equal(request.signal, controller.signal);
+          controller.abort();
+          throw new Error("provider parse aborted");
+        },
+      },
+    ]),
+    ffmpeg: disableFfmpegLookup(),
+    maxJobs: 1,
+    signal: controller.signal,
+  });
+
+  assert.deepEqual(results, []);
+  assert.deepEqual(requeueFilters, [
+    {
+      attachmentId,
+      captureId: capture.captureId,
+      state: "running",
+    },
+  ]);
+  assert.equal(runtime.getCapture(capture.captureId)?.attachments[0]?.parseState, "pending");
+  const jobs = runtime.listAttachmentParseJobs({ captureId: capture.captureId, limit: 10 });
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0]?.state, "pending");
+  assert.equal(jobs[0]?.attempts, 1);
+  assert.equal(jobs[0]?.errorCode ?? null, null);
+  assert.equal(jobs[0]?.errorMessage ?? null, null);
+
+  pipeline.close();
+});
+
 test("stale running parser attempts do not overwrite a requeued rerun", async () => {
   const vaultRoot = await makeTempDirectory("murph-parser-worker-race-vault");
   const sourceRoot = await makeTempDirectory("murph-parser-worker-race-source");


### PR DESCRIPTION
## Why this PR exists

A parser provider can cooperatively throw when the worker abort signal fires during shutdown or preemption. The worker currently records that routine cancellation as a terminal parse failure, so a safely interrupted attachment is not retried.

## User goal / user-visible behavior

Attachments interrupted by parser-worker shutdown remain pending and can be parsed on the next worker run instead of being permanently marked failed.

## User experience

No direct UI change. This improves background recovery: an interrupted attachment parse retries after the worker restarts rather than surfacing as a failed parse.

## Invariants

- Only the job claimed by the aborted worker is requeued.
- Genuine provider failures with a live signal remain terminal failures.
- Requeue preserves the attempt count and clears no successful result from another attempt.
- The existing parser runtime remains the sole job-state owner; this adds no new state, service, or lifecycle abstraction.

## Non-obvious affected surfaces

- Parser consumers that pass shutdown signals (including the inbox daemon) now receive an empty worker result for cooperative cancellation. Regression proof: the focused parser test asserts signal forwarding, exact requeue scope, pending state, retained attempts, and absent error metadata; the diff-aware verifier passed across all reverse dependents.

## Change shape

Classification rule: production TypeScript is source; Vitest regression code is tests/fixtures; no generated or binary files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 9 | 0 |
| Tests / fixtures | 99 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **108** | **0** |

ReviewGPT first-reviewed head: 0fb812ec0f9dd1e9b7edaf96ff3d8a9b604d889f

Current reviewed head: `0fb812ec0f9dd1e9b7edaf96ff3d8a9b604d889f`

## Verification

- `pnpm --dir packages/parsers exec vitest run --config vitest.config.ts test/parsers.test.ts --no-coverage`
- `pnpm --filter @murphai/parsers typecheck`
- `pnpm --dir packages/parsers test:coverage`
- `pnpm test:diff packages/parsers/src/pipelines/worker.ts packages/parsers/test/parsers.test.ts`
- Independent `coverage-write` audit: zero findings, no edits

Supersedes #625 with only its independently reproduced parser-abort fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786719434&installation_id=127572939&pr_number=684&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F684&signature=cf5ec7bf6ff94686df98ab19e8c5cede3401558eeb1375e0f77c98df5c1dba38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->