### PR TITLE
Fix Sol access for Family Edge seats

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-family-edge-sol-entitlement.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-family-edge-sol-entitlement.md
@@ -1,0 +1,80 @@
+# Family Edge Sol Entitlement
+
+Status: completed
+Updated: 2026-07-15
+
+## Goal
+
+Let an active personal member assigned to a paid Family Edge seat choose GPT-5.6
+Sol through Settings or conversation, while Family Pulse seats and inactive
+Family memberships remain ineligible.
+
+## Root Cause
+
+The assistant-model resolver predates mixed-tier Family billing and reads only
+the member's direct billing reference for Sol eligibility. Family conversion
+correctly clears direct billing and stores the member's tier on the active
+Family membership, so a paid Family Edge seat is currently misclassified as
+non-Edge even though usage allowance and Settings both project it as Edge.
+
+## Invariants
+
+- Web-owned Postgres member, membership, and group facts remain the only
+  entitlement authority; do not add a cache, flag, or duplicate plan state.
+- Direct paid Edge remains eligible and direct Pulse/trial remains ineligible.
+- Family Edge is eligible only while the personal member, membership, and
+  sponsoring group are active and unsuspended; Family Pulse stays ineligible.
+- Synthetic thread containers keep their existing derived Sol behavior and
+  remain unable to persist personal model preferences.
+- Model writes lock and re-read sponsored-access rows so a stale page or turn
+  cannot save Sol after a concurrent Family downgrade or removal.
+- No schema, protocol, Cloudflare, or runner change is required.
+
+## Plan
+
+1. Extend the existing assistant-model member projection with the assigned
+   Family tier and derive Sol eligibility from direct paid Edge or active
+   Family Edge access.
+2. Lock sponsored-access rows before the transactional eligibility re-read.
+3. Add focused coverage for Family Edge eligibility, Family Pulse rejection,
+   inactive/suspended Family rejection, runtime projection, and stale-write
+   locking.
+4. Update the durable hosted plan docs to reflect Family Edge model access.
+5. Run scoped verification, direct Settings proof, required audit passes, final
+   review, and the normal PR ReviewGPT/CI loop.
+
+## Verification Target
+
+- A Family owner or member with an active Edge assignment sees Sol in Settings,
+  can save it, and receives the Sol next-turn runtime override.
+- A Family Pulse member still sees the locked Sol explanation and cannot save
+  Sol through either Settings or conversation.
+- Direct Edge, direct Pulse, dormant Sol restoration, reasoning preferences,
+  and thread-container defaults retain their existing behavior.
+
+## Deployment
+
+This is a Vercel web-only entitlement correction. No schema or cross-plane
+protocol changes are involved; old and new web functions read the same existing
+rows. After deploy, refresh Settings and save Sol. The next hosted invocation
+consumes the existing signed workspace projection; an already-running turn may
+keep its current model until the normal invocation boundary.
+
+## Completion Evidence
+
+- The focused assistant-model resolver test passed with 15 tests.
+- The adjacent Settings snapshot, component, route, and hosted assistant-tool
+  suite passed with 51 tests.
+- `pnpm test:diff` passed the full hosted-web verification lane: repository
+  guards, dependency and workspace boundaries, TypeScript, lint, Next
+  development smoke, production build, and 5,215 passing tests across 429 test
+  files.
+- A direct production-code scenario invocation proved that an active Family
+  Edge assignment with no direct billing reference resolves as Sol-eligible.
+- The coverage-write audit found the existing proof sufficient and made no
+  test changes. The frontend audit returned zero evidence-backed findings.
+- Interactive rendered proof remains unavailable because the in-app browser
+  had no available browser target. No component markup or styling changed; the
+  affected projection and mutation states retain server-rendered and route
+  coverage.
+Completed: 2026-07-15

--- a/agent-docs/product-specs/hosted-family-plan.md
+++ b/agent-docs/product-specs/hosted-family-plan.md
@@ -24,6 +24,8 @@ invite has one assigned tier and receives that tier's individual usage cap.
   membership are active.
 - Every sponsored member gets their assigned tier's member-level usage
   allowance. There is no shared Family usage pool.
+- An active Family Edge assignment unlocks Edge model choices, including Sol;
+  a Family Pulse assignment does not.
 - Every family member remains a separate `HostedMember` with their own routing,
   mailbox, workspace/runtime state, legal consent, export, and deletion rights.
 - The owner can see seat and setup status, such as invited, joined, messaging

--- a/agent-docs/product-specs/hosted-plan-downgrades.md
+++ b/agent-docs/product-specs/hosted-plan-downgrades.md
@@ -42,10 +42,10 @@ that Murph should use on the next hosted turn:
   explains that Sol requires paid Edge access. A paid Pulse member who is
   eligible for the direct upgrade sees the existing Edge upgrade action; other
   ineligible members see the Edge requirement without a billing action.
-- Only an active, unsuspended personal member whose own current billing state is
-  paid Edge can choose Sol. Sponsored Family access, Pulse, and trials do not
-  qualify. Synthetic thread-container members receive their derived Sol target
-  but cannot mutate or persist a preference.
+- Only an active, unsuspended personal member with direct paid Edge access or an
+  active paid Family Edge assignment can choose Sol. Family Pulse assignments,
+  direct Pulse, and trials do not qualify. Synthetic thread-container members
+  receive their derived Sol target but cannot mutate or persist a preference.
 - The common reasoning choices are `low`, `medium`, `high`, and `xhigh`. `low`
   is the default when no reasoning override is stored.
 - Postgres stores nullable non-default model and reasoning intent only for the

--- a/apps/web/src/lib/hosted-onboarding/assistant-model-preference.ts
+++ b/apps/web/src/lib/hosted-onboarding/assistant-model-preference.ts
@@ -22,11 +22,13 @@ import {
 import {
   parseHostedBillingPhase,
   parseHostedBillingPlanCode,
+  parseHostedPlanCode,
 } from "./billing-plans";
 import { hasActiveHostedMemberAccess } from "./member-access";
 import { hostedOnboardingError } from "./errors";
 import {
   lockHostedMemberRow,
+  lockHostedMemberSponsoredAccessRows,
 } from "./shared";
 
 const HOSTED_MEMBER_ASSISTANT_MODEL_SELECT = {
@@ -38,6 +40,7 @@ const HOSTED_MEMBER_ASSISTANT_MODEL_SELECT = {
           suspendedAt: true,
         },
       },
+      planCode: true,
       status: true,
     },
     where: {
@@ -101,17 +104,36 @@ export interface HostedMemberAssistantModelUpdateResult
 }
 
 export function isHostedMemberSolModelEligible(input: {
+  accountGroupMemberships: readonly {
+    group: {
+      billingStatus: HostedBillingStatus;
+      suspendedAt: Date | null;
+    };
+    planCode: string;
+    status: string;
+  }[];
   billingStatus: HostedBillingStatus;
   currentBillingPhase: string | null;
   currentBillingPlanCode: string | null;
   isThreadContainerMember: boolean;
   suspendedAt: Date | null;
 }): boolean {
-  return input.billingStatus === HostedBillingStatus.active
-    && input.suspendedAt === null
+  if (input.suspendedAt !== null || input.isThreadContainerMember) {
+    return false;
+  }
+
+  const hasDirectPaidEdgeAccess =
+    input.billingStatus === HostedBillingStatus.active
     && parseHostedBillingPhase(input.currentBillingPhase) === "paid"
-    && parseHostedBillingPlanCode(input.currentBillingPlanCode) === "launch_edge_monthly"
-    && !input.isThreadContainerMember;
+    && parseHostedBillingPlanCode(input.currentBillingPlanCode) === "launch_edge_monthly";
+  const hasFamilyEdgeAccess = input.accountGroupMemberships.some(
+    (membership) => membership.status === "active"
+      && parseHostedPlanCode(membership.planCode) === "edge"
+      && membership.group.billingStatus === HostedBillingStatus.active
+      && membership.group.suspendedAt === null,
+  );
+
+  return hasDirectPaidEdgeAccess || hasFamilyEdgeAccess;
 }
 
 export async function readHostedMemberAssistantModelPreference(input: {
@@ -166,6 +188,7 @@ export async function updateHostedMemberAssistantConfigurationTx(input: {
     });
   }
   await lockHostedMemberRow(input.prisma, input.memberId);
+  await lockHostedMemberSponsoredAccessRows(input.prisma, input.memberId);
 
   const member = await readHostedMemberAssistantModelState(input);
   if (!member) {
@@ -278,6 +301,7 @@ function resolveHostedMemberAssistantModel(
     member,
   );
   const solAvailable = isHostedMemberSolModelEligible({
+    accountGroupMemberships: member.accountGroupMemberships,
     billingStatus: member.billingStatus,
     currentBillingPhase: member.billingRef?.currentBillingPhase ?? null,
     currentBillingPlanCode: member.billingRef?.currentBillingPlanCode ?? null,

--- a/apps/web/test/hosted-onboarding-assistant-model-preference.test.ts
+++ b/apps/web/test/hosted-onboarding-assistant-model-preference.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   findUniqueHostedMember: vi.fn(),
   lockHostedMemberRow: vi.fn(),
+  lockHostedMemberSponsoredAccessRows: vi.fn(),
   updateHostedMember: vi.fn(),
 }));
 
@@ -11,6 +12,7 @@ vi.mock("server-only", () => ({}));
 
 vi.mock("@/src/lib/hosted-onboarding/shared", () => ({
   lockHostedMemberRow: mocks.lockHostedMemberRow,
+  lockHostedMemberSponsoredAccessRows: mocks.lockHostedMemberSponsoredAccessRows,
 }));
 
 import {
@@ -25,11 +27,13 @@ describe("hosted member assistant model preference", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.lockHostedMemberRow.mockResolvedValue(undefined);
+    mocks.lockHostedMemberSponsoredAccessRows.mockResolvedValue(undefined);
     mocks.updateHostedMember.mockResolvedValue({});
   });
 
-  it("limits Sol eligibility to unsuspended active paid Edge owners", () => {
+  it("limits Sol eligibility to direct paid Edge or active Family Edge personal members", () => {
     const eligible = {
+      accountGroupMemberships: [],
       billingStatus: HostedBillingStatus.active,
       currentBillingPhase: "paid",
       currentBillingPlanCode: "launch_edge_monthly",
@@ -58,6 +62,57 @@ describe("hosted member assistant model preference", () => {
       ...eligible,
       suspendedAt: new Date("2026-07-09T00:00:00.000Z"),
     })).toBe(false);
+
+    const familyEdgeMembership = {
+      group: {
+        billingStatus: HostedBillingStatus.active,
+        suspendedAt: null,
+      },
+      planCode: "edge",
+      status: "active",
+    };
+    const familyEdge = {
+      ...eligible,
+      accountGroupMemberships: [familyEdgeMembership],
+      billingStatus: HostedBillingStatus.not_started,
+      currentBillingPhase: null,
+      currentBillingPlanCode: null,
+    };
+    expect(isHostedMemberSolModelEligible(familyEdge)).toBe(true);
+    expect(isHostedMemberSolModelEligible({
+      ...familyEdge,
+      accountGroupMemberships: [{
+        ...familyEdgeMembership,
+        planCode: "pulse",
+      }],
+    })).toBe(false);
+    expect(isHostedMemberSolModelEligible({
+      ...familyEdge,
+      accountGroupMemberships: [{
+        ...familyEdgeMembership,
+        status: "removed",
+      }],
+    })).toBe(false);
+    expect(isHostedMemberSolModelEligible({
+      ...familyEdge,
+      accountGroupMemberships: [{
+        ...familyEdgeMembership,
+        group: {
+          billingStatus: HostedBillingStatus.unpaid,
+          suspendedAt: null,
+        },
+      }],
+    })).toBe(false);
+    expect(isHostedMemberSolModelEligible({
+      ...familyEdge,
+      accountGroupMemberships: [{
+        ...familyEdgeMembership,
+        group: {
+          billingStatus: HostedBillingStatus.active,
+          suspendedAt: new Date("2026-07-15T00:00:00.000Z"),
+        },
+      }],
+    })).toBe(false);
   });
 
   it("resolves an eligible stored Sol preference to the runtime override", async () => {
@@ -67,6 +122,27 @@ describe("hosted member assistant model preference", () => {
 
     await expect(readHostedMemberAssistantModelPreference({
       memberId: "member_edge",
+      prisma: createReadClient(),
+    })).resolves.toMatchObject({
+      hostedAssistantModelOverride: "gpt-5.6-sol",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "low",
+      solAvailable: true,
+    });
+  });
+
+  it("resolves an active Family Edge member's stored Sol preference to the runtime override", async () => {
+    mocks.findUniqueHostedMember.mockResolvedValue(buildMemberState({
+      assistantModelPreference: "gpt-5.6-sol",
+      billingStatus: HostedBillingStatus.not_started,
+      currentBillingPhase: null,
+      currentBillingPlanCode: null,
+      familyBillingStatus: HostedBillingStatus.active,
+      familyPlanCode: "edge",
+    }));
+
+    await expect(readHostedMemberAssistantModelPreference({
+      memberId: "member_family_edge",
       prisma: createReadClient(),
     })).resolves.toMatchObject({
       hostedAssistantModelOverride: "gpt-5.6-sol",
@@ -135,6 +211,10 @@ describe("hosted member assistant model preference", () => {
       .mockResolvedValueOnce(buildMemberState({
         assistantModelPreference: "gpt-5.6-sol",
         billingStatus: HostedBillingStatus.not_started,
+        currentBillingPhase: null,
+        currentBillingPlanCode: null,
+        familyBillingStatus: HostedBillingStatus.active,
+        familyPlanCode: "pulse",
       }))
       .mockResolvedValueOnce(null);
 
@@ -151,7 +231,7 @@ describe("hosted member assistant model preference", () => {
       memberId: "member_family_sponsored",
       prisma,
     })).resolves.toMatchObject({
-      dormantSolPreference: false,
+      dormantSolPreference: true,
       model: "gpt-5.6-terra",
       reasoningEffort: "low",
       solAvailable: false,
@@ -252,12 +332,57 @@ describe("hosted member assistant model preference", () => {
       updated: true,
     });
     expect(mocks.lockHostedMemberRow).toHaveBeenCalledWith(tx, "member_edge");
+    expect(mocks.lockHostedMemberSponsoredAccessRows).toHaveBeenCalledWith(
+      tx,
+      "member_edge",
+    );
     expect(mocks.updateHostedMember).toHaveBeenCalledWith({
       data: {
         assistantModelPreference: "gpt-5.6-sol",
       },
       where: {
         id: "member_edge",
+      },
+    });
+  });
+
+  it("locks current sponsorship and saves Sol for an active Family Edge member", async () => {
+    const tx = createTransactionClient();
+    mocks.findUniqueHostedMember.mockResolvedValue(buildMemberState({
+      assistantModelPreference: null,
+      billingStatus: HostedBillingStatus.not_started,
+      currentBillingPhase: null,
+      currentBillingPlanCode: null,
+      familyBillingStatus: HostedBillingStatus.active,
+      familyPlanCode: "edge",
+    }));
+
+    await expect(updateHostedMemberAssistantModelPreferenceTx({
+      memberId: "member_family_edge",
+      model: "gpt-5.6-sol",
+      prisma: tx,
+    })).resolves.toMatchObject({
+      hostedAssistantModelOverride: "gpt-5.6-sol",
+      model: "gpt-5.6-sol",
+      solAvailable: true,
+      effectiveModelUpdated: true,
+      updated: true,
+    });
+    expect(mocks.lockHostedMemberRow).toHaveBeenCalledWith(tx, "member_family_edge");
+    expect(mocks.lockHostedMemberSponsoredAccessRows).toHaveBeenCalledWith(
+      tx,
+      "member_family_edge",
+    );
+    expect(mocks.lockHostedMemberRow.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.lockHostedMemberSponsoredAccessRows.mock.invocationCallOrder[0]!);
+    expect(mocks.lockHostedMemberSponsoredAccessRows.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.findUniqueHostedMember.mock.invocationCallOrder[0]!);
+    expect(mocks.updateHostedMember).toHaveBeenCalledWith({
+      data: {
+        assistantModelPreference: "gpt-5.6-sol",
+      },
+      where: {
+        id: "member_family_edge",
       },
     });
   });
@@ -295,7 +420,11 @@ describe("hosted member assistant model preference", () => {
     const tx = createTransactionClient();
     mocks.findUniqueHostedMember.mockResolvedValue(buildMemberState({
       assistantModelPreference: null,
-      currentBillingPlanCode: "launch_monthly",
+      billingStatus: HostedBillingStatus.not_started,
+      currentBillingPhase: null,
+      currentBillingPlanCode: null,
+      familyBillingStatus: HostedBillingStatus.active,
+      familyPlanCode: "pulse",
     }));
 
     await expect(updateHostedMemberAssistantModelPreferenceTx({
@@ -391,6 +520,9 @@ function buildMemberState(input: {
   currentBillingPhase?: string | null;
   currentBillingPlanCode?: string | null;
   familyBillingStatus?: HostedBillingStatus | null;
+  familyMembershipStatus?: string;
+  familyPlanCode?: string;
+  familySuspendedAt?: Date | null;
   suspendedAt?: Date | null;
   threadContainerMemberId?: string | null;
 }) {
@@ -400,9 +532,10 @@ function buildMemberState(input: {
       : [{
           group: {
             billingStatus: input.familyBillingStatus,
-            suspendedAt: null,
+            suspendedAt: input.familySuspendedAt ?? null,
           },
-          status: "active",
+          planCode: input.familyPlanCode ?? "pulse",
+          status: input.familyMembershipStatus ?? "active",
         }],
     assistantModelPreference: input.assistantModelPreference,
     assistantReasoningEffortPreference:


### PR DESCRIPTION
## Why this PR exists

Family Edge members were classified for Sol using only their direct billing reference. Family conversion intentionally clears direct billing and stores the assigned tier on the active Family membership, so a paid Family Edge seat could appear as non-Edge in model settings.

## User goal / user-visible behavior

An active, unsuspended personal member assigned to Family Edge can see, select, and save GPT-5.6 Sol. Family Pulse, inactive or suspended Family access, direct Pulse/trial access, and synthetic thread containers retain their existing restrictions.

## User experience

In Settings → AI Model, eligible Family Edge members now see Sol alongside Luna and Terra instead of the Edge-required notice. Selecting Sol uses the existing save feedback and applies on the next hosted turn. Conversation-based model configuration uses the same resolver. If access changes before save, the route rechecks the entitlement transactionally and returns the existing Edge requirement.

## Invariants

- Web-owned member, Family membership, and sponsoring-group rows remain the only entitlement authority.
- Direct paid Edge behavior remains unchanged; Pulse and trial access do not unlock Sol.
- Personal member, active membership, active group billing, and unsuspended member/group state are required.
- Synthetic thread containers retain derived Sol behavior but cannot persist personal preferences.
- Model writes lock the member plus active sponsored-access rows before rereading eligibility.

## Non-obvious affected surfaces

- Hosted runtime model projection: the same resolver feeds Settings, assistant configuration tools, and the next-turn workspace projection. Focused resolver/tool/route tests plus the full hosted-web suite cover that shared path.
- Transaction ordering: model saves now reuse the existing sponsored-access row lock so a concurrent Family downgrade/removal cannot be accepted from stale page state. Unit ordering proof and the existing SQL lock-shape test cover the mechanism.

## Verification

- `pnpm test:diff apps/web/src/lib/hosted-onboarding/assistant-model-preference.ts apps/web/test/hosted-onboarding-assistant-model-preference.test.ts agent-docs/product-specs/hosted-family-plan.md agent-docs/product-specs/hosted-plan-downgrades.md`
  - repository guards, dependency/workspace boundaries, TypeScript, lint, Next dev smoke, and production build passed
  - 429 test files passed; 5,215 tests passed
- Direct production-code scenario invocation confirmed active Family Edge with no direct billing reference resolves as Sol-eligible.
- Coverage-write: existing proof sufficient; no edits.
- Frontend review: zero evidence-backed findings.
- Rendered browser proof was unavailable because no in-app browser target was exposed; no component markup or styling changed.

## Change-shape breakdown

Classification is by repository role in the base-to-head authored diff; the completed execution plan and product specs are docs. No binaries or generated files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 28 | 4 |
| Tests / fixtures | 138 | 5 |
| Docs | 86 | 4 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **252** | **13** |

ReviewGPT first-reviewed head: e96a67cc2a1ad3e0a73c6b8d0355be02fa7f94bc

## Deployment skew / compatibility

Vercel web-only change. No schema, Cloudflare Worker/container, protocol, or persisted-state shape changes; old and new web functions read the same existing rows. Refresh Settings after deployment; an already-running turn can retain its current model until the next normal invocation boundary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786722276&installation_id=127572939&pr_number=686&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F686&signature=47ff6810a41424a9314a84a3824b999c68afa95b69889c141532da602796ed63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->