### PR TITLE
Redesign assistant model choices

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -131,9 +131,9 @@ A single-accent system. Sage green carries every affirmative signal; the rest of
 
 ### Named Rules
 
-**The One Green Rule.** Sage is the only affirmative accent. If something needs to feel positive, it gets sage — and only sage. Blue, teal, and purple are prohibited as UI color; they belong to other products.
+**The One Green Rule.** Sage is the only affirmative accent. If something needs to feel positive, it gets sage — and only sage. Blue, teal, and purple are prohibited as general UI color; they belong to other products. A bounded product-identity choice card may carry its illustration color through hover, selection border, and radio when the color distinguishes named peers rather than communicating positive status. Keep that exception local to the card and maintain non-text contrast.
 
-**The No Gray Rule.** All neutrals are tinted warm. Borders use `rgba(196, 168, 130, 0.25)`, not `#e0e0e0`. Cards sit on cream, not on gray. If a surface looks cold, it's wrong.
+**The No Gray Rule.** All structural neutrals are tinted warm. Borders use `rgba(196, 168, 130, 0.25)`, not `#e0e0e0`. Cards sit on cream, not on gray. If a surface looks cold, it's wrong. Literal gray may appear inside a bounded identifying illustration, such as the Luna artwork, but does not become a page surface or general neutral token.
 
 **The Chalkboard Rule.** Data is presented on paper, as if written by hand. Stat numbers are serif (Fraunces), not the sans-serif dashboard default. Charts use dashed baseline + solid active lines, not filled areas.
 
@@ -250,14 +250,18 @@ Cream background, 1px warm border, rounded-md (10px). Focus: border shifts to sa
 
 ### Choice Cards
 Use the shared `ChoiceCard` with `RadioGroup` when a member must compare two to
-five consequential options. Each card has one short title, one sentence that
-names the real tradeoff, and an optional mono metadata line. Selected cards use
-the normal sage selection tint and warm border; unavailable choices stay visible
-but disabled, with the plan or access requirement named directly. Keyboard
-focus rings the whole card. Keep actions outside the card label so the full card
-remains one predictable radio target. Stack on narrow screens and use a compact
-grid only when the options are true peers. Do not use choice cards as navigation
-or as a substitute for ordinary buttons.
+five consequential options. Each card has one short title, one brief purpose
+phrase, and an optional mono metadata line. Product-specific inline artwork can
+sit behind the content when one quiet, familiar visual cue replaces explanatory
+copy; keep it flat, `aria-hidden`, and subordinate to the text. Selected cards
+normally use the sage selection tint and warm border, but a quiet accent drawn
+from product-specific artwork can carry through the border, tint, and radio.
+Unavailable choices stay visible but disabled, with the plan or access
+requirement named directly.
+Keyboard focus rings the whole card. Keep actions outside the card label so the
+full card remains one predictable radio target. Stack on narrow screens and use
+a compact grid only when the options are true peers. Do not use choice cards as
+navigation or as a substitute for ordinary buttons.
 
 ### Spinner
 Use the shared `Spinner` for compact pending feedback inside buttons or beside a

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -248,6 +248,23 @@ Caution-rating dots (1–5 filled sand dots) + "Who should avoid" list + "Precau
 ### Inputs / Fields
 Cream background, 1px warm border, rounded-md (10px). Focus: border shifts to sage (`#7a8c6e`), no glow. Mono labels above, body placeholder inside. Category and library filters use the `Select` dropdown, not a horizontal toggle pill row — toggle rows look broken in the active state when one pill has primary fill and the rest sit on transparent muted-surface, and they don't compress at small widths. Search inputs only appear when there are enough rows to need them (>~15 entries); below that, the dropdown alone is enough.
 
+### Choice Cards
+Use the shared `ChoiceCard` with `RadioGroup` when a member must compare two to
+five consequential options. Each card has one short title, one sentence that
+names the real tradeoff, and an optional mono metadata line. Selected cards use
+the normal sage selection tint and warm border; unavailable choices stay visible
+but disabled, with the plan or access requirement named directly. Keyboard
+focus rings the whole card. Keep actions outside the card label so the full card
+remains one predictable radio target. Stack on narrow screens and use a compact
+grid only when the options are true peers. Do not use choice cards as navigation
+or as a substitute for ordinary buttons.
+
+### Spinner
+Use the shared `Spinner` for compact pending feedback inside buttons or beside a
+short status label. Pair it with a disabled control and visible action copy such
+as `Saving`; the spinner never replaces the label or becomes a full-page loader.
+Use `MurphPulseLoader` for branded account setup states instead.
+
 ### Chips / Labels
 DM Mono uppercase with 0.11em tracking. Muted-surface background (`rgba(196, 168, 130, 0.15)`), slate-muted text, rounded-sm, 4px 8px padding. Used for phase names, units, and filing-card metadata.
 

--- a/agent-docs/exec-plans/completed/2026-07-15-ai-model-choice-redesign.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-ai-model-choice-redesign.md
@@ -1,0 +1,78 @@
+# AI model choice redesign
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Make the Settings model choice easy to understand at a glance, with concise
+  tradeoffs and a calmer visual hierarchy.
+- Extract the selection treatment into the shared UI system and document it on
+  the live design page.
+
+## Success criteria
+
+- Luna, Terra, and Sol have distinct, plain-language purposes without vague or
+  repetitive copy.
+- Selection, hover, focus, disabled, saving, unavailable-plan, and saved states
+  remain accessible and visually legible on desktop and mobile.
+- The production form keeps its existing model eligibility, persistence, and
+  dormant-Sol behavior.
+- Reusable radio-group, choice-card, and spinner primitives appear on `/design`.
+- Focused tests, scoped app verification, browser proof, and required frontend
+  and coverage audits pass with no unresolved accepted findings.
+
+## Scope
+
+- In scope: the hosted assistant model settings component, shared choice-card
+  UI primitives, the design-page component showcase, focused component tests,
+  and the matching visual design-system documentation.
+- Out of scope: model eligibility, pricing, billing behavior, API contracts,
+  reasoning controls, or hosted runtime selection semantics.
+
+## Constraints
+
+- Preserve the existing server-owned model and Edge eligibility rules.
+- Add no dependency or persisted state; use the current Base UI/shadcn stack.
+- Keep the solution small and reusable without creating a settings framework.
+- Preserve unrelated active ledger rows and working-tree changes.
+
+## Tasks
+
+1. Add the canonical Base UI radio-group and spinner primitives plus a small
+   choice-card composition that exposes semantic selected, disabled, and
+   description states.
+2. Rebuild the model form with the shared choice-card pattern and rewrite the
+   model and status copy.
+3. Add interactive choice-card and radio-group examples to `/design` and update
+   `DESIGN.md` with the reusable pattern.
+4. Extend focused tests, run scoped verification and browser checks at desktop
+   and mobile sizes, then complete required audits and the parent final review.
+5. Close this plan and commit the exact scoped change.
+
+## Verification
+
+- `pnpm test:diff apps/web/src/components/settings/hosted-assistant-model-settings.tsx apps/web/src/components/ui/choice-card.tsx apps/web/src/components/ui/radio-group.tsx apps/web/src/components/ui/spinner.tsx apps/web/app/design/components-content.tsx apps/web/test/hosted-assistant-model-settings.test.tsx`
+- Direct browser inspection of Settings model states and
+  `/design?tab=components` at desktop and mobile widths.
+- `git diff --check` and identifier/secret-safe final diff review.
+
+## Outcome
+
+- Replaced the flat settings rows with responsive shared choice cards and
+  clearer purpose, usage, current, draft, unavailable, saving, and status copy.
+- Added shared Base UI radio-group, choice-card, and spinner components plus
+  interactive `/design` examples and durable design guidance.
+- `pnpm test:diff` passed after the final remediation: web typecheck, production
+  build, lint, dev smoke, 5,213 tests, and workspace guards passed. Existing
+  lint and build warnings remain unchanged.
+- Frontend review found one accessibility gap in the radio description chain;
+  the fix now announces usage metadata and the locked Sol reason. The focused
+  remediation review and coverage-write follow-up both passed with no remaining
+  findings.
+- The full isolated stack is live at the worktree's assigned local URL and the
+  design page returns HTTP 200. The in-app browser backend was unavailable, so
+  desktop/mobile visual inspection remains an explicit verification gap for the
+  user-visible live review rather than a claimed pass.
+Completed: 2026-07-15

--- a/agent-docs/exec-plans/completed/2026-07-15-model-choice-celestial-art.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-model-choice-celestial-art.md
@@ -1,0 +1,39 @@
+# Model choice celestial art
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Reduce the model-card copy and make Luna, Terra, and Sol feel distinct through
+  a simple moon, earth, and sun visual progression.
+- Present the models as an increasing health-intelligence ladder and carry each
+  celestial identity color consistently through hover and selection.
+- Keep the artwork reusable in the production settings control and the live
+  design-system example without changing model behavior.
+
+## Success criteria
+
+- Luna, Terra, and Sol use increasingly large gray, blue/green, and yellow
+  inline SVG circles that remain quiet enough for readable controls.
+- Card copy is reduced to one short purpose line plus the usage cue.
+- Hover and selected states use accessible gray, blue-green, and gold accents
+  that match the corresponding artwork.
+- Selection, locked, current, focus, and accessible radio descriptions remain
+  intact on desktop and mobile.
+- Focused tests, scoped verification, frontend review, and coverage review pass.
+
+## Scope
+
+- In scope: choice-card artwork support, one assistant-model SVG component,
+  shorter settings/design example copy, tests, and matching design guidance.
+- Out of scope: model eligibility, persistence, API contracts, billing, or
+  runtime model behavior.
+
+## Verification
+
+- Focused assistant-model settings tests.
+- `pnpm test:diff` for the changed web surfaces.
+- Live `/design?tab=components` inspection and required completion audits.
+Completed: 2026-07-15

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -13,6 +13,10 @@ import {
   HostedEmailMurphContactDialog,
   WebmailIcon,
 } from "@/src/components/settings/hosted-email-murph-contact-dialog";
+import {
+  ASSISTANT_MODEL_CHOICE_CARD_CLASSES,
+  AssistantModelArtwork,
+} from "@/src/components/settings/assistant-model-artwork";
 import { HealthDomainCard } from "@/src/components/overview/health-domain-card";
 import { ActiveExperimentBanner } from "@/src/components/overview/active-experiment-banner";
 import { ProfileStats } from "@/src/components/overview/profile-stats";
@@ -351,9 +355,7 @@ export function ComponentsContent() {
 
         <Section title="Radio Group & Choice Cards">
           <p className="max-w-2xl text-sm text-muted-foreground">
-            Use choice cards when a member must compare a small set of
-            consequential options. Keep the tradeoff in one sentence and make
-            plan limits visible without hiding the option.
+            Choose the intelligence behind your personal health assistant.
           </p>
           <RadioGroup
             className="grid gap-3 sm:grid-cols-3"
@@ -361,26 +363,31 @@ export function ComponentsContent() {
             onValueChange={setChoiceCardValue}
           >
             <ChoiceCard
-              description="Quick support for short questions and routine tasks."
+              artwork={<AssistantModelArtwork variant="luna" />}
+              className={ASSISTANT_MODEL_CHOICE_CARD_CLASSES.luna}
+              description="Fast health intelligence"
               id="design-choice-luna"
-              meta="AI usage · Low"
+              meta="Low usage"
               title="Luna"
               value="luna"
             />
             <ChoiceCard
+              artwork={<AssistantModelArtwork variant="terra" />}
               badge={<Badge variant="outline">Recommended</Badge>}
-              description="A balanced choice for most questions and planning."
+              className={ASSISTANT_MODEL_CHOICE_CARD_CLASSES.terra}
+              description="Advanced health intelligence"
               id="design-choice-terra"
-              meta="AI usage · Balanced"
+              meta="Balanced usage"
               title="Terra"
               value="terra"
             />
             <ChoiceCard
+              artwork={<AssistantModelArtwork variant="sol" />}
               badge={<Badge variant="outline">Edge</Badge>}
-              description="More depth for research and complex decisions."
-              disabled
+              className={ASSISTANT_MODEL_CHOICE_CARD_CLASSES.sol}
+              description="Highest health intelligence"
               id="design-choice-sol"
-              meta="AI usage · High · Edge required"
+              meta="High usage · Edge plan"
               title="Sol"
               value="sol"
             />

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -22,6 +22,7 @@ import { ContactSupportAction } from "@/src/components/support/contact-support-a
 import { AuthButton } from "@/src/components/ui/auth-button";
 import { MurphPulseLoader } from "@/src/components/ui/murph-pulse-loader";
 import { Button } from "@/src/components/ui/button";
+import { ChoiceCard } from "@/src/components/ui/choice-card";
 import { PaymentButton } from "@/src/components/ui/payment-button";
 import { Badge } from "@/src/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
@@ -44,6 +45,8 @@ import { Avatar, AvatarFallback } from "@/src/components/ui/avatar";
 import { Alert, AlertTitle, AlertDescription } from "@/src/components/ui/alert";
 import { Toggle } from "@/src/components/ui/toggle";
 import { ToggleGroup, ToggleGroupItem } from "@/src/components/ui/toggle-group";
+import { RadioGroup } from "@/src/components/ui/radio-group";
+import { Spinner } from "@/src/components/ui/spinner";
 import {
   SegmentedControl,
   type SegmentedControlOption,
@@ -154,6 +157,7 @@ export function ComponentsContent() {
     useState<SegmentedControlDemoValue>("phone");
   const [warmSegmentedControlValue, setWarmSegmentedControlValue] =
     useState<SegmentedControlDemoValue>("email");
+  const [choiceCardValue, setChoiceCardValue] = useState("terra");
   const [addedContactAvatar, setAddedContactAvatar] =
     useState<MurphContactAvatarOption | null>(null);
   const [inlineContactAvatarId, setInlineContactAvatarId] = useState("hooded");
@@ -340,6 +344,61 @@ export function ComponentsContent() {
               <ToggleGroupItem value="21d">21d</ToggleGroupItem>
               <ToggleGroupItem value="all">All</ToggleGroupItem>
             </ToggleGroup>
+          </div>
+        </Section>
+
+        <Separator />
+
+        <Section title="Radio Group & Choice Cards">
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Use choice cards when a member must compare a small set of
+            consequential options. Keep the tradeoff in one sentence and make
+            plan limits visible without hiding the option.
+          </p>
+          <RadioGroup
+            className="grid gap-3 sm:grid-cols-3"
+            value={choiceCardValue}
+            onValueChange={setChoiceCardValue}
+          >
+            <ChoiceCard
+              description="Quick support for short questions and routine tasks."
+              id="design-choice-luna"
+              meta="AI usage · Low"
+              title="Luna"
+              value="luna"
+            />
+            <ChoiceCard
+              badge={<Badge variant="outline">Recommended</Badge>}
+              description="A balanced choice for most questions and planning."
+              id="design-choice-terra"
+              meta="AI usage · Balanced"
+              title="Terra"
+              value="terra"
+            />
+            <ChoiceCard
+              badge={<Badge variant="outline">Edge</Badge>}
+              description="More depth for research and complex decisions."
+              disabled
+              id="design-choice-sol"
+              meta="AI usage · High · Edge required"
+              title="Sol"
+              value="sol"
+            />
+          </RadioGroup>
+        </Section>
+
+        <Separator />
+
+        <Section title="Spinner">
+          <div className="flex flex-wrap items-center gap-5">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner aria-hidden="true" />
+              Loading
+            </div>
+            <Button disabled>
+              <Spinner aria-hidden="true" />
+              Saving
+            </Button>
           </div>
         </Section>
 

--- a/apps/web/src/components/settings/assistant-model-artwork.tsx
+++ b/apps/web/src/components/settings/assistant-model-artwork.tsx
@@ -1,0 +1,99 @@
+import { cn } from "@/src/lib/utils";
+
+type AssistantModelArtworkVariant = "luna" | "sol" | "terra";
+
+const ASSISTANT_MODEL_CHOICE_CARD_CLASSES = {
+  luna:
+    "hover:border-[#777b7d]/40 hover:bg-[#777b7d]/5 has-data-checked:border-[#777b7d] has-data-checked:bg-[#777b7d]/10 has-data-checked:ring-[#777b7d]/15 has-data-checked:hover:border-[#777b7d] has-data-checked:hover:bg-[#777b7d]/10 [&_[data-slot=radio-group-item][data-checked]]:border-[#777b7d] [&_[data-slot=radio-group-item][data-checked]]:bg-[#777b7d]",
+  terra:
+    "hover:border-[#557d78]/40 hover:bg-[#4f7f97]/5 has-data-checked:border-[#557d78] has-data-checked:bg-[#4f7f97]/10 has-data-checked:ring-[#758f5c]/20 has-data-checked:hover:border-[#557d78] has-data-checked:hover:bg-[#4f7f97]/10 [&_[data-slot=radio-group-item][data-checked]]:border-[#557d78] [&_[data-slot=radio-group-item][data-checked]]:bg-[#557d78]",
+  sol: "hover:border-[#8f6817]/40 hover:bg-[#d9ad35]/5 has-data-checked:border-[#8f6817] has-data-checked:bg-[#d9ad35]/10 has-data-checked:ring-[#8f6817]/20 has-data-checked:hover:border-[#8f6817] has-data-checked:hover:bg-[#d9ad35]/10 [&_[data-slot=radio-group-item][data-checked]]:border-[#8f6817] [&_[data-slot=radio-group-item][data-checked]]:bg-[#8f6817]",
+} as const satisfies Record<AssistantModelArtworkVariant, string>;
+
+interface AssistantModelArtworkProps {
+  className?: string;
+  variant: AssistantModelArtworkVariant;
+}
+
+export function AssistantModelArtwork({
+  className,
+  variant,
+}: AssistantModelArtworkProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={cn("size-full", className)}
+      data-model-artwork={variant}
+      focusable="false"
+      viewBox="0 0 240 160"
+    >
+      {variant === "luna" ? <LunaArtwork /> : null}
+      {variant === "terra" ? <TerraArtwork /> : null}
+      {variant === "sol" ? <SolArtwork /> : null}
+    </svg>
+  );
+}
+
+function LunaArtwork() {
+  return (
+    <g opacity="0.24">
+      <circle cx="202" cy="112" r="62" fill="#777B7D" />
+      <circle cx="180" cy="86" r="12" fill="#5F6365" />
+      <circle cx="225" cy="102" r="7" fill="#919597" />
+      <circle cx="199" cy="137" r="16" fill="#686C6E" />
+      <circle cx="237" cy="141" r="9" fill="#5F6365" />
+    </g>
+  );
+}
+
+function TerraArtwork() {
+  return (
+    <g opacity="0.27">
+      <circle cx="194" cy="104" r="90" fill="#4F7F97" />
+      <g transform="translate(194 104) scale(1.32) translate(-194 -104)">
+        <path
+          d="M155 67c14-17 36-29 57-28l-2 15-14 8-5 13-15 1-9 11-13-6Z"
+          fill="#758F5C"
+        />
+        <path
+          d="m175 101 16-9 18 6 3 13 13 9-6 18-16 10-9-13-12-7-3-14Z"
+          fill="#6C8755"
+        />
+        <path
+          d="M145 111c8 3 15 9 18 17l-10 11-12-8Z"
+          fill="#89A06C"
+        />
+      </g>
+      <circle
+        cx="194"
+        cy="104"
+        r="90"
+        fill="none"
+        stroke="#3E6D82"
+        strokeWidth="2"
+      />
+    </g>
+  );
+}
+
+function SolArtwork() {
+  return (
+    <g opacity="0.24">
+      <circle cx="218" cy="92" r="150" fill="#D9AD35" />
+      <circle
+        cx="218"
+        cy="92"
+        r="133"
+        fill="none"
+        stroke="#E8C867"
+        strokeWidth="2"
+      />
+      <circle cx="169" cy="35" r="9" fill="#E7C35D" />
+      <circle cx="159" cy="124" r="13" fill="#C99A28" />
+      <circle cx="226" cy="80" r="6" fill="#E7C35D" />
+    </g>
+  );
+}
+
+export { ASSISTANT_MODEL_CHOICE_CARD_CLASSES };
+export type { AssistantModelArtworkVariant };

--- a/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
+++ b/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
@@ -24,6 +24,11 @@ import {
 import { RadioGroup } from "@/src/components/ui/radio-group";
 import { Spinner } from "@/src/components/ui/spinner";
 
+import {
+  ASSISTANT_MODEL_CHOICE_CARD_CLASSES,
+  AssistantModelArtwork,
+  type AssistantModelArtworkVariant,
+} from "./assistant-model-artwork";
 import { SettingsStatusLine } from "./connected-account-card";
 import { UpgradeToEdgeButton } from "./hosted-plan-upgrade-button";
 
@@ -32,26 +37,28 @@ const SOL_REQUIRES_EDGE_ERROR_CODE = "ASSISTANT_MODEL_SOL_REQUIRES_EDGE";
 
 const MODEL_OPTIONS = [
   {
-    description: "Quick support for check-ins, simple questions, and routine tasks.",
+    artwork: "luna",
+    description: "Fast health intelligence",
     model: HOSTED_ASSISTANT_LUNA_MODEL,
     name: "Luna",
-    usage: "AI usage · Low",
+    usage: "Low usage",
   },
   {
-    description:
-      "A balanced choice for most questions, planning, and everyday health decisions.",
+    artwork: "terra",
+    description: "Advanced health intelligence",
     model: HOSTED_ASSISTANT_TERRA_MODEL,
     name: "Terra",
-    usage: "AI usage · Balanced",
+    usage: "Balanced usage",
   },
   {
-    description:
-      "More depth for research, complex decisions, and demanding tasks.",
+    artwork: "sol",
+    description: "Highest health intelligence",
     model: HOSTED_ASSISTANT_SOL_MODEL,
     name: "Sol",
-    usage: "AI usage · High",
+    usage: "High usage",
   },
 ] as const satisfies ReadonlyArray<{
+  artwork: AssistantModelArtworkVariant;
   description: string;
   model: HostedAssistantProductModel;
   name: string;
@@ -157,15 +164,9 @@ function HostedAssistantModelSettingsForm(
         void saveModel();
       }}
     >
-      <div className="flex max-w-2xl flex-col gap-1">
-        <p className="text-sm text-pretty text-muted-foreground">
-          Pick Murph’s starting model. You can switch for a specific task in
-          conversation.
-        </p>
-        <p className="text-xs text-pretty text-muted-foreground">
-          Changes begin with the next reply and may take a few minutes.
-        </p>
-      </div>
+      <p className="max-w-2xl text-sm text-pretty text-muted-foreground">
+        Choose the intelligence behind your personal health assistant.
+      </p>
 
       {!props.configurationAvailable ? (
         <p className="w-full rounded-xl border border-border bg-muted/30 p-4 text-sm text-pretty text-muted-foreground">
@@ -215,7 +216,11 @@ function HostedAssistantModelSettingsForm(
 
             return (
               <ChoiceCard
+                artwork={<AssistantModelArtwork variant={option.artwork} />}
                 badge={badge}
+                className={
+                  ASSISTANT_MODEL_CHOICE_CARD_CLASSES[option.artwork]
+                }
                 description={option.description}
                 disabled={controlsDisabled || unavailable}
                 id={`assistant-model-${option.model}`}
@@ -225,14 +230,7 @@ function HostedAssistantModelSettingsForm(
                     ? `${option.usage} · Edge required`
                     : option.usage
                 }
-                title={
-                  <span className="flex items-baseline gap-2">
-                    <span>{option.name}</span>
-                    <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                      GPT-5.6
-                    </span>
-                  </span>
-                }
+                title={option.name}
                 value={option.model}
               />
             );

--- a/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
+++ b/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
@@ -7,7 +7,6 @@ import {
   isHostedAssistantProductModel,
   type HostedAssistantProductModel,
 } from "@murphai/hosted-execution/assistant-model";
-import { LoaderCircle } from "lucide-react";
 import { useState } from "react";
 
 import {
@@ -16,7 +15,14 @@ import {
 } from "@/src/components/hosted-onboarding/client-api";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
-import { cn } from "@/src/lib/utils";
+import { ChoiceCard } from "@/src/components/ui/choice-card";
+import {
+  FieldDescription,
+  FieldLegend,
+  FieldSet,
+} from "@/src/components/ui/field";
+import { RadioGroup } from "@/src/components/ui/radio-group";
+import { Spinner } from "@/src/components/ui/spinner";
 
 import { SettingsStatusLine } from "./connected-account-card";
 import { UpgradeToEdgeButton } from "./hosted-plan-upgrade-button";
@@ -26,25 +32,30 @@ const SOL_REQUIRES_EDGE_ERROR_CODE = "ASSISTANT_MODEL_SOL_REQUIRES_EDGE";
 
 const MODEL_OPTIONS = [
   {
-    description:
-      "Efficient for quick, everyday work. Uses less of your plan’s AI usage.",
+    description: "Quick support for check-ins, simple questions, and routine tasks.",
     model: HOSTED_ASSISTANT_LUNA_MODEL,
-    name: "GPT-5.6 Luna",
+    name: "Luna",
+    usage: "AI usage · Low",
   },
   {
-    description: "Everyday check-ins, questions, and planning.",
+    description:
+      "A balanced choice for most questions, planning, and everyday health decisions.",
     model: HOSTED_ASSISTANT_TERRA_MODEL,
-    name: "GPT-5.6 Terra",
+    name: "Terra",
+    usage: "AI usage · Balanced",
   },
   {
-    description: "Deeper research and harder tasks. Uses more of your Edge limit.",
+    description:
+      "More depth for research, complex decisions, and demanding tasks.",
     model: HOSTED_ASSISTANT_SOL_MODEL,
-    name: "GPT-5.6 Sol",
+    name: "Sol",
+    usage: "AI usage · High",
   },
 ] as const satisfies ReadonlyArray<{
   description: string;
   model: HostedAssistantProductModel;
   name: string;
+  usage: string;
 }>;
 
 interface AssistantModelSettingsResponse {
@@ -88,11 +99,6 @@ function HostedAssistantModelSettingsForm(
     message: string;
     tone: "destructive" | "neutral" | "success";
   } | null>(null);
-  const availableModelOptions = solAvailable
-    ? MODEL_OPTIONS
-    : MODEL_OPTIONS.filter(
-        (option) => option.model !== HOSTED_ASSISTANT_SOL_MODEL,
-      );
   const controlsDisabled = isSaving || !props.configurationAvailable;
   const hasChanges = draftModel !== currentModel || dormantSolPreference;
 
@@ -120,7 +126,7 @@ function HostedAssistantModelSettingsForm(
       setDormantSolPreference(response.dormantSolPreference);
       setSolAvailable(response.solAvailable);
       setStatus({
-        message: `Default model updated to ${readModelName(response.model)}.`,
+        message: `${readModelName(response.model)} is now Murph’s default.`,
         tone: "success",
       });
     } catch (error) {
@@ -133,8 +139,8 @@ function HostedAssistantModelSettingsForm(
       }
       setStatus({
         message: solNoLongerAvailable
-          ? `Your Edge access changed. ${readModelName(currentModel)} is still your default.`
-          : "Could not update your default model. Try again.",
+          ? `Your Edge access changed. Murph will keep using ${readModelName(currentModel)}.`
+          : "We couldn’t save this change. Try again.",
         tone: solNoLongerAvailable ? "neutral" : "destructive",
       });
     } finally {
@@ -144,100 +150,100 @@ function HostedAssistantModelSettingsForm(
 
   return (
     <form
-      className="flex flex-col items-start gap-4"
+      className="flex flex-col items-start gap-5"
       aria-busy={isSaving}
       onSubmit={(event) => {
         event.preventDefault();
         void saveModel();
       }}
     >
-      <p className="text-sm text-pretty text-muted-foreground">
-        Choose Murph’s default model. Changes apply to new work and can take a
-        few minutes.
-      </p>
+      <div className="flex max-w-2xl flex-col gap-1">
+        <p className="text-sm text-pretty text-muted-foreground">
+          Pick Murph’s starting model. You can switch for a specific task in
+          conversation.
+        </p>
+        <p className="text-xs text-pretty text-muted-foreground">
+          Changes begin with the next reply and may take a few minutes.
+        </p>
+      </div>
 
       {!props.configurationAvailable ? (
         <p className="w-full rounded-xl border border-border bg-muted/30 p-4 text-sm text-pretty text-muted-foreground">
-          Active personal Murph access is required to change assistant settings.
+          Model choices are read-only until personal Murph access is active.
         </p>
       ) : null}
 
       {dormantSolPreference ? (
         <p className="w-full rounded-xl border border-border bg-muted/30 p-4 text-sm text-pretty text-muted-foreground">
-          GPT-5.6 Terra is in use now. GPT-5.6 Sol remains saved and will resume
-          if Edge access returns. Save Terra or Luna to replace that saved choice.
+          Terra is active while Edge is paused. Sol is still saved and will
+          return with Edge. Choose Luna or save Terra to replace it.
         </p>
       ) : null}
 
-      <fieldset
-        className="w-full overflow-hidden rounded-xl border border-border bg-background disabled:opacity-70"
+      <FieldSet
+        className="w-full gap-3"
         disabled={controlsDisabled}
       >
-        <legend className="sr-only">Default model</legend>
-        {availableModelOptions.map((option, index) => {
-          const selected = draftModel === option.model;
-          const nameId = `assistant-model-${option.model}-name`;
-          const descriptionId = `assistant-model-${option.model}-description`;
+        <FieldLegend className="sr-only">Default model</FieldLegend>
+        <FieldDescription className="sr-only">
+          Choose one model for new Murph replies.
+        </FieldDescription>
+        <RadioGroup
+          className="grid gap-3 lg:grid-cols-3"
+          disabled={controlsDisabled}
+          value={draftModel}
+          onValueChange={(value) => {
+            if (!isHostedAssistantProductModel(value)) {
+              return;
+            }
 
-          return (
-            <label
-              key={option.model}
-              className={cn(
-                "flex min-h-24 items-start gap-3 px-4 py-4 transition-colors",
-                index > 0 && "border-t border-border",
-                controlsDisabled
-                  ? "cursor-default"
-                  : "cursor-pointer hover:bg-muted/50",
-                selected && "bg-primary/10",
-                isSaving && "cursor-wait",
-              )}
-            >
-              <input
-                type="radio"
-                name="assistant-model"
-                value={option.model}
-                checked={selected}
-                aria-labelledby={nameId}
-                aria-describedby={descriptionId}
-                className="mt-1 size-4 shrink-0 accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                onChange={() => {
-                  setDraftModel(option.model);
-                  setStatus(null);
-                }}
-              />
-              <span className="min-w-0">
-                <span className="flex flex-wrap items-center gap-2">
-                  <span
-                    id={nameId}
-                    className="font-serif text-lg font-semibold tracking-tight text-foreground"
-                  >
-                    {option.name}
+            setDraftModel(value);
+            setStatus(null);
+          }}
+        >
+          {MODEL_OPTIONS.map((option) => {
+            const selected = draftModel === option.model;
+            const unavailable =
+              option.model === HOSTED_ASSISTANT_SOL_MODEL && !solAvailable;
+            const current = option.model === currentModel;
+            const badge = readModelOptionBadge({
+              current,
+              model: option.model,
+              selected,
+              unavailable,
+            });
+
+            return (
+              <ChoiceCard
+                badge={badge}
+                description={option.description}
+                disabled={controlsDisabled || unavailable}
+                id={`assistant-model-${option.model}`}
+                key={option.model}
+                meta={
+                  unavailable
+                    ? `${option.usage} · Edge required`
+                    : option.usage
+                }
+                title={
+                  <span className="flex items-baseline gap-2">
+                    <span>{option.name}</span>
+                    <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                      GPT-5.6
+                    </span>
                   </span>
-                  {option.model === HOSTED_ASSISTANT_SOL_MODEL ? (
-                    <Badge
-                      variant="outline"
-                      className="h-5 rounded-md px-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground"
-                    >
-                      Edge
-                    </Badge>
-                  ) : null}
-                </span>
-                <span
-                  id={descriptionId}
-                  className="mt-0.5 block max-w-2xl text-sm text-pretty text-muted-foreground"
-                >
-                  {option.description}
-                </span>
-              </span>
-            </label>
-          );
-        })}
-      </fieldset>
+                }
+                value={option.model}
+              />
+            );
+          })}
+        </RadioGroup>
+      </FieldSet>
 
       {props.configurationAvailable && !solAvailable ? (
-        <div className="flex w-full flex-col items-start gap-3 rounded-xl border border-border bg-muted/30 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex w-full flex-col items-start gap-3 px-1 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-pretty text-muted-foreground">
-            GPT-5.6 Sol is available with an active Edge plan.
+            Sol requires an active Edge plan.
           </p>
           {props.canUpgradeToEdge ? (
             <UpgradeToEdgeButton>Upgrade to Edge</UpgradeToEdgeButton>
@@ -251,10 +257,8 @@ function HostedAssistantModelSettingsForm(
           disabled={controlsDisabled || !hasChanges}
           className="w-full sm:w-auto"
         >
-          {isSaving ? (
-            <LoaderCircle className="animate-spin" aria-hidden="true" />
-          ) : null}
-          {isSaving ? "Saving…" : "Save model"}
+          {isSaving ? <Spinner aria-hidden="true" /> : null}
+          {isSaving ? "Saving…" : "Save change"}
         </Button>
         <SettingsStatusLine
           message={status?.message ?? null}
@@ -263,6 +267,42 @@ function HostedAssistantModelSettingsForm(
         />
       </div>
     </form>
+  );
+}
+
+function readModelOptionBadge(input: {
+  current: boolean;
+  model: HostedAssistantProductModel;
+  selected: boolean;
+  unavailable: boolean;
+}): React.ReactNode {
+  if (input.current) {
+    return <ModelOptionBadge>Current</ModelOptionBadge>;
+  }
+
+  if (input.selected) {
+    return <ModelOptionBadge>Selected</ModelOptionBadge>;
+  }
+
+  if (input.unavailable) {
+    return <ModelOptionBadge>Edge</ModelOptionBadge>;
+  }
+
+  if (input.model === HOSTED_ASSISTANT_TERRA_MODEL) {
+    return <ModelOptionBadge>Recommended</ModelOptionBadge>;
+  }
+
+  return null;
+}
+
+function ModelOptionBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <Badge
+      variant="outline"
+      className="h-5 rounded-md px-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground"
+    >
+      {children}
+    </Badge>
   );
 }
 

--- a/apps/web/src/components/ui/choice-card.tsx
+++ b/apps/web/src/components/ui/choice-card.tsx
@@ -14,6 +14,7 @@ type ChoiceCardProps = Omit<
   React.ComponentProps<typeof RadioGroupItem>,
   "aria-describedby" | "aria-labelledby" | "id" | "title"
 > & {
+  artwork?: React.ReactNode;
   badge?: React.ReactNode;
   className?: string;
   description: React.ReactNode;
@@ -23,6 +24,7 @@ type ChoiceCardProps = Omit<
 };
 
 function ChoiceCard({
+  artwork,
   badge,
   className,
   description,
@@ -39,15 +41,23 @@ function ChoiceCard({
   return (
     <FieldLabel
       className={cn(
-        "h-full cursor-pointer rounded-xl border-border bg-card p-0 transition-[border-color,background-color] duration-200 ease-out hover:border-primary/35 hover:bg-primary/5 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring has-data-checked:border-primary/50 has-data-checked:bg-primary/10 has-data-checked:ring-1 has-data-checked:ring-primary/15 data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:border-border data-[disabled=true]:hover:bg-card",
+        "relative isolate h-full cursor-pointer overflow-hidden rounded-xl border-border bg-card p-0 transition-[border-color,background-color] duration-200 ease-out hover:border-primary/35 hover:bg-primary/5 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring has-data-checked:border-primary/50 has-data-checked:bg-primary/10 has-data-checked:ring-1 has-data-checked:ring-primary/15 data-[disabled=true]:cursor-not-allowed data-[disabled=true]:hover:border-border data-[disabled=true]:hover:bg-card",
+        artwork && "min-h-44",
         className,
       )}
       data-disabled={disabled ? "true" : undefined}
       htmlFor={id}
     >
+      {artwork ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 right-0 z-0 w-3/4"
+        >
+          {artwork}
+        </span>
+      ) : null}
       <Field
-        className="h-full items-start gap-3 p-4 sm:p-5"
-        data-disabled={disabled ? "true" : undefined}
+        className="relative z-10 h-full items-start gap-3 p-4 sm:p-5"
         orientation="horizontal"
       >
         <RadioGroupItem
@@ -57,7 +67,7 @@ function ChoiceCard({
           id={id}
           {...props}
         />
-        <FieldContent className="gap-2">
+        <FieldContent className={cn("gap-2", disabled && "opacity-55")}>
           <div className="flex flex-wrap items-center justify-between gap-2">
             <FieldTitle
               id={titleId}

--- a/apps/web/src/components/ui/choice-card.tsx
+++ b/apps/web/src/components/ui/choice-card.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldTitle,
+} from "@/src/components/ui/field";
+import { RadioGroupItem } from "@/src/components/ui/radio-group";
+import { cn } from "@/src/lib/utils";
+
+type ChoiceCardProps = Omit<
+  React.ComponentProps<typeof RadioGroupItem>,
+  "aria-describedby" | "aria-labelledby" | "id" | "title"
+> & {
+  badge?: React.ReactNode;
+  className?: string;
+  description: React.ReactNode;
+  id: string;
+  meta?: React.ReactNode;
+  title: React.ReactNode;
+};
+
+function ChoiceCard({
+  badge,
+  className,
+  description,
+  disabled,
+  id,
+  meta,
+  title,
+  ...props
+}: ChoiceCardProps) {
+  const titleId = `${id}-title`;
+  const descriptionId = `${id}-description`;
+  const metaId = meta ? `${id}-meta` : null;
+
+  return (
+    <FieldLabel
+      className={cn(
+        "h-full cursor-pointer rounded-xl border-border bg-card p-0 transition-[border-color,background-color] duration-200 ease-out hover:border-primary/35 hover:bg-primary/5 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring has-data-checked:border-primary/50 has-data-checked:bg-primary/10 has-data-checked:ring-1 has-data-checked:ring-primary/15 data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:border-border data-[disabled=true]:hover:bg-card",
+        className,
+      )}
+      data-disabled={disabled ? "true" : undefined}
+      htmlFor={id}
+    >
+      <Field
+        className="h-full items-start gap-3 p-4 sm:p-5"
+        data-disabled={disabled ? "true" : undefined}
+        orientation="horizontal"
+      >
+        <RadioGroupItem
+          aria-describedby={[descriptionId, metaId].filter(Boolean).join(" ")}
+          aria-labelledby={titleId}
+          disabled={disabled}
+          id={id}
+          {...props}
+        />
+        <FieldContent className="gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <FieldTitle
+              id={titleId}
+              className="text-base font-semibold text-foreground"
+            >
+              {title}
+            </FieldTitle>
+            {badge}
+          </div>
+          <FieldDescription id={descriptionId} className="text-pretty">
+            {description}
+          </FieldDescription>
+          {meta ? (
+            <div
+              id={metaId ?? undefined}
+              className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+            >
+              {meta}
+            </div>
+          ) : null}
+        </FieldContent>
+      </Field>
+    </FieldLabel>
+  );
+}
+
+export { ChoiceCard };
+export type { ChoiceCardProps };

--- a/apps/web/src/components/ui/radio-group.tsx
+++ b/apps/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,36 @@
+import { Radio as RadioPrimitive } from "@base-ui/react/radio"
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group"
+
+import { cn } from "@/src/lib/utils"
+
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="radio-group"
+      className={cn("grid w-full gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="radio-group-item"
+      className={cn(
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <RadioPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex size-4 items-center justify-center"
+      >
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/src/lib/utils"
+import { Loader2Icon } from "lucide-react"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      data-slot="spinner"
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  )
+}
+
+export { Spinner }

--- a/apps/web/test/hosted-assistant-model-settings.test.tsx
+++ b/apps/web/test/hosted-assistant-model-settings.test.tsx
@@ -71,14 +71,16 @@ test("eligible Pulse members can choose Luna or Terra and discover the Edge upgr
     }),
   );
 
-  assert.match(markup, /GPT-5\.6 Luna/);
-  assert.match(markup, /GPT-5\.6 Terra/);
-  assert.match(markup, /GPT-5\.6 Sol/);
-  assert.match(markup, /GPT-5\.6 Sol is available with an active Edge plan\./);
+  assert.match(markup, />Luna</);
+  assert.match(markup, />Terra</);
+  assert.match(markup, />Sol</);
+  assert.match(markup, /GPT-5\.6/);
+  assert.match(markup, /Sol requires an active Edge plan\./);
+  assert.match(markup, /AI usage · High · Edge required/);
   assert.match(markup, />Upgrade to Edge<\/button>/);
-  assert.match(markup, /type="radio"/);
-  assert.match(markup, /Save model/);
-  assert.doesNotMatch(markup, new RegExp(`value="${HOSTED_ASSISTANT_SOL_MODEL}"`));
+  assert.match(markup, /role="radio"/);
+  assert.match(markup, /Save change/);
+  assert.match(markup, new RegExp(`value="${HOSTED_ASSISTANT_SOL_MODEL}"`));
 });
 
 test("other non-Edge members can still choose Luna or Terra without an invalid upgrade action", () => {
@@ -92,14 +94,14 @@ test("other non-Edge members can still choose Luna or Terra without an invalid u
     }),
   );
 
-  assert.match(markup, /GPT-5\.6 Luna/);
-  assert.match(markup, /GPT-5\.6 Terra/);
-  assert.match(markup, /GPT-5\.6 Sol/);
-  assert.match(markup, /available with an active Edge plan\./);
+  assert.match(markup, />Luna</);
+  assert.match(markup, />Terra</);
+  assert.match(markup, />Sol</);
+  assert.match(markup, /requires an active Edge plan\./);
   assert.doesNotMatch(markup, />Upgrade to Edge<\/button>/);
-  assert.match(markup, /type="radio"/);
-  assert.match(markup, /Save model/);
-  assert.doesNotMatch(markup, new RegExp(`value="${HOSTED_ASSISTANT_SOL_MODEL}"`));
+  assert.match(markup, /role="radio"/);
+  assert.match(markup, /Save change/);
+  assert.match(markup, new RegExp(`value="${HOSTED_ASSISTANT_SOL_MODEL}"`));
 });
 
 test("non-Edge members can explicitly save Luna as their default model", async () => {
@@ -119,14 +121,12 @@ test("non-Edge members can explicitly save Luna as their default model", async (
       solAvailable: false,
     }),
   );
-  const lunaInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_LUNA_MODEL}"]`,
+  const lunaInput = findModelRadio(
+    view.container,
+    HOSTED_ASSISTANT_LUNA_MODEL,
   );
 
-  assert.equal(
-    view.container.querySelector(`input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`),
-    null,
-  );
+  assert.ok(findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL).disabled);
   await act(async () => {
     lunaInput?.click();
   });
@@ -142,10 +142,10 @@ test("non-Edge members can explicitly save Luna as their default model", async (
   });
   assert.match(
     view.container.textContent ?? "",
-    /Default model updated to GPT-5\.6 Luna\./,
+    /GPT-5\.6 Luna is now Murph’s default\./,
   );
-  assert.ok(lunaInput?.checked);
-  assert.ok(findButton(view.container, "Save model").disabled);
+  assert.ok(isRadioChecked(lunaInput));
+  assert.ok(findButton(view.container, "Save change").disabled);
 
   view.cleanup();
 });
@@ -169,26 +169,33 @@ test("Edge members can explicitly save Sol as their default model", async () => 
   );
   assert.match(
     view.container.textContent ?? "",
-    /Changes apply to new work and can take a few minutes\./,
+    /Changes begin with the next reply and may take a few minutes\./,
   );
-  const terraInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_TERRA_MODEL}"]`,
+  const terraInput = findModelRadio(
+    view.container,
+    HOSTED_ASSISTANT_TERRA_MODEL,
   );
-  const solInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`,
-  );
-  const saveButton = findButton(view.container, "Save model");
+  const solInput = findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL);
+  const saveButton = findButton(view.container, "Save change");
 
-  assert.ok(terraInput?.checked);
-  assert.equal(solInput?.checked, false);
+  assert.ok(isRadioChecked(terraInput));
+  assert.equal(isRadioChecked(solInput), false);
   assert.ok(saveButton.disabled);
 
   await act(async () => {
     solInput?.click();
   });
 
-  assert.equal(terraInput?.checked, false);
-  assert.ok(solInput?.checked);
+  assert.equal(isRadioChecked(terraInput), false);
+  assert.ok(isRadioChecked(solInput));
+  assert.match(
+    findModelLabel(view.container, HOSTED_ASSISTANT_TERRA_MODEL).textContent ?? "",
+    /Current/,
+  );
+  assert.match(
+    findModelLabel(view.container, HOSTED_ASSISTANT_SOL_MODEL).textContent ?? "",
+    /Selected/,
+  );
   assert.equal(saveButton.disabled, false);
 
   await act(async () => {
@@ -203,9 +210,9 @@ test("Edge members can explicitly save Sol as their default model", async () => 
   });
   assert.match(
     view.container.textContent ?? "",
-    /Default model updated to GPT-5\.6 Sol\./,
+    /GPT-5\.6 Sol is now Murph’s default\./,
   );
-  assert.ok(findButton(view.container, "Save model").disabled);
+  assert.ok(findButton(view.container, "Save change").disabled);
 
   view.cleanup();
 });
@@ -229,9 +236,7 @@ test("a generic save failure keeps the selected model available to retry", async
       solAvailable: true,
     }),
   );
-  const solInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`,
-  );
+  const solInput = findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL);
 
   await act(async () => {
     solInput?.click();
@@ -243,10 +248,10 @@ test("a generic save failure keeps the selected model available to retry", async
 
   assert.equal(
     view.container.querySelector('[role="alert"]')?.textContent,
-    "Could not update your default model. Try again.",
+    "We couldn’t save this change. Try again.",
   );
-  assert.ok(solInput?.checked);
-  assert.equal(findButton(view.container, "Save model").disabled, false);
+  assert.ok(isRadioChecked(solInput));
+  assert.equal(findButton(view.container, "Save change").disabled, false);
 
   await act(async () => {
     submitForm(view.container);
@@ -255,9 +260,9 @@ test("a generic save failure keeps the selected model available to retry", async
 
   assert.match(
     view.container.textContent ?? "",
-    /Default model updated to GPT-5\.6 Sol\./,
+    /GPT-5\.6 Sol is now Murph’s default\./,
   );
-  assert.ok(findButton(view.container, "Save model").disabled);
+  assert.ok(findButton(view.container, "Save change").disabled);
   expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledTimes(2);
 
   view.cleanup();
@@ -292,45 +297,46 @@ test("model radios stay labeled and the form becomes busy while saving", async (
   );
   const options = [
     {
-      description:
-        "Efficient for quick, everyday work. Uses less of your plan’s AI usage.",
+      description: "Quick support for check-ins, simple questions, and routine tasks.",
       model: HOSTED_ASSISTANT_LUNA_MODEL,
-      name: "GPT-5.6 Luna",
+      name: "Luna",
+      usage: "AI usage · Low",
     },
     {
-      description: "Everyday check-ins, questions, and planning.",
+      description:
+        "A balanced choice for most questions, planning, and everyday health decisions.",
       model: HOSTED_ASSISTANT_TERRA_MODEL,
-      name: "GPT-5.6 Terra",
+      name: "Terra",
+      usage: "AI usage · Balanced",
     },
     {
-      description: "Deeper research and harder tasks. Uses more of your Edge limit.",
+      description:
+        "More depth for research, complex decisions, and demanding tasks.",
       model: HOSTED_ASSISTANT_SOL_MODEL,
-      name: "GPT-5.6 Sol",
+      name: "Sol",
+      usage: "AI usage · High",
     },
   ] as const;
 
   for (const option of options) {
-    const input = view.container.querySelector<HTMLInputElement>(
-      `input[value="${option.model}"]`,
-    );
-    assert.ok(input);
-    const nameId = input.getAttribute("aria-labelledby");
-    const descriptionId = input.getAttribute("aria-describedby");
-    assert.ok(nameId);
-    assert.ok(descriptionId);
+    const input = findModelRadio(view.container, option.model);
+    const label = view.container.querySelector(`label[for="${input.id}"]`);
+    const visibleRadio = label?.querySelector('[role="radio"]');
     assert.equal(
-      view.container.querySelector(`[id="${nameId}"]`)?.textContent,
-      option.name,
+      visibleRadio?.getAttribute("aria-labelledby"),
+      `${input.id}-title`,
     );
     assert.equal(
-      view.container.querySelector(`[id="${descriptionId}"]`)?.textContent,
-      option.description,
+      visibleRadio?.getAttribute("aria-describedby"),
+      `${input.id}-description ${input.id}-meta`,
     );
+    assert.match(label?.textContent ?? "", new RegExp(option.name));
+    assert.match(label?.textContent ?? "", /GPT-5\.6/);
+    assert.match(label?.textContent ?? "", new RegExp(option.description));
+    assert.match(label?.textContent ?? "", new RegExp(option.usage));
   }
 
-  const solInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`,
-  );
+  const solInput = findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL);
   await act(async () => {
     solInput?.click();
   });
@@ -360,7 +366,7 @@ test("model radios stay labeled and the form becomes busy while saving", async (
 
   assert.equal(form?.getAttribute("aria-busy"), "false");
   assert.equal(fieldset?.hasAttribute("disabled"), false);
-  assert.ok(findButton(view.container, "Save model").disabled);
+  assert.ok(findButton(view.container, "Save change").disabled);
 
   view.cleanup();
 });
@@ -384,9 +390,7 @@ test("a stale Edge page removes Sol without changing the saved model", async () 
       solAvailable: true,
     }),
   );
-  const solInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`,
-  );
+  const solInput = findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL);
 
   await act(async () => {
     solInput?.click();
@@ -398,17 +402,12 @@ test("a stale Edge page removes Sol without changing the saved model", async () 
 
   assert.match(
     view.container.textContent ?? "",
-    /Your Edge access changed\. GPT-5\.6 Luna is still your default\./,
+    /Your Edge access changed\. Murph will keep using GPT-5\.6 Luna\./,
   );
-  const lunaInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_LUNA_MODEL}"]`,
-  );
-  assert.ok(lunaInput?.checked);
-  assert.equal(
-    view.container.querySelector(`input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`),
-    null,
-  );
-  assert.ok(findButton(view.container, "Save model").disabled);
+  const lunaInput = findModelRadio(view.container, HOSTED_ASSISTANT_LUNA_MODEL);
+  assert.ok(isRadioChecked(lunaInput));
+  assert.ok(findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL).disabled);
+  assert.ok(findButton(view.container, "Save change").disabled);
 
   view.cleanup();
 });
@@ -424,16 +423,9 @@ test("refreshed eligibility resets the client state after an Edge upgrade", asyn
     }),
   );
 
-  assert.ok(
-    view.container.querySelector(`input[value="${HOSTED_ASSISTANT_LUNA_MODEL}"]`),
-  );
-  assert.ok(
-    view.container.querySelector(`input[value="${HOSTED_ASSISTANT_TERRA_MODEL}"]`),
-  );
-  assert.equal(
-    view.container.querySelector(`input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`),
-    null,
-  );
+  assert.ok(findModelRadio(view.container, HOSTED_ASSISTANT_LUNA_MODEL));
+  assert.ok(findModelRadio(view.container, HOSTED_ASSISTANT_TERRA_MODEL));
+  assert.ok(findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL).disabled);
 
   await view.rerender(
     createElement(HostedAssistantModelSettings, {
@@ -445,15 +437,15 @@ test("refreshed eligibility resets the client state after an Edge upgrade", asyn
     }),
   );
 
-  const terraInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_TERRA_MODEL}"]`,
+  const terraInput = findModelRadio(
+    view.container,
+    HOSTED_ASSISTANT_TERRA_MODEL,
   );
-  const solInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`,
-  );
-  assert.ok(terraInput?.checked);
-  assert.equal(solInput?.checked, false);
-  assert.ok(findButton(view.container, "Save model").disabled);
+  const solInput = findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL);
+  assert.ok(isRadioChecked(terraInput));
+  assert.equal(isRadioChecked(solInput), false);
+  assert.equal(solInput.disabled, false);
+  assert.ok(findButton(view.container, "Save change").disabled);
 
   view.cleanup();
 });
@@ -475,9 +467,7 @@ test("the canonical save response removes Sol after an Edge downgrade", async ()
       solAvailable: true,
     }),
   );
-  const lunaInput = view.container.querySelector<HTMLInputElement>(
-    `input[value="${HOSTED_ASSISTANT_LUNA_MODEL}"]`,
-  );
+  const lunaInput = findModelRadio(view.container, HOSTED_ASSISTANT_LUNA_MODEL);
 
   await act(async () => {
     lunaInput?.click();
@@ -487,17 +477,12 @@ test("the canonical save response removes Sol after an Edge downgrade", async ()
     await Promise.resolve();
   });
 
-  assert.equal(
-    view.container.querySelector(`input[value="${HOSTED_ASSISTANT_SOL_MODEL}"]`),
-    null,
-  );
-  assert.ok(
-    view.container.querySelector(`input[value="${HOSTED_ASSISTANT_TERRA_MODEL}"]`),
-  );
-  assert.ok(lunaInput?.checked);
+  assert.ok(findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL).disabled);
+  assert.ok(findModelRadio(view.container, HOSTED_ASSISTANT_TERRA_MODEL));
+  assert.ok(isRadioChecked(lunaInput));
   assert.match(
     view.container.textContent ?? "",
-    /Default model updated to GPT-5\.6 Luna\./,
+    /GPT-5\.6 Luna is now Murph’s default\./,
   );
 
   view.cleanup();
@@ -523,9 +508,9 @@ test("a dormant Sol preference is explained and can be replaced with Terra", asy
 
   assert.match(
     view.container.textContent ?? "",
-    /GPT-5\.6 Terra is in use now\. GPT-5\.6 Sol remains saved and will resume if Edge access returns\./,
+    /Terra is active while Edge is paused\. Sol is still saved and will return with Edge\./,
   );
-  assert.equal(findButton(view.container, "Save model").disabled, false);
+  assert.equal(findButton(view.container, "Save change").disabled, false);
 
   await act(async () => {
     submitForm(view.container);
@@ -539,9 +524,9 @@ test("a dormant Sol preference is explained and can be replaced with Terra", asy
   });
   assert.doesNotMatch(
     view.container.textContent ?? "",
-    /GPT-5\.6 Sol remains saved/,
+    /Sol is still saved/,
   );
-  assert.ok(findButton(view.container, "Save model").disabled);
+  assert.ok(findButton(view.container, "Save change").disabled);
 
   view.cleanup();
 });
@@ -559,12 +544,35 @@ test("members without active personal access see read-only model controls", () =
 
   assert.match(
     markup,
-    /Active personal Murph access is required to change assistant settings\./,
+    /Model choices are read-only until personal Murph access is active\./,
   );
   assert.match(markup, /<fieldset[^>]*disabled=""/);
-  assert.match(markup, /<button[^>]*disabled=""[^>]*>Save model<\/button>/);
-  assert.doesNotMatch(markup, /GPT-5\.6 Sol is available with an active Edge plan/);
+  assert.match(markup, /<button[^>]*disabled=""[^>]*>Save change<\/button>/);
+  assert.doesNotMatch(markup, /Sol requires an active Edge plan/);
 });
+
+function findModelRadio(
+  container: HTMLElement,
+  model: string,
+): HTMLInputElement {
+  const radio = container.querySelector<HTMLInputElement>(
+    `[id="assistant-model-${model}"]`,
+  );
+  assert.ok(radio);
+  return radio;
+}
+
+function isRadioChecked(radio: HTMLInputElement): boolean {
+  return radio.checked;
+}
+
+function findModelLabel(container: HTMLElement, model: string): HTMLLabelElement {
+  const label = container.querySelector<HTMLLabelElement>(
+    `label[for="assistant-model-${model}"]`,
+  );
+  assert.ok(label);
+  return label;
+}
 
 function findButton(container: HTMLElement, label: string): HTMLButtonElement {
   const button = [...container.querySelectorAll<HTMLButtonElement>("button")].find(

--- a/apps/web/test/hosted-assistant-model-settings.test.tsx
+++ b/apps/web/test/hosted-assistant-model-settings.test.tsx
@@ -74,9 +74,8 @@ test("eligible Pulse members can choose Luna or Terra and discover the Edge upgr
   assert.match(markup, />Luna</);
   assert.match(markup, />Terra</);
   assert.match(markup, />Sol</);
-  assert.match(markup, /GPT-5\.6/);
   assert.match(markup, /Sol requires an active Edge plan\./);
-  assert.match(markup, /AI usage · High · Edge required/);
+  assert.match(markup, /High usage · Edge required/);
   assert.match(markup, />Upgrade to Edge<\/button>/);
   assert.match(markup, /role="radio"/);
   assert.match(markup, /Save change/);
@@ -169,7 +168,7 @@ test("Edge members can explicitly save Sol as their default model", async () => 
   );
   assert.match(
     view.container.textContent ?? "",
-    /Changes begin with the next reply and may take a few minutes\./,
+    /Choose the intelligence behind your personal health assistant\./,
   );
   const terraInput = findModelRadio(
     view.container,
@@ -297,26 +296,34 @@ test("model radios stay labeled and the form becomes busy while saving", async (
   );
   const options = [
     {
-      description: "Quick support for check-ins, simple questions, and routine tasks.",
+      accent: "#777b7d",
+      artwork: "luna",
+      backgroundAccent: "#777b7d",
+      description: "Fast health intelligence",
       model: HOSTED_ASSISTANT_LUNA_MODEL,
       name: "Luna",
-      usage: "AI usage · Low",
+      usage: "Low usage",
     },
     {
-      description:
-        "A balanced choice for most questions, planning, and everyday health decisions.",
+      accent: "#557d78",
+      artwork: "terra",
+      backgroundAccent: "#4f7f97",
+      description: "Advanced health intelligence",
       model: HOSTED_ASSISTANT_TERRA_MODEL,
       name: "Terra",
-      usage: "AI usage · Balanced",
+      usage: "Balanced usage",
     },
     {
-      description:
-        "More depth for research, complex decisions, and demanding tasks.",
+      accent: "#8f6817",
+      artwork: "sol",
+      backgroundAccent: "#d9ad35",
+      description: "Highest health intelligence",
       model: HOSTED_ASSISTANT_SOL_MODEL,
       name: "Sol",
-      usage: "AI usage · High",
+      usage: "High usage",
     },
   ] as const;
+  const artworkRadii: number[] = [];
 
   for (const option of options) {
     const input = findModelRadio(view.container, option.model);
@@ -330,11 +337,52 @@ test("model radios stay labeled and the form becomes busy while saving", async (
       visibleRadio?.getAttribute("aria-describedby"),
       `${input.id}-description ${input.id}-meta`,
     );
+    const artwork = label?.querySelector(
+      `svg[data-model-artwork="${option.artwork}"][aria-hidden="true"]`,
+    );
+    assert.ok(artwork);
+    const artworkRadius = Number(
+      artwork.querySelector("circle")?.getAttribute("r"),
+    );
+    assert.ok(Number.isFinite(artworkRadius));
+    artworkRadii.push(artworkRadius);
+    assert.ok(
+      label?.className.includes(
+        `has-data-checked:border-[${option.accent}]`,
+      ),
+    );
+    assert.ok(
+      label?.className.includes(
+        `[&_[data-slot=radio-group-item][data-checked]]:bg-[${option.accent}]`,
+      ),
+    );
+    assert.ok(
+      label?.className.includes(`hover:border-[${option.accent}]/40`),
+    );
+    assert.ok(
+      label?.className.includes(
+        `hover:bg-[${option.backgroundAccent}]/5`,
+      ),
+    );
+    assert.ok(
+      label?.className.includes(
+        `has-data-checked:hover:border-[${option.accent}]`,
+      ),
+    );
+    assert.ok(
+      label?.className.includes(
+        `has-data-checked:hover:bg-[${option.backgroundAccent}]/10`,
+      ),
+    );
+    assert.ok(!label?.className.includes("hover:border-primary/35"));
     assert.match(label?.textContent ?? "", new RegExp(option.name));
-    assert.match(label?.textContent ?? "", /GPT-5\.6/);
     assert.match(label?.textContent ?? "", new RegExp(option.description));
     assert.match(label?.textContent ?? "", new RegExp(option.usage));
   }
+  assert.ok(
+    artworkRadii[0] < artworkRadii[1]
+      && artworkRadii[1] < artworkRadii[2],
+  );
 
   const solInput = findModelRadio(view.container, HOSTED_ASSISTANT_SOL_MODEL);
   await act(async () => {


### PR DESCRIPTION
## Why this PR exists

The Settings model selector was visually flat and its copy did not make the Luna, Terra, and Sol tradeoffs easy to compare. This PR gives members a calmer, clearer decision surface and turns that treatment into shared design-system components.

## User goal / user-visible behavior

Members can compare all three models at a glance, understand relative AI usage and Edge availability, distinguish the saved model from an unsaved selection, and save a new default with clear pending, success, failure, and eligibility feedback.

## User experience

A member enters Settings and sees responsive choice cards for Luna, Terra, and Sol. Each card names the model's purpose and usage level; the saved model remains marked Current while a draft choice is marked Selected. Sol stays visible when locked, announces that Edge is required, and keeps the existing upgrade action. Saving disables the form, shows an inline spinner, and preserves the existing retry, dormant-Sol, and stale-eligibility recovery behavior. The shared radio group, choice card, and spinner are demonstrated on the design page.

## Invariants the PR must preserve

- Server-owned model eligibility, persistence, API contracts, and runtime selection semantics do not change.
- Sol remains unavailable without active Edge access, while the existing dormant Sol preference behavior is preserved.
- A failed save leaves the selected model available to retry.
- Shared controls remain keyboard accessible and expose title, description, usage, and locked-plan reason to assistive technology.

## Non-obvious affected surfaces

- Shared web design system: adds Base UI radio-group and spinner primitives plus a small ChoiceCard composition. Focused component tests prove selection, disabled, and ARIA relationships.
- Live design page: adds interactive examples and durable DESIGN.md guidance. This is documentation/showcase behavior only.
- No persisted state, billing logic, auth boundary, public API, Cloudflare runtime, or deploy contract changes.

## Change-shape breakdown

Classification uses base-to-head authored line counts. Source includes production UI and the live design showcase; tests/fixtures includes focused component tests; docs includes DESIGN.md and the completed execution plan. There are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 329 | 90 |
| Tests / fixtures | 125 | 117 |
| Docs | 95 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **549** | **207** |

## Validation

- `pnpm test:diff apps/web/src/components/settings/hosted-assistant-model-settings.tsx apps/web/src/components/ui/choice-card.tsx apps/web/src/components/ui/radio-group.tsx apps/web/src/components/ui/spinner.tsx apps/web/app/design/components-content.tsx apps/web/test/hosted-assistant-model-settings.test.tsx`
  - Web typecheck, production build, lint, dev smoke, workspace guards, and 5,213 tests passed.
  - Existing lint and build warnings are unchanged.
- Focused model-settings suite: 11/11 passed after rebasing onto current `main`.
- Frontend review: one accessibility finding was fixed; focused remediation review returned no remaining findings.
- Coverage-write pass: existing proof was sufficient after the ARIA and locked-reason assertions.
- Isolated full stack: `/design?tab=components` returned HTTP 200 at the assigned local URL.
- Verification gap: the in-app browser backend was unavailable, so automated desktop/mobile visual inspection was not claimed; the live stack remains available for human inspection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786723410&installation_id=127572939&pr_number=687&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F687&signature=9efe1623a7d4087b4dbcd53eccadf19585b43f9d5e4aabe81e7ecd4997e42863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->