### PR TITLE
Collapse device runtime config onto canonical provider owners

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-complexity-collapse-wave-one.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-complexity-collapse-wave-one.md
@@ -1,0 +1,70 @@
+# Complexity collapse roadmap and device runtime-config adoption
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Record the ordered complexity-collapse program and complete its first high-confidence lane by making device runtime configuration reuse the canonical provider configuration owners.
+
+## Success criteria
+
+- Runtime configuration reads, serializes, and parses provider settings through the existing canonical helpers.
+- Junction explicit resource selections retain the canonical required defaults.
+- Unknown fields, provider admin secrets, incomplete credentials, array aliasing, and missing runtime gates remain fail-closed.
+- The package loses the duplicate provider registry and parser implementation without a replacement abstraction.
+- The six-wave roadmap remains preserved in this completed plan snapshot.
+
+## Program roadmap
+
+1. **Wave 1 — high-confidence consolidation.** Land four isolated PRs: device runtime-config adoption; redundant Vitest alias deletion; one lookup-ID family owner; and proven micro-deletions.
+2. **Wave 2 — privacy-policy ownership.** Consolidate exact duplicate diagnostic safe-text redaction under the hosted observability owner, remove the dead Cloudflare object walker, centralize structural persisted-JSON allowlisting separately, and add only the demonstrated signed-callback JSON helper. Keep structural redaction and diagnostic text redaction as distinct contracts.
+3. **Wave 3 — runner write-fence hard cut.** Remove unread runner-state projections, legacy-named test adapters, inert wake/backoff state, stale liveness remnants, and obsolete documentation while preserving dormant-object migration of active invocation identity and the public status contract.
+4. **Wave 4 — measurement-gated compatibility retirement.** Query production-shaped state and close explicit rollback windows before deleting legacy snapshot restore/GC paths, historical runtime-control kinds, Linq authority fallbacks, vault-share capability fallbacks, and foreground-pending compatibility.
+5. **Wave 5 — ownership boundaries.** Delete unused automation-pass ports and the private hosted-local programmatic harness after active lanes settle; move device control implementation from operator-config to CLI; move the typed assistant daemon HTTP client to assistantd. Do not introduce generic RPC or lifecycle frameworks.
+6. **Wave 6 — build, docs, and process compression.** Collapse non-web Vitest aliases first, then matrix the repeated Cloudflare deploy gates, retire package-boundary tombstones, compress the always-read architecture/index corpus, and delete stale seam-review documents after overlapping PRs resolve.
+
+Each later wave is a recommendation, not authorization to implement it in this PR. Re-check current main, production evidence, active ledger rows, and open PR overlap before opening any later lane.
+
+## Scope
+
+- In scope: `packages/device-syncd/src/config/runtime-config.ts`, canonical provider configuration helpers, focused tests, this plan, and the coordination ledger.
+- Out of scope: provider behavior changes, device control-plane work, new registries, later roadmap waves, and unrelated open-PR fixes.
+
+## Constraints
+
+- Keep public runtime-config shape and missing-config behavior stable.
+- Reuse the current provider-config and serializable-config owners; do not add an intermediary abstraction.
+- Preserve fail-closed secret and field validation.
+- Keep this PR independently reviewable and deployable.
+
+## Risks and mitigations
+
+1. Risk: canonical Junction default merging changes hosted/local parity.
+   Mitigation: add focused parity coverage and treat the canonical provider reader as the intended source of truth.
+2. Risk: serialization accidentally admits secret/admin fields or aliases mutable arrays.
+   Mitigation: exercise the existing canonical parser and clone helpers directly in runtime-config tests.
+3. Risk: a broad cleanup collides with open device PRs.
+   Mitigation: limit the diff to runtime configuration and its focused tests.
+
+## Tasks
+
+1. Re-check current-main and open-PR overlap.
+2. Replace duplicate provider readers/registry/parsers with canonical helpers.
+3. Add or update focused parity and fail-closed tests.
+4. Run owner-scoped verification and the required coverage-write audit.
+5. Complete final review, archive this plan, commit, publish a draft PR, and run the PR review gates.
+
+## Decisions
+
+- Preserve the multi-wave program in this completed execution-plan snapshot rather than create a permanent speculative architecture roadmap.
+- Keep later compatibility deletion explicitly evidence-gated.
+
+## Verification
+
+- `pnpm test:diff packages/device-syncd`
+- Focused device-syncd runtime-config tests selected by the diff lane.
+- Required write-capable `coverage-write` audit.
+- ReviewGPT and PR CI on the exact pushed head.
+Completed: 2026-07-15

--- a/packages/device-syncd/src/config/runtime-config.ts
+++ b/packages/device-syncd/src/config/runtime-config.ts
@@ -1,59 +1,17 @@
+import { optionalEnv } from "./provider-config-helpers.ts";
 import {
-  JUNCTION_API_KEY_ENV_KEYS,
-  JUNCTION_CLIENT_USER_ID_SECRET_ENV_KEYS,
-  JUNCTION_ENV_ENV_KEYS,
-  JUNCTION_PROVIDER_FILTER_ENV_KEYS,
-  JUNCTION_RECONCILE_DAYS_ENV_KEYS,
-  JUNCTION_RECONCILE_INTERVAL_MS_ENV_KEYS,
-  JUNCTION_REGION_ENV_KEYS,
-  JUNCTION_REQUEST_TIMEOUT_MS_ENV_KEYS,
-  JUNCTION_SUMMARY_BACKFILL_DAYS_ENV_KEYS,
-  JUNCTION_SUMMARY_RESOURCES_ENV_KEYS,
-  JUNCTION_TIMESERIES_BACKFILL_DAYS_ENV_KEYS,
-  JUNCTION_TIMESERIES_RESOURCES_ENV_KEYS,
-  JUNCTION_WEBHOOK_SECRET_ENV_KEYS,
-  JUNCTION_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-  OURA_API_BASE_URL_ENV_KEYS,
-  OURA_AUTH_BASE_URL_ENV_KEYS,
-  OURA_BACKFILL_DAYS_ENV_KEYS,
-  OURA_CLIENT_ID_ENV_KEYS,
-  OURA_CLIENT_SECRET_ENV_KEYS,
-  OURA_RECONCILE_DAYS_ENV_KEYS,
-  OURA_RECONCILE_INTERVAL_MS_ENV_KEYS,
-  OURA_REQUEST_TIMEOUT_MS_ENV_KEYS,
-  OURA_SCOPES_ENV_KEYS,
-  OURA_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-  STRAVA_API_BASE_URL_ENV_KEYS,
-  STRAVA_AUTH_BASE_URL_ENV_KEYS,
-  STRAVA_BACKFILL_DAYS_ENV_KEYS,
-  STRAVA_CLIENT_ID_ENV_KEYS,
-  STRAVA_CLIENT_SECRET_ENV_KEYS,
-  STRAVA_RECONCILE_DAYS_ENV_KEYS,
-  STRAVA_RECONCILE_INTERVAL_MS_ENV_KEYS,
-  STRAVA_REQUEST_TIMEOUT_MS_ENV_KEYS,
-  STRAVA_SCOPES_ENV_KEYS,
-  STRAVA_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-  WHOOP_BACKFILL_DAYS_ENV_KEYS,
-  WHOOP_BASE_URL_ENV_KEYS,
-  WHOOP_CLIENT_ID_ENV_KEYS,
-  WHOOP_CLIENT_SECRET_ENV_KEYS,
-  WHOOP_RECONCILE_DAYS_ENV_KEYS,
-  WHOOP_RECONCILE_INTERVAL_MS_ENV_KEYS,
-  WHOOP_REQUEST_TIMEOUT_MS_ENV_KEYS,
-  WHOOP_SCOPES_ENV_KEYS,
-  WHOOP_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-} from "./provider-env.ts";
+  hasConfiguredDeviceSyncProviderConfigs,
+  readConfiguredDeviceSyncProviderConfigs,
+} from "./provider-configs.ts";
 import {
-  optionalEnv,
-  parseCsvEnv,
-  parseIntegerEnv,
-  readOptionalCredentialPair,
-} from "./provider-config-helpers.ts";
+  cloneSerializableConfiguredDeviceSyncProviderConfigs,
+  parseSerializableConfiguredDeviceSyncProviderConfigs,
+  requireSerializableConfigObject,
+  requireSerializableString,
+} from "./serializable-provider-configs.ts";
 
 import type {
-  ConfiguredDeviceSyncProviderKey,
   DeviceSyncEnvSource,
-  SerializableConfiguredDeviceSyncProviderConfigByKey,
   SerializableConfiguredDeviceSyncProviderConfigs,
 } from "./provider-types.ts";
 
@@ -74,98 +32,17 @@ const DEVICE_SYNC_PUBLIC_BASE_URL_ENV_KEYS = [
 const DEVICE_SYNC_SECRET_ENV_KEYS = [
   "DEVICE_SYNC_SECRET",
 ] as const;
-const SERIALIZABLE_PROVIDER_KEYS = [
-  "junction",
-  "oura",
-  "whoop",
-  "strava",
-] as const satisfies readonly ConfiguredDeviceSyncProviderKey[];
-const SERIALIZABLE_PROVIDER_FIELDS = {
-  junction: {
-    allowedLinkHosts: "string[]",
-    environment: "string",
-    providerFilter: "string[]",
-    reconcileDays: "number",
-    reconcileIntervalMs: "number",
-    region: "string",
-    requestTimeoutMs: "number",
-    summaryBackfillDays: "number",
-    summaryResources: "string[]",
-    timeseriesBackfillDays: "number",
-    timeseriesResources: "string[]",
-    webhookTimestampToleranceMs: "number",
-  },
-  oura: {
-    apiBaseUrl: "string",
-    authBaseUrl: "string",
-    backfillDays: "number",
-    clientId: "string",
-    clientSecret: "string",
-    reconcileDays: "number",
-    reconcileIntervalMs: "number",
-    requestTimeoutMs: "number",
-    scopes: "string[]",
-    webhookTimestampToleranceMs: "number",
-  },
-  whoop: {
-    backfillDays: "number",
-    baseUrl: "string",
-    clientId: "string",
-    clientSecret: "string",
-    reconcileDays: "number",
-    reconcileIntervalMs: "number",
-    requestTimeoutMs: "number",
-    scopes: "string[]",
-    webhookTimestampToleranceMs: "number",
-  },
-  strava: {
-    apiBaseUrl: "string",
-    authBaseUrl: "string",
-    backfillDays: "number",
-    clientId: "string",
-    clientSecret: "string",
-    reconcileDays: "number",
-    reconcileIntervalMs: "number",
-    requestTimeoutMs: "number",
-    scopes: "string[]",
-    webhookTimestampToleranceMs: "number",
-  },
-} as const;
-const SERIALIZABLE_PROVIDER_DISALLOWED_FIELDS = {
-  junction: {
-    apiKey:
-      "is a provider-owned API secret and is not supported in serialized runtime config.",
-    clientUserIdSecret:
-      "is a provider-owned HMAC secret and is not supported in serialized runtime config.",
-    fetchImpl: "is not supported in serialized runtime config.",
-    webhookSecret:
-      "is a provider-owned webhook secret and is not supported in serialized runtime config.",
-  },
-  oura: {
-    fetchImpl: "is not supported in serialized runtime config.",
-    webhookVerificationToken:
-      "is a provider-owned admin secret and is not supported in serialized runtime config.",
-  },
-  whoop: {
-    fetchImpl: "is not supported in serialized runtime config.",
-  },
-  strava: {
-    fetchImpl: "is not supported in serialized runtime config.",
-    webhookSigningSecret:
-      "is a provider-owned webhook signing secret and is not supported in serialized runtime config.",
-    webhookVerifyToken:
-      "is a provider-owned admin secret and is not supported in serialized runtime config.",
-  },
-} as const;
 
 export function readConfiguredDeviceSyncRuntimeConfig(
   env: DeviceSyncEnvSource,
 ): ConfiguredDeviceSyncRuntimeConfig | null {
-  const providerConfigs = readSerializableConfiguredDeviceSyncProviderConfigs(env);
+  const providerConfigs = cloneSerializableConfiguredDeviceSyncProviderConfigs(
+    readConfiguredDeviceSyncProviderConfigs(env),
+  );
   const publicBaseUrl = optionalEnv(env, DEVICE_SYNC_PUBLIC_BASE_URL_ENV_KEYS);
   const secret = optionalEnv(env, DEVICE_SYNC_SECRET_ENV_KEYS);
 
-  if (!publicBaseUrl || !secret || !hasSerializableProviderConfigs(providerConfigs)) {
+  if (!publicBaseUrl || !secret || !hasConfiguredDeviceSyncProviderConfigs(providerConfigs)) {
     return null;
   }
 
@@ -183,7 +60,7 @@ export function parseConfiguredDeviceSyncRuntimeConfig(
   const record = requireSerializableDeviceSyncRuntimeConfigRecord(value, label);
 
   return {
-    providerConfigs: parseSerializableProviderConfigs(
+    providerConfigs: parseSerializableConfiguredDeviceSyncProviderConfigs(
       record.providerConfigs,
       `${label}.providerConfigs`,
     ),
@@ -196,212 +73,13 @@ export function cloneConfiguredDeviceSyncRuntimeConfig(
   config: ConfiguredDeviceSyncRuntimeConfig,
 ): ConfiguredDeviceSyncRuntimeConfig {
   return {
-    providerConfigs: parseSerializableProviderConfigs(
-      structuredClone(config.providerConfigs),
+    providerConfigs: parseSerializableConfiguredDeviceSyncProviderConfigs(
+      config.providerConfigs,
       "runtimeConfig.providerConfigs",
     ),
     publicBaseUrl: config.publicBaseUrl,
     secret: config.secret,
   };
-}
-
-function readSerializableConfiguredDeviceSyncProviderConfigs(
-  env: DeviceSyncEnvSource,
-): SerializableConfiguredDeviceSyncProviderConfigs {
-  return {
-    ...readSerializableJunctionConfig(env),
-    ...readSerializableOuraConfig(env),
-    ...readSerializableWhoopConfig(env),
-    ...readSerializableStravaConfig(env),
-  };
-}
-
-function readSerializableJunctionConfig(
-  env: DeviceSyncEnvSource,
-): Pick<SerializableConfiguredDeviceSyncProviderConfigs, "junction"> {
-  const apiKey = optionalEnv(env, JUNCTION_API_KEY_ENV_KEYS);
-  const clientUserIdSecret = optionalEnv(env, JUNCTION_CLIENT_USER_ID_SECRET_ENV_KEYS);
-  const environment = optionalEnv(env, JUNCTION_ENV_ENV_KEYS);
-  const region = optionalEnv(env, JUNCTION_REGION_ENV_KEYS);
-  const webhookSecret = optionalEnv(env, JUNCTION_WEBHOOK_SECRET_ENV_KEYS);
-
-  if (!apiKey && !clientUserIdSecret && !environment && !region && !webhookSecret) {
-    return {};
-  }
-
-  if (!apiKey || !clientUserIdSecret || !environment || !region) {
-    throw new TypeError(
-      "Junction configuration is incomplete. Set JUNCTION_API_KEY, JUNCTION_CLIENT_USER_ID_SECRET, JUNCTION_ENV, and JUNCTION_REGION together.",
-    );
-  }
-
-  const parsedEnvironment = parseJunctionEnvironment(environment);
-  const parsedRegion = parseJunctionRegion(region);
-  assertJunctionApiKeyMatchesProfile(apiKey, parsedEnvironment, parsedRegion);
-  const config: SerializableConfiguredDeviceSyncProviderConfigByKey["junction"] = {
-    environment: parsedEnvironment,
-    region: parsedRegion,
-  };
-  const providerFilter = parseCsvEnv(env, JUNCTION_PROVIDER_FILTER_ENV_KEYS);
-  const summaryResources = parseCsvEnv(env, JUNCTION_SUMMARY_RESOURCES_ENV_KEYS);
-  const timeseriesResources = parseCsvEnv(env, JUNCTION_TIMESERIES_RESOURCES_ENV_KEYS);
-  const summaryBackfillDays = parseIntegerEnv(env, JUNCTION_SUMMARY_BACKFILL_DAYS_ENV_KEYS);
-  const timeseriesBackfillDays = parseIntegerEnv(env, JUNCTION_TIMESERIES_BACKFILL_DAYS_ENV_KEYS);
-  const reconcileDays = parseIntegerEnv(env, JUNCTION_RECONCILE_DAYS_ENV_KEYS);
-  const reconcileIntervalMs = parseIntegerEnv(env, JUNCTION_RECONCILE_INTERVAL_MS_ENV_KEYS);
-  const requestTimeoutMs = parseIntegerEnv(env, JUNCTION_REQUEST_TIMEOUT_MS_ENV_KEYS);
-  const webhookTimestampToleranceMs = parseIntegerEnv(
-    env,
-    JUNCTION_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-  );
-  if (providerFilter !== undefined) config.providerFilter = providerFilter;
-  if (summaryResources !== undefined) config.summaryResources = summaryResources;
-  if (timeseriesResources !== undefined) config.timeseriesResources = timeseriesResources;
-  if (summaryBackfillDays !== undefined) config.summaryBackfillDays = summaryBackfillDays;
-  if (timeseriesBackfillDays !== undefined) config.timeseriesBackfillDays = timeseriesBackfillDays;
-  if (reconcileDays !== undefined) config.reconcileDays = reconcileDays;
-  if (reconcileIntervalMs !== undefined) config.reconcileIntervalMs = reconcileIntervalMs;
-  if (requestTimeoutMs !== undefined) config.requestTimeoutMs = requestTimeoutMs;
-  if (webhookTimestampToleranceMs !== undefined) {
-    config.webhookTimestampToleranceMs = webhookTimestampToleranceMs;
-  }
-
-  return {
-    junction: config,
-  };
-}
-
-function readSerializableOuraConfig(
-  env: DeviceSyncEnvSource,
-): Pick<SerializableConfiguredDeviceSyncProviderConfigs, "oura"> {
-  const credentials = readOptionalCredentialPair(
-    env,
-    OURA_CLIENT_ID_ENV_KEYS,
-    OURA_CLIENT_SECRET_ENV_KEYS,
-    "Oura",
-  );
-
-  if (!credentials) {
-    return {};
-  }
-
-  const config: SerializableConfiguredDeviceSyncProviderConfigByKey["oura"] = {
-    clientId: credentials.clientId,
-    clientSecret: credentials.clientSecret,
-  };
-  const authBaseUrl = optionalEnv(env, OURA_AUTH_BASE_URL_ENV_KEYS);
-  const apiBaseUrl = optionalEnv(env, OURA_API_BASE_URL_ENV_KEYS);
-  const scopes = parseCsvEnv(env, OURA_SCOPES_ENV_KEYS);
-  const backfillDays = parseIntegerEnv(env, OURA_BACKFILL_DAYS_ENV_KEYS);
-  const reconcileDays = parseIntegerEnv(env, OURA_RECONCILE_DAYS_ENV_KEYS);
-  const reconcileIntervalMs = parseIntegerEnv(env, OURA_RECONCILE_INTERVAL_MS_ENV_KEYS);
-  const webhookTimestampToleranceMs = parseIntegerEnv(
-    env,
-    OURA_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-  );
-  const requestTimeoutMs = parseIntegerEnv(env, OURA_REQUEST_TIMEOUT_MS_ENV_KEYS);
-  if (authBaseUrl !== undefined) config.authBaseUrl = authBaseUrl;
-  if (apiBaseUrl !== undefined) config.apiBaseUrl = apiBaseUrl;
-  if (scopes !== undefined) config.scopes = scopes;
-  if (backfillDays !== undefined) config.backfillDays = backfillDays;
-  if (reconcileDays !== undefined) config.reconcileDays = reconcileDays;
-  if (reconcileIntervalMs !== undefined) config.reconcileIntervalMs = reconcileIntervalMs;
-  if (webhookTimestampToleranceMs !== undefined) {
-    config.webhookTimestampToleranceMs = webhookTimestampToleranceMs;
-  }
-  if (requestTimeoutMs !== undefined) config.requestTimeoutMs = requestTimeoutMs;
-
-  return { oura: config };
-}
-
-function readSerializableWhoopConfig(
-  env: DeviceSyncEnvSource,
-): Pick<SerializableConfiguredDeviceSyncProviderConfigs, "whoop"> {
-  const credentials = readOptionalCredentialPair(
-    env,
-    WHOOP_CLIENT_ID_ENV_KEYS,
-    WHOOP_CLIENT_SECRET_ENV_KEYS,
-    "WHOOP",
-  );
-
-  if (!credentials) {
-    return {};
-  }
-
-  const config: SerializableConfiguredDeviceSyncProviderConfigByKey["whoop"] = {
-    clientId: credentials.clientId,
-    clientSecret: credentials.clientSecret,
-  };
-  const baseUrl = optionalEnv(env, WHOOP_BASE_URL_ENV_KEYS);
-  const scopes = parseCsvEnv(env, WHOOP_SCOPES_ENV_KEYS);
-  const backfillDays = parseIntegerEnv(env, WHOOP_BACKFILL_DAYS_ENV_KEYS);
-  const reconcileDays = parseIntegerEnv(env, WHOOP_RECONCILE_DAYS_ENV_KEYS);
-  const reconcileIntervalMs = parseIntegerEnv(env, WHOOP_RECONCILE_INTERVAL_MS_ENV_KEYS);
-  const webhookTimestampToleranceMs = parseIntegerEnv(
-    env,
-    WHOOP_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-  );
-  const requestTimeoutMs = parseIntegerEnv(env, WHOOP_REQUEST_TIMEOUT_MS_ENV_KEYS);
-  if (baseUrl !== undefined) config.baseUrl = baseUrl;
-  if (scopes !== undefined) config.scopes = scopes;
-  if (backfillDays !== undefined) config.backfillDays = backfillDays;
-  if (reconcileDays !== undefined) config.reconcileDays = reconcileDays;
-  if (reconcileIntervalMs !== undefined) config.reconcileIntervalMs = reconcileIntervalMs;
-  if (webhookTimestampToleranceMs !== undefined) {
-    config.webhookTimestampToleranceMs = webhookTimestampToleranceMs;
-  }
-  if (requestTimeoutMs !== undefined) config.requestTimeoutMs = requestTimeoutMs;
-
-  return { whoop: config };
-}
-
-function readSerializableStravaConfig(
-  env: DeviceSyncEnvSource,
-): Pick<SerializableConfiguredDeviceSyncProviderConfigs, "strava"> {
-  const credentials = readOptionalCredentialPair(
-    env,
-    STRAVA_CLIENT_ID_ENV_KEYS,
-    STRAVA_CLIENT_SECRET_ENV_KEYS,
-    "Strava",
-  );
-
-  if (!credentials) {
-    return {};
-  }
-
-  const config: SerializableConfiguredDeviceSyncProviderConfigByKey["strava"] = {
-    clientId: credentials.clientId,
-    clientSecret: credentials.clientSecret,
-  };
-  const authBaseUrl = optionalEnv(env, STRAVA_AUTH_BASE_URL_ENV_KEYS);
-  const apiBaseUrl = optionalEnv(env, STRAVA_API_BASE_URL_ENV_KEYS);
-  const scopes = parseCsvEnv(env, STRAVA_SCOPES_ENV_KEYS);
-  const backfillDays = parseIntegerEnv(env, STRAVA_BACKFILL_DAYS_ENV_KEYS);
-  const reconcileDays = parseIntegerEnv(env, STRAVA_RECONCILE_DAYS_ENV_KEYS);
-  const reconcileIntervalMs = parseIntegerEnv(env, STRAVA_RECONCILE_INTERVAL_MS_ENV_KEYS);
-  const requestTimeoutMs = parseIntegerEnv(env, STRAVA_REQUEST_TIMEOUT_MS_ENV_KEYS);
-  const webhookTimestampToleranceMs = parseIntegerEnv(
-    env,
-    STRAVA_WEBHOOK_TIMESTAMP_TOLERANCE_MS_ENV_KEYS,
-  );
-  if (authBaseUrl !== undefined) config.authBaseUrl = authBaseUrl;
-  if (apiBaseUrl !== undefined) config.apiBaseUrl = apiBaseUrl;
-  if (scopes !== undefined) config.scopes = scopes;
-  if (backfillDays !== undefined) config.backfillDays = backfillDays;
-  if (reconcileDays !== undefined) config.reconcileDays = reconcileDays;
-  if (reconcileIntervalMs !== undefined) config.reconcileIntervalMs = reconcileIntervalMs;
-  if (requestTimeoutMs !== undefined) config.requestTimeoutMs = requestTimeoutMs;
-  if (webhookTimestampToleranceMs !== undefined) {
-    config.webhookTimestampToleranceMs = webhookTimestampToleranceMs;
-  }
-
-  return { strava: config };
-}
-
-function hasSerializableProviderConfigs(
-  configs: SerializableConfiguredDeviceSyncProviderConfigs,
-): boolean {
-  return SERIALIZABLE_PROVIDER_KEYS.some((provider) => configs[provider] !== undefined);
 }
 
 function requireSerializableDeviceSyncRuntimeConfigRecord(
@@ -418,163 +96,4 @@ function requireSerializableDeviceSyncRuntimeConfigRecord(
   }
 
   return record;
-}
-
-function parseSerializableProviderConfigs(
-  value: unknown,
-  label: string,
-): SerializableConfiguredDeviceSyncProviderConfigs {
-  const record = requireSerializableConfigObject(value, label);
-  const configs: SerializableConfiguredDeviceSyncProviderConfigs = {};
-
-  for (const key of Object.keys(record)) {
-    if (!isSerializableProviderKey(key)) {
-      throw new TypeError(`${label}.${key} is not a supported device-sync provider config.`);
-    }
-  }
-
-  if (record.junction !== undefined) {
-    configs.junction = parseSerializableProviderConfig(
-      "junction",
-      record.junction,
-      `${label}.junction`,
-    );
-  }
-  if (record.oura !== undefined) {
-    configs.oura = parseSerializableProviderConfig("oura", record.oura, `${label}.oura`);
-  }
-  if (record.whoop !== undefined) {
-    configs.whoop = parseSerializableProviderConfig("whoop", record.whoop, `${label}.whoop`);
-  }
-  if (record.strava !== undefined) {
-    configs.strava = parseSerializableProviderConfig("strava", record.strava, `${label}.strava`);
-  }
-
-  return configs;
-}
-
-function parseSerializableProviderConfig<TProvider extends ConfiguredDeviceSyncProviderKey>(
-  provider: TProvider,
-  value: unknown,
-  label: string,
-): SerializableConfiguredDeviceSyncProviderConfigByKey[TProvider] {
-  const record = requireSerializableConfigObject(value, label);
-  const fields = SERIALIZABLE_PROVIDER_FIELDS[provider];
-  const disallowed = SERIALIZABLE_PROVIDER_DISALLOWED_FIELDS[provider];
-  const parsed: Record<string, boolean | number | string | string[]> = {};
-
-  for (const [key, message] of Object.entries(disallowed)) {
-    if (record[key] !== undefined) {
-      throw new TypeError(`${label}.${key} ${message}`);
-    }
-  }
-
-  for (const key of Object.keys(record)) {
-    if (!Object.hasOwn(fields, key)) {
-      throw new TypeError(`${label}.${key} is not a supported serialized provider config field.`);
-    }
-  }
-
-  for (const [key, kind] of Object.entries(fields)) {
-    const fieldValue = record[key];
-    if (fieldValue === undefined) {
-      continue;
-    }
-    parsed[key] = parseSerializableFieldValue(kind, fieldValue, `${label}.${key}`);
-  }
-
-  return parsed as SerializableConfiguredDeviceSyncProviderConfigByKey[TProvider];
-}
-
-function parseSerializableFieldValue(
-  kind: "boolean" | "number" | "string" | "string[]",
-  value: unknown,
-  label: string,
-): boolean | number | string | string[] {
-  switch (kind) {
-    case "boolean":
-      return requireSerializableBoolean(value, label);
-    case "number":
-      return requireSerializableNumber(value, label);
-    case "string":
-      return requireSerializableString(value, label);
-    case "string[]":
-      return requireSerializableStringArray(value, label);
-  }
-}
-
-function requireSerializableConfigObject(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new TypeError(`${label} must be an object.`);
-  }
-
-  return value as Record<string, unknown>;
-}
-
-function requireSerializableString(value: unknown, label: string): string {
-  if (typeof value !== "string" || value.length === 0) {
-    throw new TypeError(`${label} must be a non-empty string.`);
-  }
-
-  return value;
-}
-
-function requireSerializableBoolean(value: unknown, label: string): boolean {
-  if (typeof value !== "boolean") {
-    throw new TypeError(`${label} must be a boolean.`);
-  }
-
-  return value;
-}
-
-function requireSerializableNumber(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new TypeError(`${label} must be a finite number.`);
-  }
-
-  return value;
-}
-
-function requireSerializableStringArray(value: unknown, label: string): string[] {
-  if (!Array.isArray(value)) {
-    throw new TypeError(`${label} must be an array of strings.`);
-  }
-
-  return value.map((entry, index) => requireSerializableString(entry, `${label}[${index}]`));
-}
-
-function isSerializableProviderKey(value: string): value is ConfiguredDeviceSyncProviderKey {
-  return (SERIALIZABLE_PROVIDER_KEYS as readonly string[]).includes(value);
-}
-
-function parseJunctionEnvironment(value: string): "sandbox" | "production" {
-  if (value === "sandbox" || value === "production") {
-    return value;
-  }
-
-  throw new TypeError("JUNCTION_ENV must be sandbox or production.");
-}
-
-function parseJunctionRegion(value: string): "us" | "eu" {
-  if (value === "us" || value === "eu") {
-    return value;
-  }
-
-  throw new TypeError("JUNCTION_REGION must be us or eu.");
-}
-
-function assertJunctionApiKeyMatchesProfile(
-  apiKey: string,
-  environment: "sandbox" | "production",
-  region: "us" | "eu",
-): void {
-  const expectedPrefix = environment === "production"
-    ? region === "us" ? "pk_us_" : "pk_eu_"
-    : region === "us" ? "sk_us_" : "sk_eu_";
-
-  if (!apiKey.startsWith(expectedPrefix)) {
-    throw new TypeError(
-      `JUNCTION_API_KEY must start with ${expectedPrefix} for ${environment}/${region}.`,
-    );
-  }
 }

--- a/packages/device-syncd/test/config.test.ts
+++ b/packages/device-syncd/test/config.test.ts
@@ -5,6 +5,10 @@ import { Writable } from "node:stream";
 import { test } from "vitest";
 
 import {
+  JUNCTION_DEFAULT_TIMESERIES_RESOURCES,
+} from "@murphai/importers/device-providers/junction-resources";
+
+import {
   cloneConfiguredDeviceSyncRuntimeConfig,
   cloneSerializableConfiguredDeviceSyncProviderConfigs,
   configuredDeviceSyncProviderKeys,
@@ -437,6 +441,28 @@ test("readConfiguredDeviceSyncRuntimeConfig keeps only the shared hosted runtime
   );
 });
 
+test("readConfiguredDeviceSyncRuntimeConfig preserves canonical Junction timeseries defaults", () => {
+  const env = {
+    DEVICE_SYNC_PUBLIC_BASE_URL: "https://device-sync.example.test",
+    DEVICE_SYNC_SECRET: "runtime-codec-secret",
+    JUNCTION_API_KEY: "sk_us_test_runtime",
+    JUNCTION_CLIENT_USER_ID_SECRET: "<REDACTED_JUNCTION_CLIENT_USER_ID_SECRET>",
+    JUNCTION_ENV: "sandbox",
+    JUNCTION_REGION: "us",
+    JUNCTION_TIMESERIES_RESOURCES: "blood_oxygen",
+  };
+  const runtimeConfig = requireValue(readConfiguredDeviceSyncRuntimeConfig(env));
+  const canonicalProviderConfigs = cloneSerializableConfiguredDeviceSyncProviderConfigs(
+    readConfiguredDeviceSyncProviderConfigs(env),
+  );
+
+  assert.deepEqual(runtimeConfig.providerConfigs, canonicalProviderConfigs);
+  assert.deepEqual(
+    runtimeConfig.providerConfigs.junction?.timeseriesResources,
+    JUNCTION_DEFAULT_TIMESERIES_RESOURCES,
+  );
+});
+
 test("parseConfiguredDeviceSyncRuntimeConfig accepts the shared hosted runtime shape", () => {
   const parsed = parseConfiguredDeviceSyncRuntimeConfig(
     {
@@ -496,6 +522,15 @@ test("readConfiguredDeviceSyncRuntimeConfig returns null when hosted runtime pre
       DEVICE_SYNC_SECRET: "runtime-codec-secret",
     }),
     null,
+  );
+  assert.throws(
+    () =>
+      readConfiguredDeviceSyncRuntimeConfig({
+        DEVICE_SYNC_PUBLIC_BASE_URL: "https://device-sync.example.test",
+        DEVICE_SYNC_SECRET: "runtime-codec-secret",
+        OURA_CLIENT_ID: "oura-client-id",
+      }),
+    /Oura configuration is incomplete/u,
   );
 });
 


### PR DESCRIPTION
## Why this PR exists

Device runtime configuration still maintained a second provider registry, four duplicate environment readers, and a duplicate serialization parser after the canonical provider-manifest work landed. That fork had already drifted: explicit Junction resources did not receive the required canonical defaults.

## User goal / user-visible behavior

Hosted and local device sync should interpret one provider configuration the same way. Existing connections keep the same runtime envelope, while Junction resource selection now consistently includes the required defaults.

## User experience

No UI flow changes. Device connections and sync continue through the existing surfaces; this removes an internal disagreement in how their runtime configuration is assembled.

## Invariants the PR must preserve

- The outer `{ providerConfigs, publicBaseUrl, secret }` runtime shape remains unchanged and rejects unknown keys.
- A public URL, runtime secret, and at least one complete provider configuration remain mandatory.
- Unknown providers/fields, incomplete credentials, and provider-owned admin secrets fail closed.
- Env-to-runtime projection strips provider-only secrets.
- Cloned provider arrays do not alias the input.
- Canonical Junction default-resource merging applies in every configuration path.

## Non-obvious affected surfaces

- **Provider-owned secrets:** the canonical full provider reader now runs before the canonical serializable projection. Manifest tests and runtime-config tests prove that admin/provider secrets remain excluded and rejected at the serialized boundary.
- **Junction resource selection:** explicit resource configuration now intentionally uses the same required-default merge as the canonical Junction owner. A focused parity test compares runtime output directly with the canonical provider projection.
- **Runtime cloning:** the canonical parser replaces a redundant `structuredClone` plus duplicate parser. Existing array non-aliasing coverage remains green.
- **Program planning:** the completed execution plan records the six-wave complexity-collapse roadmap; waves two through six are recommendations only and are explicitly outside this PR.

## Change-shape breakdown

Classification: device-syncd implementation is source; `config.test.ts` is tests; the completed execution plan is docs; there are no config/tooling, generated, moved, or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 16 | 497 |
| Tests/fixtures | 35 | 0 |
| Docs | 70 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **121** | **497** |

## Verification

- Focused runtime-config/provider-manifest tests: 60/60 passed.
- Device-syncd typecheck passed.
- Device-syncd coverage: 42 files / 823 tests passed; 90.63% statements, 81.52% branches, 95.34% functions, 90.65% lines.
- Required coverage-write audit found every material changed branch already proven and made no edits.
- Diff-aware verification passed dependency policy, boundaries, guards, all 14 affected typechecks, and device-syncd tests, then hit unrelated fresh-worktree artifact prerequisites in hosted-local-harness and isolated CLI generated Health Commons fixtures. PR CI is the final integrated gate.

## Deployment compatibility

The serialized runtime shape, env key names, and consumer contract do not change, so old and new processes can coexist during a normal rollout. New processes include canonical Junction required resources; older processes retain the prior explicit-only selection until restarted. No tandem deploy, migration, immediate container rollout, or compatibility shim is required.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 1ad79c86c80d90501decae085ea7db586c6495ff

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `1ad79c86c80d90501decae085ea7db586c6495ff` | 16 | 497 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786726401&installation_id=127572939&pr_number=690&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F690&signature=681363c38f372207a3eb69b7b3e7411d50f70cc5eab9d649d3ed893d5fa4697d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->