### PR TITLE
Collapse Vitest aliases onto root paths

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-vitest-alias-collapse.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-vitest-alias-collapse.md
@@ -1,0 +1,53 @@
+# Collapse redundant Vitest workspace aliases
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Delete non-web package-specific Vitest alias catalogs that duplicate the root TypeScript path map.
+
+## Success criteria
+
+- Shared Vitest configuration derives workspace aliases from the root TypeScript configuration only.
+- Package, CLI, and Cloudflare Vitest configs no longer repeat workspace source-entry maps.
+- Hosted web's deliberate source-resolution/transpilation allowlist remains unchanged.
+- Workspace boundary enforcement and all affected tests/typechecks stay green.
+
+## Scope
+
+- In scope: `config/vitest-package.ts`, package Vitest configs using `workspaceSourceEntryRelativePaths`, `apps/cloudflare/vitest.shared.ts`, `packages/cli/vitest.workspace.ts`, and focused tests.
+- Out of scope: hosted-web source-resolution policy, dependency graph changes, and test-runner redesign.
+
+## Constraints
+
+- Delete configuration; do not replace it with another generated catalog.
+- Preserve root/subpath resolution and generic boundary enforcement.
+- Keep the change tooling-only and behavior-neutral.
+
+## Risks and mitigations
+
+1. Risk: a package import is not covered by the root paths.
+   Mitigation: verify the root path-derived alias set against affected configs and run the diff-selected test lane.
+2. Risk: web's explicit allowlist is removed accidentally.
+   Mitigation: leave the hosted-web source-resolution module and web configs out of scope.
+
+## Tasks
+
+1. Inventory every caller of `workspaceSourceEntryRelativePaths` and manual CLI/Cloudflare aliases.
+2. Delete the redundant option and maps.
+3. Add or update focused configuration coverage if the existing suite does not prove root-path resolution.
+4. Run scoped verification and the required coverage-write audit.
+5. Archive this plan, commit, and publish a draft PR.
+
+## Decisions
+
+- The root TypeScript paths are the single current owner of workspace source aliases for non-web Vitest.
+
+## Verification
+
+- `pnpm test:diff config/vitest-package.ts apps/cloudflare/vitest.shared.ts packages/cli/vitest.workspace.ts` plus all changed Vitest configs.
+- Required write-capable `coverage-write` audit.
+- PR CI on the exact pushed head.
+Completed: 2026-07-15

--- a/apps/cloudflare/vitest.shared.ts
+++ b/apps/cloudflare/vitest.shared.ts
@@ -1,11 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import {
-  createVitestAliasesFromTsconfigPaths,
-  createVitestWorkspaceRuntimeAliases,
-  resolveWorkspaceSourceEntries,
-} from "../../config/workspace-source-resolution.ts";
+import { createVitestAliasesFromTsconfigPaths } from "../../config/workspace-source-resolution.ts";
 
 export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const appDir = path.join(repoRoot, "apps/cloudflare");
@@ -26,31 +22,6 @@ export const cloudflareVitestAliases = [
     find: "@",
     replacement: path.resolve(repoRoot, "apps/web"),
   },
-  ...createVitestWorkspaceRuntimeAliases(
-    resolveWorkspaceSourceEntries(repoRoot, {
-      "@murphai/assistant-engine": "packages/assistant-engine/src/index.ts",
-      "@murphai/operator-config": "packages/operator-config/package.json",
-      "@murphai/assistant-runtime": "packages/assistant-runtime/src/index.ts",
-      "@murphai/cloudflare-hosted-control": "packages/cloudflare-hosted-control/package.json",
-      "#hosted-web-testing": "apps/web/test/support/hosted-web-testkit.ts",
-      "@murphai/murph": "packages/cli/src/index.ts",
-      "@murphai/contracts": "packages/contracts/src/index.ts",
-      "@murphai/core": "packages/core/src/index.ts",
-      "@murphai/device-syncd": "packages/device-syncd/src/index.ts",
-      "@murphai/gateway-core": "packages/gateway-core/src/index.ts",
-      "@murphai/health-metrics": "packages/health-metrics/src/index.ts",
-      "@murphai/hosted-execution": "packages/hosted-execution/src/index.ts",
-      "@murphai/hosted-local-harness": "packages/hosted-local-harness/package.json",
-      "@murphai/importers": "packages/importers/src/index.ts",
-      "@murphai/inbox-services": "packages/inbox-services/src/index.ts",
-      "@murphai/inboxd": "packages/inboxd/src/index.ts",
-      "@murphai/messaging-ingress": "packages/messaging-ingress/package.json",
-      "@murphai/parsers": "packages/parsers/src/index.ts",
-      "@murphai/query": "packages/query/src/index.ts",
-      "@murphai/runtime-state": "packages/runtime-state/src/index.ts",
-      "@murphai/vault-usecases": "packages/vault-usecases/src/index.ts",
-    }),
-  ),
   ...createVitestAliasesFromTsconfigPaths({
     workspaceDir: appDir,
     specifierFilter: isCloudflareWorkspaceSourceSpecifier,

--- a/config/vitest-package.ts
+++ b/config/vitest-package.ts
@@ -12,33 +12,17 @@ import {
   resolveMurphVitestMaxWorkers,
 } from "./vitest-parallelism.js";
 import { murphVitestNoTimeouts } from "./vitest-timeouts.js";
-import {
-  createVitestAliasesFromTsconfigPaths,
-  createVitestWorkspaceRuntimeAliases,
-  type WorkspaceSourceEntryRelativePaths,
-  resolveWorkspaceSourceEntries,
-} from "./workspace-source-resolution.js";
-
-type MurphVitestAlias = {
-  find: RegExp;
-  replacement: string;
-};
+import { createVitestAliasesFromTsconfigPaths } from "./workspace-source-resolution.js";
 
 type MurphVitestTestOptions = Omit<
   TestUserConfig,
   "name" | "environment" | "include" | "coverage"
 >;
 
-type MurphVitestExtraAliases =
-  | readonly MurphVitestAlias[]
-  | ((input: { packageDir: string }) => readonly MurphVitestAlias[]);
-
 export interface MurphPackageVitestConfigInput {
   configUrl: string;
   name: string;
   rootRelativePath?: string;
-  workspaceSourceEntryRelativePaths?: WorkspaceSourceEntryRelativePaths;
-  extraAliases?: MurphVitestExtraAliases;
   coverage?: ReturnType<typeof createMurphVitestCoverage>;
   coverageInclude?: readonly string[];
   coverageExclude?: readonly string[];
@@ -50,18 +34,10 @@ export interface MurphPackageVitestConfigInput {
 
 export function createMurphPackageVitestConfig(input: MurphPackageVitestConfigInput) {
   const packageDir = path.dirname(fileURLToPath(input.configUrl));
-  const aliases = [
-    ...(input.workspaceSourceEntryRelativePaths
-      ? createVitestWorkspaceRuntimeAliases(
-          resolveWorkspaceSourceEntries(packageDir, input.workspaceSourceEntryRelativePaths),
-        )
-      : []),
-    ...resolveExtraAliases(packageDir, input.extraAliases),
-    ...createVitestAliasesFromTsconfigPaths({
-      workspaceDir: packageDir,
-      specifierFilter: isWorkspaceSourceSpecifier,
-    }),
-  ];
+  const aliases = createVitestAliasesFromTsconfigPaths({
+    workspaceDir: packageDir,
+    specifierFilter: isWorkspaceSourceSpecifier,
+  });
 
   return defineConfig({
     ...(input.rootRelativePath
@@ -89,15 +65,4 @@ export function createMurphPackageVitestConfig(input: MurphPackageVitestConfigIn
 
 function isWorkspaceSourceSpecifier(specifier: string): boolean {
   return specifier === "murph" || specifier.startsWith("@murphai/");
-}
-
-function resolveExtraAliases(
-  packageDir: string,
-  extraAliases: MurphVitestExtraAliases | undefined,
-): MurphVitestAlias[] {
-  if (!extraAliases) {
-    return [];
-  }
-
-  return [...(typeof extraAliases === "function" ? extraAliases({ packageDir }) : extraAliases)];
 }

--- a/packages/assistant-cli/vitest.config.ts
+++ b/packages/assistant-cli/vitest.config.ts
@@ -1,25 +1,8 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/assistant-cli": "./package.json",
-  "@murphai/assistant-engine": "../assistant-engine/src/index.ts",
-  "@murphai/assistantd": "../assistantd/package.json",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/gateway-core": "../gateway-core/src/index.ts",
-  "@murphai/inbox-services": "../inbox-services/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases": "../vault-usecases/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "assistant-cli",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
   useDefaultConcurrency: false,
   useDefaultTimeouts: false,
 });

--- a/packages/assistant-engine/vitest.config.ts
+++ b/packages/assistant-engine/vitest.config.ts
@@ -1,29 +1,7 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/assistant-engine": "./src/index.ts",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/gateway-core": "../gateway-core/src/index.ts",
-  "@murphai/health-commons": "../health-commons/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/hosted-execution/action-approval": "../hosted-execution/src/action-approval.ts",
-  "@murphai/hosted-execution/connected-apps": "../hosted-execution/src/connected-apps.ts",
-  "@murphai/hosted-execution/computer-use": "../hosted-execution/src/computer-use.ts",
-  "@murphai/hosted-execution/return-contact": "../hosted-execution/src/return-contact.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/parsers": "../parsers/src/index.ts",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases": "../vault-usecases/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "assistant-engine",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
   coverageExclude: ["src/assistant/system-prompt.ts"],
 });

--- a/packages/assistant-runtime/vitest.config.ts
+++ b/packages/assistant-runtime/vitest.config.ts
@@ -1,27 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/assistant-engine": "../assistant-engine/src/index.ts",
-  "@murphai/assistant-runtime": "./src/index.ts",
-  "@murphai/clinical-records": "../clinical-records/src/index.ts",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/hosted-execution": "../hosted-execution/src/index.ts",
-  "@murphai/hosted-execution/clinical-records": "../hosted-execution/src/clinical-records.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/parsers": "../parsers/src/index.ts",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases": "../vault-usecases/src/index.ts",
-  "@murphai/vault-usecases/clinical-records": "../vault-usecases/src/clinical-records.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "assistant-runtime",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/assistantd/vitest.config.ts
+++ b/packages/assistantd/vitest.config.ts
@@ -1,25 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/assistantd": "./package.json",
-  "@murphai/assistant-engine": "../assistant-engine/src/index.ts",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/hosted-execution": "../hosted-execution/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/parsers": "../parsers/src/index.ts",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases": "../vault-usecases/src/index.ts",
-  murph: "../cli/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "assistantd",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,32 +1,8 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 import { cliVitestCoverage } from "./vitest.workspace.ts";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/assistantd": "../assistantd/package.json",
-  "@murphai/assistant-cli": "../assistant-cli/package.json",
-  "@murphai/assistant-engine": "../assistant-engine/src/index.ts",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/setup-cli": "../setup-cli/package.json",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/device-syncd/client": "../device-syncd/src/client.ts",
-  "@murphai/gateway-core": "../gateway-core/src/index.ts",
-  "@murphai/hosted-execution": "../hosted-execution/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/inbox-services": "../inbox-services/src/index.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/parsers": "../parsers/src/index.ts",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases/testing": "../vault-usecases/src/testing.ts",
-  murph: "./src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "cli",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
   coverage: cliVitestCoverage,
 });

--- a/packages/cli/vitest.workspace.ts
+++ b/packages/cli/vitest.workspace.ts
@@ -12,11 +12,7 @@ import {
   resolveMurphVitestMaxWorkers,
 } from "../../config/vitest-parallelism.js";
 import { murphVitestNoTimeouts } from "../../config/vitest-timeouts.js";
-import {
-  createVitestAliasesFromTsconfigPaths,
-  createVitestWorkspaceRuntimeAliases,
-  resolveWorkspaceSourceEntries,
-} from "../../config/workspace-source-resolution.js";
+import { createVitestAliasesFromTsconfigPaths } from "../../config/workspace-source-resolution.js";
 import {
   resolveVitestBucketFiles,
   type VitestBucketSeed,
@@ -32,33 +28,6 @@ const cliVitestCoverageThresholds = {
   branches: 55,
   statements: 80,
 } as const;
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/assistantd": "../assistantd/package.json",
-  "@murphai/assistant-cli": "../assistant-cli/package.json",
-  "@murphai/assistant-engine": "../assistant-engine/src/index.ts",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/setup-cli": "../setup-cli/package.json",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/device-syncd/client": "../device-syncd/src/client.ts",
-  "@murphai/exercise-library": "../exercise-library/src/index.ts",
-  "@murphai/exercise-library/runtime": "../exercise-library/src/runtime.ts",
-  "@murphai/gateway-core": "../gateway-core/src/index.ts",
-  "@murphai/hosted-execution": "../hosted-execution/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/inbox-services": "../inbox-services/src/index.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/parsers": "../parsers/src/index.ts",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases": "../vault-usecases/src/index.ts",
-  murph: "./src/index.ts",
-} as const;
-const cliVitestRuntimeAliases = createVitestWorkspaceRuntimeAliases(
-  resolveWorkspaceSourceEntries(packageDir, WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS),
-);
 const cliVitestTsconfigAliases = createVitestAliasesFromTsconfigPaths({
   workspaceDir: packageDir,
   specifierFilter: (specifier) =>
@@ -95,7 +64,7 @@ export function createCliVitestProject(name: string, fileNames: readonly string[
 
   return defineConfig({
     resolve: {
-      alias: [...cliVitestRuntimeAliases, ...cliVitestTsconfigAliases],
+      alias: cliVitestTsconfigAliases,
     },
     test: {
       ...murphVitestNoTimeouts,

--- a/packages/clinical-records/vitest.config.ts
+++ b/packages/clinical-records/vitest.config.ts
@@ -1,12 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/clinical-records": "./src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "clinical-records",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/cloudflare-hosted-control/vitest.config.ts
+++ b/packages/cloudflare-hosted-control/vitest.config.ts
@@ -1,14 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/cloudflare-hosted-control/client": "./src/client.ts",
-  "@murphai/cloudflare-hosted-control/routes": "./src/routes.ts",
-  "@murphai/hosted-execution": "../hosted-execution/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "cloudflare-hosted-control",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,13 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "./src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "core",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/device-syncd/vitest.config.ts
+++ b/packages/device-syncd/vitest.config.ts
@@ -1,15 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "./src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "device-syncd",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/gateway-core/vitest.config.ts
+++ b/packages/gateway-core/vitest.config.ts
@@ -1,11 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/gateway-core": "./src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "gateway-core",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/health-commons/vitest.config.ts
+++ b/packages/health-commons/vitest.config.ts
@@ -1,13 +1,7 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/health-commons": "./src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "health-commons",
   rootRelativePath: ".",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/hosted-execution/vitest.config.ts
+++ b/packages/hosted-execution/vitest.config.ts
@@ -1,24 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/device-syncd/hosted-runtime": "../device-syncd/src/hosted-runtime.ts",
-  "@murphai/gateway-core": "../gateway-core/src/index.ts",
-  "@murphai/hosted-execution": "./src/index.ts",
-  "@murphai/hosted-execution/assistant-identifiers": "./src/assistant-identifiers.ts",
-  "@murphai/hosted-execution/computer-use": "./src/computer-use.ts",
-  "@murphai/hosted-execution/clinical-records": "./src/clinical-records.ts",
-  "@murphai/hosted-execution/dashboard-replica": "./src/dashboard-replica.ts",
-  "@murphai/hosted-execution/legacy-dashboard-replica": "./src/legacy-dashboard-replica.ts",
-  "@murphai/hosted-execution/orchestration-control": "./src/orchestration-control.ts",
-  "@murphai/hosted-execution/return-contact": "./src/return-contact.ts",
-  "@murphai/hosted-execution/runtime-control": "./src/runtime-control.ts",
-  "@murphai/hosted-execution/temporal-env": "./src/temporal-env.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "hosted-execution",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/hosted-orchestrator-temporal/vitest.config.ts
+++ b/packages/hosted-orchestrator-temporal/vitest.config.ts
@@ -1,21 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/hosted-execution": "../hosted-execution/src/index.ts",
-  "@murphai/hosted-execution/auth": "../hosted-execution/src/auth.ts",
-  "@murphai/hosted-execution/contracts": "../hosted-execution/src/contracts.ts",
-  "@murphai/hosted-execution/env": "../hosted-execution/src/env.ts",
-  "@murphai/hosted-execution/orchestration-control":
-    "../hosted-execution/src/orchestration-control.ts",
-  "@murphai/hosted-execution/parsers": "../hosted-execution/src/parsers.ts",
-  "@murphai/hosted-execution/runtime-control":
-    "../hosted-execution/src/runtime-control.ts",
-  "@murphai/hosted-execution/temporal-env":
-    "../hosted-execution/src/temporal-env.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "hosted-orchestrator-temporal",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/importers/vitest.config.ts
+++ b/packages/importers/vitest.config.ts
@@ -1,15 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/clinical-records": "../clinical-records/src/index.ts",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/importers": "./src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "importers",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/inbox-services/vitest.config.ts
+++ b/packages/inbox-services/vitest.config.ts
@@ -1,19 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/health-metrics": "../health-metrics/src/index.ts",
-  "@murphai/inbox-services": "./src/index.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases": "../vault-usecases/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "inbox-services",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/inboxd/vitest.config.ts
+++ b/packages/inboxd/vitest.config.ts
@@ -1,16 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/inboxd": "./src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/parsers": "../parsers/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "inboxd",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/messaging-ingress/vitest.config.ts
+++ b/packages/messaging-ingress/vitest.config.ts
@@ -1,11 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/messaging-ingress": "./package.json",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "messaging-ingress",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/operator-config/vitest.config.ts
+++ b/packages/operator-config/vitest.config.ts
@@ -1,17 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/gateway-core": "../gateway-core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/operator-config": "./package.json",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "operator-config",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/parsers/vitest.config.ts
+++ b/packages/parsers/vitest.config.ts
@@ -1,15 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/parsers": "./src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "parsers",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/query/vitest.config.ts
+++ b/packages/query/vitest.config.ts
@@ -1,15 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/health-metrics": "../health-metrics/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/query": "./src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "query",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/runtime-state/vitest.config.ts
+++ b/packages/runtime-state/vitest.config.ts
@@ -1,11 +1,6 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/runtime-state": "./src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "runtime-state",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
 });

--- a/packages/setup-cli/vitest.config.ts
+++ b/packages/setup-cli/vitest.config.ts
@@ -1,27 +1,8 @@
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/assistant-engine": "../assistant-engine/src/index.ts",
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/gateway-core": "../gateway-core/src/index.ts",
-  "@murphai/hosted-execution": "../hosted-execution/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/inbox-services": "../inbox-services/src/index.ts",
-  "@murphai/inboxd": "../inboxd/src/index.ts",
-  "@murphai/messaging-ingress": "../messaging-ingress/package.json",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/parsers": "../parsers/src/index.ts",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-  "@murphai/vault-usecases": "../vault-usecases/src/index.ts",
-} as const;
-
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "setup-cli",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
   useDefaultConcurrency: false,
   useDefaultTimeouts: false,
   test: {

--- a/packages/vault-usecases/vitest.config.ts
+++ b/packages/vault-usecases/vitest.config.ts
@@ -7,52 +7,11 @@ import {
 } from "../../config/vitest-coverage.js";
 import { createMurphPackageVitestConfig } from "../../config/vitest-package.js";
 
-const WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
-  "@murphai/contracts": "../contracts/src/index.ts",
-  "@murphai/core": "../core/src/index.ts",
-  "@murphai/device-syncd": "../device-syncd/src/index.ts",
-  "@murphai/importers": "../importers/src/index.ts",
-  "@murphai/operator-config": "../operator-config/package.json",
-  "@murphai/query": "../query/src/index.ts",
-  "@murphai/runtime-state": "../runtime-state/src/index.ts",
-} as const;
-
 const PACKAGE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 export default createMurphPackageVitestConfig({
   configUrl: import.meta.url,
   name: "vault-usecases",
-  workspaceSourceEntryRelativePaths: WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS,
-  extraAliases: ({ packageDir }) => [
-    {
-      find: /^@murphai\/vault-usecases$/,
-      replacement: path.resolve(packageDir, "./src/index.ts"),
-    },
-    {
-      find: /^@murphai\/vault-usecases\/helpers$/,
-      replacement: path.resolve(packageDir, "./src/helpers.ts"),
-    },
-    {
-      find: /^@murphai\/vault-usecases\/records$/,
-      replacement: path.resolve(packageDir, "./src/records.ts"),
-    },
-    {
-      find: /^@murphai\/vault-usecases\/runtime$/,
-      replacement: path.resolve(packageDir, "./src/runtime.ts"),
-    },
-    {
-      find: /^@murphai\/vault-usecases\/testing$/,
-      replacement: path.resolve(packageDir, "./src/testing.ts"),
-    },
-    {
-      find: /^@murphai\/vault-usecases\/vault-services$/,
-      replacement: path.resolve(packageDir, "./src/vault-services.ts"),
-    },
-    {
-      find: /^@murphai\/vault-usecases\/workouts$/,
-      replacement: path.resolve(packageDir, "./src/workouts.ts"),
-    },
-  ],
   coverage: createMurphVitestCoverage({
     customProviderModule: resolveMurphVitestCoverageProviderModule(PACKAGE_DIR),
     include: ["src/**/*.ts"],

--- a/scripts/workspace-source-resolution.test.ts
+++ b/scripts/workspace-source-resolution.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  createVitestAliasesFromTsconfigPaths,
   createVitestWorkspaceRuntimeAliases,
   resolveHostedWebWorkspaceSourceEntries,
 } from "../config/workspace-source-resolution.ts";
@@ -101,6 +102,35 @@ describe("workspace source resolution", () => {
       );
 
     expect(broadSourceAliases).toEqual([]);
+  });
+
+  it("derives non-web Vitest workspace aliases from the root tsconfig paths", () => {
+    const aliases = createVitestAliasesFromTsconfigPaths({
+      workspaceDir: path.join(repoRoot, "packages/core"),
+      specifierFilter: (specifier) =>
+        specifier === "#hosted-web-testing"
+        || specifier === "murph"
+        || specifier.startsWith("@murphai/"),
+    });
+
+    expect(resolveAliasReplacement(aliases, "@murphai/core")).toBe(
+      path.join(repoRoot, "packages/core/src/index.ts"),
+    );
+    expect(resolveAliasReplacement(aliases, "@murphai/vault-usecases/testing")).toBe(
+      path.join(repoRoot, "packages/vault-usecases/src/testing.ts"),
+    );
+    expect(resolveAliasReplacement(aliases, "@murphai/device-syncd/client")).toBe(
+      path.join(repoRoot, "packages/device-syncd/src/client.ts"),
+    );
+    expect(resolveAliasReplacement(aliases, "@murphai/importers/clinical-records")).toBe(
+      path.join(repoRoot, "packages/importers/src/clinical-records/index.ts"),
+    );
+    expect(resolveAliasReplacement(aliases, "#hosted-web-testing")).toBe(
+      path.join(repoRoot, "apps/web/test/support/hosted-web-testkit.ts"),
+    );
+    expect(resolveAliasReplacement(aliases, "murph")).toBe(
+      path.join(repoRoot, "packages/cli/src/index.ts"),
+    );
   });
 
   it("keeps shared public package aliases on explicit exported subpaths", () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -57,9 +57,6 @@
       "@murphai/hosted-execution/assistant-personalization": [
         "./packages/hosted-execution/src/assistant-personalization.ts"
       ],
-      "@murphai/hosted-execution/assistant-configuration-approval": [
-        "./packages/hosted-execution/src/assistant-configuration-approval.ts"
-      ],
       "@murphai/hosted-execution/assistant-usage": [
         "./packages/hosted-execution/src/assistant-usage.ts"
       ],
@@ -227,6 +224,9 @@
       ],
       "@murphai/importers": [
         "./packages/importers/src/index.ts"
+      ],
+      "@murphai/importers/clinical-records": [
+        "./packages/importers/src/clinical-records/index.ts"
       ],
       "@murphai/importers/device-providers/provider-descriptors": [
         "./packages/importers/src/device-providers/provider-descriptors.ts"
@@ -422,9 +422,6 @@
       ],
       "@murphai/inbox-services": [
         "./packages/inbox-services/src/index.ts"
-      ],
-      "@murphai/inbox-services/linq-endpoint": [
-        "./packages/inbox-services/src/linq-endpoint.ts"
       ],
       "@murphai/inbox-services/testing": [
         "./packages/inbox-services/src/testing.ts"


### PR DESCRIPTION
## Why this PR exists

Twenty-three package Vitest configs, the CLI workspace, and Cloudflare repeated 245 workspace alias declarations already represented by the root TypeScript path map. Every package rename or subpath change therefore had several test-only catalogs that could drift independently.

## User goal / user-visible behavior

Tests should resolve workspace packages from one canonical path map, so refactors do not fail or silently exercise the wrong source because a package-local alias list was missed. Runtime and product behavior are unchanged.

## User experience

No UI or production flow changes. This makes local and CI test resolution simpler and more consistent.

## Invariants the PR must preserve

- Package roots and explicit/nested public subpaths resolve to workspace source.
- The CLI’s `murph` alias and Cloudflare’s genuine app-local aliases remain intact.
- Hosted web’s deliberate source/transpilation allowlist and boundary policy remain unchanged.
- Dynamic `@murphai/importers/clinical-records` imports resolve from source.
- Missing or broad wildcard targets are not introduced to make tests pass.
- The dependency graph, lockfile, and production runtime configuration do not change.

## Non-obvious affected surfaces

- **Shared Vitest factory:** deletes the redundant `workspaceSourceEntryRelativePaths` and unused `extraAliases` seams; it now derives package aliases directly from root paths.
- **CLI and Cloudflare:** delete their second workspace maps while retaining their genuine local aliases and existing filters.
- **Root TypeScript paths:** add the one exact clinical-records subpath required by a dynamic import and delete two exact mappings whose target files no longer exist.
- **Hosted web:** remains intentionally outside this consolidation because its source-resolution allowlist also controls a separate transpilation/boundary policy.

## Change-shape breakdown

Classification: Vitest and TypeScript configuration is config/tooling; the workspace-resolution regression file is tests; the completed execution plan is docs; there are no production-source, generated, moved, or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 30 | 0 |
| Docs | 53 | 0 |
| Config/tooling | 11 | 417 |
| Generated/other | 0 | 0 |
| **Total** | **94** | **417** |

## Verification

- Root workspace source-resolution test: 7/7 passed.
- Static workspace-specifier audit: 198 used specifiers, 0 uncovered, 0 missing targets, and 0 missing exact root targets.
- Repo-tools suite: 337/337 passed.
- Cloudflare: 1,827/1,827 passed.
- Vault-usecases: 195/195 passed.
- Hosted-local-harness: 391 passed, 1 skipped after building its clean-worktree runtime prerequisite.
- Setup CLI sequential suite: 124/124 passed.
- All other affected owner suites and typechecks passed; frozen offline install passed and the lockfile stayed unchanged.
- Required coverage-write audit passed without edits; the root-derived alias owner and its major consumer shapes have direct regression coverage.
- `git diff --check`, stale-option search, and changed-file privacy scan passed.

Two broad-run interruptions were independently cleared: a fresh worktree initially lacked the assistant-runtime build artifact, and one parallel setup-CLI TTY test was timing-sensitive; building the prerequisite plus focused and full sequential reruns passed.

## Deployment compatibility

This changes test tooling only. There is no runtime, persisted-data, API, environment, or deployment-topology change, so no rollout coordination or migration is required.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 774cd610b24d4359fe482bf7b56fb9187e39cbf4

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `774cd610b24d4359fe482bf7b56fb9187e39cbf4` | 0 | 0 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786727785&installation_id=127572939&pr_number=693&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F693&signature=4c882a8fdb8661ba88bff9467e27d8bc62b239f07f18ce30c219ad933c77411f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->