### PR TITLE
Remove redundant GPT rollout preflight

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-remove-gpt-rollout-preflight.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-remove-gpt-rollout-preflight.md
@@ -1,0 +1,51 @@
+Goal (incl. success criteria):
+- Remove the redundant GPT-5.6-specific Cloudflare deploy-preflight branch and completed-rollout prose.
+- Success means production non-immediate container rollouts remain rejected by the generic state-isolation gate, GPT-5.6 Terra remains allowance-priced and smoke-tested, and current deploy documentation no longer describes a completed staged model rollout.
+
+Constraints/Assumptions:
+- Preserve the generic production state-isolation rollout gate and its default-to-immediate behavior.
+- Preserve OpenAI provider, priced-model, and production reasoning-effort validation.
+- Preserve GPT-5.5 and GPT-5.6 catalog/pricing support plus the live Terra deploy smoke.
+- Completed execution plans are immutable historical snapshots.
+- `apps/cloudflare/DEPLOY.md` overlaps the active runner-bundle dependency-prune lane; keep this edit limited to the hosted assistant rollout paragraphs.
+
+Key decisions:
+- Delete the model-specific branch instead of renaming it because every failing case is already rejected by the earlier generic state-isolation gate.
+- Keep a Terra-plus-gradual regression assertion, but make it assert the generic rollout error so the retained protection stays explicit.
+- Treat this as deploy-tooling cleanup with no runtime, persisted-state, or cross-service compatibility change.
+
+State:
+- Completed; implementation, scoped verification, the required coverage-write audit, and parent final review are complete.
+
+Done:
+- Confirmed the GPT-5.6-specific condition is a strict subset of the generic production state-isolation condition.
+- Confirmed the live Terra smoke, model catalog patch, usage pricing, provider gate, and reasoning-effort gate are independent surfaces that must remain.
+- Deleted the redundant model-specific preflight constants, condition, and duplicate diagnostic.
+- Repointed the Terra gradual/immediate regression assertions at the retained generic state-isolation gate.
+- Removed only the completed GPT-5.6 staged-rollout prose from the current deploy guide.
+- Passed `corepack pnpm install --frozen-lockfile --offline`.
+- Passed the focused deploy-preflight test: 1 file and 44 tests.
+- Passed `pnpm test:diff apps/cloudflare/scripts/deploy-preflight.ts apps/cloudflare/test/deploy-preflight.test.ts apps/cloudflare/DEPLOY.md`: Cloudflare Node lane 105 files and 1,829 tests, Workers-runtime lane 1 file and 1 test, plus dependency, boundary, Temporal, crypto, raw-log, and typecheck guards.
+- Passed `git diff --check`.
+- Required coverage-write audit passed with no edits or actionable proof gaps; the focused live-model smoke contract also passed 5 tests.
+- Parent final review confirmed the diff removes only duplicate rollout diagnostics and historical prose while preserving the generic gate and Terra smoke.
+
+Now:
+- Close the plan through the scoped commit helper.
+
+Next:
+- Push the scoped commit, open the PR, and run CI plus ReviewGPT.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- `apps/cloudflare/scripts/deploy-preflight.ts`
+- `apps/cloudflare/test/deploy-preflight.test.ts`
+- `apps/cloudflare/DEPLOY.md`
+- `agent-docs/exec-plans/active/COORDINATION_LEDGER.md`
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/deploy-preflight.test.ts`
+- `pnpm test:diff apps/cloudflare/scripts/deploy-preflight.ts apps/cloudflare/test/deploy-preflight.test.ts apps/cloudflare/DEPLOY.md`
+Status: completed
+Updated: 2026-07-15
+Completed: 2026-07-15

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -311,7 +311,7 @@ Hosted crypto authority metadata:
 Hosted assistant config:
 
 - `HOSTED_ASSISTANT_PROVIDER`
-- `HOSTED_ASSISTANT_MODEL`; worker deploy preflight requires an explicit allowance-priced direct OpenAI model slug. Supported slugs are `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; the target production slug for this rollout is `gpt-5.6-terra`, with `HOSTED_ASSISTANT_REASONING_EFFORT=low`.
+- `HOSTED_ASSISTANT_MODEL`; worker deploy preflight requires an explicit allowance-priced direct OpenAI model slug. Supported slugs are `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. Production deploys require `HOSTED_ASSISTANT_REASONING_EFFORT=low`.
 - `HOSTED_ASSISTANT_APPROVAL_POLICY`
 - `HOSTED_ASSISTANT_REASONING_EFFORT`
 - `HOSTED_ASSISTANT_SANDBOX`
@@ -319,19 +319,6 @@ Hosted assistant config:
 When changing hosted assistant model pricing or allowance enforcement, deploy the
 Cloudflare Worker/runner model config before or atomically with the hosted web
 allowance logic so runtime usage callbacks keep using an allowance-priced model.
-For the GPT-5.6 rollout, first merge and deploy the web allowance logic plus
-Worker/runner catalog patch while production remains on
-`HOSTED_ASSISTANT_MODEL=gpt-5.5`. Use `container_rollout=immediate`, leave the
-default live-model smoke enabled, and require that preparatory deploy to report
-`gpt-5.6-terra` and `OK`; this proves the production OpenAI project and deployed
-runner before user turns move. Then set
-`HOSTED_ASSISTANT_MODEL=gpt-5.6-terra` and redeploy Cloudflare with
-`container_rollout=immediate` and the live-model smoke still enabled. Immediate
-rollout is required because a gradual rollout can leave warm old-bundle
-containers without the GPT-5.6 catalog. The rollback floor is
-`HOSTED_ASSISTANT_MODEL=gpt-5.5`; when Terra itself is the reason for rollback,
-set `live_model_turn=false` on that rollback deploy so the Terra-specific smoke
-does not block restoring the floor.
 
 Vault-share selector-scope production deploys must also use
 `container_rollout=immediate` until the distance/count selector-scope runner

--- a/apps/cloudflare/scripts/deploy-preflight.ts
+++ b/apps/cloudflare/scripts/deploy-preflight.ts
@@ -37,9 +37,7 @@ const HOSTED_DEPLOY_CONTEXTS = [
   "production",
 ] as const;
 const REQUIRED_HOSTED_ASSISTANT_PROVIDER = "openai";
-const PRODUCTION_HOSTED_ASSISTANT_ROLLBACK_MODEL = "gpt-5.5";
 const PRODUCTION_HOSTED_ASSISTANT_REASONING_EFFORT = "low";
-const GPT_56_HOSTED_ASSISTANT_MODEL_CONTAINER_ROLLOUT = "immediate";
 const STATE_ISOLATION_CONTAINER_ROLLOUT = "immediate";
 const HOSTED_DEPLOY_CONTEXT_SET = new Set<string>(HOSTED_DEPLOY_CONTEXTS);
 
@@ -304,18 +302,6 @@ export function listHostedDeployEnvironmentInvariantErrors(
   if (hostedExecutionContainerRollout !== STATE_ISOLATION_CONTAINER_ROLLOUT) {
     errors.push(
       `production state-isolation deploys must use HOSTED_EXECUTION_CONTAINER_ROLLOUT=${STATE_ISOLATION_CONTAINER_ROLLOUT}; rollback floor is the audience-key and selector-scope runner bundle.`,
-    );
-  }
-
-  if (
-    hostedAssistantModelIsPriced
-    && hostedAssistantModel
-    && hostedAssistantModel !== PRODUCTION_HOSTED_ASSISTANT_ROLLBACK_MODEL
-    && hostedExecutionContainerRollout
-      !== GPT_56_HOSTED_ASSISTANT_MODEL_CONTAINER_ROLLOUT
-  ) {
-    errors.push(
-      `production hosted assistant GPT-5.6 deploys must set HOSTED_EXECUTION_CONTAINER_ROLLOUT=${GPT_56_HOSTED_ASSISTANT_MODEL_CONTAINER_ROLLOUT}; rollback floor is HOSTED_ASSISTANT_MODEL=${PRODUCTION_HOSTED_ASSISTANT_ROLLBACK_MODEL}.`,
     );
   }
 

--- a/apps/cloudflare/test/deploy-preflight.test.ts
+++ b/apps/cloudflare/test/deploy-preflight.test.ts
@@ -13,8 +13,6 @@ type EnvSource = Readonly<Record<string, string | undefined>>;
 
 const HOSTED_ASSISTANT_MODEL_PRICING_ERROR =
   "HOSTED_ASSISTANT_MODEL must be one of gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna for hosted AI usage allowance pricing.";
-const HOSTED_ASSISTANT_GPT_56_ROLLOUT_ERROR =
-  "production hosted assistant GPT-5.6 deploys must set HOSTED_EXECUTION_CONTAINER_ROLLOUT=immediate; rollback floor is HOSTED_ASSISTANT_MODEL=gpt-5.5.";
 const HOSTED_STATE_ISOLATION_ROLLOUT_ERROR =
   "production state-isolation deploys must use HOSTED_EXECUTION_CONTAINER_ROLLOUT=immediate; rollback floor is the audience-key and selector-scope runner bundle.";
 
@@ -412,7 +410,7 @@ describe("deploy preflight helpers", () => {
         }),
         { deployWorker: true },
       ),
-    ).toContain(HOSTED_ASSISTANT_GPT_56_ROLLOUT_ERROR);
+    ).toContain(HOSTED_STATE_ISOLATION_ROLLOUT_ERROR);
 
     expect(
       listHostedDeployEnvironmentInvariantErrors(
@@ -422,7 +420,7 @@ describe("deploy preflight helpers", () => {
         }),
         { deployWorker: true },
       ),
-    ).not.toContain(HOSTED_ASSISTANT_GPT_56_ROLLOUT_ERROR);
+    ).not.toContain(HOSTED_STATE_ISOLATION_ROLLOUT_ERROR);
 
     expect(
       listHostedDeployEnvironmentInvariantErrors(


### PR DESCRIPTION
## Why this PR exists

The Cloudflare deploy preflight still carried a GPT-5.6-specific rollout rejection that was a strict subset of the generic production state-isolation rollout gate. The duplicate branch and completed rollout prose no longer represented an independent safety control.

## User goal / user-visible behavior

Operators get one canonical rollout invariant and one accurate diagnostic for unsafe production container rollouts. There is no user-facing product behavior change.

## User experience

No UI or conversation flow changes.

## Invariants the PR must preserve

- Production non-immediate container rollouts remain rejected by the generic state-isolation gate.
- Omitted production rollout mode continues to resolve to the safe immediate default.
- GPT-5.5 and GPT-5.6 model pricing/catalog support remains intact.
- The live Terra deployment smoke and production low-reasoning requirement remain intact.

## Non-obvious affected surfaces

- **Deploy diagnostics:** Terra with a gradual rollout now reports only the generic state-isolation error. The focused preflight test proves the accept/reject behavior is unchanged.
- **Deployment documentation:** only the completed staged GPT-5.6 rollout and rollback instructions are removed. Current model configuration and Terra smoke guidance remain.
- **Runtime behavior:** None; this changes pre-deploy validation and documentation only.

## Change-shape breakdown

Classification rule: deploy-preflight implementation is source, its Vitest file is tests, and the deploy guide plus completed execution plan are docs. No binary, generated, moved, config/tooling, or other files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 14 |
| Tests/fixtures | 2 | 4 |
| Docs | 52 | 14 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **54** | **32** |

## Verification

- Focused deploy-preflight test: 44/44 passed.
- Live-model smoke-contract test: 5/5 passed.
- `pnpm test:diff`: Cloudflare typecheck passed; Workers lane 1/1 passed; Node lane 105 files and 1,829 tests passed; repository guards passed.
- Required coverage-write audit: PASS with no edits or actionable proof gaps.
- `git diff --check` and stale-symbol/prose scans passed.

## Deployment compatibility

No runtime deployment, tandem release, schema migration, or new rollback floor is required. The retained generic gate continues to require immediate production container rollout.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 5cda2db41679aa83e744b284c379f1e7aeac0fed

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `5cda2db41679aa83e744b284c379f1e7aeac0fed` | 0 | 14 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786729411&installation_id=127572939&pr_number=694&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F694&signature=5cccbf28a79e193e91ca06e740f1d17c7a0416a5ea6fcccfbdf17bf32c89296b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->