### PR TITLE
Select Murph voice from audio preview

### DIFF
--- a/apps/web/src/components/murph/murph-assistant-style-picker.tsx
+++ b/apps/web/src/components/murph/murph-assistant-style-picker.tsx
@@ -507,7 +507,15 @@ function VoiceCard({
         </span>
         <SelectedCheck selected={selected} />
       </label>
-      <div onClick={(event) => event.stopPropagation()} role="presentation">
+      <div
+        onClick={(event) => {
+          event.stopPropagation();
+          if (!disabled) {
+            onSelect();
+          }
+        }}
+        role="presentation"
+      >
         <VoiceMemoPlayer
           ref={playerRef}
           src={option.previewPath}

--- a/apps/web/test/murph-assistant-style-picker.test.tsx
+++ b/apps/web/test/murph-assistant-style-picker.test.tsx
@@ -1,11 +1,19 @@
 import assert from "node:assert/strict";
 
-import { act, createElement, type HTMLAttributes, type ReactNode } from "react";
+import {
+  act,
+  createElement,
+  forwardRef,
+  useImperativeHandle,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 import { afterEach, beforeEach, test, vi } from "vitest";
 
 import { renderClientComponent } from "./render-client-component";
 
 const componentMocks = vi.hoisted(() => ({
+  playerPlay: vi.fn(),
   useIsMobile: vi.fn(() => false),
 }));
 
@@ -62,9 +70,12 @@ vi.mock("@/src/components/ui/drawer", () => ({
 }));
 
 vi.mock("@/src/components/ui/voice-memo-player", () => ({
-  VoiceMemoPlayer({ src }: { src: string }) {
-    return createElement("div", { "data-voice-preview": src });
-  },
+  VoiceMemoPlayer: forwardRef<{ play: () => void }, { src: string }>(
+    function MockVoiceMemoPlayer({ src }, ref) {
+      useImperativeHandle(ref, () => ({ play: componentMocks.playerPlay }));
+      return createElement("div", { "data-voice-preview": src });
+    },
+  ),
 }));
 
 vi.mock("@/src/hooks/use-mobile", () => ({
@@ -72,6 +83,7 @@ vi.mock("@/src/hooks/use-mobile", () => ({
 }));
 
 beforeEach(() => {
+  componentMocks.playerPlay.mockReset();
   componentMocks.useIsMobile.mockReturnValue(false);
 });
 
@@ -571,6 +583,93 @@ test("MurphAssistantStylePicker selects a voice when the row outside the label i
 
     assert.equal(findRadioInput(rendered.container, "Grandpa")?.checked, true);
     assert.equal(findRadioInput(rendered.container, "New York")?.checked, false);
+    assert.equal(componentMocks.playerPlay.mock.calls.length, 1);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("MurphAssistantStylePicker selects a voice when its audio preview is clicked", async () => {
+  const { MurphAssistantStylePicker } = await import(
+    "@/src/components/murph/murph-assistant-style-picker"
+  );
+  const rendered = await renderClientComponent(
+    createElement(MurphAssistantStylePicker, {
+      initialStep: "voice",
+      initialVoice: "classic",
+      onOpenChange: () => {},
+      open: true,
+    }),
+    {
+      requireButton: false,
+    },
+  );
+
+  try {
+    const grandpaRow = findRadioInput(rendered.container, "Grandpa")?.closest("div");
+    assert.ok(grandpaRow, "Missing grandpa row");
+    const preview = grandpaRow.querySelector("[data-voice-preview]");
+    assert.ok(preview, "Missing grandpa audio preview");
+
+    await act(async () => {
+      preview.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+    });
+
+    assert.equal(findRadioInput(rendered.container, "Grandpa")?.checked, true);
+    assert.equal(findRadioInput(rendered.container, "New York")?.checked, false);
+    assert.equal(componentMocks.playerPlay.mock.calls.length, 0);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("MurphAssistantStylePicker keeps the voice selection frozen when a disabled preview is clicked", async () => {
+  let resolveSave: (() => void) | null = null;
+  const savePreference = vi.fn(
+    () =>
+      new Promise<{ tone: null; voice: "classic" }>((resolve) => {
+        resolveSave = () => resolve({ tone: null, voice: "classic" });
+      }),
+  );
+  const { MurphAssistantStylePicker } = await import(
+    "@/src/components/murph/murph-assistant-style-picker"
+  );
+  const rendered = await renderClientComponent(
+    createElement(MurphAssistantStylePicker, {
+      initialStep: "voice",
+      initialVoice: "classic",
+      onOpenChange: () => {},
+      open: true,
+      savePreference,
+      singleStep: true,
+    }),
+    {
+      requireButton: false,
+    },
+  );
+
+  try {
+    await clickButton(rendered, "Save");
+    assert.equal(savePreference.mock.calls.length, 1);
+
+    const grandpaInput = findRadioInput(rendered.container, "Grandpa");
+    assert.equal(grandpaInput?.disabled, true);
+    const grandpaRow = grandpaInput?.closest("div");
+    assert.ok(grandpaRow, "Missing grandpa row");
+    const preview = grandpaRow.querySelector("[data-voice-preview]");
+    assert.ok(preview, "Missing grandpa audio preview");
+
+    await act(async () => {
+      preview.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+    });
+
+    assert.equal(findRadioInput(rendered.container, "New York")?.checked, true);
+    assert.equal(findRadioInput(rendered.container, "Grandpa")?.checked, false);
+    assert.equal(componentMocks.playerPlay.mock.calls.length, 0);
+
+    await act(async () => {
+      resolveSave?.();
+    });
   } finally {
     await rendered.cleanup();
   }


### PR DESCRIPTION
## Why this PR exists

The voice picker's audio preview stopped click propagation to preserve the player's controls, but did not forward that interaction to the existing voice selection handler. As a result, clicking the waveform or playback surface could play audio without selecting that voice.

## User goal and experience

While choosing Murph's voice, clicking anywhere on a voice's audio preview now selects that voice. The play button keeps its normal play/pause behavior, card clicks still start playback once, and selection remains frozen while a save is in progress.

## Invariants

- The existing `VoiceCard` selection callback remains the only selection owner.
- Preview clicks do not bubble to the card and trigger duplicate imperative playback.
- Disabled voice choices cannot change while the save request is active.
- Existing desktop and mobile picker layouts remain unchanged.

## Non-obvious affected surfaces

None.

## Verification

- Focused Vitest: 14 tests passed.
- Web prepared typecheck passed.
- Focused ESLint passed.
- `git diff --check` passed.
- Required frontend review returned zero findings.
- Required coverage review added direct proof for preview selection, single playback, and disabled-state behavior.

## Change-shape breakdown

Classification: production component code is source; Vitest files are tests. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 9 | 1 |
| Tests/fixtures | 103 | 4 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **112** | **5** |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786729451&installation_id=127572939&pr_number=695&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F695&signature=d5df9466078704ee904d6d2a3e20a9d1442b29cf2287e689ad627a1b6fa4b78b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->