### PR TITLE
Require browser-vault member proof

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-remove-browser-vault-memberid-compat.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-remove-browser-vault-memberid-compat.md
@@ -1,0 +1,50 @@
+# Remove Browser-Vault Member-ID Compatibility
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+Remove the browser-vault client's temporary tolerance for successful `empty`
+and `not_modified` responses that omit member identity. Success means those
+responses fail closed unless they carry a non-empty `memberId`, while ready
+replicas continue to bind identity through encrypted AAD and local unauthorized
+results continue to use the intentional synthetic `memberId: null` state.
+
+## Scope
+
+- Tighten the successful browser-vault session response parser.
+- Replace legacy-acceptance tests with strict missing-proof coverage.
+- Document the permanent hosted-web rollback floor created by the hard cut.
+
+## Constraints
+
+- Preserve the existing cross-member identity-change behavior.
+- Preserve ready-replica identity from `replicaAad.userId`; do not add a
+  redundant top-level member field to ready responses.
+- Preserve the local 401/403 synthetic empty result with `memberId: null`.
+- Do not change the server producer or add compatibility machinery.
+- Preserve unrelated working-tree and coordination-ledger work.
+
+## Tasks
+
+1. Make successful `empty` and `not_modified` session responses require a
+   non-empty `memberId` and delete the legacy parser helper.
+2. Add focused strict-parser regression coverage while retaining unauthorized
+   synthetic-null and valid identity proofs.
+3. Record the #586 hosted-web rollback floor in the app owner documentation.
+4. Run focused tests, stale-language searches, diff hygiene, and the truthful
+   diff-aware hosted-web verification lane.
+
+## Verification
+
+- Focused browser-vault loader Vitest passed: 10/10 tests.
+- Stale helper, legacy-language, privacy, and secret scans passed.
+- `git diff --check` passed.
+- `pnpm test:diff` passed TypeScript, dev smoke, lint with zero errors, 430
+  test files and 5,216 tests, and the production Web build.
+- Required coverage-write audit passed with no edits or actionable proof gaps.
+- Parent final review confirmed successful wire responses fail closed while
+  ready AAD identity and the synthetic unauthorized null state remain intact.
+Completed: 2026-07-15

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -39,6 +39,22 @@ workspace-runtime pass, and checkpoints through the web-owned workspace CAS. It 
 opaque encrypted runtime blobs and explicit execution-time callback data, but it is not the
 canonical owner of hosted product facts.
 
+## Browser-vault member-proof rollback floor
+
+Successful browser-vault session responses in the `empty` and `not_modified`
+states carry the authenticated member's non-empty `memberId`. Ready responses
+bind that identity through the encrypted replica AAD's `userId` instead of a
+redundant top-level field. The browser client fails closed when either
+non-ready success response omits its member proof; only the local synthetic
+401/403 empty result intentionally uses `memberId: null`.
+
+PR #586 is the permanent hosted-web rollback floor for this contract. The
+production alias and retained ready deployments were proved to descend that
+producer before the omitted-field reader was removed. Do not roll the Web
+alias below #586: a browser loaded from a current deployment can outlive an
+alias change and reject an older producer's unproved response. For an incident,
+deploy a forward fix or roll forward to #586 or newer.
+
 ## Approval-outcome deployment compatibility
 
 Deploy the gate-disabled web bundle that serves the internal action-approval

--- a/apps/web/src/lib/browser-vault/loader.ts
+++ b/apps/web/src/lib/browser-vault/loader.ts
@@ -141,9 +141,6 @@ export async function loadBrowserVaultReplica({
   }
 
   if (session.state === "not_modified") {
-    if (session.memberId === null) {
-      return { state: "identity_changed" };
-    }
     assertBrowserVaultReplicaRefsMatch({
       actual: session.replicaRef,
       expected: knownReplicaRef,
@@ -252,7 +249,7 @@ export type BrowserVaultSessionResponse =
       encryptedReplica: null;
       deviceSyncImportPending: boolean;
       freshness: BrowserVaultFreshness;
-      memberId: string | null;
+      memberId: string;
       replicaAad: null;
       replicaKeyEnvelope: null;
       replicaRef: null;
@@ -264,7 +261,7 @@ export type BrowserVaultSessionResponse =
       encryptedReplica: null;
       deviceSyncImportPending: boolean;
       freshness: BrowserVaultFreshness;
-      memberId: string | null;
+      memberId: string;
       replicaAad: null;
       replicaKeyEnvelope: null;
       replicaRef: HostedBrowserVaultReplicaRef;
@@ -300,7 +297,7 @@ export function parseBrowserVaultSessionResponse(value: unknown): BrowserVaultSe
         "deviceSyncImportPending",
       ),
       freshness: parseBrowserVaultFreshness(record.freshness, "stale"),
-      memberId: readLegacyCompatibleMemberId(
+      memberId: requireNonEmptyString(
         record.memberId,
         "Browser vault session response.memberId",
       ),
@@ -324,7 +321,7 @@ export function parseBrowserVaultSessionResponse(value: unknown): BrowserVaultSe
         "deviceSyncImportPending",
       ),
       freshness: parseBrowserVaultFreshness(record.freshness, "fresh"),
-      memberId: readLegacyCompatibleMemberId(
+      memberId: requireNonEmptyString(
         record.memberId,
         "Browser vault session response.memberId",
       ),
@@ -535,15 +532,6 @@ function requireNonEmptyString(value: unknown, label: string): string {
   }
 
   return value;
-}
-
-function readLegacyCompatibleMemberId(
-  value: unknown,
-  label: string,
-): string | null {
-  // The pre-member-proof endpoint omitted this additive field. Missing proof
-  // can represent empty data, but it must never authorize cached private data.
-  return value === undefined ? null : requireNonEmptyString(value, label);
 }
 
 function createEmptyLoadResult(): Extract<BrowserVaultSessionLoadResult, { state: "empty" }> {

--- a/apps/web/test/browser-vault-loader.test.ts
+++ b/apps/web/test/browser-vault-loader.test.ts
@@ -23,49 +23,20 @@ test("browser vault session parser rejects encrypted payloads on not_modified re
   );
 });
 
-test("browser vault session parser preserves missing legacy not_modified member proof as null", () => {
-  const response = parseBrowserVaultSessionResponse({
-    encryptedReplica: null,
-    replicaAad: null,
-    replicaKeyEnvelope: null,
-    replicaRef: createReplicaRef(),
-    state: "not_modified",
-  });
-
-  assert.equal(response.state, "not_modified");
-  assert.equal(response.memberId, null);
-});
-
-test("browser vault session parser accepts legacy empty responses without member authority", () => {
-  const response = parseBrowserVaultSessionResponse({
-    encryptedReplica: null,
-    replicaAad: null,
-    replicaKeyEnvelope: null,
-    replicaRef: null,
-    state: "empty",
-  });
-
-  assert.equal(response.state, "empty");
-  assert.equal(response.memberId, null);
-});
-
 test.each(["empty", "not_modified"] as const)(
-  "legacy %s responses cannot authorize a cached member",
-  async (state) => {
+  "browser vault session parser rejects %s responses without member proof",
+  (state) => {
     const replicaRef = state === "not_modified" ? createReplicaRef() : null;
-    const result = await loadBrowserVaultReplica({
-      expectedMemberId: "member_123",
-      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+    assert.throws(
+      () => parseBrowserVaultSessionResponse({
         encryptedReplica: null,
         replicaAad: null,
         replicaKeyEnvelope: null,
         replicaRef,
         state,
-      }), { status: 200 })),
-      knownReplicaRef: replicaRef,
-    });
-
-    assert.deepEqual(result, { state: "identity_changed" });
+      }),
+      /Browser vault session response\.memberId must be a non-empty string\./u,
+    );
   },
 );
 


### PR DESCRIPTION
## Why this PR exists

The browser-vault client still tolerated successful `empty` and `not_modified` responses that omitted authenticated member identity. Production producers and retained deployments have converged on the member-proof contract, so the legacy parser path now weakens an otherwise fail-closed identity boundary.

## User goal / user-visible behavior

A signed-in member's browser vault accepts successful non-ready responses only when the server proves the member identity. Unsupported older responses now fail closed instead of being treated as identity-less success.

## User experience

Normal dashboard loading is unchanged. If a manually promoted pre-#586 Web deployment omits member proof, the current browser reports the existing load failure/identity-change path rather than authorizing cached private data.

## Invariants the PR must preserve

- Successful `empty` and `not_modified` wire responses require a non-empty `memberId`.
- Ready replicas continue to bind identity through encrypted replica AAD `userId`.
- Cross-member responses continue to fail closed.
- The local synthetic 401/403 empty result intentionally remains `memberId: null`.
- No top-level identity field is added to ready responses.

## Non-obvious affected surfaces

- **Browser-vault wire parser:** omitted member proof becomes a hard parse failure for successful non-ready responses. Focused tests cover both states.
- **Unauthorized local fallback:** its synthetic null identity is not a wire response and remains unchanged.
- **Deployment operations:** PR #586 becomes the permanent Web rollback floor; retained older deployment artifacts must not be manually promoted.

## Change-shape breakdown

Classification rule: the loader is source, the loader test is tests, and the Web owner guide plus completed execution plan are docs. No binary, generated, moved, config/tooling, or other files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 16 |
| Tests/fixtures | 7 | 36 |
| Docs | 66 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **77** | **52** |

## Verification

- Focused browser-vault loader test: 10/10 passed on the final rebased head.
- `pnpm test:diff`: TypeScript, dev smoke, lint with zero errors, 430 test files/5,216 tests, and production Web build passed.
- Required coverage-write audit: PASS with no edits or actionable proof gaps.
- Stale compatibility, privacy, secret, and `git diff --check` scans passed.

## Deployment compatibility

Normal forward Web deployment is sufficient; no Cloudflare tandem deploy is required. Do not manually promote or redeploy a Web commit older than #586 after this hard cut. Existing old browser tabs remain compatible with the additive current producer response.

## ReviewGPT baseline

ReviewGPT first-reviewed head: c1205a4acfb09a02f0b965e35baee81b83ebc41a

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `c1205a4acfb09a02f0b965e35baee81b83ebc41a` | 4 | 16 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786729517&installation_id=127572939&pr_number=696&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F696&signature=e761ef24b617c96928c440a5104861a0d6f90a016a2e50145e80d360afb6795c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->