### PR TITLE
Remove legacy requested abort status

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-remove-requested-abort-status.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-remove-requested-abort-status.md
@@ -1,0 +1,51 @@
+# Remove Legacy Requested Abort Status
+
+Status: completed
+Updated: 2026-07-15
+
+## Goal
+
+Delete the retired `requested` workspace-invocation abort result now that the
+current container boundary always settles a missing-pointer abort to
+`accepted`, `inactive`, or `stale` before returning to the Durable Object.
+
+Success criteria:
+
+- Remove the impossible status from the exported type and controller branch.
+- Remove request-only compatibility tests and protocol prose.
+- Preserve exact attempt, lease-generation, and user identity checks.
+- Preserve stale retry, inactive handling, and fail-closed shell recycling.
+
+## Constraints
+
+- Keep the change limited to the retired `requested` result. Do not simplify
+  other abort statuses or lifecycle behavior in this task.
+- Do not modify or close the separate hosted runner destroy-timeout plan or its
+  coordination-ledger row.
+- Keep the current Cloudflare rollback floor at PR #627 or newer; this cleanup
+  does not authorize an older Worker or runner rollback.
+- Do not add a replacement flag, compatibility manager, or persisted state.
+
+## Approach
+
+1. Remove `requested` from the runner abort result type.
+2. Remove the controller-only `acceptRequestedAbort` option and branch.
+3. Delete or update tests whose only purpose was the old request-only result.
+4. Delete the corresponding deploy-skew paragraph from the runtime protocol.
+5. Run focused Cloudflare tests, stale-string checks, `git diff --check`, and
+   the truthful diff-aware verification lane.
+
+## Deployment Compatibility
+
+This is a Cloudflare Worker/container contract cleanup with no web-side change.
+Current runner code no longer produces `requested`; a stale runtime string would
+fall through to retry rather than clear a fence. Deploy and rollback remain
+bounded to PR #627 or newer, where the settled abort behavior is already live.
+
+## State
+
+Implementation and local verification are complete. The focused Cloudflare
+tests, stale-string checks, diff hygiene, and diff-aware workspace verification
+all pass. Commit, PR publication, CI, and ReviewGPT remain pending the parent
+coordination flow.
+Completed: 2026-07-15

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -293,9 +293,7 @@ proof owns the container lifecycle while it delivers the identity-checked abort.
 A stale result preserves the fence and retries. An accepted or queued result, or
 an ambiguous delivery failure, recycles the old shell fail-closed before the
 container returns `accepted`; only that settled stop allows the controller to
-clear the exact fence and start a replacement. A deploy-skewed request-only
-`requested` result remains non-authoritative without inactive proof and
-preserves the fence for retry.
+clear the exact fence and start a replacement.
 
 The foreground-priority rule does not weaken correctness checks. Wrong-user
 authority, invalid auth, undecryptable mailbox payloads, stale leases, and

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -248,11 +248,10 @@ export type RunnerWorkspaceInvocationAbortStatus =
   | "failed"
   | "inactive"
   | "queued"
-  | "requested"
   | "stale";
 
 type RunnerWorkspaceInvocationAbortPostStatus =
-  Exclude<RunnerWorkspaceInvocationAbortStatus, "inactive" | "requested">;
+  Exclude<RunnerWorkspaceInvocationAbortStatus, "inactive">;
 
 type RunnerContainerDestroyReason =
   | "activity-expired"

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -405,7 +405,6 @@ export class RuntimeProcessingController {
       });
     if (activeRuntimeState.outcome === "inactive") {
       const abortResult = await this.abortActiveRuntimeFence({
-        acceptRequestedAbort: true,
         activeFence,
         commandBudget: input.commandBudget,
         record,
@@ -452,7 +451,6 @@ export class RuntimeProcessingController {
   }
 
   private async abortActiveRuntimeFence(input: {
-    acceptRequestedAbort?: boolean;
     activeFence: NonNullable<RunnerStateRecord["writeFence"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     record: RunnerStateRecord;
@@ -503,7 +501,6 @@ export class RuntimeProcessingController {
       if (
         abortStatus === "accepted"
         || abortStatus === "inactive"
-        || (input.acceptRequestedAbort === true && abortStatus === "requested")
       ) {
         return { aborted: true };
       }

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -489,9 +489,6 @@ describe("HostedUserRunner execution coordination", () => {
   it("accepts runtime processing start before the invocation reaches idle", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
-    const abortWorkspaceInvocation = vi.fn<
-      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => "requested");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const { invoke, runner, sql } = createRunnerHarness({
       invocationResults: [invocationResult.promise],
@@ -2051,12 +2048,64 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
+  it("preserves the active retention fence when the settled abort is stale", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const abortWorkspaceInvocation = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+    >(async () => "stale");
+    let activeAttemptId = "";
+    let activeGeneration = "";
+    const readActiveRuntimeUserFence = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
+    >(async () => ({
+      active: true,
+      attemptId: activeAttemptId,
+      leaseGeneration: activeGeneration,
+      userId: TEST_USER_ID,
+    }));
+    const { invoke, runner, sql } = createRunnerHarness({
+      abortWorkspaceInvocation,
+      readActiveRuntimeUserFence,
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      processingMode: "inbox_media_retention",
+      runnerContainerName: TEST_USER_ID,
+      workspaceVersion: "7",
+    });
+    activeAttemptId = token.attemptId;
+    activeGeneration = String(token.generation);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt-default-behind-stale-retention",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:05.000Z",
+    });
+
+    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
+    expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
+      attemptId: token.attemptId,
+      leaseGeneration: String(token.generation),
+      userId: TEST_USER_ID,
+    });
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      active_expires_at: null,
+      wake_at: null,
+    });
+  });
+
   it("preempts a legacy retention fence with no persisted container name", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const abortWorkspaceInvocation = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => "accepted");
+    >(async () => "inactive");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const versionedContainerName = `${TEST_USER_ID}--v-current`;
     const versionedInvoke = vi.fn<HostedExecutionContainerStubLike["invoke"]>(
@@ -2221,86 +2270,6 @@ describe("HostedUserRunner execution coordination", () => {
       active_attempt_id: token.attemptId,
       active_expires_at: null,
       wake_at: null,
-    });
-  });
-
-  it("waits for inactive proof after requesting abort for indeterminate retention liveness", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_NOW));
-    const abortWorkspaceInvocation = vi.fn<
-      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => "requested");
-    const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
-    let activeRuntimeState: "inactive" | "indeterminate" = "indeterminate";
-    const readActiveRuntimeUserFence = vi.fn<
-      NonNullable<HostedExecutionContainerStubLike["readActiveRuntimeUserFence"]>
-    >(async () => {
-      if (activeRuntimeState === "inactive") {
-        return {
-          active: false,
-          reason: "no_active_runtime",
-        };
-      }
-      throw new Error("container health still reports active workspace work");
-    });
-    const { invoke, runner, sql } = createRunnerHarness({
-      abortWorkspaceInvocation,
-      invocationResults: [invocationResult.promise],
-      readActiveRuntimeUserFence,
-      workspace: createWorkspaceState({ version: "7" }),
-    });
-    await runner.bindUser(TEST_USER_ID);
-    const token = writeRuntimeFenceForTest(sql, {
-      processingMode: "inbox_media_retention",
-      runnerContainerName: TEST_USER_ID,
-      workspaceVersion: "7",
-    });
-
-    await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-default-behind-indeterminate-retention",
-      userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
-      kind: "retry_later",
-      retryAt: "2026-04-27T00:00:05.000Z",
-    });
-
-    expect(readActiveRuntimeUserFence).toHaveBeenCalledOnce();
-    expect(abortWorkspaceInvocation).toHaveBeenCalledOnce();
-    expect(invoke).not.toHaveBeenCalled();
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: token.attemptId,
-      active_expires_at: null,
-      wake_at: null,
-    });
-
-    activeRuntimeState = "inactive";
-    vi.setSystemTime(new Date("2026-04-27T00:00:05.000Z"));
-    await expect(runner.ensureRuntimeProcessingForUser({
-      orchestrationAttemptId: "test-orchestration-attempt-default-behind-inactive-retention",
-      userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
-      action: "replaced",
-      kind: "runtime_processing_accepted",
-      runtimeAttemptId: expect.not.stringMatching(token.attemptId),
-    });
-
-    expect(readActiveRuntimeUserFence).toHaveBeenCalledTimes(2);
-    expect(abortWorkspaceInvocation).toHaveBeenCalledTimes(2);
-    expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
-      attemptId: token.attemptId,
-      leaseGeneration: String(token.generation),
-      userId: TEST_USER_ID,
-    });
-    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
-    expect(readRunnerMeta(sql)).toMatchObject({
-      active_attempt_id: expect.not.stringMatching(token.attemptId),
-      active_expires_at: null,
-      wake_at: null,
-    });
-
-    invocationResult.resolve({
-      nextWakeAt: null,
-      status: "idle",
     });
   });
 
@@ -2491,7 +2460,7 @@ describe("HostedUserRunner execution coordination", () => {
     vi.setSystemTime(new Date(FIXED_NOW));
     const abortWorkspaceInvocation = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
-    >(async () => "requested");
+    >(async () => "accepted");
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
     const onStatusRead = vi.fn();
     const ensureProcessing = vi.fn<NonNullable<HostedExecutionContainerStubLike["ensureProcessing"]>>(


### PR DESCRIPTION
## Why this PR exists

The Cloudflare abort contract still admitted a `requested` result that the current runner boundary can no longer return. Keeping that status left a controller-only compatibility branch which could clear an active runtime fence without the settled `accepted`, `inactive`, or `stale` result now required by the container.

## User goal / user-visible behavior

Runtime replacement keeps the same externally visible behavior while using the settled abort contract exclusively. There is no UI or conversation-flow change.

## User experience

No user-facing flow changes. Active work remains protected by the existing exact attempt, lease-generation, and member identity checks.

## Invariants the PR must preserve

- `accepted` and `inactive` remain successful settled abort results.
- `stale` preserves the exact active fence and retries without invoking replacement.
- Ambiguous or failed abort delivery continues to recycle the old shell fail-closed.
- Exact attempt, lease-generation, and user identity checks remain intact.
- Cloudflare Worker and runner rollback remains bounded to PR #627 or newer.

## Non-obvious affected surfaces

- **Controller preemption:** the request-only acceptance flag and branch are deleted; only settled results can clear a fence.
- **Runner contract:** the impossible status is removed from the exported Cloudflare type.
- **Regression proof:** direct controller coverage now exercises both the surviving `inactive` success path and `stale` retry path.
- **Deployment:** this is a Worker/container contract cleanup; Web is unaffected.

## Change-shape breakdown

Classification: Cloudflare implementation is source, the alarm regression file is tests, and the runtime protocol plus completed execution plan are docs. No config/tooling or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 5 |
| Tests/fixtures | 54 | 85 |
| Docs | 52 | 3 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **107** | **93** |

## Verification

- Final rebased focused Cloudflare tests: 2 files / 238 tests passed.
- `pnpm test:diff`: Cloudflare Node 105 files / 1,829 tests; Workers 1 file / 1 test; typecheck and repository guards passed.
- Required coverage-write audit: PASS after adding direct `inactive` and `stale` controller proof; no unresolved findings.
- Requested-status residue, privacy, secret, and whitespace scans passed.

## Deployment compatibility

Deploy the Cloudflare Worker and runner bundle together through the normal artifact flow. No Web tandem deploy or schema migration is required. Keep deployments and rollback at PR #627 or newer; a stale unexpected status remains fail-closed.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 79244eeab064e6f8f9a71c270914ad91d3de57f2

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `79244eeab064e6f8f9a71c270914ad91d3de57f2` | 1 | 5 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786730596&installation_id=127572939&pr_number=700&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F700&signature=6a0a1a9247c5074b99d92f5255aaccd0931a5f13f2bbf2ed467545ed7a4bb60c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->