### PR TITLE
Remove newsletter rollout compatibility

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-remove-newsletter-read-stats.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-remove-newsletter-read-stats.md
@@ -1,0 +1,54 @@
+Goal (incl. success criteria):
+- Remove the fully drained PR #608 newsletter runner version-negotiation surface.
+- Success means the shared newsletter contract accepts only `prepare` and `send`, no source or live current doc references `read_stats`, `includeAuthorizationProof`, `includeAuthorizationSnapshot`, or `newsletter_runner_upgrade_required`, and current preparation still returns the address-free live authorization snapshot plus proof used by filtering and delivery revalidation.
+- Preserve scheduled-occurrence retry, delivery idempotency, immutable occurrence manifests, proof-required provider entry, and the unrelated missing-email nudge flow.
+
+Constraints/Assumptions:
+- Keep the signed, member-bound Web callback and strict current request/response parsing.
+- Do not change the actual authorization proof, exact share-id/scope filtering, repeatable-read authority resolution, one-shot prepare/send capability, outbox parent/child lifecycle, or recipient re-resolution.
+- Do not add a compatibility shim, schema change, state owner, route, retry path, or dependency.
+- Use a separate ReviewGPT-eligible PR lane; do not run local deep-review for the completed patch.
+- Preserve unrelated active work and resolve the separate WhatsApp test-file hunk by ordinary rebase if needed.
+
+Key decisions:
+- Delete the old request action, fail-closed legacy response, and rollout marker fields together instead of retaining no-op version flags.
+- Treat the marker fields as version negotiation only: they carry no member identity, grant, proof, or recipient authority and are checked only before the real preparation owner is called.
+- Deploy Web first, then Cloudflare/runner with immediate rollout. Current retry ownership preserves any newsletter occurrence that observes the short incompatible window.
+- After both planes deploy, the cleanup head is the independent rollback floor; a coordinated rollback may return both planes to the #608 contract, Cloudflare first and then Web, but never to a pre-#608 runner.
+
+State:
+- Implementation and focused verification complete; uncommitted for parent handoff.
+
+Done:
+- Verified current model-facing schemas expose only `prepare` and `send`.
+- Verified current ready Web deployments and successful immediate Cloudflare deployments descend PR #608, and runner fingerprint admission rejects stale bundles.
+- Traced the rollout markers to request parsing/routing only and separately traced the real proof/filter/outbox/provider-entry protections that must remain.
+- Removed the retired request action, rollout marker fields, fail-closed compatibility response, Web route gate, and forwarding branches without changing the live authorization owner or delivery protections.
+- Added direct proof that a rejected Web newsletter request becomes a closed capability plus an unavailable send result; the existing cron proof verifies that result preserves the exact pending occurrence and schedules retry.
+- Passed focused parser (51), assistant/newsletter/cron (149), Web route (2), scenario-integrity (204 scenarios), stale-reference, and `git diff --check` verification.
+- Ran the unscoped diff-aware lane truthfully. After preparing the documented runtime artifacts and lowering host concurrency, all affected typechecks and the full assistant-engine (2,233), assistant-runtime (1,692), assistant CLI (128), and assistantd (40) suites passed; the parent requested handoff while the unrelated CLI breadth was still running, so that owned verifier was stopped and must be rerun by the parent/PR lane.
+
+Now:
+- Hand the isolated, uncommitted diff and verification evidence to the parent agent.
+
+Next:
+- Complete coverage-write, parent final review, final unscoped diff-aware verification, scoped plan-closing commit, PR/CI, and ReviewGPT in the parent workflow.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/hosted-execution/src/runtime-control.ts
+- packages/hosted-execution/src/parsers/runtime-control.ts
+- packages/hosted-execution/test/parsers.test.ts
+- packages/assistant-engine/src/assistant/newsletter-outbox.ts
+- packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+- packages/assistant-engine/test/assistant-codex-group-tool.test.ts
+- apps/web/app/api/internal/hosted-execution/groups/newsletter-tool/route.ts
+- apps/web/test/hosted-group-newsletter-route.test.ts
+- agent-docs/product-specs/group-health-newsletter.md
+- agent-docs/exec-plans/active/COORDINATION_LEDGER.md
+
+Status: completed
+Updated: 2026-07-15
+Completed: 2026-07-15

--- a/agent-docs/product-specs/group-health-newsletter.md
+++ b/agent-docs/product-specs/group-health-newsletter.md
@@ -1,6 +1,6 @@
 # Group Health Newsletter
 
-Last verified: 2026-07-14
+Last verified: 2026-07-15
 Status: Implemented
 
 ## Current State
@@ -286,33 +286,31 @@ Everything else is reuse: scheduling, health projections, rollup engine, roster,
 
 ## Deployment Concerns
 
-The hosted newsletter callback keeps old `read_stats`, snapshot-less, and
-proof-less
-`prepare` requests wire-compatible only so they can fail closed with
-`newsletter_runner_upgrade_required`. A successful `prepare` requires
-both `includeAuthorizationSnapshot: true` and
-`includeAuthorizationProof: true`, and returns the address-free live grant
-snapshot plus its SHA-256 proof. The model-facing schema exposes only `prepare`
-and `send`; the proof and HTML stay in trusted outbox/effect state. The legacy request
-parser exists only to prevent an ambiguous transport failure during rollout.
+The hosted newsletter callback accepts only `prepare` and `send`. Every
+successful `prepare` returns the address-free live grant snapshot plus its
+SHA-256 proof. The model-facing schema exposes the same two actions, while the
+proof and HTML stay in trusted outbox/effect state. The signed, member-bound
+callback, live membership and grant resolution, exact share-id/scope filtering,
+and proof-required delivery revalidation remain the authorization boundary; the
+retired request-version negotiation did not contribute authority.
 
-Deploy the fail-closed Vercel/web callback first and keep that version as the
-web rollback floor. Then deploy Cloudflare/runner with
-`container_rollout=immediate`, with no newsletter occurrence between those
-deploys. An old runner in that interval receives
-`newsletter_runner_upgrade_required`, not participant or health data, because
-it omits the new proof marker. Its cron path predates the current retry contract,
-so the operational schedule gap is required to avoid spending an occurrence
-without a send. Do not roll web back below this authorization-proof floor while
-the current runner is active. After both are live, run one
-preparation call and confirm the trusted web wire contains only member ids,
-email eligibility, and address-free share ids/scope keys, while the model-facing
-runner result contains only the authorized current-week facts and no raw email
-addresses or grant metadata. Confirm a scheduled send first persists the
-existing-outbox parent and recipient children, re-resolves the current
-authorization snapshot, fails closed when either recipients or health grants
-change after preparation, and preserves its idempotency key without replaying a
-sent or ambiguous child.
+For the contract cleanup, deploy Vercel/web first, then deploy the
+Cloudflare/runner bundle with `container_rollout=immediate`. During the short
+skew window, the strict web parser rejects the prior runner's request shape; the
+current runner records the unavailable result and preserves the newsletter
+occurrence for retry rather than spending it. After both planes deploy, the
+cleanup head is the independent rollback floor for each plane. A coordinated
+rollback may return both planes to the PR #608 contract by rolling Cloudflare
+back first and Vercel/web second; never roll the runner below PR #608. After
+both are live, run one preparation call and confirm the trusted web wire contains
+only member ids, email eligibility, and address-free share ids/scope keys, while
+the model-facing runner result contains only the authorized current-week facts
+and no raw email addresses or grant metadata. Confirm a scheduled send first
+persists the existing-outbox parent and recipient children, re-resolves the
+current authorization snapshot, fails closed when either recipients or health
+grants change after preparation, preserves the occurrence until a terminal
+delivery result, and preserves its idempotency key without replaying a sent or
+ambiguous child.
 
 The base newsletter change spans **Cloudflare** (`apps/cloudflare`: HTML MIME, group-send path, address-resolution callback, inbound thread participation) and **Vercel/web** (`apps/web`: `group-email.v0` display + default request, address-resolution endpoint, `?addEmail=true`). Safe deploy order is **web first, then Cloudflare** — the web resolution endpoint and the new grant kind must exist before the Worker calls them. Both sides must recognize `group-email.v0` during the window.
 

--- a/apps/web/app/api/internal/hosted-execution/groups/newsletter-tool/route.ts
+++ b/apps/web/app/api/internal/hosted-execution/groups/newsletter-tool/route.ts
@@ -29,25 +29,6 @@ export const POST = withJsonError(async (request: Request) => {
     payloadText.trim() ? JSON.parse(payloadText) : {},
   );
 
-  if (
-    body.action === "read_stats"
-    || (
-      body.action === "prepare"
-      && (
-        body.includeAuthorizationProof !== true
-        || body.includeAuthorizationSnapshot !== true
-      )
-    )
-  ) {
-    return jsonOk({
-      action: body.action,
-      result: {
-        status: "unavailable",
-        unavailableReason: "newsletter_runner_upgrade_required",
-      },
-    });
-  }
-
   if (body.action === "prepare") {
     const result = await prepareHostedGroupNewsletterParticipants({
       groupId: body.groupId,

--- a/apps/web/test/hosted-group-newsletter-route.test.ts
+++ b/apps/web/test/hosted-group-newsletter-route.test.ts
@@ -59,58 +59,21 @@ describe("hosted group newsletter route", () => {
     });
   });
 
-  it("rejects snapshot-less prepare requests without reading participant state", async () => {
+  it("rejects unsupported actions without reading participant state", async () => {
+    const response = await route.POST(buildRequest("retired_action"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Invalid request.",
+      },
+    });
+    expect(mocks.prepareHostedGroupNewsletterParticipants).not.toHaveBeenCalled();
+  });
+
+  it("returns the address-free current grant snapshot", async () => {
     const response = await route.POST(buildRequest("prepare"));
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      action: "prepare",
-      result: {
-        status: "unavailable",
-        unavailableReason: "newsletter_runner_upgrade_required",
-      },
-    });
-    expect(mocks.prepareHostedGroupNewsletterParticipants).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    { includeAuthorizationSnapshot: true as const },
-    { includeAuthorizationProof: true as const },
-  ])("rejects one-sided authorization opt-ins without reading participant state", async (
-    authorization,
-  ) => {
-    const response = await route.POST(buildRequest("prepare", authorization));
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      action: "prepare",
-      result: {
-        status: "unavailable",
-        unavailableReason: "newsletter_runner_upgrade_required",
-      },
-    });
-    expect(mocks.prepareHostedGroupNewsletterParticipants).not.toHaveBeenCalled();
-  });
-
-  it("rejects legacy read_stats without reading participant state", async () => {
-    const response = await route.POST(buildRequest("read_stats"));
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      action: "read_stats",
-      result: {
-        status: "unavailable",
-        unavailableReason: "newsletter_runner_upgrade_required",
-      },
-    });
-    expect(mocks.prepareHostedGroupNewsletterParticipants).not.toHaveBeenCalled();
-  });
-
-  it("returns the address-free current grant snapshot only when requested", async () => {
-    const response = await route.POST(buildRequest("prepare", {
-      includeAuthorizationProof: true,
-      includeAuthorizationSnapshot: true,
-    }));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -149,20 +112,13 @@ describe("hosted group newsletter route", () => {
   });
 });
 
-function buildRequest(
-  action: "prepare" | "read_stats",
-  authorization: {
-    includeAuthorizationProof?: true;
-    includeAuthorizationSnapshot?: true;
-  } = {},
-): Request {
+function buildRequest(action: string): Request {
   return new Request(
     "https://web.test/api/internal/hosted-execution/groups/newsletter-tool",
     {
       body: JSON.stringify({
         action,
         groupId: "group_123",
-        ...authorization,
       }),
       headers: { "content-type": "application/json" },
       method: "POST",

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -3060,19 +3060,10 @@ async function executeNewsletterTool(input: {
         return groupSharedProjectionUnavailableResult(input.request.action)
       }
     }
-    const request: HostedRuntimeNewsletterToolRequest =
-      input.request.action === 'send' || input.request.action === 'prepare'
-        ? {
-            ...input.request,
-            ...(input.request.action === 'prepare'
-              ? {
-                  includeAuthorizationProof: true as const,
-                  includeAuthorizationSnapshot: true as const,
-                }
-              : {}),
-            scheduledAutomationAuthority,
-          }
-        : input.request
+    const request: HostedRuntimeNewsletterToolRequest = {
+      ...input.request,
+      scheduledAutomationAuthority,
+    }
     const result = await newsletterTool.request(request)
     if (result.action === 'send') {
       input.hostedToolContext?.recordNewsletterSendResult?.(result)

--- a/packages/assistant-engine/src/assistant/newsletter-outbox.ts
+++ b/packages/assistant-engine/src/assistant/newsletter-outbox.ts
@@ -43,9 +43,6 @@ export function createAssistantNewsletterOutboxTool(input: {
   return {
     closeCapability,
     async request(request) {
-      if (request.action === 'read_stats') {
-        return await input.newsletterTool.request(request)
-      }
       if (request.action === 'prepare') {
         if (prepareAttempted || sendAttempted) {
           closeCapability()
@@ -55,8 +52,6 @@ export function createAssistantNewsletterOutboxTool(input: {
         const result = await input.newsletterTool.request({
           action: 'prepare',
           groupId: request.groupId,
-          includeAuthorizationProof: true,
-          includeAuthorizationSnapshot: true,
         })
         if (
           input.authority

--- a/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
@@ -1438,8 +1438,6 @@ describe("murph.newsletter dynamic tool", () => {
       expect(newsletterRequest).toHaveBeenCalledWith({
         action: "prepare",
         groupId: "group_1",
-        includeAuthorizationProof: true,
-        includeAuthorizationSnapshot: true,
         scheduledAutomationAuthority: {
           automationId: "automation_newsletter",
           occurrenceAt: "2026-07-06T03:30:00.000Z",
@@ -1652,6 +1650,49 @@ describe("murph.newsletter dynamic tool", () => {
     } finally {
       await rm(vaultRoot, { force: true, recursive: true });
     }
+  });
+
+  it("records a rejected newsletter request as an unavailable send result", async () => {
+    const closeNewsletterCapability = vi.fn();
+    const recordNewsletterSendResult = vi.fn();
+    const request = readMurphDynamicToolRequest(newsletterToolCall({
+      action: "prepare",
+      groupId: "group_1",
+    }));
+    if (!request || request.kind !== "newsletter") {
+      throw new Error("Expected newsletter request.");
+    }
+
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext: createNewsletterHostedToolContext({
+        closeNewsletterCapability,
+        newsletterRequest: async () => {
+          throw new Error("Web callback rejected the request.");
+        },
+        recordNewsletterSendResult,
+      }),
+      nextUsageOrdinal: () => 1,
+      progressDelivery: null,
+      request,
+      vaultRoot: null,
+    });
+
+    expect(result.rpcResult).toEqual({
+      contentItems: [
+        { type: "inputText", text: "newsletter tool request failed" },
+      ],
+      success: false,
+    });
+    expect(closeNewsletterCapability).toHaveBeenCalledTimes(1);
+    expect(recordNewsletterSendResult).toHaveBeenCalledWith({
+      action: "send",
+      result: {
+        status: "unavailable",
+        unavailableReason: "newsletter_tool_failed",
+      },
+    });
   });
 
   it("returns a failed tool result and records post-turn failure for all-recipient send failure", async () => {

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -1488,46 +1488,8 @@ export function parseHostedRuntimeNewsletterToolRequest(
   if (action === "prepare") {
     assertAllowedObjectKeys(
       record,
-      new Set([
-        "action",
-        "groupId",
-        "includeAuthorizationProof",
-        "includeAuthorizationSnapshot",
-      ]),
-      "Hosted runtime newsletter tool prepare request",
-    );
-    if (
-      record.includeAuthorizationProof !== undefined
-      && record.includeAuthorizationProof !== true
-    ) {
-      throw new TypeError(
-        "Hosted runtime newsletter tool includeAuthorizationProof must be true when present.",
-      );
-    }
-    if (
-      record.includeAuthorizationSnapshot !== undefined
-      && record.includeAuthorizationSnapshot !== true
-    ) {
-      throw new TypeError(
-        "Hosted runtime newsletter tool includeAuthorizationSnapshot must be true when present.",
-      );
-    }
-    return {
-      action,
-      groupId: requireString(record.groupId, "Hosted runtime newsletter tool groupId"),
-      ...(record.includeAuthorizationProof === true
-        ? { includeAuthorizationProof: true as const }
-        : {}),
-      ...(record.includeAuthorizationSnapshot === true
-        ? { includeAuthorizationSnapshot: true as const }
-        : {}),
-    };
-  }
-  if (action === "read_stats") {
-    assertAllowedObjectKeys(
-      record,
       new Set(["action", "groupId"]),
-      "Hosted runtime newsletter tool read_stats request",
+      "Hosted runtime newsletter tool prepare request",
     );
     return {
       action,
@@ -1619,28 +1581,6 @@ export function parseHostedRuntimeNewsletterToolResponse(
         result,
         new Set(["status", "unavailableReason"]),
         "Hosted runtime newsletter tool prepare unavailable response result",
-      );
-      return {
-        action,
-        result: {
-          status,
-          unavailableReason: requireString(
-            result.unavailableReason,
-            "Hosted runtime newsletter tool unavailableReason",
-          ),
-        },
-      };
-    }
-  }
-
-  if (action === "read_stats") {
-    const result = requireObject(record.result, "Hosted runtime newsletter tool read_stats response result");
-    const status = requireString(result.status, "Hosted runtime newsletter tool read_stats response status");
-    if (status === "unavailable") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "unavailableReason"]),
-        "Hosted runtime newsletter tool read_stats unavailable response result",
       );
       return {
         action,

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -1066,10 +1066,7 @@ export type HostedRuntimeGroupToolResponse =
         | { status: "unavailable"; unavailableReason: string };
     };
 
-export type HostedRuntimeNewsletterToolAction =
-  | "prepare"
-  | "read_stats"
-  | "send";
+export type HostedRuntimeNewsletterToolAction = "prepare" | "send";
 
 export const HOSTED_RUNTIME_NEWSLETTER_SUBJECT_MAX_LENGTH = 160;
 export const HOSTED_RUNTIME_NEWSLETTER_TEXT_MAX_LENGTH = 100_000;
@@ -1116,17 +1113,12 @@ export interface HostedRuntimeNewsletterToolSendRequest {
 export interface HostedRuntimeNewsletterToolPrepareRequest {
   action: "prepare";
   groupId: string;
-  /** Required for successful preparation; older runners fail closed when they omit it. */
-  includeAuthorizationSnapshot?: true;
-  /** Required for successful preparation; keeps the proof private from model-facing output. */
-  includeAuthorizationProof?: true;
   /** Trusted runtime context; stripped before the web callback request. */
   scheduledAutomationAuthority?: HostedRuntimeNewsletterScheduledAuthority | null;
 }
 
 export type HostedRuntimeNewsletterToolRequest =
   | HostedRuntimeNewsletterToolPrepareRequest
-  | { action: "read_stats"; groupId: string }
   | ({ action: "send" } & HostedRuntimeNewsletterToolSendRequest);
 
 export type HostedRuntimeNewsletterToolResponse =
@@ -1144,13 +1136,6 @@ export type HostedRuntimeNewsletterToolResponse =
             status: "unavailable";
             unavailableReason: string;
           };
-    }
-  | {
-      action: "read_stats";
-      result: {
-        status: "unavailable";
-        unavailableReason: string;
-      };
     }
   | {
       action: "send";

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -1739,44 +1739,19 @@ describe("parseHostedRuntimeNewsletterTool", () => {
     memberId: "member_123",
   };
 
-  it("parses current, legacy, and scheduled send requests", () => {
+  it("parses prepare and send requests", () => {
     expect(parseHostedRuntimeNewsletterToolRequest({
       action: "prepare",
       groupId: "group_123",
     })).toEqual({
       action: "prepare",
       groupId: "group_123",
-    });
-
-    expect(parseHostedRuntimeNewsletterToolRequest({
-      action: "prepare",
-      groupId: "group_123",
-      includeAuthorizationProof: true,
-      includeAuthorizationSnapshot: true,
-    })).toEqual({
-      action: "prepare",
-      groupId: "group_123",
-      includeAuthorizationProof: true,
-      includeAuthorizationSnapshot: true,
     });
     expect(() => parseHostedRuntimeNewsletterToolRequest({
       action: "prepare",
       groupId: "group_123",
-      includeAuthorizationProof: false,
-    })).toThrow(/must be true/u);
-    expect(() => parseHostedRuntimeNewsletterToolRequest({
-      action: "prepare",
-      groupId: "group_123",
-      includeAuthorizationSnapshot: false,
-    })).toThrow(/must be true/u);
-
-    expect(parseHostedRuntimeNewsletterToolRequest({
-      action: "read_stats",
-      groupId: "group_123",
-    })).toEqual({
-      action: "read_stats",
-      groupId: "group_123",
-    });
+      retiredVersionMarker: true,
+    })).toThrow(/not allowed/u);
 
     expect(parseHostedRuntimeNewsletterToolRequest({
       action: "send",
@@ -1833,6 +1808,10 @@ describe("parseHostedRuntimeNewsletterTool", () => {
         subject: " ",
       })
     ).toThrow(/subject must not be blank/u);
+    expect(() => parseHostedRuntimeNewsletterToolRequest({
+      action: "retired_action",
+      groupId: "group_123",
+    })).toThrow(/action is not supported/u);
   });
 
   it("requires authorization snapshots in successful prepare responses", () => {
@@ -1942,36 +1921,14 @@ describe("parseHostedRuntimeNewsletterTool", () => {
     })).toThrow(/participants must contain at most 100 entries/u);
   });
 
-  it("accepts only fail-closed legacy responses", () => {
-    const legacyParticipant = {
-      ...PARTICIPANT,
-      displayName: null,
-    };
+  it("rejects unsupported response actions", () => {
     expect(() => parseHostedRuntimeNewsletterToolResponse({
-      action: "read_stats",
+      action: "retired_action",
       result: {
-        groupId: "group_123",
-        missingEmailParticipants: [
-          { ...legacyParticipant, hasEmail: false },
-        ],
-        participants: [legacyParticipant],
-        status: "ok",
+        status: "unavailable",
+        unavailableReason: "unsupported_action",
       },
     })).toThrow(/not supported/u);
-
-    expect(parseHostedRuntimeNewsletterToolResponse({
-      action: "read_stats",
-      result: {
-        status: "unavailable",
-        unavailableReason: "newsletter_runner_upgrade_required",
-      },
-    })).toEqual({
-      action: "read_stats",
-      result: {
-        status: "unavailable",
-        unavailableReason: "newsletter_runner_upgrade_required",
-      },
-    });
   });
 
   it("parses newsletter send outcomes and validates partial counts", () => {


### PR DESCRIPTION
## Why this PR exists

The hosted group-newsletter contract still carried the retired `read_stats` action, two request-version markers, and a Web upgrade-gate response from the #608 rollout. The current model surface exposes only `prepare` and `send`, and the markers never contributed member, grant, proof, recipient, or delivery authority.

## User goal / user-visible behavior

Scheduled group newsletters continue to prepare and send through the current authorization-proof and outbox flow, with a smaller strict contract and no obsolete rollout negotiation.

## User experience

Normal newsletter preparation, delivery, missing-email nudges, and retries are unchanged. During the documented brief Web-first deploy skew, a current runner records the rejected request as unavailable and preserves the exact occurrence for retry.

## Invariants the PR must preserve

- Successful preparation still returns the address-free live authorization snapshot and SHA-256 proof.
- Exact share IDs and scope keys remain filtered against live grants.
- Final provider entry re-resolves recipients and requires the same authorization proof.
- Prepare/send capability remains one-shot.
- Outbox parent/child manifests, delivery idempotency, and ambiguous-send non-replay remain intact.
- Unavailable preparation does not consume the scheduled occurrence.
- Missing-email nudge routing and once-ever idempotency remain intact.
- Pre-#608 runners remain outside the supported rollback floor.

## Non-obvious affected surfaces

- **Web parser/route:** old marker-bearing requests now fail strict parsing instead of returning an upgrade result.
- **Runner transport:** Web rejection becomes `newsletter_tool_failed`, closes the capability, and records an unavailable send result.
- **Cron ownership:** unavailable results preserve `pendingOccurrenceAt` and schedule the existing 30-second retry.
- **Authorization:** the live snapshot/proof, grant filtering, and proof-required delivery path are unchanged.
- **Deployment:** Web must lead the hard cut; the runner follows with immediate rollout.

## Change-shape breakdown

Classification: runtime contracts, parsers, Web route, and assistant newsletter implementation are source; focused parser/assistant/Web regressions are tests; the product spec and completed execution plan are docs. No config/tooling or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 114 |
| Tests/fixtures | 63 | 109 |
| Docs | 80 | 28 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **149** | **251** |

## Verification

- Final rebased focused checks: hosted parser 51/51; assistant newsletter/outbox/cron 149/149; Web newsletter route/authorization 24/24.
- Scenario integrity: 204 scenarios passed.
- Affected typechecks passed. The serialized broad lane additionally passed assistant-engine 2,233, assistant-runtime 1,692, assistant CLI 128, and assistantd 40 before the parent stopped unrelated CLI breadth.
- Required coverage-write audit: PASS after one test-only strict-parser assertion; hosted-execution coverage passed 33 files / 340 tests and all focused owner lanes were green.
- Stale retired-action/marker, privacy, secret, and whitespace scans passed.

## Deployment compatibility

Deploy Web first, then deploy the Cloudflare Worker/runner with `container_rollout=immediate`. A #608-or-newer runner that encounters the short incompatible window preserves the occurrence for retry. After convergence, this cleanup head is the rollback floor for each plane. For a coordinated rollback to the #608 contract, roll Cloudflare back first and Web second; never restore a pre-#608 runner. Post-deploy, verify one preparation snapshot/proof and one scheduled retry-safe send.

## ReviewGPT baseline

ReviewGPT first-reviewed head: d115696b261b4bd532145c67ba9555a189c0a683

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `d115696b261b4bd532145c67ba9555a189c0a683` | 6 | 114 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786733359&installation_id=127572939&pr_number=704&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F704&signature=4c51a827f7f0f292dd22023b8ff823d71417920aff103dac14f4774f81fa1bda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->