### PR TITLE
Remove recovered input preselection

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-remove-recovered-input-preselection.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-remove-recovered-input-preselection.md
@@ -1,0 +1,53 @@
+# Remove Recovered Input Preselection
+
+Status: completed
+Updated: 2026-07-15
+
+## Goal
+
+Delete the redundant outer background-input selection in the hosted assistant
+automation lane and keep the inner selection immediately before automation as
+the single owner of foreground and background input selection.
+
+Success criteria:
+
+- Remove `initialBackgroundSelection`, `hasRecoveredReplyableInput`, and
+  `initialInputSelection` plumbing.
+- Keep one authoritative selection before the automation pass.
+- Preserve cron deferral for selected input and foreground-maintenance yield.
+- Preserve pending-index compaction, causal input ordering, and scan sizing.
+- Preserve explicit skip and unconfigured-assistant behavior.
+
+## Constraints
+
+- Do not change input eligibility, grouping, ordering, or pending-index rules.
+- Do not move selection into the automation engine or add replacement state.
+- Keep the change isolated from the broader active mailbox-consumption lane.
+- Remove the selection result type's public export only if no consumer remains.
+
+## Approach
+
+1. Delete the lane-level background preselection and option forwarding.
+2. Make the existing inner foreground/background selection unconditional.
+3. Make the selection result type private if repository-wide search confirms it
+   has no external consumer.
+4. Adjust focused maintenance tests to prove readiness, selection, automation,
+   cron deferral, scan sizing, and skipped behavior remain correctly ordered.
+5. Run focused assistant-runtime tests, stale-symbol searches, diff hygiene, and
+   the truthful diff-aware verification lane.
+
+## Deployment Compatibility
+
+This is an internal assistant-runtime control-flow simplification. It changes no
+persisted data, mailbox schema, provider contract, or cross-deploy interface.
+
+## State
+
+Implementation and focused verification are complete. The maintenance and
+turn-input suites pass, stale-symbol and diff-hygiene checks pass, and the
+cleanup reduces both the runner entry chunk and static boot closure by 486
+bytes in a same-source local comparison. The diff-aware gate passed typechecks
+and repository guards, then reported three unrelated full-suite timing failures;
+all three targets passed immediately in a serial isolated rerun. Coverage audit,
+commit, PR publication, CI, and ReviewGPT remain pending the parent flow.
+Completed: 2026-07-15

--- a/packages/assistant-runtime/src/hosted-runtime/maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/maintenance.ts
@@ -43,7 +43,6 @@ import type {
 import {
   createHostedAssistantInputSource,
   selectHostedAssistantInputIds,
-  type HostedAssistantInputSelection,
 } from "./turn-input.ts";
 import {
   createHostedAssistantTurnEnvironment,
@@ -157,15 +156,6 @@ export async function runHostedAssistantAutomationLane(input: {
 }): Promise<HostedAssistantAutomationLaneMetrics> {
   const startedAt = Date.now();
   const freshAssistantInputIds = input.freshAssistantInputIds ?? [];
-  const initialBackgroundSelection = freshAssistantInputIds.length === 0
-    ? await selectHostedAssistantInputIds({
-        limit: DEFAULT_ASSISTANT_AUTOMATION_SCAN_LIMIT,
-        mode: "background",
-        vaultRoot: input.vaultRoot,
-      })
-    : null;
-  const hasRecoveredReplyableInput =
-    (initialBackgroundSelection?.inputIds.length ?? 0) > 0;
   const resolveReadiness = async () => {
     const readinessStartedAt = Date.now();
     const readiness = await resolveHostedAssistantAutomationReadiness({
@@ -210,9 +200,6 @@ export async function runHostedAssistantAutomationLane(input: {
           buildBackgroundDynamicContextPrompt:
             input.buildBackgroundDynamicContextPrompt,
           latencyTracePort: input.runtime.platform.latencyTracePort ?? null,
-          ...(hasRecoveredReplyableInput && initialBackgroundSelection
-            ? { initialInputSelection: initialBackgroundSelection }
-            : {}),
           now: input.now ?? null,
           preProviderPhase: input.preProviderPhase ?? null,
           runtimeAttemptId: input.runtimeAttemptId ?? null,
@@ -286,7 +273,6 @@ export async function runHostedAssistantAutomation(
     operationScope?: AssistantAutomationOperationScope | null;
     buildBackgroundDynamicContextPrompt?: HostedBackgroundDynamicContextPromptBuilder;
     latencyTracePort?: HostedRuntimePlatform["latencyTracePort"] | null;
-    initialInputSelection?: HostedAssistantInputSelection;
     now?: Date | null;
     preProviderPhase?: HostedRuntimeLatencyPhaseBreakdown["preProvider"] | null;
     runtimeAttemptId?: string | null;
@@ -328,20 +314,19 @@ export async function runHostedAssistantAutomation(
   let activeProviderMilestoneTraceContext: HostedAssistantMilestoneTraceContext | null = null;
   const recordedProviderMilestones = new Set<string>();
   const freshAssistantInputIdCount = new Set(freshAssistantInputIds).size;
-  const selectedInputIds = options?.initialInputSelection
-    ?? await selectHostedAssistantInputIds(
-      freshAssistantInputIdCount > 0
-        ? {
-            freshAssistantInputIds,
-            mode: "foreground",
-            vaultRoot,
-          }
-        : {
-            limit: DEFAULT_ASSISTANT_AUTOMATION_SCAN_LIMIT,
-            mode: "background",
-            vaultRoot,
-          },
-    );
+  const selectedInputIds = await selectHostedAssistantInputIds(
+    freshAssistantInputIdCount > 0
+      ? {
+          freshAssistantInputIds,
+          mode: "foreground",
+          vaultRoot,
+        }
+      : {
+          limit: DEFAULT_ASSISTANT_AUTOMATION_SCAN_LIMIT,
+          mode: "background",
+          vaultRoot,
+        },
+  );
   const baseInputSource = createHostedAssistantInputSource({
     initialPendingInputIds: selectedInputIds.pendingInputIds,
     pendingInputRefreshMode:

--- a/packages/assistant-runtime/src/hosted-runtime/turn-input.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/turn-input.ts
@@ -30,7 +30,7 @@ const DEFAULT_HOSTED_ASSISTANT_INPUT_QUERY_LIMIT = 100;
 
 type HostedPendingInputRefreshMode = "compact" | "none";
 
-export type HostedAssistantInputSelection =
+type HostedAssistantInputSelection =
   | {
       freshInputIds: string[];
       inputIds: string[];

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -4001,19 +4001,40 @@ describe("runHostedAssistantAutomationLane", () => {
     });
   });
 
-  it("sizes a background scan to the selected causal batch", async () => {
+  it("selects a background causal batch once after readiness and sizes the scan to it", async () => {
+    const callOrder: string[] = [];
     const selectedInputIds = [
       "ain_background_batch_000000000000000001",
       "ain_background_batch_000000000000000002",
     ];
-    mocks.selectHostedAssistantInputIds.mockResolvedValueOnce({
-      inputIds: selectedInputIds,
-      mode: "background",
-      pendingInputIds: selectedInputIds,
+    mocks.readHostedAssistantRuntimeState.mockImplementationOnce(async () => {
+      callOrder.push("readiness");
+      return {
+        assistantActiveProfileId: null,
+        assistantActiveProfileManagedBy: null,
+        assistantActiveProfileReady: false,
+        assistantConfigInvalid: false,
+        assistantConfigPresent: true,
+        assistantConfigStatus: "saved",
+        assistantConfigured: true,
+        assistantProvider: "codex-cli",
+      };
     });
-    mocks.runAssistantAutomationPass.mockResolvedValueOnce({
-      nextWakeAt: null,
-      progressed: true,
+    mocks.selectHostedAssistantInputIds.mockImplementationOnce(async () => {
+      callOrder.push("selection");
+      return {
+        inputIds: selectedInputIds,
+        mode: "background",
+        pendingInputIds: selectedInputIds,
+      };
+    });
+    mocks.runAssistantAutomationPass.mockImplementationOnce(async (input) => {
+      callOrder.push("automation");
+      expect(input.shouldDeferCron?.()).toBe(true);
+      return {
+        nextWakeAt: null,
+        progressed: true,
+      };
     });
 
     await runHostedAssistantAutomationLane({
@@ -4041,6 +4062,8 @@ describe("runHostedAssistantAutomationLane", () => {
         maxPerScan: selectedInputIds.length,
       }),
     );
+    expect(callOrder).toEqual(["readiness", "selection", "automation"]);
+    expect(mocks.selectHostedAssistantInputIds).toHaveBeenCalledOnce();
   });
 
   it("does not synthesize a wake when assistant work progressed without a due time", async () => {
@@ -4430,6 +4453,7 @@ describe("runHostedAssistantAutomationLane", () => {
     expect(result).not.toHaveProperty("postCheckpointRecord");
     assert.equal(typeof result.totalElapsedMs, "number");
     expect(mocks.runAssistantAutomationPass).not.toHaveBeenCalled();
+    expect(mocks.selectHostedAssistantInputIds).not.toHaveBeenCalled();
     expect(mocks.emitHostedExecutionStructuredLog).not.toHaveBeenCalled();
   });
 
@@ -4507,6 +4531,7 @@ describe("runHostedAssistantAutomationLane", () => {
       ],
     });
     expect(mocks.runAssistantAutomationPass).not.toHaveBeenCalled();
+    expect(mocks.selectHostedAssistantInputIds).not.toHaveBeenCalled();
     expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
       expect.objectContaining({
         level: "warn",


### PR DESCRIPTION
## Why

The hosted maintenance lane selected recovered background input twice before one automation attempt. The outer preselection was redundant and could drift from the authoritative selection immediately before automation.

## User-visible goal and UX

No intended UX change. Recovered foreground/background work remains selected once, immediately before automation, while cron and foreground-maintenance deferral behavior stays intact.

## Invariants

- Readiness completes before input selection.
- Foreground/background input selection happens exactly once per automation attempt.
- Selected input still defers cron.
- Empty background selection preserves refresh capacity.
- Pending-index compaction, causal ordering, and scan sizing are unchanged.
- Explicit skip and unconfigured-assistant paths do not select input.
- No persisted schema or cross-deploy contract changes.

## Non-obvious behavior

The inner selection was already the authoritative owner. This removes only the earlier speculative selection and its forwarding state; it does not broaden eligibility or move selection into the automation engine.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 14 | 29 |
| Tests | 33 | 8 |
| Docs | 53 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **100** | **37** |

## Verification

- Focused maintenance and turn-input suites: 93 passed.
- Full assistant-runtime owner suite: 1,692 passed, 2 skipped.
- Assistant-runtime typecheck and repository guards passed in the diff-aware lane.
- Fresh coverage-write audit: PASS, no edits.
- Canonical production bundle comparison: entry chunk and static boot closure each decreased by 486 bytes.
- Post-rebase focused rerun: 93 passed.
- ReviewGPT runs against this exact pushed head concurrently with CI.

## Deployment

No compatibility window or coordinated deployment is required. This is an internal control-flow deletion with no persisted-data, mailbox, provider, or cross-service schema change.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 2bd29868a9c3f11c9ac6ff7f13fc5a7dddc14614

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `2bd29868a9c3f11c9ac6ff7f13fc5a7dddc14614` | 14 | 29 |