### PR TITLE
Remove Linq current-inbound compatibility

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-remove-linq-current-inbound-compat.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-remove-linq-current-inbound-compat.md
@@ -1,0 +1,74 @@
+# Remove Linq Current-Inbound Compatibility
+
+Status: completed
+Created: 2026-07-15
+
+## Goal
+
+Delete the retired Web-side `currentInbound` Linq egress compatibility proof
+and its derived provider-dispatch idempotency fallback after the #627 runner
+fleet drain, while making the current `authorityCheckOnly` discriminator
+explicit and required end to end.
+
+## Invariants
+
+- Keep `authorityCheckOnly: true` as the authority-only preflight and
+  `authorityCheckOnly: false` as the final atomic provider-dispatch claim.
+- Final provider entry requires an explicit idempotency key.
+- Preserve exact `answeredMailboxItemIds` authority and the bounded recent-100
+  mailbox recovery path.
+- Preserve member, direct/group audience, route, provider-reply, dispatch-fence,
+  and signup-welcome authorization checks.
+- Do not change the unrelated webhook `currentInboundReply` read-receipt proof,
+  delivery-time mailbox consumption, or legacy personal-home route repair.
+
+## Plan
+
+1. Remove the legacy engagement-route parser, proof type/branches, and
+   `legacy-current-inbound:` provider-dispatch key fallback.
+2. Require an explicit boolean `authorityCheckOnly` at the Web/runtime wire
+   boundary and make every current producer state `true` or `false` directly.
+3. Replace legacy tests with current-protocol success/failure coverage and
+   update the deployment guide with the #627-or-newer rollback floor.
+4. Run focused Web and assistant-runtime tests, stale-reference checks,
+   diff-aware verification, and hosted-local Linq scenarios when the local
+   environment can support them.
+
+## Deployment
+
+Current production runners already omit `currentInbound`, send explicit
+`authorityCheckOnly`, and use explicit provider-dispatch idempotency keys. The
+Web hard cut is independently deployable, but after it ships the
+Cloudflare/runner rollback floor is #627 or newer. Immediate rollout is not
+required because the request shape is already deployed and fingerprint
+admission prevents stale runner bundles from receiving user work.
+
+## Verification
+
+- Focused hosted-Web Linq engagement tests.
+- Focused assistant-runtime callback, channel-activity, scheduled-route, and
+  workspace-runner tests.
+- Stale searches for egress `currentInbound` and `legacy-current-inbound`.
+- `git diff --check` and truthful `pnpm test:diff` coverage.
+- Hosted-local `linq-delivery`, `linq-webhook`, and
+  `linq-scheduled-reminder` scenarios after the deterministic lanes pass.
+
+## Verification outcomes
+
+- The full diff-aware lane passed assistant-runtime (1,692 tests), Web (5,212
+  tests plus typecheck, lint, development smoke, and production build), and
+  Cloudflare (1,829 Node tests plus Workers).
+- The required coverage-write audit added only boundary proof for the retired
+  `currentInbound` key fallback, explicit provider-claim identity, authority-
+  only no-claim behavior, foreign-member group routes, signup-welcome claims,
+  and Cloudflare boolean transport.
+- The post-audit focused runs passed Web 30/30, assistant callbacks 169/169,
+  Cloudflare 130/130, and the retained read-receipt/mailbox-consumption slice
+  2/2; Web, assistant-runtime, and Cloudflare typechecks also passed.
+- Stale egress-path searches and `git diff --check` passed. The unrelated
+  webhook `currentInboundReply` proof remains covered and unchanged.
+- Hosted-local scenarios were blocked by the pre-existing runner static-boot
+  closure failure rather than this patch; PR CI and exact-head ReviewGPT remain
+  the final external gates after publication.
+Updated: 2026-07-15
+Completed: 2026-07-15

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -132,31 +132,25 @@ delivery, where Web may resolve or validate the concrete target before media
 work. Anchored replies, reactions, and voice memos do not make that redundant
 round trip.
 
-The original provider-claim rollout used this order:
+Every engagement request must state `authorityCheckOnly` explicitly. `true`
+performs only the bounded preflight and never claims provider dispatch. `false`
+is the final provider boundary, requires an explicit idempotency key, and must
+return the additive `providerDispatchClaimed` marker before the runner enters
+the provider. Web no longer derives authority or provider-dispatch identity
+from the retired `currentInbound` request proof.
 
-1. Deploy `apps/web` first. An old runner may omit `authorityCheckOnly`; Web
-   keeps treating that legacy call as its provider-start claim for the bounded
-   rollout window.
-2. Deploy the Cloudflare Worker and runner bundle with
-   `container_rollout=immediate`, then require managed-container smoke to report
-   the new runner-bundle fingerprint.
-3. After convergence, send one Linq group-thread test turn and confirm the
-   thread container owns both model execution and provider delivery.
+The Cloudflare Worker and runner rollback floor for this protocol is #627 or
+newer. Do not deploy or restore an older runner after the Web hard cut; there is
+no supported old-runner/new-Web compatibility window. Immediate rollout is not
+required for ordinary later deploys because current runners already use this
+shape and per-invocation fingerprint admission replaces stale warm shells.
+After deployment, smoke one authority-only current-home resolution, one final
+provider claim, and one Linq group-thread turn, then confirm the thread
+container owns model execution and provider delivery.
 
-A new runner requires the additive `providerDispatchClaimed` response marker at
-its final provider boundary, so it fails closed against an old Web deployment.
-Do not roll Web back while that runner protocol is active. To roll the pair
-back, first roll the runner bundle back with an immediate rollout and confirm
-the old fingerprint, then roll Web back. The old-runner/new-Web interval is
-supported only during the Web-first rollout: old runners ignore the additive
-response marker and retain their existing early-claim behavior.
-
-After that rollout has converged, removing obsolete runner authority hints from
-the engagement and post-send outcome payloads is independently deployable: Web
-ignores unknown legacy JSON fields, and both old and new runners use the same
-final provider claim. New runners may send an optional `lineLookupKey` solely
-for post-send line-health attribution; old Web ignores it, and new Web retains
-its existing fallback when an old runner omits it.
+New runners may send an optional `lineLookupKey` solely for post-send
+line-health attribution; old Web ignores it, and new Web retains its existing
+fallback when an older supported runner omits it.
 
 ## Thread Usage Crossing Notice Rollout
 

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -4367,9 +4367,13 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       const request = input instanceof Request ? input : new Request(input, init);
       expect(new URL(request.url).pathname).toBe(HOSTED_RUNTIME_LINQ_EGRESS_ENGAGEMENT_PATH);
       responseCount += 1;
+      const body = await request.json() as { authorityCheckOnly?: unknown };
+      expect(body.authorityCheckOnly).toBe(responseCount === 1 ? false : true);
       return new Response(JSON.stringify({
         ok: true,
-        providerDispatchClaimed: true,
+        ...(body.authorityCheckOnly === false
+          ? { providerDispatchClaimed: true }
+          : {}),
         threadIsDirect: responseCount === 1 ? false : "false",
       }), {
         headers: { "content-type": "application/json; charset=utf-8" },
@@ -4393,6 +4397,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
 
     await expect(assertLinqRecentInboundEngagement({
+      authorityCheckOnly: false,
       target: "chat_123",
       targetKind: "thread",
     })).resolves.toEqual({
@@ -4400,11 +4405,10 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       threadIsDirect: false,
     });
     await expect(assertLinqRecentInboundEngagement({
+      authorityCheckOnly: true,
       target: "chat_456",
       targetKind: "thread",
-    })).resolves.toEqual({
-      providerDispatchClaimed: true,
-    });
+    })).resolves.toEqual({});
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     for (const [index, call] of fetchMock.mock.calls.entries()) {

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
@@ -34,21 +34,18 @@ export const POST = withJsonError(async (request: Request) => {
   const answeredMailboxItemIds = parseAnsweredMailboxItemIds(
     body.answeredMailboxItemIds,
   );
-  const currentInbound = parseHostedLinqLegacyCurrentInboundProof(body.currentInbound);
+  const authorityCheckOnly = parseRequiredAuthorityCheckOnly(
+    body.authorityCheckOnly,
+  );
   const directRecipientPhoneNumber = readOptionalBodyString(
     body.directRecipientPhoneNumber,
   );
   const fromPhoneNumber = readOptionalBodyString(body.fromPhoneNumber);
   const idempotencyKey = readOptionalBodyString(body.idempotencyKey);
-  const authorityCheckOnly = body.authorityCheckOnly === true;
   const intentId = readOptionalBodyString(body.intentId);
   const replyToMessageId = readOptionalBodyString(body.replyToMessageId);
   const target = readOptionalBodyString(body.target);
   const targetKind = readOptionalBodyString(body.targetKind);
-  const providerDispatchIdempotencyKey = idempotencyKey
-    ?? (currentInbound
-      ? `legacy-current-inbound:${currentInbound.dedupeKey}`
-      : null);
   const prisma = getPrisma();
 
   const assertion = await prisma.$transaction(async (tx) => {
@@ -68,7 +65,6 @@ export const POST = withJsonError(async (request: Request) => {
     const asserted = await assertHostedLinqRecentInboundEngagementForRuntime({
       answeredMailboxItemIds,
       authorityCheckOnly,
-      currentInbound,
       directRecipientPhoneNumber,
       fromPhoneNumber,
       homeRouteFallbackAllowed: body.homeRouteFallbackAllowed === true,
@@ -92,7 +88,7 @@ export const POST = withJsonError(async (request: Request) => {
       });
       await assertHostedLinqRecentInboundEngagementForRuntime({
         answeredMailboxItemIds,
-        currentInbound,
+        authorityCheckOnly,
         directRecipientPhoneNumber,
         fromPhoneNumber,
         homeRouteFallbackAllowed: false,
@@ -107,7 +103,7 @@ export const POST = withJsonError(async (request: Request) => {
 
     let providerDispatchClaimed: boolean | null = null;
     if (!authorityCheckOnly) {
-      if (!providerDispatchIdempotencyKey) {
+      if (!idempotencyKey) {
         throw hostedOnboardingError({
           code: "HOSTED_LINQ_PROVIDER_DISPATCH_IDEMPOTENCY_REQUIRED",
           httpStatus: 400,
@@ -116,11 +112,11 @@ export const POST = withJsonError(async (request: Request) => {
         });
       }
       const claim = await recordHostedLinqRuntimeProviderDispatchFenceTx({
-        idempotencyKey: providerDispatchIdempotencyKey,
+        idempotencyKey,
         linqChatId: providerTargetKind === "participant" ? null : providerTarget,
         phoneNumber: fromPhoneNumber,
         prisma: tx,
-        sourceRef: intentId ?? providerDispatchIdempotencyKey,
+        sourceRef: intentId ?? idempotencyKey,
         targetKind: providerTargetKind,
       });
       if (!claim.claimed) {
@@ -154,6 +150,18 @@ export const POST = withJsonError(async (request: Request) => {
 function readOptionalBodyString(value: unknown): string | null {
   const normalized = typeof value === "string" ? value.trim() : "";
   return normalized.length > 0 ? normalized : null;
+}
+
+function parseRequiredAuthorityCheckOnly(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  throw hostedOnboardingError({
+    code: "HOSTED_LINQ_EGRESS_AUTHORITY_CHECK_ONLY_INVALID",
+    httpStatus: 400,
+    message: "Hosted Linq egress authorityCheckOnly must be a boolean.",
+    retryable: false,
+  });
 }
 
 function parseAnsweredMailboxItemIds(value: unknown): string[] {
@@ -197,56 +205,4 @@ function parseAnsweredMailboxItemIds(value: unknown): string[] {
   }
 
   return itemIds;
-}
-
-function parseHostedLinqLegacyCurrentInboundProof(value: unknown): {
-  dedupeKey: string;
-  eventId: string;
-  mailboxItemId: string;
-  occurredAt: string;
-  replyToMessageId: string;
-  target: string;
-} | null {
-  if (value === undefined || value === null) {
-    return null;
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throwHostedLinqCurrentInboundInvalid();
-  }
-
-  const record = value as Record<string, unknown>;
-  const dedupeKey = readOptionalBodyString(record.dedupeKey);
-  const eventId = readOptionalBodyString(record.eventId);
-  const mailboxItemId = readOptionalBodyString(record.mailboxItemId);
-  const occurredAt = readOptionalBodyString(record.occurredAt);
-  const replyToMessageId = readOptionalBodyString(record.replyToMessageId);
-  const target = readOptionalBodyString(record.target);
-  if (
-    !dedupeKey
-    || !eventId
-    || !mailboxItemId
-    || !occurredAt
-    || !replyToMessageId
-    || !target
-  ) {
-    throwHostedLinqCurrentInboundInvalid();
-  }
-
-  return {
-    dedupeKey,
-    eventId,
-    mailboxItemId,
-    occurredAt,
-    replyToMessageId,
-    target,
-  };
-}
-
-function throwHostedLinqCurrentInboundInvalid(): never {
-  throw hostedOnboardingError({
-    code: "HOSTED_LINQ_EGRESS_CURRENT_INBOUND_INVALID",
-    httpStatus: 400,
-    message: "Hosted Linq egress current inbound proof is invalid.",
-    retryable: false,
-  });
 }

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -29,14 +29,6 @@ import {
 } from "../hosted-mailbox/store";
 
 type HostedLinqEngagementClient = PrismaClient | Prisma.TransactionClient;
-type HostedLinqLegacyCurrentInboundProof = {
-  dedupeKey: string;
-  eventId: string;
-  mailboxItemId: string;
-  occurredAt: string;
-  replyToMessageId: string;
-  target: string;
-};
 export type HostedLinqRuntimeEgressTargetOverride = {
   target: string;
   targetKind: "thread";
@@ -80,8 +72,7 @@ export function assertHostedLinqRouteAuthorityMatchesTarget(input: {
 
 export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
   answeredMailboxItemIds?: readonly string[] | null;
-  authorityCheckOnly?: boolean | null;
-  currentInbound?: HostedLinqLegacyCurrentInboundProof | null;
+  authorityCheckOnly: boolean;
   directRecipientPhoneNumber?: string | null;
   fromPhoneNumber?: string | null;
   homeRouteFallbackAllowed?: boolean | null;
@@ -128,7 +119,6 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
 
   if (await matchesPersistedHostedLinqDirectInbound({
     answeredMailboxItemIds: input.answeredMailboxItemIds ?? [],
-    currentInbound: input.currentInbound ?? null,
     memberId: input.memberId,
     prisma: input.prisma,
     replyToMessageId: input.replyToMessageId,
@@ -161,40 +151,14 @@ function isHostedLinqCurrentHomeOnlyAssertion(input: {
 
 async function matchesPersistedHostedLinqDirectInbound(input: {
   answeredMailboxItemIds: readonly string[];
-  currentInbound: HostedLinqLegacyCurrentInboundProof | null;
   memberId: string;
   prisma: HostedLinqEngagementClient;
   replyToMessageId?: string | null;
   target: string | null;
 }): Promise<boolean> {
-  const proof = input.currentInbound;
   const target = normalizeNullable(input.target);
   const requestReplyToMessageId = normalizeNullable(input.replyToMessageId);
-  if (!target) {
-    return false;
-  }
-
-  if (
-    proof
-    && normalizeNullable(proof.target) === target
-    && normalizeNullable(proof.eventId) === normalizeNullable(proof.dedupeKey)
-    && (
-      requestReplyToMessageId === null
-      || normalizeNullable(proof.replyToMessageId) === requestReplyToMessageId
-    )
-    && await matchesPersistedHostedLinqDirectInboundMailboxItem({
-      legacyProof: proof,
-      mailboxItemId: proof.mailboxItemId,
-      memberId: input.memberId,
-      prisma: input.prisma,
-      replyToMessageId: proof.replyToMessageId,
-      target,
-    })
-  ) {
-    return true;
-  }
-
-  if (!requestReplyToMessageId) {
+  if (!target || !requestReplyToMessageId) {
     return false;
   }
   for (let index = input.answeredMailboxItemIds.length - 1; index >= 0; index -= 1) {
@@ -202,7 +166,6 @@ async function matchesPersistedHostedLinqDirectInbound(input: {
     if (
       mailboxItemId
       && await matchesPersistedHostedLinqDirectInboundMailboxItem({
-        legacyProof: null,
         mailboxItemId,
         memberId: input.memberId,
         prisma: input.prisma,
@@ -225,7 +188,6 @@ async function matchesPersistedHostedLinqDirectInbound(input: {
     if (
       !answeredMailboxItemIds.has(mailboxItemId)
       && await matchesPersistedHostedLinqDirectInboundMailboxItem({
-        legacyProof: null,
         mailboxItemId,
         memberId: input.memberId,
         prisma: input.prisma,
@@ -241,7 +203,6 @@ async function matchesPersistedHostedLinqDirectInbound(input: {
 }
 
 async function matchesPersistedHostedLinqDirectInboundMailboxItem(input: {
-  legacyProof: HostedLinqLegacyCurrentInboundProof | null;
   mailboxItemId: string;
   memberId: string;
   prisma: HostedLinqEngagementClient;
@@ -258,13 +219,6 @@ async function matchesPersistedHostedLinqDirectInboundMailboxItem(input: {
     || item.userId !== input.memberId
     || item.kind !== "conversation.message"
     || item.lane !== "conversation"
-    || (
-      input.legacyProof !== null
-      && (
-        item.dedupeKey !== input.legacyProof.dedupeKey
-        || item.occurredAt !== input.legacyProof.occurredAt
-      )
-    )
   ) {
     return false;
   }
@@ -301,13 +255,6 @@ async function matchesPersistedHostedLinqDirectInboundMailboxItem(input: {
     && wake.userId === input.memberId
     && wake.eventId === item.dedupeKey
     && wake.occurredAt === item.occurredAt
-    && (
-      input.legacyProof === null
-      || (
-        wake.eventId === input.legacyProof.eventId
-        && wake.occurredAt === input.legacyProof.occurredAt
-      )
-    )
     && wake.message.channel === "linq"
     && wake.message.linqMessage.isFromMe === false
     && wake.message.linqMessage.threadIsDirect === true

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -51,6 +51,10 @@ import {
 import {
   assertHostedLinqRecentInboundEngagementForRuntime,
 } from "@/src/lib/hosted-onboarding/linq-egress-engagement";
+import {
+  createHostedLinqDeliveryIdempotencyLookupKey,
+  createHostedLinqDeliverySourceRefLookupKey,
+} from "@/src/lib/hosted-onboarding/linq-observability-identifiers";
 import { POST as postHostedLinqEgressEngagement } from "../app/api/internal/hosted-runtime/linq-egress/engagement/route";
 
 describe("hosted Linq egress authority", () => {
@@ -79,6 +83,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       fromPhoneNumber: "+15550100099",
       idempotencyKey: "signup-welcome:member-1",
       memberId: "member-1",
@@ -100,6 +105,7 @@ describe("hosted Linq egress authority", () => {
 
   it("rejects first contact without signup-welcome authority", async () => {
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       fromPhoneNumber: "+15550100099",
       idempotencyKey: "signup-welcome:member-2",
       memberId: "member-1",
@@ -122,6 +128,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       fromPhoneNumber: "+15550100099",
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
@@ -133,6 +140,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       fromPhoneNumber: "+15550100100",
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
@@ -144,6 +152,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       fromPhoneNumber: "+15550100099",
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
@@ -162,6 +171,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-home",
@@ -169,6 +179,7 @@ describe("hosted Linq egress authority", () => {
     })).resolves.toEqual({ targetOverride: null, threadIsDirect: true });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-pending",
@@ -176,6 +187,7 @@ describe("hosted Linq egress authority", () => {
     })).resolves.toEqual({ targetOverride: null, threadIsDirect: true });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-other",
@@ -192,6 +204,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-authorized",
@@ -213,6 +226,21 @@ describe("hosted Linq egress authority", () => {
       code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
       httpStatus: 403,
     });
+
+    const foreignRoutePrisma = createPrismaStub({
+      threadRouteContainerMemberId: "member-2",
+    });
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
+      memberId: "member-1",
+      prisma: asRuntimeEngagementPrisma(foreignRoutePrisma),
+      target: "chat-authorized",
+      targetKind: "thread",
+    })).rejects.toMatchObject({
+      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
+      httpStatus: 403,
+    });
+    expect(foreignRoutePrisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
   });
 
   it("rejects non-participant sends before route resolution when member access is inactive", async () => {
@@ -222,6 +250,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-authorized",
@@ -242,6 +271,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-home",
@@ -310,6 +340,7 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       replyToMessageId: "linq-message-reply",
@@ -323,7 +354,7 @@ describe("hosted Linq egress authority", () => {
     expect(mocks.readHostedMemberRoutingPrivateState).not.toHaveBeenCalled();
   });
 
-  it("allows an exact persisted direct inbound after its home chat binding changes", async () => {
+  it("allows an exact answered direct inbound after its home chat binding changes", async () => {
     const prisma = createPrismaStub({
       homeChatId: "chat-current-home",
     });
@@ -337,14 +368,8 @@ describe("hosted Linq egress authority", () => {
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      currentInbound: {
-        dedupeKey: "linq-event-current",
-        eventId: "linq-event-current",
-        mailboxItemId: "mailbox-current",
-        occurredAt: "2026-07-14T00:02:47.000Z",
-        replyToMessageId: "linq-message-current",
-        target: "chat-inbound",
-      },
+      answeredMailboxItemIds: ["mailbox-current"],
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       replyToMessageId: "linq-message-current",
@@ -429,6 +454,7 @@ describe("hosted Linq egress authority", () => {
     ]);
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       replyToMessageId: "linq-message-recovered",
@@ -462,6 +488,7 @@ describe("hosted Linq egress authority", () => {
     ]);
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       replyToMessageId: "linq-message-former-group",
@@ -551,6 +578,7 @@ describe("hosted Linq egress authority", () => {
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       answeredMailboxItemIds: ["mailbox-current"],
+      authorityCheckOnly: false,
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       replyToMessageId: requestedMessageId,
@@ -590,130 +618,13 @@ describe("hosted Linq egress authority", () => {
     });
   });
 
-  it.each([
-    {
-      label: "another member",
-      mailboxUserId: "member-2",
-      threadIsDirect: true,
-    },
-    {
-      label: "unknown directness",
-      mailboxUserId: "member-1",
-      threadIsDirect: null,
-    },
-  ])("rejects persisted inbound proof for $label", async ({
-    mailboxUserId,
-    threadIsDirect,
-  }) => {
-    const prisma = createPrismaStub({
-      homeChatId: "chat-current-home",
-    });
-    mockPersistedLinqInbound({
-      chatId: "chat-inbound",
-      dedupeKey: "linq-event-current",
-      mailboxItemId: "mailbox-current",
-      messageId: "linq-message-current",
-      occurredAt: "2026-07-14T00:02:47.000Z",
-      threadIsDirect,
-      userId: mailboxUserId,
-    });
-
-    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      currentInbound: {
-        dedupeKey: "linq-event-current",
-        eventId: "linq-event-current",
-        mailboxItemId: "mailbox-current",
-        occurredAt: "2026-07-14T00:02:47.000Z",
-        replyToMessageId: "linq-message-current",
-        target: "chat-inbound",
-      },
-      memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-      replyToMessageId: "linq-message-current",
-      target: "chat-inbound",
-      targetKind: "thread",
-    })).rejects.toMatchObject({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
-      httpStatus: 403,
-    });
-  });
-
-  it("rejects a persisted non-direct inbound after its live thread route is gone", async () => {
-    const prisma = createPrismaStub({
-      homeChatId: "chat-current-home",
-    });
-    mockPersistedLinqInbound({
-      chatId: "chat-former-group",
-      dedupeKey: "linq-event-group",
-      mailboxItemId: "mailbox-group",
-      messageId: "linq-message-group",
-      occurredAt: "2026-07-14T00:02:47.000Z",
-      threadIsDirect: false,
-    });
-
-    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      currentInbound: {
-        dedupeKey: "linq-event-group",
-        eventId: "linq-event-group",
-        mailboxItemId: "mailbox-group",
-        occurredAt: "2026-07-14T00:02:47.000Z",
-        replyToMessageId: "linq-message-group",
-        target: "chat-former-group",
-      },
-      memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-      replyToMessageId: "linq-message-group",
-      target: "chat-former-group",
-      targetKind: "thread",
-    })).rejects.toMatchObject({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
-      httpStatus: 403,
-    });
-
-    expect(prisma.hostedMemberRouting.findUnique).toHaveBeenCalled();
-  });
-
-  it("rejects a current-inbound proof whose provider message does not match", async () => {
-    const prisma = createPrismaStub({
-      homeChatId: "chat-current-home",
-    });
-    mockPersistedLinqInbound({
-      chatId: "chat-inbound",
-      dedupeKey: "linq-event-current",
-      mailboxItemId: "mailbox-current",
-      messageId: "linq-message-other",
-      occurredAt: "2026-07-14T00:02:47.000Z",
-      threadIsDirect: true,
-    });
-
-    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      currentInbound: {
-        dedupeKey: "linq-event-current",
-        eventId: "linq-event-current",
-        mailboxItemId: "mailbox-current",
-        occurredAt: "2026-07-14T00:02:47.000Z",
-        replyToMessageId: "linq-message-current",
-        target: "chat-inbound",
-      },
-      memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-      replyToMessageId: "linq-message-current",
-      target: "chat-inbound",
-      targetKind: "thread",
-    })).rejects.toMatchObject({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
-      httpStatus: 403,
-    });
-
-    expect(prisma.hostedMemberRouting.findUnique).toHaveBeenCalled();
-  });
-
   it("keeps stale explicit direct-recipient targets strict", async () => {
     const prisma = createPrismaStub({
       homeChatId: "chat-current-home",
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: false,
       directRecipientPhoneNumber: "+15550100001",
       memberId: "member-1",
       prisma: asRuntimeEngagementPrisma(prisma),
@@ -727,9 +638,35 @@ describe("hosted Linq egress authority", () => {
     expect(mocks.readHostedMemberRoutingPrivateState).not.toHaveBeenCalled();
   });
 
-  it("accepts old-runner currentInbound payloads for external thread egress authority", async () => {
+  it.each([
+    { authorityCheckOnly: undefined, label: "missing" },
+    { authorityCheckOnly: "false", label: "non-boolean" },
+  ])("rejects $label authorityCheckOnly", async ({ authorityCheckOnly }) => {
+    const response = await postHostedLinqEgressEngagement(
+      new Request("https://internal.example.test/engagement", {
+        body: JSON.stringify({
+          ...(authorityCheckOnly === undefined ? {} : { authorityCheckOnly }),
+          target: "chat-home",
+          targetKind: "thread",
+        }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_LINQ_EGRESS_AUTHORITY_CHECK_ONLY_INVALID",
+      },
+    });
+    expect(mocks.getPrisma).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit idempotency key even when retired currentInbound proof is supplied", async () => {
     const prisma = createPrismaStub({
-      homeChatId: "chat-home",
       threadRouteContainerMemberId: "member-1",
     });
     mocks.getPrisma.mockReturnValue(prisma);
@@ -737,19 +674,14 @@ describe("hosted Linq egress authority", () => {
     const response = await postHostedLinqEgressEngagement(
       new Request("https://internal.example.test/engagement", {
         body: JSON.stringify({
+          authorityCheckOnly: false,
           currentInbound: {
-            dedupeKey: "linq_external_event",
-            eventId: "linq_external_event",
-            mailboxItemId: "mailbox_external",
-            occurredAt: "2026-06-01T12:00:00.000Z",
-            replyToMessageId: "message_external",
+            dedupeKey: "linq-event-retired",
+            eventId: "linq-event-retired",
+            mailboxItemId: "mailbox-retired",
+            occurredAt: "2026-07-14T00:02:47.000Z",
+            replyToMessageId: "linq-message-retired",
             target: "chat-external",
-          },
-          routeAuthority: {
-            accountLookupKey: "hbidx:phone:v1:stale-line",
-            channel: "linq",
-            containerMemberId: "member-stale",
-            threadId: "chat-stale",
           },
           target: "chat-external",
           targetKind: "thread",
@@ -761,115 +693,13 @@ describe("hosted Linq egress authority", () => {
       }),
     );
 
-    await expect(response.json()).resolves.toEqual({
-      ok: true,
-      providerDispatchClaimed: true,
-      threadIsDirect: false,
-    });
-    expect(response.status).toBe(200);
-    expect(mocks.requireHostedCloudflareCallbackRequest).toHaveBeenCalled();
-    expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
-    expect(mocks.acquireHostedMemberHomeLinqRouteLockTx).toHaveBeenCalledWith({
-      memberId: "member-1",
-      prisma: expect.any(Object),
-    });
-    expect(prisma.hostedLinqDelivery.createMany).toHaveBeenCalledWith({
-      data: [expect.objectContaining({
-        linqChatLookupKey: createRequiredLinqChatLookupKey("chat-external"),
-        source: "hosted_runtime_linq_delivery",
-        status: "provider_dispatch_started",
-        targetKind: "thread",
-      })],
-      skipDuplicates: true,
-    });
-  });
-
-  it("rejects old-runner currentInbound payloads for another member's external thread", async () => {
-    const prisma = createPrismaStub({
-      threadRouteContainerMemberId: "member-2",
-    });
-    mockPersistedLinqInbound({
-      chatId: "chat-external",
-      dedupeKey: "linq_external_event",
-      mailboxItemId: "mailbox_external",
-      messageId: "message_external",
-      occurredAt: "2026-06-01T12:00:00.000Z",
-      threadIsDirect: true,
-    });
-
-    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      currentInbound: {
-        dedupeKey: "linq_external_event",
-        eventId: "linq_external_event",
-        mailboxItemId: "mailbox_external",
-        occurredAt: "2026-06-01T12:00:00.000Z",
-        replyToMessageId: "message_external",
-        target: "chat-external",
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_LINQ_PROVIDER_DISPATCH_IDEMPOTENCY_REQUIRED",
       },
-      memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-      target: "chat-external",
-      targetKind: "thread",
-    })).rejects.toMatchObject({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
-      httpStatus: 403,
     });
-
-    expect(mocks.readHostedMailboxLiveItemById).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    { currentInbound: null, label: "missing" },
-    {
-      currentInbound: {
-        dedupeKey: "linq_external_event",
-        eventId: "linq_external_event",
-        mailboxItemId: "mailbox_external",
-        occurredAt: "2026-06-01T12:00:00.000Z",
-        replyToMessageId: "message_external",
-        target: "chat-other",
-      },
-      label: "target-mismatched",
-    },
-  ])("uses the live route with $label old-runner inbound proof", async ({
-    currentInbound,
-  }) => {
-    const prisma = createPrismaStub({
-      threadRouteContainerMemberId: "member-1",
-    });
-
-    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      currentInbound,
-      memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-      target: "chat-external",
-      targetKind: "thread",
-    })).resolves.toEqual({ targetOverride: null, threadIsDirect: false });
-  });
-
-  it("rejects old-runner currentInbound payloads when external thread access is inactive", async () => {
-    const prisma = createPrismaStub({
-      activeMemberAccess: false,
-      threadRouteContainerMemberId: "member-1",
-    });
-
-    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      currentInbound: {
-        dedupeKey: "linq_external_event",
-        eventId: "linq_external_event",
-        mailboxItemId: "mailbox_external",
-        occurredAt: "2026-06-01T12:00:00.000Z",
-        replyToMessageId: "message_external",
-        target: "chat-external",
-      },
-      memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-      target: "chat-external",
-      targetKind: "thread",
-    })).rejects.toMatchObject({
-      code: "HOSTED_THREAD_ROUTE_EGRESS_UNAUTHORIZED",
-      httpStatus: 403,
-    });
+    expect(prisma.hostedLinqDelivery.createMany).not.toHaveBeenCalled();
   });
 
   it("holds member-home authority before the chat and provider dispatch fence", async () => {
@@ -892,6 +722,7 @@ describe("hosted Linq egress authority", () => {
     const response = await postHostedLinqEgressEngagement(
       new Request("https://internal.example.test/engagement", {
         body: JSON.stringify({
+          authorityCheckOnly: false,
           idempotencyKey: "assistant-outbox:intent-home",
           target: "chat-home",
           targetKind: "thread",
@@ -904,11 +735,28 @@ describe("hosted Linq egress authority", () => {
     );
 
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      providerDispatchClaimed: true,
+      threadIsDirect: true,
+    });
     expect(observedOrder).toEqual([
       "member-home",
       "chat",
       "provider-dispatch",
     ]);
+    expect(prisma.hostedLinqDelivery.createMany).toHaveBeenCalledWith({
+      data: [expect.objectContaining({
+        idempotencyKey: createHostedLinqDeliveryIdempotencyLookupKey(
+          "assistant-outbox:intent-home",
+        ),
+        sourceRef: createHostedLinqDeliverySourceRefLookupKey(
+          "assistant-outbox:intent-home",
+        ),
+        status: "provider_dispatch_started",
+      })],
+      skipDuplicates: true,
+    });
   });
 
   it("checks route authority without claiming provider dispatch", async () => {
@@ -921,6 +769,7 @@ describe("hosted Linq egress authority", () => {
       new Request("https://internal.example.test/engagement", {
         body: JSON.stringify({
           authorityCheckOnly: true,
+          idempotencyKey: "assistant-outbox:authority-only",
           target: "chat-home",
           targetKind: "thread",
         }),
@@ -1008,6 +857,7 @@ describe("hosted Linq egress authority", () => {
     const response = await postHostedLinqEgressEngagement(
       new Request("https://internal.example.test/engagement", {
         body: JSON.stringify({
+          authorityCheckOnly: false,
           idempotencyKey: "assistant-outbox:intent-active",
           target: "chat-home",
           targetKind: "thread",

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -2344,6 +2344,7 @@ async function deliverHostedPreparedAssistantDelivery(input: {
                   await assertHostedAssistantLinqRecentInboundEngagementForDelivery({
                     answeredMailboxItemIds:
                       input.assistantDeliveryEffect.payload.answeredMailboxItemIds,
+                    authorityCheckOnly: false,
                     directRecipientPhoneNumber:
                       deliveryContext?.directRecipientPhoneNumber ?? null,
                     effectsPort: input.effectsPort,
@@ -2847,6 +2848,7 @@ function createHostedAssistantLinqSendDependency(input: {
         onProviderDispatchEntered: async () => {
           await assertHostedAssistantLinqRecentInboundEngagementForDelivery({
             answeredMailboxItemIds: request.answeredMailboxItemIds,
+            authorityCheckOnly: false,
             directRecipientPhoneNumber,
             effectsPort: input.effectsPort ?? null,
             fromPhoneNumber,
@@ -3132,6 +3134,7 @@ function createHostedAssistantLinqVoiceMemoSendDependency(input: {
         onProviderDispatchEntered: async () => {
           await assertHostedAssistantLinqRecentInboundEngagementForDelivery({
             answeredMailboxItemIds: request.answeredMailboxItemIds,
+            authorityCheckOnly: false,
             directRecipientPhoneNumber:
               deliveryContext?.directRecipientPhoneNumber ?? null,
             effectsPort: input.effectsPort ?? null,
@@ -3448,7 +3451,7 @@ function readTrustedHostedAssistantLinqDeliveryFailureReason(
 
 async function assertHostedAssistantLinqRecentInboundEngagementForDelivery(input: {
   answeredMailboxItemIds?: readonly string[] | null;
-  authorityCheckOnly?: boolean;
+  authorityCheckOnly: boolean;
   directRecipientPhoneNumber: string | null;
   effectsPort?: Pick<HostedRuntimeEffectsPort, "assertLinqRecentInboundEngagement"> | null;
   fromPhoneNumber: string | null;
@@ -3476,7 +3479,7 @@ async function assertHostedAssistantLinqRecentInboundEngagementForDelivery(input
       ...(input.answeredMailboxItemIds?.length
         ? { answeredMailboxItemIds: [...input.answeredMailboxItemIds] }
         : {}),
-      authorityCheckOnly: input.authorityCheckOnly === true,
+      authorityCheckOnly: input.authorityCheckOnly,
       directRecipientPhoneNumber: input.directRecipientPhoneNumber,
       fromPhoneNumber: input.fromPhoneNumber,
       homeRouteFallbackAllowed: input.homeRouteFallbackAllowed,

--- a/packages/assistant-runtime/src/hosted-runtime/platform.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/platform.ts
@@ -248,7 +248,7 @@ export interface HostedRuntimeLinqSendResponse {
 
 export interface HostedRuntimeLinqRecentInboundEngagementRequest {
   answeredMailboxItemIds?: readonly string[] | null;
-  authorityCheckOnly?: boolean | null;
+  authorityCheckOnly: boolean;
   directRecipientPhoneNumber?: string | null;
   fromPhoneNumber?: string | null;
   homeRouteFallbackAllowed?: boolean | null;

--- a/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
@@ -257,7 +257,7 @@ function createDelivery(overrides: Record<string, unknown> = {}) {
 }
 
 function buildClaimedLinqEngagementResult(request: {
-  authorityCheckOnly?: boolean | null;
+  authorityCheckOnly: boolean;
 }) {
   return request.authorityCheckOnly === true
     ? {}
@@ -265,7 +265,7 @@ function buildClaimedLinqEngagementResult(request: {
 }
 
 async function assertLinqEngagementWithExistingProviderClaim(request: {
-  authorityCheckOnly?: boolean | null;
+  authorityCheckOnly: boolean;
 }) {
   if (request.authorityCheckOnly === true) {
     return {};
@@ -7500,6 +7500,7 @@ describe("hosted runtime callbacks", () => {
 
     expect(assertRecentInbound).toHaveBeenCalledWith(
       expect.objectContaining({
+        authorityCheckOnly: false,
         directRecipientPhoneNumber: null,
         fromPhoneNumber: "+15550100099",
         idempotencyKey: "signup-welcome:member_123",
@@ -8778,7 +8779,7 @@ describe("hosted runtime callbacks", () => {
       transportIdempotent: true,
     });
     const assertRecentInbound = vi.fn(async (
-      request: { authorityCheckOnly?: boolean | null },
+      request: { authorityCheckOnly: boolean },
     ) => buildClaimedLinqEngagementResult(request));
     mocks.sendLinqMessage.mockResolvedValueOnce({
       providerMessageId: "linq_message_sent",

--- a/packages/assistant-runtime/test/hosted-runtime-channel-activity.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-channel-activity.test.ts
@@ -84,7 +84,7 @@ function buildLinqRouteAuthority(threadId: string) {
 }
 
 function buildClaimedLinqEngagementResult(request: {
-  authorityCheckOnly?: boolean | null;
+  authorityCheckOnly: boolean;
 }) {
   return request.authorityCheckOnly === true
     ? {}

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -8485,7 +8485,7 @@ function createPlatform(input: {
     },
     effectsPort: {
       async assertLinqRecentInboundEngagement(request: {
-        authorityCheckOnly?: boolean | null;
+        authorityCheckOnly: boolean;
       }) {
         return request.authorityCheckOnly === true
           ? {}


### PR DESCRIPTION
## Why this PR exists

The hosted Linq egress path still carried the retired currentInbound proof and a derived provider-dispatch idempotency fallback from the #583/#627 rollout. Production runners now use the explicit authorityCheckOnly protocol and explicit provider-dispatch keys, so the compatibility path can be deleted.

## User goal / user-visible behavior

Linq replies, group-thread delivery, signup welcomes, and scheduled sends keep their current behavior. The change makes the deployed authority protocol strict and removes obsolete fallback state.

## Invariants

- authorityCheckOnly true performs authority resolution only and never claims provider dispatch.
- authorityCheckOnly false is the final provider boundary and requires an explicit idempotency key.
- Exact answered mailbox IDs and bounded recent-100 mailbox recovery remain authoritative.
- Member, direct/group audience, route, provider-reply, dispatch-fence, and signup-welcome checks remain intact.
- The webhook currentInboundReply read-receipt proof and delivery-time mailbox consumption are unchanged.
- The supported runner rollback floor remains #627 or newer.

## Non-obvious affected surfaces

- Web rejects a missing or non-boolean authorityCheckOnly before opening a transaction.
- Retired currentInbound JSON is ignored and cannot recreate the deleted idempotency fallback.
- Assistant-runtime producers state true or false explicitly at every call site.
- Cloudflare transports both discriminator values unchanged.
- Personal-home repair, external group ownership, provider-reply, welcome, and recent-mailbox recovery paths remain on their existing owners.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 27 | 121 |
| Tests/fixtures | 111 | 256 |
| Docs | 93 | 25 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **231** | **402** |

## Verification

- Full diff-aware lane: assistant-runtime 1,692 tests; Web 5,212 tests plus typecheck, lint, dev smoke, and production build; Cloudflare 1,829 Node tests plus Workers.
- Required coverage-write audit: PASS after adding only boundary assertions for the deleted fallback and retained authority fences.
- Post-audit and post-rebase: Web 30/30; assistant-runtime 288/288; Cloudflare 130/130; Web, assistant-runtime, and Cloudflare typechecks passed.
- Retained read-receipt/mailbox-consumption slice: 2/2.
- Stale egress-path, privacy, and whitespace scans passed.

## Deployment compatibility

Deploy Web first, then Cloudflare/runner. Current production runners already send this request shape, so no compatibility flag or migration is required. Never roll the runner below #627 while this Web hard cut is deployed. After convergence, smoke one authority-only current-home resolution, one final provider claim, and one Linq group-thread delivery.

## ReviewGPT baseline

ReviewGPT first-reviewed head: c0c4c1c80d0a1c7cbd193e348a6c82eeb215d885

| Review state | Head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| First review | `c0c4c1c80d0a1c7cbd193e348a6c82eeb215d885` | 27 | 121 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786737131&installation_id=127572939&pr_number=711&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F711&signature=a638f100d06579b57faabb22c3785cb28251e30c91778b46a674198f600e22c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->