### PR TITLE
Fix first-visit handoff after shared signup

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-initial-visit-auth-redirect.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-initial-visit-auth-redirect.md
@@ -1,0 +1,70 @@
+# Preserve first-visit auth redirect
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Ensure a newly created hosted member who completes sign-up through the shared
+  auth dialog reaches the existing `/home?initialVisit=true` handoff so the
+  first-visit onboarding dialogs appear.
+
+## Success criteria
+
+- The shared auth provider preserves `initialVisitEligible` for accessible
+  onboarding stages.
+- Existing-member sign-in still redirects to `/home`.
+- Protected action, device-connect, computer-handoff, integration-connect, and
+  data-privacy resume URLs keep their current precedence.
+- Focused regression coverage and the required web verification/review gates
+  pass.
+
+## Scope
+
+- In scope: the shared hosted auth completion redirect and its focused component
+  tests.
+- Out of scope: member-creation eligibility, Privy authentication, home-dialog
+  rendering, onboarding state, and unrelated auth or navigation refactors.
+
+## Constraints
+
+- Keep the server-derived eligibility flag authoritative.
+- Reuse the canonical hosted app route constants.
+- Do not weaken authenticated re-verification or protected-URL resume behavior.
+
+## Tasks
+
+1. Add a focused failing regression for a new member completing shared-dialog
+   sign-up.
+2. Route eligible accessible-stage completions through the canonical first-visit
+   home path while retaining all existing branches.
+3. Run focused and diff-aware verification plus the required coverage and
+   frontend review passes.
+4. Complete the scoped commit and PR review path.
+
+## Decisions
+
+- Fix the shared provider branch rather than changing server eligibility or home
+  dialog behavior because the completion payload already carries the correct
+  eligibility bit and only this caller discards it.
+- Keep protected resume URLs ahead of the first-visit handoff so authentication
+  does not strand device-connect or other user-critical continuation flows.
+
+## Verification
+
+- Regression-first focused component test failed on the old `/home` behavior,
+  then passed after the redirect fix.
+- Focused auth-provider suite passed: 8 tests.
+- Hosted Web TypeScript 7 typecheck passed.
+- Truthful diff verification passed: dependency/workspace/hosted guards, 5,222
+  Web tests with 140 skips, lint with zero errors, development smoke, and the
+  production Next.js build.
+- The required coverage-write pass strengthened device-connect precedence for
+  an eligible first-visit payload; its focused rerun passed all 8 tests.
+- The required frontend review found no evidence-backed UX, accessibility,
+  responsive, or design-system issues. The change has no visual/layout surface.
+- Parent scope, call-path, diff, and invariant review found no unresolved issue.
+- A live provider-backed Telegram signup replay remains a manual verification
+  gap; the component boundary and full Web verification cover the changed code.
+Completed: 2026-07-15

--- a/apps/web/src/components/hosted-onboarding/auth-dialog-provider.tsx
+++ b/apps/web/src/components/hosted-onboarding/auth-dialog-provider.tsx
@@ -11,6 +11,10 @@ import {
 } from "react";
 
 import { AuthDialog } from "@/src/components/hosted-onboarding/auth-dialog";
+import {
+  HOSTED_APP_HOME_PATH,
+  HOSTED_APP_INITIAL_VISIT_HOME_PATH,
+} from "@/src/lib/hosted-onboarding/app-routes";
 import { isHostedOnboardingAccessibleStage } from "@/src/lib/hosted-onboarding/stage";
 import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
 import { subscribeBrowserVaultSessionInvalidation } from "@/src/lib/browser-vault/session-invalidation";
@@ -72,7 +76,11 @@ export function AuthProvider({
     }
 
     if (isHostedOnboardingAccessibleStage(payload.stage)) {
-      navigateHostedAuthRedirect("/home");
+      navigateHostedAuthRedirect(
+        payload.initialVisitEligible === true
+          ? HOSTED_APP_INITIAL_VISIT_HOME_PATH
+          : HOSTED_APP_HOME_PATH,
+      );
       return;
     }
 

--- a/apps/web/test/auth-dialog-provider.test.tsx
+++ b/apps/web/test/auth-dialog-provider.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   authDialogProps: null as {
     onCompleted?: (payload: {
       activationPending: boolean;
+      initialVisitEligible?: boolean;
       inviteCode: string;
       joinUrl: string;
       stage: string;
@@ -27,6 +28,7 @@ vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
   AuthDialog(props: {
     onCompleted?: (payload: {
       activationPending: boolean;
+      initialVisitEligible?: boolean;
       inviteCode: string;
       joinUrl: string;
       stage: string;
@@ -126,7 +128,7 @@ test("AuthProvider reloads a document that receives a cross-tab session transiti
   await rendered.cleanup();
 });
 
-test("AuthProvider resumes a pending device connect intent after sign-in completion", async () => {
+test("AuthProvider keeps a pending device connect intent ahead of the first-visit redirect", async () => {
   const { AuthProvider, useAuth } = await import(
     "@/src/components/hosted-onboarding/auth-dialog-provider"
   );
@@ -169,13 +171,14 @@ test("AuthProvider resumes a pending device connect intent after sign-in complet
     rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
   });
 
-  const completeButton = Array.from(rendered.container.querySelectorAll("button")).find(
-    (button) => button.textContent === "Complete auth",
-  );
-  expect(completeButton).toBeTruthy();
-
   await act(async () => {
-    completeButton?.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+    await mocks.authDialogProps?.onCompleted?.({
+      activationPending: false,
+      initialVisitEligible: true,
+      inviteCode: "invite-code",
+      joinUrl: "/join/invite-code",
+      stage: "active",
+    });
   });
 
   expect(reload).toHaveBeenCalledTimes(1);
@@ -425,6 +428,61 @@ test("AuthProvider keeps the default home redirect for ordinary sign-in completi
   });
 
   expect(assign).toHaveBeenCalledWith("/home");
+
+  await rendered.cleanup();
+});
+
+test("AuthProvider preserves the first-visit redirect for newly created members", async () => {
+  const { AuthProvider, useAuth } = await import(
+    "@/src/components/hosted-onboarding/auth-dialog-provider"
+  );
+  const assign = vi.fn();
+
+  function OpenAuthButton() {
+    const { openAuthDialog } = useAuth();
+    return createElement(
+      "button",
+      {
+        type: "button",
+        onClick: openAuthDialog,
+      },
+      "Sign up",
+    );
+  }
+
+  const rendered = await renderClientComponent(
+    createElement(AuthProvider, {
+      authenticated: false,
+    }, createElement(OpenAuthButton)),
+  );
+
+  Object.defineProperty(rendered.window, "location", {
+    configurable: true,
+    value: {
+      assign,
+      hash: "",
+      href: "https://join.example.test/home",
+      origin: "https://join.example.test",
+      pathname: "/home",
+      search: "",
+    },
+  });
+
+  await act(async () => {
+    rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await act(async () => {
+    await mocks.authDialogProps?.onCompleted?.({
+      activationPending: false,
+      initialVisitEligible: true,
+      inviteCode: "invite-code",
+      joinUrl: "/join/invite-code",
+      stage: "active",
+    });
+  });
+
+  expect(assign).toHaveBeenCalledWith("/home?initialVisit=true");
 
   await rendered.cleanup();
 });


### PR DESCRIPTION
## Why

The shared hosted auth dialog discarded the server-derived first-visit eligibility flag after a new member completed sign-up. That sent Telegram and other shared-dialog sign-ups to ordinary /home, so the existing onboarding dialogs never mounted.

## User-visible goal and UX

- A newly created member completing the shared sign-up dialog lands on /home?initialVisit=true and sees the existing first-visit dialog sequence.
- An existing member still lands on ordinary /home.
- Auth-required action approvals, device connection, computer handoff, integration connection, and data-privacy flows still resume their current URL before any first-visit redirect is considered.

## Invariants

- The server-owned initialVisitEligible result remains the authority; the browser does not infer new-member state.
- No persisted onboarding state, auth/session boundary, or launch-consent behavior changes.
- Product-critical protected-flow resumption retains precedence.
- The home client keeps its existing one-shot query cleanup and dialog behavior.

## Non-obvious affected surfaces

- The shared AuthProvider is used by anonymous dashboard actions, including sign-up from /home; other completion paths already honored the same eligibility flag.
- The initialVisit query parameter is intentionally removed after the home dialog mounts, so it may disappear from the address bar while the dialog sequence remains active.

## Verification

- Regression-first auth-provider test failed before the fix and passed after it.
- Focused AuthProvider suite: 8 passed.
- Hosted Web TypeScript 7 typecheck passed.
- Truthful diff verification passed: 5,222 Web tests with 140 skips, lint with zero errors, development smoke, and production build.
- Required coverage-write pass strengthened protected device-connect precedence; required frontend review found no evidence-backed findings.
- Live provider-backed Telegram replay remains a manual gap; the changed component boundary and full Web lane are covered.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 9 | 1 |
| Tests | 65 | 7 |
| Docs | 70 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 9c0acecbff68d362565294b09622b52d4510cc79

| Review round | Current head | Source added | Source deleted |
| --- | --- | ---: | ---: |
| 1 | 9c0acecbff68d362565294b09622b52d4510cc79 | 9 | 1 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786746767&installation_id=127572939&pr_number=717&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F717&signature=66f69bc177a8f644c2e332cfe28ac9462c8c0283cff53c35e3c5a605eade4ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->