### PR TITLE
Play voice previews from waveform clicks

### DIFF
--- a/apps/web/src/components/ui/voice-memo-player.tsx
+++ b/apps/web/src/components/ui/voice-memo-player.tsx
@@ -211,7 +211,18 @@ export const VoiceMemoPlayer = forwardRef<
           )}
         </button>
 
-        <div className="flex h-7 flex-1 items-center justify-between">
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={unavailable}
+          aria-label={
+            playing
+              ? "Pause voice memo from waveform"
+              : "Play voice memo from waveform"
+          }
+          data-voice-memo-waveform
+          className="flex h-7 flex-1 cursor-pointer items-center justify-between rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed"
+        >
           {barHeightsFor(bars).map((h, i) => {
             const filled = (i + 1) / bars <= progress;
             return (
@@ -225,7 +236,7 @@ export const VoiceMemoPlayer = forwardRef<
               />
             );
           })}
-        </div>
+        </button>
 
         <span className="shrink-0 font-mono text-[11px] tabular-nums text-[#736a58]">
           {unavailable ? unavailableLabel : formatTime(displayTime)}

--- a/apps/web/test/voice-memo-player.test.tsx
+++ b/apps/web/test/voice-memo-player.test.tsx
@@ -43,6 +43,40 @@ test("VoiceMemoPlayer pauses sibling players in the same exclusive group", async
   }
 });
 
+test("VoiceMemoPlayer starts playback when the waveform is clicked", async () => {
+  const rendered = await renderClientComponent(
+    createElement(VoiceMemoPlayer, {
+      src: "/audio/grandpa.mp3",
+    }),
+    {
+      requireButton: false,
+    },
+  );
+
+  try {
+    const audio = rendered.container.querySelector("audio");
+    assert.ok(audio);
+    const play = vi.fn(() => Promise.resolve());
+    Object.defineProperty(audio, "play", {
+      configurable: true,
+      value: play,
+    });
+
+    const waveform = rendered.container.querySelector(
+      "button[data-voice-memo-waveform]",
+    );
+    assert.ok(waveform instanceof rendered.window.HTMLButtonElement);
+
+    await act(async () => {
+      waveform.click();
+    });
+
+    assert.equal(play.mock.calls.length, 1);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
 test("VoiceMemoPlayer disables playback and shows the unavailable label after an audio error", async () => {
   const rendered = await renderClientComponent(
     createElement(VoiceMemoPlayer, {


### PR DESCRIPTION
## Why this PR exists

Voice previews only started when the circular play button was clicked. The visible waveform looked interactive but did nothing, including on the Grandpa voice card.

## User goal / user-visible behavior

A member can click the waveform in any voice memo preview to start or pause the same audio, including selecting and previewing Grandpa from the voice picker.

## User experience

The member opens the voice picker, finds a voice, and clicks either the circular play control or the waveform. Both controls use the same playback state, the selected voice card updates normally, unavailable previews remain disabled, and only one preview in the exclusive voice group plays at a time.

## Invariants the PR must preserve

- The existing circular play/pause control continues to work.
- Waveform and circular controls share one audio state and toggle path.
- Unavailable audio remains disabled and labeled.
- Exclusive voice groups continue pausing sibling previews.
- The waveform is keyboard-focusable and has a truthful play/pause accessible label.
- The existing desktop and mobile layout does not change.

## Non-obvious affected surfaces

- All shared `VoiceMemoPlayer` consumers gain the same waveform click affordance. This is intentional because the waveform is part of the shared playback primitive; focused component tests and desktop/mobile browser proof cover the behavior.

## Change-shape breakdown

Classification rule: `apps/web/src/**` is source, `apps/web/test/**` is tests/fixtures, and no docs, config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 13 | 2 |
| Tests / fixtures | 34 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **47** | **2** |

No binary files changed.

## Verification

- `pnpm test:diff apps/web/src/components/ui/voice-memo-player.tsx apps/web/test/voice-memo-player.test.tsx`
- Focused player and picker suites: 17 tests passed.
- Browser proof at 1440x1000 and 390x844: clicking the Grandpa waveform selected Grandpa and started playback.
- Required `frontend-review`: zero findings.
- Required `coverage-write`: existing proof sufficient; no findings or edits.

ReviewGPT first-reviewed head: 745ffde60e8eb0c705ffe7f4833e25345cec083e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786746924&installation_id=127572939&pr_number=718&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F718&signature=7f6b55d6578c8e3df940f2f6b0e0f4729c701f9b835e064aef010ee51afc66c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->