### PR TITLE
test(cloudflare): seed recovery context before artifacts

### DIFF
--- a/apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts
@@ -469,10 +469,6 @@ async function seedPreferenceReceiptRecoveryIncident(): Promise<
     receiptLogArtifact.ref.sha256,
     receiptLogArtifact.bytes,
   );
-  for (const [sha256, bytes] of artifactsBySha256) {
-    await uploadHostedArtifact(preferenceRecoveryUserId, sha256, bytes);
-  }
-
   const checkpoint = await seedHostedWorkspaceCheckpointForTest({
     browserVaultReplicaRef: createPreferenceRecoveryBrowserVaultReplicaRef(
       snapshotHash,
@@ -490,6 +486,10 @@ async function seedPreferenceReceiptRecoveryIncident(): Promise<
     userId: preferenceRecoveryUserId,
   });
   expect(checkpoint.status).toBe("updated");
+
+  for (const [sha256, bytes] of artifactsBySha256) {
+    await uploadHostedArtifact(preferenceRecoveryUserId, sha256, bytes);
+  }
 
   return {
     auditIds: [firstAudit.auditId, secondAudit.auditId],


### PR DESCRIPTION
## Why this PR exists

The preference-receipt cold-recovery fixture uploaded encrypted artifacts before establishing the synthetic member runtime crypto context. That made the default branch durability E2E fail with a 403 before it reached the behavior under test, blocking unrelated pull requests.

## User goal / user-visible behavior

CI can exercise preference-receipt recovery truthfully again. There is no production or user-facing behavior change.

## User experience

None; this changes test setup only.

## Invariants

- Encrypted artifact upload still requires a valid member runtime crypto context.
- The fixture continues to seed the same checkpoint and identical artifact bytes.
- Production runtime, persisted schemas, and deploy surfaces remain unchanged.

## Non-obvious affected surfaces

None.

## Verification

- pnpm test:diff apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts
- Exact preference-receipt recovery scenario passed end to end after the reorder.
- Coverage-write audit: no edits or actionable findings.
- ReviewGPT: exempt as a low-risk test-fixture-only correction with no production behavior change.

## Change shape

Classification rule: authored TypeScript under test directories is tests/fixtures; all other categories are empty.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 4 | 4 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 4 | 4 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786747578&installation_id=127572939&pr_number=720&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F720&signature=198b09f2191bdafd8dd857d5017f8501f2fca0b5c308fde451d0c3ac60937786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->