### PR TITLE
Record Linq message.sent provider evidence

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-linq-message-sent-observability.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-linq-message-sent-observability.md
@@ -1,0 +1,53 @@
+Goal (incl. success criteria):
+- Persist and correlate Linq `message.sent` webhooks so SMS first-contact sends have durable provider-sent evidence.
+- Preserve the distinction between provider-sent, carrier/handset-delivered, and failed outcomes.
+- Success means duplicate-safe signed webhook ingestion records `message.sent`, correlates it to the existing delivery row without claiming delivery, and focused tests prove the state transitions.
+
+Constraints/Assumptions:
+- Web remains the owner of provider webhook verification, persisted delivery observability, and line-health effects.
+- `message.sent` must not be treated as a handset delivery receipt or trigger delivered-only behavior.
+- Preserve existing retry, idempotency, line-health, alerting, and first-contact behavior.
+- Do not add a new queue, polling loop, schema column, or provider reconciliation service unless the existing provider-event and delivery state model cannot represent the fact correctly.
+- Preserve unrelated worktree and coordination-ledger edits.
+
+Key decisions:
+- Extend the existing Linq provider-event pipeline at its current ownership boundary.
+- Prefer existing persisted event metadata and delivery correlation over new state.
+- Treat provider/dashboard webhook enablement as external rollout context; this repository change handles the event once received.
+
+State:
+- Implementation and local completion gates complete; PR gate pending.
+
+Done:
+- Production incident audit proved the affected member runtime is healthy and isolated the missing `message.sent` observability path.
+- Static tracing confirmed the webhook event is accepted by Linq configuration but ignored by hosted provider-event parsing.
+- Added privacy-safe parsing for both supported Linq webhook shapes, durable provider-event persistence, and explicit no-op line-health/alert semantics.
+- Added hosted-local subscription parity and focused parser, store-correlation, webhook-route, and registration coverage.
+- Focused tests passed: 136 hosted-web tests and 25 hosted-local webhook tunnel tests.
+- Diff-aware verification passed after building the isolated worktree's Cloudflare workspace dependency artifacts: hosted-local harness 391 passed / 1 skipped, hosted web 5,225 passed / 140 skipped, Cloudflare 1,833 passed, plus typechecks, lint, and production build.
+- Required `coverage-write` audit passed with no edits; existing proof covers both payload versions, privacy, exact message correlation, nonterminal delivery state, no operational side effects, and local subscription parity.
+- Parent final review found no unresolved correctness, privacy, or architecture finding.
+
+Now:
+- Close the execution plan and create the scoped commit.
+
+Next:
+- Rebase onto current `main`, open the PR, and run CI plus the required ReviewGPT gate.
+
+Open questions (UNCONFIRMED if needed):
+- None. `message.sent` remains nonterminal evidence in the provider-event ledger; delivery status remains `accepted` until a delivered/failed receipt.
+
+Working set (files/ids/commands):
+- apps/web/src/lib/hosted-onboarding/linq-provider-events.ts
+- apps/web/src/lib/hosted-onboarding/linq-provider-event-store.ts
+- apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+- apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+- apps/web/test/hosted-onboarding-linq-provider-events.test.ts
+- apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
+- packages/hosted-local-harness/src/dev-hosted-local/linq-webhook-tunnel.ts
+- packages/hosted-local-harness/test/dev-hosted-local/linq-webhook-tunnel.test.ts
+- agent-docs/operations/imessage-deliverability.md
+- `pnpm test:diff <touched paths>`
+Status: completed
+Updated: 2026-07-15
+Completed: 2026-07-15

--- a/agent-docs/operations/imessage-deliverability.md
+++ b/agent-docs/operations/imessage-deliverability.md
@@ -55,6 +55,7 @@ Read and apply this guide when touching any of these surfaces:
 
 7. Monitor and fail closed on line health.
    - Watch delivery receipts. "Sent" without "delivered" can indicate silent dropping.
+   - Persist and correlate `message.sent` as provider-sent evidence, never as handset delivery. SMS/MMS normally emit `message.sent` or `message.failed` but no delivered/read receipt, so the absence of `message.delivered` is expected on those protocols.
    - If delivery failures spike on a line, immediately reduce or stop automated volume on that line.
    - If a line is suspected or known flagged, stop all automated sending from it until line health is investigated.
    - Do not retry through a flagged line in a way that increases volume or repeats the same content.
@@ -168,7 +169,7 @@ Design your messaging flows to get a reply within the first 3 messages. Apple's 
 
 #### Monitoring Your Line Health
 
-- Watch your delivery receipts. If messages show as "sent" but never "delivered," Apple may be silently dropping them. This is the first sign of trouble.
+- Watch delivery receipts on receipt-capable protocols. If iMessage messages show as "sent" but never "delivered," Apple may be silently dropping them. SMS/MMS do not produce delivered/read receipts, so `message.sent` is their highest positive provider signal and must not be presented as handset delivery.
 - If you see delivery failures spike on a line, reduce volume immediately. Do not keep sending; you are making it worse.
 - If a line gets flagged, stop all automated sending on it immediately. Continued sending on a flagged line can escalate from temporary throttle to permanent block.
 - Contact the provider if you suspect a line is flagged. They can check the line health status and help with recovery before it becomes permanent.

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -451,6 +451,8 @@ export async function projectHostedLinqLineForProviderEventTx(input: {
       return projectMessageDelivered(input.prisma, lineLookupKey, input.event);
     case "message.failed":
       return projectMessageFailed(input.prisma, lineLookupKey, input.event);
+    case "message.sent":
+      return false;
     case "phone_number.status_updated":
       return projectPhoneNumberStatusUpdated(input.prisma, lineLookupKey, input.event);
     case "participant.added":

--- a/apps/web/src/lib/hosted-onboarding/linq-provider-event-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-provider-event-store.ts
@@ -174,6 +174,7 @@ function resolveHostedLinqAlertKind(event: ParsedHostedLinqProviderEvent): strin
     case "phone_number.status_updated":
       return "phone_number_status_updated";
     case "message.delivered":
+    case "message.sent":
     case "message.received":
     case "participant.added":
     case "participant.removed":

--- a/apps/web/src/lib/hosted-onboarding/linq-provider-events.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-provider-events.ts
@@ -23,6 +23,7 @@ import { normalizeNullableString, sha256Hex } from "../primitives";
 
 export const HOSTED_LINQ_PROVIDER_EVENT_TYPES = [
   "message.received",
+  "message.sent",
   "message.delivered",
   "message.failed",
   "participant.added",
@@ -76,6 +77,13 @@ export type ParsedHostedLinqProviderEvent = {
 const GENERIC_LINE_PHONE_PATHS = [
   ["phone_number"],
   ["phoneNumber"],
+  ["chat", "owner_handle", "handle"],
+  ["chat", "ownerHandle", "handle"],
+  ["sender_handle", "handle"],
+  ["senderHandle", "handle"],
+  ["from_handle", "handle"],
+  ["fromHandle", "handle"],
+  ["from"],
   ["line", "phone_number"],
   ["line", "phoneNumber"],
   ["line", "number"],
@@ -447,7 +455,14 @@ function parseGenericHostedLinqProviderEvent(input: {
       ["updated_at"],
       ["updatedAt"],
     ] as const))
-    : null;
+    : input.event.event_type === "message.sent"
+      ? parseProviderDate(readFirstStringAtPaths(data, [
+        ["sent_at"],
+        ["sentAt"],
+        ["message", "sent_at"],
+        ["message", "sentAt"],
+      ] as const))
+      : null;
   const failureCode = readFirstStringAtPaths(data, [
     ["code"],
     ["error_code"],
@@ -472,7 +487,8 @@ function parseGenericHostedLinqProviderEvent(input: {
   return buildParsedProviderEvent({
     chatId,
     deliveryStatus,
-    direction: readFirstStringAtPaths(data, [["direction"]] as const),
+    direction: readFirstStringAtPaths(data, [["direction"]] as const)
+      ?? (input.event.event_type === "message.sent" ? "outbound" : null),
     event: input.event,
     extraction: {
       chatIdPresent: chatId !== null,

--- a/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
@@ -149,6 +149,86 @@ describe("hosted Linq observability stores", () => {
     },
   );
 
+  it("persists message.sent correlation without advancing delivery or line health", async () => {
+    const fixture = createObservabilityPrismaFixture();
+    const messageId = "provider_message_sent_sms";
+    fixture.hostedLinqLineFindUnique.mockResolvedValueOnce({
+      phoneNumberHint: "+0000",
+      phoneNumberLookupKey: "hbidx:phone:runtime-line",
+    });
+
+    await expect(recordHostedLinqRuntimeDeliveryOutcomeTx({
+      acceptedAt: new Date("2026-03-26T12:00:01.000Z"),
+      attemptedAt: new Date("2026-03-26T12:00:00.000Z"),
+      idempotencyKey: "assistant-outbox:intent_sent_sms",
+      linqChatId: "chat_sent_sms",
+      messageId,
+      phoneNumber: "+15550000000",
+      prisma: fixture.prisma as never,
+      sourceRef: "intent_sent_sms",
+      targetKind: "participant",
+      userId: "member_123",
+    })).resolves.toMatchObject({
+      recorded: true,
+    });
+
+    const acceptedDelivery = fixture.hostedLinqDeliveryCreate.mock.calls[0]?.[0]?.data;
+    expect(acceptedDelivery).toMatchObject({
+      messageLookupKey: expect.stringMatching(/^hbidx:linq-message:/u),
+      status: "accepted",
+    });
+    const deliveryUpdateCount = fixture.hostedLinqDeliveryUpdateMany.mock.calls.length;
+    const lineUpdateCount = fixture.hostedLinqLineUpdate.mock.calls.length;
+    const lineUpdateManyCount = fixture.hostedLinqLineUpdateMany.mock.calls.length;
+
+    const event = requireParsedProviderEvent(buildProviderEvent({
+      createdAt: "2026-03-26T12:00:03.000Z",
+      data: {
+        chat: {
+          id: "chat_sent_sms",
+          owner_handle: {
+            handle: "+15550000000",
+            is_me: true,
+            service: "SMS",
+          },
+        },
+        direction: "outbound",
+        id: messageId,
+        sent_at: "2026-03-26T12:00:02.000Z",
+        service: "SMS",
+      },
+      eventId: "evt_sent_sms",
+      eventType: "message.sent",
+    }));
+
+    await expect(ingestHostedLinqProviderEventTx({
+      event,
+      prisma: fixture.prisma as never,
+      receivedAt: new Date("2026-03-26T12:00:04.000Z"),
+    })).resolves.toEqual({
+      alertIds: [],
+      duplicate: false,
+    });
+
+    expect(fixture.hostedLinqProviderEventCreateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          deliveryStatus: null,
+          direction: "outbound",
+          eventType: "message.sent",
+          messageLookupKey: acceptedDelivery?.messageLookupKey,
+          providerCreatedAt: new Date("2026-03-26T12:00:02.000Z"),
+          service: "SMS",
+        }),
+        skipDuplicates: true,
+      }),
+    );
+    expect(fixture.hostedLinqDeliveryUpdateMany).toHaveBeenCalledTimes(deliveryUpdateCount);
+    expect(fixture.hostedLinqLineUpdate).toHaveBeenCalledTimes(lineUpdateCount);
+    expect(fixture.hostedLinqLineUpdateMany).toHaveBeenCalledTimes(lineUpdateManyCount);
+    expect(fixture.hostedLinqAlertCreateMany).not.toHaveBeenCalled();
+  });
+
   it("records failed provider events, updates projections, and claims one event-scoped alert", async () => {
     const fixture = createObservabilityPrismaFixture();
     fixture.hostedLinqDeliveryFindFirst.mockResolvedValue({

--- a/apps/web/test/hosted-onboarding-linq-provider-events.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-events.test.ts
@@ -70,6 +70,80 @@ describe("parseHostedLinqProviderEvent", () => {
     expect(JSON.stringify(parsed)).not.toContain("+15551234567");
   });
 
+  it.each([
+    {
+      data: {
+        chat: {
+          id: "chat_sent_2026",
+          owner_handle: {
+            handle: "+15550000000",
+            is_me: true,
+            service: "SMS",
+          },
+        },
+        direction: "outbound",
+        id: "msg_sent_2026",
+        parts: [{ type: "text", value: "private sent text" }],
+        sent_at: "2026-03-26T12:00:01.000Z",
+        service: "SMS",
+      },
+      messageId: "msg_sent_2026",
+      providerCreatedAt: "2026-03-26T12:00:01.000Z",
+      version: "2026-02-03",
+    },
+    {
+      data: {
+        chat_id: "chat_sent_2025",
+        from: "+15550000000",
+        from_handle: {
+          handle: "+15550000000",
+          is_me: true,
+          service: "SMS",
+        },
+        is_from_me: true,
+        message: {
+          id: "msg_sent_2025",
+          parts: [{ type: "text", value: "private sent text" }],
+          sent_at: "2026-03-26T12:00:02.000Z",
+        },
+        service: "SMS",
+      },
+      messageId: "msg_sent_2025",
+      providerCreatedAt: "2026-03-26T12:00:02.000Z",
+      version: "2025-01-01",
+    },
+  ])("parses $version message.sent as non-delivery provider evidence", ({
+    data,
+    messageId,
+    providerCreatedAt,
+    version,
+  }) => {
+    const parsed = parseHostedLinqProviderEvent({
+      event: buildGenericEvent({
+        createdAt: "2026-03-26T12:00:03.000Z",
+        data,
+        eventType: "message.sent",
+        webhookVersion: version,
+      }),
+    });
+
+    expect(parsed).toMatchObject({
+      deliveryStatus: null,
+      direction: "outbound",
+      eventType: "message.sent",
+      phoneNumberHint: expect.stringContaining("0000"),
+      phoneNumberRole: "line",
+      providerCreatedAt: new Date(providerCreatedAt),
+      service: "SMS",
+      webhookVersion: version,
+    });
+    expect(parsed?.linqChatLookupKey).toEqual(expect.stringMatching(/^hbidx:linq-chat:/u));
+    expect(parsed?.messageLookupKey).toEqual(expect.stringMatching(/^hbidx:linq-message:/u));
+    expect(parsed?.messageIdSuffix).toBe(messageId.slice(-6));
+    expect(JSON.stringify(parsed?.payloadSanitizedJson)).not.toContain("private sent text");
+    expect(JSON.stringify(parsed?.payloadShapeJson)).not.toContain("private sent text");
+  });
+
   it("parses delivered and failed events with shape metadata only", () => {
     const delivered = parseHostedLinqProviderEvent({
       event: buildGenericEvent({
@@ -496,6 +570,7 @@ function buildGenericEvent(input: {
   createdAt?: string;
   data: Record<string, unknown>;
   eventType: string;
+  webhookVersion?: string;
 }): HostedLinqWebhookEvent {
   return {
     api_version: "v3",
@@ -504,6 +579,6 @@ function buildGenericEvent(input: {
     event_id: "evt_123",
     event_type: input.eventType,
     trace_id: "trace_1234567890",
-    webhook_version: "2026-02-03",
+    webhook_version: input.webhookVersion ?? "2026-02-03",
   } as HostedLinqWebhookEvent;
 }

--- a/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
@@ -353,6 +353,46 @@ describe("hosted onboarding Linq webhook hard-cut flows", () => {
     expect(mocks.claimHostedLinqOnboardingLinkNotice).not.toHaveBeenCalled();
   });
 
+  it("records message.sent without treating it as delivery or inbound work", async () => {
+    const prisma = createPrismaStub();
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    await expect(
+      handleHostedOnboardingLinqWebhook({
+        rawBody: buildLinqMessageWebhookBody({
+          eventType: "message.sent",
+          isFromMe: true,
+          service: "SMS",
+        }),
+        signature: null,
+        timestamp: null,
+      }),
+    ).resolves.toMatchObject({
+      ignored: true,
+      ok: true,
+      reason: "recorded-linq-provider-event:message.sent",
+    });
+
+    expect(prisma.hostedLinqProviderEvent.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          deliveryStatus: null,
+          direction: "outbound",
+          eventType: "message.sent",
+          messageLookupKey: expect.stringMatching(/^hbidx:linq-message:/u),
+          service: "SMS",
+        }),
+        skipDuplicates: true,
+      }),
+    );
+    expect(prisma.hostedLinqAlert.createMany).not.toHaveBeenCalled();
+    expect(prisma.hostedLinqDelivery.updateMany).not.toHaveBeenCalled();
+    expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(mocks.nudgeHostedRunnerUserBestEffort).not.toHaveBeenCalled();
+    expect(mocks.claimHostedLinqOnboardingLinkNotice).not.toHaveBeenCalled();
+  });
+
   it("coalesces routed participant additions without scheduling, sending, or waking", async () => {
     const prisma = createPrismaStub();
     const scheduleAfterResponse = vi.fn();

--- a/packages/hosted-local-harness/src/dev-hosted-local/linq-webhook-tunnel.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/linq-webhook-tunnel.ts
@@ -13,6 +13,7 @@ import type { HostedLocalDevConfig } from "./types.ts";
 export const HOSTED_LOCAL_LINQ_WEBHOOK_PATH =
   "/api/hosted-onboarding/linq/webhook";
 const HOSTED_LOCAL_LINQ_WEBHOOK_EVENTS = [
+  "message.sent",
   "message.received",
   "participant.added",
   "participant.removed",

--- a/packages/hosted-local-harness/test/dev-hosted-local/linq-webhook-tunnel.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/linq-webhook-tunnel.test.ts
@@ -19,6 +19,7 @@ type LinqWebhookSubscriptionResult = {
 };
 
 const HOSTED_LOCAL_LINQ_WEBHOOK_EVENTS = [
+  "message.sent",
   "message.received",
   "participant.added",
   "participant.removed",


### PR DESCRIPTION
## Why this PR exists

Linq `message.sent` webhooks were signature-verified and acknowledged but then ignored, leaving SMS sends without durable provider-sent evidence. This PR records and correlates that event through the existing provider-event ledger.

## User goal / user-visible behavior

Operators can distinguish “Linq confirmed the message was sent” from API acceptance, handset delivery, and failure. Member-facing messaging behavior does not change.

## User experience

There is no new UI or conversation step. Outbound messages, retries, replies, and follow-ups behave exactly as before; the change adds accurate operational evidence behind the scenes.

## Invariants

- `message.sent` is nonterminal evidence: it does not mark a delivery delivered or failed, and the delivery remains `accepted` until a terminal receipt arrives.
- It does not change retries, line health, counters, alerts, first-contact state, mailbox work, runtime wakes, outbound sends, or AI usage.
- Existing webhook signature verification, event-ID deduplication, and hashed message correlation remain authoritative.
- Persisted telemetry excludes message content and stores privacy-safe phone correlation only.
- `message.delivered` and `message.failed` retain their existing terminal behavior.

## Non-obvious affected surfaces

- The shared generic provider-event parser now recognizes Linq's canonical v2026 owner/sender handle paths and v2025 from-handle paths. This is necessary to identify the sending line for both supported `message.sent` shapes; the same shared extraction also improves canonical line attribution for existing delivered/failed operational events. Versioned parser fixtures and the existing delivered/failed suites cover the shared path.
- Hosted-local Linq registration now subscribes to `message.sent`, keeping local incident reproduction aligned with production. The tunnel registration suite proves the exact event set.
- The messaging operations guide now states that SMS/MMS normally have sent/failed evidence but no delivered/read receipt, preventing `message.sent` from being presented as handset delivery.

## Verification

- Focused hosted-web tests: 3 files, 136 passed.
- Focused hosted-local webhook tunnel tests: 1 file, 25 passed.
- Diff-aware verification: hosted-local 391 passed / 1 skipped; hosted web 5,225 passed / 140 skipped; Cloudflare 1,833 passed; typechecks, lint, and production build passed.
- Required `coverage-write` audit: pass, no edits needed.
- Focused suites reran successfully after rebasing onto current `main`.

## Deployment skew / compatibility

This is an additive Vercel web-handler change; there is no Cloudflare Worker, runner-container, schema, credential, or persisted-contract skew and no tandem deployment is required. The provider subscription is already enabled, so `message.sent` events received before the web deploy are acknowledged by the old handler and are not backfilled. Deploy Vercel promptly; a normal minutes-long rollout can at most miss provider-sent evidence arriving in that window, without changing delivery or retry behavior. The investigated trigger was one signup; the global `message.sent` rate is not yet measured. Rollback safely returns to the prior ignored-event behavior. Post-deploy, verify new `message.sent` rows appear with matching message lookup keys and null delivery status.

## Change shape

Classification: production TypeScript is source; `*.test.ts` is tests/fixtures; authored plans and operations guidance are docs; hosted-local registration code is config/tooling; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 21 | 2 |
| Tests/fixtures | 197 | 1 |
| Docs | 55 | 1 |
| Config/tooling | 1 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **274** | **4** |

ReviewGPT first-reviewed head: f0120caa30a6d47959e11180e24c8f8083b360db

| ReviewGPT round | Current head | Scope | Authored source added/deleted |
| --- | --- | --- | ---: |
| 1 | `f0120caa30a6d47959e11180e24c8f8083b360db` | Full patch | 21 / 2 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786747976&installation_id=127572939&pr_number=721&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F721&signature=19bc311399cebd22015bda70fa714e836672af847c16fb29167960ccf9da7d37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->