### PR TITLE
test(cloudflare): provision checkpoint recovery workspace

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-checkpoint-ci-workspace-seed.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-checkpoint-ci-workspace-seed.md
@@ -1,0 +1,46 @@
+# Checkpoint CI workspace seed
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Restore the required runtime-checkpoint CI lane by provisioning the fixture member's hosted workspace before the test-only encrypted artifact route requests that member's runtime crypto context.
+
+## Success criteria
+
+- The recovery scenario uses the existing activation path before seeding encrypted artifacts.
+- The focused hosted-local checkpoint E2E passes without weakening crypto-context authorization.
+- Required scoped verification is green and the fix lands separately from the personality feature PR.
+
+## Scope
+
+- In scope: the failing checkpoint E2E setup and its focused verification.
+- Out of scope: production crypto authorization, personality behavior, runtime architecture, or new harness abstractions.
+
+## Constraints
+
+- Technical constraints: preserve the active-member-plus-workspace crypto-context gate; reuse the scenario's established activation helper.
+- Product/process constraints: keep this as a separate prerequisite PR so the already-reviewed personality patch remains unchanged.
+
+## Risks and mitigations
+
+1. Risk: Activation setup could add unrelated provider or delivery work.
+   Mitigation: Reuse the exact activation setup already proven by the preceding scenario and capture provider/delivery baselines afterward.
+
+## Tasks
+
+1. Add the missing activation and workspace-completion setup to the second scenario.
+2. Run the focused checkpoint E2E and required scoped checks.
+3. Commit, open the prerequisite PR, and merge only after required CI passes.
+
+## Decisions
+
+- Preserve the production 403 for active members without a provisioned workspace; repair the test fixture ordering instead.
+
+## Verification
+
+- Commands to run: focused runtime checkpoint E2E, relevant typecheck/test lane, privacy scan, and required PR CI.
+- Expected outcomes: fixture seeding succeeds and all checkpoint recovery assertions pass.
+Completed: 2026-07-15

--- a/apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts
@@ -232,6 +232,14 @@ describe("hosted local canonical receipt lost-ack recovery e2e", () => {
       memberId: preferenceRecoveryUserId,
       memberPhone,
     });
+    await requireScenario().runWake(
+      buildActivationWake(preferenceRecoveryUserId),
+      preferenceRecoveryUserId,
+    );
+    const activationStatus = await requireScenario().waitForHostedCompletion(
+      preferenceRecoveryUserId,
+    );
+    expect(activationStatus.workspace).not.toBeNull();
     await requireScenario().bindActiveHostedLinqHomeChat({
       chatId: preferenceRecoveryChatId,
       memberId: preferenceRecoveryUserId,


### PR DESCRIPTION
## Why

The required Runtime checkpoint durability E2E was deterministically failing before encrypted fixture upload because its second scenario activated a member but never provisioned that member's hosted workspace. The test-only artifact route therefore reached the production crypto-context gate without its required workspace and correctly received HTTP 403.

## User-visible goal and UX

There is no product UI or runtime behavior change. This restores a trustworthy required release gate so unrelated production changes can proceed only after the checkpoint recovery scenario proves its intended behavior.

## Invariants

- Runtime crypto context remains fail-closed for inactive members and members without a hosted workspace.
- The scenario provisions the workspace through the existing activation wake path; no authorization or harness shortcut is added.
- Provider and delivery baselines remain captured after activation.
- Production source and runtime configuration are unchanged.

## Non-obvious surfaces

The second preference-recovery scenario now waits for activation completion and asserts a non-null workspace before binding its chat and uploading encrypted incident artifacts.

## Change breakdown

- Source: +0 / -0
- Tests: +8 / -0
- Docs: +46 / -0 (completed execution plan)
- Config/tooling: +0 / -0
- Generated/other: +0 / -0

## Verification

- `pnpm hosted-local e2e canonical-receipt-lost-ack-recovery` — passed, 2/2 tests
- `pnpm test:diff apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts` — passed, 105 files / 1,833 tests
- Required coverage-write audit — passed with zero findings and no edits
- Parent final review, diff check, and privacy scan — passed
