### PR TITLE
Optimize device sidebar database reads

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-device-sidebar-query-fanout.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-device-sidebar-query-fanout.md
@@ -1,0 +1,49 @@
+# Device Sidebar Query Fanout
+
+## Goal
+
+Replace the authenticated dashboard sidebar's full device-settings load with a
+narrow summary projection that uses a constant number of database queries and
+never reads or decrypts external account ids or provider credentials.
+
+## Constraints
+
+- Preserve the existing sidebar status messages, provider labels, attention
+  states, authentication, and no-store response behavior.
+- Use one member-scoped connection query plus at most one batched source query.
+- Keep the full Settings and `/connect` data contract intact.
+- Do not add shared client state merely to seed the persistent sidebar from the
+  child `/connect` page.
+- Do not widen into hosted runtime snapshot or device-sync execution changes.
+
+## Plan
+
+1. Add a narrow Prisma connection projection and a batched source reader for
+   sidebar status.
+2. Route only the sidebar summary endpoint through that projection while
+   preserving the existing pure status summarizer.
+3. Add deterministic query-count and secret-selection coverage for zero, one,
+   and multiple connections.
+4. Run the scoped hosted-web verification, required completion audits, local
+   final review, and the PR ReviewGPT/CI loop.
+
+## Verification
+
+- Focused device-sync route/service/store tests: 36 passed.
+- Hosted-web typecheck, dependency/boundary guards, dev smoke, lint, and
+  production build passed. The full app suite passed 5,212 tests before an
+  unrelated pre-existing Family settings timer fired after jsdom teardown.
+- Direct source inspection proved that the sidebar query excludes encrypted
+  secret fields and performs no per-connection database work.
+- `coverage-write` added a full-Settings batching regression and reported no
+  remaining proof gaps.
+- `frontend-review` reported no findings and confirmed the visible contract,
+  authentication, no-store behavior, and provider/status inputs are preserved.
+- PR CI and ReviewGPT remain the final post-push gates.
+
+## State
+
+Implementation and local verification complete; awaiting PR CI and ReviewGPT.
+Status: completed
+Updated: 2026-07-15
+Completed: 2026-07-15

--- a/apps/web/src/lib/device-sync/prisma-store/sources.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/sources.ts
@@ -214,6 +214,36 @@ export class PrismaHostedConnectionSourceStore {
     return records.map(mapHostedConnectionSourceRecord);
   }
 
+  async listConnectionSourcesForConnections(
+    connectionIds: readonly string[],
+    tx?: HostedPrismaTransactionClient,
+  ): Promise<HostedDeviceConnectionSource[]> {
+    const prisma = tx ?? this.prisma;
+    const normalizedConnectionIds = [...new Set(connectionIds.map(requireConnectionId))];
+
+    if (normalizedConnectionIds.length === 0) {
+      return [];
+    }
+
+    const records = await prisma.deviceConnectionSource.findMany({
+      where: {
+        connectionId: {
+          in: normalizedConnectionIds,
+        },
+      },
+      orderBy: [
+        { connectionId: "asc" },
+        { lastSeenAt: "desc" },
+        { sourceProviderSlug: "asc" },
+        { sourceInstanceKey: "asc" },
+        { id: "asc" },
+      ],
+      ...hostedConnectionSourceRecordArgs,
+    });
+
+    return records.map(mapHostedConnectionSourceRecord);
+  }
+
   async listRuntimeSnapshotConnectionSources(
     input: ListHostedRuntimeSnapshotConnectionSourcesInput,
   ): Promise<HostedDeviceConnectionSource[]> {

--- a/apps/web/src/lib/device-sync/public-connection.ts
+++ b/apps/web/src/lib/device-sync/public-connection.ts
@@ -4,12 +4,34 @@ import { formatDeviceSyncAccountLabel } from "@murphai/device-syncd/provider-lab
 import type { PublicDeviceSyncAccount } from "@murphai/device-syncd/types";
 
 import { formatHostedDeviceSyncProviderLabel } from "./provider-label";
+import {
+  normalizeHostedDeviceSyncLifecycleStatus,
+  normalizeHostedDeviceSyncSetupPhase,
+} from "./prisma-store/connection-records";
+import { maybeIsoTimestamp, normalizeNullableString } from "./shared";
 
 export interface HostedBrowserDeviceSyncConnection extends Omit<PublicDeviceSyncAccount, "externalAccountId"> {
   id: string;
 }
 
 const HOSTED_PUBLIC_CONNECTION_ID_PREFIX = "dspc_";
+
+export interface HostedSidebarDeviceSyncConnectionRecord {
+  connectedAt: Date;
+  createdAt: Date;
+  id: string;
+  lastErrorCode: string | null;
+  lastSyncCompletedAt: Date | null;
+  lastSyncErrorAt: Date | null;
+  lastSyncStartedAt: Date | null;
+  lastWebhookAt: Date | null;
+  nextReconcileAt: Date | null;
+  provider: string;
+  setupExpiresAt: Date | null;
+  setupPhase: string | null;
+  status: string;
+  updatedAt: Date;
+}
 
 export function createHostedBrowserConnectionId(secret: Buffer | Uint8Array | string, connectionId: string): string {
   return `${HOSTED_PUBLIC_CONNECTION_ID_PREFIX}${createHmac("sha256", normalizeSecret(secret))
@@ -28,6 +50,33 @@ export function toHostedBrowserDeviceSyncConnection(
     ...rest,
     displayName: sanitizeHostedBrowserDisplayName(account),
     id: createHostedBrowserConnectionId(secret, id),
+  };
+}
+
+export function toHostedBrowserDeviceSyncSidebarConnection(
+  record: HostedSidebarDeviceSyncConnectionRecord,
+  secret: Buffer | Uint8Array | string,
+): HostedBrowserDeviceSyncConnection {
+  return {
+    accessTokenExpiresAt: null,
+    connectedAt: record.connectedAt.toISOString(),
+    createdAt: record.createdAt.toISOString(),
+    displayName: null,
+    id: createHostedBrowserConnectionId(secret, record.id),
+    lastErrorCode: normalizeNullableString(record.lastErrorCode),
+    lastErrorMessage: null,
+    lastSyncCompletedAt: maybeIsoTimestamp(record.lastSyncCompletedAt),
+    lastSyncErrorAt: maybeIsoTimestamp(record.lastSyncErrorAt),
+    lastSyncStartedAt: maybeIsoTimestamp(record.lastSyncStartedAt),
+    lastWebhookAt: maybeIsoTimestamp(record.lastWebhookAt),
+    metadata: {},
+    nextReconcileAt: maybeIsoTimestamp(record.nextReconcileAt),
+    provider: record.provider,
+    scopes: [],
+    setupExpiresAt: maybeIsoTimestamp(record.setupExpiresAt),
+    setupPhase: normalizeHostedDeviceSyncSetupPhase(record.setupPhase),
+    status: normalizeHostedDeviceSyncLifecycleStatus(record.status),
+    updatedAt: record.updatedAt.toISOString(),
   };
 }
 

--- a/apps/web/src/lib/device-sync/sidebar-status-service.ts
+++ b/apps/web/src/lib/device-sync/sidebar-status-service.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import type { Prisma } from "@prisma/client";
 import {
   readConfiguredDeviceSyncProviderConfigs,
 } from "@murphai/device-syncd/provider-configs";
@@ -10,9 +11,17 @@ import {
 import { getPrisma } from "../prisma";
 import { readHostedDeviceSyncEnvironment } from "./env";
 import { toHostedBrowserDeviceSyncConnectionSource } from "./browser-connection-source";
-import { toHostedBrowserDeviceSyncConnection } from "./public-connection";
+import {
+  createHostedBrowserConnectionId,
+  toHostedBrowserDeviceSyncConnection,
+  toHostedBrowserDeviceSyncSidebarConnection,
+  type HostedBrowserDeviceSyncConnection,
+} from "./public-connection";
 import { PrismaHostedConnectionStore } from "./prisma-store/connections";
-import { PrismaHostedConnectionSourceStore } from "./prisma-store/sources";
+import {
+  PrismaHostedConnectionSourceStore,
+  type HostedDeviceConnectionSource,
+} from "./prisma-store/sources";
 import {
   buildHostedDeviceSyncSettingsSources,
   type HostedDeviceSyncSettingsConnectTarget,
@@ -23,11 +32,30 @@ import {
   type SidebarDeviceSyncStatusResponse,
 } from "./sidebar-status";
 
+const hostedSidebarDeviceSyncConnectionRecordArgs = {
+  select: {
+    connectedAt: true,
+    createdAt: true,
+    id: true,
+    lastErrorCode: true,
+    lastSyncCompletedAt: true,
+    lastSyncErrorAt: true,
+    lastSyncStartedAt: true,
+    lastWebhookAt: true,
+    nextReconcileAt: true,
+    provider: true,
+    setupExpiresAt: true,
+    setupPhase: true,
+    status: true,
+    updatedAt: true,
+  },
+} satisfies Prisma.DeviceConnectionDefaultArgs;
+
 export async function buildHostedDeviceSyncSidebarStatusResponse(input: {
   memberId: string;
   publicBaseUrl: string | null;
 }): Promise<SidebarDeviceSyncStatusResponse> {
-  const sources = await buildHostedDeviceSyncSettingsSourcesForMember({
+  const sources = await buildHostedDeviceSyncSidebarSourcesForMember({
     memberId: input.memberId,
     publicBaseUrl: input.publicBaseUrl,
   });
@@ -61,31 +89,68 @@ async function buildHostedDeviceSyncSettingsSourcesForMember(input: {
   const connectionStore = new PrismaHostedConnectionStore({ prisma });
   const sourceStore = new PrismaHostedConnectionSourceStore(prisma);
   const connections = await connectionStore.listConnectionsForUser(input.memberId);
-  const connectionEntries = await Promise.all(
-    connections.map(async (connection) => {
-      const browserConnection = toHostedBrowserDeviceSyncConnection(
-        connection,
-        env.routingIndexKey,
-      );
-      const sources = await sourceStore.listConnectionSources(connection.id);
-
-      return {
-        browserConnection,
-        sources,
-      };
-    }),
+  const connectionSources = await sourceStore.listConnectionSourcesForConnections(
+    connections.map((connection) => connection.id),
   );
+
+  return buildSettingsSources({
+    browserConnections: connections.map((connection) =>
+      toHostedBrowserDeviceSyncConnection(connection, env.routingIndexKey)
+    ),
+    connectTargets: input.connectTargets,
+    connectionSources,
+    publicBaseUrl: input.publicBaseUrl,
+    routingIndexKey: env.routingIndexKey,
+  });
+}
+
+async function buildHostedDeviceSyncSidebarSourcesForMember(input: {
+  memberId: string;
+  publicBaseUrl: string | null;
+}) {
+  const env = readHostedDeviceSyncEnvironment(process.env);
+  const prisma = getPrisma();
+  const connectionRecords = await prisma.deviceConnection.findMany({
+    where: {
+      userId: input.memberId,
+    },
+    orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
+    ...hostedSidebarDeviceSyncConnectionRecordArgs,
+  });
+  const connectionSources = await new PrismaHostedConnectionSourceStore(prisma)
+    .listConnectionSourcesForConnections(
+      connectionRecords.map((connection) => connection.id),
+    );
+
+  return buildSettingsSources({
+    browserConnections: connectionRecords.map((connection) =>
+      toHostedBrowserDeviceSyncSidebarConnection(connection, env.routingIndexKey)
+    ),
+    connectionSources,
+    publicBaseUrl: input.publicBaseUrl,
+    routingIndexKey: env.routingIndexKey,
+  });
+}
+
+function buildSettingsSources(input: {
+  browserConnections: readonly HostedBrowserDeviceSyncConnection[];
+  connectTargets?: readonly HostedDeviceSyncSettingsConnectTarget[];
+  connectionSources: readonly HostedDeviceConnectionSource[];
+  publicBaseUrl: string | null;
+  routingIndexKey: Buffer;
+}) {
   const providers = listConfiguredDeviceSyncPublicProviderDescriptors(
     readConfiguredDeviceSyncProviderConfigs(process.env),
     { publicBaseUrl: input.publicBaseUrl },
   );
   const sources = buildHostedDeviceSyncSettingsSources({
-    connectionSources: connectionEntries.flatMap((entry) =>
-      entry.sources.map((source) =>
-        toHostedBrowserDeviceSyncConnectionSource(source, entry.browserConnection.id)
+    connectionSources: input.connectionSources.map((source) =>
+      toHostedBrowserDeviceSyncConnectionSource(
+        source,
+        createHostedBrowserConnectionId(input.routingIndexKey, source.connectionId),
       )
     ),
-    connections: connectionEntries.map((entry) => entry.browserConnection),
+    connections: input.browserConnections,
     connectTargets: input.connectTargets,
     providers,
   });

--- a/apps/web/test/device-sync-settings-routes.test.ts
+++ b/apps/web/test/device-sync-settings-routes.test.ts
@@ -502,6 +502,48 @@ describe("device sync settings routes", () => {
     });
   });
 
+  it("batches full settings source reads across multiple connections", async () => {
+    mocks.findManyDeviceConnections.mockResolvedValueOnce([
+      buildDeviceConnectionRecord({
+        id: "dsc_oura_123",
+        provider: "oura",
+      }),
+      buildDeviceConnectionRecord({
+        id: "dsc_oura_456",
+        provider: "oura",
+        updatedAt: new Date("2026-04-01T08:06:00.000Z"),
+      }),
+    ]);
+
+    const response = await settingsDeviceSyncRoute.GET(
+      new Request("https://join.example.test/api/settings/device-sync"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.findManyDeviceConnections).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyDeviceConnectionSources).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyDeviceConnectionSources).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        connectionId: {
+          in: ["dsc_oura_123", "dsc_oura_456"],
+        },
+      },
+    }));
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      sources: [
+        {
+          connectionId: expect.stringMatching(/^dspc_/),
+          provider: "oura",
+        },
+        {
+          connectionId: expect.stringMatching(/^dspc_/),
+          provider: "oura",
+        },
+      ],
+    });
+  });
+
   it("does not mark settings sources configured when authoritative provider config is invalid", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     vi.stubEnv("OURA_RECONCILE_DAYS", "soon");
@@ -578,11 +620,98 @@ describe("device sync settings routes", () => {
         userId: "member_123",
       },
     }));
+    expect(mocks.findManyDeviceConnections).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyDeviceConnectionSources).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyDeviceConnectionSources).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        connectionId: {
+          in: ["dsc_oura_123"],
+        },
+      },
+    }));
+    expect(mocks.findManyDeviceConnections.mock.calls[0]?.[0]?.select).toEqual({
+      connectedAt: true,
+      createdAt: true,
+      id: true,
+      lastErrorCode: true,
+      lastSyncCompletedAt: true,
+      lastSyncErrorAt: true,
+      lastSyncStartedAt: true,
+      lastWebhookAt: true,
+      nextReconcileAt: true,
+      provider: true,
+      setupExpiresAt: true,
+      setupPhase: true,
+      status: true,
+      updatedAt: true,
+    });
+    expect(mocks.findManyDeviceConnections.mock.calls[0]?.[0]?.select).not.toHaveProperty(
+      "externalAccountIdEncrypted",
+    );
+    expect(mocks.findManyDeviceConnections.mock.calls[0]?.[0]?.select).not.toHaveProperty(
+      "accessTokenEncrypted",
+    );
+    expect(mocks.findManyDeviceConnections.mock.calls[0]?.[0]?.select).not.toHaveProperty(
+      "refreshTokenEncrypted",
+    );
     await expect(response.json()).resolves.toEqual({
       generatedAt: "2026-04-03T12:00:00.000Z",
       ok: true,
       status: {
         message: "Oura connected",
+        tone: "connected",
+      },
+    });
+  });
+
+  it("uses only the connection query when the sidebar member has no connections", async () => {
+    mocks.findManyDeviceConnections.mockResolvedValueOnce([]);
+
+    const response = await settingsDeviceSyncSidebarStatusRoute.GET(
+      new Request("https://join.example.test/api/settings/device-sync/sidebar-status"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.findManyDeviceConnections).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyDeviceConnectionSources).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      generatedAt: "2026-04-03T12:00:00.000Z",
+      ok: true,
+      status: null,
+    });
+  });
+
+  it("keeps sidebar database reads constant for multiple connections", async () => {
+    mocks.findManyDeviceConnections.mockResolvedValueOnce([
+      buildDeviceConnectionRecord({
+        id: "dsc_oura_123",
+        provider: "oura",
+      }),
+      buildDeviceConnectionRecord({
+        id: "dsc_oura_456",
+        provider: "oura",
+        updatedAt: new Date("2026-04-01T08:06:00.000Z"),
+      }),
+    ]);
+
+    const response = await settingsDeviceSyncSidebarStatusRoute.GET(
+      new Request("https://join.example.test/api/settings/device-sync/sidebar-status"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.findManyDeviceConnections).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyDeviceConnectionSources).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyDeviceConnectionSources).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        connectionId: {
+          in: ["dsc_oura_123", "dsc_oura_456"],
+        },
+      },
+    }));
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      status: {
+        message: "2 wearables connected",
         tone: "connected",
       },
     });


### PR DESCRIPTION
## Why

Every authenticated dashboard sidebar loaded the full device Settings surface. That caused one source query and one encrypted external-account-ID decryption per connection, increasing database and KMS work as connections grew.

## User-visible goal and UX

Keep the existing sidebar provider labels, connected/attention/unavailable states, connect links, authentication, loading behavior, and no-store response contract while making database work constant. Members should see the same sidebar status as before.

## Invariants

- The sidebar reads only member-scoped connection and source status fields.
- It never selects or decrypts external account IDs, access tokens, refresh tokens, or provider credentials.
- Database work is one connection query plus at most one batched source query; the empty case performs only the connection query.
- Public connection identifiers remain deterministic HMAC-derived IDs.
- Full Settings and /connect response behavior remains intact.

## Non-obvious affected surfaces

- The full device Settings reader now batches source rows across all connections too; its response contract is unchanged and has a multi-connection route regression.
- /connect does not seed the persistent parent sidebar. The child page cannot safely supply data upward without broad shared client state or eagerly querying every dashboard load.
- This is a Vercel-hosted web reader change only. It changes no database schema, Cloudflare runtime contract, or deployment ordering requirement.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Authored source | 164 | 20 |
| Tests | 129 | 0 |
| Docs/plans | 49 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 667dca2e273d7c4924f1c7f2e07f7eda70342961

## Verification

- Focused device-sync route/service/store suite: 36 passed.
- Hosted-web typecheck passed after Prisma client regeneration on the latest main base.
- Required coverage-write audit: one Settings batching regression added; no remaining findings.
- Required frontend-review audit: no findings; visible and API contracts preserved.
- Full hosted-web verification passed dependency/boundary guards, typecheck, dev smoke, lint, and production build. The app suite passed 5,212 tests before an unrelated Family settings timer fired after jsdom teardown.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786756959&installation_id=127572939&pr_number=727&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F727&signature=c9dabd24baabfce2e1cc0645f7ab3c3e67d4627cf0bf125de827686ad2e98c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->