### PR TITLE
Deduplicate fresh Privy auth database reads

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-db-privy-auth-dedupe.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-db-privy-auth-dedupe.md
@@ -1,0 +1,62 @@
+# Deduplicate fresh Privy auth database reads
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Remove two proven duplicate database reads from the fresh-Privy request-authentication path without weakening or reordering any independent authentication, identity-binding, membership, or hosted-access checks.
+
+## Success criteria
+
+- Fresh Privy authentication reuses the member already returned with the verified identity lookup instead of rereading the same member row.
+- After fresh Privy and app-session member ids match, hosted access is evaluated once and that single decision is used for both proofs.
+- Independent Privy token verification, app-session verification, identity/member equality, suspended/billing/sponsored/container access semantics, fail-closed ordering, and error behavior remain unchanged.
+- Focused tests prove database call counts plus denial/failure ordering for the changed path.
+- Required hosted-web verification, coverage audit, parent final review, PR CI, ReviewGPT, and mergeability gates pass.
+
+## Scope
+
+- In scope: `apps/web/src/lib/hosted-onboarding/request-auth.ts`, focused request-auth tests, and task plan/ledger lifecycle artifacts.
+- Out of scope: combining the app-session token/session-row lookup with the app-session member lookup; changing Privy verification, cookie/session formats, access policy, error types/statuses, database schema, or deploy contracts.
+
+## Constraints
+
+- Technical constraints: preserve the current authority boundaries and exact fail-closed ordering; prefer deletion and returned data already owned by the existing lookup; add no cache, new owner, or state.
+- Product/process constraints: isolated worktree and PR; full auth/high-risk verification; ReviewGPT is the sole cross-cutting gate; no local deep review.
+
+## Risks and mitigations
+
+1. Risk: Reusing a relation-loaded member could accidentally weaken a later membership existence or state check.
+   Mitigation: prove the selected member fields and compare the existing branch/error behavior in focused tests.
+2. Risk: Collapsing two access checks could change denial order or evaluate different member ids.
+   Mitigation: retain the identity/member equality check before the single access read and add call-order tests for mismatch and inactive-access cases.
+
+## Tasks
+
+1. Trace the fresh-Privy and app-session authentication path and record the exact duplicate reads and current failure order.
+2. Add or tighten focused tests that fail on duplicate row/access reads and prove authority/failure ordering.
+3. Delete the redundant reads with the smallest production change.
+4. Run focused and required hosted-web verification; complete the coverage-write pass and resolve findings.
+5. Perform the parent final review, close the plan with a scoped commit, push/open the PR, and complete CI plus ReviewGPT and mergeability proof.
+
+## Decisions
+
+- Keep the app-session session-row and member lookup as separate validation boundaries; the accepted audit finding explicitly excludes combining them.
+- Reuse only the member already loaded through the Privy principal relation. The verified principal remains the authority, and a stale custom-metadata member id never selects a different member.
+- Run one unchanged hosted-access decision only after the fresh Privy member id and independently verified app-session member id match.
+
+## Verification
+
+- Commands to run: focused request-auth Vitest; `pnpm verify:acceptance`; `git diff --check`; required coverage-write audit; PR CI; ReviewGPT; merge-tree/preflight checks.
+- Expected outcomes: all checks pass; focused tests prove one fresh-Privy identity/member read, one app-session member read, and one active-access read after member equality with unchanged denial order.
+
+## Local evidence
+
+- The focused request-auth suite passed 22 tests. The new regression assertions produced four failures against the previous production implementation before the redundant reads were deleted.
+- Hosted web typecheck and lint passed; lint reported only twelve pre-existing warnings outside the changed paths.
+- The full hosted web verifier passed 5,213 tests with expected skips, the development smoke check, and the production Next.js build. Cloudflare app verification passed 1,833 tests.
+- The workspace acceptance command passed all task-relevant app and package lanes. Assistant-engine coverage in an untouched package exhausted the default four-gigabyte heap under parallel load; an isolated eight-gigabyte rerun completed and exposed two unrelated process-lifecycle test failures while 2,259 other tests passed.
+- The required coverage-write audit reran the focused suite with coverage: 22 tests passed, every changed statement and branch executed, and no additional high-value proof or actionable coverage finding remained.
+Completed: 2026-07-15

--- a/apps/web/src/lib/hosted-onboarding/request-auth.ts
+++ b/apps/web/src/lib/hosted-onboarding/request-auth.ts
@@ -5,10 +5,7 @@ import {
   requireHostedAppSessionFromRequest,
   type HostedAppSession,
 } from "./app-session";
-import {
-  readHostedMemberCoreState,
-  type HostedMemberCoreState,
-} from "./hosted-member-store";
+import { type HostedMemberCoreState } from "./hosted-member-store";
 import {
   assertActiveHostedMemberAccessAllowed,
 } from "./member-access";
@@ -57,18 +54,10 @@ export async function resolvePrivyMemberAuthFromSession(input: {
   member: HostedMemberCoreState | null;
   memberLookup: HostedMemberPrivyIdentityLookup | null;
 }> {
-  const [memberLookup, sessionMember] = await Promise.all([
-    lookupHostedMemberForPrivyPrincipal({
-      identity: input.identity,
-      prisma: input.prisma,
-    }),
-    input.memberId
-      ? readHostedMemberCoreState({
-          memberId: input.memberId,
-          prisma: input.prisma,
-        })
-      : Promise.resolve(null),
-  ]);
+  const memberLookup = await lookupHostedMemberForPrivyPrincipal({
+    identity: input.identity,
+    prisma: input.prisma,
+  });
 
   if (!input.memberId) {
     return {
@@ -84,7 +73,7 @@ export async function resolvePrivyMemberAuthFromSession(input: {
     };
   }
 
-  if (!sessionMember || sessionMember.id !== memberLookup.core.id) {
+  if (input.memberId !== memberLookup.core.id) {
     return {
       member: memberLookup.core,
       memberLookup,
@@ -92,7 +81,7 @@ export async function resolvePrivyMemberAuthFromSession(input: {
   }
 
   return {
-    member: sessionMember,
+    member: memberLookup.core,
     memberLookup: null,
   };
 }
@@ -295,15 +284,9 @@ export async function requireFreshActivePrivyMemberAuthForHostedAppSession(
   freshPrivy: AuthenticatedPrivyMemberAuthContext;
 }> {
   const context = await requireFreshPrivyMemberAuthForHostedAppSession(request, prisma);
-  await Promise.all([
-    assertActiveHostedMemberAccessAllowed({
-      memberId: context.appSession.member.id,
-      prisma,
-    }),
-    assertActiveHostedMemberAccessAllowed({
-      memberId: context.freshPrivy.member.id,
-      prisma,
-    }),
-  ]);
+  await assertActiveHostedMemberAccessAllowed({
+    memberId: context.appSession.member.id,
+    prisma,
+  });
   return context;
 }

--- a/apps/web/test/hosted-onboarding-request-auth.test.ts
+++ b/apps/web/test/hosted-onboarding-request-auth.test.ts
@@ -165,18 +165,17 @@ describe("hosted Privy request auth", () => {
     }));
   });
 
-  it("starts the identity lookup and direct member read in parallel", async () => {
+  it("uses the member already returned by the Privy principal lookup", async () => {
     const member = createHostedMember();
     const memberLookup = createHostedMemberLookup({
       core: member,
     });
-    const lookupDeferred = createDeferred<typeof memberLookup | null>();
-    const readDeferred = createDeferred<HostedMember | null>();
+    mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(memberLookup);
+    mocks.readHostedMemberCoreState.mockRejectedValue(
+      new Error("unexpected duplicate member read"),
+    );
 
-    mocks.lookupHostedMemberForPrivyPrincipal.mockReturnValue(lookupDeferred.promise);
-    mocks.readHostedMemberCoreState.mockReturnValue(readDeferred.promise);
-
-    const authPromise = resolvePrivyMemberAuthFromSession({
+    await expect(resolvePrivyMemberAuthFromSession({
       identity: {
         phone: {
           number: "+14155552671",
@@ -187,18 +186,13 @@ describe("hosted Privy request auth", () => {
       },
       memberId: member.id,
       prisma,
-    });
-
-    expect(mocks.lookupHostedMemberForPrivyPrincipal).toHaveBeenCalledTimes(1);
-    expect(mocks.readHostedMemberCoreState).toHaveBeenCalledTimes(1);
-
-    lookupDeferred.resolve(memberLookup);
-    readDeferred.resolve(member);
-
-    await expect(authPromise).resolves.toMatchObject({
+    })).resolves.toMatchObject({
       member,
       memberLookup: null,
     });
+
+    expect(mocks.lookupHostedMemberForPrivyPrincipal).toHaveBeenCalledTimes(1);
+    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("requires identity lookup confirmation before trusting the session Murph member id", async () => {
@@ -218,7 +212,6 @@ describe("hosted Privy request auth", () => {
         id: "did:privy:user_123",
       },
     });
-    mocks.readHostedMemberCoreState.mockResolvedValue(member);
     mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(createHostedMemberLookup({
       core: member,
     }));
@@ -229,10 +222,7 @@ describe("hosted Privy request auth", () => {
       },
       memberLookup: null,
     });
-    expect(mocks.readHostedMemberCoreState).toHaveBeenCalledWith({
-      memberId: member.id,
-      prisma,
-    });
+    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
     expect(mocks.lookupHostedMemberForPrivyPrincipal).toHaveBeenCalledWith(expect.objectContaining({
       identity: expect.objectContaining({
         userId: "did:privy:user_123",
@@ -531,6 +521,10 @@ describe("hosted Privy request auth", () => {
     });
     expect(mocks.requireHostedAppSessionFromRequest).toHaveBeenCalledWith(expect.any(Request));
     expect(mocks.resolveHostedPrivySessionFromRequest).toHaveBeenCalledWith(expect.any(Request));
+    expect(mocks.requireHostedAppSessionFromRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveHostedPrivySessionFromRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.lookupHostedMemberForPrivyPrincipal).toHaveBeenCalledTimes(1);
+    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("rejects fresh Privy proof for a different hosted member than the app session", async () => {
@@ -544,14 +538,45 @@ describe("hosted Privy request auth", () => {
     });
 
     await expect(
-      requireFreshPrivyMemberAuthForHostedAppSession(createAuthenticatedRequest(), prisma),
+      requireFreshActivePrivyMemberAuthForHostedAppSession(createAuthenticatedRequest(), prisma),
     ).rejects.toMatchObject({
       code: "PRIVY_SESSION_MEMBER_MISMATCH",
       httpStatus: 409,
     });
+    expect(hostedMemberAccessFindUnique).not.toHaveBeenCalled();
   });
 
-  it("applies active-member checks to both app session and fresh Privy proof", async () => {
+  it("does not trust the app-session member when the fresh Privy principal has no member", async () => {
+    mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(null);
+
+    await expect(
+      requireFreshActivePrivyMemberAuthForHostedAppSession(createAuthenticatedRequest(), prisma),
+    ).rejects.toMatchObject({
+      code: "HOSTED_MEMBER_NOT_FOUND",
+      httpStatus: 403,
+    });
+    expect(mocks.requireHostedAppSessionFromRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.lookupHostedMemberForPrivyPrincipal).toHaveBeenCalledTimes(1);
+    expect(hostedMemberAccessFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("keeps app-session verification independent from fresh Privy verification", async () => {
+    const appSessionError = Object.assign(new Error("Sign in to continue."), {
+      code: "AUTH_REQUIRED",
+      httpStatus: 401,
+    });
+    mocks.requireHostedAppSessionFromRequest.mockRejectedValue(appSessionError);
+
+    await expect(
+      requireFreshActivePrivyMemberAuthForHostedAppSession(createAuthenticatedRequest(), prisma),
+    ).rejects.toBe(appSessionError);
+    expect(mocks.requireHostedAppSessionFromRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveHostedPrivySessionFromRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.lookupHostedMemberForPrivyPrincipal).toHaveBeenCalledTimes(1);
+    expect(hostedMemberAccessFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("applies one active-member check after app-session and fresh-Privy members match", async () => {
     mocks.requireHostedAppSessionFromRequest.mockResolvedValue({
       expiresAt: new Date("2026-04-26T00:00:00.000Z"),
       member: createHostedMember({
@@ -570,6 +595,41 @@ describe("hosted Privy request auth", () => {
       code: "HOSTED_ACCESS_REQUIRED",
       httpStatus: 403,
     });
+    expect(hostedMemberAccessFindUnique).toHaveBeenCalledTimes(1);
+    expect(hostedMemberAccessFindUnique).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        id: "member_123",
+      },
+    }));
+  });
+
+  it("preserves thread-container access semantics with the single post-match check", async () => {
+    hostedMemberAccessFindUnique.mockResolvedValue(createHostedMemberAccessState({
+      billingStatus: HostedBillingStatus.not_started,
+      threadContainer: {
+        owner: {
+          accountGroupMemberships: [],
+          billingStatus: HostedBillingStatus.active,
+          suspendedAt: null,
+        },
+      },
+    }));
+
+    await expect(
+      requireFreshActivePrivyMemberAuthForHostedAppSession(createAuthenticatedRequest(), prisma),
+    ).resolves.toMatchObject({
+      appSession: {
+        member: {
+          id: "member_123",
+        },
+      },
+      freshPrivy: {
+        member: {
+          id: "member_123",
+        },
+      },
+    });
+    expect(hostedMemberAccessFindUnique).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -680,21 +740,5 @@ function createHostedMemberLookup(overrides: Partial<{
       "privyUserId",
     ],
     ...overrides,
-  };
-}
-
-function createDeferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
-
-  return {
-    promise,
-    reject,
-    resolve,
   };
 }


### PR DESCRIPTION
## Why this PR exists

Fresh Privy authentication was rereading a member row already returned by the verified principal lookup, then running the same active-access query twice after proving both authenticated member IDs were equal. This removes those duplicate reads from a high-frequency auth boundary.

## User goal / user-visible behavior

Authenticated requests keep the same sign-in, mismatch, suspension, billing, sponsored-access, and thread-container outcomes with less database work. There is no user-facing UI or recovery-flow change.

## Invariants

- Privy token verification and app-session verification remain independent.
- App-session verification still validates its session row and then reads its member separately.
- The verified Privy principal remains the member authority; custom session metadata cannot select another member.
- Member mismatch and missing-principal failures happen before hosted-access evaluation.
- The unchanged hosted-access policy still owns suspension, billing, sponsorship, and thread-container decisions.

## Non-obvious affected surfaces

- Browser and native bearer Privy member resolution share `resolvePrivyMemberAuthFromSession`; both now reuse the member relation loaded by the principal identity query. Focused resolver tests prove stale, matching, and missing identity behavior plus a zero-call assertion on the deleted direct read.
- The fresh-Privy plus app-session active wrapper now performs one access query only after equality is established. Focused tests prove mismatch/missing-principal ordering, inactive denial, and thread-container success.

## Verification

- Focused request-auth tests: 22/22 passed, including direct database-boundary call counts. The new assertions failed four ways against the previous implementation before the production change.
- Focused coverage audit: 22/22 passed; every changed statement and branch executed; zero actionable findings.
- Hosted web: typecheck and lint passed; full verifier passed 5,213 tests, development smoke, and production build.
- Cloudflare app verifier: 1,833 tests passed.
- Workspace acceptance passed all task-relevant lanes. Assistant-engine coverage in an untouched package exhausted the default heap under parallel load; an isolated larger-heap rerun completed with two unrelated process-lifecycle test failures while 2,259 other tests passed.

## Change shape

Classification uses the base-to-head authored diff; no binary or generated files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 11 | 28 |
| Tests / fixtures | 83 | 39 |
| Docs | 62 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **156** | **67** |

## Deployment compatibility

Web-only and backward compatible. There are no schema, persisted-state, protocol, runtime-env, Worker, or container changes; normal Vercel rollout is sufficient with no tandem deploy.

ReviewGPT first-reviewed head: 130579294d8ac66c9a2a2d708facf8c76c0cc876
