### PR TITLE
perf(web): reduce settings database read fanout

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-settings-db-read-fanout.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-settings-db-read-fanout.md
@@ -1,0 +1,57 @@
+# Settings database read fanout
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Preserve the current Settings experience while removing its duplicate account/contact read and reducing private-field decrypt fanout to the fields the page actually uses.
+
+## Success criteria
+
+- Settings derives the voice-test contact target from its already-loaded account and routing data without calling the broad hosted contact-context loader.
+- The account Settings composite issues one narrow member query and decrypts only the rendered phone, email, routing, and billing facts.
+- Multi-field decrypts reuse one scoped hosted-domain root unwrap without changing data classification or key lifetime.
+- Regression tests mechanically cover query composition, decrypt scope, and voice-test routing behavior.
+- Required hosted-web verification, specialist audits, PR CI, ReviewGPT, and mergeability proof are green.
+
+## Scope
+
+- In scope: the Settings server page, its account Settings snapshot owner, existing narrow private-field projectors, and focused hosted-web tests.
+- Out of scope: the shared hosted contact-context/dashboard-shell rewrite, database schema, persisted data, billing or access policy, and visible Settings UI changes.
+
+## Constraints
+
+- Do not edit `apps/web/src/lib/hosted-onboarding/hosted-contact-context.ts` or global dashboard contact behavior.
+- Preserve verified-versus-checkout email precedence, pending/home Linq presentation, Telegram linkage, assistant preferences/model availability, and billing actions.
+- Keep private values encrypted at rest and confined to the existing server-side Settings boundary.
+- Prefer one explicit Settings projection over a new generic snapshot framework.
+
+## Tasks
+
+1. Trace the current Settings field requirements and contact-routing semantics.
+2. Add one narrow Settings member projection under the hosted domain-root unwrap cache.
+3. Derive the voice-test contact option from the loaded Settings projection.
+4. Add focused query-count/composition, decrypt-scope, and routing regressions.
+5. Run hosted-web verification, required coverage and frontend reviews, local final review, and close the plan with a scoped commit.
+6. Push, open the required-format PR, run CI and ReviewGPT to pass, and prove mergeability.
+
+## Risks and mitigations
+
+1. Risk: narrowing the query drops a field that controls billing or messaging presentation.
+   Mitigation: enumerate every page consumer, keep exact existing field precedence, and assert the Prisma select and rendered props in tests.
+2. Risk: deriving voice routing locally changes channel preference behavior.
+   Mitigation: reuse the existing pure `resolveMurphContactOptions` owner with the same channel booleans, preferred kind, destination values, and email-only suppression.
+3. Risk: a crypto cache scope extends key lifetime or crosses requests.
+   Mitigation: reuse the existing AsyncLocalStorage scope and deterministic zeroization boundary only around the single Settings composite.
+
+## Verification
+
+- Focused Settings/account projection tests passed: 4 files, 47 tests.
+- Final `pnpm test:diff` passed on the reconciled base: all workspace guards, hosted-web production build, TypeScript, development smoke, lint with zero errors, and 431 passing test files / 5,224 passing tests.
+- `coverage-write` found the existing exact-query, narrow-select, unwrap-scope, projection, and voice-routing proof sufficient and made no edits.
+- `frontend-review` found no evidence-backed findings. No authenticated browser pass was run because the diff changes no rendered markup, styling, copy, focus behavior, or client interaction; source-equivalence and static-render coverage were used instead.
+- Local final review passed `git diff --check`, privacy scanning, and static readback proving the Settings owners no longer call the broad snapshot/preferences/model/contact loaders.
+- PR CI, exact-head ReviewGPT pass, and mergeability proof remain before handoff.
+Completed: 2026-07-15

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -4,7 +4,6 @@ import { HOSTED_ASSISTANT_TERRA_MODEL } from "@murphai/hosted-execution/assistan
 import { assistantPersonalityCausalWritesEnabled } from "@murphai/contracts";
 
 import { HostedPrivyProvider } from "@/src/components/hosted-onboarding/privy-provider";
-import { resolveHostedMurphContactOption } from "@/src/components/murph/hosted-murph-contact-action";
 import { CustomizeMurphSettings } from "@/src/components/settings/customize-murph-settings";
 import { HostedAccountSettingsCards } from "@/src/components/settings/hosted-account-settings-cards";
 import { HostedAssistantModelSettings } from "@/src/components/settings/hosted-assistant-model-settings";
@@ -35,6 +34,7 @@ import { getPrisma } from "@/src/lib/prisma";
 import { readHostedSecureApprovalStatus } from "@/src/lib/sensitive-actions/secure-approval-status";
 import { createMurphPageMetadata } from "@/src/lib/site-metadata";
 import { readHostedPersonalAiUsageStatus } from "@/src/lib/hosted-execution/usage-status";
+import { resolveMurphContactOptions } from "@/src/lib/murph-contact-routing";
 
 export const metadata: Metadata = createMurphPageMetadata({
   title: "Settings — Murph",
@@ -132,13 +132,21 @@ export default async function SettingsPage({
   // The member sends this to Murph right after picking a voice, so the reply
   // comes back as a voice memo in the new voice. Voice memos only deliver over
   // text and Telegram, so an email-only member gets no redirect.
-  const resolvedVoiceTestOption = authenticatedMember
-    ? await resolveHostedMurphContactOption({
+  const resolvedVoiceTestOption = account
+    ? resolveMurphContactOptions({
+        contactChannels: {
+          email: Boolean(account.email.murphEmailAddress),
+          telegram: Boolean(account.telegram.telegramUserId),
+          text: Boolean(account.phone.number),
+        },
         message: {
           body: "just picked a new voice for you! send me a voice memo so I can hear it",
         },
+        murphEmailAddress: account.email.murphEmailAddress ?? null,
+        murphPhoneNumber: routing?.linqRecipientPhone ?? null,
         preferredKind: "text",
-      })
+        userEmailAddress: account.email.address,
+      })[0] ?? null
     : null;
   const voiceTestContactOption =
     resolvedVoiceTestOption && resolvedVoiceTestOption.kind !== "email"

--- a/apps/web/src/lib/hosted-onboarding/account-settings-snapshot.ts
+++ b/apps/web/src/lib/hosted-onboarding/account-settings-snapshot.ts
@@ -6,16 +6,23 @@ import type {
   AssistantVoiceOptionId,
 } from "@murphai/contracts";
 import type { HostedAssistantProductModel } from "@murphai/hosted-execution/assistant-model";
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 
+import { runWithHostedDomainRootUnwrapCache } from "../hosted-crypto/domain-root-unwrap-cache";
 import { getPrisma } from "../prisma";
-import { readHostedMemberAssistantModelPreference } from "./assistant-model-preference";
-import { createHostedMemberReplyAliasRouteFromLookupKey } from "./hosted-email-reply-alias";
 import {
-  readHostedMemberSnapshot,
-  type HostedMemberSnapshot,
-} from "./hosted-member-store";
-import { readHostedMemberAssistantPreferences } from "./member-preferences";
+  HOSTED_MEMBER_ASSISTANT_MODEL_SELECT,
+  resolveHostedMemberAssistantModel,
+} from "./assistant-model-preference";
+import { createHostedMemberReplyAliasRouteFromLookupKey } from "./hosted-email-reply-alias";
+import { projectHostedMemberEmailAuthorizationState } from "./hosted-member-store";
+import type { HostedMemberStripeBillingRefSnapshot } from "./hosted-member-billing-store";
+import {
+  readHostedMemberBillingPrivateState,
+  readHostedMemberIdentityPhoneNumber,
+  readHostedMemberRoutingPrivateState,
+} from "./member-private-codecs";
+import { projectHostedMemberAssistantPreferences } from "./member-preferences";
 import {
   extractHostedPrivyEmailAccount,
   extractHostedPrivyTelegramAccount,
@@ -56,9 +63,74 @@ export interface HostedAccountSettingsSnapshot {
 
 export interface HostedAccountSettingsPageSnapshot {
   account: HostedAccountSettingsSnapshot;
-  billingRef: HostedMemberSnapshot["billingRef"];
-  routing: HostedMemberSnapshot["routing"];
+  billingRef: HostedAccountSettingsBillingRef | null;
+  routing: HostedAccountSettingsRouting | null;
 }
+
+export type HostedAccountSettingsBillingRef = Pick<
+  HostedMemberStripeBillingRefSnapshot,
+  | "currentBillingPhase"
+  | "currentBillingPlanCode"
+  | "currentCheckoutOffer"
+  | "currentPeriodEnd"
+  | "scheduledBillingEffectiveAt"
+  | "scheduledBillingPlanCode"
+  | "stripeCustomerId"
+  | "stripeSubscriptionId"
+>;
+
+export interface HostedAccountSettingsRouting {
+  linqRecipientPhone: string | null;
+  pendingLinqRecipientPhone: string | null;
+}
+
+const hostedAccountSettingsMemberSelect =
+  Prisma.validator<Prisma.HostedMemberSelect>()({
+    ...HOSTED_MEMBER_ASSISTANT_MODEL_SELECT,
+    assistantDetail: true,
+    assistantHumor: true,
+    assistantPush: true,
+    assistantTone: true,
+    assistantVoice: true,
+    billingRef: {
+      select: {
+        ...HOSTED_MEMBER_ASSISTANT_MODEL_SELECT.billingRef.select,
+        currentCheckoutOffer: true,
+        currentPeriodEnd: true,
+        memberId: true,
+        scheduledBillingEffectiveAt: true,
+        scheduledBillingPlanCode: true,
+        stripeCustomerIdEncrypted: true,
+        stripeSubscriptionIdEncrypted: true,
+      },
+    },
+    emailAuthorization: {
+      select: {
+        memberId: true,
+        stripeCheckoutEmailAddressEncrypted: true,
+        stripeCheckoutEmailCollectedAt: true,
+        verifiedEmailAddressEncrypted: true,
+        verifiedEmailLookupKey: true,
+        verifiedEmailVerifiedAt: true,
+      },
+    },
+    identity: {
+      select: {
+        memberId: true,
+        phoneNumberEncrypted: true,
+        phoneNumberVerifiedAt: true,
+      },
+    },
+    routing: {
+      select: {
+        linqRecipientPhoneEncrypted: true,
+        memberId: true,
+        pendingLinqRecipientPhoneEncrypted: true,
+        replyAliasLookupKey: true,
+        telegramUserIdEncrypted: true,
+      },
+    },
+  });
 
 export async function readHostedAccountSettingsSnapshot(input: {
   memberId: string;
@@ -71,27 +143,63 @@ export async function readHostedAccountSettingsPageSnapshot(input: {
   prisma?: PrismaClient;
 }): Promise<HostedAccountSettingsPageSnapshot> {
   const prisma = input.prisma ?? getPrisma();
-  const [snapshot, assistantPreferences, assistantModel] = await Promise.all([
-    readHostedMemberSnapshot({
-      memberId: input.memberId,
-      prisma,
-    }),
-    readHostedMemberAssistantPreferences({
-      memberId: input.memberId,
-      prisma,
-    }),
-    readHostedMemberAssistantModelPreference({
-      memberId: input.memberId,
-      prisma,
-    }),
-  ]);
-  const verifiedEmail = snapshot?.emailAuthorization?.verifiedEmail ?? null;
-  const murphEmailRoute = verifiedEmail
-    ? await createHostedMemberReplyAliasRouteFromLookupKey({
-        replyAliasLookupKey: snapshot?.routing?.replyAliasLookupKey,
+  const member = await prisma.hostedMember.findUnique({
+    select: hostedAccountSettingsMemberSelect,
+    where: {
+      id: input.memberId,
+    },
+  });
+  const assistantPreferences = projectHostedMemberAssistantPreferences(member);
+  const assistantModel = resolveHostedMemberAssistantModel(member);
+  const privateSettings = member
+    ? await runWithHostedDomainRootUnwrapCache(async () => {
+        const [billingPrivate, emailAuthorization, phoneNumber, routingPrivate] =
+          await Promise.all([
+            member.billingRef
+              ? readHostedMemberBillingPrivateState(member.billingRef, prisma)
+              : null,
+            member.emailAuthorization
+              ? projectHostedMemberEmailAuthorizationState(
+                  {
+                    ...member.emailAuthorization,
+                    directPublicSenderAddressEncrypted: null,
+                    directPublicSenderAuthorizedAt: null,
+                    directPublicSenderLookupKey: null,
+                  },
+                  prisma,
+                )
+              : null,
+            member.identity
+              ? readHostedMemberIdentityPhoneNumber(member.identity, prisma)
+              : null,
+            member.routing
+              ? readHostedMemberRoutingPrivateState(
+                  {
+                    ...member.routing,
+                    linqChatIdEncrypted: null,
+                    pendingLinqChatIdEncrypted: null,
+                    pendingLinqParticipantContactEncrypted: null,
+                  },
+                  prisma,
+                )
+              : null,
+          ]);
+
+        return {
+          billingPrivate,
+          emailAuthorization,
+          phoneNumber,
+          routingPrivate,
+        };
       })
     : null;
-  const telegramUserId = snapshot?.routing?.telegramUserId ?? null;
+  const verifiedEmail = privateSettings?.emailAuthorization?.verifiedEmail ?? null;
+  const murphEmailRoute = verifiedEmail
+    ? await createHostedMemberReplyAliasRouteFromLookupKey({
+        replyAliasLookupKey: member?.routing?.replyAliasLookupKey,
+      })
+    : null;
+  const telegramUserId = privateSettings?.routingPrivate?.telegramUserId ?? null;
 
   return {
     account: {
@@ -104,21 +212,40 @@ export async function readHostedAccountSettingsPageSnapshot(input: {
       },
       email: {
         address: verifiedEmail?.address
-          ?? snapshot?.emailAuthorization?.stripeCheckoutEmail?.address
+          ?? privateSettings?.emailAuthorization?.stripeCheckoutEmail?.address
           ?? null,
         murphEmailAddress: murphEmailRoute?.address ?? null,
         verifiedAt: verifiedEmail?.verifiedAt.toISOString() ?? null,
       },
       phone: {
-        number: snapshot?.identity?.phoneNumber ?? null,
-        verifiedAt: snapshot?.identity?.phoneNumberVerifiedAt?.toISOString() ?? null,
+        number: privateSettings?.phoneNumber ?? null,
+        verifiedAt: member?.identity?.phoneNumberVerifiedAt?.toISOString() ?? null,
       },
       telegram: {
         telegramUserId,
       },
     },
-    billingRef: snapshot?.billingRef ?? null,
-    routing: snapshot?.routing ?? null,
+    billingRef: member?.billingRef
+      ? {
+          currentBillingPhase: member.billingRef.currentBillingPhase,
+          currentBillingPlanCode: member.billingRef.currentBillingPlanCode,
+          currentCheckoutOffer: member.billingRef.currentCheckoutOffer,
+          currentPeriodEnd: member.billingRef.currentPeriodEnd,
+          scheduledBillingEffectiveAt: member.billingRef.scheduledBillingEffectiveAt,
+          scheduledBillingPlanCode: member.billingRef.scheduledBillingPlanCode,
+          stripeCustomerId: privateSettings?.billingPrivate?.stripeCustomerId ?? null,
+          stripeSubscriptionId:
+            privateSettings?.billingPrivate?.stripeSubscriptionId ?? null,
+        }
+      : null,
+    routing: member?.routing
+      ? {
+          linqRecipientPhone:
+            privateSettings?.routingPrivate?.linqRecipientPhone ?? null,
+          pendingLinqRecipientPhone:
+            privateSettings?.routingPrivate?.pendingLinqRecipientPhone ?? null,
+        }
+      : null,
   };
 }
 

--- a/apps/web/src/lib/hosted-onboarding/assistant-model-preference.ts
+++ b/apps/web/src/lib/hosted-onboarding/assistant-model-preference.ts
@@ -31,7 +31,7 @@ import {
   lockHostedMemberSponsoredAccessRows,
 } from "./shared";
 
-const HOSTED_MEMBER_ASSISTANT_MODEL_SELECT = {
+export const HOSTED_MEMBER_ASSISTANT_MODEL_SELECT = {
   accountGroupMemberships: {
     select: {
       group: {
@@ -281,7 +281,7 @@ async function readHostedMemberAssistantModelState(input: {
   });
 }
 
-function resolveHostedMemberAssistantModel(
+export function resolveHostedMemberAssistantModel(
   member: HostedMemberAssistantModelState | null,
 ): HostedMemberAssistantModelResolution {
   if (!member) {

--- a/apps/web/src/lib/hosted-onboarding/member-preferences.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-preferences.ts
@@ -297,6 +297,19 @@ export async function readHostedMemberAssistantPreferences(input: {
     },
   });
 
+  return projectHostedMemberAssistantPreferences(member);
+}
+
+export function projectHostedMemberAssistantPreferences(
+  member: (HostedMemberPersonalityColumns & {
+    assistantTone: string | null;
+    assistantVoice: string | null;
+  }) | null,
+): {
+  personality: HostedMemberAssistantPersonalitySnapshot;
+  tone: AssistantTonePreference | null;
+  voice: AssistantVoiceOptionId | null;
+} {
   return {
     personality: normalizeStoredAssistantPersonality(member),
     tone: normalizeStoredAssistantTone(member?.assistantTone ?? null),

--- a/apps/web/test/account-settings-snapshot.test.ts
+++ b/apps/web/test/account-settings-snapshot.test.ts
@@ -4,14 +4,24 @@ import { createHostedEmailUserReplyAliasRoute } from "@murphai/hosted-execution/
 const mocks = vi.hoisted(() => ({
   findUniqueHostedMember: vi.fn(),
   getPrisma: vi.fn(),
-  readHostedMemberAssistantModelPreference: vi.fn(),
-  readHostedMemberSnapshot: vi.fn(),
+  projectHostedMemberAssistantPreferences: vi.fn(),
+  projectHostedMemberEmailAuthorizationState: vi.fn(),
+  readHostedMemberBillingPrivateState: vi.fn(),
+  readHostedMemberIdentityPhoneNumber: vi.fn(),
+  readHostedMemberRoutingPrivateState: vi.fn(),
+  resolveHostedMemberAssistantModel: vi.fn(),
+  runWithHostedDomainRootUnwrapCache: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
 
 vi.mock("@/src/lib/prisma", () => ({
   getPrisma: mocks.getPrisma,
+}));
+
+vi.mock("@/src/lib/hosted-crypto/domain-root-unwrap-cache", () => ({
+  runWithHostedDomainRootUnwrapCache:
+    mocks.runWithHostedDomainRootUnwrapCache,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", async () => {
@@ -21,14 +31,50 @@ vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", async () => {
 
   return {
     ...actual,
-    readHostedMemberSnapshot: mocks.readHostedMemberSnapshot,
+    projectHostedMemberEmailAuthorizationState:
+      mocks.projectHostedMemberEmailAuthorizationState,
   };
 });
 
-vi.mock("@/src/lib/hosted-onboarding/assistant-model-preference", () => ({
-  readHostedMemberAssistantModelPreference:
-    mocks.readHostedMemberAssistantModelPreference,
-}));
+vi.mock("@/src/lib/hosted-onboarding/assistant-model-preference", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/assistant-model-preference")
+  >("@/src/lib/hosted-onboarding/assistant-model-preference");
+
+  return {
+    ...actual,
+    resolveHostedMemberAssistantModel:
+      mocks.resolveHostedMemberAssistantModel,
+  };
+});
+
+vi.mock("@/src/lib/hosted-onboarding/member-preferences", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/member-preferences")
+  >("@/src/lib/hosted-onboarding/member-preferences");
+
+  return {
+    ...actual,
+    projectHostedMemberAssistantPreferences:
+      mocks.projectHostedMemberAssistantPreferences,
+  };
+});
+
+vi.mock("@/src/lib/hosted-onboarding/member-private-codecs", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/member-private-codecs")
+  >("@/src/lib/hosted-onboarding/member-private-codecs");
+
+  return {
+    ...actual,
+    readHostedMemberBillingPrivateState:
+      mocks.readHostedMemberBillingPrivateState,
+    readHostedMemberIdentityPhoneNumber:
+      mocks.readHostedMemberIdentityPhoneNumber,
+    readHostedMemberRoutingPrivateState:
+      mocks.readHostedMemberRoutingPrivateState,
+  };
+});
 
 import { getPrisma } from "@/src/lib/prisma";
 import {
@@ -49,12 +95,45 @@ describe("hosted account settings snapshot", () => {
     process.env.HOSTED_EMAIL_LOCAL_PART = "murph";
     process.env.HOSTED_EMAIL_SIGNING_SECRET = "test-email-signing-secret";
     mocks.findUniqueHostedMember.mockResolvedValue(null);
-    mocks.readHostedMemberAssistantModelPreference.mockResolvedValue({
+    mocks.projectHostedMemberAssistantPreferences.mockReturnValue({
+      personality: {
+        detail: null,
+        humor: null,
+        push: null,
+      },
+      tone: null,
+      voice: null,
+    });
+    mocks.projectHostedMemberEmailAuthorizationState.mockResolvedValue({
+      directPublicSender: null,
+      memberId: "member_123",
+      stripeCheckoutEmail: null,
+      verifiedEmail: null,
+    });
+    mocks.readHostedMemberBillingPrivateState.mockResolvedValue({
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionScheduleId: null,
+    });
+    mocks.readHostedMemberIdentityPhoneNumber.mockResolvedValue(null);
+    mocks.readHostedMemberRoutingPrivateState.mockResolvedValue({
+      linqChatId: null,
+      linqRecipientPhone: null,
+      pendingLinqChatId: null,
+      pendingLinqParticipantContact: null,
+      pendingLinqRecipientPhone: null,
+      telegramThreadId: null,
+      telegramUserId: null,
+    });
+    mocks.resolveHostedMemberAssistantModel.mockReturnValue({
       configurationAvailable: true,
       dormantSolPreference: false,
       model: "gpt-5.6-terra",
       solAvailable: false,
     });
+    mocks.runWithHostedDomainRootUnwrapCache.mockImplementation(
+      async (run: () => Promise<unknown>) => run(),
+    );
     mocks.getPrisma.mockReturnValue({
       hostedMember: {
         findUnique: mocks.findUniqueHostedMember,
@@ -70,18 +149,24 @@ describe("hosted account settings snapshot", () => {
   });
 
   it("prefills settings from the unverified Stripe checkout email when no verified email exists", async () => {
-    mocks.readHostedMemberSnapshot.mockResolvedValue({
+    mocks.findUniqueHostedMember.mockResolvedValue(makeSettingsMemberRecord({
       emailAuthorization: {
-        directPublicSender: null,
         memberId: "member_123",
-        stripeCheckoutEmail: {
-          address: "payer@example.com",
-          collectedAt: new Date("2026-05-01T00:00:00.000Z"),
-        },
-        verifiedEmail: null,
+        stripeCheckoutEmailAddressEncrypted: "encrypted-checkout-email",
+        stripeCheckoutEmailCollectedAt: new Date("2026-05-01T00:00:00.000Z"),
+        verifiedEmailAddressEncrypted: null,
+        verifiedEmailLookupKey: null,
+        verifiedEmailVerifiedAt: null,
       },
-      identity: null,
-      routing: null,
+    }));
+    mocks.projectHostedMemberEmailAuthorizationState.mockResolvedValue({
+      directPublicSender: null,
+      memberId: "member_123",
+      stripeCheckoutEmail: {
+        address: "payer@example.com",
+        collectedAt: new Date("2026-05-01T00:00:00.000Z"),
+      },
+      verifiedEmail: null,
     });
 
     await expect(readHostedAccountSettingsSnapshot({
@@ -93,38 +178,60 @@ describe("hosted account settings snapshot", () => {
         verifiedAt: null,
       },
     });
+    expect(mocks.projectHostedMemberEmailAuthorizationState).toHaveBeenCalledWith({
+      directPublicSenderAddressEncrypted: null,
+      directPublicSenderAuthorizedAt: null,
+      directPublicSenderLookupKey: null,
+      memberId: "member_123",
+      stripeCheckoutEmailAddressEncrypted: "encrypted-checkout-email",
+      stripeCheckoutEmailCollectedAt: new Date("2026-05-01T00:00:00.000Z"),
+      verifiedEmailAddressEncrypted: null,
+      verifiedEmailLookupKey: null,
+      verifiedEmailVerifiedAt: null,
+    }, expect.any(Object));
   });
 
   it("reuses the member aggregate for the Settings page billing and routing slices", async () => {
-    const billingRef = {
+    const billingRecord = {
       currentBillingPhase: "paid",
       currentBillingPlanCode: "launch_monthly",
-      memberId: "member_123",
-      stripeCustomerId: "cus_123",
-      stripeSubscriptionId: "sub_123",
+      currentCheckoutOffer: "standard",
+      currentPeriodEnd: new Date("2026-08-01T00:00:00.000Z"),
+      scheduledBillingEffectiveAt: null,
+      scheduledBillingPlanCode: null,
+      stripeCustomerIdEncrypted: "encrypted-customer",
+      stripeSubscriptionIdEncrypted: "encrypted-subscription",
     };
-    const routing = {
-      linqRecipientPhone: "+15550100001",
+    const routingRecord = {
+      linqRecipientPhoneEncrypted: "encrypted-home-line",
       memberId: "member_123",
-      pendingLinqRecipientPhone: null,
-      telegramUserId: "456",
+      pendingLinqRecipientPhoneEncrypted: null,
+      replyAliasLookupKey: null,
+      telegramUserIdEncrypted: "encrypted-telegram",
     };
-    mocks.readHostedMemberSnapshot.mockResolvedValue({
-      billingRef,
-      core: {
-        billingStatus: "active",
-        id: "member_123",
-        suspendedAt: null,
-      },
-      emailAuthorization: null,
+    mocks.findUniqueHostedMember.mockResolvedValue(makeSettingsMemberRecord({
+      billingRef: billingRecord,
       identity: {
         memberId: "member_123",
-        phoneLookupKey: "phone_lookup",
-        phoneNumber: "+15550100002",
+        phoneNumberEncrypted: "encrypted-phone",
         phoneNumberVerifiedAt: new Date("2026-07-15T12:00:00.000Z"),
-        privyUserId: "did:privy:user_123",
       },
-      routing,
+      routing: routingRecord,
+    }));
+    mocks.readHostedMemberBillingPrivateState.mockResolvedValue({
+      stripeCustomerId: "cus_123",
+      stripeSubscriptionId: "sub_123",
+      stripeSubscriptionScheduleId: null,
+    });
+    mocks.readHostedMemberIdentityPhoneNumber.mockResolvedValue("+15550100002");
+    mocks.readHostedMemberRoutingPrivateState.mockResolvedValue({
+      linqChatId: null,
+      linqRecipientPhone: "+15550100001",
+      pendingLinqChatId: null,
+      pendingLinqParticipantContact: null,
+      pendingLinqRecipientPhone: null,
+      telegramThreadId: null,
+      telegramUserId: "456",
     });
     const prisma = getPrisma();
     mocks.getPrisma.mockClear();
@@ -134,8 +241,20 @@ describe("hosted account settings snapshot", () => {
       prisma,
     });
 
-    expect(result.billingRef).toBe(billingRef);
-    expect(result.routing).toBe(routing);
+    expect(result.billingRef).toEqual({
+      currentBillingPhase: "paid",
+      currentBillingPlanCode: "launch_monthly",
+      currentCheckoutOffer: "standard",
+      currentPeriodEnd: new Date("2026-08-01T00:00:00.000Z"),
+      scheduledBillingEffectiveAt: null,
+      scheduledBillingPlanCode: null,
+      stripeCustomerId: "cus_123",
+      stripeSubscriptionId: "sub_123",
+    });
+    expect(result.routing).toEqual({
+      linqRecipientPhone: "+15550100001",
+      pendingLinqRecipientPhone: null,
+    });
     expect(result.account).toMatchObject({
       assistant: {
         model: "gpt-5.6-terra",
@@ -148,21 +267,63 @@ describe("hosted account settings snapshot", () => {
         telegramUserId: "456",
       },
     });
-    expect(mocks.readHostedMemberSnapshot).toHaveBeenCalledTimes(1);
-    expect(mocks.readHostedMemberSnapshot).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma,
-    });
-    expect(mocks.readHostedMemberAssistantModelPreference).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma,
-    });
     expect(mocks.findUniqueHostedMember).toHaveBeenCalledTimes(1);
+    const query = mocks.findUniqueHostedMember.mock.calls[0]?.[0];
+    expect(query).toEqual({
+      select: expect.any(Object),
+      where: { id: "member_123" },
+    });
+    expect(query.select.identity.select).toEqual({
+      memberId: true,
+      phoneNumberEncrypted: true,
+      phoneNumberVerifiedAt: true,
+    });
+    expect(query.select.routing.select).toEqual({
+      linqRecipientPhoneEncrypted: true,
+      memberId: true,
+      pendingLinqRecipientPhoneEncrypted: true,
+      replyAliasLookupKey: true,
+      telegramUserIdEncrypted: true,
+    });
+    expect(query.select.emailAuthorization.select).toEqual({
+      memberId: true,
+      stripeCheckoutEmailAddressEncrypted: true,
+      stripeCheckoutEmailCollectedAt: true,
+      verifiedEmailAddressEncrypted: true,
+      verifiedEmailLookupKey: true,
+      verifiedEmailVerifiedAt: true,
+    });
+    expect(query.select.billingRef.select).toEqual({
+      currentBillingPhase: true,
+      currentBillingPlanCode: true,
+      currentCheckoutOffer: true,
+      currentPeriodEnd: true,
+      memberId: true,
+      scheduledBillingEffectiveAt: true,
+      scheduledBillingPlanCode: true,
+      stripeCustomerIdEncrypted: true,
+      stripeSubscriptionIdEncrypted: true,
+    });
+    expect(mocks.runWithHostedDomainRootUnwrapCache).toHaveBeenCalledTimes(1);
+    expect(mocks.readHostedMemberBillingPrivateState).toHaveBeenCalledWith(
+      billingRecord,
+      prisma,
+    );
+    expect(mocks.readHostedMemberIdentityPhoneNumber).toHaveBeenCalledWith({
+      memberId: "member_123",
+      phoneNumberEncrypted: "encrypted-phone",
+      phoneNumberVerifiedAt: new Date("2026-07-15T12:00:00.000Z"),
+    }, prisma);
+    expect(mocks.readHostedMemberRoutingPrivateState).toHaveBeenCalledWith({
+      ...routingRecord,
+      linqChatIdEncrypted: null,
+      pendingLinqChatIdEncrypted: null,
+      pendingLinqParticipantContactEncrypted: null,
+    }, prisma);
     expect(mocks.getPrisma).not.toHaveBeenCalled();
   });
 
   it("returns explicit null Settings slices when the member aggregate is absent", async () => {
-    mocks.readHostedMemberSnapshot.mockResolvedValue(null);
     const prisma = getPrisma();
     mocks.getPrisma.mockClear();
 
@@ -192,11 +353,12 @@ describe("hosted account settings snapshot", () => {
       billingRef: null,
       routing: null,
     });
-    expect(mocks.readHostedMemberSnapshot).toHaveBeenCalledOnce();
-    expect(mocks.readHostedMemberSnapshot).toHaveBeenCalledWith({
-      memberId: "member_missing",
-      prisma,
+    expect(mocks.findUniqueHostedMember).toHaveBeenCalledOnce();
+    expect(mocks.findUniqueHostedMember).toHaveBeenCalledWith({
+      select: expect.any(Object),
+      where: { id: "member_missing" },
     });
+    expect(mocks.runWithHostedDomainRootUnwrapCache).not.toHaveBeenCalled();
     expect(mocks.getPrisma).not.toHaveBeenCalled();
   });
 
@@ -207,23 +369,34 @@ describe("hosted account settings snapshot", () => {
       signingSecret: "test-email-signing-secret",
       userId: "member_123",
     });
-    mocks.readHostedMemberSnapshot.mockResolvedValue({
+    mocks.findUniqueHostedMember.mockResolvedValue(makeSettingsMemberRecord({
       emailAuthorization: {
-        directPublicSender: null,
         memberId: "member_123",
-        stripeCheckoutEmail: {
-          address: "payer@example.com",
-          collectedAt: new Date("2026-05-01T00:00:00.000Z"),
-        },
-        verifiedEmail: {
-          address: "verified@example.com",
-          lookupKey: "lookup_verified",
-          verifiedAt: new Date("2026-05-02T00:00:00.000Z"),
-        },
+        stripeCheckoutEmailAddressEncrypted: "encrypted-checkout-email",
+        stripeCheckoutEmailCollectedAt: new Date("2026-05-01T00:00:00.000Z"),
+        verifiedEmailAddressEncrypted: "encrypted-verified-email",
+        verifiedEmailLookupKey: "lookup_verified",
+        verifiedEmailVerifiedAt: new Date("2026-05-02T00:00:00.000Z"),
       },
-      identity: null,
       routing: {
+        linqRecipientPhoneEncrypted: null,
+        memberId: "member_123",
+        pendingLinqRecipientPhoneEncrypted: null,
         replyAliasLookupKey: replyAlias.aliasKey,
+        telegramUserIdEncrypted: null,
+      },
+    }));
+    mocks.projectHostedMemberEmailAuthorizationState.mockResolvedValue({
+      directPublicSender: null,
+      memberId: "member_123",
+      stripeCheckoutEmail: {
+        address: "payer@example.com",
+        collectedAt: new Date("2026-05-01T00:00:00.000Z"),
+      },
+      verifiedEmail: {
+        address: "verified@example.com",
+        lookupKey: "lookup_verified",
+        verifiedAt: new Date("2026-05-02T00:00:00.000Z"),
       },
     });
 
@@ -239,18 +412,15 @@ describe("hosted account settings snapshot", () => {
   });
 
   it("normalizes assistant preferences for settings display", async () => {
-    mocks.readHostedMemberSnapshot.mockResolvedValue({
-      core: null,
-      emailAuthorization: null,
-      identity: null,
-      routing: null,
-    });
-    mocks.findUniqueHostedMember.mockResolvedValue({
-      assistantDetail: 8,
-      assistantHumor: 7,
-      assistantPush: 6,
-      assistantTone: "casual",
-      assistantVoice: "warm",
+    mocks.findUniqueHostedMember.mockResolvedValue(makeSettingsMemberRecord());
+    mocks.projectHostedMemberAssistantPreferences.mockReturnValue({
+      personality: {
+        detail: 8,
+        humor: 7,
+        push: 6,
+      },
+      tone: "casual",
+      voice: "warm",
     });
 
     await expect(readHostedAccountSettingsSnapshot({
@@ -273,12 +443,14 @@ describe("hosted account settings snapshot", () => {
 
     // Roster ids can be retired, so stored values that no longer resolve fall
     // back to the defaults instead of leaking a stale id into the settings UI.
-    mocks.findUniqueHostedMember.mockResolvedValue({
-      assistantDetail: 12,
-      assistantHumor: -1,
-      assistantPush: 2.5,
-      assistantTone: "stale-tone",
-      assistantVoice: "stale-voice",
+    mocks.projectHostedMemberAssistantPreferences.mockReturnValue({
+      personality: {
+        detail: null,
+        humor: null,
+        push: null,
+      },
+      tone: null,
+      voice: null,
     });
 
     await expect(readHostedAccountSettingsSnapshot({
@@ -299,14 +471,6 @@ describe("hosted account settings snapshot", () => {
   });
 
   it("returns empty assistant preferences when the member row is missing", async () => {
-    mocks.readHostedMemberSnapshot.mockResolvedValue({
-      core: null,
-      emailAuthorization: null,
-      identity: null,
-      routing: null,
-    });
-    mocks.findUniqueHostedMember.mockResolvedValue(null);
-
     await expect(readHostedAccountSettingsSnapshot({
       memberId: "member_123",
     })).resolves.toMatchObject({
@@ -325,13 +489,8 @@ describe("hosted account settings snapshot", () => {
   });
 
   it("includes the canonical effective model and Sol availability", async () => {
-    mocks.readHostedMemberSnapshot.mockResolvedValue({
-      core: null,
-      emailAuthorization: null,
-      identity: null,
-      routing: null,
-    });
-    mocks.readHostedMemberAssistantModelPreference.mockResolvedValue({
+    mocks.findUniqueHostedMember.mockResolvedValue(makeSettingsMemberRecord());
+    mocks.resolveHostedMemberAssistantModel.mockReturnValue({
       configurationAvailable: true,
       dormantSolPreference: false,
       hostedAssistantModelOverride: "gpt-5.6-sol",
@@ -349,20 +508,14 @@ describe("hosted account settings snapshot", () => {
         solAvailable: true,
       },
     });
-    expect(mocks.readHostedMemberAssistantModelPreference).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma: expect.objectContaining({ readonly: true }),
-    });
+    expect(mocks.resolveHostedMemberAssistantModel).toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "active" }),
+    );
   });
 
   it("includes canonical configuration availability and dormant Sol state", async () => {
-    mocks.readHostedMemberSnapshot.mockResolvedValue({
-      core: null,
-      emailAuthorization: null,
-      identity: null,
-      routing: null,
-    });
-    mocks.readHostedMemberAssistantModelPreference.mockResolvedValue({
+    mocks.findUniqueHostedMember.mockResolvedValue(makeSettingsMemberRecord());
+    mocks.resolveHostedMemberAssistantModel.mockReturnValue({
       configurationAvailable: true,
       dormantSolPreference: true,
       model: "gpt-5.6-terra",
@@ -451,6 +604,29 @@ describe("hosted account settings snapshot", () => {
     });
   });
 });
+
+function makeSettingsMemberRecord(
+  input: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    accountGroupMemberships: [],
+    assistantDetail: null,
+    assistantHumor: null,
+    assistantModelPreference: null,
+    assistantPush: null,
+    assistantReasoningEffortPreference: null,
+    assistantTone: null,
+    assistantVoice: null,
+    billingRef: null,
+    billingStatus: "active",
+    emailAuthorization: null,
+    identity: null,
+    routing: null,
+    suspendedAt: null,
+    threadContainer: null,
+    ...input,
+  };
+}
 
 function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) {

--- a/apps/web/test/settings-page.test.ts
+++ b/apps/web/test/settings-page.test.ts
@@ -30,11 +30,11 @@ const mocks = vi.hoisted(() => ({
       null,
       `Hosted account settings ${String(props.murphPhoneNumber ?? "")}`,
     )),
-  resolveHostedMurphContactOption: vi.fn(async () => ({
+  resolveMurphContactOptions: vi.fn(() => [{
     href: "sms:+15550100001?body=voice%20test",
     kind: "text",
     label: "Messages",
-  })),
+  }]),
   HostedAssistantModelSettings: vi.fn((props: {
     canUpgradeToEdge: boolean;
     configurationAvailable: boolean;
@@ -159,8 +159,8 @@ vi.mock("@/src/components/settings/customize-murph-settings", () => ({
   CustomizeMurphSettings: mocks.CustomizeMurphSettings,
 }));
 
-vi.mock("@/src/components/murph/hosted-murph-contact-action", () => ({
-  resolveHostedMurphContactOption: mocks.resolveHostedMurphContactOption,
+vi.mock("@/src/lib/murph-contact-routing", () => ({
+  resolveMurphContactOptions: mocks.resolveMurphContactOptions,
 }));
 
 vi.mock("@/src/components/settings/hosted-assistant-model-settings", () => ({
@@ -485,11 +485,19 @@ test("SettingsPage reads the app session and persisted account settings into the
         label: "Messages",
       },
     }), undefined);
-    expect(mocks.resolveHostedMurphContactOption).toHaveBeenCalledWith({
+    expect(mocks.resolveMurphContactOptions).toHaveBeenCalledWith({
+      contactChannels: {
+        email: false,
+        telegram: true,
+        text: true,
+      },
       message: {
         body: "just picked a new voice for you! send me a voice memo so I can hear it",
       },
+      murphEmailAddress: null,
+      murphPhoneNumber: "+15550100001",
       preferredKind: "text",
+      userEmailAddress: "verified@example.com",
     });
     expect(mocks.HostedPasskeySettings).toHaveBeenCalledWith(expect.objectContaining({
       authenticated: true,
@@ -651,11 +659,11 @@ test("SettingsPage drops the voice-test chat link for an email-only member", asy
       },
     },
   });
-  mocks.resolveHostedMurphContactOption.mockResolvedValueOnce({
+  mocks.resolveMurphContactOptions.mockReturnValueOnce([{
     href: "mailto:murph@mail.withmurph.ai?body=test",
     kind: "email",
     label: "Email",
-  });
+  }]);
 
   const { default: SettingsPage } = await import("../app/(dashboard)/settings/page");
 


### PR DESCRIPTION
## Why

The Settings page loaded overlapping member, contact, preference, and model snapshots. In the worst Settings-specific path, that meant seven Prisma client reads and up to 38 populated private-field decrypt operations for data the page already had or did not render.

## User-visible goal and UX

Settings should render the same account, billing, assistant, phone, Telegram, and email state with less database and KMS pressure. The voice-test action keeps the same behavior: active text line first, Telegram fallback, and no redirect for an email-only member. There is no intended markup, styling, copy, accessibility, or interaction change.

## What changed

- Replace three overlapping account/preferences/model readers with one narrow member aggregate query.
- Select and decrypt only the private fields Settings consumes, under one request-local domain-root unwrap scope.
- Derive the voice-test contact option from the already-loaded Settings account/routing projection instead of loading the broad contact context again.
- Reuse the existing assistant model, assistant preference, email, billing, identity, routing, and contact-routing owners rather than adding a new state owner.

The Settings-specific path is reduced from seven Prisma client calls to one member aggregate call, and from up to 38 populated private decrypts to at most eight under one shared root unwrap scope. Prisma may still choose its own internal relation SQL strategy.

## Invariants

- Preserve verified-email precedence over the Stripe checkout email and create a Murph reply alias only for verified email.
- Preserve active and pending Linq presentation, but keep the voice-test target on the active Linq route exactly as before.
- Preserve Telegram linkage, assistant model eligibility, personality/tone/voice normalization, billing actions, and Privy display hints.
- Keep private values encrypted at rest and scoped to the existing server-only Settings boundary.
- Do not change shared dashboard contact-context behavior.

## Non-obvious affected surfaces

- The existing assistant-model select and resolver are exported so the Settings aggregate can use the canonical eligibility logic without issuing a second query.
- The existing assistant-preferences reader now delegates to an exported pure projector so the same normalization can consume the aggregate row without another query.
- Existing private projectors receive explicit null placeholders for ciphertext columns the narrow Settings query intentionally excludes; tests assert those exclusions.
- `readHostedAccountSettingsSnapshot` remains the shared canonical account projection wrapper, so existing contact-context consumers such as dashboard/feature contact actions and the family-invite acceptance route now execute through the narrow aggregate and scoped unwrap boundary. Keeping those callers on the same owner is necessary to avoid a Settings-only duplicate loader and restore the read/decrypt fanout this PR removes.
- Aggregate select/output compatibility is covered by `apps/web/test/account-settings-snapshot.test.ts`; contact-channel behavior through the shared account projection is covered by `apps/web/test/sidebar-chat-action.test.tsx`; verified-versus-unverified email binding at family acceptance is covered by `apps/web/test/family-invite-accept-route.test.ts`.

## ReviewGPT round 1 disposition

- Accepted the necessary-but-undisclosed Purpose Drift finding. The production patch and head are unchanged; this description now names the two shared consumer classes, explains why the canonical projection boundary is required, and identifies their regression proof.

## Verification

- `pnpm test:diff` for all changed hosted-web paths: passed on the current base.
- Production build, TypeScript, development smoke, dependency/workspace/runtime guards: passed.
- Full hosted-web suite: 431 files and 5,224 tests passed; 3 files / 141 tests skipped.
- Lint: passed with zero errors and 11 pre-existing warnings.
- Focused account/Settings/preferences/model tests: 4 files and 47 tests passed.
- Required coverage-write audit: no missing proof and no edits.
- Required frontend-review audit: no findings; no authenticated browser pass because no rendered surface changed.
- Local final review, privacy scan, `git diff --check`, and static duplicate-loader readback: passed.
- All exact-head PR checks passed, including release gates and hosted E2E/device-sync gates.

## Change shape

Classification: source includes production TypeScript/TSX; tests includes test files; docs includes the completed execution plan; config/tooling and generated/other are empty.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 184 | 36 |
| Tests | 299 | 115 |
| Docs | 57 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **540** | **151** |

ReviewGPT first-reviewed head: 512b8b8f77f4f3432c12505b0d5688570f69e1bd

| Review round | Current head | Authored source additions | Authored source deletions |
| --- | --- | ---: | ---: |
| 1 | `512b8b8f77f4f3432c12505b0d5688570f69e1bd` | 184 | 36 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786757434&installation_id=127572939&pr_number=730&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F730&signature=702464342a0f791b3f6e920d91f57b0a4f71de46c86028dadb9a4caa0c7fcb3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
