### PR TITLE
fix(web): batch Linq reply authority reads

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-db-linq-authority-batching.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-db-linq-authority-batching.md
@@ -1,0 +1,101 @@
+# Batch Linq egress mailbox authority reads
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Keep Linq runtime reply authority checks exact while replacing per-candidate
+  mailbox and payload reads with bounded batch reads inside the existing locked
+  engagement transaction.
+
+## Success criteria
+
+- Answered mailbox ids retain reverse-input priority and recent mailbox rows
+  retain descending lane-sequence priority.
+- Cross-member, non-conversation, non-direct, wrong-target, wrong-message, and
+  malformed payload evidence remains unauthorized.
+- Up to 100 answered ids plus 100 recent rows use a constant number of mailbox
+  item/payload queries and one scoped ingress-root unwrap instead of per-row
+  database/KMS work.
+- Focused regression/query-count coverage and the required hosted-web
+  verification, coverage audit, PR ReviewGPT loop, CI, and mergeability proof
+  all pass.
+
+## Scope
+
+- In scope:
+  - `apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts`
+  - `apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts`
+- Out of scope:
+  - Hosted mailbox schema, store ownership, retention policy, and wire format.
+  - Engagement route locking, provider-dispatch claim semantics, or authority
+    policy changes.
+
+## Constraints
+
+- Technical constraints:
+  - Preserve the current 100 answered-id and 100 recent-row bounds.
+  - Preserve live-row retention/expiry filtering and sidecar ref binding.
+  - Reuse the already-fetched mailbox rows; do not reread them per sidecar.
+  - Keep decoding ordered and short-circuit on the first exact match.
+- Product/process constraints:
+  - Avoid `apps/web/src/lib/hosted-mailbox/store.ts`, which overlaps the active
+    mailbox consumed-at lane.
+  - Use the isolated task branch, scoped plan/ledger closure, PR-lane
+    ReviewGPT, and no local deep-review.
+
+## Risks and mitigations
+
+1. Risk: batching changes candidate precedence or dedupe behavior.
+   Mitigation: build maps only for query reuse, then iterate the original
+   answered-reverse and recent-desc candidate sequence unchanged.
+2. Risk: broader batch reads expose or decrypt another member's evidence.
+   Mitigation: keep live/member/kind/lane checks before sidecar selection and
+   decode, and query sidecars only for already-authorized candidate rows.
+3. Risk: a retention or payload-ref mismatch becomes authority.
+   Mitigation: mirror the mailbox live predicate at the query boundary and
+   retain exact payload-ref-to-item binding before the sidecar query.
+
+## Tasks
+
+1. Add bounded local Prisma batch readers and ordered candidate assembly.
+2. Decode the batch under one scoped hosted-domain root unwrap cache while
+   preserving all existing authority comparisons.
+3. Add behavior and constant-query-count regressions for the full 200-candidate
+   bound, sidecars, ordering, and invalid evidence.
+4. Run focused checks, full acceptance, coverage-write, parent final review,
+   plan closure, push/PR, ReviewGPT with CI, and mergeability proof.
+
+## Decisions
+
+- Keep the batch projection local to the Linq engagement owner to avoid the
+  active mailbox-store lane; do not introduce a generic mailbox batching API.
+- Use explicit Prisma `findMany` calls rather than relation `include` so the
+  query bound is visible and testable.
+
+## Verification
+
+- Focused hosted-web Vitest passed with 32 tests after rebasing onto the latest
+  `origin/main`.
+- The truthful owner lane passed twice with conservative worker caps:
+  `pnpm test:diff apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts`.
+  The final coverage-write run passed 5,212 tests with 141 skipped, plus web
+  typecheck, lint, build, and dev smoke.
+- The 200-candidate regression proves two mailbox-item queries, one sidecar
+  query, one unwrap-cache scope, answered-reverse/recent-desc ordering, and
+  reuse of every prefetched sidecar ciphertext.
+- Boundary proof covers the shared live-row predicate, malformed payload refs,
+  and foreign-member rows. `git diff --check`, scoped ESLint, and the
+  identifier/secret-safe parent diff review passed.
+
+## Completion audits
+
+- `coverage-write` added the missing live-predicate and malformed/foreign-ref
+  proof, reran the owner verification lane, and reported no unresolved
+  actionable coverage findings.
+- Parent final review preserved route locks, authority comparisons, retention,
+  payload-ref binding, candidate priority, and fail-closed foreign evidence.
+- The PR-lane ReviewGPT gate, CI, and mergeability proof remain post-push steps.
+Completed: 2026-07-15

--- a/apps/web/src/lib/hosted-mailbox/store.ts
+++ b/apps/web/src/lib/hosted-mailbox/store.ts
@@ -2007,7 +2007,7 @@ function hasHostedMailboxDedupeConflict(input: {
   );
 }
 
-function resolveHostedMailboxPayloadRef(payloadRef: string): string {
+export function resolveHostedMailboxPayloadRef(payloadRef: string): string {
   return payloadRef.startsWith(HOSTED_MAILBOX_PAYLOAD_REF_PREFIX)
     ? payloadRef.slice(HOSTED_MAILBOX_PAYLOAD_REF_PREFIX.length)
     : payloadRef;
@@ -2084,7 +2084,7 @@ function isHostedMailboxItemExpired(
   );
 }
 
-function buildHostedMailboxLiveItemWhere(at: Date): {
+export function buildHostedMailboxLiveItemWhere(at: Date): {
   createdAt: { gte: Date };
   OR: [{ expiresAt: null }, { expiresAt: { gt: Date } }];
 } {

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -25,7 +25,9 @@ import {
   runWithHostedDomainRootUnwrapCache,
 } from "../hosted-crypto/domain-root-unwrap-cache";
 import {
+  buildHostedMailboxLiveItemWhere,
   decodeHostedMailboxStoredPayload,
+  resolveHostedMailboxPayloadRef,
 } from "../hosted-mailbox/store";
 
 type HostedLinqEngagementClient = PrismaClient | Prisma.TransactionClient;
@@ -40,8 +42,6 @@ export type HostedLinqRuntimeEgressAssertionResult = {
 
 const HOSTED_LINQ_SIGNUP_WELCOME_IDEMPOTENCY_PREFIX = "signup-welcome:";
 const HOSTED_LINQ_RECENT_DIRECT_INBOUND_SCAN_LIMIT = 100;
-const HOSTED_LINQ_DIRECT_INBOUND_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
-const HOSTED_MAILBOX_PAYLOAD_REF_PREFIX = "hosted-mailbox-payload:";
 
 const HOSTED_LINQ_DIRECT_INBOUND_MAILBOX_ITEM_SELECT = {
   createdAt: true,
@@ -280,7 +280,7 @@ async function readHostedLinqDirectInboundCandidates(input: {
         select: HOSTED_LINQ_DIRECT_INBOUND_MAILBOX_ITEM_SELECT,
         where: {
           id: { in: [...new Set(answeredMailboxItemIds)] },
-          ...buildHostedLinqDirectInboundLiveMailboxWhere(input.availableAt),
+          ...buildHostedMailboxLiveItemWhere(input.availableAt),
         },
       })
     : [];
@@ -289,7 +289,7 @@ async function readHostedLinqDirectInboundCandidates(input: {
     select: HOSTED_LINQ_DIRECT_INBOUND_MAILBOX_ITEM_SELECT,
     take: HOSTED_LINQ_RECENT_DIRECT_INBOUND_SCAN_LIMIT,
     where: {
-      ...buildHostedLinqDirectInboundLiveMailboxWhere(input.availableAt),
+      ...buildHostedMailboxLiveItemWhere(input.availableAt),
       kind: "conversation.message",
       lane: "conversation",
       userId: input.memberId,
@@ -322,12 +322,14 @@ async function readHostedLinqDirectInboundPayloads(input: {
   prisma: HostedLinqEngagementClient;
 }) {
   const mailboxItemIds = [...new Set(input.candidates
-    .filter((item) => (
-      item.userId === input.memberId
-      && item.kind === "conversation.message"
-      && item.lane === "conversation"
-      && resolvesHostedMailboxPayloadRefToItem(item.payloadRef, item.id)
-    ))
+    .filter((item) => {
+      const payloadRef = normalizeNullable(item.payloadRef);
+      return item.userId === input.memberId
+        && item.kind === "conversation.message"
+        && item.lane === "conversation"
+        && payloadRef !== null
+        && resolveHostedMailboxPayloadRef(payloadRef) === item.id;
+    })
     .map((item) => item.id))];
   if (mailboxItemIds.length === 0) {
     return new Map<string, { payloadCiphertext: string }>();
@@ -339,43 +341,12 @@ async function readHostedLinqDirectInboundPayloads(input: {
       payloadCiphertext: true,
     },
     where: {
-      mailboxItem: buildHostedLinqDirectInboundLiveMailboxWhere(input.availableAt),
+      mailboxItem: buildHostedMailboxLiveItemWhere(input.availableAt),
       mailboxItemId: { in: mailboxItemIds },
       userId: input.memberId,
     },
   });
   return new Map(payloads.map((payload) => [payload.mailboxItemId, payload]));
-}
-
-function resolvesHostedMailboxPayloadRefToItem(
-  payloadRef: string | null,
-  mailboxItemId: string,
-): boolean {
-  const normalizedPayloadRef = normalizeNullable(payloadRef);
-  if (!normalizedPayloadRef) {
-    return false;
-  }
-  const resolvedMailboxItemId = normalizedPayloadRef.startsWith(
-    HOSTED_MAILBOX_PAYLOAD_REF_PREFIX,
-  )
-    ? normalizedPayloadRef.slice(HOSTED_MAILBOX_PAYLOAD_REF_PREFIX.length)
-    : normalizedPayloadRef;
-  return resolvedMailboxItemId === mailboxItemId;
-}
-
-function buildHostedLinqDirectInboundLiveMailboxWhere(at: Date): {
-  createdAt: { gte: Date };
-  OR: [{ expiresAt: null }, { expiresAt: { gt: Date } }];
-} {
-  return {
-    createdAt: {
-      gte: new Date(at.getTime() - HOSTED_LINQ_DIRECT_INBOUND_RETENTION_MS),
-    },
-    OR: [
-      { expiresAt: null },
-      { expiresAt: { gt: at } },
-    ],
-  };
 }
 
 async function assertHostedMemberLinqRouteMatchesEgressTarget(input: {

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -22,10 +22,10 @@ import {
   readHostedThreadRouteByThreadIdentity,
 } from "../hosted-routing/thread-route-store";
 import {
+  runWithHostedDomainRootUnwrapCache,
+} from "../hosted-crypto/domain-root-unwrap-cache";
+import {
   decodeHostedMailboxStoredPayload,
-  readHostedMailboxLiveItemById,
-  readHostedMailboxPayload,
-  readHostedMailboxRecentLiveConversationItemIds,
 } from "../hosted-mailbox/store";
 
 type HostedLinqEngagementClient = PrismaClient | Prisma.TransactionClient;
@@ -40,6 +40,27 @@ export type HostedLinqRuntimeEgressAssertionResult = {
 
 const HOSTED_LINQ_SIGNUP_WELCOME_IDEMPOTENCY_PREFIX = "signup-welcome:";
 const HOSTED_LINQ_RECENT_DIRECT_INBOUND_SCAN_LIMIT = 100;
+const HOSTED_LINQ_DIRECT_INBOUND_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const HOSTED_MAILBOX_PAYLOAD_REF_PREFIX = "hosted-mailbox-payload:";
+
+const HOSTED_LINQ_DIRECT_INBOUND_MAILBOX_ITEM_SELECT = {
+  createdAt: true,
+  dedupeKey: true,
+  expiresAt: true,
+  id: true,
+  kind: true,
+  lane: true,
+  laneSeq: true,
+  occurredAt: true,
+  payloadInlineCiphertext: true,
+  payloadRef: true,
+  payloadSchema: true,
+  userId: true,
+} satisfies Prisma.HostedMailboxItemSelect;
+
+type HostedLinqDirectInboundMailboxItem = Prisma.HostedMailboxItemGetPayload<{
+  select: typeof HOSTED_LINQ_DIRECT_INBOUND_MAILBOX_ITEM_SELECT;
+}>;
 
 export function assertHostedLinqRouteAuthorityMatchesTarget(input: {
   chatId: string | null | undefined;
@@ -161,85 +182,67 @@ async function matchesPersistedHostedLinqDirectInbound(input: {
   if (!target || !requestReplyToMessageId) {
     return false;
   }
-  for (let index = input.answeredMailboxItemIds.length - 1; index >= 0; index -= 1) {
-    const mailboxItemId = input.answeredMailboxItemIds[index];
-    if (
-      mailboxItemId
-      && await matchesPersistedHostedLinqDirectInboundMailboxItem({
-        mailboxItemId,
-        memberId: input.memberId,
-        prisma: input.prisma,
-        replyToMessageId: requestReplyToMessageId,
-        target,
-      })
-    ) {
-      return true;
-    }
-  }
 
-  const answeredMailboxItemIds = new Set(input.answeredMailboxItemIds);
-  const recentMailboxItemIds = await readHostedMailboxRecentLiveConversationItemIds({
-    availableAt: new Date(),
-    limit: HOSTED_LINQ_RECENT_DIRECT_INBOUND_SCAN_LIMIT,
-    prisma: input.prisma,
-    userId: input.memberId,
+  return runWithHostedDomainRootUnwrapCache(async () => {
+    const availableAt = new Date();
+    const candidates = await readHostedLinqDirectInboundCandidates({
+      answeredMailboxItemIds: input.answeredMailboxItemIds,
+      availableAt,
+      memberId: input.memberId,
+      prisma: input.prisma,
+    });
+    const payloadsByMailboxItemId = await readHostedLinqDirectInboundPayloads({
+      availableAt,
+      candidates,
+      memberId: input.memberId,
+      prisma: input.prisma,
+    });
+
+    for (const item of candidates) {
+      if (
+        await matchesPersistedHostedLinqDirectInboundMailboxItem({
+          item,
+          memberId: input.memberId,
+          payloadCiphertext:
+            payloadsByMailboxItemId.get(item.id)?.payloadCiphertext ?? null,
+          prisma: input.prisma,
+          replyToMessageId: requestReplyToMessageId,
+          target,
+        })
+      ) {
+        return true;
+      }
+    }
+
+    return false;
   });
-  for (const mailboxItemId of recentMailboxItemIds) {
-    if (
-      !answeredMailboxItemIds.has(mailboxItemId)
-      && await matchesPersistedHostedLinqDirectInboundMailboxItem({
-        mailboxItemId,
-        memberId: input.memberId,
-        prisma: input.prisma,
-        replyToMessageId: requestReplyToMessageId,
-        target,
-      })
-    ) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 async function matchesPersistedHostedLinqDirectInboundMailboxItem(input: {
-  mailboxItemId: string;
+  item: HostedLinqDirectInboundMailboxItem;
   memberId: string;
+  payloadCiphertext: string | null;
   prisma: HostedLinqEngagementClient;
   replyToMessageId: string;
   target: string;
 }): Promise<boolean> {
-  const item = await readHostedMailboxLiveItemById({
-    availableAt: new Date(),
-    mailboxItemId: input.mailboxItemId,
-    prisma: input.prisma,
-  });
+  const item = input.item;
   if (
-    !item
-    || item.userId !== input.memberId
+    item.userId !== input.memberId
     || item.kind !== "conversation.message"
     || item.lane !== "conversation"
   ) {
     return false;
   }
 
-  const payload = item.payloadRef
-    ? await readHostedMailboxPayload({
-        dedupeKey: item.dedupeKey,
-        mailboxItemId: item.id,
-        payloadRef: item.payloadRef,
-        prisma: input.prisma,
-        userId: item.userId,
-      })
-    : null;
   const decoded = await decodeHostedMailboxStoredPayload({
     dedupeKey: item.dedupeKey,
     kind: item.kind,
     lane: item.lane,
-    laneSeq: item.laneSeq,
+    laneSeq: item.laneSeq.toString(),
     mailboxItemId: item.id,
-    occurredAt: item.occurredAt,
-    payloadCiphertext: payload?.payloadCiphertext ?? null,
+    occurredAt: item.occurredAt.toISOString(),
+    payloadCiphertext: input.payloadCiphertext,
     payloadInlineCiphertext: item.payloadInlineCiphertext,
     payloadSchema: item.payloadSchema,
     prisma: input.prisma,
@@ -254,13 +257,125 @@ async function matchesPersistedHostedLinqDirectInboundMailboxItem(input: {
     wake.kind === "conversation.message"
     && wake.userId === input.memberId
     && wake.eventId === item.dedupeKey
-    && wake.occurredAt === item.occurredAt
+    && wake.occurredAt === item.occurredAt.toISOString()
     && wake.message.channel === "linq"
     && wake.message.linqMessage.isFromMe === false
     && wake.message.linqMessage.threadIsDirect === true
     && wake.message.linqMessage.chatId === input.target
     && wake.message.linqMessage.messageId === input.replyToMessageId
   );
+}
+
+async function readHostedLinqDirectInboundCandidates(input: {
+  answeredMailboxItemIds: readonly string[];
+  availableAt: Date;
+  memberId: string;
+  prisma: HostedLinqEngagementClient;
+}): Promise<HostedLinqDirectInboundMailboxItem[]> {
+  const answeredMailboxItemIds = input.answeredMailboxItemIds.filter(
+    (mailboxItemId) => mailboxItemId.length > 0,
+  );
+  const answeredRows = answeredMailboxItemIds.length > 0
+    ? await input.prisma.hostedMailboxItem.findMany({
+        select: HOSTED_LINQ_DIRECT_INBOUND_MAILBOX_ITEM_SELECT,
+        where: {
+          id: { in: [...new Set(answeredMailboxItemIds)] },
+          ...buildHostedLinqDirectInboundLiveMailboxWhere(input.availableAt),
+        },
+      })
+    : [];
+  const recentRows = await input.prisma.hostedMailboxItem.findMany({
+    orderBy: { laneSeq: "desc" },
+    select: HOSTED_LINQ_DIRECT_INBOUND_MAILBOX_ITEM_SELECT,
+    take: HOSTED_LINQ_RECENT_DIRECT_INBOUND_SCAN_LIMIT,
+    where: {
+      ...buildHostedLinqDirectInboundLiveMailboxWhere(input.availableAt),
+      kind: "conversation.message",
+      lane: "conversation",
+      userId: input.memberId,
+    },
+  });
+
+  const answeredRowsById = new Map(answeredRows.map((item) => [item.id, item]));
+  const candidates: HostedLinqDirectInboundMailboxItem[] = [];
+  for (let index = input.answeredMailboxItemIds.length - 1; index >= 0; index -= 1) {
+    const mailboxItemId = input.answeredMailboxItemIds[index];
+    const item = mailboxItemId ? answeredRowsById.get(mailboxItemId) : null;
+    if (item) {
+      candidates.push(item);
+    }
+  }
+
+  const answeredMailboxItemIdSet = new Set(input.answeredMailboxItemIds);
+  for (const item of recentRows) {
+    if (!answeredMailboxItemIdSet.has(item.id)) {
+      candidates.push(item);
+    }
+  }
+  return candidates;
+}
+
+async function readHostedLinqDirectInboundPayloads(input: {
+  availableAt: Date;
+  candidates: readonly HostedLinqDirectInboundMailboxItem[];
+  memberId: string;
+  prisma: HostedLinqEngagementClient;
+}) {
+  const mailboxItemIds = [...new Set(input.candidates
+    .filter((item) => (
+      item.userId === input.memberId
+      && item.kind === "conversation.message"
+      && item.lane === "conversation"
+      && resolvesHostedMailboxPayloadRefToItem(item.payloadRef, item.id)
+    ))
+    .map((item) => item.id))];
+  if (mailboxItemIds.length === 0) {
+    return new Map<string, { payloadCiphertext: string }>();
+  }
+
+  const payloads = await input.prisma.hostedMailboxPayload.findMany({
+    select: {
+      mailboxItemId: true,
+      payloadCiphertext: true,
+    },
+    where: {
+      mailboxItem: buildHostedLinqDirectInboundLiveMailboxWhere(input.availableAt),
+      mailboxItemId: { in: mailboxItemIds },
+      userId: input.memberId,
+    },
+  });
+  return new Map(payloads.map((payload) => [payload.mailboxItemId, payload]));
+}
+
+function resolvesHostedMailboxPayloadRefToItem(
+  payloadRef: string | null,
+  mailboxItemId: string,
+): boolean {
+  const normalizedPayloadRef = normalizeNullable(payloadRef);
+  if (!normalizedPayloadRef) {
+    return false;
+  }
+  const resolvedMailboxItemId = normalizedPayloadRef.startsWith(
+    HOSTED_MAILBOX_PAYLOAD_REF_PREFIX,
+  )
+    ? normalizedPayloadRef.slice(HOSTED_MAILBOX_PAYLOAD_REF_PREFIX.length)
+    : normalizedPayloadRef;
+  return resolvedMailboxItemId === mailboxItemId;
+}
+
+function buildHostedLinqDirectInboundLiveMailboxWhere(at: Date): {
+  createdAt: { gte: Date };
+  OR: [{ expiresAt: null }, { expiresAt: { gt: Date } }];
+} {
+  return {
+    createdAt: {
+      gte: new Date(at.getTime() - HOSTED_LINQ_DIRECT_INBOUND_RETENTION_MS),
+    },
+    OR: [
+      { expiresAt: null },
+      { expiresAt: { gt: at } },
+    ],
+  };
 }
 
 async function assertHostedMemberLinqRouteMatchesEgressTarget(input: {

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -29,7 +29,8 @@ vi.mock("@/src/lib/prisma", () => ({
   getPrisma: mocks.getPrisma,
 }));
 
-vi.mock("@/src/lib/hosted-mailbox/store", () => ({
+vi.mock("@/src/lib/hosted-mailbox/store", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/src/lib/hosted-mailbox/store")>(),
   decodeHostedMailboxStoredPayload: mocks.decodeHostedMailboxStoredPayload,
 }));
 

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -5,11 +5,9 @@ const mocks = vi.hoisted(() => ({
   acquireHostedMemberHomeLinqRouteLockTx: vi.fn(),
   getPrisma: vi.fn(),
   decodeHostedMailboxStoredPayload: vi.fn(),
-  readHostedMailboxLiveItemById: vi.fn(),
-  readHostedMailboxPayload: vi.fn(),
-  readHostedMailboxRecentLiveConversationItemIds: vi.fn(),
   requireHostedCloudflareCallbackRequest: vi.fn(),
   readHostedMemberRoutingPrivateState: vi.fn(),
+  runWithHostedDomainRootUnwrapCache: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-routing/linq-chat-ownership-lock", () => ({
@@ -33,10 +31,11 @@ vi.mock("@/src/lib/prisma", () => ({
 
 vi.mock("@/src/lib/hosted-mailbox/store", () => ({
   decodeHostedMailboxStoredPayload: mocks.decodeHostedMailboxStoredPayload,
-  readHostedMailboxLiveItemById: mocks.readHostedMailboxLiveItemById,
-  readHostedMailboxPayload: mocks.readHostedMailboxPayload,
-  readHostedMailboxRecentLiveConversationItemIds:
-    mocks.readHostedMailboxRecentLiveConversationItemIds,
+}));
+
+vi.mock("@/src/lib/hosted-crypto/domain-root-unwrap-cache", () => ({
+  runWithHostedDomainRootUnwrapCache:
+    mocks.runWithHostedDomainRootUnwrapCache,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/member-private-codecs", () => ({
@@ -62,9 +61,9 @@ describe("hosted Linq egress authority", () => {
     vi.clearAllMocks();
     mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue("member-1");
     mocks.decodeHostedMailboxStoredPayload.mockResolvedValue(null);
-    mocks.readHostedMailboxLiveItemById.mockResolvedValue(null);
-    mocks.readHostedMailboxPayload.mockResolvedValue(null);
-    mocks.readHostedMailboxRecentLiveConversationItemIds.mockResolvedValue([]);
+    mocks.runWithHostedDomainRootUnwrapCache.mockImplementation(
+      async (run: () => Promise<unknown>) => run(),
+    );
     mocks.readHostedMemberRoutingPrivateState.mockResolvedValue({
       linqChatId: null,
       linqRecipientPhone: null,
@@ -364,6 +363,7 @@ describe("hosted Linq egress authority", () => {
       mailboxItemId: "mailbox-current",
       messageId: "linq-message-current",
       occurredAt: "2026-07-14T00:02:47.000Z",
+      prisma,
       threadIsDirect: true,
     });
 
@@ -391,7 +391,7 @@ describe("hosted Linq egress authority", () => {
       prisma: asRuntimeEngagementPrisma(prisma),
       userId: "member-1",
     });
-    expect(mocks.readHostedMailboxPayload).not.toHaveBeenCalled();
+    expect(prisma.hostedMailboxPayload.findMany).not.toHaveBeenCalled();
   });
 
   it("allows retry authority from persisted answered mailbox ids without current inbound context", async () => {
@@ -404,6 +404,7 @@ describe("hosted Linq egress authority", () => {
       mailboxItemId: "mailbox-retry",
       messageId: "linq-message-retry",
       occurredAt: "2026-07-14T00:04:47.000Z",
+      prisma,
       threadIsDirect: true,
     });
     mocks.getPrisma.mockReturnValue(prisma);
@@ -429,11 +430,7 @@ describe("hosted Linq egress authority", () => {
       ok: true,
       threadIsDirect: true,
     });
-    expect(mocks.readHostedMailboxLiveItemById).toHaveBeenCalledWith({
-      availableAt: expect.any(Date),
-      mailboxItemId: "mailbox-retry",
-      prisma: expect.any(Object),
-    });
+    expect(prisma.hostedMailboxItem.findMany).toHaveBeenCalledTimes(2);
     expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
   });
 
@@ -447,11 +444,9 @@ describe("hosted Linq egress authority", () => {
       mailboxItemId: "mailbox-recovered",
       messageId: "linq-message-recovered",
       occurredAt: "2026-07-14T00:06:47.000Z",
+      prisma,
       threadIsDirect: true,
     });
-    mocks.readHostedMailboxRecentLiveConversationItemIds.mockResolvedValue([
-      "mailbox-recovered",
-    ]);
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       authorityCheckOnly: false,
@@ -462,11 +457,15 @@ describe("hosted Linq egress authority", () => {
       targetKind: "thread",
     })).resolves.toEqual({ targetOverride: null, threadIsDirect: true });
 
-    expect(mocks.readHostedMailboxRecentLiveConversationItemIds).toHaveBeenCalledWith({
-      availableAt: expect.any(Date),
-      limit: 100,
-      prisma: asRuntimeEngagementPrisma(prisma),
-      userId: "member-1",
+    expect(prisma.hostedMailboxItem.findMany).toHaveBeenCalledWith({
+      orderBy: { laneSeq: "desc" },
+      select: expect.any(Object),
+      take: 100,
+      where: expect.objectContaining({
+        kind: "conversation.message",
+        lane: "conversation",
+        userId: "member-1",
+      }),
     });
     expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
   });
@@ -481,11 +480,9 @@ describe("hosted Linq egress authority", () => {
       mailboxItemId: "mailbox-former-group",
       messageId: "linq-message-former-group",
       occurredAt: "2026-07-14T00:07:47.000Z",
+      prisma,
       threadIsDirect: false,
     });
-    mocks.readHostedMailboxRecentLiveConversationItemIds.mockResolvedValue([
-      "mailbox-former-group",
-    ]);
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       authorityCheckOnly: false,
@@ -498,6 +495,179 @@ describe("hosted Linq egress authority", () => {
       code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
       httpStatus: 403,
     });
+  });
+
+  it("batches the maximum answered and recent mailbox authority scan", async () => {
+    const prisma = createPrismaStub({
+      homeChatId: "chat-current-home",
+    });
+    const occurredAt = "2026-07-14T00:08:47.000Z";
+    const answeredMailboxItemIds = Array.from(
+      { length: 100 },
+      (_, index) => `mailbox-answered-${index}`,
+    );
+    const answeredRows = answeredMailboxItemIds.map((mailboxItemId, index) =>
+      buildPersistedLinqMailboxItem({
+        dedupeKey: `linq-event-answered-${index}`,
+        mailboxItemId,
+        occurredAt,
+        payloadRef: `hosted-mailbox-payload:${mailboxItemId}`,
+      }));
+    const recentRows = Array.from(
+      { length: 100 },
+      (_, index) => buildPersistedLinqMailboxItem({
+        dedupeKey: `linq-event-recent-${index}`,
+        mailboxItemId: `mailbox-recent-${index}`,
+        occurredAt,
+        payloadRef: `hosted-mailbox-payload:mailbox-recent-${index}`,
+      }),
+    );
+    const candidates = [...answeredRows].reverse().concat(recentRows);
+    prisma.hostedMailboxItem.findMany
+      .mockResolvedValueOnce(answeredRows)
+      .mockResolvedValueOnce(recentRows);
+    prisma.hostedMailboxPayload.findMany.mockResolvedValue(
+      candidates.map((item) => ({
+        mailboxItemId: item.id,
+        payloadCiphertext: `sidecar:${item.id}`,
+      })),
+    );
+
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      answeredMailboxItemIds,
+      authorityCheckOnly: false,
+      memberId: "member-1",
+      prisma: asRuntimeEngagementPrisma(prisma),
+      replyToMessageId: "linq-message-unmatched",
+      target: "chat-unmatched",
+      targetKind: "thread",
+    })).rejects.toMatchObject({
+      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
+      httpStatus: 403,
+    });
+
+    expect(prisma.hostedMailboxItem.findMany).toHaveBeenCalledTimes(2);
+    expect(prisma.hostedMailboxPayload.findMany).toHaveBeenCalledTimes(1);
+    expect(mocks.runWithHostedDomainRootUnwrapCache).toHaveBeenCalledTimes(1);
+    expect(prisma.hostedMailboxItem.findMany).toHaveBeenNthCalledWith(1, {
+      select: expect.any(Object),
+      where: {
+        createdAt: { gte: expect.any(Date) },
+        id: { in: answeredMailboxItemIds },
+        OR: [
+          { expiresAt: null },
+          { expiresAt: { gt: expect.any(Date) } },
+        ],
+      },
+    });
+    expect(prisma.hostedMailboxItem.findMany).toHaveBeenNthCalledWith(2, {
+      orderBy: { laneSeq: "desc" },
+      select: expect.any(Object),
+      take: 100,
+      where: {
+        createdAt: { gte: expect.any(Date) },
+        kind: "conversation.message",
+        lane: "conversation",
+        OR: [
+          { expiresAt: null },
+          { expiresAt: { gt: expect.any(Date) } },
+        ],
+        userId: "member-1",
+      },
+    });
+    expect(prisma.hostedMailboxPayload.findMany).toHaveBeenCalledWith({
+      select: {
+        mailboxItemId: true,
+        payloadCiphertext: true,
+      },
+      where: {
+        mailboxItem: {
+          createdAt: { gte: expect.any(Date) },
+          OR: [
+            { expiresAt: null },
+            { expiresAt: { gt: expect.any(Date) } },
+          ],
+        },
+        mailboxItemId: {
+          in: candidates.map((item) => item.id),
+        },
+        userId: "member-1",
+      },
+    });
+    expect(mocks.decodeHostedMailboxStoredPayload).toHaveBeenCalledTimes(200);
+    expect(mocks.decodeHostedMailboxStoredPayload.mock.calls.map(
+      ([decodeInput]) => decodeInput.mailboxItemId,
+    )).toEqual(candidates.map((item) => item.id));
+    expect(mocks.decodeHostedMailboxStoredPayload.mock.calls.map(
+      ([decodeInput]) => decodeInput.payloadCiphertext,
+    )).toEqual(candidates.map((item) => `sidecar:${item.id}`));
+
+    const answeredQuery = prisma.hostedMailboxItem.findMany.mock.calls[0][0];
+    const recentQuery = prisma.hostedMailboxItem.findMany.mock.calls[1][0];
+    const payloadQuery = prisma.hostedMailboxPayload.findMany.mock.calls[0][0];
+    expect(answeredQuery.where.createdAt.gte).toEqual(
+      recentQuery.where.createdAt.gte,
+    );
+    expect(answeredQuery.where.OR[1].expiresAt.gt).toBe(
+      recentQuery.where.OR[1].expiresAt.gt,
+    );
+    expect(payloadQuery.where.mailboxItem).toEqual({
+      createdAt: answeredQuery.where.createdAt,
+      OR: answeredQuery.where.OR,
+    });
+    expect(
+      answeredQuery.where.OR[1].expiresAt.gt.getTime()
+      - answeredQuery.where.createdAt.gte.getTime(),
+    ).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("keeps malformed refs outside payload reads and foreign rows outside decrypts", async () => {
+    const prisma = createPrismaStub({
+      homeChatId: "chat-current-home",
+    });
+    const malformedMemberItem = buildPersistedLinqMailboxItem({
+      dedupeKey: "linq-event-malformed-sidecar",
+      mailboxItemId: "mailbox-malformed-sidecar",
+      occurredAt: "2026-07-14T00:09:47.000Z",
+      payloadRef: "hosted-mailbox-payload:mailbox-other",
+    });
+    const foreignMemberItem = buildPersistedLinqMailboxItem({
+      dedupeKey: "linq-event-foreign-sidecar",
+      mailboxItemId: "mailbox-foreign-sidecar",
+      occurredAt: "2026-07-14T00:09:48.000Z",
+      payloadRef: "hosted-mailbox-payload:mailbox-foreign-sidecar",
+      userId: "member-2",
+    });
+    prisma.hostedMailboxItem.findMany
+      .mockResolvedValueOnce([malformedMemberItem, foreignMemberItem])
+      .mockResolvedValueOnce([]);
+
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      answeredMailboxItemIds: [
+        foreignMemberItem.id,
+        malformedMemberItem.id,
+      ],
+      authorityCheckOnly: false,
+      memberId: "member-1",
+      prisma: asRuntimeEngagementPrisma(prisma),
+      replyToMessageId: "linq-message-unmatched",
+      target: "chat-unmatched",
+      targetKind: "thread",
+    })).rejects.toMatchObject({
+      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
+      httpStatus: 403,
+    });
+
+    expect(prisma.hostedMailboxPayload.findMany).not.toHaveBeenCalled();
+    expect(mocks.decodeHostedMailboxStoredPayload).toHaveBeenCalledTimes(1);
+    expect(mocks.decodeHostedMailboxStoredPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mailboxItemId: malformedMemberItem.id,
+        payloadCiphertext: null,
+        payloadInlineCiphertext: null,
+        userId: "member-1",
+      }),
+    );
   });
 
   it.each([
@@ -572,6 +742,7 @@ describe("hosted Linq egress authority", () => {
       mailboxItemId: "mailbox-current",
       messageId: persistedMessageId,
       occurredAt: "2026-07-14T00:02:47.000Z",
+      prisma,
       threadIsDirect,
       userId: mailboxUserId,
     });
@@ -962,6 +1133,12 @@ function createPrismaStub(input: {
         telegramUserIdEncrypted: null,
       }),
     },
+    hostedMailboxItem: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    hostedMailboxPayload: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
     hostedThreadRoute: {
       findMany: vi.fn().mockResolvedValue(input.threadRouteContainerMemberId
         ? [buildHostedLinqRouteRow(input.threadRouteContainerMemberId)]
@@ -990,27 +1167,19 @@ function mockPersistedLinqInbound(input: {
   mailboxItemId: string;
   messageId: string;
   occurredAt: string;
+  prisma: ReturnType<typeof createPrismaStub>;
   threadIsDirect: boolean | null;
   userId?: string;
 }) {
   const userId = input.userId ?? "member-1";
-  mocks.readHostedMailboxLiveItemById.mockResolvedValue({
-    consumedAt: null,
-    createdAt: input.occurredAt,
-    dedupeKey: input.dedupeKey,
-    expiresAt: null,
-    id: input.mailboxItemId,
-    kind: "conversation.message",
-    lane: "conversation",
-    laneSeq: "1",
-    occurredAt: input.occurredAt,
-    payloadBytes: 1,
-    payloadInlineCiphertext: "encrypted-mailbox-payload",
-    payloadRef: null,
-    payloadSchema: "murph.hosted-mailbox-item-payload.v1",
-    updatedAt: input.occurredAt,
-    userId,
-  });
+  input.prisma.hostedMailboxItem.findMany.mockResolvedValue([
+    buildPersistedLinqMailboxItem({
+      dedupeKey: input.dedupeKey,
+      mailboxItemId: input.mailboxItemId,
+      occurredAt: input.occurredAt,
+      userId,
+    }),
+  ]);
   mocks.decodeHostedMailboxStoredPayload.mockResolvedValue({
     eventId: input.dedupeKey,
     kind: "conversation.message",
@@ -1039,6 +1208,31 @@ function mockPersistedLinqInbound(input: {
     occurredAt: input.occurredAt,
     userId,
   });
+}
+
+function buildPersistedLinqMailboxItem(input: {
+  dedupeKey: string;
+  mailboxItemId: string;
+  occurredAt: string;
+  payloadRef?: string | null;
+  userId?: string;
+}) {
+  return {
+    createdAt: new Date(input.occurredAt),
+    dedupeKey: input.dedupeKey,
+    expiresAt: null,
+    id: input.mailboxItemId,
+    kind: "conversation.message",
+    lane: "conversation",
+    laneSeq: 1n,
+    occurredAt: new Date(input.occurredAt),
+    payloadInlineCiphertext: input.payloadRef
+      ? null
+      : "encrypted-mailbox-payload",
+    payloadRef: input.payloadRef ?? null,
+    payloadSchema: "murph.hosted-mailbox-item-payload.v1",
+    userId: input.userId ?? "member-1",
+  };
 }
 
 function buildHostedLinqRouteRow(containerMemberId: string) {


### PR DESCRIPTION
## Why

Linq reply-authority checks could issue 401 database operations for 200 inline candidates or 801 for 200 sidecar candidates while member/chat locks were held. The repeated item, sidecar, crypto-envelope, and KMS work made a legitimate retry path capable of saturating the database pool.

## Goal and flow

Keep the Linq egress contract unchanged: validate the active member and route, inspect answered mailbox evidence newest-first, then recent direct-message evidence newest-first, and authorize only an exact direct inbound reply anchor. The implementation now fetches the bounded evidence set in batches and reuses it during ordered decoding. There is no user-facing UI change.

## Invariants

- Preserve the existing transaction and member/chat lock ordering.
- Preserve answered-id reverse priority, recent `laneSeq` descending priority, and first-match short circuiting.
- Preserve the mailbox owner’s live retention/expiry filtering and exact sidecar-ref binding.
- Fail closed for foreign members, wrong lanes/kinds, groups, unknown directness, wrong targets/messages, and malformed evidence.
- Never log or expose mailbox content, ciphertext, identifiers, SQL, or query arguments.

## What changed

- Batch answered rows and the bounded 100-row recent scan into at most two mailbox-item reads.
- Batch eligible sidecars into one payload read and reuse the fetched rows.
- Decode the ordered candidates inside one bounded hosted-domain-root unwrap cache scope.
- Add max-cardinality query-shape, ordering, cache, live-row, sidecar-ref, and foreign-member regressions.

## Non-obvious affected surfaces

`apps/web/src/lib/hosted-mailbox/store.ts` now exports its two existing pure mailbox-policy helpers so Linq batching reuses the canonical retention predicate and payload-ref resolver. Their bodies and store behavior are unchanged. This symbol-only overlap with the active Mailbox consumed-at Part 1a lane was explicitly coordinated before editing.

## Verification

- Focused Linq engagement suite: 32/32 passed on the reconciled first head.
- Mailbox-owner plus Linq route suites after ReviewGPT remediation: 83/83 passed.
- Capped `pnpm test:diff` owner lane: web typecheck, lint, dev smoke, production build, and 5,212 tests passed with 141 skipped.
- Required `coverage-write`: PASS with no unresolved actionable proof gaps.
- Remediation scoped ESLint, regenerated-client web typecheck, and `git diff --check`: PASS.

## ReviewGPT resolution

Round 1 accepted one complexity finding: the first patch duplicated mailbox retention and payload-ref policy in the Linq owner. The correction exports and reuses the existing mailbox-owner helpers, deleting the local constants and policy functions. The remediation delta is 15 production additions and 44 production deletions (net -29 authored source lines), plus a 2-addition/1-deletion test-mock update.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 148 | 62 |
| Tests | 240 | 45 |
| Docs/plan | 101 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 03a2ec22c36eb2499b28a7d2724020efaf6dc8fd

| Review round | Current head | Scope |
| --- | --- | --- |
| 1 | `03a2ec22c36eb2499b28a7d2724020efaf6dc8fd` | Full patch |
| 2 | `509dc172ed2d13f1a1191e16ca96977ad6676612` | Correction: shared mailbox policy ownership |