### PR TITLE
docs: archive hosted ChatGPT provider fix plan

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-hosted-chatgpt-provider-validation.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-hosted-chatgpt-provider-validation.md
@@ -1,0 +1,46 @@
+Goal (incl. success criteria):
+- Restore hosted Telegram welcome and foreground replies when local hosted execution uses ChatGPT subscription auth.
+- Success means the generated `hosted-chatgpt-openai` provider id passes the shared Codex provider validation boundary and remains backed by the prewritten hosted Codex config.
+
+Constraints/Assumptions:
+- Preserve ChatGPT subscription auth and the existing generated provider transport configuration.
+- Preserve API-key, local-test, and other registered provider behavior.
+- Do not add queues, retries, fallback providers, persisted state, or schema changes.
+- Keep runtime diagnostics secret-safe.
+
+Key decisions:
+- Define the internal hosted ChatGPT provider id once in operator config, which owns provider validation.
+- Reuse that shared constant when the hosted runtime writes Codex configuration.
+- Cover both session option validation and provider override resolution so the exact pre-Codex failure boundary cannot regress.
+
+State:
+- Completed.
+
+Done:
+- Proved Telegram ingress, mailbox persistence, Temporal signaling, and workspace staging were healthy.
+- Proved assistant execution failed before Codex startup because `hosted-chatgpt-openai` was absent from the shared reserved-provider set.
+- Registered the internal provider id at the shared operator-config validation boundary and reused that owner constant in hosted runtime Codex config generation.
+- Added focused regression coverage for session serialization, provider override resolution, and hosted runtime target normalization.
+- Passed focused package tests, affected package typechecks, and the required coverage-write audit.
+- Ran diff-aware verification; all affected suites passed except an unchanged assistant-engine timeout under concurrent load whose initiating test passed in isolation.
+- Restarted the preserved local stack on the patched commit and proved the queued Telegram wake resumed, assistant execution completed, and Telegram accepted outbound delivery with HTTP 200.
+
+Now:
+- None.
+
+Next:
+- Push the task branch, open the PR, and complete the required ReviewGPT and CI gates.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/operator-config/src/assistant/target-runtime.ts
+- packages/operator-config/test/assistant-provider-config-normalization.test.ts
+- packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+- packages/assistant-runtime/test/hosted-runtime-codex-local-provider-target.test.ts
+- packages/assistant-engine/test/codex-provider-overrides.test.ts
+- pnpm test:diff
+Status: completed
+Updated: 2026-07-15
+Completed: 2026-07-15


### PR DESCRIPTION
# Why this exists

The hosted ChatGPT provider validation fix landed directly on the default branch before normal PR closeout. This follow-up preserves the execution record and verification evidence without presenting a documentation-only diff as the implementation review.

# User-visible goal and UX

Telegram signup welcomes and inbound messages must reach the hosted assistant, pass provider validation, run the model, and deliver the reply back to the same Telegram thread.

# Invariants

- Unknown Codex provider ids continue to fail closed.
- The hosted ChatGPT internal provider remains backed by the generated Codex configuration.
- Telegram ingress, durable mailbox handling, and delivery semantics are unchanged.
- No secrets, credentials, identifiers, schema changes, or persisted-state changes are introduced.

# Non-obvious and affected surfaces

- This PR changes only the completed execution-plan record.
- The implementation is already on the default branch in commit 479ee38088.
- Local runtime proof resumed the queued wake, completed assistant passes, and received successful Telegram delivery responses.

# Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests | 0 | 0 |
| Docs | 46 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

# Deployment

No deployment is required for this documentation-only PR. The implementation affects the hosted Cloudflare runner bundle; default-branch build and deployment checks are already running for the implementation commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786760951&installation_id=127572939&pr_number=734&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F734&signature=d963b2c5958979729ab6a2446cbcfa37338610cec5742384e0ec283186dab2e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->