### PR TITLE
fix(hosted): upload canonical artifacts concurrently

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-15-canonical-artifact-upload-concurrency.md
+++ b/agent-docs/exec-plans/completed/2026-07-15-canonical-artifact-upload-concurrency.md
@@ -1,0 +1,118 @@
+# Canonical artifact upload concurrency
+
+Status: completed
+Created: 2026-07-15
+Updated: 2026-07-15
+
+## Goal
+
+- Remove avoidable foreground reply latency from hosted canonical-write
+  persistence without weakening its durability, rollback, or recovery
+  guarantees.
+
+## Success criteria
+
+- A canonical write prepares and validates its complete immutable artifact set
+  before starting any upload.
+- Payload, receipt, and receipt-log objects upload with one small fixed
+  concurrency bound; the recovery pointer is published only after every
+  required upload succeeds.
+- If any upload fails, all started uploads settle, no recovery pointer is
+  published, and the existing `WriteBatch` failure path remains authoritative
+  for local rollback.
+- Focused tests prove concurrent start, bounded scheduling, failure draining,
+  validation-before-upload, and checkpoint ordering.
+- Required verification, coverage audit, green CI, and the exact-head
+  ReviewGPT loop complete with no accepted findings.
+
+## Scope
+
+- In scope: the assistant-runtime canonical receipt-log upload owner, its
+  workspace-runner call site, focused tests, and the hosted-runtime protocol
+  description of the publication barrier.
+- Out of scope: background persistence, new queues or state owners, Codex
+  process prewarming, artifact-store transport changes, schema changes, and
+  unrelated foreground reply work.
+
+## Constraints
+
+- Preserve the synchronous canonical-write commit barrier and status-only
+  checkpoint CAS.
+- Add no dependency, configuration knob, retry loop, compatibility layer, or
+  lifecycle state.
+- Keep the implementation local to the existing receipt-log owner and use a
+  fixed internal bound.
+- Work only on `codex/canonical-artifact-upload-concurrency` in the isolated
+  worktree; preserve unrelated active lanes and primary-checkout changes.
+
+## Risks and mitigations
+
+1. Risk: publishing the log pointer before a referenced payload or receipt is
+   durable would make cold recovery incomplete.
+   Mitigation: return the log ref only after the complete upload barrier
+   succeeds; keep checkpoint publication at the existing caller boundary.
+2. Risk: fail-fast promises could leave escaped network work after local
+   rollback begins.
+   Mitigation: settle every upload in the active bounded wave before surfacing
+   its first failure, and do not schedule later waves after failure.
+3. Risk: unconstrained fanout could trade latency for memory or connection
+   pressure on unusually large writes.
+   Mitigation: use one fixed small batch size and prove later waves do not start
+   early.
+
+## Tasks
+
+1. Register the isolated lane and trace current write, checkpoint, rollback,
+   restore, and artifact-store boundaries.
+2. Move the complete artifact upload set into the existing receipt-log owner
+   and add bounded concurrent upload with settled-wave failure handling.
+3. Add focused deterministic tests for concurrency and publication ordering.
+4. Run scoped verification, the required coverage-write audit, and parent
+   architecture/failure-path review; resolve accepted findings.
+5. Close the plan with a scoped commit, push, open the intent-complete PR, and
+   run CI plus ReviewGPT to completion.
+
+## Decisions
+
+- Keep persistence synchronous. Backgrounding would let a reply escape before
+  the canonical mutation is durably recoverable and would bypass the existing
+  `WriteBatch` rollback contract.
+- Do not prewarm the app server in this change. That would require a separate
+  prepared-turn/process-reservation lifecycle and is not needed to remove the
+  measured sequential artifact-upload cost.
+- Upload the receipt-log object in the same unpublished artifact wave as its
+  referenced objects. Until the existing status checkpoint publishes its hash,
+  any partial success is unreachable content-addressed residue, not product
+  truth.
+
+## Audit outcomes
+
+- The required independent `coverage-write` pass found no unresolved gap. It
+  strengthened the failed-wave test so all eight started uploads must drain and
+  the deferred ninth upload must remain unscheduled.
+- The first full package run exposed a stale sequential assumption in the
+  existing host-abort regression: it checked a shared upload count after an
+  await. Capturing the per-call ordinal before the await restores the intended
+  concurrent proof; the entrypoint still commits the receipt checkpoint and
+  preserves the canonical write before surfacing the host abort.
+- Parent final review found no additional owner, lifecycle, retry, schema,
+  compatibility, or deployment coupling. The change remains one private
+  upload helper plus a smaller runner call site.
+
+## Verification
+
+- `pnpm --dir packages/assistant-runtime exec vitest run --config
+  vitest.config.ts --isolate=true --no-coverage
+  test/hosted-runtime-canonical-write-receipt-log.test.ts
+  test/hosted-runtime-workspace-runner.test.ts`: 109 passed.
+- Focused host-abort entrypoint regression: 1 passed, 223 skipped.
+- `pnpm test:diff` over the two production files, three focused test files, and
+  protocol doc: assistant-runtime 74 files / 1,718 passed / 2 skipped;
+  Cloudflare reverse-dependent verification 105 files / 1,833 passed.
+- `git diff --check`, identifier-path scan, banned-cast scan, hosted Temporal,
+  crypto, log-payload, dependency, workspace-boundary, and package typechecks:
+  passed.
+- Remaining external gates after the scoped commit: exact pushed-head PR
+  preflight, ReviewGPT round(s), PR CI, and mergeability proof against latest
+  `main`.
+Completed: 2026-07-15

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1023,8 +1023,11 @@ or artifact-sidecar v2 producers. `idle_shutdown` is the only new checkpoint
 snapshot producer. `canonical_runtime_commit` instead uploads exact canonical
 write receipts and publishes a receipt-log ref, bounded to 64 pending entries
 and 64 KiB, through a status-only workspace checkpoint that retains the prior
-snapshot ref. Capacity and log shape are validated before referenced payloads
-are uploaded. If that checkpoint has an ambiguous transport outcome, the
+snapshot ref. Capacity, log shape, and payload lengths are validated before
+upload. The complete immutable payload, receipt, and log artifact set then
+uploads in small fixed concurrent waves; every started wave settles before a
+failure returns, and the checkpoint publishes the log ref only after the whole
+set succeeds. If that checkpoint has an ambiguous transport outcome, the
 Cloudflare workspace port retries the identical expected-version CAS once. It
 accepts a version-conflict response only when the active invocation fence still
 matches and the returned workspace is the exact requested successor, including

--- a/packages/assistant-runtime/src/hosted-runtime/canonical-write-receipt-log.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/canonical-write-receipt-log.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import type {
   HostedCanonicalWriteReceipt,
   HostedCanonicalWriteReceiptContentRef,
+  HostedCanonicalWritePayload,
 } from "@murphai/core";
 import {
   HOSTED_CANONICAL_WRITE_RECEIPT_LOG_BYTE_SIZE_STATUS_KEY,
@@ -18,6 +19,7 @@ import type {
 } from "./platform.ts";
 
 const HOSTED_CANONICAL_WRITE_RECEIPT_LOG_SCHEMA = "murph.hosted-canonical-write-receipt-log.v1";
+const HOSTED_CANONICAL_WRITE_ARTIFACT_UPLOAD_CONCURRENCY = 8;
 export const HOSTED_CANONICAL_WRITE_RECEIPT_LOG_MAX_ENTRIES = 64;
 export const HOSTED_CANONICAL_WRITE_RECEIPT_LOG_MAX_BYTES = 64 * 1024;
 const LEGACY_LOG_COUNT_STATUS_KEY = "hostedCanonicalWriteReceiptLogEntryCount";
@@ -43,7 +45,7 @@ export interface HostedCanonicalWriteReceiptRecoveryWake {
 
 export async function appendHostedCanonicalWriteReceiptToArtifactLog(input: {
   artifactStore: HostedRuntimeArtifactStore;
-  beforeReceiptUpload?: () => Promise<void>;
+  payloads: readonly HostedCanonicalWritePayload[];
   previousStatus: HostedRuntimeRedactedJson | null | undefined;
   receipt: HostedCanonicalWriteReceipt;
 }): Promise<HostedCanonicalWriteReceiptLogUpdate> {
@@ -66,18 +68,58 @@ export async function appendHostedCanonicalWriteReceiptToArtifactLog(input: {
   if (logArtifact.bytes.byteLength > HOSTED_CANONICAL_WRITE_RECEIPT_LOG_MAX_BYTES) {
     throw new Error("Hosted canonical write receipt log exceeds its size limit.");
   }
-  await input.beforeReceiptUpload?.();
-  await input.artifactStore.put({
-    bytes: receiptArtifact.bytes,
-    sha256: receiptArtifact.ref.sha256,
-  });
-  await input.artifactStore.put({
-    bytes: logArtifact.bytes,
-    sha256: logArtifact.ref.sha256,
+  for (const payload of input.payloads) {
+    if (payload.bytes.byteLength !== payload.byteLength) {
+      throw new TypeError(
+        "Hosted canonical write payload length does not match its receipt.",
+      );
+    }
+  }
+  await uploadHostedCanonicalWriteArtifacts({
+    artifacts: [
+      ...input.payloads.map((payload) => ({
+        bytes: payload.bytes,
+        sha256: payload.sha256,
+      })),
+      {
+        bytes: receiptArtifact.bytes,
+        sha256: receiptArtifact.ref.sha256,
+      },
+      {
+        bytes: logArtifact.bytes,
+        sha256: logArtifact.ref.sha256,
+      },
+    ],
+    artifactStore: input.artifactStore,
   });
   return {
     logRef: logArtifact.ref,
   };
+}
+
+async function uploadHostedCanonicalWriteArtifacts(input: {
+  artifacts: readonly {
+    bytes: Uint8Array;
+    sha256: string;
+  }[];
+  artifactStore: HostedRuntimeArtifactStore;
+}): Promise<void> {
+  for (
+    let offset = 0;
+    offset < input.artifacts.length;
+    offset += HOSTED_CANONICAL_WRITE_ARTIFACT_UPLOAD_CONCURRENCY
+  ) {
+    const results = await Promise.allSettled(
+      input.artifacts
+        .slice(offset, offset + HOSTED_CANONICAL_WRITE_ARTIFACT_UPLOAD_CONCURRENCY)
+        .map((artifact) => input.artifactStore.put(artifact)),
+    );
+    for (const result of results) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+    }
+  }
 }
 
 export function hostedCanonicalWriteReceiptLogStatusFields(

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -2528,21 +2528,7 @@ function createHostedWorkspaceCanonicalWritePort(input: {
         }
         const receiptLogUpdate = await appendHostedCanonicalWriteReceiptToArtifactLog({
           artifactStore: input.input.platform.artifactStore,
-          beforeReceiptUpload: async () => {
-            for (const payload of writeInput.payloads) {
-              if (payload.bytes.byteLength !== payload.byteLength) {
-                throw new TypeError(
-                  "Hosted canonical write payload length does not match its receipt.",
-                );
-              }
-            }
-            for (const payload of writeInput.payloads) {
-              await input.input.platform.artifactStore.put({
-                bytes: payload.bytes,
-                sha256: payload.sha256,
-              });
-            }
-          },
+          payloads: writeInput.payloads,
           previousStatus: input.readPreviousRedactedStatus(),
           receipt: writeInput.receipt,
         });

--- a/packages/assistant-runtime/test/hosted-runtime-canonical-write-receipt-log.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-canonical-write-receipt-log.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 
 import { test } from "vitest";
-import type { HostedCanonicalWriteReceipt } from "@murphai/core";
+import type {
+  HostedCanonicalWritePayload,
+  HostedCanonicalWriteReceipt,
+} from "@murphai/core";
 
 import {
   appendHostedCanonicalWriteReceiptToArtifactLog,
@@ -27,6 +30,7 @@ test("hosted canonical receipt log accepts the final bounded entry", async () =>
 
   const update = await appendHostedCanonicalWriteReceiptToArtifactLog({
     artifactStore,
+    payloads: [],
     previousStatus: createReceiptLogStatus(seeded),
     receipt: createReceipt(),
   });
@@ -45,14 +49,11 @@ test("hosted canonical receipt log rejects an additional pending entry before up
   const { artifactStore, putCalls } = createHostedRuntimeArtifactStoreStub({
     [seeded.sha256]: seeded.bytes,
   });
-  let beforeReceiptUploadCalls = 0;
 
   await assert.rejects(
     appendHostedCanonicalWriteReceiptToArtifactLog({
       artifactStore,
-      beforeReceiptUpload: async () => {
-        beforeReceiptUploadCalls += 1;
-      },
+      payloads: [createPayload(0)],
       previousStatus: createReceiptLogStatus(seeded),
       receipt: createReceipt(),
     }),
@@ -61,7 +62,133 @@ test("hosted canonical receipt log rejects an additional pending entry before up
       && error.message === "Hosted canonical write receipt log reached its pending entry limit."
     ),
   );
-  assert.equal(beforeReceiptUploadCalls, 0);
+  assert.equal(putCalls.length, 0);
+});
+
+test("hosted canonical receipt log starts a five-object artifact set concurrently", async () => {
+  const payloads = [createPayload(0), createPayload(1), createPayload(2)];
+  const putCalls: string[] = [];
+  let releaseUploads!: () => void;
+  const uploadsReleased = new Promise<void>((resolve) => {
+    releaseUploads = resolve;
+  });
+
+  const append = appendHostedCanonicalWriteReceiptToArtifactLog({
+    artifactStore: {
+      async get() {
+        return null;
+      },
+      async put(artifact) {
+        putCalls.push(artifact.sha256);
+        await uploadsReleased;
+      },
+    },
+    payloads,
+    previousStatus: null,
+    receipt: createReceipt(payloads),
+  });
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(putCalls.length, 5);
+  releaseUploads();
+  await append;
+});
+
+test("hosted canonical receipt log limits artifact upload fanout to eight", async () => {
+  const payloads = Array.from({ length: 7 }, (_, index) => createPayload(index));
+  const putCalls: string[] = [];
+  let releaseFirstWave!: () => void;
+  let releaseSecondWave!: () => void;
+  const firstWaveReleased = new Promise<void>((resolve) => {
+    releaseFirstWave = resolve;
+  });
+  const secondWaveReleased = new Promise<void>((resolve) => {
+    releaseSecondWave = resolve;
+  });
+
+  const append = appendHostedCanonicalWriteReceiptToArtifactLog({
+    artifactStore: {
+      async get() {
+        return null;
+      },
+      async put(artifact) {
+        putCalls.push(artifact.sha256);
+        await (putCalls.length <= 8 ? firstWaveReleased : secondWaveReleased);
+      },
+    },
+    payloads,
+    previousStatus: null,
+    receipt: createReceipt(payloads),
+  });
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(putCalls.length, 8);
+  releaseFirstWave();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(putCalls.length, 9);
+  releaseSecondWave();
+  await append;
+});
+
+test("hosted canonical receipt log drains a failed wave without scheduling the next wave", async () => {
+  const payloads = Array.from({ length: 7 }, (_, index) => createPayload(index));
+  const putCalls: string[] = [];
+  let releaseSuccessfulUploads!: () => void;
+  const successfulUploadsReleased = new Promise<void>((resolve) => {
+    releaseSuccessfulUploads = resolve;
+  });
+  let settled = false;
+
+  const completion = appendHostedCanonicalWriteReceiptToArtifactLog({
+    artifactStore: {
+      async get() {
+        return null;
+      },
+      async put(artifact) {
+        putCalls.push(artifact.sha256);
+        if (putCalls.length === 1) {
+          throw new Error("Synthetic canonical artifact upload failure.");
+        }
+        await successfulUploadsReleased;
+      },
+    },
+    payloads,
+    previousStatus: null,
+    receipt: createReceipt(payloads),
+  }).then(
+    () => {
+      settled = true;
+      return null;
+    },
+    (error: unknown) => {
+      settled = true;
+      return error;
+    },
+  );
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(putCalls.length, 8);
+  assert.equal(settled, false);
+  releaseSuccessfulUploads();
+  const error = await completion;
+  assert.ok(error instanceof Error);
+  assert.equal(error.message, "Synthetic canonical artifact upload failure.");
+  assert.equal(putCalls.length, 8);
+});
+
+test("hosted canonical receipt log validates every payload before upload", async () => {
+  const payload = createPayload(0);
+  const { artifactStore, putCalls } = createHostedRuntimeArtifactStoreStub();
+
+  await assert.rejects(
+    appendHostedCanonicalWriteReceiptToArtifactLog({
+      artifactStore,
+      payloads: [{ ...payload, byteLength: payload.byteLength + 1 }],
+      previousStatus: null,
+      receipt: createReceipt([payload]),
+    }),
+    /payload length does not match its receipt/u,
+  );
   assert.equal(putCalls.length, 0);
 });
 
@@ -112,9 +239,21 @@ test("hosted canonical receipt recovery preserves and clears the prior wake mark
   assert.equal(omitHostedCanonicalWriteReceiptLogStatusFields(status), null);
 });
 
-function createReceipt(): HostedCanonicalWriteReceipt {
+function createReceipt(
+  payloads: readonly HostedCanonicalWritePayload[] = [],
+): HostedCanonicalWriteReceipt {
   return {
-    actions: [],
+    actions: payloads.map((payload, index) => ({
+      byteLength: payload.byteLength,
+      contentRef: {
+        byteSize: payload.byteLength,
+        sha256: payload.sha256,
+      },
+      effect: "create",
+      kind: "text_upsert",
+      sha256: payload.sha256,
+      targetRelativePath: `bank/bounded-receipt-log-${index}.md`,
+    })),
     committedAt: "2026-07-09T00:00:00.000Z",
     createdAt: "2026-07-09T00:00:00.000Z",
     occurredAt: "2026-07-09T00:00:00.000Z",
@@ -123,6 +262,15 @@ function createReceipt(): HostedCanonicalWriteReceipt {
     schema: "murph.hosted-canonical-write-receipt.v1",
     summary: "Exercise the bounded hosted receipt log.",
     updatedAt: "2026-07-09T00:00:00.000Z",
+  };
+}
+
+function createPayload(index: number): HostedCanonicalWritePayload {
+  const bytes = new TextEncoder().encode(`payload-${index}\n`);
+  return {
+    byteLength: bytes.byteLength,
+    bytes,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
   };
 }
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -19472,9 +19472,9 @@ describe("hosted workspace runtime entrypoint", () => {
       const putArtifact = platform.artifactStore.put;
       let artifactPutCount = 0;
       platform.artifactStore.put = async (artifact) => {
-        artifactPutCount += 1;
+        const artifactPutOrdinal = ++artifactPutCount;
         await putArtifact(artifact);
-        if (artifactPutCount === 1 && !abortController.signal.aborted) {
+        if (artifactPutOrdinal === 1 && !abortController.signal.aborted) {
           abortController.abort(abortReason);
         }
       };

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -3188,6 +3188,91 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
     }
   });
 
+  test("rolls back a canonical write without checkpointing when artifact upload fails", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-runner-"));
+    await initializeVault({
+      createdAt: new Date(TEST_NOW),
+      timezone: "UTC",
+      title: "Hosted Workspace Runner Failed Artifact Upload Test Vault",
+      vaultRoot,
+    });
+    const artifactPutCalls: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const { mailboxPort } = createMailboxPort({ items: [] });
+    let checkpointAttempted = false;
+
+    try {
+      await assert.rejects(
+        runHostedWorkspaceUntilIdleOrBudget({
+          async checkpointRuntimeRedactedStatus() {
+            checkpointAttempted = true;
+            throw new Error("Artifact upload failure must prevent checkpointing.");
+          },
+          checkpointRequestBuilder: createHostedWorkspaceCheckpointRequestBuilder({
+            attemptId: "attempt_synthetic_runner_failed_artifact_upload",
+            expectedWorkspaceVersion: "0",
+            leaseGeneration: "1",
+            nextWakeAt: null,
+            nextWakeReason: null,
+            snapshotRef: null,
+          }),
+          expectedUserId: TEST_USER_ID,
+          async importItem() {
+            throw new Error("Initial mailbox import was already provided.");
+          },
+          initialMailboxImport: createDeferredMailboxImportResult(),
+          limitPerLane: 10,
+          platform: createPlatform({
+            async artifactPut() {
+              throw new Error("Synthetic canonical artifact upload failure.");
+            },
+            artifactPutCalls,
+            mailboxPort,
+            workspacePort: createWorkspacePort({ checkpointRequests }),
+          }),
+          requestId: "request_synthetic_runner_failed_artifact_upload",
+          async runAssistantPhase() {
+            await applyCanonicalWriteBatch({
+              audit: {
+                action: "experiment_update",
+                commandName: "test.failedArtifactUpload",
+                summary: "Synthetic canonical write with failed artifact upload.",
+              },
+              operationType: "failed_artifact_upload_test",
+              summary: "Synthetic canonical write with failed artifact upload",
+              textWrites: [
+                {
+                  content: "must roll back\n",
+                  overwrite: true,
+                  relativePath: "bank/failed-artifact-upload.md",
+                },
+              ],
+              vaultRoot,
+            });
+            return {
+              checkpointReason: "canonical_runtime_commit",
+              progressed: true,
+            };
+          },
+          vaultRoot,
+          workspace: createWorkspaceState({ version: "0" }),
+          now: () => TEST_NOW,
+        }),
+        /Synthetic canonical artifact upload failure/u,
+      );
+
+      assert.equal(artifactPutCalls.length >= 3, true);
+      assert.equal(checkpointAttempted, false);
+      assert.deepEqual(checkpointRequests, []);
+      await assert.rejects(readFile(path.join(vaultRoot, "bank", "failed-artifact-upload.md")));
+    } finally {
+      await rm(vaultRoot, {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
   test("checkpoints canonical writes performed while importing mailbox items", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-runner-"));
     await initializeVault({
@@ -8464,6 +8549,7 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
 function createPlatform(input: {
   artifactBytesByHash?: ReadonlyMap<string, Uint8Array>;
   artifactGetCalls?: string[];
+  artifactPut?: (artifact: { bytes: Uint8Array; sha256: string }) => Promise<void>;
   artifactPutCalls?: string[];
   effectsPort?: Partial<HostedRuntimeEffectsPort>;
   logRequests?: HostedRuntimeLogRequest[];
@@ -8478,9 +8564,9 @@ function createPlatform(input: {
         input.artifactGetCalls?.push(sha256);
         return input.artifactBytesByHash?.get(sha256) ?? null;
       },
-      async put(artifact: { sha256: string }) {
+      async put(artifact: { bytes: Uint8Array; sha256: string }) {
         input.artifactPutCalls?.push(artifact.sha256);
-        return undefined;
+        await input.artifactPut?.(artifact);
       },
     },
     effectsPort: {


### PR DESCRIPTION
## Why

Hosted preference/style canonical writes currently put each immutable payload, the write receipt, and the receipt log one after another on the foreground reply commit barrier. The observed three-payload case therefore pays for five network round trips serially. This PR keeps the durability barrier but removes that avoidable serialization.

## User goal and UX

Replies that persist preferences or other multi-artifact canonical writes should spend roughly one upload wave, rather than the sum of five upload durations, before replying. There is no UI or copy change.

## Invariants

- Keep canonical persistence synchronous with `WriteBatch`; a reply cannot escape before durable recovery state exists.
- Validate capacity, log shape, and every payload length before the first upload.
- Publish the receipt-log status pointer only after every referenced payload, the receipt, and the log artifact succeed.
- On failure, settle every started upload, schedule no later wave, publish no pointer, and preserve the existing local rollback path.
- Add no queue, background worker, state owner, retry loop, schema, dependency, or configuration knob.

## Non-obvious affected surfaces and proof

- The existing receipt-log owner now receives the payloads directly and owns the complete immutable upload set. The workspace runner call site only awaits it before the unchanged `canonical_runtime_commit` checkpoint.
- A fixed eight-wide wave covers the observed five-object case while bounding larger writes. `Promise.allSettled` prevents escaped uploads after failure.
- The existing host-abort entrypoint regression now captures its per-upload ordinal before awaiting, so it remains valid when uploads start concurrently.
- Deterministic tests prove five-object concurrent start, eight-object fanout, deferred ninth-object scheduling, failed-wave draining, validation-before-upload, no checkpoint on upload failure, local rollback, and host-abort preservation.
- Local diff-aware verification passed assistant-runtime (74 files; 1,718 passed, 2 skipped) and the Cloudflare reverse-dependent surface (105 files; 1,833 passed).

## Change shape

ReviewGPT first-reviewed head: cdd2089222842f83c0c41c2b6186255117cd6a6f

### Immutable first-reviewed baseline

| Category | Added | Deleted |
| --- | ---: | ---: |
| Authored source | 52 | 24 |
| Tests | 246 | 12 |
| Docs | 123 | 2 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

### Current head

| Head | Source | Tests | Docs | Config/tooling | Generated/other |
| --- | --- | --- | --- | --- | --- |
| `cdd2089222842f83c0c41c2b6186255117cd6a6f` | +52/-24 | +246/-12 | +123/-2 | +0/-0 | +0/-0 |

Review-driven authored-source growth: 0 lines.

## Deployment concerns

This is protocol- and schema-compatible across Worker/container skew. Old warm containers continue the safe sequential path; new runner bundles use bounded concurrent uploads against the same artifact-store and checkpoint APIs. No tandem deploy or compatibility layer is required. After rollout, compare canonical artifact upload durations/ordinals and monitor artifact-upload plus `canonical_runtime_commit` failure rates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786761331&installation_id=127572939&pr_number=735&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F735&signature=88844ea1012ad2e6644cce8c9e918d09faffeed4cb8dc35b46cc19c7a3df86e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->