### PR TITLE
Specify hosted usage top-ups

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-hosted-usage-topups-spec.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-hosted-usage-topups-spec.md
@@ -1,0 +1,140 @@
+# Hosted usage top-up specification
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Land a durable product and engineering specification for fixed-value hosted
+  usage top-ups that extends Murph's existing usage-limit product behavior with
+  the smallest composable payment and credit-accounting primitive.
+
+## Success criteria
+
+- The specification defines the individual Pulse/Edge MVP, including Settings
+  UX, one-time Stripe Checkout, replay-safe fulfillment, credit consumption,
+  refunds, disputes, rollout, rollback, and verification.
+- Payer and beneficiary are separate durable facts so the same beneficiary
+  ledger can later support authenticated group-container funding without a
+  second balance system.
+- Base included allowance, subscription entitlement, Stripe payment state, and
+  Murph usage credit remain separate owners.
+- The document reflects the confirmed product contract that usage exhaustion
+  blocks subsequent usage-bearing work and explicitly records the contradictory
+  checked-out source state for implementation reconciliation.
+- Canonical indexes and the related current-state usage doc link to the proposal.
+
+## Scope
+
+- In scope:
+  - The corrected target-state product/engineering specification.
+  - Canonical product-spec and agent-doc index entries.
+  - Bounded source-state notes in the current usage-visibility and downgrade
+    specs so their advisory implementation snapshots are not product authority.
+- Out of scope:
+  - Runtime, schema, Stripe Dashboard, API, or UI implementation.
+  - Resolving the current source/runtime enforcement discrepancy.
+  - Group funding, Family funding, arbitrary amounts, or auto-recharge.
+
+## Constraints
+
+- Technical constraints:
+  - Reuse `HostedMember.id` as the beneficiary owner for both people and future
+    synthetic group containers; do not add a speculative `UsageAccount` owner.
+  - Keep Stripe as payment evidence and `apps/web` as usage-credit authority.
+  - Keep the existing included allowance and plan entitlement owners intact.
+  - Fulfill from verified Stripe state through the existing receipt/retry owner;
+    never grant from the browser return.
+- Product/process constraints:
+  - Initial personal offers are fixed at $5, $10, and $25.
+  - Accepted blocked conversation input stays durable and becomes runnable after
+    a verified grant restores capacity.
+  - This is docs/process-only work using the Markdown verification fast path.
+
+## Risks and mitigations
+
+1. Risk: A top-up-only schema prevents later group funding.
+   Mitigation: Persist payer and beneficiary separately and key the credit ledger
+   to the existing `HostedMember` beneficiary boundary.
+2. Risk: Payment facts, subscription state, and usage capacity become one
+   ambiguous balance.
+   Mitigation: Keep immutable cash, grant, conversion-policy, entitlement, and
+   consumption facts separate even when v1 converts one-for-one.
+3. Risk: Retries or out-of-order webhooks duplicate payable Checkout Sessions or
+   usage grants.
+   Mitigation: Freeze the exact Checkout request, fence ambiguous creation, and
+   use semantic-source uniqueness plus append-only compensating ledger entries.
+4. Risk: The spec encodes the checked-out advisory source state as product truth.
+   Mitigation: Treat enforced exhaustion as the confirmed product contract and
+   make source-state reconciliation an explicit implementation prerequisite.
+
+## Tasks
+
+1. Reconstruct the corrected specification on the latest `origin/main` in an
+   isolated worktree.
+2. Update canonical indexes and the existing usage-visibility cross-reference.
+3. Read back every touched document, verify references and privacy, and inspect
+   the scoped diff.
+4. Finish the plan through the repo commit helper, push the branch, and open a
+   draft PR with the required intent and change-shape contract.
+5. After the routed completion commit, run the user-requested ReviewGPT PR loop
+   to `ROUND_OUTCOME: PASS`, remediate accepted findings if any, and verify final
+   PR CI.
+
+## Decisions
+
+- Use one Stripe Product with reusable one-time Prices for $5, $10, and $25.
+- Use a Murph-owned append-only usage-credit ledger, with included allowance
+  consumed before purchased credit and purchased credit carrying until used.
+- Keep one beneficiary-scoped ordering/locking boundary for grants, debits, and
+  reversals; do not mutate the derived base period limit.
+- Keep the append-only ledger canonical while maintaining bounded rebuildable
+  balance/version fields on the beneficiary for the admission hot path.
+- Use one durable `claimed` Checkout-create state from before Stripe I/O until
+  attachment or proven absence, instead of separate in-flight and unknown
+  states that can diverge after a crash.
+- Separate the authenticated payer from the `HostedMember` beneficiary now so
+  future group funding changes authorization and presentation, not accounting.
+- Extend the existing enforced usage-limit owner and trigger an idempotent
+  runtime recheck after an eligible grant; do not add another gate or terminal
+  policy.
+- Record the current advisory source/tests/copy mismatch without expanding this
+  docs-only PR into an unproven runtime repair.
+- Mark the current usage-visibility document as a source snapshot rather than
+  leaving its advisory implementation statements as product authority.
+
+## Verification
+
+- Commands to run:
+  - Read back every touched Markdown file.
+  - `git diff --check` on the scoped patch.
+  - Verify every new repository-local reference exists.
+  - Search touched docs for direct personal identifiers and local paths.
+  - Run an independent final specification consistency review.
+  - Run the PR ReviewGPT loop on the exact pushed head and confirm final CI.
+- Expected outcomes:
+  - A docs-only patch with no whitespace errors or personal identifiers.
+  - Canonical indexes resolve to the new proposal.
+  - ReviewGPT returns `ROUND_OUTCOME: PASS` with zero accepted findings.
+  - Required PR checks are green on the final head.
+
+### Local completion results
+
+- Read back every touched Markdown file and confirmed the isolated copy matched
+  the corrected specification from the original checkout before the reviewed
+  remediations below.
+- `git diff --check` and untracked-file whitespace checks completed without
+  errors.
+- Repository-local references and canonical index links resolve.
+- The touched-file privacy scan found no direct identifiers, local home paths,
+  credentials, or secrets.
+- `pnpm docs:drift` passed.
+- The independent consistency review's five initial findings were remediated by
+  simplifying Checkout ambiguity state, bounding the admission read, explicitly
+  representing future paid-but-unfulfillable funding, distinguishing required
+  queue semantics from checked-out source state, and demoting advisory source
+  snapshots from product authority. Its final re-review returned no findings.
+- ReviewGPT and final PR CI remain post-completion gates against the exact pushed
+  head and are recorded on the PR rather than treated as pre-push local proof.
+Completed: 2026-07-16

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -1,6 +1,6 @@
 # Murph Agent Docs Index
 
-Last verified: 2026-07-15
+Last verified: 2026-07-16
 
 ## Purpose
 
@@ -40,12 +40,13 @@ It intentionally lists live architecture, product, verification, and package-bou
 | `agent-docs/compliance/ftc-hbnr-notice-templates.md` | Counsel-reviewed template starting points for consumer, FTC, media, vendor, and internal incident notices. | Health-data notice workflow | High | 2026-04-29 |
 | `agent-docs/compliance/vendor-health-data-addendum.md` | Vendor clause library and procurement checklist for providers that process identifiable health data or health-context metadata. | Vendor health-data contracting | High | 2026-04-29 |
 | `agent-docs/compliance/health-data-tracking-and-ads-rule.md` | Hard rule and review checklist for analytics, telemetry, ad pixels, attribution, and marketing tools on health-data surfaces. | Health-data tracking policy | High | 2026-04-29 |
-| `agent-docs/product-specs/index.md` | Index for product-spec docs. | Product-spec inventory | High | 2026-07-10 |
+| `agent-docs/product-specs/index.md` | Index for product-spec docs. | Product-spec inventory | High | 2026-07-16 |
 | `agent-docs/product-specs/repo.md` | Canonical repository posture and success criteria. | Current repo product spec | High | 2026-04-06 |
 | `agent-docs/product-specs/pulse-trial-checkout-offer.md` | Implemented Pulse Trial checkout-offer architecture over existing hosted billing and hosted AI usage allowance primitives. | Hosted billing/product spec | High | 2026-05-05 |
 | `agent-docs/product-specs/pulse-trial-start-paid-pulse.md` | Implemented exhausted Pulse Trial conversion to paid Pulse by ending the Stripe trial and billing the existing Pulse subscription. | Hosted billing/product spec | High | 2026-05-13 |
-| `agent-docs/product-specs/hosted-plan-downgrades.md` | Edge-to-Pulse renewal switches plus the web-owned hosted assistant configuration and personalization resolvers, including the fully deployed input-bound-only model/reasoning update contract, personal Luna/Terra choices, billing-gated Sol, relation-derived group-chat Sol, reasoning and conversation style controls, advisory monthly included usage, and the one-time durable-workflow recheck rollout. | Hosted billing/product spec | High | 2026-07-15 |
-| `agent-docs/product-specs/hosted-plan-usage.md` | Web-owned advisory included-usage projection shared by Settings and the read-only assistant tool, including forecast, server-selected action, explicit management handoff, and group privacy boundaries. | Hosted billing/product spec | High | 2026-07-15 |
+| `agent-docs/product-specs/hosted-plan-downgrades.md` | Edge-to-Pulse renewal switches plus the web-owned hosted assistant configuration and personalization resolvers, including the fully deployed input-bound-only model/reasoning update contract, personal Luna/Terra choices, billing-gated Sol, relation-derived group-chat Sol, reasoning and conversation style controls, and a checked-out advisory-allowance snapshot with a known enforced-contract discrepancy. | Hosted billing/source-state spec | High | 2026-07-16 |
+| `agent-docs/product-specs/hosted-plan-usage.md` | Checked-out advisory projection snapshot shared by Settings and the read-only assistant tool; it records the source discrepancy with the confirmed enforced usage contract. | Hosted billing/source-state spec | High | 2026-07-16 |
+| `agent-docs/product-specs/hosted-usage-topups.md` | Proposed one-time Stripe Checkout plus Murph-owned usage-credit ledger that extends the enforced usage limit for direct paid plans, with a future group payer/beneficiary boundary. | Hosted billing/product spec | High | 2026-07-16 |
 | `agent-docs/product-specs/hosted-family-plan.md` | Hosted Family plan for 2-6 sponsored people, mixed Pulse/Edge member assignments, direct per-member tier management, webhook-owned capacity, private member accounts, chat-first invites, and privacy boundaries. | Hosted billing/product spec | High | 2026-07-15 |
 | `agent-docs/product-specs/health-commons.md` | Health Commons product boundary for wiki-like pages, build-time catalog generation, scoped runtime artifacts, future aggregate outcome summaries, revisions, and artifact manifests. | Health Commons behavior | High | 2026-06-05 |
 | `agent-docs/product-specs/protocol-summary-copy.md` | Source-of-truth copy rules for Health Commons protocol `summary:` fields shown on `/experiments` cards. | Health Commons protocol card copy | High | 2026-04-30 |

--- a/agent-docs/product-specs/hosted-plan-downgrades.md
+++ b/agent-docs/product-specs/hosted-plan-downgrades.md
@@ -104,6 +104,13 @@ delivery.
 
 ## Included Usage Behavior
 
+Source-state note: this section records the checked-out implementation and is
+not product authority for exhaustion. The confirmed product contract blocks
+subsequent usage-bearing work at the limit. The correction and the requirement
+to reconcile one admission owner before top-ups ship are defined in
+`agent-docs/product-specs/hosted-plan-usage.md` and
+`agent-docs/product-specs/hosted-usage-topups.md`.
+
 Monthly included AI allowance remains a measured billing and product signal,
 not a runtime access gate for an otherwise active member. Murph continues to
 record usage, attribute the requested and served model reported by Codex App

--- a/agent-docs/product-specs/hosted-plan-usage.md
+++ b/agent-docs/product-specs/hosted-plan-usage.md
@@ -1,12 +1,16 @@
 # Hosted Plan Usage Visibility
 
-Last verified: 2026-07-15
+Last verified: 2026-07-16
+Status: Checked-out source snapshot with a known product-contract discrepancy
 
 ## Goal
 
 Give a member one honest view of their current included AI usage without
 creating another billing system. Settings and Murph's read-only plan-usage tool
-must consume the same web-owned projection.
+must consume the same web-owned projection. This document records the current
+checked-out projection implementation; it is not product authority for whether
+exhaustion blocks. The confirmed enforced contract and required source
+reconciliation live in `agent-docs/product-specs/hosted-usage-topups.md`.
 
 ## Ownership
 
@@ -79,6 +83,12 @@ Family change happened. It must not provide the private management handoff for
 
 ## Runtime Access And Notices
 
+The following advisory behavior describes the checked-out source and tests,
+not the confirmed product contract. That contract blocks subsequent
+usage-bearing work at exhaustion. The discrepancy must be reconciled at the
+single admission owner before top-ups ship; adding a second gate is not a valid
+correction.
+
 Included usage is advisory. Reaching 100% does not deny otherwise-authorized
 assistant or system work, and the plan-usage projection is never model-work
 admission. Admission reads only the hosted member-access owner, where inactive,
@@ -132,6 +142,12 @@ fallback is valid for an accepted group conversation.
 This feature adds no schema, second usage ledger, Stripe read, persisted
 forecast, queue, cron, automatic nudge, group balance, top-up flow, or billing
 mutation tool.
+
+The separately proposed target-state extension lives in
+`agent-docs/product-specs/hosted-usage-topups.md`. That specification treats
+usage-limit blocking as the confirmed product behavior and supersedes this
+snapshot's advisory statements as product policy. It also records the
+checked-out source discrepancy that must be reconciled before implementation.
 
 ## Deployment
 

--- a/agent-docs/product-specs/hosted-usage-topups.md
+++ b/agent-docs/product-specs/hosted-usage-topups.md
@@ -1,0 +1,774 @@
+# Hosted Usage Top-Ups
+
+Status: Proposed target state
+Last verified: 2026-07-16
+
+## Decision
+
+Use Stripe-hosted Checkout to collect a one-time payment and a Murph-owned,
+append-only usage-credit ledger to decide who receives the usage and how it is
+consumed.
+
+The initial individual-plan offer is:
+
+| Offer code | Checkout subtotal | Usage credit granted |
+| --- | ---: | ---: |
+| `usage_5_usd` | $5 USD | $5 of Murph usage credit |
+| `usage_10_usd` | $10 USD | $10 of Murph usage credit |
+| `usage_25_usd` | $25 USD | $25 of Murph usage credit |
+
+The cash subtotal and granted usage value are separate versioned facts even
+when the initial conversion is one-for-one. One dollar of v1 usage credit is
+one dollar of capacity under Murph's existing cost-weighted AI usage meter. It
+is not a token count, bank balance, Stripe customer balance, subscription
+invoice credit, transferable asset, or promise of cash redemption.
+
+Stripe proves money movement. `apps/web` remains authoritative for the payer,
+beneficiary, offer, grant, available usage credit, consumption, refund
+adjustments, and future group authorization.
+
+## Enforced Usage Contract
+
+Hosted included-usage exhaustion blocks subsequent usage-bearing work. This is
+the confirmed product contract and matches the historical gate behavior, even
+though the checked-out source currently conflicts with it. Top-ups extend the
+capacity evaluated by that one enforced boundary; they do not introduce a
+second admission owner or a second exhaustion policy.
+
+1. Active subscription or sponsored entitlement remains the prerequisite for
+   service. Credit never creates or extends entitlement.
+2. Current-period included allowance is used first.
+3. Purchased usage credit is used next.
+4. When neither is available, the usage-limit block remains in force. The
+   restored or extended gate must keep accepted conversation input durable and
+   pending rather than silently dropping it or inventing a second terminal
+   policy.
+5. A request admitted before its usage crosses the boundary may finish. Later
+   usage-bearing work observes the settled exhausted state, so the product must
+   not promise an exact token-level cutoff.
+6. A fulfilled top-up makes effective capacity positive and must trigger the
+   same retry/recheck path that reopens pending accepted work after an allowance
+   reset, once source reconciliation has identified and proven that owner.
+
+No Stripe request belongs on the model-start or reply critical path. The
+reconciled single gate must read only Murph's local durable effective-capacity
+projection: included capacity remaining plus eligible purchased credit
+remaining.
+
+### Source-State Reconciliation
+
+The checked-out source currently contains an advisory allowance branch, tests,
+and copy that conflict with the enforced product behavior confirmed for this
+spec. Before implementing top-ups, reconcile that source-state discrepancy and
+identify the single deployed usage-gate owner, blocked-input disposition,
+reset/retry behavior, and route-specific notice. Restore or extend that one
+owner; do not preserve the discrepancy by adding a second gate. This is a
+current-source correction, not a new product-policy prerequisite for top-ups.
+
+## Product Outcome
+
+An eligible paid Pulse or Edge member can:
+
+1. See included usage in its existing percentage presentation.
+2. Open a small **Add usage** dialog over Settings.
+3. Choose $5, $10, or $25 without a preselected or promoted option.
+4. Continue to Stripe-hosted Checkout.
+5. Return to Settings with an honest pending state while webhook fulfillment
+   completes.
+6. See a separately labeled usage-credit amount after the verified grant.
+7. If usage was blocked, have pending accepted work become runnable after the
+   verified grant restores capacity.
+8. Continue using that credit after an included-usage reset until the credit is
+   consumed.
+
+The same primitive can later credit a synthetic group-container member while a
+different personal member pays. Group funding does not require a second balance
+system or a polymorphic usage-account service.
+
+## Individual MVP
+
+### Eligibility
+
+The first release permits purchases only when all of these are true:
+
+- the browser has a current authenticated hosted app session;
+- the beneficiary is that same direct personal member;
+- hosted access is active and not suspended;
+- the member has a paid Pulse or paid Edge subscription;
+- the member has one canonical existing Stripe Customer binding; and
+- the selected offer is active in the server-owned catalog.
+
+Pulse Trial keeps **Start Pulse** rather than selling top-ups. Sponsored Family
+members are excluded because their payer and beneficiary already differ and
+belong with the later sponsored/group funding policy. Cancellation, past-due,
+suspension, malformed billing state, and an expired trial fail closed.
+
+Purchased credit does not expire in v1. It survives monthly allowance resets
+and a subscription cancellation, but it is usable only after an eligible plan
+is active again. It cannot be transferred between members or applied to a
+subscription invoice.
+
+### Presentation
+
+Included usage remains the existing bounded percentage. Buying credit must not
+make that percentage move backward or expose the internal dollar value of a
+plan's included allowance.
+
+Purchased value appears separately, for example:
+
+- `100% of included usage used`
+- `$8.42 usage credit remaining`
+
+The value is rounded down for display to whole cents while accounting stays in
+integer USD micros. Copy must call it **usage credit**, never cash, wallet
+funds, account balance, or refundable dollars.
+
+Settings may show a quiet **Add usage** action at any utilization for an
+eligible paid member. Home and assistant surfaces should surface the action
+only when the current forecast predicts exhaustion, at least 80% of included
+usage is used, or included and purchased capacity is exhausted. Pulse's Edge
+upgrade remains available through the plan card instead of creating a
+multi-action usage contract.
+
+### Settings Dialog
+
+`PlanUsageBand` remains the surface owner. Add one client leaf using the
+existing `Dialog`, `RadioGroup`, `ChoiceCard`, and `PaymentButton` primitives;
+do not add a generic payment-modal framework.
+
+The target composition is:
+
+- Title: **Add usage**
+- Description: **Choose how much usage credit to add. Stripe confirms the
+  payment before Murph adds it.**
+- Three equal choices: **$5**, **$10**, and **$25**
+- No default selection and no “popular” badge
+- Primary action after selection: **Continue to checkout · $10**
+- Pending action: **Opening Stripe…**
+- Secondary action: **Cancel**
+- An inline accessible error for checkout-creation failure
+
+Offer descriptors come from the server projection. The browser submits only an
+opaque offer code and a single-use client request key, never a dollar amount,
+grant amount, Stripe Price ID, payer ID, or beneficiary ID.
+
+Home or a private assistant handoff opens the same dialog through a one-shot
+Settings URL such as `/settings?addUsage=true#subscription`. Settings removes
+the query parameter after initializing the dialog so refresh and Back do not
+replay it.
+
+### Checkout Return
+
+The success and cancel URLs return to Settings with the opaque Murph purchase
+ID. They do not need to expose a Stripe Session ID. The app session must own the
+purchase before any status is returned.
+
+The browser renders only server-read status:
+
+| State | Copy |
+| --- | --- |
+| Checkout canceled or expired | **Checkout canceled. No usage was added.** |
+| Payment processing | **Payment submitted. Stripe is confirming it.** |
+| Fulfilled | **Usage added.** |
+| Payment failed | **The payment did not complete. No usage was added.** |
+| Reconciliation delayed | **Your payment is still being confirmed. You can safely leave this page.** |
+
+A success query parameter is never proof of payment. Settings may poll a
+bounded authenticated purchase-status endpoint or request the same idempotent
+reconciliation used by the webhook, then refresh its server projection. It
+must not say **Usage added** until the grant entry is committed.
+
+Likewise, Stripe's `cancel_url` does not itself cancel an open Session. The
+authenticated cancel-return handler re-fetches the bound Session and
+idempotently expires it only when it is still open. A concurrent paid or
+processing state wins and renders its truthful status; a query parameter alone
+never marks the purchase expired.
+
+### Conversation And Notice Copy
+
+The assistant may explain the server-projected state and offer the first-party
+Settings handoff. It cannot select an offer, create Checkout, choose a payer or
+beneficiary, or claim that a purchase completed.
+
+A reply-anchored personal exhaustion message may say:
+
+> You've used your included usage and any usage credit. You can add more in
+> Settings.
+
+Keep the wording factual, conversational, and low-pressure. Use only a full
+first-party Settings URL, never a shortened URL. Do not add recurring nudges,
+marketing language, urgency, or cold re-engagement.
+
+A fulfilled grant invalidates a queued stale exhaustion notice. If credit is
+later exhausted again, at most one new reply-anchored notice is eligible for
+the new capacity epoch derived from the newest grant entry. Multiple grants
+before exhaustion collapse into one epoch. The delivery claim must re-read
+current effective capacity immediately before sending.
+
+## Ownership And Data Flow
+
+```text
+Settings -> apps/web purchase service -> Stripe Checkout
+                                      -> Stripe payment
+Stripe webhook -> HostedStripeEvent -> verified purchase reconciliation
+                                      -> immutable credit grant
+Usage callback -> canonical HostedAiUsage -> included allowance settlement
+                                         -> immutable credit debit
+Projection -> Settings / Home / assistant handoff
+```
+
+`apps/web` owns every durable record and decision in this flow. Cloudflare and
+assistant runtime receive only the bounded projection/action needed for the
+current conversation. Stripe metadata is a lookup hint, never authorization.
+
+Personal members and synthetic thread containers already consume usage through
+`HostedMember.id`. Use that existing identifier as the beneficiary key. Do not
+add a generic `UsageAccount` table unless a later non-member usage subject
+proves it necessary.
+
+## Durable Model
+
+The names below are illustrative; the semantics are required.
+
+### `HostedUsageCreditPurchase`
+
+One row represents one intentional attempt to purchase one offer.
+
+| Field | Contract |
+| --- | --- |
+| `id` | Random opaque Murph purchase ID; safe as the only Stripe metadata lookup key. |
+| `payerMemberId` | Authenticated personal member paying. Separate from beneficiary even when equal in v1. |
+| `beneficiaryMemberId` | `HostedMember.id` whose usage receives credit. |
+| `authorizationContext` | Versioned value such as `personal_self_v1`; future group authorization is explicit. |
+| `offerCode` | Immutable internal catalog code. |
+| `cashCurrency` / `cashAmountMinor` | Expected Checkout subtotal, initially USD cents. |
+| `grantUsdMicros` | Usage capacity promised by the offer. |
+| `conversionPolicyVersion` | Freezes cash-to-usage semantics for audit and future pricing changes. |
+| `clientRequestKey` | Payer-scoped unique key that makes a lost browser response safely retryable. |
+| `requestFingerprint` | Immutable digest of offer and target semantics; reusing a client key with a different request conflicts. |
+| `checkoutRequestPolicyVersion` | Version plus explicit frozen Checkout fields used to reconstruct the exact Stripe request after ambiguity. |
+| `checkoutCreateState` | `not_started`, `claimed`, `attached`, or `closed`; `claimed` is the durable ambiguity fence from before provider I/O until one Session is attached or absence is proven. |
+| `status` | `created`, `checkout_open`, `payment_pending`, `fulfilled`, `expired`, `payment_failed`, or future-group `paid_unfulfillable`. Refund/dispute projections are separate. |
+| Stripe references | Checkout Session, PaymentIntent, Charge, and Customer lookup/encrypted references using the existing hosted billing-ref pattern. |
+| timestamps | Creation, Checkout-create retry cutoff, Checkout expiry, paid, fulfilled, and terminal timestamps. |
+
+Cash amount, grant amount, and conversion version are copied from the
+server-owned offer catalog when the purchase is created. They are never
+re-derived from the mutable current catalog or from Stripe's final amount.
+Before provider I/O, also freeze the exact reusable Price reference, Customer
+reference, mode, quantity, tax and payment-method settings, exact success and
+cancel URLs, metadata, client reference, and expiration. Retries reconstruct
+the same normalized request from those explicit fields; a later catalog,
+environment, domain, or payment-policy
+change cannot alter it. Store a request digest for verification, not as a
+substitute for the reconstructible fields.
+
+Financial records must not blindly cascade with member or group deletion.
+Implementation must extend the account export/deletion workflow with the
+minimum legally required payment record, identity detachment, and retention
+policy before launch.
+
+### `HostedUsageCreditEntry`
+
+The source of truth for usage credit is an append-only set of signed entries.
+
+| Entry kind | Amount | Unique source |
+| --- | ---: | --- |
+| `purchase_grant` | positive | paid purchase / Checkout Session |
+| `usage_debit` | negative | canonical `HostedAiUsage.id` plus the grant entry it consumes |
+| `refund_reversal` | negative | Stripe Refund, grant entry, and cumulative refund state |
+| `dispute_reversal` | negative | Stripe Dispute funds-withdrawn state plus grant entry |
+| `reversal_restoration` | positive | failed refund or reinstated dispute funds plus original reversal |
+
+Each entry contains beneficiary member, signed USD micros, effective time,
+source type and opaque source identity, purchase and parent grant when
+applicable, a beneficiary-monotonic sequence, and creation time. The existing
+beneficiary `HostedMember` also holds a compact, rebuildable available-credit
+projection and credit-version counter. While holding the beneficiary row lock,
+every entry append increments the version and updates the projected balance in
+the same transaction. Admission reads only those bounded fields under that
+lock, so it never aggregates an indefinitely growing ledger and rollback or
+commit order cannot make a later grant eligible to earlier work. The ledger
+remains canonical; a bounded operator repair can rebuild both projection fields
+from its entries.
+
+One usage event may allocate across multiple grants, so its debit uniqueness
+is `(usage event, grant entry)` rather than the usage event alone. A uniqueness
+constraint on each semantic source prevents duplicate grants or allocations
+even when Stripe creates multiple Event objects or handlers run concurrently.
+
+Never edit or delete an entry to correct history. Append a compensating entry.
+The compact balance/version fields are a read projection, not an independent
+source of truth, and every mutation verifies that their result remains
+nonnegative before commit.
+
+Available credit is the sum of effective entries and has a nonnegative
+invariant. A refund or dispute can revoke only unused credit attributable to
+that purchase. Any already-consumed amount whose payment is forcibly reversed
+is recorded as a private purchase loss/risk fact, not negative usage credit,
+not a deduction from a later purchase, and not a reason to silently suspend an
+otherwise valid plan.
+
+## Usage Settlement
+
+Do not increment `HostedAiUsagePeriod.limitUsdMicros` and do not mutate a
+thread container's configured monthly limit. Current allowance reconciliation
+derives the base limit and repairs a mismatched stored period value, so either
+shortcut would be overwritten.
+
+The allowance resolver instead derives two independent quantities:
+
+- base included capacity for the usage event's plan and period; and
+- purchased credit still available from positive entries that were eligible
+  when the counted platform operation was admitted.
+
+Every purchase grant, usage debit, refund reversal, dispute reversal,
+restoration, and effective-capacity recomputation must acquire the same
+beneficiary-scoped database lock before any purchase, period, or grant lock.
+Period-row locking alone is insufficient because carryover credit can be
+consumed concurrently by late prior-period and current-period usage. Use one
+fixed lock order across all paths and revalidate rows after acquiring it.
+Credit-aware admission briefly acquires that same lock to read the compact
+balance/version projection and issue its cutoff.
+
+For each newly canonical usage event, under that beneficiary-wide lock:
+
+1. Preserve the current server-owned pricing, counted/not-counted,
+   provider-credential, model-fail-closed, period, and abuse-limit rules.
+2. Apply the event to the period's monotonic total spend as today.
+3. Compute the portion of this event covered by remaining included capacity.
+4. For only the excess portion, consume still-available positive entries at or
+   before the event's trusted credit-eligibility sequence, oldest grant first,
+   and append one allocation debit per grant used by the canonical usage event.
+5. Cap the debit at credit actually available for that event. Any amount by
+   which a crossing operation exceeds the capacity visible at admission is
+   absorbed by Murph; it is not debt and is never collected from a later
+   purchase.
+6. Recompute effective exhaustion from base remaining plus available purchased
+   credit.
+
+Every counted platform operation receives a web-authoritative
+`creditEligibilitySequence` with its local admission decision: the latest
+credit-ledger sequence visible before provider work starts, or explicit
+absence. The transport carries an opaque web-issued token bound to member,
+operation identity, and cutoff rather than exposing the numeric sequence.
+Web validates the token and persists the resolved value with the usage record.
+Runtime and model cannot select it. Positive grants or restorations created
+after the cutoff are never eligible for that operation, while all intervening
+debits and reversals still reduce current availability. A missing, legacy, or
+invalid cutoff fails closed to no purchased-credit debit; it must never infer
+eligibility from callback arrival time.
+
+This makes a provider operation started before checkout unable to consume the
+new purchase even if its usage callback arrives afterward. The existing
+`occurredAt` is captured after provider result and is insufficient for this
+boundary. Base included capacity still settles in beneficiary-serialized
+accounting order rather than rewriting immutable events chronologically. If a
+late pre-grant event would have changed which earlier event used included
+capacity, Murph absorbs the conservative difference instead of retroactively
+charging purchased credit. Semantic-source uniqueness makes replay idempotent,
+and the beneficiary lock makes the original allocation order singular.
+
+Fulfillment reads the purchase's beneficiary, acquires the beneficiary lock,
+then locks and revalidates the purchase, appends the grant, marks the purchase
+fulfilled, and, only when a current allowance-period row already exists,
+recomputes its exhaustion marker in one transaction. It clears that marker only
+when effective capacity is positive. Fulfillment must not create a synthetic
+allowance period merely because an eligible member bought credit before their
+first counted usage. Notice claim and model-admission readers must derive the
+same effective state whether or not a period row exists.
+
+After commit, if the beneficiary still has active entitlement and runnable
+usage-blocked work, fulfillment must send one idempotent recheck through the
+existing Stripe-event retry owner or another already-durable owner proven by
+source reconciliation. Top-ups must not add a second wake queue. The event path
+is not operationally complete until the grant is durable and the required
+handoff is accepted or the proven owner supplies an equivalent wake. A delayed
+payment that settles after cancellation or suspension still grants the
+purchased credit but does not require a runtime wake; entitlement reactivation
+must perform the later recheck. The browser return is never the wake or
+fulfillment authority.
+
+## Checkout Creation
+
+Add a dedicated usage-credit service beside, not inside, subscription
+onboarding checkout. The current subscription service rejects active members
+and creates `mode=subscription` Sessions; top-ups are repeatable one-time
+payments.
+
+The authenticated Settings route performs this sequence:
+
+1. Verify same-origin/CSRF protections and the hosted app session.
+2. Parse a strict bounded body containing only offer code and client request
+   key.
+3. Derive payer and personal beneficiary from the app session.
+4. Recheck active direct paid Pulse/Edge access and non-suspension.
+5. Resolve the offer through a server allowlist.
+6. Load the payer's canonical Stripe Customer; missing or ambiguous billing
+   state fails closed for repair rather than creating a duplicate Customer.
+7. Reconcile or return any existing nonterminal Checkout for the payer; v1
+   permits only one claimed, open, or payment-pending purchase at a time.
+8. Create or return the durable purchase for the client request key. Reuse with
+   a different request fingerprint is a conflict, not a returned old purchase.
+9. Freeze the reconstructible Checkout request fields and request digest.
+10. Atomically move its one Checkout-create attempt from `not_started` to
+    `claimed` before provider I/O.
+11. Recheck that the frozen create-retry cutoff has not passed, then create one
+    Stripe Checkout Session with an idempotency key derived from the purchase
+    ID. A passed cutoff enters adoption-only reconciliation without calling the
+    create API.
+12. Persist the returned references and redirect URL before returning it.
+
+The Stripe Session uses:
+
+- `mode=payment`;
+- one reusable one-time Price with quantity `1`;
+- the existing payer Customer;
+- `client_reference_id` equal to the opaque purchase ID;
+- Session metadata containing only purchase ID, purpose, and policy version;
+- the same opaque purchase ID in `payment_intent_data.metadata` for later
+  refund/dispute correlation;
+- a frozen `expires_at` 90 minutes after purchase creation plus a frozen
+  Checkout-create retry cutoff 30 minutes after purchase creation;
+- no adjustable quantity, promotion codes, or caller-selected Price; and
+- server-generated Settings success/cancel URLs.
+
+Use a distinct purchase ID for every intentional purchase. A member can buy
+the same pack twice, so member-plus-offer is not an idempotency key.
+
+The create call has one explicit ambiguous-outcome fence. `claimed` means the
+process may have crashed before the request, during it, or after Stripe accepted
+it; no stale-owner timeout reopens creation. Never send the purchase with a new
+Stripe idempotency key, create a replacement purchase for that payer while it
+is claimed, or tell the browser to retry as a fresh purchase.
+
+Reconciliation reconstructs the frozen request and verifies its digest. It may
+make any initial or retry create call with that same key only before the frozen
+30-minute retry cutoff. The frozen 90-minute `expires_at` therefore remains at
+least 60 minutes after any permitted create call, satisfying Stripe's
+create-time expiration window without mutating the request. After the retry
+cutoff, reconciliation
+only consumes matching webhooks or boundedly lists Sessions for the expected
+Customer and creation window to adopt exactly one Session with the purchase's
+client reference and metadata. Zero matches remain claimed until the frozen
+Session expiry and event-reconciliation window prove no payable Session
+remains; multiple matches are an incident and fail closed. Only then may the
+attempt close and the payer start another purchase. Stripe's temporary
+idempotency window protects the external call; the request key, request
+fingerprint, attempt fence, and unique grant sources provide permanent
+Murph-side convergence.
+
+## Stripe Catalog And Payment Configuration
+
+Create one Stripe Product named **Murph usage credit** and reusable one-time
+Prices for $5, $10, and $25 USD. Keep Price IDs in server configuration and map
+them from internal offer codes. Archive rather than mutate an old Price when
+cash or grant semantics change, and create a new conversion-policy version.
+
+Reusable Prices are preferable to inline `price_data` for fixed packs because
+they remain governed and searchable in Stripe's catalog. Inline prices remain
+a possible later implementation for genuinely arbitrary server-calculated
+amounts, not this MVP.
+
+Use Dashboard-managed dynamic payment methods unless a reviewed requirement
+limits the top-up configuration to immediately confirmed methods. Delayed
+methods are safe only because the UI and fulfillment model include
+`payment_pending`; Checkout completion alone never grants credit.
+
+Before live launch, finance/counsel must classify the prepaid service credit,
+configure the Product tax code and Price tax behavior, and decide where Stripe
+Tax is enabled. If tax is charged in addition to the pack subtotal, the member
+still receives the catalog's exact usage grant. Never derive credit from
+`amount_total`, which can include tax, discounts, or other adjustments.
+
+## Webhook Fulfillment
+
+Reuse the existing signed Stripe webhook receipt and pointer-only
+`HostedStripeEvent` reconciliation workflow. Add an explicit usage-purchase
+branch before subscription-shaped Checkout handling so a one-time Session can
+never bind or mutate subscription entitlement.
+
+Relevant events include:
+
+- `checkout.session.completed`;
+- `checkout.session.async_payment_succeeded`;
+- `checkout.session.async_payment_failed`;
+- `checkout.session.expired`;
+- `refund.created`, `refund.updated`, and `refund.failed`; and
+- `charge.dispute.created`, `charge.dispute.updated`,
+  `charge.dispute.funds_withdrawn`, `charge.dispute.funds_reinstated`, and
+  `charge.dispute.closed`.
+
+The event is a nudge, not the grant payload. Reconciliation re-fetches live
+Stripe state and, before granting, verifies all of these against the immutable
+purchase:
+
+- expected Session ID association and live/test mode;
+- `mode=payment` and `payment_status=paid`;
+- exact Customer when supplied;
+- exact reusable Price and quantity `1` from retrieved line items;
+- exact subtotal and currency;
+- expected purchase metadata and client reference; and
+- associated PaymentIntent/Charge identity.
+
+An unpaid `checkout.session.completed` becomes `payment_pending`.
+`checkout.session.async_payment_succeeded` can later fulfill it. A failed or
+expired Session never grants credit.
+
+The webhook is authoritative. The Settings return endpoint may call the same
+reconciler for latency, but concurrent calls must converge on the same purchase
+and unique grant entry. A fast `2xx`, signature verification, existing event
+dedupe, semantic source uniqueness, bounded retries, and poison-event handling
+remain mandatory because Stripe delivery can be duplicated and out of order.
+
+## Refunds And Disputes
+
+V1 has no instant self-service cash-out. A payer may request a support-assisted
+refund; another group participant or beneficiary cannot refund someone else's
+purchase.
+
+For ordinary refunds, return only the unused attributable portion of a
+purchase. A partial successful refund produces a proportional cumulative grant
+reversal, with the final reversal receiving any integer-rounding remainder. A
+full refund is permitted only while the full grant remains unused, and then
+reverses the full grant. Store each Stripe Refund's latest authoritative state
+and recompute the desired cumulative reversal rather than assuming event order.
+
+Never delete the original grant or rewrite usage. Apply no reversal for a
+failed refund. If Stripe later changes an already-applied refund to a failed
+state, append a restoration rather than rewriting history.
+
+Disputes are keyed by Stripe Dispute ID. A created dispute flags the associated
+purchase for review. Withdrawn funds revoke the unused remainder attributable
+to that purchase; reinstated funds append a restoration of what was actually
+revoked. Multiple disputes or refunds for one payment must never reverse more
+than its unused grant.
+
+If forcibly reversed cash exceeds unused credit, record the consumed portion
+as a private payment loss/risk fact. Do not make a later top-up repay it,
+silently disable current entitlement, erase canonical usage, expose debt in a
+group chat, or charge another participant.
+
+## Security And Privacy
+
+- The browser cannot select payer or beneficiary identity.
+- The model cannot select identity, amount, offer, Price, or Checkout URL.
+- Stripe metadata contains only the opaque purchase lookup and non-sensitive
+  fixed-purpose/version values; no contact, plan, group, or health data.
+- Raw Stripe references follow the existing encrypted-reference plus blind
+  lookup-key pattern and never enter logs, assistant state, or user-visible
+  URLs.
+- Checkout status is visible only to its authenticated payer in v1.
+- Webhook signatures and live Stripe re-fetch are both required.
+- Logs and metrics use fixed status/reason codes and counts, not member IDs,
+  payer identity, metadata payloads, receipts, or raw webhook bodies.
+- Checkout creation is bounded per authenticated payer and request key; Stripe
+  Radar and a reviewed operational velocity ceiling must be configured before
+  production launch.
+- Payment records and health-sharing permissions remain separate. Buying usage
+  never grants access to another person's data.
+
+## Future Group-Container Funding
+
+The later group feature reuses the same purchase and credit-entry semantics:
+
+- `payerMemberId` is the authenticated person entering Checkout;
+- `beneficiaryMemberId` is the group's synthetic thread-container
+  `HostedMember.id`; and
+- Stripe Customer belongs to the payer, never automatically to the group owner
+  or synthetic container.
+
+The first safe meaning of “anyone in the group can fund” is any authenticated,
+currently active participant whose relationship to the exact group is proven
+by web-owned authority. Anonymous public funding, email-sender identity, and a
+stale participant roster are not payment authority.
+
+The group handoff must be a new opaque, short-lived funding intent bound to the
+exact originating container and route. It must not reuse a personal Settings
+URL, group join code, or vault-sharing capability. Browser authentication and a
+fresh relationship check precede purchase creation. After a paid Checkout, the
+bound beneficiary remains fixed even if the payer later leaves; if the group
+was deleted or made ineligible before fulfillment, reconciliation atomically
+records the purchase as `paid_unfulfillable` without a grant and the existing
+Stripe-event retry owner requests an idempotent full refund. That durable state
+remains visible to private payer support/status reads until Stripe confirms the
+refund; value is never redirected elsewhere.
+
+Group chat may show only aggregate included usage and aggregate usage credit.
+It must not reveal who paid, contribution history, email, Customer ID, card,
+personal plan, refund request, dispute, or private receipt. Receipt and refund
+control stay in the payer's private billing surface. Delivery stays on the
+exact originating group route with no personal-home fallback.
+
+Future group offers may use reusable $1, $2, $5, $10, and $20 USD Prices. The
+$1 amount is above Stripe's general $0.50 USD minimum, but its processing-fee,
+tax, fraud, and support economics require explicit launch approval. Offer
+denominations remain catalog policy rather than ledger schema.
+
+## Observability And Reconciliation
+
+Track secret-safe counts and latency for:
+
+- purchase created and Checkout creation failed;
+- Checkout creation claimed and time spent awaiting attachment or proven
+  absence;
+- Checkout open, payment pending, fulfilled, expired, and failed;
+- future-group paid-unfulfillable purchases and refund resolution;
+- paid-to-grant reconciliation latency;
+- refund/dispute reversal and restoration;
+- available-credit exhaustion; and
+- status-route polling and terminal reconciliation failures.
+
+Alert on invariant violations:
+
+- verified paid eligible purchase without a grant after the retry window,
+  excluding a recorded `paid_unfulfillable` purchase under refund recovery;
+- grant without a verified paid purchase;
+- more than one grant for one semantic payment source;
+- more than one Stripe Session for one purchase or a claimed create past its
+  reconciliation window;
+- Stripe subtotal/Price/currency/Customer mismatch;
+- purchase routed into subscription entitlement handling;
+- stale exhaustion notice after positive effective capacity;
+- ledger projection drift; and
+- a ledger projection below zero or an unreconciled forced-payment loss.
+
+Provide an operator reconciliation command or bounded job that reads purchase
+IDs, re-fetches Stripe, and runs the same idempotent state transition. Do not
+make a second queue or second fulfillment implementation.
+
+## Rollout And Rollback
+
+1. Finalize tax classification, catalog semantics, and refund policy. Resolve
+   the checked-out source discrepancy and prove the single enforced usage gate
+   that this primitive will extend.
+2. Add the database schema, deletion/export coverage, ledger invariants, and
+   read-only projection with the feature disabled.
+3. Deploy webhook/event consumers and refund/dispute reconciliation before any
+   producer can create a top-up Checkout.
+4. Create and verify the Stripe Product, Prices, payment-method configuration,
+   tax settings, event subscriptions, Radar rules, and environment mappings in
+   test mode, then live mode.
+5. Exercise duplicate, concurrent, delayed-payment, refund, dispute, and stale
+   notice paths in test mode. Run shadow effective-capacity calculations
+   against canonical usage without changing admission.
+6. Expand the signed usage contract and storage to accept an optional
+   web-issued credit-eligibility cutoff, then deploy every paid-credit-consuming
+   producer. Legacy omission means no purchased-credit debit. Do not let
+   purchased credit authorize usage until every admitted counted operation
+   either carries a valid cutoff or is explicitly excluded.
+7. If assistant/runtime receives a new `add_usage` action, deploy the tolerant
+   consumer contract before web can emit it. Web-only Settings/Home UI can ship
+   independently behind the flag.
+8. Activate the purchased-credit extension and paid Checkout together only
+   after production smoke proof shows that no-credit exhaustion remains
+   blocked and a fulfilled grant wakes pending work and restores service.
+9. Observe reconciliation lag and invariant alerts before widening exposure.
+
+Rollback disables new Checkout creation and the Add usage actions first. It
+does not delete purchases or grants and must not disable the existing usage
+limit. A rollback must keep already-purchased credit effective or preserve a
+compatible reader until it is consumed or refunded; it cannot strand paid
+capacity behind an older gate.
+
+## Verification
+
+Implementation requires focused tests for:
+
+- offer allowlisting, CSRF/session auth, eligibility, and missing billing refs;
+- same-pack intentional repurchase, lost-response retry, and client-key reuse
+  with a different offer;
+- process loss before/after Checkout creation, same-key adoption, zero/multiple
+  Session reconciliation, and no second payable Session after Stripe's
+  idempotency window;
+- exact Checkout request reconstruction after catalog, domain, tax, or
+  payment-policy configuration changes;
+- Checkout request shape and one-time/subscription dispatch separation;
+- spoofed Price, subtotal, currency, Customer, metadata, environment, and
+  beneficiary rejection;
+- duplicate and concurrent webhook/success reconciliation;
+- completed-but-unpaid, async success, async failure, and expiry;
+- cancel-return expiry versus concurrent payment completion;
+- atomic grant plus effective-exhaustion recomputation;
+- fulfillment before any allowance-period row exists, without creating one;
+- delayed-payment fulfillment after cancellation or suspension, without a
+  poisoned runtime-recheck retry;
+- included-first settlement, crossing-event partial debit, carryover, monthly
+  reset, serialized late-callback behavior, and no debit of usage already
+  committed before the grant;
+- pre-grant in-flight work, post-grant work, later grant/restoration exclusion,
+  cutoff replay/binding, and missing/invalid cutoff behavior;
+- grant commit versus admission-cutoff ordering, rollback, and concurrent
+  counter allocation under the beneficiary lock;
+- concurrent prior-period/current-period usage, grant, refund, and dispute
+  mutations under the beneficiary-wide lock;
+- canceled/suspended/trial/Family access behavior;
+- partial/full refunds, failed refunds, multiple disputes, and reinstatement;
+- notice invalidation and one notice per capacity epoch;
+- purchase export/deletion and financial retention behavior;
+- Settings dialog accessibility, selection, redirect, pending, success,
+  cancellation, error, and one-shot deep-link cleanup;
+- shared Settings/Home/assistant projections and low-pressure copy;
+- no-credit exhaustion blocking, crossing-operation behavior, pending-input
+  preservation, route-correct notice delivery, grant-triggered runtime recheck,
+  re-exhaustion after credit consumption, and deploy-skew behavior; and
+- future payer-not-beneficiary and group privacy/route fixtures.
+
+Required implementation verification includes the relevant web tests,
+workspace typecheck, schema/migration checks, Stripe webhook test fixtures, and
+browser proof for desktop and mobile Settings flows.
+
+## Non-Goals
+
+The individual MVP does not add arbitrary amounts, auto-recharge, saved-card
+off-session charges, discounts, gifting, transfers, cash redemption, public or
+anonymous funding, Family funding, group funding, Stripe Meter reporting, or a
+second usage/accounting service.
+
+## Rejected Alternatives
+
+- **Stripe Billing Credits:** limited to eligible metered subscription items
+  reported through Stripe Meters and applied when invoices finalize. It does
+  not match Murph's existing immediate cost-weighted allowance.
+- **Stripe token billing:** the current official docs label it private preview.
+  The primitive must not depend on access Murph does not have.
+- **Stripe advanced usage-based billing:** its real-time credit burn and
+  automatic top-ups require adopting Stripe's separate Metronome-backed usage,
+  pricing, and billing stack. That is a billing-system migration, not the
+  smallest extension of Murph's current authoritative meter.
+- **Stripe Customer invoice balance:** automatically applies to invoices and
+  is not product-usage capacity.
+- **Stripe Entitlements:** represents feature access, not a quantified credit
+  balance.
+- **Payment Links:** cannot safely derive and bind payer, beneficiary, offer,
+  purchase idempotency, and group authorization in Murph's control plane.
+- **Inline arbitrary Checkout prices:** fixed packs are safer as governed,
+  reusable Prices.
+- **Mutating the allowance-period limit:** current resolver repair overwrites
+  it and carryover would duplicate value across periods.
+- **A new generic usage-account service/table:** `HostedMember.id` already
+  unifies personal and synthetic-container usage ownership.
+- **Granting on the success redirect:** the browser may never return and the
+  redirect is not payment authority.
+
+## Official Stripe References
+
+- [Checkout Sessions create API](https://docs.stripe.com/api/checkout/sessions/create)
+- [Expire a Checkout Session](https://docs.stripe.com/api/checkout/sessions/expire)
+- [Checkout fulfillment](https://docs.stripe.com/checkout/fulfillment)
+- [Checkout success-page guidance](https://docs.stripe.com/payments/checkout/custom-success-page)
+- [Products and Prices](https://docs.stripe.com/products-prices/how-products-and-prices-work)
+- [Manage Prices](https://docs.stripe.com/products-prices/manage-prices)
+- [Webhooks](https://docs.stripe.com/webhooks)
+- [Idempotent requests](https://docs.stripe.com/api/idempotent_requests)
+- [Metadata](https://docs.stripe.com/metadata)
+- [Refunds](https://docs.stripe.com/refunds)
+- [Disputes](https://docs.stripe.com/disputes/how-disputes-work)
+- [Stripe Tax with Checkout](https://docs.stripe.com/payments/checkout/taxes)
+- [Dynamic payment methods](https://docs.stripe.com/payments/payment-methods/dynamic-payment-methods)
+- [Currency minimums](https://docs.stripe.com/currencies)
+- [Customer invoice balance](https://docs.stripe.com/billing/customer/balance)
+- [Stripe Entitlements](https://docs.stripe.com/billing/entitlements)
+- [Billing Credits](https://docs.stripe.com/billing/subscriptions/usage-based/billing-credits)
+- [Token billing](https://docs.stripe.com/billing/token-billing)
+- [Advanced usage-based billing comparison](https://docs.stripe.com/billing/subscriptions/usage-based/advanced/compare)

--- a/agent-docs/product-specs/index.md
+++ b/agent-docs/product-specs/index.md
@@ -1,6 +1,6 @@
 # Product Specs Index
 
-Last verified: 2026-07-15
+Last verified: 2026-07-16
 
 | Path | Purpose | Status |
 | --- | --- | --- |
@@ -8,7 +8,8 @@ Last verified: 2026-07-15
 | `agent-docs/product-specs/pulse-trial-checkout-offer.md` | Implemented Pulse Trial checkout-offer architecture over the existing hosted billing and AI usage allowance system. | Active |
 | `agent-docs/product-specs/pulse-trial-start-paid-pulse.md` | Implemented exhausted Pulse Trial conversion to paid Pulse through Stripe trial-end billing. | Active |
 | `agent-docs/product-specs/hosted-plan-downgrades.md` | Edge-to-Pulse renewal switches plus the billing-gated Edge assistant-model choice, downgrade behavior, and deployment compatibility contract. | Active |
-| `agent-docs/product-specs/hosted-plan-usage.md` | Web-owned advisory included-usage projection shared by Settings and the read-only assistant tool, including forecast, server-selected action, and group privacy boundaries. | Active |
+| `agent-docs/product-specs/hosted-plan-usage.md` | Checked-out advisory projection snapshot with a known discrepancy from the confirmed enforced usage contract. | Source snapshot |
+| `agent-docs/product-specs/hosted-usage-topups.md` | Proposed one-time Stripe Checkout plus Murph-owned usage-credit ledger that extends the enforced limit for paid Pulse/Edge plans, with a payer/beneficiary seam for future group funding. | Proposed |
 | `agent-docs/product-specs/hosted-family-plan.md` | Hosted Family plan MVP: fixed four-person sponsored access, private member accounts, chat-first invites, and privacy boundaries. | Active |
 | `agent-docs/product-specs/health-commons.md` | Health Commons page graph, catalog, versioning, future aggregate outcome summaries, and artifact-storage product boundary. | Active |
 | `agent-docs/product-specs/protocol-summary-copy.md` | Source-of-truth copy rules for Health Commons protocol `summary:` fields shown on `/experiments` cards. | Active |


### PR DESCRIPTION
## Why this exists

Murph needs one durable primitive for buying additional hosted usage without
turning Stripe into the usage authority or creating a personal-only balance
system that must later be replaced for group funding.

This PR specifies the target architecture for fixed-value Pulse and Edge
top-ups. It also records a known source-state discrepancy: confirmed product
behavior blocks subsequent usage-bearing work at exhaustion, while the current
checked-out source and some implementation snapshots describe an advisory
gate. Implementation must reconcile the single real admission owner before
top-ups ship.

## User-visible goal and UX

- Eligible paid Pulse and Edge members can open an **Add usage** dialog in
  Settings.
- The dialog offers fixed $5, $10, and $25 usage-credit packs with no default or
  promoted selection.
- Checkout is a one-time Stripe-hosted payment.
- The return surface reports pending state honestly and shows **Usage added**
  only after verified webhook-backed fulfillment commits the grant.
- A fulfilled grant restores effective capacity and rechecks durable blocked
  work through the single proven runtime owner.
- The payer/beneficiary boundary can later fund a synthetic group container
  without introducing another balance service.

## Invariants

- Stripe proves payment; `apps/web` owns eligibility, payer, beneficiary, grant,
  balance, consumption, reversals, and authorization.
- Subscription entitlement, included allowance, purchased credit, and cash
  settlement remain separate facts.
- The append-only credit ledger is canonical. Bounded rebuildable balance and
  version fields serve the admission hot path.
- Included allowance is consumed before purchased credit; purchased credit
  carries until consumed and never creates entitlement.
- Checkout creation uses one durable claimed state and one exact idempotency key
  across ambiguous outcomes.
- Only verified Stripe state can grant credit; a browser redirect never can.
- One beneficiary lock orders admission cutoffs, grants, debits, refunds, and
  disputes.
- Top-ups extend one enforced usage gate and one durable retry path; they do not
  add a second gate, queue, usage account, or fulfillment implementation.
- Future group funding separates payer from beneficiary and never exposes payer
  identity or private billing facts in group chat.

## Non-obvious affected surfaces

- This is a docs-only target-state specification. It does not add schema,
  runtime admission changes, Stripe configuration, API routes, or UI.
- `hosted-plan-usage.md` and the included-usage section of
  `hosted-plan-downgrades.md` are explicitly labeled as checked-out source
  snapshots, not product authority for exhaustion.
- The contradictory checked-out admission source remains unchanged in this PR;
  restoring/proving its single owner is an implementation prerequisite.
- Future group purchases whose beneficiary disappears before fulfillment have
  an explicit paid-unfulfillable state and idempotent refund path rather than an
  untracked support limbo.
- Checkout freezes a 90-minute expiration with a 30-minute create-retry cutoff,
  preserving exact retries while satisfying Stripe's create-time expiration
  constraint.

## Change shape

ReviewGPT first-reviewed head: 10b9b06ba4bd50a1e680f4789e1446c51a199f2c

### First-reviewed baseline

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests | 0 | 0 |
| Docs/process | 947 | 8 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

### Current head

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests | 0 | 0 |
| Docs/process | 947 | 8 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Review remediation authored-source growth: 0 added, 0 deleted.

## Validation

- `pnpm docs:drift`
- `git diff --check`
- Readback and repository-reference verification for every touched document
- Touched-file privacy scan for direct identifiers, local paths, credentials,
  and secrets
- Independent architecture, queue-semantics, and privacy review; final
  re-review returned no findings

No runtime tests or typecheck were run because the patch contains only Markdown
documentation and follows the repository's docs-only verification path.

ReviewGPT and PR CI run against the exact pushed head after this draft opens.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786773852&installation_id=127572939&pr_number=740&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F740&signature=40ee67fbd80c4204a87407c33c8dbcc3d3d0a19a468320006e3972e5015b8aa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->