### PR TITLE
Gate WHOOP direct connects with an Apple Health fallback

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-whoop-cap-fallback.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-whoop-cap-fallback.md
@@ -1,0 +1,108 @@
+# WHOOP direct-connect capacity fallback
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Keep direct WHOOP connection available while Murph is below WHOOP's
+  10-member development cap, then guide additional members through WHOOP's
+  Apple Health sync and the Murph iPhone app.
+
+## Success criteria
+
+- The authenticated Web connect-start boundary counts distinct current WHOOP
+  members across direct WHOOP and Junction `whoop_v2` connections.
+- A member already counted can reconnect at capacity; a new member receives a
+  stable, non-retryable capacity error when 10 members are already counted.
+- Both dashboard starts and assistant-issued connect intents use the same gate.
+- The connect page recognizes only that capacity error and shows an accessible,
+  focused Apple Health setup path with the official Murph App Store link.
+- No assistant-runtime behavior, migration, reservation, lock, feature flag,
+  dependency, or new persisted state is introduced.
+- Focused tests, Web typecheck, browser proof, required specialist audits,
+  green PR CI, and the exact-head ReviewGPT loop all pass.
+
+## Scope
+
+- In scope: the Web-owned connect-start policy, typed error recognition,
+  connect-page fallback UI, focused tests, and existing durable product copy if
+  implementation proof finds it stale.
+- Out of scope: assistant runtime prompts, WHOOP OAuth-session reservations,
+  concurrency locking, provider-account deletion, schema changes, and native
+  app changes.
+
+## Constraints
+
+- Prefer one bounded read at the authenticated start boundary and reuse the
+  existing source identity model.
+- Treat `disconnected` connections and sources as not occupying a current
+  member slot; do not expose member counts or identifiers to the browser.
+- Preserve existing consent, authentication, intent-claim, and provider-start
+  ordering and release behavior.
+- Reuse installed shadcn/Base UI primitives and semantic theme tokens.
+
+## Risks and mitigations
+
+1. Risk: direct WHOOP and Junction WHOOP rows could double-count one member.
+   Mitigation: query distinct member IDs across both canonical storage paths.
+2. Risk: a page-only check could be bypassed by dashboard starts or stale UI.
+   Mitigation: enforce at the shared authenticated server start boundary and
+   use the page only to present the typed error.
+3. Risk: two new members could race for the last slot.
+   Mitigation: accept this low-scale theoretical race explicitly; do not add a
+   lock or reservation unless observed usage makes that complexity necessary.
+4. Risk: provider-specific fallback behavior could leak into assistant runtime.
+   Mitigation: keep link issuance unchanged and contain the policy in the Web
+   device-connect owner.
+
+## Tasks
+
+1. Prove the current WHOOP target identities, persisted connection statuses,
+   error transport, and connect-page state transitions.
+2. Implement the minimal server capacity assertion and typed error.
+3. Add the inline Apple Health fallback and exact error recognition.
+4. Add focused server, helper, and UI coverage; run typecheck and browser proof.
+5. Run frontend and coverage audits, parent final review, then commit, push, open
+   the PR, and complete CI plus the ReviewGPT loop.
+
+## Decisions
+
+- Enforce at the shared Web connect-start boundary so all Web entry points share
+  one policy while assistant link generation remains unchanged.
+- Count distinct current members, not concurrent requests or historical rows.
+- Allow an already-counted member to reconnect even when capacity is full.
+- Present Apple Health as the supported fallback only after the server reports
+  that direct WHOOP capacity is full.
+
+## Outcome
+
+- Added one Web-owned admission check at the shared authenticated connect-start
+  seam. It counts distinct current WHOOP members across the direct provider and
+  Junction `whoop_v2`, preserves reconnects, and returns one typed capacity
+  error before provider work begins.
+- Kept assistant link issuance unchanged. The existing connect page handles the
+  typed error for both manual starts and assistant-issued intents and presents
+  the Apple Health fallback inline.
+- Added no schema, persisted state, lock, reservation, feature flag, dependency,
+  or assistant-runtime behavior.
+
+## Verification results
+
+- Focused Vitest: 3 files and 110 tests passed, including the ninth-to-tenth
+  member boundary, rejection at 10, reconnect at 10, intent release, and both
+  fallback entry paths.
+- Scoped Web verifier passed dependency and boundary guards, typecheck, dev
+  smoke, lint with no errors, 5,283 tests, and the production Next build.
+- Final targeted typecheck and lint passed after audit remediation.
+- Desktop 1440×900 and mobile 390×844 browser proof passed with no horizontal
+  overflow, correct external-link semantics, visible keyboard focus, and no
+  inherited link underline.
+- `coverage-write` passed after the exact last-slot test was added.
+- `frontend-review` passed after contrast and prose-link styling findings were
+  remediated and re-verified.
+- Parent final review, identifier/credential scans, and `git diff --check`
+  passed locally. PR CI and ReviewGPT remain the required post-push gates before
+  merge-readiness.
+Completed: 2026-07-16

--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -21,6 +21,7 @@ import {
   filterConnectSourcesForSearch,
   isHostedConsentRequiredError,
   isHostedDeviceConnectIntentUnavailableError,
+  isHostedWhoopDirectConnectCapReachedError,
   markCallbackConnectedSource,
   markLocallyDisconnectedSources,
   readDeviceConnectIntentFromCurrentLocation,
@@ -34,6 +35,7 @@ import {
 } from "./connect-page-helpers";
 import { SourceCard } from "./connect-source-card";
 import { sortConnectSourcesByConnectionState } from "./connect-source-order";
+import { WhoopAppleHealthFallback } from "./whoop-apple-health-fallback";
 import type {
   ConnectCallbackInput,
   ConnectCallbackNotice,
@@ -79,6 +81,7 @@ export function ConnectSourcesGrid({
   const [consentRequest, setConsentRequest] = useState<ConnectConsentRequest | null>(null);
   const [connectIntentRecovery, setConnectIntentRecovery] =
     useState<ConnectIntentRecoveryRequest | null>(null);
+  const [showWhoopAppleHealthFallback, setShowWhoopAppleHealthFallback] = useState(false);
   const [disconnectSource, setDisconnectSource] = useState<ConnectSource | null>(null);
   const [disconnectedConnectionIds, setDisconnectedConnectionIds] = useState<ReadonlySet<string>>(
     () => new Set(),
@@ -161,6 +164,7 @@ export function ConnectSourcesGrid({
     setNotice(null);
     setConsentRequest(null);
     setConnectIntentRecovery(null);
+    setShowWhoopAppleHealthFallback(false);
 
     try {
       const authorizationUrl = await requestConnectionAuthorizationUrl(source, options);
@@ -180,6 +184,12 @@ export function ConnectSourcesGrid({
           message: error.message,
           sourceName: source.name,
         });
+        setPendingSourceId(null);
+        return;
+      }
+
+      if (isHostedWhoopDirectConnectCapReachedError(error)) {
+        setShowWhoopAppleHealthFallback(true);
         setPendingSourceId(null);
         return;
       }
@@ -232,6 +242,11 @@ export function ConnectSourcesGrid({
             intentClaim: activeConnectIntent.claim,
             source,
           });
+          return;
+        }
+
+        if (isHostedWhoopDirectConnectCapReachedError(error)) {
+          setShowWhoopAppleHealthFallback(true);
           return;
         }
 
@@ -320,46 +335,54 @@ export function ConnectSourcesGrid({
         )
       ) : null}
 
-      <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <p className="font-mono text-[10px] font-medium uppercase tracking-[0.11em] text-muted-foreground">
-            Sources
-          </p>
-          <p className="mt-1 text-xs tabular-nums text-muted-foreground">
-            {filteredSources.length} of {displaySources.length} sources
-          </p>
-        </div>
-        <Input
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search sources"
-          aria-label="Search sources"
-          className="w-full sm:w-64"
+      {showWhoopAppleHealthFallback ? (
+        <WhoopAppleHealthFallback
+          onViewOtherSources={() => setShowWhoopAppleHealthFallback(false)}
         />
-      </div>
-
-      {filteredSources.length === 0 ? (
-        <Alert>
-          <AlertTitle>No sources matched</AlertTitle>
-          <AlertDescription>
-            Try a different search to get back to the full source list.
-          </AlertDescription>
-        </Alert>
       ) : (
-        <div className="grid min-w-0 grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-4">
-          {filteredSources.map((source) => (
-            <SourceCard
-              key={source.id}
-              authenticated={authenticated}
-              errorMessage={visibleActionError?.sourceId === source.id ? visibleActionError.message : null}
-              pending={pendingSourceId === source.id}
-              pendingDisconnect={pendingDisconnectSourceId === source.id}
-              source={source}
-              onDisconnectTargetChange={setDisconnectSource}
-              onStartConnection={startConnection}
+        <>
+          <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-mono text-[10px] font-medium uppercase tracking-[0.11em] text-muted-foreground">
+                Sources
+              </p>
+              <p className="mt-1 text-xs tabular-nums text-muted-foreground">
+                {filteredSources.length} of {displaySources.length} sources
+              </p>
+            </div>
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search sources"
+              aria-label="Search sources"
+              className="w-full sm:w-64"
             />
-          ))}
-        </div>
+          </div>
+
+          {filteredSources.length === 0 ? (
+            <Alert>
+              <AlertTitle>No sources matched</AlertTitle>
+              <AlertDescription>
+                Try a different search to get back to the full source list.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <div className="grid min-w-0 grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-4">
+              {filteredSources.map((source) => (
+                <SourceCard
+                  key={source.id}
+                  authenticated={authenticated}
+                  errorMessage={visibleActionError?.sourceId === source.id ? visibleActionError.message : null}
+                  pending={pendingSourceId === source.id}
+                  pendingDisconnect={pendingDisconnectSourceId === source.id}
+                  source={source}
+                  onDisconnectTargetChange={setDisconnectSource}
+                  onStartConnection={startConnection}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
 
       <ConnectConsentDialog

--- a/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
@@ -48,6 +48,10 @@ export function isHostedDeviceConnectIntentUnavailableError(
   return code?.startsWith("HOSTED_DEVICE_CONNECT_INTENT_") === true;
 }
 
+export function isHostedWhoopDirectConnectCapReachedError(error: unknown): boolean {
+  return readHostedOnboardingErrorCode(error) === "WHOOP_DIRECT_CONNECT_CAP_REACHED";
+}
+
 export function resolveCallbackSourceId(
   input: ConnectCallbackInput,
   sources: readonly ConnectSource[],

--- a/apps/web/app/(dashboard)/connect/whoop-apple-health-fallback.tsx
+++ b/apps/web/app/(dashboard)/connect/whoop-apple-health-fallback.tsx
@@ -1,0 +1,67 @@
+import { DownloadIcon, SmartphoneIcon } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { Button, buttonVariants } from "@/src/components/ui/button";
+
+const MURPH_IOS_APP_STORE_URL = "https://apps.apple.com/us/app/murph-ai/id6786145859";
+
+export function WhoopAppleHealthFallback({
+  onViewOtherSources,
+}: {
+  onViewOtherSources: () => void;
+}) {
+  return (
+    <Alert className="px-5 py-5 sm:px-6 sm:py-6">
+      <SmartphoneIcon />
+      <AlertTitle
+        id="whoop-apple-health-fallback-title"
+        role="heading"
+        aria-level={2}
+        className="flex flex-col gap-2"
+      >
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.11em] text-card-foreground">
+          WHOOP via Apple Health
+        </span>
+        <span className="text-xl leading-snug">Keep WHOOP syncing through Apple Health</span>
+      </AlertTitle>
+      <AlertDescription
+        aria-labelledby="whoop-apple-health-fallback-title"
+        className="flex flex-col gap-5 text-card-foreground"
+      >
+        <p>
+          Direct WHOOP connections are full right now. You can still sync your WHOOP data through
+          Apple Health on your iPhone.
+        </p>
+        <ol className="flex list-decimal flex-col gap-3 pl-5 text-left marker:font-mono marker:text-card-foreground">
+          <li>In WHOOP, open More → App Settings → Integrations → Apple Health.</li>
+          <li>Tap Connect, choose the categories you want to share, then tap Allow.</li>
+          <li>Download or open Murph, sign in, and connect Apple Health.</li>
+        </ol>
+      </AlertDescription>
+      <div className="col-start-2 mt-4 flex flex-col gap-2 sm:flex-row">
+        <a
+          aria-label="Download Murph for iPhone (opens in a new tab)"
+          className={buttonVariants({
+            className: "w-full sm:w-auto",
+            size: "lg",
+          })}
+          href={MURPH_IOS_APP_STORE_URL}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <DownloadIcon data-icon="inline-start" />
+          Download Murph for iPhone
+        </a>
+        <Button
+          type="button"
+          className="w-full sm:w-auto"
+          size="lg"
+          variant="ghost"
+          onClick={onViewOtherSources}
+        >
+          View other sources
+        </Button>
+      </div>
+    </Alert>
+  );
+}

--- a/apps/web/src/lib/device-sync/hosted-connect-start.ts
+++ b/apps/web/src/lib/device-sync/hosted-connect-start.ts
@@ -3,6 +3,7 @@ import "server-only";
 import type { DeviceSyncConnectTarget } from "@murphai/device-syncd/connect-config";
 
 import { createHostedDeviceSyncPublicIngressService } from "./public-ingress-service";
+import { assertHostedWhoopConnectCapacityAvailable } from "./whoop-connect-capacity";
 import { requireActiveHostedAppSessionFromRequest } from "../hosted-onboarding/app-session";
 import { assertHostedOnboardingMutationOrigin } from "../hosted-onboarding/csrf";
 import {
@@ -25,6 +26,11 @@ export async function startHostedDeviceSyncConnection(input: {
   await assertHostedLaunchRequiredConsentGranted({
     memberId: auth.member.id,
     prisma,
+  });
+  await assertHostedWhoopConnectCapacityAvailable({
+    memberId: auth.member.id,
+    prisma,
+    target: input.target,
   });
   const publicIngress = createHostedDeviceSyncPublicIngressService(input.request);
   const started = await publicIngress.startConnection(

--- a/apps/web/src/lib/device-sync/whoop-connect-capacity.ts
+++ b/apps/web/src/lib/device-sync/whoop-connect-capacity.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+import type { PrismaClient } from "@prisma/client";
+import type { DeviceSyncConnectTarget } from "@murphai/device-syncd/connect-config";
+import { deviceSyncError } from "@murphai/device-syncd/errors";
+
+const WHOOP_DIRECT_CONNECT_MEMBER_LIMIT = 10;
+
+export async function assertHostedWhoopConnectCapacityAvailable(input: {
+  memberId: string;
+  prisma: PrismaClient;
+  target: DeviceSyncConnectTarget;
+}): Promise<void> {
+  if (!isHostedWhoopConnectTarget(input.target)) {
+    return;
+  }
+
+  const currentMembers = await input.prisma.deviceConnection.findMany({
+    where: {
+      status: { not: "disconnected" },
+      OR: [
+        { provider: "whoop" },
+        {
+          provider: "junction",
+          sources: {
+            some: {
+              sourceProviderSlug: "whoop_v2",
+              status: { not: "disconnected" },
+            },
+          },
+        },
+      ],
+    },
+    select: { userId: true },
+    distinct: ["userId"],
+  });
+
+  if (
+    currentMembers.length < WHOOP_DIRECT_CONNECT_MEMBER_LIMIT
+    || currentMembers.some((member) => member.userId === input.memberId)
+  ) {
+    return;
+  }
+
+  throw deviceSyncError({
+    code: "WHOOP_DIRECT_CONNECT_CAP_REACHED",
+    httpStatus: 409,
+    message:
+      "Direct WHOOP connections are full right now. You can keep WHOOP syncing through Apple Health in the Murph app.",
+    retryable: false,
+  });
+}
+
+function isHostedWhoopConnectTarget(target: DeviceSyncConnectTarget): boolean {
+  return target.provider === "whoop"
+    || (target.provider === "junction" && target.sourceProviderSlug === "whoop_v2");
+}

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -2214,6 +2214,148 @@ test("ConnectSourcesGrid shows a recovery dialog when a device connect intent is
   await rendered.cleanup();
 });
 
+test("ConnectSourcesGrid shows the WHOOP Apple Health fallback when an intent reaches capacity", async () => {
+  const claim = "dc_12345678901234567890123456789012";
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({
+      error: {
+        code: "WHOOP_DIRECT_CONNECT_CAP_REACHED",
+        message:
+          "Direct WHOOP connections are full right now. You can keep WHOOP syncing through Apple Health in the Murph app.",
+        retryable: false,
+      },
+    }, { status: 409 });
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    initialConnectIntent: {
+      claim,
+      connectSource: "whoop",
+    },
+    sources: [
+      {
+        description: "Recovery, strain, sleep, and heart rate.",
+        id: "whoop",
+        logo: {
+          className: "h-auto max-h-7 w-auto max-w-[8rem] object-contain",
+          height: 15,
+          src: "/brand-logos/connect/whoop.svg",
+          width: 96,
+        },
+        name: "Whoop",
+      },
+    ],
+  }));
+
+  await vi.waitFor(() => {
+    assert.equal(fetch.mock.calls.length, 1);
+    assert.match(rendered.container.textContent ?? "", /Keep WHOOP syncing through Apple Health/);
+  });
+
+  assert.equal(fetch.mock.calls[0]?.[0], `/device/connect/${claim}`);
+  assert.doesNotMatch(rendered.container.textContent ?? "", /Connecting Whoop/);
+  assert.doesNotMatch(rendered.container.textContent ?? "", /Connection link unavailable/);
+  assert.equal(
+    rendered.container.querySelector("input[aria-label='Search sources']"),
+    null,
+  );
+  assert.match(
+    rendered.container.textContent ?? "",
+    /More → App Settings → Integrations → Apple Health/,
+  );
+  assert.match(
+    rendered.container.textContent ?? "",
+    /Tap Connect, choose the categories you want to share, then tap Allow/,
+  );
+  assert.match(
+    rendered.container.textContent ?? "",
+    /Download or open Murph, sign in, and connect Apple Health/,
+  );
+
+  const appStoreLink = rendered.container.querySelector(
+    "a[href='https://apps.apple.com/us/app/murph-ai/id6786145859']",
+  );
+  assert.ok(appStoreLink instanceof rendered.window.HTMLAnchorElement);
+  assert.equal(appStoreLink.target, "_blank");
+  assert.equal(appStoreLink.rel, "noopener noreferrer");
+  assert.equal(
+    appStoreLink.getAttribute("aria-label"),
+    "Download Murph for iPhone (opens in a new tab)",
+  );
+  assert.equal(rendered.assign.mock.calls.length, 0);
+
+  const viewOtherSourcesButton = [...rendered.container.querySelectorAll("button")]
+    .find((button) => button.textContent === "View other sources");
+  assert.ok(viewOtherSourcesButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    viewOtherSourcesButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  assert.ok(rendered.container.querySelector("input[aria-label='Search sources']"));
+  assert.doesNotMatch(rendered.container.textContent ?? "", /Keep WHOOP syncing through Apple Health/);
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid shows the WHOOP Apple Health fallback for a manual start", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({
+      error: {
+        code: "WHOOP_DIRECT_CONNECT_CAP_REACHED",
+        message:
+          "Direct WHOOP connections are full right now. You can keep WHOOP syncing through Apple Health in the Murph app.",
+        retryable: false,
+      },
+    }, { status: 409 });
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connectTarget: "whoop",
+        description: "Recovery, strain, sleep, and heart rate.",
+        id: "whoop",
+        logo: {
+          className: "h-auto max-h-7 w-auto max-w-[8rem] object-contain",
+          height: 15,
+          src: "/brand-logos/connect/whoop.svg",
+          width: 96,
+        },
+        name: "Whoop",
+      },
+    ],
+  }));
+
+  await act(async () => {
+    rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(rendered.container.textContent ?? "", /Keep WHOOP syncing through Apple Health/);
+  });
+
+  assert.equal(fetch.mock.calls[0]?.[0], "/api/connect-sources/whoop/start");
+  assert.equal(rendered.assign.mock.calls.length, 0);
+  assert.doesNotMatch(rendered.container.textContent ?? "", /Connection could not be started/);
+
+  await rendered.cleanup();
+});
+
 test("ConnectSourcesGrid labels Telegram recovery as texting Murph", async () => {
   const claim = "dc_12345678901234567890123456789012";
   const fetch = vi.fn(async () =>

--- a/apps/web/test/device-connect-intent-route.test.ts
+++ b/apps/web/test/device-connect-intent-route.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { deviceSyncError } from "@murphai/device-syncd/errors";
+
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 
 import { createRouteContext } from "./route-test-helpers";
@@ -267,6 +269,40 @@ describe("hosted device connect intent route", () => {
     );
 
     expect(response.status).toBe(500);
+    expect(mocks.releaseHostedDeviceConnectIntentStart).toHaveBeenCalledWith({
+      claim: "dc_opaque",
+      memberId: "member_123",
+    });
+  });
+
+  it("returns the WHOOP capacity error to the connect page and releases the claim", async () => {
+    mocks.startHostedDeviceSyncConnection.mockRejectedValueOnce(deviceSyncError({
+      code: "WHOOP_DIRECT_CONNECT_CAP_REACHED",
+      httpStatus: 409,
+      message:
+        "Direct WHOOP connections are full right now. You can keep WHOOP syncing through Apple Health in the Murph app.",
+      retryable: false,
+    }));
+
+    const response = await deviceConnectIntentRoute.POST(
+      new Request("https://join.example.test/device/connect/dc_opaque", {
+        headers: {
+          accept: "application/json",
+        },
+        method: "POST",
+      }),
+      createRouteContext({ claim: "dc_opaque" }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "WHOOP_DIRECT_CONNECT_CAP_REACHED",
+        message:
+          "Direct WHOOP connections are full right now. You can keep WHOOP syncing through Apple Health in the Murph app.",
+        retryable: false,
+      },
+    });
     expect(mocks.releaseHostedDeviceConnectIntentStart).toHaveBeenCalledWith({
       claim: "dc_opaque",
       memberId: "member_123",

--- a/apps/web/test/device-sync-settings-routes.test.ts
+++ b/apps/web/test/device-sync-settings-routes.test.ts
@@ -1266,6 +1266,7 @@ describe("device sync settings routes", () => {
     await expect(response.json()).resolves.toEqual({
       authorizationUrl: "https://provider.example.test/oauth/source-start",
     });
+    expect(mocks.findManyDeviceConnections).not.toHaveBeenCalled();
   });
 
   it("starts a hosted connect source flow through Junction by source id", async () => {
@@ -1335,6 +1336,124 @@ describe("device sync settings routes", () => {
         connectSourceId: "whoop",
         connectTarget: "whoop",
         sourceProviderSlug: "whoop_v2",
+      },
+    );
+    expect(mocks.findManyDeviceConnections).toHaveBeenCalledWith({
+      where: {
+        status: { not: "disconnected" },
+        OR: [
+          { provider: "whoop" },
+          {
+            provider: "junction",
+            sources: {
+              some: {
+                sourceProviderSlug: "whoop_v2",
+                status: { not: "disconnected" },
+              },
+            },
+          },
+        ],
+      },
+      select: { userId: true },
+      distinct: ["userId"],
+    });
+  });
+
+  it("rejects a new member when current WHOOP capacity is full", async () => {
+    vi.stubEnv("WHOOP_CLIENT_ID", "whoop-client-id");
+    vi.stubEnv("WHOOP_CLIENT_SECRET", "whoop-client-secret");
+    mocks.findManyDeviceConnections.mockResolvedValueOnce(
+      Array.from({ length: 10 }, (_, index) => ({ userId: `member_existing_${index}` })),
+    );
+
+    const response = await connectSourceStartRoute.POST(
+      createJsonPostRequest(
+        "https://join.example.test/api/connect-sources/whoop/start",
+        {},
+        {
+          headers: {
+            origin: "https://join.example.test",
+          },
+        },
+      ),
+      createRouteContext({ sourceId: "whoop" }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "WHOOP_DIRECT_CONNECT_CAP_REACHED",
+        message:
+          "Direct WHOOP connections are full right now. You can keep WHOOP syncing through Apple Health in the Murph app.",
+        retryable: false,
+      },
+    });
+    expect(mocks.startConnection).not.toHaveBeenCalled();
+  });
+
+  it("allows a new member to take the tenth current WHOOP slot", async () => {
+    vi.stubEnv("WHOOP_CLIENT_ID", "whoop-client-id");
+    vi.stubEnv("WHOOP_CLIENT_SECRET", "whoop-client-secret");
+    mocks.findManyDeviceConnections.mockResolvedValueOnce(
+      Array.from({ length: 9 }, (_, index) => ({ userId: `member_existing_${index}` })),
+    );
+
+    const response = await connectSourceStartRoute.POST(
+      createJsonPostRequest(
+        "https://join.example.test/api/connect-sources/whoop/start",
+        {},
+        {
+          headers: {
+            origin: "https://join.example.test",
+          },
+        },
+      ),
+      createRouteContext({ sourceId: "whoop" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.startConnection).toHaveBeenCalledWith(
+      "member_123",
+      "whoop",
+      "/device-sync/connect/complete?source=connect&connectSource=whoop&connectTarget=whoop",
+      {
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        sourceProviderSlug: null,
+      },
+    );
+  });
+
+  it("allows an existing WHOOP member to reconnect when capacity is full", async () => {
+    vi.stubEnv("WHOOP_CLIENT_ID", "whoop-client-id");
+    vi.stubEnv("WHOOP_CLIENT_SECRET", "whoop-client-secret");
+    mocks.findManyDeviceConnections.mockResolvedValueOnce([
+      { userId: "member_123" },
+      ...Array.from({ length: 9 }, (_, index) => ({ userId: `member_existing_${index}` })),
+    ]);
+
+    const response = await connectSourceStartRoute.POST(
+      createJsonPostRequest(
+        "https://join.example.test/api/connect-sources/whoop/start",
+        {},
+        {
+          headers: {
+            origin: "https://join.example.test",
+          },
+        },
+      ),
+      createRouteContext({ sourceId: "whoop" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.startConnection).toHaveBeenCalledWith(
+      "member_123",
+      "whoop",
+      "/device-sync/connect/complete?source=connect&connectSource=whoop&connectTarget=whoop",
+      {
+        connectSourceId: "whoop",
+        connectTarget: "whoop",
+        sourceProviderSlug: null,
       },
     );
   });


### PR DESCRIPTION
## Why this PR exists

WHOOP's development access is capped at 10 members. Murph needs to keep direct WHOOP setup available while capacity remains, then give additional members a useful path instead of a failed OAuth start.

## User goal and experience

- Murph continues sending the existing connect link; assistant-runtime behavior does not change.
- On the connect page, manual WHOOP starts and assistant-issued WHOOP intents share one authenticated server check.
- Below the cap, or when the member already occupies a slot, the normal direct WHOOP authorization continues.
- At capacity, a new member sees an inline WHOOP → Apple Health guide with the official Murph App Store action and can return to the other source options.

## Invariants

- The server is authoritative; a page-only check cannot bypass the limit.
- Distinct current members are counted once across direct WHOOP and Junction `whoop_v2`; disconnected connections and sources do not occupy a slot.
- Existing WHOOP members can reconnect at capacity, and non-WHOOP starts do not pay for the capacity query.
- Authentication, CSRF, required consent, intent-claim release, and provider-start ordering remain intact.
- Member counts and identifiers are never returned to the browser.
- No schema, persisted reservation, lock, feature flag, dependency, or assistant-runtime state is added. The accepted low-scale tradeoff is a theoretical race for the final slot.

## Non-obvious affected surfaces

- Shared hosted connect-start: both dashboard source starts and assistant-issued intent starts use this seam. Route tests prove non-WHOOP bypass, the exact WHOOP query, admission at nine, rejection at 10, and reconnect at 10.
- Device-connect intent claims: the typed capacity error crosses the JSON route while the claimed intent is released. A focused route test proves both behaviors.
- Connect-page state: automatic and manual starts recognize only `WHOOP_DIRECT_CONNECT_CAP_REACHED`; focused component tests and desktop/mobile browser proof cover the fallback, recovery action, link semantics, focus, and overflow.

## Change shape

Classification is by authored file purpose in the base-to-head diff; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 194 | 37 |
| Tests / fixtures | 297 | 0 |
| Docs | 108 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **599** | **37** |

## Deployment skew / compatibility

This is a Web-only change with no Cloudflare, runner-container, schema, environment, credential, or persisted-state counterpart. It can use the normal Vercel rollout; no tandem deploy or immediate container rollout is required. The old deployment continues the existing direct-connect behavior until the alias moves, while the new deployment contains both the gate and its UI handling. Rollback is a normal Web rollback. Current evidence is seven current WHOOP members and low connect-start volume, leaving three apparent slots; monitoring is the typed 409 plus normal connect completion behavior.

## Verification

- `pnpm test:diff apps/web` — passed, including 5,283 tests, typecheck, lint with no errors, dev smoke, and production build.
- Focused final-head suite — 3 files, 110 tests passed.
- Final-head Web typecheck and targeted lint — passed.
- Desktop 1440×900 and mobile 390×844 browser proof — passed with no overflow, correct external-link semantics, visible keyboard focus, AA-safe copy, and no inherited CTA underline.
- `coverage-write` and `frontend-review` — passed after their accepted findings were remediated and re-audited.

ReviewGPT first-reviewed head: a0de8e3ee74bf27448e8194f2e541938e1d02b95

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786777205&installation_id=127572939&pr_number=741&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F741&signature=74984145b8ad25e42c4f15d27670c42c3eb2b58547fbc28824e7096e2e2a1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->