### PR TITLE
fix(assistant): restore notification reply continuity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-notification-reply-continuity.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-notification-reply-continuity.md
@@ -1,0 +1,131 @@
+# Preserve notification reply conversation continuity
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Make an authenticated inbound reply continue the latest authorized direct
+  conversation even when the immediately preceding Murph message came from a
+  scheduled notification turn.
+
+## Success criteria
+
+- Reconstruct the reported scheduled-notification and inbound-reply sequence
+  from the supplied vault plus secret-safe hosted evidence and identify the
+  exact boundary that lost conversational context.
+- Keep one existing conversation/session owner and one continuity path; do not
+  add a notification-specific history store, queue, scheduler, or parallel
+  transcript.
+- Preserve direct/group audience isolation, route authority, reply idempotency,
+  provider-native continuity, durable transcript fallback, and foreground reply
+  priority.
+- Add production-faithful regression proof for notification-turn context being
+  available to the next inbound reply, including the relevant cold-restore or
+  stale-native-resume boundary when that is the proven failure.
+- Pass the required verification, direct scenario proof, specialist audits,
+  exact-head ReviewGPT loop, PR CI, and merge-conflict check.
+
+## Scope
+
+- In scope: supplied-vault and hosted-runtime diagnosis; direct-message session
+  selection, transcript/native-resume persistence, scheduled notification turn
+  handling, hosted snapshot integration, focused tests, and matching current
+  runtime/architecture docs.
+- Out of scope: changing reminder product policy or copy, adding durable product
+  state, broad assistant-session redesign, group-audience behavior beyond
+  preserving its current isolation, and unrelated mailbox/orchestration work.
+
+## Constraints
+
+- Prove the root cause from concrete vault, code-path, log, deployment, or test
+  evidence before editing production behavior.
+- Prefer deletion, reordering, or reuse of the existing session/transcript
+  owner. Add no notification-specific context state or compatibility machinery
+  without evidence that the existing owner cannot satisfy the requirement.
+- Keep member content, direct identifiers, local account paths, secrets, raw
+  message bodies, and provider payloads out of commits, plans, logs, fixtures,
+  review artifacts, and PR text.
+- Work only in the isolated task worktree and preserve the non-exclusive active
+  mailbox/runtime lanes recorded in the coordination ledger.
+
+## Risks and mitigations
+
+1. Risk: treating the screenshot as proof of a session-key bug when provider
+   resume loss, transcript omission, or deployment skew could produce the same
+   symptom.
+   Mitigation: correlate the vault's session, input, transcript, automation,
+   outbox, and checkpoint evidence with runtime metadata and recent code before
+   choosing a fix.
+2. Risk: broadening continuity can cross direct/group audience or route
+   boundaries.
+   Mitigation: preserve the canonical conversation key and monotonic binding
+   checks; only make already-authorized same-conversation notification output
+   visible through the existing continuity owner.
+3. Risk: a local passing test may miss hosted cold-restore behavior.
+   Mitigation: include the proven restore/resume boundary in focused coverage
+   and run the narrowest production-faithful hosted scenario available.
+
+## Tasks
+
+1. Inspect the supplied vault safely and query secret-safe hosted evidence for
+   the reported time window.
+2. Trace scheduled notification session selection, provider-native resume,
+   transcript persistence, hosted snapshot inclusion, and later inbound session
+   lookup through current code and tests.
+3. Write a failing regression that reproduces the proven context loss.
+4. Implement the smallest owner-level correction and update current durable
+   docs only where the runtime contract changes or is clarified.
+5. Run verification, direct scenario proof, required coverage audit, parent
+   final review, exact-head ReviewGPT, CI, and clean-merge proof.
+6. Close the plan with a scoped commit, push the task branch, open the PR, and
+   report any cross-plane deployment order or remaining live-production proof.
+
+## Decisions
+
+- Vault and hosted metadata prove the scheduled message and later inbound reply
+  used the same provider chat but different assistant sessions. Ingress,
+  Temporal handoff, restore, provider execution, delivery, and deploy version
+  were healthy.
+- Preserve automations with full conversation locators already resolve the live
+  conversation session. This older keyless automation correctly retained its
+  separate pinned session, so the existing outbox-to-turn context bridge is the
+  intended continuity owner for the next inbound reply.
+- The bridge has rejected normal production deliveries since introduction:
+  persisted message deliveries omit the optional `kind: "message"`
+  discriminator, while three local match/read helpers require it. Reaction
+  deliveries alone carry `kind: "message-reaction"`.
+- Classify reactions once at the existing outbox-list boundary, narrow the
+  downstream helpers to the normal-message delivery type, and make the shared
+  fixture use the production shape. Do not merge sessions, rewrite automation
+  routes, clear provider resume state, add persistence, or change hosted
+  orchestration.
+
+## Verification
+
+- Production-shaped failing proof: removing the fixture's fabricated normal
+  message discriminator made 17 cross-session event-path cases fail before the
+  matcher correction.
+- Focused event-path verification passes all 32 cases, including the exact Linq
+  cron-route scenario, native reply anchors, causal cutoffs, route isolation,
+  same-session exclusion, and receipt-watermark suppression.
+- Assistant-engine typecheck passes. A full package run reached 2,285 passing
+  tests and only two unrelated 60-second timeout failures; both timed-out cases
+  pass in isolated reruns. An earlier unconstrained package run passed all 2,287
+  tests with five skips.
+- Truthful diff verification passed repository guards, affected typechecks, and
+  all affected package suites except unrelated CLI timeouts. The missing
+  ignored Health Commons prerequisite was generated through its standard
+  command and the affected 32-test CLI file then passed. The remaining isolated
+  CLI intervention timeout reproduces on untouched `origin/main`; the other
+  timed-out CLI file passes all six tests alone.
+- Required `coverage-write` audit completed with no edits and no actionable
+  proof gaps. `git diff --check` and the secret/direct-identifier readback pass.
+- Parent final review found no remaining correctness, coverage, privacy, or
+  handoff gap. The scope-and-shape check reduced three duplicate runtime guards
+  to one owner-boundary classification plus compiler-enforced helper types.
+- Remaining external gates: exact pushed-head ReviewGPT pass, green PR CI,
+  clean latest-base merge proof, and a post-deploy live scheduled-message reply
+  check.
+Completed: 2026-07-16

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -4031,6 +4031,11 @@ type AssistantAutoReplyOutboxDelivery = NonNullable<
   AssistantAutoReplyOutboxIntent['delivery']
 >
 
+type AssistantAutoReplyOutboxMessageDelivery = Extract<
+  AssistantAutoReplyOutboxDelivery,
+  { kind?: 'message' }
+>
+
 async function listAssistantAutoReplyMatchingOutboxDeliveries(input: {
   deliveryTarget: string | null
   historyReader: AssistantAutoReplyHistoryReader
@@ -4105,14 +4110,10 @@ async function resolveAssistantAutoReplyExistingSession(input: {
 
 function assistantAutoReplyOutboxMatchesInput(input: {
   conversation: AssistantInputConversationRef
-  delivery: AssistantAutoReplyOutboxDelivery
+  delivery: AssistantAutoReplyOutboxMessageDelivery
   deliveryTarget: string
   intent: AssistantAutoReplyOutboxIntent
 }): boolean {
-  if (input.delivery.kind !== 'message') {
-    return false
-  }
-
   const exactTargetMatch = assistantAutoReplyOutboxDeliveryMatchesExactTarget({
     delivery: input.delivery,
     deliveryTarget: input.deliveryTarget,
@@ -4160,13 +4161,9 @@ function assistantAutoReplyOutboxIntentMatchesConversation(input: {
 }
 
 function assistantAutoReplyOutboxDeliveryMatchesExactTarget(input: {
-  delivery: AssistantAutoReplyOutboxDelivery
+  delivery: AssistantAutoReplyOutboxMessageDelivery
   deliveryTarget: string
 }): boolean {
-  if (input.delivery.kind !== 'message') {
-    return false
-  }
-
   return [input.delivery.target, input.delivery.providerThreadId].some(
     (candidate) => normalizeNullableString(candidate) === input.deliveryTarget,
   )
@@ -4174,7 +4171,7 @@ function assistantAutoReplyOutboxDeliveryMatchesExactTarget(input: {
 
 function assistantAutoReplyOutboxDeliveryMatchesStableConversationFallback(input: {
   conversation: AssistantInputConversationRef
-  delivery: AssistantAutoReplyOutboxDelivery
+  delivery: AssistantAutoReplyOutboxMessageDelivery
   intent: AssistantAutoReplyOutboxIntent
 }): boolean {
   const conversation = conversationRefFromAssistantInputConversation(
@@ -4190,12 +4187,8 @@ function assistantAutoReplyOutboxDeliveryMatchesStableConversationFallback(input
 }
 
 function readAssistantAutoReplyOutboxDeliveryProviderMessageIds(
-  delivery: AssistantAutoReplyOutboxDelivery,
+  delivery: AssistantAutoReplyOutboxMessageDelivery,
 ): string[] {
-  if (delivery.kind !== 'message') {
-    return []
-  }
-
   const ids = [
     readProviderRouteScalar(delivery.providerMessageId),
     ...(Array.isArray(delivery.providerMessageIds)

--- a/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
@@ -1962,9 +1962,10 @@ function createOutboxMessage(input: {
     delivery:
       status === 'sent'
         ? {
+            // Production message deliveries omit the optional discriminator;
+            // only reaction deliveries require an explicit `kind`.
             channel,
             idempotencyKey: null,
-            kind: 'message',
             messageLength: input.message.length,
             providerMessageId: input.providerMessageId ?? null,
             ...(input.providerMessageIds


### PR DESCRIPTION
## Why

Replies immediately following a scheduled assistant message could resume the interactive session without receiving that scheduled message as turn context. This made short, context-dependent replies look unrelated even though both messages used the same authorized provider conversation.

## User-visible goal

When someone responds to a scheduled Murph message in an established direct conversation, the next reply should interpret that response against the scheduled message while preserving the existing interactive session.

## Root cause and approach

Normal sent-message delivery receipts intentionally omit the optional `kind: "message"` discriminator; only reaction receipts require an explicit kind. The existing cross-session context bridge required the optional normal-message discriminator in three downstream helpers, while its tests fabricated it.

This patch keeps the existing bridge and state owners. It classifies reactions once at the outbox-list boundary, narrows downstream helpers to the normal-message receipt type, and makes the shared fixture production-shaped.

## Invariants

- Keep channel, provider-thread, account, participant, and target isolation unchanged.
- Inject only confirmed deliveries from another session.
- Preserve native reply anchors, causal cutoff/clock-skew handling, same-session exclusion, and one-time receipt watermarking.
- Keep reactions excluded from normal message context.
- Add no transcript merge, session rewrite, queue, schema, persistence owner, or hosted orchestration path.

## Non-obvious affected surfaces

The change is confined to assistant-engine inbound auto-reply planning over confirmed sent-outbox history. It does not change scheduler behavior, automation routing, provider delivery, session persistence, or hosted control-plane code.

Because three existing decisions intentionally share this canonical normal-message classification boundary, restoring production-shaped sent-message matching also restores:

- provider-ID and bounded-text self-echo suppression; and
- exact-target attestation and message context for affirmative Linq reactions, including same-session targets.

This shared scope is necessary to correct the malformed receipt assumption once rather than create scheduler-, echo-, or reaction-specific classifiers. The production-shaped event-path suite covers both echo modes, attested cross-session and same-session affirmative reactions, and terminal suppression when no same-route target is attested.

## Verification

- Production-shaped failing proof: 17 cross-session cases failed when the fixture stopped fabricating the discriminator before the matcher fix.
- Assistant-engine event-path suite: 32/32 passed, including the Linq cron-route scenario and isolation/watermark cases.
- Assistant-engine typecheck passed.
- Required coverage-write audit passed with no edits or actionable gaps.
- Diff-aware guards, affected typechecks, and affected package suites passed except local 60-second timeout noise. Each timeout was isolated: the relevant files passed alone, and the one remaining CLI intervention timeout reproduced on untouched `origin/main`.
- `git diff --check` and privacy/identifier readback passed.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 9 | 16 |
| Tests | 2 | 1 |
| Docs | 131 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 0dc20636b93177ba643ce12550e075562043d7d2

| Review round | Current head | Authored-source change from baseline |
| --- | --- | ---: |
| 1 | `0dc20636b93177ba643ce12550e075562043d7d2` | baseline |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786777856&installation_id=127572939&pr_number=742&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F742&signature=8f40ab731f2c4b51298d80070c3161d46605cb4acbf8ec87dac7996d4cacdd1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
