### PR TITLE
Account Retell call costs in included usage

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-retell-phone-call-usage-accounting.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-retell-phone-call-usage-accounting.md
@@ -1,0 +1,65 @@
+# Retell phone-call usage accounting
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Count each terminal Retell phone call's provider-reported combined cost exactly once in the existing hosted included-usage allowance.
+
+## Success criteria
+
+- Completed, failed, unanswered, and zero-cost Retell calls produce one deterministic hosted usage row and at most one allowance-period increment.
+- Provider-reported combined cost in cents is converted to integer USD micros without estimating from duration or product names.
+- Transfer calls wait for `transfer_ended` so transfer-leg cost is included.
+- Duplicate, reordered, and concurrent terminal callbacks converge on the same immutable usage identity.
+- The pre-armed phone-call reconciliation workflow retrieves terminal provider usage when callbacks are lost.
+- Retell cost remains web-owned and cannot be asserted through the signed hosted-runtime usage callback.
+- Focused tests, full acceptance, required coverage review, PR CI, and exact-head ReviewGPT all pass.
+
+## Scope
+
+- In scope: Retell terminal payload parsing, webhook subscription/routing, a web-internal deterministic usage writer, allowance pricing for that trusted record shape, the existing reconciliation workflow, focused tests, and current Retell docs.
+- Out of scope: direct Stripe metered invoicing, hard usage enforcement, a second usage aggregate, provider product-level cost persistence, and unrelated phone-call behavior.
+
+## Constraints
+
+- Use the stored `HostedPhoneCall.memberId` as billing authority; never trust callback metadata for member attribution.
+- Persist only bounded aggregate cost facts, not transcripts, recordings, destinations, or product labels.
+- Keep the runtime usage parser unable to accept provider-reported Retell cost.
+- Preserve current result, privacy, storage-mode, and provider-authority gates.
+
+## Risks and mitigations
+
+1. Risk: `call_ended` can precede a transfer leg's final cost.
+   Mitigation: defer `call_transfer` observations until `transfer_ended` or terminal provider retrieval.
+2. Risk: webhook replay or reconciliation can double count usage.
+   Mitigation: derive one usage id from the immutable Murph phone-call id and reuse the existing usage-row and allowance compare-and-set owners.
+3. Risk: callback loss can leave a call permanently unaccounted.
+   Mitigation: keep the pre-armed reconciliation step pending until the provider call is terminal and its deterministic usage record is accounted.
+4. Risk: a runtime-supplied usage record could forge provider cost.
+   Mitigation: construct and persist Retell cost only inside `apps/web`; do not add its raw cost key to the shared runtime parser allowlist.
+
+## Tasks
+
+1. Add strict terminal Retell usage normalization and a web-internal deterministic usage writer/pricer.
+2. Account signed terminal callbacks, including `transfer_ended`, independently of post-call result success.
+3. Extend the existing provider reconciliation path to retrieve and account terminal usage after callback loss.
+4. Add focused replay, transfer, zero/fractional-cost, attribution, reconciliation, and period tests; update durable Retell docs.
+5. Run focused verification, coverage review, full acceptance, parent final review, close the plan with a scoped commit, then open the PR and run CI plus ReviewGPT concurrently.
+
+## Decisions
+
+- This PR updates Murph's advisory cost-weighted included usage. It does not enable the intentionally disabled Stripe usage export or introduce per-call overage invoices.
+- Retell's `call_cost.combined_cost` is authoritative because it includes provider products, discounts, and transfer-leg cost.
+- `HostedAiUsage` and `HostedAiUsagePeriod` remain the only usage row and aggregate owners.
+
+## Verification
+
+- Focused Retell routes/runtime/reconciliation and hosted allowance suite: 6 files, 193 tests passed.
+- `pnpm --filter ./apps/web typecheck:prepared`: passed.
+- Required `coverage-write`: found one oversized-cost ingress boundary; the committed regression and bounded parser fix passed its focused 9-test route suite.
+- `pnpm verify:acceptance`: workspace guards, all app/package typechecks, web build, web lint, web dev smoke, and all 5,289 web tests passed. The workspace coverage fan-out later exhausted its 4 GB Node heap in an unrelated CLI meal-import test and emitted one unrelated worker-exit error; the exact CLI file passed cleanly afterward (8 tests).
+- Remaining handoff gates: `git diff --check`, exact-head ReviewGPT, PR CI, and clean merge proof against current `main`.
+Completed: 2026-07-16

--- a/agent-docs/phone-calls/retell-analysis-fields.md
+++ b/agent-docs/phone-calls/retell-analysis-fields.md
@@ -3,9 +3,15 @@
 Configure these fields on the published Retell agent version. Murph stores the final analysis result,
 not the raw transcript.
 
-Subscribe the Retell webhook to `call_ended` and `call_analyzed` only, pointing at
+Subscribe the Retell webhook to `call_ended`, `call_analyzed`, and
+`transfer_ended` only, pointing at
 `/api/retell/webhook`. Murph verifies the raw `X-Retell-Signature`, updates the existing
 `HostedPhoneCall` row idempotently, and runs result handling only once when analysis first lands.
+Signed terminal callbacks also record Retell's provider-reported aggregate call
+cost in the web-owned included-usage ledger. A `call_transfer` observation stays
+pending until `transfer_ended` so the immutable usage row includes transfer-leg
+cost. The pre-armed reconciliation workflow retrieves terminal usage when the
+callbacks do not arrive.
 For local development, `RETELL_WEBHOOK_PUBLIC_BASE_URL` may point individual created calls at
 the local public tunnel without changing the published agent or workspace webhook configuration.
 
@@ -32,5 +38,6 @@ follow_up
 ```
 
 Privacy baseline: Retell stores basic attributes only; Murph stores the call brief and final result.
-Do not persist raw Retell transcripts, webhook bodies, function bodies, recordings, or audio in
-Murph.
+For usage, Murph stores only the bounded aggregate cost and duration. Do not
+persist raw Retell transcripts, webhook bodies, function bodies, recordings,
+audio, transfer destinations, or product-level cost labels in Murph.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -207,7 +207,8 @@ The hosted Prisma schema keeps ownership sharp and nested:
   prerequisites. After the reservation commits, a pointer-only web Workflow is
   armed within the same 40-second aggregate deadline and before Retell dispatch,
   so the durable row remains blocking authority while the bounded Workflow
-  reconciles ambiguous starts, provider-id binding failures, and unsafe cleanup.
+  reconciles ambiguous starts, provider-id binding failures, unsafe cleanup,
+  and terminal provider usage after callback loss.
   Immediately before Retell dispatch, web advances the reservation epoch; a
   reconciliation attempt may mutate only the exact epoch it read, preventing an
   older no-match result from releasing a newly dispatched call. Recovery resolves
@@ -514,6 +515,7 @@ Hosted AI usage metering:
 
 - Hosted AI usage rows are recorded locally for allowance, audit, and future billing analysis. The hosted app no longer attaches Stripe usage prices at checkout or posts Stripe meter events.
 - Hosted AI included-allowance accounting is app-owned: web prices recorded `HostedAiUsage` rows into allowance columns and maintains `HostedAiUsagePeriod` spend snapshots from current hosted billing state. The allowance is an advisory product and billing signal, not a runtime gate for an otherwise active member.
+- Retell phone calls use the same ledger through a web-internal deterministic row keyed by the Murph call id. Web records Retell's final provider-reported combined cost, including discounts and transfer-leg cost, and never accepts that cost field from the hosted-runtime usage callback. `transfer_ended` and the pre-armed phone-call reconciliation workflow prevent a provisional transfer cost or lost callback from becoming permanent undercounting.
 - Web derives one read-only member plan-usage projection from that same allowance resolver and usage ledger for Settings and `murph.plan_usage`. It persists no forecast and performs no Stripe read. `recommendedAction` remains a thresholded suggestion. An opted-in `subscriptionActionQuote` instead returns current terms for an explicit request, even below the threshold; it is not a recommendation or consent. Callers that send the original empty request receive the original response shape with that field omitted.
 - Web owns the separate `murph.subscription` callback for an explicit private member choice to continue Pulse at trial end, start Pulse now, or upgrade Pulse to Edge. It binds the runtime-supplied accepted input id to the callback member, atomically claims the first action on that existing mailbox row, re-derives current eligibility, and delegates to the existing billing services. An exact retry is allowed and a conflicting action fails closed. Pulse activation keeps its existing Stripe-hosted invoice or Customer Portal handoff when payment is required; a pending Edge change returns Customer Portal without a separate invoice lookup. No custom checkout or second billing owner is introduced.
 - Homepage period facts come from the same allowance owner. Spend accounting ensure-creates a fresh billing or calendar period inside the spend transaction, with no reset cron.

--- a/apps/web/app/api/retell/webhook/route.ts
+++ b/apps/web/app/api/retell/webhook/route.ts
@@ -5,6 +5,7 @@ import {
   handleRetellCallAnalyzed,
   handleRetellCallEnded,
 } from "@/src/lib/phone-calls/result";
+import { accountRetellPhoneCallUsage } from "@/src/lib/phone-calls/usage";
 import { verifyRetellSignature } from "@/src/lib/phone-calls/retell-signature";
 import { signalHostedMailboxAppendRuntime } from "@/src/lib/hosted-orchestration/signal-runtime";
 
@@ -23,9 +24,11 @@ export const POST = withJsonError(async (request: Request) => {
   const payload = retellWebhookPayloadSchema.parse(JSON.parse(rawBody));
   switch (payload.event) {
     case "call_ended":
+      await accountRetellPhoneCallUsage({ call: payload.call });
       await handleRetellCallEnded({ call: payload.call });
       break;
     case "call_analyzed": {
+      await accountRetellPhoneCallUsage({ call: payload.call });
       const result = await handleRetellCallAnalyzed({ call: payload.call });
       if (result.notificationMailboxItemId) {
         await signalHostedMailboxAppendRuntime({
@@ -35,6 +38,9 @@ export const POST = withJsonError(async (request: Request) => {
       }
       break;
     }
+    case "transfer_ended":
+      await accountRetellPhoneCallUsage({ call: payload.call });
+      break;
   }
 
   return new Response(null, { status: 204 });

--- a/apps/web/app/api/retell/webhook/route.ts
+++ b/apps/web/app/api/retell/webhook/route.ts
@@ -24,18 +24,24 @@ export const POST = withJsonError(async (request: Request) => {
   const payload = retellWebhookPayloadSchema.parse(JSON.parse(rawBody));
   switch (payload.event) {
     case "call_ended":
-      await accountRetellPhoneCallUsage({ call: payload.call });
-      await handleRetellCallEnded({ call: payload.call });
+      await settleRetellWebhookBranches([
+        () => accountRetellPhoneCallUsage({ call: payload.call }),
+        () => handleRetellCallEnded({ call: payload.call }),
+      ]);
       break;
     case "call_analyzed": {
-      await accountRetellPhoneCallUsage({ call: payload.call });
-      const result = await handleRetellCallAnalyzed({ call: payload.call });
-      if (result.notificationMailboxItemId) {
-        await signalHostedMailboxAppendRuntime({
-          expectedUserId: result.notificationUserId,
-          mailboxItemId: result.notificationMailboxItemId,
-        });
-      }
+      await settleRetellWebhookBranches([
+        () => accountRetellPhoneCallUsage({ call: payload.call }),
+        async () => {
+          const result = await handleRetellCallAnalyzed({ call: payload.call });
+          if (result.notificationMailboxItemId) {
+            await signalHostedMailboxAppendRuntime({
+              expectedUserId: result.notificationUserId,
+              mailboxItemId: result.notificationMailboxItemId,
+            });
+          }
+        },
+      ]);
       break;
     }
     case "transfer_ended":
@@ -45,3 +51,17 @@ export const POST = withJsonError(async (request: Request) => {
 
   return new Response(null, { status: 204 });
 });
+
+async function settleRetellWebhookBranches(
+  branches: ReadonlyArray<() => Promise<unknown>>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    branches.map((run) => Promise.resolve().then(run)),
+  );
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) {
+    throw failure.reason;
+  }
+}

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -50,6 +50,13 @@ import {
 } from "../hosted-onboarding/member-access";
 import { getPrisma } from "../prisma";
 import { renderUserFacingMessage } from "../hosted-messages/user-facing-messages";
+import {
+  HOSTED_RETELL_USAGE_COST_KEY,
+  HOSTED_RETELL_USAGE_PRICING_SOURCE,
+  HOSTED_RETELL_USAGE_PRICING_VERSION,
+  HOSTED_RETELL_USAGE_SOURCE_PATH,
+  HOSTED_RETELL_USAGE_VERSION,
+} from "./usage-retell";
 
 type HostedAiUsageAllowanceClient = PrismaClient | Prisma.TransactionClient;
 export type HostedAiUsageGateDeniedReason =
@@ -533,6 +540,28 @@ function resolveHostedAiUsageAllowancePricingDecision(
   const tokenPricingBasis =
     normalizeAssistantUsageTokenPricingBasis(record.tokenPricingBasis);
 
+  const retellMatch = matchHostedAiUsageRetellPhoneCallRecord(record);
+  if (retellMatch !== null) {
+    assertHostedAiUsageRetellTokenPricingBasis(tokenPricingBasis);
+    return {
+      kind: "priced",
+      priced: {
+        costUsdMicros: counted ? retellMatch.combinedCostUsdMicros : 0n,
+        counted,
+        pricingSnapshot: {
+          credentialSource,
+          providerCost: {
+            combinedCostUsdMicros: retellMatch.combinedCostUsdMicros.toString(),
+          },
+          pricingSource: HOSTED_RETELL_USAGE_PRICING_SOURCE,
+          schema: "murph.hosted-ai-usage-allowance-pricing.v1",
+          tokenPricingBasis,
+        },
+        pricingVersion: HOSTED_RETELL_USAGE_PRICING_VERSION,
+      },
+    };
+  }
+
   if (isHostedAiUsageAllowanceAudioModelRecord(record)) {
     assertHostedAiUsageAllowanceAudioTokenPricingBasis(tokenPricingBasis);
     return {
@@ -708,6 +737,11 @@ function validateHostedAiUsageAllowanceDeniedTokenPricingBasis(
 ): AssistantUsageTokenPricingBasis {
   const tokenPricingBasis =
     normalizeAssistantUsageTokenPricingBasis(record.tokenPricingBasis);
+
+  if (matchHostedAiUsageRetellPhoneCallRecord(record) !== null) {
+    assertHostedAiUsageRetellTokenPricingBasis(tokenPricingBasis);
+    return tokenPricingBasis;
+  }
 
   if (isHostedAiUsageAllowanceAudioModelRecord(record)) {
     assertHostedAiUsageAllowanceAudioTokenPricingBasis(tokenPricingBasis);
@@ -2203,6 +2237,64 @@ function resolveHostedAiUsageAllowanceOpenAiImageModel(
     model: null,
     source: null,
   };
+}
+
+function matchHostedAiUsageRetellPhoneCallRecord(record: AssistantUsageRecord): {
+  combinedCostUsdMicros: bigint;
+} | null {
+  const rawUsageJson = record.rawUsageJson;
+  if (
+    record.provider !== "retell"
+    || record.providerName !== "Retell AI"
+    || record.apiKeyEnv !== "RETELL_API_KEY"
+    || record.baseUrl !== "https://api.retellai.com"
+    || record.credentialSource !== "platform"
+    || record.featureKey !== "phone-call"
+    || record.surface !== "hosted-web"
+    || record.triggerKind !== "phone-call"
+    || record.usageExtractionSourcePath !== HOSTED_RETELL_USAGE_SOURCE_PATH
+    || record.usageExtractionVersion !== HOSTED_RETELL_USAGE_VERSION
+    || record.requestedModel !== null
+    || record.servedModel !== null
+    || record.inputTokens !== null
+    || record.outputTokens !== null
+    || record.reasoningTokens !== null
+    || record.cachedInputTokens !== null
+    || record.cacheWriteTokens !== null
+    || record.totalTokens !== null
+    || rawUsageJson === null
+    || !Object.keys(rawUsageJson).every((key) => key === HOSTED_RETELL_USAGE_COST_KEY)
+  ) {
+    return null;
+  }
+
+  const combinedCostUsdMicros = readHostedAiUsageNonNegativeInteger(
+    rawUsageJson[HOSTED_RETELL_USAGE_COST_KEY],
+  );
+  if (combinedCostUsdMicros === null) {
+    return null;
+  }
+  return {
+    combinedCostUsdMicros,
+  };
+}
+
+function assertHostedAiUsageRetellTokenPricingBasis(
+  tokenPricingBasis: AssistantUsageTokenPricingBasis,
+): void {
+  if (tokenPricingBasis !== "standard") {
+    throw new TypeError(
+      "Retell phone-call hosted usage must use standard token pricing basis.",
+    );
+  }
+}
+
+function readHostedAiUsageNonNegativeInteger(value: unknown): bigint | null {
+  return typeof value === "number"
+      && Number.isSafeInteger(value)
+      && value >= 0
+    ? BigInt(value)
+    : null;
 }
 
 // Only Worker-recorded Workers AI transcription rows take the audio-priced

--- a/apps/web/src/lib/hosted-execution/usage-retell.ts
+++ b/apps/web/src/lib/hosted-execution/usage-retell.ts
@@ -1,0 +1,88 @@
+import {
+  ASSISTANT_USAGE_SCHEMA,
+  createAssistantUsageId,
+  type AssistantUsageRecord,
+} from "@murphai/hosted-execution/assistant-usage";
+
+export const HOSTED_RETELL_USAGE_COST_KEY = "combinedCostUsdMicros";
+export const HOSTED_RETELL_USAGE_SOURCE_PATH = "retell.call.call_cost";
+export const HOSTED_RETELL_USAGE_VERSION = "retell-call-cost-v1";
+export const HOSTED_RETELL_USAGE_PRICING_VERSION =
+  "retell-reported-call-cost-2026-07-16";
+export const HOSTED_RETELL_USAGE_PRICING_SOURCE =
+  "https://docs.retellai.com/api-references/get-call";
+
+export function buildHostedRetellPhoneCallUsageRecord(input: {
+  combinedCostUsdMicros: number;
+  memberId: string;
+  occurredAt: Date;
+  phoneCallId: string;
+  providerCallId: string;
+}): AssistantUsageRecord {
+  requireNonNegativeSafeInteger(input.combinedCostUsdMicros, "Retell combined call cost");
+  const phoneCallId = requireNonEmptyString(input.phoneCallId, "Murph phone call id");
+  const memberId = requireNonEmptyString(input.memberId, "Hosted member id");
+  const providerCallId = requireNonEmptyString(input.providerCallId, "Retell call id");
+  if (Number.isNaN(input.occurredAt.getTime())) {
+    throw new TypeError("Retell usage occurrence time must be valid.");
+  }
+
+  const turnId = `turn_phone_call_${phoneCallId}`;
+  return {
+    apiKeyEnv: "RETELL_API_KEY",
+    attemptCount: 1,
+    baseUrl: "https://api.retellai.com",
+    cacheWriteTokens: null,
+    cachedInputTokens: null,
+    credentialSource: "platform",
+    featureKey: "phone-call",
+    gatewayTags: [],
+    inputTokens: null,
+    memberId,
+    occurredAt: input.occurredAt.toISOString(),
+    outputTokens: null,
+    provider: "retell",
+    providerName: "Retell AI",
+    providerRequestId: providerCallId,
+    providerRequestOutcome: "succeeded",
+    providerRequestOrdinal: 0,
+    rawUsageJson: {
+      [HOSTED_RETELL_USAGE_COST_KEY]: input.combinedCostUsdMicros,
+    },
+    rawUsageJsonHash: null,
+    reasoningTokens: null,
+    reportingUserId: null,
+    requestedModel: null,
+    routeId: null,
+    schema: ASSISTANT_USAGE_SCHEMA,
+    servedModel: null,
+    sessionId: turnId,
+    stripeMeterSource: "murph",
+    surface: "hosted-web",
+    tokenPricingBasis: "standard",
+    totalTokens: null,
+    triggerKind: "phone-call",
+    turnId,
+    turnProfileJson: null,
+    usageId: createAssistantUsageId({
+      attemptCount: 1,
+      turnId,
+    }),
+    usageExtractionSourcePath: HOSTED_RETELL_USAGE_SOURCE_PATH,
+    usageExtractionVersion: HOSTED_RETELL_USAGE_VERSION,
+  };
+}
+
+function requireNonNegativeSafeInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${label} must be a non-negative safe integer.`);
+  }
+}
+
+function requireNonEmptyString(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new TypeError(`${label} is required.`);
+  }
+  return normalized;
+}

--- a/apps/web/src/lib/hosted-execution/usage.ts
+++ b/apps/web/src/lib/hosted-execution/usage.ts
@@ -15,6 +15,7 @@ import {
   accountHostedAiUsageForAllowanceTx,
   type HostedAiUsageLimitNoticeCandidate,
 } from "./usage-allowance";
+import { buildHostedRetellPhoneCallUsageRecord } from "./usage-retell";
 import {
   sendClaimedHostedAiUsageLimitNoticeToLinqChat,
   sendClaimedHostedAiUsageLimitNoticeToTelegramThread,
@@ -120,6 +121,27 @@ export async function recordHostedAiUsageRecordsAndSendLimitNotices(input: {
   return {
     recordedIds: result.recordedIds,
   };
+}
+
+export async function recordHostedRetellPhoneCallUsageTx(input: {
+  combinedCostUsdMicros: number;
+  memberId: string;
+  occurredAt: Date;
+  phoneCallId: string;
+  providerCallId: string;
+  tx: Prisma.TransactionClient;
+}): Promise<void> {
+  const record = buildHostedRetellPhoneCallUsageRecord(input);
+  await persistHostedAiUsageRecordTx({
+    memberId: input.memberId,
+    record,
+    tx: input.tx,
+  });
+  await accountHostedAiUsageForAllowanceTx({
+    memberId: input.memberId,
+    record,
+    tx: input.tx,
+  });
 }
 
 async function recordHostedAiUsageRecordsForAccounting(input: {

--- a/apps/web/src/lib/phone-calls/reconciliation.ts
+++ b/apps/web/src/lib/phone-calls/reconciliation.ts
@@ -8,7 +8,11 @@ import {
   isHostedPhoneCallReadyForProviderReconciliation,
 } from "./authority";
 import { createRetellPhoneCallRuntime } from "./retell-runtime";
-import type { PhoneCallRuntime } from "./types";
+import type {
+  HostedPhoneCallProviderUsage,
+  PhoneCallRuntime,
+} from "./types";
+import { recordRetellPhoneCallProviderUsage } from "./usage";
 
 export interface HostedPhoneCallReconciliationStore {
   markCleanupEnded(input: {
@@ -37,6 +41,10 @@ export interface HostedPhoneCallReconciliationStore {
       };
     }): Promise<{ count: number }>;
   };
+  recordTerminalUsage?(input: {
+    call: HostedPhoneCall;
+    usage: HostedPhoneCallProviderUsage;
+  }): Promise<void>;
 }
 
 export async function processHostedPhoneCallRecoveryById(input: {
@@ -47,7 +55,7 @@ export async function processHostedPhoneCallRecoveryById(input: {
 }): Promise<"complete" | "missing" | "pending"> {
   const store = input.prisma ?? resolveHostedPhoneCallReconciliationStore();
   const runtime = input.runtime ?? createRetellPhoneCallRuntime();
-  const call = await waitForAbortableOperation(input.signal, () =>
+  let call = await waitForAbortableOperation(input.signal, () =>
     store.hostedPhoneCall.findUnique({
       where: { id: input.phoneCallId },
     }));
@@ -55,7 +63,7 @@ export async function processHostedPhoneCallRecoveryById(input: {
     return "missing";
   }
   if (isHostedPhoneCallProviderCleanupPending(call) && call.providerCallId) {
-    return await stopHostedPhoneCallCleanupAuthority({
+    const stopped = await stopHostedPhoneCallCleanupAuthority({
       call: {
         id: call.id,
         providerCallId: call.providerCallId,
@@ -63,34 +71,37 @@ export async function processHostedPhoneCallRecoveryById(input: {
       runtime,
       signal: input.signal,
       store,
-    }) ? "complete" : "pending";
+    });
+    if (!stopped) {
+      return "pending";
+    }
   }
-  if (hasPhoneCallAdvancedBeyondStart(call)) {
-    return "complete";
-  }
-  if (!isHostedPhoneCallReadyForProviderReconciliation(call)) {
-    return "pending";
-  }
-  const result = await reconcileHostedPhoneCallProviderAuthority({
-    call,
-    runtime,
-    signal: input.signal,
-    store,
-  });
-  if (result.status === "starting") {
-    return "pending";
-  }
-  if (result.status === "failed") {
+
+  if (isHostedPhoneCallReadyForProviderReconciliation(call)) {
+    const result = await reconcileHostedPhoneCallProviderAuthority({
+      call,
+      runtime,
+      signal: input.signal,
+      store,
+    });
+    if (result.status === "starting") {
+      return "pending";
+    }
+
     const current = await waitForAbortableOperation(input.signal, () =>
       store.hostedPhoneCall.findUnique({
         where: { id: input.phoneCallId },
       }));
+    if (!current) {
+      return "missing";
+    }
+    call = current;
     if (
-      current
+      result.status === "failed"
       && isHostedPhoneCallProviderCleanupPending(current)
       && current.providerCallId
     ) {
-      return await stopHostedPhoneCallCleanupAuthority({
+      const stopped = await stopHostedPhoneCallCleanupAuthority({
         call: {
           id: current.id,
           providerCallId: current.providerCallId,
@@ -98,10 +109,44 @@ export async function processHostedPhoneCallRecoveryById(input: {
         runtime,
         signal: input.signal,
         store,
-      }) ? "complete" : "pending";
+      });
+      if (!stopped) {
+        return "pending";
+      }
     }
   }
-  return "complete";
+
+  const providerCallId = call.providerCallId;
+  const resolveTerminalUsage = runtime.resolveTerminalUsage;
+  const recordTerminalUsage = store.recordTerminalUsage;
+  if (providerCallId && resolveTerminalUsage && recordTerminalUsage) {
+    let resolution;
+    try {
+      resolution = await waitForAbortableOperation(input.signal, () =>
+        resolveTerminalUsage.call(runtime, providerCallId, {
+          signal: input.signal,
+        }));
+    } catch {
+      input.signal.throwIfAborted();
+      return "pending";
+    }
+    if (resolution.state === "pending") {
+      return "pending";
+    }
+    try {
+      await waitForAbortableOperation(input.signal, () =>
+        recordTerminalUsage({
+          call,
+          usage: resolution.usage,
+        }));
+    } catch {
+      input.signal.throwIfAborted();
+      return "pending";
+    }
+    return "complete";
+  }
+
+  return hasPhoneCallAdvancedBeyondStart(call) ? "complete" : "pending";
 }
 
 export async function stopHostedPhoneCallCleanupAuthority(input: {
@@ -251,5 +296,11 @@ function resolveHostedPhoneCallReconciliationStore(): HostedPhoneCallReconciliat
       findUniqueOrThrow: async (input) => prisma.hostedPhoneCall.findUniqueOrThrow(input),
       updateMany: async (input) => prisma.hostedPhoneCall.updateMany(input),
     },
+    recordTerminalUsage: async ({ call, usage }) =>
+      recordRetellPhoneCallProviderUsage({
+        call,
+        prisma,
+        usage,
+      }),
   };
 }

--- a/apps/web/src/lib/phone-calls/result.ts
+++ b/apps/web/src/lib/phone-calls/result.ts
@@ -30,10 +30,13 @@ import {
 } from "./notification-route";
 import {
   hasRetellBasicAttributesOnlyStorage,
-  readRetellMurphPhoneCallId,
+  readRetellCallEndAt,
   type RetellCallPayload,
 } from "./retell-payloads";
 import { isHostedPhoneCallProviderCleanupPending } from "./authority";
+import {
+  readRetellWebhookCallTarget,
+} from "./webhook-target";
 
 interface HostedPhoneCallWebhookTx {
   appendResultNotification(
@@ -83,13 +86,6 @@ interface HostedPhoneCallWebhookStore {
   $transaction<T>(
     callback: (tx: HostedPhoneCallWebhookTx) => Promise<T>,
   ): Promise<T>;
-}
-
-interface RetellWebhookCallTarget {
-  call: HostedPhoneCall;
-  providerCallIdData: {
-    providerCallId?: string;
-  };
 }
 
 export interface RetellCallAnalyzedHandlingResult {
@@ -143,7 +139,7 @@ export async function handleRetellCallEnded(input: {
     await tx.hostedPhoneCall.updateMany({
       data: {
         ...target.providerCallIdData,
-        endedAt: readRetellEndedAt(input.call) ?? new Date(),
+        endedAt: readRetellCallEndAt(input.call) ?? new Date(),
         status: preserveFailedStatus
           ? "failed"
           : classifyEndedStatus(input.call.disconnection_reason),
@@ -203,7 +199,7 @@ export async function handleRetellCallAnalyzed(input: {
       data: {
         ...target.providerCallIdData,
         analyzedAt: new Date(),
-        endedAt: readRetellEndedAt(input.call) ?? undefined,
+        endedAt: readRetellCallEndAt(input.call) ?? undefined,
         resultEncrypted,
         resultJson: Prisma.DbNull,
         status: mapPhoneCallStatus(result.outcome),
@@ -332,34 +328,6 @@ function hostedPhoneCallResultNotificationError(
     message,
     retryable: true,
   });
-}
-
-async function readRetellWebhookCallTarget(input: {
-  call: RetellCallPayload;
-  prisma: HostedPhoneCallWebhookTx;
-}): Promise<RetellWebhookCallTarget | null> {
-  const murphCallId = readRetellMurphPhoneCallId(input.call);
-  const call = murphCallId
-    ? await input.prisma.hostedPhoneCall.findUnique({
-      where: { id: murphCallId },
-    })
-    : await input.prisma.hostedPhoneCall.findUnique({
-      where: { providerCallId: input.call.call_id },
-    });
-
-  if (!call || call.provider !== "retell") {
-    return null;
-  }
-  if (call.providerCallId && call.providerCallId !== input.call.call_id) {
-    return null;
-  }
-
-  return {
-    call,
-    providerCallIdData: call.providerCallId
-      ? {}
-      : { providerCallId: input.call.call_id },
-  };
 }
 
 function resolveHostedPhoneCallWebhookStore(
@@ -525,25 +493,6 @@ function classifyEndedStatus(reason: string | null | undefined): HostedPhoneCall
     return "failed";
   }
   return "ended";
-}
-
-function readRetellEndedAt(call: RetellCallPayload): Date | null {
-  const value = call.end_timestamp;
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return new Date(value < 1_000_000_000_000 ? value * 1_000 : value);
-  }
-  if (typeof value !== "string" || !value.trim()) {
-    return null;
-  }
-
-  const text = value.trim();
-  if (/^\d+$/u.test(text)) {
-    const numeric = Number.parseInt(text, 10);
-    return new Date(numeric < 1_000_000_000_000 ? numeric * 1_000 : numeric);
-  }
-
-  const parsed = new Date(text);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 function readOutcome(value: unknown): HostedPhoneCallResult["outcome"] {

--- a/apps/web/src/lib/phone-calls/retell-payloads.ts
+++ b/apps/web/src/lib/phone-calls/retell-payloads.ts
@@ -4,14 +4,21 @@ export interface RetellCallAnalysisPayload {
   [key: string]: unknown;
 }
 
+export interface RetellCallCostPayload {
+  combined_cost: number;
+}
+
 export interface RetellCallPayload {
   call_analysis?: RetellCallAnalysisPayload | null;
+  call_cost?: RetellCallCostPayload | null;
   call_id: string;
   data_storage_setting?: string | null;
   disconnection_reason?: string | null;
+  duration_ms?: number | null;
   end_timestamp?: number | string | null;
   metadata?: Record<string, unknown> | null;
   transcript?: string | null;
+  transfer_end_timestamp?: number | string | null;
   [key: string]: unknown;
 }
 
@@ -30,6 +37,9 @@ export interface RetellWebhookPayload {
   event: string;
   [key: string]: unknown;
 }
+
+const USD_MICROS_PER_CENT = 10_000;
+const MAX_RETELL_COMBINED_COST_CENTS = Number.MAX_SAFE_INTEGER / USD_MICROS_PER_CENT;
 
 export const retellCallPayloadSchema = {
   parse: parseRetellCallPayload,
@@ -50,6 +60,14 @@ export function readRetellMurphPhoneCallId(call: RetellCallPayload): string | nu
 
 export function hasRetellBasicAttributesOnlyStorage(call: RetellCallPayload): boolean {
   return call.data_storage_setting?.trim().toLowerCase() === "basic_attributes_only";
+}
+
+export function readRetellCallEndAt(call: RetellCallPayload): Date | null {
+  return readRetellTimestamp(call.end_timestamp);
+}
+
+export function readRetellTransferEndAt(call: RetellCallPayload): Date | null {
+  return readRetellTimestamp(call.transfer_end_timestamp);
 }
 
 function parseRetellAskMurphPayload(value: unknown): RetellAskMurphPayload {
@@ -83,11 +101,13 @@ function parseRetellWebhookPayload(value: unknown): RetellWebhookPayload {
 function parseRetellCallPayload(value: unknown): RetellCallPayload {
   const record = requireRecord(value, "Retell call payload");
   const callAnalysis = readOptionalCallAnalysis(record.call_analysis);
+  const callCost = readOptionalCallCost(record.call_cost);
 
   return {
     ...record,
     call_id: requireTrimmedString(record.call_id, "Retell call id", 200),
     ...(callAnalysis === undefined ? {} : { call_analysis: callAnalysis }),
+    ...(callCost === undefined ? {} : { call_cost: callCost }),
     data_storage_setting: readOptionalString(
       record.data_storage_setting,
       "Retell data storage setting",
@@ -96,9 +116,30 @@ function parseRetellCallPayload(value: unknown): RetellCallPayload {
       record.disconnection_reason,
       "Retell disconnection reason",
     ),
+    duration_ms: readOptionalNonNegativeInteger(record.duration_ms),
     end_timestamp: readOptionalTimestamp(record.end_timestamp),
     metadata: readOptionalRecord(record.metadata, "Retell call metadata"),
     transcript: readOptionalString(record.transcript, "Retell transcript"),
+    transfer_end_timestamp: readOptionalTimestamp(record.transfer_end_timestamp),
+  };
+}
+
+function readOptionalCallCost(value: unknown): RetellCallCostPayload | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  if (!isRecord(value)) {
+    return null;
+  }
+  const combinedCost = readNonNegativeFiniteNumber(value.combined_cost);
+  if (combinedCost === null) {
+    return null;
+  }
+  if (combinedCost > MAX_RETELL_COMBINED_COST_CENTS) {
+    return null;
+  }
+  return {
+    combined_cost: combinedCost,
   };
 }
 
@@ -173,6 +214,45 @@ function readOptionalTimestamp(value: unknown): number | string | null | undefin
     return value;
   }
   throw new TypeError("Retell end timestamp must be a string or finite number.");
+}
+
+function readOptionalNonNegativeInteger(value: unknown): number | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+function readNonNegativeFiniteNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+function readRetellTimestamp(value: number | string | null | undefined): Date | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return validRetellDate(value < 1_000_000_000_000 ? value * 1_000 : value);
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  const text = value.trim();
+  if (/^\d+$/u.test(text)) {
+    const numeric = Number.parseInt(text, 10);
+    return validRetellDate(numeric < 1_000_000_000_000 ? numeric * 1_000 : numeric);
+  }
+
+  return validRetellDate(text);
+}
+
+function validRetellDate(value: number | string): Date | null {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/src/lib/phone-calls/retell-runtime.ts
+++ b/apps/web/src/lib/phone-calls/retell-runtime.ts
@@ -11,11 +11,13 @@ import type {
 } from "retell-sdk/resources/call";
 
 import type {
+  HostedPhoneCallProviderUsageResolution,
   HostedPhoneCallRuntimeRecord,
   PhoneCallRuntime,
   PhoneCallRuntimeReconciliationResult,
   PhoneCallRuntimeStartResult,
 } from "./types";
+import { readRetellTerminalProviderUsage } from "./usage";
 import { markPhoneCallRuntimeNoActiveEffect } from "./types";
 import { hostedOnboardingError } from "../hosted-onboarding/errors";
 
@@ -24,7 +26,7 @@ const RETELL_START_TIMEOUT_MS = 15_000;
 const RETELL_BASIC_ATTRIBUTES_ONLY_STORAGE_SETTING = "basic_attributes_only";
 const RETELL_WEBHOOK_PATH = "/api/retell/webhook";
 const RETELL_PUBLIC_BASE_DYNAMIC_VARIABLE = "murph_public_base_url";
-const RETELL_WEBHOOK_EVENTS = ["call_ended", "call_analyzed"] as const;
+const RETELL_WEBHOOK_EVENTS = ["call_ended", "call_analyzed", "transfer_ended"] as const;
 const RETELL_MISSING_ASSET_MESSAGE =
   "Cannot find requested asset under given api key.";
 
@@ -145,6 +147,34 @@ class RetellPhoneCallRuntime implements PhoneCallRuntime, RetellPhoneCallAccount
       providerCallId,
       state: "cleanup_required",
     };
+  }
+
+  async resolveTerminalUsage(
+    providerCallId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<HostedPhoneCallProviderUsageResolution> {
+    const client = this.buildClient();
+    const call = await client.call.retrieve(providerCallId, {
+      signal: options.signal,
+    });
+    if (call.call_status === "registered" || call.call_status === "ongoing") {
+      return { state: "pending" };
+    }
+
+    return readRetellTerminalProviderUsage({
+      call_id: call.call_id,
+      ...(call.call_cost
+        ? { call_cost: { combined_cost: call.call_cost.combined_cost } }
+        : {}),
+      ...(call.disconnection_reason
+        ? { disconnection_reason: call.disconnection_reason }
+        : {}),
+      ...(call.duration_ms === undefined ? {} : { duration_ms: call.duration_ms }),
+      ...(call.end_timestamp === undefined ? {} : { end_timestamp: call.end_timestamp }),
+      ...(call.transfer_end_timestamp === undefined
+        ? {}
+        : { transfer_end_timestamp: call.transfer_end_timestamp }),
+    });
   }
 
   async deleteProviderCall(

--- a/apps/web/src/lib/phone-calls/types.ts
+++ b/apps/web/src/lib/phone-calls/types.ts
@@ -29,6 +29,19 @@ export type PhoneCallRuntimeReconciliationResult =
       state: "not_found";
     };
 
+export type HostedPhoneCallProviderUsage = {
+  combinedCostUsdMicros: number;
+  occurredAt: Date;
+  providerCallId: string;
+};
+
+export type HostedPhoneCallProviderUsageResolution =
+  | { state: "pending" }
+  | {
+      state: "ready";
+      usage: HostedPhoneCallProviderUsage;
+    };
+
 const phoneCallRuntimeNoActiveEffectErrors = new WeakSet<object>();
 
 export function markPhoneCallRuntimeNoActiveEffect<TError>(error: TError): TError {
@@ -44,6 +57,10 @@ export function hasPhoneCallRuntimeNoActiveEffect(error: unknown): boolean {
 }
 
 export interface PhoneCallRuntime {
+  resolveTerminalUsage?(
+    providerCallId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<HostedPhoneCallProviderUsageResolution>;
   resolveProviderCall(
     murphPhoneCallId: string,
     options?: { signal?: AbortSignal },

--- a/apps/web/src/lib/phone-calls/usage.ts
+++ b/apps/web/src/lib/phone-calls/usage.ts
@@ -1,0 +1,172 @@
+import {
+  type HostedPhoneCall,
+  type Prisma,
+  type PrismaClient,
+} from "@prisma/client";
+
+import { recordHostedRetellPhoneCallUsageTx } from "../hosted-execution/usage";
+import { getPrisma } from "../prisma";
+import {
+  readRetellCallEndAt,
+  readRetellTransferEndAt,
+  type RetellCallPayload,
+} from "./retell-payloads";
+import {
+  readRetellWebhookCallTarget,
+  type RetellWebhookCallTargetStore,
+} from "./webhook-target";
+import type { HostedPhoneCallProviderUsage } from "./types";
+
+const USD_MICROS_PER_CENT = 10_000;
+
+interface RetellPhoneCallUsageTx extends RetellWebhookCallTargetStore {
+  recordUsage(input: {
+    call: HostedPhoneCall;
+    usage: HostedPhoneCallProviderUsage;
+  }): Promise<void>;
+}
+
+interface RetellPhoneCallUsageStore {
+  $transaction<T>(callback: (tx: RetellPhoneCallUsageTx) => Promise<T>): Promise<T>;
+}
+
+export type RetellPhoneCallUsageAccountingResult =
+  | "accounted"
+  | "not_ready"
+  | "not_found";
+
+export async function accountRetellPhoneCallUsage(input: {
+  call: RetellCallPayload;
+  prisma?: RetellPhoneCallUsageStore;
+}): Promise<RetellPhoneCallUsageAccountingResult> {
+  const cost = readRetellCombinedCostUsdMicros(input.call);
+  const occurredAt = readRetellTransferEndAt(input.call) ?? readRetellCallEndAt(input.call);
+  if (
+    cost === null
+    || occurredAt === null
+    || isRetellTransferStillActive(input.call)
+  ) {
+    return "not_ready";
+  }
+
+  const prisma = input.prisma ?? resolveRetellPhoneCallUsageStore();
+  return prisma.$transaction(async (tx) => {
+    const target = await readRetellWebhookCallTarget({
+      call: input.call,
+      prisma: tx,
+    });
+    if (!target) {
+      return "not_found";
+    }
+
+    await tx.recordUsage({
+      call: target.call,
+      usage: {
+        combinedCostUsdMicros: cost,
+        occurredAt,
+        providerCallId: input.call.call_id,
+      },
+    });
+    return "accounted";
+  });
+}
+
+export function readRetellTerminalProviderUsage(
+  call: RetellCallPayload,
+): { state: "pending" } | { state: "ready"; usage: HostedPhoneCallProviderUsage } {
+  const combinedCostUsdMicros = readRetellCombinedCostUsdMicros(call);
+  const occurredAt = readRetellTransferEndAt(call) ?? readRetellCallEndAt(call);
+  if (
+    combinedCostUsdMicros === null
+    || occurredAt === null
+    || isRetellTransferStillActive(call)
+  ) {
+    return { state: "pending" };
+  }
+
+  return {
+    state: "ready",
+    usage: {
+      combinedCostUsdMicros,
+      occurredAt,
+      providerCallId: call.call_id,
+    },
+  };
+}
+
+export async function recordRetellPhoneCallProviderUsage(input: {
+  call: HostedPhoneCall;
+  prisma?: PrismaClient;
+  usage: HostedPhoneCallProviderUsage;
+}): Promise<void> {
+  const prisma = input.prisma ?? getPrisma();
+  await prisma.$transaction(async (tx) => {
+    await recordRetellPhoneCallProviderUsageTx({
+      call: input.call,
+      tx,
+      usage: input.usage,
+    });
+  });
+}
+
+async function recordRetellPhoneCallProviderUsageTx(input: {
+  call: HostedPhoneCall;
+  tx: Prisma.TransactionClient;
+  usage: HostedPhoneCallProviderUsage;
+}): Promise<void> {
+  if (
+    input.call.provider !== "retell"
+    || (input.call.providerCallId !== null
+      && input.call.providerCallId !== input.usage.providerCallId)
+  ) {
+    throw new TypeError("Retell usage does not match the hosted phone call authority.");
+  }
+  await recordHostedRetellPhoneCallUsageTx({
+    ...input.usage,
+    memberId: input.call.memberId,
+    phoneCallId: input.call.id,
+    tx: input.tx,
+  });
+}
+
+function readRetellCombinedCostUsdMicros(call: RetellCallPayload): number | null {
+  const combinedCostCents = call.call_cost?.combined_cost;
+  if (combinedCostCents === undefined || combinedCostCents === null) {
+    return null;
+  }
+  const combinedCostUsdMicros = Math.round(combinedCostCents * USD_MICROS_PER_CENT);
+  if (!Number.isSafeInteger(combinedCostUsdMicros) || combinedCostUsdMicros < 0) {
+    throw new TypeError("Retell combined call cost exceeds the supported range.");
+  }
+  return combinedCostUsdMicros;
+}
+
+function isRetellTransferStillActive(call: RetellCallPayload): boolean {
+  return call.disconnection_reason?.trim().toLowerCase() === "call_transfer"
+    && readRetellTransferEndAt(call) === null;
+}
+
+function resolveRetellPhoneCallUsageStore(): RetellPhoneCallUsageStore {
+  const prisma = getPrisma();
+  return {
+    $transaction: async (callback) => prisma.$transaction(async (tx) => callback({
+      hostedPhoneCall: {
+        findUnique: async (input) => {
+          if ("id" in input.where) {
+            return tx.hostedPhoneCall.findUnique({
+              where: { id: input.where.id },
+            });
+          }
+          return tx.hostedPhoneCall.findUnique({
+            where: { providerCallId: input.where.providerCallId },
+          });
+        },
+      },
+      recordUsage: async ({ call, usage }) => recordRetellPhoneCallProviderUsageTx({
+        call,
+        tx,
+        usage,
+      }),
+    })),
+  };
+}

--- a/apps/web/src/lib/phone-calls/webhook-target.ts
+++ b/apps/web/src/lib/phone-calls/webhook-target.ts
@@ -1,0 +1,51 @@
+import type { HostedPhoneCall } from "@prisma/client";
+
+import {
+  readRetellMurphPhoneCallId,
+  type RetellCallPayload,
+} from "./retell-payloads";
+
+export interface RetellWebhookCallTarget {
+  call: HostedPhoneCall;
+  providerCallIdData: {
+    providerCallId?: string;
+  };
+}
+
+export interface RetellWebhookCallTargetStore {
+  hostedPhoneCall: {
+    findUnique(input: {
+      where:
+        | { id: string }
+        | { providerCallId: string };
+    }): Promise<HostedPhoneCall | null>;
+  };
+}
+
+export async function readRetellWebhookCallTarget(input: {
+  call: RetellCallPayload;
+  prisma: RetellWebhookCallTargetStore;
+}): Promise<RetellWebhookCallTarget | null> {
+  const murphCallId = readRetellMurphPhoneCallId(input.call);
+  const call = murphCallId
+    ? await input.prisma.hostedPhoneCall.findUnique({
+      where: { id: murphCallId },
+    })
+    : await input.prisma.hostedPhoneCall.findUnique({
+      where: { providerCallId: input.call.call_id },
+    });
+
+  if (!call || call.provider !== "retell") {
+    return null;
+  }
+  if (call.providerCallId && call.providerCallId !== input.call.call_id) {
+    return null;
+  }
+
+  return {
+    call,
+    providerCallIdData: call.providerCallId
+      ? {}
+      : { providerCallId: input.call.call_id },
+  };
+}

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@murphai/hosted-execution/runtime-control";
 import {
   buildHostedTranscriptionUsageRecord,
+  parseAssistantUsageRecord,
   ASSISTANT_IDLE_COMPACTION_USAGE_ESTIMATE_SOURCE_PATH,
   ASSISTANT_IDLE_COMPACTION_USAGE_ESTIMATE_VERSION,
   type AssistantUsageRecord,
@@ -18,6 +19,7 @@ import {
   reconcileHostedAiUsageAllowancePeriodForMemberTx,
   resolveHostedAiUsageGate,
 } from "@/src/lib/hosted-execution/usage-allowance";
+import { buildHostedRetellPhoneCallUsageRecord } from "@/src/lib/hosted-execution/usage-retell";
 
 const BASE_USAGE_RECORD = {
   apiKeyEnv: "OPENAI_API_KEY",
@@ -876,6 +878,56 @@ describe("hosted AI usage allowance pricing", () => {
         "pricing is missing",
       );
     }
+  });
+
+  it("prices web-owned Retell usage from the final provider-reported cost", () => {
+    const usage = buildHostedRetellPhoneCallUsageRecord({
+      combinedCostUsdMicros: 187_500,
+      memberId: "member_123",
+      occurredAt: new Date("2026-06-25T12:00:00.000Z"),
+      phoneCallId: "hpc_123",
+      providerCallId: "retell_call_123",
+    });
+
+    expect(usage).toMatchObject({
+      rawUsageJson: {
+        combinedCostUsdMicros: 187_500,
+      },
+      turnId: "turn_phone_call_hpc_123",
+      usageId: "turn_phone_call_hpc_123.attempt-1",
+    });
+    expect(priceHostedAiUsageForAllowance(usage)).toEqual({
+      costUsdMicros: 187_500n,
+      counted: true,
+      pricingSnapshot: {
+        credentialSource: "platform",
+        providerCost: {
+          combinedCostUsdMicros: "187500",
+        },
+        pricingSource: "https://docs.retellai.com/api-references/get-call",
+        schema: "murph.hosted-ai-usage-allowance-pricing.v1",
+        tokenPricingBasis: "standard",
+      },
+      pricingVersion: "retell-reported-call-cost-2026-07-16",
+    });
+    expect(() => parseAssistantUsageRecord(usage)).toThrow(
+      "rawUsageJson.combinedCostUsdMicros is not allowed",
+    );
+
+    expect(() => priceHostedAiUsageForAllowance({
+      ...usage,
+      rawUsageJson: {
+        combinedCostUsdMicros: 187_500,
+        durationMs: 72_500,
+      },
+    })).toThrow("pricing is missing");
+
+    expect(() => priceHostedAiUsageForAllowance({
+      ...usage,
+      rawUsageJson: {
+        combinedCostUsdMicros: -1,
+      },
+    })).toThrow("pricing is missing");
   });
 
   it("prices ElevenLabs TTS by character count for allowance accounting", () => {

--- a/apps/web/test/phone-calls-retell-routes.test.ts
+++ b/apps/web/test/phone-calls-retell-routes.test.ts
@@ -277,6 +277,72 @@ describe("Retell ask_murph route", () => {
       },
     });
     expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+    expect(mocks.accountRetellPhoneCallUsage).toHaveBeenCalledOnce();
+  });
+
+  it("keeps call-ended lifecycle handling available when accounting fails", async () => {
+    mocks.accountRetellPhoneCallUsage.mockRejectedValueOnce(
+      new Error("usage storage unavailable"),
+    );
+
+    const response = await retellWebhookRoute.POST(signedRetellRequest({
+      payload: {
+        call: {
+          call_cost: { combined_cost: 4.5 },
+          call_id: "retell_call_123",
+          end_timestamp: 1_782_386_400_000,
+        },
+        event: "call_ended",
+      },
+      url: "https://join.example.test/api/retell/webhook",
+    }));
+
+    expect(response.status).toBe(500);
+    expect(mocks.handleRetellCallEnded).toHaveBeenCalledOnce();
+  });
+
+  it("delivers analyzed results when accounting fails and converges on replay", async () => {
+    mocks.accountRetellPhoneCallUsage
+      .mockRejectedValueOnce(new Error("usage storage unavailable"))
+      .mockResolvedValueOnce("accounted");
+    mocks.handleRetellCallAnalyzed
+      .mockResolvedValueOnce({
+        notificationMailboxItemId: "mailbox_item_123",
+        notificationUserId: "member_123",
+      })
+      .mockResolvedValueOnce({
+        notificationMailboxItemId: null,
+        notificationUserId: null,
+      });
+    const request = () => signedRetellRequest({
+      payload: {
+        call: {
+          call_analysis: {
+            custom_analysis_data: {
+              outcome: "completed",
+              result: "Booked.",
+            },
+          },
+          call_cost: { combined_cost: 4.5 },
+          call_id: "retell_call_123",
+          data_storage_setting: "basic_attributes_only",
+          end_timestamp: 1_782_386_400_000,
+        },
+        event: "call_analyzed",
+      },
+      url: "https://join.example.test/api/retell/webhook",
+    });
+
+    await expect(retellWebhookRoute.POST(request())).resolves.toMatchObject({
+      status: 500,
+    });
+    await expect(retellWebhookRoute.POST(request())).resolves.toMatchObject({
+      status: 204,
+    });
+
+    expect(mocks.accountRetellPhoneCallUsage).toHaveBeenCalledTimes(2);
+    expect(mocks.handleRetellCallAnalyzed).toHaveBeenCalledTimes(2);
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledOnce();
   });
 
   it("accepts signed call_analyzed webhooks with long Retell transcripts", async () => {

--- a/apps/web/test/phone-calls-retell-routes.test.ts
+++ b/apps/web/test/phone-calls-retell-routes.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 
 const mocks = vi.hoisted(() => ({
+  accountRetellPhoneCallUsage: vi.fn(),
   consultPhoneCall: vi.fn(),
   getHostedPhoneCallForConsultation: vi.fn(),
   handleRetellCallAnalyzed: vi.fn(),
@@ -20,6 +21,10 @@ vi.mock("@/src/lib/phone-calls/consult", () => ({
 vi.mock("@/src/lib/phone-calls/result", () => ({
   handleRetellCallAnalyzed: mocks.handleRetellCallAnalyzed,
   handleRetellCallEnded: mocks.handleRetellCallEnded,
+}));
+
+vi.mock("@/src/lib/phone-calls/usage", () => ({
+  accountRetellPhoneCallUsage: mocks.accountRetellPhoneCallUsage,
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
@@ -54,6 +59,7 @@ describe("Retell ask_murph route", () => {
       answer: "Choose the 3:45 PM slot.",
       directive: "continue",
     });
+    mocks.accountRetellPhoneCallUsage.mockResolvedValue("accounted");
     mocks.handleRetellCallAnalyzed.mockResolvedValue({
       notificationMailboxItemId: "mailbox_item_123",
       notificationUserId: "member_123",
@@ -185,6 +191,17 @@ describe("Retell ask_murph route", () => {
       },
       event: "call_started",
     };
+    const transferEndedPayload = {
+      call: {
+        call_cost: {
+          combined_cost: 12.5,
+        },
+        call_id: "retell_call_123",
+        disconnection_reason: "call_transfer",
+        transfer_end_timestamp: 1_782_408_600_000,
+      },
+      event: "transfer_ended",
+    };
 
     await expect(retellWebhookRoute.POST(signedRetellRequest({
       payload: endedPayload,
@@ -196,6 +213,10 @@ describe("Retell ask_murph route", () => {
     }))).resolves.toMatchObject({ status: 204 });
     await expect(retellWebhookRoute.POST(signedRetellRequest({
       payload: ignoredPayload,
+      url: "https://join.example.test/api/retell/webhook",
+    }))).resolves.toMatchObject({ status: 204 });
+    await expect(retellWebhookRoute.POST(signedRetellRequest({
+      payload: transferEndedPayload,
       url: "https://join.example.test/api/retell/webhook",
     }))).resolves.toMatchObject({ status: 204 });
 
@@ -211,6 +232,13 @@ describe("Retell ask_murph route", () => {
     });
     expect(mocks.handleRetellCallEnded).toHaveBeenCalledTimes(1);
     expect(mocks.handleRetellCallAnalyzed).toHaveBeenCalledTimes(1);
+    expect(mocks.accountRetellPhoneCallUsage).toHaveBeenCalledTimes(3);
+    expect(mocks.accountRetellPhoneCallUsage).toHaveBeenLastCalledWith({
+      call: expect.objectContaining({
+        call_id: "retell_call_123",
+        transfer_end_timestamp: 1_782_408_600_000,
+      }),
+    });
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
       expectedUserId: "member_123",
@@ -285,6 +313,68 @@ describe("Retell ask_murph route", () => {
       expectedUserId: "member_123",
       mailboxItemId: "mailbox_item_123",
     });
+  });
+
+  it("keeps result handling available when Retell cost telemetry is malformed", async () => {
+    const response = await retellWebhookRoute.POST(signedRetellRequest({
+      payload: {
+        call: {
+          call_analysis: {
+            custom_analysis_data: {
+              outcome: "completed",
+              result: "Booked.",
+            },
+          },
+          call_cost: {
+            combined_cost: "invalid",
+          },
+          call_id: "retell_call_123",
+          data_storage_setting: "basic_attributes_only",
+          duration_ms: -1,
+        },
+        event: "call_analyzed",
+      },
+      url: "https://join.example.test/api/retell/webhook",
+    }));
+
+    expect(response.status).toBe(204);
+    expect(mocks.accountRetellPhoneCallUsage).toHaveBeenCalledWith({
+      call: expect.objectContaining({
+        call_cost: null,
+        duration_ms: null,
+      }),
+    });
+    expect(mocks.handleRetellCallAnalyzed).toHaveBeenCalledOnce();
+  });
+
+  it("keeps result handling available when Retell cost telemetry exceeds supported micros", async () => {
+    const response = await retellWebhookRoute.POST(signedRetellRequest({
+      payload: {
+        call: {
+          call_analysis: {
+            custom_analysis_data: {
+              outcome: "completed",
+              result: "Booked.",
+            },
+          },
+          call_cost: {
+            combined_cost: Number.MAX_VALUE,
+          },
+          call_id: "retell_call_123",
+          data_storage_setting: "basic_attributes_only",
+        },
+        event: "call_analyzed",
+      },
+      url: "https://join.example.test/api/retell/webhook",
+    }));
+
+    expect(response.status).toBe(204);
+    expect(mocks.accountRetellPhoneCallUsage).toHaveBeenCalledWith({
+      call: expect.objectContaining({
+        call_cost: null,
+      }),
+    });
+    expect(mocks.handleRetellCallAnalyzed).toHaveBeenCalledOnce();
   });
 
   it("does not wake the runtime when call_analyzed did not append a notification", async () => {

--- a/apps/web/test/phone-calls-retell.test.ts
+++ b/apps/web/test/phone-calls-retell.test.ts
@@ -163,12 +163,54 @@ describe("Retell phone-call runtime", () => {
     const body = JSON.parse(String(fetchCalls[0]!.init?.body));
     expect(body.agent_override).toEqual({
       agent: {
-        webhook_events: ["call_ended", "call_analyzed"],
+        webhook_events: ["call_ended", "call_analyzed", "transfer_ended"],
         webhook_url: "https://local-tunnel.example.test/api/retell/webhook",
       },
     });
     expect(body.retell_llm_dynamic_variables).toMatchObject({
       murph_public_base_url: "https://local-tunnel.example.test",
+    });
+  });
+
+  it("retrieves terminal usage and waits for a transferred call's final cost", async () => {
+    vi.stubEnv("RETELL_API_KEY", "retell-api-key");
+    let transferEnded = false;
+    const fetchImpl: typeof fetch = async () => new Response(JSON.stringify({
+      call_cost: {
+        combined_cost: transferEnded ? 18.75 : 12,
+        product_costs: [],
+        total_duration_seconds: 60,
+        total_duration_unit_price: 0.2,
+      },
+      call_id: "retell_call_123",
+      call_status: "ended",
+      disconnection_reason: "call_transfer",
+      duration_ms: 60_000,
+      end_timestamp: 1_782_386_400_000,
+      ...(transferEnded ? { transfer_end_timestamp: 1_782_408_600_000 } : {}),
+    }), {
+      headers: {
+        "content-type": "application/json",
+      },
+      status: 200,
+    });
+    const runtime = createRetellPhoneCallRuntime({ fetchImpl });
+    if (!runtime.resolveTerminalUsage) {
+      throw new Error("Retell runtime must support terminal usage retrieval.");
+    }
+
+    await expect(runtime.resolveTerminalUsage("retell_call_123")).resolves.toEqual({
+      state: "pending",
+    });
+
+    transferEnded = true;
+    await expect(runtime.resolveTerminalUsage("retell_call_123")).resolves.toEqual({
+      state: "ready",
+      usage: {
+        combinedCostUsdMicros: 187_500,
+        occurredAt: new Date(1_782_408_600_000),
+        providerCallId: "retell_call_123",
+      },
     });
   });
 

--- a/apps/web/test/phone-calls-service.test.ts
+++ b/apps/web/test/phone-calls-service.test.ts
@@ -302,7 +302,7 @@ describe("createHostedPhoneCall", () => {
     });
     const store = createPhoneCallStore({ existing });
     let stopUnavailable = true;
-    const runtime = createPhoneCallRuntime({
+    const runtimeHarness = createPhoneCallRuntime({
       onStop: () => {
         if (stopUnavailable) {
           throw new Error("provider stop unavailable");
@@ -310,11 +310,28 @@ describe("createHostedPhoneCall", () => {
       },
       providerCallId: "retell_unused",
     });
+    const terminalUsage = {
+      combinedCostUsdMicros: 25_000,
+      occurredAt: new Date("2026-06-25T01:00:00.000Z"),
+      providerCallId: "retell_unsafe",
+    };
+    const recordTerminalUsage = vi.fn(async () => undefined);
+    const runtime = {
+      ...runtimeHarness.runtime,
+      resolveTerminalUsage: vi.fn(async () => ({
+        state: "ready" as const,
+        usage: terminalUsage,
+      })),
+    };
+    const prisma = {
+      ...store.prisma,
+      recordTerminalUsage,
+    };
 
     await expect(processHostedPhoneCallRecoveryById({
       phoneCallId: existing.id,
-      prisma: store.prisma,
-      runtime: runtime.runtime,
+      prisma,
+      runtime,
       signal: new AbortController().signal,
     })).resolves.toBe("pending");
     expect(store.currentCall().endedAt).toBeNull();
@@ -322,16 +339,71 @@ describe("createHostedPhoneCall", () => {
     stopUnavailable = false;
     await expect(processHostedPhoneCallRecoveryById({
       phoneCallId: existing.id,
-      prisma: store.prisma,
-      runtime: runtime.runtime,
+      prisma,
+      runtime,
       signal: new AbortController().signal,
     })).resolves.toBe("complete");
-    expect(runtime.startCalls).toEqual([]);
-    expect(runtime.stopCalls).toEqual(["retell_unsafe", "retell_unsafe"]);
+    expect(runtimeHarness.startCalls).toEqual([]);
+    expect(runtimeHarness.stopCalls).toEqual(["retell_unsafe", "retell_unsafe"]);
+    expect(recordTerminalUsage).toHaveBeenCalledWith({
+      call: existing,
+      usage: terminalUsage,
+    });
     expect(store.currentCall()).toMatchObject({
       endedAt: expect.any(Date),
       providerCallId: "retell_unsafe",
       status: "failed",
+    });
+  });
+
+  it("keeps recovery pending until terminal Retell usage is durably recorded", async () => {
+    const existing = buildHostedPhoneCall({
+      id: "hpc_existing",
+      providerCallId: "retell_call_123",
+      status: "calling",
+    });
+    const store = createPhoneCallStore({ existing });
+    const recordTerminalUsage = vi.fn(async () => undefined);
+    const resolveTerminalUsage = vi.fn()
+      .mockResolvedValueOnce({ state: "pending" })
+      .mockResolvedValueOnce({
+        state: "ready",
+        usage: {
+          combinedCostUsdMicros: 125_000,
+          occurredAt: new Date("2026-06-25T01:00:00.000Z"),
+          providerCallId: "retell_call_123",
+        },
+      });
+    const runtime = {
+      ...createPhoneCallRuntime({ providerCallId: "retell_unused" }).runtime,
+      resolveTerminalUsage,
+    };
+    const prisma = {
+      ...store.prisma,
+      recordTerminalUsage,
+    };
+
+    await expect(processHostedPhoneCallRecoveryById({
+      phoneCallId: existing.id,
+      prisma,
+      runtime,
+      signal: new AbortController().signal,
+    })).resolves.toBe("pending");
+    expect(recordTerminalUsage).not.toHaveBeenCalled();
+
+    await expect(processHostedPhoneCallRecoveryById({
+      phoneCallId: existing.id,
+      prisma,
+      runtime,
+      signal: new AbortController().signal,
+    })).resolves.toBe("complete");
+    expect(recordTerminalUsage).toHaveBeenCalledWith({
+      call: existing,
+      usage: {
+        combinedCostUsdMicros: 125_000,
+        occurredAt: new Date("2026-06-25T01:00:00.000Z"),
+        providerCallId: "retell_call_123",
+      },
     });
   });
 

--- a/apps/web/test/phone-calls-usage.test.ts
+++ b/apps/web/test/phone-calls-usage.test.ts
@@ -1,0 +1,194 @@
+import type { HostedPhoneCall } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  accountRetellPhoneCallUsage,
+  readRetellTerminalProviderUsage,
+} from "@/src/lib/phone-calls/usage";
+
+type UsageStore = NonNullable<Parameters<typeof accountRetellPhoneCallUsage>[0]["prisma"]>;
+type UsageTx = Parameters<UsageStore["$transaction"]>[0] extends (
+  tx: infer Tx,
+) => Promise<unknown>
+  ? Tx
+  : never;
+
+describe("Retell phone-call usage", () => {
+  it("converts fractional cents and attributes usage from the stored call", async () => {
+    const call = buildHostedPhoneCall();
+    const store = createUsageStore(call);
+
+    await expect(accountRetellPhoneCallUsage({
+      call: {
+        call_cost: { combined_cost: 7.125 },
+        call_id: "retell_call_123",
+        duration_ms: 61_250,
+        end_timestamp: "2026-06-25T12:00:00.000Z",
+        metadata: {
+          murph_phone_call_id: call.id,
+        },
+      },
+      prisma: store.prisma,
+    })).resolves.toBe("accounted");
+
+    expect(store.recordUsage).toHaveBeenCalledWith({
+      call,
+      usage: {
+        combinedCostUsdMicros: 71_250,
+        occurredAt: new Date("2026-06-25T12:00:00.000Z"),
+        providerCallId: "retell_call_123",
+      },
+    });
+  });
+
+  it("records legitimate zero-cost calls with the same stable facts on replay", async () => {
+    const call = buildHostedPhoneCall();
+    const store = createUsageStore(call);
+    const providerCall = {
+      call_cost: { combined_cost: 0 },
+      call_id: "retell_call_123",
+      end_timestamp: 1_782_386_400_000,
+    };
+
+    await accountRetellPhoneCallUsage({ call: providerCall, prisma: store.prisma });
+    await accountRetellPhoneCallUsage({ call: providerCall, prisma: store.prisma });
+
+    expect(store.recordUsage).toHaveBeenCalledTimes(2);
+    expect(store.recordUsage.mock.calls[0]).toEqual(store.recordUsage.mock.calls[1]);
+    expect(store.recordUsage).toHaveBeenLastCalledWith(expect.objectContaining({
+      usage: expect.objectContaining({
+        combinedCostUsdMicros: 0,
+      }),
+    }));
+  });
+
+  it("waits for a provider terminal timestamp before making usage immutable", async () => {
+    const store = createUsageStore(buildHostedPhoneCall());
+
+    await expect(accountRetellPhoneCallUsage({
+      call: {
+        call_cost: { combined_cost: 4.5 },
+        call_id: "retell_call_123",
+      },
+      prisma: store.prisma,
+    })).resolves.toBe("not_ready");
+
+    expect(store.recordUsage).not.toHaveBeenCalled();
+  });
+
+  it("defers transferred calls until the transfer leg ends", async () => {
+    const call = buildHostedPhoneCall();
+    const store = createUsageStore(call);
+    const transferredCall = {
+      call_cost: { combined_cost: 12 },
+      call_id: "retell_call_123",
+      disconnection_reason: "call_transfer",
+      end_timestamp: 1_782_386_400_000,
+    };
+
+    await expect(accountRetellPhoneCallUsage({
+      call: transferredCall,
+      prisma: store.prisma,
+    })).resolves.toBe("not_ready");
+    expect(store.recordUsage).not.toHaveBeenCalled();
+
+    await expect(accountRetellPhoneCallUsage({
+      call: {
+        ...transferredCall,
+        call_cost: { combined_cost: 18.75 },
+        transfer_end_timestamp: 1_782_408_600_000,
+      },
+      prisma: store.prisma,
+    })).resolves.toBe("accounted");
+    expect(store.recordUsage).toHaveBeenCalledWith(expect.objectContaining({
+      usage: expect.objectContaining({
+        combinedCostUsdMicros: 187_500,
+        occurredAt: new Date(1_782_408_600_000),
+      }),
+    }));
+  });
+
+  it("rejects provider-id mismatches without trusting callback metadata for member authority", async () => {
+    const store = createUsageStore(buildHostedPhoneCall({
+      providerCallId: "retell_other",
+    }));
+
+    await expect(accountRetellPhoneCallUsage({
+      call: {
+        call_cost: { combined_cost: 5 },
+        call_id: "retell_call_123",
+        end_timestamp: 1_782_386_400_000,
+        metadata: {
+          murph_phone_call_id: "hpc_123",
+          member_id: "member_untrusted",
+        },
+      },
+      prisma: store.prisma,
+    })).resolves.toBe("not_found");
+    expect(store.recordUsage).not.toHaveBeenCalled();
+  });
+
+  it("requires final provider cost and time during reconciliation", () => {
+    expect(readRetellTerminalProviderUsage({
+      call_id: "retell_call_123",
+      end_timestamp: 1_782_386_400_000,
+    })).toEqual({ state: "pending" });
+
+    expect(readRetellTerminalProviderUsage({
+      call_cost: { combined_cost: 3.3333 },
+      call_id: "retell_call_123",
+      duration_ms: 20_000,
+      end_timestamp: 1_782_386_400_000,
+    })).toEqual({
+      state: "ready",
+      usage: {
+        combinedCostUsdMicros: 33_333,
+        occurredAt: new Date(1_782_386_400_000),
+        providerCallId: "retell_call_123",
+      },
+    });
+  });
+});
+
+function buildHostedPhoneCall(overrides: Partial<HostedPhoneCall> = {}): HostedPhoneCall {
+  const createdAt = new Date("2026-06-25T11:00:00.000Z");
+  return {
+    analyzedAt: null,
+    briefEncrypted: null,
+    briefJson: null,
+    createdAt,
+    endedAt: null,
+    id: "hpc_123",
+    memberId: "member_123",
+    provider: "retell",
+    providerCallId: "retell_call_123",
+    requestKey: "request_123",
+    resultEncrypted: null,
+    resultJson: null,
+    status: "calling",
+    updatedAt: createdAt,
+    ...overrides,
+  };
+}
+
+function createUsageStore(call: HostedPhoneCall) {
+  const recordUsage = vi.fn<UsageTx["recordUsage"]>(async () => undefined);
+  const tx: UsageTx = {
+    hostedPhoneCall: {
+      findUnique: async ({ where }) => {
+        if ("id" in where) {
+          return where.id === call.id ? call : null;
+        }
+        return where.providerCallId === call.providerCallId ? call : null;
+      },
+    },
+    recordUsage,
+  };
+  const prisma: UsageStore = {
+    $transaction: async (callback) => callback(tx),
+  };
+  return {
+    prisma,
+    recordUsage,
+  };
+}


### PR DESCRIPTION
## Why

Retell phone calls currently never enter the hosted usage ledger, so successful, failed, unanswered, and transferred calls contribute $0 to included-usage spend and Settings projections. The omission dates to the original Retell integration: terminal handlers update call lifecycle/result state but do not persist provider cost.

## User-visible goal and flow

After deployment, each terminal Retell call counts its final provider-reported combined cost once in the member's existing included-usage allowance. Existing Settings and `murph.plan_usage` projections then include phone-call spend without introducing a new UI or billing surface.

This remains advisory included-usage accounting. It does not enable the intentionally disabled Stripe meter export, create per-call overage invoices, or hard-gate otherwise-authorized usage.

## What changed

- Strictly normalize Retell `call_cost.combined_cost` and convert cents to integer USD micros.
- Build one deterministic web-owned usage row from the immutable Murph phone-call ID and account it through the existing `HostedAiUsage` / `HostedAiUsagePeriod` owners.
- Account signed `call_ended`, `call_analyzed`, and `transfer_ended` callbacks independently of result persistence.
- Defer transferred calls until the provider supplies the transfer terminal timestamp and final combined cost.
- Extend the existing pre-armed phone-call reconciliation workflow to retrieve terminal provider usage after webhook loss, including failed-call cleanup.
- Keep the signed hosted-runtime usage parser unable to assert Retell cost.
- Add focused replay, transfer, callback-loss, attribution, malformed/oversized telemetry, zero/fractional-cost, and allowance-pricing coverage.

## UX

There is no new direct UI. The existing usage percentage, period spend, forecast inputs, and plan-usage tool become accurate for Retell calls.

## Invariants

- Billing authority comes from the stored `HostedPhoneCall.memberId`; callback metadata never supplies the member.
- Provider-call identity must match the stored Retell authority.
- Replays and concurrent callback/reconciliation paths converge on one immutable usage ID and one allowance increment.
- Only final provider combined cost is immutable; optional duration telemetry is excluded so callback shapes cannot conflict.
- No transcripts, recordings, destinations, product labels, or other call content enter usage storage.
- Result/privacy/storage-mode behavior remains independent from content-free cost accounting.
- Existing Stripe usage export remains disabled.

## Non-obvious affected surfaces

- Retell webhook subscription and terminal callback routing.
- Hosted allowance pricing for one strict web-owned Retell record shape.
- Phone-call start reconciliation, which now remains pending through terminal usage persistence.
- Retell analysis-field and hosted usage architecture documentation.

No schema, dependency, lockfile, Cloudflare, or generated-artifact changes are included. Existing current-period calls are not retrospectively backfilled, consistent with the allowance owner's existing no-backfill policy. A pre-deploy transferred call already in flight may need manual reconciliation if its old workflow completed before this version; the rollout exposure is limited to that in-flight window.

## Change shape

ReviewGPT first-reviewed head: 55f8788015499c50d99ee31319e0e69389650798

### Immutable first-reviewed baseline

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 640 | 82 |
| Tests | 458 | 8 |
| Docs | 78 | 4 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

### Current head

| Head | Source + / - | Tests + / - | Docs + / - | Config/tooling + / - | Generated/other + / - |
| --- | ---: | ---: | ---: | ---: | ---: |
| `5549fa641a3032df41a1cadac4c5289d45f75b73` | 668 / 90 | 524 / 8 | 78 / 4 | 0 / 0 | 0 / 0 |

## Verification

- Focused Retell routes/runtime/reconciliation and allowance suite: 6 files, 195 tests passed.
- Prepared web typecheck: passed after regenerating the Prisma client for current `main`.
- Coverage-write audit: found and fixed an oversized-cost ingress boundary; focused route suite passed 9 tests.
- Full acceptance reached green workspace guards/typechecks, web build, lint, dev smoke, and all 5,289 web tests. The workspace coverage fan-out later exhausted a 4 GB Node heap in an unrelated CLI meal-import lane and emitted one unrelated worker-exit error; the exact CLI file passed cleanly afterward (8 tests).
- `git diff --check`: passed.
- Clean merge-tree proof against current `main`: passed.
- ReviewGPT round 1: one accepted critical-flow coupling; fixed by independently settling advisory accounting and lifecycle/result delivery, with 30 / 10 source and 66 / 0 test remediation lines. Route regressions pass 11 tests.
- Current-head PR CI: 25 / 25 checks passed. One unrelated MinIO startup-timeout shard passed on retry without a code change.
- ReviewGPT correction round 2: PASS with no findings at `5549fa641a3032df41a1cadac4c5289d45f75b73`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786778559&installation_id=127572939&pr_number=743&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F743&signature=d45db6ce9fd077c59548cf50ba052f5aa0cdc503f00663c92b830803f65c8ef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

