### PR TITLE
Reuse hosted Codex across rotating turn authority

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-cold-start-codex-reuse.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-cold-start-codex-reuse.md
@@ -1,0 +1,51 @@
+# Cold-start Codex process reuse
+
+## Goal
+
+Restore safe hosted Codex App Server reuse across member turns by separating
+stable process identity from fresh per-turn capabilities at a request-scoped
+boundary supported by the runtime.
+
+Success criteria:
+
+- Keep per-turn CLI bridge and delivery authority fresh and narrowly scoped.
+- Prevent those volatile capabilities from forcing an otherwise compatible
+  Codex App Server respawn on every hosted invocation.
+- Preserve provider authentication, thread continuity, and fail-closed launch
+  identity checks.
+- Cover reuse, capability rotation, and incompatible-launch behavior with
+  focused tests.
+
+## Constraints
+
+- Do not exclude volatile secrets from launch identity while leaving stale
+  values in the child process environment.
+- Add no new state owner, daemon, compatibility layer, or broad lifecycle
+  abstraction.
+- Preserve active hosted runtime and CLI bridge work in other lanes.
+- Keep private identifiers, payloads, credentials, and local paths out of
+  committed artifacts.
+
+## Approach
+
+1. Prove the current launch-identity respawn path and the available Codex
+   request-scoped configuration surface.
+2. Move only volatile per-turn authority to that request boundary while
+   retaining stable launch-time environment in process identity.
+3. Update focused runtime tests for safe reuse and incompatible launches.
+4. Run scoped verification, required coverage review, CI, and ReviewGPT.
+
+## State
+
+Active.
+
+## Notes
+
+- Hosted runtime evidence showed that fresh bridge and delivery capabilities
+  currently alter the App Server launch identity every invocation, guaranteeing
+  a respawn even when the container and member runtime are already warm.
+- The implementation must preserve capability freshness rather than weakening
+  the launch hash around stale child-process environment.
+Status: completed
+Updated: 2026-07-16
+Completed: 2026-07-16

--- a/packages/assistant-engine/src/assistant-ask.ts
+++ b/packages/assistant-engine/src/assistant-ask.ts
@@ -106,6 +106,7 @@ export interface ReadOnlyAssistantAskInput {
   codexHome?: string | null
   developerInstructions?: string | null
   env?: NodeJS.ProcessEnv
+  hostedProviderCredentialEnvKey?: string | null
   model?: string | null
   modelProvider?: string | null
   now?: Date
@@ -160,6 +161,7 @@ export async function executeReadOnlyAssistantAsk(
       dynamicTools: [],
       env: stripReadOnlyAssistantAskCapabilityEnv(input.env),
       ephemeral: true,
+      hostedProviderCredentialEnvKey: input.hostedProviderCredentialEnvKey,
       model: input.model,
       modelProvider: input.modelProvider,
       outputSchema: READ_ONLY_ASSISTANT_ASK_OUTPUT_SCHEMA,

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -7,7 +7,6 @@ import path from 'node:path'
 import type {
   HostedCodexAuthAction,
 } from '@murphai/hosted-execution/contracts'
-import { HOSTED_CLI_BRIDGE_TOKEN_ENV } from '@murphai/hosted-execution/cli-runtime-bridge'
 import { normalizeNullableString } from '@murphai/operator-config/text/shared'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import {
@@ -87,6 +86,7 @@ import {
   type PendingCodexRpcRequest,
 } from './assistant-codex/app-server-rpc.js'
 import {
+  resolveHostedCodexTurnBoundary,
   resolveCodexChildEnv,
   withHostedCodexModelCatalogConfigOverride,
 } from './assistant-codex/config.js'
@@ -220,8 +220,10 @@ type CodexAppServerSpawnInput = CodexAppServerProcessInput & {
 type CodexAppServerPreparedTurnInput = CodexAppServerTurnInput & {
   args: readonly string[]
   codexCommand: string
+  ephemeralApiKey: string | null
   env: NodeJS.ProcessEnv
   fetchImpl: typeof fetch
+  hostedTurn: boolean
   hostedGeneratedImageUploader: AssistantHostedGeneratedImageUploader | null
   imagePaths: readonly string[]
   launchKey: string
@@ -422,6 +424,7 @@ export interface CodexAppServerTurnInput {
   codexHome?: string | null
   env?: NodeJS.ProcessEnv
   fetchImpl?: typeof fetch | null
+  hostedProviderCredentialEnvKey?: string | null
   baseInstructions?: string | null
   developerInstructions?: string | null
   dynamicTools: readonly AssistantProviderDynamicTool[]
@@ -610,9 +613,13 @@ export async function executeCodexAppServerTurn(
   const approvalPolicy = resolveSupportedCodexAppServerApprovalPolicy(input.approvalPolicy)
   const workingDirectory = path.resolve(input.workingDirectory)
   await assertCodexAppServerWorkingDirectory(workingDirectory)
+  const hostedTurnBoundary = resolveHostedCodexTurnBoundary({
+    env: input.env,
+    providerCredentialEnvKey: input.hostedProviderCredentialEnvKey,
+  })
   const childEnv = await resolveCodexChildEnv({
     codexHome: input.codexHome,
-    env: input.env,
+    env: hostedTurnBoundary?.residentEnv ?? input.env,
   })
   const codexCommand = resolveCodexAppServerCommand(input.codexCommand)
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'murph-codex-'))
@@ -630,6 +637,12 @@ export async function executeCodexAppServerTurn(
     runtimeWorkspaceRoots: input.runtimeWorkspaceRoots?.map((root) =>
       path.resolve(root),
     ),
+    threadConfig: hostedTurnBoundary
+      ? {
+          ...(input.threadConfig ?? {}),
+          ...hostedTurnBoundary.threadConfig,
+        }
+      : input.threadConfig,
   }
   const args = buildCodexAppServerArgs(normalizedInput)
   const launchKey = buildCodexAppServerLaunchKey({
@@ -642,11 +655,13 @@ export async function executeCodexAppServerTurn(
     ...normalizedInput,
     args,
     codexCommand,
+    ephemeralApiKey: hostedTurnBoundary?.ephemeralApiKey ?? null,
     env: childEnv,
     fetchImpl: input.fetchImpl ?? fetch,
     hostedGeneratedImageUploader: input.hostedGeneratedImageUploader ?? null,
     materializeWorkspaceArtifacts: input.materializeWorkspaceArtifacts ?? null,
     imagePaths,
+    hostedTurn: hostedTurnBoundary !== null,
     launchKey,
     publicInternetFetch: input.publicInternetFetch ?? null,
     tempRoot,
@@ -953,6 +968,7 @@ class CodexAppServerProcess {
 
   beginHostedBackgroundTerminalCleanup(input: {
     binding: CodexAppServerActiveTurnBinding
+    revokeEphemeralApiKeyAuth: boolean
     threadId: string
   }): Promise<void> {
     if (this.activeTurn !== input.binding || this.state !== 'running') {
@@ -965,13 +981,22 @@ class CodexAppServerProcess {
     // turn so its provider result can proceed to durable reply delivery.
     this.activeTurn = null
     this.state = 'cleanup'
-    const cleanup = withCodexRpcTimeout(
-      this.sendRequest('thread/backgroundTerminals/clean', {
-        threadId: input.threadId,
-      }),
-      HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
-      'thread/backgroundTerminals/clean',
-    ).then(
+    const cleanup = (async () => {
+      await withCodexRpcTimeout(
+        this.sendRequest('thread/backgroundTerminals/clean', {
+          threadId: input.threadId,
+        }),
+        HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
+        'thread/backgroundTerminals/clean',
+      )
+      if (input.revokeEphemeralApiKeyAuth) {
+        await withCodexRpcTimeout(
+          this.sendRequest('account/logout', {}),
+          HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
+          'account/logout',
+        )
+      }
+    })().then(
       () => undefined,
       async (error: unknown) => {
         // Clear the timed-out RPC before stopping the exact owned process
@@ -4121,6 +4146,26 @@ async function runCodexAppServerTurnOnProcess(
       emitAppServerTimingTrace('warm-reused')
     }
 
+    if (input.ephemeralApiKey) {
+      lifecycleStage = 'provider_auth_bind'
+      try {
+        await withCodexRpcTimeout(
+          sendRequest('account/login/start', {
+            apiKey: input.ephemeralApiKey,
+            type: 'apiKey',
+          }),
+          HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
+          'account/login/start',
+        )
+      } catch {
+        throw new VaultCliError(
+          'ASSISTANT_CODEX_AUTH_FAILED',
+          'Codex app-server could not bind hosted provider authentication.',
+          { retryable: true },
+        )
+      }
+    }
+
     const resumeThreadId = requestedResumeThreadId
     const threadTimingStage = resumeThreadId ? 'thread-resumed' : 'thread-started'
     lifecycleStage = resumeThreadId ? 'thread_resume' : 'thread_start'
@@ -4218,11 +4263,12 @@ async function runCodexAppServerTurnOnProcess(
       if (
         input.processLifetime !== 'one-shot' &&
         codexThreadId &&
-        normalizeNullableString(input.env[HOSTED_CLI_BRIDGE_TOKEN_ENV])
+        input.hostedTurn
       ) {
         lifecycleStage = 'background_terminal_cleanup'
         const cleanup = codexProcess.beginHostedBackgroundTerminalCleanup({
           binding: activeTurnBinding,
+          revokeEphemeralApiKeyAuth: input.ephemeralApiKey !== null,
           threadId: codexThreadId,
         })
         trackHostedCodexPostTurnCleanup(cleanup)

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -41,6 +41,7 @@ import {
   buildCodexTurnInterruptParams,
   buildCodexThreadResumeParams,
   buildCodexThreadStartParams,
+  buildCodexThreadUnsubscribeParams,
   buildCodexTurnSteerParams,
   buildCodexTurnStartParams,
   mapCodexAppServerApprovalPolicy,
@@ -220,6 +221,7 @@ type CodexAppServerSpawnInput = CodexAppServerProcessInput & {
 type CodexAppServerPreparedTurnInput = CodexAppServerTurnInput & {
   args: readonly string[]
   codexCommand: string
+  dynamicToolEnv: NodeJS.ProcessEnv
   ephemeralApiKey: string | null
   env: NodeJS.ProcessEnv
   fetchImpl: typeof fetch
@@ -655,6 +657,9 @@ export async function executeCodexAppServerTurn(
     ...normalizedInput,
     args,
     codexCommand,
+    dynamicToolEnv: hostedTurnBoundary
+      ? { ...(input.env ?? process.env), ...childEnv }
+      : childEnv,
     ephemeralApiKey: hostedTurnBoundary?.ephemeralApiKey ?? null,
     env: childEnv,
     fetchImpl: input.fetchImpl ?? fetch,
@@ -966,6 +971,25 @@ class CodexAppServerProcess {
     }
   }
 
+  async bindEphemeralApiKeyAuth(apiKey: string): Promise<void> {
+    await withCodexRpcTimeout(
+      this.sendRequest('account/login/start', {
+        apiKey,
+        type: 'apiKey',
+      }),
+      HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
+      'account/login/start',
+    )
+  }
+
+  async revokeEphemeralApiKeyAuth(): Promise<void> {
+    await withCodexRpcTimeout(
+      this.sendRequest('account/logout', {}),
+      HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
+      'account/logout',
+    )
+  }
+
   beginHostedBackgroundTerminalCleanup(input: {
     binding: CodexAppServerActiveTurnBinding
     revokeEphemeralApiKeyAuth: boolean
@@ -990,11 +1014,7 @@ class CodexAppServerProcess {
         'thread/backgroundTerminals/clean',
       )
       if (input.revokeEphemeralApiKeyAuth) {
-        await withCodexRpcTimeout(
-          this.sendRequest('account/logout', {}),
-          HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
-          'account/logout',
-        )
+        await this.revokeEphemeralApiKeyAuth()
       }
     })().then(
       () => undefined,
@@ -1364,6 +1384,25 @@ class CodexAppServerProcess {
     return this.boundThreadId
   }
 
+  async unsubscribeBoundThreadForReuse(): Promise<void> {
+    const threadId = this.boundThreadId
+    if (threadId) {
+      await withCodexRpcTimeout(
+        this.sendRequest(
+          'thread/unsubscribe',
+          buildCodexThreadUnsubscribeParams({ threadId }),
+        ),
+        HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
+        'thread/unsubscribe',
+      )
+    }
+
+    this.boundThreadId = null
+    this.boundThreadModel = null
+    this.boundThreadServiceTier = null
+    this.lastThreadTokenUsage = null
+  }
+
   private handleIdleServerMessage(message: CodexRpcMessage): void {
     const responseId = readCodexRpcResponseId(message)
     if (responseId !== null) {
@@ -1567,14 +1606,24 @@ async function withWarmCodexSlotLock<T>(
 }
 
 async function getOrStartWarmCodexProcess(
-  input: CodexAppServerProcessInput,
+  input: CodexAppServerProcessInput & { hostedTurn: boolean },
 ): Promise<CodexAppServerProcess> {
   const launchKey = input.launchKey
   return await withWarmCodexSlotLock(async () => {
     await warmCodexProcess?.pendingPostTurnCleanup
-    if (warmCodexProcess?.isReusableFor(launchKey)) {
-      warmCodexProcess.reserveTurn()
-      return warmCodexProcess
+    const reusableProcess = warmCodexProcess
+    if (reusableProcess?.isReusableFor(launchKey)) {
+      if (input.hostedTurn) {
+        try {
+          await reusableProcess.unsubscribeBoundThreadForReuse()
+        } catch {
+          await reusableProcess.stop('process-unhealthy')
+        }
+      }
+      if (reusableProcess.isReusableFor(launchKey)) {
+        reusableProcess.reserveTurn()
+        return reusableProcess
+      }
     }
 
     const previousProcess = warmCodexProcess
@@ -1684,6 +1733,7 @@ export async function executeCodexManagedAccountOperation(
     args,
     codexCommand,
     env,
+    hostedTurn: false,
     launchKey,
   })
 
@@ -2080,6 +2130,7 @@ export type CodexWarmThreadCompactionOutcome =
 // including rollout files, and must never capture a rollout mid-teardown.
 export async function compactWarmCodexThread(input: {
   canAccountForModel?: ((model: string | null) => boolean) | null
+  ephemeralApiKey?: string | null
   minThreadTokens: number
   signal?: AbortSignal | null
   timeoutMs: number
@@ -2241,8 +2292,20 @@ export async function compactWarmCodexThread(input: {
 
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null
   const onAbort = () => settleCompaction('aborted')
+  let ephemeralApiKeyAuthBound = false
+  let shouldPoisonProcess = false
+  let outcome: CodexWarmThreadCompactionOutcome = {
+    kind: 'failed',
+    reason: 'rpc_error',
+    threadContextTokensBefore: vitals.lastInputTokens,
+    threadId: vitals.threadId,
+  }
   try {
     processInstance.bindTurn(binding)
+    if (input.ephemeralApiKey) {
+      await processInstance.bindEphemeralApiKeyAuth(input.ephemeralApiKey)
+      ephemeralApiKeyAuthBound = true
+    }
     processInstance
       .sendRequest('config/read', { includeLayers: false })
       .then(() => {
@@ -2268,7 +2331,7 @@ export async function compactWarmCodexThread(input: {
       // Vitals were cleared by the stdout observer when the compaction item
       // completed, so a repeat idle pass skips with no_thread_vitals instead
       // of re-compacting; the next turn's tokenUsage events repopulate them.
-      return {
+      outcome = {
         kind: 'compacted',
         durationMs: Date.now() - startedAt,
         model: vitals.model,
@@ -2278,31 +2341,44 @@ export async function compactWarmCodexThread(input: {
         usage: providerUsage
           ?? estimateCodexWarmThreadCompactionUsage(vitals.lastInputTokens),
       }
-    }
-
-    await processInstance.poison('idle-compaction-failed')
-    return {
-      kind: 'failed',
-      reason: settledReason,
-      threadContextTokensBefore: vitals.lastInputTokens,
-      threadId: vitals.threadId,
+    } else {
+      shouldPoisonProcess = true
+      outcome = {
+        kind: 'failed',
+        reason: settledReason,
+        threadContextTokensBefore: vitals.lastInputTokens,
+        threadId: vitals.threadId,
+      }
     }
   } catch {
-    await processInstance.poison('idle-compaction-failed')
-    return {
-      kind: 'failed',
-      reason: 'rpc_error',
-      threadContextTokensBefore: vitals.lastInputTokens,
-      threadId: vitals.threadId,
-    }
+    shouldPoisonProcess = true
   } finally {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle)
     }
     input.signal?.removeEventListener('abort', onAbort)
+    if (ephemeralApiKeyAuthBound) {
+      try {
+        await processInstance.revokeEphemeralApiKeyAuth()
+      } catch {
+        shouldPoisonProcess = true
+        if (outcome.kind === 'compacted') {
+          outcome = {
+            kind: 'failed',
+            reason: 'rpc_error',
+            threadContextTokensBefore: vitals.lastInputTokens,
+            threadId: vitals.threadId,
+          }
+        }
+      }
+    }
+    if (shouldPoisonProcess) {
+      await processInstance.poison('idle-compaction-failed')
+    }
     processInstance.releaseTurn(binding)
     processInstance.releaseReservation()
   }
+  return outcome
 }
 
 function hashCodexRawString(value: string): string {
@@ -3482,8 +3558,8 @@ async function runCodexAppServerTurnOnProcess(
           abortSignal: input.abortSignal
             ? AbortSignal.any([input.abortSignal, dynamicToolAbortController.signal])
             : dynamicToolAbortController.signal,
-          codexHome: input.codexHome ?? input.env.CODEX_HOME ?? null,
-          env: input.env,
+          codexHome: input.codexHome ?? input.dynamicToolEnv.CODEX_HOME ?? null,
+          env: input.dynamicToolEnv,
           fetchImpl: input.fetchImpl,
           hostedGeneratedImageUploader: input.hostedGeneratedImageUploader,
           hostedToolContext,
@@ -4149,14 +4225,7 @@ async function runCodexAppServerTurnOnProcess(
     if (input.ephemeralApiKey) {
       lifecycleStage = 'provider_auth_bind'
       try {
-        await withCodexRpcTimeout(
-          sendRequest('account/login/start', {
-            apiKey: input.ephemeralApiKey,
-            type: 'apiKey',
-          }),
-          HOSTED_CODEX_BACKGROUND_TERMINAL_CLEANUP_TIMEOUT_MS,
-          'account/login/start',
-        )
+        await codexProcess.bindEphemeralApiKeyAuth(input.ephemeralApiKey)
       } catch {
         throw new VaultCliError(
           'ASSISTANT_CODEX_AUTH_FAILED',

--- a/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
+++ b/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
@@ -60,6 +60,17 @@ export function buildCodexThreadResumeParams(input: {
   })
 }
 
+export function buildCodexThreadUnsubscribeParams(input: {
+  threadId: string
+}): Record<string, unknown> {
+  return {
+    threadId: assertCodexRpcIdentifier({
+      field: 'threadId',
+      value: input.threadId,
+    }),
+  }
+}
+
 export function buildCodexThreadContextParams(input: {
   includeInstructions: boolean
   includeServiceName: boolean

--- a/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
+++ b/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
@@ -114,13 +114,16 @@ function buildCodexThreadResumeContextParams(
     workingDirectory: string
   },
 ): Record<string, unknown> {
-  return {
+  return stripUndefinedRpcParams({
     approvalPolicy: mapCodexAppServerApprovalPolicy(input.approvalPolicy),
+    config: input.threadConfig
+      ? { ...input.threadConfig }
+      : undefined,
     cwd: input.workingDirectory,
     model: normalizeNullableString(input.model),
     modelProvider: normalizeNullableString(input.modelProvider),
     sandbox: mapCodexAppServerSandboxMode(input.sandbox),
-  }
+  })
 }
 
 export function buildCodexTurnStartParams(input: {

--- a/packages/assistant-engine/src/assistant-codex/config.ts
+++ b/packages/assistant-engine/src/assistant-codex/config.ts
@@ -44,25 +44,9 @@ export function resolveHostedCodexTurnBoundary(input: {
   const bridgeToken = normalizeNullableString(
     env[HOSTED_CLI_BRIDGE_TOKEN_ENV],
   )
-  if (!bridgeToken) {
-    return null
-  }
-
   const routeGrant = normalizeNullableString(
     env[HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV],
   )
-  if (!routeGrant) {
-    throw new VaultCliError(
-      'ASSISTANT_CODEX_HOSTED_AUTH_INVALID',
-      'Hosted Codex turns require a current CLI bridge route grant.',
-      { retryable: false },
-    )
-  }
-
-  const turnScopedEnv = new Map<string, string>([
-    [HOSTED_CLI_BRIDGE_TOKEN_ENV, bridgeToken],
-    [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV, routeGrant],
-  ])
   const providerCredentialEnvKey = normalizeNullableString(
     input.providerCredentialEnvKey,
   )
@@ -83,14 +67,29 @@ export function resolveHostedCodexTurnBoundary(input: {
         { retryable: true },
       )
     }
-    turnScopedEnv.set(providerCredentialEnvKey, ephemeralApiKey)
+  }
+
+  if (!bridgeToken && !providerCredentialEnvKey) {
+    return null
   }
 
   const residentEnv = { ...env }
+  delete residentEnv[HOSTED_CLI_BRIDGE_TOKEN_ENV]
+  delete residentEnv[HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]
+  if (providerCredentialEnvKey) {
+    delete residentEnv[providerCredentialEnvKey]
+  }
+
   const threadConfig: Record<string, unknown> = {}
-  for (const [name, value] of turnScopedEnv) {
-    delete residentEnv[name]
-    threadConfig[`shell_environment_policy.set.${name}`] = value
+  if (bridgeToken) {
+    threadConfig[
+      `shell_environment_policy.set.${HOSTED_CLI_BRIDGE_TOKEN_ENV}`
+    ] = bridgeToken
+    if (routeGrant) {
+      threadConfig[
+        `shell_environment_policy.set.${HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV}`
+      ] = routeGrant
+    }
   }
 
   return {

--- a/packages/assistant-engine/src/assistant-codex/config.ts
+++ b/packages/assistant-engine/src/assistant-codex/config.ts
@@ -4,6 +4,8 @@ import { homedir } from 'node:os'
 import path from 'node:path'
 
 import {
+  HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV,
+  HOSTED_CLI_BRIDGE_TOKEN_ENV,
   HOSTED_RUNTIME_CODEX_MODEL_CATALOG_JSON_ENV,
 } from '@murphai/hosted-execution/cli-runtime-bridge'
 import { normalizeNullableString } from '@murphai/operator-config/text/shared'
@@ -26,6 +28,76 @@ interface CodexDisplayConfig {
 export interface CodexDisplayOptions {
   model: string | null
   reasoningEffort: string | null
+}
+
+export interface HostedCodexTurnBoundary {
+  ephemeralApiKey: string | null
+  residentEnv: NodeJS.ProcessEnv
+  threadConfig: Readonly<Record<string, unknown>>
+}
+
+export function resolveHostedCodexTurnBoundary(input: {
+  env?: NodeJS.ProcessEnv
+  providerCredentialEnvKey?: string | null
+}): HostedCodexTurnBoundary | null {
+  const env = input.env ?? process.env
+  const bridgeToken = normalizeNullableString(
+    env[HOSTED_CLI_BRIDGE_TOKEN_ENV],
+  )
+  if (!bridgeToken) {
+    return null
+  }
+
+  const routeGrant = normalizeNullableString(
+    env[HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV],
+  )
+  if (!routeGrant) {
+    throw new VaultCliError(
+      'ASSISTANT_CODEX_HOSTED_AUTH_INVALID',
+      'Hosted Codex turns require a current CLI bridge route grant.',
+      { retryable: false },
+    )
+  }
+
+  const turnScopedEnv = new Map<string, string>([
+    [HOSTED_CLI_BRIDGE_TOKEN_ENV, bridgeToken],
+    [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV, routeGrant],
+  ])
+  const providerCredentialEnvKey = normalizeNullableString(
+    input.providerCredentialEnvKey,
+  )
+  let ephemeralApiKey: string | null = null
+  if (providerCredentialEnvKey) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(providerCredentialEnvKey)) {
+      throw new VaultCliError(
+        'ASSISTANT_CODEX_HOSTED_AUTH_INVALID',
+        'Hosted Codex provider credential environment key is invalid.',
+        { retryable: false },
+      )
+    }
+    ephemeralApiKey = normalizeNullableString(env[providerCredentialEnvKey])
+    if (!ephemeralApiKey) {
+      throw new VaultCliError(
+        'ASSISTANT_CODEX_HOSTED_AUTH_INVALID',
+        'Hosted Codex provider authentication is unavailable for this turn.',
+        { retryable: true },
+      )
+    }
+    turnScopedEnv.set(providerCredentialEnvKey, ephemeralApiKey)
+  }
+
+  const residentEnv = { ...env }
+  const threadConfig: Record<string, unknown> = {}
+  for (const [name, value] of turnScopedEnv) {
+    delete residentEnv[name]
+    threadConfig[`shell_environment_policy.set.${name}`] = value
+  }
+
+  return {
+    ephemeralApiKey,
+    residentEnv,
+    threadConfig,
+  }
 }
 
 export async function resolveCodexChildEnv(input: {

--- a/packages/assistant-engine/src/assistant/providers/codex-cli.ts
+++ b/packages/assistant-engine/src/assistant/providers/codex-cli.ts
@@ -12,10 +12,15 @@ import {
   resolveSupportedCodexAppServerApprovalPolicy,
 } from '../../assistant-codex/app-server-requests.js'
 import {
+  HOSTED_CLI_BRIDGE_TOKEN_ENV,
+} from '@murphai/hosted-execution/cli-runtime-bridge'
+import {
   isAssistantCodexTargetConfig,
   resolveAssistantChatProviderFromConfig,
 } from '@murphai/operator-config/assistant/provider-config'
 import {
+  HOSTED_OPENAI_CODEX_MODEL_PROVIDER_ID,
+  OPENAI_CODEX_MODEL_PROVIDER_CONFIG,
   resolveStrictAssistantCodexModelProvider,
 } from '@murphai/operator-config/assistant/target-runtime'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
@@ -167,12 +172,16 @@ export async function executeCodexAssistantTurnAttempt(
     providerConfig.target.modelProvider,
   )
   const modelProviderConfig = modelProviderResolution.config
+  const providerCredentialEnvKey =
+    modelProviderResolution.id === HOSTED_OPENAI_CODEX_MODEL_PROVIDER_ID
+      ? OPENAI_CODEX_MODEL_PROVIDER_CONFIG.envKey
+      : modelProviderConfig?.envKey ?? null
   const providerFailureHint = modelProviderConfig?.failureHint ?? null
   const providerSecretValue =
-    modelProviderConfig?.envKey
+    providerCredentialEnvKey
       ? normalizeNullableString(
-          input.env?.[modelProviderConfig.envKey] ??
-            process.env[modelProviderConfig.envKey],
+          input.env?.[providerCredentialEnvKey] ??
+            process.env[providerCredentialEnvKey],
         )
       : null
   const approvalPolicy = resolveSupportedCodexAppServerApprovalPolicy(
@@ -188,6 +197,11 @@ export async function executeCodexAssistantTurnAttempt(
     voiceMemoDeliveryChannel: input.voiceMemoDeliveryChannel ?? null,
   })
   const codexProcessEnv = prepareAssistantDirectCliEnv(input.env)
+  const hostedProviderCredentialEnvKey =
+    normalizeNullableString(codexProcessEnv[HOSTED_CLI_BRIDGE_TOKEN_ENV]) &&
+      providerCredentialEnvKey
+      ? providerCredentialEnvKey
+      : undefined
   const codexConfigOverrides = [
     ...(mergeCodexConfigOverrides({
       modelProvider: providerConfig.target.modelProvider,
@@ -209,6 +223,7 @@ export async function executeCodexAssistantTurnAttempt(
     configOverrides:
       codexConfigOverrides.length > 0 ? codexConfigOverrides : undefined,
     env: codexProcessEnv,
+    hostedProviderCredentialEnvKey,
     fetchImpl: input.providerFetch ?? undefined,
     hostedGeneratedImageUploader: input.generatedImageUploader ?? null,
     hostedToolContext: input.hostedToolContext ?? null,

--- a/packages/assistant-engine/test/assistant-ask.test.ts
+++ b/packages/assistant-engine/test/assistant-ask.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import {
+  HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV,
   HOSTED_CLI_BRIDGE_TOKEN_ENV,
   HOSTED_CLI_BRIDGE_URL_ENV,
 } from '@murphai/hosted-execution/cli-runtime-bridge'
@@ -67,12 +68,14 @@ describe('executeReadOnlyAssistantAsk', () => {
         developerInstructions: 'Use Murph voice.',
         env: {
           ELEVENLABS_API_KEY: 'must-be-removed',
+          [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'must-be-removed',
           [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'must-be-removed',
           [HOSTED_CLI_BRIDGE_URL_ENV]: 'http://127.0.0.1/private',
           MURPH_ASSISTANT_SKILLS_ROOT: '/private/skills',
-          OPENAI_API_KEY: 'provider-auth-stays-on-supervisor',
+          OPENAI_API_KEY: 'provider-auth-binds-natively',
           PATH: '/runtime/bin',
         },
+        hostedProviderCredentialEnvKey: 'OPENAI_API_KEY',
         model: 'gpt-5.5',
         modelProvider: 'hosted-openai',
         now,
@@ -101,6 +104,7 @@ describe('executeReadOnlyAssistantAsk', () => {
       developerInstructions: 'Use Murph voice.',
       dynamicTools: [],
       ephemeral: true,
+      hostedProviderCredentialEnvKey: 'OPENAI_API_KEY',
       model: 'gpt-5.5',
       modelProvider: 'hosted-openai',
       outputSchema: READ_ONLY_ASSISTANT_ASK_OUTPUT_SCHEMA,
@@ -122,9 +126,10 @@ describe('executeReadOnlyAssistantAsk', () => {
       'What exercise is prescribed today?',
     )
     expect(turnInput.env).toMatchObject({
-      OPENAI_API_KEY: 'provider-auth-stays-on-supervisor',
+      OPENAI_API_KEY: 'provider-auth-binds-natively',
       PATH: '/runtime/bin',
     })
+    expect(turnInput.env[HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]).toBeUndefined()
     expect(turnInput.env[HOSTED_CLI_BRIDGE_TOKEN_ENV]).toBeUndefined()
     expect(turnInput.env[HOSTED_CLI_BRIDGE_URL_ENV]).toBeUndefined()
     expect(turnInput.env.ELEVENLABS_API_KEY).toBeUndefined()

--- a/packages/assistant-engine/test/assistant-codex-config.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-config.test.ts
@@ -1,0 +1,118 @@
+import {
+  HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV,
+  HOSTED_CLI_BRIDGE_TOKEN_ENV,
+} from '@murphai/hosted-execution/cli-runtime-bridge'
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveHostedCodexTurnBoundary,
+  type HostedCodexTurnBoundary,
+} from '../src/assistant-codex/config.ts'
+
+function requireHostedBoundary(input: Parameters<
+  typeof resolveHostedCodexTurnBoundary
+>[0]): HostedCodexTurnBoundary {
+  const boundary = resolveHostedCodexTurnBoundary(input)
+  expect(boundary).not.toBeNull()
+  if (!boundary) {
+    throw new Error('Expected a hosted Codex turn boundary.')
+  }
+  return boundary
+}
+
+describe('hosted Codex turn boundary', () => {
+  it('supports a bridge-token-only turn without route authority', () => {
+    const boundary = requireHostedBoundary({
+      env: {
+        [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'bridge-token-current',
+        PATH: '/custom/bin',
+      },
+    })
+
+    expect(boundary).toEqual({
+      ephemeralApiKey: null,
+      residentEnv: {
+        PATH: '/custom/bin',
+      },
+      threadConfig: {
+        [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_TOKEN_ENV}`]:
+          'bridge-token-current',
+      },
+    })
+  })
+
+  it('treats a blank route grant as absent and strips it from the resident environment', () => {
+    const boundary = requireHostedBoundary({
+      env: {
+        [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: ' \t ',
+        [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'bridge-token-current',
+      },
+    })
+
+    expect(boundary.residentEnv).not.toHaveProperty(
+      HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV,
+    )
+    expect(boundary.residentEnv).not.toHaveProperty(
+      HOSTED_CLI_BRIDGE_TOKEN_ENV,
+    )
+    expect(boundary.threadConfig).toEqual({
+      [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_TOKEN_ENV}`]:
+        'bridge-token-current',
+    })
+  })
+
+  it('projects a nonblank route grant only into the current thread configuration', () => {
+    const boundary = requireHostedBoundary({
+      env: {
+        [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'route-grant-current',
+        [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'bridge-token-current',
+      },
+    })
+
+    expect(boundary.residentEnv).toEqual({})
+    expect(boundary.threadConfig).toEqual({
+      [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV}`]:
+        'route-grant-current',
+      [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_TOKEN_ENV}`]:
+        'bridge-token-current',
+    })
+  })
+
+  it.each([
+    'OPENAI_API_KEY',
+    'VERCEL_AI_API_KEY',
+  ] as const)(
+    'supports a provider-only hosted boundary for %s without exposing it to thread config',
+    (providerCredentialEnvKey) => {
+      const providerCredential = `credential-for-${providerCredentialEnvKey}`
+      const boundary = requireHostedBoundary({
+        env: {
+          [providerCredentialEnvKey]: providerCredential,
+          PATH: '/custom/bin',
+        },
+        providerCredentialEnvKey,
+      })
+
+      expect(boundary.ephemeralApiKey).toBe(providerCredential)
+      expect(boundary.residentEnv).toEqual({
+        PATH: '/custom/bin',
+      })
+      expect(boundary.threadConfig).toEqual({})
+      const serializedThreadConfig = JSON.stringify(boundary.threadConfig)
+      expect(serializedThreadConfig).not.toContain(providerCredentialEnvKey)
+      expect(serializedThreadConfig).not.toContain(providerCredential)
+    },
+  )
+
+  it('fails closed when a provider credential hint is invalid or unavailable', () => {
+    expect(() => resolveHostedCodexTurnBoundary({
+      env: {},
+      providerCredentialEnvKey: 'INVALID-PROVIDER-KEY',
+    })).toThrow('Hosted Codex provider credential environment key is invalid.')
+
+    expect(() => resolveHostedCodexTurnBoundary({
+      env: {},
+      providerCredentialEnvKey: 'OPENAI_API_KEY',
+    })).toThrow('Hosted Codex provider authentication is unavailable for this turn.')
+  })
+})

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -4599,7 +4599,7 @@ describe('assistant codex runtime', () => {
           'config/read',
           'thread/compact/start',
           'account/logout',
-        ].includes(method ?? '')),
+        ].includes(typeof method === 'string' ? method : '')),
     ).toEqual([
       'account/login/start',
       'config/read',

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { PassThrough } from 'node:stream'
 
 import {
+  HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV,
   HOSTED_CLI_BRIDGE_TOKEN_ENV,
   HOSTED_CLI_BRIDGE_URL_ENV,
   HOSTED_RUNTIME_CODEX_APP_SERVER_COMMAND_ENV,
@@ -3297,6 +3298,345 @@ describe('assistant codex runtime', () => {
       .filter((message) => message.method === 'initialize'),
     ).toHaveLength(1)
   })
+
+  it('reuses the warm Codex app-server across rotating hosted turn authority', async () => {
+    const workingDirectory = await createTempDir('assistant-codex-hosted-warm-work-')
+    const codexHome = await createTempDir('assistant-codex-hosted-warm-home-')
+    const spawnedChildren: MockChildProcess[] = []
+    const providerCredentialEnvKey = 'OPENAI_API_KEY'
+    const bridgeUrl = 'http://127.0.0.1:43123'
+    const startSecondTurn = createDeferred<void>()
+
+    codexMocks.spawn.mockImplementation((_command, args, options) => {
+      const child = new MockChildProcess()
+      spawnedChildren.push(child)
+
+      expect(args).toEqual(['app-server'])
+      expect(options).toMatchObject({
+        cwd: tmpdir(),
+        env: {
+          CODEX_HOME: codexHome,
+          [HOSTED_CLI_BRIDGE_URL_ENV]: bridgeUrl,
+          PATH: '/custom/bin',
+        },
+      })
+      expect(options.env).not.toHaveProperty(HOSTED_CLI_BRIDGE_TOKEN_ENV)
+      expect(options.env).not.toHaveProperty(HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV)
+      expect(options.env).not.toHaveProperty(providerCredentialEnvKey)
+      expect(JSON.stringify(args)).not.toContain('bridge-token-')
+      expect(JSON.stringify(args)).not.toContain('route-grant-')
+      expect(JSON.stringify(args)).not.toContain('provider-credential-')
+
+      queueMicrotask(() => {
+        void (async () => {
+          const initialize = await waitForRpcMethod(child, 'initialize')
+          child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+
+          const completeHostedTurn = async (input: {
+            index: number
+            suffix: 'a' | 'b'
+            threadMethod: 'thread/resume' | 'thread/start'
+          }) => {
+            const login = await waitForRpcMethodCount(
+              child,
+              'account/login/start',
+              input.index,
+            )
+            expect(login.params).toEqual({
+              apiKey: `provider-credential-${input.suffix}`,
+              type: 'apiKey',
+            })
+            child.stdout.write(jsonLine({ id: login.id, result: { type: 'apiKey' } }))
+
+            const thread = await waitForRpcMethodCount(
+              child,
+              input.threadMethod,
+              1,
+            )
+            expect(thread.params).toMatchObject({
+              config: {
+                [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV}`]:
+                  `route-grant-${input.suffix}`,
+                [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_TOKEN_ENV}`]:
+                  `bridge-token-${input.suffix}`,
+                [`shell_environment_policy.set.${providerCredentialEnvKey}`]:
+                  `provider-credential-${input.suffix}`,
+                'test.static': true,
+              },
+            })
+            const threadParams = asRecord(thread.params)
+            child.stdout.write(jsonLine({
+              id: thread.id,
+              result: {
+                approvalPolicy: threadParams.approvalPolicy,
+                cwd: threadParams.cwd,
+                model: threadParams.model,
+                modelProvider: threadParams.modelProvider,
+                sandbox: { type: 'workspaceWrite' },
+                thread: {
+                  id: 'thread-hosted-warm',
+                },
+              },
+            }))
+
+            const turn = await waitForRpcMethodCount(child, 'turn/start', input.index)
+            child.stdout.write(jsonLine({
+              id: turn.id,
+              result: {
+                turn: {
+                  id: `turn-hosted-warm-${input.suffix}`,
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'assistant.message.delta',
+              params: {
+                delta: `Answer ${input.suffix}`,
+                item: {
+                  id: `assistant-hosted-warm-${input.suffix}`,
+                  type: 'assistant_message',
+                },
+                threadId: 'thread-hosted-warm',
+                turnId: `turn-hosted-warm-${input.suffix}`,
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'turn/completed',
+              params: {
+                threadId: 'thread-hosted-warm',
+                turn: {
+                  id: `turn-hosted-warm-${input.suffix}`,
+                  status: 'completed',
+                },
+              },
+            }))
+
+            const terminalCleanup = await waitForRpcMethodCount(
+              child,
+              'thread/backgroundTerminals/clean',
+              input.index,
+            )
+            child.stdout.write(jsonLine({ id: terminalCleanup.id, result: {} }))
+            const logout = await waitForRpcMethodCount(
+              child,
+              'account/logout',
+              input.index,
+            )
+            child.stdout.write(jsonLine({ id: logout.id, result: {} }))
+          }
+
+          await completeHostedTurn({
+            index: 1,
+            suffix: 'a',
+            threadMethod: 'thread/start',
+          })
+          await startSecondTurn.promise
+          await completeHostedTurn({
+            index: 2,
+            suffix: 'b',
+            threadMethod: 'thread/resume',
+          })
+        })()
+      })
+
+      return child
+    })
+
+    const buildHostedEnv = (suffix: 'a' | 'b') => ({
+      [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: `route-grant-${suffix}`,
+      [HOSTED_CLI_BRIDGE_TOKEN_ENV]: `bridge-token-${suffix}`,
+      [HOSTED_CLI_BRIDGE_URL_ENV]: bridgeUrl,
+      [providerCredentialEnvKey]: `provider-credential-${suffix}`,
+      PATH: '/custom/bin',
+    })
+    const baseInput = {
+      approvalPolicy: 'never',
+      codexHome,
+      hostedProviderCredentialEnvKey: providerCredentialEnvKey,
+      sandbox: 'workspace-write' as const,
+      threadConfig: {
+        'test.static': true,
+      },
+      workingDirectory,
+    }
+
+    await expect(executeCodexAppServerTurn({
+      ...baseInput,
+      env: buildHostedEnv('a'),
+      prompt: 'First hosted warm turn',
+    })).resolves.toMatchObject({
+      finalMessage: 'Answer a',
+      sessionId: 'thread-hosted-warm',
+    })
+    startSecondTurn.resolve()
+    await expect(executeCodexAppServerTurn({
+      ...baseInput,
+      env: buildHostedEnv('b'),
+      prompt: 'Second hosted warm turn',
+      resumeSessionId: 'thread-hosted-warm',
+    })).resolves.toMatchObject({
+      finalMessage: 'Answer b',
+      sessionId: 'thread-hosted-warm',
+    })
+    await drainHostedCodexPostTurnCleanups()
+
+    expect(codexMocks.spawn).toHaveBeenCalledTimes(1)
+    const messages = readWrittenRpcMessages(
+      requireMockChildProcess(spawnedChildren[0] ?? null),
+    )
+    expect(messages.filter((message) => message.method === 'initialize'))
+      .toHaveLength(1)
+    expect(messages.filter((message) => message.method === 'account/logout'))
+      .toHaveLength(2)
+    const hostedLifecycleMethods = [
+      'account/login/start',
+      'thread/start',
+      'thread/resume',
+      'turn/start',
+      'thread/backgroundTerminals/clean',
+      'account/logout',
+    ]
+    expect(
+      messages
+        .map((message) => message.method)
+        .filter(
+          (method): method is string =>
+            typeof method === 'string' && hostedLifecycleMethods.includes(method),
+        ),
+    ).toEqual([
+      'account/login/start',
+      'thread/start',
+      'turn/start',
+      'thread/backgroundTerminals/clean',
+      'account/logout',
+      'account/login/start',
+      'thread/resume',
+      'turn/start',
+      'thread/backgroundTerminals/clean',
+      'account/logout',
+    ])
+  })
+
+  it.each([
+    'account/login/start',
+    'account/logout',
+  ] as const)(
+    'replaces hosted Codex when %s fails',
+    async (failureMethod) => {
+      const workingDirectory = await createTempDir('assistant-codex-hosted-auth-failure-work-')
+      const codexHome = await createTempDir('assistant-codex-hosted-auth-failure-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      const providerCredentialEnvKey = 'OPENAI_API_KEY'
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        const processNumber = spawnedChildren.length + 1
+        child.pid = 34_000 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        child.stdin.onWrite = (write) => {
+          for (const line of write.split('\n')) {
+            if (!line.trim()) {
+              continue
+            }
+            const message = asRecord(JSON.parse(line))
+            queueMicrotask(() => {
+              const shouldFail = processNumber === 1 && message.method === failureMethod
+              switch (message.method) {
+                case 'initialize':
+                  child.stdout.write(jsonLine({ id: message.id, result: {} }))
+                  break
+                case 'account/login/start':
+                  child.stdout.write(jsonLine(
+                    shouldFail
+                      ? { error: { message: 'hosted auth bind unavailable' }, id: message.id }
+                      : { id: message.id, result: { type: 'apiKey' } },
+                  ))
+                  break
+                case 'thread/start':
+                  child.stdout.write(jsonLine({
+                    id: message.id,
+                    result: {
+                      thread: { id: `thread-hosted-auth-failure-${processNumber}` },
+                    },
+                  }))
+                  break
+                case 'turn/start':
+                  child.stdout.write(jsonLine({
+                    id: message.id,
+                    result: {
+                      turn: { id: `turn-hosted-auth-failure-${processNumber}` },
+                    },
+                  }))
+                  child.stdout.write(jsonLine({
+                    method: 'turn/completed',
+                    params: {
+                      threadId: `thread-hosted-auth-failure-${processNumber}`,
+                      turn: {
+                        id: `turn-hosted-auth-failure-${processNumber}`,
+                        status: 'completed',
+                      },
+                    },
+                  }))
+                  break
+                case 'thread/backgroundTerminals/clean':
+                  child.stdout.write(jsonLine({ id: message.id, result: {} }))
+                  break
+                case 'account/logout':
+                  child.stdout.write(jsonLine(
+                    shouldFail
+                      ? { error: { message: 'hosted auth revoke unavailable' }, id: message.id }
+                      : { id: message.id, result: {} },
+                  ))
+                  break
+              }
+            })
+          }
+        }
+
+        return child
+      })
+
+      const executeHostedTurn = (prompt: string) => executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: {
+          [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'stable-route-grant',
+          [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'stable-bridge-token',
+          [HOSTED_CLI_BRIDGE_URL_ENV]: 'http://127.0.0.1:43123',
+          [providerCredentialEnvKey]: 'stable-provider-credential',
+          PATH: '/custom/bin',
+        },
+        hostedProviderCredentialEnvKey: providerCredentialEnvKey,
+        prompt,
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      const firstTurn = executeHostedTurn('first hosted auth failure turn')
+      if (failureMethod === 'account/login/start') {
+        await expect(firstTurn).rejects.toMatchObject({
+          code: 'ASSISTANT_CODEX_AUTH_FAILED',
+        })
+      } else {
+        await expect(firstTurn).resolves.toMatchObject({
+          sessionId: 'thread-hosted-auth-failure-1',
+          turnId: 'turn-hosted-auth-failure-1',
+        })
+        await drainHostedCodexPostTurnCleanups()
+      }
+
+      await expect(executeHostedTurn('replacement hosted auth turn')).resolves.toMatchObject({
+        sessionId: 'thread-hosted-auth-failure-2',
+        turnId: 'turn-hosted-auth-failure-2',
+      })
+      await drainHostedCodexPostTurnCleanups()
+
+      expect(codexMocks.spawn).toHaveBeenCalledTimes(2)
+      expect(process.kill).toHaveBeenCalledWith(-34_000, 'SIGTERM')
+    },
+  )
 
   it('reuses the warm Codex app-server when resolved local child env is unchanged', async () => {
     const workingDirectory = await createTempDir('assistant-codex-local-warm-stable-env-work-')
@@ -8299,6 +8639,7 @@ describe('assistant codex runtime', () => {
     })
 
     const hostedEnv = {
+      [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'route-grant-stable',
       [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'bridge-token-stable',
       [HOSTED_CLI_BRIDGE_URL_ENV]: 'http://127.0.0.1:9174/',
       CODEX_HOME: hostedCodexHome,
@@ -8660,13 +9001,6 @@ describe('assistant codex runtime', () => {
 
   it.each([
     {
-      name: 'CLI bridge token',
-      secondEnv: {
-        [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'bridge-token-two',
-      },
-      useSecondCodexHome: false,
-    },
-    {
       name: 'stable bridge URL',
       secondEnv: {
         [HOSTED_CLI_BRIDGE_URL_ENV]: 'http://127.0.0.1:9175/',
@@ -8761,6 +9095,7 @@ describe('assistant codex runtime', () => {
       })
 
       const baseEnv = {
+        [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'route-grant-one',
         [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'bridge-token-one',
         [HOSTED_CLI_BRIDGE_URL_ENV]: 'http://127.0.0.1:9174/',
         CODEX_HOME: firstCodexHome,
@@ -8870,6 +9205,7 @@ describe('assistant codex runtime', () => {
 
     const stableInput = {
       env: {
+        [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'stable-route-grant',
         [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'stable-bridge-token',
         CODEX_HOME: codexHome,
         PATH: '/usr/bin',
@@ -9007,6 +9343,7 @@ describe('assistant codex runtime', () => {
 
     const stableInput = {
       env: {
+        [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'stable-route-grant',
         [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'stable-bridge-token',
         CODEX_HOME: codexHome,
         PATH: '/usr/bin',
@@ -9114,6 +9451,7 @@ describe('assistant codex runtime', () => {
 
       await expect(executeCodexAppServerTurn({
         env: {
+          [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'stable-route-grant',
           [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'stable-bridge-token',
           CODEX_HOME: codexHome,
           PATH: '/usr/bin',
@@ -9594,6 +9932,7 @@ describe('assistant codex runtime', () => {
     })
 
     const hostedEnv = {
+      [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: 'route-grant-stable',
       [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'bridge-token-stable',
       [HOSTED_CLI_BRIDGE_URL_ENV]: 'http://127.0.0.1:9174/',
       CODEX_HOME: hostedCodexHome,

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -3306,6 +3306,38 @@ describe('assistant codex runtime', () => {
     const providerCredentialEnvKey = 'OPENAI_API_KEY'
     const bridgeUrl = 'http://127.0.0.1:43123'
     const startSecondTurn = createDeferred<void>()
+    const startThirdTurn = createDeferred<void>()
+    const webpBytes = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46,
+      0x00, 0x00, 0x00, 0x00,
+      0x57, 0x45, 0x42, 0x50,
+    ])
+    const imageProviderAuthHeaders: Array<string | null> = []
+    const fetchImpl = vi.fn(async (
+      fetchRequest: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      imageProviderAuthHeaders.push(
+        new Request(fetchRequest, init).headers.get('authorization'),
+      )
+      return new Response(JSON.stringify({
+        data: [{ b64_json: Buffer.from(webpBytes).toString('base64') }],
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      })
+    })
+    const uploader = {
+      uploadGeneratedImage: vi.fn(async (
+        uploadInput: { alt: string | null; source: string | null },
+      ) => ({
+        alt: uploadInput.alt,
+        kind: 'image' as const,
+        source: uploadInput.source,
+        url: 'https://imagedelivery.net/account/generated/public',
+      })),
+    }
 
     codexMocks.spawn.mockImplementation((_command, args, options) => {
       const child = new MockChildProcess()
@@ -3332,11 +3364,13 @@ describe('assistant codex runtime', () => {
           const initialize = await waitForRpcMethod(child, 'initialize')
           child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
 
-          const completeHostedTurn = async (input: {
-            index: number
-            suffix: 'a' | 'b'
-            threadMethod: 'thread/resume' | 'thread/start'
-          }) => {
+            const completeHostedTurn = async (input: {
+              hasRouteGrant: boolean
+              index: number
+              suffix: 'a' | 'b' | 'c'
+              threadMethod: 'thread/resume' | 'thread/start'
+              threadRequestCount: number
+            }) => {
             const login = await waitForRpcMethodCount(
               child,
               'account/login/start',
@@ -3348,24 +3382,34 @@ describe('assistant codex runtime', () => {
             })
             child.stdout.write(jsonLine({ id: login.id, result: { type: 'apiKey' } }))
 
-            const thread = await waitForRpcMethodCount(
-              child,
-              input.threadMethod,
-              1,
-            )
-            expect(thread.params).toMatchObject({
-              config: {
-                [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV}`]:
-                  `route-grant-${input.suffix}`,
+              const thread = await waitForRpcMethodCount(
+                child,
+                input.threadMethod,
+                input.threadRequestCount,
+              )
+              const threadParams = asRecord(thread.params)
+              const threadConfig = asRecord(threadParams.config)
+              expect(threadConfig).toMatchObject({
                 [`shell_environment_policy.set.${HOSTED_CLI_BRIDGE_TOKEN_ENV}`]:
                   `bridge-token-${input.suffix}`,
-                [`shell_environment_policy.set.${providerCredentialEnvKey}`]:
-                  `provider-credential-${input.suffix}`,
                 'test.static': true,
-              },
-            })
-            const threadParams = asRecord(thread.params)
-            child.stdout.write(jsonLine({
+              })
+              if (input.hasRouteGrant) {
+                expect(threadConfig).toHaveProperty(
+                  `shell_environment_policy.set.${HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV}`,
+                  `route-grant-${input.suffix}`,
+                )
+              } else {
+                expect(threadConfig).not.toHaveProperty(
+                  `shell_environment_policy.set.${HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV}`,
+                )
+                expect(JSON.stringify(threadConfig)).not.toContain('route-grant-')
+              }
+              expect(threadConfig).not.toHaveProperty(
+                `shell_environment_policy.set.${providerCredentialEnvKey}`,
+              )
+              expect(JSON.stringify(threadConfig)).not.toContain('provider-credential-')
+              child.stdout.write(jsonLine({
               id: thread.id,
               result: {
                 approvalPolicy: threadParams.approvalPolicy,
@@ -3388,6 +3432,25 @@ describe('assistant codex runtime', () => {
                 },
               },
             }))
+            const toolRequestId = 80 + input.index
+            child.stdout.write(jsonLine({
+              id: toolRequestId,
+              method: 'item/tool/call',
+              params: {
+                arguments: {
+                  alt: `Generated ${input.suffix}`,
+                  prompt: `Render ${input.suffix}`,
+                },
+                namespace: 'murph',
+                threadId: 'thread-hosted-warm',
+                tool: 'generate_image',
+                turnId: `turn-hosted-warm-${input.suffix}`,
+              },
+            }))
+            await expect(waitForRpcResponse(child, toolRequestId)).resolves.toMatchObject({
+              id: toolRequestId,
+              result: { success: true },
+            })
             child.stdout.write(jsonLine({
               method: 'assistant.message.delta',
               params: {
@@ -3425,25 +3488,60 @@ describe('assistant codex runtime', () => {
             child.stdout.write(jsonLine({ id: logout.id, result: {} }))
           }
 
-          await completeHostedTurn({
-            index: 1,
-            suffix: 'a',
-            threadMethod: 'thread/start',
-          })
-          await startSecondTurn.promise
-          await completeHostedTurn({
-            index: 2,
-            suffix: 'b',
-            threadMethod: 'thread/resume',
-          })
+            await completeHostedTurn({
+              hasRouteGrant: true,
+              index: 1,
+              suffix: 'a',
+              threadMethod: 'thread/start',
+              threadRequestCount: 1,
+            })
+            await startSecondTurn.promise
+            const firstUnsubscribe = await waitForRpcMethodCount(
+              child,
+              'thread/unsubscribe',
+              1,
+            )
+            expect(firstUnsubscribe.params).toEqual({
+              threadId: 'thread-hosted-warm',
+            })
+            child.stdout.write(jsonLine({ id: firstUnsubscribe.id, result: {} }))
+            await completeHostedTurn({
+              hasRouteGrant: false,
+              index: 2,
+              suffix: 'b',
+              threadMethod: 'thread/resume',
+              threadRequestCount: 1,
+            })
+            await startThirdTurn.promise
+            const secondUnsubscribe = await waitForRpcMethodCount(
+              child,
+              'thread/unsubscribe',
+              2,
+            )
+            expect(secondUnsubscribe.params).toEqual({
+              threadId: 'thread-hosted-warm',
+            })
+            child.stdout.write(jsonLine({ id: secondUnsubscribe.id, result: {} }))
+            await completeHostedTurn({
+              hasRouteGrant: true,
+              index: 3,
+              suffix: 'c',
+              threadMethod: 'thread/resume',
+              threadRequestCount: 2,
+            })
         })()
       })
 
       return child
     })
 
-    const buildHostedEnv = (suffix: 'a' | 'b') => ({
-      [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: `route-grant-${suffix}`,
+    const buildHostedEnv = (
+      suffix: 'a' | 'b' | 'c',
+      includeRouteGrant: boolean,
+    ) => ({
+      ...(includeRouteGrant
+        ? { [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: `route-grant-${suffix}` }
+        : {}),
       [HOSTED_CLI_BRIDGE_TOKEN_ENV]: `bridge-token-${suffix}`,
       [HOSTED_CLI_BRIDGE_URL_ENV]: bridgeUrl,
       [providerCredentialEnvKey]: `provider-credential-${suffix}`,
@@ -3452,7 +3550,10 @@ describe('assistant codex runtime', () => {
     const baseInput = {
       approvalPolicy: 'never',
       codexHome,
+      fetchImpl,
+      hostedGeneratedImageUploader: uploader,
       hostedProviderCredentialEnvKey: providerCredentialEnvKey,
+      requireHostedGeneratedImageUploader: true,
       sandbox: 'workspace-write' as const,
       threadConfig: {
         'test.static': true,
@@ -3460,40 +3561,66 @@ describe('assistant codex runtime', () => {
       workingDirectory,
     }
 
-    await expect(executeCodexAppServerTurn({
-      ...baseInput,
-      env: buildHostedEnv('a'),
+      await expect(executeCodexAppServerTurn({
+        ...baseInput,
+        env: buildHostedEnv('a', true),
       prompt: 'First hosted warm turn',
     })).resolves.toMatchObject({
       finalMessage: 'Answer a',
       sessionId: 'thread-hosted-warm',
     })
     startSecondTurn.resolve()
-    await expect(executeCodexAppServerTurn({
-      ...baseInput,
-      env: buildHostedEnv('b'),
-      prompt: 'Second hosted warm turn',
-      resumeSessionId: 'thread-hosted-warm',
+      await expect(executeCodexAppServerTurn({
+        ...baseInput,
+        env: buildHostedEnv('b', false),
+        prompt: 'Scheduled hosted warm turn without a route grant',
+        resumeSessionId: 'thread-hosted-warm',
     })).resolves.toMatchObject({
-      finalMessage: 'Answer b',
-      sessionId: 'thread-hosted-warm',
-    })
-    await drainHostedCodexPostTurnCleanups()
+        finalMessage: 'Answer b',
+        sessionId: 'thread-hosted-warm',
+      })
+      startThirdTurn.resolve()
+      await expect(executeCodexAppServerTurn({
+        ...baseInput,
+        env: buildHostedEnv('c', true),
+        prompt: 'Third interactive hosted warm turn',
+        resumeSessionId: 'thread-hosted-warm',
+      })).resolves.toMatchObject({
+        finalMessage: 'Answer c',
+        sessionId: 'thread-hosted-warm',
+      })
+      await drainHostedCodexPostTurnCleanups()
 
     expect(codexMocks.spawn).toHaveBeenCalledTimes(1)
+    expect(imageProviderAuthHeaders).toEqual([
+        'Bearer provider-credential-a',
+        'Bearer provider-credential-b',
+        'Bearer provider-credential-c',
+      ])
+      expect(uploader.uploadGeneratedImage).toHaveBeenCalledTimes(3)
     const messages = readWrittenRpcMessages(
       requireMockChildProcess(spawnedChildren[0] ?? null),
     )
     expect(messages.filter((message) => message.method === 'initialize'))
       .toHaveLength(1)
-    expect(messages.filter((message) => message.method === 'account/logout'))
-      .toHaveLength(2)
+      expect(messages.filter((message) => message.method === 'account/logout'))
+        .toHaveLength(3)
+      expect(
+        messages
+          .filter((message) => message.method === 'account/login/start')
+          .map((message) => message.params),
+      ).toEqual([
+        { apiKey: 'provider-credential-a', type: 'apiKey' },
+        { apiKey: 'provider-credential-b', type: 'apiKey' },
+        { apiKey: 'provider-credential-c', type: 'apiKey' },
+      ])
     const hostedLifecycleMethods = [
       'account/login/start',
       'thread/start',
       'thread/resume',
       'turn/start',
       'thread/backgroundTerminals/clean',
+      'thread/unsubscribe',
       'account/logout',
     ]
     expect(
@@ -3509,17 +3636,25 @@ describe('assistant codex runtime', () => {
       'turn/start',
       'thread/backgroundTerminals/clean',
       'account/logout',
+      'thread/unsubscribe',
       'account/login/start',
       'thread/resume',
       'turn/start',
-      'thread/backgroundTerminals/clean',
-      'account/logout',
-    ])
+        'thread/backgroundTerminals/clean',
+        'account/logout',
+        'thread/unsubscribe',
+        'account/login/start',
+        'thread/resume',
+        'turn/start',
+        'thread/backgroundTerminals/clean',
+        'account/logout',
+      ])
   })
 
   it.each([
     'account/login/start',
     'account/logout',
+    'thread/unsubscribe',
   ] as const)(
     'replaces hosted Codex when %s fails',
     async (failureMethod) => {
@@ -3582,6 +3717,13 @@ describe('assistant codex runtime', () => {
                   break
                 case 'thread/backgroundTerminals/clean':
                   child.stdout.write(jsonLine({ id: message.id, result: {} }))
+                  break
+                case 'thread/unsubscribe':
+                  child.stdout.write(jsonLine(
+                    shouldFail
+                      ? { error: { message: 'hosted thread unsubscribe unavailable' }, id: message.id }
+                      : { id: message.id, result: {} },
+                  ))
                   break
                 case 'account/logout':
                   child.stdout.write(jsonLine(
@@ -4275,11 +4417,14 @@ describe('assistant codex runtime', () => {
   it('uses estimated idle compaction usage when generic token usage arrives before zero recompute updates', async () => {
     const workingDirectory = await createTempDir('assistant-codex-compact-provider-usage-work-')
     const codexHome = await createTempDir('assistant-codex-compact-provider-usage-home-')
+    const ephemeralApiKey = 'provider-credential-compact'
+    const spawnedChildren: MockChildProcess[] = []
     const threadId = 'thread-compact-provider-usage'
     const turnId = 'turn-compact-provider-usage'
 
     codexMocks.spawn.mockImplementation(() => {
       const child = new MockChildProcess()
+      spawnedChildren.push(child)
 
       queueMicrotask(() => {
         void (async () => {
@@ -4334,6 +4479,12 @@ describe('assistant codex runtime', () => {
             },
           }))
 
+          const login = await waitForRpcMethod(child, 'account/login/start')
+          expect(login.params).toEqual({
+            apiKey: ephemeralApiKey,
+            type: 'apiKey',
+          })
+          child.stdout.write(jsonLine({ id: login.id, result: { type: 'apiKey' } }))
           const barrier = await waitForRpcMethod(child, 'config/read')
           child.stdout.write(jsonLine({ id: barrier.id, result: {} }))
           const compact = await waitForRpcMethod(child, 'thread/compact/start')
@@ -4397,6 +4548,8 @@ describe('assistant codex runtime', () => {
               },
             },
           }))
+          const logout = await waitForRpcMethod(child, 'account/logout')
+          child.stdout.write(jsonLine({ id: logout.id, result: {} }))
         })()
       })
 
@@ -4422,6 +4575,7 @@ describe('assistant codex runtime', () => {
 
     await expect(
       compactWarmCodexThread({
+        ephemeralApiKey,
         minThreadTokens: 100_000,
         timeoutMs: 5_000,
       }),
@@ -4437,7 +4591,203 @@ describe('assistant codex runtime', () => {
         totalTokens: 125_000,
       },
     })
+    expect(
+      readWrittenRpcMessages(requireMockChildProcess(spawnedChildren[0] ?? null))
+        .map((message) => message.method)
+        .filter((method) => [
+          'account/login/start',
+          'config/read',
+          'thread/compact/start',
+          'account/logout',
+        ].includes(method ?? '')),
+    ).toEqual([
+      'account/login/start',
+      'config/read',
+      'thread/compact/start',
+      'account/logout',
+    ])
   })
+
+  it.each([
+    'account/login/start',
+    'account/logout',
+  ] as const)(
+    'poisons the exact warm Codex process when idle compaction %s fails',
+    async (failureMethod) => {
+      const workingDirectory = await createTempDir('assistant-codex-compact-auth-failure-work-')
+      const codexHome = await createTempDir('assistant-codex-compact-auth-failure-home-')
+      const ephemeralApiKey = 'provider-credential-compact-failure'
+      const threadId = 'thread-compact-auth-failure'
+      const turnId = 'turn-compact-auth-failure'
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        const processNumber = spawnedChildren.length + 1
+        child.pid = 25_700 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId,
+              turnId,
+            })
+            child.stdout.write(jsonLine({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId,
+                turnId,
+                tokenUsage: {
+                  last: {
+                    cachedInputTokens: 10_000,
+                    inputTokens: 125_000,
+                    outputTokens: 100,
+                    totalTokens: 125_100,
+                  },
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: `assistant-compact-auth-failure-${processNumber}`,
+                  message: 'Seeded before compaction auth failure',
+                  type: 'assistant_message',
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'turn/completed',
+              params: {
+                turn: {
+                  id: turnId,
+                  status: 'completed',
+                },
+              },
+            }))
+
+            if (processNumber !== 1) {
+              return
+            }
+            const login = await waitForRpcMethod(child, 'account/login/start')
+            expect(login.params).toEqual({
+              apiKey: ephemeralApiKey,
+              type: 'apiKey',
+            })
+            if (failureMethod === 'account/login/start') {
+              child.stdout.write(jsonLine({
+                error: { message: 'compaction auth bind unavailable' },
+                id: login.id,
+              }))
+              return
+            }
+            child.stdout.write(jsonLine({ id: login.id, result: { type: 'apiKey' } }))
+
+            const barrier = await waitForRpcMethod(child, 'config/read')
+            child.stdout.write(jsonLine({ id: barrier.id, result: {} }))
+            const compact = await waitForRpcMethod(child, 'thread/compact/start')
+            expect(asRecord(compact.params)).toEqual({ threadId })
+            child.stdout.write(jsonLine({ id: compact.id, result: {} }))
+            writeContextCompactionStarted({
+              child,
+              itemId: 'context-compact-auth-failure',
+              threadId,
+            })
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'context-compact-auth-failure',
+                  type: 'contextCompaction',
+                },
+              },
+            }))
+            const logout = await waitForRpcMethod(child, 'account/logout')
+            child.stdout.write(jsonLine({
+              error: { message: 'compaction auth revoke unavailable' },
+              id: logout.id,
+            }))
+          })()
+        })
+
+        return child
+      })
+
+      await expect(
+        executeCodexAppServerTurn({
+          approvalPolicy: 'never',
+          codexHome,
+          env: { PATH: '/custom/bin' },
+          prompt: 'seed compact auth failure',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        }),
+      ).resolves.toMatchObject({
+        finalMessage: 'Seeded before compaction auth failure',
+        sessionId: threadId,
+        turnId,
+      })
+
+      await expect(
+        compactWarmCodexThread({
+          ephemeralApiKey,
+          minThreadTokens: 100_000,
+          timeoutMs: 5_000,
+        }),
+      ).resolves.toMatchObject({
+        kind: 'failed',
+        threadId,
+      })
+
+      const firstProcessMethods = readWrittenRpcMessages(spawnedChildren[0]!)
+        .map((message) => message.method)
+      if (failureMethod === 'account/login/start') {
+        expect(firstProcessMethods).not.toContain('thread/compact/start')
+        expect(firstProcessMethods).not.toContain('account/logout')
+      } else {
+        expect(firstProcessMethods).toEqual(expect.arrayContaining([
+          'account/login/start',
+          'config/read',
+          'thread/compact/start',
+          'account/logout',
+        ]))
+      }
+      expect(process.kill).toHaveBeenCalledWith(-25_700, 'SIGTERM')
+
+      const replacementTrace = vi.fn()
+      await expect(
+        executeCodexAppServerTurn({
+          approvalPolicy: 'never',
+          codexHome,
+          env: { PATH: '/custom/bin' },
+          onTraceEvent: replacementTrace,
+          prompt: 'turn after compaction auth failure',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        }),
+      ).resolves.toMatchObject({
+        sessionId: threadId,
+        turnId,
+      })
+      expect(codexMocks.spawn).toHaveBeenCalledTimes(2)
+      expect(replacementTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rawEvent: expect.objectContaining({
+            codexTimingColdStartReason: 'previous-idle-compaction-failure',
+            codexTimingStage: 'initialized',
+          }),
+        }),
+      )
+    },
+  )
 
   it('uses provider usage attached to the context compaction completion', async () => {
     const workingDirectory = await createTempDir('assistant-codex-compact-explicit-usage-work-')
@@ -9292,6 +9642,9 @@ describe('assistant codex runtime', () => {
             await waitForRpcMethod(child, 'thread/backgroundTerminals/clean'),
           )
 
+          const unsubscribe = await waitForRpcMethod(child, 'thread/unsubscribe')
+          child.stdout.write(jsonLine({ id: unsubscribe.id, result: {} }))
+
           const resumedThread = await waitForRpcMethod(child, 'thread/resume')
           const resumedParams = asRecord(resumedThread.params)
           child.stdout.write(jsonLine({
@@ -9895,6 +10248,9 @@ describe('assistant codex runtime', () => {
           )
           child.stdout.write(jsonLine({ id: firstCleanup.id, result: {} }))
 
+          const unsubscribe = await waitForRpcMethod(child, 'thread/unsubscribe')
+          child.stdout.write(jsonLine({ id: unsubscribe.id, result: {} }))
+
           const resumedThread = await waitForRpcMethod(child, 'thread/resume')
           const resumedThreadParams = asRecord(resumedThread.params)
           child.stdout.write(jsonLine({
@@ -9967,6 +10323,8 @@ describe('assistant codex runtime', () => {
       requireMockChildProcess(spawnedChildren[0] ?? null),
     )
     expect(messages.filter((message) => message.method === 'thread/resume'))
+      .toHaveLength(1)
+    expect(messages.filter((message) => message.method === 'thread/unsubscribe'))
       .toHaveLength(1)
     expect(messages.filter(
       (message) => message.method === 'thread/backgroundTerminals/clean',

--- a/packages/assistant-engine/test/codex-runtime-helpers.test.ts
+++ b/packages/assistant-engine/test/codex-runtime-helpers.test.ts
@@ -29,6 +29,9 @@ import {
   ASSISTANT_USAGE_SCHEMA,
   parseAssistantUsageRecord,
 } from '@murphai/hosted-execution/assistant-usage'
+import {
+  HOSTED_CLI_BRIDGE_TOKEN_ENV,
+} from '@murphai/hosted-execution/cli-runtime-bridge'
 import { normalizeAssistantProviderConfig } from '@murphai/operator-config/assistant/provider-config'
 import { serializeAssistantProviderSessionOptions } from '@murphai/operator-config/assistant/provider-config'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
@@ -2454,7 +2457,7 @@ describe('Codex assistant registry helpers', () => {
     )
   })
 
-  it('never passes a multi_agent_v2 CLI override on hosted turns', async () => {
+  it('keeps hosted feature ownership while forwarding the provider credential key', async () => {
     // Hosted config.toml owns [features.multi_agent_v2] (including
     // root_agent_usage_hint_text); a CLI boolean override would take
     // precedence and silently reset that table to feature defaults.
@@ -2474,6 +2477,7 @@ describe('Codex assistant registry helpers', () => {
 
     const attempt = await executeCodexAssistantTurnAttempt({
       env: {
+        [HOSTED_CLI_BRIDGE_TOKEN_ENV]: 'test-bridge-token',
         [HOSTED_RUNTIME_PROCESS_ENV_MARKER]: '1',
         OPENAI_API_KEY: 'test-key',
         PATH: '/usr/bin',
@@ -2490,6 +2494,9 @@ describe('Codex assistant registry helpers', () => {
     expect(attempt.ok).toBe(true)
     const appServerInput = codexAppServerMocks.executeCodexAppServerTurn.mock
       .calls[0]?.[0]
+    expect(appServerInput).toMatchObject({
+      hostedProviderCredentialEnvKey: 'OPENAI_API_KEY',
+    })
     expect(
       appServerInput?.configOverrides?.some(
         (override: string) => override.includes('multi_agent'),

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1641,6 +1641,11 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       return await returnInitialMailboxImportBeforeForeground();
     }
     const runtimeEnv = hostedCodexRuntime.runtimeEnv;
+    const hostedProviderCredentialEnvKey =
+      hostedCodexRuntime.hostedProviderCredentialEnvKey;
+    const hostedEphemeralApiKey = hostedProviderCredentialEnvKey
+      ? runtimeEnv[hostedProviderCredentialEnvKey] ?? null
+      : null;
     let stagedDeviceSyncDirtyAcks: HostedDeviceSyncDirtyProcessedPostCheckpointRecord[] = [];
     let suppressDirtyPendingFetchUntilCheckpoint = false;
     let deviceSyncWorkspaceWakeHandledUntilCheckpoint: HostedWorkspaceRunnerHandledDeviceSyncWake | null = null;
@@ -1962,6 +1967,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       assistantAskPort: runtime.platform.assistantAskPort ?? null,
       codexHome: hostedCodexRuntime.codexHome,
       env: hostedCodexRuntime.runtimeEnv,
+      hostedProviderCredentialEnvKey,
       onStateMutation() {
         runtimeStateDirty = true;
         markIdleCheckpointTimerAfterDirtyWork();
@@ -3015,6 +3021,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                 provider: "codex-cli",
                 userEnvKeys: Object.keys(guardedRuntime.userEnv),
               }),
+              ephemeralApiKey: hostedEphemeralApiKey,
               materializeWorkspaceArtifacts: restored.materializeWorkspaceArtifacts,
               memberId: input.request.userId,
               model: idleMaintenanceModel,
@@ -3725,6 +3732,7 @@ function buildHostedRuntimePhaseTraceMetadata(
 // without changing this signature.
 export async function runHostedPendingInputProtectedIdleMaintenance(input: {
   credentialSource: Parameters<typeof runHostedIdleCheckpointMaintenance>[0]["credentialSource"];
+  ephemeralApiKey?: string | null;
   materializeWorkspaceArtifacts: HostedWorkspaceArtifactMaterializer;
   memberId: string;
   model: string | null;
@@ -3742,6 +3750,7 @@ export async function runHostedPendingInputProtectedIdleMaintenance(input: {
     });
   return await runHostedIdleCheckpointMaintenance({
     credentialSource: input.credentialSource,
+    ephemeralApiKey: input.ephemeralApiKey ?? null,
     materializeRetentionCandidatePaths: async (storedPaths) => {
       const materialized = await input.materializeWorkspaceArtifacts(storedPaths);
       return {

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -521,14 +521,13 @@ export function buildHostedCodexConfigToml(input: {
       ? []
       : [
           `base_url = ${tomlString(input.provider.baseUrl)}`,
-          `env_key = ${tomlString(input.provider.envKey)}`,
         ]),
     `wire_api = ${tomlString(input.provider.wireApi)}`,
     ...(input.provider.supportsWebSockets
       ? ["supports_websockets = true"]
       : []),
     `stream_idle_timeout_ms = ${HOSTED_CODEX_PROVIDER_STREAM_IDLE_TIMEOUT_MS}`,
-    `requires_openai_auth = ${input.chatGptAuth ? "true" : "false"}`,
+    "requires_openai_auth = true",
     `request_max_retries = ${HOSTED_CODEX_PROVIDER_REQUEST_MAX_RETRIES}`,
     `stream_max_retries = ${HOSTED_CODEX_PROVIDER_STREAM_MAX_RETRIES}`,
     "",
@@ -536,7 +535,7 @@ export function buildHostedCodexConfigToml(input: {
 
   return [
     ...(input.model ? [`model = ${tomlString(input.model)}`] : []),
-    ...(input.chatGptAuth ? ['cli_auth_credentials_store = "file"'] : []),
+    `cli_auth_credentials_store = ${tomlString(input.chatGptAuth ? "file" : "ephemeral")}`,
     `model_provider = ${tomlString(modelProviderId)}`,
     `model_reasoning_effort = ${tomlString(input.reasoningEffort)}`,
     `model_auto_compact_token_limit = ${DEFAULT_HOSTED_CODEX_AUTO_COMPACT_TOKEN_LIMIT}`,

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -155,6 +155,7 @@ export interface HostedCodexRuntimeEnvironmentInput {
 export interface HostedCodexRuntimeEnvironmentResult {
   codexConfigPath: string;
   codexHome: string;
+  hostedProviderCredentialEnvKey: string | null;
   runtimeEnv: Record<string, string>;
 }
 
@@ -247,6 +248,7 @@ export async function prepareHostedCodexRuntimeEnvironment(
   return {
     codexConfigPath,
     codexHome,
+    hostedProviderCredentialEnvKey: chatGptAuth ? null : providerConfig.envKey,
     runtimeEnv,
   };
 }

--- a/packages/assistant-runtime/src/hosted-runtime/detached-assistant-ask.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/detached-assistant-ask.ts
@@ -37,6 +37,7 @@ export interface HostedDetachedAssistantAskControllerInput {
   assistantAskPort: HostedRuntimeAssistantAskPort | null;
   codexHome: string | null;
   env: Readonly<Record<string, string>>;
+  hostedProviderCredentialEnvKey?: string | null;
   executeAsk?: (
     input: ReadOnlyAssistantAskInput,
   ) => Promise<ReadOnlyAssistantAskResult>;
@@ -76,6 +77,7 @@ export function createHostedDetachedAssistantAskController(
       codexHome: input.codexHome,
       env: input.env,
       executeAsk,
+      hostedProviderCredentialEnvKey: input.hostedProviderCredentialEnvKey,
       now,
       onStateMutation: input.onStateMutation,
       vaultRoot: input.vaultRoot,
@@ -163,6 +165,7 @@ async function runOneHostedDetachedAssistantAsk(input: {
   executeAsk: (
     input: ReadOnlyAssistantAskInput,
   ) => Promise<ReadOnlyAssistantAskResult>;
+  hostedProviderCredentialEnvKey?: string | null;
   now: () => string;
   onStateMutation(): void;
   vaultRoot: string;
@@ -214,6 +217,12 @@ async function runOneHostedDetachedAssistantAsk(input: {
       abortSignal: input.abortSignal,
       codexHome: input.codexHome,
       env: { ...input.env },
+      ...(input.hostedProviderCredentialEnvKey
+        ? {
+            hostedProviderCredentialEnvKey:
+              input.hostedProviderCredentialEnvKey,
+          }
+        : {}),
       now: new Date(input.now()),
       question: prepared.question,
       workspaceRoot: input.vaultRoot,

--- a/packages/assistant-runtime/src/hosted-runtime/idle-maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/idle-maintenance.ts
@@ -62,6 +62,7 @@ export type HostedIdleMaintenanceOutcome =
 // as additional plain statements.
 export async function runHostedIdleCheckpointMaintenance(input: {
   credentialSource: AssistantUsageCredentialSource;
+  ephemeralApiKey?: string | null;
   materializeRetentionCandidatePaths?: ((
     storedPaths: readonly string[]
   ) => Promise<InboxMediaRetentionMaterializeResult | void>) | null;
@@ -179,6 +180,9 @@ export async function runHostedIdleCheckpointMaintenance(input: {
         canAccountForModel: (model) =>
           model !== null &&
           normalizeHostedAiUsageAllowancePricedModelId(model) !== null,
+        ...(input.ephemeralApiKey
+          ? { ephemeralApiKey: input.ephemeralApiKey }
+          : {}),
         minThreadTokens: HOSTED_IDLE_COMPACT_MIN_THREAD_TOKENS,
         signal: abortController.signal,
         timeoutMs: HOSTED_IDLE_COMPACT_TIMEOUT_MS,

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -157,6 +157,7 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
 
   assert.equal(result.codexHome, path.join(operatorHomeRoot, ".codex-hosted"));
   assert.equal(result.codexConfigPath, path.join(operatorHomeRoot, ".codex-hosted", "config.toml"));
+  assert.equal(result.hostedProviderCredentialEnvKey, "OPENAI_API_KEY");
   assert.equal(result.runtimeEnv.CODEX_HOME, result.codexHome);
   assert.ok(result.runtimeEnv[MURPH_ASSISTANT_SKILLS_ROOT_ENV]);
   assert.match(
@@ -496,6 +497,7 @@ test("hosted Codex runtime config uses ChatGPT subscription auth in local dev", 
     result.runtimeEnv[HOSTED_CODEX_EFFECTIVE_MODEL_PROVIDER_ID_ENV],
     "hosted-chatgpt-openai",
   );
+  assert.equal(result.hostedProviderCredentialEnvKey, null);
   // Token material must not linger in the runtime env; image-gen keeps the key.
   assert.equal(result.runtimeEnv[HOSTED_RUNTIME_CODEX_CHATGPT_AUTH_JSON_ENV], undefined);
   assert.equal(result.runtimeEnv.OPENAI_API_KEY, "secret-openai-key");

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -23,7 +23,10 @@ import {
   HostedAssistantConfigurationError,
 } from "@murphai/operator-config/hosted-assistant-config";
 import {
+  HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV,
   HOSTED_CLI_BRIDGE_TIMEOUT_MS_ENV,
+  HOSTED_CLI_BRIDGE_TOKEN_ENV,
+  HOSTED_CLI_BRIDGE_URL_ENV,
   HOSTED_RUNTIME_CODEX_APP_SERVER_COMMAND_ENV,
   HOSTED_RUNTIME_CODEX_MODEL_CATALOG_JSON_ENV,
   HOSTED_RUNTIME_PROCESS_ENV,
@@ -192,14 +195,14 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
   assert.doesNotMatch(config, /\[model_providers\."openai"\]/u);
   assert.match(config, /\[model_providers\."hosted-openai"\]/u);
   assert.match(config, /base_url = "https:\/\/api\.openai\.com\/v1"/u);
-  assert.match(config, /env_key = "OPENAI_API_KEY"/u);
+  assert.match(config, /^cli_auth_credentials_store = "ephemeral"$/mu);
+  assert.doesNotMatch(config, /^env_key = /mu);
   assert.match(config, /wire_api = "responses"/u);
   assert.match(config, /^supports_websockets = true$/mu);
   assert.match(config, /^stream_idle_timeout_ms = 90000$/mu);
-  assert.match(config, /^requires_openai_auth = false$/mu);
+  assert.match(config, /^requires_openai_auth = true$/mu);
   assert.match(config, /^request_max_retries = 4$/mu);
   assert.match(config, /^stream_max_retries = 0$/mu);
-  assert.doesNotMatch(config, /^requires_openai_auth = true$/mu);
   assert.match(
     config,
     new RegExp(
@@ -448,8 +451,9 @@ test("hosted Codex runtime config accepts a local test-only model provider base 
   assert.match(config, /model_provider = "hosted-openai"/u);
   assert.match(config, /\[model_providers\."hosted-openai"\]/u);
   assert.match(config, /base_url = "http:\/\/host\.docker\.internal:4567\/v1"/u);
-  assert.match(config, /env_key = "OPENAI_API_KEY"/u);
-  assert.match(config, /requires_openai_auth = false/u);
+  assert.doesNotMatch(config, /env_key/u);
+  assert.match(config, /^cli_auth_credentials_store = "ephemeral"$/mu);
+  assert.match(config, /requires_openai_auth = true/u);
   assert.doesNotMatch(config, /^supports_websockets = true$/mu);
   assert.match(config, /stream_idle_timeout_ms = 90000/u);
   assert.match(config, /request_max_retries = 4/u);
@@ -735,7 +739,7 @@ test("hosted Codex runtime config removes invalid persistent ChatGPT auth", asyn
     );
 
     const config = await readFile(result.codexConfigPath, "utf8");
-    assert.doesNotMatch(config, /^cli_auth_credentials_store = "file"$/mu);
+    assert.match(config, /^cli_auth_credentials_store = "ephemeral"$/mu);
     assert.match(config, /^model_provider = "hosted-openai"$/mu);
     assert.doesNotMatch(config, /chatgpt-access-token/u);
   }
@@ -835,8 +839,9 @@ testHostedCodexAuthE2e(
 
       assert.match(config, /^model_provider = "hosted-openai"$/mu);
       assert.match(config, /\[model_providers\."hosted-openai"\]/u);
-      assert.match(config, /^env_key = "OPENAI_API_KEY"$/mu);
-      assert.match(config, /^requires_openai_auth = false$/mu);
+      assert.match(config, /^cli_auth_credentials_store = "ephemeral"$/mu);
+      assert.doesNotMatch(config, /^env_key = /mu);
+      assert.match(config, /^requires_openai_auth = true$/mu);
       assert.doesNotMatch(config, /^model_provider = "openai"$/mu);
 
       const fixedResult = await executeCodexAppServerTurn({
@@ -845,9 +850,13 @@ testHostedCodexAuthE2e(
         env: {
           CODEX_HOME: result.runtimeEnv.CODEX_HOME,
           HOME: operatorHomeRoot,
+          [HOSTED_CLI_BRIDGE_ROUTE_GRANT_ENV]: "hosted-auth-e2e-route-grant",
+          [HOSTED_CLI_BRIDGE_TOKEN_ENV]: "hosted-auth-e2e-bridge-token",
+          [HOSTED_CLI_BRIDGE_URL_ENV]: "http://127.0.0.1:43123",
           OPENAI_API_KEY: result.runtimeEnv.OPENAI_API_KEY,
           PATH: result.runtimeEnv.PATH ?? process.env.PATH ?? "",
         },
+        hostedProviderCredentialEnvKey: "OPENAI_API_KEY",
         prompt: "hello hosted auth regression",
         sandbox: "danger-full-access",
         workingDirectory: operatorHomeRoot,
@@ -1349,6 +1358,7 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
   assert.equal(
     config,
     [
+      'cli_auth_credentials_store = "ephemeral"',
       'model_provider = "openai"',
       'model_reasoning_effort = "medium"',
       `model_auto_compact_token_limit = ${HOSTED_CODEX_EXPECTED_AUTO_COMPACT_TOKEN_LIMIT}`,
@@ -1361,10 +1371,9 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
       '[model_providers."openai"]',
       'name = "OpenAI"',
       'base_url = "https://api.openai.com/v1"',
-      'env_key = "OPENAI_API_KEY"',
       'wire_api = "responses"',
       "stream_idle_timeout_ms = 90000",
-      "requires_openai_auth = false",
+      "requires_openai_auth = true",
       "request_max_retries = 4",
       "stream_max_retries = 0",
       "",

--- a/packages/assistant-runtime/test/hosted-runtime-codex-self-brick-e2e.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-self-brick-e2e.test.ts
@@ -96,7 +96,8 @@ test("hosted Codex cannot permanently brick later wakes by corrupting its writab
   assert.match(nextConfig, /wire_api = "responses"/u);
   assert.doesNotMatch(nextConfig, /env_http_headers/u);
   assert.doesNotMatch(nextConfig, /MURPH_HOSTED_CODEX_/u);
-  assert.match(nextConfig, /requires_openai_auth = false/u);
+  assert.match(nextConfig, /^cli_auth_credentials_store = "ephemeral"$/mu);
+  assert.match(nextConfig, /requires_openai_auth = true/u);
   assert.doesNotMatch(nextConfig, /not valid hosted codex config/u);
   await assert.rejects(
     () => access(path.join(restored.operatorHomeRoot, ".murph", "config.json")),

--- a/packages/assistant-runtime/test/hosted-runtime-detached-assistant-ask.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-detached-assistant-ask.test.ts
@@ -70,7 +70,10 @@ describe("hosted detached assistant ask controller", () => {
     const vaultRoot = await createVaultRoot();
     const firstAnswer = createDeferred<void>();
     const secondAnswer = createDeferred<void>();
-    const executeAsk = vi.fn(async (input: { question: string }) => {
+    const executeAsk = vi.fn(async (input: {
+      hostedProviderCredentialEnvKey?: string | null;
+      question: string;
+    }) => {
       if (input.question === "first question") {
         await firstAnswer.promise;
         return { answer: "first answer", outcome: "answered" as const };
@@ -110,8 +113,9 @@ describe("hosted detached assistant ask controller", () => {
       const controller = createHostedDetachedAssistantAskController({
         assistantAskPort,
         codexHome: null,
-        env: {},
+        env: { OPENAI_API_KEY: "provider-auth-binds-natively" },
         executeAsk,
+        hostedProviderCredentialEnvKey: "OPENAI_API_KEY",
         now: () => TEST_NOW,
         onStateMutation() {},
         vaultRoot,
@@ -120,6 +124,10 @@ describe("hosted detached assistant ask controller", () => {
       controller.kick();
       await waitUntil(() => assert.equal(executeAsk.mock.calls.length, 1));
       assert.equal(executeAsk.mock.calls[0]?.[0].question, "first question");
+      assert.equal(
+        executeAsk.mock.calls[0]?.[0].hostedProviderCredentialEnvKey,
+        "OPENAI_API_KEY",
+      );
       assert.deepEqual(
         (await readHostedSystemMailboxState(vaultRoot)).pending.map((item) => [
           item.itemId,
@@ -134,6 +142,10 @@ describe("hosted detached assistant ask controller", () => {
       firstAnswer.resolve();
       await waitUntil(() => assert.equal(executeAsk.mock.calls.length, 2));
       assert.equal(executeAsk.mock.calls[1]?.[0].question, "second question");
+      assert.equal(
+        executeAsk.mock.calls[1]?.[0].hostedProviderCredentialEnvKey,
+        "OPENAI_API_KEY",
+      );
       assert.deepEqual(completedRequestIds, ["ask_event_1"]);
 
       secondAnswer.resolve();

--- a/packages/assistant-runtime/test/hosted-runtime-idle-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-idle-maintenance.test.ts
@@ -100,6 +100,7 @@ describe("runHostedIdleCheckpointMaintenance", () => {
 
     const outcome = await runHostedIdleCheckpointMaintenance({
       credentialSource: "member",
+      ephemeralApiKey: "fixture-provider-credential",
       memberId: "member_1",
       model: "gpt-5.6-sol",
       providerName: "hosted-openai",
@@ -118,6 +119,7 @@ describe("runHostedIdleCheckpointMaintenance", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(compactWarmCodexThread).toHaveBeenCalledWith({
       canAccountForModel: expect.any(Function),
+      ephemeralApiKey: "fixture-provider-credential",
       minThreadTokens: HOSTED_IDLE_COMPACT_MIN_THREAD_TOKENS,
       signal: expect.any(AbortSignal),
       timeoutMs: HOSTED_IDLE_COMPACT_TIMEOUT_MS,


### PR DESCRIPTION
## Why this PR exists

Hosted turns put bridge tokens, route grants, and provider credentials into the resident Codex child environment. Those rotating values participate in the launch identity, so otherwise-compatible turns respawn Codex App Server and repeatedly pay its cold-start cost.

## User goal / user-visible behavior

Reduce cold-start latency by safely reusing one healthy Codex App Server across turns whose stable launch configuration is unchanged. The prior loaded thread is unsubscribed at the next hosted acquisition so current turn authority is reconstructed without respawning the resident process.

## User experience

There is no UI change. Replies use the same provider and route semantics, but compatible hosted turns can reuse the already-running Codex process instead of launching a new one.

## Invariants preserved

- The exact launch-key algorithm remains unchanged for stable environment and configuration inputs.
- Resident process state contains no rotating bridge token, route grant, or provider credential.
- Bridge identity is turn-scoped; route authority is optional and appears only on authenticated interactive turns.
- Provider credentials never enter thread or model-shell configuration. They bind only through native account login for the operation that needs provider access.
- A reusable hosted process unsubscribes its prior loaded thread before resume, causing the pinned App Server to reconstruct the same thread/history with current complete configuration.
- Foreground turns, detached Assistant Ask, and idle compaction all use bounded native API-key bind/revoke boundaries.
- Login, turn, cleanup, unsubscribe, compaction, and logout failures poison the exact process rather than risk stale authority reuse.
- Host-side dynamic image tools retain only the current invocation credential; ChatGPT file-backed authentication remains unchanged.
- No new service, state owner, persisted state, or compatibility shim is introduced.

## Non-obvious affected surfaces

- The change spans assistant-engine launch/auth orchestration and assistant-runtime hosted Codex configuration because those packages jointly define the runner bundle boundary.
- Scheduled, proactive, and system turns carry bridge identity without an interactive route grant and must still execute.
- Detached Assistant Ask and idle compaction call App Server outside the foreground adapter, so they now receive operation-scoped native authentication explicitly.
- The provider-egress bearer stays in host-side operation inputs and never crosses into thread RPC or model-shell state.
- No web/Worker wire protocol, database schema, or user-facing state changes.
- Existing launch hashing and the single warm-process slot remain the only process reuse owners; this PR adds no cache or lifecycle manager.

## Verification

- Focused assistant-engine suites: 208/208 passed.
- Focused assistant-runtime suites: 67 passed, 2 expected skips.
- Provider/shell authority hard-cut: 5/5 passed.
- Fresh runner bundle assembled and all affected workspace packages built/typechecked successfully.
- Production-shaped hosted-local E2Es on that exact bundle: scheduled reminders 2/2, Codex image media 2/2, and runner warm reuse 2/2.
- `pnpm test:diff source test`: passed repository syntax, Temporal architecture, hosted crypto, raw-log payload, TypeScript-tooling, and dependency-policy guards.
- ReviewGPT round 1 returned three authority/authentication findings. The production remediation head passed round 2 with `ROUND_OUTCOME: PASS` and zero qualifying findings. The final head adds only a test-expression type guard; all CI gates are green on that final head.

## ReviewGPT round 1 remediation

- Token-only hosted turns now remain valid while route grants are optional. Next-acquisition unsubscribe reconstructs the thread with no stale grant.
- Provider credentials were deleted from thread/shell configuration and remain only in native login plus host-side dynamic-tool inputs.
- Detached Assistant Ask and idle compaction now bind/revoke native auth at their existing operation boundary; failures poison only the exact owned process.

## Change-shape breakdown

Classification rule: authored runtime code is source, test code and fixtures are tests, and the archived execution plan is docs. There are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 280 | 40 |
| Tests | 877 | 24 |
| Docs | 51 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1208** | **64** |

## Deployment skew / compatibility

Assistant-engine and assistant-runtime ship in the same runner artifact, and no shared wire or persisted-state format changes. Existing warm containers can finish with old behavior; the reuse benefit begins after the new runner bundle is deployed. No immediate rollout is required. After deploy, inspect `warm-reused` timing and hosted-auth error rates.

ReviewGPT first-reviewed head: be0600cfe432b0d4a3ae1cb62c5e12c0639a3269

Immutable first-review change shape: 579 additions and 37 deletions across 10 authored text files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786786099&installation_id=127572939&pr_number=748&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F748&signature=639b7cebe7eec72fc9250151153b01fe1fe33e5c00cf3483834d9a8b43a74f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


