### PR TITLE
Fix group reminder local-date attribution

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-group-reminder-local-window.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-group-reminder-local-window.md
@@ -1,0 +1,121 @@
+# Group reminder local action window
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Prevent a scheduled group reminder from treating evidence from a different
+  local action window as completion for the current occurrence.
+
+## Success criteria
+
+- Every scheduled notification turn receives its exact occurrence instant as
+  engine-owned per-turn context.
+- Notification guidance derives the occurrence's local calendar date from the
+  vault timezone and requires completion evidence to belong to the relevant
+  local action window before suppressing the occurrence.
+- Ambiguous or unavailable attribution remains unknown rather than complete,
+  while preserving the existing privacy boundary and automation lifecycle
+  ownership.
+- Regression coverage proves the UTC-midnight case where an instant on July 15
+  UTC is still July 14 in New York.
+- Required verification, local specialist audits, PR CI, and the exact-head
+  ReviewGPT loop complete with no accepted finding remaining.
+
+## Scope
+
+- In scope: the assistant notification turn contract, cron execution handoff,
+  notification decision prompt context, and focused assistant-engine tests.
+- Out of scope: persisted automation schema, continuity policy, scheduler
+  cadence, transcript timestamp storage, route ownership, and a generic model
+  for cross-midnight action windows.
+
+## Constraints
+
+- Keep the occurrence context ephemeral and engine-owned; do not add persisted
+  state or a second scheduler/date owner.
+- Preserve group privacy boundaries and the existing default-to-silence rule.
+- Treat the local occurrence date as an anchor for the automation's relevant
+  action window, not as a universal same-calendar-day completion policy.
+- Preserve unrelated active work that also touches the system prompt by keeping
+  edits narrow and based on current `origin/main`.
+
+## Risks and mitigations
+
+1. Risk: applying a same-day rule globally would break legitimate overnight
+   or pre-bed action windows.
+   Mitigation: expose the local occurrence anchor and instruct the decision to
+   use the automation's relevant action window rather than enforcing equality
+   in scheduler code.
+2. Risk: a generic notification could accidentally receive group-only behavior.
+   Mitigation: keep shared occurrence facts separate from scope-specific
+   decision guidance and test both layers.
+3. Risk: a resumed provider thread could reuse stale occurrence context.
+   Mitigation: keep the occurrence fact in rebuilt per-turn dynamic context,
+   outside thread-stable instructions and route identity.
+
+## Tasks
+
+1. Add the scheduled occurrence instant to the existing per-turn notification
+   envelope and carry it through the local notification input.
+2. Render a compact local occurrence context in the notification decision
+   system prompt and tighten group completion attribution guidance.
+3. Add focused midnight-boundary and handoff regression coverage.
+4. Run scoped verification, required prompt and coverage audits, and parent
+   final review.
+5. Close the plan with a scoped commit, push, open the intent-complete PR, then
+   run CI and the exact-head ReviewGPT loop concurrently to completion.
+
+## Decisions
+
+- Reuse the occurrence instant already computed by cron execution and carry it
+  as one optional per-turn message field; do not persist it or create a second
+  schedule/date owner.
+- Derive the local occurrence date in dynamic notification context from the
+  same canonical vault timezone used by cron schedule projection and prompt
+  planning.
+- Use that local date as an action-window anchor rather than a universal
+  calendar-equality rule, preserving explicit overnight and multi-day windows.
+- For an explicitly authorized accountability check-in, treat unclear
+  attribution as unknown and ask one neutral outcome question without implying
+  that anyone missed the activity.
+
+## Audit outcomes
+
+- `prompt-review` passed twice with no finding: once for the occurrence context
+  and attribution guard, then again after the parent added the narrow unknown-
+  outcome question rule. The rerun confirmed privacy, default-silence,
+  deliverability, evidence, and structured-output invariants remain intact.
+- `coverage-write` found one useful proof gap and added a notification-boundary
+  assertion that the non-null occurrence survives into `AssistantMessageInput`.
+  No production edit or further coverage finding was recommended.
+- Parent final review re-walked cron occurrence computation, notification input
+  construction, route planning, dynamic prompt placement, group scope rules,
+  and all three regression boundaries. No unresolved finding remains.
+
+## Verification
+
+- Commands to run: focused assistant-engine tests during implementation; final
+  `pnpm test:diff` for touched assistant-engine source and tests; `git diff
+  --check`; required `prompt-review` and `coverage-write` passes; exact-head PR
+  preflight, ReviewGPT round(s), CI status, and merge-tree proof against latest
+  `main`.
+- Direct scenario: prove `2026-07-15T02:07:00Z` and a
+  `2026-07-16T01:00:00Z` occurrence map to different New York local dates.
+- Focused post-audit verification: 3 files, 201 tests passed; assistant-engine
+  typecheck passed; `git diff --check` passed.
+- Owner coverage: 158 files passed and 1 skipped; 2,305 tests passed and 5
+  skipped; 89.7% statements, 81.73% branches, 94.16% functions, and 89.73%
+  lines. The exact post-wording-change rerun used one worker and an 8 GB Node
+  heap to avoid unrelated concurrent coverage pressure.
+- The broader `pnpm test:diff` lane cleared dependency, workspace-boundary,
+  hosted-runtime, logging, and all affected typechecks. Assistant runtime (1,736
+  tests), assistantd, assistant-cli, and setup-cli passed before unrelated CLI
+  command tests repeatedly hit their 60-second timeouts under concurrent test
+  saturation; the session-owned run was stopped and replaced with the green
+  owner coverage lane above.
+- PR CI, exact-head ReviewGPT, and latest-base mergeability remain external
+  post-push gates.
+Completed: 2026-07-16

--- a/packages/assistant-engine/src/assistant/automation/turn-envelope.ts
+++ b/packages/assistant-engine/src/assistant/automation/turn-envelope.ts
@@ -18,6 +18,7 @@ export type AssistantAutomationTurnEnvelope = Pick<
   | 'deliveryDispatchMode'
   | 'executionContext'
   | 'scheduledAutomationAuthority'
+  | 'scheduledOccurrenceAt'
   | 'serviceTier'
   | 'turnEnvironment'
   | 'turnTrigger'
@@ -28,6 +29,7 @@ export function buildAssistantAutomationTurnEnvelope(input: {
   deliveryDispatchMode?: AssistantOutboxDispatchMode
   executionContext?: AssistantExecutionContext | null
   scheduledAutomationAuthority?: AssistantMessageInput['scheduledAutomationAuthority']
+  scheduledOccurrenceAt?: string | null
   serviceTier?: AssistantProviderServiceTier | null
   signal?: AbortSignal
   turnEnvironment?: AssistantTurnEnvironment | null
@@ -43,6 +45,7 @@ export function buildAssistantAutomationTurnEnvelope(input: {
     deliveryDispatchMode: input.deliveryDispatchMode,
     executionContext: input.executionContext,
     scheduledAutomationAuthority: input.scheduledAutomationAuthority ?? null,
+    scheduledOccurrenceAt: input.scheduledOccurrenceAt ?? null,
     serviceTier: input.serviceTier ?? null,
     turnEnvironment: input.turnEnvironment ?? null,
     turnTrigger: input.turnTrigger,

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -566,6 +566,7 @@ export async function resolveAssistantRouteTurnPlan(input: {
             currentTimeZone: input.promptTimeContext.currentTimeZone,
             conversationScope,
             hostedRuntime: input.executionContext?.hosted != null,
+            scheduledOccurrenceAt: input.input.scheduledOccurrenceAt ?? null,
           }, {
             toolSchemaHash,
           })

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -652,6 +652,7 @@ export async function executeClaimedAssistantCronJob(
             occurrenceAt,
             trigger: input.trigger,
           }),
+          scheduledOccurrenceAt: occurrenceAt,
           serviceTier,
           signal: yieldCancellation.signal,
           turnEnvironment: input.turnEnvironment ?? null,

--- a/packages/assistant-engine/src/assistant/notification-turn.ts
+++ b/packages/assistant-engine/src/assistant/notification-turn.ts
@@ -192,6 +192,7 @@ export interface AssistantNotificationInput
       | 'operatorAuthority'
       | 'assistantTargetOverride'
       | 'scheduledAutomationAuthority'
+      | 'scheduledOccurrenceAt'
       | 'serviceTier'
       | 'showThinkingTraces'
       | 'turnEnvironment'
@@ -1212,6 +1213,7 @@ function buildAssistantNotificationMessageInput(
     reasoningEffort: input.reasoningEffort,
     sandbox: input.sandbox,
     scheduledAutomationAuthority: input.scheduledAutomationAuthority ?? null,
+    scheduledOccurrenceAt: input.scheduledOccurrenceAt ?? null,
     serviceTier: input.serviceTier ?? null,
     sessionId: input.sessionId,
     showThinkingTraces: input.showThinkingTraces,

--- a/packages/assistant-engine/src/assistant/service-contracts.ts
+++ b/packages/assistant-engine/src/assistant/service-contracts.ts
@@ -157,6 +157,9 @@ export interface AssistantMessageInput extends AssistantSessionResolutionFields 
   userMessageContent?: AssistantUserMessageContentPart[] | null
   receiptMetadata?: Record<string, string> | null
   scheduledAutomationAuthority?: HostedRuntimeNewsletterScheduledAuthority | null
+  // Exact engine-owned occurrence for this scheduled turn. This is ephemeral
+  // decision context, not persisted automation or session state.
+  scheduledOccurrenceAt?: string | null
   // Per-turn provider processing tier; never part of session/route identity.
   serviceTier?: AssistantProviderServiceTier | null
   showThinkingTraces?: boolean

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -11,6 +11,7 @@ import {
   MURPH_PRODUCT_ORIGIN,
   type AssistantPersonalityPreferences,
   defaultAssistantTonePreference,
+  toLocalDayKey,
   type AssistantTonePreference,
 } from "@murphai/contracts";
 import {
@@ -68,6 +69,7 @@ export interface AssistantNotificationDecisionSystemPromptInput {
   conversationScope?: AssistantConversationScope;
   hostedRuntime?: boolean;
   maintenanceTurn?: boolean;
+  scheduledOccurrenceAt?: string | null;
 }
 
 export interface AssistantAskContinuationSystemPromptInput {
@@ -771,6 +773,12 @@ export function buildAssistantNotificationDecisionSystemPromptLayers(
             currentMurphProductBaseUrl: null,
             currentTimeZone: input.currentTimeZone,
           }),
+      conversationScope === "unverified-external"
+        ? null
+        : buildAssistantScheduledOccurrenceContextText({
+            occurrenceAt: input.scheduledOccurrenceAt ?? null,
+            timeZone: input.currentTimeZone,
+          }),
       ...(conversationScope === "unverified-external"
         ? []
         : normalizeAssistantDynamicContextPrompts(
@@ -1268,6 +1276,8 @@ function buildAssistantGroupNotificationDecisionGuidanceText(
     `Group notification execution rules:
 - Decide whether this room-owned reminder still earns one short message. Default to staying silent.
 - Ground the decision only in the automation, recent room conversation, public sources, group-owned state, and server-approved shared projections. Never read or write a participant's personal records, memory, settings, accounts, devices, or preferences from the room container.
+- Before treating a room report as completion, convert its timestamp to the scheduled occurrence timezone and verify that it belongs to this occurrence's relevant local action window. Evidence from another local action window cannot complete this occurrence; unclear attribution is unknown, not complete.
+- For an explicitly authorized accountability check-in, when completion is still unknown after that attribution check, send one neutral outcome question; never state or imply that anyone missed the activity.
 - Scheduled room turns do not own automation lifecycle. Do not create, update, archive, or reroute automations; use the current evidence only to decide whether this occurrence should send or skip.
 - Skip when the room already completed the activity, the reminder was declined or moved, the support window ended, or the message would expose or infer personal health data. The platform delivers the structured output; do not deliver it yourself.`,
     channelText,
@@ -1279,6 +1289,26 @@ function buildAssistantGroupNotificationDecisionGuidanceText(
 - Text is the single final room message. Subject applies only to a new outbound email.
 - Never include personal settings, billing, device, account, authorization, or browser-handoff URLs, except when an owning group workflow explicitly provides a clearly labeled per-person enrollment link. Describe that exception as changing only that participant's account, never the room settings. Other URLs are allowed only for group-owned deliverables.`
   );
+}
+
+function buildAssistantScheduledOccurrenceContextText(input: {
+  occurrenceAt: string | null;
+  timeZone: string;
+}): string | null {
+  if (!input.occurrenceAt) {
+    return null;
+  }
+
+  const occurrence = new Date(input.occurrenceAt);
+  if (!Number.isFinite(occurrence.getTime())) {
+    return null;
+  }
+
+  return `Scheduled occurrence context:
+- Occurrence instant: ${code(occurrence.toISOString())}.
+- Occurrence timezone: ${code(input.timeZone)}.
+- Occurrence local date: ${code(toLocalDayKey(occurrence, input.timeZone))}.
+- Use the local date as the anchor for this automation's relevant action window. Treat message and record timestamps as instants and convert them to the occurrence timezone before assigning evidence to a local date.`;
 }
 
 function buildAssistantNotificationDecisionGuidanceText(

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -5402,6 +5402,7 @@ describe('assistant cron runtime orchestration', () => {
     expect(result.run.status).toBe('succeeded')
     expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
       expect.objectContaining({
+        scheduledOccurrenceAt: '2026-04-08T10:00:00.000Z',
         sessionId: null,
         threadId: 'thread-1',
       }),

--- a/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
@@ -305,6 +305,7 @@ test('sendAssistantNotificationLocal persists the turn before outbound delivery 
     assistantTargetOverride: {
       reasoningEffort: 'high',
     },
+    scheduledOccurrenceAt: '2026-07-16T01:00:00.000Z',
     vault: '/vaults/test',
   } satisfies Parameters<typeof sendAssistantNotificationLocal>[0] & Record<string, unknown>
 
@@ -371,6 +372,10 @@ test('sendAssistantNotificationLocal persists the turn before outbound delivery 
   assert.deepEqual(firstResolvedNotificationSessionInput.message.assistantTargetOverride, {
     reasoningEffort: 'high',
   })
+  assert.equal(
+    firstResolvedNotificationSessionInput.message.scheduledOccurrenceAt,
+    '2026-07-16T01:00:00.000Z',
+  )
   assert.deepEqual(result.decision, {
     kind: 'send_message',
     privateSummary: 'summary',

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -1,4 +1,4 @@
-import { MURPH_PRODUCT_ORIGIN } from '@murphai/contracts'
+import { MURPH_PRODUCT_ORIGIN, toLocalDayKey } from '@murphai/contracts'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -1910,11 +1910,30 @@ describe('assistant notification decision guidance', () => {
           { label: 'Garmin', provider: 'garmin' },
         ],
         conversationScope: 'group',
+        currentLocalDate: '2026-07-15',
+        currentTimeZone: 'America/New_York',
+        scheduledOccurrenceAt: '2026-07-16T01:00:00.000Z',
       }),
     ).prompt
 
     expect(prompt).toContain('Group notification execution rules:')
     expect(prompt).toContain('Scheduled room turns do not own automation lifecycle.')
+    expect(prompt).toContain('Occurrence instant: `2026-07-16T01:00:00.000Z`.')
+    expect(prompt).toContain('Occurrence timezone: `America/New_York`.')
+    expect(prompt).toContain('Occurrence local date: `2026-07-15`.')
+    expect(
+      toLocalDayKey(new Date('2026-07-15T02:07:00.000Z'), 'America/New_York'),
+    ).toBe('2026-07-14')
+    expect(
+      toLocalDayKey(new Date('2026-07-16T01:00:00.000Z'), 'America/New_York'),
+    ).toBe('2026-07-15')
+    expect(prompt).toContain('convert its timestamp to the scheduled occurrence timezone')
+    expect(prompt).toContain('Evidence from another local action window cannot complete this occurrence')
+    expect(prompt).toContain('unclear attribution is unknown, not complete')
+    expect(prompt).toContain(
+      'when completion is still unknown after that attribution check, send one neutral outcome question',
+    )
+    expect(prompt).toContain('never state or imply that anyone missed the activity')
     expect(prompt).toContain('Do not create, update, archive, or reroute automations')
     expect(prompt).not.toContain('PRIVATE_GROUP_NOTIFICATION_CONTEXT')
     expect(prompt).not.toContain('same full read and write tools')
@@ -1947,6 +1966,20 @@ describe('assistant notification decision guidance', () => {
       }),
     ).prompt
     expect(nonHostedPrompt).not.toContain('Assistant tone preference:')
+  })
+
+  it('keeps scheduled occurrence context out of unverified external prompts', () => {
+    const prompt = buildAssistantNotificationDecisionSystemPromptWithCacheMetadata(
+      createCommonNotificationPromptInput({
+        conversationScope: 'unverified-external',
+        currentTimeZone: 'America/New_York',
+        scheduledOccurrenceAt: '2026-07-16T01:00:00.000Z',
+      }),
+    ).prompt
+
+    expect(prompt).not.toContain('Scheduled occurrence context:')
+    expect(prompt).not.toContain('2026-07-16T01:00:00.000Z')
+    expect(prompt).not.toContain('America/New_York')
   })
 
   it('renders only a fail-closed skip contract for an unverified external audience', () => {


### PR DESCRIPTION
## Why this PR exists

A scheduled group accountability reminder skipped because a late-evening report was compared by its UTC calendar date instead of the reminder occurrence's local action window. This PR gives notification decisions explicit engine-owned occurrence context so a prior local day's report cannot silently complete the current occurrence.

## User goal / user-visible behavior

Scheduled group check-ins attribute room reports in the occurrence timezone before deciding to skip. Completion from another local action window does not suppress the current reminder; if an explicitly authorized accountability check-in remains unknown, Murph asks one neutral outcome question without claiming anyone missed the activity.

## User experience

The existing schedule and group thread stay unchanged. At the scheduled time, Murph uses the occurrence instant, vault timezone, and local occurrence date to interpret recent room evidence. Completed, declined, moved, expired, or privacy-unsafe reminders still skip. Ambiguous completion can produce one short neutral question, and later occurrences continue under the existing continuity policy.

## Invariants

- The cron scheduler remains the sole occurrence owner; no persisted state or second date/schedule model is added.
- The vault timezone remains the canonical timezone for cron projection and prompt planning.
- The local occurrence date anchors the relevant action window but does not impose a universal same-calendar-day rule on explicit overnight or multi-day windows.
- Group privacy, room-owned evidence, default silence, automation lifecycle ownership, route ownership, and `continuityPolicy` semantics are unchanged.
- Unverified external audiences do not receive occurrence context.

## Non-obvious affected surfaces

- **All authenticated notification decisions:** the existing notification message contract now carries an optional per-turn occurrence instant so direct and group prompts can receive the same trusted temporal facts. The field is ephemeral and excluded from session/route identity. Regression proof covers cron handoff, notification input construction, dynamic prompt rendering, and external-audience withholding.
- **Prompt cache placement:** occurrence values are appended only in rebuilt dynamic turn context after the stable prefix, so each scheduled turn receives its own facts without rotating stable instructions.

## Verification

- Focused post-rebase suite: 203 passed.
- Assistant-engine typecheck: passed.
- Owner coverage before the base refresh: 2,305 passed, 5 skipped; 89.7% statements / 81.73% branches.
- Post-rebase owner coverage exercised 2,311 passing tests and found two unrelated warm-Codex lifecycle test-state failures; the exact affected file then passed 192/192 in isolation. The changed cron/notification/prompt paths remained green.
- Required `prompt-review`: passed on the original change, the unknown-outcome rule, and the rebased hosted-group prompt with zero findings.
- Required `coverage-write`: added one notification-boundary propagation assertion; no remaining finding.
- `git diff --check`, identifier/privacy scan, and synthetic merge-tree proof against current `origin/main`: passed.

## Change shape

Classification rule: production TypeScript is source; Vitest files are tests/fixtures; the completed execution plan is docs; no binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 40 | 0 |
| Tests / fixtures | 40 | 1 |
| Docs | 121 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **201** | **1** |

ReviewGPT first-reviewed head: 07751444928616b1bebc3c52c47379f958dad584

| ReviewGPT round | Current head | Source | Tests | Docs | Config / tooling | Generated / other |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| 1 | `07751444928616b1bebc3c52c47379f958dad584` | +40/-0 | +40/-1 | +121/-0 | +0/-0 | +0/-0 |

## Deployment skew / compatibility

There is no persisted schema, API, or cross-component payload change. Old warm runner containers retain the old reminder decision behavior until replaced; new runner bundles use the new context immediately. Mixed versions are behaviorally compatible but leave the original false-skip risk on old containers, so an immediate runner rollout is preferable to minimize that window, followed by the scheduled-reminder smoke and a check that new reminder turns contain the local occurrence context without exposing prompt contents.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786810836&installation_id=127572939&pr_number=753&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F753&signature=c984b72b70087f948fb036768b89e72d902dea7f6fa2b35d4e3a591f25a4a132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->