### PR TITLE
Restore Temporal-first direct runner wake ordering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -532,15 +532,16 @@ in `@murphai/contracts` so local CLI and hosted Worker validation cannot drift.
 Hosted Linq typing events are verified and ignored. The Temporal mailbox
 signal remains the only durable wake authority for hosted runtime work. For a
 committed known-checkpoint Linq message, web first verifies the checkpoint owner
-and canonical participant-aware live access, then starts the unconditional
-Temporal pointer signal and one best-effort direct `ensure-processing` request
-to Cloudflare concurrently (Vercel OIDC, fire and forget, no retries). Access
-denial or expiry starts neither wake. The direct request exists only to cut wake
-latency and may be dropped at any time with no correctness impact: accepted Linq
-delivery stamps the exact mailbox item with `consumedAt`, so a later Temporal
-ensure imports an already-answered item as context-only, while the Durable
-Object write fence coalesces runners that overlap in the same invocation. There
-is no other web-to-Cloudflare prewarm or nudge path.
+and canonical participant-aware live access as part of the unconditional
+Temporal pointer signal. Only after Temporal accepts that durable signal does
+web start one best-effort direct `ensure-processing` request to Cloudflare
+(Vercel OIDC, fire and forget, no retries). Access denial, expiry, or Temporal
+acceptance failure starts no direct wake. The direct request exists only to cut
+wake latency and may be dropped at any time with no correctness impact:
+accepted Linq reply delivery stamps the exact mailbox item with `consumedAt`, so
+a later ensure imports an already-answered item as context-only, while the
+Durable Object write fence coalesces runners that overlap in the same invocation.
+There is no other web-to-Cloudflare prewarm or nudge path.
 
 Hosted Linq participant-change webhooks are privacy-minimized provider-ledger
 facts, not runtime work. A unique participant addition may set one nullable

--- a/agent-docs/exec-plans/completed/2026-07-16-restore-temporal-wake-order.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-restore-temporal-wake-order.md
@@ -1,0 +1,49 @@
+Goal (incl. success criteria):
+- Restore the direct Linq runner wake to the simpler post-Temporal-acceptance order because the concurrent overlap has no demonstrated material end-to-end latency benefit.
+- Preserve the direct wake as a best-effort latency hint and keep Temporal as the durable wake authority.
+- Success means Temporal acceptance completes before the direct ensure starts, access or Temporal failure starts no direct wake, focused ordering tests pass, required local audits are resolved, and the PR reaches ReviewGPT `PASS` plus green CI.
+
+Constraints/Assumptions:
+- Prefer deletion and existing owners; add no queue, state machine, scheduler, persisted table, or compatibility path.
+- Keep web as mailbox and `consumedAt` owner, Temporal as durable signal owner, and Cloudflare as the thin execution adapter.
+- Preserve unrelated worktree changes and active coordination-ledger rows.
+- Coordinate narrowly with the non-exclusive hosted-ingress-wake-repair and mailbox-consumed-at lanes.
+
+Key decisions:
+- Recompose the known-checkpoint path through the existing `signalHostedMailboxAppendRuntime` owner rather than retaining a prepare-plus-overlap branch.
+- Keep the already-merged production-faithful late-ensure regression for accepted text replies unchanged.
+- Treat the pre-existing reaction-only consume-authority gap as a separate correctness change because it requires generic persisted outbox retry semantics and is not caused by PR #749.
+
+State:
+- Done.
+
+Done:
+- Reconstructed PR #749, its earlier revert history, and PR #383's durable consume boundary.
+- Verified production ordering and measured only a small direct-request scheduling lead with no demonstrated warm provider-start improvement.
+- Verified the reaction-only path drops answered mailbox ids before the accepted delivery outcome; split that independent issue from this rollback to preserve a narrow review and rollback boundary.
+- Restored all three production files exactly to PR #749's immediate parent while retaining stronger ordering, failure, access-denial, and late-timeout proof.
+- Coverage-write found no actionable proof gap: 43 owner tests passed with 93.28% statements, 85.86% branches, 100% functions, and 93.15% lines; the eight-file focused suite passed 275 tests.
+- Web TypeScript 7 typecheck, production build, lint, repository guards, and focused suites passed. The parallel full-web lane exposed only load-related dev-smoke and unrelated dynamic-import hook timeouts; isolated reruns passed the smoke and all 11 affected route tests.
+- Parent final review confirmed a narrow net-deletion rollback with no new persisted state, owner, queue, retry path, or deployment coupling.
+
+Now:
+- Commit and publish the reviewed rollback.
+
+Next:
+- Open the PR, then complete the exact-head ReviewGPT and CI gates.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
+- apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
+- apps/web/src/lib/hosted-orchestration/signal-runtime.ts
+- apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
+- apps/web/test/hosted-orchestration-signal-runtime.test.ts
+- apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+- ARCHITECTURE.md
+- agent-docs/references/hosted-runtime-protocol.md
+Status: completed
+Updated: 2026-07-16
+Completed: 2026-07-16

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -502,19 +502,17 @@ processing is needed, calls Cloudflare's short-lived `ensure-processing`
 adapter. Linq webhook ingress may additionally fire one best-effort direct
 `ensure-processing` request (Vercel OIDC, fire and forget, no retries, no
 message payload) after the committed known checkpoint's owner matches and the
-canonical live active-access check succeeds. That participant-aware gate runs
-once; only then do the unconditional Temporal `signalWithStart` and the direct
-ensure start concurrently. An access failure starts neither operation. This is
-a latency hint only, not a second durable wake authority: it is Linq-only
-because accepted Linq reply delivery stamps `HostedMailboxItem.consumedAt`, so
-a racing ensure may import an already-consumed row but it stages with a null
-reply target and cannot be answered again. Do not add workflow-side direct-wake
-flags, derived-floor SQL, or lag netting merely to avoid harmless post-delivery
-no-op ensures. There is no direct web-to-Cloudflare message path and no second
-durable wake authority. If the Temporal signal cannot be accepted after the
-live gate, the existing post-commit handoff failure semantics remain
-authoritative even though the one-shot direct hint may already have fired.
-Temporal remains the sole durable retry and reconciliation owner. The existing
+canonical live active-access check succeeds. Web first awaits the unconditional
+Temporal `signalWithStart`; only after Temporal accepts that durable signal does
+web start the direct ensure. An access failure or Temporal acceptance failure
+starts no direct wake. This is a latency hint only, not a second durable wake
+authority: it is Linq-only because accepted Linq reply delivery stamps
+`consumedAt` on the exact `HostedMailboxItem`, so a later ensure imports an
+already-consumed row with a null reply target and cannot answer it again. Do not
+add workflow-side direct-wake flags, derived-floor SQL, or lag netting merely to
+avoid harmless post-delivery no-op ensures. There is no direct web-to-Cloudflare
+message path and no second durable wake authority. Temporal remains the sole
+durable retry and reconciliation owner. The existing
 Temporal scheduled-reconcile
 command also runs one bounded preference-handoff sweep. Web selects live
 `member.preferences.updated` rows above the authoritative system-lane

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
@@ -6,9 +6,9 @@ import type { HostedLinqThreadRouteEgressAuthority } from "../hosted-routing/thr
 
 // Lane facts from the planner's own mailbox append/dedupe row. Presence means
 // the planning transaction already proved the active member, admission, and
-// workspace row for this wake. After commit, Linq handoff owner-checks these
-// facts and rechecks live active access before starting the Temporal signal and
-// direct runtime ensure concurrently.
+// workspace row for this wake, so Linq handoff can include them in its
+// Temporal signal and, after that signal is accepted, fire the direct runtime
+// ensure fast path.
 export type HostedWebhookWakeMailboxCheckpoint = {
   lane: HostedMailboxLane;
   laneSeq: string;

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
@@ -13,9 +13,7 @@ import {
   readHostedExecutionControlClientIfConfigured,
 } from "../hosted-execution/control";
 import {
-  prepareHostedMailboxAppendRuntimeSignal,
   signalHostedMailboxAppendRuntime,
-  signalHostedUserRuntimeWorkflow,
 } from "../hosted-orchestration/signal-runtime";
 import {
   recordHostedIngressAcceptedFromMailboxItem,
@@ -98,59 +96,17 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
 
   let signal: Awaited<ReturnType<typeof signalHostedMailboxAppendRuntime>>;
   let temporalSignalAcceptedAt: Date | null = null;
-  let directEnsureWake: Promise<void> | null = null;
   try {
-    const temporalSignal = waitForHostedPostCommitOperation({
+    signal = await waitForHostedPostCommitOperation({
       deadlineMs: createHostedPostCommitDeadline(input.timeoutMs),
-      operation: async (abortSignal) => {
-        if (!knownCheckpoint || source !== "linq") {
-          return await signalHostedMailboxAppendRuntime({
-            abortSignal,
-            expectedUserId: userId,
-            ...(knownCheckpoint ? { knownCheckpoint } : {}),
-            mailboxItemId,
-          });
-        }
-
-        const preparedSignal = await prepareHostedMailboxAppendRuntimeSignal({
-          expectedUserId: userId,
-          knownCheckpoint,
-          mailboxItemId,
-        });
-        abortSignal.throwIfAborted();
-        const requiredTemporalSignal = signalHostedUserRuntimeWorkflow({
-          abortSignal,
-          ensureWorkspace: false,
-          signal: preparedSignal.signal,
-          userId: preparedSignal.userId,
-        });
-
-        // Linq-only latency fast path, started alongside the required Temporal
-        // signal after the committed mailbox pointer's owner and live access
-        // have been confirmed. With consumed_at live, a racing ensure is
-        // harmless: consumed mailbox items restage with a null reply target,
-        // and a gap invocation that imports only already-consumed work finds
-        // nothing replyable and exits.
-        directEnsureWake = startHostedDirectEnsureWakeBestEffort({
-          mailboxItemId,
-          source: "linq",
-          userId,
-        });
-        const scheduledDirectEnsureWake = directEnsureWake;
-        if (input.scheduleAfterResponse) {
-          // Keep the in-flight request alive past the response without ever
-          // putting its latency on the provider success path.
-          input.scheduleAfterResponse(() => scheduledDirectEnsureWake);
-        } else {
-          void scheduledDirectEnsureWake;
-        }
-
-        return await requiredTemporalSignal;
-      },
+      operation: (abortSignal) => signalHostedMailboxAppendRuntime({
+        abortSignal,
+        expectedUserId: userId,
+        ...(knownCheckpoint ? { knownCheckpoint } : {}),
+        mailboxItemId,
+      }),
       signal: input.signal,
     });
-
-    signal = await temporalSignal;
     temporalSignalAcceptedAt = new Date();
   } catch (error) {
     scheduleHostedWebhookIngressLatencyTraceWritesAfterResponse({
@@ -162,10 +118,31 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
     });
     const errorName = deriveHostedOnboardingTimingErrorName(error);
     finishHostedOnboardingTiming(handoffTiming, "failed", {
-      directEnsureWakeStarted: Boolean(directEnsureWake),
+      directEnsureWakeStarted: false,
       errorName,
     });
     throw error;
+  }
+
+  // Linq-only latency fast path, after Temporal has accepted the durable wake.
+  // With consumed_at live, a racing ensure is harmless: consumed mailbox items
+  // restage with a null reply target, and a gap invocation that imports only
+  // already-consumed work finds nothing replyable and exits.
+  const directEnsureWake = directEnsureEligible
+    ? startHostedDirectEnsureWakeBestEffort({
+        mailboxItemId,
+        source: "linq",
+        userId,
+      })
+    : null;
+  if (directEnsureWake) {
+    if (input.scheduleAfterResponse) {
+      // Keep the in-flight request alive past the response without ever
+      // putting its latency on the provider success path.
+      input.scheduleAfterResponse(() => directEnsureWake);
+    } else {
+      void directEnsureWake;
+    }
   }
 
   scheduleHostedWebhookIngressLatencyTraceWritesAfterResponse({

--- a/apps/web/src/lib/hosted-orchestration/signal-runtime.ts
+++ b/apps/web/src/lib/hosted-orchestration/signal-runtime.ts
@@ -61,12 +61,6 @@ export interface SignalHostedUserRuntimeWorkflowInput {
   userId: string;
 }
 
-export interface HostedMailboxAppendKnownCheckpoint {
-  lane: HostedMailboxLane;
-  laneSeq: string;
-  userId: string;
-}
-
 export interface SignalHostedMailboxAppendInput {
   abortSignal?: AbortSignal;
   client?: HostedRuntimeTemporalSignalClient | null;
@@ -78,21 +72,13 @@ export interface SignalHostedMailboxAppendInput {
   // and workspace upsert. Active access is still rechecked before signaling
   // because legacy Temporal histories may execute mailbox pointers without
   // the reconciliation gate.
-  knownCheckpoint?: HostedMailboxAppendKnownCheckpoint;
+  knownCheckpoint?: {
+    lane: HostedMailboxLane;
+    laneSeq: string;
+    userId: string;
+  };
   mailboxItemId: string;
   prisma?: PrismaClient;
-}
-
-export interface PrepareHostedMailboxAppendRuntimeSignalInput {
-  expectedUserId?: string | null;
-  knownCheckpoint: HostedMailboxAppendKnownCheckpoint;
-  mailboxItemId: string;
-  prisma?: PrismaClient;
-}
-
-export interface PreparedHostedMailboxAppendRuntimeSignal {
-  signal: HostedRuntimeSignal;
-  userId: string;
 }
 
 export interface SignalHostedBrowserVaultRefreshInput {
@@ -143,25 +129,7 @@ export function hostedUserRuntimeWorkflowId(userId: string): string {
 export async function signalHostedMailboxAppendRuntime(
   input: SignalHostedMailboxAppendInput,
 ): Promise<HostedRuntimeSignalResult> {
-  if (input.knownCheckpoint) {
-    const prepared = await prepareHostedMailboxAppendRuntimeSignal({
-      expectedUserId: input.expectedUserId,
-      knownCheckpoint: input.knownCheckpoint,
-      mailboxItemId: input.mailboxItemId,
-      prisma: input.prisma,
-    });
-    return signalHostedUserRuntimeWorkflow({
-      abortSignal: input.abortSignal,
-      client: input.client,
-      environment: input.environment,
-      ensureWorkspace: false,
-      prisma: input.prisma,
-      signal: prepared.signal,
-      userId: prepared.userId,
-    });
-  }
-
-  const mailboxItem = await readHostedMailboxItemCheckpointById({
+  const mailboxItem = input.knownCheckpoint ?? await readHostedMailboxItemCheckpointById({
     mailboxItemId: input.mailboxItemId,
     prisma: input.prisma,
   });
@@ -173,12 +141,19 @@ export async function signalHostedMailboxAppendRuntime(
     expectedUserId: input.expectedUserId ?? null,
     mailboxItemUserId: mailboxItem.userId,
   });
+  if (input.knownCheckpoint) {
+    await requireHostedRuntimeActiveAccess(mailboxItem.userId, {
+      code: "HOSTED_RUNTIME_USER_INACTIVE",
+      message: "Hosted runtime user is not active.",
+      prisma: input.prisma ?? getPrisma(),
+    });
+  }
 
   return signalHostedUserRuntimeWorkflow({
     abortSignal: input.abortSignal,
     client: input.client,
     environment: input.environment,
-    ensureWorkspace: true,
+    ensureWorkspace: input.knownCheckpoint === undefined,
     prisma: input.prisma,
     signal: parseHostedRuntimeSignal({
       kind: "mailbox_appended",
@@ -188,30 +163,6 @@ export async function signalHostedMailboxAppendRuntime(
     }),
     userId: mailboxItem.userId,
   });
-}
-
-export async function prepareHostedMailboxAppendRuntimeSignal(
-  input: PrepareHostedMailboxAppendRuntimeSignalInput,
-): Promise<PreparedHostedMailboxAppendRuntimeSignal> {
-  assertExpectedHostedMailboxOwner({
-    expectedUserId: input.expectedUserId ?? null,
-    mailboxItemUserId: input.knownCheckpoint.userId,
-  });
-  await requireHostedRuntimeActiveAccess(input.knownCheckpoint.userId, {
-    code: "HOSTED_RUNTIME_USER_INACTIVE",
-    message: "Hosted runtime user is not active.",
-    prisma: input.prisma ?? getPrisma(),
-  });
-
-  return {
-    signal: parseHostedRuntimeSignal({
-      kind: "mailbox_appended",
-      lane: input.knownCheckpoint.lane,
-      laneSeq: input.knownCheckpoint.laneSeq,
-      mailboxItemId: input.mailboxItemId,
-    }),
-    userId: input.knownCheckpoint.userId,
-  };
 }
 
 export async function signalHostedBrowserVaultRefreshRuntime(

--- a/apps/web/test/hosted-execution-handoff.test.ts
+++ b/apps/web/test/hosted-execution-handoff.test.ts
@@ -33,16 +33,11 @@ vi.mock("@/src/lib/hosted-execution/logging", () => ({
 }));
 
 const signalMocks = vi.hoisted(() => ({
-  prepareHostedMailboxAppendRuntimeSignal: vi.fn(),
   signalHostedMailboxAppendRuntime: vi.fn(),
-  signalHostedUserRuntimeWorkflow: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
-  prepareHostedMailboxAppendRuntimeSignal:
-    signalMocks.prepareHostedMailboxAppendRuntimeSignal,
   signalHostedMailboxAppendRuntime: signalMocks.signalHostedMailboxAppendRuntime,
-  signalHostedUserRuntimeWorkflow: signalMocks.signalHostedUserRuntimeWorkflow,
 }));
 
 const latencyStoreMocks = vi.hoisted(() => ({

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -131,12 +131,10 @@ const mocks = vi.hoisted(() => {
     sendHostedLinqChatMessage: vi.fn(),
     createHostedLinqChat: vi.fn(),
     sendHostedLinqReadReceipt: vi.fn(),
-    prepareHostedMailboxAppendRuntimeSignal: vi.fn(),
     signalHostedMailboxAppendRuntime: vi.fn(async () => ({
       signalAccepted: true,
       workflowId: "hosted-user-runtime:member_123",
     })),
-    signalHostedUserRuntimeWorkflow: vi.fn(),
     startHostedOnboardingTiming: vi.fn((step: string, baseDetails: Record<string, unknown> = {}) => ({
       baseDetails,
       startedAtMs: 0,
@@ -276,10 +274,7 @@ vi.mock("@/src/lib/hosted-onboarding/linq-first-contact-admission", async () => 
 });
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
-  prepareHostedMailboxAppendRuntimeSignal:
-    mocks.prepareHostedMailboxAppendRuntimeSignal,
   signalHostedMailboxAppendRuntime: mocks.signalHostedMailboxAppendRuntime,
-  signalHostedUserRuntimeWorkflow: mocks.signalHostedUserRuntimeWorkflow,
 }));
 
 vi.mock("../src/lib/hosted-onboarding/linq-client", async () => {

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -138,26 +138,11 @@ vi.mock("../src/lib/hosted-orchestration/signal-runtime", async (importOriginal)
   const actual = await importOriginal<typeof import("../src/lib/hosted-orchestration/signal-runtime")>();
   return {
     ...actual,
-    prepareHostedMailboxAppendRuntimeSignal: vi.fn(async (
-      input: Parameters<typeof actual.prepareHostedMailboxAppendRuntimeSignal>[0],
-    ) => ({
-      signal: {
-        kind: "mailbox_appended" as const,
-        lane: input.knownCheckpoint.lane,
-        laneSeq: input.knownCheckpoint.laneSeq,
-        mailboxItemId: input.mailboxItemId,
-      },
-      userId: input.knownCheckpoint.userId,
-    })),
     signalHostedMailboxAppendRuntime: vi.fn().mockResolvedValue({
       signalAccepted: true,
       workflowId: "workflow_group_123",
     }),
     signalHostedRuntimeMaintenanceRuntime: vi.fn(),
-    signalHostedUserRuntimeWorkflow: vi.fn().mockResolvedValue({
-      signalAccepted: true,
-      workflowId: "workflow_group_123",
-    }),
   };
 });
 
@@ -2964,7 +2949,8 @@ describe("Linq group chat auto-provision", () => {
         removedAt: null,
       },
     });
-    expect(signalRuntime.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledWith({
+    expect(signalRuntime.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: containerCreate.data.memberId,
       knownCheckpoint: {
         lane: "conversation",
@@ -2972,17 +2958,6 @@ describe("Linq group chat auto-provision", () => {
         userId: containerCreate.data.memberId,
       },
       mailboxItemId: "mailbox_group_123",
-    });
-    expect(signalRuntime.signalHostedUserRuntimeWorkflow).toHaveBeenCalledWith({
-      abortSignal: expect.any(AbortSignal),
-      ensureWorkspace: false,
-      signal: {
-        kind: "mailbox_appended",
-        lane: "conversation",
-        laneSeq: "1",
-        mailboxItemId: "mailbox_group_123",
-      },
-      userId: containerCreate.data.memberId,
     });
   });
 
@@ -3024,7 +2999,8 @@ describe("Linq group chat auto-provision", () => {
         reason: "wake-appended-thread-route",
       });
       expect(prisma.hostedThreadContainerParticipant.upsert).not.toHaveBeenCalled();
-      expect(signalRuntime.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledWith({
+      expect(signalRuntime.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+        abortSignal: expect.any(AbortSignal),
         expectedUserId: containerCreate.data.memberId,
         knownCheckpoint: {
           lane: "conversation",
@@ -3032,17 +3008,6 @@ describe("Linq group chat auto-provision", () => {
           userId: containerCreate.data.memberId,
         },
         mailboxItemId: "mailbox_group_123",
-      });
-      expect(signalRuntime.signalHostedUserRuntimeWorkflow).toHaveBeenCalledWith({
-        abortSignal: expect.any(AbortSignal),
-        ensureWorkspace: false,
-        signal: {
-          kind: "mailbox_appended",
-          lane: "conversation",
-          laneSeq: "1",
-          mailboxItemId: "mailbox_group_123",
-        },
-        userId: containerCreate.data.memberId,
       });
       expect(warn).toHaveBeenCalledWith(
         "Hosted thread-container participant reconcile skipped.",

--- a/apps/web/test/hosted-onboarding-linq-usage-reset-e2e.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-usage-reset-e2e.test.ts
@@ -108,12 +108,10 @@ const mocks = vi.hoisted(() => {
       startedAtMs: 0,
       step,
     })),
-    prepareHostedMailboxAppendRuntimeSignal: vi.fn(),
     signalHostedMailboxAppendRuntime: vi.fn(async () => ({
       signalAccepted: true,
       workflowId: "hosted-user-runtime:member_usage_reset",
     })),
-    signalHostedUserRuntimeWorkflow: vi.fn(),
     upsertHostedMemberHomeLinqBindingTx: vi.fn(async () => undefined),
   };
 
@@ -196,10 +194,7 @@ vi.mock("@/src/lib/hosted-runner/control", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
-  prepareHostedMailboxAppendRuntimeSignal:
-    mocks.prepareHostedMailboxAppendRuntimeSignal,
   signalHostedMailboxAppendRuntime: mocks.signalHostedMailboxAppendRuntime,
-  signalHostedUserRuntimeWorkflow: mocks.signalHostedUserRuntimeWorkflow,
 }));
 
 vi.mock("../src/lib/hosted-onboarding/linq", async () => {

--- a/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
@@ -52,12 +52,10 @@ const mocks = vi.hoisted(() => {
         usageGateDenied: false,
       };
     }),
-    prepareHostedMailboxAppendRuntimeSignal: vi.fn(),
     signalHostedMailboxAppendRuntime: vi.fn(async () => ({
       signalAccepted: true,
       workflowId: "hosted-user-runtime:member_123",
     })),
-    signalHostedUserRuntimeWorkflow: vi.fn(),
     materializePendingHostedGroupJoinConfirmationsBestEffort: vi.fn(async () => {}),
     provisionActiveHostedDomainRootEnvelopeForUserOnly: vi.fn(async () => ({})),
     readHostedMailboxItemByDedupeKey: vi.fn(async () => null),
@@ -172,10 +170,7 @@ vi.mock("@/src/lib/hosted-runner/assistant-nudge", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
-  prepareHostedMailboxAppendRuntimeSignal:
-    mocks.prepareHostedMailboxAppendRuntimeSignal,
   signalHostedMailboxAppendRuntime: mocks.signalHostedMailboxAppendRuntime,
-  signalHostedUserRuntimeWorkflow: mocks.signalHostedUserRuntimeWorkflow,
 }));
 
 vi.mock("@/src/lib/hosted-crypto/domain-root-store", async () => {

--- a/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
@@ -53,9 +53,7 @@ const mocks = vi.hoisted(() => ({
   }),
   nudgeHostedRunnerUserBestEffort: vi.fn(),
   nudgeHostedRunnerUserBestEffortResult: vi.fn(),
-  prepareHostedMailboxAppendRuntimeSignal: vi.fn(),
   signalHostedMailboxAppendRuntime: vi.fn(),
-  signalHostedUserRuntimeWorkflow: vi.fn(),
   upsertHostedMemberHomeLinqBindingTx: vi.fn(),
   upsertHostedMemberPendingLinqBindingTx: vi.fn(),
   verifyAndParseHostedLinqWebhookRequest: vi.fn(),
@@ -90,10 +88,7 @@ vi.mock("@/src/lib/hosted-execution/usage-allowance", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
-  prepareHostedMailboxAppendRuntimeSignal:
-    mocks.prepareHostedMailboxAppendRuntimeSignal,
   signalHostedMailboxAppendRuntime: mocks.signalHostedMailboxAppendRuntime,
-  signalHostedUserRuntimeWorkflow: mocks.signalHostedUserRuntimeWorkflow,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/invite-service", () => ({

--- a/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
@@ -8,13 +8,11 @@ import {
 
 const mocks = vi.hoisted(() => ({
   ensureRuntimeProcessing: vi.fn(),
-  prepareHostedMailboxAppendRuntimeSignal: vi.fn(),
   readHostedExecutionControlClientIfConfigured: vi.fn(),
   recordHostedIngressAcceptedFromMailboxItem: vi.fn(async () => undefined),
   recordHostedIngressDirectEnsureTiming: vi.fn(async () => undefined),
   recordHostedIngressTemporalSignalAccepted: vi.fn(async () => undefined),
   signalHostedMailboxAppendRuntime: vi.fn(),
-  signalHostedUserRuntimeWorkflow: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-execution/control", () => ({
@@ -23,10 +21,7 @@ vi.mock("@/src/lib/hosted-execution/control", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
-  prepareHostedMailboxAppendRuntimeSignal:
-    mocks.prepareHostedMailboxAppendRuntimeSignal,
   signalHostedMailboxAppendRuntime: mocks.signalHostedMailboxAppendRuntime,
-  signalHostedUserRuntimeWorkflow: mocks.signalHostedUserRuntimeWorkflow,
 }));
 
 vi.mock("@/src/lib/hosted-runtime-latency/store", () => ({
@@ -47,16 +42,6 @@ const response = {
   ok: true,
   reason: "wake-appended-active-member",
 } as never;
-
-const preparedMailboxSignal = {
-  signal: {
-    kind: "mailbox_appended",
-    lane: "conversation",
-    laneSeq: "42",
-    mailboxItemId: "mailbox_123",
-  },
-  userId: "member_123",
-};
 
 type DirectEnsureInput = {
   onTiming: (timing: {
@@ -86,14 +71,7 @@ function buildWakeHandoff(
 describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.prepareHostedMailboxAppendRuntimeSignal.mockResolvedValue(
-      preparedMailboxSignal,
-    );
     mocks.signalHostedMailboxAppendRuntime.mockResolvedValue({
-      signalAccepted: true,
-      workflowId: "hosted-user-runtime:member_123",
-    });
-    mocks.signalHostedUserRuntimeWorkflow.mockResolvedValue({
       signalAccepted: true,
       workflowId: "hosted-user-runtime:member_123",
     });
@@ -108,20 +86,14 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     });
   });
 
-  it("lets direct ensure finish before delayed Temporal acceptance after preparation", async () => {
+  it("starts the direct ensure only after Temporal accepts the durable signal", async () => {
     const afterResponseTasks: Array<() => Promise<void>> = [];
     const wakeOrder: string[] = [];
-    let resolvePreparation!: (value: typeof preparedMailboxSignal) => void;
     let resolveTemporalSignal!: (value: {
       signalAccepted: true;
       workflowId: string;
     }) => void;
-    mocks.prepareHostedMailboxAppendRuntimeSignal.mockImplementationOnce(() =>
-      new Promise((resolve) => {
-        resolvePreparation = resolve;
-      })
-    );
-    mocks.signalHostedUserRuntimeWorkflow.mockImplementationOnce(() => {
+    mocks.signalHostedMailboxAppendRuntime.mockImplementationOnce(() => {
       wakeOrder.push("temporal");
       return new Promise((resolve) => {
         resolveTemporalSignal = resolve;
@@ -161,29 +133,11 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     );
 
     await vi.waitFor(() => {
-      expect(mocks.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledTimes(1);
+      expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
     });
-    expect(mocks.signalHostedUserRuntimeWorkflow).not.toHaveBeenCalled();
     expect(mocks.readHostedExecutionControlClientIfConfigured).not.toHaveBeenCalled();
     expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
     expect(afterResponseTasks).toHaveLength(0);
-    expect(handoffSettled).toBe(false);
-
-    resolvePreparation(preparedMailboxSignal);
-    await vi.waitFor(() => {
-      expect(mocks.signalHostedUserRuntimeWorkflow).toHaveBeenCalledTimes(1);
-      expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledTimes(1);
-      expect(afterResponseTasks).toHaveLength(1);
-    });
-    expect(handoffSettled).toBe(false);
-    expect(wakeOrder).toEqual(["temporal", "direct"]);
-
-    // Recreate the ordering that exposed the historical duplicate-reply
-    // window: direct processing may finish while Temporal acceptance is still
-    // pending. The durable signal must remain mandatory, but it must not hold
-    // the latency-only direct request behind it.
-    await Promise.all(afterResponseTasks.map((task) => task()));
-    expect(mocks.recordHostedIngressDirectEnsureTiming).toHaveBeenCalledTimes(1);
     expect(handoffSettled).toBe(false);
 
     resolveTemporalSignal({
@@ -197,13 +151,16 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       workflowId: "hosted-user-runtime:member_123",
     });
 
+    expect(handoffSettled).toBe(true);
+    expect(wakeOrder).toEqual(["temporal", "direct"]);
     expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledTimes(1);
     expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledWith({
       onTiming: expect.any(Function),
       orchestrationAttemptId: expect.stringMatching(/^web-ingress-[0-9a-f-]{36}$/u),
       userId: "member_123",
     });
-    expect(mocks.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledWith({
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_123",
       knownCheckpoint: {
         lane: "conversation",
@@ -212,12 +169,7 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       },
       mailboxItemId: "mailbox_123",
     });
-    expect(mocks.signalHostedUserRuntimeWorkflow).toHaveBeenCalledWith({
-      abortSignal: expect.any(AbortSignal),
-      ensureWorkspace: false,
-      signal: preparedMailboxSignal.signal,
-      userId: "member_123",
-    });
+    await Promise.all(afterResponseTasks.map((task) => task()));
     expect(mocks.recordHostedIngressDirectEnsureTiming).toHaveBeenCalledWith({
       expectedUserId: "member_123",
       mailboxItemId: "mailbox_123",
@@ -297,8 +249,7 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       signalAccepted: true,
     });
 
-    expect(mocks.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledTimes(1);
-    expect(mocks.signalHostedUserRuntimeWorkflow).toHaveBeenCalledTimes(1);
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => {
       expect(consoleWarn).toHaveBeenCalledWith(
@@ -323,8 +274,7 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       signalAccepted: true,
     });
 
-    expect(mocks.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledTimes(1);
-    expect(mocks.signalHostedUserRuntimeWorkflow).toHaveBeenCalledTimes(1);
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledTimes(1);
     expect(consoleWarn).toHaveBeenCalledWith(
       "Hosted direct ensure wake failed.",
@@ -346,7 +296,7 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     });
 
     expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledTimes(1);
-    expect(mocks.signalHostedUserRuntimeWorkflow).toHaveBeenCalledTimes(1);
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
   });
 
   it("skips the direct ensure for non-Linq sources even with checkpoint facts", async () => {
@@ -364,22 +314,21 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
   });
 
-  it("starts the direct ensure but still rejects when the Temporal signal throws", async () => {
+  it("does not start the direct ensure when the Temporal signal fails", async () => {
     mocks.ensureRuntimeProcessing.mockReturnValue(new Promise(() => undefined));
-    mocks.signalHostedUserRuntimeWorkflow.mockRejectedValue(new Error("temporal down"));
+    mocks.signalHostedMailboxAppendRuntime.mockRejectedValue(new Error("temporal down"));
 
     await expect(maybeHandoffHostedExecutionWebhookWake({
       response,
       wakeHandoff: buildWakeHandoff(),
     })).rejects.toThrow("temporal down");
 
-    expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledTimes(1);
-    expect(mocks.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledTimes(1);
-    expect(mocks.signalHostedUserRuntimeWorkflow).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
   });
 
-  it("starts neither wake when participant-aware preparation denies access", async () => {
-    mocks.prepareHostedMailboxAppendRuntimeSignal.mockRejectedValue(
+  it("starts no direct wake when participant-aware signaling denies access", async () => {
+    mocks.signalHostedMailboxAppendRuntime.mockRejectedValue(
       new Error("Hosted runtime user is not active."),
     );
 
@@ -388,14 +337,12 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       wakeHandoff: buildWakeHandoff(),
     })).rejects.toThrow("Hosted runtime user is not active.");
 
-    expect(mocks.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledTimes(1);
-    expect(mocks.signalHostedUserRuntimeWorkflow).not.toHaveBeenCalled();
-    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.readHostedExecutionControlClientIfConfigured).not.toHaveBeenCalled();
     expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
   });
 
-  it("proceeds to the Temporal signal when the control client setup throws synchronously", async () => {
+  it("keeps the accepted Temporal handoff when control client setup throws synchronously", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mocks.readHostedExecutionControlClientIfConfigured.mockImplementation(() => {
       throw new TypeError("Hosted execution baseUrl must be configured.");
@@ -406,7 +353,7 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       wakeHandoff: buildWakeHandoff(),
     })).resolves.toMatchObject({ signalAccepted: true });
 
-    expect(mocks.signalHostedUserRuntimeWorkflow).toHaveBeenCalledTimes(1);
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
     expect(consoleWarn).toHaveBeenCalledWith(
       "Hosted direct ensure wake client is misconfigured.",
       expect.objectContaining({ source: "linq" }),
@@ -467,7 +414,7 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
   it("bounds an omitted-timeout Temporal handoff that never settles", async () => {
     vi.useFakeTimers();
     try {
-      mocks.signalHostedUserRuntimeWorkflow.mockReturnValueOnce(new Promise(() => {}));
+      mocks.signalHostedMailboxAppendRuntime.mockReturnValueOnce(new Promise(() => {}));
 
       const handoff = maybeHandoffHostedExecutionWebhookWake({
         response,
@@ -477,19 +424,22 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       await vi.advanceTimersByTimeAsync(5_000);
 
       await rejected;
-      expect(mocks.ensureRuntimeProcessing).toHaveBeenCalledTimes(1);
+      expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("starts neither wake when preparation resolves after the shared timeout", async () => {
+  it("does not start a direct wake when Temporal resolves after the shared timeout", async () => {
     vi.useFakeTimers();
     try {
-      let resolvePreparation!: (value: typeof preparedMailboxSignal) => void;
-      mocks.prepareHostedMailboxAppendRuntimeSignal.mockReturnValueOnce(
+      let resolveTemporalSignal!: (value: {
+        signalAccepted: true;
+        workflowId: string;
+      }) => void;
+      mocks.signalHostedMailboxAppendRuntime.mockReturnValueOnce(
         new Promise((resolve) => {
-          resolvePreparation = resolve;
+          resolveTemporalSignal = resolve;
         }),
       );
 
@@ -501,14 +451,15 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       await vi.advanceTimersByTimeAsync(5_000);
 
       await rejected;
-      expect(mocks.prepareHostedMailboxAppendRuntimeSignal).toHaveBeenCalledTimes(1);
-      expect(mocks.signalHostedUserRuntimeWorkflow).not.toHaveBeenCalled();
+      expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
       expect(mocks.readHostedExecutionControlClientIfConfigured).not.toHaveBeenCalled();
       expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
 
-      resolvePreparation(preparedMailboxSignal);
+      resolveTemporalSignal({
+        signalAccepted: true,
+        workflowId: "hosted-user-runtime:member_123",
+      });
       await vi.advanceTimersByTimeAsync(0);
-      expect(mocks.signalHostedUserRuntimeWorkflow).not.toHaveBeenCalled();
       expect(mocks.readHostedExecutionControlClientIfConfigured).not.toHaveBeenCalled();
       expect(mocks.ensureRuntimeProcessing).not.toHaveBeenCalled();
     } finally {

--- a/apps/web/test/hosted-orchestration-signal-runtime.test.ts
+++ b/apps/web/test/hosted-orchestration-signal-runtime.test.ts
@@ -67,7 +67,6 @@ vi.mock("@/src/lib/hosted-orchestration/runtime-usage-decision", () => ({
 }));
 
 import {
-  prepareHostedMailboxAppendRuntimeSignal,
   signalHostedBrowserVaultRefreshRuntime,
   signalHostedDeviceSyncMailboxRuntime,
   signalHostedMailboxAppendRuntime,
@@ -198,7 +197,7 @@ describe("hosted runtime Temporal signaling", () => {
     );
   });
 
-  it("prepares planner lane facts for participant-authorized thread containers without signaling", async () => {
+  it("signals planner lane facts for participant-authorized thread containers", async () => {
     mocks.hostedMemberFindUnique.mockResolvedValue(buildActiveMemberRecord({
       billingStatus: "canceled",
       threadContainer: {
@@ -213,7 +212,8 @@ describe("hosted runtime Temporal signaling", () => {
       participantMemberId: "member_active_participant",
     });
 
-    await expect(prepareHostedMailboxAppendRuntimeSignal({
+    await expect(signalHostedMailboxAppendRuntime({
+      client: buildClient(),
       expectedUserId: "member_123",
       knownCheckpoint: {
         lane: "conversation",
@@ -222,21 +222,27 @@ describe("hosted runtime Temporal signaling", () => {
       },
       mailboxItemId: "mailbox_123",
     })).resolves.toEqual({
-      signal: {
-        kind: "mailbox_appended",
-        lane: "conversation",
-        laneSeq: "42",
-        mailboxItemId: "mailbox_123",
-      },
-      userId: "member_123",
+      signalAccepted: true,
+      workflowId: "hosted-user-runtime:member_123",
     });
 
     expectHostedRuntimeActiveAccessRead(mocks.hostedMemberFindUnique, "member_123");
     expect(mocks.hostedThreadContainerParticipantFindFirst).toHaveBeenCalledTimes(1);
-    expect(mocks.signalWithStart).not.toHaveBeenCalled();
+    expect(mocks.signalWithStart).toHaveBeenCalledWith(
+      HOSTED_USER_RUNTIME_WORKFLOW_TYPE,
+      expect.objectContaining({
+        signalArgs: [{
+          kind: "mailbox_appended",
+          lane: "conversation",
+          laneSeq: "42",
+          mailboxItemId: "mailbox_123",
+        }],
+        workflowId: "hosted-user-runtime:member_123",
+      }),
+    );
   });
 
-  it("does not prepare planner lane facts without active owner or participant access", async () => {
+  it("does not signal planner lane facts without active owner or participant access", async () => {
     mocks.hostedMemberFindUnique.mockResolvedValue(buildActiveMemberRecord({
       billingStatus: "canceled",
       threadContainer: {
@@ -248,7 +254,8 @@ describe("hosted runtime Temporal signaling", () => {
       },
     }));
 
-    await expect(prepareHostedMailboxAppendRuntimeSignal({
+    await expect(signalHostedMailboxAppendRuntime({
+      client: buildClient(),
       expectedUserId: "member_123",
       knownCheckpoint: {
         lane: "conversation",


### PR DESCRIPTION
## Why

PR #749 let the best-effort direct Cloudflare wake begin while the required Temporal signal was still pending. In the post-deploy sample, that produced only a 33 ms median and 86 ms p95 request-start lead across 14 comparable traces. Warm Temporal-accepted-to-provider-start latency was effectively unchanged at 2,365 ms before versus 2,362 ms after, with only three post-deploy warm samples. That does not justify the extra concurrent partial-failure state.

## User-visible goal

Keep the direct Linq runner wake as a latency hint, but restore Temporal durable acceptance as the ordering boundary. The expected tradeoff is roughly 30 to 90 ms of scheduling lead, with no demonstrated end-to-end provider-start loss.

## Invariants

- Temporal remains the sole durable wake and reconciliation authority.
- The direct wake remains Linq-only, known-checkpoint-gated, fire-and-forget, and best effort.
- Access denial, expiry, Temporal failure, or handoff timeout starts no direct wake.
- Direct Cloudflare failure cannot invalidate an accepted Temporal handoff.
- PR #383 consumedAt and replay protections remain intact; this does not remove the direct wake.
- The independent reaction-only consumedAt gap predates #749 and is deliberately excluded because correcting it changes generic persisted outbox retry semantics and deserves a separate review boundary.

## What changed

- Route the known-checkpoint path back through the single signalHostedMailboxAppendRuntime owner.
- Await Temporal signalWithStart acceptance before starting direct ensure-processing.
- Delete the prepare-plus-manual-signal split and its mock plumbing.
- Retain stronger tests for pending Temporal, failure, access denial, timeout, late resolution, and direct-wake failure isolation.
- Update durable architecture and runtime-protocol docs.

## Verification

- 8 focused web files: 275 tests passed.
- Coverage-write: 43 owner tests passed; 93.28% statements, 85.86% branches, 100% functions, 93.15% lines; no finding.
- Web TypeScript 7 typecheck passed.
- Next production build passed.
- ESLint passed with 0 errors.
- Prepared-local-env dev smoke passed in isolated rerun.
- The only full-lane test timeout was an unrelated dynamic-import hook under concurrent load; its isolated rerun passed 11/11.
- Repository dependency, workspace-boundary, Temporal, crypto, stale-runtime, and raw-log guards passed.

## Change shape

- Source: +46 / -118
- Tests: +58 / -160
- Docs/process: +70 / -22
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
- Total: +174 / -300

## Deployment

Web-only ordering change. No Cloudflare tandem deploy or compatibility window is required.

## ReviewGPT baseline

ReviewGPT first-reviewed head: f6ef1235e37175ae6b5bdc1ce5e6579f50736349

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786820231&installation_id=127572939&pr_number=754&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F754&signature=b119024d5311361eaac1193ec47a434a5cbbbd92bb484ec2d14cf2d6d0fd699f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
