### PR TITLE
feat(hosted): add provider-turn latency boundaries

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-provider-turn-latency-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-provider-turn-latency-telemetry.md
@@ -1,0 +1,108 @@
+# Hosted Provider-Turn Latency Telemetry
+
+Status: completed
+Updated: 2026-07-16
+
+## Why
+
+A production warm-runtime trace measured 5,648 ms between the local Codex
+`turn/start` boundary and provider completion, with the first local output at
+5,569 ms. Existing hosted milestones cannot determine how much of that interval
+belongs to the Murph-to-App-Server handoff versus provider execution. The
+current App Server protocol does not expose upstream dispatch, response-header,
+or first-byte boundaries, so better local metadata is needed before changing
+provider or runtime behavior.
+
+## Outcome
+
+Extend the existing hosted turn-timing telemetry with the smallest truthful
+content-free boundaries already emitted by Codex App Server. The added fields
+must let operators separate locally observable handoff/stream phases without
+adding awaited I/O or size-dependent work, or claiming upstream phases that the
+current protocol does not expose.
+
+## Invariants
+
+- No new foreground await, synchronous request, network call, database write,
+  body buffering, stream transformation, dependency, or persisted state class.
+- No prompt, transcript, model output, request/response body, identifier, token,
+  URL, filesystem path, or other content in telemetry.
+- New values are bounded numeric durations, booleans, or closed enums parsed by
+  the existing strict schema and emitted only through the existing best-effort
+  runtime-log path.
+- Telemetry adds only constant-time timestamp/property bookkeeping at existing
+  local RPC boundaries. Missing optional timing metadata degrades only
+  observability.
+- Do not invent a boundary. If Codex exposes no truthful upstream dispatch or
+  first-byte event, report that limitation and instrument only the nearest
+  existing observable ownership transitions.
+
+## Scope
+
+- Inspect the Codex App Server protocol adapter and the Worker provider-egress
+  interceptor before selecting fields.
+- Extend only the existing assistant event and hosted runtime log
+  contracts needed for the selected boundaries.
+- Add focused package regression proof for strict redaction/schema parsing and no
+  foreground await or delivery-order regression.
+- Update the owning runtime/observability docs when the field contract changes.
+
+## Steps
+
+1. Trace `turn/start` through App Server output and Worker provider egress;
+   inventory which metadata-only timestamps are already observable.
+2. Choose the smallest owner-correct timing extension and record its limits.
+3. Implement strict parsing plus queued best-effort emission without new I/O.
+4. Add focused package coverage and direct ordering proof.
+5. Run truthful diff/owner verification, required `coverage-write`, parent final
+   review, scoped plan-closing commit, and open a draft PR.
+6. Start ReviewGPT on the exact pushed head concurrently with PR CI; address
+   accepted findings without broadening the architecture.
+
+## Design Chosen
+
+- Add assign-once, cumulative local offsets to the existing App Server
+  `turn-completed` timing trace, joined by the existing provider-request
+  ordinal. The offsets cover local `turn/start` acknowledgement, the App Server
+  `turn/started` and `turn/completed` notifications, and completion-trace
+  emission after local drains. Existing attempt-bound assistant milestones
+  remain the source of truth for first local output/text.
+- Do not inspect WebSocket frames or mediate response bodies. Existing GET/101
+  logs describe only the WebSocket handshake and cannot be durably joined to a
+  turn, so they are documented as coarse supporting evidence rather than a
+  provider-generation boundary.
+
+## Verification
+
+- Focused tests for each changed parser/event/log owner during iteration.
+- `pnpm test:diff <touched paths>` when its selected owner coverage is truthful;
+  otherwise the required owner coverage commands from the verification map.
+- Static and behavioral proof that telemetry adds no awaited I/O, network call,
+  body mediation, size-dependent work, or delivery-order dependency. Only
+  constant-time timing and strict field allowlisting run on existing paths.
+- `git diff --check`, privacy/redaction inspection, base-to-head scope review,
+  and exact-head PR/mergeability checks.
+
+## Results
+
+- Exact-head focused App Server telemetry test: passed.
+- Exact-head reverse-order/assign-once timing test: passed.
+- Exact-head hosted runtime parser/redaction suite: 33 passed.
+- Assistant-engine and assistant-runtime typechecks: passed.
+- Required coverage-write, security/privacy, simplify, and task-finish audits:
+  zero unresolved findings after remediation.
+- `pnpm test:diff` passed guards and all six affected typechecks, then failed in
+  reverse-dependent package tests under severe machine contention. Unrelated
+  setup-cli targets hit their 5-second limits in isolation; with a 30-second
+  override one passed and the other timed out after 30.3 seconds following a
+  120-second import. No changed-owner failure reproduced.
+- `git diff --check`, stale-field search, privacy review, and exact base
+  alignment passed.
+
+## Deployment Concerns
+
+The assistant-engine producer and assistant-runtime parser ship in the same
+runner bundle. Every new field remains optional and unknown or absent metadata
+is ignored, so no coordinated Worker/Web deployment or schema migration is
+required.
+Completed: 2026-07-16

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -525,16 +525,39 @@ conversation controls, not a second queue or a generic mailbox-lag scheduler.
 Other missed post-commit signals still have no web cron backstop.
 
 Hosted reply-latency telemetry records only boundaries observed by their owning
-process. The web-owned `provider_started` field means the runtime observed a
-local Codex `turn/start`; it is not evidence of an upstream OpenAI request or
-first token. The runtime may also emit metadata-only `assistant_milestone`
-events for Linq typing request start/acceptance and the first locally observed
-Codex output/text. Web accepts those milestones only for the exact staged
-runtime attempt and merges them into the existing phase document under a row
-lock. Emission is queued off the reply path and may retry only the bounded
-staging/trace-row race; it carries no message, prompt, response, reasoning, or
-provider payload. Post-generation delivery guards must never create or
-overwrite the local Codex start milestone.
+process. Its ingress `acceptedAt` value copies the mailbox row's PostgreSQL
+`created_at`; because that default uses transaction-start time, the interval
+from `acceptedAt` includes the remainder of the append transaction and must not
+be labeled row-insert or commit latency. The web-owned `provider_started` field
+means the runtime observed a local Codex `turn/start`; it is not evidence of an
+upstream OpenAI request or first token. The runtime may also emit metadata-only
+`assistant_milestone` events for Linq typing request start/acceptance and the
+first locally observed Codex output/text. Web accepts those milestones only for
+the exact staged runtime attempt and merges them into the existing phase
+document under a row lock. Emission is queued off the reply path and may retry
+only the bounded staging/trace-row race; it carries no message, prompt,
+response, reasoning, or provider payload. Post-generation delivery guards must
+never create or overwrite the local Codex start milestone.
+
+The existing App Server `turn-completed` diagnostic additionally carries
+cumulative, assign-once local offsets from that `turn/start` write to the local
+RPC acknowledgement, the `turn/started` notification that proves Codex core
+began the turn task, the completion notification, and completion-trace emission
+after local drains. The RPC acknowledgement and `turn/started` notification are
+independent deliveries and have no guaranteed arrival order. Its provider
+request ordinal joins those offsets to the existing provider-result and
+reply-dispatched timing entries for the same wake; the existing assistant
+milestones remain the source of truth for first local output/text. The total
+completion offset ends after local dynamic-tool/progress drains; the outer
+provider-result boundary remains the separate assistant turn-timing entry. None
+of these fields is an upstream request-start, response-header, or first-token
+boundary. The offsets retain the existing same-process `Date.now()` clock
+semantics, clamp negative values to zero, and must not be used for strict
+ordering assertions if the wall clock moves during a turn. The existing
+Cloudflare provider-egress GET/101 durations end at the Responses WebSocket
+upgrade handshake; per-turn metadata and generation events live inside frames
+that the interceptor deliberately does not inspect, so those egress logs must
+not be interpreted as model latency or a durable attempt/turn join.
 
 Runner-to-Worker legacy artifact reads carry one fixed-vocabulary purpose and
 one UUID correlation id per logical fetch; retries retain that same id. Both

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -2796,6 +2796,10 @@ async function runCodexAppServerTurnOnProcess(
   let lastTimingAt = Date.now()
   const codexAppServerTurnStartedAt = lastTimingAt
   const codexAppServerProviderStartTiming: AssistantProviderRequestStartTiming = {}
+  let codexProviderRequestStartedAtMs: number | null = null
+  let codexTimingTurnStartAckElapsedMs: number | null = null
+  let codexTimingTurnStartedNotificationElapsedMs: number | null = null
+  let codexTimingTurnCompletedNotificationElapsedMs: number | null = null
   let liveInterruptRequested = false
 
   let completeTurn: (() => void) | null = null
@@ -3007,6 +3011,34 @@ async function runCodexAppServerTurnOnProcess(
           codexTimingStage: stage,
           codexTimingTotalElapsedMs: codexProcess.processLifetimeMs,
           codexTimingTurnIdPresent: turnId !== null,
+          ...(stage === 'turn-completed' && codexProviderRequestStartedAtMs !== null
+            ? {
+                // Every cumulative field below is measured from the local
+                // turn/start request write. These are App Server/runtime
+                // boundaries, not upstream provider request or SSE timing.
+                ...(typeof input.providerRequestOrdinal === 'number'
+                  ? { codexTimingProviderRequestOrdinal: input.providerRequestOrdinal }
+                  : {}),
+                // This ends when the completion trace is emitted after local
+                // dynamic-tool/progress drains. The outer provider-result
+                // boundary is recorded separately by assistant.turn.timing.
+                codexTimingTurnCompleteElapsedMs: Math.max(
+                  0,
+                  now - codexProviderRequestStartedAtMs,
+                ),
+                ...(codexTimingTurnStartAckElapsedMs === null
+                  ? {}
+                  : { codexTimingTurnStartAckElapsedMs }),
+                ...(codexTimingTurnStartedNotificationElapsedMs === null
+                  ? {}
+                  : { codexTimingTurnStartedNotificationElapsedMs }),
+                ...(codexTimingTurnCompletedNotificationElapsedMs === null
+                  ? {}
+                  : {
+                      codexTimingTurnCompletedNotificationElapsedMs,
+                    }),
+              }
+            : {}),
         },
         updates: [],
       })
@@ -3244,6 +3276,7 @@ async function runCodexAppServerTurnOnProcess(
     }
     providerRequestStartedNotified = true
     const startedAtMs = Date.now()
+    codexProviderRequestStartedAtMs = startedAtMs
     notifyCodexAppServerProviderRequestStartedBestEffort({
       hook: input.onProviderRequestStarted ?? null,
       startedAt: new Date(startedAtMs).toISOString(),
@@ -3892,6 +3925,36 @@ async function runCodexAppServerTurnOnProcess(
     method: string | null,
   ): void => {
     acceptJsonEvent(message)
+    const providerRequestStartedAtMs = codexProviderRequestStartedAtMs
+    const isTurnStartedNotification = isCodexTurnStartedMethod(method)
+    const isTurnCompletedNotification = isCodexTurnCompletedMethod(method)
+    const shouldCaptureTurnStartedNotification =
+      providerRequestStartedAtMs !== null &&
+      isTurnStartedNotification &&
+      codexTimingTurnStartedNotificationElapsedMs === null
+    const shouldCaptureTurnCompletedNotification =
+      providerRequestStartedAtMs !== null &&
+      isTurnCompletedNotification &&
+      codexTimingTurnCompletedNotificationElapsedMs === null
+    if (
+      providerRequestStartedAtMs !== null &&
+      (shouldCaptureTurnStartedNotification ||
+        shouldCaptureTurnCompletedNotification)
+    ) {
+      const observedAtMs = Date.now()
+      if (shouldCaptureTurnStartedNotification) {
+        codexTimingTurnStartedNotificationElapsedMs = Math.max(
+          0,
+          observedAtMs - providerRequestStartedAtMs,
+        )
+      }
+      if (shouldCaptureTurnCompletedNotification) {
+        codexTimingTurnCompletedNotificationElapsedMs = Math.max(
+          0,
+          observedAtMs - providerRequestStartedAtMs,
+        )
+      }
+    }
     for (const receiverThreadId of readCodexCollabReceiverThreadIds(message)) {
       collabReceiverThreadIds.add(receiverThreadId)
     }
@@ -4024,12 +4087,12 @@ async function runCodexAppServerTurnOnProcess(
       }
     }
 
-    if (isCodexTurnStartedMethod(method)) {
+    if (isTurnStartedNotification) {
       notifyProviderRequestStarted()
       registerLiveTurn()
     }
 
-    if (!isCodexTurnCompletedMethod(method)) {
+    if (!isTurnCompletedNotification) {
       return
     }
 
@@ -4169,6 +4232,15 @@ async function runCodexAppServerTurnOnProcess(
         return
       }
       if (pending?.method === 'turn/start') {
+        if (
+          codexProviderRequestStartedAtMs !== null &&
+          codexTimingTurnStartAckElapsedMs === null
+        ) {
+          codexTimingTurnStartAckElapsedMs = Math.max(
+            0,
+            Date.now() - codexProviderRequestStartedAtMs,
+          )
+        }
         const resultTurnId = extractCodexTurnIdFromResult(message.result)
         acceptTurnStartResultTurnId(resultTurnId)
       }

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -1166,6 +1166,7 @@ describe('assistant codex runtime', () => {
         model: 'gpt-5',
         modelProvider: 'vercel-ai-gateway',
         reasoningEffort: 'high',
+        providerRequestOrdinal: 3,
         prompt: 'Explain this',
         sandbox: 'workspace-write',
         workingDirectory,
@@ -1232,16 +1233,21 @@ describe('assistant codex runtime', () => {
         ],
       }),
     )
-    expect(onTraceEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rawEvent: expect.objectContaining({
-          codexTimingStage: 'turn-completed',
-          schema: 'murph.assistant-codex-app-server-timing.v1',
-          type: 'assistant.codex.app_server_timing',
-        }),
-        updates: [],
-      }),
-    )
+    const turnCompletedTiming = onTraceEvent.mock.calls
+      .map(([event]) => event?.rawEvent)
+      .find((event) =>
+        event?.type === 'assistant.codex.app_server_timing' &&
+        event.codexTimingStage === 'turn-completed'
+      )
+    expect(turnCompletedTiming).toEqual(expect.objectContaining({
+      codexTimingProviderRequestOrdinal: 3,
+      codexTimingTurnCompleteElapsedMs: expect.any(Number),
+      codexTimingTurnCompletedNotificationElapsedMs: expect.any(Number),
+      codexTimingTurnStartAckElapsedMs: expect.any(Number),
+      codexTimingTurnStartedNotificationElapsedMs: expect.any(Number),
+      schema: 'murph.assistant-codex-app-server-timing.v1',
+      type: 'assistant.codex.app_server_timing',
+    }))
     expect(onTraceEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         rawEvent: expect.objectContaining({
@@ -5624,6 +5630,13 @@ describe('assistant codex runtime', () => {
   it('trusts tagged turn/started when the turn/start response omits the turn id', async () => {
     const workingDirectory = await createTempDir('assistant-codex-local-prestart-tagged-work-')
     const codexHome = await createTempDir('assistant-codex-local-prestart-tagged-home-')
+    const realDateNow = Date.now.bind(Date)
+    let controlledNowMs: number | null = null
+    vi.spyOn(Date, 'now').mockImplementation(
+      () => controlledNowMs ?? realDateNow(),
+    )
+    const onProviderRequestStarted = vi.fn()
+    const onTraceEvent = vi.fn()
     const spawnedChildren: MockChildProcess[] = []
     mockProcessGroupSignalsForChildren(spawnedChildren)
 
@@ -5663,6 +5676,11 @@ describe('assistant codex runtime', () => {
             },
           }))
           const secondTurn = await waitForRpcMethodCount(child, 'turn/start', 2)
+          const secondProviderStartedAtMs = Date.parse(
+            onProviderRequestStarted.mock.calls.at(-1)?.[0]?.startedAt ?? '',
+          )
+          expect(Number.isFinite(secondProviderStartedAtMs)).toBe(true)
+          controlledNowMs = secondProviderStartedAtMs + 10
           child.stdout.write(jsonLine({
             method: 'turn/started',
             params: {
@@ -5671,10 +5689,21 @@ describe('assistant codex runtime', () => {
               },
             },
           }))
+          controlledNowMs = secondProviderStartedAtMs + 20
+          child.stdout.write(jsonLine({
+            method: 'turn/started',
+            params: {
+              turn: {
+                id: 'turn-local-prestart-tagged-2',
+              },
+            },
+          }))
+          controlledNowMs = secondProviderStartedAtMs + 30
           child.stdout.write(jsonLine({
             id: secondTurn.id,
             result: {},
           }))
+          controlledNowMs = secondProviderStartedAtMs + 40
           child.stdout.write(jsonLine({
             method: 'assistant.message.delta',
             params: {
@@ -5686,6 +5715,7 @@ describe('assistant codex runtime', () => {
               turnId: 'turn-local-prestart-tagged-2',
             },
           }))
+          controlledNowMs = secondProviderStartedAtMs + 50
           child.stdout.write(jsonLine({
             method: 'turn/completed',
             params: {
@@ -5707,6 +5737,8 @@ describe('assistant codex runtime', () => {
       env: {
         PATH: '/custom/bin',
       },
+      onProviderRequestStarted,
+      onTraceEvent,
       sandbox: 'workspace-write' as const,
       workingDirectory,
     }
@@ -5724,6 +5756,7 @@ describe('assistant codex runtime', () => {
     await expect(
       executeCodexAppServerTurn({
         ...stableInput,
+        providerRequestOrdinal: 7,
         prompt: 'second local turn with tagged prestart turn/started',
       }),
     ).resolves.toMatchObject({
@@ -5731,6 +5764,22 @@ describe('assistant codex runtime', () => {
       sessionId: 'thread-local-prestart-tagged-2',
       turnId: 'turn-local-prestart-tagged-2',
     })
+    controlledNowMs = null
+
+    const secondTurnCompletedTiming = onTraceEvent.mock.calls
+      .map(([event]) => event?.rawEvent)
+      .filter((event) =>
+        event?.type === 'assistant.codex.app_server_timing' &&
+        event.codexTimingStage === 'turn-completed'
+      )
+      .at(-1)
+    expect(secondTurnCompletedTiming).toEqual(expect.objectContaining({
+      codexTimingProviderRequestOrdinal: 7,
+      codexTimingTurnCompleteElapsedMs: 50,
+      codexTimingTurnCompletedNotificationElapsedMs: 50,
+      codexTimingTurnStartAckElapsedMs: 30,
+      codexTimingTurnStartedNotificationElapsedMs: 10,
+    }))
   })
 
   it('accepts tagged warm server requests after turn/started establishes the current turn', async () => {

--- a/packages/assistant-runtime/src/hosted-runtime/events/provider-trace-log.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/provider-trace-log.ts
@@ -992,6 +992,21 @@ function readHostedAssistantCodexAppServerTimingTrace(
     "codexTimingProviderActionCount",
     readHostedAssistantProviderDiagnosticNonnegativeNumber(record, "codexTimingProviderActionCount"),
   );
+  if (stage === "turn-completed") {
+    for (const key of [
+      "codexTimingProviderRequestOrdinal",
+      "codexTimingTurnStartAckElapsedMs",
+      "codexTimingTurnStartedNotificationElapsedMs",
+      "codexTimingTurnCompletedNotificationElapsedMs",
+      "codexTimingTurnCompleteElapsedMs",
+    ] as const) {
+      maybeSetHostedAssistantProviderDiagnosticDetail(
+        details,
+        key,
+        readHostedAssistantProviderDiagnosticNonnegativeNumber(record, key),
+      );
+    }
+  }
   maybeSetHostedAssistantProviderDiagnosticDetail(
     details,
     "codexTimingThreadIdPresent",

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -864,6 +864,84 @@ describe("executeHostedMailboxEvent", () => {
     }
   });
 
+  it("captures local Codex turn-completion boundaries without raw provider metadata", () => {
+    const wake = buildHostedExecutionAssistantNotificationRequestedWake({
+      eventId: "evt_codex_turn_completion_timing",
+      memberId: "member_123",
+      notification: {
+        instructions: "Reply in chat.",
+        route: {
+          actorId: "actor_codex_turn_completion_timing",
+          channel: "linq",
+          delivery: {
+            kind: "thread",
+            target: "thread_123",
+          },
+          identityId: "hbidx:phone:v1:test",
+          threadId: "thread_123",
+          threadIsDirect: true,
+        },
+      },
+      occurredAt: "2026-07-16T00:00:00.000Z",
+    });
+    const completionBoundaries = {
+      codexTimingProviderRequestOrdinal: 2,
+      codexTimingTurnStartAckElapsedMs: 14,
+      codexTimingTurnStartedNotificationElapsedMs: 16,
+      codexTimingTurnCompletedNotificationElapsedMs: 5_610,
+      codexTimingTurnCompleteElapsedMs: 5_622,
+    } as const;
+
+    const entry = emitHostedAssistantProviderTraceLog({
+      details: { requestId: "req_123" },
+      event: {
+        rawEvent: {
+          schema: "murph.assistant-codex-app-server-timing.v1",
+          type: "assistant.codex.app_server_timing",
+          codexTimingStage: "turn-completed",
+          ...completionBoundaries,
+          rawTurnId: "raw-turn-id",
+          rawProviderUrl: "https://api.openai.com/v1/responses",
+        },
+      },
+      wake,
+    });
+
+    expect(entry?.redacted).toEqual(expect.objectContaining({
+      codexTimingProviderRequestOrdinal: 2,
+      codexTimingTurnCompleteElapsedMs: 5_622,
+      codexTimingTurnCompletedNotificationElapsedMs: 5_610,
+      codexTimingTurnStartAckElapsedMs: 14,
+      codexTimingTurnStartedNotificationElapsedMs: 16,
+      codexTimingTraceType: "app-server",
+      providerTraceKind: "codex.app_server_timing",
+    }));
+    expect(JSON.stringify(entry?.redacted)).not.toContain("raw-turn-id");
+    expect(JSON.stringify(entry?.redacted)).not.toContain("api.openai.com");
+
+    const nonCompletionEntry = emitHostedAssistantProviderTraceLog({
+      details: { requestId: "req_123" },
+      event: {
+        rawEvent: {
+          schema: "murph.assistant-codex-app-server-timing.v1",
+          type: "assistant.codex.app_server_timing",
+          codexTimingStage: "turn-started",
+          ...completionBoundaries,
+        },
+      },
+      wake,
+    });
+
+    expect(nonCompletionEntry?.redacted).toEqual(expect.objectContaining({
+      codexTimingStage: "turn-started",
+      codexTimingTraceType: "app-server",
+      providerTraceKind: "codex.app_server_timing",
+    }));
+    for (const key of Object.keys(completionBoundaries)) {
+      expect(nonCompletionEntry?.redacted).not.toHaveProperty(key);
+    }
+  });
+
   it("captures hosted Codex action diagnostics without raw payloads", () => {
     const wake = buildHostedExecutionAssistantNotificationRequestedWake({
       eventId: "evt_codex_action_diagnostics",


### PR DESCRIPTION
## Why

A warm hosted reply spent 5,648 ms between Murph's local Codex `turn/start`
write and provider completion, with first local output at 5,569 ms. Existing
telemetry could not separate local App Server acknowledgement/start/completion
boundaries from provider execution, which made optimization guesses unsafe.

## User-visible goal and flow

There is no member-facing behavior or UI change. On hosted Codex turns, the
existing `turn-completed` diagnostic now includes content-free cumulative
offsets for:

1. local `turn/start` acknowledgement;
2. the App Server `turn/started` notification;
3. the App Server `turn/completed` notification; and
4. completion-trace emission after local drains.

The existing provider-request ordinal joins those offsets to the same wake's
provider-result/reply-dispatched diagnostics. Existing attempt-bound assistant
milestones remain the source of truth for first local output/text.

## Invariants

- No new await, network call, database write, log emission, persisted state,
  body read/buffer, response wrapper, or stream transform.
- Runtime work is limited to assign-once `Date.now()` deltas at existing
  JSON-RPC boundaries and strict allowlisting on the existing queued log path.
- No prompt, transcript, output, identifier, token, URL, epoch, or provider
  payload is added.
- Every field is optional; malformed or absent telemetry affects observability
  only.
- Local `turn/start` is not described as upstream provider dispatch, response
  headers, or first token.
- RPC acknowledgement and `turn/started` have no guaranteed delivery order.
- Existing Responses WebSocket GET/101 timing remains handshake-only and is not
  treated as model latency.

## Non-obvious affected surfaces

- The App Server timing trace and hosted runtime redaction parser are the only
  production owners changed.
- The parser admits the five new numeric fields only on the `turn-completed`
  stage.
- A deterministic fixture sends duplicate `turn/started` notifications before
  the ACK and proves first-observation/assign-once behavior.
- The protocol reference also clarifies that ingress `acceptedAt` copies
  PostgreSQL transaction-start `created_at`, not physical insert or commit
  time.
- No Cloudflare egress enrichment remains; the initial HTTP-only approach was
  deleted because the observed path uses Responses WebSockets and synchronous
  parsing would add work without decomposing the turn.

## Verification

- Assistant-engine primary App Server telemetry target: passed.
- Assistant-engine reverse-order/assign-once target: passed on the exact
  production patch before a later base-doc-only rebase; the production/test
  patch remained byte-identical.
- Assistant-runtime parser/redaction suite: 33/33 passed on the pushed code.
- Assistant-engine and assistant-runtime package typechecks: passed.
- `git diff --check`, stale-field search, privacy review, and exact-base review:
  passed.
- Required coverage-write, security/privacy, simplify, and task-finish audits:
  zero unresolved findings.
- `pnpm test:diff` passed every guard and six affected typechecks, then hit
  widespread unrelated package-test timeouts under machine contention. The two
  isolated setup-cli targets still hit their configured 5-second limits; with
  a 30-second override one passed and the other timed out after 30.3 seconds
  following a 120-second import. No changed-owner failure reproduced.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 89 | 2 |
| Tests | 137 | 10 |
| Docs/plans | 141 | 10 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: ade6b7490fe38e2ba1a46eeea78a0f24da360a2d

| Review round | Current head | Scope | Source | Tests | Docs/plans | Config/tooling | Generated/other |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| 1 | `ade6b7490fe38e2ba1a46eeea78a0f24da360a2d` | Full patch | +89/-2 | +137/-10 | +141/-10 | +0/-0 | +0/-0 |

## Deployment concerns

The assistant-engine producer and assistant-runtime parser ship in the same
runner bundle, and all fields are optional. No coordinated Worker/Web deployment
or schema migration is required. Deploy the normal Cloudflare runner bundle;
post-deploy, confirm a new `turn-completed` runtime diagnostic carries the
ordinal and available local offsets while existing first-output and delivery
milestones remain unchanged.
