### PR TITLE
fix(web): restore biomarker detail routes

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-fix-biomarker-runtime-trace.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-fix-biomarker-runtime-trace.md
@@ -1,0 +1,99 @@
+# Restore biomarker detail pages to production bundles
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Restore every published `/biomarkers/[biomarkerId]` detail page in the
+  production Next server bundle, including `/biomarkers/hrv-rmssd`, without
+  widening the deployed Health Commons artifact set beyond the biomarker web
+  projections those routes read.
+
+## Success criteria
+
+- A production build trace for biomarker detail and research routes contains
+  the route index plus representative shell, overview, and research artifacts.
+- The production-built server renders the canonical HRV/RMSSD page instead of
+  emitting `NEXT_HTTP_ERROR_FALLBACK;404`.
+- The Health Commons trace guard fails when biomarker detail artifacts are
+  absent, so the deployment regression cannot pass the web build again.
+- Routed apps/web verification, completion audits, CI, and the selected
+  ReviewGPT PR gate are green.
+
+## Scope
+
+- In scope: biomarker generated-artifact tracing, the production trace guard,
+  focused regression coverage, and direct production-build/server proof.
+- Out of scope: authored biomarker content, slug or alias changes, visual
+  redesign, private biomarker trends, and unrelated Health Commons routes.
+
+## Constraints
+
+- Technical constraints: generated catalogs remain ignored build outputs;
+  runtime routes consume only compact `generated/web` projections; preserve the
+  build-memory work that removed broad automatic catalog tracing.
+- Product/process constraints: keep the canonical URL unchanged, use the
+  isolated worktree/PR lane, preserve unrelated work, and complete the required
+  frontend, coverage, and ReviewGPT gates.
+
+## Risks and mitigations
+
+1. Risk: a broad tracing change restores the page by packaging the full Health
+   Commons catalog and regresses build memory.
+   Mitigation: prove exact `.nft.json` contents and retain the existing guard
+   against catalog and unrelated bundle leakage.
+2. Risk: unit tests pass against local generated files while Vercel still omits
+   them.
+   Mitigation: make the post-build trace guard assert representative biomarker
+   projections and run the production server against the built output.
+
+## Tasks
+
+1. Reproduce the soft 404 and prove the missing production trace boundary.
+2. Determine the narrowest Next tracing/path change that includes biomarker web
+   projections without restoring broad catalog tracing.
+3. Extend the production trace guard and focused tests for the canonical HRV
+   route artifacts.
+4. Run apps/web verification, production-server scenario proof, specialist
+   audits, parent review, and privacy/diff checks.
+5. Finish the scoped commit, open the PR, run ReviewGPT concurrently with CI,
+   and resolve every accepted finding.
+
+## Decisions
+
+- The canonical content and route id are valid; no content or redirect change
+  is warranted.
+- Treat the wire-level HTTP 200 as a failure because the streamed response
+  contains `NEXT_HTTP_ERROR_FALLBACK;404` and `robots=noindex`.
+- Consolidate the 20 compact biomarker projections under the `/biomarkers`
+  trace prefix because the Turbopack build applies that entry across the route
+  subtree while the narrower dynamic entries did not affect deployed traces.
+- Keep overview and research trace assertions independent so one correctly
+  packaged function cannot mask the other.
+
+## Verification
+
+- Passed: focused Next config tests (36/36), a fresh production build, and the
+  Health Commons checker across 213 Next traces.
+- Passed: exact overview and research trace inspection found the route index,
+  HRV shell, and matching overview/research projection in each function, with
+  no monolithic catalog.
+- Passed: production-built overview and research requests returned HTTP 200,
+  rendered `Heart Rate Variability`, and contained neither the embedded 404
+  marker nor `robots=noindex`.
+- Passed: full hosted-web tests (5,376 passed, 141 skipped), lint with only
+  pre-existing warnings, and a clean TypeScript check.
+- Required audits: frontend review returned no findings; coverage-write found
+  the production trace checker sufficient and made no edits.
+- Required second-model UI double-check: Fable was unavailable because of a
+  server-side overload; the allowed Opus fallback independently inspected the
+  built traces and unchanged route failure path, then returned no findings and
+  made no repository edits.
+- Local gap: the browser runtime exposed no backend for desktop/mobile
+  screenshots. The diff-aware lane's dev smoke also reached Next `Ready` but
+  intermittently exceeded its fixed 90-second health-route window on the slow
+  worktree filesystem; one isolated prepared-environment run passed, and the
+  production build/server path remained green.
+Completed: 2026-07-16

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -307,13 +307,6 @@ export function buildHostedWebNextConfig(phase: string): NextConfig {
       ],
       "/biomarkers": [
         "../../packages/health-commons/generated/web/browse/biomarkers.json",
-      ],
-      "/biomarkers/[biomarkerId]": [
-        "../../packages/health-commons/generated/web/routes/index.json",
-        "../../packages/health-commons/generated/web/shell/biomarkers/**/*.json",
-        "../../packages/health-commons/generated/web/pages/biomarkers/**/*.json",
-      ],
-      "/biomarkers/[biomarkerId]/research": [
         "../../packages/health-commons/generated/web/routes/index.json",
         "../../packages/health-commons/generated/web/shell/biomarkers/**/*.json",
         "../../packages/health-commons/generated/web/pages/biomarkers/**/*.json",

--- a/apps/web/scripts/check-health-commons-traces.ts
+++ b/apps/web/scripts/check-health-commons-traces.ts
@@ -27,6 +27,16 @@ const requiredExperimentTraceArtifacts = [
 const requiredBrowseTraceArtifacts = [
   "packages/health-commons/generated/web/browse/experiments.json",
 ] as const;
+const requiredBiomarkerOverviewTraceArtifacts = [
+  "packages/health-commons/generated/web/routes/index.json",
+  "packages/health-commons/generated/web/shell/biomarkers/hrv-rmssd.json",
+  "packages/health-commons/generated/web/pages/biomarkers/hrv-rmssd/overview.json",
+] as const;
+const requiredBiomarkerResearchTraceArtifacts = [
+  "packages/health-commons/generated/web/routes/index.json",
+  "packages/health-commons/generated/web/shell/biomarkers/hrv-rmssd.json",
+  "packages/health-commons/generated/web/pages/biomarkers/hrv-rmssd/research.json",
+] as const;
 const requiredMeasurementMethodTraceArtifacts = [
   "packages/health-commons/generated/web/routes/index.json",
   "packages/health-commons/generated/web/bundles/measurement_method/home-standardized-photo-roi-analysis.json",
@@ -42,6 +52,8 @@ const traceFiles = listFiles(distDir).filter((file) => file.endsWith(".nft.json"
 const violations: string[] = [];
 const experimentTraceArtifacts = new Set<string>();
 const browseTraceArtifacts = new Set<string>();
+const biomarkerOverviewTraceArtifacts = new Set<string>();
+const biomarkerResearchTraceArtifacts = new Set<string>();
 const measurementMethodTraceArtifacts = new Set<string>();
 
 for (const traceFile of traceFiles) {
@@ -53,6 +65,12 @@ for (const traceFile of traceFiles) {
   );
   const isExperimentBrowseTrace = relativeTraceFile.endsWith(
     "server/app/(dashboard)/experiments/page.js.nft.json",
+  );
+  const isBiomarkerOverviewTrace = relativeTraceFile.endsWith(
+    "server/app/(dashboard)/biomarkers/[biomarkerId]/page.js.nft.json",
+  );
+  const isBiomarkerResearchTrace = relativeTraceFile.endsWith(
+    "server/app/(dashboard)/biomarkers/[biomarkerId]/research/page.js.nft.json",
   );
   const isMeasurementMethodTrace = relativeTraceFile.includes(
     "server/app/measurement-methods/[measurementMethodId]/",
@@ -89,6 +107,22 @@ for (const traceFile of traceFiles) {
       }
     }
 
+    if (isBiomarkerOverviewTrace) {
+      for (const requiredArtifact of requiredBiomarkerOverviewTraceArtifacts) {
+        if (normalizedTracedFile.endsWith(requiredArtifact)) {
+          biomarkerOverviewTraceArtifacts.add(requiredArtifact);
+        }
+      }
+    }
+
+    if (isBiomarkerResearchTrace) {
+      for (const requiredArtifact of requiredBiomarkerResearchTraceArtifacts) {
+        if (normalizedTracedFile.endsWith(requiredArtifact)) {
+          biomarkerResearchTraceArtifacts.add(requiredArtifact);
+        }
+      }
+    }
+
     if (isMeasurementMethodTrace) {
       for (const requiredArtifact of requiredMeasurementMethodTraceArtifacts) {
         if (normalizedTracedFile.endsWith(requiredArtifact)) {
@@ -113,6 +147,12 @@ const missingExperimentArtifacts = requiredExperimentTraceArtifacts.filter((arti
 const missingBrowseArtifacts = requiredBrowseTraceArtifacts.filter((artifact) =>
   !browseTraceArtifacts.has(artifact)
 );
+const missingBiomarkerOverviewArtifacts = requiredBiomarkerOverviewTraceArtifacts.filter((artifact) =>
+  !biomarkerOverviewTraceArtifacts.has(artifact)
+);
+const missingBiomarkerResearchArtifacts = requiredBiomarkerResearchTraceArtifacts.filter((artifact) =>
+  !biomarkerResearchTraceArtifacts.has(artifact)
+);
 const missingMeasurementMethodArtifacts = requiredMeasurementMethodTraceArtifacts.filter((artifact) =>
   !measurementMethodTraceArtifacts.has(artifact)
 );
@@ -120,6 +160,8 @@ const missingMeasurementMethodArtifacts = requiredMeasurementMethodTraceArtifact
 if (
   missingExperimentArtifacts.length > 0 ||
   missingBrowseArtifacts.length > 0 ||
+  missingBiomarkerOverviewArtifacts.length > 0 ||
+  missingBiomarkerResearchArtifacts.length > 0 ||
   missingMeasurementMethodArtifacts.length > 0
 ) {
   throw new Error([
@@ -127,6 +169,8 @@ if (
     "Public Health Commons routes need compact generated/web artifacts at runtime.",
     ...missingExperimentArtifacts.map((artifact) => `- missing experiment detail trace artifact: ${artifact}`),
     ...missingBrowseArtifacts.map((artifact) => `- missing experiment browse trace artifact: ${artifact}`),
+    ...missingBiomarkerOverviewArtifacts.map((artifact) => `- missing biomarker overview trace artifact: ${artifact}`),
+    ...missingBiomarkerResearchArtifacts.map((artifact) => `- missing biomarker research trace artifact: ${artifact}`),
     ...missingMeasurementMethodArtifacts.map((artifact) => `- missing measurement method trace artifact: ${artifact}`),
   ].join("\n"));
 }

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -414,23 +414,18 @@ test("next.config traces generated Health Commons route files without the monoli
     productionNextConfig.outputFileTracingIncludes?.["/biomarkers"],
     [
       "../../packages/health-commons/generated/web/browse/biomarkers.json",
+      "../../packages/health-commons/generated/web/routes/index.json",
+      "../../packages/health-commons/generated/web/shell/biomarkers/**/*.json",
+      "../../packages/health-commons/generated/web/pages/biomarkers/**/*.json",
     ],
   );
-  assert.deepEqual(
+  assert.equal(
     productionNextConfig.outputFileTracingIncludes?.["/biomarkers/[biomarkerId]"],
-    [
-      "../../packages/health-commons/generated/web/routes/index.json",
-      "../../packages/health-commons/generated/web/shell/biomarkers/**/*.json",
-      "../../packages/health-commons/generated/web/pages/biomarkers/**/*.json",
-    ],
+    undefined,
   );
-  assert.deepEqual(
+  assert.equal(
     productionNextConfig.outputFileTracingIncludes?.["/biomarkers/[biomarkerId]/research"],
-    [
-      "../../packages/health-commons/generated/web/routes/index.json",
-      "../../packages/health-commons/generated/web/shell/biomarkers/**/*.json",
-      "../../packages/health-commons/generated/web/pages/biomarkers/**/*.json",
-    ],
+    undefined,
   );
   assert.doesNotMatch(
     JSON.stringify(productionNextConfig.outputFileTracingIncludes),


### PR DESCRIPTION
## Why this PR exists

The published HRV/RMSSD biomarker detail route soft-404s in production because its compact generated projections are missing from the deployed Next.js server trace.

## User goal / user-visible behavior

People can open `/biomarkers/hrv-rmssd` and its research tab and see the existing published content instead of the embedded 404 response.

## User experience

Direct entry and in-app navigation render the existing overview and research experiences without visual, copy, interaction, or responsive changes. Unknown biomarker IDs continue through the existing `notFound()` path.

## Invariants the PR must preserve

- Keep authored Health Commons content, canonical slugs, and route behavior unchanged.
- Trace only compact `generated/web` biomarker projections; never restore the monolithic catalog or unrelated bundles.
- Keep overview and research trace coverage independent and fail the production build when either route omits required runtime artifacts.

## Non-obvious affected surfaces

- Next.js output-file tracing for the `/biomarkers` route subtree is consolidated under the parent prefix because that is the route key the production build applies across the subtree. Regression proof: exact overview and research `.nft.json` inspection plus the post-build trace guard.
- The Health Commons post-build checker now uses HRV/RMSSD as a representative published biomarker and verifies the shell and matching overview/research projections independently. Regression proof: a fresh production build and checker run across 213 traces.

## Verification

- Focused Next config tests: 36 passed.
- Full hosted-web suite: 5,376 passed, 141 skipped.
- TypeScript check: passed.
- Lint: passed with only pre-existing warnings.
- Fresh production build and Health Commons trace checker: passed across 213 traces.
- Production-built overview and research requests: HTTP 200, rendered `Heart Rate Variability`, no embedded 404 marker, and no robots noindex.
- Frontend specialist review, coverage review, and required Opus UI fallback: no findings or additional changes.
- Visual screenshot gap: the in-app browser backend was unavailable; no visual source changed, and production-built HTML/runtime proof covers the user-visible failure boundary.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 79bf04f41fa3556ecd8bf888829ace9b8e858427

Classification rule: authored runtime code is source; test files are tests/fixtures; the completed execution plan is docs; Next config and the post-build checker are config/tooling; generated outputs remain separate.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 6 | 11 |
| Docs | 99 | 0 |
| Config/tooling | 44 | 7 |
| Generated/other | 0 | 0 |
| **Total** | **149** | **18** |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786825381&installation_id=127572939&pr_number=756&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F756&signature=859ac8dd61f067983408d958752d2ea2b16de4796432e387569f9595fae27747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->