### PR TITLE
Compact completed experiment cards on Home

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -200,12 +200,13 @@ and mobile-landscape widths, and one where the open desktop sidebar constrains
 the content column.
 Inside each card, keep the category and title, then show every comparable result
 as a small primary-first grid of mono labels and Fraunces deltas. Positive
-evidence may use sage; unfavorable and neutral movement stays slate because a
-mixed result is not a warning state. Keep the date, but omit the redundant
-Completed badge, circled privacy lock, Baseline-to-Latest block, and visible
-View arrow. The entire card remains the link to the detailed result. Active and
-paused cards keep the larger progress-first treatment. Keep privacy legible with
-a small unbordered lock beside the date rather than a separate header control.
+evidence uses sage, unfavorable movement retains amber, and neutral movement
+stays slate so mixed results remain distinguishable. Keep the date, but omit the
+redundant Completed badge, circled privacy lock, Baseline-to-Latest block, and
+visible View arrow. The entire card remains the link to the detailed result.
+Active and paused cards keep the larger progress-first treatment, and stopped
+runs keep the standard history-card treatment. Keep privacy legible with a small
+unbordered lock beside the date rather than a separate header control.
 
 ### Library List Pattern (Hero / Standard / Table)
 For long lists of recommendations (e.g. experiments-that-may-move-this-biomarker, recipes, protocols), break the rhythm into three tiers instead of an identical-card grid:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -200,8 +200,9 @@ and mobile-landscape widths, and one where the open desktop sidebar constrains
 the content column.
 Inside each card, keep the category and title, then show every comparable result
 as a small primary-first grid of mono labels and Fraunces deltas. Positive
-evidence uses sage, unfavorable movement retains amber, and neutral movement
-stays slate so mixed results remain distinguishable. Keep the date, but omit the
+evidence uses sage, unfavorable movement uses Tailwind amber-700 rather than the
+lighter decorative amber grain token, and neutral movement stays slate so mixed
+results remain distinguishable. Keep the date, but omit the
 redundant Completed badge, circled privacy lock, Baseline-to-Latest block, and
 visible View arrow. The entire card remains the link to the detailed result.
 Active and paused cards keep the larger progress-first treatment, and stopped

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -193,6 +193,20 @@ Every component lives on cream paper, wears warm hairline borders, and speaks in
 ### Signal Cards
 Large Fraunces stat number (the value) + DM Mono unit label + delta in sage green + expected range from protocol underneath. In finished state, show "was X" baseline value under the stat. One card per tracked signal; never grid five-abreast — prefer two or three across with room to breathe.
 
+### Home Experiment History Cards
+Completed experiment cards on `/home` are compact index entries, not miniature
+results pages. Use three columns at wide desktop widths, two at small desktop
+and mobile-landscape widths, and one where the open desktop sidebar constrains
+the content column.
+Inside each card, keep the category and title, then show every comparable result
+as a small primary-first grid of mono labels and Fraunces deltas. Positive
+evidence may use sage; unfavorable and neutral movement stays slate because a
+mixed result is not a warning state. Keep the date, but omit the redundant
+Completed badge, circled privacy lock, Baseline-to-Latest block, and visible
+View arrow. The entire card remains the link to the detailed result. Active and
+paused cards keep the larger progress-first treatment. Keep privacy legible with
+a small unbordered lock beside the date rather than a separate header control.
+
 ### Library List Pattern (Hero / Standard / Table)
 For long lists of recommendations (e.g. experiments-that-may-move-this-biomarker, recipes, protocols), break the rhythm into three tiers instead of an identical-card grid:
 1. **Hero rows (top 1–2)** — full-width row, image on the left (320px on desktop, 16:9 above on mobile), content on the right. Category eyebrow + serif h3 title + qualitative fit label top-right + mechanism prose + 4-stat band (`Exp. change` · `Duration` · `Burden` · `Evidence`). Optional small mono pill over the image (`RECOMMENDED FOR YOU`). The whole card is the link — no diagonal up-right arrow (it reads as "external" and is misleading); no "Open the experiment" CTA strip — the card surface itself is the affordance.

--- a/agent-docs/exec-plans/completed/2026-07-16-home-experiment-history-metrics.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-home-experiment-history-metrics.md
@@ -1,0 +1,76 @@
+# Compact home experiment history metrics
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Make completed experiment cards on `/home` substantially more compact while
+  showing the run's measured outcomes instead of reducing a multi-metric run to
+  one arbitrarily selected trend.
+
+## Success criteria
+
+- Completed history cards remove redundant baseline/latest and completion UI,
+  keep the full card as the navigation target, and occupy materially less
+  vertical space on desktop and mobile.
+- A completed run with several comparable outcome signals shows each concise
+  metric delta, preserving primary-first source order and honest sentiment.
+- Active and paused experiment cards retain their progress-first treatment.
+- Focused tests, truthful scoped verification, desktop/mobile browser proof,
+  required frontend and coverage audits, second-model UI review, parent final
+  review, scoped commit, and PR gates complete with no unresolved findings.
+
+## Scope
+
+- In scope: the `/home` experiment-history card projection, rendering, focused
+  tests, and any narrow durable design-system documentation needed to describe
+  the compact history-card pattern.
+- Out of scope: experiment analysis semantics, canonical experiment storage,
+  detail-page results, progress-card images, experiment status normalization,
+  and active/paused card redesign.
+
+## Constraints
+
+- Keep experiment data flow projection-driven and browser-safe.
+- Do not rank or cherry-pick outcomes across unlike units; preserve the run's
+  primary-first signal order and make the detail page the full analysis owner.
+- Do not modify the active PR feedback symbols `runStatusForTrackedExperiment`
+  or `splitHomeExperimentCards` in `library-cards.ts`.
+- Add no persisted state, schema, dependency, or new component abstraction.
+
+## Tasks
+
+1. Validate the real multi-metric run and current one-metric projection path.
+2. Project all concise comparable metrics and render the compact history state.
+3. Add focused projection and component regressions.
+4. Run verification, visual proof, specialist audits, second-model review, and
+   parent final review; resolve evidence-backed findings.
+5. Close the plan with the scoped commit, open the PR, and complete its gates.
+
+## Decisions
+
+- Prefer a compact list of measured deltas over choosing the most favorable
+  metric. This resolves the missing-metric complaint without hiding an adverse
+  or unchanged primary outcome.
+- Keep baseline/current detail on the experiment page. The home history card is
+  an index entry, not the complete result report.
+
+## Verification
+
+- Focused component and projection coverage passed: 2 files, 11 tests.
+- Serialized diff-aware verification passed, including repository guards,
+  TypeScript, 437 test files (5,381 tests passed, 141 skipped), ESLint with no
+  errors, the development smoke test, and the production Next.js build.
+- Coverage-write and final frontend review completed with no unresolved
+  findings. The parent final review confirmed active cards retain their existing
+  primary-metric selection while history cards use the complete ordered metric
+  projection.
+- The second-model UI review's evidence-backed responsive, status, and sparse
+  metric findings were corrected before the final review.
+- Desktop and mobile browser inspection could not run because no browser backend
+  was available. Static server-render coverage verifies the responsive classes,
+  compact/history split, full-card link, privacy label, and status treatment;
+  rendered visual proof remains the explicitly reported verification gap.
+Completed: 2026-07-16

--- a/apps/web/src/components/home/home-experiment-card.tsx
+++ b/apps/web/src/components/home/home-experiment-card.tsx
@@ -12,29 +12,35 @@ import { cn } from "@/src/lib/utils";
 
 interface HomeExperimentCardProps {
   card: ExperimentLibraryCard;
+  variant: "history" | "progress";
 }
 
-export function HomeExperimentCard({ card }: HomeExperimentCardProps) {
+export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
   const dateLabel = resolveDateLabel(card);
   const content = (
     <article
       className={cn(
-        "group flex h-full min-h-[240px] flex-col rounded-xl border border-border/70 bg-card/70 p-5 transition-colors",
+        "group flex h-full flex-col rounded-xl border border-border/70 bg-card/70 transition-colors",
+        variant === "history" ? "p-4" : "min-h-[240px] p-5",
         card.href ? "hover:border-primary/35 hover:bg-card" : "",
       )}
       data-home-experiment-card
+      data-home-experiment-card-variant={variant}
     >
       <header className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
             {card.category}
           </p>
-          <h3 className="mt-1 text-balance font-serif text-xl font-semibold leading-tight text-foreground">
+          <h3 className={cn(
+            "mt-1 text-balance font-serif font-semibold leading-tight text-foreground",
+            variant === "history" ? "text-lg" : "text-xl",
+          )}>
             {card.title}
           </h3>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {card.privateBadgeLabel ? (
+          {variant === "progress" && card.privateBadgeLabel ? (
             <span
               className="inline-flex size-7 items-center justify-center rounded-full border border-border/70 text-muted-foreground"
               title={card.privateBadgeLabel}
@@ -43,7 +49,9 @@ export function HomeExperimentCard({ card }: HomeExperimentCardProps) {
               <span className="sr-only">{card.privateBadgeLabel}</span>
             </span>
           ) : null}
-          {card.statusLabel ? (
+          {card.statusLabel && (
+            variant === "progress" || !isRedundantHistoryStatus(card.statusLabel)
+          ) ? (
             <Badge variant={card.statusVariant ?? "outline"} className="font-normal">
               {card.statusLabel}
             </Badge>
@@ -51,15 +59,27 @@ export function HomeExperimentCard({ card }: HomeExperimentCardProps) {
         </div>
       </header>
 
-      <div className="mt-5 flex flex-1 items-center border-t border-border/60 pt-5">
-        <ExperimentDataVisual card={card} />
+      <div className={cn(
+        "flex flex-1 items-center border-t border-border/60",
+        variant === "history" ? "mt-3 pt-3" : "mt-5 pt-5",
+      )}>
+        <ExperimentDataVisual card={card} variant={variant} />
       </div>
 
-      <footer className="mt-5 flex items-center justify-between gap-4 text-[11px] text-muted-foreground">
-        <span className="min-w-0 truncate tabular-nums">
+      <footer className={cn(
+        "flex items-center justify-between gap-4 text-[11px] text-muted-foreground",
+        variant === "history" ? "mt-3" : "mt-5",
+      )}>
+        <span className="inline-flex min-w-0 items-center gap-1.5 truncate tabular-nums">
+          {variant === "history" && card.privateBadgeLabel ? (
+            <>
+              <LockKeyhole aria-hidden="true" className="size-3 shrink-0" />
+              <span className="sr-only">{card.privateBadgeLabel}</span>
+            </>
+          ) : null}
           {dateLabel ?? "Stored in your private vault"}
         </span>
-        {card.href ? (
+        {variant === "progress" && card.href ? (
           <span className="inline-flex shrink-0 items-center gap-1 font-medium text-foreground/70 transition-colors group-hover:text-foreground">
             View
             <ArrowRight
@@ -86,19 +106,24 @@ export function HomeExperimentCard({ card }: HomeExperimentCardProps) {
   );
 }
 
-function ExperimentDataVisual({ card }: HomeExperimentCardProps) {
+function ExperimentDataVisual({ card, variant }: HomeExperimentCardProps) {
   const summary = card.runSummary;
-  const inProgress = card.runStatus === "active" || card.runStatus === "paused";
+  const primaryMetric = summary?.metric;
+  const comparableMetrics = summary?.metrics.filter((metric) => metric.delta?.trim()) ?? [];
 
-  if (inProgress && typeof summary?.completionPercent === "number") {
+  if (variant === "progress" && typeof summary?.completionPercent === "number") {
     return <ExperimentProgress summary={summary} />;
   }
 
-  if (summary?.metric) {
-    return <ExperimentResult metric={summary.metric} />;
+  if (variant === "history" && comparableMetrics.length > 0) {
+    return <ExperimentResults metrics={comparableMetrics} />;
   }
 
-  const fallback = inProgress
+  if (variant === "progress" && primaryMetric) {
+    return <ExperimentResult metric={primaryMetric} />;
+  }
+
+  const fallback = variant === "progress"
     ? "Collecting data"
     : summary
       ? "No clear signal"
@@ -112,6 +137,26 @@ function ExperimentDataVisual({ card }: HomeExperimentCardProps) {
       <p className="mt-2 font-serif text-3xl font-semibold leading-none text-foreground">
         {fallback}
       </p>
+    </div>
+  );
+}
+
+function ExperimentResults({ metrics }: { metrics: ExperimentRunCardMetric[] }) {
+  return (
+    <div className="grid w-full grid-cols-2 gap-x-4 gap-y-3">
+      {metrics.map((metric, index) => (
+        <div key={`${metric.label}:${index}`} className="min-w-0">
+          <p className="font-mono text-[9px] uppercase leading-tight tracking-widest text-muted-foreground">
+            {metric.label}
+          </p>
+          <p className={cn(
+            "mt-1 font-serif text-xl font-semibold leading-none tabular-nums",
+            resolveMetricTone(metric),
+          )}>
+            {metric.delta || metric.current}
+          </p>
+        </div>
+      ))}
     </div>
   );
 }
@@ -210,8 +255,11 @@ function resolveDateLabel(card: ExperimentLibraryCard): string | null {
 
 function resolveMetricTone(metric: ExperimentRunCardMetric): string {
   if (metric.sentiment === "positive") return "text-primary";
-  if (metric.sentiment === "negative") return "text-amber-600";
   return "text-foreground";
+}
+
+function isRedundantHistoryStatus(label: string): boolean {
+  return /^(?:complete|completed|finished)$/iu.test(label.trim());
 }
 
 function clampProgress(value: number): number {

--- a/apps/web/src/components/home/home-experiment-card.tsx
+++ b/apps/web/src/components/home/home-experiment-card.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/src/lib/utils";
 
 interface HomeExperimentCardProps {
   card: ExperimentLibraryCard;
-  variant: "history" | "progress";
+  variant: "default" | "history";
 }
 
 export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
@@ -20,8 +20,8 @@ export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
   const content = (
     <article
       className={cn(
-        "group flex h-full flex-col rounded-xl border border-border/70 bg-card/70 transition-colors",
-        variant === "history" ? "p-4" : "min-h-[240px] p-5",
+        "group flex flex-col rounded-xl border border-border/70 bg-card/70 transition-colors",
+        variant === "history" ? "h-fit p-4" : "h-full min-h-[240px] p-5",
         card.href ? "hover:border-primary/35 hover:bg-card" : "",
       )}
       data-home-experiment-card
@@ -40,7 +40,7 @@ export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
           </h3>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {variant === "progress" && card.privateBadgeLabel ? (
+          {variant === "default" && card.privateBadgeLabel ? (
             <span
               className="inline-flex size-7 items-center justify-center rounded-full border border-border/70 text-muted-foreground"
               title={card.privateBadgeLabel}
@@ -50,7 +50,7 @@ export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
             </span>
           ) : null}
           {card.statusLabel && (
-            variant === "progress" || !isRedundantHistoryStatus(card.statusLabel)
+            variant === "default" || !isRedundantHistoryStatus(card.statusLabel)
           ) ? (
             <Badge variant={card.statusVariant ?? "outline"} className="font-normal">
               {card.statusLabel}
@@ -79,7 +79,7 @@ export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
           ) : null}
           {dateLabel ?? "Stored in your private vault"}
         </span>
-        {variant === "progress" && card.href ? (
+        {variant === "default" && card.href ? (
           <span className="inline-flex shrink-0 items-center gap-1 font-medium text-foreground/70 transition-colors group-hover:text-foreground">
             View
             <ArrowRight
@@ -99,7 +99,10 @@ export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
   return (
     <Link
       href={card.href}
-      className="block h-full rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className={cn(
+        "block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        variant === "default" ? "h-full" : "",
+      )}
     >
       {content}
     </Link>
@@ -108,10 +111,10 @@ export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
 
 function ExperimentDataVisual({ card, variant }: HomeExperimentCardProps) {
   const summary = card.runSummary;
-  const primaryMetric = summary?.metric;
-  const comparableMetrics = summary?.metrics.filter((metric) => metric.delta?.trim()) ?? [];
+  const inProgress = card.runStatus === "active" || card.runStatus === "paused";
+  const comparableMetrics = summary?.metrics ?? [];
 
-  if (variant === "progress" && typeof summary?.completionPercent === "number") {
+  if (inProgress && typeof summary?.completionPercent === "number") {
     return <ExperimentProgress summary={summary} />;
   }
 
@@ -119,11 +122,11 @@ function ExperimentDataVisual({ card, variant }: HomeExperimentCardProps) {
     return <ExperimentResults metrics={comparableMetrics} />;
   }
 
-  if (variant === "progress" && primaryMetric) {
-    return <ExperimentResult metric={primaryMetric} />;
+  if (variant === "default" && summary?.metric) {
+    return <ExperimentResult metric={summary.metric} />;
   }
 
-  const fallback = variant === "progress"
+  const fallback = inProgress
     ? "Collecting data"
     : summary
       ? "No clear signal"
@@ -255,6 +258,7 @@ function resolveDateLabel(card: ExperimentLibraryCard): string | null {
 
 function resolveMetricTone(metric: ExperimentRunCardMetric): string {
   if (metric.sentiment === "positive") return "text-primary";
+  if (metric.sentiment === "negative") return "text-amber-600";
   return "text-foreground";
 }
 

--- a/apps/web/src/components/home/home-experiment-card.tsx
+++ b/apps/web/src/components/home/home-experiment-card.tsx
@@ -70,14 +70,16 @@ export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
         "flex items-center justify-between gap-4 text-[11px] text-muted-foreground",
         variant === "history" ? "mt-3" : "mt-5",
       )}>
-        <span className="inline-flex min-w-0 items-center gap-1.5 truncate tabular-nums">
+        <span className="inline-flex min-w-0 items-center gap-1.5 tabular-nums">
           {variant === "history" && card.privateBadgeLabel ? (
             <>
               <LockKeyhole aria-hidden="true" className="size-3 shrink-0" />
               <span className="sr-only">{card.privateBadgeLabel}</span>
             </>
           ) : null}
-          {dateLabel ?? "Stored in your private vault"}
+          <span className="min-w-0 truncate">
+            {dateLabel ?? "Stored in your private vault"}
+          </span>
         </span>
         {variant === "default" && card.href ? (
           <span className="inline-flex shrink-0 items-center gap-1 font-medium text-foreground/70 transition-colors group-hover:text-foreground">
@@ -137,7 +139,10 @@ function ExperimentDataVisual({ card, variant }: HomeExperimentCardProps) {
       <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
         Experiment status
       </p>
-      <p className="mt-2 font-serif text-3xl font-semibold leading-none text-foreground">
+      <p className={cn(
+        "mt-2 font-serif font-semibold leading-none text-foreground",
+        variant === "history" ? "text-2xl" : "text-3xl",
+      )}>
         {fallback}
       </p>
     </div>
@@ -147,25 +152,33 @@ function ExperimentDataVisual({ card, variant }: HomeExperimentCardProps) {
 function ExperimentResults({ metrics }: { metrics: ExperimentRunCardMetric[] }) {
   return (
     <div className="grid w-full grid-cols-2 gap-x-4 gap-y-3">
-      {metrics.map((metric, index) => (
-        <div key={`${metric.label}:${index}`} className="min-w-0">
-          <p className="font-mono text-[9px] uppercase leading-tight tracking-widest text-muted-foreground">
-            {metric.label}
-          </p>
-          <p className={cn(
-            "mt-1 font-serif text-xl font-semibold leading-none tabular-nums",
-            resolveMetricTone(metric),
-          )}>
-            {metric.delta || metric.current}
-          </p>
-        </div>
-      ))}
+      {metrics.map((metric, index) => {
+        const sentimentLabel = resolveMetricSentimentLabel(metric);
+
+        return (
+          <div key={`${metric.label}:${index}`} className="min-w-0">
+            <p className="font-mono text-[9px] uppercase leading-tight tracking-widest text-muted-foreground">
+              {metric.label}
+            </p>
+            <p className={cn(
+              "mt-1 font-serif text-xl font-semibold leading-none tabular-nums",
+              resolveMetricTone(metric),
+            )}>
+              {metric.delta || metric.current}
+              {sentimentLabel ? (
+                <span className="sr-only">{sentimentLabel}</span>
+              ) : null}
+            </p>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 function ExperimentResult({ metric }: { metric: ExperimentRunCardMetric }) {
   const headline = metric.delta || metric.current;
+  const sentimentLabel = resolveMetricSentimentLabel(metric);
 
   return (
     <div className="w-full">
@@ -177,6 +190,9 @@ function ExperimentResult({ metric }: { metric: ExperimentRunCardMetric }) {
         resolveMetricTone(metric),
       )}>
         {headline}
+        {sentimentLabel ? (
+          <span className="sr-only">{sentimentLabel}</span>
+        ) : null}
       </p>
       <div className="mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-4 border-y border-border/60 py-3">
         <ResultValue label="Baseline" value={metric.baseline ?? "—"} />
@@ -258,8 +274,14 @@ function resolveDateLabel(card: ExperimentLibraryCard): string | null {
 
 function resolveMetricTone(metric: ExperimentRunCardMetric): string {
   if (metric.sentiment === "positive") return "text-primary";
-  if (metric.sentiment === "negative") return "text-amber-600";
+  if (metric.sentiment === "negative") return "text-amber-700";
   return "text-foreground";
+}
+
+function resolveMetricSentimentLabel(metric: ExperimentRunCardMetric): string | null {
+  if (metric.sentiment === "positive") return ", favorable";
+  if (metric.sentiment === "negative") return ", unfavorable";
+  return null;
 }
 
 function isRedundantHistoryStatus(label: string): boolean {

--- a/apps/web/src/components/home/home-experiments.tsx
+++ b/apps/web/src/components/home/home-experiments.tsx
@@ -6,6 +6,7 @@ import { ArrowRight } from "lucide-react";
 import { HomeExperimentCard } from "./home-experiment-card";
 
 import type { ExperimentLibraryCard } from "@/src/lib/experiments/library-cards";
+import { cn } from "@/src/lib/utils";
 
 const HISTORY_CARD_LIMIT = 6;
 
@@ -36,6 +37,7 @@ export function HomeExperiments({ inProgress, history }: HomeExperimentsProps) {
           label="In progress"
           cards={inProgress}
           action={browseAction}
+          variant="progress"
         />
       ) : null}
       {history.length > 0 ? (
@@ -43,6 +45,7 @@ export function HomeExperiments({ inProgress, history }: HomeExperimentsProps) {
           label="Your history"
           cards={history.slice(0, HISTORY_CARD_LIMIT)}
           action={inProgress.length === 0 ? browseAction : undefined}
+          variant="history"
         />
       ) : null}
     </div>
@@ -53,10 +56,12 @@ function HomeExperimentsSection({
   label,
   cards,
   action,
+  variant,
 }: {
   label: string;
   cards: ExperimentLibraryCard[];
   action?: React.ReactNode;
+  variant: "history" | "progress";
 }) {
   return (
     <section className="flex flex-col gap-4">
@@ -66,9 +71,14 @@ function HomeExperimentsSection({
         </span>
         {action ?? null}
       </div>
-      <div className="grid gap-5 sm:grid-cols-2">
+      <div className={cn(
+        "grid sm:grid-cols-2",
+        variant === "history"
+          ? "gap-3 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+          : "gap-5",
+      )}>
         {cards.map((card) => (
-          <HomeExperimentCard key={card.id} card={card} />
+          <HomeExperimentCard key={card.id} card={card} variant={variant} />
         ))}
       </div>
     </section>

--- a/apps/web/src/components/home/home-experiments.tsx
+++ b/apps/web/src/components/home/home-experiments.tsx
@@ -37,7 +37,7 @@ export function HomeExperiments({ inProgress, history }: HomeExperimentsProps) {
           label="In progress"
           cards={inProgress}
           action={browseAction}
-          variant="progress"
+          variant="default"
         />
       ) : null}
       {history.length > 0 ? (
@@ -61,8 +61,10 @@ function HomeExperimentsSection({
   label: string;
   cards: ExperimentLibraryCard[];
   action?: React.ReactNode;
-  variant: "history" | "progress";
+  variant: "default" | "history";
 }) {
+  const historyLayout = variant === "history";
+
   return (
     <section className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -72,14 +74,40 @@ function HomeExperimentsSection({
         {action ?? null}
       </div>
       <div className={cn(
-        "grid sm:grid-cols-2",
-        variant === "history"
-          ? "gap-3 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
-          : "gap-5",
+        "grid",
+        historyLayout
+          ? "grid-cols-6 items-start gap-5"
+          : "gap-5 sm:grid-cols-2",
       )}>
-        {cards.map((card) => (
-          <HomeExperimentCard key={card.id} card={card} variant={variant} />
-        ))}
+        {cards.map((card) => {
+          const cardVariant = historyLayout && card.runStatus === "finished"
+            ? "history"
+            : "default";
+
+          if (!historyLayout) {
+            return (
+              <HomeExperimentCard
+                key={card.id}
+                card={card}
+                variant={cardVariant}
+              />
+            );
+          }
+
+          return (
+            <div
+              key={card.id}
+              className={cn(
+                "col-span-6",
+                cardVariant === "history"
+                  ? "h-fit sm:col-span-3 md:col-span-6 lg:col-span-3 xl:col-span-2"
+                  : "self-stretch sm:col-span-3",
+              )}
+            >
+              <HomeExperimentCard card={card} variant={cardVariant} />
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/lib/experiments/run-card-summary.ts
+++ b/apps/web/src/lib/experiments/run-card-summary.ts
@@ -36,24 +36,16 @@ export function buildExperimentRunCardSummary(
     metric: primarySignal || primaryTrend
       ? buildMetric(primarySignal, primaryTrend)
       : undefined,
-    metrics: buildMetrics(run.signals, run.trends),
+    metrics: buildMetrics(run.signals),
   };
 }
 
 function buildMetrics(
   signals: ExperimentRunProjection["signals"],
-  trends: ExperimentRunProjection["trends"],
 ): ExperimentRunCardMetric[] {
-  const usableTrends = trends.filter(hasTrendPoints);
-  const trendsByLabel = new Map(usableTrends.map((trend) => [trend.label, trend]));
-  const signalLabels = new Set(signals.map((signal) => signal.label));
-
-  return [
-    ...signals.map((signal) => buildMetric(signal, trendsByLabel.get(signal.label))),
-    ...usableTrends
-      .filter((trend) => !signalLabels.has(trend.label))
-      .map((trend) => buildMetric(undefined, trend)),
-  ];
+  return signals
+    .filter((signal) => signal.delta.trim().length > 0)
+    .map((signal) => buildMetric(signal, undefined));
 }
 
 function buildMetric(

--- a/apps/web/src/lib/experiments/run-card-summary.ts
+++ b/apps/web/src/lib/experiments/run-card-summary.ts
@@ -18,6 +18,7 @@ export interface ExperimentRunCardSummary {
   dateRange?: string;
   day?: number;
   metric?: ExperimentRunCardMetric;
+  metrics: ExperimentRunCardMetric[];
 }
 
 export function buildExperimentRunCardSummary(
@@ -32,18 +33,33 @@ export function buildExperimentRunCardSummary(
     completionPercent: run.completionPercent,
     dateRange: run.dateRange,
     day: run.day,
-    metric: buildMetric(primarySignal, primaryTrend),
+    metric: primarySignal || primaryTrend
+      ? buildMetric(primarySignal, primaryTrend)
+      : undefined,
+    metrics: buildMetrics(run.signals, run.trends),
   };
+}
+
+function buildMetrics(
+  signals: ExperimentRunProjection["signals"],
+  trends: ExperimentRunProjection["trends"],
+): ExperimentRunCardMetric[] {
+  const usableTrends = trends.filter(hasTrendPoints);
+  const trendsByLabel = new Map(usableTrends.map((trend) => [trend.label, trend]));
+  const signalLabels = new Set(signals.map((signal) => signal.label));
+
+  return [
+    ...signals.map((signal) => buildMetric(signal, trendsByLabel.get(signal.label))),
+    ...usableTrends
+      .filter((trend) => !signalLabels.has(trend.label))
+      .map((trend) => buildMetric(undefined, trend)),
+  ];
 }
 
 function buildMetric(
   signal: ExperimentSignal | undefined,
   trend: TrendData | undefined,
-): ExperimentRunCardMetric | undefined {
-  if (!signal && !trend) {
-    return undefined;
-  }
-
+): ExperimentRunCardMetric {
   return {
     baseline: signal?.baseline ?? (trend
       ? formatValueWithUnit(trend.baselineAvg, trend.unit)

--- a/apps/web/test/experiment-detail-private-run.test.tsx
+++ b/apps/web/test/experiment-detail-private-run.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/src/components/experiments/experiment-detail/trend-chart";
 import { resolveBrowserVaultExperimentRun } from "@/src/lib/browser-vault/experiment-run";
 import { composeExperimentDetail } from "@/src/lib/experiments/experiment-detail";
+import { buildExperimentRunCardSummary } from "@/src/lib/experiments/run-card-summary";
 import { resolveHealthCommonsExperimentProtocol } from "@/src/lib/health-commons/experiment-detail";
 
 type BrowserVaultEntity = Parameters<typeof createVaultReadModel>[0]["entities"][number];
@@ -583,6 +584,93 @@ describe("experiment detail private-run composition", () => {
     );
 
     expect(trendMarkup).not.toContain("Expected");
+  });
+
+  it("projects ordered comparable card metrics from production browser-vault signals", async () => {
+    const protocol = resolveHealthCommonsExperimentProtocol("finnish-sauna");
+
+    expect(protocol).not.toBeNull();
+
+    const privateRun = resolveBrowserVaultExperimentRun({
+      client: await createClient({
+        generatedAt: "2026-04-10T12:00:00.000Z",
+        metricRows: [
+          ...metricRows("resting-heart-rate", "bpm", [
+            ["2026-04-01", 63],
+            ["2026-04-02", 62],
+            ["2026-04-03", 61],
+            ["2026-04-08", 60],
+            ["2026-04-09", 59],
+            ["2026-04-10", 58],
+          ]),
+          ...metricRows("hrv-rmssd", "ms", [
+            ["2026-04-01", 60],
+            ["2026-04-02", 60],
+            ["2026-04-03", 60],
+            ["2026-04-08", 55],
+            ["2026-04-09", 55],
+            ["2026-04-10", 55],
+          ]),
+          ...metricRows("deep-sleep-minutes", "min", [
+            ["2026-04-01", 90],
+            ["2026-04-02", 90],
+            ["2026-04-03", 90],
+            ["2026-04-08", 90],
+            ["2026-04-09", 90],
+            ["2026-04-10", 90],
+          ]),
+          ...metricRows("rem-sleep-minutes", "min", [
+            ["2026-04-01", 80],
+            ["2026-04-02", 80],
+            ["2026-04-03", 80],
+            ["2026-04-08", 82],
+          ]),
+        ],
+        trackedExperiments: [{
+          frontmatter: createExperimentFrontmatter({
+            analysisPlan: {
+              desiredDirection: "decrease",
+              primaryBiomarkerKey: "biomarker:resting-heart-rate",
+              secondaryBiomarkerKeys: [
+                "biomarker:hrv-rmssd",
+                "biomarker:deep-sleep-minutes",
+                "biomarker:rem-sleep-minutes",
+              ],
+            },
+            id: "exp_sauna_card_metrics",
+            runPlan: {
+              baselineEnd: "2026-04-03",
+              baselineStart: "2026-04-01",
+              interventionEnd: "2026-04-10",
+              interventionStart: "2026-04-08",
+            },
+            slug: "finnish-sauna",
+            startedOn: "2026-04-01",
+            status: "finished",
+            title: "Private sauna run",
+          }),
+          id: "exp_sauna_card_metrics",
+          slug: "finnish-sauna",
+          startedOn: "2026-04-01",
+          status: "finished",
+          summary: "Production card-metric projection.",
+          tags: ["sauna"],
+          title: "Private sauna run",
+        }],
+      }),
+      protocol: protocol!,
+    });
+
+    expect(privateRun).not.toBeNull();
+    expect(buildExperimentRunCardSummary(privateRun!).metrics.map((metric) => ({
+      label: metric.label,
+      sentiment: metric.sentiment,
+    }))).toEqual([
+      { label: "Resting Heart Rate", sentiment: "positive" },
+      { label: "Hrv Rmssd", sentiment: "negative" },
+      { label: "Deep Sleep Minutes", sentiment: "neutral" },
+    ]);
+    expect(privateRun?.signals.find((signal) => signal.label === "Rem Sleep Minutes")?.delta).toBe("");
   });
 
   it("hides deltas until the intervention window has enough days to compare", async () => {
@@ -1702,11 +1790,19 @@ function createContextEntity(input: {
 }
 
 function restingHeartRateRows(entries: readonly (readonly [string, number])[]): BrowserVaultMetricRow[] {
+  return metricRows("resting-heart-rate", "bpm", entries);
+}
+
+function metricRows(
+  metricKey: string,
+  unit: string,
+  entries: readonly (readonly [string, number])[],
+): BrowserVaultMetricRow[] {
   return entries.map(([date, value]) =>
     metricRow({
       date,
-      metricKey: "resting-heart-rate",
-      unit: "bpm",
+      metricKey,
+      unit,
       value,
     }),
   );
@@ -1718,8 +1814,15 @@ function metricRow(input: {
   unit: string;
   value: number;
 }): BrowserVaultMetricRow {
+  const biomarkerKeyByMetricKey: Readonly<Record<string, string>> = {
+    "deep-sleep-minutes": "biomarker:deep-sleep-minutes",
+    "hrv-rmssd": "biomarker:hrv-rmssd",
+    "rem-sleep-minutes": "biomarker:rem-sleep-minutes",
+    "resting-heart-rate": "biomarker:resting-heart-rate",
+  };
+
   return {
-    biomarkerKey: input.metricKey === "resting-heart-rate" ? "biomarker:resting-heart-rate" : null,
+    biomarkerKey: biomarkerKeyByMetricKey[input.metricKey] ?? null,
     confidence: "medium",
     context: {},
     date: input.date,

--- a/apps/web/test/home-experiment-card.test.tsx
+++ b/apps/web/test/home-experiment-card.test.tsx
@@ -50,7 +50,7 @@ test("HomeExperimentCard shows the member's result instead of protocol imagery a
   );
   assert.match(
     markup,
-    /Sleep efficiency<\/p><p class="[^"]*text-foreground[^"]*">-0\.7 percent<\/p>/,
+    /Sleep efficiency<\/p><p class="[^"]*text-amber-600[^"]*">-0\.7 percent<\/p>/,
   );
   assert.match(
     markup,
@@ -71,6 +71,7 @@ test("HomeExperimentCard shows the member's result instead of protocol imagery a
   assert.doesNotMatch(markup, /inline-flex size-7/);
   assert.doesNotMatch(markup, />Completed</);
   assert.doesNotMatch(markup, />View</);
+  assert.doesNotMatch(markup, /h-full/);
   assert.doesNotMatch(markup, /min-h-\[240px\]/);
   assert.doesNotMatch(markup, /<img/);
   assert.doesNotMatch(markup, /Protocol preview copy that should stay hidden/);
@@ -127,10 +128,11 @@ test("HomeExperimentCard keeps low-confidence completed runs concise", async () 
     completionPercent: 100,
     dateRange: "May 1 to May 14",
     day: 14,
-    metrics: [{
+    metric: {
       current: "18 min",
       label: "Sleep latency",
-    }],
+    },
+    metrics: [],
   };
   const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
     card,
@@ -150,7 +152,7 @@ test("HomeExperimentCard combines current data with progress for an active run",
   );
   const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
     card: progressCard(),
-    variant: "progress",
+    variant: "default",
   }));
 
   assert.match(markup, /Resting heart rate/);
@@ -159,7 +161,7 @@ test("HomeExperimentCard combines current data with progress for an active run",
   assert.match(markup, /Day 6/);
   assert.match(markup, /role="progressbar"/);
   assert.match(markup, /aria-valuenow="43"/);
-  assert.match(markup, /data-home-experiment-card-variant="progress"/);
+  assert.match(markup, /data-home-experiment-card-variant="default"/);
   assert.match(markup, /min-h-\[240px\] p-5/);
   assert.match(markup, /inline-flex size-7/);
   assert.match(markup, />Active</);
@@ -177,13 +179,86 @@ test("HomeExperiments gives history a denser three-column layout", async () => {
     inProgress: [progressCard()],
   }));
 
-  assert.match(markup, /data-home-experiment-card-variant="progress"/);
+  assert.match(markup, /data-home-experiment-card-variant="default"/);
   assert.match(markup, /data-home-experiment-card-variant="history"/);
+  assert.match(markup, /grid grid-cols-6 items-start gap-5/);
   assert.match(
     markup,
-    /gap-3 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3/,
+    /col-span-6 h-fit sm:col-span-3 md:col-span-6 lg:col-span-3 xl:col-span-2/,
   );
-  assert.match(markup, /grid sm:grid-cols-2 gap-5/);
+  assert.match(markup, /grid gap-5 sm:grid-cols-2/);
+});
+
+test("HomeExperiments preserves the standard card treatment for stopped runs", async () => {
+  const { HomeExperiments } = await import(
+    "@/src/components/home/home-experiments"
+  );
+  const markup = renderToStaticMarkup(createElement(HomeExperiments, {
+    history: [stoppedCard()],
+    inProgress: [],
+  }));
+
+  assert.match(markup, /data-home-experiment-card-variant="default"/);
+  assert.doesNotMatch(markup, /data-home-experiment-card-variant="history"/);
+  assert.match(markup, /grid grid-cols-6 items-start gap-5/);
+  assert.match(markup, /col-span-6 self-stretch sm:col-span-3/);
+  assert.doesNotMatch(markup, /xl:col-span-2/);
+  assert.match(markup, /<a class="block [^"]* h-full" href=/);
+  assert.match(markup, /h-full min-h-\[240px\] p-5/);
+  assert.match(markup, />Stopped</);
+  assert.match(markup, /Deep sleep/);
+  assert.match(markup, /Baseline/);
+  assert.match(markup, /Latest/);
+  assert.doesNotMatch(markup, /Sleep latency/);
+  assert.match(markup, /Private data/);
+  assert.match(markup, /inline-flex size-7/);
+  assert.match(markup, />View</);
+  assert.match(
+    markup,
+    /<a[^>]*href="\/experiments\/red-light-glasses"[^>]*><article/,
+  );
+});
+
+test("HomeExperiments keeps mixed history cards on lifecycle-specific grid spans", async () => {
+  const { HomeExperiments } = await import(
+    "@/src/components/home/home-experiments"
+  );
+  const stopped = stoppedCard();
+  stopped.id = "red-light-glasses-stopped";
+  const markup = renderToStaticMarkup(createElement(HomeExperiments, {
+    history: [resultCard(), stopped],
+    inProgress: [],
+  }));
+
+  assert.match(markup, /grid grid-cols-6 items-start gap-5/);
+  assert.match(
+    markup,
+    /class="col-span-6 h-fit sm:col-span-3 md:col-span-6 lg:col-span-3 xl:col-span-2"/,
+  );
+  assert.equal(
+    markup.match(/class="col-span-6 self-stretch sm:col-span-3"/g)?.length,
+    1,
+  );
+  assert.match(
+    markup,
+    /class="col-span-6 h-fit sm:col-span-3 md:col-span-6 lg:col-span-3 xl:col-span-2"[\s\S]*class="col-span-6 self-stretch sm:col-span-3"/,
+  );
+  assert.equal(
+    markup.match(/data-home-experiment-card-variant="history"/g)?.length,
+    1,
+  );
+  assert.equal(
+    markup.match(/data-home-experiment-card-variant="default"/g)?.length,
+    1,
+  );
+  assert.match(
+    markup,
+    /data-home-experiment-card-variant="history"[\s\S]*data-home-experiment-card-variant="default"/,
+  );
+  assert.match(
+    markup,
+    /data-home-experiment-card-variant="history"[\s\S]*h-full min-h-\[240px\][\s\S]*data-home-experiment-card-variant="default"/,
+  );
 });
 
 function resultCard(): ExperimentLibraryCard {
@@ -201,10 +276,6 @@ function resultCard(): ExperimentLibraryCard {
       dateRange: "May 1 to May 14",
       day: 14,
       metrics: [
-        {
-          current: "18 min",
-          label: "Sleep latency",
-        },
         {
           baseline: "94.8 percent",
           current: "94.1 percent",
@@ -241,6 +312,30 @@ function resultCard(): ExperimentLibraryCard {
     statusVariant: "outline",
     title: "Red Light Glasses Before Bed",
   };
+}
+
+function stoppedCard(): ExperimentLibraryCard {
+  const card = resultCard();
+  card.runStatus = "stopped";
+  card.statusLabel = "Stopped";
+  card.statusVariant = "destructive";
+  card.runSummary = {
+    completionPercent: 43,
+    dateRange: "May 1 to May 7",
+    day: 7,
+    metric: {
+      baseline: "96.4 min",
+      current: "116.8 min",
+      delta: "+20.4 min",
+      label: "Deep sleep",
+      sentiment: "positive",
+    },
+    metrics: [{
+      current: "18 min",
+      label: "Sleep latency",
+    }],
+  };
+  return card;
 }
 
 function progressCard(): ExperimentLibraryCard {

--- a/apps/web/test/home-experiment-card.test.tsx
+++ b/apps/web/test/home-experiment-card.test.tsx
@@ -50,11 +50,11 @@ test("HomeExperimentCard shows the member's result instead of protocol imagery a
   );
   assert.match(
     markup,
-    /Sleep efficiency<\/p><p class="[^"]*text-amber-600[^"]*">-0\.7 percent<\/p>/,
+    /Sleep efficiency<\/p><p class="[^"]*text-amber-700[^"]*">-0\.7 percent<span class="sr-only">, unfavorable<\/span><\/p>/,
   );
   assert.match(
     markup,
-    /Deep sleep<\/p><p class="[^"]*text-primary[^"]*">\+20\.4 min<\/p>/,
+    /Deep sleep<\/p><p class="[^"]*text-primary[^"]*">\+20\.4 min<span class="sr-only">, favorable<\/span><\/p>/,
   );
   assert.match(
     markup,
@@ -64,6 +64,10 @@ test("HomeExperimentCard shows the member's result instead of protocol imagery a
   assert.doesNotMatch(markup, /Latest/);
   assert.match(markup, /Private data/);
   assert.match(markup, /size-3 shrink-0/);
+  assert.match(
+    markup,
+    /<span class="min-w-0 truncate">May 1 to May 14<\/span>/,
+  );
   assert.match(
     markup,
     /^<a[^>]*href="\/experiments\/red-light-glasses"[^>]*><article/,
@@ -138,8 +142,31 @@ test("HomeExperimentCard keeps low-confidence completed runs concise", async () 
     card,
     variant: "history",
   }));
+  const defaultCard = resultCard();
+  defaultCard.runSummary = {
+    completionPercent: 100,
+    dateRange: "May 1 to May 14",
+    day: 14,
+    metrics: [],
+  };
+  const defaultMarkup = renderToStaticMarkup(createElement(HomeExperimentCard, {
+    card: defaultCard,
+    variant: "default",
+  }));
 
   assert.match(markup, /No clear signal/);
+  assert.match(
+    markup,
+    /<p class="[^"]*text-2xl[^"]*">No clear signal<\/p>/,
+  );
+  assert.doesNotMatch(
+    markup,
+    /<p class="[^"]*text-3xl[^"]*">No clear signal<\/p>/,
+  );
+  assert.match(
+    defaultMarkup,
+    /<p class="[^"]*text-3xl[^"]*">No clear signal<\/p>/,
+  );
   assert.doesNotMatch(markup, /Sleep latency/);
   assert.doesNotMatch(markup, /18 min/);
   assert.doesNotMatch(markup, /Protocol preview copy that should stay hidden/);
@@ -207,6 +234,10 @@ test("HomeExperiments preserves the standard card treatment for stopped runs", a
   assert.match(markup, /h-full min-h-\[240px\] p-5/);
   assert.match(markup, />Stopped</);
   assert.match(markup, /Deep sleep/);
+  assert.match(
+    markup,
+    /\+20\.4 min<span class="sr-only">, favorable<\/span>/,
+  );
   assert.match(markup, /Baseline/);
   assert.match(markup, /Latest/);
   assert.doesNotMatch(markup, /Sleep latency/);

--- a/apps/web/test/home-experiment-card.test.tsx
+++ b/apps/web/test/home-experiment-card.test.tsx
@@ -29,18 +29,93 @@ test("HomeExperimentCard shows the member's result instead of protocol imagery a
   );
   const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
     card: resultCard(),
+    variant: "history",
   }));
 
   assert.match(markup, /data-home-experiment-card/);
+  assert.match(markup, /data-home-experiment-card-variant="history"/);
+  assert.match(markup, /Sleep efficiency/);
+  assert.match(markup, /-0\.7 percent/);
   assert.match(markup, /Deep sleep/);
-  assert.match(markup, /\+13 min/);
-  assert.match(markup, /Baseline/);
-  assert.match(markup, /70 min/);
-  assert.match(markup, /Latest/);
-  assert.match(markup, /83 min/);
+  assert.match(markup, /\+20\.4 min/);
+  assert.match(markup, /HRV RMSSD/);
+  assert.match(markup, /\+0\.6 ms/);
+  assert.match(markup, /Resting heart rate/);
+  assert.match(markup, /-3\.3 bpm/);
+  assert.doesNotMatch(markup, /Sleep latency/);
+  assert.doesNotMatch(markup, /18 min/);
+  assert.match(
+    markup,
+    /Sleep efficiency[\s\S]*Deep sleep[\s\S]*HRV RMSSD[\s\S]*Resting heart rate/,
+  );
+  assert.match(
+    markup,
+    /Sleep efficiency<\/p><p class="[^"]*text-foreground[^"]*">-0\.7 percent<\/p>/,
+  );
+  assert.match(
+    markup,
+    /Deep sleep<\/p><p class="[^"]*text-primary[^"]*">\+20\.4 min<\/p>/,
+  );
+  assert.match(
+    markup,
+    /HRV RMSSD<\/p><p class="[^"]*text-foreground[^"]*">\+0\.6 ms<\/p>/,
+  );
+  assert.doesNotMatch(markup, /Baseline/);
+  assert.doesNotMatch(markup, /Latest/);
   assert.match(markup, /Private data/);
+  assert.match(markup, /size-3 shrink-0/);
+  assert.match(
+    markup,
+    /^<a[^>]*href="\/experiments\/red-light-glasses"[^>]*><article/,
+  );
+  assert.doesNotMatch(markup, /inline-flex size-7/);
+  assert.doesNotMatch(markup, />Completed</);
+  assert.doesNotMatch(markup, />View</);
+  assert.doesNotMatch(markup, /min-h-\[240px\]/);
   assert.doesNotMatch(markup, /<img/);
   assert.doesNotMatch(markup, /Protocol preview copy that should stay hidden/);
+});
+
+test("HomeExperimentCard preserves a non-redundant history status", async () => {
+  const { HomeExperimentCard } = await import(
+    "@/src/components/home/home-experiment-card"
+  );
+  const card = resultCard();
+  card.statusLabel = "Review due";
+  const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
+    card,
+    variant: "history",
+  }));
+
+  assert.match(markup, />Review due</);
+});
+
+test("HomeExperimentCard does not hide a source Done status", async () => {
+  const { HomeExperimentCard } = await import(
+    "@/src/components/home/home-experiment-card"
+  );
+  const card = resultCard();
+  card.statusLabel = "Done";
+  const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
+    card,
+    variant: "history",
+  }));
+
+  assert.match(markup, />Done</);
+});
+
+test("HomeExperimentCard hides a redundant Finished history status", async () => {
+  const { HomeExperimentCard } = await import(
+    "@/src/components/home/home-experiment-card"
+  );
+  const card = resultCard();
+  card.statusLabel = "Finished";
+  const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
+    card,
+    variant: "history",
+  }));
+
+  assert.doesNotMatch(markup, />Finished</);
 });
 
 test("HomeExperimentCard keeps low-confidence completed runs concise", async () => {
@@ -52,10 +127,19 @@ test("HomeExperimentCard keeps low-confidence completed runs concise", async () 
     completionPercent: 100,
     dateRange: "May 1 to May 14",
     day: 14,
+    metrics: [{
+      current: "18 min",
+      label: "Sleep latency",
+    }],
   };
-  const markup = renderToStaticMarkup(createElement(HomeExperimentCard, { card }));
+  const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
+    card,
+    variant: "history",
+  }));
 
   assert.match(markup, /No clear signal/);
+  assert.doesNotMatch(markup, /Sleep latency/);
+  assert.doesNotMatch(markup, /18 min/);
   assert.doesNotMatch(markup, /Protocol preview copy that should stay hidden/);
   assert.doesNotMatch(markup, /<img/);
 });
@@ -66,6 +150,7 @@ test("HomeExperimentCard combines current data with progress for an active run",
   );
   const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
     card: progressCard(),
+    variant: "progress",
   }));
 
   assert.match(markup, /Resting heart rate/);
@@ -74,7 +159,31 @@ test("HomeExperimentCard combines current data with progress for an active run",
   assert.match(markup, /Day 6/);
   assert.match(markup, /role="progressbar"/);
   assert.match(markup, /aria-valuenow="43"/);
+  assert.match(markup, /data-home-experiment-card-variant="progress"/);
+  assert.match(markup, /min-h-\[240px\] p-5/);
+  assert.match(markup, /inline-flex size-7/);
+  assert.match(markup, />Active</);
+  assert.doesNotMatch(markup, /Sleep efficiency/);
+  assert.doesNotMatch(markup, /94\.1 percent/);
   assert.doesNotMatch(markup, /<img/);
+});
+
+test("HomeExperiments gives history a denser three-column layout", async () => {
+  const { HomeExperiments } = await import(
+    "@/src/components/home/home-experiments"
+  );
+  const markup = renderToStaticMarkup(createElement(HomeExperiments, {
+    history: [resultCard()],
+    inProgress: [progressCard()],
+  }));
+
+  assert.match(markup, /data-home-experiment-card-variant="progress"/);
+  assert.match(markup, /data-home-experiment-card-variant="history"/);
+  assert.match(
+    markup,
+    /gap-3 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3/,
+  );
+  assert.match(markup, /grid sm:grid-cols-2 gap-5/);
 });
 
 function resultCard(): ExperimentLibraryCard {
@@ -91,13 +200,40 @@ function resultCard(): ExperimentLibraryCard {
       completionPercent: 100,
       dateRange: "May 1 to May 14",
       day: 14,
-      metric: {
-        baseline: "70 min",
-        current: "83 min",
-        delta: "+13 min",
-        label: "Deep sleep",
-        sentiment: "positive",
-      },
+      metrics: [
+        {
+          current: "18 min",
+          label: "Sleep latency",
+        },
+        {
+          baseline: "94.8 percent",
+          current: "94.1 percent",
+          delta: "-0.7 percent",
+          label: "Sleep efficiency",
+          sentiment: "negative",
+        },
+        {
+          baseline: "96.4 min",
+          current: "116.8 min",
+          delta: "+20.4 min",
+          label: "Deep sleep",
+          sentiment: "positive",
+        },
+        {
+          baseline: "60.6 ms",
+          current: "61.2 ms",
+          delta: "+0.6 ms",
+          label: "HRV RMSSD",
+          sentiment: "neutral",
+        },
+        {
+          baseline: "50.4 bpm",
+          current: "47.1 bpm",
+          delta: "-3.3 bpm",
+          label: "Resting heart rate",
+          sentiment: "positive",
+        },
+      ],
     },
     searchText: "red light glasses",
     startedOn: "2026-05-01",
@@ -127,6 +263,13 @@ function progressCard(): ExperimentLibraryCard {
         label: "Resting heart rate",
         sentiment: "positive",
       },
+      metrics: [{
+        baseline: "94.8 percent",
+        current: "94.1 percent",
+        delta: "-0.7 percent",
+        label: "Sleep efficiency",
+        sentiment: "negative",
+      }],
     },
     searchText: "cold plunge",
     startedOn: "2026-06-01",

--- a/apps/web/test/run-card-summary.test.ts
+++ b/apps/web/test/run-card-summary.test.ts
@@ -33,6 +33,15 @@ test("buildExperimentRunCardSummary preserves every comparable metric in run ord
   const summary = buildExperimentRunCardSummary(createRun({
     signals: [
       {
+        baseline: "20 min",
+        delta: "",
+        direction: "neutral",
+        expected: "",
+        label: "Sleep latency",
+        unit: "min",
+        value: "18",
+      },
+      {
         baseline: "94.8 percent",
         delta: "-0.7 percent",
         direction: "down",
@@ -51,6 +60,16 @@ test("buildExperimentRunCardSummary preserves every comparable metric in run ord
         sentiment: "positive",
         unit: "min",
         value: "116.8",
+      },
+      {
+        baseline: "60.6 ms",
+        delta: "+0.6 ms",
+        direction: "up",
+        expected: "",
+        label: "HRV RMSSD",
+        sentiment: "neutral",
+        unit: "ms",
+        value: "61.2",
       },
       {
         baseline: "50.4 bpm",
@@ -96,8 +115,8 @@ test("buildExperimentRunCardSummary preserves every comparable metric in run ord
   })), [
     { delta: "-0.7 percent", label: "Sleep efficiency", sentiment: "negative" },
     { delta: "+20.4 min", label: "Deep sleep", sentiment: "positive" },
+    { delta: "+0.6 ms", label: "HRV RMSSD", sentiment: "neutral" },
     { delta: "-3.3 bpm", label: "Resting heart rate", sentiment: "positive" },
-    { delta: "+0.6 ms", label: "HRV RMSSD", sentiment: undefined },
   ]);
   assert.equal(summary.metric?.label, "Deep sleep");
 });
@@ -114,7 +133,7 @@ test("buildExperimentRunCardSummary falls back to trend values", () => {
     label: "Deep sleep",
     sentiment: undefined,
   });
-  assert.deepEqual(summary.metrics, [summary.metric]);
+  assert.deepEqual(summary.metrics, []);
 });
 
 test("buildExperimentRunCardSummary stays honest when no comparable metric exists", () => {

--- a/apps/web/test/run-card-summary.test.ts
+++ b/apps/web/test/run-card-summary.test.ts
@@ -19,7 +19,87 @@ test("buildExperimentRunCardSummary projects a compact primary result", () => {
       label: "Deep sleep",
       sentiment: "positive",
     },
+    metrics: [{
+      baseline: "70 min",
+      current: "83 min",
+      delta: "+13 min",
+      label: "Deep sleep",
+      sentiment: "positive",
+    }],
   });
+});
+
+test("buildExperimentRunCardSummary preserves every comparable metric in run order", () => {
+  const summary = buildExperimentRunCardSummary(createRun({
+    signals: [
+      {
+        baseline: "94.8 percent",
+        delta: "-0.7 percent",
+        direction: "down",
+        expected: "",
+        label: "Sleep efficiency",
+        sentiment: "negative",
+        unit: "percent",
+        value: "94.1",
+      },
+      {
+        baseline: "96.4 min",
+        delta: "+20.4 min",
+        direction: "up",
+        expected: "",
+        label: "Deep sleep",
+        sentiment: "positive",
+        unit: "min",
+        value: "116.8",
+      },
+      {
+        baseline: "50.4 bpm",
+        delta: "-3.3 bpm",
+        direction: "down",
+        expected: "",
+        label: "Resting heart rate",
+        sentiment: "positive",
+        unit: "bpm",
+        value: "47.1",
+      },
+    ],
+    trends: [
+      {
+        active: [{ day: 4, value: 116.8 }],
+        baseline: [{ day: 1, value: 96.4 }],
+        baselineAvg: 96.4,
+        currentValue: 116.8,
+        delta: "+20.4 min",
+        history: [],
+        label: "Deep sleep",
+        startDate: "2026-05-01",
+        unit: "min",
+      },
+      {
+        active: [{ day: 4, value: 61.2 }],
+        baseline: [{ day: 1, value: 60.6 }],
+        baselineAvg: 60.6,
+        currentValue: 61.2,
+        delta: "+0.6 ms",
+        history: [],
+        label: "HRV RMSSD",
+        startDate: "2026-05-01",
+        unit: "ms",
+      },
+    ],
+  }));
+
+  assert.deepEqual(summary.metrics.map((metric) => ({
+    delta: metric.delta,
+    label: metric.label,
+    sentiment: metric.sentiment,
+  })), [
+    { delta: "-0.7 percent", label: "Sleep efficiency", sentiment: "negative" },
+    { delta: "+20.4 min", label: "Deep sleep", sentiment: "positive" },
+    { delta: "-3.3 bpm", label: "Resting heart rate", sentiment: "positive" },
+    { delta: "+0.6 ms", label: "HRV RMSSD", sentiment: undefined },
+  ]);
+  assert.equal(summary.metric?.label, "Deep sleep");
 });
 
 test("buildExperimentRunCardSummary falls back to trend values", () => {
@@ -34,6 +114,7 @@ test("buildExperimentRunCardSummary falls back to trend values", () => {
     label: "Deep sleep",
     sentiment: undefined,
   });
+  assert.deepEqual(summary.metrics, [summary.metric]);
 });
 
 test("buildExperimentRunCardSummary stays honest when no comparable metric exists", () => {
@@ -46,6 +127,7 @@ test("buildExperimentRunCardSummary stays honest when no comparable metric exist
     dateRange: "May 1 to May 14",
     day: 14,
     metric: undefined,
+    metrics: [],
   });
 });
 


### PR DESCRIPTION
## Why

Completed experiment cards on Home consumed too much space and reduced multi-metric runs to one arbitrary result, which could hide the useful shape of a mixed outcome.

## User-visible goal

- Make completed experiment history cards materially smaller.
- Show every comparable outcome delta in the run’s source order without cherry-picking favorable evidence.
- Preserve the existing progress-first treatment for active and paused experiments.

## End-to-end UX

On Home, active experiments continue to show progress and their existing primary metric. Completed experiments use a denser responsive grid, show concise metric deltas, retain honest positive/neutral/unfavorable tone, keep privacy labeling beside the date, and remain whole-card links to the detailed experiment result.

## Invariants

- No experiment storage, analysis semantics, status normalization, schema, dependency, or detail-page behavior changes.
- Active and paused cards retain their prior primary-metric selector and larger visual treatment.
- History preserves source order and includes mixed evidence; it does not rank unlike units or choose only favorable outcomes.
- Sparse current-only values do not masquerade as comparable completed outcomes.

## Non-obvious affected surfaces

- The run-card projection now exposes an ordered metrics collection alongside the preserved primary metric.
- The durable design guide documents the compact Home history-card pattern.
- The shared standard result renderer used by stopped cards also receives the contrast-safe negative tone and assistive-technology sentiment suffix. This keeps equivalent result meaning from being conveyed by color alone on one lifecycle treatment; the stopped-card test pins the standard renderer and favorable suffix, while the completed-card assertion pins amber-700 and the unfavorable suffix.

## Verification

- Diff-aware repository verification passed: guards, TypeScript, 437 test files / 5,384 tests (141 skipped), ESLint with zero errors and 12 unrelated warnings, dev smoke, and production Next.js build.
- Focused component test passed: 9/9 tests after the Fable remediation and coverage follow-up.
- Fable's initial design review identified targeted accessibility and hierarchy refinements; its correction review returned PASS.
- Coverage-write added one standard-card hierarchy assertion, and the required frontend review found no unresolved issues.
- Browser visual proof remains unavailable because no browser backend was attached; static server-render coverage verifies responsive and semantic behavior.

ReviewGPT first-reviewed head: 35e888c1dc7fc03b6acd3db6dbaeef9660e20223

## First-reviewed change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 99 | 25 |
| Tests / fixtures | 238 | 13 |
| Docs | 90 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **427** | **38** |

## Current head after review remediation

Current pushed head: 6db6bbb66da12e7c02852d230d8a988dfeff3667

- Preserved the accepted round-1 corrections for stopped-run purpose, sentiment separation, and comparable-metric ownership.
- Applied the requested Fable UI pass: unfavorable deltas now use AA-compliant amber-700, result sentiment is exposed to assistive technology, footer dates ellipsize correctly, and empty compact cards retain proportional hierarchy.
- Preserved the explicit two-column standard treatment for stopped cards; finished cards alone use the compact three-column wide-desktop span.
- Clarified the design-system distinction between readable amber result text and the decorative amber grain token.

## Round 3 anomaly retrospective

Round 3 is required because this is the third substantive ReviewGPT head. The original requirement remains unchanged: compact completed Home cards must show all comparable outcomes honestly while active, paused, and stopped lifecycle treatments remain intact.

- First-reviewed authored source: 99 additions / 25 deletions.
- Current authored source: 146 additions / 26 deletions (172 lines of churn, well below the 2,000-line threshold).
- Source additions grew by 47 (+47.5%): 22 lines from accepted round-1 lifecycle/ownership corrections and 25 lines from the user's requested Fable accessibility and hierarchy pass.
- The Fable delta adds no dependency, owner, persisted state, schema, route, service, state machine, or architectural abstraction. It stays inside the existing card component and shared metric projection.
- Decision: continue this PR without splitting or redesigning. The growth is proportional, directly user-requested UI refinement with focused proof, not repeated tactical machinery.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 146 | 26 |
| Tests / fixtures | 489 | 16 |
| Docs | 92 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **727** | **42** |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786825797&installation_id=127572939&pr_number=758&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F758&signature=98a0a82b0af22ee46bf06589fbed0ffa79c904e06330802f2fe9a27c0d057ce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

