### PR TITLE
Reduce hosted checkpoint CPU

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-cloudflare-checkpoint-cpu.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-cloudflare-checkpoint-cpu.md
@@ -1,0 +1,96 @@
+# Cloudflare Checkpoint CPU Reduction
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- Reduce the CPU and memory cost of hosted workspace checkpoint and restore work without adding foreground user latency or weakening snapshot integrity, interruptibility, encryption, or workspace-version fencing.
+- Diagnose concentrated high-CPU runner instances with production-faithful Docker measurements and land the smallest maintainable fix set that the evidence supports.
+
+## Success criteria
+
+- A private production vault can be exercised through the production runner image without copying its contents into the repository or emitting file names, paths, or payloads.
+- Baseline and changed runs report aggregate wall time, CPU time, peak cgroup memory, archive bytes, and file counts for the same workload.
+- Each production-code optimization removes demonstrated duplicate work or an avoidable allocation and has focused correctness/failure coverage.
+- Foreground-priority, abort, archive-integrity, encryption, and workspace-CAS invariants remain intact.
+- Required Cloudflare verification, production-image proof, completion audits, CI, and ReviewGPT reach a clean result before merge.
+
+## Scope
+
+- In scope:
+  - `apps/cloudflare` local v2 snapshot writer/restore implementation and focused tests.
+  - Existing runner Docker bundle/image tooling needed for production-faithful proof.
+  - Directly affected snapshot protocol and verification documentation.
+  - One cohesive PR by default; split only if the evidence yields independently deployable fixes with materially different risk.
+- Out of scope:
+  - Reducing the production container size before post-change telemetry proves `basic` headroom.
+  - Shortening the warm container TTL under the zero-added-latency constraint.
+  - New queues, services, persisted state, cache managers, or profiler subsystems.
+  - Unrelated browser-vault, Codex transcript, or hosted orchestration refactors.
+
+## Constraints
+
+- Technical constraints:
+  - Preserve authenticate-before-extract, symlink/path safety, snapshot bounds, canonical-write locking, and pre-publication abort behavior.
+  - Keep the snapshot body on the direct container-to-R2 path; do not move it through the Worker.
+  - Benchmark the exact production app-layer image on a constrained Linux container; local ARM64 emulation limitations must be reported rather than hidden.
+- Product/process constraints:
+  - Foreground input must not wait for checkpoint or maintenance work.
+  - The private vault is read-only test input and must never enter Git, logs, docs, fixtures, uploaded artifacts, PR text, or review packets.
+  - Favor deletion and single-pass data flow over new abstractions.
+
+## Risks and mitigations
+
+1. Risk: Removing validation work could accept an unsafe or incomplete archive.
+   Mitigation: Map each current validation to its owning invariant, retain independent proof where required, and add corruption/race tests before deleting a pass.
+2. Risk: A faster wall-clock result could use the same or more billed CPU.
+   Mitigation: Measure CPU-seconds and throttling alongside elapsed time and memory peak.
+3. Risk: Docker Desktop architecture emulation could distort production sizing conclusions.
+   Mitigation: use relative before/after comparisons on the same image and configuration, record the architecture gap, and rely on native CI for final AMD64 image proof.
+4. Risk: Test instrumentation could become production complexity.
+   Mitigation: keep one-off private benchmarks outside Git and add only reusable aggregate observability when it directly closes a production decision gap.
+
+## Tasks
+
+1. Map snapshot/checkpoint invariants and reproduce current CPU/memory behavior in the production runner image.
+2. Attribute duplicate work by phase and verify whether concentrated CPU aligns with snapshot size/file count or another runtime phase.
+3. Select the smallest high-value fixes supported by repeatable evidence.
+4. Implement focused fixes and regression tests.
+5. Re-run identical Docker measurements, full required verification, coverage-write, CI, and ReviewGPT.
+6. Commit, push, open the PR, resolve findings, and merge when all required gates are green.
+
+## Decisions
+
+- Default to one cohesive checkpoint/restore PR; do not manufacture multiple PRs without an independent deployment or review boundary.
+- Do not lower container resources in this task. The result should create evidence and headroom for a later canary.
+- Use the private production vault only for local aggregate benchmark evidence; committed tests use synthetic fixtures.
+- Keep the existing two-thread zstd setting. A separate six-pair one-thread experiment was noisy, with effectively flat median wall time and no repeatable advantage large enough to justify another behavior change.
+- Replace the post-write decrypt/decompress/tar-list pass with validation of the original tar process's verbose manifest plus a byte-for-byte encrypted-file digest check. This preserves plan, archive, and exact-upload-object proof without a second archive traversal.
+- Cache each selected path's `lstat` result only within one preflight pass. The canonical workspace write lock remains the concurrency owner, while the post-archive pass starts with a fresh cache and retains the existing unchanged-state comparison.
+
+## Evidence
+
+- The production runner base image was exercised as Linux AMD64 with one CPU, 3 GiB memory, no network, and read-only private-vault input. Only aggregate measurements were emitted; the workload contents and paths stayed outside the repository and review artifacts.
+- Across six paired before/after runs on the same representative workload, median checkpoint-build CPU fell 63.3%, checkpoint-build wall time fell 66.6%, and end-to-end snapshot/restore CPU fell 51.6%. Peak memory was effectively flat and slightly lower in the paired median.
+- A separate six-pair isolation run showed that eliminating repeated ancestor metadata reads accounted for the dominant improvement: median checkpoint-build CPU fell 69.6% and wall time fell 73.0% relative to the otherwise identical single-pass implementation.
+
+## Verification
+
+- Focused snapshot writer/restore tests, including abort and corruption cases.
+- `pnpm test:diff <changed paths>` during iteration.
+- `pnpm verify:acceptance` for the final high-risk Cloudflare runtime patch.
+- Production runner image build and identical before/after checkpoint/restore benchmark under explicit CPU/memory limits.
+- `pnpm --dir apps/cloudflare runner:docker:smoke:prepared-base` or the strongest applicable production-image smoke supported by the local architecture.
+- Required `coverage-write` audit, privacy/diff review, CI, and ReviewGPT on the exact pushed PR head.
+
+## Local completion results
+
+- Focused snapshot coverage passed with 17 tests, including emitted-manifest divergence, redundant-process deletion, abort cleanup, and encrypted-file digest mismatch cleanup.
+- The required `coverage-write` audit added only the encrypted-file digest mismatch proof and returned with no unresolved findings.
+- Cloudflare typecheck passed during the scoped diff lane. The wider app test bucket did not complete locally: default-parallel, serial, and single-worker attempts each stalled in unrelated package-build subprocess I/O under shared-host contention after the changed focused suite had passed.
+- The production runner bundle and AMD64 application image built successfully. The local container smoke reached the Codex permission probe, then stopped because Docker Desktop's emulated Linux kernel returned `ENOSYS` while Codex installed its nested seccomp filter; native Linux CI remains the authoritative smoke lane.
+- `pnpm verify:acceptance` could not start because an unrelated verification process held the single shared-host slot while idle for more than 22 minutes. The queued waiter was cancelled without signaling the unowned slot holder.
+- `git diff --check` passed. PR CI and ReviewGPT remain the post-push merge-readiness gates.
+Completed: 2026-07-16

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -190,7 +190,6 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
       hash: encryptedObjectHash,
       maxBytes: input.maxEncryptedBytes,
     });
-    await assertHostedWorkspaceSnapshotZstdCliAvailable();
     assertHostedWorkspaceSnapshotConstructionLive(input.signal);
     const tar = spawn("tar", [
       "-C",
@@ -199,7 +198,7 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
       "--null",
       "-T",
       tarListPath,
-      "-cf",
+      "-cvvf",
       "-",
     ], {
       env: { ...process.env, COPYFILE_DISABLE: "1" },
@@ -208,6 +207,10 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
     const zstd = spawn("zstd", [...HOSTED_WORKSPACE_SNAPSHOT_ZSTD_ARGS], {
       stdio: ["pipe", "pipe", "pipe"],
     });
+    const emittedTarEntries = collectHostedWorkspaceSnapshotVerboseTarEntries(
+      tar.stderr,
+      input.signal,
+    );
     const tarExit = waitForHostedWorkspaceSnapshotProcess(tar, "tar");
     const zstdExit = waitForHostedWorkspaceSnapshotProcess(zstd, "zstd");
     const pipelineOptions = input.signal ? { signal: input.signal } : {};
@@ -223,7 +226,7 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
         pipeline(tar.stdout, zstd.stdin, pipelineOptions),
         [tarExit, zstdExit],
       );
-      await Promise.all([
+      const [, , , , tarEntries] = await Promise.all([
         archiveInputPipe,
         pipeline(
           zstd.stdout,
@@ -235,7 +238,13 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
         ),
         tarExit,
         zstdExit,
+        emittedTarEntries,
       ]);
+      assertHostedWorkspaceSnapshotArchiveMatchesState({
+        entries: tarEntries,
+        expected: preflight,
+        signal: input.signal,
+      });
     } catch (error) {
       tar.kill("SIGTERM");
       zstd.kill("SIGTERM");
@@ -266,17 +275,16 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
     if (encryptedStat.size !== encryptedByteSize) {
       throw new Error("Hosted workspace snapshot encrypted size accounting failed.");
     }
-    await assertHostedWorkspaceSnapshotEncryptedArchiveMatchesState({
-      aad: input.aad,
-      authTag,
-      dataKey,
-      encryptedByteSize,
-      encryptedFilePath,
-      expected: preflight,
-      iv,
+    const encryptedObjectSha256 = encryptedObjectHash.digest("hex");
+    const encryptedFileSha256 = await hashHostedWorkspaceSnapshotFile({
+      filePath: encryptedFilePath,
       signal: input.signal,
     });
-    assertHostedWorkspaceSnapshotConstructionLive(input.signal);
+    if (encryptedFileSha256 !== encryptedObjectSha256) {
+      throw new Error(
+        "Hosted workspace snapshot encrypted file digest does not match its output.",
+      );
+    }
     const postArchivePreflight = await readHostedWorkspaceSnapshotSelectedEntryState({
       archiveEntries: input.archiveEntries,
       durableRoot,
@@ -290,7 +298,7 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
       compression: HOSTED_WORKSPACE_SNAPSHOT_COMPRESSION,
       encryptedByteSize,
       encryptedFilePath,
-      encryptedObjectSha256: encryptedObjectHash.digest("hex"),
+      encryptedObjectSha256,
       fileCount: preflight.fileCount,
       ivBase64: input.ivBase64,
       plaintextArchiveSha256: plaintextArchiveHash.digest("hex"),
@@ -303,6 +311,20 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
       await rm(tempDir, { force: true, recursive: true });
     }
   }
+}
+
+async function hashHostedWorkspaceSnapshotFile(input: {
+  filePath: string;
+  signal?: AbortSignal | null;
+}): Promise<string> {
+  const hash = createHash("sha256");
+  const stream = createReadStream(input.filePath);
+  for await (const chunk of stream) {
+    assertHostedWorkspaceSnapshotConstructionLive(input.signal);
+    hash.update(chunk);
+  }
+  assertHostedWorkspaceSnapshotConstructionLive(input.signal);
+  return hash.digest("hex");
 }
 
 function assertHostedWorkspaceSnapshotConstructionLive(
@@ -404,7 +426,6 @@ export async function restoreEncryptedWorkspaceSnapshotFromEncryptedStream(input
   const durableRoot = path.resolve(input.durableRoot);
   const durableParent = path.dirname(durableRoot);
   await mkdir(durableParent, { mode: 0o700, recursive: true });
-  await assertHostedWorkspaceSnapshotZstdCliAvailable();
   const restoreTempDir = await mkdtemp(path.join(durableParent, ".workspace-snapshot-restore-"));
   const restoreRoot = path.join(restoreTempDir, "durable-root");
   const backupRoot = path.join(restoreTempDir, "previous-durable-root");
@@ -654,6 +675,7 @@ async function readHostedWorkspaceSnapshotSelectedEntryState(input: {
   const entries = new Map<string, "directory" | "file">();
   const files = new Map<string, HostedWorkspaceSnapshotDurableRootFileState>();
   const seen = new Set<string>();
+  const statsByPath = new Map<string, Stats>();
   const tarEntryPaths: string[] = [];
   let totalPlainBytes = 0;
 
@@ -679,6 +701,7 @@ async function readHostedWorkspaceSnapshotSelectedEntryState(input: {
       archivePath,
       root,
       signal: input.signal,
+      statsByPath,
     });
     assertHostedWorkspaceSnapshotConstructionLive(input.signal);
     if (isHostedWorkspaceSnapshotEnvPath(archivePath)) {
@@ -721,6 +744,7 @@ async function readHostedWorkspaceSnapshotSelectedEntryStats(input: {
   archivePath: string;
   root: string;
   signal?: AbortSignal | null;
+  statsByPath: Map<string, Stats>;
 }): Promise<Stats> {
   assertHostedWorkspaceSnapshotConstructionLive(input.signal);
   const segments = input.archivePath.split("/");
@@ -729,11 +753,15 @@ async function readHostedWorkspaceSnapshotSelectedEntryStats(input: {
   for (const [index, segment] of segments.entries()) {
     assertHostedWorkspaceSnapshotConstructionLive(input.signal);
     currentPath = path.join(currentPath, segment);
-    try {
-      stats = await lstat(currentPath);
-    } catch (error) {
-      assertHostedWorkspaceSnapshotConstructionLive(input.signal);
-      throw error;
+    stats = input.statsByPath.get(currentPath) ?? null;
+    if (!stats) {
+      try {
+        stats = await lstat(currentPath);
+      } catch (error) {
+        assertHostedWorkspaceSnapshotConstructionLive(input.signal);
+        throw error;
+      }
+      input.statsByPath.set(currentPath, stats);
     }
     assertHostedWorkspaceSnapshotConstructionLive(input.signal);
     if (stats.isSymbolicLink()) {
@@ -752,25 +780,19 @@ async function readHostedWorkspaceSnapshotSelectedEntryStats(input: {
   return stats;
 }
 
-async function assertHostedWorkspaceSnapshotEncryptedArchiveMatchesState(input: {
-  aad: HostedWorkspaceSnapshotV2Aad;
-  authTag: Buffer;
-  dataKey: Uint8Array;
-  encryptedByteSize: number;
-  encryptedFilePath: string;
+function assertHostedWorkspaceSnapshotArchiveMatchesState(input: {
+  entries: readonly string[];
   expected: HostedWorkspaceSnapshotDurableRootState;
-  iv: Buffer;
   signal?: AbortSignal | null;
-}): Promise<void> {
+}): void {
   assertHostedWorkspaceSnapshotConstructionLive(input.signal);
   const expected = input.expected;
   const remaining = new Map(expected.entries);
   const seenPaths = new Set<string>();
-  const entries = await listHostedWorkspaceSnapshotEncryptedVerboseTarEntries(input);
   let fileCount = 0;
   let totalPlainBytes = 0;
 
-  for (const entry of entries) {
+  for (const entry of input.entries) {
     assertHostedWorkspaceSnapshotConstructionLive(input.signal);
     const parsed = parseHostedWorkspaceSnapshotVerboseTarEntry(entry);
     const parsedArchivePath = normalizeHostedWorkspaceSnapshotTarEntryPath(parsed.path);
@@ -819,97 +841,29 @@ async function assertHostedWorkspaceSnapshotEncryptedArchiveMatchesState(input: 
   }
 }
 
-async function listHostedWorkspaceSnapshotEncryptedVerboseTarEntries(input: {
-  aad: HostedWorkspaceSnapshotV2Aad;
-  authTag: Buffer;
-  dataKey: Uint8Array;
-  encryptedByteSize: number;
-  encryptedFilePath: string;
-  iv: Buffer;
-  signal?: AbortSignal | null;
-}): Promise<string[]> {
-  assertHostedWorkspaceSnapshotConstructionLive(input.signal);
-  const decipher = createDecipheriv(
-    "aes-256-gcm",
-    Buffer.from(input.dataKey),
-    input.iv,
-  );
-  decipher.setAAD(Buffer.from(serializeHostedWorkspaceSnapshotV2Aad(input.aad)));
-  decipher.setAuthTag(input.authTag);
-  const zstd = spawn("zstd", [
-    "-d",
-    "--stdout",
-  ], {
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  const tar = spawn("tar", [
-    "-tvf",
-    "-",
-  ], {
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  if (!zstd.stdin || !zstd.stdout || !tar.stdin) {
-    throw new Error("Hosted workspace snapshot tar list streams are unavailable.");
+async function collectHostedWorkspaceSnapshotVerboseTarEntries(
+  stream: Readable | null,
+  signal: AbortSignal | null | undefined,
+): Promise<string[]> {
+  if (!stream) {
+    throw new Error("Hosted workspace snapshot tar stderr is unavailable.");
   }
-  if (!tar.stdout) {
-    throw new Error("Hosted workspace snapshot tar list stdout is unavailable.");
-  }
-  tar.stdout.setEncoding("utf8");
-  const zstdExit = waitForHostedWorkspaceSnapshotProcess(zstd, "zstd");
-  const tarExit = waitForHostedWorkspaceSnapshotProcess(tar, "tar");
-  const pipelineOptions = input.signal ? { signal: input.signal } : {};
-  const decryptPipe = waitForHostedWorkspaceSnapshotProcessPipe(
-    pipeline(
-      createReadStream(input.encryptedFilePath, {
-        end: input.encryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES - 1,
-        start: 0,
-      }),
-      decipher,
-      zstd.stdin,
-      pipelineOptions,
-    ),
-    [zstdExit, tarExit],
-  );
-  const archivePipe = waitForHostedWorkspaceSnapshotProcessPipe(
-    pipeline(zstd.stdout, tar.stdin, pipelineOptions),
-    [zstdExit, tarExit],
-  );
   const lines = createInterface({
     crlfDelay: Number.POSITIVE_INFINITY,
-    input: tar.stdout,
+    input: stream,
   });
   const entries: string[] = [];
-  try {
-    for await (const line of lines) {
-      assertHostedWorkspaceSnapshotConstructionLive(input.signal);
-      if (line.trim().length === 0) {
-        continue;
-      }
-      entries.push(line);
-      if (entries.length > HOSTED_WORKSPACE_SNAPSHOT_MAX_TAR_ENTRIES) {
-        throw new Error("Hosted workspace snapshot tar entry count is unsafe.");
-      }
+  for await (const line of lines) {
+    assertHostedWorkspaceSnapshotConstructionLive(signal);
+    if (line.trim().length === 0) {
+      continue;
     }
-    await Promise.all([decryptPipe, archivePipe]);
-    await Promise.all([zstdExit, tarExit]);
-    assertHostedWorkspaceSnapshotConstructionLive(input.signal);
-  } catch (error) {
-    zstd.kill("SIGTERM");
-    tar.kill("SIGTERM");
-    const processFailure = await readHostedWorkspaceSnapshotProcessFailure([
-      zstdExit,
-      tarExit,
-    ]);
-    await Promise.allSettled([decryptPipe, archivePipe]);
-    assertHostedWorkspaceSnapshotConstructionLive(input.signal);
-    if (
-      processFailure
-      && shouldPreferHostedWorkspaceSnapshotProcessFailure(error)
-    ) {
-      throw processFailure;
+    entries.push(line);
+    if (entries.length > HOSTED_WORKSPACE_SNAPSHOT_MAX_TAR_ENTRIES) {
+      throw new Error("Hosted workspace snapshot tar entry count is unsafe.");
     }
-    throw error;
   }
+  assertHostedWorkspaceSnapshotConstructionLive(signal);
   return entries;
 }
 
@@ -918,11 +872,12 @@ function parseHostedWorkspaceSnapshotVerboseTarEntry(entry: string): {
   size: number;
   type: "directory" | "file";
 } {
-  const type = entry[0];
+  const normalizedEntry = entry.startsWith("a ") ? entry.slice(2) : entry;
+  const type = normalizedEntry[0];
   if (type !== "-" && type !== "d") {
     throw new Error("Hosted workspace snapshot tar entry type is unsafe.");
   }
-  const parsed = parseHostedWorkspaceSnapshotVerboseTarEntryFields(entry);
+  const parsed = parseHostedWorkspaceSnapshotVerboseTarEntryFields(normalizedEntry);
   if (!parsed) {
     throw new Error("Hosted workspace snapshot tar entry format is unsupported.");
   }
@@ -1123,13 +1078,6 @@ function createBoundedHashTransform(input: {
     get: () => byteCount,
   });
   return transform;
-}
-
-async function assertHostedWorkspaceSnapshotZstdCliAvailable(): Promise<void> {
-  const zstd = spawn("zstd", ["--version"], {
-    stdio: ["ignore", "ignore", "pipe"],
-  });
-  await waitForHostedWorkspaceSnapshotProcess(zstd, "zstd");
 }
 
 function waitForHostedWorkspaceSnapshotProcess(

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -276,15 +276,6 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
       throw new Error("Hosted workspace snapshot encrypted size accounting failed.");
     }
     const encryptedObjectSha256 = encryptedObjectHash.digest("hex");
-    const encryptedFileSha256 = await hashHostedWorkspaceSnapshotFile({
-      filePath: encryptedFilePath,
-      signal: input.signal,
-    });
-    if (encryptedFileSha256 !== encryptedObjectSha256) {
-      throw new Error(
-        "Hosted workspace snapshot encrypted file digest does not match its output.",
-      );
-    }
     const postArchivePreflight = await readHostedWorkspaceSnapshotSelectedEntryState({
       archiveEntries: input.archiveEntries,
       durableRoot,
@@ -311,20 +302,6 @@ export async function createEncryptedWorkspaceSnapshotFile(input: {
       await rm(tempDir, { force: true, recursive: true });
     }
   }
-}
-
-async function hashHostedWorkspaceSnapshotFile(input: {
-  filePath: string;
-  signal?: AbortSignal | null;
-}): Promise<string> {
-  const hash = createHash("sha256");
-  const stream = createReadStream(input.filePath);
-  for await (const chunk of stream) {
-    assertHostedWorkspaceSnapshotConstructionLive(input.signal);
-    hash.update(chunk);
-  }
-  assertHostedWorkspaceSnapshotConstructionLive(input.signal);
-  return hash.digest("hex");
 }
 
 function assertHostedWorkspaceSnapshotConstructionLive(

--- a/apps/cloudflare/test/hosted-local-direct-r2-presigned-put-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-direct-r2-presigned-put-e2e.test.ts
@@ -65,6 +65,8 @@ describe("hosted local direct R2 presigned PUT e2e", () => {
       `direct-r2-presigned-put/${userId}/${randomUUID()}-changed-metadata.bin`;
     const negativeMissingChecksumObjectKey =
       `direct-r2-presigned-put/${userId}/${randomUUID()}-missing-checksum.bin`;
+    const negativeWrongBodyObjectKey =
+      `direct-r2-presigned-put/${userId}/${randomUUID()}-wrong-body.bin`;
     const metadata = {
       encryptedsha256: payload.sha256Hex,
       schema: HOSTED_WORKSPACE_SNAPSHOT_V2_REF_SCHEMA,
@@ -188,10 +190,28 @@ describe("hosted local direct R2 presigned PUT e2e", () => {
       });
       expect(missingChecksumResponse.ok).toBe(false);
 
+      const wrongBodyPutUrl = await createHostedR2PresignedPutUrl({
+        checksumSha256Base64: payload.sha256Base64,
+        contentType: directR2ContentType,
+        environment,
+        expiresSeconds: 300,
+        key: negativeWrongBodyObjectKey,
+        metadata,
+      });
+      const wrongBodyBytes = payload.bytes.slice(0);
+      new Uint8Array(wrongBodyBytes)[0] ^= 0xff;
+      const wrongBodyResponse = await putPresignedObject({
+        headers: requestHeaders,
+        payload: wrongBodyBytes,
+        url: wrongBodyPutUrl.url,
+      });
+      expect(wrongBodyResponse.ok).toBe(false);
+
       for (const negativeObjectKey of [
         negativeMissingMetadataObjectKey,
         negativeChangedMetadataObjectKey,
         negativeMissingChecksumObjectKey,
+        negativeWrongBodyObjectKey,
       ]) {
         const negativeHeadUrl = await createHostedR2PresignedHeadUrl({
           environment,
@@ -209,6 +229,7 @@ describe("hosted local direct R2 presigned PUT e2e", () => {
       await deletePresignedObjectBestEffort(environment, negativeMissingMetadataObjectKey);
       await deletePresignedObjectBestEffort(environment, negativeChangedMetadataObjectKey);
       await deletePresignedObjectBestEffort(environment, negativeMissingChecksumObjectKey);
+      await deletePresignedObjectBestEffort(environment, negativeWrongBodyObjectKey);
     }
   }, directR2PresignedPutTimeoutMs);
 });

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   buildHostedWorkspaceSnapshotV2Aad,
@@ -840,66 +840,6 @@ exec "$REAL_TAR" "$@"
       delete process.env.MURPH_TEST_DURABLE_ROOT;
       delete process.env.MURPH_TEST_REAL_TAR;
       delete process.env.MURPH_TEST_TAR_MARKER;
-      await rm(tempRoot, { force: true, recursive: true });
-      dataKey.fill(0);
-    }
-  });
-
-  it("rejects an encrypted output that changes before its upload digest proof", async () => {
-    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-test-"));
-    const durableRoot = path.join(tempRoot, "durable");
-    const notePath = path.join(durableRoot, "vault", "note.md");
-    const outputDir = path.join(tempRoot, "scratch");
-    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
-
-    try {
-      await mkdir(path.dirname(notePath), { recursive: true });
-      await writeFile(notePath, "note\n", "utf8");
-      vi.doMock("node:fs", async () => {
-        const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-        let intercepted = false;
-        return {
-          ...actual,
-          createReadStream: (
-            filePath: Parameters<typeof actual.createReadStream>[0],
-            options?: Parameters<typeof actual.createReadStream>[1],
-          ) => {
-            if (!intercepted) {
-              intercepted = true;
-              actual.appendFileSync(filePath, "tampered");
-            }
-            return actual.createReadStream(filePath, options);
-          },
-        };
-      });
-      vi.resetModules();
-      const { createEncryptedWorkspaceSnapshotFile: createSnapshot } = await import(
-        "../src/workspace-snapshot-local.ts"
-      );
-
-      await expect(createSnapshot({
-        aad: buildHostedWorkspaceSnapshotV2Aad({
-          objectKey: "users/hsn_test/workspace-snapshots/output_digest.snapshot.enc",
-          snapshotId: "snapshot_output_digest",
-          userId: "member_123",
-        }),
-        archiveEntries: [{
-          absolutePath: notePath,
-          archivePath: "vault/note.md",
-          kind: "file",
-        }],
-        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
-        durableRoot,
-        ivBase64: Buffer.alloc(12, 7).toString("base64url"),
-        maxEncryptedBytes: 16 * 1024 * 1024,
-        outputDir,
-      })).rejects.toThrow(
-        "Hosted workspace snapshot encrypted file digest does not match its output.",
-      );
-      await expect(readdir(outputDir)).resolves.toEqual([]);
-    } finally {
-      vi.doUnmock("node:fs");
-      vi.resetModules();
       await rm(tempRoot, { force: true, recursive: true });
       dataKey.fill(0);
     }

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildHostedWorkspaceSnapshotV2Aad,
@@ -666,6 +666,110 @@ describe("workspace snapshot local restore", () => {
     }
   });
 
+  it("creates and restores with only the archive and compression processes", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-test-"));
+    const durableRoot = path.join(tempRoot, "durable");
+    const vaultRoot = path.join(durableRoot, "vault");
+    const notePath = path.join(vaultRoot, "note.md");
+    const wrapperDir = path.join(tempRoot, "bin");
+    const processMarkerPath = path.join(tempRoot, "snapshot-processes");
+    const originalPath = process.env.PATH;
+    const realTarPath = (await execFileAsync("which", ["tar"])).stdout.trim();
+    const realZstdPath = (await execFileAsync("which", ["zstd"])).stdout.trim();
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+    const objectKey = "users/hsn_test/workspace-snapshots/snapshot_processes.snapshot.enc";
+    const snapshotId = "snapshot_processes";
+    const userId = "member_123";
+
+    try {
+      await mkdir(vaultRoot, { recursive: true });
+      await mkdir(wrapperDir, { recursive: true });
+      await writeFile(notePath, "note\n", "utf8");
+      await writeFile(
+        path.join(wrapperDir, "tar"),
+        `#!/bin/sh
+case " $* " in
+  *" -xf "*) operation=tar-extract ;;
+  *) operation=tar-create ;;
+esac
+printf '%s\\n' "$operation" >> "\${MURPH_TEST_SNAPSHOT_PROCESS_MARKER:?}"
+exec "\${MURPH_TEST_REAL_TAR:?}" "$@"
+`,
+        { mode: 0o700 },
+      );
+      await writeFile(
+        path.join(wrapperDir, "zstd"),
+        `#!/bin/sh
+case "\${1:-}" in
+  --version) operation=zstd-version ;;
+  -d) operation=zstd-decompress ;;
+  *) operation=zstd-compress ;;
+esac
+printf '%s\\n' "$operation" >> "\${MURPH_TEST_SNAPSHOT_PROCESS_MARKER:?}"
+exec "\${MURPH_TEST_REAL_ZSTD:?}" "$@"
+`,
+        { mode: 0o700 },
+      );
+
+      process.env.MURPH_TEST_REAL_TAR = realTarPath;
+      process.env.MURPH_TEST_REAL_ZSTD = realZstdPath;
+      process.env.MURPH_TEST_SNAPSHOT_PROCESS_MARKER = processMarkerPath;
+      process.env.PATH = `${wrapperDir}${path.delimiter}${originalPath ?? ""}`;
+
+      const aad = buildHostedWorkspaceSnapshotV2Aad({ objectKey, snapshotId, userId });
+      const encrypted = await createEncryptedWorkspaceSnapshotFile({
+        aad,
+        archiveEntries: [
+          {
+            absolutePath: vaultRoot,
+            archivePath: "vault",
+            kind: "directory",
+          },
+          {
+            absolutePath: notePath,
+            archivePath: "vault/note.md",
+            kind: "file",
+          },
+        ],
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot,
+        ivBase64: Buffer.alloc(12, 9).toString("base64url"),
+        maxEncryptedBytes: 16 * 1024 * 1024,
+        outputDir: path.join(tempRoot, "scratch"),
+      });
+      await restoreEncryptedWorkspaceSnapshot({
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot: path.join(tempRoot, "restored", "durable"),
+        encryptedFilePath: encrypted.encryptedFilePath,
+        ref: createHostedWorkspaceSnapshotTestRef({
+          aad,
+          encrypted,
+          objectKey,
+          snapshotId,
+          userId,
+        }),
+      });
+
+      const operations = (await readFile(processMarkerPath, "utf8"))
+        .trim()
+        .split("\n")
+        .sort();
+      expect(operations).toEqual([
+        "tar-create",
+        "tar-extract",
+        "zstd-compress",
+        "zstd-decompress",
+      ]);
+    } finally {
+      process.env.PATH = originalPath;
+      delete process.env.MURPH_TEST_REAL_TAR;
+      delete process.env.MURPH_TEST_REAL_ZSTD;
+      delete process.env.MURPH_TEST_SNAPSHOT_PROCESS_MARKER;
+      await rm(tempRoot, { force: true, recursive: true });
+      dataKey.fill(0);
+    }
+  });
+
   it("rejects emitted tar members that differ from the planned entry state", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-test-"));
     const durableRoot = path.join(tempRoot, "durable");
@@ -736,6 +840,66 @@ exec "$REAL_TAR" "$@"
       delete process.env.MURPH_TEST_DURABLE_ROOT;
       delete process.env.MURPH_TEST_REAL_TAR;
       delete process.env.MURPH_TEST_TAR_MARKER;
+      await rm(tempRoot, { force: true, recursive: true });
+      dataKey.fill(0);
+    }
+  });
+
+  it("rejects an encrypted output that changes before its upload digest proof", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-test-"));
+    const durableRoot = path.join(tempRoot, "durable");
+    const notePath = path.join(durableRoot, "vault", "note.md");
+    const outputDir = path.join(tempRoot, "scratch");
+    const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+
+    try {
+      await mkdir(path.dirname(notePath), { recursive: true });
+      await writeFile(notePath, "note\n", "utf8");
+      vi.doMock("node:fs", async () => {
+        const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+        let intercepted = false;
+        return {
+          ...actual,
+          createReadStream: (
+            filePath: Parameters<typeof actual.createReadStream>[0],
+            options?: Parameters<typeof actual.createReadStream>[1],
+          ) => {
+            if (!intercepted) {
+              intercepted = true;
+              actual.appendFileSync(filePath, "tampered");
+            }
+            return actual.createReadStream(filePath, options);
+          },
+        };
+      });
+      vi.resetModules();
+      const { createEncryptedWorkspaceSnapshotFile: createSnapshot } = await import(
+        "../src/workspace-snapshot-local.ts"
+      );
+
+      await expect(createSnapshot({
+        aad: buildHostedWorkspaceSnapshotV2Aad({
+          objectKey: "users/hsn_test/workspace-snapshots/output_digest.snapshot.enc",
+          snapshotId: "snapshot_output_digest",
+          userId: "member_123",
+        }),
+        archiveEntries: [{
+          absolutePath: notePath,
+          archivePath: "vault/note.md",
+          kind: "file",
+        }],
+        dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
+        durableRoot,
+        ivBase64: Buffer.alloc(12, 7).toString("base64url"),
+        maxEncryptedBytes: 16 * 1024 * 1024,
+        outputDir,
+      })).rejects.toThrow(
+        "Hosted workspace snapshot encrypted file digest does not match its output.",
+      );
+      await expect(readdir(outputDir)).resolves.toEqual([]);
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
       await rm(tempRoot, { force: true, recursive: true });
       dataKey.fill(0);
     }


### PR DESCRIPTION
## Why this exists

Hosted idle checkpoints were repeatedly walking the same ancestor paths and then traversing the completed archive a second time by decrypting, decompressing, and listing it. On representative production-shaped state, that maintenance work dominated runner CPU and concentrated load in checkpoint-heavy containers.

## User-visible goal and flow

The member-facing flow does not change. After the existing idle floor, the runner still plans, encrypts, uploads, and CAS-publishes the same v2 workspace snapshot. This patch makes that background construction substantially cheaper so checkpoint maintenance completes sooner without delaying foreground work or changing restore compatibility.

## What changed

- Cache each selected path's `lstat` result within one preflight or postflight pass, while retaining a fresh cache and unchanged-state comparison for the later pass.
- Validate the manifest emitted by the original verbose tar process instead of decrypting, decompressing, and listing the encrypted archive in a second traversal.
- Delete redundant `zstd --version` child processes from create and restore.
- Keep the cipher-stream SHA-256 as the snapshot ref and use the existing signed R2 upload checksum plus completion-time `HEAD` verification as the sole exact-object publication proof, avoiding a duplicate local file reread.
- Add focused process-count and tar-divergence coverage, plus a real MinIO negative test proving a same-length changed body is rejected when its signed checksum no longer matches.

## Invariants preserved

- Snapshot creation remains idle-only, abortable, and subordinate to foreground work.
- The canonical workspace write lock remains the only concurrency owner; no cache crosses a pass or call.
- Planned and emitted entry paths, types, sizes, counts, and bounds must agree.
- Preflight and postflight durable state must agree before publication.
- Symlink, hardlink, special-file, environment-file, path traversal, encryption/AAD/GCM, cleanup, and authenticate-before-extract protections remain intact.
- The direct upload signs the cipher-stream digest as `x-amz-checksum-sha256`; storage rejects body mismatches, and completion verifies provider checksum, metadata, and size before workspace CAS publication.
- Snapshot schema, encryption, compression, object/ref shape, R2 upload, and workspace CAS fencing are unchanged.

## Non-obvious affected surfaces

- Tar now runs with double verbosity so its original stderr manifest can own entry validation on both GNU tar in the runner image and BSD tar in local tests.
- Process-failure diagnostics continue consuming the same stderr stream but persist only aggregate markers/counts, never archive paths.
- Restore behavior changes only by deleting the redundant zstd availability probe; extraction and authentication are otherwise unchanged.

## Evidence

- Six counterbalanced Linux AMD64 production-base pairs at 1 CPU, 3 GiB memory, and no network on the same private read-only representative workload, rebuilt from the final remediated code: checkpoint-build CPU **-64.59%**, checkpoint-build wall time **-65.27%**, end-to-end snapshot/restore CPU **-52.07%**, and end-to-end wall time **-48.29%**. Peak memory was effectively flat/slightly lower (**-1.11%**).
- Every baseline and candidate run restored the same aggregate file count, directory count, and plaintext byte count; no private paths or contents were emitted.
- Six additional isolation pairs attributed the dominant win to ancestor-stat deduplication: checkpoint-build CPU **-69.6%** and wall time **-73.0%** versus the otherwise identical single-pass implementation.
- A separate six-pair one-thread zstd experiment was noisy and showed effectively flat median wall time, so the existing two-thread setting was intentionally retained.

## Verification

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/workspace-snapshot-local.test.ts` — passed, 16 tests on the final head.
- `MURPH_E2E_DIRECT_R2_PRESIGNED_PUT_BYTES=1048576 pnpm hosted-local e2e direct-r2-presigned-put --profile e2e:stub` — passed against isolated PostgreSQL, Temporal, and MinIO; includes same-length wrong-body checksum rejection.
- `pnpm --dir apps/cloudflare typecheck` — passed on the final head.
- Required `coverage-write` audit completed; its first-head duplicate-digest test was removed with the duplicate implementation, and the real storage-boundary negative proof replaces it.
- Production runner bundle assembly and AMD64 application-image build passed.
- All 25 required GitHub checks passed on both the remediation head and the patch-identical base-updated head.
- Local Docker Desktop smoke reached the Codex permission probe, then hit the known emulated-kernel limitation: nested seccomp installation returned `ENOSYS`. Native Linux CI is authoritative for that smoke.
- Local `pnpm test:diff ...` attempts stalled in unrelated package-build subprocess I/O after the focused suite/typecheck; `pnpm verify:acceptance` was then externally blocked before start by an unrelated idle process holding the single shared-host slot. Neither unowned process was signaled.
- `git diff --check` passed.

## ReviewGPT

- Round 1 on the immutable first head found one complexity issue: the new encrypted-file reread duplicated the existing upload/publication integrity boundary.
- Accepted and remediated by deleting the reread, helper, and mock-only test, while retaining the stream digest, size accounting, signed upload checksum, completion `HEAD`, and cleanup fences.
- Added real MinIO proof that same-length changed bytes are rejected by the signed checksum boundary.
- Round 2 passed with no findings on remediation head `f26694f2e5d0`; model verification confirmed the requested Pro model (`gpt-5-6-pro`).
- The later base-only rebase produced identical stable patch IDs for both PR commits, so the documented base-update-only exception applies and ReviewGPT was not rerun.

## Deployment skew / compatibility

The snapshot format and Worker/container protocol are unchanged. Old and new warm runner containers can coexist during gradual rollout, and either version can restore snapshots produced by the other. No tandem web/Worker deploy, immediate container rollout, migration, or compatibility window is required. After deploy, check checkpoint success/error telemetry and snapshot-build CPU before considering any separate container-size canary.

## Change shape

ReviewGPT first-reviewed head: 42bf11a6f5b6eed4a114c5f83b354ee4125c78e1

| Head | Source | Tests | Docs | Config/tooling | Generated/other |
| --- | ---: | ---: | ---: | ---: | ---: |
| First reviewed (`42bf11a6f5b6`) | +69/-121 | +165/-1 | +96/-0 | +0/-0 | +0/-0 |
| Current base-updated (`402182a3b860`) | +48/-123 | +125/-0 | +96/-0 | +0/-0 | +0/-0 |

Current base-updated head: `402182a3b860c4062875f1e531e5115e31f2b269`

Source is now a net deletion of 75 lines. The remaining test growth is focused process/tar-boundary proof plus the existing direct-R2 integration boundary; the documentation addition is the archived execution plan and local-verification record.
