### PR TITLE
Assert hosted App Server warm reuse across turns

### DIFF
--- a/apps/cloudflare/test/hosted-local-warm-reuse-egress-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-warm-reuse-egress-e2e.test.ts
@@ -1,9 +1,13 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { listHostedRuntimeLogsForTest } from "#hosted-web-testing";
+
 import {
   startHostedLocalLinqEgressScenario,
   type HostedLocalEgressScenario,
 } from "./helpers/hosted-local-egress-scenario.js";
+
+const runtimeLogLimit = 2_000;
 
 let egress: HostedLocalEgressScenario | null = null;
 
@@ -34,11 +38,30 @@ describe("hosted local warm-reuse egress e2e", () => {
       expectedReplyText: "First warm-reuse turn completed.",
       text: "This is the first warm-reuse egress turn.",
     });
+    const secondTurnStartedAt = new Date().toISOString();
+
     await harness.sendInboundTurn({
       eventSuffix: "warm_reuse_second",
       expectedReplyText: "Second warm-reuse turn completed.",
       text: "This is the second warm-reuse egress turn.",
     });
+    const runtimeLogsAfterSecondTurn = await listHostedRuntimeLogsForTest({
+      environment: harness.scenario.runtimeEnv,
+      limit: runtimeLogLimit,
+      userId: harness.userId,
+    });
+    expect(runtimeLogsAfterSecondTurn.length).toBeLessThan(runtimeLogLimit);
+    const secondTurnTimingLogs = runtimeLogsAfterSecondTurn
+      .filter((entry) =>
+        entry.at > secondTurnStartedAt
+        && entry.eventCode === "assistant.automation_detail"
+        && entry.redactedJson?.providerTraceKind === "codex.app_server_timing"
+      );
+    expect(secondTurnTimingLogs.map((entry) => entry.redactedJson?.codexTimingStage))
+      .toContain("warm-reused");
+    expect(secondTurnTimingLogs.map((entry) =>
+      entry.redactedJson?.codexTimingColdStartReason
+    )).not.toContain("previous-launch-identity-change");
 
     expect(harness.countProviderRequests("/v1/responses")).toBeGreaterThanOrEqual(
       baselineResponses + 2,


### PR DESCRIPTION
## Why this PR exists

Merged #746 keeps the hosted Codex App Server resident across ordinary turns. This test-only follow-up protects the assumption that deterministic provider-credential reminting preserves the same launch identity; it intentionally carries over none of #748's login/logout, thread-unsubscribe, or cleanup lifecycle.

## User goal / user-visible behavior

Consecutive hosted turns for the same user continue through the warm resident App Server instead of cold-starting because launch identity changed. There is no new user-facing UI or workflow; this PR adds regression proof only.

## Invariants

- Turn two must persist a `codex.app_server_timing` trace with `codexTimingStage: "warm-reused"`.
- Turn two must not report `previous-launch-identity-change`.
- No production auth, App Server, detached-child, checkpoint, unsubscribe, or cleanup behavior changes.
- The assertion must be scoped to turn two rather than activation or turn one.

## Non-obvious affected surfaces

None. The diff changes one existing hosted E2E test and no production, runtime, schema, config, or deploy surface.

## Change-shape breakdown

Classification is by authored base-to-head diff; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 23 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **23** | **0** |

## Verification

- `MURPH_VERIFY_STEP_PARALLEL=0 VITEST_MAX_WORKERS=1 pnpm test:diff apps/cloudflare/test/hosted-local-warm-reuse-egress-e2e.test.ts` — passed (Cloudflare typecheck; 106 node test files / 1,832 tests; 1 Worker test).
- `pnpm hosted-local e2e warm-reuse-egress --profile e2e:stub` — passed before and after rebasing onto current `main`.
- Required `coverage-write` audit — `NO FINDINGS`; no audit edits.
- ReviewGPT is intentionally skipped under the test-only, no-production-behavior exemption.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786828532&installation_id=127572939&pr_number=762&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F762&signature=71363c0b81d79a41723202968dd8b2379f0cd74cd5c9ccb87179dfa23e7d1b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->