### PR TITLE
perf(web): merge hosted app-session and member core-state reads

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-auth-session-query-tax.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-auth-session-query-tax.md
@@ -1,0 +1,41 @@
+# Merge hosted app-session and member core-state reads
+
+Status: completed
+Created: 2026-07-16
+Updated: 2026-07-16
+
+## Goal
+
+- `resolveHostedAppSessionFromToken` runs on every authenticated request and
+  cost two sequential queries: `hostedWebSession.findUnique` then
+  `hostedMember.findUnique` for the core state. Fetch the member core state
+  through the session row's `member` relation in the same query, cutting the
+  per-request auth tax from 3 sequential queries to 2 on
+  `requireActiveHostedAppSessionFromRequest` paths (and 2 to 1 for plain
+  session reads).
+
+## Success criteria
+
+- Session resolution semantics unchanged: authenticator verification,
+  revocation, and expiry checks still gate the result; a forged or tampered
+  token still resolves to null; the returned `HostedAppSession` shape is
+  identical.
+- `assertActiveHostedMemberAccessAllowed` (the unified access resolver) is
+  untouched.
+- Session tests updated to the joined read shape and passing; scoped
+  verification passes.
+
+## Scope
+
+- In scope: `apps/web/src/lib/hosted-onboarding/app-session.ts`,
+  `apps/web/test/hosted-app-session.test.ts`.
+- Out of scope: member-access policy, Privy auth, session issuance/revocation
+  logic, request-level caching changes.
+
+## Constraints
+
+- Auth trust boundary: no weakening of fail-closed behavior. The joined read
+  fetches member core state in the same statement as the session row; when
+  the authenticator check fails the result is discarded and resolution still
+  returns null.
+Completed: 2026-07-16

--- a/apps/web/src/lib/hosted-onboarding/app-session.ts
+++ b/apps/web/src/lib/hosted-onboarding/app-session.ts
@@ -12,7 +12,7 @@ import {
 } from "./member-access";
 import { hostedOnboardingError } from "./errors";
 import {
-  readHostedMemberCoreState,
+  hostedMemberCoreStateSelect,
   type HostedMemberCoreState,
 } from "./hosted-member-store";
 import {
@@ -206,8 +206,16 @@ async function resolveHostedAppSessionFromToken(value: string | null | undefined
   const hmacKey = readHostedAppSessionHmacKey();
   const prisma = getPrisma();
   const now = new Date();
+  // One round trip for session plus member: this resolver runs on every
+  // authenticated request, so the member core state rides the session read
+  // instead of costing a second sequential query.
   const record = await prisma.hostedWebSession.findUnique({
     where: { id: token.sessionId },
+    include: {
+      member: {
+        select: hostedMemberCoreStateSelect,
+      },
+    },
   });
 
   if (
@@ -219,18 +227,9 @@ async function resolveHostedAppSessionFromToken(value: string | null | undefined
     return null;
   }
 
-  const member = await readHostedMemberCoreState({
-    memberId: record.memberId,
-    prisma,
-  });
-
-  if (!member) {
-    return null;
-  }
-
   return {
     expiresAt: record.expiresAt,
-    member,
+    member: record.member,
     privyUserId: record.privyUserId,
     sessionId: record.id,
   };

--- a/apps/web/test/hosted-app-session.test.ts
+++ b/apps/web/test/hosted-app-session.test.ts
@@ -4,17 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
-  readHostedMemberCoreState: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
 
 vi.mock("@/src/lib/prisma", () => ({
   getPrisma: mocks.getPrisma,
-}));
-
-vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
-  readHostedMemberCoreState: mocks.readHostedMemberCoreState,
 }));
 
 interface StoredHostedWebSession {
@@ -62,6 +57,11 @@ interface HostedWebSessionFindManyInput {
 }
 
 interface HostedWebSessionFindUniqueInput {
+  include?: {
+    member?: {
+      select: Record<string, true>;
+    };
+  };
   where: {
     id: string;
   };
@@ -89,7 +89,6 @@ describe("hosted app session", () => {
     vi.clearAllMocks();
     harness = createPrismaHarness();
     mocks.getPrisma.mockReturnValue(harness.prismaClient);
-    mocks.readHostedMemberCoreState.mockResolvedValue(createHostedMember());
     process.env.HOSTED_APP_SESSION_HMAC_KEY = TEST_APP_SESSION_HMAC_KEY;
   });
 
@@ -204,16 +203,49 @@ describe("hosted app session", () => {
 
     const session = await getHostedAppSessionFromRequest(requestWithCookie(result.cookie));
 
-    expect(mocks.readHostedMemberCoreState).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma: harness.prismaClient,
-    });
     expect(session).toEqual({
       expiresAt: new Date("2099-01-31T00:00:00.000Z"),
       member: createHostedMember(),
       privyUserId: "did:privy:user_123",
       sessionId: result.sessionId,
     });
+    expect(harness.rootHostedWebSession.findUnique).toHaveBeenCalledTimes(1);
+    expect(harness.rootHostedWebSession.findUnique).toHaveBeenCalledWith({
+      where: { id: result.sessionId },
+      include: {
+        member: {
+          select: {
+            billingStatus: true,
+            createdAt: true,
+            id: true,
+            suspendedAt: true,
+            updatedAt: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("returns the member bound to the session row rather than a fixed member", async () => {
+    const {
+      getHostedAppSessionFromRequest,
+      issueHostedAppSession,
+    } = await import("@/src/lib/hosted-onboarding/app-session");
+    const result = await issueHostedAppSession({
+      memberId: "member_456",
+      now: new Date("2099-01-01T00:00:00.000Z"),
+      privyUserId: "did:privy:user_456",
+    });
+
+    const session = await getHostedAppSessionFromRequest(requestWithCookie(result.cookie));
+
+    expect(session).toEqual({
+      expiresAt: new Date("2099-01-31T00:00:00.000Z"),
+      member: createHostedMember("member_456"),
+      privyUserId: "did:privy:user_456",
+      sessionId: result.sessionId,
+    });
+    expect(session?.member.id).toBe(findStoredSession(result.sessionId).memberId);
   });
 
   it("rejects a caller-computable forged database row before member access", async () => {
@@ -234,7 +266,6 @@ describe("hosted app session", () => {
     await expect(
       getHostedAppSessionFromRequest(requestWithToken(token)),
     ).resolves.toBeNull();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("rejects mutation of every claim bound by the session authenticator", async () => {
@@ -267,7 +298,6 @@ describe("hosted app session", () => {
       ).resolves.toBeNull();
     }
 
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("rejects a valid tag copied to a different session id with the same bearer", async () => {
@@ -297,7 +327,6 @@ describe("hosted app session", () => {
     await expect(
       getHostedAppSessionFromRequest(requestWithToken(copiedToken)),
     ).resolves.toBeNull();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("rejects a substituted bearer for an otherwise valid session id", async () => {
@@ -317,7 +346,6 @@ describe("hosted app session", () => {
     await expect(
       getHostedAppSessionFromRequest(requestWithToken(substitutedToken)),
     ).resolves.toBeNull();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("rejects legacy, malformed, and non-canonical session cookies before database access", async () => {
@@ -344,7 +372,6 @@ describe("hosted app session", () => {
     }
 
     expect(harness.rootHostedWebSession.findUnique).not.toHaveBeenCalled();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("rejects an oversized bearer before database access", async () => {
@@ -359,7 +386,6 @@ describe("hosted app session", () => {
     ).resolves.toBeNull();
 
     expect(harness.rootHostedWebSession.findUnique).not.toHaveBeenCalled();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("rejects authentically issued expired or revoked sessions without reading member state", async () => {
@@ -374,7 +400,6 @@ describe("hosted app session", () => {
     });
 
     await expect(getHostedAppSessionFromRequest(requestWithCookie(expired.cookie))).resolves.toBeNull();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
 
     const revoked = await issueHostedAppSession({
       memberId: "member_123",
@@ -385,7 +410,6 @@ describe("hosted app session", () => {
     revokedRecord.revokedAt = new Date("2099-02-02T00:00:00.000Z");
 
     await expect(getHostedAppSessionFromRequest(requestWithCookie(revoked.cookie))).resolves.toBeNull();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
   it("revokes only the authenticated session id and tag pair and returns a clearing cookie", async () => {
@@ -511,7 +535,6 @@ describe("hosted app session", () => {
 
     expect(harness.rootHostedWebSession.findUnique).not.toHaveBeenCalled();
     expect(harness.rootHostedWebSession.updateMany).not.toHaveBeenCalled();
-    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 });
 
@@ -567,9 +590,15 @@ function createHostedWebSessionDelegate(records: StoredHostedWebSession[]) {
     }
     return { count };
   });
-  const findUnique = vi.fn(async (input: HostedWebSessionFindUniqueInput): Promise<StoredHostedWebSession | null> =>
-    records.find((record) => record.id === input.where.id) ?? null,
-  );
+  const findUnique = vi.fn(async (input: HostedWebSessionFindUniqueInput) => {
+    const record = records.find((candidate) => candidate.id === input.where.id) ?? null;
+    if (!record) {
+      return null;
+    }
+    return input.include?.member
+      ? { ...record, member: createHostedMember(record.memberId) }
+      : record;
+  });
   const updateMany = vi.fn(async (input: HostedWebSessionUpdateManyInput): Promise<{ count: number }> => {
     let count = 0;
     for (const record of records) {
@@ -712,11 +741,11 @@ function readSetCookieToken(cookie: string): string {
   return decodeURIComponent(firstPart.slice(separatorIndex + 1));
 }
 
-function createHostedMember() {
+function createHostedMember(id = "member_123") {
   return {
     billingStatus: "active",
     createdAt: new Date("2026-05-02T00:00:00.000Z"),
-    id: "member_123",
+    id,
     suspendedAt: null,
     updatedAt: new Date("2026-05-02T00:00:00.000Z"),
   };


### PR DESCRIPTION
## Why this PR exists
Every authenticated API call pays a flat auth tax: `resolveHostedAppSessionFromToken` ran `hostedWebSession.findUnique` and then a second sequential `hostedMember.findUnique` for the member core state. With the access assert that made ~3 sequential queries per call across ~150 route handlers, a standing contributor to pool pressure and latency.

## User goal / user-visible behavior
No user-visible behavior change; every authenticated request does one less database round trip.

## User experience
No user-facing effect.

## Invariants the PR must preserve
- Fail-closed auth semantics unchanged: forged rows, mutated claims (memberId/privyUserId/expiresAt), copied tags, substituted bearers, revoked and expired sessions all still resolve to null before any authority is granted.
- The returned member is the one bound to the session row (proven by a new binding test using a second member id).
- The member read selects exactly the core-state fields (include select pinned literally in tests) — no over-fetch on the auth hot path.
- `assertActiveHostedMemberAccessAllowed` (the unified access resolver from the family-plan gate fix) is untouched.

## Non-obvious affected surfaces
- The joined read is one statement, so the prior cross-query race (member deleted between session read and member read) is narrowed, not widened. `HostedWebSession.member` is a required FK relation with cascade delete.

## Change-shape breakdown
Classification rule: by path — `apps/web/src/**` source, `apps/web/test/**` tests, `agent-docs/**` docs. No binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 10 | 11 |
| Tests/fixtures | 53 | 24 |
| Docs | 41 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **104** | **35** |

## Verification
- `pnpm test:diff apps/web/src/lib/hosted-onboarding/app-session.ts apps/web/test/hosted-app-session.test.ts` passed (includes app verification).
- Focused session suites: 15/15 and 1/1 passing. Coverage-write audit de-vacuated the session:member binding proof and pinned the exact include select.
- Required coverage-write audit ran on the parent model: both local Codex CLI homes are usage-limited until Jul 23, so the repo's documented parent-model fallback was used.

ReviewGPT first-reviewed head: 9b5d5eb62b956074c5d6d660931c01b4e5f0e6f5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786844035&installation_id=127572939&pr_number=775&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F775&signature=d7f2f19babb189d3264f57f9f801ac9795131e2f2636bc9a9dbcad7bee855f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->