### PR TITLE
feat(growth): record daily message volume in snapshot and add homepage volume line

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-16-growth-snapshot-message-counts.md
+++ b/agent-docs/exec-plans/completed/2026-07-16-growth-snapshot-message-counts.md
@@ -1,0 +1,38 @@
+# Growth Snapshot Message Counts + Homepage Volume Line
+
+Status: completed
+Updated: 2026-07-16
+
+## Why
+
+There is no durable record of message volume: inbound `conversation.message`
+mailbox rows expire on TTL (~30 days) and the Linq delivery ledger only dates
+to 2026-06-30, so all-time totals can only be estimated (~6,000 exchanged as
+of 2026-07-16). The daily growth snapshot cron (00:10 UTC) already persists
+member/MRR metrics; adding per-day message counts there makes volume durable
+before the source rows expire, with no new cron, table, or user-facing query
+path.
+
+## What
+
+1. `HostedGrowthDailySnapshot` gains nullable `inbound_messages_prior_day`
+   and `outbound_messages_prior_day` columns (additive migration
+   `20260716220000_hosted_growth_snapshot_message_counts`).
+2. `captureHostedGrowthDailySnapshot` counts, for the full UTC day before
+   `snapshot_date` (deterministic on rerun): inbound `conversation.message`
+   mailbox items by `occurred_at`, and Linq deliveries with status
+   `accepted`/`delivered`/`sent_no_receipt_expected` by `attempted_at`.
+   Counts run in the existing cron's `Promise.all`; no request-path work.
+   Outbound counts only the Linq ledger; Telegram/email egress has no
+   delivery ledger yet (known undercount, documented in code).
+3. Homepage trust section gains a static right-aligned header line:
+   "6,000+ messages and counting" (seeded from the 2026-07-16 estimate; no
+   data fetch).
+
+## Verification
+
+- `apps/web` scoped vitest: growth metrics (window + upsert payload), trust
+  section markup, migration guard list. Typecheck green.
+- Required audits: `frontend-review`, `coverage-write`; ReviewGPT PR lane as
+  the cross-cutting gate if eligible.
+Completed: 2026-07-16

--- a/apps/web/prisma/migrations/20260716220000_hosted_growth_snapshot_message_counts/migration.sql
+++ b/apps/web/prisma/migrations/20260716220000_hosted_growth_snapshot_message_counts/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "hosted_growth_daily_snapshot"
+ADD COLUMN "inbound_messages_prior_day" INTEGER,
+ADD COLUMN "outbound_messages_prior_day" INTEGER;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1189,6 +1189,10 @@ model HostedGrowthDailySnapshot {
   coveredMembers     Int      @map("covered_members")
   trialingMembers    Int      @map("trialing_members")
   mrrUsdCents        Int      @map("mrr_usd_cents")
+  // Message volume for the full UTC day before snapshot_date, captured here
+  // because the live source rows are short-lived (mailbox TTL, delivery churn).
+  inboundMessagesPriorDay  Int? @map("inbound_messages_prior_day")
+  outboundMessagesPriorDay Int? @map("outbound_messages_prior_day")
 
   @@map("hosted_growth_daily_snapshot")
 }

--- a/apps/web/src/components/homepage/trust-section.tsx
+++ b/apps/web/src/components/homepage/trust-section.tsx
@@ -32,13 +32,18 @@ export function TrustSection() {
   return (
     <section className="bg-[#f5f0e8] px-5 py-16 sm:px-10 lg:px-16 lg:py-24">
       <div className="mx-auto max-w-[1080px]">
-        <div className="flex items-center gap-3">
-          <span
-            aria-hidden="true"
-            className="inline-block h-px w-10 bg-[#2d3436]/40"
-          />
-          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-[#2d3436]">
-            Why people trust Murph
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden="true"
+              className="inline-block h-px w-10 bg-[#2d3436]/40"
+            />
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-[#2d3436]">
+              Why people trust Murph
+            </span>
+          </div>
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-[#736a58]">
+            6,000+ messages and counting
           </span>
         </div>
 

--- a/apps/web/src/lib/hosted-ops/growth-metrics.ts
+++ b/apps/web/src/lib/hosted-ops/growth-metrics.ts
@@ -60,9 +60,18 @@ type HostedGrowthPrisma = Pick<
   PrismaClient,
   | "hostedAccountGroup"
   | "hostedGrowthDailySnapshot"
+  | "hostedLinqDelivery"
+  | "hostedMailboxItem"
   | "hostedMember"
   | "hostedMemberBillingRef"
 >;
+
+const INBOUND_MESSAGE_MAILBOX_KIND = "conversation.message";
+const OUTBOUND_LINQ_SENT_STATUSES = [
+  "accepted",
+  "delivered",
+  "sent_no_receipt_expected",
+] as const;
 
 export type HostedGrowthStatusKey = (typeof CHURN_STATUS_KEYS)[number];
 
@@ -115,7 +124,9 @@ export interface HostedGrowthTrialStartRow {
 export interface HostedGrowthSnapshotRow {
   capturedAt: Date;
   coveredMembers: number;
+  inboundMessagesPriorDay: number | null;
   mrrUsdCents: number;
+  outboundMessagesPriorDay: number | null;
   payingCustomers: number;
   payingFamilyGroups: number;
   payingFamilySeats: number;
@@ -748,19 +759,51 @@ export async function readHostedGrowthDashboard(
 /**
  * Paying metrics use paid billing phase, active billing status, and unsuspended
  * rows. Family paid groups also require at least one billed seat.
+ *
+ * Message counts cover the full UTC day before `snapshot_date`, so reruns on
+ * the same date are deterministic. Inbound counts `conversation.message`
+ * mailbox items across all channels; those rows expire, so the snapshot is
+ * the durable record. Outbound counts sent rows in the Linq delivery ledger,
+ * currently the only channel with a delivery ledger.
  */
 export async function captureHostedGrowthDailySnapshot(
   now: Date,
   prisma: HostedGrowthPrisma = getPrisma(),
 ): Promise<HostedGrowthSnapshotRow> {
-  const current = await readCurrentHostedGrowthMetrics(now, prisma);
   const snapshotDate = startOfUtcDay(now);
+  const priorDayStart = addUtcDays(snapshotDate, -1);
+  const [current, inboundMessagesPriorDay, outboundMessagesPriorDay] =
+    await Promise.all([
+      readCurrentHostedGrowthMetrics(now, prisma),
+      prisma.hostedMailboxItem.count({
+        where: {
+          kind: INBOUND_MESSAGE_MAILBOX_KIND,
+          occurredAt: {
+            gte: priorDayStart,
+            lt: snapshotDate,
+          },
+        },
+      }),
+      prisma.hostedLinqDelivery.count({
+        where: {
+          attemptedAt: {
+            gte: priorDayStart,
+            lt: snapshotDate,
+          },
+          status: {
+            in: [...OUTBOUND_LINQ_SENT_STATUSES],
+          },
+        },
+      }),
+    ]);
 
   return prisma.hostedGrowthDailySnapshot.upsert({
     create: {
       capturedAt: now,
       coveredMembers: current.coveredMembers,
+      inboundMessagesPriorDay,
       mrrUsdCents: current.mrrUsdCents,
+      outboundMessagesPriorDay,
       payingCustomers: current.payingCustomers,
       payingFamilyGroups: current.payingFamilyGroups,
       payingFamilySeats: current.payingFamilySeats,
@@ -773,7 +816,9 @@ export async function captureHostedGrowthDailySnapshot(
     update: {
       capturedAt: now,
       coveredMembers: current.coveredMembers,
+      inboundMessagesPriorDay,
       mrrUsdCents: current.mrrUsdCents,
+      outboundMessagesPriorDay,
       payingCustomers: current.payingCustomers,
       payingFamilyGroups: current.payingFamilyGroups,
       payingFamilySeats: current.payingFamilySeats,
@@ -959,7 +1004,9 @@ function keyIfInWindow(
 const growthSnapshotSelect = {
   capturedAt: true,
   coveredMembers: true,
+  inboundMessagesPriorDay: true,
   mrrUsdCents: true,
+  outboundMessagesPriorDay: true,
   payingCustomers: true,
   payingFamilyGroups: true,
   payingFamilySeats: true,

--- a/apps/web/test/homepage-trust-section.test.tsx
+++ b/apps/web/test/homepage-trust-section.test.tsx
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
+
+import { TrustSection } from "@/src/components/homepage/trust-section";
+
+test("TrustSection renders the trust pillars and message volume line", () => {
+  const markup = renderToStaticMarkup(createElement(TrustSection));
+
+  assert.match(markup, /Why people trust Murph/);
+  assert.match(markup, /6,000\+ messages and counting/);
+  assert.match(markup, /Studies cited/);
+  assert.match(markup, /Apache 2\.0/);
+  assert.match(markup, /Never sold/);
+  assert.match(markup, /Take everything with you on the way out\./);
+});

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -636,6 +636,13 @@ describe("hosted Prisma baseline migration", () => {
       ),
       "utf8",
     );
+    const hostedGrowthSnapshotMessageCountsMigrationSql = readFileSync(
+      new URL(
+        "../prisma/migrations/20260716220000_hosted_growth_snapshot_message_counts/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     const hostedAssistantPersonalityProjectionWatermarkContractMigrationSql = readFileSync(
       new URL(
         "../prisma/contract-migrations/20260715193000_seed_hosted_assistant_personality_projection_watermarks/migration.sql",
@@ -852,6 +859,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260715230000_hosted_mailbox_subscription_action_claim",
       "20260716160000_hosted_usage_credits",
       "20260716190000_linq_signup_welcome_reservation",
+      "20260716220000_hosted_growth_snapshot_message_counts",
       "migration_lock.toml",
     ]);
     expect(hostedMailboxSubscriptionActionClaimMigrationSql).toContain(
@@ -867,6 +875,16 @@ describe("hosted Prisma baseline migration", () => {
       'ADD COLUMN "proactive_conversation_count" INTEGER',
     );
     expect(linqSignupWelcomeReservationMigrationSql).not.toContain("UPDATE");
+    expect(hostedGrowthSnapshotMessageCountsMigrationSql).toContain(
+      'ALTER TABLE "hosted_growth_daily_snapshot"',
+    );
+    expect(hostedGrowthSnapshotMessageCountsMigrationSql).toContain(
+      'ADD COLUMN "inbound_messages_prior_day" INTEGER',
+    );
+    expect(hostedGrowthSnapshotMessageCountsMigrationSql).toContain(
+      'ADD COLUMN "outbound_messages_prior_day" INTEGER',
+    );
+    expect(hostedGrowthSnapshotMessageCountsMigrationSql).not.toContain("UPDATE");
     expect(hostedFamilyMixedTierCapacityMigrationSql).toContain(
       'ADD COLUMN "plan_code" TEXT DEFAULT \'pulse\'',
     );

--- a/apps/web/test/hosted-ops-growth.test.ts
+++ b/apps/web/test/hosted-ops-growth.test.ts
@@ -26,6 +26,12 @@ const mocks = vi.hoisted(() => ({
     findMany: vi.fn(),
     upsert: vi.fn(),
   },
+  hostedLinqDelivery: {
+    count: vi.fn(),
+  },
+  hostedMailboxItem: {
+    count: vi.fn(),
+  },
   hostedMember: {
     count: vi.fn(),
     findMany: vi.fn(),
@@ -77,6 +83,8 @@ const originalHostedOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
 const prisma = {
   hostedAccountGroup: mocks.hostedAccountGroup,
   hostedGrowthDailySnapshot: mocks.hostedGrowthDailySnapshot,
+  hostedLinqDelivery: mocks.hostedLinqDelivery,
+  hostedMailboxItem: mocks.hostedMailboxItem,
   hostedMember: mocks.hostedMember,
   hostedMemberBillingRef: mocks.hostedMemberBillingRef,
 };
@@ -103,6 +111,8 @@ describe("hosted ops growth metrics", () => {
       member: { id: "member_ops" },
     });
     mocks.getPrisma.mockReturnValue(prisma);
+    mocks.hostedLinqDelivery.count.mockResolvedValue(0);
+    mocks.hostedMailboxItem.count.mockResolvedValue(0);
     mocks.requireActiveHostedAppSession.mockResolvedValue({
       member: { id: "member_ops" },
     });
@@ -528,6 +538,70 @@ describe("hosted ops growth metrics", () => {
     ).toEqual(startOfUtcDay(now));
   });
 
+  it("records prior-day message counts in the snapshot", async () => {
+    const now = new Date("2026-07-06T12:00:00.000Z");
+    queueCurrentMetricMocks();
+    mocks.hostedMailboxItem.count.mockResolvedValueOnce(42);
+    mocks.hostedLinqDelivery.count.mockResolvedValueOnce(57);
+    mocks.hostedGrowthDailySnapshot.upsert.mockResolvedValueOnce(
+      snapshotRow("2026-07-06", 2_900),
+    );
+
+    await captureHostedGrowthDailySnapshot(now);
+
+    expect(mocks.hostedMailboxItem.count.mock.calls[0]?.[0]).toEqual({
+      where: {
+        kind: "conversation.message",
+        occurredAt: {
+          gte: new Date("2026-07-05T00:00:00.000Z"),
+          lt: new Date("2026-07-06T00:00:00.000Z"),
+        },
+      },
+    });
+    expect(mocks.hostedLinqDelivery.count.mock.calls[0]?.[0]).toEqual({
+      where: {
+        attemptedAt: {
+          gte: new Date("2026-07-05T00:00:00.000Z"),
+          lt: new Date("2026-07-06T00:00:00.000Z"),
+        },
+        status: {
+          in: ["accepted", "delivered", "sent_no_receipt_expected"],
+        },
+      },
+    });
+    const upsertArg = mocks.hostedGrowthDailySnapshot.upsert.mock.calls[0]?.[0];
+    expect(upsertArg?.create).toMatchObject({
+      inboundMessagesPriorDay: 42,
+      outboundMessagesPriorDay: 57,
+    });
+    expect(upsertArg?.update).toMatchObject({
+      inboundMessagesPriorDay: 42,
+      outboundMessagesPriorDay: 57,
+    });
+  });
+
+  it("anchors the prior-day message window to the UTC day at exactly midnight", async () => {
+    const now = new Date("2026-07-06T00:00:00.000Z");
+    queueCurrentMetricMocks();
+    mocks.hostedGrowthDailySnapshot.upsert.mockResolvedValueOnce(
+      snapshotRow("2026-07-06", 2_900),
+    );
+
+    await captureHostedGrowthDailySnapshot(now);
+
+    expect(mocks.hostedMailboxItem.count.mock.calls[0]?.[0]?.where.occurredAt).toEqual({
+      gte: new Date("2026-07-05T00:00:00.000Z"),
+      lt: new Date("2026-07-06T00:00:00.000Z"),
+    });
+    expect(mocks.hostedLinqDelivery.count.mock.calls[0]?.[0]?.where.attemptedAt).toEqual({
+      gte: new Date("2026-07-05T00:00:00.000Z"),
+      lt: new Date("2026-07-06T00:00:00.000Z"),
+    });
+    expect(
+      mocks.hostedGrowthDailySnapshot.upsert.mock.calls[0]?.[0].where.snapshotDate,
+    ).toEqual(new Date("2026-07-06T00:00:00.000Z"));
+  });
+
   it("fails closed before reading growth data when page ops access is missing", async () => {
     delete process.env.HOSTED_OPS_MEMBER_IDS;
 
@@ -672,7 +746,9 @@ function snapshotRow(date: string, mrrUsdCents: number) {
   return {
     capturedAt: new Date(`${date}T00:05:00.000Z`),
     coveredMembers: 3,
+    inboundMessagesPriorDay: 0,
     mrrUsdCents,
+    outboundMessagesPriorDay: 0,
     payingCustomers: 3,
     payingFamilyGroups: 1,
     payingFamilySeats: 1,


### PR DESCRIPTION
## What

- The daily growth snapshot cron (00:10 UTC) now also records message volume for the full UTC day before `snapshot_date`: inbound `conversation.message` mailbox items (all channels, counted by `occurred_at`) and sent Linq deliveries (`accepted`/`delivered`/`sent_no_receipt_expected`, counted by `attempted_at`). Both land in new nullable columns `inbound_messages_prior_day` / `outbound_messages_prior_day` on `hosted_growth_daily_snapshot` (additive migration).
- The homepage trust section header gains a quiet right-aligned static line: "6,000+ messages and counting".

## Why

Message volume has no durable record today: inbound mailbox rows expire on TTL (~30 days) and the Linq delivery ledger only dates to 2026-06-30, so all-time totals can only be estimated (~6,000 exchanged as of 2026-07-16, from per-turn ratios applied to all-time usage turns). Snapshotting per-day counts in the existing cron makes volume durable going forward with no new cron, table, or request-path work.

## Resulting UX

Homepage trust section: the header row is now `justify-between` with the existing rule + "Why people trust Murph" label on the left and the muted mono stat line on the right; on narrow viewports the stat wraps to its own line below the label. No other visual or behavioral change. The stat is static copy (no data fetch), seeded from the estimate above; the new columns exist so it can be kept honest or wired live later.

## Notes

- Prior-day window is deterministic on same-date reruns; midnight-boundary behavior is pinned by a dedicated test.
- Outbound counts only the Linq ledger; Telegram/email egress has no delivery ledger yet (documented undercount in code).
- The count queries run inside the cron's existing `Promise.all`; zero user-facing latency impact.
- Historical snapshot rows keep `NULL` for both columns (columns are nullable; no backfill).

## Change shape (base → head diff)

Classification rule: paths under `apps/web/test/` are tests; `agent-docs/` is docs; `prisma/migrations/` + `prisma/schema.prisma` are config/schema; the rest is source. No binary files.

| Class | Added | Deleted |
| --- | --- | --- |
| Source (`growth-metrics.ts`, `trust-section.tsx`) | 60 | 8 |
| Tests (3 files) | 112 | 0 |
| Config/schema (migration + `schema.prisma`) | 7 | 0 |
| Docs (completed exec plan) | 38 | 0 |

## Verification

- Scoped vitest (growth metrics, trust section markup, migration guard): 3 files, 22 tests passed.
- `apps/web` typecheck green (regenerated Prisma client).
- Required audit passes ran (frontend-review: zero blocking findings; coverage-write: added the midnight-boundary test). Note: Codex CLI audit routing was unavailable (usage limits on all local Codex homes until Jul 23), so both passes ran on the parent model per the completion-workflow fallback. Rendered browser inspection of the trust section was not performed in the audit pass; the change is a single static line reusing existing styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786849343&installation_id=127572939&pr_number=777&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F777&signature=7f387d2c41870a3778c35cfec429486166230bbe0200a3f1b72ebd4c98d5cf14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## ReviewGPT baseline

ReviewGPT first-reviewed head: 8c6e13889d97080fdcba97d4c25839a96ff117c3
