### PR TITLE
feat(onboarding): simplify brain-dump voice-memo lead-in

### DIFF
--- a/packages/assistant-engine/skills/murph-onboarding/SKILL.md
+++ b/packages/assistant-engine/skills/murph-onboarding/SKILL.md
@@ -349,7 +349,7 @@ four serial questions. Send one message in this shape, adapting the lead-in
 wording but keeping the bulleted list and the explicit voice-memo ask:
 
 ```text
-Last thing before I quit interrogating you — easiest if you just talk me through it. Send a voice memo (or type, whatever's easier) covering whatever's true for you:
+Can you send me a voice memo covering a few things?
 
 - how you move right now — gym, running, sports, mostly desk-bound — and whether you're training for anything specific
 - anything you take regularly — supplements, protein, that stuff — brands if you know them
@@ -358,6 +358,9 @@ Last thing before I quit interrogating you — easiest if you just talk me throu
 
 Ramble as long as you want, I'll sort it out.
 ```
+
+Only add a "type instead if that's easier" note to the lead-in when saved
+evidence shows the user is over 55; otherwise leave the voice-memo ask as-is.
 
 Do not send this as a generated voice memo (a bulleted list has to be text),
 and do not add a companion text to narrate it. One reply covers all four

--- a/packages/assistant-engine/test/assistant-skill-assets.test.ts
+++ b/packages/assistant-engine/test/assistant-skill-assets.test.ts
@@ -1848,7 +1848,7 @@ describe('assistant skill assets', () => {
     expect(compact).toContain(
       'Send one message in this shape, adapting the lead-in wording but keeping the bulleted list and the explicit voice-memo ask',
     )
-    expect(compact).toContain('Last thing before I quit interrogating you')
+    expect(compact).toContain('Can you send me a voice memo covering a few things?')
     expect(compact).toContain(
       'spawn a separate background child for each: the medical-persistence child owns the entire medical save, and the supplement child owns label enrichment',
     )


### PR DESCRIPTION
Replace the "quit interrogating you" lead-in with a plain voice-memo ask, drop the "cover whatever's true for you" line, and gate the "type instead" fallback on users over 55.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786914610&installation_id=127572939&pr_number=783&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F783&signature=fe38057a7c10f9cb8e554a7ab9b65e8acd15e0f904566103b01dbb1f091f2607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->