### PR TITLE
Improve privacy-safe command attribution

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-18-command-label-observability.md
+++ b/agent-docs/exec-plans/completed/2026-07-18-command-label-observability.md
@@ -1,0 +1,59 @@
+# Command Label Observability
+
+## Goal
+
+Reduce the generic `command` bucket in hosted assistant turn profiles by using
+Codex's existing structured command actions to recover a safe executable label
+when shell-wrapper quoting prevents the current raw-command labeler from doing
+so.
+
+## Scope
+
+- `packages/assistant-engine/src/assistant/providers/helpers.ts`
+- `packages/assistant-engine/test/codex-runtime-helpers.test.ts`
+- This plan and its coordination-ledger row
+
+## Invariants
+
+- Persist structured-action executable names only from a fixed allowlist;
+  never persist structured command arguments, search queries, paths,
+  member-authored content, or arbitrary action text.
+- Keep the current raw-command label path authoritative when it already yields
+  a specific safe label.
+- Fall back to `command` whenever structured action data is absent, malformed,
+  path-invoked, shell-headed, or not explicitly allowlisted.
+- Keep the existing turn-profile schema and callback contract unchanged.
+
+## Plan
+
+1. Add a narrow structured-action fallback to the existing command label
+   builder.
+2. Cover representative `rg`, `sed`, and quoted Vault CLI wrappers plus
+   adversarial member-content and malformed-action cases.
+3. Run focused tests, the routed diff lane, the required `coverage-write`
+   specialist pass, and the parent's final review. Use ReviewGPT as the sole
+   cross-cutting PR gate because this touches privacy-sensitive telemetry.
+4. Commit through the plan-finishing workflow and open a draft PR.
+
+## Verification
+
+- `pnpm exec vitest run packages/assistant-engine/test/codex-runtime-helpers.test.ts`
+  passed with 54 tests.
+- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @murphai/assistant-engine test`
+  passed with 2,487 tests and 5 skips.
+- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @murphai/murph test`
+  passed with 1,086 tests and 1 skip after generating the ignored Health
+  Commons inputs required by that package's tests.
+- `NODE_OPTIONS=--max-old-space-size=8192 pnpm test:diff packages/assistant-engine/src/assistant/providers/helpers.ts packages/assistant-engine/test/codex-runtime-helpers.test.ts`
+  passed the guards, affected typechecks, and every selected package lane. The
+  final parallel assistant-engine worker stalled after the other lanes
+  completed; the same full owner suite passed independently above.
+- The required `coverage-write` pass added one raw-command precedence/privacy
+  assertion, reran the focused suite successfully, and reported no unresolved
+  coverage findings.
+- Parent final review confirmed the structured fallback reads only the first
+  action's first token, accepts only fixed constant labels, and leaves the
+  existing raw-command path and persisted schema unchanged.
+Status: completed
+Updated: 2026-07-18
+Completed: 2026-07-18

--- a/packages/assistant-engine/src/assistant/providers/helpers.ts
+++ b/packages/assistant-engine/src/assistant/providers/helpers.ts
@@ -608,6 +608,21 @@ const ASSISTANT_TURN_PROFILE_SHELL_WRAPPER_PREFIX_PATTERN =
 // other command the first positional token can be member content (search
 // terms, vault paths), so the label stops at the binary name.
 const ASSISTANT_TURN_PROFILE_SUBCOMMAND_HEAD_BINARIES = new Set(['vault-cli', 'murph'])
+// Codex also emits a best-effort parsed commandActions array. Use only these
+// fixed executable names when shell-wrapper quoting makes the raw command fail
+// closed; never persist an action argument, path, query, or arbitrary head.
+const ASSISTANT_TURN_PROFILE_STRUCTURED_COMMAND_HEAD_BINARIES = new Set([
+  'cat',
+  'grep',
+  'head',
+  'jq',
+  'murph',
+  'printf',
+  'rg',
+  'sed',
+  'tail',
+  'vault-cli',
+])
 
 interface AssistantTurnProfileToolAggregate {
   calls: number
@@ -717,6 +732,7 @@ function readAssistantTurnProfileToolAggregate(
       durationMs: readAssistantProviderInteger(item, 'durationMs', 'duration_ms') ?? 0,
       label: buildAssistantTurnProfileCommandLabel(
         readAssistantProviderString(item.command),
+        item.commandActions ?? item.command_actions,
       ),
       outputChars: readAssistantTurnProfileTextLength(
         item.aggregatedOutput ?? item.aggregated_output,
@@ -748,7 +764,10 @@ function readAssistantTurnProfileToolAggregate(
 // head binary is a known subcommand-style CLI, because the first positional
 // argument of arbitrary commands (grep patterns, file paths) can carry member
 // health content even when it matches a benign-looking token charset.
-function buildAssistantTurnProfileCommandLabel(command: string | null): string {
+function buildAssistantTurnProfileCommandLabel(
+  command: string | null,
+  commandActions: unknown,
+): string {
   const tokens = unwrapAssistantTurnProfileShellWrapper(command ?? '')
     .split(/\s+/u)
     .filter((token) => token.length > 0)
@@ -783,9 +802,33 @@ function buildAssistantTurnProfileCommandLabel(command: string | null): string {
     }
   }
 
-  return truncateAssistantTurnProfileLabel(
-    labelTokens.length > 0 ? labelTokens.join(' ') : 'command',
-  )
+  if (labelTokens.length > 0) {
+    return truncateAssistantTurnProfileLabel(labelTokens.join(' '))
+  }
+
+  return readAssistantTurnProfileStructuredCommandHead(commandActions) ?? 'command'
+}
+
+function readAssistantTurnProfileStructuredCommandHead(
+  value: unknown,
+): string | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return null
+  }
+
+  const firstAction = readAssistantProviderRecord(value[0])
+  const command = readAssistantProviderString(firstAction?.command)
+  const head = command?.split(/\s/u, 1)[0] ?? null
+  if (
+    !head
+    || head.includes('/')
+    || !ASSISTANT_TURN_PROFILE_SAFE_TOKEN_PATTERN.test(head)
+    || !ASSISTANT_TURN_PROFILE_STRUCTURED_COMMAND_HEAD_BINARIES.has(head)
+  ) {
+    return null
+  }
+
+  return head
 }
 
 // Strip one `bash -lc <script>` wrapper layer so the inner head binary can be

--- a/packages/assistant-engine/test/codex-runtime-helpers.test.ts
+++ b/packages/assistant-engine/test/codex-runtime-helpers.test.ts
@@ -614,13 +614,19 @@ describe('Codex assistant registry helpers', () => {
   })
 
   it('keeps per-turn profile command labels member-content safe at the edges', () => {
-    const commandEvent = (id: string, command: string, outputChars: number) => ({
+    const commandEvent = (
+      id: string,
+      command: string,
+      outputChars: number,
+      commandActions?: unknown,
+    ) => ({
       method: 'item/completed',
       params: {
         item: {
           type: 'commandExecution',
           id,
           command,
+          ...(commandActions === undefined ? {} : { commandActions }),
           aggregatedOutput: 'x'.repeat(outputChars),
           durationMs: 10,
         },
@@ -631,7 +637,14 @@ describe('Codex assistant registry helpers', () => {
         { method: 'turn/started', params: { turn: { id: 'turn_labels' } } },
         // Uppercase positional token fails the subcommand shape even after an
         // allowlisted head binary: 'Samples' could be a member-named vault dir.
-        commandEvent('item_1', 'vault-cli Samples', 40),
+        // The safe raw-command label stays authoritative over a conflicting
+        // structured fallback and its private-looking query.
+        commandEvent(
+          'item_1',
+          'vault-cli Samples',
+          40,
+          [{ type: 'search', command: 'rg private-query', query: 'private-query' }],
+        ),
         // 'murph' is the second allowlisted head binary; labels stop at three
         // tokens so trailing args never persist.
         commandEvent('item_2', 'murph reminders list --all glucose', 30),
@@ -653,6 +666,51 @@ describe('Codex assistant registry helpers', () => {
         // Multiple quoted regions are not a single wrapped script; the greedy
         // splice must not surface inner words as a head binary.
         commandEvent('item_9', 'bash -lc "hypertension log" > "out"', 3),
+        // Codex's parsed action recovers only the fixed executable head when
+        // POSIX quote splicing makes the raw shell wrapper fail closed.
+        commandEvent(
+          'item_10',
+          "bash -lc 'rg -n '\\''sleep score'\\'' records'",
+          8,
+          [{ type: 'search', command: 'rg -n \'sleep score\' records', query: 'sleep score' }],
+        ),
+        commandEvent(
+          'item_11',
+          "bash -lc 'sed -n '\\''1,80p'\\'' journal.md'",
+          7,
+          [{ type: 'read', command: "sed -n '1,80p' journal.md", path: 'journal.md' }],
+        ),
+        // The fallback persists only the executable, not Vault CLI arguments.
+        commandEvent(
+          'item_12',
+          "bash -lc 'vault-cli memory show '\\''private-memory'\\'''",
+          6,
+          [{ type: 'unknown', command: "vault-cli memory show 'private-memory'" }],
+        ),
+        // Arbitrary names and path-invoked binaries stay collapsed even when
+        // supplied as structured actions.
+        commandEvent(
+          'item_13',
+          "bash -lc 'hypertension '\\''private'\\'''",
+          2,
+          [{ type: 'unknown', command: 'hypertension log' }],
+        ),
+        commandEvent(
+          'item_14',
+          'bash -lc "/tmp/rg secret"',
+          1,
+          [{ type: 'search', command: '/tmp/rg secret' }],
+        ),
+        // Never skip an untrusted first action to label a later pipeline stage.
+        commandEvent(
+          'item_15',
+          "bash -lc 'hypertension '\\''private'\\'' | rg secret'",
+          1,
+          [
+            { type: 'unknown', command: 'hypertension' },
+            { type: 'search', command: 'rg secret' },
+          ],
+        ),
       ],
       turnId: 'turn_labels',
     })
@@ -666,12 +724,18 @@ describe('Codex assistant registry helpers', () => {
     })
     expect(profile?.tools).toEqual([
       { calls: 2, durationMs: 20, label: 'murph reminders list', outputChars: 55 },
-      { calls: 1, durationMs: 10, label: 'vault-cli', outputChars: 40 },
+      { calls: 2, durationMs: 20, label: 'vault-cli', outputChars: 46 },
       { calls: 1, durationMs: 10, label: 'vault-cli samples query', outputChars: 20 },
+      { calls: 6, durationMs: 60, label: 'command', outputChars: 16 },
       { calls: 1, durationMs: 10, label: 'grep', outputChars: 15 },
-      { calls: 3, durationMs: 30, label: 'command', outputChars: 12 },
       { calls: 1, durationMs: 10, label: 'a'.repeat(64), outputChars: 10 },
+      { calls: 1, durationMs: 10, label: 'rg', outputChars: 8 },
+      { calls: 1, durationMs: 10, label: 'sed', outputChars: 7 },
     ])
+    expect(JSON.stringify(profile)).not.toContain('sleep score')
+    expect(JSON.stringify(profile)).not.toContain('private-memory')
+    expect(JSON.stringify(profile)).not.toContain('private-query')
+    expect(JSON.stringify(profile)).not.toContain('journal.md')
   })
 
   it('fails closed on adversarial shell-wrapper quoting shapes', () => {


### PR DESCRIPTION
## Why this PR exists

Hosted turn profiles can collapse expensive shell-wrapped tool calls into the generic `command` bucket when POSIX quote splicing defeats the raw parser. This makes it harder to tell whether `rg`, `sed`, or Vault CLI output caused a costly turn.

## User goal / user-visible behavior

Operators can attribute large tool-output turns to a safe executable family more often, while member-authored command arguments, queries, and paths remain absent from persisted telemetry.

## User experience

No member-facing UX changes. This only improves internal usage observability.

## Invariants

- The existing raw-command label remains authoritative whenever it yields a label.
- The structured fallback reads only the first action and first token.
- Structured labels must be one of ten fixed executable constants; arguments, queries, paths, arbitrary heads, and later pipeline stages never persist.
- Unsafe or malformed structured data remains the generic `command` label.
- The turn-profile schema and callback contract remain unchanged.

## Non-obvious affected surfaces

None.

## Verification

- Focused helper suite: 54 tests passed.
- Full assistant-engine suite: 2,487 tests passed, 5 skipped.
- Assistant CLI suite: 1,086 tests passed, 1 skipped.
- Routed affected typechecks, guards, and package lanes passed. Its final parallel assistant-engine worker stalled after all other lanes completed; the same complete owner suite passed independently.
- Required `coverage-write` audit added raw-label precedence proof and reported no unresolved findings.

## Change-shape breakdown

Classification: production TypeScript is source; test TypeScript is tests/fixtures; the completed execution plan is docs; no config/tooling, generated files, or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 47 | 4 |
| Tests / fixtures | 68 | 4 |
| Docs | 59 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **174** | **8** |

ReviewGPT first-reviewed head: 039ae2d3f2756909ce0c327148215188a84b14a9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786994940&installation_id=127572939&pr_number=790&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F790&signature=aca06284dba102b45fd1899db08047343b6ea59f3ea99d93d2b29ca5618b3427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->