### PR TITLE
Fix phone link authorization and modal UX

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-20-phone-link-flow.md
+++ b/agent-docs/exec-plans/completed/2026-07-20-phone-link-flow.md
@@ -1,0 +1,61 @@
+# Fix phone linking authorization and empty-state UX
+
+Status: completed
+Created: 2026-07-20
+Updated: 2026-07-20
+
+## Goal
+
+- Let an authenticated member link or replace a phone number from Settings without a false signup-completion error, while keeping the fresh Privy proof bound to the current Murph app session.
+- Open the phone-link dialog directly on a focused phone input without repeating the Settings account-status card inside the modal.
+
+## Success criteria
+
+- A fresh Privy session for the exact Privy user named by the current app session can sync a newly linked identity before that identity has been persisted in Murph.
+- A fresh Privy session for another Privy user or an identity that resolves to another hosted member remains rejected.
+- Auto-opened phone settings render the link form without the redundant heading/status card and opt the phone input into autofocus for both first-link and change-number flows.
+- Focused regression tests, diff-aware verification, required frontend and coverage audits, and parent review pass; any unavailable runtime proof is reported explicitly.
+
+## Scope
+
+- In scope: hosted app-session/fresh-Privy binding for identity sync; phone settings modal hierarchy and focus; focused auth and component tests.
+- Out of scope: changes to Privy authentication itself, signup, persisted identity schema, messaging delivery, the outer Settings account-status card, or other Settings layouts.
+
+## Constraints
+
+- Technical constraints: preserve the app-session and fresh-Privy dual proof; bind by exact Privy user ID; reject cross-member resolution; add no new state or dependency.
+- Product/process constraints: preserve product-critical signup and phone messaging flows; retain the existing warm editorial Settings design; use the PR lane and required auth/frontend verification gates.
+
+## Risks and mitigations
+
+1. Risk: trusting the app session alone could weaken identity-link authorization.
+   Mitigation: continue verifying the fresh Privy session and require its exact Privy user ID to match the current app session before deriving the hosted member from that session.
+2. Risk: a linked identity could already belong to another hosted member.
+   Mitigation: reject any fresh Privy principal lookup that resolves to a member other than the app-session member and retain the transactional identity uniqueness checks.
+3. Risk: autofocus or modal simplification could alter the ordinary Settings card.
+   Mitigation: scope both behaviors to the existing `autoOpen` dialog mode and keep the standalone Settings rendering unchanged.
+
+## Tasks
+
+1. Add focused failing coverage for the unpersisted same-Privy identity and modal entry state.
+2. Correct the dual-session binding and simplify the auto-open phone form.
+3. Run focused tests and diff-aware verification.
+4. Run full acceptance, attempt desktop/mobile browser proof, and complete the required specialist audits.
+5. Finish the plan and commit; then push, open the PR, and complete ReviewGPT, CI, and mergeability proof.
+
+## Decisions
+
+- Keep the outer Settings “Not connected / Link phone” card; only remove its duplicate from the modal.
+- Treat the app session as the hosted-member authority only after a fresh verified Privy session proves the exact same Privy user ID.
+- Keep the correction inside the existing request-auth and dialog-mode owners: add no state, service, dependency, compatibility path, or parallel authentication flow.
+- Skip the optional second-model UI review at the user's direction after its local authentication was unavailable.
+
+## Verification
+
+- Focused hosted-web regression suites passed: 3 files, 37 tests.
+- `pnpm test:diff` passed, including hosted-web tests, typecheck, lint, development smoke, and the production build.
+- `pnpm verify:acceptance` passed every completed gate but the assistant-engine coverage worker exceeded Node's default 4 GB heap. Its exact failed target passed when rerun with an 8 GB heap: 169 files and 2,514 tests.
+- Required `frontend-review` and `coverage-write` audits returned no findings. Parent review confirmed the correction uses existing owners and introduces no new architectural concepts.
+- Browser proof was attempted through the required in-app browser lane, but no browser backend was available. Static component tracing and regression coverage confirm the dialog passes autofocus through to the phone input and omits the duplicate card for blank and existing phone states.
+- PR CI, ReviewGPT, and mergeability proof run after the scoped commit is pushed.
+Completed: 2026-07-20

--- a/apps/web/src/components/settings/hosted-phone-settings.tsx
+++ b/apps/web/src/components/settings/hosted-phone-settings.tsx
@@ -62,17 +62,18 @@ export function HostedPhoneSettings(props: {
   const statusTone = errorMessage ? "destructive" : successMessage ? "success" : "neutral";
   const statusMessage = errorMessage ?? successMessage;
 
-  const isChangeFlow = Boolean(props.autoOpen && currentPhoneNumber);
+  const isDialogFlow = Boolean(props.autoOpen);
+  const isChangeFlow = Boolean(isDialogFlow && currentPhoneNumber);
 
   return (
     <div className="space-y-5">
-      {isChangeFlow ? null : (
+      {isDialogFlow ? null : (
         <div className="space-y-2">
           <h2 className="font-serif text-lg font-medium tracking-tight text-foreground">Phone</h2>
         </div>
       )}
 
-      {isChangeFlow ? null : currentPhoneNumber ? (
+      {isDialogFlow ? null : currentPhoneNumber ? (
         <ConnectedAccountCard
           value={formatMaskedPhoneNumber(currentPhoneNumber)}
           action={
@@ -99,7 +100,7 @@ export function HostedPhoneSettings(props: {
         />
       )}
 
-      {props.murphPhoneNumber && !isChangeFlow ? (
+      {props.murphPhoneNumber && !isDialogFlow ? (
         <SettingsContactLink
           href={`sms:${props.murphPhoneNumber}`}
           label="Text Murph"
@@ -112,6 +113,7 @@ export function HostedPhoneSettings(props: {
         <HostedPhoneAuth
           intent="link"
           phoneFieldLabel={isChangeFlow ? "New phone number" : undefined}
+          phoneInputAutoFocus={isDialogFlow}
           onLinked={handleLinked}
         />
       ) : null}

--- a/apps/web/src/lib/hosted-onboarding/request-auth.ts
+++ b/apps/web/src/lib/hosted-onboarding/request-auth.ts
@@ -261,10 +261,13 @@ export async function requireFreshPrivyMemberAuthForHostedAppSession(
 }> {
   const [appSession, freshPrivy] = await Promise.all([
     requireHostedAppSessionFromRequest(request),
-    requirePrivyMemberAuth(request, prisma),
+    requireVerifiedPrivyMemberAuth(request, prisma),
   ]);
 
-  if (freshPrivy.member.id !== appSession.member.id) {
+  if (
+    freshPrivy.identity.userId !== appSession.privyUserId
+    || (freshPrivy.member && freshPrivy.member.id !== appSession.member.id)
+  ) {
     throw hostedOnboardingError({
       code: "PRIVY_SESSION_MEMBER_MISMATCH",
       message:
@@ -273,7 +276,16 @@ export async function requireFreshPrivyMemberAuthForHostedAppSession(
     });
   }
 
-  return { appSession, freshPrivy };
+  // Account linking proves the fresh Privy identity before Murph can persist
+  // its new login method, so the exact Privy-user match lets the app session
+  // supply the already-authenticated hosted member during that handoff.
+  return {
+    appSession,
+    freshPrivy: {
+      ...freshPrivy,
+      member: appSession.member,
+    },
+  };
 }
 
 export async function requireFreshActivePrivyMemberAuthForHostedAppSession(

--- a/apps/web/test/hosted-onboarding-request-auth.test.ts
+++ b/apps/web/test/hosted-onboarding-request-auth.test.ts
@@ -533,6 +533,23 @@ describe("hosted Privy request auth", () => {
       member: createHostedMember({
         id: "member_other",
       }),
+      privyUserId: "did:privy:user_123",
+      sessionId: "hws_other",
+    });
+
+    await expect(
+      requireFreshActivePrivyMemberAuthForHostedAppSession(createAuthenticatedRequest(), prisma),
+    ).rejects.toMatchObject({
+      code: "PRIVY_SESSION_MEMBER_MISMATCH",
+      httpStatus: 409,
+    });
+    expect(hostedMemberAccessFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects fresh Privy proof for a different Privy user than the app session", async () => {
+    mocks.requireHostedAppSessionFromRequest.mockResolvedValue({
+      expiresAt: new Date("2026-04-26T00:00:00.000Z"),
+      member: createHostedMember(),
       privyUserId: "did:privy:user_other",
       sessionId: "hws_other",
     });
@@ -546,18 +563,34 @@ describe("hosted Privy request auth", () => {
     expect(hostedMemberAccessFindUnique).not.toHaveBeenCalled();
   });
 
-  it("does not trust the app-session member when the fresh Privy principal has no member", async () => {
+  it("uses the app-session member when the matching fresh Privy identity is not persisted yet", async () => {
     mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(null);
 
     await expect(
       requireFreshActivePrivyMemberAuthForHostedAppSession(createAuthenticatedRequest(), prisma),
-    ).rejects.toMatchObject({
-      code: "HOSTED_MEMBER_NOT_FOUND",
-      httpStatus: 403,
+    ).resolves.toMatchObject({
+      appSession: {
+        member: {
+          id: "member_123",
+        },
+      },
+      freshPrivy: {
+        identity: {
+          userId: "did:privy:user_123",
+        },
+        member: {
+          id: "member_123",
+        },
+      },
     });
     expect(mocks.requireHostedAppSessionFromRequest).toHaveBeenCalledTimes(1);
     expect(mocks.lookupHostedMemberForPrivyPrincipal).toHaveBeenCalledTimes(1);
-    expect(hostedMemberAccessFindUnique).not.toHaveBeenCalled();
+    expect(hostedMemberAccessFindUnique).toHaveBeenCalledTimes(1);
+    expect(hostedMemberAccessFindUnique).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        id: "member_123",
+      },
+    }));
   });
 
   it("keeps app-session verification independent from fresh Privy verification", async () => {

--- a/apps/web/test/settings-phone-settings.test.ts
+++ b/apps/web/test/settings-phone-settings.test.ts
@@ -1,10 +1,14 @@
 import { act, createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderClientComponent } from "./render-client-component";
 
 const mocks = vi.hoisted(() => ({
+  phoneAuthProps: [] as Array<{
+    phoneFieldLabel?: string | null;
+    phoneInputAutoFocus?: boolean;
+  }>,
   refreshUser: vi.fn(),
   useUser: vi.fn(),
 }));
@@ -14,7 +18,14 @@ vi.mock("@privy-io/react-auth", () => ({
 }));
 
 vi.mock("@/src/components/hosted-onboarding/hosted-phone-auth", () => ({
-  HostedPhoneAuth() {
+  HostedPhoneAuth(props: {
+    phoneFieldLabel?: string | null;
+    phoneInputAutoFocus?: boolean;
+  }) {
+    mocks.phoneAuthProps.push({
+      phoneFieldLabel: props.phoneFieldLabel,
+      phoneInputAutoFocus: props.phoneInputAutoFocus,
+    });
     return createElement(
       "div",
       {
@@ -28,6 +39,11 @@ vi.mock("@/src/components/hosted-onboarding/hosted-phone-auth", () => ({
 let cleanupRender: (() => Promise<void>) | null = null;
 
 describe("HostedPhoneSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.phoneAuthProps = [];
+  });
+
   afterEach(async () => {
     if (cleanupRender) {
       await cleanupRender();
@@ -111,6 +127,40 @@ describe("HostedPhoneSettings", () => {
 
     expect(container.querySelector('[data-testid="hosted-phone-auth"]')).toBeTruthy();
   });
+
+  it.each([
+    [null, undefined],
+    ["+14046257706", "New phone number"],
+  ] as const)(
+    "opens the dialog phone form directly without a duplicate account card for %s",
+    async (initialPhoneNumber, phoneFieldLabel) => {
+      mocks.useUser.mockReturnValue({
+        refreshUser: mocks.refreshUser,
+        user: null,
+      });
+
+      const { HostedPhoneSettings } = await import("@/src/components/settings/hosted-phone-settings");
+
+      const { cleanup, container } = await renderClientComponent(
+        createElement(HostedPhoneSettings, {
+          authenticated: true,
+          autoOpen: true,
+          initialPhoneNumber,
+        }),
+        { requireButton: false },
+      );
+      cleanupRender = cleanup;
+
+      expect(container.querySelector('[data-testid="hosted-phone-auth"]')).toBeTruthy();
+      expect(container.textContent).not.toContain("Not connected");
+      expect(container.textContent).not.toContain("Link phone");
+      expect(container.textContent).not.toContain("•••• 7706");
+      expect(mocks.phoneAuthProps.at(-1)).toEqual({
+        phoneFieldLabel,
+        phoneInputAutoFocus: true,
+      });
+    },
+  );
 
   it("does not use Privy client user state as the displayed phone authority", async () => {
     mocks.useUser.mockReturnValue({


### PR DESCRIPTION
## Why this PR exists

Linking a phone could fail after successful Privy verification because the shared settings auth helper required the newly linked identity to already exist in Murph. The link dialog also repeated the outer Settings account card before the phone form.

## User goal / user-visible behavior

An authenticated member can link or replace a phone number without a false signup-completion error. The link dialog opens directly on the focused phone input, while the ordinary Settings page keeps its existing account-status card.

## User experience

The member selects **Link phone** or changes an existing number in Settings. The dialog opens on the phone field without a duplicate “Not connected / Link phone” row; after SMS verification, the same authenticated Privy identity is synchronized to the current Murph member. Existing mismatch and conflict errors continue to fail closed.

## Invariants

- Require both the Murph app session and a fresh verified Privy session.
- Bind the fresh proof to the exact Privy user ID stored in the app session.
- Reject a fresh identity that resolves to another hosted member.
- Preserve the downstream transactional member lock, identity mismatch check, and unique-constraint mapping.
- Keep standalone Settings cards and non-dialog rendering unchanged.
- Add no state owner, dependency, compatibility layer, or parallel authentication flow.

## Non-obvious affected surfaces

- Settings email and Telegram synchronization call the same dual-session auth helper. They receive the same exact-user pre-persistence handoff semantics because that helper owns fresh identity-link authorization across Settings. The request-auth regression suite proves same-user handoff plus different-user and different-member rejection; the full hosted-web diff test run kept the existing route suites green.

## Change-shape breakdown

Classification is by file ownership: runtime React/TypeScript is source, Vitest files are tests, the completed execution plan is docs, and generated output is separate. No binary files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 21 | 7 |
| Tests / fixtures | 90 | 7 |
| Docs | 61 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **172** | **14** |

## Verification

- Focused hosted-web regression suites: 3 files, 37 tests passed.
- `pnpm test:diff`: passed on the complete patch, including hosted-web tests, typecheck, lint, development smoke, and production build.
- Post-rebase workspace typecheck: passed on the pushed head.
- `pnpm verify:acceptance`: every completed gate passed; assistant-engine coverage alone exceeded Node's default 4 GB heap. Its exact target passed with an 8 GB heap (169 files, 2,514 tests).
- Required frontend and coverage audits: no findings.
- In-app browser proof was attempted, but no browser backend was available; component tracing and regression coverage verify autofocus propagation and dialog-only card removal.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 25964267a25ed68679191e6f5ba91cc920d8f359

| Review state | Head |
| --- | --- |
| First-reviewed / current | `25964267a25ed68679191e6f5ba91cc920d8f359` |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787155426&installation_model_id=19880&pr_number=796&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F796&signature=b9a4be84f2ee7f35ac4ae760fe17113bea806014498f7d1c1eeeeaa7103d1cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->