### PR TITLE
fix(web): recover approval client authentication

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-20-action-approval-client-auth.md
+++ b/agent-docs/exec-plans/completed/2026-07-20-action-approval-client-auth.md
@@ -1,0 +1,51 @@
+Goal (incl. success criteria):
+- Prevent secure action approvals from timing out when Murph's durable app session is valid but the current browser no longer has an authenticated Privy client session.
+- Success means the approval screen preserves the existing first-click hydration wait, offers the existing same-device reauthentication flow once Privy reports an unauthenticated client, and does not issue a server challenge from that known unauthenticated state.
+
+Constraints/Assumptions:
+- Preserve the existing approval binding, passkey-only MFA, exact embedded-wallet selection, signature verification, and server session checks.
+- Reuse the shared auth dialog and current-page resume behavior; add no new auth owner or persisted state.
+- Keep approval identifiers, member identifiers, wallet addresses, and private presentation data out of tests, docs, and logs.
+
+Key decisions:
+- Treat the app session and Privy browser session as separate readiness facts, using the existing shared-auth control behavior.
+- Gate the approval action before challenge issuance once Privy has finished loading and reports that the browser is unauthenticated; preserve the existing first-click wait while client state is still initializing.
+- Stop an in-flight hydration wait immediately if Privy resolves to a known unauthenticated state, so the shared sign-in action becomes usable without another timeout.
+- Leave the connected-wallet hydration wait in place for already-authenticated clients.
+
+State:
+- Implementation, scoped verification, and required local audits are complete; final review and PR delivery remain.
+
+Done:
+- Read required architecture, security, reliability, frontend, product, verification, approval protocol, Privy, and browser-control guidance.
+- Confirmed production approval remains pending with the expected Privy identity and embedded Ethereum wallet.
+- Confirmed the failed click reached server challenge issuance and then stopped before a decision.
+- Traced the missing branch: the shared `AuthButton` already supports same-device reauthentication for an app-authenticated page whose Privy client is unauthenticated, while the approval card bypassed it and started an unresolvable readiness wait.
+- Added the shared-auth-dialog gate for a known unauthenticated Privy client without changing server challenge, signature, or wallet-selection contracts.
+- Made the readiness wait stop immediately when Privy resolves to a known unauthenticated state, allowing the sign-in recovery action to become usable after a fast first click.
+- Added component and hook regressions for stable signed-out state, transient hydration, ready-without-user exit, enabled sign-in recovery, and no second challenge.
+- Passed the focused four-file Vitest lane with 19 tests.
+- Passed `pnpm test:diff` for the touched web source/tests: dependency and architecture/privacy guards, TypeScript 7 web check, 5,913 tests, lint with zero errors, dev smoke, and the Next production build.
+- Frontend review found one fast-click timing issue; fixed it and completed a clean re-audit with no findings.
+- Coverage-write found the existing paired hook/component proof sufficient and made no edits.
+- Fable and Opus UI double-check attempts were both blocked by an expired Claude OAuth session.
+
+Now:
+- Re-read the final diff and call paths, reconcile current `main`, close the plan, and commit the scoped patch.
+
+Next:
+- Open the PR, start ReviewGPT concurrently with CI, resolve any accepted findings, and prove mergeability against current `main`.
+
+Open questions (UNCONFIRMED if needed):
+- Browser interaction proof is unavailable in this session because no in-app browser target is present; cover the state with component behavior tests and report the browser-proof limitation.
+
+Working set (files/ids/commands):
+- `apps/web/src/components/sensitive-actions/action-approval-card.tsx`
+- `apps/web/src/components/sensitive-actions/use-passkey-wallet-mfa.ts`
+- `apps/web/test/action-approval-client-auth.test.tsx`
+- `apps/web/test/action-approval-card-accessibility.test.tsx`
+- `apps/web/test/action-approval-passkey-wallet-mfa.test.tsx`
+- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/action-approval-client-auth.test.tsx apps/web/test/action-approval-card-accessibility.test.tsx apps/web/test/action-approval-passkey-wallet-mfa.test.tsx apps/web/test/auth-dialog-provider.test.tsx --no-coverage`
+Status: completed
+Updated: 2026-07-20
+Completed: 2026-07-20

--- a/apps/web/src/components/sensitive-actions/action-approval-card.tsx
+++ b/apps/web/src/components/sensitive-actions/action-approval-card.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import { requestHostedOnboardingJson } from "@/src/components/hosted-onboarding/client-api";
 import { ActionApprovalScreen } from "@/src/components/sensitive-actions/action-approval-screen";
+import { AuthButton } from "@/src/components/ui/auth-button";
 import { Button } from "@/src/components/ui/button";
 import type {
   HostedActionApprovalDecisionResponse,
@@ -79,7 +80,11 @@ export function ActionApprovalCard({
   }
 
   const busy = submission !== null;
-  const primaryLabel = authorization.setup.pendingLabel
+  const clientAuthenticationRequired =
+    authorization.setup.ready && !authorization.setup.clientAuthenticated;
+  const primaryLabel = clientAuthenticationRequired
+    ? "Sign in to approve"
+    : authorization.setup.pendingLabel
     ?? (submission === "approving" ? "Verifying approval…" : "Approve with passkey");
   const busyStatus = authorization.setup.pendingLabel
     ?? (submission === "approving"
@@ -112,7 +117,8 @@ export function ActionApprovalCard({
           aria-busy={busy}
           className="flex flex-col gap-3 sm:flex-row sm:items-center"
         >
-          <Button
+          <AuthButton
+            authSatisfied={!clientAuthenticationRequired}
             className="w-full sm:w-auto"
             disabled={busy}
             onClick={approve}
@@ -120,7 +126,7 @@ export function ActionApprovalCard({
             type="button"
           >
             {primaryLabel}
-          </Button>
+          </AuthButton>
           <Button
             className="w-full sm:w-auto sm:px-5"
             disabled={busy}

--- a/apps/web/src/components/sensitive-actions/use-passkey-wallet-mfa.ts
+++ b/apps/web/src/components/sensitive-actions/use-passkey-wallet-mfa.ts
@@ -168,8 +168,11 @@ async function waitForClientReady(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (state.readyRef.current && state.userRef.current) {
-      return;
+    if (state.readyRef.current) {
+      if (state.userRef.current) {
+        return;
+      }
+      throw new Error("Sign in on this device to continue.");
     }
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }

--- a/apps/web/test/action-approval-card-accessibility.test.tsx
+++ b/apps/web/test/action-approval-card-accessibility.test.tsx
@@ -16,8 +16,10 @@ vi.mock("@/src/components/hosted-onboarding/client-api", () => ({
 vi.mock("@/src/components/sensitive-actions/use-sensitive-action-authorization", () => ({
   useSensitiveActionAuthorization: () => ({
     setup: {
+      clientAuthenticated: true,
       error: null,
       pendingLabel: null,
+      ready: true,
     },
     signChallenge: mocks.signChallenge,
   }),

--- a/apps/web/test/action-approval-client-auth.test.tsx
+++ b/apps/web/test/action-approval-client-auth.test.tsx
@@ -1,0 +1,154 @@
+import { createElement } from "react";
+import { act } from "react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { renderClientComponent } from "./render-client-component";
+
+const mocks = vi.hoisted(() => ({
+  openAuthDialog: vi.fn(),
+  requestHostedOnboardingJson: vi.fn(),
+  setup: {
+    clientAuthenticated: false,
+    error: null as string | null,
+    pendingLabel: null as string | null,
+    ready: true,
+  },
+  signChallenge: vi.fn(),
+}));
+
+vi.mock("@/src/components/hosted-onboarding/auth-dialog-provider", () => ({
+  useAuth: () => ({
+    authenticated: true,
+    openAuthDialog: mocks.openAuthDialog,
+  }),
+}));
+
+vi.mock("@/src/components/hosted-onboarding/client-api", () => ({
+  requestHostedOnboardingJson: mocks.requestHostedOnboardingJson,
+}));
+
+vi.mock("@/src/components/sensitive-actions/use-sensitive-action-authorization", () => ({
+  useSensitiveActionAuthorization: () => ({
+    setup: mocks.setup,
+    signChallenge: mocks.signChallenge,
+  }),
+}));
+
+import { ActionApprovalCard } from "@/src/components/sensitive-actions/action-approval-card";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requestHostedOnboardingJson.mockReset();
+  mocks.signChallenge.mockReset();
+  mocks.setup.clientAuthenticated = false;
+  mocks.setup.error = null;
+  mocks.setup.pendingLabel = null;
+  mocks.setup.ready = true;
+});
+
+test("reauthenticates the Privy client before issuing an approval challenge", async () => {
+  const rendered = await renderClientComponent(createElement(ActionApprovalCard, {
+    approval: pendingApproval(),
+  }));
+
+  expect(rendered.button.textContent).toBe("Sign in to approve");
+
+  await act(async () => {
+    rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  expect(mocks.openAuthDialog).toHaveBeenCalledTimes(1);
+  expect(mocks.requestHostedOnboardingJson).not.toHaveBeenCalled();
+  expect(mocks.signChallenge).not.toHaveBeenCalled();
+
+  await rendered.cleanup();
+});
+
+test("preserves the first approval click while Privy is still initializing", async () => {
+  mocks.setup.ready = false;
+  mocks.requestHostedOnboardingJson.mockReturnValue(new Promise(() => {}));
+  const rendered = await renderClientComponent(createElement(ActionApprovalCard, {
+    approval: pendingApproval(),
+  }));
+
+  expect(rendered.button.textContent).toBe("Approve with passkey");
+
+  await act(async () => {
+    rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+
+  expect(mocks.openAuthDialog).not.toHaveBeenCalled();
+  expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledTimes(1);
+
+  await rendered.cleanup();
+});
+
+test("recovers a first-click hydration race into the sign-in action", async () => {
+  const signing = deferred<void>();
+  mocks.setup.ready = false;
+  mocks.requestHostedOnboardingJson.mockResolvedValue({
+    message: "approval challenge",
+    token: "challenge-token",
+  });
+  mocks.signChallenge.mockReturnValue(signing.promise);
+  const rendered = await renderClientComponent(createElement(ActionApprovalCard, {
+    approval: pendingApproval(),
+  }));
+
+  await act(async () => {
+    rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+
+  expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledTimes(1);
+  expect(mocks.signChallenge).toHaveBeenCalledTimes(1);
+
+  mocks.setup.ready = true;
+  await rendered.rerender(createElement(ActionApprovalCard, {
+    approval: pendingApproval(),
+  }));
+
+  expect(rendered.button.textContent).toBe("Sign in to approve");
+  expect(rendered.button.disabled).toBe(true);
+
+  await act(async () => {
+    signing.reject(new Error("Sign in on this device to continue."));
+    await Promise.resolve();
+  });
+
+  expect(rendered.button.textContent).toBe("Sign in to approve");
+  expect(rendered.button.disabled).toBe(false);
+
+  await act(async () => {
+    rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  expect(mocks.openAuthDialog).toHaveBeenCalledTimes(1);
+  expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledTimes(1);
+
+  await rendered.cleanup();
+});
+
+function pendingApproval() {
+  return {
+    approvalId: "approval-test",
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    presentation: {
+      body: "Allow the requested action.",
+      title: "Approve action",
+    },
+    returnContactKind: null,
+    status: "pending" as const,
+  };
+}
+
+function deferred<T>() {
+  let reject!: (reason?: unknown) => void;
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/apps/web/test/action-approval-passkey-wallet-mfa.test.tsx
+++ b/apps/web/test/action-approval-passkey-wallet-mfa.test.tsx
@@ -162,6 +162,34 @@ test("times out the first approval setup click if Privy never finishes loading",
   }
 });
 
+test("stops waiting when Privy finishes loading without an authenticated user", async () => {
+  const rendered = await renderClientComponent(createElement(PasskeySetupHarness));
+
+  await act(async () => {
+    rendered.button.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  expect(rendered.button.textContent).toBe("Loading secure approval…");
+  expect(readResult(rendered.container)).toBe("idle");
+
+  mocks.privy.ready = true;
+  mocks.privy.user = null;
+  await rendered.rerender(createElement(PasskeySetupHarness));
+
+  await act(async () => {
+    await delay(75);
+  });
+
+  expect(readResult(rendered.container)).toBe(
+    "error:Sign in on this device to continue.",
+  );
+  expect(rendered.button.textContent).toBe("Start");
+  expect(mocks.createWallet).not.toHaveBeenCalled();
+  expect(mocks.linkWithPasskey).not.toHaveBeenCalled();
+
+  await rendered.cleanup();
+});
+
 function PasskeySetupHarness() {
   const setup = usePasskeyWalletMfa();
   const [result, setResult] = useState("idle");

--- a/apps/web/test/auth-button.test.ts
+++ b/apps/web/test/auth-button.test.ts
@@ -123,6 +123,45 @@ test("AuthButton can require a stronger caller-provided auth condition", async (
   expect(onClick).not.toHaveBeenCalled();
 });
 
+test("AuthButton follows a stronger auth condition when it changes after render", async () => {
+  const onClick = vi.fn();
+  const onConnect = vi.fn();
+  const rendered = await renderClientComponent(
+    createElement(
+      AuthButton,
+      {
+        authSatisfied: true,
+        onClick,
+        onConnect,
+      },
+      "Continue",
+    ),
+  );
+  cleanupRender = rendered.cleanup;
+
+  await rendered.rerender(
+    createElement(
+      AuthButton,
+      {
+        authSatisfied: false,
+        onClick,
+        onConnect,
+      },
+      "Continue",
+    ),
+  );
+
+  await act(async () => {
+    rendered.button.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
+  });
+
+  expect(mocks.openAuthDialog).toHaveBeenCalledTimes(1);
+  expect(onConnect).not.toHaveBeenCalled();
+  expect(onClick).not.toHaveBeenCalled();
+});
+
 test("AuthButton lets callers handle auth-required clicks", async () => {
   const onAuthRequired = vi.fn();
   const onClick = vi.fn();


### PR DESCRIPTION
## Why this PR exists

Murph's durable app session can remain valid when the current browser no longer has an authenticated Privy client session. The approval screen treated the server session as sufficient, so approval entered a client-readiness wait that could never authenticate the browser and ended with a generic loading timeout.

## User goal / user-visible behavior

A signed-in Murph member can recover a secure approval on the same page: once Privy reports that the browser is unauthenticated, the primary action becomes **Sign in to approve** and opens the existing authentication dialog. A transient first-click hydration race still waits for the current client and wallet; if that race resolves signed out, it exits immediately into the usable sign-in state instead of waiting ten seconds.

## User experience

- Enter through the existing private approval link.
- If Privy is already authenticated, approve with the existing passkey flow.
- If Privy is ready but signed out, sign in on this device and resume the same approval URL.
- If a click lands during client hydration and hydration resolves signed out, the busy state clears immediately and sign-in becomes available.
- Denial remains available without a passkey, as before.

## Invariants preserved

- The exact member, app session, approval action, challenge, signature, and destination bindings are unchanged.
- Passkey-only MFA and exact linked embedded-wallet selection remain unchanged.
- No approval, wallet, session, or member identifiers are logged or persisted by this change.
- The server challenge and decision routes are unchanged.

## Non-obvious affected surfaces

- `usePasskeyWalletMfa` is also used by secure Settings actions. A ready-but-unauthenticated Privy client now returns an actionable sign-in error immediately instead of consuming the full readiness timeout. The focused hook regression proves the transition from unresolved readiness to ready-without-user.
- The shared `AuthButton` and `AuthProvider` current-page resume path are reused, not changed. Existing auth-dialog resume tests and the new approval-card test prove that reauthentication opens without issuing a second challenge.

## Change-shape breakdown

Classification rule: authored app runtime files are **Source**; files under `apps/web/test` are **Tests/fixtures**; the completed execution plan is **Docs**. There are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 14 | 5 |
| Tests/fixtures | 184 | 0 |
| Docs | 51 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **249** | **5** |

## Verification

- Focused approval/auth suite: 5 files, 27 tests passed.
- All 20 direct `AuthButton` call sites were inspected. The nine Privy-dependent actions use the shared live-client condition; ordinary actions intentionally retain durable server-session auth.
- `pnpm test:diff` for the touched web source and tests: dependency and architecture/privacy guards passed; TypeScript 7 web check passed; 5,915 tests passed with 148 skipped; lint completed with zero errors; dev smoke passed; Next production build passed.
- Frontend audit: one fast-click timing finding accepted and fixed; re-audit returned no findings.
- Coverage-write audit: existing paired component/hook proof was sufficient; no edits.
- ReviewGPT round 1 on the immutable production head: no findings, `ROUND_OUTCOME: PASS`. The current head adds only the shared AuthButton regression test, so the test-only exception applies.
- Final-head GitHub CI: all required checks passed. One unrelated assistant-engine warm-process timeout cascaded in the first package-coverage attempt; the failed-job retry passed on the unchanged head.
- Merge-tree proof against current `main` passed before push.

Rendered browser proof could not run because no in-app browser target was available. The interaction states are covered at the component and hook boundaries.

## ReviewGPT baseline

ReviewGPT first-reviewed head: aaa03e62da57929281e7c6356a855c3f57100db0

| Review state | Head | Source | Tests/fixtures | Docs | Config/tooling | Generated/other |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| First-reviewed baseline | `aaa03e62da57929281e7c6356a855c3f57100db0` | +14/-5 | +184/-0 | +51/-0 | +0/-0 | +0/-0 |
| Current head | `10184c11c4387e9763a47417602a0ae8491af2b5` | +14/-5 | +223/-0 | +51/-0 | +0/-0 | +0/-0 |

Authored-source growth from review remediation: +0/-0
