### PR TITLE
Restore device reading cards on Biomarkers

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-20-biomarker-device-cards.md
+++ b/agent-docs/exec-plans/completed/2026-07-20-biomarker-device-cards.md
@@ -1,0 +1,78 @@
+# Restore device metric cards on Biomarkers
+
+Status: completed
+Created: 2026-07-20
+Updated: 2026-07-20
+
+## Goal
+
+- Restore the prior icon-led card treatment for real wearable-derived readings in the `/biomarkers` page's `From your devices` section without changing the measured lab-history flow.
+
+## Success criteria
+
+- Device metrics with real wearable-derived readings render as responsive cards with their biomarker icon, latest value, reading count, history span, and latest date.
+- The cards remain full-surface links to the existing public biomarker detail routes and have clear hover and keyboard-focus states.
+- Manual entries and lab values still cannot qualify a metric for `From your devices`, and signed-out or device-empty states still omit the section.
+- The existing measured lab-result groups, empty/loading/stale/error states, and header count remain behaviorally unchanged.
+- Focused tests, desktop and mobile browser proof, required frontend and coverage audits, scoped verification, commit, PR, CI, and mergeability checks complete with no unresolved accepted findings.
+
+## Scope
+
+- In scope:
+  - Restore a small reusable device-reading card derived from the deleted biomarker browse-card treatment.
+  - Replace only the `From your devices` list rows with a responsive card grid.
+  - Extend the existing server-provided device biomarker descriptor only with presentation metadata already present in the generated biomarker index.
+  - Update focused web tests for the restored structure and states.
+- Out of scope:
+  - Changing wearable selection, device-only filtering, freshness policy, browser-vault data, or query ownership.
+  - Changing measured lab-result grouping or its private detail routes.
+  - Restoring the old public biomarker library as the primary page experience.
+  - New dependencies, persisted state, APIs, schemas, or design-system tokens.
+
+## Constraints
+
+- The query-owned device summary remains the only source of `From your devices` eligibility and reading metadata.
+- The card stays a presentation component with no data fetching or duplicate health interpretation.
+- Use the current Murph paper-card, Fraunces-number, mono-label, and bespoke biomarker-icon system.
+- Preserve unrelated working-tree and coordination-ledger work.
+
+## Risks and mitigations
+
+1. Risk: restoring the old card accidentally restores all-source or empty catalog behavior.
+   Mitigation: keep `selectBrowserVaultDeviceMetricSummary` and render cards only from its non-null summaries.
+2. Risk: a multi-column card becomes cramped at narrower dashboard widths.
+   Mitigation: use one column by default, two at medium widths, and three only at wider content widths; verify desktop and mobile renders.
+3. Risk: metadata or long units overflow a card.
+   Mitigation: keep the value and unit wrap-safe and preserve responsive text sizing and focus containment.
+
+## Tasks
+
+1. Recreate the historical device-reading card as a focused current-pattern component.
+2. Wire the existing device-only summaries into a responsive card grid and update server presentation metadata.
+3. Add focused component/page coverage for card structure, links, filtering, staleness, and signed-out/empty states.
+4. Capture desktop and mobile browser evidence, resolve required frontend and coverage audits, run scoped verification, and complete the PR lane.
+
+## Decisions
+
+- The historical deleted `BiomarkerBrowseCard` is the visual source, but the restored component is device-specific so the removed public-library behavior does not return.
+- The existing query-owned device summary remains unchanged; this is a presentation-only restoration.
+- No generated image or new mock is needed because the prior component and the user's current screenshot define the before/target boundary.
+
+## Verification
+
+- Focused biomarker device-card and page component tests during implementation.
+- `pnpm test:diff` for every touched `apps/web` path.
+- Authenticated fixture-safe browser proof at desktop and mobile widths when the local route can be rendered; otherwise record the exact authenticated-state gap and use direct component-render proof for populated device cards.
+- Required `frontend-review`, `coverage-write`, Claude Code UI double-check, parent final review, CI, and clean mergeability proof. ReviewGPT is expected to be exempt because the meaningful diff is minor frontend presentation that does not alter workflow, state, data flow, or authority.
+
+## Completion evidence
+
+- Focused biomarker device-metrics test: 3 tests passed.
+- Final scoped `pnpm test:diff` passed for the touched `apps/web` files: TypeScript, 5,910 tests, lint with no errors, dev smoke, and production build.
+- `frontend-review`: no evidence-backed findings; it confirmed the device-only selector and existing detail routes remain intact.
+- `coverage-write`: added the cross-year history-span assertion and returned with no unresolved coverage findings.
+- Parent scope/final review: the change remains a device-card presentation boundary with no new state, query, dependency, or workflow owner.
+- ReviewGPT exemption: the meaningful production change is minor frontend presentation only and does not change UI state, data flow, authority, or a product-critical flow.
+- Rendered browser inspection was attempted through the required in-app browser and blocked by `No browser is available`; the populated page-boundary component test is the available direct proof.
+- Claude Code UI double-check was attempted with Fable and the required Opus fallback; both were blocked by `OAuth session expired and could not be refreshed`. The completed Codex `frontend-review` is the available substitute, without claiming the Claude check passed.
+Completed: 2026-07-20

--- a/apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx
@@ -7,13 +7,13 @@ import {
   selectBrowserVaultDeviceMetricSummary,
   selectBrowserVaultMeasuredBiomarkers,
   type BrowserVaultBiomarkerMetricBinding,
-  type BrowserVaultBiomarkerTrendDefaults,
   type BrowserVaultDeviceMetricSummary,
   type BrowserVaultMeasuredBiomarker,
   type BrowserVaultQueryClient,
 } from "@murphai/query/browser-biomarkers";
 
 import { LabResultValue } from "@/src/components/biomarkers/lab-result-value";
+import { BiomarkerDeviceReadingCard } from "@/src/components/biomarkers/biomarker-device-reading-card";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { AuthButton } from "@/src/components/ui/auth-button";
 import { Badge } from "@/src/components/ui/badge";
@@ -40,11 +40,11 @@ import {
 import { formatMetricValue } from "@/src/lib/browser-vault/trend-comparison";
 
 export interface DeviceTrackedBiomarker {
-  key: string;
+  category: string | null;
   privateMetricBindings: readonly BrowserVaultBiomarkerMetricBinding[];
   routeId: string;
   shortName: string;
-  trendDefaults: BrowserVaultBiomarkerTrendDefaults;
+  summary: string | null;
   unit: string;
   valuePrecision: number;
 }
@@ -216,13 +216,10 @@ function DeviceMetricsSection({ items }: { items: DeviceMetricListItem[] }) {
         </span>
       </div>
 
-      <ul className="overflow-hidden rounded-xl border border-border/70 bg-card/90">
+      <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {items.map((item) => (
-          <li
-            className="border-b border-border/60 last:border-b-0"
-            key={item.entry.routeId}
-          >
-            <DeviceMetricRow item={item} />
+          <li className="min-w-0" key={item.entry.routeId}>
+            <DeviceMetricCard item={item} />
           </li>
         ))}
       </ul>
@@ -230,49 +227,22 @@ function DeviceMetricsSection({ items }: { items: DeviceMetricListItem[] }) {
   );
 }
 
-function DeviceMetricRow({ item }: { item: DeviceMetricListItem }) {
+function DeviceMetricCard({ item }: { item: DeviceMetricListItem }) {
   const { entry, summary } = item;
 
   return (
-    <Link
-      className="group flex min-h-24 items-center gap-3 px-4 py-4 transition-colors hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:gap-4 sm:px-5"
-      href={`/biomarkers/${encodeURIComponent(entry.routeId)}`}
-    >
-      <div className="min-w-0 flex-1">
-        <h3 className="break-words font-serif text-lg font-semibold tracking-tight text-foreground">
-          {entry.shortName}
-        </h3>
-        <p className="mt-1 text-xs text-muted-foreground">
-          {summary.readingCount} {summary.readingCount === 1 ? "reading" : "readings"}
-          <span aria-hidden="true"> · </span>
-          {formatDeviceSpan(summary)}
-          {summary.stale ? (
-            <>
-              <span aria-hidden="true"> · </span>
-              Out of date
-            </>
-          ) : null}
-        </p>
-      </div>
-
-      <div className="flex min-w-0 max-w-[55%] flex-col items-end text-right">
-        <span className="break-words font-serif text-xl font-semibold tracking-tight tabular-nums text-foreground">
-          {formatMetricValue(summary.latest.value, entry.valuePrecision)}{labUnitSuffix(summary.latest.unit ?? entry.unit)}
-        </span>
-        <time
-          className="mt-1 block text-xs text-muted-foreground"
-          dateTime={summary.latest.date}
-        >
-          {formatLabDate(summary.latest.date)}
-        </time>
-      </div>
-
-      <ChevronRight
-        aria-hidden="true"
-        className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-foreground"
-        strokeWidth={1.75}
-      />
-    </Link>
+    <BiomarkerDeviceReadingCard
+      category={entry.category}
+      date={summary.latest.date}
+      dateLabel={formatLabDate(summary.latest.date)}
+      historyLabel={formatDeviceSpan(summary)}
+      readingCount={summary.readingCount}
+      routeId={entry.routeId}
+      stale={summary.stale}
+      summary={entry.summary}
+      title={entry.shortName}
+      valueLabel={`${formatMetricValue(summary.latest.value, entry.valuePrecision)}${labUnitSuffix(summary.latest.unit ?? entry.unit)}`}
+    />
   );
 }
 

--- a/apps/web/app/(dashboard)/biomarkers/page.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/page.tsx
@@ -32,11 +32,11 @@ function listDeviceTrackedBiomarkers(): DeviceTrackedBiomarker[] {
       }
 
       return [{
-        key: overview.key,
+        category: entry.categories[0] ?? null,
         privateMetricBindings: overview.privateMetricBindings,
         routeId: entry.routeId,
         shortName: overview.shortName,
-        trendDefaults: overview.trendDefaults,
+        summary: entry.summary,
         unit: overview.unit,
         valuePrecision: overview.valuePrecision,
       } satisfies DeviceTrackedBiomarker];

--- a/apps/web/src/components/biomarkers/biomarker-device-reading-card.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-device-reading-card.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+
+import { BiomarkerIcon } from "./biomarker-icon";
+import { cn } from "@/src/lib/utils";
+
+export interface BiomarkerDeviceReadingCardProps {
+  category: string | null;
+  className?: string;
+  date: string;
+  dateLabel: string;
+  historyLabel: string;
+  readingCount: number;
+  routeId: string;
+  stale: boolean;
+  summary: string | null;
+  title: string;
+  valueLabel: string;
+}
+
+export function BiomarkerDeviceReadingCard({
+  category,
+  className,
+  date,
+  dateLabel,
+  historyLabel,
+  readingCount,
+  routeId,
+  stale,
+  summary,
+  title,
+  valueLabel,
+}: BiomarkerDeviceReadingCardProps) {
+  return (
+    <Link
+      className={cn(
+        "group flex h-full min-h-72 flex-col rounded-xl border border-border/60 bg-card/90 p-5 transition-colors duration-200 hover:border-border hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
+      href={`/biomarkers/${encodeURIComponent(routeId)}`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <BiomarkerIcon className="size-10 shrink-0" routeId={routeId} />
+        {stale ? (
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            Out of date
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-5 flex flex-col gap-2">
+        {category ? (
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            {formatCategory(category)}
+          </span>
+        ) : null}
+        <h3 className="text-balance font-serif text-[22px] font-semibold tracking-tight text-foreground">
+          {title}
+        </h3>
+      </div>
+
+      {summary ? (
+        <p className="mt-3 line-clamp-2 text-pretty text-sm/6 text-muted-foreground">
+          {summary}
+        </p>
+      ) : null}
+
+      <div className="mt-auto border-t border-border/60 pt-4">
+        <p className="break-words font-serif text-3xl font-semibold tracking-tight tabular-nums text-foreground">
+          {valueLabel}
+        </p>
+        <time className="mt-1 block text-xs text-muted-foreground" dateTime={date}>
+          {dateLabel}
+        </time>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3 border-t border-border/60 pt-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+        <span>
+          {readingCount} {readingCount === 1 ? "reading" : "readings"}
+        </span>
+        <span>{historyLabel}</span>
+      </div>
+    </Link>
+  );
+}
+
+function formatCategory(value: string): string {
+  return value
+    .split(/[-_\s]+/u)
+    .filter((part) => part.length > 0)
+    .map((part) => part.toUpperCase())
+    .join(" ");
+}

--- a/apps/web/test/biomarker-device-metrics.test.tsx
+++ b/apps/web/test/biomarker-device-metrics.test.tsx
@@ -53,38 +53,31 @@ import {
   type DeviceTrackedBiomarker,
 } from "../app/(dashboard)/biomarkers/biomarkers-page-client";
 
-const TREND_DEFAULTS = {
-  aggregation: "mean",
-  comparisonWindowDays: 30,
-  latestWindowDays: 7,
-  minimumPoints: 3,
-} as const;
-
 const DEVICE_BIOMARKERS: DeviceTrackedBiomarker[] = [
   {
-    key: "biomarker:resting-heart-rate",
+    category: "heart-health",
     privateMetricBindings: [{ metricKey: "resting-heart-rate", role: "primary" }],
     routeId: "resting-heart-rate",
     shortName: "Resting heart rate",
-    trendDefaults: TREND_DEFAULTS,
+    summary: "Resting heart rate reflects recovery load.",
     unit: "bpm",
     valuePrecision: 0,
   },
   {
-    key: "biomarker:hrv",
+    category: "heart-health",
     privateMetricBindings: [{ metricKey: "hrv", role: "primary" }],
     routeId: "hrv",
     shortName: "HRV",
-    trendDefaults: TREND_DEFAULTS,
+    summary: "Beat-to-beat variation can reflect recovery and stress.",
     unit: "ms",
     valuePrecision: 0,
   },
   {
-    key: "biomarker:vo2-max",
+    category: "cardiorespiratory-fitness",
     privateMetricBindings: [{ metricKey: "vo2-max", role: "primary" }],
     routeId: "vo2-max",
     shortName: "VO2 max",
-    trendDefaults: TREND_DEFAULTS,
+    summary: "An estimate of aerobic capacity.",
     unit: "mL/kg/min",
     valuePrecision: 1,
   },
@@ -105,7 +98,7 @@ test("only device-derived readings render, count, and decide the latest value", 
   browserVaultMock.value.client = clientWithMetricRows([
     // Device history for resting heart rate, plus newer manual and lab rows
     // that must not surface under a device heading.
-    metricRow({ date: "2026-07-10", id: "w1", metricKey: "resting-heart-rate", sourceKind: "wearable-summary", value: 61 }),
+    metricRow({ date: "2025-07-20", id: "w1", metricKey: "resting-heart-rate", sourceKind: "wearable-summary", value: 61 }),
     metricRow({ date: "2026-07-14", id: "w2", metricKey: "resting-heart-rate", sourceKind: "wearable-summary", value: 59 }),
     metricRow({ date: "2026-07-15", id: "m1", metricKey: "resting-heart-rate", sourceKind: "observation", value: 70 }),
     metricRow({ date: "2026-07-15", id: "t1", metricKey: "resting-heart-rate", sourceKind: "test-result", value: 75 }),
@@ -136,6 +129,15 @@ test("only device-derived readings render, count, and decide the latest value", 
 
     const link = rendered.container.querySelector('a[href="/biomarkers/resting-heart-rate"]');
     expect(link).not.toBeNull();
+    expect(link?.querySelector("svg")).not.toBeNull();
+    expect(link?.textContent).toContain("HEART HEALTH");
+    expect(link?.textContent).toContain("Resting heart rate reflects recovery load.");
+    expect(link?.textContent).toContain("Jul 14, 2026");
+    expect(link?.textContent).toContain("2025 to 2026");
+
+    const section = rendered.container.querySelector('[aria-labelledby="biomarker-devices-heading"]');
+    expect(section?.querySelector("ul")?.className).toContain("md:grid-cols-2");
+    expect(section?.querySelector("ul")?.className).toContain("xl:grid-cols-3");
 
     // The header count includes only the device metrics that render.
     expect(text).toContain("1 biomarker");


### PR DESCRIPTION
## Why this exists

The `/biomarkers` page regressed its wearable-derived readings from the earlier icon-led cards to plain list rows. This restores the richer, more scannable card treatment specifically for real device readings without restoring the removed public biomarker-library behavior.

## User-visible goal and UX

`From your devices` now renders a responsive one-, two-, or three-column card grid. Each full-surface card keeps the biomarker icon, category, summary, latest value and date, reading count, history span, freshness label, and existing biomarker-detail destination.

## Invariants

- `selectBrowserVaultDeviceMetricSummary` remains the only eligibility and reading-summary owner.
- Manual observations and lab/test-result rows still cannot render, count, or decide freshness in `From your devices`.
- Existing measured lab-history groups and private result routes are unchanged.
- Existing public biomarker detail routes remain the card destinations.
- No persisted state, schema, API, dependency, auth, privacy, billing, or health-safety behavior changes.

## Non-obvious surfaces

- The server descriptor now passes only existing generated presentation metadata (`category` and `summary`) into the client card.
- Metric freshness, latest-reading selection, count, and history boundaries remain query-owned rather than duplicated in the presentation component.
- Deployment skew: none; this is a single web presentation change with no cross-component contract.

## Regression proof

- Page-boundary component coverage proves only wearable-derived readings render and that newer manual/lab values cannot replace the device value.
- Coverage proves the full card link, icon, category, summary, latest date, cross-year history label, responsive grid classes, staleness label, and signed-out/device-empty omission.

## Verification

- `pnpm test:diff -- 'apps/web/app/(dashboard)/biomarkers/page.tsx' 'apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx' apps/web/src/components/biomarkers/biomarker-device-reading-card.tsx apps/web/test/biomarker-device-metrics.test.tsx`
  - TypeScript passed.
  - 472 test files passed and 5 skipped; 5,910 tests passed and 148 skipped.
  - Lint passed with 0 errors and 8 unrelated existing warnings.
  - Dev smoke and production build passed.
- Required `frontend-review`: no evidence-backed findings.
- Required `coverage-write`: added cross-year history-span proof; no unresolved findings.
- `git diff --check`: passed.
- Rendered desktop/mobile inspection was attempted through the required in-app browser and blocked by the exact tool error `No browser is available`; no visual-pass claim is made.
- Claude Code UI review was attempted with Fable and the required Opus fallback; both were blocked by `OAuth session expired and could not be refreshed`. The completed Codex `frontend-review` is the documented substitute, without claiming the Claude review passed.

## Review gate

ReviewGPT is exempt under the proportional low-risk rule: the meaningful production diff is minor frontend presentation only and does not change workflow, UI state, data flow, authority, or any product-critical flow.

## Change-shape breakdown

Classification rule: authored app/page/component code is source; Vitest coverage is tests/fixtures; the completed execution plan is docs; no binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 113 | 51 |
| Tests/fixtures | 16 | 14 |
| Docs | 78 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **207** | **65** |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787175324&installation_model_id=19880&pr_number=806&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F806&signature=534589fb2b7492bd83ce6856af77bc2ada776f9383b920174fefd28f7a5c46fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->