### PR TITLE
Temporarily disable Strava connection offers

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-20-disable-strava-connect.md
+++ b/agent-docs/exec-plans/completed/2026-07-20-disable-strava-connect.md
@@ -1,0 +1,62 @@
+# Temporarily disable Strava connection offers
+
+Status: completed
+Created: 2026-07-20
+Updated: 2026-07-20
+
+## Goal
+
+- Stop Murph and the web product from offering Strava connection or reconnection while preserving existing Strava ingestion, stored connections, and disconnect behavior for a small future re-enable.
+
+## Success criteria
+
+- The shared connect-target catalog omits Strava for direct and Junction-backed starts even when credentials or provider filters include it.
+- Murph's hosted device capability list cannot advertise or issue a new Strava connect link.
+- `/connect` hides Strava for members without an existing Strava lifecycle state and never renders a Strava connect/reconnect action.
+- Existing active or recovery-state Strava connections remain visible where needed for status and disconnect, without a connect target.
+- Public homepage connection examples no longer advertise Strava.
+- Focused tests, web/device-sync typechecks, required UI review, and the selected PR review gate pass on the exact pushed head.
+
+## Scope
+
+- In scope: shared device connect availability, assistant/web connect target derivation, `/connect` presentation, public homepage examples, focused regression tests, and completion evidence.
+- Out of scope: Strava provider/importer/webhook deletion, credential removal, stored connection mutation, historical data changes, or setup CLI support for self-hosted provider configurations.
+
+## Constraints
+
+- Technical constraints: preserve provider registry/runtime configuration so already-authorized Strava accounts continue syncing; fail closed at the shared user-facing connection-target owner; avoid an environment flag or new persisted state.
+- Product/process constraints: use an isolated worktree and scoped PR; preserve unrelated ledger rows; keep re-enable to deleting one availability entry and restoring two marketing examples.
+
+## Risks and mitigations
+
+1. Risk: hiding Strava by deleting provider support could stop existing sync or revocation.
+   Mitigation: keep routes, provider configs, importers, webhooks, and stored-connection handling intact; filter only connect-target issuance.
+2. Risk: a hidden card could still be reachable through a direct start route or an old assistant intent.
+   Mitigation: enforce the gate in both ordinary and exact reconnect target catalogs, which own direct starts and intent resolution.
+3. Risk: removing Strava from `/connect` could also remove disconnect controls for existing members.
+   Mitigation: retain lifecycle-state cards while stripping their connect target; hide only idle Strava cards.
+
+## Tasks
+
+1. Add a shared, reversible source-connection availability gate and apply it to connect and reconnect targets.
+2. Make `/connect` omit idle disabled sources while preserving existing-source status/disconnect behavior.
+3. Remove Strava from public homepage connection examples.
+4. Update focused device-sync, route, assistant/runtime, and web presentation tests.
+5. Run required verification, UI proof, completion reviews, commit, push, open the PR, and complete the selected review gate.
+
+## Decisions
+
+- Preserve Strava as a configured provider and ingestion source; "disabled" applies only to starting or renewing a user-facing connection.
+- Centralize the temporary product decision in `packages/device-syncd` so Murph, `/connect`, start routes, old connect intents, and recovery-link tooling agree.
+- Carry the derived availability fact into the `/connect` client so a locally disconnected Strava card disappears as soon as its last lifecycle state is removed.
+- Keep disabled recovery states visible for truthful status/disconnect handling, but replace reconnect promises and disabled connection affordances with explicit temporary-unavailability copy.
+
+## Verification
+
+- Focused device-sync, web route/page, assistant-runtime, and homepage tests passed; the final connect-page remediation suite passed 76/76.
+- Affected package typechecks passed. The affected package test lane passed through all reverse dependents after preparing the fresh-worktree CLI and assistant-runtime build artifacts; the hosted-local harness passed 406 tests and the remaining five downstream packages passed 700 tests.
+- `pnpm test:apps` passed: hosted web typecheck, 5,916 tests, lint with eight unrelated warnings, dev smoke, and production build; Cloudflare typecheck and 1,842 tests also passed.
+- `pnpm docs:drift` and `git diff --check` passed. The required coverage audit added a homepage no-Strava assertion and returned no unresolved findings.
+- The frontend audit's two accepted findings were fixed and its re-review returned no findings. Approved desktop/mobile browser proof remains blocked by `No browser is available`; the allowed Fable and Opus checks were both blocked by an expired OAuth session, so the local frontend audit is the documented substitute.
+- ReviewGPT and required GitHub CI remain the post-push exact-head gates.
+Completed: 2026-07-20

--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -103,6 +103,12 @@ export function ConnectSourcesGrid({
       markLocallyDisconnectedSources(
         markCallbackConnectedSource(sources, callbackConnectedSourceId),
         disconnectedConnectionIds,
+      ).filter((source) =>
+        source.connectionAvailable !== false
+        || source.connected === true
+        || source.requiresReconnect === true
+        || Boolean(source.recoveryKind)
+        || source.historicalResetIncomplete === true
       ),
     ),
     [callbackConnectedSourceId, disconnectedConnectionIds, sources],

--- a/apps/web/app/(dashboard)/connect/connect-page-types.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-types.ts
@@ -6,6 +6,7 @@ export type LogoAsset = {
 };
 
 export type ConnectSource = {
+  connectionAvailable?: boolean;
   connectProvider?: string;
   connectTarget?: string;
   connected?: boolean;

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -33,6 +33,8 @@ export function SourceCard({
   const actionLabel = source.requiresReconnect ? "Reconnect" : "Connect";
   const disconnectAriaLabel = resolveDisconnectAriaLabel(source);
   const reconnectUnavailable = source.requiresReconnect && !isAvailable;
+  const connectionOfferEnabled = source.connectionAvailable !== false;
+  const historicalReconnectUnavailable = historicalResetIncomplete && !connectionOfferEnabled;
   const showReconnectStateDisconnect = canDisconnect
     && (reconnectUnavailable || requiresConnectionReset || source.disconnectScope === "junction_account");
   const unavailableMessage = !source.requiresReconnect && !requiresConnectionReset && !isAvailable
@@ -102,7 +104,9 @@ export function SourceCard({
           <div className="flex shrink-0 flex-col items-start gap-2 sm:mt-auto sm:shrink">
             {requiresConnectionReset ? (
               <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
-                {`${source.name} needs a fresh connection. Disconnect it first, then connect it again.`}
+                {connectionOfferEnabled
+                  ? `${source.name} needs a fresh connection. Disconnect it first, then connect it again.`
+                  : `${source.name} needs a fresh connection, but reconnecting is temporarily unavailable. You can disconnect the old connection here.`}
               </p>
             ) : source.requiresReconnect ? (
               <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
@@ -112,7 +116,9 @@ export function SourceCard({
               </p>
             ) : historicalResetIncomplete ? (
               <p className="max-w-[22rem] text-sm leading-relaxed text-pretty text-destructive">
-                {`The last reset for ${source.name} did not finish. Remove the old connection in your wearable provider account, then connect it again here.`}
+                {connectionOfferEnabled
+                  ? `The last reset for ${source.name} did not finish. Remove the old connection in your wearable provider account, then connect it again here.`
+                  : `The last reset for ${source.name} did not finish. Remove the old connection in your wearable provider account. Reconnecting through Murph is temporarily unavailable.`}
               </p>
             ) : null}
             {unavailableMessage ? (
@@ -146,7 +152,10 @@ export function SourceCard({
               >
                 {source.unavailableActionLabel}
               </Button>
-            ) : reconnectUnavailable || requiresConnectionReset || unavailableMessage ? null : (
+            ) : reconnectUnavailable
+              || requiresConnectionReset
+              || historicalReconnectUnavailable
+              || unavailableMessage ? null : (
               <Button
                 type="button"
                 disabled={!canStart || pending}

--- a/apps/web/app/(dashboard)/connect/page.tsx
+++ b/apps/web/app/(dashboard)/connect/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import {
   DEVICE_CONNECT_SOURCES,
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncConnectTargets,
   normalizeDeviceConnectSourceId,
   normalizeDeviceSyncConnectTargetKey,
@@ -394,6 +395,7 @@ export function resolveConfiguredConnectSources(
 
   return sortConnectSourcesByConnectionState(
     sources.map((source) => {
+      const connectionAvailable = isDeviceConnectSourceAvailableForConnection(source.id);
       const connectTarget = connectTargetBySourceId.get(source.id);
       const connected = options.connectedSourceIds?.has(source.id) === true;
       const recoveryKind = !connected ? options.recoveryKindBySourceId?.get(source.id) : undefined;
@@ -405,10 +407,13 @@ export function resolveConfiguredConnectSources(
       const disconnectScope = options.disconnectScopeBySourceId?.get(source.id);
       const reconnectProvider = options.reconnectProviderBySourceId?.get(source.id);
       const reconnectTarget = options.reconnectTargetBySourceId?.get(source.id);
-      const resolvedConnectTarget = reconnectTarget ?? connectTarget;
+      const resolvedConnectTarget = connectionAvailable
+        ? reconnectTarget ?? connectTarget
+        : undefined;
 
       return {
         ...source,
+        connectionAvailable,
         ...(reconnectProvider ? { connectProvider: reconnectProvider } : {}),
         ...(resolvedConnectTarget ? { connectTarget: resolvedConnectTarget } : {}),
         ...(disconnectConnectionId ? { disconnectConnectionId } : {}),
@@ -419,6 +424,12 @@ export function resolveConfiguredConnectSources(
         ...(connected ? { connected } : {}),
       };
     }),
+  ).filter((source) =>
+    source.connectionAvailable !== false
+    || source.connected === true
+    || source.requiresReconnect === true
+    || Boolean(source.recoveryKind)
+    || source.historicalResetIncomplete === true
   );
 }
 

--- a/apps/web/app/api/internal/device-sync/connect-targets/[connectTarget]/connect-link/route.ts
+++ b/apps/web/app/api/internal/device-sync/connect-targets/[connectTarget]/connect-link/route.ts
@@ -1,6 +1,7 @@
 import { deviceSyncError } from "@murphai/device-syncd/errors";
 import {
   configuredDeviceSyncProviderKeys,
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncConnectTargets,
   readConfiguredDeviceSyncConnectTargetConfigs,
   resolveConfiguredDeviceSyncConnectTarget,
@@ -173,7 +174,10 @@ function resolveHostedDeviceConnectTarget(connectTarget: string) {
     remapHostedDeviceConnectBackendSetupError(error, "connect_target_setup");
   }
 
-  if (!target) {
+  if (
+    !target
+    || !isDeviceConnectSourceAvailableForConnection(target.connectSourceId)
+  ) {
     throw deviceSyncError({
       code: "HOSTED_DEVICE_CONNECT_TARGET_NOT_CONFIGURED",
       httpStatus: 404,

--- a/apps/web/app/device/connect/[claim]/route.ts
+++ b/apps/web/app/device/connect/[claim]/route.ts
@@ -1,5 +1,6 @@
 import { isDeviceSyncError } from "@murphai/device-syncd/errors";
 import {
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncReconnectTargets,
   readConfiguredDeviceSyncConnectTargetConfigs,
 } from "@murphai/device-syncd/connect-config";
@@ -125,7 +126,8 @@ function resolveHostedDeviceConnectIntentTarget(intent: HostedDeviceConnectInten
   return listConfiguredDeviceSyncReconnectTargets(
     readConfiguredDeviceSyncConnectTargetConfigs(process.env),
   ).find((target) =>
-    target.provider === intent.provider
+    isDeviceConnectSourceAvailableForConnection(target.connectSourceId)
+    && target.provider === intent.provider
     && target.connectSourceId === intent.connectSourceId
     && target.connectTarget === intent.connectTarget
     && (target.sourceProviderSlug ?? null) === intent.sourceProviderSlug

--- a/apps/web/src/components/homepage/how-it-works-section.tsx
+++ b/apps/web/src/components/homepage/how-it-works-section.tsx
@@ -5,7 +5,7 @@ const SYNC_DEVICES: ReadonlyArray<{
   { connected: true, name: "Oura" },
   { name: "WHOOP" },
   { name: "Garmin" },
-  { name: "Strava" },
+  { name: "Fitbit" },
 ];
 
 const CHAT_INPUTS = ["Meals", "Supplements", "Workouts"] as const;

--- a/apps/web/src/components/homepage/integrations-section.tsx
+++ b/apps/web/src/components/homepage/integrations-section.tsx
@@ -19,7 +19,7 @@ const INTEGRATIONS: ReadonlyArray<Integration | "murph" | "lab"> = [
   "murph",
   { label: "Eight Sleep", src: "/brand-logos/connect/eight-sleep.svg" },
   { label: "Withings", src: "/brand-logos/connect/withings.png" },
-  { label: "Strava", src: "/brand-logos/connect/strava.svg" },
+  { label: "Peloton", src: "/brand-logos/connect/peloton.svg" },
   { label: "Cronometer", src: "/brand-logos/connect/cronometer.png" },
   { label: "Gmail", src: "/brand-logos/connect/gmail.svg" },
   { label: "Google Calendar", src: "/brand-logos/connect/google-calendar.svg" },

--- a/apps/web/src/lib/device-sync/hosted-connect-start.ts
+++ b/apps/web/src/lib/device-sync/hosted-connect-start.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-import type { DeviceSyncConnectTarget } from "@murphai/device-syncd/connect-config";
+import {
+  isDeviceConnectSourceAvailableForConnection,
+  type DeviceSyncConnectTarget,
+} from "@murphai/device-syncd/connect-config";
+import { deviceSyncError } from "@murphai/device-syncd/errors";
 
 import { createHostedDeviceSyncPublicIngressService } from "./public-ingress-service";
 import { assertHostedWhoopConnectCapacityAvailable } from "./whoop-connect-capacity";
@@ -20,6 +24,15 @@ export async function startHostedDeviceSyncConnection(input: {
   request: Request;
   target: DeviceSyncConnectTarget;
 }): Promise<HostedDeviceSyncConnectResponse> {
+  if (!isDeviceConnectSourceAvailableForConnection(input.target.connectSourceId)) {
+    throw deviceSyncError({
+      code: "HOSTED_DEVICE_CONNECT_SOURCE_NOT_CONFIGURED",
+      httpStatus: 404,
+      message: "Hosted device connect source is not configured.",
+      retryable: false,
+    });
+  }
+
   assertHostedOnboardingMutationOrigin(input.request);
   const prisma = getPrisma();
   const auth = await requireActiveHostedAppSessionFromRequest(input.request);

--- a/apps/web/src/lib/device-sync/reconnect-link-tool.ts
+++ b/apps/web/src/lib/device-sync/reconnect-link-tool.ts
@@ -1,4 +1,5 @@
 import {
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncReconnectTargets,
   normalizeDeviceConnectSourceId,
   normalizeDeviceSyncConnectTargetKey,
@@ -111,7 +112,8 @@ export function resolveHostedDeviceReconnectLinkTarget(
   const matches = listConfiguredDeviceSyncReconnectTargets(
     readConfiguredDeviceSyncConnectTargetConfigs(env),
   ).filter((target) =>
-    (!connectSourceId || target.connectSourceId === connectSourceId)
+    isDeviceConnectSourceAvailableForConnection(target.connectSourceId)
+    && (!connectSourceId || target.connectSourceId === connectSourceId)
     && (!connectTarget || target.connectTarget === connectTarget)
     && (!sourceProviderSlug || (target.sourceProviderSlug ?? null) === sourceProviderSlug)
   );

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -132,7 +132,7 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
   assert.match(markup, /Live Well/);
   assert.match(markup, /placeholder="Search sources"/);
   assert.match(markup, /aria-label="Search sources"/);
-  assert.match(markup, />28 of 28 sources</);
+  assert.match(markup, />27 of 27 sources</);
   assert.match(markup, /lg:grid-cols-2 xl:grid-cols-4/);
   assert.doesNotMatch(markup, /data-priority list/);
   assert.doesNotMatch(markup, /Priority/u);
@@ -183,11 +183,6 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
       assetPath: "/brand-logos/connect/beurer.png",
       description: "Blood pressure, scale, glucose, and home health measurements from Beurer.",
       name: "Beurer",
-    },
-    {
-      assetPath: "/brand-logos/connect/strava.svg",
-      description: "Rides, runs, workouts, route context, power, and training load from Strava.",
-      name: "Strava",
     },
     {
       assetPath: "/brand-logos/connect/omron.png",
@@ -281,7 +276,7 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
     },
   ];
 
-  assert.equal(sources.length, 28);
+  assert.equal(sources.length, 27);
   assert.equal(markup.match(/data-connection-state="idle"/gu)?.length, sources.length);
   assert.equal(markup.match(/>Not available<\/button>/gu)?.length, sources.length - 1);
   assert.match(markup, /disabled=""/);
@@ -302,12 +297,12 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
   assert.doesNotMatch(markup, />Contour BLE</u);
   assert.doesNotMatch(markup, />OneTouch</u);
   assert.doesNotMatch(markup, />Manual</u);
+  assert.doesNotMatch(markup, />Strava</u);
   assert.doesNotMatch(markup, /Whoop V2/u);
   assert.ok(sourceHeadingIndex(markup, "Apple Health") < sourceHeadingIndex(markup, "Garmin"));
   assert.ok(sourceHeadingIndex(markup, "Garmin") < sourceHeadingIndex(markup, "Fitbit"));
   assert.ok(sourceHeadingIndex(markup, "Fitbit") < sourceHeadingIndex(markup, "Google Fit"));
-  assert.ok(sourceHeadingIndex(markup, "Google Fit") < sourceHeadingIndex(markup, "Strava"));
-  assert.ok(sourceHeadingIndex(markup, "Strava") < sourceHeadingIndex(markup, "Withings"));
+  assert.ok(sourceHeadingIndex(markup, "Google Fit") < sourceHeadingIndex(markup, "Withings"));
   assert.ok(sourceHeadingIndex(markup, "Withings") < sourceHeadingIndex(markup, "Oura"));
   assert.ok(sourceHeadingIndex(markup, "Oura") < sourceHeadingIndex(markup, "Whoop"));
   assert.ok(sourceHeadingIndex(markup, "Whoop") < sourceHeadingIndex(markup, "Dexcom"));
@@ -485,6 +480,77 @@ test("ConnectPage enables Garmin when Junction exposes Garmin as a connect targe
   assert.equal(markup.match(/>Connect<\/button>/gu)?.length, 1);
 });
 
+test("ConnectPage hides Strava when direct and Junction connection routes are configured", async () => {
+  vi.stubEnv("STRAVA_CLIENT_ID", "strava-client-id");
+  vi.stubEnv("STRAVA_CLIENT_SECRET", "strava-client-secret");
+  vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+  vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+  vi.stubEnv("JUNCTION_ENV", "sandbox");
+  vi.stubEnv("JUNCTION_PROVIDER_FILTER", "strava");
+  vi.stubEnv("JUNCTION_REGION", "us");
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.doesNotMatch(markup, />Strava</u);
+  assert.doesNotMatch(markup, /Connect Strava/u);
+});
+
+test("ConnectPage preserves an existing Strava connection for status and disconnect only", async () => {
+  vi.stubEnv("STRAVA_CLIENT_ID", "strava-client-id");
+  vi.stubEnv("STRAVA_CLIENT_SECRET", "strava-client-secret");
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_strava_123",
+        provider: "strava",
+        state: "active",
+        upstreamSources: [],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Strava connected/u);
+  assert.match(markup, /aria-label="Disconnect Strava"/u);
+  assert.doesNotMatch(markup, /aria-label="Connect Strava"/u);
+  assert.doesNotMatch(markup, /aria-label="Reconnect Strava"/u);
+});
+
+test("ConnectPage does not offer Strava reconnection for an existing account needing access", async () => {
+  vi.stubEnv("STRAVA_CLIENT_ID", "strava-client-id");
+  vi.stubEnv("STRAVA_CLIENT_SECRET", "strava-client-secret");
+  mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValueOnce({
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    ok: true,
+    sources: [
+      {
+        connectionId: "dsc_strava_123",
+        connectSourceId: "strava",
+        connectTarget: "strava",
+        primaryAction: {
+          kind: "reconnect",
+          label: "Reconnect",
+        },
+        provider: "strava",
+        state: "reauthorization_required",
+        upstreamSources: [],
+      },
+    ],
+  });
+
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage());
+
+  assert.match(markup, /Strava needs attention from the connected app/u);
+  assert.match(markup, /aria-label="Disconnect Strava"/u);
+  assert.doesNotMatch(markup, /aria-label="Reconnect Strava"/u);
+});
+
 test("ConnectPage enables every Link source exposed by the shared Junction defaults", async () => {
   vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
   vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
@@ -498,7 +564,10 @@ test("ConnectPage enables every Link source exposed by the shared Junction defau
   const { JUNCTION_DEFAULT_PROVIDER_FILTER } = await import("@murphai/device-syncd/config");
   const markup = renderToStaticMarkup(await ConnectPage());
 
-  assert.equal(markup.match(/>Connect<\/button>/gu)?.length, JUNCTION_DEFAULT_PROVIDER_FILTER.length);
+  assert.equal(
+    markup.match(/>Connect<\/button>/gu)?.length,
+    JUNCTION_DEFAULT_PROVIDER_FILTER.filter((providerSlug) => providerSlug !== "strava").length,
+  );
   assert.equal(markup.match(/>Not available<\/button>/gu)?.length ?? 0, 0);
   assert.match(markup, /aria-label="Download app for Apple Health"/u);
   assert.doesNotMatch(markup, />Accu-Chek</u);
@@ -1612,6 +1681,67 @@ test("SourceCard stacks connection-reset content vertically at the base breakpoi
   );
 });
 
+test("SourceCard does not promise unavailable Strava recovery connections", async () => {
+  const { SourceCard } = await import("../app/(dashboard)/connect/connect-source-card");
+  const logo = {
+    className: "h-auto max-h-9 w-auto max-w-[8rem] object-contain",
+    height: 20,
+    src: "/brand-logos/connect/strava.svg",
+    width: 96,
+  };
+  const cardProps = {
+    authenticated: true,
+    errorMessage: null,
+    onDisconnectTargetChange: () => {},
+    onStartConnection: async () => {},
+    pending: false,
+    pendingDisconnect: false,
+  };
+
+  const resetMarkup = renderToStaticMarkup(createElement(SourceCard, {
+    ...cardProps,
+    source: {
+      connectionAvailable: false,
+      description: "Rides, runs, workouts, route context, power, and training load.",
+      disconnectConnectionId: "dsc_strava_reset",
+      id: "strava",
+      logo,
+      name: "Strava",
+      recoveryKind: "connection_reset" as const,
+    },
+  }));
+
+  assert.match(
+    resetMarkup,
+    /Strava needs a fresh connection, but reconnecting is temporarily unavailable\./u,
+  );
+  assert.doesNotMatch(resetMarkup, /then connect it again/u);
+  assert.doesNotMatch(resetMarkup, /aria-label="(?:Connect|Reconnect) Strava"/u);
+  assert.doesNotMatch(resetMarkup, />Not available</u);
+
+  const historicalResetMarkup = renderToStaticMarkup(createElement(SourceCard, {
+    ...cardProps,
+    source: {
+      connectionAvailable: false,
+      description: "Rides, runs, workouts, route context, power, and training load.",
+      disconnectConnectionId: "dsc_strava_historical_reset",
+      disconnectScope: "junction_account" as const,
+      historicalResetIncomplete: true,
+      id: "strava",
+      logo,
+      name: "Strava",
+    },
+  }));
+
+  assert.match(
+    historicalResetMarkup,
+    /Reconnecting through Murph is temporarily unavailable\./u,
+  );
+  assert.doesNotMatch(historicalResetMarkup, /connect it again here/u);
+  assert.doesNotMatch(historicalResetMarkup, /aria-label="(?:Connect|Reconnect) Strava"/u);
+  assert.doesNotMatch(historicalResetMarkup, />Not available</u);
+});
+
 test("SourceCard stacks Apple Health app content vertically at the base breakpoint", async () => {
   const { SourceCard } = await import("../app/(dashboard)/connect/connect-source-card");
   const logo = { className: "size-11 object-contain", height: 44, src: "/logo.png", width: 44 };
@@ -2700,6 +2830,70 @@ test("ConnectSourcesGrid disconnects a connected source after confirmation", asy
   });
   assert.match(rendered.container.textContent ?? "", /Whoop not connected/);
   assert.equal(rendered.container.querySelector("button[aria-label='Connect Whoop']")?.textContent, "Connect");
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid hides a connection-disabled source after its local disconnect", async () => {
+  const fetch = vi.fn(async (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ) => {
+    void _input;
+    void _init;
+    return Response.json({});
+  });
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import("../app/(dashboard)/connect/connect-page-client");
+  const rendered = await renderClientComponent(createElement(ConnectSourcesGrid, {
+    sources: [
+      {
+        connectionAvailable: false,
+        connected: true,
+        description: "Rides, runs, workouts, route context, power, and training load.",
+        disconnectConnectionId: "dsc_strava_123",
+        id: "strava",
+        logo: {
+          className: "h-auto max-h-9 w-auto max-w-[8rem] object-contain",
+          height: 20,
+          src: "/brand-logos/connect/strava.svg",
+          width: 96,
+        },
+        name: "Strava",
+      },
+    ],
+  }));
+
+  assert.match(rendered.container.textContent ?? "", /1 of 1 sources/u);
+  const disconnectButton = rendered.container.querySelector("button[aria-label='Disconnect Strava']");
+  assert.ok(disconnectButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    disconnectButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  const confirmButton = [...rendered.container.querySelectorAll("button")]
+    .filter((button) => button.textContent === "Disconnect")
+    .at(-1);
+  assert.ok(confirmButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    confirmButton.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
+  });
+
+  await vi.waitFor(() => {
+    assert.match(rendered.container.textContent ?? "", /Disconnected Strava\. Your history is still saved\./u);
+    assert.match(rendered.container.textContent ?? "", /0 of 0 sources/u);
+  });
+
+  assert.equal(
+    [...rendered.container.querySelectorAll("h2")]
+      .some((heading) => heading.textContent === "Strava"),
+    false,
+  );
+  assert.equal(rendered.container.querySelector("button[aria-label='Disconnect Strava']"), null);
+  assert.doesNotMatch(rendered.container.textContent ?? "", /Not available/u);
 
   await rendered.cleanup();
 });

--- a/apps/web/test/device-connect-intent-route.test.ts
+++ b/apps/web/test/device-connect-intent-route.test.ts
@@ -140,7 +140,7 @@ describe("hosted device connect intent route", () => {
     });
   });
 
-  it("starts source-specific Junction reconnect intents when a direct target has the same public source", async () => {
+  it("rejects existing Strava intents while direct and Junction provider support remain configured", async () => {
     vi.stubEnv("WHOOP_CLIENT_ID", "");
     vi.stubEnv("WHOOP_CLIENT_SECRET", "");
     vi.stubEnv("STRAVA_CLIENT_ID", "strava-client");
@@ -168,18 +168,13 @@ describe("hosted device connect intent route", () => {
       createRouteContext({ claim: "dc_opaque" }),
     );
 
-    expect(response.status).toBe(303);
-    expect(mocks.startHostedDeviceSyncConnection).toHaveBeenCalledWith({
-      defaultReturnTo:
-        "/device-sync/connect/complete?source=assistant&connectSource=strava&connectTarget=strava",
-      request: expect.any(Request),
-      target: expect.objectContaining({
-        connectSourceId: "strava",
-        connectTarget: "strava",
-        provider: "junction",
-        sourceProviderSlug: "strava",
-      }),
+    expect(response.status).toBe(404);
+    expect(await response.text()).toContain("This device connection is not available right now.");
+    expect(mocks.releaseHostedDeviceConnectIntentStart).toHaveBeenCalledWith({
+      claim: "dc_opaque",
+      memberId: "member_123",
     });
+    expect(mocks.startHostedDeviceSyncConnection).not.toHaveBeenCalled();
   });
 
   it("returns JSON for app-page intent starts", async () => {

--- a/apps/web/test/device-reconnect-link-tool.test.ts
+++ b/apps/web/test/device-reconnect-link-tool.test.ts
@@ -68,6 +68,25 @@ describe("hosted device reconnect link tool", () => {
     expect(result.status === "ambiguous" ? result.matches : []).toHaveLength(2);
   });
 
+  it("does not issue a hosted reconnect target for configured Strava routes", async () => {
+    const { resolveHostedDeviceReconnectLinkTarget } = await import(
+      "@/src/lib/device-sync/reconnect-link-tool"
+    );
+
+    expect(resolveHostedDeviceReconnectLinkTarget({
+      ...configuredWhoopEnv,
+      JUNCTION_PROVIDER_FILTER: "strava",
+      STRAVA_CLIENT_ID: "strava-client",
+      STRAVA_CLIENT_SECRET: "strava-secret",
+      WHOOP_CLIENT_ID: "",
+      WHOOP_CLIENT_SECRET: "",
+    }, {
+      connectSourceId: "strava",
+      connectTarget: null,
+      sourceProviderSlug: null,
+    })).toEqual({ status: "missing" });
+  });
+
   it("creates a long-lived source-specific connect intent for the selected target", async () => {
     mocks.createHostedDeviceConnectIntentTx.mockResolvedValueOnce({
       claim: "dc_opaque",

--- a/apps/web/test/device-sync-internal-connect-route.test.ts
+++ b/apps/web/test/device-sync-internal-connect-route.test.ts
@@ -104,6 +104,38 @@ describe("device sync internal connect-link route", () => {
     expect(JSON.stringify(infoSpy.mock.calls)).not.toContain("opaque-state");
   });
 
+  it("does not issue a hosted connect link for configured Strava routes", async () => {
+    vi.stubEnv("WHOOP_CLIENT_ID", "");
+    vi.stubEnv("WHOOP_CLIENT_SECRET", "");
+    vi.stubEnv("STRAVA_CLIENT_ID", "strava-client");
+    vi.stubEnv("STRAVA_CLIENT_SECRET", "strava-secret");
+    vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+    vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+    vi.stubEnv("JUNCTION_ENV", "sandbox");
+    vi.stubEnv("JUNCTION_PROVIDER_FILTER", "strava");
+    vi.stubEnv("JUNCTION_REGION", "us");
+
+    const response = await internalDeviceSyncConnectLinkRoute.POST(
+      new Request("https://join.example.test/api/internal/device-sync/connect-targets/strava/connect-link", {
+        method: "POST",
+      }),
+      {
+        params: Promise.resolve({
+          connectTarget: "strava",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.createHostedDeviceConnectIntent).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "HOSTED_DEVICE_CONNECT_TARGET_NOT_CONFIGURED",
+        retryable: false,
+      },
+    });
+  });
+
   it("rejects wearable authorization for a synthetic group container", async () => {
     mocks.isHostedThreadContainerMember.mockResolvedValue(true);
 

--- a/apps/web/test/device-sync-settings-routes.test.ts
+++ b/apps/web/test/device-sync-settings-routes.test.ts
@@ -1276,6 +1276,39 @@ describe("device sync settings routes", () => {
     expect(mocks.findManyDeviceConnections).not.toHaveBeenCalled();
   });
 
+  it("rejects Strava source starts even when direct and Junction credentials are configured", async () => {
+    vi.stubEnv("STRAVA_CLIENT_ID", "strava-client-id");
+    vi.stubEnv("STRAVA_CLIENT_SECRET", "strava-client-secret");
+    vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
+    vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");
+    vi.stubEnv("JUNCTION_ENV", "sandbox");
+    vi.stubEnv("JUNCTION_PROVIDER_FILTER", "strava");
+    vi.stubEnv("JUNCTION_REGION", "us");
+
+    const response = await connectSourceStartRoute.POST(
+      createJsonPostRequest(
+        "https://join.example.test/api/connect-sources/strava/start",
+        {},
+        {
+          headers: {
+            origin: "https://join.example.test",
+          },
+        },
+      ),
+      createRouteContext({ sourceId: "strava" }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "HOSTED_DEVICE_CONNECT_SOURCE_NOT_CONFIGURED",
+        message: "Hosted device connect source is not configured.",
+        retryable: false,
+      },
+    });
+    expect(mocks.startConnection).not.toHaveBeenCalled();
+  });
+
   it("starts a hosted connect source flow through Junction by source id", async () => {
     vi.stubEnv("JUNCTION_API_KEY", "sk_us_junction-test");
     vi.stubEnv("JUNCTION_CLIENT_USER_ID_SECRET", "junction-client-user-id-secret");

--- a/apps/web/test/page.test.ts
+++ b/apps/web/test/page.test.ts
@@ -230,6 +230,7 @@ test("HomePage renders the canonical landing page at the root route", async () =
   assert.match(markup, /Research may be incomplete, mixed, or not applicable to your situation/);
   assert.doesNotMatch(markup, /GPT-5\.5 Pro/);
   assert.match(markup, /Wearable apps show status/);
+  assert.doesNotMatch(markup, /Strava/);
   assert.doesNotMatch(markup, /Perplexity Health/);
   assert.doesNotMatch(markup, /Your wearable shows data/);
 });

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-status-prompt.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-status-prompt.ts
@@ -19,6 +19,7 @@ type HostedDeviceSyncRuntimeConnectionSourceSnapshot = NonNullable<
 >[number];
 
 export interface HostedDeviceSyncStatusPromptReconnectTarget {
+  connectionAvailable?: boolean | null;
   connectTarget: string;
   connectTargetAmbiguous?: boolean | null;
   connectTargetCommandSafe?: boolean | null;
@@ -338,7 +339,9 @@ function buildHostedDeviceSyncSourceReconnectNotice(input: {
   const sourceProviderSlug = normalizeHostedDeviceSyncKey(input.source.sourceProviderSlug);
 
   return {
-    commandConnectTarget: reconnectTarget?.connectTarget ?? null,
+    commandConnectTarget: reconnectTarget?.connectionAvailable === false
+      ? null
+      : reconnectTarget?.connectTarget ?? null,
     commandConnectTargetSafe: isHostedDeviceSyncReconnectCommandSafe(reconnectTarget),
     errorCode,
     label: reconnectTarget?.label
@@ -372,7 +375,9 @@ function buildHostedDeviceSyncAccountReconnectNotice(input: {
   ) ?? "REAUTHORIZATION_REQUIRED";
 
   return {
-    commandConnectTarget: reconnectTarget?.connectTarget ?? null,
+    commandConnectTarget: reconnectTarget?.connectionAvailable === false
+      ? null
+      : reconnectTarget?.connectTarget ?? null,
     commandConnectTargetSafe: isHostedDeviceSyncReconnectCommandSafe(reconnectTarget),
     errorCode,
     label: reconnectTarget?.label

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -68,6 +68,7 @@ import {
   resolveDeliveryCandidates,
 } from "@murphai/assistant-engine/assistant-channel-adapters";
 import {
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncConnectTargets,
   listConfiguredDeviceSyncReconnectTargets,
 } from "@murphai/device-syncd/connect-config";
@@ -6730,10 +6731,14 @@ function resolveHostedWorkspaceDeviceConnectProviders(
     return [];
   }
 
-  return listConfiguredDeviceSyncConnectTargets(providerConfigs).map((target) => ({
-    label: target.label,
-    provider: target.connectTarget,
-  }));
+  return listConfiguredDeviceSyncConnectTargets(providerConfigs)
+    .filter((target) =>
+      isDeviceConnectSourceAvailableForConnection(target.connectSourceId)
+    )
+    .map((target) => ({
+      label: target.label,
+      provider: target.connectTarget,
+    }));
 }
 
 function resolveHostedWorkspaceDeviceReconnectTargets(
@@ -6746,10 +6751,14 @@ function resolveHostedWorkspaceDeviceReconnectTargets(
 
   const targets = listConfiguredDeviceSyncReconnectTargets(providerConfigs);
   const publicTargetsByConnectTarget = new Map(
-    listConfiguredDeviceSyncConnectTargets(providerConfigs).map((target) => [
-      target.connectTarget,
-      target,
-    ]),
+    listConfiguredDeviceSyncConnectTargets(providerConfigs)
+      .filter((target) =>
+        isDeviceConnectSourceAvailableForConnection(target.connectSourceId)
+      )
+      .map((target) => [
+        target.connectTarget,
+        target,
+      ]),
   );
   const connectTargetCounts = new Map<string, number>();
   for (const target of targets) {
@@ -6760,6 +6769,9 @@ function resolveHostedWorkspaceDeviceReconnectTargets(
   }
 
   return targets.map((target) => ({
+    connectionAvailable: isDeviceConnectSourceAvailableForConnection(
+      target.connectSourceId,
+    ),
     connectTarget: target.connectTarget,
     connectTargetAmbiguous: (connectTargetCounts.get(target.connectTarget) ?? 0) > 1,
     connectTargetCommandSafe: sameHostedDeviceSyncConnectTarget(

--- a/packages/assistant-runtime/test/hosted-runtime-device-sync-status-prompt.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-device-sync-status-prompt.test.ts
@@ -188,6 +188,40 @@ describe("hosted device sync status prompt", () => {
     expect(prompt).toContain("verify it with `vault-cli wearables sources list --format json`");
   });
 
+  it("keeps disabled Junction Strava status visible without offering a reconnect command", () => {
+    const prompt = buildHostedDeviceSyncStatusPromptFromSnapshot({
+      reconnectTargets: [
+        {
+          connectionAvailable: false,
+          connectTarget: "strava",
+          connectTargetCommandSafe: false,
+          label: "Strava",
+          provider: "junction",
+          sourceProviderSlug: "strava",
+        },
+      ],
+      snapshot: buildSnapshot({
+        sources: [
+          {
+            displayName: null,
+            firstSeenAt: "2026-06-01T00:00:00.000Z",
+            lastErrorCode: "TOKEN_REFRESH_FAILED",
+            lastErrorMessage: "refresh failed",
+            lastSeenAt: "2026-06-29T00:00:00.000Z",
+            resourceCount: 0,
+            sourceProviderSlug: "strava",
+            status: "error",
+          },
+        ],
+      }),
+    });
+
+    expect(prompt).toContain("Strava currently needs reconnect");
+    expect(prompt).toContain("source `strava`");
+    expect(prompt).toContain("No hosted reconnect target is configured for this wearable/source");
+    expect(prompt).not.toContain("vault-cli device connect strava --format json");
+  });
+
   it("guides Garmin historical recovery through the confirmed connection reset", () => {
     const prompt = buildHostedDeviceSyncStatusPromptFromSnapshot({
       reconnectTargets: [

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -6077,6 +6077,34 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
                 },
               ],
             },
+            {
+              connection: {
+                accessTokenExpiresAt: null,
+                connectedAt: "2026-04-28T00:00:00.000Z",
+                createdAt: "2026-04-28T00:00:00.000Z",
+                displayName: null,
+                externalAccountId: "synthetic-strava-account",
+                id: "conn_synthetic_strava",
+                metadata: {},
+                provider: "strava",
+                scopes: ["activity:read"],
+                setupPhase: "source_confirmed",
+                status: "reauthorization_required",
+              },
+              credential: {
+                credentialMetadata: {},
+                kind: "none",
+              },
+              localState: {
+                lastErrorCode: "TOKEN_REFRESH_FAILED",
+                lastErrorMessage: "refresh failed",
+                lastSyncCompletedAt: "2026-04-22T00:00:00.000Z",
+                lastSyncErrorAt: "2026-04-29T00:00:00.000Z",
+                lastSyncStartedAt: "2026-04-29T00:00:00.000Z",
+                lastWebhookAt: null,
+                nextReconcileAt: null,
+              },
+            },
           ],
           generatedAt: "2026-04-29T00:00:00.000Z",
           userId: "member_synthetic_phase",
@@ -6104,6 +6132,10 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
             clientId: "synthetic-oura-client",
             clientSecret: "synthetic-oura-secret",
           },
+          strava: {
+            clientId: "synthetic-strava-client",
+            clientSecret: "synthetic-strava-secret",
+          },
         },
         publicBaseUrl: "https://device-sync.example.test",
         secret: "synthetic-device-sync-secret",
@@ -6119,6 +6151,9 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     expect(prompt).toContain("source `oura`");
     expect(prompt).toContain("generic device-connect command is ambiguous");
     expect(prompt).not.toContain("vault-cli device connect oura --format json");
+    expect(prompt).toContain("Strava currently needs reconnect");
+    expect(prompt).toContain("No hosted reconnect target is configured for this wearable/source");
+    expect(prompt).not.toContain("vault-cli device connect strava --format json");
   });
 
   it("skips lazy device context when pending input appears before the automation lane", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -5680,6 +5680,10 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
             providerFilter: ["fitbit"],
             region: "us",
           },
+          strava: {
+            clientId: "synthetic-strava-client",
+            clientSecret: "synthetic-strava-secret",
+          },
           whoop: {
             clientId: "synthetic-whoop-client",
             clientSecret: "synthetic-whoop-secret",
@@ -5764,6 +5768,10 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     await expect(deviceTool.request({
       action: "connect",
       provider: "unconfigured-provider",
+    })).rejects.toThrow("not available to connect");
+    await expect(deviceTool.request({
+      action: "connect",
+      provider: "strava",
     })).rejects.toThrow("not available to connect");
     expect(connectLinkRequests).toHaveLength(1);
     await Promise.resolve();

--- a/packages/cli/test/device-cli.test.ts
+++ b/packages/cli/test/device-cli.test.ts
@@ -424,7 +424,7 @@ test('device account list rejects an explicit base URL in hosted runtime', async
 })
 
 deviceControlPlaneTest(
-  'local daemon connect reports the requested mapped connect target',
+  'local daemon connect preserves Junction-backed Strava routing',
   async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-device-cli-mapped-connect-'))
     let connectBody: Record<string, unknown> | null = null
@@ -441,9 +441,9 @@ deviceControlPlaneTest(
         connectBody = await readJsonBody(request)
         respondJson(response, 200, {
           provider: 'junction',
-          state: 'state_garmin_01',
+          state: 'state_strava_01',
           expiresAt: '2026-03-17T13:00:00.000Z',
-          authorizationUrl: 'https://junction.test/connect/garmin?state=state_garmin_01',
+          authorizationUrl: 'https://junction.test/connect/strava?state=state_strava_01',
         })
         return
       }
@@ -474,7 +474,7 @@ deviceControlPlaneTest(
         }>([
           'device',
           'connect',
-          'garmin',
+          'strava',
           '--vault',
           vaultRoot,
           '--base-url',
@@ -484,18 +484,20 @@ deviceControlPlaneTest(
             JUNCTION_API_KEY: 'sk_us_junction-test',
             JUNCTION_CLIENT_USER_ID_SECRET: 'junction-client-user-id-secret',
             JUNCTION_ENV: 'sandbox',
-            JUNCTION_PROVIDER_FILTER: 'garmin',
+            JUNCTION_PROVIDER_FILTER: 'strava',
             JUNCTION_REGION: 'us',
             MURPH_CLI_TEST_PERSISTENT_HARNESS: '0',
+            STRAVA_CLIENT_ID: '',
+            STRAVA_CLIENT_SECRET: '',
           },
         }),
       )
 
       assert.equal(connect.backend, 'local-daemon')
-      assert.equal(connect.provider, 'garmin')
-      assert.equal(connect.authorizationUrl.includes('state_garmin_01'), true)
+      assert.equal(connect.provider, 'strava')
+      assert.equal(connect.authorizationUrl.includes('state_strava_01'), true)
       assert.deepEqual(connectBody, {
-        sourceProviderSlug: 'garmin',
+        sourceProviderSlug: 'strava',
       })
     } finally {
       await new Promise<void>((resolve, reject) => {

--- a/packages/device-syncd/src/config.ts
+++ b/packages/device-syncd/src/config.ts
@@ -182,6 +182,7 @@ export {
   readConfiguredDeviceSyncRuntimeConfig,
 } from "./config/runtime-config.ts";
 export {
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncConnectTargets,
   listConfiguredDeviceSyncReconnectTargets,
   normalizeDeviceSyncConnectTargetKey,

--- a/packages/device-syncd/src/config/connect-targets.ts
+++ b/packages/device-syncd/src/config/connect-targets.ts
@@ -170,7 +170,6 @@ function addDeviceSyncConnectTarget(
   if (
     !connectSourceId
     || !connectTarget
-    || !isDeviceConnectSourceAvailableForConnection(connectSourceId)
     || (options.dedupeBySourceId && targetsBySourceId.has(connectSourceId))
   ) {
     return;

--- a/packages/device-syncd/src/config/connect-targets.ts
+++ b/packages/device-syncd/src/config/connect-targets.ts
@@ -25,6 +25,9 @@ type DeviceSyncConnectTargetProviderConfigs = ConfiguredDeviceSyncProviderPresen
 };
 
 const JUNCTION_PREFERRED_CONNECT_SOURCE_IDS = new Set(["whoop"]);
+// Keep provider ingestion configured for existing accounts while this product
+// gate controls whether a fresh user-facing connection can be started.
+const DISABLED_DEVICE_CONNECT_SOURCE_IDS = new Set(["strava"]);
 
 export function normalizeDeviceSyncConnectTargetKey(value: string): string | null {
   const normalized = value
@@ -34,6 +37,13 @@ export function normalizeDeviceSyncConnectTargetKey(value: string): string | nul
     .replace(/^_+|_+$/gu, "");
 
   return normalized || null;
+}
+
+export function isDeviceConnectSourceAvailableForConnection(
+  connectSourceId: string,
+): boolean {
+  const normalized = normalizeDeviceConnectSourceId(connectSourceId);
+  return Boolean(normalized && !DISABLED_DEVICE_CONNECT_SOURCE_IDS.has(normalized));
 }
 
 export function listConfiguredDeviceSyncConnectTargets(
@@ -160,6 +170,7 @@ function addDeviceSyncConnectTarget(
   if (
     !connectSourceId
     || !connectTarget
+    || !isDeviceConnectSourceAvailableForConnection(connectSourceId)
     || (options.dedupeBySourceId && targetsBySourceId.has(connectSourceId))
   ) {
     return;

--- a/packages/device-syncd/src/connect-config.ts
+++ b/packages/device-syncd/src/connect-config.ts
@@ -20,6 +20,7 @@ import {
 import { assertValidJunctionClientConfig } from "./config/junction-client-config.ts";
 
 export {
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncConnectTargets,
   listConfiguredDeviceSyncReconnectTargets,
   normalizeDeviceSyncConnectTargetKey,

--- a/packages/device-syncd/src/index.ts
+++ b/packages/device-syncd/src/index.ts
@@ -37,6 +37,7 @@ export {
   getConfiguredDeviceSyncProviderManifest,
   getConfiguredDeviceSyncProviderJobDefinition,
   hasConfiguredDeviceSyncProviderConfigs,
+  isDeviceConnectSourceAvailableForConnection,
   listDefaultJunctionLinkProviderSlugs,
   listConfiguredDeviceSyncConnectTargets,
   listDirectDeviceConnectRouteEntries,

--- a/packages/device-syncd/test/config.test.ts
+++ b/packages/device-syncd/test/config.test.ts
@@ -237,7 +237,7 @@ test("Junction default connect targets cover the shared provider filter", () => 
     listConfiguredDeviceSyncConnectTargets(configs).map((target) =>
       target.sourceProviderSlug ?? target.connectTarget
     ),
-    JUNCTION_DEFAULT_PROVIDER_FILTER,
+    JUNCTION_DEFAULT_PROVIDER_FILTER.filter((providerSlug) => providerSlug !== "strava"),
   );
 });
 

--- a/packages/device-syncd/test/config.test.ts
+++ b/packages/device-syncd/test/config.test.ts
@@ -237,7 +237,7 @@ test("Junction default connect targets cover the shared provider filter", () => 
     listConfiguredDeviceSyncConnectTargets(configs).map((target) =>
       target.sourceProviderSlug ?? target.connectTarget
     ),
-    JUNCTION_DEFAULT_PROVIDER_FILTER.filter((providerSlug) => providerSlug !== "strava"),
+    JUNCTION_DEFAULT_PROVIDER_FILTER,
   );
 });
 

--- a/packages/device-syncd/test/connect-targets.test.ts
+++ b/packages/device-syncd/test/connect-targets.test.ts
@@ -34,7 +34,6 @@ test("connect targets prefer direct providers except Junction-backed WHOOP", () 
     })),
     [
       { connectSourceId: "oura", connectTarget: "oura", provider: "oura", sourceProviderSlug: null },
-      { connectSourceId: "strava", connectTarget: "strava", provider: "strava", sourceProviderSlug: null },
       { connectSourceId: "whoop", connectTarget: "whoop", provider: "junction", sourceProviderSlug: "whoop_v2" },
       { connectSourceId: "fitbit", connectTarget: "fitbit", provider: "junction", sourceProviderSlug: "fitbit" },
     ],
@@ -46,12 +45,7 @@ test("connect targets prefer direct providers except Junction-backed WHOOP", () 
     label: "Oura",
     provider: "oura",
   });
-  assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), {
-    connectSourceId: "strava",
-    connectTarget: "strava",
-    label: "Strava",
-    provider: "strava",
-  });
+  assert.equal(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), null);
   assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "WHOOP"), {
     connectSourceId: "whoop",
     connectTarget: "whoop",
@@ -91,6 +85,23 @@ test("reconnect targets retain duplicate direct and Junction routes for exact re
       { connectSourceId: "whoop", connectTarget: "whoop", provider: "junction", sourceProviderSlug: "whoop_v2" },
     ],
   );
+});
+
+test("Strava stays out of connect and reconnect targets while its provider remains configured", () => {
+  const configs = readConfiguredDeviceSyncProviderConfigs({
+    JUNCTION_API_KEY: "sk_us_junction-test",
+    JUNCTION_CLIENT_USER_ID_SECRET: "junction-client-user-id-secret",
+    JUNCTION_ENV: "sandbox",
+    JUNCTION_PROVIDER_FILTER: "strava",
+    JUNCTION_REGION: "us",
+    STRAVA_CLIENT_ID: "strava-client-id",
+    STRAVA_CLIENT_SECRET: "strava-client-secret",
+  });
+
+  assert.ok(configs.strava);
+  assert.deepEqual(listConfiguredDeviceSyncConnectTargets(configs), []);
+  assert.deepEqual(listConfiguredDeviceSyncReconnectTargets(configs), []);
+  assert.equal(resolveConfiguredDeviceSyncConnectTargetBySourceId(configs, "strava"), null);
 });
 
 test("WHOOP stays direct when the Junction provider filter excludes WHOOP", () => {
@@ -169,7 +180,7 @@ test("connect target source-id lookups resolve direct and Junction sources", () 
   });
 });
 
-test("connect targets keep Oura and Strava direct with the default Junction source list", () => {
+test("connect targets keep Oura and WHOOP available with the default Junction source list", () => {
   const configs = readConfiguredDeviceSyncProviderConfigs({
     JUNCTION_API_KEY: "sk_us_junction-test",
     JUNCTION_CLIENT_USER_ID_SECRET: "junction-client-user-id-secret",
@@ -189,12 +200,7 @@ test("connect targets keep Oura and Strava direct with the default Junction sour
     label: "Oura",
     provider: "oura",
   });
-  assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), {
-    connectSourceId: "strava",
-    connectTarget: "strava",
-    label: "Strava",
-    provider: "strava",
-  });
+  assert.equal(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), null);
   assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "WHOOP"), {
     connectSourceId: "whoop",
     connectTarget: "whoop",

--- a/packages/device-syncd/test/connect-targets.test.ts
+++ b/packages/device-syncd/test/connect-targets.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 
 import {
+  isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncConnectTargets,
   listConfiguredDeviceSyncReconnectTargets,
   readConfiguredDeviceSyncProviderConfigs,
@@ -34,6 +35,7 @@ test("connect targets prefer direct providers except Junction-backed WHOOP", () 
     })),
     [
       { connectSourceId: "oura", connectTarget: "oura", provider: "oura", sourceProviderSlug: null },
+      { connectSourceId: "strava", connectTarget: "strava", provider: "strava", sourceProviderSlug: null },
       { connectSourceId: "whoop", connectTarget: "whoop", provider: "junction", sourceProviderSlug: "whoop_v2" },
       { connectSourceId: "fitbit", connectTarget: "fitbit", provider: "junction", sourceProviderSlug: "fitbit" },
     ],
@@ -45,7 +47,12 @@ test("connect targets prefer direct providers except Junction-backed WHOOP", () 
     label: "Oura",
     provider: "oura",
   });
-  assert.equal(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), null);
+  assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), {
+    connectSourceId: "strava",
+    connectTarget: "strava",
+    label: "Strava",
+    provider: "strava",
+  });
   assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "WHOOP"), {
     connectSourceId: "whoop",
     connectTarget: "whoop",
@@ -87,7 +94,7 @@ test("reconnect targets retain duplicate direct and Junction routes for exact re
   );
 });
 
-test("Strava stays out of connect and reconnect targets while its provider remains configured", () => {
+test("Strava remains configured for status and self-hosted routing while its offer gate is disabled", () => {
   const configs = readConfiguredDeviceSyncProviderConfigs({
     JUNCTION_API_KEY: "sk_us_junction-test",
     JUNCTION_CLIENT_USER_ID_SECRET: "junction-client-user-id-secret",
@@ -99,9 +106,34 @@ test("Strava stays out of connect and reconnect targets while its provider remai
   });
 
   assert.ok(configs.strava);
-  assert.deepEqual(listConfiguredDeviceSyncConnectTargets(configs), []);
-  assert.deepEqual(listConfiguredDeviceSyncReconnectTargets(configs), []);
-  assert.equal(resolveConfiguredDeviceSyncConnectTargetBySourceId(configs, "strava"), null);
+  assert.equal(isDeviceConnectSourceAvailableForConnection("strava"), false);
+  assert.deepEqual(listConfiguredDeviceSyncConnectTargets(configs), [{
+    connectSourceId: "strava",
+    connectTarget: "strava",
+    label: "Strava",
+    provider: "strava",
+  }]);
+  assert.deepEqual(listConfiguredDeviceSyncReconnectTargets(configs), [
+    {
+      connectSourceId: "strava",
+      connectTarget: "strava",
+      label: "Strava",
+      provider: "strava",
+    },
+    {
+      connectSourceId: "strava",
+      connectTarget: "strava",
+      label: "Strava",
+      provider: "junction",
+      sourceProviderSlug: "strava",
+    },
+  ]);
+  assert.deepEqual(resolveConfiguredDeviceSyncConnectTargetBySourceId(configs, "strava"), {
+    connectSourceId: "strava",
+    connectTarget: "strava",
+    label: "Strava",
+    provider: "strava",
+  });
 });
 
 test("WHOOP stays direct when the Junction provider filter excludes WHOOP", () => {
@@ -200,7 +232,12 @@ test("connect targets keep Oura and WHOOP available with the default Junction so
     label: "Oura",
     provider: "oura",
   });
-  assert.equal(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), null);
+  assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "Strava"), {
+    connectSourceId: "strava",
+    connectTarget: "strava",
+    label: "Strava",
+    provider: "strava",
+  });
   assert.deepEqual(resolveConfiguredDeviceSyncConnectTarget(configs, "WHOOP"), {
     connectSourceId: "whoop",
     connectTarget: "whoop",


### PR DESCRIPTION
## Why

Strava connection onboarding is temporarily unavailable. Murph and `/connect` must stop offering new or renewed Strava connections without disrupting already-connected members, provider ingestion, or the self-hosted configuration needed for later re-enable.

## User-visible goal and UX

- Murph no longer advertises or issues a Strava connection link.
- `/connect` hides Strava for idle members and exposes no Strava connect or reconnect action.
- Existing Strava lifecycle state remains visible for truthful status and disconnect handling.
- Disabled recovery states say reconnection is temporarily unavailable instead of promising a path that cannot complete.
- After an existing Strava account is disconnected, its card disappears immediately in the same session.
- Public homepage connection examples no longer advertise Strava.

## Invariants

- Preserve configured Strava ingestion, refresh, webhook, revocation, stored connections, historical data, and status projection.
- Preserve the shared configured-target catalog as configuration truth, including direct and Junction-backed Strava routing for self-hosted CLI use.
- Fail closed only at hosted offer and execution boundaries: assistant capabilities, source starts, saved intents, internal connect-link issuance, recovery-link tooling, and `/connect`.
- Do not add persisted state, an environment flag, a dependency, or a new lifecycle owner.
- Preserve status and disconnect controls for existing accounts.

## Non-obvious affected surfaces

The shared configured-target catalog serves status projection and self-hosted routing as well as hosted onboarding. The availability helper therefore leaves that catalog intact and is applied only where the hosted product advertises, issues, or executes a connection. The `/connect` client carries the derived availability fact so local disconnect state obeys the same hide-when-idle rule.

## ReviewGPT round 1 disposition

The round 1 purpose-drift finding was accepted. The first head filtered Strava inside the shared configured-target catalog, which could hide existing status and break Junction-only self-hosted routing. The correction restores direct and Junction Strava targets as configuration truth, moves refusal to the hosted boundaries above, keeps disabled status visible without a reconnect command, and adds direct regression proof. A round-2 anomaly retrospective is not required because this is the first remediation round and the correction remains scoped to the reported boundary.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 98 | 20 |
| Tests | 427 | 31 |
| Docs | 62 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 7bdc15b9155ffd298ebd68fbf61e892ac3ef6939

| Review state | Head | Source + / - |
| --- | --- | ---: |
| First reviewed | 7bdc15b9155ffd298ebd68fbf61e892ac3ef6939 | 47 / 6 |
| Current | 038998ffd21967e0eeedb61540f7857f148b2548 | 98 / 20 |

## Verification

- Focused device-sync tests passed: 49/49.
- Focused assistant-runtime tests passed: 257/257; the coverage follow-up status-prompt suite passed 23/23.
- Focused hosted-web route/page tests passed: 133/133.
- The self-hosted CLI proof routes Strava through Junction and passed.
- The remediation coverage audit returned no unresolved findings and added one source-level status/no-command case.
- The diff-coverage preflight passed all affected typechecks and assistant-cli (128 tests) before assistant-engine hit the known 4 GB heap ceiling. An 8 GB retry remained starved behind the shared-host verification queue; current-head GitHub CI subsequently passed in full.
- Changed hosted-web files lint cleanly; `git diff --check` and the added-line privacy scan passed.
- The prior full app verification passed on the first reviewed head: hosted web typecheck, 5,916 tests, lint with eight unrelated existing warnings, dev smoke, production build, Cloudflare typecheck, and 1,842 Cloudflare tests.
- ReviewGPT round 2 passed on the exact current head with no qualifying findings.
- The frontend audit's two accepted findings were fixed, and re-review returned no findings.
- Approved browser proof remains blocked by `No browser is available`. Fable and Opus checks remain blocked by an expired OAuth session; the required local frontend audit is the documented substitute.

## Deployment compatibility

Deploy Vercel web first, then the hosted runner/Cloudflare surface, or deploy them together. Web-first removes `/connect` and route-level offers immediately; an older assistant may still mention Strava briefly, but the updated web route fails closed. Runner-first can leave the old `/connect` offer visible until Vercel catches up. After deployment, confirm `/connect` has no idle Strava card and a Strava start request returns unavailable.


