### PR TITLE
fix: preserve signup welcome conversation continuity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-20-telegram-welcome-session-continuity.md
+++ b/agent-docs/exec-plans/completed/2026-07-20-telegram-welcome-session-continuity.md
@@ -1,0 +1,112 @@
+# Preserve signup-welcome conversation continuity
+
+Status: completed
+Created: 2026-07-20
+Updated: 2026-07-20
+
+## Goal
+
+- Ensure the first attended Telegram message continues from the already-delivered
+  signup welcome instead of starting a second assistant introduction.
+
+## Success criteria
+
+- A fixed-text signup welcome and the first attended turn resolve to one logical
+  conversation history.
+- Provider-native resume state is never reused across an incompatible execution
+  policy.
+- Focused regression coverage fails on the current behavior and passes after the
+  owner-level correction.
+- Required owner verification, completion audits, PR review, and parent final
+  review have no unresolved findings.
+
+## Scope
+
+- In scope: notification message planning for exact-text responses that never
+  invoke a provider; focused assistant-engine and hosted notification/onboarding
+  regression proof; current owner documentation only if the existing contract is
+  incomplete.
+- Out of scope: welcome copy, Telegram provider delivery, first-contact policy,
+  onboarding prompt changes, or a new persisted state owner.
+
+## Constraints
+
+- Keep the restrictive read-only policy for detached notifications that invoke a
+  provider.
+- Preserve one conversation history for exact-text notifications, which have no
+  provider-native resume state to isolate.
+- Do not touch the live main-checkout development process or unrelated onboarding
+  edits.
+- Preserve external delivery idempotency and existing session lookup keys.
+
+## Risks and mitigations
+
+1. Risk: relaxing all detached notification policy would let model-backed turns
+   run with broader authority.
+   Mitigation: branch only for `require_send_exact_text`, and assert the direct
+   model-backed notification remains read-only.
+2. Risk: changing generic session rotation would weaken provider-native
+   continuity isolation across real execution-policy changes.
+   Mitigation: leave session resolution and fingerprint rotation untouched; fix
+   the exact-text message plan before session lookup.
+3. Risk: a test stubs the next assistant answer and misses the missing-history
+   defect.
+   Mitigation: assert session/transcript continuity directly, including the
+   delivered welcome and the new inbound message.
+
+## Tasks
+
+1. Trace fingerprint rotation, session lookup, transcript persistence, and native
+   resume invalidation through the current owners and tests.
+2. Add a focused failing regression for a restrictive exact-text welcome followed
+   by an attended Telegram turn.
+3. Implement the smallest notification-planning correction without changing
+   session ownership or provider-backed execution policy.
+4. Run focused tests, typecheck, diff-aware verification, required audits, and
+   direct scenario proof.
+5. Finish the scoped plan commit, open the PR, and complete ReviewGPT and CI.
+
+## Decisions
+
+- Use an isolated guarded worktree because the primary checkout has unrelated
+  active onboarding edits and a running local stack.
+- Treat the container evidence as proof of the observed boundary: two distinct
+  outbox messages used one conversation key but separate sessions whose policy
+  fingerprints differed.
+- Keep continuity-fingerprint rotation unchanged. The root cause is earlier:
+  exact-text notifications were assigned a read-only provider policy even though
+  they never start a provider, so their delivered transcript was persisted in a
+  session the first attended turn could not reuse.
+- Use the ordinary requested sandbox for scheduled notifications and exact-text
+  notifications; continue forcing other detached notifications to read-only.
+
+## Verification
+
+- Failing-before proof: focused assistant-engine integration test failed because
+  the attended turn created a second session.
+- Focused assistant-engine notification/session suite: 46 passed.
+- Assistant-engine typecheck: passed.
+- Assistant runtime hosted-event suite: 33 passed.
+- Assistant-runtime local-service suite with an 8 GiB test heap: 93 passed.
+- Cloudflare typecheck: passed.
+- Diff-aware verification reached and passed all affected guards, typechecks,
+  assistant-cli (128), assistant-engine (2,527 with 5 skipped),
+  assistant-runtime (1,737 with 2 skipped), and assistantd (40) before an owned
+  interrupted verifier left an empty CLI artifact-repair lock.
+- The two reported CLI files passed after clearing that owned empty lock and
+  generating the standard ignored Health Commons artifact: 74 passed.
+- Docker-backed `pnpm hosted-local e2e telegram-first-contact --no-bundle` after
+  a fresh runner-bundle build: 5 passed. The scenario sends exactly one signup
+  welcome and proves the first inbound provider `input` includes that welcome.
+- Coverage-write audit: existing proof is sufficient; no edits or unresolved
+  findings.
+- Clean final diff-aware verification passed end to end with an 8 GiB test heap:
+  all guards and affected typechecks; assistant-cli 128; assistant-engine 2,527
+  with 5 skipped; assistant-runtime 1,737 with 2 skipped; assistantd 40; CLI
+  1,077 with 1 skipped; setup-cli 124; Cloudflare node 1,841; Cloudflare Workers
+  1.
+- Parent final review: no unresolved findings; the production change is one
+  branch in the existing notification planner, with no new state owner,
+  abstraction, dependency, or compatibility path.
+- ReviewGPT and CI: pending.
+Completed: 2026-07-20

--- a/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
@@ -1,11 +1,14 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE } from "@murphai/contracts";
 import {
   buildHostedExecutionMemberActivatedWake,
   buildHostedExecutionTelegramConversationMessageWake,
 } from "@murphai/hosted-execution";
 import {
+  createHostedAssistantConversationIdentifierBlind,
   createHostedMailboxAssistantInputId,
+  hashHostedAssistantConversationIdentifier,
 } from "@murphai/hosted-execution/assistant-identifiers";
 
 import {
@@ -73,7 +76,7 @@ describe("hosted local Telegram auto-reply e2e", () => {
 
   it("sends Telegram typing and a reply after an inbound Telegram message", async () => {
     await requireScenario().seedActiveHostedMember({ memberId: userId });
-    await requireScenario().runWake(buildActivationWake(userId), userId);
+    await requireScenario().runWake(buildSignupWelcomeActivationWake(userId), userId);
 
     await requireScenario().waitForHostedCompletion(userId);
     await requireTelegramStub().waitForRequestsToSettle({
@@ -84,6 +87,8 @@ describe("hosted local Telegram auto-reply e2e", () => {
     requireScenario().queueAssistantResponses([HOSTED_TELEGRAM_DEFAULT_ASSISTANT_REPLY_TEXT], {
       matchInputContains: defaultTelegramInboundText,
     });
+    const assistantProviderRequestCountBeforeInbound =
+      requireScenario().assistantProviderRequests.length;
     const requestCountBeforeInbound = requireTelegramStub().observedRequests.length;
     await requireScenario().runWake(buildInboundTelegramWake(userId), userId);
 
@@ -101,7 +106,10 @@ describe("hosted local Telegram auto-reply e2e", () => {
     });
     const sendRequest = await requireTelegramStub().waitForRequest({
       expectedPath: `/bot${hostedLocalTelegramRequestToken}/sendMessage`,
-      matchRequest: requireTelegramStub().createSendMessageMatcher(userId),
+      matchRequest: (request) =>
+        requireTelegramStub().createSendMessageMatcher(userId)(request)
+        && requireTelegramStub().parseObservedJson(request.body)?.text ===
+          HOSTED_TELEGRAM_DEFAULT_ASSISTANT_REPLY_TEXT,
       scenario: requireScenario(),
       userId,
     });
@@ -130,6 +138,26 @@ describe("hosted local Telegram auto-reply e2e", () => {
     });
     expect(requireTelegramStub().parseObservedJson(sendRequest.body))
       .not.toHaveProperty("reply_to_message_id");
+    const signupWelcomeRequests = requireTelegramStub().observedRequests.filter((request) =>
+      request.url === `/bot${hostedLocalTelegramRequestToken}/sendMessage`
+      && requireTelegramStub().createSendMessageMatcher(userId)(request)
+      && requireTelegramStub().parseObservedJson(request.body)?.text ===
+        MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE
+    );
+    expect(signupWelcomeRequests).toHaveLength(1);
+
+    const firstInboundProviderRequest = requireScenario().assistantProviderRequests
+      .slice(assistantProviderRequestCountBeforeInbound)
+      .find((request) =>
+        request.url === "/v1/responses"
+        && readAssistantProviderRequestText(request).includes(defaultTelegramInboundText)
+      );
+    if (!firstInboundProviderRequest) {
+      throw new Error("Expected the first inbound Telegram provider request.");
+    }
+    expect(readAssistantProviderRequestText(firstInboundProviderRequest)).toContain(
+      MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE,
+    );
     await requireTelegramStub().waitForRequestsToSettle({
       scenario: requireScenario(),
       userId,
@@ -402,6 +430,45 @@ function buildActivationWake(userId: string) {
   });
 }
 
+function buildSignupWelcomeActivationWake(userId: string) {
+  const identifierBlind = createHostedAssistantConversationIdentifierBlind({
+    secret: buildTelegramThreadId(userId),
+    userId,
+  });
+  const threadId = buildTelegramThreadId(userId);
+
+  return buildHostedExecutionMemberActivatedWake({
+    eventId: `member.activated:local:${userId}:evt_telegram_signup_welcome`,
+    memberId: userId,
+    memberChannels: {
+      email: false,
+      linq: false,
+      telegram: true,
+    },
+    occurredAt: new Date().toISOString(),
+    signupWelcome: {
+      route: {
+        actorId: null,
+        channel: "telegram",
+        delivery: {
+          kind: "thread",
+          target: threadId,
+        },
+        identityId: hashHostedAssistantConversationIdentifier(
+          identifierBlind,
+          "telegram:bot",
+        ),
+        threadId: hashHostedAssistantConversationIdentifier(
+          identifierBlind,
+          threadId,
+        ),
+        threadIsDirect: true,
+      },
+      text: MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE,
+    },
+  });
+}
+
 function buildInboundTelegramWake(
   userId: string,
   overrides: {
@@ -433,6 +500,27 @@ function buildAcceptedTelegramMessageRef(userId: string, eventId: string): strin
     secret: buildTelegramThreadId(userId),
     userId,
   });
+}
+
+function readAssistantProviderRequestText(request: { body: string }): string {
+  const body = JSON.parse(request.body) as Record<string, unknown>;
+  return collectJsonStrings(body.input).join("\n\n");
+}
+
+function collectJsonStrings(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectJsonStrings(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).flatMap((entry) => collectJsonStrings(entry));
+  }
+
+  return [];
 }
 
 function requireScenario(): HostedLocalFullStackScenario {

--- a/packages/assistant-engine/src/assistant/notification-turn.ts
+++ b/packages/assistant-engine/src/assistant/notification-turn.ts
@@ -1195,6 +1195,9 @@ function buildAssistantNotificationMessageInput(
   const instructions = normalizeRequiredText(input.instructions, 'instructions')
   const maintenanceTurn = isAssistantNotificationMaintenanceExactSkip(input)
   const scheduledOccurrence = isAssistantNotificationScheduledOccurrence(input)
+  const firstContactExactText =
+    input.responsePolicy?.kind === 'require_send_exact_text' &&
+    input.firstContactPolicy?.markSeenOnDeliveryAccepted === true
   // One overlay for each non-user turn boundary, so provider-audit policy
   // cannot drift across caller-specific configuration.
   const executionOverlay = maintenanceTurn
@@ -1248,12 +1251,11 @@ function buildAssistantNotificationMessageInput(
     provider: input.provider,
     receiptMetadata: null,
     reasoningEffort: input.reasoningEffort,
-    // Exact-text notifications do not start a provider. Keep their durable
-    // conversation session on the ordinary target so a restrictive detached
-    // notification policy cannot split the next attended turn from the text
-    // that was already delivered.
+    // First-contact exact text does not start a provider. Keep its durable
+    // conversation session on the ordinary target so the next attended turn
+    // continues from the welcome that was already delivered.
     sandbox:
-      scheduledOccurrence || input.responsePolicy?.kind === 'require_send_exact_text'
+      scheduledOccurrence || firstContactExactText
         ? input.sandbox
         : 'read-only',
     scheduledAutomationAuthority: input.scheduledAutomationAuthority ?? null,

--- a/packages/assistant-engine/src/assistant/notification-turn.ts
+++ b/packages/assistant-engine/src/assistant/notification-turn.ts
@@ -1248,7 +1248,14 @@ function buildAssistantNotificationMessageInput(
     provider: input.provider,
     receiptMetadata: null,
     reasoningEffort: input.reasoningEffort,
-    sandbox: scheduledOccurrence ? input.sandbox : 'read-only',
+    // Exact-text notifications do not start a provider. Keep their durable
+    // conversation session on the ordinary target so a restrictive detached
+    // notification policy cannot split the next attended turn from the text
+    // that was already delivered.
+    sandbox:
+      scheduledOccurrence || input.responsePolicy?.kind === 'require_send_exact_text'
+        ? input.sandbox
+        : 'read-only',
     scheduledAutomationAuthority: input.scheduledAutomationAuthority ?? null,
     scheduledOccurrenceAt: input.scheduledOccurrenceAt ?? null,
     serviceTier: input.serviceTier ?? null,

--- a/packages/assistant-engine/test/assistant-notification-audience-authority.integration.test.ts
+++ b/packages/assistant-engine/test/assistant-notification-audience-authority.integration.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import type { executeCodexTurnWithRecovery } from '../src/assistant/codex-turn-runner.ts'
 import type { persistAssistantTurnAndSession } from '../src/assistant/turn-finalizer.ts'
 import { sendAssistantNotificationLocal } from '../src/assistant/notification-turn.ts'
+import { resolveAssistantSessionForMessage } from '../src/assistant/session-resolution.ts'
 import { resolveAssistantSession } from '../src/assistant/store.ts'
 import { createTempVaultContext } from './test-helpers.ts'
 
@@ -214,6 +215,7 @@ describe('notification audience authority integration', () => {
     expect(result.deliveryOutcome?.kind).toBe('sent')
     expect(boundaries.executeProvider).toHaveBeenCalledTimes(1)
     const providerInput = boundaries.executeProvider.mock.calls[0]?.[0]
+    expect(providerInput?.route.providerOptions.sandbox).toBe('read-only')
     expect(providerInput?.plan.conversationPolicy.audience).toMatchObject({
       effectiveThreadIsDirect: threadIsDirect,
       explicitTarget: target,
@@ -284,6 +286,74 @@ describe('notification audience authority integration', () => {
 
     expect(boundaries.executeProvider).not.toHaveBeenCalled()
     expect(boundaries.deliverMessage).not.toHaveBeenCalled()
+  })
+
+  it('keeps an exact Telegram welcome on the attended conversation session', async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'telegram-exact-welcome-continuity-',
+    )
+    cleanupPaths.push(parentRoot)
+    const welcomeText = 'Welcome to Murph.'
+    const locator = {
+      actorId: 'h1_444444444444444444444444',
+      channel: 'telegram',
+      identityId: 'h1_555555555555555555555555',
+      threadId: 'h1_666666666666666666666666',
+      threadIsDirect: true,
+    } as const
+    const executionContext = {
+      hosted: {
+        defaultTarget: modelTarget,
+        memberId: 'member-exact-welcome',
+        userEnvKeys: [],
+      },
+    } as const
+
+    const welcome = await sendAssistantNotificationLocal({
+      ...locator,
+      bindingDeliveryTarget: locator.threadId,
+      deliveryIdempotencyKey: 'signup-welcome:member-exact-welcome',
+      deliveryKind: 'thread',
+      deliveryTarget: locator.threadId,
+      executionContext,
+      firstContactPolicy: {
+        markSeenOnDeliveryAccepted: true,
+      },
+      instructions: 'Send the exact signup welcome.',
+      responsePolicy: {
+        kind: 'require_send_exact_text',
+        text: welcomeText,
+      },
+      vault: vaultRoot,
+    })
+
+    expect(boundaries.executeProvider).not.toHaveBeenCalled()
+    expect(welcome.session.providerOptions.sandbox).toBe('danger-full-access')
+    expect(boundaries.appendTranscript).toHaveBeenCalledWith(
+      welcome.session.sessionId,
+      [
+        {
+          createdAt: expect.any(String),
+          kind: 'assistant',
+          text: welcomeText,
+        },
+      ],
+    )
+
+    const attended = await resolveAssistantSessionForMessage({
+      boundaryDefaultTarget: modelTarget,
+      defaults: null,
+      message: {
+        ...locator,
+        executionContext,
+        prompt: 'Hey Murph, do your thing.',
+        vault: vaultRoot,
+      },
+    })
+
+    expect(attended.created).toBe(false)
+    expect(attended.session.sessionId).toBe(welcome.session.sessionId)
+    expect(attended.session.providerOptions.sandbox).toBe('danger-full-access')
   })
 })
 

--- a/packages/assistant-engine/test/assistant-notification-audience-authority.integration.test.ts
+++ b/packages/assistant-engine/test/assistant-notification-audience-authority.integration.test.ts
@@ -288,6 +288,60 @@ describe('notification audience authority integration', () => {
     expect(boundaries.deliverMessage).not.toHaveBeenCalled()
   })
 
+  it('keeps exact text without first-contact policy on a detached session', async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'linq-exact-detached-session-',
+    )
+    cleanupPaths.push(parentRoot)
+    const locator = {
+      actorId: 'h1_777777777777777777777777',
+      channel: 'linq',
+      identityId: 'h1_888888888888888888888888',
+      threadId: 'h1_999999999999999999999999',
+      threadIsDirect: true,
+    } as const
+    const executionContext = {
+      hosted: {
+        defaultTarget: modelTarget,
+        memberId: 'member-exact-detached',
+        userEnvKeys: [],
+      },
+    } as const
+
+    const notification = await sendAssistantNotificationLocal({
+      ...locator,
+      bindingDeliveryTarget: locator.threadId,
+      deliveryIdempotencyKey: 'group-join:member-exact-detached',
+      deliveryKind: 'thread',
+      deliveryTarget: locator.threadId,
+      executionContext,
+      instructions: 'Send the exact group confirmation.',
+      responsePolicy: {
+        kind: 'require_send_exact_text',
+        text: 'You joined the group.',
+      },
+      vault: vaultRoot,
+    })
+
+    expect(boundaries.executeProvider).not.toHaveBeenCalled()
+    expect(notification.session.providerOptions.sandbox).toBe('read-only')
+
+    const attended = await resolveAssistantSessionForMessage({
+      boundaryDefaultTarget: modelTarget,
+      defaults: null,
+      message: {
+        ...locator,
+        executionContext,
+        prompt: 'What did I miss?',
+        vault: vaultRoot,
+      },
+    })
+
+    expect(attended.created).toBe(true)
+    expect(attended.session.sessionId).not.toBe(notification.session.sessionId)
+    expect(attended.session.providerOptions.sandbox).toBe('danger-full-access')
+  })
+
   it('keeps an exact Telegram welcome on the attended conversation session', async () => {
     const { parentRoot, vaultRoot } = await createTempVaultContext(
       'telegram-exact-welcome-continuity-',


### PR DESCRIPTION
## Why this PR exists

An exact-text signup welcome was persisted under a forced read-only provider target even though that path never invokes a provider. The first attended Telegram or Linq/iMessage turn then selected the ordinary hosted target, rotated to a second session, and could generate another introduction without the delivered welcome in its history.

## User goal / user-visible behavior

A member receives one signup welcome, and their first message continues that same conversation instead of making Murph introduce itself again.

## User experience

Signup sends the existing welcome copy once. When the member replies on Telegram or iMessage, Murph sees that delivered welcome in the conversation history and answers the member's message normally. Delivery failures and existing first-contact/idempotency behavior are unchanged.

## Invariants

- First-contact exact-text notifications do not invoke a provider and keep the ordinary conversation target.
- Exact-text notifications without first-contact policy remain detached and read-only.
- Detached notifications that invoke a provider remain forced to read-only sandbox authority.
- Generic continuity-fingerprint rotation remains unchanged for genuinely incompatible provider execution policies.
- Signup delivery idempotency, welcome copy, first-contact state, and session lookup keys remain unchanged.

## Non-obvious affected surfaces

- Assistant notification planning: only exact-text notifications carrying the existing `markSeenOnDeliveryAccepted` first-contact policy select the ordinary sandbox before existing session resolution. Focused integration proof asserts transcript append and attended-session reuse for signup welcomes, detached read-only ownership for other exact text, and read-only routing for model-backed notifications.
- Telegram and Linq/iMessage signup activation: both channels already emit the same exact-text response policy plus first-contact policy into the channel-neutral assistant-engine owner. No channel-specific branch was added.
- Cloudflare runner bundle: hosted Telegram first-contact E2E constructs the real signup-welcome activation, observes exactly one welcome, and proves the first inbound Responses API `input` contains it.

## First-reviewed change shape (immutable baseline)

Classification is by authored file purpose in the base-to-head diff; no binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 8 | 1 |
| Tests / fixtures | 160 | 2 |
| Docs | 112 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **280** | **3** |

ReviewGPT first-reviewed head: f3e89cf773c2559fb7f885fb85c0a1c220b6bedb

## Current-head change shape

Current head: `5884a023dd18e7b3d4977497c35e2e6149ce63ac`

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 1 |
| Tests / fixtures | 214 | 2 |
| Docs | 112 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **336** | **3** |

Review remediation changed the source footprint from +8/-1 to +10/-1. The correction commit is +7/-5 source and +54/-0 tests; it narrows the existing condition and adds no state owner, abstraction, dependency, compatibility path, or channel-specific behavior.

## Review finding disposition

- Round 1 Purpose Drift: accepted. Generic exact text also serves group-join and family notifications, which must retain their prior detached ownership. The exception is now scoped to the existing semantic first-contact policy, and a failing-before regression locks non-first-contact exact text to a distinct read-only session.
- Retrospective: not required. This is round 2, remediation added 7 authored-source lines, total source churn is 11 lines, and no new architectural mechanism was introduced.

## Deployment skew / compatibility

This is a backward-compatible runner-bundle behavior change: it adds no Worker/container protocol, environment, credential, API, schema, or persisted-state shape. During a hypothetical gradual rollout, old warm containers can still produce the duplicate-introduction behavior while new containers preserve continuity, but either version can safely process existing data. This change itself does not require an immediate rollout; the current production workflow already defaults to and enforces `container_rollout=immediate` for an independent active rollout guard, so use that normal path and its managed-container fingerprint smoke. The configured rollout grace is 300 seconds.

Aggregate production evidence at review time: 6 members have Telegram routes and 0 such routes were created in the last 7 days. At that observed rate, zero operations are expected to encounter this first-signup-only skew window; any exposure is bounded to a rare new signup that sends its first message on an old warm container before convergence. The change is reversible by reverting the runner bundle, and it requires no data migration or repair. After deploy, require the managed-container bundle fingerprint smoke and one fresh signup -> welcome -> first inbound smoke; monitor hosted runtime errors and outbound delivery outcomes.

## Verification

- Failing-before remediation proof: non-first-contact exact text resolved to `danger-full-access`; after narrowing, it remains `read-only` and detached.
- Focused notification/session suite: 59/59 passed; owner integration: 7/7 passed.
- Assistant-engine typecheck: passed.
- Fresh Docker-backed `pnpm hosted-local e2e telegram-first-contact`: 5/5 passed after rebuilding the runner bundle.
- Remediation coverage-write audit: no findings or edits; static trace confirmed both Telegram and Linq signup paths use the channel-neutral first-contact branch.
- Clean final diff-aware verification passed end to end with an 8 GiB test heap: all guards and affected typechecks; assistant-cli 128; assistant-engine 2,528 with 5 skipped; assistant-runtime 1,737 with 2 skipped; assistantd 40; CLI 1,077 with 1 skipped; setup-cli 124; Cloudflare node 1,841; Cloudflare Workers 1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787182206&installation_model_id=19880&pr_number=811&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F811&signature=ded7a8b304e51f0980067a5583b834da7dd917f7d48aace09aab52a820665815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
