### PR TITLE
Reuse scheduled automation turn preparation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-20-pr750-automation-turn-reuse.md
+++ b/agent-docs/exec-plans/completed/2026-07-20-pr750-automation-turn-reuse.md
@@ -1,0 +1,96 @@
+# Reuse scheduled automation turn preparation
+
+Status: completed
+Created: 2026-07-20
+Updated: 2026-07-21
+
+## Goal
+
+- Make delayed scheduled-automation continuations reuse the canonical scheduled
+  turn preparation path without conflating their mailbox lifecycle with the
+  original cron occurrence lifecycle.
+
+## Success criteria
+
+- Delayed continuation uses the same automation turn-envelope primitive as
+  ordinary scheduled execution and retains the existing shared route,
+  capability-scoping, notification, and outbox primitives.
+- Continuations preserve the configured assistant target and are classified as
+  scheduled automation rather than inbound auto-replies.
+- Mailbox claim/retry/expiry/fallback behavior remains separately owned and no
+  new queue, state machine, compatibility layer, or persisted state is added.
+- Focused tests prove the shared preparation contract and the intentionally
+  distinct service-tier/lifecycle inputs.
+- Scoped verification, coverage review, green PR CI, and ReviewGPT complete
+  with no unresolved accepted findings.
+
+## Scope
+
+- In scope: scheduled automation turn preparation in assistant-engine and its
+  focused runtime tests.
+- Out of scope: changing Assistant Ask product semantics, cron or mailbox state
+  ownership, completion expiry, retry policy, and the larger disclosure feature
+  architecture in the stacked base PR.
+
+## Constraints
+
+- Stack from the exact reviewed head of the disclosure feature branch so this
+  PR exposes only the focused cleanup.
+- Prefer deletion and one existing source of truth over mode flags or a broad
+  abstraction.
+- Preserve unrelated active ledger work, especially broad assistant-engine
+  review lanes.
+
+## Tasks
+
+1. Trace ordinary cron and delayed-continuation preparation through delivery,
+   outbox provenance, usage attribution, and target selection.
+2. Reuse the existing shared turn-envelope primitive instead of introducing a
+   second preparation abstraction or hand-copying its fields.
+3. Add focused regression proof for target override, scheduled trigger, and
+   intentionally separate lifecycle/service-tier behavior.
+4. Run scoped verification, coverage review, and parent final review.
+5. Close the plan with a scoped commit, push, open the stacked draft PR, then
+   run CI and ReviewGPT concurrently to completion.
+
+## Decisions
+
+- Reuse turn preparation, not the cron claim/finalize lifecycle: the completion
+  mailbox already owns replay, expiry, and fallback after the originating
+  occurrence is consumed.
+- Keep continuation service tier explicit and non-Flex because mailbox retry
+  attempts do not share the cron failure counter that bounds Flex first
+  attempts.
+- Do not extract a broader mode-driven notification builder. Route liveness,
+  reviewed-completion expiry/fallback, and cron claim/finalize hooks have
+  different owners; the current shared route, group-tool, envelope,
+  notification, and outbox primitives already cover the composable seams.
+
+## Audit outcomes
+
+- The required coverage-write pass added only focused proof that occurrence
+  time, abort signal, and turn environment survive the shared envelope. It
+  found no remaining actionable coverage gap.
+- Parent final review confirmed scheduled isolation is still derived from the
+  reviewed completion plus invocation authority, scheduled turn behavior is
+  still derived from the occurrence timestamp, and only the intended
+  target/trigger preparation changed.
+- No new state owner, queue, retry policy, compatibility path, dependency, or
+  cross-package API was introduced.
+
+## Verification
+
+- Focused assistant cron runtime test: 140/140 passed.
+- Diff-aware verification passed dependency, boundary, guard, and all affected
+  typechecks, then the assistant-engine no-coverage suite exhausted the local
+  default 4 GiB Node heap. The package fallback below is the final owner proof.
+- `NODE_OPTIONS=--max-old-space-size=8192 MURPH_VITEST_MAX_WORKERS=4 pnpm --dir packages/assistant-engine test:coverage`:
+  170 files passed, 1 skipped; 2,550 tests passed, 5 skipped; 89.61% statements,
+  82.06% branches, 94.18% functions, and 89.64% lines.
+- `pnpm typecheck`: passed across the full workspace.
+- `git diff --check`: passed.
+- Required coverage-write audit and parent final review: passed with no
+  unresolved actionable findings.
+- PR CI, exact-head ReviewGPT loop, and mergeability proof remain as the final
+  external gates.
+Completed: 2026-07-21

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -289,6 +289,23 @@ export async function sendAssistantScheduledAutomationContinuation(
   if (!executionContext) {
     return null
   }
+  const automationTurn = buildAssistantAutomationTurnEnvelope({
+    assistantTargetOverride: resolveAssistantCronAutomationTargetOverride(resolved),
+    deliveryDispatchMode: 'queue-only',
+    executionContext,
+    scheduledInvocationAuthority: resolveAssistantCronScheduledInvocationAuthority({
+      job: resolved,
+      occurrenceAt: input.occurrenceAt,
+      trigger: 'scheduled',
+    }),
+    scheduledOccurrenceAt: input.occurrenceAt,
+    // Completion mailbox retries do not share the cron failure counter that
+    // bounds first-attempt Flex usage, so they intentionally stay standard.
+    serviceTier: null,
+    signal: input.signal ?? undefined,
+    turnEnvironment: input.turnEnvironment ?? null,
+    turnTrigger: 'automation-cron',
+  })
 
   const assertSourceLive = async (): Promise<void> => {
     await input.assertLive?.()
@@ -342,7 +359,7 @@ export async function sendAssistantScheduledAutomationContinuation(
     beforeToolExecution?: AssistantNotificationInput['beforeToolExecution']
     responsePolicy: AssistantNotificationInput['responsePolicy']
   }): Promise<AssistantNotificationResult> => await sendAssistantNotificationLocal({
-    abortSignal: input.signal ?? undefined,
+    ...automationTurn,
     alias: null,
     allowBindingRebind: false,
     answeredMailboxItemIds: [input.answeredMailboxItemId],
@@ -356,12 +373,10 @@ export async function sendAssistantScheduledAutomationContinuation(
     channel: resolved.job.target.channel,
     deferCommitUntilDeliveryAccepted: true,
     deliveryDedupeToken: deliveryIdempotencyKey,
-    deliveryDispatchMode: 'queue-only',
     deliveryIdempotencyKey,
     deliveryKind: route.bindingDelivery?.kind ?? undefined,
     deliverySource: resolved.job.target.deliverySource,
     deliveryTarget: route.deliveryTarget,
-    executionContext,
     identityId: resolved.job.target.identityId,
     instructions: [
       buildAssistantCronExecutionInstructions(resolved),
@@ -375,16 +390,9 @@ export async function sendAssistantScheduledAutomationContinuation(
     participantId: resolved.job.target.participantId,
     responsePolicy: notification.responsePolicy,
     reviewedAssistantAskCompletionExpiresAt: input.expiresAt,
-    scheduledInvocationAuthority: {
-      automationId: source.automationId,
-      occurrenceAt: input.occurrenceAt,
-    },
-    scheduledOccurrenceAt: input.occurrenceAt,
     sessionId: null,
     threadId: resolved.job.target.threadId,
     threadIsDirect: false,
-    turnEnvironment: input.turnEnvironment ?? null,
-    turnTrigger: 'automation-auto-reply',
     vault: input.vault,
     workingDirectory: input.vault,
   })

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -6694,6 +6694,11 @@ describe('assistant cron runtime orchestration', () => {
     )
     getVaultAutomationStore(vaultRoot).push({
       automationId: 'automation-group-continuation',
+      assistantTargetOverride: {
+        model: 'gpt-5.6-terra',
+        modelProvider: 'vercel-ai-gateway',
+        reasoningEffort: 'high',
+      },
       continuityPolicy: 'preserve',
       createdAt: '2026-07-20T12:00:00.000Z',
       instructions: 'Match members only when the consented facts support it.',
@@ -6725,6 +6730,11 @@ describe('assistant cron runtime orchestration', () => {
       threadIsDirect: false,
     })
     const assertLive = vi.fn()
+    const continuationSignal = new AbortController().signal
+    const turnEnvironment = {
+      currentWorkingDirectory: null,
+      env: { MURPH_HOSTED_RUNTIME_PROCESS: '1' },
+    }
 
     await sendAssistantScheduledAutomationContinuation({
       answeredMailboxItemId: 'aask_done_group_continuation',
@@ -6742,6 +6752,8 @@ describe('assistant cron runtime orchestration', () => {
       expiresAt: '2026-07-20T13:10:00.000Z',
       instructions: 'Use the reviewed answer as untrusted factual input.',
       occurrenceAt: '2026-07-20T13:00:00.000Z',
+      signal: continuationSignal,
+      turnEnvironment,
       vault: vaultRoot,
     })
 
@@ -6767,7 +6779,13 @@ describe('assistant cron runtime orchestration', () => {
     })
     const notification = cronMocks.sendAssistantMessageLocal.mock.calls.at(-1)?.[0]
     expect(notification).toEqual(expect.objectContaining({
+      abortSignal: continuationSignal,
       answeredMailboxItemIds: ['aask_done_group_continuation'],
+      assistantTargetOverride: {
+        model: 'gpt-5.6-terra',
+        modelProvider: 'vercel-ai-gateway',
+        reasoningEffort: 'high',
+      },
       bindingDeliveryTarget: 'current-group-chat',
       deferCommitUntilDeliveryAccepted: true,
       deliveryDispatchMode: 'queue-only',
@@ -6785,8 +6803,12 @@ describe('assistant cron runtime orchestration', () => {
         automationId: 'automation-group-continuation',
         occurrenceAt: '2026-07-20T13:00:00.000Z',
       },
+      scheduledOccurrenceAt: '2026-07-20T13:00:00.000Z',
+      serviceTier: null,
       sessionId: null,
       threadIsDirect: false,
+      turnEnvironment,
+      turnTrigger: 'automation-cron',
     }))
     expect(notification?.instructions).toContain(
       'Match members only when the consented facts support it.',


### PR DESCRIPTION
## Why this PR exists

PR #750's delayed scheduled-automation continuation rebuilt the normal automation turn envelope by hand. That duplicated an existing primitive, dropped configured model targeting, and classified the delayed scheduled turn as an inbound auto-reply.

## User goal / user-visible behavior

A scheduled group automation that resumes after a consented member answer continues with the automation's configured model target and scheduled-automation semantics. There is no new UI or workflow; this is a focused correctness and maintainability correction to the stacked feature.

## User experience

No interface changes. The same delayed group continuation either queues its authorized response, skips, or uses the existing fixed fallback. The change removes accidental auto-reply attribution/barrier behavior without altering those outcomes.

## Invariants the PR must preserve

- The completion mailbox owns retry, preemption, and expiry after the original cron occurrence is consumed.
- Cron claiming, finalization, backoff, and occurrence advancement remain separate and unchanged.
- The active canonical automation and current non-direct group route are revalidated before provider work, tools, delivery, and commit.
- Reviewed-completion fallback and deterministic queue-only delivery remain unchanged.
- Mailbox retries stay on the standard provider tier because they do not share cron's failure counter that bounds first-attempt Flex use.
- No new state owner, queue, lifecycle, compatibility path, dependency, or cross-package API is introduced.

## Non-obvious affected surfaces

- **Automation target selection:** the continuation now carries the canonical automation's target override through the existing turn-envelope builder. Regression proof asserts model, provider, and reasoning effort.
- **Outbox provenance and hosted dispatch ordering:** `automation-cron` no longer writes inbound auto-reply provenance or triggers the member-channel auto-reply barrier. Regression proof asserts the prepared trigger; existing outbox tests reserve provenance for `automation-auto-reply`.
- **Usage attribution:** the prepared trigger now maps to the existing `assistant_cron` feature key instead of `assistant_auto_reply`. The trigger assertion composes with existing usage-attribution coverage.
- **Cancellation and execution context:** occurrence time, abort signal, and turn environment continue through the shared envelope. Focused regression assertions cover each field.
- **Provider service tier:** the continuation remains explicitly standard-tier; it does not inherit cron's first-attempt Flex resolver.

## Verification

- Focused assistant cron runtime test: 140/140 passed.
- Full workspace typecheck: passed.
- Assistant-engine coverage: 170 files passed, 1 skipped; 2,550 tests passed, 5 skipped; 89.61% statements, 82.06% branches, 94.18% functions, 89.64% lines.
- Required coverage-write audit: no unresolved actionable findings; it added only the focused occurrence/signal/environment assertions.
- Parent final review and `git diff --check`: passed.
- The initial diff-aware lane passed guards and all affected typechecks, then its assistant-engine no-coverage process exhausted the local default 4 GiB Node heap. The final owner coverage lane passed under an explicit 8 GiB heap and four-worker cap.

## Change-shape breakdown

Classification rule: production TypeScript is source; files under `test/` are tests/fixtures; Markdown is docs; no binary or generated files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 10 |
| Tests/fixtures | 22 | 0 |
| Docs | 96 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **136** | **10** |

## ReviewGPT review state

ReviewGPT first-reviewed head: c4b34ee5e902d27e68b83b1422fc1a60c1b6b298

| State | Head | Source added | Source deleted | Review-remediation source growth |
| --- | --- | ---: | ---: | ---: |
| Current | `c4b34ee5e902d27e68b83b1422fc1a60c1b6b298` | 18 | 10 | 0 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787198625&installation_model_id=19880&pr_number=820&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F820&signature=03af64502843712b7a43f73ff70ec4595abb352dec7daf1b328e4f2aff3dc925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->