### PR TITLE
Add hosted group usage funding and awareness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -571,9 +571,15 @@ purchase-derived idempotency key, permits identical creation retries for a
 derived 30-minute window, and fences ambiguity through its frozen 90-minute
 expiry. The financial movements described above use only signed
 `refund_adjustment` and `dispute_adjustment` ledger entries; there are no
-separate reversal or restoration kinds. Separate payer and beneficiary
-identifiers are only a composition seam: group authorization, lifecycle,
-deletion, and key semantics remain unimplemented.
+separate reversal or restoration kinds. Personal and hosted-group funding use
+the same purchase lifecycle. Group funding resolves the existing opaque join
+code to the group's synthetic `HostedMember`, which remains the beneficiary;
+it adds no group wallet, usage account, or separate funding code. The
+authenticated contributor remains the payer. A deleted payer can detach only
+from a terminal cross-owner purchase after encrypted provider references are
+cleared, while retained blind lookup keys keep later refund and dispute
+reconciliation possible. Beneficiary deletion still removes its credit and
+purchase history in ownership order.
 
 Hosted app-session cookies use a strict v2 session-id plus bearer format. The existing token-hash field stores a dedicated web-key HMAC over the session id, bearer, member id, Privy identity, and expiry, so Postgres write access alone cannot mint or retarget browser authority; legacy unsigned cookies are rejected.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -576,10 +576,12 @@ the same purchase lifecycle. Group funding resolves the existing opaque join
 code to the group's synthetic `HostedMember`, which remains the beneficiary;
 it adds no group wallet, usage account, or separate funding code. The
 authenticated contributor remains the payer. A deleted payer can detach only
-from a terminal cross-owner purchase after encrypted provider references are
-cleared, while retained blind lookup keys keep later refund and dispute
-reconciliation possible. Beneficiary deletion still removes its credit and
-purchase history in ownership order.
+from a terminal cross-owner purchase after the existing reconciliation-version
+fence advances and encrypted provider references are cleared. That advance
+makes payer-era preparation retry against the detached row, while retained
+blind lookup keys keep later refund and dispute reconciliation possible.
+Beneficiary deletion still removes its credit and purchase history in ownership
+order.
 
 Hosted app-session cookies use a strict v2 session-id plus bearer format. The existing token-hash field stores a dedicated web-key HMAC over the session id, bearer, member id, Privy identity, and expiry, so Postgres write access alone cannot mint or retarget browser authority; legacy unsigned cookies are rejected.
 

--- a/agent-docs/exec-plans/completed/2026-07-20-group-usage-funding.md
+++ b/agent-docs/exec-plans/completed/2026-07-20-group-usage-funding.md
@@ -1,0 +1,142 @@
+# Group usage funding and awareness
+
+Status: completed
+Created: 2026-07-20
+Updated: 2026-07-21
+
+## Goal
+
+- Let authenticated group members fund the existing synthetic group runtime
+  with fixed one-time usage-credit packs and see a coarse group usage state,
+  while preserving the current personal top-up, usage-accounting, Stripe,
+  messaging, and account-deletion owners.
+
+## Success criteria
+
+- A current member can open `/groups/fund/[joinCode]`, select a server-projected
+  $5, $10, or $25 offer, complete Stripe-hosted Checkout, and fund only that
+  group's current synthetic runtime beneficiary.
+- Group usage reads expose only `healthy`, `low`, or `exhausted`, plus an
+  authorized first-party funding URL, without internal USD-micro or personal
+  billing facts.
+- Group low-usage and exhaustion messaging is route-authorized, idempotent,
+  reply-oriented, and uses the existing delivery/retry owners.
+- Purchase creation, replay, fulfillment, settlement, refund/dispute
+  reconciliation, payer deletion, beneficiary deletion, and detached-payer
+  invariants have focused regression proof.
+- Personal top-ups retain their current behavior.
+- Required acceptance verification, specialist audits, PR ReviewGPT, CI, and
+  merge-conflict proof pass with no unresolved accepted findings.
+
+## Scope
+
+- In scope:
+  - `apps/web` schema/migration, group authorization, funding page/routes,
+    generalized fixed-pack Checkout, Stripe reconciliation, accounting,
+    deletion lifecycle, usage status, and focused tests.
+  - Existing hosted-execution group-tool and usage-notice contracts only where
+    the current public boundary must be extended.
+  - Existing Settings top-up UI reuse and the smallest group funding UI.
+  - Durable architecture, security, reliability, product-spec, app, and
+    verification docs required to describe the shipped behavior.
+- Out of scope:
+  - Anonymous/public funding, arbitrary amounts, auto-recharge, transfers,
+    Family funding, group wallets, a second usage account, new queues or crons,
+    and a separate funding-code lifecycle.
+
+## Constraints
+
+- Technical constraints:
+  - `apps/web` remains the only billing, Stripe, group-membership, usage-ledger,
+    and account-lifecycle owner; Stripe webhook reconciliation remains the only
+    grant authority.
+  - Reuse the existing group `joinCode` public locator and synthetic
+    `HostedMember` beneficiary. Do not add a usage account or funding token.
+  - The browser submits only an offer code and request key. Payer, beneficiary,
+    Price, amount, Customer, and return destinations are server-derived.
+  - Preserve beneficiary-first ledger locking, append-only adjustments,
+    included-first FIFO settlement, durable receipt retries, and runtime
+    rechecks.
+  - Payer deletion may detach fulfilled group purchases only after resolving
+    nonterminal payment state; later terminal financial reconciliation must
+    remain possible without the payer row.
+- Product/process constraints:
+  - Treat the supplied malformed patch as behavioral intent, not overwrite
+    authority. Reconstruct against current `main` and delete speculative pieces.
+  - Do not expose group credit amounts, payer identity, personal plans, Stripe
+    references, raw group codes beyond their authorized URL role, or private
+    identifiers in logs or artifacts.
+  - Keep messaging reciprocal and low-pressure; no recurring nudge mechanism.
+
+## Risks and mitigations
+
+1. Risk: cross-owner payer/beneficiary lifecycle can orphan payment state or
+   cascade fulfilled credit.
+   Mitigation: explicit nullable-payer terminal invariant, deletion ordering,
+   database constraints, and focused concurrent/lifecycle tests.
+2. Risk: stale membership or join-code lookup can fund the wrong runtime.
+   Mitigation: resolve and revalidate current membership and the exact current
+   thread-container relation under web-owned locks before freezing a purchase.
+3. Risk: a browser return or replay can grant or retarget credit.
+   Mitigation: keep grant authority webhook-only and bind replay to the frozen
+   funding target, eligibility policy, offer, and return destination.
+4. Risk: Vercel, Cloudflare, and schema deploy skew can strand notices or new
+   group-tool fields.
+   Mitigation: additive schema/protocol changes, consumer-first rollout where
+   required, explicit rollback floors, and post-deploy scenario checks.
+
+## Tasks
+
+1. Reconstruct the supplied intent against current owners and document the
+   exact minimal data, authority, and lifecycle changes.
+2. Implement schema/service/accounting/deletion behavior with focused tests.
+3. Wire authenticated funding, group-tool status, low-usage/exhaustion copy,
+   and the reused top-up UI with route/component tests.
+4. Update the durable owner docs and deploy contract.
+5. Run focused proof, full acceptance, direct scenario/browser proof, and the
+   required coverage/frontend audits.
+6. Finish the scoped commit, push a draft PR, run ReviewGPT concurrently with
+   CI, resolve findings, reconcile current `main`, and report deployment order.
+
+## Decisions
+
+- Reuse the existing opaque group `joinCode` for `/groups/fund/[joinCode]`.
+- Keep the synthetic group `HostedMember` as the usage beneficiary.
+- Extend the group control surface rather than the personal plan-usage union.
+- Generalize the current fixed-pack Checkout core by server-resolved target,
+  policy, and return destination.
+- Add no group wallet, funding-token lifecycle, scheduler, queue, or low-usage
+  table.
+- The downloaded reconstructed patch is malformed and incomplete on current
+  `main`; it is evidence of intent only.
+
+## Verification
+
+- Commands to run:
+  - focused Vitest suites for every changed owner and migration invariant
+  - `pnpm test:diff <touched paths>` during iteration
+  - `pnpm verify:acceptance` for the final high-risk baseline
+  - guarded real-PostgreSQL usage-credit lifecycle/concurrency proof
+  - desktop and mobile browser proof for the funding route and dialog states
+  - `git diff --check`, privacy/secret/path scans, and parent final diff review
+- Expected outcomes:
+  - all scripted checks pass; direct proof confirms authenticated group funding,
+    coarse group status, replay safety, personal top-up preservation, and
+    detached-payer reconciliation behavior.
+
+## Completion evidence
+
+- `pnpm verify:acceptance` passed the workspace typechecks, package coverage,
+  6,132 hosted-web tests, 1,844 Cloudflare tests, production Next build, app
+  lint, package-boundary checks, fixture coverage, and artifact guards.
+- Focused service, route, component, contract, accounting, lifecycle, migration,
+  and real-PostgreSQL concurrency suites passed after the final assertion-only
+  cleanup.
+- Required coverage-write and Codex frontend-review passes ended with no
+  unresolved findings. The configured Fable review was unavailable because its
+  account had no remaining credits, so the completion workflow used the Codex
+  frontend-review substitute.
+- The local browser connector exposed no controllable browser target. Route,
+  responsive-state, accessibility, dialog-recovery, and production-build proof
+  passed, but no desktop or mobile screenshot artifact was captured.
+Completed: 2026-07-21

--- a/agent-docs/product-specs/hosted-plan-usage.md
+++ b/agent-docs/product-specs/hosted-plan-usage.md
@@ -1,6 +1,6 @@
 # Hosted Plan Usage And Subscription Actions
 
-Last verified: 2026-07-16
+Last verified: 2026-07-20
 Status: Implemented current-state contract
 
 ## Goal
@@ -11,7 +11,7 @@ and let a private Murph conversation carry out the smallest billing action the
 member clearly chooses. Settings and Murph's read-only plan-usage tool consume
 the same web-owned projection. Stripe and the existing web billing services
 remain the payment system; Murph owns allowance and purchased usage capacity.
-The personal top-up implementation contract lives in
+The personal and group top-up implementation contract lives in
 `agent-docs/product-specs/hosted-usage-topups.md`.
 
 ## Ownership
@@ -202,11 +202,13 @@ expired trial entitlement, and existing abuse controls remain separate
 fail-closed reasons. The read-only plan-usage projection remains an
 included-period view and must not be treated as the gate result.
 
-Usage accounting may create a period-scoped notice candidate when the
-operation consumes the last effective capacity. A message-triggered record
-carries its originating Linq or Telegram target through the current invocation
-and signed usage-record seam. Every rendered limit notice states the included
-allowance as 100% used before the channel-specific follow-up copy.
+Usage accounting may create a period-scoped notice candidate when remaining
+effective capacity crosses the 20% low threshold or reaches zero. A
+message-triggered record carries its originating Linq or Telegram target
+through the current invocation and signed usage-record seam. Every rendered
+personal limit notice states the included allowance as 100% used before the
+channel-specific follow-up copy.
+
 Before claiming delivery, web re-authorizes a personal target against current
 member routing or an external Linq target against persisted thread authority.
 An omitted target means no accepted conversation and permits the legacy
@@ -240,23 +242,32 @@ balance, or use guilt, urgency, or scarcity language.
 ## Group Usage
 
 Classify a group-thread allowance from its source, never by comparing its
-numeric cap with a trial cap. `murph.plan_usage` returns
-`group_not_supported`, and any group-thread usage notice stays neutral: no
-account link, personal plan, model choice, upgrade, top-up, or payer identity.
-The notice may use only the exact originating external-thread target
-after web re-authorizes its persisted thread authority; no personal-home
-fallback is valid for an accepted group conversation.
+numeric cap with a trial cap. `murph.plan_usage` still returns
+`group_not_supported`; group capacity is not projected as a personal plan or a
+synthetic personal allowance. The existing `murph.group` tool's `read_usage`
+action reports only `healthy`, `low`, or `exhausted` plus the current period and
+first-party funding URL. It never exposes internal USD-micro accounting,
+contributors, receipts, or payer identity.
+
+A group low-usage or exhaustion notice may use only the exact originating
+external-thread target after web re-authorizes its persisted thread authority;
+no personal-home fallback is valid for an accepted group conversation. At
+delivery time Web rechecks the expected coarse state and may append the
+group's `/groups/fund/[joinCode]` link. The notice stays reply-oriented and does
+not name a payer, claim that payment occurred, or add a separate scheduler or
+money-prompt lifecycle.
 
 ## Non-Goals
 
 The subscription-action surface adds one nullable action claim to the existing
 mailbox row. The composed usage system adds no second admission gate, persisted
 forecast, billing queue, cron, trial-ending webhook, automatic nudge, group
-balance, automatic model switch, custom card form, App Clip, or mini app. It
-does not add a general Stripe API tool: the subscription action contract
+wallet or usage account, automatic model switch, custom card form, App Clip,
+or mini app. It does not add a general Stripe API tool: the subscription action contract
 exposes only the three current web-owned operations above, and personal usage
-top-ups remain an authenticated Stripe-hosted Settings handoff. Group and
-Family funding remain unimplemented.
+top-ups remain an authenticated Stripe-hosted Settings handoff. Group funding
+uses the existing join code and synthetic member through an authenticated
+fixed-pack page; anonymous and Family funding remain unimplemented.
 
 ## Deployment
 

--- a/agent-docs/product-specs/hosted-usage-topups.md
+++ b/agent-docs/product-specs/hosted-usage-topups.md
@@ -342,10 +342,11 @@ deleted member before removing local owner state.
 Financial records do not cascade blindly through the Prisma relations. When a
 beneficiary is deleted, its ledger entries and purchases are removed before the
 member. When only the payer is deleted, terminal credit owned by a surviving
-beneficiary remains: the purchase detaches the payer and clears encrypted
-provider references while retaining non-secret lookup keys needed for later
-refund or dispute reconciliation. Stripe retains payment records under its
-required retention.
+beneficiary remains: the purchase detaches the payer, advances the existing
+reconciliation-version fence so payer-era preparation must retry, and clears
+encrypted provider references while retaining non-secret lookup keys needed for
+later refund or dispute reconciliation. Stripe retains payment records under
+its required retention.
 
 Browser-vault export omits payment identifiers, Checkout URLs, semantic source
 keys, usage references, and allocation history.

--- a/agent-docs/product-specs/hosted-usage-topups.md
+++ b/agent-docs/product-specs/hosted-usage-topups.md
@@ -1,7 +1,7 @@
 # Hosted Usage Top-Ups
 
-Status: Implemented personal v1; group funding remains future scope
-Last verified: 2026-07-16
+Status: Implemented personal and hosted-group funding
+Last verified: 2026-07-20
 
 ## Decision
 
@@ -25,7 +25,9 @@ invoice credit, transferable asset, or promise of cash redemption.
 
 Stripe proves money movement. `apps/web` is authoritative for the payer,
 beneficiary, offer, grant, available usage credit, consumption, and refund and
-dispute adjustments. Group authorization is not implemented in v1.
+dispute adjustments. An authenticated member may also fund an active hosted
+group by presenting that group's existing opaque join code; the group's
+synthetic thread-container member is the beneficiary.
 
 ## Enforced Usage Contract
 
@@ -76,10 +78,11 @@ An eligible paid Pulse or Edge member can:
 8. Continue using that credit after an included-usage reset until the credit is
    consumed.
 
-The persisted payer and beneficiary identifiers leave one narrow composition
-seam for a later group-funded purchase. V1 does not define or implement group
-authorization, funding-intent keys, lifecycle, deletion, refund control, or
-beneficiary-replacement behavior.
+An authenticated member can open `/groups/fund/[joinCode]`, see only the
+group's coarse `healthy`, `low`, or `exhausted` usage state, and buy the same
+fixed packs for that group's synthetic runtime beneficiary. This does not
+require the payer to have an individual paid plan. The browser still submits
+only offer code and request key; Web resolves payer and beneficiary.
 
 ## Individual MVP
 
@@ -99,7 +102,7 @@ The first release permits purchases only when all of these are true:
 
 Pulse Trial keeps **Start Pulse** rather than selling top-ups. Sponsored Family
 owners and members are excluded because their payer/beneficiary policy belongs
-with later group funding. An inactive, unpaid, or suspended group relationship
+with later Family funding. An inactive, unpaid, or suspended group relationship
 does not exclude an otherwise eligible direct paid member. Cancellation,
 past-due, suspension, malformed billing state, and an expired trial fail closed.
 
@@ -285,11 +288,13 @@ notices, allowance exhaustion, and the runtime recheck are derived consumers,
 not new lifecycle owners. The beneficiary row lock is the single serialization
 boundary for grant, debit, adjustment, and projection updates.
 
-The only group-oriented state in this v1 is the separate payer and beneficiary
-identifiers. Do not infer group funding authority from those columns. Group
-membership authorization, checkout-intent identity, payer departure,
-beneficiary or container deletion, refund control, and key rotation are all
-deferred until a concrete group flow defines them together.
+Group funding composes these same owners without adding a group wallet, usage
+account, funding-code lifecycle, scheduler, or queue. The existing opaque
+`HostedGroup.joinCode` locates an active group funding target, and the group's
+synthetic thread-container `HostedMember` remains the beneficiary. The
+authenticated contributor is the payer. Checkout, accounting, allowance,
+refund, dispute, runtime-recheck, and delivery idempotency remain owned by the
+same personal top-up services.
 
 ## Durable Model
 
@@ -302,7 +307,7 @@ One row represents one intentional attempt to purchase one offer.
 | Field | Contract |
 | --- | --- |
 | `id` | Random opaque Murph purchase ID; safe as the only Stripe metadata lookup key. |
-| `payerMemberId` | Authenticated personal member paying. Separate from beneficiary even when equal in v1. |
+| `payerMemberId` | Authenticated member paying. Separate from the beneficiary and nullable only after the payer is deleted from a terminal cross-owner purchase. |
 | `beneficiaryMemberId` | `HostedMember.id` whose usage receives credit. |
 | `offerCode` | Immutable internal catalog code. |
 | `cashCurrency` / `cashAmountMinor` | Expected Checkout subtotal, initially USD cents. |
@@ -326,16 +331,22 @@ or drain `created` purchases that use it.
 
 The initial authenticated transaction authorizes and persists one purchase
 before Stripe I/O. That `created` row is the durable ambiguity fence. Replaying
-the same payer/request-key/offer continues the same purchase with the same
-purchase-derived Stripe idempotency key; using the key for a different offer
-conflicts. Replay must not reinterpret the purchase against the mutable catalog,
-mint a replacement attempt, or require a second browser authorization. Account
-deletion suspends new Checkout creation and resolves or expires every
-outstanding nonterminal purchase before removing its local owner state.
+the same payer/request-key/offer and funding target continues the same purchase
+with the same purchase-derived Stripe idempotency key; using the key for a
+different offer or target conflicts. Replay must not reinterpret the purchase
+against the mutable catalog, mint a replacement attempt, or require a second
+browser authorization. Account deletion suspends new Checkout creation and
+resolves or expires every outstanding nonterminal purchase involving the
+deleted member before removing local owner state.
 
-Financial records do not cascade blindly through the Prisma relations. The
-account deletion owner removes local ledger entries before purchases and the
-member, while Stripe retains payment records under its required retention.
+Financial records do not cascade blindly through the Prisma relations. When a
+beneficiary is deleted, its ledger entries and purchases are removed before the
+member. When only the payer is deleted, terminal credit owned by a surviving
+beneficiary remains: the purchase detaches the payer and clears encrypted
+provider references while retaining non-secret lookup keys needed for later
+refund or dispute reconciliation. Stripe retains payment records under its
+required retention.
+
 Browser-vault export omits payment identifiers, Checkout URLs, semantic source
 keys, usage references, and allocation history.
 
@@ -445,23 +456,28 @@ The dedicated usage-credit service sits beside, not inside, subscription
 onboarding checkout. Subscription onboarding creates `mode=subscription`
 Sessions; top-ups are repeatable one-time payments.
 
-The authenticated Settings route performs this sequence:
+The authenticated personal Settings route and group funding route share this
+sequence:
 
 1. Verify same-origin/CSRF protections and the hosted app session.
 2. Parse a strict bounded body containing only offer code and client request
    key.
-3. Derive payer and personal beneficiary from the app session.
+3. Derive the payer from the app session and resolve the beneficiary server
+   side: the payer for personal funding, or the active group's synthetic member
+   for `/groups/fund/[joinCode]`.
 4. Continue an exact existing request-key purchase; reuse with a different
    offer is a conflict.
 5. Under the payer lock, expire an unattached purchase whose frozen window
-   ended, then recover any remaining nonterminal purchase before consulting
-   mutable eligibility or offer configuration. V1 permits only one created,
-   open, or payment-pending purchase at a time.
-6. For a genuinely new purchase, read the single personal eligibility
-   projection and require the requested offer code to be currently authorized.
-7. Decrypt the payer's canonical Stripe Customer and Subscription only after
-   authorization; missing billing state fails closed for repair rather than
-   creating a duplicate Customer.
+   ended, then recover a nonterminal purchase only when its payer and
+   beneficiary match the requested target. A purchase for another target
+   conflicts. Only one created, open, or payment-pending purchase may exist for
+   one payer at a time.
+6. For a genuinely new purchase, require a current server-owned offer. Personal
+   funding also requires the direct-paid eligibility projection; active group
+   funding does not require the payer to hold an individual paid plan.
+7. Resolve the payer's canonical Stripe Customer only after authorization.
+   Existing billing state is reused; otherwise the existing idempotent hosted
+   customer owner creates and binds one for the authenticated payer.
 8. Create the durable purchase for the client request key.
 9. Freeze the offer, Price, Customer, return URLs, 90-minute expiry, and request
    policy in the `created` purchase before provider I/O.
@@ -488,7 +504,7 @@ The Stripe Session uses:
 - Adaptive Pricing explicitly disabled so Dashboard defaults cannot change the
   frozen USD catalog contract;
 - no adjustable quantity, promotion codes, or caller-selected Price; and
-- server-generated Settings success/cancel URLs.
+- server-generated personal Settings or group-funding success/cancel URLs.
 
 Use a distinct purchase ID for every intentional purchase. A member can buy
 the same pack twice, so member-plus-offer is not an idempotency key.
@@ -583,9 +599,11 @@ can be duplicated and out of order.
 
 ## Refunds And Disputes
 
-V1 has no instant self-service cash-out. A payer may request a support-assisted
-refund; another group participant or beneficiary cannot refund someone else's
-purchase.
+There is no instant self-service cash-out. A payer may request a
+support-assisted refund; another group participant or beneficiary cannot refund
+someone else's purchase. If the payer account is later deleted, terminal
+refund and dispute events remain reconcilable from retained blind lookup keys
+and live Stripe state without restoring payer identity.
 
 For ordinary refunds, return only the unused attributable portion of a
 purchase. Reconciliation re-fetches the relevant Refund when available, its
@@ -620,7 +638,7 @@ expose debt in a group chat, or charge another participant.
 - Raw Stripe references follow the existing encrypted-reference plus blind
   lookup-key pattern and never enter logs, assistant state, or user-visible
   URLs.
-- Checkout status is visible only to its authenticated payer in v1.
+- Checkout status is visible only to its authenticated payer.
 - Webhook signatures and live Stripe re-fetch are both required.
 - Logs and metrics use fixed status/reason codes and counts, not member IDs,
   payer identity, metadata payloads, receipts, or raw webhook bodies.
@@ -630,24 +648,21 @@ expose debt in a group chat, or charge another participant.
 - Payment records and health-sharing permissions remain separate. Buying usage
   never grants access to another person's data.
 
-## Future Group-Container Funding
+## Group-Container Funding
 
-The persisted model leaves only this composition seam for a later group
-feature:
+An authenticated contributor opens `/groups/fund/[joinCode]`. Possession of the
+group's existing opaque join code is the public targeting capability; no second
+funding code or rotation policy exists. Web resolves the active group and its
+synthetic member, shows only `healthy`, `low`, or `exhausted`, and offers the
+same fixed $5, $10, and $25 packs. The browser never submits payer or
+beneficiary identity.
 
-- `payerMemberId` is the authenticated person entering Checkout;
-- `beneficiaryMemberId` is the group's synthetic thread-container
-  `HostedMember.id`; and
-- Stripe Customer belongs to the payer, never automatically to the group owner
-  or synthetic container.
-
-That seam is not group support. Before enabling it, a separate product change
-must define and implement group membership authorization, the funding-intent
-and idempotency key boundary, route binding, eligible denominations, privacy
-and receipt visibility, refund control, payer departure, beneficiary or group
-deletion, and any key-rotation or retention behavior. V1 contains no generic
-group authorization context or lifecycle to reuse, and personal account
-deletion may rely on payer and beneficiary being the same member.
+The Stripe Customer belongs to the payer, never to the group owner or synthetic
+container. Fulfilled credit belongs to the beneficiary. Payer departure and
+beneficiary deletion therefore follow the separate lifecycle rules above.
+Checkout status remains visible only to its authenticated payer; group state
+does not expose contributors, receipts, cash value, or internal USD-micro
+accounting.
 
 ## Operations And Reconciliation
 
@@ -670,17 +685,24 @@ Stripe and call the same idempotent reconciler by purchase ID.
    disabled for this flow, confirm equal subtotal/total behavior, and verify
    payment settings, webhook event subscriptions, Radar rules, and environment
    mappings in Stripe test mode, then live mode.
-2. Apply the database migration before deploying the web release.
-3. Deploy the Cloudflare/runner bundle that accepts the new `add_usage`
-   plan-usage action, then wait for the tolerant consumer to be current. It owns
-   no billing, Stripe, purchase, or credit state and remains compatible with the
-   old web response.
-4. Deploy the web release containing the enforced gate, ledger, webhook branch,
-   refund/dispute reconciliation, Settings routes, and `add_usage` projection
-   together.
-5. Before widening exposure, smoke a blocked no-credit member, a paid webhook
-   grant, runtime recheck, subsequent usage debit, negative refund/dispute
-   adjustments, and a positive dispute adjustment in Stripe test mode.
+2. Apply the expand-only database migration that makes the payer and its
+   payer-encrypted Price and Customer references nullable. Existing Web remains
+   compatible because no old writer creates detached rows.
+3. Deploy Web first. It contains the group funding route, `read_usage` consumer,
+   low/exhausted notice projection, target-aware Checkout, and detached-payer
+   reconciliation. Old Cloudflare/runner bundles do not send `read_usage` and
+   remain compatible during this window.
+4. Deploy the Cloudflare/runner bundle that advertises and parses `read_usage`,
+   then verify the exact runner fingerprint converges. A new runner must not be
+   allowed to send the action to an older Web deployment.
+5. After the new Web deployment is current and the prior function window has
+   drained, run the hosted Web contract migration. It installs both
+   detached-payer checks as `NOT VALID` new-write guards and then validates
+   existing rows.
+6. Before widening exposure, smoke group funding, a paid webhook grant, the
+   runtime recheck and subsequent usage debit, low and exhausted notices, payer
+   deletion, and later negative/positive refund or dispute adjustments in
+   Stripe test mode.
 
 Rollback disables new Checkout creation and the Add usage actions first. It
 does not delete purchases or grants and must not disable the existing usage
@@ -717,7 +739,13 @@ Current focused unit and component coverage exercises:
 - composed usage blocking, carryover credit, trial and group behavior, and
   current-period block clearing; and
 - the Settings dialog's no-default selection, exact offer post, stable-key
-  retry, redirect, read-only return polling, cancel expiry, and delayed state.
+  retry, redirect, read-only return polling, cancel expiry, and delayed state;
+- group funding target resolution, active-runtime eligibility, fixed-pack
+  checkout without an individual paid plan, target-aware replay/conflicts, and
+  reuse of the same dialog state machine;
+- coarse group usage reads, low/exhausted delivery-time funding links, and
+  route-authorized idempotent low-usage delivery; and
+- cross-owner deletion plus payerless terminal refund/dispute reconciliation.
 
 These suites do not prove a real Stripe test-mode webhook or deployed browser
 behavior. Release verification therefore still needs the scoped web tests and
@@ -726,10 +754,10 @@ plus webhook smoke.
 
 ## Non-Goals
 
-The individual MVP does not add arbitrary amounts, auto-recharge, saved-card
-off-session charges, discounts, gifting, transfers, cash redemption, public or
-anonymous funding, Family funding, group funding, Stripe Meter reporting, or a
-second usage/accounting service.
+The implementation does not add arbitrary amounts, auto-recharge, saved-card
+off-session charges, discounts, transfers, cash redemption, public or anonymous
+funding, Family funding, a group wallet, Stripe Meter reporting, or a second
+usage/accounting service.
 
 ## Rejected Alternatives
 

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -369,6 +369,7 @@ async function readSettingsPageData(input: {
     prisma,
   }).catch(() => []);
   const usageTopUpActivePurchase = await readHostedActiveUsageCreditPurchaseForPayer({
+    beneficiaryMemberId: memberId,
     payerMemberId: memberId,
     prisma,
   }).catch(() => null);

--- a/apps/web/app/api/groups/fund/[joinCode]/usage-credit/checkout/route.ts
+++ b/apps/web/app/api/groups/fund/[joinCode]/usage-credit/checkout/route.ts
@@ -1,0 +1,43 @@
+import { requireHostedAppSessionFromRequest } from "@/src/lib/hosted-onboarding/app-session";
+import { assertHostedOnboardingMutationOrigin } from "@/src/lib/hosted-onboarding/csrf";
+import { assertHostedMemberNotSuspended } from "@/src/lib/hosted-onboarding/entitlement";
+import {
+  jsonOk,
+  readHostedOnboardingJsonObject,
+  withJsonError,
+} from "@/src/lib/hosted-onboarding/http";
+import {
+  createHostedGroupUsageCreditCheckout,
+  parseHostedUsageCreditCheckoutRequest,
+} from "@/src/lib/hosted-onboarding/usage-credit-purchase-service";
+import { resolveDecodedRouteParam } from "@/src/lib/http";
+import { getPrisma } from "@/src/lib/prisma";
+
+const HOSTED_GROUP_USAGE_CREDIT_CHECKOUT_BODY_LIMIT_BYTES = 1_024;
+
+export const POST = withJsonError(async (
+  request: Request,
+  context: { params: Promise<{ joinCode: string }> },
+) => {
+  assertHostedOnboardingMutationOrigin(request);
+  const auth = await requireHostedAppSessionFromRequest(request);
+  assertHostedMemberNotSuspended(auth.member);
+  const [body, joinCode] = await Promise.all([
+    readHostedOnboardingJsonObject(request, {
+      limitBytes: HOSTED_GROUP_USAGE_CREDIT_CHECKOUT_BODY_LIMIT_BYTES,
+      tooLargeErrorCode: "HOSTED_USAGE_CREDIT_CHECKOUT_BODY_TOO_LARGE",
+      tooLargeErrorMessage: "Usage-credit checkout request body is too large.",
+    }),
+    resolveDecodedRouteParam(context.params, "joinCode"),
+  ]);
+  const checkoutRequest = parseHostedUsageCreditCheckoutRequest(body);
+  const checkout = await createHostedGroupUsageCreditCheckout({
+    clientRequestKey: checkoutRequest.clientRequestKey,
+    joinCode,
+    offerCode: checkoutRequest.offerCode,
+    payerMemberId: auth.member.id,
+    prisma: getPrisma(),
+  });
+
+  return jsonOk(checkout);
+});

--- a/apps/web/app/groups/fund/[joinCode]/page.tsx
+++ b/apps/web/app/groups/fund/[joinCode]/page.tsx
@@ -1,0 +1,249 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { GroupFundingSignInButton } from "@/src/components/hosted-groups/group-funding-sign-in-button";
+import {
+  HostedUsageTopUpDialog,
+  type HostedUsageTopUpOffer,
+  type HostedUsageTopUpReturn,
+} from "@/src/components/settings/hosted-usage-top-up-dialog";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+} from "@/src/components/ui/card";
+import {
+  readHostedGroupUsageFundingTargetByJoinCode,
+  readHostedGroupUsageStatus,
+} from "@/src/lib/hosted-groups/group-usage-funding";
+import { getHostedPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
+import { readHostedConfiguredUsageCreditOfferCodes } from "@/src/lib/hosted-onboarding/personal-usage-credit-eligibility";
+import {
+  getHostedUsageCreditOfferDefinition,
+  type HostedUsageCreditOfferCode,
+} from "@/src/lib/hosted-onboarding/usage-credit-offers";
+import {
+  readHostedActiveUsageCreditPurchaseForPayer,
+  readHostedUsageCreditPurchaseStatus,
+} from "@/src/lib/hosted-onboarding/usage-credit-purchase-service";
+import { resolveDecodedRouteParam } from "@/src/lib/http";
+import { getPrisma } from "@/src/lib/prisma";
+import { createMurphPageMetadata } from "@/src/lib/site-metadata";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const revalidate = 0;
+
+const HOSTED_USAGE_CREDIT_PURCHASE_ID_PATTERN = /^hucp_[A-Za-z0-9_-]{16}$/u;
+
+type GroupFundingSearchParams = {
+  usageCheckout?: string | string[] | undefined;
+  usagePurchase?: string | string[] | undefined;
+};
+
+export const metadata: Metadata = {
+  ...createMurphPageMetadata({
+    title: "Add group usage · Murph",
+    description: "Add one-time usage credit to a Murph group.",
+  }),
+  robots: { follow: false, index: false },
+};
+
+export default async function GroupFundingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ joinCode: string }>;
+  searchParams?: Promise<GroupFundingSearchParams>;
+}) {
+  const [joinCode, resolvedSearchParams] = await Promise.all([
+    resolveDecodedRouteParam(params, "joinCode"),
+    searchParams ?? Promise.resolve<GroupFundingSearchParams>({}),
+  ]);
+  const prisma = getPrisma();
+  const [auth, target] = await Promise.all([
+    getHostedPageAuthSnapshot(),
+    readHostedGroupUsageFundingTargetByJoinCode({ joinCode, prisma }),
+  ]);
+  if (!target) {
+    return <GroupFundingUnavailable />;
+  }
+
+  const groupName = target.displayName?.trim() || describeGroupKind(target.kind);
+  const member = auth.authenticatedMember;
+  const requestedPurchaseReturn = readUsageTopUpPurchaseReturn(
+    resolvedSearchParams,
+  );
+  const [usageStatus, activePurchase, purchaseReturnMatchesTarget] =
+    await Promise.all([
+      readHostedGroupUsageStatus({
+        prisma,
+        runtimeMemberId: target.runtimeMemberId,
+      }),
+      member
+        ? readHostedActiveUsageCreditPurchaseForPayer({
+            beneficiaryMemberId: target.runtimeMemberId,
+            payerMemberId: member.id,
+            prisma,
+          }).catch(() => null)
+        : Promise.resolve(null),
+      member && requestedPurchaseReturn
+        ? readHostedUsageCreditPurchaseStatus({
+            beneficiaryMemberId: target.runtimeMemberId,
+            payerMemberId: member.id,
+            prisma,
+            purchaseId: requestedPurchaseReturn.purchaseId,
+          }).then(() => true).catch(() => false)
+        : Promise.resolve(false),
+    ]);
+  if (!usageStatus) {
+    return <GroupFundingUnavailable />;
+  }
+  const offers = member && !member.suspendedAt
+    ? projectHostedUsageTopUpOffers(readHostedConfiguredUsageCreditOfferCodes())
+    : [];
+  const purchaseReturn = purchaseReturnMatchesTarget
+    ? requestedPurchaseReturn
+    : null;
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-lg flex-col justify-center px-6 py-16">
+      <Card>
+        <CardHeader>
+          <Badge variant="secondary" className="w-fit">
+            {readCapacityLabel(usageStatus.capacityState)}
+          </Badge>
+          <h1 className="font-serif text-3xl font-medium leading-snug">
+            Add usage to {groupName}
+          </h1>
+          <CardDescription className="text-pretty leading-relaxed">
+            Choose a one-time usage-credit amount for this group. Stripe confirms the payment before Murph adds it.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm leading-6 text-muted-foreground">
+            The credit belongs to the group and is used only after its included usage. It does not change anyone&apos;s personal plan.
+          </p>
+        </CardContent>
+        <CardFooter className="flex-col items-stretch gap-2">
+          {member ? (
+            offers.length > 0 || activePurchase ? (
+              <HostedUsageTopUpDialog
+                activePurchase={activePurchase}
+                checkoutUrl={`/api/groups/fund/${encodeURIComponent(target.joinCode)}/usage-credit/checkout`}
+                offers={offers}
+                purchaseReturn={purchaseReturn}
+                scope="group"
+              />
+            ) : (
+              <p className="py-2 text-center text-sm text-muted-foreground">
+                Usage credit isn&apos;t available from this account right now.
+              </p>
+            )
+          ) : (
+            <GroupFundingSignInButton />
+          )}
+          <Button render={<Link href="/home" />} nativeButton={false} variant="ghost">
+            Open Murph
+          </Button>
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}
+
+function GroupFundingUnavailable() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-16">
+      <Card>
+        <CardHeader>
+          <h1 className="font-serif text-base font-medium leading-snug">
+            This group funding link isn&apos;t available
+          </h1>
+          <CardDescription>
+            Ask the group to share its current Murph usage link.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Button render={<Link href="/home" />} nativeButton={false} className="w-full">
+            Open Murph
+          </Button>
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}
+
+function readCapacityLabel(
+  capacityState: "exhausted" | "healthy" | "low" | null,
+): string {
+  switch (capacityState) {
+    case "healthy":
+      return "Usage available";
+    case "low":
+      return "Usage running low";
+    case "exhausted":
+      return "Usage paused";
+    default:
+      return "Group usage";
+  }
+}
+
+function readUsageTopUpPurchaseReturn(
+  searchParams: GroupFundingSearchParams,
+): HostedUsageTopUpReturn | null {
+  const kind = readOnlySearchParamValue(searchParams.usageCheckout);
+  const purchaseId = readOnlySearchParamValue(searchParams.usagePurchase);
+  if (
+    (kind !== "success" && kind !== "cancel")
+    || typeof purchaseId !== "string"
+    || !HOSTED_USAGE_CREDIT_PURCHASE_ID_PATTERN.test(purchaseId)
+  ) {
+    return null;
+  }
+  return { kind, purchaseId };
+}
+
+function readOnlySearchParamValue(
+  value: string | string[] | undefined,
+): string | undefined {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  return value.length === 1 ? value[0] : undefined;
+}
+
+function projectHostedUsageTopUpOffers(
+  offerCodes: readonly HostedUsageCreditOfferCode[],
+): HostedUsageTopUpOffer[] {
+  return offerCodes.map((offerCode) => {
+    const offer = getHostedUsageCreditOfferDefinition(offerCode);
+    return {
+      amountLabel: formatUsageTopUpAmount(offer.cashAmountMinor),
+      offerCode: offer.code,
+    };
+  });
+}
+
+function formatUsageTopUpAmount(amountUsdCents: number): string {
+  const wholeDollars = Math.floor(amountUsdCents / 100);
+  const cents = amountUsdCents % 100;
+  return cents === 0
+    ? `$${wholeDollars}`
+    : `$${wholeDollars}.${String(cents).padStart(2, "0")}`;
+}
+
+function describeGroupKind(kind: string): string {
+  switch (kind) {
+    case "couple": return "this couple";
+    case "family": return "this family";
+    case "friends": return "this circle";
+    case "household": return "this household";
+    case "team": return "this team";
+    default: return "this group";
+  }
+}

--- a/apps/web/prisma/contract-migrations/20260720233000_hosted_group_usage_funding_invariants/migration.sql
+++ b/apps/web/prisma/contract-migrations/20260720233000_hosted_group_usage_funding_invariants/migration.sql
@@ -1,0 +1,48 @@
+ALTER TABLE "hosted_usage_credit_purchase"
+  ADD CONSTRAINT "hosted_usage_credit_purchase_active_payer_required"
+    CHECK (
+      (
+        "payer_member_id" IS NOT NULL
+        AND "stripe_price_id_encrypted" IS NOT NULL
+        AND "stripe_customer_id_encrypted" IS NOT NULL
+      )
+      OR (
+        "payer_member_id" IS NULL
+        AND "status" = 'expired'
+        AND "terminal_at" IS NOT NULL
+        AND "last_reconciled_at" IS NOT NULL
+      )
+      OR (
+        "payer_member_id" IS NULL
+        AND "status" = 'payment_failed'
+        AND "terminal_at" IS NOT NULL
+        AND "last_reconciled_at" IS NOT NULL
+        AND "stripe_checkout_session_lookup_key" IS NOT NULL
+      )
+      OR (
+        "payer_member_id" IS NULL
+        AND "status" = 'fulfilled'
+        AND "terminal_at" IS NOT NULL
+        AND "last_reconciled_at" IS NOT NULL
+        AND "paid_at" IS NOT NULL
+        AND "stripe_checkout_session_lookup_key" IS NOT NULL
+        AND "stripe_payment_intent_lookup_key" IS NOT NULL
+        AND "stripe_charge_lookup_key" IS NOT NULL
+      )
+    ) NOT VALID,
+  ADD CONSTRAINT "hosted_usage_credit_purchase_deleted_payer_ciphertext_cleared"
+    CHECK (
+      "payer_member_id" IS NOT NULL
+      OR (
+        "stripe_price_id_encrypted" IS NULL
+        AND "stripe_customer_id_encrypted" IS NULL
+        AND "stripe_checkout_session_id_encrypted" IS NULL
+        AND "stripe_checkout_url_encrypted" IS NULL
+        AND "stripe_payment_intent_id_encrypted" IS NULL
+        AND "stripe_charge_id_encrypted" IS NULL
+      )
+    ) NOT VALID;
+
+ALTER TABLE "hosted_usage_credit_purchase"
+  VALIDATE CONSTRAINT "hosted_usage_credit_purchase_active_payer_required",
+  VALIDATE CONSTRAINT "hosted_usage_credit_purchase_deleted_payer_ciphertext_cleared";

--- a/apps/web/prisma/migrations/20260720230000_hosted_group_usage_funding/migration.sql
+++ b/apps/web/prisma/migrations/20260720230000_hosted_group_usage_funding/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "hosted_usage_credit_purchase"
+  ALTER COLUMN "payer_member_id" DROP NOT NULL,
+  ALTER COLUMN "stripe_price_id_encrypted" DROP NOT NULL,
+  ALTER COLUMN "stripe_customer_id_encrypted" DROP NOT NULL;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1245,7 +1245,7 @@ model HostedStripeEvent {
 
 model HostedUsageCreditPurchase {
   id                                String                               @id
-  payerMemberId                     String                               @map("payer_member_id")
+  payerMemberId                     String?                              @map("payer_member_id")
   beneficiaryMemberId               String                               @map("beneficiary_member_id")
   offerCode                         String                               @map("offer_code")
   cashCurrency                      String                               @map("cash_currency")
@@ -1257,9 +1257,9 @@ model HostedUsageCreditPurchase {
   status                            HostedUsageCreditPurchaseStatus       @default(created)
   stripeLiveMode                    Boolean                              @map("stripe_live_mode")
   stripePriceLookupKey              String                               @map("stripe_price_lookup_key")
-  stripePriceIdEncrypted            String                               @map("stripe_price_id_encrypted")
+  stripePriceIdEncrypted            String?                              @map("stripe_price_id_encrypted")
   stripeCustomerLookupKey           String                               @map("stripe_customer_lookup_key")
-  stripeCustomerIdEncrypted         String                               @map("stripe_customer_id_encrypted")
+  stripeCustomerIdEncrypted         String?                              @map("stripe_customer_id_encrypted")
   stripeCheckoutSessionLookupKey    String?                              @unique(map: "hosted_usage_credit_purchase_session_lookup_key") @map("stripe_checkout_session_lookup_key")
   stripeCheckoutSessionIdEncrypted  String?                              @map("stripe_checkout_session_id_encrypted")
   stripeCheckoutUrlEncrypted        String?                              @map("stripe_checkout_url_encrypted")
@@ -1276,7 +1276,7 @@ model HostedUsageCreditPurchase {
   reconciliationVersion             BigInt                               @default(0) @map("reconciliation_version")
   createdAt                         DateTime                             @default(now()) @map("created_at")
   updatedAt                         DateTime                             @updatedAt @map("updated_at")
-  payer                             HostedMember                         @relation("HostedUsageCreditPurchasePayer", fields: [payerMemberId], references: [id], onDelete: Restrict)
+  payer                             HostedMember?                        @relation("HostedUsageCreditPurchasePayer", fields: [payerMemberId], references: [id], onDelete: Restrict)
   beneficiary                       HostedMember                         @relation("HostedUsageCreditPurchaseBeneficiary", fields: [beneficiaryMemberId], references: [id], onDelete: Restrict)
   entries                           HostedUsageCreditEntry[]
 

--- a/apps/web/src/components/home/usage-limit-banner.tsx
+++ b/apps/web/src/components/home/usage-limit-banner.tsx
@@ -20,7 +20,10 @@ const resettableMonthlyNoticeCodes = new Set<HostedAiUsageGateNoticeCode>([
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const usageLimitBannerCopy: Record<
-  Exclude<HostedAiUsageGateNoticeCode, "thread_usage_limit_reached">,
+  Exclude<
+    HostedAiUsageGateNoticeCode,
+    "thread_usage_limit_reached" | "thread_usage_low"
+  >,
   {
     body: string;
     title: string;
@@ -54,7 +57,10 @@ export function UsageLimitBanner({
   recommendedAction,
   resetAt,
 }: UsageLimitBannerProps) {
-  if (noticeCode === "thread_usage_limit_reached") {
+  if (
+    noticeCode === "thread_usage_limit_reached"
+    || noticeCode === "thread_usage_low"
+  ) {
     return null;
   }
 

--- a/apps/web/src/components/hosted-groups/group-funding-sign-in-button.tsx
+++ b/apps/web/src/components/hosted-groups/group-funding-sign-in-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+import { AuthDialog } from "@/src/components/hosted-onboarding/auth-dialog";
+import { navigateHostedAuthRedirect } from "@/src/components/hosted-onboarding/hosted-auth-navigation";
+import { Button } from "@/src/components/ui/button";
+
+export function GroupFundingSignInButton() {
+  const [open, setOpen] = useState(true);
+
+  function handleCompleted() {
+    navigateHostedAuthRedirect(readCurrentGroupFundingPath());
+  }
+
+  return (
+    <>
+      <Button type="button" size="xl" onClick={() => setOpen(true)}>
+        Continue to add usage
+      </Button>
+      <AuthDialog
+        open={open}
+        onCompleted={handleCompleted}
+        onOpenChange={setOpen}
+        requireLaunchConsentOnCompletion
+        title="Add usage to this Murph group"
+        description="Create or open your private Murph account, then we'll bring you back here."
+      />
+    </>
+  );
+}
+
+function readCurrentGroupFundingPath(): string {
+  if (typeof window === "undefined") {
+    return "/";
+  }
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}

--- a/apps/web/src/components/settings/hosted-usage-top-up-contract.ts
+++ b/apps/web/src/components/settings/hosted-usage-top-up-contract.ts
@@ -30,9 +30,11 @@ interface HostedUsageTopUpReturn {
 
 interface HostedUsageTopUpDialogProps {
   activePurchase?: HostedUsageTopUpActivePurchase | null;
+  checkoutUrl?: string;
   initialOpen?: boolean;
   offers: readonly HostedUsageTopUpOffer[];
   purchaseReturn?: HostedUsageTopUpReturn | null;
+  scope?: "group" | "personal";
 }
 
 interface HostedUsageTopUpPurchaseResponse {
@@ -41,6 +43,7 @@ interface HostedUsageTopUpPurchaseResponse {
   restartAt: string | null;
   retryAllowed: boolean;
   status: HostedUsageTopUpPurchaseStatus;
+  targetConflict: boolean;
   url: string | null;
 }
 
@@ -56,6 +59,7 @@ function readPurchaseResponse(value: unknown): HostedUsageTopUpPurchaseResponse 
       (value.status !== "reconciling" ||
         !isCanonicalIsoTimestamp(value.restartAt))) ||
     (value.retryAllowed !== undefined && value.retryAllowed !== true) ||
+    (value.targetConflict !== undefined && value.targetConflict !== true) ||
     (value.url !== undefined &&
       value.url !== null &&
       typeof value.url !== "string")
@@ -69,6 +73,7 @@ function readPurchaseResponse(value: unknown): HostedUsageTopUpPurchaseResponse 
     restartAt: typeof value.restartAt === "string" ? value.restartAt : null,
     retryAllowed: value.retryAllowed === true,
     status: value.status,
+    targetConflict: value.targetConflict === true,
     url:
       typeof value.url === "string" && value.url.length > 0 ? value.url : null,
   };
@@ -111,8 +116,60 @@ function readStatusContent(input: {
   canRetryCheckout: boolean;
   pollKind: "dormant" | "checking" | "exhausted" | "failed";
   returnedFromSuccessfulCheckout: boolean;
+  scope?: "group" | "personal";
   status: HostedUsageTopUpPurchaseStatus | null;
+  targetConflict?: boolean;
 }): { message: string; title: string } {
+  if (input.targetConflict) {
+    if (input.pollKind === "failed") {
+      return content(
+        "Couldn't check the other checkout",
+        "We couldn't check the unfinished checkout right now. Try again.",
+      );
+    }
+    if (input.status === "checkout_open") {
+      return content(
+        "Another checkout is already open",
+        input.canResumeCheckout
+          ? "Resume or cancel the unfinished checkout for the other usage destination before starting this one."
+          : "Cancel the unfinished checkout for the other usage destination before starting this one.",
+      );
+    }
+    if (
+      input.pollKind === "exhausted"
+      && (!input.status || shouldPollPurchaseStatus(input.status))
+    ) {
+      return content(
+        "Other checkout still processing",
+        "The unfinished checkout for the other usage destination is still being confirmed.",
+      );
+    }
+    switch (input.status) {
+      case "fulfilled":
+        return content(
+          "Other checkout completed",
+          "The other usage destination received its credit. Close this dialog and try again.",
+        );
+      case "expired":
+        return content(
+          "Other checkout canceled",
+          "The unfinished checkout was canceled. Close this dialog and try again.",
+        );
+      case "payment_failed":
+        return content(
+          "Other payment not completed",
+          "The other payment did not complete. Close this dialog and try again.",
+        );
+      case "payment_pending":
+      case "reconciling":
+      case null:
+        return content(
+          "Checking another checkout",
+          "Murph is checking the unfinished checkout for the other usage destination.",
+        );
+    }
+  }
+
   if (input.pollKind === "failed") {
     return content(
       "Couldn't check payment",
@@ -155,7 +212,12 @@ function readStatusContent(input: {
 
   switch (input.status) {
     case "fulfilled":
-      return content("Usage added", "Your available usage has been updated.");
+      return content(
+        "Usage added",
+        input.scope === "group"
+          ? "This group's available usage has been updated."
+          : "Your available usage has been updated.",
+      );
     case "expired":
       return content("Checkout canceled", "Checkout canceled. No usage was added.");
     case "payment_failed":

--- a/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
@@ -101,7 +101,9 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
         returnedFromSuccessfulCheckout:
           props.purchaseReturn?.kind === "success" &&
           props.purchaseReturn.purchaseId === purchase.purchaseId,
+        scope: props.scope,
         status: purchase.status,
+        targetConflict: purchase.targetConflict,
       })
     : null;
   const hasAttempt = selection !== null && selection.attempt.kind !== "idle";
@@ -117,7 +119,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
         <DialogTrigger
           render={<Button type="button" variant="outline" size="lg" />}
         >
-          {purchaseTriggerLabel ?? "Add usage"}
+          {purchaseTriggerLabel ?? (props.scope === "group" ? "Add group usage" : "Add usage")}
         </DialogTrigger>
       ) : null}
       <DialogContent
@@ -134,14 +136,22 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
               ? statusContent.title
               : props.offers.length === 0
                 ? "Usage credit unavailable"
-                : "Add usage"}
+                : props.scope === "group"
+                  ? "Add group usage"
+                  : "Add usage"}
           </DialogTitle>
           <DialogDescription>
             {purchase
-              ? "Murph checks Stripe before changing your available usage."
+              ? purchase.targetConflict
+                ? "Manage the unfinished checkout before starting one for this usage destination."
+                : props.scope === "group"
+                ? "Murph checks Stripe before changing this group's available usage."
+                : "Murph checks Stripe before changing your available usage."
               : props.offers.length === 0
                 ? "There isn’t a usage-credit offer available for this account right now."
-                : "Choose how much usage credit to add in a one-time payment. Stripe confirms the payment before Murph adds it."}
+                : props.scope === "group"
+                  ? "Choose how much usage credit to add to this group in a one-time payment. Stripe confirms the payment before Murph adds it."
+                  : "Choose how much usage credit to add in a one-time payment. Stripe confirms the payment before Murph adds it."}
           </DialogDescription>
         </DialogHeader>
 
@@ -259,7 +269,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
                   <ChoiceCard
                     key={offer.offerCode}
                     ref={index === 0 ? firstOfferRef : undefined}
-                    id={`usage-top-up-${index}`}
+                    id={`${props.scope === "group" ? "group-" : ""}usage-top-up-${index}`}
                     value={offer.offerCode}
                     disabled={hasAttempt}
                     title={
@@ -267,7 +277,11 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
                         {offer.amountLabel}
                       </span>
                     }
-                    description={<span className="sr-only">Usage credit</span>}
+                    description={
+                      <span className="sr-only">
+                        {props.scope === "group" ? "Group usage credit" : "Usage credit"}
+                      </span>
+                    }
                   />
                 ))}
               </RadioGroup>

--- a/apps/web/src/components/settings/hosted-usage-top-up-state.ts
+++ b/apps/web/src/components/settings/hosted-usage-top-up-state.ts
@@ -40,6 +40,7 @@ interface HostedUsageTopUpPurchaseScreen {
   retryOfferCode: string | null;
   retryRequestKey: string | null;
   status: HostedUsageTopUpPurchaseStatus | null;
+  targetConflict: boolean;
 }
 
 type HostedUsageTopUpScreen =
@@ -384,6 +385,7 @@ function screenFromResponse(
     retryOfferCode,
     retryRequestKey: retryOfferCode ? retryRequestKey : null,
     status: response.status,
+    targetConflict: response.targetConflict || previous?.targetConflict === true,
   };
 }
 
@@ -405,6 +407,7 @@ function createPurchaseScreen(
     retryOfferCode: null,
     retryRequestKey: null,
     status: null,
+    targetConflict: false,
   };
 }
 

--- a/apps/web/src/components/settings/use-hosted-usage-top-up-dialog.ts
+++ b/apps/web/src/components/settings/use-hosted-usage-top-up-dialog.ts
@@ -37,6 +37,7 @@ interface OwnedCheckoutRequest {
 
 function useHostedUsageTopUpDialog({
   activePurchase = null,
+  checkoutUrl = CHECKOUT_URL,
   initialOpen = false,
   offers,
   purchaseReturn = null,
@@ -381,14 +382,18 @@ function useHostedUsageTopUpDialog({
         method: "POST",
         payload: { offerCode, clientRequestKey: requestKey },
         signal,
-        url: CHECKOUT_URL,
+        url: checkoutUrl,
       });
       const response = readPurchaseResponse(value);
-      const checkoutUrl = response.url ? readCheckoutUrl(response.url) : null;
-      if (response.recovered && response.status === "checkout_open" && !checkoutUrl) {
+      const resolvedCheckoutUrl = response.url ? readCheckoutUrl(response.url) : null;
+      if (
+        response.recovered
+        && response.status === "checkout_open"
+        && !resolvedCheckoutUrl
+      ) {
         throw new Error("Could not open Stripe right now. Try again.");
       }
-      return { checkoutUrl, response };
+      return { checkoutUrl: resolvedCheckoutUrl, response };
     });
 
     if (outcome.ok) {

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -73,6 +73,7 @@ export type HostedAiUsageGateNoticeCode =
   | "edge_usage_limit_reached"
   | "family_usage_limit_reached"
   | "pulse_upgrade_edge"
+  | "thread_usage_low"
   | "thread_usage_limit_reached"
   | "trial_usage_limit_reached"
   | "trial_conversion_pending";
@@ -1709,8 +1710,17 @@ async function accountHostedAiUsageAllowancePeriodSpendTx(input: {
 
   const remainingBeforeUsdMicros =
     baseRemainingUsdMicros + input.period.usageCreditBalanceUsdMicros;
-  const noticeEligible = remainingBeforeUsdMicros > 0n
+  const limitNoticeEligible = remainingBeforeUsdMicros > 0n
     && input.costUsdMicros >= remainingBeforeUsdMicros;
+  const remainingAfterUsdMicros = input.costUsdMicros >= remainingBeforeUsdMicros
+    ? 0n
+    : remainingBeforeUsdMicros - input.costUsdMicros;
+  const lowThresholdUsdMicros = (input.period.limitUsdMicros + 4n) / 5n;
+  const lowNoticeEligible =
+    input.period.allowanceSource === "thread_container"
+    && remainingBeforeUsdMicros > lowThresholdUsdMicros
+    && remainingAfterUsdMicros > 0n
+    && remainingAfterUsdMicros <= lowThresholdUsdMicros;
 
   const updated = await input.tx.$executeRaw`
     UPDATE "hosted_ai_usage_period"
@@ -1735,7 +1745,7 @@ async function accountHostedAiUsageAllowancePeriodSpendTx(input: {
     throw new TypeError("Hosted AI usage allowance period spend lost its locked row.");
   }
 
-  if (!noticeEligible) {
+  if (!limitNoticeEligible && !lowNoticeEligible) {
     return null;
   }
 
@@ -1746,13 +1756,18 @@ async function accountHostedAiUsageAllowancePeriodSpendTx(input: {
     periodStart: input.period.periodStart,
     sourceUsageId: input.sourceUsageId,
     usageCreditLedgerVersion,
-    userNotice: buildHostedAiUsageGateLimitNotice({
-      allowanceSource: input.period.allowanceSource,
-      billingPlanCode: input.period.billingPlanCode,
-      limitUsdMicros: input.period.limitUsdMicros,
-      memberId: input.memberId,
-      periodStart: input.period.periodStart,
-    }),
+    userNotice: lowNoticeEligible
+      ? buildHostedAiUsageGateThreadLowNotice({
+          memberId: input.memberId,
+          periodStart: input.period.periodStart,
+        })
+      : buildHostedAiUsageGateLimitNotice({
+          allowanceSource: input.period.allowanceSource,
+          billingPlanCode: input.period.billingPlanCode,
+          limitUsdMicros: input.period.limitUsdMicros,
+          memberId: input.memberId,
+          periodStart: input.period.periodStart,
+        }),
   };
 }
 
@@ -2871,6 +2886,24 @@ function buildHostedAiUsageGateLimitNotice(input: {
       noticeCode: "pulse_upgrade_edge",
       periodStart: input.periodStart,
     }),
+  };
+}
+
+function buildHostedAiUsageGateThreadLowNotice(input: {
+  memberId: string;
+  periodStart: Date;
+}): HostedAiUsageLimitNotice {
+  return {
+    code: "thread_usage_low",
+    message: renderUserFacingMessage({
+      context: {},
+      key: "linq.ai_usage.thread_low",
+      seed: buildHostedAiUsageNoticeSeed({
+        memberId: input.memberId,
+        noticeCode: "thread_usage_low",
+        periodStart: input.periodStart,
+      }),
+    }).text,
   };
 }
 

--- a/apps/web/src/lib/hosted-execution/usage-limit-notice-claim.ts
+++ b/apps/web/src/lib/hosted-execution/usage-limit-notice-claim.ts
@@ -24,6 +24,7 @@ import {
 import {
   HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
 } from "../hosted-onboarding/shared";
+import type { HostedAiUsageLimitNoticeCode } from "./usage-allowance";
 import {
   assertHostedThreadRouteEgressAuthority,
   lockHostedThreadRouteByThreadIdentityTx,
@@ -39,6 +40,7 @@ export async function startAuthorizedHostedAiUsageLimitNoticeDispatchTx(input: {
   ) => Promise<void>;
   attemptedAt: Date;
   memberId: string;
+  noticeCode?: HostedAiUsageLimitNoticeCode;
   noticeDeliveryTarget: HostedRuntimeUsageNoticeDeliveryTarget;
   periodStart: Date;
   prisma: PrismaClient;
@@ -76,6 +78,7 @@ export async function startAuthorizedHostedAiUsageLimitNoticeDispatchTx(input: {
           if (!await lockHostedAiUsageLimitNoticeEligibilityTx({
             attemptedAt: input.attemptedAt,
             memberId: input.memberId,
+            noticeCode: input.noticeCode ?? "thread_usage_limit_reached",
             periodStart: input.periodStart,
             tx: claimPrisma,
           })) {
@@ -87,6 +90,7 @@ export async function startAuthorizedHostedAiUsageLimitNoticeDispatchTx(input: {
           ? { linqChatId: input.noticeDeliveryTarget.target }
           : {}),
         memberId: input.memberId,
+        ...(input.noticeCode ? { noticeCode: input.noticeCode } : {}),
         periodStart: input.periodStart,
         prisma,
         source: input.source,
@@ -131,19 +135,44 @@ async function lockHostedAiUsageLimitNoticeCapacityEpochTx(input: {
 async function lockHostedAiUsageLimitNoticeEligibilityTx(input: {
   attemptedAt: Date;
   memberId: string;
+  noticeCode: HostedAiUsageLimitNoticeCode;
   periodStart: Date;
   tx: Prisma.TransactionClient;
 }): Promise<boolean> {
-  const rows = await input.tx.$queryRaw<Array<{ eligible: boolean }>>`
-    SELECT TRUE AS "eligible"
-    FROM "hosted_ai_usage_period"
-    WHERE "member_id" = ${input.memberId}
-      AND "period_start" = ${input.periodStart}
-      AND "period_start" <= ${input.attemptedAt}
-      AND "period_end" > ${input.attemptedAt}
-      AND "blocked_at" IS NOT NULL
-    FOR UPDATE
-  `;
+  const rows = input.noticeCode === "thread_usage_low"
+    ? await input.tx.$queryRaw<Array<{ eligible: boolean }>>`
+        SELECT TRUE AS "eligible"
+        FROM "hosted_ai_usage_period" AS "period"
+        INNER JOIN "hosted_member" AS "member"
+          ON "member"."id" = "period"."member_id"
+        INNER JOIN "hosted_thread_container" AS "container"
+          ON "container"."member_id" = "member"."id"
+        WHERE "period"."member_id" = ${input.memberId}
+          AND "period"."period_start" = ${input.periodStart}
+          AND "period"."period_start" <= ${input.attemptedAt}
+          AND "period"."period_end" > ${input.attemptedAt}
+          AND "period"."blocked_at" IS NULL
+          AND GREATEST(
+            "period"."limit_usd_micros" - "period"."spent_usd_micros",
+            0
+          ) + COALESCE("member"."usage_credit_balance_usd_micros", 0) > 0
+          AND GREATEST(
+            "period"."limit_usd_micros" - "period"."spent_usd_micros",
+            0
+          ) + COALESCE("member"."usage_credit_balance_usd_micros", 0)
+            <= ("period"."limit_usd_micros" + 4) / 5
+        FOR UPDATE OF "period"
+      `
+    : await input.tx.$queryRaw<Array<{ eligible: boolean }>>`
+        SELECT TRUE AS "eligible"
+        FROM "hosted_ai_usage_period"
+        WHERE "member_id" = ${input.memberId}
+          AND "period_start" = ${input.periodStart}
+          AND "period_start" <= ${input.attemptedAt}
+          AND "period_end" > ${input.attemptedAt}
+          AND "blocked_at" IS NOT NULL
+        FOR UPDATE
+      `;
 
   return rows[0]?.eligible === true;
 }

--- a/apps/web/src/lib/hosted-execution/usage-limit-notice-message.ts
+++ b/apps/web/src/lib/hosted-execution/usage-limit-notice-message.ts
@@ -3,6 +3,8 @@ import "server-only";
 import type { PrismaClient } from "@prisma/client";
 import { MURPH_PRODUCT_ORIGIN } from "@murphai/contracts";
 
+import { readHostedGroupUsageStatus } from "../hosted-groups/group-usage-funding";
+import type { HostedAiUsageLimitNoticeCode } from "./usage-allowance";
 import { readHostedPersonalAiUsageStatus } from "./usage-status";
 
 /**
@@ -12,9 +14,34 @@ import { readHostedPersonalAiUsageStatus } from "./usage-status";
 export async function projectHostedAiUsageLimitNoticeForDelivery(input: {
   memberId: string;
   message: string;
+  noticeCode?: HostedAiUsageLimitNoticeCode;
   prisma: PrismaClient;
 }): Promise<string> {
   try {
+    if (
+      input.noticeCode === "thread_usage_low"
+      || input.noticeCode === "thread_usage_limit_reached"
+    ) {
+      const status = await readHostedGroupUsageStatus({
+        prisma: input.prisma,
+        runtimeMemberId: input.memberId,
+      });
+      const expectedCapacityState = input.noticeCode === "thread_usage_low"
+        ? "low"
+        : "exhausted";
+      if (
+        status?.capacityState !== expectedCapacityState
+        || !status.fundingUrl
+      ) {
+        return input.message;
+      }
+      const fundingUrl = new URL(status.fundingUrl, `${MURPH_PRODUCT_ORIGIN}/`);
+      if (fundingUrl.origin !== MURPH_PRODUCT_ORIGIN) {
+        return input.message;
+      }
+      return `${input.message}\n\nAdd group usage: ${fundingUrl.toString()}`;
+    }
+
     const usageStatus = await readHostedPersonalAiUsageStatus({
       memberId: input.memberId,
       prisma: input.prisma,

--- a/apps/web/src/lib/hosted-execution/usage-limit-notice.ts
+++ b/apps/web/src/lib/hosted-execution/usage-limit-notice.ts
@@ -91,6 +91,7 @@ export async function sendClaimedHostedAiUsageLimitNoticeToLinqChat(input: {
 export async function sendClaimedHostedAiUsageLimitNoticeToTelegramThread(input: {
   memberId: string;
   message: string;
+  noticeCode?: HostedAiUsageLimitNoticeCode;
   periodStart: Date;
   prisma: PrismaClient;
   replyToMessageId: string;
@@ -122,6 +123,7 @@ export async function sendClaimedHostedAiUsageLimitNoticeToTelegramThread(input:
         dispatch.claim = await startAuthorizedHostedAiUsageLimitNoticeDispatchTx({
           attemptedAt: input.sentAt,
           memberId: input.memberId,
+          ...(input.noticeCode ? { noticeCode: input.noticeCode } : {}),
           noticeDeliveryTarget: {
             channel: "telegram",
             replyToMessageId: input.replyToMessageId,

--- a/apps/web/src/lib/hosted-execution/usage.ts
+++ b/apps/web/src/lib/hosted-execution/usage.ts
@@ -197,6 +197,7 @@ function dedupeHostedAiUsageLimitNoticeCandidates(
       candidate.memberId,
       candidate.periodStart.toISOString(),
       candidate.usageCreditLedgerVersion.toString(),
+      candidate.userNotice.code,
     ].join("\u0000");
     if (!byCapacityEpoch.has(key)) {
       byCapacityEpoch.set(key, candidate);
@@ -233,6 +234,7 @@ async function sendHostedAiUsageLimitNoticeCandidate(input: {
         message: await projectHostedAiUsageLimitNoticeForDelivery({
           memberId: input.candidate.memberId,
           message: input.candidate.userNotice.message,
+          noticeCode: input.candidate.userNotice.code,
           prisma: input.prisma,
         }),
         noticeCode: input.candidate.userNotice.code,
@@ -251,8 +253,10 @@ async function sendHostedAiUsageLimitNoticeCandidate(input: {
         message: await projectHostedAiUsageLimitNoticeForDelivery({
           memberId: input.candidate.memberId,
           message: input.candidate.userNotice.message,
+          noticeCode: input.candidate.userNotice.code,
           prisma: input.prisma,
         }),
+        noticeCode: input.candidate.userNotice.code,
         periodStart: input.candidate.periodStart,
         prisma: input.prisma,
         replyToMessageId: input.noticeDeliveryTarget.replyToMessageId,
@@ -297,6 +301,7 @@ async function sendHostedAiUsageLimitNoticeCandidate(input: {
       message: await projectHostedAiUsageLimitNoticeForDelivery({
         memberId: input.candidate.memberId,
         message: input.candidate.userNotice.message,
+        noticeCode: input.candidate.userNotice.code,
         prisma: input.prisma,
       }),
       noticeCode: input.candidate.userNotice.code,

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -65,6 +65,7 @@ import { assertHostedLinqRouteEgressAuthority } from "../hosted-routing/thread-r
 import { resolveHostedPublicBaseUrl } from "../hosted-web/public-url";
 import { getPrisma } from "../prisma";
 import { buildHostedGroupJoinUrl } from "./group-links";
+import { readHostedGroupUsageStatus } from "./group-usage-funding";
 import { requestHostedGroupAssistantAsk } from "./group-assistant-ask";
 import {
   enqueueHostedGroupNewsletterEmailNeededNudgeIfNeededBestEffort,
@@ -132,6 +133,7 @@ export const HOSTED_RUNTIME_GROUP_TOOL_ACCESS_CLASSIFICATION = {
   preflight_set_chat_avatar: "owner_active",
   read_chat_participants: "participant_aware",
   read_current: "participant_aware",
+  read_usage: "participant_aware",
   read_shared: "participant_aware",
   revoke_own_email_share: "participant_aware",
   set_chat_avatar: "owner_active",
@@ -253,6 +255,22 @@ export async function handleHostedRuntimeGroupTool(input: {
         },
       };
     }
+  }
+
+  if (input.request.action === "read_usage") {
+    const usage = await readHostedGroupUsageStatus({
+      runtimeMemberId: input.memberId,
+    });
+    return {
+      action: "read_usage",
+      result: usage
+        ? { status: "ok", usage }
+        : {
+            status: "unavailable",
+            unavailableReason: "group_usage_unavailable",
+            usage: null,
+          },
+    };
   }
 
   if (!await hasHostedRuntimeActiveAccess(input.memberId)) {

--- a/apps/web/src/lib/hosted-groups/group-usage-capacity.ts
+++ b/apps/web/src/lib/hosted-groups/group-usage-capacity.ts
@@ -1,0 +1,18 @@
+export type HostedGroupUsageCapacityState = "healthy" | "low" | "exhausted";
+
+const HOSTED_GROUP_USAGE_LOW_PERCENT = 20n;
+
+export function classifyHostedGroupUsageCapacity(input: {
+  limitUsdMicros: bigint;
+  remainingUsdMicros: bigint;
+}): HostedGroupUsageCapacityState {
+  if (input.remainingUsdMicros <= 0n) {
+    return "exhausted";
+  }
+
+  const lowThresholdUsdMicros =
+    (input.limitUsdMicros * HOSTED_GROUP_USAGE_LOW_PERCENT + 99n) / 100n;
+  return input.remainingUsdMicros <= lowThresholdUsdMicros
+    ? "low"
+    : "healthy";
+}

--- a/apps/web/src/lib/hosted-groups/group-usage-funding.ts
+++ b/apps/web/src/lib/hosted-groups/group-usage-funding.ts
@@ -1,0 +1,150 @@
+import "server-only";
+
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+import { readHostedAiUsageGate } from "../hosted-execution/usage-allowance";
+import { hasHostedRuntimeActiveAccess } from "../hosted-mailbox/runtime-access";
+import { resolveHostedPublicBaseUrl } from "../hosted-web/public-url";
+import { normalizeNullableString } from "../primitives";
+import { getPrisma } from "../prisma";
+import {
+  classifyHostedGroupUsageCapacity,
+  type HostedGroupUsageCapacityState,
+} from "./group-usage-capacity";
+
+export type HostedGroupUsageFundingClient =
+  | PrismaClient
+  | Prisma.TransactionClient;
+
+export interface HostedGroupUsageFundingTarget {
+  displayName: string | null;
+  fundingPath: string;
+  joinCode: string;
+  kind: string;
+  runtimeMemberId: string;
+}
+
+export interface HostedGroupUsageStatus {
+  capacityState: HostedGroupUsageCapacityState;
+  fundingUrl: string | null;
+  periodEnd: string;
+}
+
+export async function readHostedGroupUsageFundingTargetByJoinCode(input: {
+  joinCode: string;
+  prisma?: HostedGroupUsageFundingClient;
+}): Promise<HostedGroupUsageFundingTarget | null> {
+  const joinCode = normalizeHostedGroupUsageJoinCode(input.joinCode);
+  if (!joinCode) {
+    return null;
+  }
+
+  const prisma = input.prisma ?? getPrisma();
+  const group = await prisma.hostedGroup.findUnique({
+    select: {
+      displayName: true,
+      joinCode: true,
+      kind: true,
+      runtimeMemberId: true,
+    },
+    where: { joinCode },
+  });
+  if (!group?.joinCode || !group.runtimeMemberId) {
+    return null;
+  }
+  const [container, hasActiveAccess] = await Promise.all([
+    prisma.hostedThreadContainer.findUnique({
+      select: { memberId: true },
+      where: { memberId: group.runtimeMemberId },
+    }),
+    hasHostedRuntimeActiveAccess(group.runtimeMemberId, { prisma }),
+  ]);
+  if (!container || !hasActiveAccess) {
+    return null;
+  }
+
+  return {
+    displayName: normalizeNullableString(group.displayName),
+    fundingPath: buildHostedGroupUsageFundingPath(group.joinCode),
+    joinCode: group.joinCode,
+    kind: group.kind,
+    runtimeMemberId: group.runtimeMemberId,
+  };
+}
+
+export async function readHostedGroupUsageStatus(input: {
+  prisma?: HostedGroupUsageFundingClient;
+  runtimeMemberId: string;
+}): Promise<HostedGroupUsageStatus | null> {
+  const prisma = input.prisma ?? getPrisma();
+  const [decision, group, container, hasActiveAccess] = await Promise.all([
+    readHostedAiUsageGate({
+      memberId: input.runtimeMemberId,
+      prisma,
+    }),
+    prisma.hostedGroup.findUnique({
+      select: { joinCode: true },
+      where: { runtimeMemberId: input.runtimeMemberId },
+    }),
+    prisma.hostedThreadContainer.findUnique({
+      select: { memberId: true },
+      where: { memberId: input.runtimeMemberId },
+    }),
+    hasHostedRuntimeActiveAccess(input.runtimeMemberId, { prisma }),
+  ]);
+  if (
+    !group
+    || !container
+    || !hasActiveAccess
+    || decision.allowanceSource !== "thread_container"
+    || (!decision.allowed && decision.reason !== "ai_usage_limit_exceeded")
+  ) {
+    return null;
+  }
+
+  return {
+    capacityState: classifyHostedGroupUsageCapacity({
+      limitUsdMicros: decision.limitUsdMicros,
+      remainingUsdMicros: decision.remainingUsdMicros,
+    }),
+    fundingUrl: group.joinCode
+      ? buildHostedGroupUsageFundingUrl({ joinCode: group.joinCode })
+      : null,
+    periodEnd: decision.periodEnd.toISOString(),
+  };
+}
+
+export function buildHostedGroupUsageFundingUrl(input: {
+  joinCode: string;
+  publicBaseUrl?: string | null;
+}): string | null {
+  const joinCode = normalizeHostedGroupUsageJoinCode(input.joinCode);
+  const publicBaseUrl = input.publicBaseUrl === undefined
+    ? resolveHostedPublicBaseUrl()
+    : input.publicBaseUrl;
+  if (!joinCode || !publicBaseUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(
+      buildHostedGroupUsageFundingPath(joinCode),
+      `${publicBaseUrl.replace(/\/+$/u, "")}/`,
+    ).toString();
+  } catch {
+    return null;
+  }
+}
+
+export function buildHostedGroupUsageFundingPath(joinCode: string): string {
+  return `/groups/fund/${encodeURIComponent(joinCode)}`;
+}
+
+export function normalizeHostedGroupUsageJoinCode(value: unknown): string | null {
+  const normalized = typeof value === "string"
+    ? normalizeNullableString(value)
+    : null;
+  return normalized && /^[A-Za-z0-9_-]{16,128}$/u.test(normalized)
+    ? normalized
+    : null;
+}

--- a/apps/web/src/lib/hosted-messages/user-facing-messages.ts
+++ b/apps/web/src/lib/hosted-messages/user-facing-messages.ts
@@ -19,6 +19,7 @@ const USER_FACING_MESSAGE_TEMPLATE_KEYS = [
   "linq.ai_usage.edge_limit_reached",
   "linq.ai_usage.family_limit_reached",
   "linq.ai_usage.pulse_upgrade_edge",
+  "linq.ai_usage.thread_low",
   "linq.ai_usage.thread_limit_reached",
 ] as const
 
@@ -52,6 +53,7 @@ export interface UserFacingMessageContextByKey {
   "linq.ai_usage.pulse_upgrade_edge": {
     homeUrl: string
   }
+  "linq.ai_usage.thread_low": Record<string, never>
   "linq.ai_usage.thread_limit_reached": Record<string, never>
 }
 
@@ -484,6 +486,28 @@ Sound good?`,
     `This chat hit its monthly included Murph amount. AI usage is paused until the allowance resets.`,
     `The chat's monthly included usage is reached. AI usage is paused until the chat's allowance resets.`,
     `Included Murph usage is used for this chat this month. AI usage is paused until the allowance resets.`,
+  ],
+  "linq.ai_usage.thread_low": [
+    `This chat is running low on Murph usage for the current period.`,
+    `The chat's Murph usage is getting low for this period.`,
+    `This chat has a small amount of Murph usage left in the current period.`,
+    `Murph usage for this chat is running low this period.`,
+    `The current period's Murph usage is nearly used for this chat.`,
+    `This chat is nearing its Murph usage amount for the period.`,
+    `There is not much Murph usage left for this chat this period.`,
+    `The chat is getting close to its Murph usage amount for this period.`,
+    `This period's Murph usage is running low for the chat.`,
+    `This chat has limited Murph usage remaining in the current period.`,
+    `The chat's remaining Murph usage is low for this period.`,
+    `Murph usage is nearing the period amount for this chat.`,
+    `This chat is close to using its Murph usage for the current period.`,
+    `Only a small amount of Murph usage remains for this chat this period.`,
+    `This chat's Murph usage is low for the current period.`,
+    `The chat is nearing the end of its Murph usage for this period.`,
+    `This period's remaining Murph usage is limited for the chat.`,
+    `The chat has almost used its Murph usage for the current period.`,
+    `Murph usage left for this chat is getting low this period.`,
+    `This chat is approaching its Murph usage amount for the current period.`,
   ],
 } satisfies Record<UserFacingMessageTemplateKey, readonly string[]>
 

--- a/apps/web/src/lib/hosted-onboarding/hosted-member-stripe-customer.ts
+++ b/apps/web/src/lib/hosted-onboarding/hosted-member-stripe-customer.ts
@@ -1,0 +1,83 @@
+import "server-only";
+
+import type { PrismaClient } from "@prisma/client";
+
+import { getPrisma } from "../prisma";
+import { hostedOnboardingError } from "./errors";
+import {
+  bindHostedMemberStripeCustomerIdIfMissingTx,
+  readHostedMemberStripeBillingRef,
+} from "./hosted-member-billing-store";
+import { createHostedPulseTrialStripeCustomer } from "./pulse-trial-customer";
+import { requireHostedStripeApiMode } from "./runtime";
+import {
+  HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+  lockHostedMemberRow,
+} from "./shared";
+
+/**
+ * Reuses the member-scoped Stripe Customer identity and its existing provider
+ * idempotency key, including for a member who does not have a paid plan.
+ */
+export async function ensureHostedMemberStripeCustomer(input: {
+  memberId: string;
+  prisma?: PrismaClient;
+}): Promise<string> {
+  const prisma = input.prisma ?? getPrisma();
+  const existing = await readHostedMemberStripeBillingRef({
+    memberId: input.memberId,
+    prisma,
+  });
+  if (existing?.stripeCustomerId) {
+    return existing.stripeCustomerId;
+  }
+
+  const { stripe } = requireHostedStripeApiMode();
+  const candidateStripeCustomerId = await createHostedPulseTrialStripeCustomer({
+    memberId: input.memberId,
+    stripe,
+  });
+
+  return prisma.$transaction(async (tx) => {
+    await lockHostedMemberRow(tx, input.memberId);
+    const member = await tx.hostedMember.findUnique({
+      select: {
+        suspendedAt: true,
+        threadContainer: { select: { memberId: true } },
+      },
+      where: { id: input.memberId },
+    });
+    if (!member || member.suspendedAt || member.threadContainer) {
+      throw buildHostedUsageCreditPayerNotEligibleError();
+    }
+
+    const current = await readHostedMemberStripeBillingRef({
+      memberId: input.memberId,
+      prisma: tx,
+    });
+    const billingRef = current?.stripeCustomerId
+      ? current
+      : await bindHostedMemberStripeCustomerIdIfMissingTx({
+          memberId: input.memberId,
+          stripeCustomerId: candidateStripeCustomerId,
+          tx,
+        });
+    if (!billingRef?.stripeCustomerId) {
+      throw hostedOnboardingError({
+        code: "HOSTED_USAGE_CREDIT_CUSTOMER_BIND_FAILED",
+        httpStatus: 409,
+        message: "Murph could not prepare Stripe checkout. Try again.",
+        retryable: true,
+      });
+    }
+    return billingRef.stripeCustomerId;
+  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+}
+
+function buildHostedUsageCreditPayerNotEligibleError() {
+  return hostedOnboardingError({
+    code: "HOSTED_USAGE_CREDIT_PAYER_NOT_ELIGIBLE",
+    httpStatus: 403,
+    message: "This Murph account cannot start a usage-credit checkout.",
+  });
+}

--- a/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
@@ -419,6 +419,7 @@ export async function startHostedAiUsageLimitNoticeDispatchTx(input: {
   attemptedAt: Date;
   linqChatId?: string | null;
   memberId: string;
+  noticeCode?: string;
   periodStart: Date;
   phoneNumber?: string | null;
   prisma: HostedLinqDeliveryClient;
@@ -501,6 +502,7 @@ async function runHostedLinqDeliveryTransaction<T>(
 
 export function buildHostedAiUsageGateNoticeIdempotencyKey(input: {
   memberId: string;
+  noticeCode?: string;
   periodStart: Date | string;
   usageCreditLedgerVersion: bigint;
 }): string {
@@ -520,6 +522,9 @@ export function buildHostedAiUsageGateNoticeIdempotencyKey(input: {
         periodStart: periodStart.toISOString(),
         usageCreditLedgerVersion: input.usageCreditLedgerVersion.toString(),
       };
+  if (input.noticeCode === "thread_usage_low") {
+    Object.assign(capacityEpoch, { noticeCode: input.noticeCode });
+  }
   return `ai-usage-gate:${sha256Hex(JSON.stringify(capacityEpoch)).slice(0, 32)}`;
 }
 

--- a/apps/web/src/lib/hosted-onboarding/personal-usage-credit-eligibility.ts
+++ b/apps/web/src/lib/hosted-onboarding/personal-usage-credit-eligibility.ts
@@ -65,11 +65,7 @@ export async function readHostedPersonalUsageCreditOfferCodes(input: {
   memberId: string;
   prisma?: HostedOnboardingReadClient;
 }): Promise<HostedUsageCreditOfferCode[]> {
-  const priceIdsByOffer =
-    getHostedOnboardingEnvironment().stripeUsageCreditPriceIdsByOffer;
-  const configuredOfferCodes = HOSTED_USAGE_CREDIT_OFFER_CODES.filter(
-    (offerCode) => Boolean(priceIdsByOffer[offerCode]),
-  );
+  const configuredOfferCodes = readHostedConfiguredUsageCreditOfferCodes();
   if (configuredOfferCodes.length === 0) {
     return [];
   }
@@ -105,4 +101,12 @@ export async function readHostedPersonalUsageCreditOfferCodes(input: {
   }
 
   return configuredOfferCodes;
+}
+
+export function readHostedConfiguredUsageCreditOfferCodes(): HostedUsageCreditOfferCode[] {
+  const priceIdsByOffer =
+    getHostedOnboardingEnvironment().stripeUsageCreditPriceIdsByOffer;
+  return HOSTED_USAGE_CREDIT_OFFER_CODES.filter(
+    (offerCode) => Boolean(priceIdsByOffer[offerCode]),
+  );
 }

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion.ts
@@ -148,6 +148,9 @@ export async function assertHostedUsageCreditPurchasesReadyForAccountDeletionTx(
       const detached = await prisma.hostedUsageCreditPurchase.updateMany({
         data: {
           payerMemberId: null,
+          reconciliationVersion: {
+            increment: 1n,
+          },
           stripeChargeIdEncrypted: null,
           stripeCheckoutSessionIdEncrypted: null,
           stripeCheckoutUrlEncrypted: null,

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion.ts
@@ -32,6 +32,7 @@ import {
   reconstructHostedUsageCreditStripeCheckoutRequest,
   requireHostedUsageCreditEncryptedValue,
   requireHostedUsageCreditLookupKey,
+  requireHostedUsageCreditPurchasePayerMemberId,
   retrieveAndExpireHostedUsageCreditStripeSession,
 } from "./usage-credit-purchase-stripe";
 import { getPrisma } from "../prisma";
@@ -55,6 +56,7 @@ export async function closeHostedUsageCreditPurchasesForAccountDeletion(input: {
 
   for (const listedPurchase of purchases) {
     const purchase = await prepareHostedUsageCreditPurchaseForAccountDeletion({
+      memberIds,
       prisma,
       purchase: listedPurchase,
     });
@@ -99,6 +101,7 @@ export async function closeHostedUsageCreditPurchasesForAccountDeletion(input: {
 export async function assertHostedUsageCreditPurchasesReadyForAccountDeletionTx(
   input: {
     memberIds: readonly string[];
+    now?: Date;
     prisma?: HostedOnboardingReadClient;
   },
 ): Promise<void> {
@@ -111,6 +114,7 @@ export async function assertHostedUsageCreditPurchasesReadyForAccountDeletionTx(
   const purchases = await prisma.hostedUsageCreditPurchase.findMany({
     select: {
       beneficiaryMemberId: true,
+      id: true,
       lastReconciledAt: true,
       paidAt: true,
       payerMemberId: true,
@@ -119,8 +123,11 @@ export async function assertHostedUsageCreditPurchasesReadyForAccountDeletionTx(
       stripeChargeLookupKey: true,
       stripeCheckoutSessionIdEncrypted: true,
       stripeCheckoutSessionLookupKey: true,
+      stripeCheckoutUrlEncrypted: true,
+      stripeCustomerIdEncrypted: true,
       stripePaymentIntentIdEncrypted: true,
       stripePaymentIntentLookupKey: true,
+      stripePriceIdEncrypted: true,
       terminalAt: true,
     },
     where: buildHostedUsageCreditAccountDeletionScope(memberIds),
@@ -132,6 +139,38 @@ export async function assertHostedUsageCreditPurchasesReadyForAccountDeletionTx(
     });
     if (!isHostedUsageCreditPurchaseSafeForAccountDeletion(purchase)) {
       throw buildHostedUsageCreditAccountDeletionUnresolvedError();
+    }
+    if (
+      purchase.payerMemberId
+      && memberIds.includes(purchase.payerMemberId)
+      && !memberIds.includes(purchase.beneficiaryMemberId)
+    ) {
+      const detached = await prisma.hostedUsageCreditPurchase.updateMany({
+        data: {
+          payerMemberId: null,
+          stripeChargeIdEncrypted: null,
+          stripeCheckoutSessionIdEncrypted: null,
+          stripeCheckoutUrlEncrypted: null,
+          stripeCustomerIdEncrypted: null,
+          stripePaymentIntentIdEncrypted: null,
+          stripePriceIdEncrypted: null,
+          updatedAt: input.now ?? new Date(),
+        },
+        where: {
+          id: purchase.id,
+          payerMemberId: purchase.payerMemberId,
+          status: {
+            in: [
+              HostedUsageCreditPurchaseStatus.expired,
+              HostedUsageCreditPurchaseStatus.fulfilled,
+              HostedUsageCreditPurchaseStatus.payment_failed,
+            ],
+          },
+        },
+      });
+      if (detached.count !== 1) {
+        throw buildHostedUsageCreditAccountDeletionUnresolvedError();
+      }
     }
   }
 }
@@ -152,10 +191,13 @@ async function resolveHostedUsageCreditStripeSessionForAccountDeletion(input: {
       message: "Usage-credit checkout is temporarily unavailable.",
     });
   }
+  const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+    input.purchase,
+  );
 
   const sessionId = await decryptHostedUsageCreditPurchaseStripeField({
     field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutSessionId,
-    payerMemberId: input.purchase.payerMemberId,
+    payerMemberId,
     prisma: input.prisma,
     value: input.purchase.stripeCheckoutSessionIdEncrypted,
   });
@@ -285,25 +327,46 @@ async function findHostedUsageCreditStripeSessionForExpiredAttempt(input: {
 }
 
 async function prepareHostedUsageCreditPurchaseForAccountDeletion(input: {
+  memberIds: readonly string[];
   prisma: PrismaClient;
   purchase: HostedUsageCreditPurchase;
 }): Promise<HostedUsageCreditPurchase> {
   return input.prisma.$transaction(async (tx) => {
-    await lockHostedMemberRow(tx, input.purchase.payerMemberId);
+    const ownedMemberIds = [
+      input.purchase.beneficiaryMemberId,
+      input.purchase.payerMemberId,
+    ].filter(
+      (memberId): memberId is string =>
+        memberId !== null && input.memberIds.includes(memberId),
+    );
+    for (const memberId of [...new Set(ownedMemberIds)].sort()) {
+      await lockHostedMemberRow(tx, memberId);
+    }
     const current = await tx.hostedUsageCreditPurchase.findUnique({
       where: { id: input.purchase.id },
     });
-    if (!current || current.payerMemberId !== input.purchase.payerMemberId) {
+    if (!current) {
       throw buildHostedUsageCreditAccountDeletionUnresolvedError();
     }
-    const member = await tx.hostedMember.findUnique({
-      select: {
-        suspendedAt: true,
-      },
-      where: { id: current.payerMemberId },
+    assertHostedUsageCreditPurchaseHasCurrentAccountDeletionOwnership({
+      memberIds: input.memberIds,
+      purchase: current,
     });
-    if (!member?.suspendedAt) {
-      throw buildHostedUsageCreditAccountDeletionUnresolvedError();
+    const currentOwnedMemberIds = [
+      current.beneficiaryMemberId,
+      current.payerMemberId,
+    ].filter(
+      (memberId): memberId is string =>
+        memberId !== null && input.memberIds.includes(memberId),
+    );
+    for (const memberId of [...new Set(currentOwnedMemberIds)]) {
+      const member = await tx.hostedMember.findUnique({
+        select: { suspendedAt: true },
+        where: { id: memberId },
+      });
+      if (!member?.suspendedAt) {
+        throw buildHostedUsageCreditAccountDeletionUnresolvedError();
+      }
     }
     return current;
   }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
@@ -327,17 +390,20 @@ async function persistHostedUsageCreditAccountDeletionSessionState(input: {
     createHostedStripeCheckoutSessionLookupKey(input.session.id),
     "checkout_session",
   );
+  const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+    input.purchase,
+  );
   const [stripeCheckoutSessionIdEncrypted, stripeCheckoutUrlEncrypted] =
     await Promise.all([
       encryptHostedUsageCreditPurchaseStripeField({
         field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutSessionId,
-        payerMemberId: input.purchase.payerMemberId,
+        payerMemberId,
         prisma: input.prisma,
         value: input.session.id,
       }),
       encryptHostedUsageCreditPurchaseStripeField({
         field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutUrl,
-        payerMemberId: input.purchase.payerMemberId,
+        payerMemberId,
         prisma: input.prisma,
         value: null,
       }),
@@ -346,11 +412,11 @@ async function persistHostedUsageCreditAccountDeletionSessionState(input: {
     ? HostedUsageCreditPurchaseStatus.expired
     : HostedUsageCreditPurchaseStatus.payment_pending;
   return input.prisma.$transaction(async (tx) => {
-    await lockHostedMemberRow(tx, input.purchase.payerMemberId);
+    await lockHostedMemberRow(tx, payerMemberId);
     const current = await tx.hostedUsageCreditPurchase.findUnique({
       where: { id: input.purchase.id },
     });
-    if (!current || current.payerMemberId !== input.purchase.payerMemberId) {
+    if (!current || current.payerMemberId !== payerMemberId) {
       throw buildHostedUsageCreditAccountDeletionUnresolvedError();
     }
     if (isHostedUsageCreditPurchaseSafeForAccountDeletion(current)) {
@@ -424,11 +490,14 @@ async function persistHostedUsageCreditAccountDeletionNoSessionProof(input: {
   }
 
   return input.prisma.$transaction(async (tx) => {
-    await lockHostedMemberRow(tx, input.purchase.payerMemberId);
+    const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+      input.purchase,
+    );
+    await lockHostedMemberRow(tx, payerMemberId);
     const current = await tx.hostedUsageCreditPurchase.findUnique({
       where: { id: input.purchase.id },
     });
-    if (!current || current.payerMemberId !== input.purchase.payerMemberId) {
+    if (!current || current.payerMemberId !== payerMemberId) {
       throw buildHostedUsageCreditAccountDeletionUnresolvedError();
     }
     if (isHostedUsageCreditPurchaseSafeForAccountDeletion(current)) {
@@ -500,8 +569,11 @@ function assertHostedUsageCreditPurchaseHasCurrentAccountDeletionOwnership(input
   >;
 }): void {
   if (
-    input.purchase.payerMemberId !== input.purchase.beneficiaryMemberId ||
-    !input.memberIds.includes(input.purchase.payerMemberId)
+    !input.memberIds.includes(input.purchase.beneficiaryMemberId)
+    && (
+      input.purchase.payerMemberId === null
+      || !input.memberIds.includes(input.purchase.payerMemberId)
+    )
   ) {
     throw buildHostedUsageCreditAccountDeletionUnresolvedError();
   }
@@ -511,18 +583,53 @@ function isHostedUsageCreditPurchaseSafeForAccountDeletion(input: Pick<
   HostedUsageCreditPurchase,
   | "lastReconciledAt"
   | "paidAt"
+  | "payerMemberId"
   | "status"
   | "stripeChargeIdEncrypted"
   | "stripeChargeLookupKey"
   | "stripeCheckoutSessionIdEncrypted"
   | "stripeCheckoutSessionLookupKey"
+  | "stripeCheckoutUrlEncrypted"
+  | "stripeCustomerIdEncrypted"
   | "stripePaymentIntentIdEncrypted"
   | "stripePaymentIntentLookupKey"
+  | "stripePriceIdEncrypted"
   | "terminalAt"
 >): boolean {
   if (!input.lastReconciledAt || !input.terminalAt) {
     return false;
   }
+
+  if (input.payerMemberId === null) {
+    const privateReferencesCleared =
+      input.stripeChargeIdEncrypted === null
+      && input.stripeCheckoutSessionIdEncrypted === null
+      && input.stripeCheckoutUrlEncrypted === null
+      && input.stripeCustomerIdEncrypted === null
+      && input.stripePaymentIntentIdEncrypted === null
+      && input.stripePriceIdEncrypted === null;
+    if (!privateReferencesCleared) {
+      return false;
+    }
+    switch (input.status) {
+      case HostedUsageCreditPurchaseStatus.expired:
+        return true;
+      case HostedUsageCreditPurchaseStatus.payment_failed:
+        return input.stripeCheckoutSessionLookupKey !== null;
+      case HostedUsageCreditPurchaseStatus.fulfilled:
+        return Boolean(
+          input.paidAt
+          && input.stripeChargeLookupKey
+          && input.stripeCheckoutSessionLookupKey
+          && input.stripePaymentIntentLookupKey,
+        );
+      case HostedUsageCreditPurchaseStatus.created:
+      case HostedUsageCreditPurchaseStatus.checkout_open:
+      case HostedUsageCreditPurchaseStatus.payment_pending:
+        return false;
+    }
+  }
+
   const hasSessionProof = Boolean(
     input.stripeCheckoutSessionIdEncrypted &&
     input.stripeCheckoutSessionLookupKey,

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-service.ts
@@ -12,8 +12,12 @@ import {
   createHostedStripePriceLookupKey,
 } from "./contact-privacy";
 import { hostedOnboardingError, isHostedOnboardingError } from "./errors";
+import { ensureHostedMemberStripeCustomer } from "./hosted-member-stripe-customer";
 import { readHostedMemberStripeBillingRef } from "./hosted-member-billing-store";
-import { readHostedPersonalUsageCreditOfferCodes } from "./personal-usage-credit-eligibility";
+import {
+  readHostedConfiguredUsageCreditOfferCodes,
+  readHostedPersonalUsageCreditOfferCodes,
+} from "./personal-usage-credit-eligibility";
 import {
   requireHostedOnboardingPublicBaseUrl,
   requireHostedStripeApiMode,
@@ -48,7 +52,14 @@ import {
   reconstructHostedUsageCreditStripeCheckoutRequest,
   requireHostedUsageCreditEncryptedValue,
   requireHostedUsageCreditLookupKey,
+  requireHostedUsageCreditPurchasePayerMemberId,
 } from "./usage-credit-purchase-stripe";
+import {
+  buildHostedGroupUsageFundingPath,
+  normalizeHostedGroupUsageJoinCode,
+  readHostedGroupUsageFundingTargetByJoinCode,
+} from "../hosted-groups/group-usage-funding";
+import { hasHostedRuntimeActiveAccessForUpdateTx } from "../hosted-mailbox/runtime-access";
 import { generateHostedRandomPrefixedId } from "../primitives";
 import { getPrisma } from "../prisma";
 
@@ -91,6 +102,19 @@ export interface HostedUsageCreditCheckoutRequest {
   clientRequestKey: string;
   offerCode: HostedUsageCreditOfferCode;
 }
+
+type HostedUsageCreditCheckoutTarget =
+  | {
+      beneficiaryMemberId: string;
+      kind: "personal";
+      payerMemberId: string;
+    }
+  | {
+      beneficiaryMemberId: string;
+      joinCode: string;
+      kind: "group";
+      payerMemberId: string;
+    };
 
 export function parseHostedUsageCreditCheckoutRequest(
   value: Record<string, unknown>,
@@ -142,72 +166,175 @@ export async function createHostedUsageCreditCheckout(input: {
   offerCode: HostedUsageCreditOfferCode;
   prisma?: PrismaClient;
 }): Promise<HostedUsageCreditCheckoutResult> {
+  return createHostedUsageCreditCheckoutForTarget({
+    clientRequestKey: input.clientRequestKey,
+    now: input.now,
+    offerCode: input.offerCode,
+    prisma: input.prisma,
+    target: {
+      beneficiaryMemberId: input.memberId,
+      kind: "personal",
+      payerMemberId: input.memberId,
+    },
+  });
+}
+
+export async function createHostedGroupUsageCreditCheckout(input: {
+  clientRequestKey: string;
+  joinCode: string;
+  now?: Date;
+  offerCode: HostedUsageCreditOfferCode;
+  payerMemberId: string;
+  prisma?: PrismaClient;
+}): Promise<HostedUsageCreditCheckoutResult> {
+  const prisma = input.prisma ?? getPrisma();
+  const joinCode = normalizeHostedGroupUsageJoinCode(input.joinCode);
+  const fundingTarget = joinCode
+    ? await readHostedGroupUsageFundingTargetByJoinCode({ joinCode, prisma })
+    : null;
+  if (!fundingTarget) {
+    throw buildHostedUsageCreditNotEligibleError("group");
+  }
+  const stripeCustomerId = await ensureHostedMemberStripeCustomer({
+    memberId: input.payerMemberId,
+    prisma,
+  });
+
+  return createHostedUsageCreditCheckoutForTarget({
+    clientRequestKey: input.clientRequestKey,
+    groupStripeCustomerId: stripeCustomerId,
+    now: input.now,
+    offerCode: input.offerCode,
+    prisma,
+    target: {
+      beneficiaryMemberId: fundingTarget.runtimeMemberId,
+      joinCode: fundingTarget.joinCode,
+      kind: "group",
+      payerMemberId: input.payerMemberId,
+    },
+  });
+}
+
+async function createHostedUsageCreditCheckoutForTarget(input: {
+  clientRequestKey: string;
+  groupStripeCustomerId?: string;
+  now?: Date;
+  offerCode: HostedUsageCreditOfferCode;
+  prisma?: PrismaClient;
+  target: HostedUsageCreditCheckoutTarget;
+}): Promise<HostedUsageCreditCheckoutResult> {
   const prisma = input.prisma ?? getPrisma();
   const now = input.now ?? new Date();
   const resolution = await prisma.$transaction(async (tx) => {
-    await lockHostedMemberRow(tx, input.memberId);
+    await lockHostedMemberRow(tx, input.target.payerMemberId);
+    const payer = await tx.hostedMember.findUnique({
+      select: {
+        suspendedAt: true,
+        threadContainer: { select: { memberId: true } },
+      },
+      where: { id: input.target.payerMemberId },
+    });
+    if (!payer || payer.suspendedAt || payer.threadContainer) {
+      throw buildHostedUsageCreditNotEligibleError(input.target.kind);
+    }
 
     const racedExisting = await tx.hostedUsageCreditPurchase.findUnique({
       where: {
         payerMemberId_clientRequestKey: {
           clientRequestKey: input.clientRequestKey,
-          payerMemberId: input.memberId,
+          payerMemberId: input.target.payerMemberId,
         },
       },
     });
     if (racedExisting) {
       assertHostedUsageCreditRequestMatches({
-        memberId: input.memberId,
         offerCode: input.offerCode,
         purchase: racedExisting,
+        target: input.target,
       });
       return {
         purchase: racedExisting,
         recovered: false,
+        targetConflict: false,
       };
     }
 
     await closeExpiredUnattachedHostedUsageCreditPurchasesTx({
       now,
-      payerMemberId: input.memberId,
+      payerMemberId: input.target.payerMemberId,
       tx,
     });
 
     const existingActive = await tx.hostedUsageCreditPurchase.findFirst({
       where: {
-        payerMemberId: input.memberId,
+        payerMemberId: input.target.payerMemberId,
         status: {
           in: [...HOSTED_USAGE_CREDIT_NONTERMINAL_PURCHASE_STATUSES],
         },
       },
     });
     if (existingActive) {
+      if (hostedUsageCreditTargetMatches({
+        purchase: existingActive,
+        target: input.target,
+      })) {
+        return {
+          purchase: existingActive,
+          recovered: true,
+          targetConflict: false,
+        };
+      }
       return {
         purchase: existingActive,
         recovered: true,
+        targetConflict: true,
       };
     }
 
-    const authorizedOfferCodes =
-      await readHostedPersonalUsageCreditOfferCodes({
-        memberId: input.memberId,
+    let authorizedOfferCodes: HostedUsageCreditOfferCode[];
+    let stripeCustomerId: string;
+    if (input.target.kind === "personal") {
+      authorizedOfferCodes = await readHostedPersonalUsageCreditOfferCodes({
+        memberId: input.target.payerMemberId,
         prisma: tx,
       });
-    if (!authorizedOfferCodes.includes(input.offerCode)) {
-      throw buildHostedUsageCreditNotEligibleError();
-    }
-
-    const billingRef = await readHostedMemberStripeBillingRef({
-      memberId: input.memberId,
-      prisma: tx,
-    });
-    const stripeCustomerId = billingRef?.stripeCustomerId;
-    if (!stripeCustomerId || !billingRef?.stripeSubscriptionId) {
-      throw hostedOnboardingError({
-        code: "HOSTED_USAGE_CREDIT_BILLING_NOT_READY",
-        httpStatus: 409,
-        message: "Your subscription is not ready for usage-credit checkout yet.",
+      const billingRef = await readHostedMemberStripeBillingRef({
+        memberId: input.target.payerMemberId,
+        prisma: tx,
       });
+      if (!billingRef?.stripeCustomerId || !billingRef.stripeSubscriptionId) {
+        throw hostedOnboardingError({
+          code: "HOSTED_USAGE_CREDIT_BILLING_NOT_READY",
+          httpStatus: 409,
+          message: "Your subscription is not ready for usage-credit checkout yet.",
+        });
+      }
+      stripeCustomerId = billingRef.stripeCustomerId;
+    } else {
+      const fundingTargets = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "group"."id"
+        FROM "hosted_group" AS "group"
+        INNER JOIN "hosted_thread_container" AS "container"
+          ON "container"."member_id" = "group"."runtime_member_id"
+        WHERE "group"."join_code" = ${input.target.joinCode}
+          AND "group"."runtime_member_id" = ${input.target.beneficiaryMemberId}
+        FOR SHARE OF "group", "container"
+      `;
+      if (
+        fundingTargets.length !== 1
+        || !(await hasHostedRuntimeActiveAccessForUpdateTx(
+          input.target.beneficiaryMemberId,
+          { prisma: tx },
+        ))
+        || !input.groupStripeCustomerId
+      ) {
+        throw buildHostedUsageCreditNotEligibleError("group");
+      }
+      authorizedOfferCodes = readHostedConfiguredUsageCreditOfferCodes();
+      stripeCustomerId = input.groupStripeCustomerId;
+    }
+    if (!authorizedOfferCodes.includes(input.offerCode)) {
+      throw buildHostedUsageCreditNotEligibleError(input.target.kind);
     }
 
     const checkoutConfig = requireHostedStripeUsageCreditCheckoutConfig({
@@ -223,22 +350,24 @@ export async function createHostedUsageCreditCheckout(input: {
       outcome: "success",
       publicBaseUrl,
       purchaseId,
+      target: input.target,
     });
     const checkoutCancelUrl = buildHostedUsageCreditCheckoutReturnUrl({
       outcome: "cancel",
       publicBaseUrl,
       purchaseId,
+      target: input.target,
     });
     const [stripePriceIdEncrypted, stripeCustomerIdEncrypted] = await Promise.all([
       encryptHostedUsageCreditPurchaseStripeField({
         field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.priceId,
-        payerMemberId: input.memberId,
+        payerMemberId: input.target.payerMemberId,
         prisma: tx,
         value: checkoutConfig.priceId,
       }),
       encryptHostedUsageCreditPurchaseStripeField({
         field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.customerId,
-        payerMemberId: input.memberId,
+        payerMemberId: input.target.payerMemberId,
         prisma: tx,
         value: stripeCustomerId,
       }),
@@ -254,7 +383,7 @@ export async function createHostedUsageCreditCheckout(input: {
 
     const created = await tx.hostedUsageCreditPurchase.create({
       data: {
-        beneficiaryMemberId: input.memberId,
+        beneficiaryMemberId: input.target.beneficiaryMemberId,
         cashAmountMinor: offer.cashAmountMinor,
         cashCurrency: offer.cashCurrency,
         checkoutCancelUrl,
@@ -265,7 +394,7 @@ export async function createHostedUsageCreditCheckout(input: {
         grantUsdMicros: offer.grantUsdMicros,
         id: purchaseId,
         offerCode: offer.code,
-        payerMemberId: input.memberId,
+        payerMemberId: input.target.payerMemberId,
         status: HostedUsageCreditPurchaseStatus.created,
         stripeCustomerIdEncrypted: requireHostedUsageCreditEncryptedValue(
           stripeCustomerIdEncrypted,
@@ -285,6 +414,7 @@ export async function createHostedUsageCreditCheckout(input: {
     return {
       purchase: created,
       recovered: false,
+      targetConflict: false,
     };
   }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
 
@@ -294,9 +424,11 @@ export async function createHostedUsageCreditCheckout(input: {
       prisma,
       purchase: resolution.purchase,
     });
-    return resolution.recovered
-      ? { ...checkout, recovered: true }
-      : checkout;
+    return {
+      ...checkout,
+      ...(resolution.recovered ? { recovered: true as const } : {}),
+      ...(resolution.targetConflict ? { targetConflict: true as const } : {}),
+    };
   } catch (error) {
     if (
       resolution.recovered &&
@@ -315,6 +447,7 @@ export async function createHostedUsageCreditCheckout(input: {
       return {
         ...checkout,
         recovered: true,
+        ...(resolution.targetConflict ? { targetConflict: true as const } : {}),
         ...(canRetryHostedUsageCreditCheckoutCreate({ now, purchase })
           ? { retryAllowed: true as const }
           : {}),
@@ -392,7 +525,7 @@ async function continueHostedUsageCreditCheckout(input: {
     session,
   });
   await assertHostedUsageCreditCheckoutCanBeReturned({
-    memberId: purchase.payerMemberId,
+    memberId: requireHostedUsageCreditPurchasePayerMemberId(purchase),
     prisma: input.prisma,
   });
 
@@ -407,12 +540,20 @@ async function prepareHostedUsageCreditPurchaseForCheckout(input: {
   prisma: PrismaClient;
   purchase: HostedUsageCreditPurchase;
 }): Promise<HostedUsageCreditPurchase> {
+  const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+    input.purchase,
+  );
   return input.prisma.$transaction(async (tx) => {
-    await lockHostedMemberRow(tx, input.purchase.payerMemberId);
+    await lockHostedMemberRow(tx, payerMemberId);
     const current = await tx.hostedUsageCreditPurchase.findUnique({
       where: { id: input.purchase.id },
     });
-    if (!current || current.payerMemberId !== input.purchase.payerMemberId) {
+    if (
+      !current
+      || current.payerMemberId !== payerMemberId
+      || current.offerCode !== input.purchase.offerCode
+      || current.beneficiaryMemberId !== input.purchase.beneficiaryMemberId
+    ) {
       throw buildHostedUsageCreditPurchaseNotFoundError();
     }
     const member = await tx.hostedMember.findUnique({
@@ -422,11 +563,9 @@ async function prepareHostedUsageCreditPurchaseForCheckout(input: {
     if (!member || member.suspendedAt) {
       throw buildHostedUsageCreditNotEligibleError();
     }
-    assertHostedUsageCreditRequestMatches({
-      memberId: input.purchase.payerMemberId,
-      offerCode: parseHostedUsageCreditOfferCode(input.purchase.offerCode),
-      purchase: current,
-    });
+    if (!parseHostedUsageCreditOfferCode(input.purchase.offerCode)) {
+      throw buildHostedUsageCreditPurchaseNotFoundError();
+    }
 
     if (
       current.status === HostedUsageCreditPurchaseStatus.created &&
@@ -483,24 +622,27 @@ async function bindHostedUsageCreditCheckoutSession(input: {
   purchase: HostedUsageCreditPurchase;
   session: Stripe.Checkout.Session;
 }): Promise<HostedUsageCreditPurchase> {
+  const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+    input.purchase,
+  );
   const sessionLookupKey = requireHostedUsageCreditLookupKey(
     createHostedStripeCheckoutSessionLookupKey(input.session.id),
     "checkout_session",
   );
 
   return input.prisma.$transaction(async (tx) => {
-    await lockHostedMemberRow(tx, input.purchase.payerMemberId);
+    await lockHostedMemberRow(tx, payerMemberId);
     const current = await tx.hostedUsageCreditPurchase.findUnique({
       where: { id: input.purchase.id },
     });
-    if (!current || current.payerMemberId !== input.purchase.payerMemberId) {
+    if (!current || current.payerMemberId !== payerMemberId) {
       throw buildHostedUsageCreditPurchaseNotFoundError();
     }
 
     if (current.stripeCheckoutSessionLookupKey) {
       const currentSessionId = await decryptHostedUsageCreditPurchaseStripeField({
         field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutSessionId,
-        payerMemberId: current.payerMemberId,
+        payerMemberId,
         prisma: tx,
         value: current.stripeCheckoutSessionIdEncrypted,
       });
@@ -518,13 +660,13 @@ async function bindHostedUsageCreditCheckoutSession(input: {
       await Promise.all([
         encryptHostedUsageCreditPurchaseStripeField({
           field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutSessionId,
-          payerMemberId: current.payerMemberId,
+          payerMemberId,
           prisma: tx,
           value: input.session.id,
         }),
         encryptHostedUsageCreditPurchaseStripeField({
           field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutUrl,
-          payerMemberId: current.payerMemberId,
+          payerMemberId,
           prisma: tx,
           value: input.session.url,
         }),
@@ -569,28 +711,31 @@ function buildHostedUsageCreditCheckoutReturnUrl(input: {
   outcome: "cancel" | "success";
   publicBaseUrl: string;
   purchaseId: string;
+  target: HostedUsageCreditCheckoutTarget;
 }): string {
-  const url = new URL("/settings", input.publicBaseUrl);
+  const url = new URL(
+    input.target.kind === "personal"
+      ? "/settings"
+      : buildHostedGroupUsageFundingPath(input.target.joinCode),
+    input.publicBaseUrl,
+  );
   url.searchParams.set("usageCheckout", input.outcome);
   url.searchParams.set("usagePurchase", input.purchaseId);
-  url.hash = "subscription";
+  if (input.target.kind === "personal") {
+    url.hash = "subscription";
+  }
   return url.toString();
 }
 
 function assertHostedUsageCreditRequestMatches(input: {
-  memberId: string;
   offerCode: HostedUsageCreditOfferCode | null;
   purchase: Pick<
     HostedUsageCreditPurchase,
     "beneficiaryMemberId" | "offerCode" | "payerMemberId"
   >;
+  target: HostedUsageCreditCheckoutTarget;
 }): void {
-  if (
-    !input.offerCode ||
-    input.purchase.offerCode !== input.offerCode ||
-    input.purchase.payerMemberId !== input.memberId ||
-    input.purchase.beneficiaryMemberId !== input.memberId
-  ) {
+  if (!hostedUsageCreditRequestMatches(input)) {
     throw hostedOnboardingError({
       code: "HOSTED_USAGE_CREDIT_REQUEST_KEY_CONFLICT",
       httpStatus: 409,
@@ -599,10 +744,40 @@ function assertHostedUsageCreditRequestMatches(input: {
   }
 }
 
-function buildHostedUsageCreditNotEligibleError() {
+function hostedUsageCreditTargetMatches(input: {
+  purchase: Pick<
+    HostedUsageCreditPurchase,
+    "beneficiaryMemberId" | "payerMemberId"
+  >;
+  target: HostedUsageCreditCheckoutTarget;
+}): boolean {
+  return input.purchase.payerMemberId === input.target.payerMemberId
+    && input.purchase.beneficiaryMemberId === input.target.beneficiaryMemberId;
+}
+
+function hostedUsageCreditRequestMatches(input: {
+  offerCode: HostedUsageCreditOfferCode | null;
+  purchase: Pick<
+    HostedUsageCreditPurchase,
+    "beneficiaryMemberId" | "offerCode" | "payerMemberId"
+  >;
+  target: HostedUsageCreditCheckoutTarget;
+}): boolean {
+  return Boolean(
+    input.offerCode
+    && input.purchase.offerCode === input.offerCode
+    && hostedUsageCreditTargetMatches(input)
+  );
+}
+
+function buildHostedUsageCreditNotEligibleError(
+  kind: HostedUsageCreditCheckoutTarget["kind"] = "personal",
+) {
   return hostedOnboardingError({
     code: "HOSTED_USAGE_CREDIT_NOT_ELIGIBLE",
     httpStatus: 403,
-    message: "Usage credit is available for active paid Pulse or Edge plans.",
+    message: kind === "group"
+      ? "Usage credit is not available for this group."
+      : "Usage credit is available for active paid Pulse or Edge plans.",
   });
 }

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-status-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-status-service.ts
@@ -22,6 +22,7 @@ import {
   decryptHostedUsageCreditPurchaseStripeField,
   HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS,
   projectHostedUsageCreditStripeSessionState,
+  requireHostedUsageCreditPurchasePayerMemberId,
   retrieveAndExpireHostedUsageCreditStripeSession,
 } from "./usage-credit-purchase-stripe";
 import { getPrisma } from "../prisma";
@@ -47,6 +48,7 @@ export interface HostedUsageCreditCheckoutResult {
   restartAt?: string;
   retryAllowed?: true;
   status: HostedUsageCreditPublicPurchaseStatus;
+  targetConflict?: true;
   url?: string;
 }
 
@@ -64,6 +66,7 @@ export interface HostedActiveUsageCreditPurchaseProjection
 }
 
 export async function readHostedUsageCreditPurchaseStatus(input: {
+  beneficiaryMemberId?: string;
   payerMemberId: string;
   prisma?: HostedOnboardingReadClient;
   purchaseId: string;
@@ -80,6 +83,9 @@ export async function readHostedUsageCreditPurchaseStatus(input: {
       status: true,
     },
     where: {
+      ...(input.beneficiaryMemberId
+        ? { beneficiaryMemberId: input.beneficiaryMemberId }
+        : {}),
       id: input.purchaseId,
       payerMemberId: input.payerMemberId,
     },
@@ -92,6 +98,7 @@ export async function readHostedUsageCreditPurchaseStatus(input: {
 }
 
 export async function readHostedActiveUsageCreditPurchaseForPayer(input: {
+  beneficiaryMemberId?: string;
   now?: Date;
   payerMemberId: string;
   prisma?: HostedOnboardingReadClient;
@@ -120,6 +127,9 @@ export async function readHostedActiveUsageCreditPurchaseForPayer(input: {
           status: HostedUsageCreditPurchaseStatus.created,
         },
       ],
+      ...(input.beneficiaryMemberId
+        ? { beneficiaryMemberId: input.beneficiaryMemberId }
+        : {}),
       payerMemberId: input.payerMemberId,
     },
   });
@@ -130,6 +140,9 @@ export async function readHostedActiveUsageCreditPurchaseForPayer(input: {
   const offerCode = parseHostedUsageCreditOfferCode(purchase.offerCode);
   if (!offerCode) {
     throw buildHostedUsageCreditInvariantError("purchase_offer_invalid");
+  }
+  if (!purchase.payer) {
+    throw buildHostedUsageCreditInvariantError("purchase_payer_missing");
   }
   const checkout = purchase.payer.suspendedAt
     ? buildHostedUsageCreditPurchaseStatusResult(purchase)
@@ -188,7 +201,7 @@ export async function expireHostedUsageCreditCheckout(input: {
 
   const sessionId = await decryptHostedUsageCreditPurchaseStripeField({
     field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutSessionId,
-    payerMemberId: purchase.payerMemberId,
+    payerMemberId: input.payerMemberId,
     prisma,
     value: purchase.stripeCheckoutSessionIdEncrypted,
   });
@@ -236,7 +249,7 @@ export async function expireHostedUsageCreditCheckout(input: {
 
     const currentSessionId = await decryptHostedUsageCreditPurchaseStripeField({
       field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutSessionId,
-      payerMemberId: current.payerMemberId,
+      payerMemberId: input.payerMemberId,
       prisma: tx,
       value: current.stripeCheckoutSessionIdEncrypted,
     });
@@ -309,7 +322,7 @@ export async function projectHostedUsageCreditCheckoutResult(input: {
 
   const url = await decryptHostedUsageCreditPurchaseStripeField({
     field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutUrl,
-    payerMemberId: input.purchase.payerMemberId,
+    payerMemberId: requireHostedUsageCreditPurchasePayerMemberId(input.purchase),
     prisma: input.prisma,
     value: input.purchase.stripeCheckoutUrlEncrypted,
   });

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-stripe.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-stripe.ts
@@ -146,16 +146,19 @@ export async function reconstructHostedUsageCreditStripeCheckoutRequest(input: {
     throw buildHostedUsageCreditInvariantError("checkout_policy_mismatch");
   }
 
+  const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+    input.purchase,
+  );
   const [priceId, stripeCustomerId] = await Promise.all([
     decryptHostedUsageCreditPurchaseStripeField({
       field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.priceId,
-      payerMemberId: input.purchase.payerMemberId,
+      payerMemberId,
       prisma: input.prisma,
       value: input.purchase.stripePriceIdEncrypted,
     }),
     decryptHostedUsageCreditPurchaseStripeField({
       field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.customerId,
-      payerMemberId: input.purchase.payerMemberId,
+      payerMemberId,
       prisma: input.prisma,
       value: input.purchase.stripeCustomerIdEncrypted,
     }),
@@ -179,6 +182,15 @@ export async function reconstructHostedUsageCreditStripeCheckoutRequest(input: {
     purchaseId: input.purchase.id,
     stripeCustomerId,
   });
+}
+
+export function requireHostedUsageCreditPurchasePayerMemberId(
+  purchase: Pick<HostedUsageCreditPurchase, "payerMemberId">,
+): string {
+  if (!purchase.payerMemberId) {
+    throw buildHostedUsageCreditInvariantError("purchase_payer_missing");
+  }
+  return purchase.payerMemberId;
 }
 
 function buildHostedUsageCreditStripeCheckoutRequest(input: {

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts
@@ -15,6 +15,7 @@ import { normalizeNullableString } from "./shared";
 import {
   decryptHostedUsageCreditPurchaseStripeField,
   HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS,
+  requireHostedUsageCreditPurchasePayerMemberId,
 } from "./usage-credit-purchase-stripe";
 import {
   assertHostedStripeLookupMatches,
@@ -307,11 +308,14 @@ async function prepareHostedUsageCreditFinancialSnapshotCheckout(input: {
 }): Promise<HostedUsageCreditPreparedPaidCheckout> {
   let sessionId: string | null = null;
   if (input.purchase.stripeCheckoutSessionIdEncrypted) {
+    const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+      input.purchase,
+    );
     sessionId = await runHostedUsageCreditKmsOperation({
       run: () => decryptHostedUsageCreditPurchaseStripeField({
         field:
           HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.checkoutSessionId,
-        payerMemberId: input.purchase.payerMemberId,
+        payerMemberId,
         prisma: input.prisma,
         signal: takeHostedUsageCreditKmsSignal(input.context),
         value: input.purchase.stripeCheckoutSessionIdEncrypted,

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation-context.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation-context.ts
@@ -300,19 +300,22 @@ export async function buildHostedUsageCreditStripePrivateReferences(input: {
   purchase: HostedUsageCreditPurchaseForReconciliation;
   sessionId: string;
 }): Promise<HostedUsageCreditStripePrivateReferences> {
+  const payerMemberId = input.purchase.payerMemberId;
   const encryptPrivateReference = (
     field: HostedUsageCreditPurchaseStripePrivateField,
     value: string | null,
   ) =>
-    runHostedUsageCreditKmsOperation({
-      run: () => encryptHostedUsageCreditPurchaseStripeField({
-        field,
-        payerMemberId: input.purchase.payerMemberId,
-        prisma: input.prisma,
-        signal: takeHostedUsageCreditKmsSignal(input.context),
-        value,
-      }),
-    });
+    payerMemberId === null
+      ? Promise.resolve(null)
+      : runHostedUsageCreditKmsOperation({
+          run: () => encryptHostedUsageCreditPurchaseStripeField({
+            field,
+            payerMemberId,
+            prisma: input.prisma,
+            signal: takeHostedUsageCreditKmsSignal(input.context),
+            value,
+          }),
+        });
   const [
     stripeCheckoutSessionIdEncrypted,
     stripePaymentIntentIdEncrypted,

--- a/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
@@ -269,6 +269,7 @@ function buildHostedWebhookLinqMessageEffectId(
   if (input.template === "ai_usage_quota" && input.claimToken) {
     return buildHostedAiUsageGateNoticeIdempotencyKey({
       memberId: input.memberId,
+      noticeCode: input.noticeCode,
       periodStart: input.claimToken.periodStart,
       usageCreditLedgerVersion: parseHostedAiUsageCreditLedgerVersion(
         input.claimToken.usageCreditLedgerVersion,
@@ -507,6 +508,7 @@ async function sendHostedLinqSideEffect(
         },
         attemptedAt,
         memberId: usageLimitPayload.memberId,
+        noticeCode: usageLimitPayload.noticeCode,
         noticeDeliveryTarget: {
           channel: "linq",
           replyToMessageId: usageLimitPayload.replyToMessageId,

--- a/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
+++ b/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
@@ -452,6 +452,7 @@ async function sendHostedRuntimeUsageDeniedNoticeForPendingConversation(input: {
       message: await projectHostedAiUsageLimitNoticeForDelivery({
         memberId: input.userId,
         message: decision.userNotice.message,
+        noticeCode: decision.userNotice.code,
         prisma: input.prisma,
       }),
       noticeCode: decision.userNotice.code,
@@ -470,8 +471,10 @@ async function sendHostedRuntimeUsageDeniedNoticeForPendingConversation(input: {
       message: await projectHostedAiUsageLimitNoticeForDelivery({
         memberId: input.userId,
         message: decision.userNotice.message,
+        noticeCode: decision.userNotice.code,
         prisma: input.prisma,
       }),
+      noticeCode: decision.userNotice.code,
       periodStart: decision.periodStart,
       prisma: input.prisma,
       replyToMessageId: wake.message.telegramMessage.messageId,

--- a/apps/web/src/lib/hosted-privacy/account-data-service.ts
+++ b/apps/web/src/lib/hosted-privacy/account-data-service.ts
@@ -669,6 +669,7 @@ export async function deleteHostedAccountData(input: {
     });
     await assertHostedUsageCreditPurchasesReadyForAccountDeletionTx({
       memberIds: transactionDeletionMemberIds,
+      now: deletionStartedAt,
       prisma: tx,
     });
     await assertHostedPhoneCallsReadyForAccountDeletionTx({
@@ -914,7 +915,6 @@ function buildHostedUsageCreditEntryDeletionWhere(
     OR: [
       { beneficiaryMemberId: memberIdFilter },
       { purchase: { beneficiaryMemberId: memberIdFilter } },
-      { purchase: { payerMemberId: memberIdFilter } },
     ],
   };
 }
@@ -922,12 +922,7 @@ function buildHostedUsageCreditEntryDeletionWhere(
 function buildHostedUsageCreditPurchaseDeletionWhere(
   memberIdFilter: string | { in: string[] },
 ): Prisma.HostedUsageCreditPurchaseWhereInput {
-  return {
-    OR: [
-      { beneficiaryMemberId: memberIdFilter },
-      { payerMemberId: memberIdFilter },
-    ],
-  };
+  return { beneficiaryMemberId: memberIdFilter };
 }
 
 function buildHostedLinqInviteSignupDeliveryWhere(

--- a/apps/web/test/hosted-account-data-service.test.ts
+++ b/apps/web/test/hosted-account-data-service.test.ts
@@ -406,17 +406,13 @@ describe("deleteHostedAccountData", () => {
           OR: [
             { beneficiaryMemberId: "member_123" },
             { purchase: { beneficiaryMemberId: "member_123" } },
-            { purchase: { payerMemberId: "member_123" } },
           ],
         },
       },
       {
         model: "hostedUsageCreditPurchase",
         where: {
-          OR: [
-            { beneficiaryMemberId: "member_123" },
-            { payerMemberId: "member_123" },
-          ],
+          beneficiaryMemberId: "member_123",
         },
       },
     ]));

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -1379,6 +1379,27 @@ describe("accountHostedAiUsageForAllowanceTx", () => {
     });
   });
 
+  it("returns one coarse low-usage notice when a thread crosses 20% remaining", async () => {
+    const tx = createAllowanceTx({
+      executeRaw: vi.fn<AllowanceExecuteRaw>(async () => 1),
+      hostedAiUsageUpdateMany: vi.fn(async () => ({ count: 1 })),
+      spentUsdMicros: 3_599_948n,
+      threadContainerLimitUsdMicros: 4_500_000n,
+    });
+
+    await expect(accountHostedAiUsageForAllowanceTx({
+      memberId: "member_123",
+      now: new Date("2026-03-29T12:00:05.000Z"),
+      record: BASE_USAGE_RECORD,
+      tx: tx as never,
+    })).resolves.toMatchObject({
+      userNotice: {
+        code: "thread_usage_low",
+        message: expect.not.stringMatching(/\$|USD|https?:\/\//u),
+      },
+    });
+  });
+
   it("accounts a worker-built transcription record with duration pricing", async () => {
     const updateMany = vi.fn(async () => ({ count: 1 }));
     const executeRaw = vi.fn<AllowanceExecuteRaw>(async () => 1);

--- a/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
+++ b/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
@@ -113,6 +113,37 @@ describe("hosted usage-limit notice claim authority", () => {
     });
   });
 
+  it("rechecks low group capacity under the route-authorized claim", async () => {
+    claimMocks.readHostedMemberRoutingState.mockResolvedValue({
+      linqChatId: "linq_chat_current",
+    });
+
+    await expect(startAuthorizedHostedAiUsageLimitNoticeDispatchTx({
+      attemptedAt,
+      memberId: "member_group_runtime",
+      noticeCode: "thread_usage_low",
+      noticeDeliveryTarget: {
+        channel: "linq",
+        replyToMessageId: "linq_message_1",
+        routeAuthority: null,
+        target: "linq_chat_current",
+      },
+      periodStart,
+      prisma: prisma as never,
+      source: "hosted_webhook_side_effect",
+      sourceRef: "usage_event_low_1",
+      targetKind: "thread",
+      usageCreditLedgerVersion: 4n,
+    })).resolves.toMatchObject({ status: "claimed" });
+
+    const rawSql = transaction.$queryRaw.mock.calls
+      .map(([strings]) => Array.from(strings as TemplateStringsArray).join(""))
+      .join("\n");
+    expect(rawSql).toContain("hosted_thread_container");
+    expect(rawSql).toContain('"blocked_at" IS NULL');
+    expect(rawSql).toContain('"limit_usd_micros" + 4');
+  });
+
   it("rejects a stale personal Linq target inside the delivery claim transaction", async () => {
     claimMocks.readHostedMemberRoutingState.mockResolvedValue({
       linqChatId: "linq_chat_new",

--- a/apps/web/test/hosted-execution-usage.test.ts
+++ b/apps/web/test/hosted-execution-usage.test.ts
@@ -190,6 +190,7 @@ describe("recordHostedAiUsageRecords", () => {
       .toHaveBeenCalledExactlyOnceWith({
         memberId: "member_123",
         message: "You hit your monthly Murph AI limit.",
+        noticeCode: "edge_usage_limit_reached",
         prisma,
       });
   });
@@ -471,6 +472,55 @@ describe("recordHostedAiUsageRecords", () => {
         sourceEventId: "turn_123.attempt-1",
       }),
     );
+  });
+
+  it("keeps low and exhausted crossings distinct within one capacity epoch", async () => {
+    const hostedAiUsageUpsert = vi.fn(
+      async (args: { create: Record<string, unknown> }) => args.create,
+    );
+    const prisma = makeUsagePrisma(hostedAiUsageUpsert);
+    allowanceMocks.accountHostedAiUsageForAllowanceTx
+      .mockResolvedValueOnce(buildUsageLimitNoticeCandidate({
+        noticeCode: "thread_usage_low",
+        noticeMessage: "This chat is running low on Murph usage.",
+        sourceUsageId: "turn_123.attempt-1",
+      }))
+      .mockResolvedValueOnce(buildUsageLimitNoticeCandidate({
+        noticeCode: "thread_usage_limit_reached",
+        noticeMessage: "Murph usage is paused for this chat.",
+        sourceUsageId: "turn_123.request-1.attempt-1",
+      }));
+
+    await recordHostedAiUsageRecordsAndSendLimitNotices({
+      accountAllowance: true,
+      noticeDeliveryTarget: {
+        channel: "linq",
+        replyToMessageId: "linq_message_usage_origin",
+        routeAuthority: {
+          channel: "linq",
+          containerMemberId: "container_member_usage_origin",
+          threadId: "linq_thread_usage_origin",
+        },
+        target: "linq_chat_usage_origin",
+      },
+      prisma: prisma as never,
+      trustedUserId: "member_123",
+      usage: [
+        BASE_USAGE_RECORD,
+        {
+          ...BASE_USAGE_RECORD,
+          providerRequestOrdinal: 1,
+          usageId: "turn_123.request-1.attempt-1",
+        },
+      ],
+    });
+
+    expect(noticeMocks.sendClaimedHostedAiUsageLimitNoticeToLinqChat)
+      .toHaveBeenCalledTimes(2);
+    expect(
+      noticeMocks.sendClaimedHostedAiUsageLimitNoticeToLinqChat.mock.calls
+        .map(([input]) => input.noticeCode),
+    ).toEqual(["thread_usage_low", "thread_usage_limit_reached"]);
   });
 
   it("passes Family-sponsored notice codes through the same crossing send path", async () => {

--- a/apps/web/test/hosted-group-funding-page.test.tsx
+++ b/apps/web/test/hosted-group-funding-page.test.tsx
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getHostedPageAuthSnapshot: vi.fn(),
+  getPrisma: vi.fn(() => ({ label: "test-prisma" })),
+  HostedUsageTopUpDialog: vi.fn((props: Record<string, unknown>) =>
+    React.createElement("div", null, `top-up:${String(props.scope)}`)
+  ),
+  readHostedActiveUsageCreditPurchaseForPayer: vi.fn(),
+  readHostedGroupUsageFundingTargetByJoinCode: vi.fn(),
+  readHostedGroupUsageStatus: vi.fn(),
+  readHostedUsageCreditPurchaseStatus: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/link", () => ({
+  default: (props: { children?: React.ReactNode; href: string }) =>
+    React.createElement("a", { href: props.href }, props.children),
+}));
+
+vi.mock("@/src/components/hosted-groups/group-funding-sign-in-button", () => ({
+  GroupFundingSignInButton: () => React.createElement("button", null, "Sign in"),
+}));
+
+vi.mock("@/src/components/settings/hosted-usage-top-up-dialog", () => ({
+  HostedUsageTopUpDialog: mocks.HostedUsageTopUpDialog,
+}));
+
+vi.mock("@/src/components/ui/badge", () => ({
+  Badge: (props: { children?: React.ReactNode }) =>
+    React.createElement("span", null, props.children),
+}));
+
+vi.mock("@/src/components/ui/button", () => ({
+  Button: (props: { children?: React.ReactNode }) =>
+    React.createElement("button", null, props.children),
+}));
+
+vi.mock("@/src/components/ui/card", () => ({
+  Card: (props: { children?: React.ReactNode }) =>
+    React.createElement("section", null, props.children),
+  CardContent: (props: { children?: React.ReactNode }) =>
+    React.createElement("div", null, props.children),
+  CardDescription: (props: { children?: React.ReactNode }) =>
+    React.createElement("p", null, props.children),
+  CardFooter: (props: { children?: React.ReactNode }) =>
+    React.createElement("footer", null, props.children),
+  CardHeader: (props: { children?: React.ReactNode }) =>
+    React.createElement("header", null, props.children),
+}));
+
+vi.mock("@/src/lib/hosted-groups/group-usage-funding", () => ({
+  readHostedGroupUsageFundingTargetByJoinCode:
+    mocks.readHostedGroupUsageFundingTargetByJoinCode,
+  readHostedGroupUsageStatus: mocks.readHostedGroupUsageStatus,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/page-auth", () => ({
+  getHostedPageAuthSnapshot: mocks.getHostedPageAuthSnapshot,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/personal-usage-credit-eligibility", () => ({
+  readHostedConfiguredUsageCreditOfferCodes: () => ["usage_5_usd"],
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/usage-credit-purchase-service", () => ({
+  readHostedActiveUsageCreditPurchaseForPayer:
+    mocks.readHostedActiveUsageCreditPurchaseForPayer,
+  readHostedUsageCreditPurchaseStatus:
+    mocks.readHostedUsageCreditPurchaseStatus,
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: mocks.getPrisma,
+}));
+
+import GroupFundingPage from "@/app/groups/fund/[joinCode]/page";
+
+const PURCHASE_ID = "hucp_abcdefghijklmnop";
+
+describe("hosted group funding page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getHostedPageAuthSnapshot.mockResolvedValue({
+      authenticatedMember: { id: "member_payer", suspendedAt: null },
+    });
+    mocks.readHostedGroupUsageFundingTargetByJoinCode.mockResolvedValue({
+      displayName: "Sunday sleep crew",
+      joinCode: "group_join_code_1234",
+      kind: "friends",
+      runtimeMemberId: "member_group_runtime",
+    });
+    mocks.readHostedGroupUsageStatus.mockResolvedValue({
+      capacityState: "low",
+      fundingUrl: "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+      periodEnd: "2026-08-01T00:00:00.000Z",
+    });
+    mocks.readHostedActiveUsageCreditPurchaseForPayer.mockResolvedValue(null);
+    mocks.readHostedUsageCreditPurchaseStatus.mockResolvedValue({
+      purchaseId: PURCHASE_ID,
+      status: "fulfilled",
+    });
+  });
+
+  it("passes a checkout return only after payer and group beneficiary validation", async () => {
+    const markup = renderToStaticMarkup(await GroupFundingPage({
+      params: Promise.resolve({ joinCode: "group_join_code_1234" }),
+      searchParams: Promise.resolve({
+        usageCheckout: "success",
+        usagePurchase: PURCHASE_ID,
+      }),
+    }));
+
+    assert.match(markup, /<h1[^>]*>Add usage to Sunday sleep crew<\/h1>/u);
+    assert.match(
+      markup,
+      /Choose a one-time usage-credit amount for this group\./u,
+    );
+    assert.match(
+      markup,
+      /The credit belongs to the group and is used only after its included usage\./u,
+    );
+    expect(mocks.readHostedUsageCreditPurchaseStatus).toHaveBeenCalledWith({
+      beneficiaryMemberId: "member_group_runtime",
+      payerMemberId: "member_payer",
+      prisma: { label: "test-prisma" },
+      purchaseId: PURCHASE_ID,
+    });
+    expect(mocks.HostedUsageTopUpDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purchaseReturn: { kind: "success", purchaseId: PURCHASE_ID },
+        scope: "group",
+      }),
+      undefined,
+    );
+  });
+
+  it("ignores a checkout return belonging to another funding target", async () => {
+    mocks.readHostedUsageCreditPurchaseStatus.mockRejectedValueOnce(
+      new Error("purchase target mismatch"),
+    );
+
+    renderToStaticMarkup(await GroupFundingPage({
+      params: Promise.resolve({ joinCode: "group_join_code_1234" }),
+      searchParams: Promise.resolve({
+        usageCheckout: "cancel",
+        usagePurchase: PURCHASE_ID,
+      }),
+    }));
+
+    expect(mocks.HostedUsageTopUpDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ purchaseReturn: null, scope: "group" }),
+      undefined,
+    );
+  });
+
+  it("fails closed when the linked runtime has no group usage projection", async () => {
+    mocks.readHostedGroupUsageStatus.mockResolvedValueOnce(null);
+
+    const markup = renderToStaticMarkup(await GroupFundingPage({
+      params: Promise.resolve({ joinCode: "group_join_code_1234" }),
+    }));
+
+    assert.match(
+      markup,
+      /<h1[^>]*>This group funding link isn&#x27;t available<\/h1>/u,
+    );
+    expect(mocks.HostedUsageTopUpDialog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   readHostedGroupByRuntimeMemberId: vi.fn(),
   readHostedGroupIdByRuntimeMemberId: vi.fn(),
   readHostedGroupMembershipsForMember: vi.fn(),
+  readHostedGroupUsageStatus: vi.fn(),
   readHostedGroupSharedDataByRuntimeMemberId: vi.fn(),
   recordHostedGroupJoinOfferTx: vi.fn(),
   releaseHostedLinqContactCardShareAttempt: vi.fn(),
@@ -116,6 +117,10 @@ vi.mock("@/src/lib/hosted-groups/group-newsletter", () => ({
 
 vi.mock("@/src/lib/hosted-groups/group-assistant-ask", () => ({
   requestHostedGroupAssistantAsk: mocks.requestHostedGroupAssistantAsk,
+}));
+
+vi.mock("@/src/lib/hosted-groups/group-usage-funding", () => ({
+  readHostedGroupUsageStatus: mocks.readHostedGroupUsageStatus,
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
@@ -254,6 +259,11 @@ describe("handleHostedRuntimeGroupTool", () => {
       }],
       truncated: false,
     });
+    mocks.readHostedGroupUsageStatus.mockResolvedValue({
+      capacityState: "low",
+      fundingUrl: "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+      periodEnd: "2026-08-01T00:00:00.000Z",
+    });
     mocks.revokeHostedGroupMemberEmailShareTx.mockResolvedValue({
       groupId: "hgrp_123",
       kind: "ok",
@@ -303,11 +313,33 @@ describe("handleHostedRuntimeGroupTool", () => {
       preflight_set_chat_avatar: "owner_active",
       read_chat_participants: "participant_aware",
       read_current: "participant_aware",
+      read_usage: "participant_aware",
       read_shared: "participant_aware",
       revoke_own_email_share: "participant_aware",
       set_chat_avatar: "owner_active",
       share_contact_card: "owner_active",
       update_display_name: "owner_active",
+    });
+  });
+
+  it("returns only coarse usage state and the first-party group funding link", async () => {
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_group_runtime",
+      request: { action: "read_usage" },
+    })).resolves.toEqual({
+      action: "read_usage",
+      result: {
+        status: "ok",
+        usage: {
+          capacityState: "low",
+          fundingUrl:
+            "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+          periodEnd: "2026-08-01T00:00:00.000Z",
+        },
+      },
+    });
+    expect(mocks.readHostedGroupUsageStatus).toHaveBeenCalledWith({
+      runtimeMemberId: "member_group_runtime",
     });
   });
 

--- a/apps/web/test/hosted-group-usage-funding-migration.test.ts
+++ b/apps/web/test/hosted-group-usage-funding-migration.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL(
+    "../prisma/migrations/20260720230000_hosted_group_usage_funding/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const contractMigrationSql = readFileSync(
+  new URL(
+    "../prisma/contract-migrations/20260720233000_hosted_group_usage_funding_invariants/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("hosted group usage funding migration", () => {
+  it("expands payer storage before enforcing detached-payer invariants", () => {
+    expect(migrationSql).toContain('"payer_member_id" DROP NOT NULL');
+    expect(migrationSql).not.toMatch(/DROP CONSTRAINT|ADD CONSTRAINT/iu);
+    expect(contractMigrationSql).toContain(
+      '"hosted_usage_credit_purchase_active_payer_required"',
+    );
+    expect(contractMigrationSql).toContain(
+      '"hosted_usage_credit_purchase_deleted_payer_ciphertext_cleared"',
+    );
+    expect(contractMigrationSql).toContain('"stripe_customer_id_encrypted" IS NULL');
+    expect(contractMigrationSql).toContain('"stripe_charge_id_encrypted" IS NULL');
+    expect(contractMigrationSql.match(/NOT VALID/gu)).toHaveLength(2);
+    expect(contractMigrationSql.match(/VALIDATE CONSTRAINT/gu)).toHaveLength(2);
+  });
+
+  it("does not add a second public funding capability", () => {
+    expect(`${migrationSql}\n${contractMigrationSql}`).not.toMatch(
+      /funding_code|funding_token/iu,
+    );
+  });
+});

--- a/apps/web/test/hosted-group-usage-funding.test.ts
+++ b/apps/web/test/hosted-group-usage-funding.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  hasHostedRuntimeActiveAccess: vi.fn(),
+  readHostedAiUsageGate: vi.fn(),
+  resolveHostedPublicBaseUrl: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/src/lib/hosted-execution/usage-allowance", () => ({
+  readHostedAiUsageGate: mocks.readHostedAiUsageGate,
+}));
+
+vi.mock("@/src/lib/hosted-mailbox/runtime-access", () => ({
+  hasHostedRuntimeActiveAccess: mocks.hasHostedRuntimeActiveAccess,
+}));
+
+vi.mock("@/src/lib/hosted-web/public-url", () => ({
+  resolveHostedPublicBaseUrl: mocks.resolveHostedPublicBaseUrl,
+}));
+
+import {
+  readHostedGroupUsageFundingTargetByJoinCode,
+  readHostedGroupUsageStatus,
+} from "@/src/lib/hosted-groups/group-usage-funding";
+
+describe("hosted group usage funding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(true);
+    mocks.resolveHostedPublicBaseUrl.mockReturnValue("https://www.withmurph.ai");
+  });
+
+  it("uses the existing opaque join code for an active group target", async () => {
+    const prisma = {
+      hostedGroup: {
+        findUnique: vi.fn(async () => ({
+          displayName: "Sunday sleep crew",
+          joinCode: "group_join_code_1234",
+          kind: "friends",
+          runtimeMemberId: "member_group_runtime",
+        })),
+      },
+      hostedThreadContainer: {
+        findUnique: vi.fn(async () => ({ memberId: "member_group_runtime" })),
+      },
+    };
+
+    await expect(readHostedGroupUsageFundingTargetByJoinCode({
+      joinCode: "group_join_code_1234",
+      prisma: prisma as never,
+    })).resolves.toEqual({
+      displayName: "Sunday sleep crew",
+      fundingPath: "/groups/fund/group_join_code_1234",
+      joinCode: "group_join_code_1234",
+      kind: "friends",
+      runtimeMemberId: "member_group_runtime",
+    });
+    expect(mocks.hasHostedRuntimeActiveAccess).toHaveBeenCalledWith(
+      "member_group_runtime",
+      { prisma },
+    );
+  });
+
+  it.each([
+    [3_000_000n, "healthy"],
+    [900_000n, "low"],
+    [0n, "exhausted"],
+  ] as const)("projects %s remaining as %s without exposing accounting", async (
+    remainingUsdMicros,
+    capacityState,
+  ) => {
+    const prisma = {
+      hostedGroup: {
+        findUnique: vi.fn(async () => ({ joinCode: "group_join_code_1234" })),
+      },
+      hostedThreadContainer: {
+        findUnique: vi.fn(async () => ({ memberId: "member_group_runtime" })),
+      },
+    };
+    mocks.readHostedAiUsageGate.mockResolvedValue({
+      allowanceSource: "thread_container",
+      allowed: remainingUsdMicros > 0n,
+      limitUsdMicros: 4_500_000n,
+      periodEnd: new Date("2026-08-01T00:00:00.000Z"),
+      reason: remainingUsdMicros > 0n ? undefined : "ai_usage_limit_exceeded",
+      remainingUsdMicros,
+    });
+
+    await expect(readHostedGroupUsageStatus({
+      prisma: prisma as never,
+      runtimeMemberId: "member_group_runtime",
+    })).resolves.toEqual({
+      capacityState,
+      fundingUrl:
+        "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+      periodEnd: "2026-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("fails closed when the group runtime is not active", async () => {
+    mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(false);
+    const prisma = {
+      hostedGroup: {
+        findUnique: vi.fn(async () => ({
+          displayName: null,
+          joinCode: "group_join_code_1234",
+          kind: "custom",
+          runtimeMemberId: "member_group_runtime",
+        })),
+      },
+      hostedThreadContainer: {
+        findUnique: vi.fn(async () => ({ memberId: "member_group_runtime" })),
+      },
+    };
+
+    await expect(readHostedGroupUsageFundingTargetByJoinCode({
+      joinCode: "group_join_code_1234",
+      prisma: prisma as never,
+    })).resolves.toBeNull();
+  });
+
+  it("fails closed when the linked runtime member is not a thread container", async () => {
+    const prisma = {
+      hostedGroup: {
+        findUnique: vi.fn(async () => ({
+          displayName: null,
+          joinCode: "group_join_code_1234",
+          kind: "custom",
+          runtimeMemberId: "member_personal",
+        })),
+      },
+      hostedThreadContainer: {
+        findUnique: vi.fn(async () => null),
+      },
+    };
+
+    await expect(readHostedGroupUsageFundingTargetByJoinCode({
+      joinCode: "group_join_code_1234",
+      prisma: prisma as never,
+    })).resolves.toBeNull();
+  });
+});

--- a/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
@@ -62,6 +62,24 @@ describe("hosted Linq observability stores", () => {
     expect(buildCurrentAiUsageNoticeKey(2n)).toBe(replenishedKey);
   });
 
+  it("keeps low and exhausted notices distinct without changing legacy limit keys", () => {
+    const limitKey = buildCurrentAiUsageNoticeKey();
+    const lowKey = buildHostedAiUsageGateNoticeIdempotencyKey({
+      memberId: AI_USAGE_NOTICE_MEMBER_ID,
+      noticeCode: "thread_usage_low",
+      periodStart: AI_USAGE_NOTICE_PERIOD_START,
+      usageCreditLedgerVersion: 0n,
+    });
+
+    expect(lowKey).not.toBe(limitKey);
+    expect(buildHostedAiUsageGateNoticeIdempotencyKey({
+      memberId: AI_USAGE_NOTICE_MEMBER_ID,
+      noticeCode: "thread_usage_limit_reached",
+      periodStart: AI_USAGE_NOTICE_PERIOD_START,
+      usageCreditLedgerVersion: 0n,
+    })).toBe(limitKey);
+  });
+
   it("keeps non-contact observability ids stable when the contact-privacy keyring rotates", () => {
     const restoreV1 = configureHostedContactPrivacyKeyringForTest({
       currentVersion: "v1",

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -862,6 +862,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260716220000_hosted_growth_snapshot_message_counts",
       "20260718090000_hosted_vault_share_projection_snapshot",
       "20260720150000_clinical_retrieval_plan",
+      "20260720230000_hosted_group_usage_funding",
       "migration_lock.toml",
     ]);
     expect(hostedMailboxSubscriptionActionClaimMigrationSql).toContain(

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -743,6 +743,7 @@ describe("hosted orchestration reconciliation facts", () => {
     expect(mocks.projectHostedAiUsageLimitNoticeForDelivery).toHaveBeenCalledWith({
       memberId: MEMBER_ID,
       message: deniedDecision.userNotice.message,
+      noticeCode: deniedDecision.userNotice.code,
       prisma: expect.objectContaining({ kind: "prisma" }),
     });
   });
@@ -780,6 +781,7 @@ describe("hosted orchestration reconciliation facts", () => {
     expect(mocks.sendClaimedHostedAiUsageLimitNoticeToTelegramThread).toHaveBeenCalledWith({
       memberId: MEMBER_ID,
       message: deniedDecision.userNotice.message,
+      noticeCode: deniedDecision.userNotice.code,
       periodStart: deniedDecision.periodStart,
       prisma: expect.objectContaining({ kind: "prisma" }),
       replyToMessageId: "7000",

--- a/apps/web/test/hosted-usage-credit-member-stripe-customer.test.ts
+++ b/apps/web/test/hosted-usage-credit-member-stripe-customer.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  bindHostedMemberStripeCustomerIdIfMissingTx: vi.fn(),
+  createHostedPulseTrialStripeCustomer: vi.fn(),
+  getPrisma: vi.fn(),
+  lockHostedMemberRow: vi.fn(),
+  readHostedMemberStripeBillingRef: vi.fn(),
+  requireHostedStripeApiMode: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-billing-store", () => ({
+  bindHostedMemberStripeCustomerIdIfMissingTx:
+    mocks.bindHostedMemberStripeCustomerIdIfMissingTx,
+  readHostedMemberStripeBillingRef: mocks.readHostedMemberStripeBillingRef,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/pulse-trial-customer", () => ({
+  createHostedPulseTrialStripeCustomer:
+    mocks.createHostedPulseTrialStripeCustomer,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
+  requireHostedStripeApiMode: mocks.requireHostedStripeApiMode,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/shared", () => ({
+  HOSTED_ONBOARDING_TRANSACTION_OPTIONS: {},
+  lockHostedMemberRow: mocks.lockHostedMemberRow,
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: mocks.getPrisma,
+}));
+
+import { ensureHostedMemberStripeCustomer } from "@/src/lib/hosted-onboarding/hosted-member-stripe-customer";
+
+describe("ensureHostedMemberStripeCustomer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireHostedStripeApiMode.mockReturnValue({ stripe: "stripe-client" });
+    mocks.createHostedPulseTrialStripeCustomer.mockResolvedValue("cus_candidate");
+  });
+
+  it("reuses an existing member customer without provider or transaction work", async () => {
+    const prisma = createPrisma();
+    mocks.readHostedMemberStripeBillingRef.mockResolvedValue({
+      stripeCustomerId: "cus_existing",
+    });
+
+    await expect(ensureHostedMemberStripeCustomer({
+      memberId: "member_payer",
+      prisma: prisma as never,
+    })).resolves.toBe("cus_existing");
+
+    expect(mocks.createHostedPulseTrialStripeCustomer).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("creates and binds one customer after locking an eligible payer", async () => {
+    const prisma = createPrisma();
+    mocks.readHostedMemberStripeBillingRef
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    mocks.bindHostedMemberStripeCustomerIdIfMissingTx.mockResolvedValue({
+      stripeCustomerId: "cus_candidate",
+    });
+
+    await expect(ensureHostedMemberStripeCustomer({
+      memberId: "member_payer",
+      prisma: prisma as never,
+    })).resolves.toBe("cus_candidate");
+
+    expect(mocks.createHostedPulseTrialStripeCustomer).toHaveBeenCalledWith({
+      memberId: "member_payer",
+      stripe: "stripe-client",
+    });
+    expect(mocks.lockHostedMemberRow).toHaveBeenCalledWith(
+      prisma.tx,
+      "member_payer",
+    );
+    expect(mocks.bindHostedMemberStripeCustomerIdIfMissingTx).toHaveBeenCalledWith({
+      memberId: "member_payer",
+      stripeCustomerId: "cus_candidate",
+      tx: prisma.tx,
+    });
+  });
+
+  it("uses a customer that won the lock race instead of rebinding", async () => {
+    const prisma = createPrisma();
+    mocks.readHostedMemberStripeBillingRef
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ stripeCustomerId: "cus_race_winner" });
+
+    await expect(ensureHostedMemberStripeCustomer({
+      memberId: "member_payer",
+      prisma: prisma as never,
+    })).resolves.toBe("cus_race_winner");
+
+    expect(mocks.bindHostedMemberStripeCustomerIdIfMissingTx).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the payer becomes suspended before binding", async () => {
+    const prisma = createPrisma({ suspendedAt: new Date("2026-07-20T12:00:00.000Z") });
+    mocks.readHostedMemberStripeBillingRef.mockResolvedValueOnce(null);
+
+    await expect(ensureHostedMemberStripeCustomer({
+      memberId: "member_payer",
+      prisma: prisma as never,
+    })).rejects.toMatchObject({
+      code: "HOSTED_USAGE_CREDIT_PAYER_NOT_ELIGIBLE",
+      httpStatus: 403,
+    });
+    expect(mocks.bindHostedMemberStripeCustomerIdIfMissingTx).not.toHaveBeenCalled();
+  });
+});
+
+function createPrisma(memberOverride: Record<string, unknown> = {}) {
+  const tx = {
+    hostedMember: {
+      findUnique: vi.fn(async () => ({
+        suspendedAt: null,
+        threadContainer: null,
+        ...memberOverride,
+      })),
+    },
+  };
+  const prisma = {
+    tx,
+    $transaction: vi.fn(async (
+      callback: (transaction: typeof tx) => Promise<unknown>,
+    ) => callback(tx)),
+  };
+  return prisma;
+}

--- a/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 
-import type { Prisma, PrismaClient } from "@prisma/client";
+import {
+  HostedUsageCreditPurchaseStatus,
+  type Prisma,
+  type PrismaClient,
+} from "@prisma/client";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,6 +13,8 @@ import {
   readHostedUsageCreditProjection,
   settleHostedUsageCreditForUsageTx,
 } from "@/src/lib/hosted-execution/usage-credits";
+import { assertHostedUsageCreditPurchasesReadyForAccountDeletionTx } from "@/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion";
+import { bindHostedUsageCreditStripeReferencesTx } from "@/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation-context";
 import { createPrismaClient } from "@/src/lib/prisma";
 
 const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
@@ -33,6 +39,7 @@ type UsageCreditFixture = {
   beneficiaryMemberId: string;
   firstClient: PrismaClient;
   observer: PrismaClient;
+  payerMemberId: string;
   purchaseId: string;
   secondClient: PrismaClient;
   thirdClient: PrismaClient;
@@ -51,13 +58,18 @@ function createDeferred<T = void>(): Deferred<T> {
   return { promise, resolve };
 }
 
-async function createUsageCreditFixture(): Promise<UsageCreditFixture> {
+async function createUsageCreditFixture(input: {
+  terminalCrossOwner?: boolean;
+} = {}): Promise<UsageCreditFixture> {
   if (!databaseUrl) {
     throw new Error("DATABASE_URL is required for the PostgreSQL concurrency proof.");
   }
 
   const fixtureId = randomUUID();
   const beneficiaryMemberId = `member_usage_credit_lock_${fixtureId}`;
+  const payerMemberId = input.terminalCrossOwner
+    ? `member_usage_credit_payer_${fixtureId}`
+    : beneficiaryMemberId;
   const purchaseId = `hucp_usage_credit_lock_${fixtureId}`;
   const observer = createPrismaClient({ databaseUrl, poolMax: 1 });
   const firstClient = createPrismaClient({ databaseUrl, poolMax: 1 });
@@ -70,6 +82,14 @@ async function createUsageCreditFixture(): Promise<UsageCreditFixture> {
       id: beneficiaryMemberId,
     },
   });
+  if (payerMemberId !== beneficiaryMemberId) {
+    await observer.hostedMember.create({
+      data: {
+        billingStatus: "active",
+        id: payerMemberId,
+      },
+    });
+  }
   await observer.hostedUsageCreditPurchase.create({
     data: {
       beneficiaryMemberId,
@@ -83,7 +103,23 @@ async function createUsageCreditFixture(): Promise<UsageCreditFixture> {
       grantUsdMicros: 5_000_000n,
       id: purchaseId,
       offerCode: "usage_5_usd",
-      payerMemberId: beneficiaryMemberId,
+      payerMemberId,
+      ...(input.terminalCrossOwner
+        ? {
+            lastReconciledAt: new Date("2026-07-16T12:05:00.000Z"),
+            paidAt: new Date("2026-07-16T12:05:00.000Z"),
+            remainingCreditUsdMicros: 5_000_000n,
+            status: HostedUsageCreditPurchaseStatus.fulfilled,
+            stripeChargeIdEncrypted: `encrypted-charge:${fixtureId}`,
+            stripeChargeLookupKey: `charge-lookup:${fixtureId}`,
+            stripeCheckoutSessionIdEncrypted: `encrypted-session:${fixtureId}`,
+            stripeCheckoutSessionLookupKey: `session-lookup:${fixtureId}`,
+            stripeCheckoutUrlEncrypted: `encrypted-url:${fixtureId}`,
+            stripePaymentIntentIdEncrypted: `encrypted-payment-intent:${fixtureId}`,
+            stripePaymentIntentLookupKey: `payment-intent-lookup:${fixtureId}`,
+            terminalAt: new Date("2026-07-16T12:05:00.000Z"),
+          }
+        : {}),
       stripeCustomerIdEncrypted: `encrypted-customer:${fixtureId}`,
       stripeCustomerLookupKey: `customer-lookup:${fixtureId}`,
       stripeLiveMode: false,
@@ -96,6 +132,7 @@ async function createUsageCreditFixture(): Promise<UsageCreditFixture> {
     beneficiaryMemberId,
     firstClient,
     observer,
+    payerMemberId,
     purchaseId,
     secondClient,
     thirdClient,
@@ -113,7 +150,14 @@ async function cleanupUsageCreditFixture(
       where: { beneficiaryMemberId: fixture.beneficiaryMemberId },
     });
     await fixture.observer.hostedMember.deleteMany({
-      where: { id: fixture.beneficiaryMemberId },
+      where: {
+        id: {
+          in: [...new Set([
+            fixture.beneficiaryMemberId,
+            fixture.payerMemberId,
+          ])],
+        },
+      },
     });
   } finally {
     await Promise.all([
@@ -453,6 +497,101 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           deletionTransaction,
           ...(grantTransaction ? [grantTransaction] : []),
         ]);
+        await cleanupUsageCreditFixture(fixture);
+      }
+    });
+
+    it("rejects payer-era Stripe references after cross-owner detachment", async () => {
+      const fixture = await createUsageCreditFixture({ terminalCrossOwner: true });
+      const preparedAt = new Date("2026-07-16T12:06:00.000Z");
+      const preparedVersion = 0n;
+      const payerEraReferences = {
+        stripeChargeIdEncrypted: "encrypted:prepared-charge",
+        stripeChargeLookupKey: "charge-lookup:prepared",
+        stripeCheckoutSessionIdEncrypted: "encrypted:prepared-session",
+        stripeCheckoutSessionLookupKey: "session-lookup:prepared",
+        stripePaymentIntentIdEncrypted: "encrypted:prepared-payment-intent",
+        stripePaymentIntentLookupKey: "payment-intent-lookup:prepared",
+      };
+
+      try {
+        await fixture.firstClient.$transaction(async (tx) => {
+          await assertHostedUsageCreditPurchasesReadyForAccountDeletionTx({
+            memberIds: [fixture.payerMemberId],
+            now: preparedAt,
+            prisma: tx,
+          });
+          await tx.hostedMember.delete({
+            where: { id: fixture.payerMemberId },
+          });
+        }, transactionOptions);
+
+        await expect(fixture.secondClient.$transaction(async (tx) =>
+          bindHostedUsageCreditStripeReferencesTx({
+            expectedReconciliationVersion: preparedVersion,
+            lastReconciledAt: preparedAt,
+            privateReferences: payerEraReferences,
+            purchaseId: fixture.purchaseId,
+            tx,
+          }), transactionOptions)
+        ).rejects.toThrow(
+          "Usage-credit purchase changed before Stripe references were bound.",
+        );
+
+        await expect(fixture.observer.hostedUsageCreditPurchase.findUniqueOrThrow({
+          select: {
+            payerMemberId: true,
+            reconciliationVersion: true,
+            stripeChargeIdEncrypted: true,
+            stripeChargeLookupKey: true,
+            stripeCheckoutSessionIdEncrypted: true,
+            stripePaymentIntentIdEncrypted: true,
+          },
+          where: { id: fixture.purchaseId },
+        })).resolves.toMatchObject({
+          payerMemberId: null,
+          reconciliationVersion: 1n,
+          stripeChargeIdEncrypted: null,
+          stripeCheckoutSessionIdEncrypted: null,
+          stripePaymentIntentIdEncrypted: null,
+        });
+
+        await fixture.thirdClient.$transaction((tx) =>
+          bindHostedUsageCreditStripeReferencesTx({
+            expectedReconciliationVersion: 1n,
+            lastReconciledAt: new Date("2026-07-16T12:07:00.000Z"),
+            privateReferences: {
+              ...payerEraReferences,
+              stripeChargeIdEncrypted: null,
+              stripeCheckoutSessionIdEncrypted: null,
+              stripePaymentIntentIdEncrypted: null,
+            },
+            purchaseId: fixture.purchaseId,
+            tx,
+          }), transactionOptions);
+
+        await expect(fixture.observer.hostedUsageCreditPurchase.findUniqueOrThrow({
+          select: {
+            payerMemberId: true,
+            reconciliationVersion: true,
+            stripeChargeIdEncrypted: true,
+            stripeChargeLookupKey: true,
+            stripeCheckoutSessionIdEncrypted: true,
+            stripePaymentIntentIdEncrypted: true,
+          },
+          where: { id: fixture.purchaseId },
+        })).resolves.toEqual({
+          payerMemberId: null,
+          reconciliationVersion: 2n,
+          stripeChargeIdEncrypted: null,
+          stripeChargeLookupKey: "charge-lookup:prepared",
+          stripeCheckoutSessionIdEncrypted: null,
+          stripePaymentIntentIdEncrypted: null,
+        });
+        await expect(fixture.observer.hostedUsageCreditEntry.count({
+          where: { beneficiaryMemberId: fixture.beneficiaryMemberId },
+        })).resolves.toBe(0);
+      } finally {
         await cleanupUsageCreditFixture(fixture);
       }
     });

--- a/apps/web/test/hosted-usage-credit-purchase-service.test.ts
+++ b/apps/web/test/hosted-usage-credit-purchase-service.test.ts
@@ -26,9 +26,13 @@ const mocks = vi.hoisted(() => ({
   encryptHostedWebNullableString: vi.fn(async (input: { value?: string | null }) =>
     input.value ? `encrypted:${input.value}` : null
   ),
+  ensureHostedMemberStripeCustomer: vi.fn(),
   getPrisma: vi.fn(),
+  hasHostedRuntimeActiveAccessForUpdateTx: vi.fn(),
   lockHostedMemberRow: vi.fn(async () => {}),
   readHostedPersonalUsageCreditOfferCodes: vi.fn(),
+  readHostedConfiguredUsageCreditOfferCodes: vi.fn(),
+  readHostedGroupUsageFundingTargetByJoinCode: vi.fn(),
   readHostedMemberStripeBillingRef: vi.fn(),
   requireHostedOnboardingPublicBaseUrl: vi.fn(() => "https://join.example.test"),
   requireHostedStripeApiMode: vi.fn(),
@@ -60,8 +64,28 @@ vi.mock("@/src/lib/hosted-onboarding/hosted-member-billing-store", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/personal-usage-credit-eligibility", () => ({
+  readHostedConfiguredUsageCreditOfferCodes:
+    mocks.readHostedConfiguredUsageCreditOfferCodes,
   readHostedPersonalUsageCreditOfferCodes:
     mocks.readHostedPersonalUsageCreditOfferCodes,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-stripe-customer", () => ({
+  ensureHostedMemberStripeCustomer: mocks.ensureHostedMemberStripeCustomer,
+}));
+
+vi.mock("@/src/lib/hosted-groups/group-usage-funding", () => ({
+  buildHostedGroupUsageFundingPath: (joinCode: string) =>
+    `/groups/fund/${encodeURIComponent(joinCode)}`,
+  normalizeHostedGroupUsageJoinCode: (value: unknown) =>
+    typeof value === "string" && value.length >= 16 ? value : null,
+  readHostedGroupUsageFundingTargetByJoinCode:
+    mocks.readHostedGroupUsageFundingTargetByJoinCode,
+}));
+
+vi.mock("@/src/lib/hosted-mailbox/runtime-access", () => ({
+  hasHostedRuntimeActiveAccessForUpdateTx:
+    mocks.hasHostedRuntimeActiveAccessForUpdateTx,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
@@ -86,6 +110,7 @@ vi.mock("@/src/lib/prisma", () => ({
 import {
   assertHostedUsageCreditPurchasesReadyForAccountDeletionTx,
   closeHostedUsageCreditPurchasesForAccountDeletion,
+  createHostedGroupUsageCreditCheckout,
   createHostedUsageCreditCheckout,
   expireHostedUsageCreditCheckout,
   parseHostedUsageCreditCheckoutRequest,
@@ -121,6 +146,20 @@ beforeEach(() => {
     "usage_10_usd",
     "usage_25_usd",
   ]);
+  mocks.readHostedConfiguredUsageCreditOfferCodes.mockReturnValue([
+    "usage_5_usd",
+    "usage_10_usd",
+    "usage_25_usd",
+  ]);
+  mocks.ensureHostedMemberStripeCustomer.mockResolvedValue("cus_group_payer");
+  mocks.hasHostedRuntimeActiveAccessForUpdateTx.mockResolvedValue(true);
+  mocks.readHostedGroupUsageFundingTargetByJoinCode.mockResolvedValue({
+    displayName: "Sunday sleep crew",
+    fundingPath: "/groups/fund/group_join_code_1234",
+    joinCode: "group_join_code_1234",
+    kind: "friends",
+    runtimeMemberId: "member_group_runtime",
+  });
   mocks.requireHostedStripeUsageCreditCheckoutConfig.mockImplementation(
     ({ offerCode }: { offerCode: string }) => ({
       offerCode,
@@ -181,6 +220,166 @@ describe("parseHostedUsageCreditCheckoutRequest", () => {
 });
 
 describe("createHostedUsageCreditCheckout", () => {
+  it("funds the server-resolved group beneficiary without requiring a paid plan", async () => {
+    const fake = createFakePrisma();
+    mocks.getPrisma.mockReturnValue(fake.prisma);
+    mocks.stripeCheckoutCreate.mockImplementationOnce(async (request) =>
+      buildStripeSession(request)
+    );
+
+    const checkout = await createHostedGroupUsageCreditCheckout({
+      clientRequestKey: CLIENT_REQUEST_KEY,
+      joinCode: "group_join_code_1234",
+      now: NOW,
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    });
+
+    expect(checkout).toMatchObject({
+      status: "checkout_open",
+      url: "https://checkout.stripe.test/session",
+    });
+    expect(onlyPurchase(fake.purchases)).toMatchObject({
+      beneficiaryMemberId: "member_group_runtime",
+      checkoutCancelUrl: expect.stringContaining(
+        "/groups/fund/group_join_code_1234?usageCheckout=cancel",
+      ),
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+    });
+    expect(mocks.readHostedPersonalUsageCreditOfferCodes).not.toHaveBeenCalled();
+    expect(mocks.readHostedMemberStripeBillingRef).not.toHaveBeenCalled();
+    expect(mocks.ensureHostedMemberStripeCustomer).toHaveBeenCalledWith({
+      memberId: MEMBER_ID,
+      prisma: fake.prisma,
+    });
+    await expect(readHostedActiveUsageCreditPurchaseForPayer({
+      beneficiaryMemberId: "member_group_runtime",
+      now: NOW,
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    })).resolves.toMatchObject({ purchaseId: checkout.purchaseId });
+    await expect(readHostedActiveUsageCreditPurchaseForPayer({
+      beneficiaryMemberId: "member_other_group_runtime",
+      now: NOW,
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    })).resolves.toBeNull();
+  });
+
+  it("rechecks the exact group thread-container target inside checkout", async () => {
+    const fake = createFakePrisma({ groupFundingTargetLocked: false });
+
+    await expect(createHostedGroupUsageCreditCheckout({
+      clientRequestKey: CLIENT_REQUEST_KEY,
+      joinCode: "group_join_code_1234",
+      now: NOW,
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    })).rejects.toMatchObject({
+      code: "HOSTED_USAGE_CREDIT_NOT_ELIGIBLE",
+      httpStatus: 403,
+    });
+    const [[queryParts, joinCode, runtimeMemberId]] =
+      fake.prisma.$queryRaw.mock.calls;
+    const queryText = Array.from(queryParts).join("");
+    expect(queryText).toContain('INNER JOIN "hosted_thread_container" AS "container"');
+    expect(queryText).toContain(
+      '"container"."member_id" = "group"."runtime_member_id"',
+    );
+    expect(queryText).toContain('"group"."join_code" = ');
+    expect(queryText).toContain('"group"."runtime_member_id" = ');
+    expect([joinCode, runtimeMemberId]).toEqual([
+      "group_join_code_1234",
+      "member_group_runtime",
+    ]);
+    expect(fake.purchases.size).toBe(0);
+    expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled();
+  });
+
+  it("recovers only the active checkout for the same funding target", async () => {
+    const fake = createFakePrisma();
+    mocks.stripeCheckoutCreate.mockImplementationOnce(async (request) =>
+      buildStripeSession(request)
+    );
+    await createHostedGroupUsageCreditCheckout({
+      clientRequestKey: CLIENT_REQUEST_KEY,
+      joinCode: "group_join_code_1234",
+      now: NOW,
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    });
+
+    await expect(createHostedGroupUsageCreditCheckout({
+      clientRequestKey: "fresh_group_key_1234",
+      joinCode: "group_join_code_1234",
+      now: new Date(NOW.getTime() + 1_000),
+      offerCode: "usage_5_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    })).resolves.toMatchObject({ recovered: true });
+
+    mocks.readHostedGroupUsageFundingTargetByJoinCode.mockResolvedValueOnce({
+      displayName: null,
+      fundingPath: "/groups/fund/other_group_code_12",
+      joinCode: "other_group_code_12",
+      kind: "custom",
+      runtimeMemberId: "member_other_group_runtime",
+    });
+    await expect(createHostedGroupUsageCreditCheckout({
+      clientRequestKey: "other_group_key_1234",
+      joinCode: "other_group_code_12",
+      now: new Date(NOW.getTime() + 2_000),
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    })).resolves.toMatchObject({
+      recovered: true,
+      status: "checkout_open",
+      targetConflict: true,
+      url: "https://checkout.stripe.test/session",
+    });
+    expect(fake.purchases.size).toBe(1);
+  });
+
+  it("rejects request-key replay against a different group target", async () => {
+    const fake = createFakePrisma();
+    mocks.stripeCheckoutCreate.mockImplementationOnce(async (request) =>
+      buildStripeSession(request)
+    );
+    await createHostedGroupUsageCreditCheckout({
+      clientRequestKey: CLIENT_REQUEST_KEY,
+      joinCode: "group_join_code_1234",
+      now: NOW,
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    });
+
+    mocks.readHostedGroupUsageFundingTargetByJoinCode.mockResolvedValueOnce({
+      displayName: null,
+      fundingPath: "/groups/fund/other_group_code_12",
+      joinCode: "other_group_code_12",
+      kind: "custom",
+      runtimeMemberId: "member_other_group_runtime",
+    });
+    await expect(createHostedGroupUsageCreditCheckout({
+      clientRequestKey: CLIENT_REQUEST_KEY,
+      joinCode: "other_group_code_12",
+      now: new Date(NOW.getTime() + 1_000),
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    })).rejects.toMatchObject({
+      code: "HOSTED_USAGE_CREDIT_REQUEST_KEY_CONFLICT",
+      httpStatus: 409,
+    });
+    expect(fake.purchases.size).toBe(1);
+  });
+
   it("persists the purchase ambiguity fence before one-time Checkout creation", async () => {
     const fake = createFakePrisma();
     mocks.getPrisma.mockReturnValue(fake.prisma);
@@ -1038,6 +1237,53 @@ describe("expireHostedUsageCreditCheckout", () => {
 });
 
 describe("usage-credit account-deletion convergence", () => {
+  it("detaches a terminal payer and later permits the group beneficiary deletion", async () => {
+    const fake = createFakePrisma();
+    const purchase = {
+      beneficiaryMemberId: "member_group_runtime",
+      id: "hucp_group_purchase",
+      lastReconciledAt: NOW,
+      paidAt: NOW,
+      payerMemberId: MEMBER_ID,
+      status: "fulfilled",
+      stripeChargeIdEncrypted: "encrypted:charge",
+      stripeChargeLookupKey: "charge:lookup",
+      stripeCheckoutSessionIdEncrypted: "encrypted:session",
+      stripeCheckoutSessionLookupKey: "session:lookup",
+      stripeCheckoutUrlEncrypted: null,
+      stripeCustomerIdEncrypted: "encrypted:customer",
+      stripePaymentIntentIdEncrypted: "encrypted:payment-intent",
+      stripePaymentIntentLookupKey: "payment-intent:lookup",
+      stripePriceIdEncrypted: "encrypted:price",
+      terminalAt: NOW,
+      updatedAt: NOW,
+    };
+    fake.purchases.set(String(purchase.id), purchase);
+
+    await expect(assertHostedUsageCreditPurchasesReadyForAccountDeletionTx({
+      memberIds: [MEMBER_ID],
+      now: new Date(NOW.getTime() + 1_000),
+      prisma: fake.prisma as never,
+    })).resolves.toBeUndefined();
+
+    expect(purchase).toMatchObject({
+      beneficiaryMemberId: "member_group_runtime",
+      payerMemberId: null,
+      stripeChargeIdEncrypted: null,
+      stripeCheckoutSessionIdEncrypted: null,
+      stripeCustomerIdEncrypted: null,
+      stripePaymentIntentIdEncrypted: null,
+      stripePriceIdEncrypted: null,
+    });
+    expect(purchase.stripeChargeLookupKey).toBe("charge:lookup");
+    expect(purchase.stripePaymentIntentLookupKey).toBe("payment-intent:lookup");
+
+    await expect(assertHostedUsageCreditPurchasesReadyForAccountDeletionTx({
+      memberIds: ["member_group_runtime"],
+      prisma: fake.prisma as never,
+    })).resolves.toBeUndefined();
+  });
+
   it("expires a bound open Session before permitting local deletion", async () => {
     const fake = createFakePrisma();
     mocks.getPrisma.mockReturnValue(fake.prisma);
@@ -1417,6 +1663,28 @@ describe("readHostedUsageCreditPurchaseStatus", () => {
       httpStatus: 404,
     });
   });
+
+  it("does not reveal a payer's purchase for another beneficiary", async () => {
+    const fake = createFakePrisma();
+    mocks.getPrisma.mockReturnValue(fake.prisma);
+    mocks.stripeCheckoutCreate.mockRejectedValueOnce(new Error("connection lost"));
+    await expect(createHostedUsageCreditCheckout({
+      clientRequestKey: CLIENT_REQUEST_KEY,
+      memberId: MEMBER_ID,
+      now: NOW,
+      offerCode: "usage_10_usd",
+    })).rejects.toBeTruthy();
+    const purchase = onlyPurchase(fake.purchases);
+
+    await expect(readHostedUsageCreditPurchaseStatus({
+      beneficiaryMemberId: "member_other_beneficiary",
+      payerMemberId: MEMBER_ID,
+      purchaseId: String(purchase.id),
+    })).rejects.toMatchObject({
+      code: "HOSTED_USAGE_CREDIT_PURCHASE_NOT_FOUND",
+      httpStatus: 404,
+    });
+  });
 });
 
 function buildStripeSession(request: Record<string, unknown>) {
@@ -1503,6 +1771,7 @@ function buildStripeSessionFromPurchase(purchase: Record<string, unknown>) {
 }
 
 function createFakePrisma(input: {
+  groupFundingTargetLocked?: boolean;
   memberOverride?: Record<string, unknown>;
 } = {}) {
   const purchases = new Map<string, Record<string, unknown>>();
@@ -1592,7 +1861,13 @@ function createFakePrisma(input: {
   };
   const prisma = {
     hostedMember,
+    hostedGroup: {
+      findUnique: vi.fn(async () => ({ runtimeMemberId: "member_group_runtime" })),
+    },
     hostedUsageCreditPurchase,
+    $queryRaw: vi.fn(async () =>
+      input.groupFundingTargetLocked === false ? [] : [{ id: "hgrp_123" }]
+    ),
     $transaction: vi.fn(),
   };
   prisma.$transaction.mockImplementation(async (

--- a/apps/web/test/hosted-usage-credit-purchase-service.test.ts
+++ b/apps/web/test/hosted-usage-credit-purchase-service.test.ts
@@ -1248,6 +1248,7 @@ describe("usage-credit account-deletion convergence", () => {
       lastReconciledAt: NOW,
       paidAt: NOW,
       payerMemberId: MEMBER_ID,
+      reconciliationVersion: 0n,
       status: "fulfilled",
       stripeChargeIdEncrypted: "encrypted:charge",
       stripeChargeLookupKey: "charge:lookup",
@@ -1272,6 +1273,7 @@ describe("usage-credit account-deletion convergence", () => {
     expect(purchase).toMatchObject({
       beneficiaryMemberId: "member_group_runtime",
       payerMemberId: null,
+      reconciliationVersion: 1n,
       stripeChargeIdEncrypted: null,
       stripeCheckoutSessionIdEncrypted: null,
       stripeCustomerIdEncrypted: null,

--- a/apps/web/test/hosted-usage-credit-purchase-service.test.ts
+++ b/apps/web/test/hosted-usage-credit-purchase-service.test.ts
@@ -282,16 +282,19 @@ describe("createHostedUsageCreditCheckout", () => {
       code: "HOSTED_USAGE_CREDIT_NOT_ELIGIBLE",
       httpStatus: 403,
     });
-    const [[queryParts, joinCode, runtimeMemberId]] =
-      fake.prisma.$queryRaw.mock.calls;
-    const queryText = Array.from(queryParts).join("");
+    expect(fake.groupFundingQueryCalls).toHaveLength(1);
+    const queryCall = fake.groupFundingQueryCalls[0];
+    if (!queryCall) {
+      throw new Error("Expected the group funding target query to run");
+    }
+    const queryText = Array.from(queryCall.queryParts).join("");
     expect(queryText).toContain('INNER JOIN "hosted_thread_container" AS "container"');
     expect(queryText).toContain(
       '"container"."member_id" = "group"."runtime_member_id"',
     );
     expect(queryText).toContain('"group"."join_code" = ');
     expect(queryText).toContain('"group"."runtime_member_id" = ');
-    expect([joinCode, runtimeMemberId]).toEqual([
+    expect(queryCall.values).toEqual([
       "group_join_code_1234",
       "member_group_runtime",
     ]);
@@ -1774,6 +1777,10 @@ function createFakePrisma(input: {
   groupFundingTargetLocked?: boolean;
   memberOverride?: Record<string, unknown>;
 } = {}) {
+  const groupFundingQueryCalls: Array<{
+    queryParts: TemplateStringsArray;
+    values: unknown[];
+  }> = [];
   const purchases = new Map<string, Record<string, unknown>>();
   const hostedUsageCreditPurchase = {
     create: vi.fn(async (query: { data: Record<string, unknown> }) => {
@@ -1865,16 +1872,22 @@ function createFakePrisma(input: {
       findUnique: vi.fn(async () => ({ runtimeMemberId: "member_group_runtime" })),
     },
     hostedUsageCreditPurchase,
-    $queryRaw: vi.fn(async () =>
-      input.groupFundingTargetLocked === false ? [] : [{ id: "hgrp_123" }]
-    ),
+    $queryRaw: vi.fn(async (
+      queryParts: TemplateStringsArray,
+      ...values: unknown[]
+    ) => {
+      groupFundingQueryCalls.push({ queryParts, values });
+      return input.groupFundingTargetLocked === false
+        ? []
+        : [{ id: "hgrp_123" }];
+    }),
     $transaction: vi.fn(),
   };
   prisma.$transaction.mockImplementation(async (
     callback: (tx: typeof prisma) => Promise<unknown>,
   ) => callback(prisma));
 
-  return { member, prisma, purchases };
+  return { groupFundingQueryCalls, member, prisma, purchases };
 }
 
 interface PurchaseQuery {

--- a/apps/web/test/hosted-usage-credit-stripe-reconciliation.test.ts
+++ b/apps/web/test/hosted-usage-credit-stripe-reconciliation.test.ts
@@ -93,6 +93,14 @@ vi.mock("@/src/lib/hosted-onboarding/usage-credit-purchase-stripe", () => ({
     paymentIntentId: "hosted_usage_credit_purchase.stripe_payment_intent_id",
     priceId: "hosted_usage_credit_purchase.stripe_price_id",
   },
+  requireHostedUsageCreditPurchasePayerMemberId: (purchase: {
+    payerMemberId: string | null;
+  }) => {
+    if (!purchase.payerMemberId) {
+      throw new Error("payer detached");
+    }
+    return purchase.payerMemberId;
+  },
 }));
 
 import {
@@ -654,6 +662,71 @@ describe("hosted usage-credit Stripe reconciliation", () => {
       mocks.decryptStripeField.mock.calls.length +
         mocks.encryptStripeField.mock.calls.length,
     ).toBe(HOSTED_USAGE_CREDIT_STRIPE_PREPARATION_BUDGET.kmsMaxOperations);
+  });
+
+  it("reconciles a terminal refund after the payer account was detached", async () => {
+    const harness = createUsageCreditStripePrismaHarness({
+      payerMemberId: null,
+      status: HostedUsageCreditPurchaseStatus.fulfilled,
+      stripeChargeLookupKey: "stripe-billing-event:ch_usage_123",
+      stripeCheckoutSessionIdEncrypted: null,
+      stripeCheckoutSessionLookupKey:
+        "stripe-checkout-session:cs_usage_123",
+      stripePaymentIntentLookupKey: "stripe-billing-event:pi_usage_123",
+      terminalAt: new Date("2026-07-16T03:20:00.000Z"),
+    });
+    mocks.stripe.charges.retrieve.mockResolvedValue(
+      makeCharge({ amountRefunded: 250 }),
+    );
+    mocks.stripe.refunds.list.mockResolvedValue(
+      makeRefundList([makeRefund()]),
+    );
+    mockExistingUsageCreditGrant();
+
+    await expect(reconcileHostedUsageCreditStripeEvent({
+      event: makeRefundEvent(),
+      prisma: harness.client,
+    })).resolves.toMatchObject({
+      beneficiaryMemberId: "member_beneficiary",
+      handled: true,
+      purchaseId: "hucp_purchase_123",
+    });
+
+    expect(mocks.reconcileRefundNetReversal).toHaveBeenCalled();
+    expect(mocks.decryptStripeField).not.toHaveBeenCalled();
+    expect(mocks.encryptStripeField).not.toHaveBeenCalled();
+    expect(harness.purchase.payerMemberId).toBeNull();
+  });
+
+  it("reconciles a terminal dispute after the payer account was detached", async () => {
+    const harness = createUsageCreditStripePrismaHarness({
+      payerMemberId: null,
+      status: HostedUsageCreditPurchaseStatus.fulfilled,
+      stripeChargeLookupKey: "stripe-billing-event:ch_usage_123",
+      stripeCheckoutSessionIdEncrypted: null,
+      stripeCheckoutSessionLookupKey:
+        "stripe-checkout-session:cs_usage_123",
+      stripePaymentIntentLookupKey: "stripe-billing-event:pi_usage_123",
+      terminalAt: new Date("2026-07-16T03:20:00.000Z"),
+    });
+    mocks.stripe.disputes.list.mockResolvedValue(
+      makeDisputeList([makeDispute({ withdrawnAmount: 250 })]),
+    );
+    mockExistingUsageCreditGrant();
+
+    await expect(reconcileHostedUsageCreditStripeEvent({
+      event: makeDisputeEvent("charge.dispute.funds_withdrawn"),
+      prisma: harness.client,
+    })).resolves.toMatchObject({
+      beneficiaryMemberId: "member_beneficiary",
+      handled: true,
+      purchaseId: "hucp_purchase_123",
+    });
+
+    expect(mocks.reconcileDisputeNetReversal).toHaveBeenCalled();
+    expect(mocks.decryptStripeField).not.toHaveBeenCalled();
+    expect(mocks.encryptStripeField).not.toHaveBeenCalled();
+    expect(harness.purchase.payerMemberId).toBeNull();
   });
 
   it("atomically grants then reverses when a refund beats Checkout fulfillment", async () => {
@@ -1334,11 +1407,13 @@ function createUsageCreditStripePrismaHarness(
 
 function makeUsageCreditPurchase(
   overrides?: Partial<{
+    payerMemberId: string | null;
     status: HostedUsageCreditPurchaseStatus;
     stripeChargeLookupKey: string | null;
     stripeCheckoutSessionIdEncrypted: string | null;
     stripeCheckoutSessionLookupKey: string | null;
     stripePaymentIntentLookupKey: string | null;
+    terminalAt: Date | null;
   }>,
 ) {
   return {
@@ -1353,7 +1428,9 @@ function makeUsageCreditPurchase(
     grantUsdMicros: 5_000_000n,
     id: "hucp_purchase_123",
     lastReconciledAt: null as Date | null,
-    payerMemberId: "member_payer",
+    payerMemberId: overrides?.payerMemberId === undefined
+      ? "member_payer"
+      : overrides.payerMemberId,
     reconciliationVersion: 0n,
     status: overrides?.status ?? HostedUsageCreditPurchaseStatus.checkout_open,
     stripeChargeIdEncrypted: null as string | null,
@@ -1371,7 +1448,7 @@ function makeUsageCreditPurchase(
     stripePaymentIntentLookupKey:
       overrides?.stripePaymentIntentLookupKey ?? null,
     stripePriceLookupKey: "stripe-price:price_usage_5",
-    terminalAt: null as Date | null,
+    terminalAt: overrides?.terminalAt ?? null,
   };
 }
 

--- a/apps/web/test/hosted-usage-limit-notice-message.test.ts
+++ b/apps/web/test/hosted-usage-limit-notice-message.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  readHostedGroupUsageStatus: vi.fn(),
   readHostedPersonalAiUsageStatus: vi.fn(),
 }));
 
@@ -10,11 +11,61 @@ vi.mock("@/src/lib/hosted-execution/usage-status", () => ({
   readHostedPersonalAiUsageStatus: mocks.readHostedPersonalAiUsageStatus,
 }));
 
+vi.mock("@/src/lib/hosted-groups/group-usage-funding", () => ({
+  readHostedGroupUsageStatus: mocks.readHostedGroupUsageStatus,
+}));
+
 import { projectHostedAiUsageLimitNoticeForDelivery } from "@/src/lib/hosted-execution/usage-limit-notice-message";
 
 describe("projectHostedAiUsageLimitNoticeForDelivery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it.each([
+    ["low", "thread_usage_low", "This chat is running low on Murph usage."],
+    ["exhausted", "thread_usage_limit_reached", "Murph usage is paused for this chat."],
+  ] as const)("appends a first-party group funding link while the group is %s", async (
+    capacityState,
+    noticeCode,
+    message,
+  ) => {
+    const prisma = { kind: "prisma" } as never;
+    mocks.readHostedGroupUsageStatus.mockResolvedValue({
+      capacityState,
+      fundingUrl:
+        "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+      periodEnd: "2026-08-01T00:00:00.000Z",
+    });
+
+    await expect(projectHostedAiUsageLimitNoticeForDelivery({
+      memberId: "member_group_runtime",
+      message,
+      noticeCode,
+      prisma,
+    })).resolves.toBe(
+      `${message}\n\n` +
+      "Add group usage: " +
+      "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+    );
+    expect(mocks.readHostedPersonalAiUsageStatus).not.toHaveBeenCalled();
+  });
+
+  it("leaves a stale group notice unchanged after capacity recovers", async () => {
+    mocks.readHostedGroupUsageStatus.mockResolvedValue({
+      capacityState: "healthy",
+      fundingUrl:
+        "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+      periodEnd: "2026-08-01T00:00:00.000Z",
+    });
+
+    await expect(projectHostedAiUsageLimitNoticeForDelivery({
+      memberId: "member_group_runtime",
+      message: "This chat is running low on Murph usage.",
+      noticeCode: "thread_usage_low",
+      prisma: {} as never,
+    })).resolves.toBe("This chat is running low on Murph usage.");
+    expect(mocks.readHostedPersonalAiUsageStatus).not.toHaveBeenCalled();
   });
 
   it("appends the canonical first-party action only for current add-usage authority", async () => {

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -264,6 +264,48 @@ test("opens from the settings deep link without preselecting a top-up", async ()
   }
 });
 
+test("reuses the dialog state machine for a server-scoped group checkout", async () => {
+  mocks.requestHostedOnboardingJson.mockResolvedValueOnce({
+    purchaseId: "hucp_group_checkout",
+    status: "checkout_open",
+    url: "https://checkout.stripe.test/group-session",
+  });
+  const { HostedUsageTopUpDialog } = await import(
+    "@/src/components/settings/hosted-usage-top-up-dialog"
+  );
+  const rendered = await renderClientComponent(
+    createElement(HostedUsageTopUpDialog, {
+      checkoutUrl:
+        "/api/groups/fund/group_join_code_1234/usage-credit/checkout",
+      initialOpen: true,
+      offers: usageCreditOffers(),
+      scope: "group",
+    }),
+    { requireButton: false },
+  );
+
+  try {
+    assert.match(rendered.container.textContent ?? "", /Add group usage/);
+    await clickRadio(rendered.container, rendered.window, "usage_500");
+    await clickButton(
+      rendered.container,
+      rendered.window,
+      "Continue to checkout · $5",
+    );
+    expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledWith({
+      method: "POST",
+      payload: {
+        clientRequestKey: "00000000-0000-4000-8000-000000000001",
+        offerCode: "usage_500",
+      },
+      signal: expect.any(AbortSignal),
+      url: "/api/groups/fund/group_join_code_1234/usage-credit/checkout",
+    });
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
 test("opens an honest unavailable state when a deep link has no current offers", async () => {
   const { HostedUsageTopUpDialog } = await import(
     "@/src/components/settings/hosted-usage-top-up-dialog"
@@ -1291,6 +1333,83 @@ test("lets the member choose a different amount with a fresh request key", async
     ]);
     assert.equal(buttonByText(rendered.container, "Resume checkout").disabled, false);
     expect(rendered.assign).not.toHaveBeenCalled();
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("offers target-neutral recovery for an active checkout on another destination", async () => {
+  mocks.requestHostedOnboardingJson.mockImplementation(async (request: {
+    method: string;
+    url: string;
+  }) => {
+    if (request.method === "POST" && request.url.endsWith("/expire")) {
+      return {
+        purchaseId: "hucp_other_target",
+        status: "expired",
+      };
+    }
+    if (request.method === "GET") {
+      return {
+        purchaseId: "hucp_other_target",
+        status: "checkout_open",
+        url: "https://checkout.stripe.test/other-target",
+      };
+    }
+    return {
+      purchaseId: "hucp_other_target",
+      recovered: true,
+      status: "checkout_open",
+      targetConflict: true,
+      url: "https://checkout.stripe.test/other-target",
+    };
+  });
+  const { HostedUsageTopUpDialog } = await import(
+    "@/src/components/settings/hosted-usage-top-up-dialog"
+  );
+  const rendered = await renderClientComponent(
+    createElement(HostedUsageTopUpDialog, {
+      initialOpen: true,
+      offers: usageCreditOffers(),
+      scope: "group",
+    }),
+    {
+      location: { href: "https://example.test/groups/fund/group_join_code_1234" },
+      requireButton: false,
+    },
+  );
+
+  try {
+    await clickRadio(rendered.container, rendered.window, "usage_500");
+    await clickButton(rendered.container, rendered.window, "Continue to checkout · $5");
+
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Another checkout is already open/,
+    );
+    assert.match(
+      rendered.container.textContent ?? "",
+      /other usage destination/,
+    );
+    assert.equal(
+      Array.from(rendered.container.querySelectorAll("button")).some(
+        (button) => button.textContent?.trim() === "Choose a different amount",
+      ),
+      false,
+    );
+
+    await clickButton(rendered.container, rendered.window, "Cancel checkout");
+
+    expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: "/api/settings/billing/usage-credit/purchases/hucp_other_target/expire",
+      }),
+    );
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Other checkout canceled/,
+    );
   } finally {
     await rendered.cleanup();
   }

--- a/apps/web/test/settings-billing-usage-credit-routes.test.ts
+++ b/apps/web/test/settings-billing-usage-credit-routes.test.ts
@@ -5,6 +5,7 @@ import { createRouteContext } from "./route-test-helpers";
 
 const mocks = vi.hoisted(() => ({
   assertHostedOnboardingMutationOrigin: vi.fn(),
+  createHostedGroupUsageCreditCheckout: vi.fn(),
   createHostedUsageCreditCheckout: vi.fn(),
   expireHostedUsageCreditCheckout: vi.fn(),
   getPrisma: vi.fn(),
@@ -30,6 +31,8 @@ vi.mock("@/src/lib/hosted-onboarding/usage-credit-purchase-service", async (impo
   >();
   return {
     ...original,
+    createHostedGroupUsageCreditCheckout:
+      mocks.createHostedGroupUsageCreditCheckout,
     createHostedUsageCreditCheckout: mocks.createHostedUsageCreditCheckout,
     expireHostedUsageCreditCheckout: mocks.expireHostedUsageCreditCheckout,
     readHostedUsageCreditPurchaseStatus: mocks.readHostedUsageCreditPurchaseStatus,
@@ -38,6 +41,9 @@ vi.mock("@/src/lib/hosted-onboarding/usage-credit-purchase-service", async (impo
 
 type CheckoutRoute = typeof import(
   "../app/api/settings/billing/usage-credit/checkout/route"
+);
+type GroupCheckoutRoute = typeof import(
+  "../app/api/groups/fund/[joinCode]/usage-credit/checkout/route"
 );
 type StatusRoute = typeof import(
   "../app/api/settings/billing/usage-credit/purchases/[purchaseId]/route"
@@ -48,6 +54,7 @@ type ExpireRoute = typeof import(
 
 let checkoutRoute: CheckoutRoute;
 let expireRoute: ExpireRoute;
+let groupCheckoutRoute: GroupCheckoutRoute;
 let statusRoute: StatusRoute;
 
 beforeEach(async () => {
@@ -65,6 +72,11 @@ beforeEach(async () => {
     purchaseId: "hucp_abcdefghijklmnop",
     status: "checkout_open",
     url: "https://checkout.stripe.test/session",
+  });
+  mocks.createHostedGroupUsageCreditCheckout.mockResolvedValue({
+    purchaseId: "hucp_abcdefghijklmnop",
+    status: "checkout_open",
+    url: "https://checkout.stripe.test/group-session",
   });
   mocks.expireHostedUsageCreditCheckout.mockResolvedValue({
     checkoutExpiresAt: "2026-07-16T18:30:00.000Z",
@@ -85,12 +97,41 @@ beforeEach(async () => {
   expireRoute = await import(
     "../app/api/settings/billing/usage-credit/purchases/[purchaseId]/expire/route"
   );
+  groupCheckoutRoute = await import(
+    "../app/api/groups/fund/[joinCode]/usage-credit/checkout/route"
+  );
   statusRoute = await import(
     "../app/api/settings/billing/usage-credit/purchases/[purchaseId]/route"
   );
 });
 
 describe("usage-credit checkout route", () => {
+  it("resolves the group and payer only on the server", async () => {
+    const request = createCheckoutRequest({
+      clientRequestKey: "request_key_123456",
+      offerCode: "usage_10_usd",
+    }, "https://join.example.test/api/groups/fund/group_join_code_1234/usage-credit/checkout");
+    const response = await groupCheckoutRoute.POST(
+      request,
+      createRouteContext({ joinCode: "group_join_code_1234" }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "checkout_open",
+      url: "https://checkout.stripe.test/group-session",
+    });
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledWith(request);
+    expect(mocks.requireHostedAppSessionFromRequest).toHaveBeenCalledWith(request);
+    expect(mocks.createHostedGroupUsageCreditCheckout).toHaveBeenCalledWith({
+      clientRequestKey: "request_key_123456",
+      joinCode: "group_join_code_1234",
+      offerCode: "usage_10_usd",
+      payerMemberId: "hbm_member123",
+      prisma: { label: "test-prisma" },
+    });
+  });
+
   it("creates an exact server-authorized checkout for the signed-in member", async () => {
     const request = createCheckoutRequest({
       clientRequestKey: "request_key_123456",
@@ -321,9 +362,12 @@ describe("usage-credit purchase expiration route", () => {
   });
 });
 
-function createCheckoutRequest(body: Record<string, unknown>): Request {
+function createCheckoutRequest(
+  body: Record<string, unknown>,
+  url = "https://join.example.test/api/settings/billing/usage-credit/checkout",
+): Request {
   return new Request(
-    "https://join.example.test/api/settings/billing/usage-credit/checkout",
+    url,
     {
       body: JSON.stringify(body),
       headers: {

--- a/apps/web/test/settings-page.test.ts
+++ b/apps/web/test/settings-page.test.ts
@@ -632,6 +632,7 @@ test("SettingsPage reads the app session and persisted account settings into the
       prisma: mocks.prisma,
     });
     expect(mocks.readHostedActiveUsageCreditPurchaseForPayer).toHaveBeenCalledWith({
+      beneficiaryMemberId: "member_123",
       payerMemberId: "member_123",
       prisma: mocks.prisma,
     });

--- a/apps/web/test/user-facing-messages.test.ts
+++ b/apps/web/test/user-facing-messages.test.ts
@@ -19,6 +19,7 @@ const TEST_TEMPLATE_KEYS = [
   "linq.ai_usage.edge_limit_reached",
   "linq.ai_usage.family_limit_reached",
   "linq.ai_usage.pulse_upgrade_edge",
+  "linq.ai_usage.thread_low",
   "linq.ai_usage.thread_limit_reached",
 ] as const satisfies readonly UserFacingMessageTemplateKey[];
 
@@ -49,6 +50,7 @@ const TEST_CONTEXT_BY_KEY = {
   "linq.ai_usage.pulse_upgrade_edge": {
     homeUrl: "https://withmurph.ai/home",
   },
+  "linq.ai_usage.thread_low": {},
   "linq.ai_usage.thread_limit_reached": {},
 } satisfies {
   [K in UserFacingMessageTemplateKey]: UserFacingMessageContextByKey[K];
@@ -114,6 +116,18 @@ describe("user-facing message variants", () => {
     for (const text of collectRenderedTexts("linq.ai_usage.thread_limit_reached")) {
       expect(text).not.toMatch(/trial|upgrade|checkout|Edge|Pulse|top[ -]?up|payer|https?:\/\//iu);
       expect(text).toMatch(/AI usage is paused until .+ allowance resets/iu);
+    }
+  });
+
+  it("keeps low thread usage copy coarse and neutral", () => {
+    for (const text of collectRenderedTexts("linq.ai_usage.thread_low")) {
+      expect(text).toMatch(/chat|Murph usage/iu);
+      expect(text).toMatch(
+        /low|small|limited|nearly|nearing|close|almost|approach|not much/iu,
+      );
+      expect(text).not.toMatch(
+        /\$|USD|dollars?|checkout|payer|contributor|https?:\/\//iu,
+      );
     }
   });
 

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -382,6 +382,11 @@ it has been explicitly elevated to a cross-cutting invariant.
 - Safety, reliability, privacy, authentication, and review fixes preserve the
   authorized success path for existing critical flows. Disabling, silently
   dropping, or degrading the flow is a product decision, not a technical fix.
+- Purchased hosted usage credit belongs to its beneficiary, not its payer. A
+  payer deletion must first resolve nonterminal payment state and must not
+  delete fulfilled credit owned by a surviving beneficiary. Terminal
+  cross-owner purchases may detach the payer only while retaining the
+  non-secret lookup evidence required to reconcile later refunds or disputes.
 - Identity, authentication, consent, privacy, recipient, and irreversible-effect
   authority fail closed. An advisory dependency may degrade only into an
   already-authorized narrower path and never silently suppress an accepted

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -385,7 +385,8 @@ it has been explicitly elevated to a cross-cutting invariant.
 - Purchased hosted usage credit belongs to its beneficiary, not its payer. A
   payer deletion must first resolve nonterminal payment state and must not
   delete fulfilled credit owned by a surviving beneficiary. Terminal
-  cross-owner purchases may detach the payer only while retaining the
+  cross-owner purchases may detach the payer only while invalidating in-flight
+  payer-era reconciliation, clearing payer-bound ciphertext, and retaining the
   non-secret lookup evidence required to reconcile later refunds or disputes.
 - Identity, authentication, consent, privacy, recipient, and irreversible-effect
   authority fail closed. An advisory dependency may degrade only into an

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -702,6 +702,7 @@ export const MURPH_GROUP_TOOL = {
   description:
     'Use action="ask" only from a personal direct conversation when the member wants an answer from one of their joined group Murphs. Supply the bounded natural-language question and, only when useful for choosing among multiple groups, the visible groupLabel the member would recognize. For this action, the runtime resolves membership and every internal target automatically; never supply or ask the member for membership, group, runtime, mailbox, session, callback, or route identifiers. The result is asynchronous, so an accepted request will return to the personal conversation later. ' +
     'Use action="read_shared" only when current group standings or diagnostics need exact consent-aware shared facts. Request one to three exact projectionScopes. The result includes every current member and each requested scope, distinguishing not_granted from granted-but-missing data. Each participantId is scoped to this group membership and carries no account, device, provider, or route identity. On an interactive iMessage turn, currentTurnHandles may identify the exact current prompt Sender on that same row; never infer identity from names, order, data, or a global id. It resolves current authority only after this tool call; never supply sender handles, member, share, runtime, group, or route identifiers. ' +
+    'Use action="read_usage" only when the current connected group asks about its Murph usage or adding more usage. The result reports only a coarse healthy, low, or exhausted state, the current period end, and a first-party funding URL when available. Never infer or disclose internal currency accounting, contributor identity, purchase history, or payment status from this action. ' +
     'Use action="list_memberships" in a personal Murph conversation to list the current member\'s hosted groups, their opaque membershipId, role, each group\'s requested permissions, the member\'s active grants, and the first-party permissionsUrl when the member owns the group and an owner-authorized join link exists. profile-name.v0 means the group is allowed to receive the member\'s preferred name; group-email.v0 means it is allowed to resolve the member\'s verified email for group email; hrv-days.v0 and other health scopes are separate explicit grants. A grant proves control-plane permission only, not that fresh source data is available in the current Web-owned snapshot. In a personal Murph conversation, when the current member explicitly asks to leave one of their hosted groups, call list_memberships first and then call action="leave_membership" with the exact nonempty membershipId returned for the chosen group. Never guess a membershipId, accept one supplied by the user, target a group by name alone, or construct, use, or expose a join URL to leave. Do not use leave_membership in a group conversation or for another person. A successful leave ends that member\'s Murph group membership and future sharing; it does not remove them from the iMessage chat or erase historical messages, provider history, backups, or third-party copies. Owners cannot leave their own group. Use action="read_current" only for membership, group creation, join, and permission-offer operations; its roster or grant fields are not authority to read or score shared records. Request an update to both the current hosted group display name and current iMessage group chat title with action="update_display_name", request an update to the current iMessage group avatar with action="set_chat_avatar", mint the shareable group join link with action="create_join_link", or post a server-owned like-to-consent offer into the current group chat with action="post_join_offer". In a connected group-chat turn, if read_current returns status="none", no hosted group record exists yet. When the group asks to create the group, join, or approve sharing, continue with create_join_link or post_join_offer instead of claiming that an external workspace-linking step is required. When an existing group adds a permission, default to post_join_offer; do not tell members to join again or make the link the primary action. update_display_name sends a provider request for the upstream iMessage group chat title on the current route-authorized group chat and stores the same name in Murph after the provider accepts the request. set_chat_avatar sends a provider request for the upstream iMessage group icon on the current route-authorized group chat after the runtime preflights chat authority and prepares a hosted image URL; generated avatar images are saved as capture media under raw/captures/** when a vault is available. A join link grants membership and shares the joiner\'s memory-backed preferred display name with this group runtime; optional permissions stay individually selected on the join page. For post_join_offer, pass the exact projectionScopes and, only when chosen by the group, displayName. Web owns the full canonical consent copy: the exact scope disclosure, accepted Like-or-heart gestures, and first-party customize link. Never supply offer text. Liking or hearting grants membership when needed and adds only the posted permission snapshot; existing members keep their membership and other grants. When these actions are available for the current connected group-chat turn, use action="read_chat_participants" to see who is in the chat and whether each participant already uses Murph; use action="share_contact_card" to drop your contact card so participants can save you and text you directly. Use action="revoke_own_email_share" only when the current sender asks to stop receiving group newsletter email; the runtime identifies the current sender and revokes only that sender\'s group-email.v0 grant. This tool does not otherwise manage members, grant Family billing access, grant private chat access, grant raw vault access, or grant email sharing except through an explicit group-email.v0 join page or offer.',
   inputSchema: {
     type: 'object',
@@ -713,6 +714,7 @@ export const MURPH_GROUP_TOOL = {
           'ask',
           'read_shared',
           'read_current',
+          'read_usage',
           'list_memberships',
           'leave_membership',
           'update_display_name',
@@ -1336,6 +1338,11 @@ const groupArgumentsSchema = z.discriminatedUnion('action', [
   z
     .object({
       action: z.literal('read_current'),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal('read_usage'),
     })
     .strict(),
   z
@@ -4902,6 +4909,7 @@ function parseGroupArguments(
   }
   if (
     parsed.data.action === 'list_memberships'
+    || parsed.data.action === 'read_usage'
     || parsed.data.action === 'read_chat_participants'
     || parsed.data.action === 'share_contact_card'
     || parsed.data.action === 'revoke_own_email_share'

--- a/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
@@ -89,6 +89,7 @@ describe("murph.group dynamic tool", () => {
       "ask",
       "read_shared",
       "read_current",
+      "read_usage",
       "list_memberships",
       "leave_membership",
       "update_display_name",
@@ -221,6 +222,13 @@ describe("murph.group dynamic tool", () => {
   });
 
   it("parses the chat-scoped actions without accepting a model-supplied thread target", () => {
+    expect(readMurphDynamicToolRequest(groupToolCall({
+      action: "read_usage",
+    }))).toEqual({
+      kind: "group",
+      request: { action: "read_usage" },
+    });
+
     expect(readMurphDynamicToolRequest(groupToolCall({
       action: "read_chat_participants",
     }))).toEqual({

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -293,6 +293,7 @@ export function createHostedGroupToolWithLinqThreadContext(input: {
       if (
         emailIngressPresent
         && request.action !== "read_current"
+        && request.action !== "read_usage"
         && request.action !== "read_shared"
         && request.action !== "revoke_own_email_share"
       ) {
@@ -346,7 +347,13 @@ export function createHostedGroupToolWithLinqThreadContext(input: {
 function buildHostedGroupEmailRestrictedActionUnavailable(
   request: Exclude<
     HostedRuntimeGroupToolRequest,
-    { action: "read_current" | "read_shared" | "revoke_own_email_share" }
+    {
+      action:
+        | "read_current"
+        | "read_shared"
+        | "read_usage"
+        | "revoke_own_email_share";
+    }
   >,
 ): HostedRuntimeGroupToolResponse {
   const unavailableReason = "authenticated_sender_required";

--- a/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
@@ -129,6 +129,9 @@ describe("createHostedGroupToolWithLinqThreadContext", () => {
     await groupTool.request({ action: "read_current" });
     expect(request).toHaveBeenLastCalledWith({ action: "read_current" });
 
+    await groupTool.request({ action: "read_usage" });
+    expect(request).toHaveBeenLastCalledWith({ action: "read_usage" });
+
     await groupTool.request({
       action: "read_shared",
       linqSenderHandles: ["forged@example.test"],

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -1003,6 +1003,7 @@ export function parseHostedRuntimeGroupToolRequest(
   }
   if (
     action === "read_current"
+    || action === "read_usage"
     || action === "list_memberships"
   ) {
     assertAllowedObjectKeys(
@@ -1859,6 +1860,96 @@ export function parseHostedRuntimeGroupToolResponse(
           status,
           unavailableReason: requireString(result.unavailableReason, "Hosted runtime group unavailableReason"),
           group: null,
+        },
+      };
+    }
+  }
+
+  if (action === "read_usage") {
+    const result = requireObject(
+      record.result,
+      "Hosted runtime group tool read_usage response result",
+    );
+    const status = requireString(
+      result.status,
+      "Hosted runtime group tool read_usage response status",
+    );
+    if (status === "ok") {
+      assertAllowedObjectKeys(
+        result,
+        new Set(["status", "usage"]),
+        "Hosted runtime group tool read_usage ok response result",
+      );
+      const usage = requireObject(
+        result.usage,
+        "Hosted runtime group tool read_usage usage",
+      );
+      assertAllowedObjectKeys(
+        usage,
+        new Set(["capacityState", "fundingUrl", "periodEnd"]),
+        "Hosted runtime group tool read_usage usage",
+      );
+      const capacityState = requireString(
+        usage.capacityState,
+        "Hosted runtime group tool read_usage capacityState",
+      );
+      if (
+        capacityState !== "healthy"
+        && capacityState !== "low"
+        && capacityState !== "exhausted"
+      ) {
+        throw new TypeError(
+          "Hosted runtime group tool read_usage capacityState is invalid.",
+        );
+      }
+      const periodEnd = requireString(
+        usage.periodEnd,
+        "Hosted runtime group tool read_usage periodEnd",
+      );
+      const periodEndDate = new Date(periodEnd);
+      if (
+        !Number.isFinite(periodEndDate.getTime())
+        || periodEndDate.toISOString() !== periodEnd
+      ) {
+        throw new TypeError(
+          "Hosted runtime group tool read_usage periodEnd must be a canonical timestamp.",
+        );
+      }
+      return {
+        action,
+        result: {
+          status,
+          usage: {
+            capacityState,
+            fundingUrl: readNullableString(
+              usage.fundingUrl,
+              "Hosted runtime group tool read_usage fundingUrl",
+            ),
+            periodEnd,
+          },
+        },
+      };
+    }
+    if (status === "unavailable") {
+      assertAllowedObjectKeys(
+        result,
+        new Set(["status", "unavailableReason", "usage"]),
+        "Hosted runtime group tool read_usage unavailable response result",
+      );
+      if (result.usage !== null) {
+        throw new TypeError(
+          "Hosted runtime group tool read_usage unavailable usage must be null.",
+        );
+      }
+      return {
+        action,
+        result: {
+          status,
+          unavailableReason: requireString(
+            result.unavailableReason,
+            "Hosted runtime group tool read_usage unavailableReason",
+          ),
+          usage: null,
         },
       };
     }

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -883,6 +883,7 @@ export type HostedRuntimeGroupToolAction =
   | "ask"
   | "read_shared"
   | "read_current"
+  | "read_usage"
   | "list_memberships"
   | "leave_membership"
   | "update_display_name"
@@ -928,6 +929,17 @@ export interface HostedRuntimeGroupSummary {
   requestedVaultShareProjectionKinds: HostedVaultShareProjectionKind[];
   requestedVaultShareProjectionScopes: HostedVaultShareProjectionScope[];
   status: string;
+}
+
+export type HostedRuntimeGroupUsageCapacityState =
+  | "healthy"
+  | "low"
+  | "exhausted";
+
+export interface HostedRuntimeGroupUsageStatus {
+  capacityState: HostedRuntimeGroupUsageCapacityState;
+  fundingUrl: string | null;
+  periodEnd: string;
 }
 
 export const HOSTED_RUNTIME_GROUP_MEMBERSHIPS_MAX = 25;
@@ -1065,6 +1077,7 @@ export type HostedRuntimeGroupToolRequest =
       question: string;
     }
   | { action: "read_current" }
+  | { action: "read_usage" }
   | ({
       action: "read_shared";
       /** Current-turn Linq sender evidence injected by the hosted runtime. */
@@ -1116,6 +1129,12 @@ export type HostedRuntimeGroupToolResponse =
         | { status: "ok"; group: HostedRuntimeGroupSummary }
         | { status: "none"; group: null }
         | { status: "unavailable"; unavailableReason: string; group: null };
+    }
+  | {
+      action: "read_usage";
+      result:
+        | { status: "ok"; usage: HostedRuntimeGroupUsageStatus }
+        | { status: "unavailable"; unavailableReason: string; usage: null };
     }
   | {
       action: "read_shared";

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -2108,6 +2108,46 @@ describe("parseHostedRuntimeGroupTool", () => {
     ).toThrow(/not allowed/u);
   });
 
+  it("parses coarse group usage responses without accepting accounting fields", () => {
+    const response = {
+      action: "read_usage" as const,
+      result: {
+        status: "ok" as const,
+        usage: {
+          capacityState: "low" as const,
+          fundingUrl: "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+          periodEnd: "2026-08-01T00:00:00.000Z",
+        },
+      },
+    };
+    expect(parseHostedRuntimeGroupToolResponse(response)).toEqual(response);
+    expect(() => parseHostedRuntimeGroupToolResponse({
+      ...response,
+      result: {
+        ...response.result,
+        usage: {
+          ...response.result.usage,
+          remainingUsdMicros: "900000",
+        },
+      },
+    })).toThrow(/not allowed/u);
+    expect(parseHostedRuntimeGroupToolResponse({
+      action: "read_usage",
+      result: {
+        status: "unavailable",
+        unavailableReason: "group_usage_unavailable",
+        usage: null,
+      },
+    })).toEqual({
+      action: "read_usage",
+      result: {
+        status: "unavailable",
+        unavailableReason: "group_usage_unavailable",
+        usage: null,
+      },
+    });
+  });
+
   it("parses share_contact_card responses", () => {
     expect(parseHostedRuntimeGroupToolResponse({
       action: "share_contact_card",


### PR DESCRIPTION
## Why this PR exists

Hosted groups can exhaust their shared runtime usage without a direct way to add more. This adds fixed-pack funding and coarse usage awareness while keeping the existing usage ledger, Stripe webhook, messaging, and runtime gate as the only authorities.

## User goal / user-visible behavior

- An authenticated person with the current group link can add a one-time $5, $10, or $25 usage pack to that group, including when their personal account has no paid plan.
- The group assistant can report only `healthy`, `low`, or `exhausted`, the period end, and an authorized first-party funding link.
- Low-usage and exhausted notices can include the group funding link without revealing internal USD-micro accounting, payer identity, or purchase history.
- Personal usage top-ups keep their current behavior.

## User experience

The person opens `/groups/fund/[joinCode]`, signs in if needed, sees the current coarse group state, chooses a fixed pack, and continues to Stripe Checkout. Murph grants credit only after webhook reconciliation and returns to the same group page with the shared top-up dialog status. If the payer already has a checkout for another beneficiary, the dialog explains that neutral conflict and lets them resume or cancel it before starting this destination. Invalid, inactive, or stale group targets fail closed with an unavailable page.

## Invariants to preserve

- The browser submits only an offer code and request key; payer, beneficiary, Stripe Price and Customer, amount, policy, and return URLs are server-resolved.
- The exact current group-to-thread-container target and active runtime access are revalidated under database locks before purchase creation. Stripe webhooks remain the only grant authority.
- The existing append-only credit ledger, included-first FIFO settlement, allowance gate, durable delivery claim, and delivery-time runtime recheck remain authoritative.
- Fulfilled group credit belongs to the beneficiary. Deleting a contributor detaches only safely reconciled terminal purchases, advances the existing reconciliation-version fence, clears payer-bound ciphertext, retains blind lookup keys, and keeps later refunds or disputes reconcilable.
- No group wallet, separate funding token, synthetic plan-usage union, scheduler, queue, or low-usage table is added.

## Non-obvious affected surfaces

- **Personal top-up core and Settings projection:** personal and group purchases share the generalized target-aware Checkout core and dialog, so Settings now scopes active purchases to the personal beneficiary. Regression proof: route, service, Settings, and dialog suites.
- **Account deletion and Stripe financial reconciliation:** payer and beneficiary lifecycles can diverge, so terminal cross-owner purchases can detach while payment reference lookup and payerless refund/dispute reconciliation continue. Regression proof: account lifecycle, webhook reconciliation, migration constraints, and real-PostgreSQL concurrency suites.
- **Usage notice idempotency and delivery:** low and exhausted group notices use distinct capacity-epoch identities, route authorization, and delivery-time state checks. Regression proof: accounting, notice claim, message projection, Linq/Telegram delivery, and reconciliation-facts suites.
- **Runtime group-tool contract:** `read_usage` crosses assistant-engine, hosted-execution parsing, assistant-runtime wrappers, and the Web control owner. Regression proof: parser, dynamic-tool, runtime wrapper, and group-tool suites.

## Deployment skew / compatibility

1. Apply the additive expand migration, then deploy Web first.
2. Deploy Cloudflare/runner consumers after Web accepts `read_usage`; ordinary gradual container rollout is safe because old warm runners do not expose the new action. `container_rollout=immediate` is not required.
3. After old Web functions have drained, apply the post-drain contract constraints.

Before the new runner rollout, maximum exposure is zero by construction because no existing producer emits `read_usage`. During gradual rollout, old runners keep the prior behavior and new runners use the already-deployed additive Web contract. A rollback should reverse consumers first, then Web; the nullable expand schema may remain. Monitor group-tool 4xx/5xx responses, usage-notice delivery failures, Stripe reconciliation backlog, and a funded-group smoke. Existing webhook reconciliation is the bounded repair path; no new persisted repair mechanism is needed.

## Verification

- `pnpm verify:acceptance`: workspace typechecks, package coverage, 5,985 passing Web tests, 1,844 Cloudflare tests, production Next build, app lint, package boundaries, fixture coverage, and artifact guards passed.
- Focused service, route, component, contract, accounting, lifecycle, migration, and real-PostgreSQL concurrency suites passed.
- Coverage-write and Codex frontend-review passes ended with no unresolved findings. Fable was unavailable because its account had no remaining credits, so the documented Codex substitute was used.
- The local browser connector exposed no controllable target; production build plus route, responsive-state, accessibility, and dialog-recovery tests passed, but no screenshot artifact was captured.

## Change-shape breakdown

Classification: authored runtime/application files under `apps/web/{app,src}` and `packages/*/src` are source; test paths are tests/fixtures; Markdown is docs; Prisma schema and migrations are config/tooling; generated/other is separate. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1393 | 132 |
| Tests / fixtures | 1447 | 14 |
| Docs | 287 | 91 |
| Config / tooling | 56 | 4 |
| Generated / other | 0 | 0 |
| **Total** | **3183** | **241** |

## ReviewGPT remediation

Round 1 found one High-severity expand/contract race: payer deletion cleared encrypted provider references without invalidating payer-era reconciliation preparation, so an in-flight bind could restore payer-bound ciphertext after detachment. The accepted correction atomically increments the existing `reconciliationVersion` fence in the same detachment update.

Proof includes a unit test that failed before the production correction, a real-PostgreSQL transaction test that rejects the stale bind and verifies payerless retry convergence, existing payerless refund/dispute coverage, focused typecheck and lint, contract-migration validation, and full `pnpm verify:acceptance`. No anomaly retrospective is required: source churn and growth remain below the configured thresholds, and the correction adds no owner, state surface, or lifecycle machinery.

Current correction head: 5d792ceb50464a2d38ae3e0d5ad04c4319592ce4

## ReviewGPT baseline

ReviewGPT first-reviewed head: 6518bafa51b3d5a386ce505ee774ffb61420ea4e

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1390 | 132 |
| Tests / fixtures | 1288 | 9 |
| Docs | 283 | 91 |
| Config / tooling | 56 | 4 |
| Generated / other | 0 | 0 |
| **Total** | **3017** | **236** |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787199879&installation_model_id=19880&pr_number=821&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F821&signature=82e9d227d424714d3f18196e964d391dbebb074a404244f64713a6a3b4a38eb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->