### PR TITLE
Fix hosted preference propagation edge cases

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-21-preference-runtime-integrity.md
+++ b/agent-docs/exec-plans/completed/2026-07-21-preference-runtime-integrity.md
@@ -1,0 +1,55 @@
+Goal (incl. success criteria):
+- Make onboarding persona, tone, and voice saves reliably reach the hosted member vault and every applicable private assistant turn.
+- Preserve replay and rolling-deploy compatibility for previously valid persona mailbox events.
+- Keep post-commit wake handoff bounded so a stalled Temporal call cannot hang onboarding or recovery.
+- Never plan a fresh reply while an immediately due newer preference remains staged.
+
+Constraints/Assumptions:
+- Web remains the canonical projection and durable mailbox producer.
+- The hosted vault remains the canonical runtime preference owner.
+- Unknown persona IDs still fail closed; only the enumerated stored legacy IDs may normalize.
+- Preserve personal/group preference isolation and product-critical reply availability.
+
+Key decisions:
+- Normalize legacy persona IDs only at the persisted/wire compatibility boundary.
+- Reuse the existing abortable Temporal signaling seam; add no queue or state owner.
+- Apply persona style to trusted scheduled private provider turns, while retaining maintenance/output-only exclusions.
+- Yield and immediately re-enter when the bounded preference page still has due work.
+
+State:
+- Complete.
+
+Done:
+- Traced Web save through mailbox, Temporal, Cloudflare, container import, vault causal state, prompt planning, and voice resolution.
+- Verified four edge cases with static and focused-test evidence.
+- Landed legacy wire normalization, bounded wake handoff, scheduled private-turn styling, and due-backlog yielding.
+- Passed focused Web, hosted-execution, Temporal, Cloudflare, assistant-runtime, assistant-engine, contracts, and core regression suites.
+- Passed owner typechecks for Web, Cloudflare, hosted-execution, Temporal, assistant-runtime, assistant-engine, contracts, and core.
+- Passed the full canonical acceptance suite.
+- Completed the required Codex coverage audit; added proof that private persona defaults do not leak into group turns.
+- Passed canonical acceptance again after the coverage-only test addition.
+
+Now:
+- None.
+
+Next:
+- After merge, deploy the Cloudflare Worker/runner bundle before Web and verify preference-event convergence.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- packages/hosted-execution/src/parsers.ts
+- packages/hosted-execution/test/*
+- apps/web/app/api/settings/assistant-style/route.ts
+- apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
+- apps/web/test/settings-assistant-style-route.test.ts
+- apps/web/test/hosted-preference-handoff-sweeper.test.ts
+- apps/cloudflare/test/runtime-bridge-mailbox-payload-decode.test.ts
+- packages/assistant-engine/src/assistant/codex-turn/planning.ts
+- packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+- packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+- packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+Status: completed
+Updated: 2026-07-21
+Completed: 2026-07-21

--- a/apps/cloudflare/test/runtime-bridge-mailbox-payload-decode.test.ts
+++ b/apps/cloudflare/test/runtime-bridge-mailbox-payload-decode.test.ts
@@ -70,6 +70,43 @@ describe("createCloudflareHostedMailboxPayloadDecoder", () => {
     expect(call?.headers.get(HOSTED_RUNTIME_WORKSPACE_VERSION_HEADER)).toBe("9");
   });
 
+  it("normalizes persisted legacy persona ids before they enter the container runtime", async () => {
+    const decoder = createCloudflareHostedMailboxPayloadDecoder({
+      fetchImpl: async () => Response.json({
+        status: "decoded",
+        wake: {
+          eventId: "event_decode_legacy_persona",
+          kind: "member.preferences.updated",
+          occurredAt: "2026-07-07T00:00:00.000Z",
+          preferences: {
+            persona: "medical-detective",
+          },
+          userId: "member_decode",
+        },
+      }),
+      readCurrentLease: () => ({
+        attemptId: "attempt_decode",
+        leaseGeneration: "4",
+        userId: "member_decode",
+        workspaceVersion: "9",
+      }),
+      timeoutMs: 1000,
+    });
+
+    await expect(decoder.decode(createDecodeInput())).resolves.toEqual({
+      status: "decoded",
+      wake: {
+        eventId: "event_decode_legacy_persona",
+        kind: "member.preferences.updated",
+        occurredAt: "2026-07-07T00:00:00.000Z",
+        preferences: {
+          persona: "scientist",
+        },
+        userId: "member_decode",
+      },
+    });
+  });
+
   it("fails closed without a current write fence before calling fetch", async () => {
     const fetchImpl = vi.fn<typeof fetch>();
     const decoder = createCloudflareHostedMailboxPayloadDecoder({

--- a/apps/web/app/api/settings/assistant-style/route.ts
+++ b/apps/web/app/api/settings/assistant-style/route.ts
@@ -14,6 +14,10 @@ import {
   signalHostedMailboxAppendRuntime,
 } from "@/src/lib/hosted-orchestration/signal-runtime";
 import { assertHostedOnboardingMutationOrigin } from "@/src/lib/hosted-onboarding/csrf";
+import {
+  createHostedPostCommitDeadline,
+  waitForHostedPostCommitOperation,
+} from "@/src/lib/hosted-onboarding/bounded-post-commit";
 import { assertHostedMemberNotSuspended } from "@/src/lib/hosted-onboarding/entitlement";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import {
@@ -175,8 +179,15 @@ async function signalHostedMailboxAppendBestEffort(input: {
   expectedUserId: string;
   mailboxItemId: string;
 }): Promise<void> {
+  const deadlineMs = createHostedPostCommitDeadline(undefined);
   try {
-    await signalHostedMailboxAppendRuntime(input);
+    await waitForHostedPostCommitOperation({
+      deadlineMs,
+      operation: (abortSignal) => signalHostedMailboxAppendRuntime({
+        ...input,
+        abortSignal,
+      }),
+    });
   } catch {
     // The durable save succeeds even when the best-effort runtime wake is unavailable.
   }

--- a/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
+++ b/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
@@ -6,6 +6,10 @@ import {
   formatHostedExecutionSafeLogErrorDetails,
 } from "../hosted-execution/logging";
 import { hasHostedRuntimeActiveAccess } from "../hosted-mailbox/runtime-access";
+import {
+  createHostedPostCommitDeadline,
+  waitForHostedPostCommitOperation,
+} from "../hosted-onboarding/bounded-post-commit";
 import { signalHostedMailboxAppendRuntime } from "./signal-runtime";
 
 const DEFAULT_HANDOFF_LIMIT = 25;
@@ -38,6 +42,7 @@ type HostedPreferenceHandoffSweepLogger = Pick<Console, "info" | "warn">;
 
 export async function runHostedPreferenceHandoffSweeper(input: {
   hasActiveAccess?: typeof hasHostedRuntimeActiveAccess;
+  handoffTimeoutMs?: number;
   handoffLimit?: number;
   logger?: HostedPreferenceHandoffSweepLogger;
   now?: Date;
@@ -85,6 +90,7 @@ export async function runHostedPreferenceHandoffSweeper(input: {
     activeUserIds.has(candidate.userId)
   );
   const selectedCandidates = activeCandidates.slice(0, handoffLimit);
+  const handoffDeadlineMs = createHostedPostCommitDeadline(input.handoffTimeoutMs);
 
   await runWithConcurrency(
     selectedCandidates,
@@ -92,9 +98,13 @@ export async function runHostedPreferenceHandoffSweeper(input: {
     async (candidate) => {
       handoffAttempted += 1;
       try {
-        const handoff = await requestHandoff({
-          expectedUserId: candidate.userId,
-          mailboxItemId: candidate.mailboxItemId,
+        const handoff = await waitForHostedPostCommitOperation({
+          deadlineMs: handoffDeadlineMs,
+          operation: (abortSignal) => requestHandoff({
+            abortSignal,
+            expectedUserId: candidate.userId,
+            mailboxItemId: candidate.mailboxItemId,
+          }),
         });
         if (handoff.signalAccepted) {
           handoffAccepted += 1;

--- a/apps/web/test/hosted-preference-handoff-sweeper.test.ts
+++ b/apps/web/test/hosted-preference-handoff-sweeper.test.ts
@@ -258,6 +258,56 @@ describe("hosted preference handoff sweeper", () => {
     });
   });
 
+  it("retries an exact current Clinical Records wake after a hung shared handoff", async () => {
+    const store = buildStore([{
+      mailboxItemId: "mailbox_clinical_hung_retry",
+      userId: "member_clinical_hung_retry",
+    }]);
+    let handoffCalls = 0;
+    const requestHandoff = vi.fn(() => {
+      handoffCalls += 1;
+      return handoffCalls === 1
+        ? new Promise<never>(() => {})
+        : Promise.resolve({
+            signalAccepted: true as const,
+            workflowId: "hosted-user-runtime:synthetic",
+          });
+    });
+
+    await expect(runHostedPreferenceHandoffSweeper({
+      handoffTimeoutMs: 1,
+      hasActiveAccess: vi.fn(async () => true),
+      logger: buildLogger(),
+      requestHandoff,
+      store,
+    })).resolves.toMatchObject({
+      handoffAccepted: 0,
+      handoffFailed: 1,
+    });
+    await expect(runHostedPreferenceHandoffSweeper({
+      handoffTimeoutMs: 1,
+      hasActiveAccess: vi.fn(async () => true),
+      logger: buildLogger(),
+      requestHandoff,
+      store,
+    })).resolves.toMatchObject({
+      handoffAccepted: 1,
+      handoffFailed: 0,
+    });
+
+    expect(requestHandoff).toHaveBeenCalledTimes(2);
+    expect(requestHandoff).toHaveBeenNthCalledWith(1, {
+      abortSignal: expect.any(AbortSignal),
+      expectedUserId: "member_clinical_hung_retry",
+      mailboxItemId: "mailbox_clinical_hung_retry",
+    });
+    expect(requestHandoff).toHaveBeenNthCalledWith(2, {
+      abortSignal: expect.any(AbortSignal),
+      expectedUserId: "member_clinical_hung_retry",
+      mailboxItemId: "mailbox_clinical_hung_retry",
+    });
+  });
+
   it("requests one wake per user when multiple pending mailbox kinds exist", async () => {
     const requestHandoff = vi.fn(async () => ({
       signalAccepted: true as const,

--- a/apps/web/test/hosted-preference-handoff-sweeper.test.ts
+++ b/apps/web/test/hosted-preference-handoff-sweeper.test.ts
@@ -34,6 +34,7 @@ describe("hosted preference handoff sweeper", () => {
     });
 
     expect(requestHandoff).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_preference_1",
       mailboxItemId: "mailbox_preference_1",
     });
@@ -86,6 +87,32 @@ describe("hosted preference handoff sweeper", () => {
     });
 
     expect(requestHandoff).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds a hung handoff so the recovery sweep can finish", async () => {
+    const requestHandoff = vi.fn(() => new Promise<never>(() => {}));
+
+    const result = await runHostedPreferenceHandoffSweeper({
+      handoffTimeoutMs: 1,
+      hasActiveAccess: vi.fn(async () => true),
+      logger: buildLogger(),
+      requestHandoff,
+      store: buildStore([{
+        mailboxItemId: "mailbox_preference_hung",
+        userId: "member_preference_hung",
+      }]),
+    });
+
+    expect(result).toMatchObject({
+      handoffAccepted: 0,
+      handoffAttempted: 1,
+      handoffFailed: 1,
+    });
+    expect(requestHandoff).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
+      expectedUserId: "member_preference_hung",
+      mailboxItemId: "mailbox_preference_hung",
+    });
   });
 
   it("skips inactive owners and keeps each sweep bounded", async () => {
@@ -141,6 +168,7 @@ describe("hosted preference handoff sweeper", () => {
     });
 
     expect(requestHandoff).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: activeCandidate.userId,
       mailboxItemId: activeCandidate.mailboxItemId,
     });
@@ -183,6 +211,7 @@ describe("hosted preference handoff sweeper", () => {
       requestHandoff.mock.invocationCallOrder[0]!,
     );
     expect(requestHandoff).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_group_runtime",
       mailboxItemId: "mailbox_group_preference",
     });
@@ -223,6 +252,7 @@ describe("hosted preference handoff sweeper", () => {
     expect(sql).toContain('"item"."lane_seq" > COALESCE("lane_counter"."consumed_seq", 0)');
     expect(sql).toContain('"item"."expires_at" IS NULL OR "item"."expires_at" > ?');
     expect(requestHandoff).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_clinical_current",
       mailboxItemId: "mailbox_clinical_current",
     });
@@ -254,6 +284,7 @@ describe("hosted preference handoff sweeper", () => {
     expect(hasActiveAccess).toHaveBeenCalledTimes(1);
     expect(requestHandoff).toHaveBeenCalledTimes(1);
     expect(requestHandoff).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_shared",
       mailboxItemId: "mailbox_preference_shared",
     });

--- a/apps/web/test/settings-assistant-style-route.test.ts
+++ b/apps/web/test/settings-assistant-style-route.test.ts
@@ -116,6 +116,7 @@ describe("assistant style settings route", () => {
       prisma: { tx: true },
     });
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_123",
       mailboxItemId: "mailbox_item_preferences",
     });
@@ -248,6 +249,29 @@ describe("assistant style settings route", () => {
       updated: true,
     });
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
+      expectedUserId: "member_123",
+      mailboxItemId: "mailbox_item_preferences",
+    });
+  });
+
+  it("returns the durable save when the best-effort runtime signal hangs", async () => {
+    mocks.signalHostedMailboxAppendRuntime.mockReturnValue(new Promise(() => {}));
+
+    const responsePromise = route.POST(jsonRequest({
+      tone: "casual",
+    }));
+    await vi.advanceTimersByTimeAsync(5_000);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      runTriggered: true,
+      updated: true,
+    });
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_123",
       mailboxItemId: "mailbox_item_preferences",
     });

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -482,7 +482,6 @@ export async function resolveAssistantRouteTurnPlan(input: {
   const assistantVoicePreferenceApplies =
     privateInteractiveAudience || hostedGroupRuntime
   const explicitAssistantPersona = privateInteractiveProviderTurn
-    && input.input.scheduledOccurrenceAt == null
     ? preferenceContext.assistantPersona ?? null
     : null
   const effectiveAssistantStyle = explicitAssistantPersona

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -507,14 +507,14 @@ describe('assistant Codex turn planning', () => {
     expect(scheduledNewsletterPlan.systemPrompt).toContain(
       'Assistant tone preference:',
     )
-    expect(scheduledNewsletterPlan.systemPrompt).not.toContain(
+    expect(scheduledNewsletterPlan.systemPrompt).toContain(
       'Be direct, disciplined, and accountable.',
     )
     expect(scheduledNewsletterPlan.systemPrompt).toContain('Humor 10/10')
     expect(scheduledNewsletterPlan.systemPrompt).toContain('Push 10/10')
     expect(scheduledNewsletterPlan.systemPrompt).toContain('Detail 10/10')
     expect(scheduledNewsletterPlan.assistantPreferredElevenLabsVoiceId).toBe(
-      resolveAssistantVoiceOptionElevenLabsVoiceId(null),
+      resolveAssistantVoiceOptionElevenLabsVoiceId('drill-sergeant'),
     )
     expect(scheduledNewsletterPlan.dynamicTools.map((tool) => tool.name)).toEqual(
       ordinaryToolNames,
@@ -545,10 +545,10 @@ describe('assistant Codex turn planning', () => {
       session: createSession(),
       sharedPlan: createSharedPlan(),
     })
-    expect(scheduledNewsletterPlan.developerInstructions).toBe(
+    expect(scheduledNewsletterPlan.developerInstructions).not.toBe(
       scheduledWithoutPersonaPlan.developerInstructions,
     )
-    expect(scheduledNewsletterPlan.assistantContractFingerprint).toBe(
+    expect(scheduledNewsletterPlan.assistantContractFingerprint).not.toBe(
       scheduledWithoutPersonaPlan.assistantContractFingerprint,
     )
 
@@ -1851,6 +1851,7 @@ describe('assistant Codex turn planning', () => {
         deliverResponse: true,
       },
       preferenceContext: {
+        assistantPersona: 'navy-seal',
         assistantPersonality: {
           detail: 7,
           humor: 9,
@@ -1892,6 +1893,9 @@ describe('assistant Codex turn planning', () => {
     expect(plan.developerInstructions).toContain('Humor 9/10')
     expect(plan.developerInstructions).toContain('Push 8/10')
     expect(plan.developerInstructions).toContain('Detail 7/10')
+    expect(plan.developerInstructions).not.toContain(
+      'Be direct, disciplined, and accountable.',
+    )
     expect(plan.developerInstructions).toContain(
       'Casual is a persistent user-facing writing invariant',
     )

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -3799,7 +3799,7 @@ async function runPrePlanningMemberPreferencesMailboxPhase(input: {
   }
 
   return {
-    continueAssistantLane: true,
+    continueAssistantLane: !hostedAssistantPhaseWakeIsDueAt(pendingWake.at, now),
     result: mergeHostedAssistantPhaseResults(
       result,
       buildPrePlanningMemberPreferencesMailboxPendingResult({

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -1163,6 +1163,7 @@ export async function runHostedWorkspaceUntilIdleOrBudget(
         assistantPhaseResult,
         latestAssistantInputBatch:
           checkpointRequestSession.latestAssistantInputBatch(),
+        now: input.now,
         selectedInitialAssistantInputIds,
         signal: input.signal ?? null,
         vaultRoot: input.vaultRoot,
@@ -1831,15 +1832,33 @@ async function rebuildHostedWorkspaceRunnerAssistantInputBatchAfterSelectedPrefi
   acceptedInitialAssistantInputBatch: HostedWorkspaceRunnerAssistantInputBatch | null;
   assistantPhaseResult: HostedWorkspaceRunnerAssistantPhaseResult;
   latestAssistantInputBatch: HostedWorkspaceRunnerAssistantInputBatch | null;
+  now?: (() => string) | null;
   selectedInitialAssistantInputIds: readonly string[];
   signal: AbortSignal | null;
   vaultRoot: string;
 }): Promise<HostedWorkspaceRunnerAssistantInputBatch | null> {
+  const foregroundReplyDeferredForImmediateAssistantWork =
+    input.assistantPhaseResult.foregroundReplyFailed === undefined
+    && input.assistantPhaseResult.nextWakeReason === "assistant"
+    && typeof input.assistantPhaseResult.nextWakeAt === "string"
+    && hostedWorkspaceRunnerWakeIsImmediate(
+      input.assistantPhaseResult.nextWakeAt,
+      input.now,
+    );
+  const foregroundReplyCompletedCleanly =
+    input.assistantPhaseResult.foregroundReplyFailed === 0;
   if (
     input.acceptedInitialAssistantInputBatch === null
     || input.assistantPhaseResult.progressed !== true
-    || input.assistantPhaseResult.foregroundReplyFailed !== 0
-    || input.selectedInitialAssistantInputIds.length < 2
+    || (
+      !foregroundReplyDeferredForImmediateAssistantWork
+      && !foregroundReplyCompletedCleanly
+    )
+    || input.selectedInitialAssistantInputIds.length === 0
+    || (
+      foregroundReplyCompletedCleanly
+      && input.selectedInitialAssistantInputIds.length < 2
+    )
     || new Set(input.selectedInitialAssistantInputIds).size
       !== input.selectedInitialAssistantInputIds.length
   ) {
@@ -1853,9 +1872,17 @@ async function rebuildHostedWorkspaceRunnerAssistantInputBatchAfterSelectedPrefi
   const pendingSelectedInputIds = input.selectedInitialAssistantInputIds.filter(
     (inputId) => pendingInputIds.has(inputId),
   );
+  // Bounded assistant-owned system work can make durable progress and yield an
+  // immediate wake before the foreground reply phase starts. In that case every
+  // selected input is still pending and must be restored to the invocation-local
+  // rerun batch. Once a reply phase has run, retain the narrower handled-prefix
+  // repair behavior below.
   if (
     pendingSelectedInputIds.length === 0
-    || pendingSelectedInputIds.length === input.selectedInitialAssistantInputIds.length
+    || (
+      pendingSelectedInputIds.length === input.selectedInitialAssistantInputIds.length
+      && !foregroundReplyDeferredForImmediateAssistantWork
+    )
   ) {
     return input.latestAssistantInputBatch;
   }

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -12436,7 +12436,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
   });
 
-  it("drains one bounded member preference page before planning fresh conversation input", async () => {
+  it("drains one bounded due preference page before rescheduling fresh conversation input", async () => {
     const now = "2026-04-27T00:00:00.000Z";
     mocks.resolveHostedSystemMailboxNextWakeCandidate.mockResolvedValue({
       at: now,
@@ -12469,8 +12469,8 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
 
     expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).toHaveBeenCalledTimes(10);
-    expect(mocks.resolveHostedSystemMailboxNextWakeCandidate).toHaveBeenCalledTimes(12);
-    expect(mocks.runHostedAssistantAutomationLane).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveHostedSystemMailboxNextWakeCandidate).toHaveBeenCalledTimes(11);
+    expect(mocks.runHostedAssistantAutomationLane).not.toHaveBeenCalled();
     expect(result).toEqual(expect.objectContaining({
       nextWakeAt: now,
       progressed: true,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -14928,6 +14928,150 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
+  test.each([11, 21])(
+    "keeps one fresh conversation input live across %i due preference items",
+    async (preferenceItemCount) => {
+      const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-preference-pages-"));
+      const events: string[] = [];
+      const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+      const runtimeAbortController = new AbortController();
+      const conversationItem = createMailboxItem({
+        id: `mailbox_item_entrypoint_preference_pages_${preferenceItemCount}`,
+        laneSeq: "1",
+      });
+      const selectedInputIdsByPhase: string[][] = [];
+      let importedInputId: string | null = null;
+      let preferencesApplied = 0;
+      let providerCalls = 0;
+
+      try {
+        await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+        await runHostedWorkspaceRuntimeJobInProcess(
+          createWorkspaceRuntimeJobInput({
+            request: {
+              attemptId: `attempt_synthetic_preference_pages_${preferenceItemCount}`,
+              budget: {
+                maxMailboxItems: 1,
+              },
+              idleCheckpointDelayMs: 1,
+              leaseGeneration: "9",
+              userId: TEST_USER_ID,
+              workspaceVersion: "4",
+            },
+          }),
+          {
+            async createCheckpointSnapshot(snapshotInput) {
+              events.push(`snapshot:${snapshotInput.reason}`);
+              return {
+                snapshotRef: createBundleRef({
+                  hash: "8".repeat(64),
+                  key: `users/bundles/member-synthetic/preference-pages-${preferenceItemCount}.bundle.json`,
+                  size: 640,
+                }),
+              };
+            },
+            async importItem(item) {
+              importedInputId = await stagePendingLinqAssistantInputForMailboxItem({
+                item: item.item,
+                threadId: "thread_preference_pages",
+                vaultRoot,
+              });
+              return {
+                assistantInputId: importedInputId,
+                status: "imported",
+              };
+            },
+            platform: createPlatform({
+              mailboxPort: createMailboxPort({
+                events,
+                items: [conversationItem],
+              }),
+              workspacePort: createWorkspacePort({
+                checkpointRequests,
+                events,
+                workspace: createWorkspaceState({ version: "4" }),
+              }),
+            }),
+            async runAssistantPhase(phaseInput) {
+              const acceptedInputIds = phaseInput.initialAssistantInputBatch?.assistantInputIds
+                ?? phaseInput.initialMailboxImport.importResult.assistantInputIds
+                ?? [];
+              const selection = await selectHostedAssistantInputIds({
+                freshAssistantInputIds: acceptedInputIds,
+                mode: "foreground",
+                vaultRoot,
+              });
+              selectedInputIdsByPhase.push(selection.inputIds);
+              if (selection.inputIds.length === 0) {
+                return {
+                  foregroundReplyFailed: 0,
+                  progressed: false,
+                };
+              }
+
+              const pageSize = Math.min(10, preferenceItemCount - preferencesApplied);
+              preferencesApplied += pageSize;
+              events.push(`preferences.applied:${preferencesApplied}`);
+              if (preferencesApplied < preferenceItemCount) {
+                return {
+                  checkpointReason: "system_mailbox_receipt" as const,
+                  nextWakeAt: TEST_NOW,
+                  nextWakeReason: "assistant",
+                  progressed: true,
+                };
+              }
+
+              events.push("provider.accepted");
+              providerCalls += 1;
+              const selectedInputId = selection.inputIds[0];
+              assert.ok(selectedInputId);
+              await writeSyntheticAssistantAutoReplyTerminalEvidence({
+                inputId: selectedInputId,
+                vaultRoot,
+              });
+              return {
+                checkpointReason: "assistant_runtime_commit" as const,
+                foregroundReplyFailed: 0,
+                nextWakeAt: null,
+                progressed: true,
+              };
+            },
+            signal: runtimeAbortController.signal,
+            vaultRoot,
+          },
+        );
+
+        assert.ok(importedInputId);
+        assert.equal(preferencesApplied, preferenceItemCount);
+        assert.equal(providerCalls, 1);
+        assert.deepEqual(
+          selectedInputIdsByPhase.filter((inputIds) => inputIds.length > 0),
+          Array.from(
+            { length: Math.ceil(preferenceItemCount / 10) },
+            () => [importedInputId],
+          ),
+        );
+        assert.ok(
+          requireEventIndex(events, `preferences.applied:${preferenceItemCount}`)
+            < requireEventIndex(events, "provider.accepted"),
+        );
+        assert.ok(
+          requireEventIndex(events, "provider.accepted")
+            < requireEventIndex(events, "workspace.checkpoint"),
+        );
+        assert.ok(
+          requireEventIndex(events, "provider.accepted")
+            < requireEventIndex(events, "snapshot:idle_shutdown"),
+        );
+        assert.equal(checkpointRequests.length, 1);
+        assert.equal(checkpointRequests[0]?.reason, "idle_shutdown");
+      } finally {
+        runtimeAbortController.abort();
+        await removeTempRoot(vaultRoot);
+      }
+    },
+  );
+
   test("keeps an uncovered successor ahead of the boundary after handled-prefix repair", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-prefix-repair-order-"));
     const events: string[] = [];

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -270,10 +270,34 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
   });
 
   test.each([
-    { foregroundReplyFailed: 0, retryKind: "bootstrap gap" },
-    { foregroundReplyFailed: 1, retryKind: "reply failure" },
+    {
+      foregroundReplyFailed: 0,
+      nextWakeAt: "2026-04-26T00:00:30.000Z",
+      nextWakeReason: "assistant",
+      retryKind: "bootstrap gap",
+    },
+    {
+      foregroundReplyFailed: 1,
+      nextWakeAt: "2026-04-26T00:00:30.000Z",
+      nextWakeReason: "assistant",
+      retryKind: "reply failure",
+    },
+    {
+      foregroundReplyFailed: undefined,
+      nextWakeAt: "2026-04-26T00:00:30.000Z",
+      nextWakeReason: "assistant",
+      retryKind: "future pre-reply assistant work",
+    },
+    {
+      foregroundReplyFailed: undefined,
+      nextWakeAt: TEST_NOW,
+      nextWakeReason: "mailbox",
+      retryKind: "immediate pre-reply mailbox work",
+    },
   ])("does not locally rerun a retryable selected initial input ahead of a distinct remainder ($retryKind)", async ({
     foregroundReplyFailed,
+    nextWakeAt,
+    nextWakeReason,
   }) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-retryable-input-tail-"));
     const olderItem = createMailboxItem({
@@ -367,8 +391,8 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
             return {
               checkpointReason: "assistant_runtime_commit",
               foregroundReplyFailed,
-              nextWakeAt: "2026-04-26T00:00:30.000Z",
-              nextWakeReason: "assistant",
+              nextWakeAt,
+              nextWakeReason,
               progressed: true,
             };
           }
@@ -416,6 +440,107 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
         olderInputId,
         newerInputId,
       ]);
+      assert.deepEqual(checkpointRequests, []);
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("restores a pre-reply selected input ahead of its existing boundary tail", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-pre-reply-input-tail-"));
+    const olderItem = createMailboxItem({
+      id: "mailbox_pre_reply_input_tail_older",
+      laneSeq: "1",
+      occurredAt: "2026-04-26T00:00:01.000Z",
+    });
+    const newerItem = createMailboxItem({
+      id: "mailbox_pre_reply_input_tail_newer",
+      laneSeq: "2",
+      occurredAt: "2026-04-26T00:00:02.000Z",
+    });
+    const importedInputIds: string[] = [];
+    const importedInputs: Array<Awaited<ReturnType<typeof upsertAssistantInputEvent>>> = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const selectedInputIdsByPass: string[][] = [];
+    const { mailboxPort } = createMailboxPort({ items: [olderItem, newerItem] });
+
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const result = await runHostedWorkspaceUntilIdleOrBudget({
+        checkpointRequestBuilder: createHostedWorkspaceCheckpointRequestBuilder({
+          attemptId: "attempt_synthetic_pre_reply_input_tail",
+          expectedWorkspaceVersion: "0",
+          leaseGeneration: "1",
+          nextWakeAt: null,
+          nextWakeReason: null,
+          snapshotRef: null,
+        }),
+        expectedUserId: TEST_USER_ID,
+        async importItem(item) {
+          const stored = await upsertAssistantInputEvent({
+            event: createStoredAssistantInputEventForMailboxItem(
+              item.item,
+              `pre-reply input ${item.item.laneSeq}`,
+            ),
+            vault: vaultRoot,
+          });
+          importedInputIds.push(stored.inputId);
+          importedInputs.push(stored);
+          await enqueueHostedPendingAssistantInputId({
+            inputId: stored.inputId,
+            vaultRoot,
+          });
+          return {
+            assistantInputId: stored.inputId,
+            status: "imported",
+          };
+        },
+        limitPerLane: 10,
+        platform: createPlatform({
+          mailboxPort,
+          workspacePort: createWorkspacePort({ checkpointRequests }),
+        }),
+        requestId: "request_synthetic_pre_reply_input_tail",
+        async runAssistantPhase(phaseInput) {
+          const selection = await selectHostedAssistantInputIds({
+            freshAssistantInputIds:
+              phaseInput.initialMailboxImport.importResult.assistantInputIds ?? [],
+            mode: "foreground",
+            vaultRoot,
+          });
+          selectedInputIdsByPass.push(selection.inputIds);
+          const selected = importedInputs[0];
+          assert.ok(selected);
+          await saveAssistantAutomationState(vaultRoot, {
+            autoReply: [{
+              channel: "linq",
+              eligibleAfter: selected.cursor,
+              enabledAt: TEST_NOW,
+            }],
+            updatedAt: TEST_NOW,
+            version: 1,
+          });
+          return {
+            checkpointReason: "system_mailbox_receipt",
+            nextWakeAt: TEST_NOW,
+            nextWakeReason: "assistant",
+            progressed: true,
+          };
+        },
+        vaultRoot,
+        workspace: createWorkspaceState({ version: "0" }),
+        now: () => TEST_NOW,
+      });
+
+      assert.deepEqual(selectedInputIdsByPass, [[importedInputIds[0]]]);
+      assert.deepEqual(
+        await readExistingHostedPendingAssistantInputIds({ vaultRoot }),
+        importedInputIds,
+      );
+      assert.deepEqual(
+        result.latestAssistantInputBatch?.assistantInputIds,
+        importedInputIds,
+      );
       assert.deepEqual(checkpointRequests, []);
     } finally {
       await rm(vaultRoot, { force: true, recursive: true });

--- a/packages/hosted-execution/src/parsers.ts
+++ b/packages/hosted-execution/src/parsers.ts
@@ -9,10 +9,10 @@ import {
 import {
   assistantPersonalitySettingIds,
   isAssistantPersonalityScore,
-  isAssistantPersonaId,
   isAssistantPersonalitySettingId,
   isAssistantTonePreference,
   isAssistantVoiceOptionId,
+  normalizeStoredAssistantPersonaId,
   normalizeIanaTimeZone,
 } from "@murphai/contracts";
 
@@ -1548,10 +1548,11 @@ function parseHostedExecutionAssistantPersonaPreference(
   label: string,
 ): HostedExecutionMemberPreferences["persona"] {
   const persona = requireString(value, label);
-  if (!isAssistantPersonaId(persona)) {
+  const normalizedPersona = normalizeStoredAssistantPersonaId(persona);
+  if (!normalizedPersona) {
     throw new TypeError(`${label} is invalid.`);
   }
-  return persona;
+  return normalizedPersona;
 }
 
 function parseHostedExecutionAssistantTonePreference(

--- a/packages/hosted-execution/test/hosted-execution-contract-guards.test.ts
+++ b/packages/hosted-execution/test/hosted-execution-contract-guards.test.ts
@@ -201,6 +201,25 @@ describe("hosted execution wake guards", () => {
       },
       userId: "user_guard",
     });
+    expect(
+      parseHostedExecutionWake({
+        eventId: "member-preferences-wake-legacy-persona",
+        kind: "member.preferences.updated",
+        occurredAt: "2026-07-07T00:00:00.000Z",
+        preferences: {
+          persona: "medical-detective",
+        },
+        userId: "user_guard",
+      }),
+    ).toEqual({
+      eventId: "member-preferences-wake-legacy-persona",
+      kind: "member.preferences.updated",
+      occurredAt: "2026-07-07T00:00:00.000Z",
+      preferences: {
+        persona: "scientist",
+      },
+      userId: "user_guard",
+    });
     expect(() =>
       parseHostedExecutionWake({
         eventId: "member-preferences-wake-empty",


### PR DESCRIPTION
## Why this PR exists

Onboarding persona, tone, and voice saves were durable, but five edge cases could leave the browser hanging after commit, wedge the system mailbox on an older valid persona id, plan a scheduled private turn without the selected persona, answer before the newest item in a large preference burst was applied, or lose the fresh foreground message from the invocation-local rerun batch while that burst drained.

## User goal / user-visible behavior

A member can save a Murph persona, tone, and voice once and have the hosted runtime use that selection on the next applicable private turn, including trusted scheduled private turns, without leaking private style into group conversations or delaying the selected foreground message until an idle checkpoint.

## User experience

The Settings/onboarding save remains successful once the transactional projection and mailbox append commit, even if the best-effort Temporal wake stalls. The recovery sweep remains bounded and retries durable lag. The container accepts current and enumerated legacy persona rows, applies all immediately due preference work before fresh planning, preserves the selected message across bounded preference pages, and preserves ordinary replies when the remaining preference wake is future-due or retryable.

## Invariants

- Web projection and the encrypted durable mailbox item remain one transaction and the runtime vault remains the style owner.
- Unknown persona ids fail closed; only enumerated stored legacy ids normalize at the wire boundary.
- Immediately due preference work runs before a fresh provider turn; retryable or future-due work does not unnecessarily suppress replies.
- A foreground input selected before bounded preference work remains invocation-local, in order ahead of any precomputed tail, and reaches the provider exactly once before idle checkpointing.
- Persona defaults apply only to private conversation provider turns, including scheduled ones; maintenance/output-only and group turns remain excluded.
- Post-commit wake failure never rolls back or misreports a committed save.

## Non-obvious affected surfaces

- Hosted wire parser / Cloudflare bridge: legacy valid persona ids normalize before container import. Proof: hosted-execution guard and Cloudflare bridge tests.
- Web Temporal handoff: route and recovery sweeper use the existing abortable bounded post-commit helper. Proof: hung-signal route and sweeper tests.
- Shared recovery sweep: preference rows and exact queued Clinical Records wakes share one five-second batch deadline, so no candidate can hang the scheduled activity; durable rows remain eligible for a later sweep. Proof: exact-current Clinical selection with an `AbortSignal`, a Clinical-labelled hung-then-later-sweep retry, and shared candidate retry tests.
- Assistant planning: scheduled private provider turns now resolve persona defaults. Proof: scheduled-turn prompt, dials, voice, and fingerprint assertions plus group-isolation proof.
- Runtime pre-planning: an immediately due item after each bounded page causes local re-entry before provider planning, while the selected foreground input is reconstructed from the accepted batch ahead of any unselected tail. Proof: production-shaped 11- and 21-item entrypoint regressions, boundary-tail ordering, future-due/non-assistant negative cases, and provider-before-snapshot assertions.

## Review remediation

- Accepted bug: the first page-limit fix could remove the selected foreground input from the active batch before the reply phase and leave it parked until idle checkpointing. Correction: restore still-pending selected records from the already accepted batch only when bounded assistant-owned work yields an immediately due assistant wake before the reply phase; keep the existing narrower handled-prefix repair after a clean reply phase. No new persisted wake or scheduler was added.
- Accepted purpose-drift disclosure: the bounded sweeper intentionally covers exact queued Clinical Records wakes as well as preferences. The shared deadline is necessary so one hung signal cannot block the scheduled recovery activity, and durable rows are retried later.

## Deployment skew / compatibility

Deploy Cloudflare Worker and the runner bundle first with `container_rollout=immediate`, then deploy Web. The new consumer is backward compatible with the current Web producer; the Web route change is also compatible with the previous consumer, but Cloudflare-first removes the known legacy-row and stale-planning risks before more saves arrive. This is a behavior-changing consumer update, so gradual warm-container rollout is not appropriate. Immediate rollout is bounded by the deploy plus managed-container smoke rather than the configured 10/25/50/100 gradual window; runner fingerprint admission prevents stale warm shells from receiving work.

A read-only production aggregate at review time showed 3 preference events for 1 member in the preceding 24 hours and 0 currently pending beyond the consumed watermark. Realistically exposed operations are therefore the small number of saves during the deploy window; they remain durable and recoverable by the sweeper. The change adds no new persisted shape or migration, so rollback is structurally compatible, although a forward fix is preferred because rollback reintroduces the corrected behaviors. Post-deploy proof: managed-container fingerprint smoke, no mailbox parse failures, one Settings save followed by a private conversational turn using the saved style, a scheduled private-turn smoke, and pending preference lag returning to zero. Temporal code is unchanged and needs no deploy.

## Verification

- `pnpm verify:acceptance` passed on the completed remediation tree: Web 488 files / 6,110 tests, assistant engine 171 files / 2,574 tests, assistant runtime 114 files / 1,078 tests, Cloudflare 106 files / 1,849 tests plus Workers, with all workspace typechecks, builds, coverage, guards, and package boundaries passing.
- Exact rebased-tree verification passed: assistant runtime workspace runner and entrypoint 335 tests, Web save/recovery 28 tests, assistant-runtime typecheck, and diff checks.
- Required Codex coverage-write audit completed with no unresolved actionable gap; its focused runtime 335-test and Web 9-test suites passed.
- `git diff --check` and identifier/privacy scan passed.

## Change-shape breakdown

Classification rule: production TypeScript is source; `test/**` is tests/fixtures; the completed execution plan is docs; no config/tooling or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 60 | 12 |
| Tests/fixtures | 445 | 11 |
| Docs | 55 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **560** | **23** |

## ReviewGPT baseline

ReviewGPT first-reviewed head: 720d53facd487ea52139a40993dd338067a270ca

Immutable round-1 baseline:

| Round | Head | Source | Tests | Docs | Config/tooling | Generated/other |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| 1 | `720d53facd487ea52139a40993dd338067a270ca` | +30/-9 | +122/-7 | +55/-0 | +0/-0 | +0/-0 |

Current correction head:

| Round | Head | Source | Tests | Docs | Config/tooling | Generated/other |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| 2 | `6461f22cf5f099c841512c583f7484cf975b4742` | +60/-12 | +445/-11 | +55/-0 | +0/-0 | +0/-0 |

Review remediation added 30 and removed 3 authored source lines in the existing workspace-runner batch-recovery path. The larger test delta adds production-shaped 11/21-page continuity, boundary ordering, negative scheduling, and Clinical retry proof. The no-content lineage merge preserves the immutable round-1 ancestor after `main` advanced; it does not change the PR patch.
