### PR TITLE
fix(hosted): preserve managed automation failure diagnostics

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-21-hosted-managed-automation-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-07-21-hosted-managed-automation-diagnostics.md
@@ -1,0 +1,37 @@
+# Hosted managed-automation diagnostics
+
+## Goal
+
+Preserve enough metadata-only production evidence to identify the exact stage
+and safe exception identity behind the recurring hosted managed-automation
+reconciliation failure.
+
+Success criteria:
+
+- Record a fixed-vocabulary reconciliation stage on failure.
+- Preserve safe error name/code/status details already allowed by hosted
+  observability without logging vault paths, content, routes, or identifiers.
+- Keep foreground reply behavior and reconciliation control flow unchanged.
+- Add focused regression coverage and run the required package verification.
+
+## Constraints
+
+- Do not log automation instructions, vault paths, delivery targets, user data,
+  or raw exception messages.
+- Do not add retries, state, scheduling, or fallback ownership.
+- Keep the change inside the existing hosted runtime logging owner.
+
+## Approach
+
+1. Extend the existing failure diagnostic helper with safe structured fields.
+2. Track the current fixed-vocabulary managed-automation stage around the
+   existing reconciliation call.
+3. Prove success and failure log shapes with focused assistant-runtime tests.
+4. Run scoped verification, required completion audits, commit, and PR gates.
+
+## State
+
+Active.
+Status: completed
+Updated: 2026-07-21
+Completed: 2026-07-21

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -61,6 +61,7 @@ export interface MurphManagedAutomationSeed {
 
 export interface ApplyMurphManagedAutomationsInput {
   defaultRoute?: AutomationRoute | null
+  onDiagnosticStage?: ((diagnostic: MurphManagedAutomationDiagnosticStage) => void) | null
   now?: Date
   operatorHomeRoot?: string | null
   routeValidationProfile?: AssistantCronDeliveryRouteValidationProfile
@@ -68,6 +69,19 @@ export interface ApplyMurphManagedAutomationsInput {
   seeds?: readonly MurphManagedAutomationSeed[]
   shouldYield?: (() => boolean) | null
   vaultRoot: string
+}
+
+export type MurphManagedAutomationDiagnosticStageName =
+  | 'experiment_lifecycle'
+  | 'seed_composition'
+  | 'managed_seed'
+  | 'onboarding_followup'
+  | 'experiment_support_series'
+
+export interface MurphManagedAutomationDiagnosticStage {
+  seedCount?: number
+  seedPosition?: number
+  stage: MurphManagedAutomationDiagnosticStageName
 }
 
 export interface ApplyMurphManagedAutomationsResult {
@@ -533,16 +547,25 @@ export async function applyMurphManagedAutomations(
   }
   // Deterministic closeout and user-facing seed composition share one
   // authoritative experiment scan and still run before route resolution.
-  const experimentLifecycle = input.seeds === undefined
-    ? await prepareExperimentLifecycleAutomations({
-        now,
-        shouldYield: input.shouldYield ?? null,
-        vaultRoot: input.vaultRoot,
-      })
-    : null
+  let experimentLifecycle: Awaited<ReturnType<
+    typeof prepareExperimentLifecycleAutomations
+  >> | null = null
+  if (input.seeds === undefined) {
+    reportMurphManagedAutomationDiagnosticStage(input, {
+      stage: 'experiment_lifecycle',
+    })
+    experimentLifecycle = await prepareExperimentLifecycleAutomations({
+      now,
+      shouldYield: input.shouldYield ?? null,
+      vaultRoot: input.vaultRoot,
+    })
+  }
   if (experimentLifecycle?.yielded === true || input.shouldYield?.() === true) {
     return { ...result, yielded: true }
   }
+  reportMurphManagedAutomationDiagnosticStage(input, {
+    stage: 'seed_composition',
+  })
   const rawSeeds =
     input.seeds ??
     markPersonalMurphManagedAutomationSeeds([
@@ -574,7 +597,12 @@ export async function applyMurphManagedAutomations(
     createRoute = await resolveMurphManagedAutomationCreateRoute(input)
     return createRoute
   }
-  for (const rawSeed of seeds) {
+  for (const [seedIndex, rawSeed] of seeds.entries()) {
+    reportMurphManagedAutomationDiagnosticStage(input, {
+      seedCount: seeds.length,
+      seedPosition: seedIndex + 1,
+      stage: 'managed_seed',
+    })
     if (input.shouldYield?.() === true) {
       return { ...result, yielded: true }
     }
@@ -808,6 +836,9 @@ export async function applyMurphManagedAutomations(
   if (input.shouldYield?.() === true) {
     return { ...result, yielded: true }
   }
+  reportMurphManagedAutomationDiagnosticStage(input, {
+    stage: 'onboarding_followup',
+  })
   const onboardingReconciliation = await reconcileExistingOnboardingFollowupAutomation({
     now,
     shouldYield: input.shouldYield ?? null,
@@ -824,6 +855,9 @@ export async function applyMurphManagedAutomations(
     if (input.shouldYield?.() === true) {
       return { ...result, yielded: true }
     }
+    reportMurphManagedAutomationDiagnosticStage(input, {
+      stage: 'experiment_support_series',
+    })
     const reconciliation = await reconcileAutomationSupportSeriesNamespace({
       desiredSeries: desiredExperimentSupportSeries,
       now,
@@ -838,6 +872,17 @@ export async function applyMurphManagedAutomations(
   }
 
   return result
+}
+
+function reportMurphManagedAutomationDiagnosticStage(
+  input: ApplyMurphManagedAutomationsInput,
+  diagnostic: MurphManagedAutomationDiagnosticStage,
+): void {
+  try {
+    input.onDiagnosticStage?.(diagnostic)
+  } catch {
+    // Diagnostics are best-effort and must not affect reconciliation.
+  }
 }
 
 function buildDesiredExperimentSupportSeries(

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -22,6 +22,7 @@ import {
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
+  type MurphManagedAutomationDiagnosticStage,
 } from '../src/assistant/managed-automations.ts'
 import { completeAssistantOnboarding } from '../src/assistant/onboarding-state.ts'
 import { ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG } from '../src/assistant/automation-tags.ts'
@@ -78,18 +79,51 @@ async function createVaultRoot(): Promise<string> {
 }
 
 describe('applyMurphManagedAutomations core integration', () => {
-  it('creates managed health automations through the canonical automation registry', async () => {
+  it('keeps diagnostic stage reporting best-effort', async () => {
     const vaultRoot = await createVaultRoot()
 
     await expect(applyMurphManagedAutomations({
       defaultRoute,
-      now: new Date('2026-06-09T12:00:00.000Z'),
+      onDiagnosticStage() {
+        throw new Error('diagnostic sink unavailable')
+      },
+      seeds: [],
       vaultRoot,
     })).resolves.toEqual({
+      created: 0,
+      skipped: 0,
+      updated: 0,
+    })
+  })
+
+  it('creates managed health automations through the canonical automation registry', async () => {
+    const vaultRoot = await createVaultRoot()
+    const diagnosticStages: MurphManagedAutomationDiagnosticStage[] = []
+
+    const result = await applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-09T12:00:00.000Z'),
+      onDiagnosticStage(diagnostic) {
+        diagnosticStages.push(diagnostic)
+      },
+      vaultRoot,
+    })
+    expect(result).toEqual({
       created: 5,
       skipped: 0,
       updated: 0,
     })
+    expect(diagnosticStages).toEqual([
+      { stage: 'experiment_lifecycle' },
+      { stage: 'seed_composition' },
+      ...Array.from({ length: 5 }, (_value, seedIndex) => ({
+        seedCount: 5,
+        seedPosition: seedIndex + 1,
+        stage: 'managed_seed' as const,
+      })),
+      { stage: 'onboarding_followup' },
+      { stage: 'experiment_support_series' },
+    ])
 
     const record = await showAutomation({
       automationId: MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -49,6 +49,7 @@ import {
   type AssistantHostedGroupPermissionOfferTool,
   type AssistantHostedGroupSharedReader,
   type AssistantInputEventRecord,
+  type MurphManagedAutomationDiagnosticStage,
   type AssistantTurnEnvironment,
   type HostedAssistantTurnTimingStage,
 } from "@murphai/assistant-engine";
@@ -2178,10 +2179,14 @@ async function applyHostedManagedAutomationsBestEffort(input: {
     return null;
   }
 
+  let diagnosticStage: MurphManagedAutomationDiagnosticStage | null = null;
   let result: Awaited<ReturnType<typeof applyMurphManagedAutomations>>;
   try {
     result = await applyMurphManagedAutomations({
       now: new Date(resolveHostedAssistantPhaseNowMs(input.input)),
+      onDiagnosticStage(stage) {
+        diagnosticStage = stage;
+      },
       operatorHomeRoot: input.input.restored.operatorHomeRoot,
       ...(input.defaultRoute !== undefined
         ? { defaultRoute: input.defaultRoute }
@@ -2195,6 +2200,7 @@ async function applyHostedManagedAutomationsBestEffort(input: {
     const failure = buildHostedRuntimeFailureDiagnostics(
       error,
       "Hosted managed automation setup failed.",
+      { includeSafeIdentity: true },
     );
     await writeHostedRuntimeLogBestEffort({
       entry: {
@@ -2210,6 +2216,7 @@ async function applyHostedManagedAutomationsBestEffort(input: {
         phase: "error",
         redactedJson: {
           ...failure.redactedJson,
+          ...buildHostedManagedAutomationStageDiagnostics(diagnosticStage),
           murphManagedAutomationFailed: true,
         },
       },
@@ -2248,6 +2255,7 @@ async function applyHostedManagedAutomationsBestEffort(input: {
     const failure = buildHostedRuntimeFailureDiagnostics(
       stableKeyFailure,
       "Hosted managed automation stable-key setup failed.",
+      { includeSafeIdentity: true },
     );
     await writeHostedRuntimeLogBestEffort({
       entry: {
@@ -2338,6 +2346,26 @@ async function applyHostedManagedAutomationsBestEffort(input: {
       murphManagedAutomationSkipped: result.skipped,
       murphManagedAutomationUpdated: result.updated,
     },
+  };
+}
+
+function buildHostedManagedAutomationStageDiagnostics(
+  diagnostic: MurphManagedAutomationDiagnosticStage | null,
+): HostedRuntimeRedactedJson {
+  if (!diagnostic) {
+    return {
+      murphManagedAutomationStage: "start",
+    };
+  }
+
+  return {
+    murphManagedAutomationStage: diagnostic.stage,
+    ...(diagnostic.seedCount === undefined
+      ? {}
+      : { murphManagedAutomationSeedCount: diagnostic.seedCount }),
+    ...(diagnostic.seedPosition === undefined
+      ? {}
+      : { murphManagedAutomationSeedPosition: diagnostic.seedPosition }),
   };
 }
 
@@ -7235,6 +7263,7 @@ async function writeHostedDeviceConnectRuntimeLog(input: {
 function buildHostedRuntimeFailureDiagnostics(
   error: unknown,
   fallbackMessage: string,
+  options: { includeSafeIdentity?: boolean } = {},
 ): {
   errorCode: string;
   redactedJson: HostedRuntimeRedactedJson;
@@ -7254,6 +7283,23 @@ function buildHostedRuntimeFailureDiagnostics(
   ) ?? fallbackMessage;
   const redactedJson: HostedRuntimeRedactedJson = {
     errorCode,
+    ...(options.includeSafeIdentity === true
+      && typeof diagnostics?.errorName === "string"
+      ? { errorName: diagnostics.errorName }
+      : {}),
+    ...(options.includeSafeIdentity === true
+      && typeof diagnostics?.errorStatus === "number"
+      ? { errorStatus: diagnostics.errorStatus }
+      : {}),
+    ...(options.includeSafeIdentity === true
+      && typeof diagnostics?.errorCodeDetail === "string"
+      ? {
+          errorCodeDetail: toHostedRuntimeLogCode(diagnostics.errorCodeDetail),
+        }
+      : {}),
+    ...(options.includeSafeIdentity === true
+      ? { errorDetailPresent: typeof diagnostics?.errorDetail === "string" }
+      : {}),
     safeErrorMessage,
   };
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -2787,6 +2787,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
 
     expect(mocks.applyMurphManagedAutomations).toHaveBeenCalledWith({
       now: new Date("2026-04-27T00:00:00.000Z"),
+      onDiagnosticStage: expect.any(Function),
       operatorHomeRoot: "/tmp/murph-hosted-operator-home",
       routeValidationProfile: "hosted",
       runtimeEnv: {},
@@ -2994,8 +2995,21 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
 
   it("does not schedule a retry loop for an unclassified managed setup failure", async () => {
     const logRequests: HostedRuntimeLogRequest[] = [];
-    const setupFailure = new Error("invalid managed automation outcome");
-    mocks.applyMurphManagedAutomations.mockRejectedValueOnce(setupFailure);
+    const setupFailure = Object.assign(
+      new TypeError("private managed automation failure detail"),
+      {
+        code: "MANAGED_SEED_SCHEMA_INVALID",
+        statusCode: 409,
+      },
+    );
+    mocks.applyMurphManagedAutomations.mockImplementationOnce(async (input) => {
+      input.onDiagnosticStage?.({
+        seedCount: 7,
+        seedPosition: 3,
+        stage: "managed_seed",
+      });
+      throw setupFailure;
+    });
 
     const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
       logRequests,
@@ -3019,9 +3033,20 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         level: "warn",
         phase: "error",
         redactedJson: expect.objectContaining({
+          errorCodeDetail: "MANAGED_SEED_SCHEMA_INVALID",
+          errorDetailPresent: true,
+          errorName: "TypeError",
+          errorStatus: 409,
           murphManagedAutomationFailed: true,
+          murphManagedAutomationSeedCount: 7,
+          murphManagedAutomationSeedPosition: 3,
+          murphManagedAutomationStage: "managed_seed",
+          safeErrorMessage: "Hosted execution runtime failed.",
         }),
       }),
+    );
+    expect(JSON.stringify(logRequests)).not.toContain(
+      "private managed automation failure detail",
     );
   });
 
@@ -3255,6 +3280,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     expect(mocks.applyMurphManagedAutomations).toHaveBeenCalledWith({
       defaultRoute,
       now: new Date("2026-04-27T00:00:00.000Z"),
+      onDiagnosticStage: expect.any(Function),
       operatorHomeRoot: "/tmp/murph-operator-home",
       routeValidationProfile: "hosted",
       runtimeEnv: {},


### PR DESCRIPTION
## Why

Recurring hosted managed-automation warnings currently collapse distinct reconciliation failures into a generic runtime error. This PR preserves enough bounded, secret-safe metadata to identify the failing reconciliation stage and machine-readable error identity on the next occurrence.

## User-visible goal and flow

There is no direct messaging or UI change. Foreground replies continue normally when best-effort managed-automation setup fails; operators gain actionable stage/code/status metadata in the existing runtime warning so the underlying defect can be diagnosed without replaying or exposing member data.

## Invariants

- Never log raw exception messages/details, vault content or paths, routes, delivery targets, or user identifiers.
- Diagnostics remain best-effort and cannot cause reconciliation failure.
- Stage values are fixed vocabulary; seed position/count are numeric; error code detail must satisfy the existing machine-code grammar.
- Do not change retries, scheduling, persistence, checkpoint behavior, or user-facing messaging.
- Keep managed-automation reconciliation owned by assistant-engine and failure logging owned by assistant-runtime.

## Non-obvious affected surfaces

- `applyMurphManagedAutomations` accepts an optional in-memory diagnostic callback and reports the current major reconciliation stage.
- The hosted assistant phase retains only the latest stage and appends bounded safe identity fields when that call throws.
- Stable-key failures reuse the same safe identity projection but retain their existing retry/control flow.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 99 | 8 |
| Tests | 64 | 4 |
| Docs | 37 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: e8067ee6032c730f1a9e07b33f0f73a78be886d3

| ReviewGPT round | Current head | Scope |
| --- | --- | --- |
| 1 | `e8067ee6032c730f1a9e07b33f0f73a78be886d3` | Full patch |

## Verification

- `pnpm verify:acceptance` — passed, including workspace guards/typechecks, all package coverage, Cloudflare verification, and the web production build.
- Focused assistant-engine Vitest — 2 passed.
- Focused assistant-runtime Vitest — 1 passed.
- Assistant-engine and assistant-runtime typechecks — passed.
- Required local `coverage-write` audit — completed with zero unresolved findings after strengthening exact stage-sequence and raw-message-absence proof.
- Canonical `pnpm test:diff ...` passed all affected owner/reverse-dependent typechecks and the assistant-engine/assistant-runtime suites; the run was stopped after unrelated CLI integration tests repeatedly self-queued on the verifier's runtime-artifact lock and timed out at 60 seconds. Full acceptance subsequently passed that broader workspace verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787276412&installation_model_id=19880&pr_number=837&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F837&signature=f6ec3f0ec7f6e0ba2593dd1184008f0a809abb20b750a599303c7f599862d3fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->