### PR TITLE
Improve biomarker UI and add reviewed reference guidance

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-21-biomarker-ui-thresholds.md
+++ b/agent-docs/exec-plans/completed/2026-07-21-biomarker-ui-thresholds.md
@@ -1,0 +1,154 @@
+# Biomarker UI and sourced reference guidance
+
+Status: completed
+Created: 2026-07-21
+Updated: 2026-07-21
+
+## Goal
+
+- Prototype and approve a calmer, denser biomarker index and result-detail
+  graph on `/design`, promote it to the production `/biomarkers` routes, then
+  add sourced one-sentence descriptions and contextual
+  reference guidance to the authored Health Commons biomarker pages needed by
+  the saved-lab experience.
+
+## Success criteria
+
+- `/design?tab=sections` shows a complete desktop and mobile-ready biomarker
+  index study with device readings, search and status controls, scannable
+  health-area disclosures, and clear flagged-first results.
+- The production `/biomarkers` index and lab-result detail routes use the
+  approved hierarchy with live private data, while preserving auth, source
+  flags, exact values, comparators, units, and empty/error behavior.
+- The result-detail study shows the latest finding, a readable longitudinal
+  plot, explicit source/lab reference context, and comparator-safe history
+  without inferred trend copy or dashboard clutter.
+- ReviewGPT returns evidence-backed threshold guidance and one plain-language
+  sentence for every requested marker, with uncertainty, population, assay,
+  sex, age, fasting, and unit caveats preserved instead of flattened into one
+  universal healthy range.
+- Authored Health Commons biomarker pages carry the reviewed sentence and
+  structured contextual guidance needed by future UI consumers; generated
+  catalog artifacts remain build outputs.
+- Focused UI tests, Health Commons verification, truthful diff verification,
+  browser proof, required frontend and coverage audits, second-model UI review,
+  ReviewGPT, CI, and parent final review complete with no accepted finding.
+
+## Scope
+
+- In scope: `/design` biomarker studies, the production `/biomarkers` index and
+  lab-result detail presentation, their shared chart/list seams, focused tests, authored Health
+  Commons biomarker content/schema/generator changes required for descriptions
+  and contextual ranges, and matching durable design/product documentation.
+- Out of scope: overriding source-reported lab flags, diagnosing a member from
+  a result, silently applying one population's thresholds to another, changing
+  canonical lab identity or unit-conversion ownership.
+
+## Constraints
+
+- Keep source-reported flags authoritative in the saved-lab index; contextual
+  research guidance is explanatory content, not a replacement reference range.
+- Use official guidance, consensus guidelines, primary literature, and lab or
+  assay documentation as appropriate. Record when no universal threshold is
+  defensible.
+- Preserve exact reported values, comparators, units, source ranges, and
+  provenance. Do not plot qualitative or boundary results as exact numbers.
+- Reuse the existing Murph paper system and shared components. Add no new
+  frontend dependency, state owner, or health-data persistence path.
+
+## Risks and mitigations
+
+1. Risk: a polished graph implies more certainty than the evidence supports.
+   Mitigation: label source ranges explicitly, keep excluded results visible in
+   history, and distinguish source ranges from contextual guidance.
+2. Risk: one-size-fits-all ranges are medically misleading.
+   Mitigation: require per-marker applicability notes and allow a reviewed
+   `no universal range` result rather than forcing numeric bounds.
+3. Risk: bulk authored content becomes generic or inconsistent.
+   Mitigation: ReviewGPT supplies sourced drafts; the parent checks schema,
+   representative content, deterministic generation, and catalog verification.
+4. Risk: the design study drifts from production data contracts.
+   Mitigation: reuse production value/chart primitives and cover the study's
+   interaction and responsive structure with focused tests and browser proof.
+
+## Tasks
+
+1. Trace the current biomarker index, result-detail chart, Health Commons page
+   schema, and `/design` study seams; define the smallest design-only prototype.
+2. Rebuild the `/design` list and detail studies around one editorial notebook
+   hierarchy, including responsive and qualitative/boundary states.
+3. Apply the approved presentation to the production `/biomarkers` index and
+   private lab-result detail routes without copying synthetic data.
+4. Send the exact requested marker inventory to ReviewGPT for deep sourced
+   research, one-sentence descriptions, contextual thresholds, caveats, and an
+   attachment-based patch for authored Health Commons pages.
+5. Validate and apply the returned content/schema changes without overriding
+   source flags or inventing universal thresholds.
+6. Run focused tests, Health Commons verification, canonical diff verification,
+   local desktop/mobile browser proof, required audits, and parent final review.
+7. Close the plan with a scoped commit, push the task branch, open a PR, start
+   ReviewGPT with CI on the exact head, and resolve every accepted finding.
+
+## Decisions
+
+- Stage the new interaction and visual hierarchy on `/design` first. The
+  production route changed only after the user inspected the rendered proposal
+  and explicitly asked to promote it; the restored pill filters remain.
+- Omit verbose chart-explanation and comparator-rationale copy at the user's
+  request. Exact comparator results remain visible in history and are still
+  excluded from numeric plots.
+- Keep controls and rows literal and scannable: centered pill contents with
+  source-status dots, compact result-status rails, “From the lab” section copy,
+  no inferred trend headline, and a full-width result ledger. On mobile,
+  device summaries clamp to two lines while their icons remain visible.
+- Route the individual-result “Chat with Murph” action through the existing
+  contact resolver with a marker-specific draft. Only the public biomarker
+  display name enters the compose URL; member values, dates, sources, ranges,
+  and flags do not.
+- Store research-backed descriptions and contextual guidance in authored Health
+  Commons pages, not in browser runtime state or a frontend-only lookup table.
+- Treat a lab's own reported reference range as the primary result-specific
+  context. Cross-source guidance may explain the result but cannot relabel it.
+- Collapse the 122 requested labels into 120 authored entities only where two
+  labels are true aliases: MPV/Mean Platelet Volume and CO2/Carbon Dioxide.
+  Keep explicit resolver mappings for the other production metric names so UI
+  labels, canonical metric keys, and Commons entities do not drift.
+- Record reviewed guidance even when no safe universal numeric interval exists.
+  The completed research classifies 120 entities as generally applicable
+  numeric (1), conditional numeric (11), calculated or method-specific (17),
+  qualitative (3), source-range-only (52), or no universal range (36). Numeric
+  bounds are structured only for the 14 entities where the evidence supports
+  them; the remaining pages preserve assay, specimen, population, unit, and
+  source-range constraints rather than manufacturing wellness targets.
+- Keep the design fixture explicitly synthetic. The supplied health record is
+  a visual reference only; its member-specific values and flags do not belong
+  in committed source or durable task artifacts.
+
+## Verification
+
+- ReviewGPT research completed on the requested inventory with the configured
+  Pro model and the exact completion marker. It covered 122 requested labels,
+  resolved them to 120 authored entities, produced one reviewed sentence for
+  each entity, and supplied contextual guidance plus source locators for every
+  page. The deterministic coverage test proves all requested names, mappings,
+  aliases, classifications, sources, comparators, and device entities.
+- `pnpm --dir packages/health-commons verify` passed: typecheck, 18 files and
+  85 tests, and deterministic generation check.
+- The final canonical `pnpm test:diff ...` passed dependency policy, workspace
+  boundaries, affected typechecks and package tests, 6,044 hosted-web tests,
+  hosted-web dev smoke/lint/production build, 1,848 Cloudflare node tests, the
+  Workers test, and package-boundary checks.
+- `pnpm verify:acceptance` completed with exit code 0, including workspace
+  typechecks, doc gardening, artifact hygiene, package coverage thresholds,
+  hosted-web verification and production build, and Cloudflare verification.
+- Focused web verification passed 51 biomarker tests; scoped web ESLint and web,
+  Contracts, and health-metrics typechecks passed. The coverage-write audit
+  added regression proof for the signed-out chat fallback, result rails/filter
+  dots, and contradictory or unsourced guidance rejection.
+- Desktop (1440 by 1000) and mobile (390 by 844) Playwright captures of the
+  public `/design?tab=sections` study were inspected after client rendering.
+  The device/lab headings match, mobile icons and two-line summaries remain
+  legible, and the result plot uses the available width without the previous
+  left gutter. The final frontend-review pass reported zero actionable
+  findings.
+Completed: 2026-07-21

--- a/agent-docs/product-specs/health-commons.md
+++ b/agent-docs/product-specs/health-commons.md
@@ -1,6 +1,6 @@
 # Health Commons
 
-Last verified: 2026-07-16
+Last verified: 2026-07-21
 
 ## Current State
 
@@ -35,6 +35,84 @@ The storage primitive is a typed wiki page plus generated projections. Product/d
 Protocol pages must include lineage, attribution, a performable protocol block, safety, and at least one test plan. Claims must cite source pages unless they are explicitly labeled as community outcomes.
 Protocol pages may also include an optional compact `experimentOnboarding` block that stores only protocol-specific onboarding deltas, such as start intent, safety-screen questions, setup slots, selected test plan, first-session guidance, adaptation policy, and tracking/support hints. Generic vault-read behavior, plan timing, adherence targets, readable logging labels, and stable session log ids come from assistant instructions plus canonical `testPlans`, `protocol.logFields`, `protocol.sessionFieldIds`, `protocol`, and `safety` fields; only stable extra confounder log ids belong in `trackingHints.confounderFields`, while prose confounder guidance stays in `trackingHints.confounders` or `notes`.
 Protocol and source pages may also include an optional `media` array for small public presentation assets such as header imagery. Keep those assets lightweight and repo-local, and do not use `media` as a substitute for research artifact manifests, PDFs, or other large external files.
+
+## Biomarker Reference Guidance
+
+Authored biomarker pages may carry calm educational context for measured
+health data under `referenceGuidance`. This content does not diagnose,
+prescribe, or decide whether a saved result is in or out of range. For saved
+laboratory results, the reporting source's flag and per-result reference
+interval remain authoritative in result UI. Commons guidance always uses
+`use: context_only`; it must never relabel a result, synthesize an absent flag,
+or override the source range.
+
+The contract lives in `packages/contracts/src/health-commons.ts`; authored
+guidance remains in `packages/health-commons/content/biomarkers/*.md`, and the
+generated biomarker research projection carries the parsed structure. Do not
+create a frontend-only guidance lookup or commit generated catalog artifacts.
+
+```yaml
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "What the reviewed source says, in concise member-readable language."
+      applicability: "The population, specimen, timing, assay, method, or clinical context in which it applies."
+      numericValues:
+        - label: "Named comparator"
+          unit: "mg/dL"
+          upperBound:
+            value: 100
+            inclusive: false
+      source:
+        title: "Source title"
+        organization: "Issuing organization or journal"
+        year: 2026
+        sourceType: clinical_guideline
+        url: "https://example.org/source"
+```
+
+A source records its title, organization or journal, year, source type, and at
+least one stable locator (`url`, `doi`, or `pmid`). For a living assay catalog
+without a stated publication date, `year` records the reviewed revision year;
+the exact title and URL identify the living document.
+
+| Classification | Meaning |
+| --- | --- |
+| `generally_applicable_numeric` | A broadly used numeric decision framework with explicit exclusions and assay requirements; it remains context, not a result label. |
+| `conditional_numeric` | Numeric guidance changes materially with population, age, sex, pregnancy, fasting state, collection time, risk stratum, treatment context, or another named condition. |
+| `qualitative` | The result is categorical, narrative, titer-based, or otherwise not represented by a manufactured numeric interval. |
+| `calculated_or_method_specific` | The value depends on a formula, component inputs, instrument, specimen, or named assay and retains that provenance. |
+| `source_range_only` | A local laboratory or assay interval is the defensible numeric source, so Commons does not substitute a portable interval. |
+| `no_universal_range` | Evidence does not support one universal numeric range for the requested entity; this is a reviewed conclusion, not missing work. |
+
+Guidance may retain conflicting sources as separate items instead of choosing a
+false consensus. Numeric values store explicit lower and upper bounds with an
+`inclusive` flag. A comparator such as `<10` is an exclusive upper bound at 10,
+never the exact point 10. Keep each source's units; add equivalents only for
+straightforward, dimensionally valid, verified conversions. Never merge
+non-equivalent assays, particle and mass concentrations, percentages and
+absolute counts, direct and calculated values, specimen types, or similarly
+named analytes.
+
+Metric identities are canonicalized in `@murphai/health-metrics`. Reuse an
+existing authored Commons entity only through
+`packages/health-commons/src/biomarker-entity-mappings.ts` and only for a true
+analyte identity. Percentage and absolute differential counts; generic,
+CKD-EPI, and historical MDRD eGFR outputs; LDL calculation methods; fatty-acid
+panels and components; specimen-specific exposures; and point-of-care troponin
+assays remain distinct when their provenance or interpretation differs.
+
+Every measured biomarker admitted to the reviewed content set has an authored
+page or an explicit mapping to the correct page. Its `summary` is one
+non-placeholder sentence explaining what the marker measures and why it can
+matter without diagnosis, hype, commands, or treating one result as a verdict.
+It also has reviewed guidance or an explicit reviewed `no_universal_range`
+classification. `packages/health-commons/test/requested-biomarker-content.test.ts`
+locks these identity, summary, source, classification, comparator, and coverage
+rules.
 
 ## Publishing And Start Identity
 

--- a/agent-docs/product-specs/measured-biomarker-index.md
+++ b/agent-docs/product-specs/measured-biomarker-index.md
@@ -52,6 +52,30 @@ member-facing biomarker.
    but none are classified, say that no recognized biomarkers are available
    while confirming that the saved records remain available.
 
+## Result detail contract
+
+- Lead with the exact latest result, source status, collection date, reported
+  source/lab, and source-specific reference range. Do not substitute Commons
+  guidance for the result's own range or flag.
+- When an authored Health Commons page maps to the canonical lab identity, use
+  its one-sentence summary below the title and keep saved-history count/date
+  context as secondary metadata.
+- Plot only exact numeric results that the query owner has already established
+  as comparable. Comparator and qualitative results stay exact in the ledger
+  and never become invented points.
+- Show a reference band or limit only when every plotted result has the same
+  normalized numeric range and unit. Otherwise omit it without implying that
+  the result lacks source context in the ledger.
+- Keep the result ledger available at every viewport. The full four-column
+  layout starts only when it fits; smaller screens use one accessible stacked
+  representation rather than duplicated desktop/mobile markup.
+- Prefer a quiet omission over long chart caveats. If there is no comparable
+  numeric series, show the exact saved history without an empty chart or a
+  rationale card.
+- Offer the existing Chat with Murph contact action with a short draft based on
+  the public biomarker display name. Do not place the member's private value,
+  date, source, flag, or reference range in an external compose URL.
+
 ## Explicitly excluded classes
 
 Unless a future owner deliberately classifies a specific measurement, the
@@ -59,6 +83,75 @@ index excludes administrative/report metadata, malformed value-as-analyte
 fields, ECG and exercise-test procedure fields, routine urinalysis attributes,
 infectious screening and culture outcomes, blood type, genetics report
 commentary, and unknown custom fields.
+
+## Reviewed content coverage
+
+The requested content set contains 122 labels: 117 saved-lab labels and 5
+device markers. Canonicalization produces 115 distinct lab identities and 5
+device identities, for 120 authored Commons entities. The two true label alias
+pairs are `MPV` / `Mean Platelet Volume` and `CO2` / `Carbon Dioxide`.
+
+| Measure | Count |
+| --- | ---: |
+| Requested labels | 122 |
+| Requested saved-lab labels | 117 |
+| Distinct saved-lab identities | 115 |
+| Requested device identities | 5 |
+| Authored Commons entities | 120 |
+| Existing pages updated | 21 |
+| New pages added | 99 |
+| Explicit metric-to-Commons mappings | 6 |
+
+The explicit mappings preserve stable metric identities while reusing the
+correct existing authored analyte page:
+
+| Metric biomarker key | Authored Commons entity |
+| --- | --- |
+| `biomarker:alt` | `biomarker:alanine-aminotransferase` |
+| `biomarker:apob` | `biomarker:apolipoprotein-b` |
+| `biomarker:ast` | `biomarker:aspartate-aminotransferase` |
+| `biomarker:creatinine` | `biomarker:serum-creatinine` |
+| `biomarker:total-bilirubin` | `biomarker:bilirubin` |
+| `biomarker:vitamin-d` | `biomarker:serum-25-hydroxyvitamin-d` |
+
+| Guidance classification | Entities |
+| --- | ---: |
+| Generally applicable numeric | 1 |
+| Conditional numeric | 11 |
+| Calculated or method-specific | 17 |
+| Qualitative | 3 |
+| Source-range-only | 52 |
+| No universal range | 36 |
+| **Total** | **120** |
+
+Twelve entities use a numeric classification. FIB-4 and vitamin D retain
+tightly scoped numeric decision items while remaining classified for the
+governing limitation: FIB-4 is calculation-specific, and vitamin D records
+conflicting guidance rather than a false universal range.
+
+The coverage tests keep distinct LDL calculation methods; generic, CKD-EPI,
+and historical MDRD eGFR outputs; percentage and absolute differential counts;
+OmegaCheck panels, individual fatty acids, and ratios; generic mercury and any
+future specimen-specific mercury assay; and POC troponin I versus any
+assay-specific troponin identity or cutoff. Historical MDRD outputs remain for
+report provenance but are not normalized into current race-free eGFR
+identities.
+
+Three evidence limitations remain explicit rather than being filled with false
+precision:
+
+1. Generic `Mercury` does not identify specimen or chemical species, so no
+   portable numeric range is encoded and specimen-specific aliases remain
+   excluded.
+2. `POC Troponin I` does not identify an instrument or assay generation, so its
+   exact 99th-percentile upper reference limit comes from the assay
+   documentation and reporting source.
+3. Several living assay catalogs do not publish a stable publication year;
+   source metadata records the 2026 review year with the exact title and URL.
+
+These are contextual limitations, not missing page coverage. The request's
+health-area groups remain navigation only and do not imply medical equivalence,
+interchangeable assays, or shared reference guidance.
 
 ## Ownership
 
@@ -84,4 +177,8 @@ commentary, and unknown custom fields.
 - UI tests cover device-first ordering, initially expanded disclosures, search,
   status filters, flagged-first ordering, the one-row notebook shape,
   full-row links, the absence of `Other`, and the saved-but-unclassified empty
-  state.
+  state. Detail tests cover exact comparators, qualitative history, reference
+  band eligibility, responsive ledger structure, and Commons summary fallback.
+- Health Commons coverage tests resolve every requested lab and device identity,
+  enforce the deliberate aliases and non-equivalences, validate one-sentence
+  summaries and source locators, and lock the guidance-classification counts.

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -62,11 +62,12 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // unit normalization, the combined head measures 9,410,180B. Current main's
 // persona redesign adds 10,122B, producing 9,420,302B. PR #824's Epic query
 // expansion measures 9,388,733B on that mainline; the exact combined graph
-// measures 9,424,514B. Ratchet the fixed total backstop to that exact
-// local measurement;
+// measures 9,424,514B. PR #838's reviewed biomarker catalog produces
+// 9,424,731B on CI Linux (+217B) and 9,460,571B on local macOS. Ratchet the
+// fixed total backstop to the larger exact measurement;
 // dynamic chunk jitter still receives no extra margin or platform-specific
 // branch.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_424_514;
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_460_571;
 // The exact PR #626 head after current-main exact-target reply handling adds
 // reviewed boot-critical batching recovery logic. Assembly measured
 // 1,486,467B on CI Linux (+699B over the prior budget) and 1,493,474B on local

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -535,7 +535,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_450_742 + 48_000 + 250_000,
       staticClosureBytes: 7_500_000 + 96_000 + 250_000,
-      totalBytes: 9_424_514,
+      totalBytes: 9_460_571,
     });
   });
 

--- a/apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx
@@ -13,7 +13,7 @@ import {
 } from "@murphai/query/browser-biomarkers";
 
 import { LabResultValue } from "@/src/components/biomarkers/lab-result-value";
-import { BiomarkerDeviceReadingCard } from "@/src/components/biomarkers/biomarker-device-reading-card";
+import { BiomarkerIcon } from "@/src/components/biomarkers/biomarker-icon";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { AuthButton } from "@/src/components/ui/auth-button";
 import { Button } from "@/src/components/ui/button";
@@ -151,13 +151,44 @@ export function BiomarkersPageClient({
       ) : null}
 
       {authenticated && !authRequired && biomarkers.length > 0 ? (
-        <MeasuredBiomarkerControls
-          counts={filterCounts}
-          filter={filter}
-          onFilterChange={setFilter}
-          onQueryChange={setQuery}
-          query={query}
-        />
+        <section aria-labelledby="lab-biomarkers-heading" className="flex flex-col gap-4">
+          <h2
+            className="font-serif text-2xl font-semibold tracking-tight text-foreground"
+            id="lab-biomarkers-heading"
+          >
+            From the lab
+          </h2>
+          <MeasuredBiomarkerControls
+            counts={filterCounts}
+            filter={filter}
+            onFilterChange={setFilter}
+            onQueryChange={setQuery}
+            query={query}
+          />
+          {groups.length > 0 ? (
+            <div className="overflow-hidden rounded-xl border border-border/70 bg-card/70">
+              {groups.map((group) => (
+                <MeasuredBiomarkerSection
+                  key={group.id}
+                  group={group}
+                />
+              ))}
+            </div>
+          ) : (
+            <div
+              aria-live="polite"
+              className="rounded-xl border border-border/70 bg-card/70 px-5 py-10 text-center"
+              role="status"
+            >
+              <p className="font-serif text-xl font-semibold text-foreground">
+                No matching biomarkers
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Try another name or status.
+              </p>
+            </div>
+          )}
+        </section>
       ) : null}
 
       {(authRequired || status === "empty" || status === "ready")
@@ -173,31 +204,6 @@ export function BiomarkersPageClient({
         />
       ) : null}
 
-      {authenticated && biomarkers.length > 0 && groups.length > 0 ? (
-        <div className="flex flex-col gap-6">
-          {groups.map((group) => (
-            <MeasuredBiomarkerSection
-              key={group.id}
-              group={group}
-            />
-          ))}
-        </div>
-      ) : null}
-
-      {authenticated && biomarkers.length > 0 && groups.length === 0 ? (
-        <div
-          aria-live="polite"
-          className="rounded-xl border border-border/70 bg-card/70 px-5 py-10 text-center"
-          role="status"
-        >
-          <p className="font-serif text-xl font-semibold text-foreground">
-            No matching biomarkers
-          </p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Try another name or status.
-          </p>
-        </div>
-      ) : null}
     </div>
   );
 }
@@ -233,10 +239,10 @@ function countSavedLabResults(client: BrowserVaultQueryClient): number {
 
 function DeviceMetricsSection({ items }: { items: DeviceMetricListItem[] }) {
   return (
-    <section aria-labelledby="biomarker-devices-heading" className="flex flex-col gap-3">
-      <div className="flex items-baseline justify-between gap-4">
+    <section aria-labelledby="biomarker-devices-heading" className="overflow-hidden rounded-xl border border-border/70 bg-card/70">
+      <div className="flex items-baseline justify-between gap-4 border-b border-border/70 px-5 py-4 sm:px-8">
         <h2
-          className="font-serif text-xl font-semibold tracking-tight text-foreground"
+          className="font-serif text-2xl font-semibold tracking-tight text-foreground"
           id="biomarker-devices-heading"
         >
           From your devices
@@ -246,10 +252,10 @@ function DeviceMetricsSection({ items }: { items: DeviceMetricListItem[] }) {
         </span>
       </div>
 
-      <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <ul>
         {items.map((item) => (
-          <li className="min-w-0" key={item.entry.routeId}>
-            <DeviceMetricCard item={item} />
+          <li className="min-w-0 border-b border-border/70 last:border-b-0" key={item.entry.routeId}>
+            <DeviceMetricRow item={item} />
           </li>
         ))}
       </ul>
@@ -257,18 +263,35 @@ function DeviceMetricsSection({ items }: { items: DeviceMetricListItem[] }) {
   );
 }
 
-function DeviceMetricCard({ item }: { item: DeviceMetricListItem }) {
+function DeviceMetricRow({ item }: { item: DeviceMetricListItem }) {
   const { entry, summary } = item;
+  const category = entry.category?.replaceAll("-", " ") ?? "Device metric";
+  const valueLabel = `${formatMetricValue(summary.latest.value, entry.valuePrecision)}${labUnitSuffix(summary.latest.unit ?? entry.unit)}`;
 
   return (
-    <BiomarkerDeviceReadingCard
-      category={entry.category}
-      routeId={entry.routeId}
-      stale={summary.stale}
-      summary={entry.summary}
-      title={entry.shortName}
-      valueLabel={`${formatMetricValue(summary.latest.value, entry.valuePrecision)}${labUnitSuffix(summary.latest.unit ?? entry.unit)}`}
-    />
+    <Link
+      className="group grid min-h-28 grid-cols-[2.5rem_minmax(0,1fr)] gap-4 px-5 py-5 transition-colors duration-200 hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-8 md:grid-cols-[2.5rem_8rem_minmax(0,1fr)_auto] md:items-center md:gap-5"
+      href={`/biomarkers/${entry.routeId}`}
+    >
+      <BiomarkerIcon className="size-9" routeId={entry.routeId} />
+      <div className="min-w-0">
+        <p className="hidden font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground md:block">
+          {category}
+        </p>
+        <p className="text-base font-semibold text-foreground md:mt-1">{entry.shortName}</p>
+      </div>
+      <p className="col-span-2 line-clamp-2 max-w-[72ch] text-sm leading-relaxed text-muted-foreground md:col-span-1 md:line-clamp-none">
+        {entry.summary ?? "A device-derived health metric from your connected data."}
+      </p>
+      <p className="col-span-2 min-w-24 text-left md:col-span-1 md:text-right">
+        <span className="font-serif text-3xl font-semibold tabular-nums text-foreground">
+          {valueLabel}
+        </span>
+        {summary.stale ? (
+          <span className="mt-1 block text-xs font-medium text-destructive">Out of date</span>
+        ) : null}
+      </p>
+    </Link>
   );
 }
 
@@ -310,7 +333,7 @@ function MeasuredBiomarkerControls({
             aria-label={`${option.label}, ${counts[option.value]}`}
             aria-pressed={filter === option.value}
             className={cn(
-              "rounded-full border-2 bg-card/60 px-5 text-sm text-foreground hover:bg-muted/30",
+              "inline-flex items-center justify-center gap-2 rounded-full border-2 bg-card/60 px-5 text-sm leading-none text-foreground hover:bg-muted/30",
               filter === option.value ? "border-foreground" : "border-border/70",
             )}
             key={option.value}
@@ -337,7 +360,7 @@ function MeasuredBiomarkerControls({
               {option.label}
             </span>
             <span aria-hidden="true" className="text-muted-foreground">·</span>
-            <span className="text-sm font-normal tabular-nums text-muted-foreground">
+            <span className="inline-flex min-w-4 items-center justify-center self-center font-mono text-xs font-normal leading-none tabular-nums text-muted-foreground">
               {counts[option.value]}
             </span>
           </Button>
@@ -358,7 +381,7 @@ function MeasuredBiomarkerSection({
   return (
     <details
       aria-labelledby={headingId}
-      className="group overflow-hidden rounded-xl border border-border/70 bg-card/70"
+      className="group border-b border-border/70 last:border-b-0"
       onToggle={(event) => {
         setOpen(event.currentTarget.open);
       }}
@@ -403,9 +426,20 @@ function MeasuredBiomarkerRow({
       href={`/biomarkers/results/${encodeURIComponent(biomarker.metricKey)}`}
       prefetch={false}
     >
-      <h3 className="min-w-0 break-words text-lg font-medium tracking-tight text-foreground">
-        {biomarker.displayName}
-      </h3>
+      <div className="flex min-w-0 items-center gap-3">
+        <span
+          aria-hidden="true"
+          className={cn(
+            "h-8 w-1 shrink-0 rounded-full",
+            status === "review" && "bg-destructive",
+            status === "in-range" && "bg-primary",
+            status === "reported" && "bg-muted-foreground/50",
+          )}
+        />
+        <h3 className="min-w-0 break-words text-lg font-medium tracking-tight text-foreground">
+          {biomarker.displayName}
+        </h3>
+      </div>
       <p className="min-w-0 break-words text-sm sm:ml-auto sm:max-w-[50%] sm:text-right">
         <strong
           className={cn(

--- a/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/lab-biomarker-detail-client.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/lab-biomarker-detail-client.tsx
@@ -35,7 +35,6 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import {
   formatLabDate,
   formatLabFlag,
-  formatLabReferenceRange,
   formatLabResultReferenceRange,
   formatLabUnit,
   labResultYear,
@@ -44,10 +43,13 @@ import {
   useBrowserVault,
   useBrowserVaultSelector,
 } from "@/src/lib/browser-vault/context";
+import { cn } from "@/src/lib/utils";
 
 interface LabBiomarkerDetailClientProps {
   authenticated: boolean;
+  chatAction?: ReactNode;
   metricKey: string;
+  summary?: string | null;
   uploadLabsAction?: ReactNode;
 }
 
@@ -58,7 +60,9 @@ interface LabResultYearGroup {
 
 export function LabBiomarkerDetailClient({
   authenticated,
+  chatAction = null,
   metricKey,
+  summary = null,
   uploadLabsAction = null,
 }: LabBiomarkerDetailClientProps) {
   const {
@@ -134,32 +138,42 @@ export function LabBiomarkerDetailClient({
   }
 
   return (
-    <BiomarkerDetailShell detail={visibleDetail}>
+    <BiomarkerDetailShell chatAction={chatAction} detail={visibleDetail} summary={summary}>
       {content}
     </BiomarkerDetailShell>
   );
 }
 
 function BiomarkerDetailShell({
+  chatAction,
   children,
   detail,
+  summary,
 }: {
+  chatAction: ReactNode;
   children: ReactNode;
   detail: BrowserVaultLabBiomarkerDetail | null;
+  summary: string | null;
 }) {
   return (
     <div className="flex flex-col gap-8">
       <div className="flex flex-col gap-4">
         <BackToBiomarkersLink />
         <header>
-          <h1 className="text-4xl font-semibold tracking-tight text-balance text-foreground sm:text-5xl">
+          <h1 className="font-serif text-4xl font-semibold tracking-tight text-balance text-foreground sm:text-5xl">
             {detail?.displayName ?? "Biomarker history"}
           </h1>
           <p className="mt-3 max-w-3xl text-base leading-relaxed text-pretty text-muted-foreground sm:text-lg">
             {detail
-              ? formatDetailSummary(detail)
+              ? summary ?? formatDetailSummary(detail)
               : "Review your saved results for one lab biomarker over time."}
           </p>
+          {detail && summary ? (
+            <p className="mt-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              {formatDetailSummary(detail)}
+            </p>
+          ) : null}
+          {chatAction ? <div className="mt-5">{chatAction}</div> : null}
         </header>
       </div>
       {children}
@@ -184,14 +198,10 @@ function BiomarkerDetailContent({
     id: point.rowId,
     value: point.value,
   }));
-  const chartNotes = buildChartNotes(detail);
   const chartRange = resolveChartedReferenceRange(detail);
-  const chartCaption = formatChartCaption(
-    chartPoints.length,
-    detail.comparableUnit,
-    chartRange,
-  );
   const latestStatus = resolveLatestResultStatus(detail.latest.flag);
+  const latestReferenceRange = formatLabResultReferenceRange(detail.latest);
+  const latestSource = detail.latest.labName ?? detail.latest.sourceLabel;
 
   return (
     <>
@@ -205,84 +215,95 @@ function BiomarkerDetailContent({
 
       <section
         aria-labelledby="biomarker-latest-result-heading"
-        className="border-y border-border/70 py-8 sm:py-10"
+        className="overflow-hidden rounded-xl border border-border/70 bg-card/70"
       >
-        <h2
-          className={latestStatus.tone === "in-range"
-            ? "text-2xl font-semibold tracking-tight text-primary"
-            : latestStatus.tone === "review"
-              ? "text-2xl font-semibold tracking-tight text-destructive"
-              : "text-2xl font-semibold tracking-tight text-foreground"}
-          id="biomarker-latest-result-heading"
-        >
-          {latestStatus.label}
-        </h2>
-        <div className="mt-3 flex min-w-0 items-baseline gap-3">
-          <span
-            aria-hidden="true"
-            className={latestStatus.tone === "in-range"
-              ? "size-3 shrink-0 self-center rounded-full bg-primary/80"
-              : latestStatus.tone === "review"
-                ? "size-3 shrink-0 self-center rounded-full bg-destructive/80"
-                : "size-3 shrink-0 self-center rounded-full bg-muted-foreground/70"}
-          />
-          <LabResultValue
-            presentation="hero"
-            result={detail.latest}
-          />
-        </div>
-        <time
-          className="mt-4 block text-sm text-muted-foreground"
-          dateTime={detail.latest.date}
-        >
-          {formatLabDate(detail.latest.date)}
-        </time>
-
-        {chartPoints.length > 0 ? (
-          <div className="mt-9 min-w-0 border-t border-border/70 pt-5">
-            <p
-              className="mb-3 text-xs text-muted-foreground"
-              id="biomarker-chart-caption"
-            >
-              {chartCaption}
+        <div className={cn(
+          "grid",
+          chartPoints.length > 0
+            && "lg:grid-cols-[minmax(17rem,0.72fr)_minmax(0,1.28fr)]",
+        )}>
+          <div className={cn(
+            "px-5 py-8 sm:px-8 sm:py-10",
+            chartPoints.length > 0 && "lg:border-r lg:border-border/70",
+          )}>
+            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              Latest reading
             </p>
-            <LabBiomarkerHistoryChart
-              ariaDescribedBy="biomarker-chart-caption"
-              displayName={detail.displayName}
-              points={chartPoints}
-              referenceRange={chartRange}
-              unit={detail.comparableUnit}
-            />
-          </div>
-        ) : (
-          <div className="mt-9 border-t border-border/70 pt-5">
-            <Card size="sm">
-              <CardHeader>
-                <CardTitle>No comparable numeric trend</CardTitle>
-                <CardDescription>
-                  Qualitative results, boundary values, and units that cannot be compared remain in the history below.
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          </div>
-        )}
+            <h2
+              className={cn(
+                "mt-4 text-xl font-semibold tracking-tight",
+                latestStatus.tone === "in-range" && "text-primary",
+                latestStatus.tone === "review" && "text-destructive",
+                latestStatus.tone === "reported" && "text-foreground",
+              )}
+              id="biomarker-latest-result-heading"
+            >
+              {latestStatus.label}
+            </h2>
+            <div className="mt-3 flex min-w-0 items-baseline gap-3">
+              <span
+                aria-hidden="true"
+                className={latestStatus.tone === "in-range"
+                  ? "size-3 shrink-0 self-center rounded-full bg-primary/80"
+                  : latestStatus.tone === "review"
+                    ? "size-3 shrink-0 self-center rounded-full bg-destructive/80"
+                    : "size-3 shrink-0 self-center rounded-full bg-muted-foreground/70"}
+              />
+              <LabResultValue
+                presentation="hero"
+                result={detail.latest}
+              />
+            </div>
+            <time
+              className="mt-4 block text-sm text-muted-foreground"
+              dateTime={detail.latest.date}
+            >
+              {formatLabDate(detail.latest.date)}
+            </time>
 
-        {chartPoints.length === 1 ? (
-          <p className="text-sm text-muted-foreground">
-            One comparable numeric result is available. A second comparable numeric result will show a change over time.
-          </p>
-        ) : null}
-
-        {chartNotes.length > 0 ? (
-          <div className="mt-5 border-t border-border/70 pt-4">
-            <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
-              Chart context
-            </span>
-            <ul className="mt-2 flex list-disc flex-col gap-1 pl-5 text-sm text-muted-foreground">
-              {chartNotes.map((note) => <li key={note}>{note}</li>)}
-            </ul>
+            <dl className="mt-8 border-t border-border/70 pt-5 text-sm">
+              <div className="grid grid-cols-[7rem_1fr] gap-3 py-1.5">
+                <dt className="text-muted-foreground">Lab range</dt>
+                <dd className="break-words font-medium text-foreground">
+                  {latestReferenceRange ?? "Not listed"}
+                </dd>
+              </div>
+              <div className="grid grid-cols-[7rem_1fr] gap-3 py-1.5">
+                <dt className="text-muted-foreground">Source</dt>
+                <dd className="break-words font-medium text-foreground">
+                  {latestSource ?? "Not listed"}
+                </dd>
+              </div>
+              <div className="grid grid-cols-[7rem_1fr] gap-3 py-1.5">
+                <dt className="text-muted-foreground">History</dt>
+                <dd className="font-medium text-foreground">
+                  {detail.rows.length} {detail.rows.length === 1 ? "result" : "results"}
+                </dd>
+              </div>
+            </dl>
           </div>
-        ) : null}
+
+          {chartPoints.length > 0 ? (
+            <div className="min-w-0 border-t border-border/70 px-5 py-8 sm:px-8 sm:py-10 lg:border-t-0">
+              <h3 className="font-serif text-2xl font-semibold tracking-tight text-foreground">
+                Results over time
+              </h3>
+              <div className="mt-4 min-w-0">
+                <LabBiomarkerHistoryChart
+                  displayName={detail.displayName}
+                  points={chartPoints}
+                  referenceRange={chartRange}
+                  unit={detail.comparableUnit}
+                />
+              </div>
+              {chartPoints.length === 1 ? (
+                <p className="mt-3 text-sm text-muted-foreground">
+                  A second comparable numeric result will show a change over time.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </section>
 
       <section aria-labelledby="biomarker-history-heading" className="flex flex-col gap-6">
@@ -561,31 +582,6 @@ function formatDetailSummary(detail: BrowserVaultLabBiomarkerDetail): string {
   return `${detail.rows.length} saved ${detail.rows.length === 1 ? "result" : "results"}, ${span}.`;
 }
 
-function formatChartCaption(
-  pointCount: number,
-  unit: string | null,
-  range: LabBiomarkerChartRange | null,
-): string {
-  const plottedUnit = unit ? ` in ${formatLabUnit(unit)}` : "";
-  const plotted = `${pointCount} ${pointCount === 1 ? "result" : "results"} plotted${plottedUnit}`;
-  if (!range) {
-    return plotted;
-  }
-
-  const formattedRange = formatLabReferenceRange({
-    ...(range.high === null ? {} : { high: range.high }),
-    ...(range.low === null ? {} : { low: range.low }),
-  }, unit);
-  if (!formattedRange) {
-    return plotted;
-  }
-
-  const rangeStyle = range.low !== null && range.high !== null
-    ? "Shaded lab range"
-    : "Dashed lab limit";
-  return `${plotted} · ${rangeStyle}: ${formattedRange}`;
-}
-
 /**
  * The chart plots normalized comparable values, so a reference band is only
  * truthful when every charted row has the same normalized numeric bounds.
@@ -635,26 +631,6 @@ function resolveChartedReferenceRange(
   }
 
   return range;
-}
-
-function buildChartNotes(detail: BrowserVaultLabBiomarkerDetail): string[] {
-  const notes: string[] = [];
-  const comparatorCount = detail.rows.filter((row) => row.comparator !== null).length;
-  const qualitativeCount = detail.rows.filter((row) =>
-    row.value === null && row.textValue !== null
-  ).length;
-
-  if (comparatorCount > 0) {
-    notes.push(`${comparatorCount} ${comparatorCount === 1 ? "result was" : "results were"} reported as a limit and ${comparatorCount === 1 ? "is" : "are"} kept in history rather than plotted as an exact value.`);
-  }
-  if (qualitativeCount > 0) {
-    notes.push(`${qualitativeCount} qualitative ${qualitativeCount === 1 ? "result is" : "results are"} shown in history but not on the numeric chart.`);
-  }
-  if (detail.hasIncompatibleHistory) {
-    notes.push("Results in units that could not be compared are kept in history; no single numeric series includes them.");
-  }
-
-  return notes;
 }
 
 function isAuthRequiredBrowserVaultError(error: string | null): boolean {

--- a/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/page.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/page.tsx
@@ -1,11 +1,18 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { resolveHealthCommonsBiomarkerEntityKey } from "@murphai/health-commons";
+import { resolveLabResultMetricDefinition } from "@murphai/health-metrics";
 
+import {
+  LabBiomarkerChatAction,
+  LabBiomarkerChatActionFallback,
+} from "@/src/components/biomarkers/lab-biomarker-chat-action";
 import {
   UploadLabsActionFallback,
   UploadLabsMurphContactAction,
 } from "@/src/components/home/upload-labs-action";
 import { getHostedDashboardPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
+import { getGeneratedBiomarkerIndex } from "@/src/lib/health-commons/generated-biomarker-artifacts";
 import { createMurphPageMetadata } from "@/src/lib/site-metadata";
 
 import { LabBiomarkerDetailClient } from "./lab-biomarker-detail-client";
@@ -22,11 +29,21 @@ export default async function LabBiomarkerResultPage({
 }) {
   const { metricKey } = await params;
   const auth = await getHostedDashboardPageAuthSnapshot();
+  const context = resolveLabBiomarkerContext(metricKey);
 
   return (
     <LabBiomarkerDetailClient
       authenticated={auth.authenticated}
+      chatAction={
+        <Suspense fallback={<LabBiomarkerChatActionFallback />}>
+          <LabBiomarkerChatAction
+            authenticated={auth.authenticated}
+            displayName={context.displayName}
+          />
+        </Suspense>
+      }
       metricKey={metricKey}
+      summary={context.summary}
       uploadLabsAction={
         <Suspense fallback={<UploadLabsActionFallback />}>
           <UploadLabsMurphContactAction />
@@ -34,4 +51,31 @@ export default async function LabBiomarkerResultPage({
       }
     />
   );
+}
+
+export function resolveLabBiomarkerContext(metricKey: string): {
+  displayName: string;
+  summary: string | null;
+} {
+  const normalizedMetricKey = metricKey.trim().toLowerCase();
+  const definition = resolveLabResultMetricDefinition(normalizedMetricKey);
+  const entityKeys = new Set([
+    definition?.biomarkerKey,
+    ...(definition?.biomarkerAliases ?? []),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => resolveHealthCommonsBiomarkerEntityKey(value)));
+  const entry = getGeneratedBiomarkerIndex().biomarkers.find((candidate) =>
+    entityKeys.has(candidate.key)
+      || candidate.routeId === normalizedMetricKey
+      || candidate.aliases.includes(normalizedMetricKey)
+  );
+
+  return {
+    displayName: definition?.displayName
+      ?? entry?.shortName
+      ?? entry?.title
+      ?? normalizedMetricKey.replaceAll("-", " "),
+    summary: entry?.summary ?? null,
+  };
 }

--- a/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/page.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { resolveHealthCommonsBiomarkerEntityKey } from "@murphai/health-commons";
+import {
+  resolveHealthCommonsBiomarkerEntityKey,
+} from "@murphai/health-commons/biomarker-entity-mappings";
 import { resolveLabResultMetricDefinition } from "@murphai/health-metrics";
 
 import {

--- a/apps/web/app/design/design-page.tsx
+++ b/apps/web/app/design/design-page.tsx
@@ -26,7 +26,7 @@ export function DesignPage() {
     <main className="min-h-screen bg-[#f5f0e8] antialiased">
       {/* Tab nav */}
       <div className="sticky top-0 z-30 border-b border-[#e5e1d8] bg-[#f5f0e8]/95 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-5xl items-center gap-1 px-6 py-3 sm:px-10 lg:px-16">
+        <div className={`mx-auto flex items-center gap-1 py-3 ${activeTab === "sections" ? "max-w-7xl px-5 sm:px-8 lg:px-12" : "max-w-5xl px-6 sm:px-10 lg:px-16"}`}>
           {TABS.map((tab) => (
             <button
               key={tab.id}

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -1,4 +1,5 @@
 import {
+  BiomarkerBoundaryResultStudy,
   BiomarkerDetailStudy,
   BiomarkerIndexStudy,
 } from "@/src/components/biomarkers/biomarker-design-studies";
@@ -24,7 +25,7 @@ function StudySection({
 
 export function SectionsContent() {
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-16 px-6 py-12 sm:px-10 lg:px-16">
+    <div className="mx-auto flex max-w-7xl flex-col gap-16 px-5 py-12 sm:px-8 lg:px-12">
       <h1 className="font-serif text-4xl font-semibold tracking-tight text-foreground">
         Sections
       </h1>
@@ -45,6 +46,12 @@ export function SectionsContent() {
 
       <StudySection title="Biomarker detail">
         <BiomarkerDetailStudy />
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Boundary result detail">
+        <BiomarkerBoundaryResultStudy />
       </StudySection>
     </div>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "@murphai/contracts": "workspace:*",
     "@murphai/device-syncd": "workspace:*",
     "@murphai/health-commons": "workspace:*",
+    "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-execution": "workspace:*",
     "@murphai/messaging-ingress": "workspace:*",
     "@murphai/query": "workspace:*",

--- a/apps/web/src/components/biomarkers/biomarker-design-data.ts
+++ b/apps/web/src/components/biomarkers/biomarker-design-data.ts
@@ -1,0 +1,346 @@
+export type BiomarkerStudyStatus = "in-range" | "reported" | "review";
+
+export interface BiomarkerStudyResult {
+  metricKey: string;
+  name: string;
+  status: BiomarkerStudyStatus;
+  statusLabel: string;
+  unit: string | null;
+  value: string;
+}
+
+export interface BiomarkerStudyGroup {
+  id: string;
+  label: string;
+  results: readonly BiomarkerStudyResult[];
+}
+
+export interface BiomarkerDeviceStudy {
+  category: string;
+  metricKey: string;
+  name: string;
+  summary: string;
+  unit: string;
+  value: string;
+}
+
+export const BIOMARKER_DEVICE_STUDIES: readonly BiomarkerDeviceStudy[] = [
+  {
+    category: "Sleep",
+    metricKey: "deep-sleep-minutes",
+    name: "Deep sleep",
+    summary: "Time spent in slow-wave sleep each night, where the brain's deepest electrical slowdown drives growth-hormone release, tissue repair, and waste clearance that lighter stages do not match.",
+    unit: "minutes",
+    value: "96",
+  },
+  {
+    category: "Recovery",
+    metricKey: "hrv-rmssd",
+    name: "HRV",
+    summary: "Beat-to-beat variation in heart timing measured at rest, where more variation signals stronger vagal brake on the heart and a nervous system with room to respond rather than one stuck in overdrive.",
+    unit: "ms",
+    value: "61",
+  },
+  {
+    category: "Sleep",
+    metricKey: "rem-sleep-minutes",
+    name: "REM",
+    summary: "Time spent in rapid-eye-movement sleep each night, where the brain fires almost as actively as when awake to consolidate memory, process emotion, and rehearse learned patterns.",
+    unit: "minutes",
+    value: "132",
+  },
+  {
+    category: "Cardiovascular",
+    metricKey: "resting-heart-rate",
+    name: "RHR",
+    summary: "How many times the heart beats per minute at full rest, where a lower count usually means the heart pumps more blood per beat and needs fewer contractions to do the same job.",
+    unit: "bpm",
+    value: "54",
+  },
+  {
+    category: "Respiratory",
+    metricKey: "blood-oxygen-spo2",
+    name: "SpO₂",
+    summary: "Percentage of hemoglobin carrying oxygen in the blood, where a consistently high reading means the lungs are loading red blood cells efficiently and tissue is getting the oxygen it needs.",
+    unit: "%",
+    value: "97.3",
+  },
+] as const;
+
+export const BIOMARKER_STUDY_GROUPS: readonly BiomarkerStudyGroup[] = [
+  {
+    id: "blood-sugar",
+    label: "Blood sugar",
+    results: [
+      result("c-peptide", "C-peptide", "ng/mL"),
+      result("glucose", "Glucose", "mg/dL"),
+      result("hba1c", "HbA1c", "%"),
+      result("insulin", "Insulin", "mIU/L"),
+    ],
+  },
+  {
+    id: "heart-lipids",
+    label: "Heart & lipids",
+    results: [
+      result("homocysteine", "Homocysteine", "umol/L"),
+      result("ldl-large-particles", "LDL large particles", "nmol/L"),
+      result("ldl-medium-particles", "LDL medium particles", "nmol/L"),
+      result("ldl-particle-number", "LDL particle number", "nmol/L"),
+      result("ldl-peak-size", "LDL peak size", "Angstrom"),
+      result("ldl-small-particles", "LDL small particles", "nmol/L"),
+      result("ldl-c", "LDL-C", "mg/dL"),
+      result("total-cholesterol", "Total cholesterol", "mmol/L"),
+      result("apob", "ApoB", "mg/dL"),
+      result("cholesterol-hdl-ratio", "Cholesterol/HDL ratio", "ratio"),
+      result("hdl-c", "HDL-C", "mg/dL"),
+      result("ldl-pattern", "LDL pattern", null),
+      result("lipoprotein-a", "Lipoprotein(a)", "nmol/L"),
+      result("non-hdl-cholesterol", "Non-HDL cholesterol", "mmol/L"),
+      result("triglycerides", "Triglycerides", "mg/dL"),
+      result("vldl-cholesterol-calculated", "Calculated VLDL cholesterol", "mg/dL"),
+      result("ldl-calculated", "LDL Calculated", "mg/dL"),
+      result("ldl-chol-calc-nih", "LDL CHOL CALC (NIH)", "mg/dL"),
+      result("poc-troponin-i", "POC Troponin I", "ng/mL"),
+    ],
+  },
+  {
+    id: "kidneys",
+    label: "Kidneys",
+    results: [
+      result("creatinine", "Creatinine", "mg/dL"),
+      result("egfr-ckd-epi", "eGFR (CKD-EPI)", "mL/min/1.73m^2"),
+      result("blood-urea-nitrogen", "Blood urea nitrogen", "mg/dL"),
+      result("egfr", "eGFR", "mL/min/1.73m^2"),
+      result("uric-acid", "Uric Acid", "mmol/L"),
+      result("urine-protein", "Urine protein", null),
+      result("bun-creatinine-ratio", "BUN/Creatinine Ratio", null),
+      result("gfr-mdrd-af-amer", "GFR MDRD Af Amer", "mL/min/1.73"),
+      result("gfr-mdrd-non-af-amer", "GFR MDRD Non Af Amer", "mL/min/1.73"),
+      result("urine-albumin-random-without-creatinine", "Urine albumin random without creatinine", "mg/dL"),
+    ],
+  },
+  {
+    id: "liver",
+    label: "Liver",
+    results: [
+      result("albumin", "Albumin", "g/dL"),
+      result("albumin-globulin-ratio", "Albumin/Globulin Ratio", "ratio"),
+      result("alkaline-phosphatase", "Alkaline phosphatase", "U/L"),
+      result("alt", "ALT", "U/L"),
+      result("ast", "AST", "U/L"),
+      result("fib4", "FIB-4", "score"),
+      result("ggt", "GGT", "U/L"),
+      result("total-globulin", "Globulin", "g/L"),
+      result("total-bilirubin", "Total bilirubin", "umol/L"),
+      result("total-protein", "Total Protein", "g/L"),
+    ],
+  },
+  {
+    id: "thyroid",
+    label: "Thyroid",
+    results: [
+      result("free-t3", "Free T3", "pg/mL"),
+      result("free-t4", "Free T4", "ng/dL"),
+      result("thyroglobulin-antibodies", "Thyroglobulin Antibodies", null),
+      result("thyroid-peroxidase-antibodies", "Thyroid Peroxidase Antibodies", "IU/mL"),
+      result("thyroid-stimulating-hormone", "Thyroid-stimulating hormone", "mIU/L"),
+    ],
+  },
+  {
+    id: "blood",
+    label: "Blood",
+    results: [
+      result("absolute-neutrophils", "Neutrophils, absolute", "x10^9/L"),
+      result("white-blood-cell-count", "White blood cells", "x10^9/L"),
+      result("basophil-percentage", "Basophils", "%"),
+      result("absolute-basophils", "Basophils, absolute", "x10^9/L"),
+      result("eosinophil-percentage", "Eosinophils", "%", "review"),
+      result("absolute-eosinophils", "Eosinophils, absolute", "x10^9/L"),
+      result("hematocrit", "Hematocrit", "%"),
+      result("hemoglobin", "Hemoglobin", "g/dL"),
+      result("lymphocyte-percentage", "Lymphocytes", "%", "review"),
+      result("absolute-lymphocytes", "Lymphocytes, absolute", "x10^9/L"),
+      result("mean-corpuscular-hemoglobin", "Mean corpuscular hemoglobin", "pg"),
+      result("mean-corpuscular-hemoglobin-concentration", "Mean corpuscular hemoglobin concentration", "g/dL"),
+      result("mean-corpuscular-volume", "Mean corpuscular volume", "fL"),
+      result("mean-platelet-volume", "Mean Platelet Volume", "fL"),
+      result("monocyte-percentage", "Monocytes", "%"),
+      result("absolute-monocytes", "Monocytes, absolute", "x10^9/L"),
+      result("neutrophil-percentage", "Neutrophils", "%"),
+      result("platelet-count", "Platelets", "x10^9/L"),
+      result("red-blood-cell-count", "Red blood cells", "x10^12/L"),
+      result("red-cell-distribution-width", "Red cell distribution width", "%"),
+      result("immature-granulocyte-percentage", "Immature granulocytes", "%"),
+      result("absolute-immature-granulocytes", "Immature granulocytes, absolute", "x10E3/uL", "review"),
+      result("mean-platelet-volume", "MPV", "fL"),
+    ],
+  },
+  {
+    id: "hormones",
+    label: "Hormones",
+    results: [
+      result("free-testosterone", "Free testosterone", "pg/mL"),
+      result("cortisol", "Cortisol", "mcg/dL"),
+      result("dhea-sulfate", "DHEA sulfate", "mcg/dL"),
+      result("sex-hormone-binding-globulin", "Sex Hormone Binding Globulin", "nmol/L"),
+      result("total-testosterone", "Total testosterone", "ng/dL"),
+      result("estradiol", "Estradiol", "pg/mL"),
+      result("follicle-stimulating-hormone", "Follicle Stimulating Hormone", "mIU/mL"),
+      result("luteinizing-hormone", "Luteinizing Hormone", "mIU/mL"),
+      result("prolactin", "Prolactin", "ng/mL"),
+    ],
+  },
+  {
+    id: "nutrients-fatty-acids",
+    label: "Nutrients & fatty acids",
+    results: [
+      result("omega-3-total-omegacheck", "Omega-3 Total / OmegaCheck", "% by wt"),
+      result("arachidonic-acid", "Arachidonic Acid", "% by wt"),
+      result("arachidonic-acid-epa-ratio", "Arachidonic Acid/EPA Ratio", null),
+      result("dha", "DHA", "% by wt"),
+      result("dpa", "DPA", "% by wt"),
+      result("epa", "EPA", "% by wt"),
+      result("ferritin", "Ferritin", "ng/mL"),
+      result("iron", "Iron", "mcg/dL"),
+      result("iron-saturation", "Iron saturation", "% (calc)"),
+      result("linoleic-acid", "Linoleic Acid", "% by wt"),
+      result("magnesium-rbc", "Magnesium RBC", "mg/dL"),
+      result("methylmalonic-acid", "Methylmalonic Acid", "nmol/L"),
+      result("omega-6-3-ratio", "Omega 6/3 Ratio", null),
+      result("total-iron-binding-capacity", "Total Iron Binding Capacity", "mcg/dL (calc)"),
+      result("vitamin-d", "Vitamin D", "ng/mL"),
+      result("zinc", "Zinc", "mcg/dL"),
+      result("omega-6-total", "Omega-6 total", "% by wt"),
+      result("omegacheck-total", "OmegaCheck total", "% by wt"),
+    ],
+  },
+  {
+    id: "inflammation-immune",
+    label: "Inflammation & immune",
+    results: [
+      result("ana-screen", "ANA screen", null),
+      result("hs-crp", "hs-CRP", "mg/L"),
+      result("rheumatoid-factor", "Rheumatoid Factor", null),
+    ],
+  },
+  {
+    id: "electrolytes",
+    label: "Electrolytes",
+    results: [
+      result("adjusted-calcium", "Adjusted Calcium", "mmol/L"),
+      result("calcium", "Calcium", "mmol/L"),
+      result("carbon-dioxide", "Carbon Dioxide", "mmol/L"),
+      result("chloride", "Chloride", "mmol/L"),
+      result("phosphate", "Phosphate", "mmol/L"),
+      result("potassium", "Potassium", "mmol/L"),
+      result("sodium", "Sodium", "mmol/L"),
+      result("anion-gap", "Anion Gap", null, "reported"),
+      result("carbon-dioxide", "CO2", "mmol/L"),
+    ],
+  },
+  {
+    id: "muscle-tissue",
+    label: "Muscle & tissue",
+    results: [
+      result("creatine-kinase", "Creatine Kinase", "U/L"),
+      result("ldh", "LDH", "U/L"),
+    ],
+  },
+  {
+    id: "environmental-exposure",
+    label: "Environmental exposure",
+    results: [
+      result("lead", "Lead", "mcg/dL"),
+      result("mercury", "Mercury", "mcg/L"),
+    ],
+  },
+  {
+    id: "prostate-health",
+    label: "Prostate health",
+    results: [
+      result("psa-free", "PSA free", "ng/mL"),
+      result("psa-percent-free", "PSA percent free", "% (calc)"),
+      result("psa-total", "PSA total", "ng/mL"),
+    ],
+  },
+] as const;
+
+function result(
+  metricKey: string,
+  name: string,
+  unit: string | null,
+  statusOverride?: BiomarkerStudyStatus,
+): BiomarkerStudyResult {
+  const seed = syntheticSeed(metricKey);
+  const statusBucket = seed % 8;
+  const generatedStatus: BiomarkerStudyStatus = statusBucket === 0
+    ? "review"
+    : statusBucket === 1
+      ? "reported"
+      : "in-range";
+  const status = statusOverride ?? generatedStatus;
+  const statusLabel = status === "review"
+    ? seed % 2 === 0 ? "Above range" : "Below range"
+    : status === "reported" ? "Reported" : "In range";
+
+  return {
+    metricKey,
+    name,
+    status,
+    statusLabel,
+    unit,
+    value: syntheticValue(metricKey, unit, seed),
+  };
+}
+
+function syntheticSeed(metricKey: string): number {
+  let seed = 0;
+  for (const character of metricKey) {
+    seed = ((seed * 31) + (character.codePointAt(0) ?? 0)) % 10_007;
+  }
+  return seed;
+}
+
+function syntheticValue(metricKey: string, unit: string | null, seed: number): string {
+  const qualitativeValues: Readonly<Record<string, string>> = {
+    "ana-screen": "Negative",
+    "ldl-pattern": "A",
+    "rheumatoid-factor": "<10",
+    "thyroglobulin-antibodies": "<1",
+    "urine-protein": "Negative",
+  };
+  const qualitativeValue = qualitativeValues[metricKey];
+  if (qualitativeValue) {
+    return qualitativeValue;
+  }
+
+  if (!unit || unit === "ratio" || unit === "score") {
+    return (1 + ((seed % 90) / 10)).toFixed(1);
+  }
+  if (unit.includes("% by wt")) {
+    return (0.5 + ((seed % 410) / 10)).toFixed(1);
+  }
+  if (unit.includes("%")) {
+    return String(10 + (seed % 81));
+  }
+  if (unit.includes("mL/min")) {
+    return String(65 + (seed % 56));
+  }
+  if (unit.includes("x10^9/L") || unit.includes("x10E3/uL")) {
+    return (0.1 + ((seed % 180) / 10)).toFixed(1);
+  }
+  if (unit.includes("x10^12/L")) {
+    return (3.8 + ((seed % 220) / 100)).toFixed(2);
+  }
+  if (unit === "g/dL") {
+    return (3.5 + ((seed % 150) / 10)).toFixed(1);
+  }
+  if (unit === "mmol/L") {
+    return (1.5 + ((seed % 85) / 10)).toFixed(1);
+  }
+  if (unit === "mg/dL") {
+    return (5 + (seed % 145)).toFixed(seed % 3 === 0 ? 1 : 0);
+  }
+
+  return String(1 + (seed % 360));
+}

--- a/apps/web/src/components/biomarkers/biomarker-design-studies.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-design-studies.tsx
@@ -1,146 +1,41 @@
 "use client";
 
 import Link from "next/link";
-import {
-  Activity,
-  ChevronRight,
-  Droplets,
-  Search,
-  TestTubes,
-} from "lucide-react";
-import { useMemo, useState, type ComponentType } from "react";
+import { ArrowLeft, ChevronDown, Search } from "lucide-react";
+import { useMemo, useState } from "react";
 
 import {
   LabBiomarkerHistoryChart,
   type LabBiomarkerChartPoint,
 } from "@/src/components/biomarkers/lab-biomarker-history-chart";
-import { LabResultValue } from "@/src/components/biomarkers/lab-result-value";
-import { Button } from "@/src/components/ui/button";
+import { BiomarkerIcon } from "@/src/components/biomarkers/biomarker-icon";
 import { Input } from "@/src/components/ui/input";
+import {
+  BIOMARKER_DEVICE_STUDIES,
+  BIOMARKER_STUDY_GROUPS,
+  type BiomarkerStudyGroup,
+  type BiomarkerStudyResult,
+  type BiomarkerStudyStatus,
+} from "@/src/components/biomarkers/biomarker-design-data";
 import { cn } from "@/src/lib/utils";
 
-type BiomarkerStudyStatus = "attention" | "in-range";
-type BiomarkerStudyFilter = "all" | BiomarkerStudyStatus;
-
-interface BiomarkerStudyResult {
-  id: string;
-  metricKey: string;
-  name: string;
-  status: BiomarkerStudyStatus;
-  statusLabel: string;
-  unit: string;
-  value: string;
-}
-
-interface BiomarkerStudyGroup {
-  icon: ComponentType<{ className?: string }>;
-  id: string;
-  label: string;
-  results: readonly BiomarkerStudyResult[];
-}
-
-const BIOMARKER_STUDY_GROUPS: readonly BiomarkerStudyGroup[] = [
-  {
-    icon: Droplets,
-    id: "blood",
-    label: "Blood",
-    results: [
-      {
-        id: "hemoglobin",
-        metricKey: "hemoglobin",
-        name: "Hemoglobin",
-        status: "attention",
-        statusLabel: "Above range",
-        unit: "g/dL",
-        value: "18.0",
-      },
-      {
-        id: "hematocrit",
-        metricKey: "hematocrit",
-        name: "Hematocrit",
-        status: "attention",
-        statusLabel: "Above range",
-        unit: "%",
-        value: "52.0",
-      },
-      {
-        id: "mch",
-        metricKey: "mean-corpuscular-hemoglobin",
-        name: "Mean corpuscular hemoglobin",
-        status: "in-range",
-        statusLabel: "In range",
-        unit: "pg",
-        value: "30.0",
-      },
-    ],
-  },
-  {
-    icon: Activity,
-    id: "metabolic",
-    label: "Metabolic",
-    results: [
-      {
-        id: "glucose",
-        metricKey: "glucose",
-        name: "Glucose",
-        status: "in-range",
-        statusLabel: "In range",
-        unit: "mg/dL",
-        value: "90",
-      },
-      {
-        id: "hemoglobin-a1c",
-        metricKey: "hba1c",
-        name: "Hemoglobin A1c",
-        status: "in-range",
-        statusLabel: "In range",
-        unit: "%",
-        value: "5.0",
-      },
-    ],
-  },
-  {
-    icon: TestTubes,
-    id: "thyroid",
-    label: "Thyroid",
-    results: [
-      {
-        id: "tsh",
-        metricKey: "thyroid-stimulating-hormone",
-        name: "Thyroid stimulating hormone",
-        status: "in-range",
-        statusLabel: "In range",
-        unit: "µIU/mL",
-        value: "2.0",
-      },
-      {
-        id: "free-t4",
-        metricKey: "free-t4",
-        name: "Free T4",
-        status: "in-range",
-        statusLabel: "In range",
-        unit: "ng/dL",
-        value: "1.0",
-      },
-    ],
-  },
-] as const;
-
-const HEMOGLOBIN_HISTORY: readonly LabBiomarkerChartPoint[] = [
-  { date: "2023-01-01", id: "synthetic-hgb-2023", value: 15 },
-  { date: "2024-01-01", id: "synthetic-hgb-2024", value: 16 },
-  { date: "2025-01-01", id: "synthetic-hgb-2025", value: 17 },
-  { date: "2026-01-01", id: "synthetic-hgb-2026", value: 18 },
-] as const;
+type BiomarkerStudyFilter = "all" | Exclude<BiomarkerStudyStatus, "reported">;
 
 const FILTERS: readonly {
   label: string;
-  tone?: BiomarkerStudyStatus;
+  tone?: "in-range" | "review";
   value: BiomarkerStudyFilter;
 }[] = [
   { label: "All", value: "all" },
-  { label: "Review", tone: "attention", value: "attention" },
+  { label: "Review", tone: "review", value: "review" },
   { label: "In range", tone: "in-range", value: "in-range" },
+] as const;
+
+const HEMOGLOBIN_HISTORY: readonly LabBiomarkerChartPoint[] = [
+  { date: "2023-02-17", displayValue: "15.4", id: "synthetic-hgb-2023", value: 15.4 },
+  { date: "2024-02-21", displayValue: "16.1", id: "synthetic-hgb-2024", value: 16.1 },
+  { date: "2025-02-19", displayValue: "17.2", id: "synthetic-hgb-2025", value: 17.2 },
+  { date: "2026-02-17", displayValue: "18.0", id: "synthetic-hgb-2026", value: 18 },
 ] as const;
 
 export function BiomarkerIndexStudy() {
@@ -153,9 +48,10 @@ export function BiomarkerIndexStudy() {
   const allResults = BIOMARKER_STUDY_GROUPS.flatMap((group) => group.results);
   const counts = {
     all: allResults.length,
-    attention: allResults.filter((result) => result.status === "attention").length,
     "in-range": allResults.filter((result) => result.status === "in-range").length,
-  } satisfies Record<BiomarkerStudyFilter, number>;
+    reported: allResults.filter((result) => result.status === "reported").length,
+    review: allResults.filter((result) => result.status === "review").length,
+  } satisfies Record<BiomarkerStudyStatus | "all", number>;
   const visibleGroups = useMemo(
     () => BIOMARKER_STUDY_GROUPS.flatMap((group) => {
       const results = group.results
@@ -165,12 +61,13 @@ export function BiomarkerIndexStudy() {
             || `${result.name} ${group.label}`.toLocaleLowerCase().includes(normalizedQuery);
           return matchesFilter && matchesQuery;
         })
-        .sort((left, right) => Number(left.status !== "attention") - Number(right.status !== "attention"));
+        .sort(compareBiomarkerStudyResults);
 
       return results.length > 0 ? [{ ...group, results }] : [];
     }),
     [filter, normalizedQuery],
   );
+
   function handleGroupToggle(groupId: string, open: boolean) {
     setOpenGroups((current) => {
       const next = new Set(current);
@@ -184,32 +81,90 @@ export function BiomarkerIndexStudy() {
   }
 
   return (
-    <section
+    <article
       aria-labelledby="biomarker-index-study-heading"
-      className="overflow-hidden rounded-xl border border-border/70 bg-card/80"
+      className="overflow-hidden rounded-xl border border-border/70 bg-card/70"
       data-design-study="biomarker-index"
     >
-      <div className="px-5 py-6 sm:px-7 sm:py-8">
-        <h3
-          className="scroll-mt-20 font-serif text-3xl font-semibold tracking-tight text-foreground sm:text-4xl"
-          id="biomarker-index-study-heading"
-        >
-          Biomarkers
-        </h3>
-      </div>
+      <header className="grid gap-8 border-b border-border/70 px-5 py-8 sm:px-8 sm:py-10 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            Synthetic interface study
+          </p>
+          <h3
+            className="mt-3 scroll-mt-20 font-serif text-4xl font-semibold tracking-tight text-foreground sm:text-5xl"
+            id="biomarker-index-study-heading"
+          >
+            Your biomarkers
+          </h3>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            Example device readings and lab-result identities, filed by what they describe rather than by which report they arrived in. Values and flags are fabricated for this layout study.
+          </p>
+        </div>
+        <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground lg:text-right">
+          {BIOMARKER_DEVICE_STUDIES.length} device metrics<br />
+          {counts.all} lab markers
+        </p>
+      </header>
 
-      <div className="border-t border-border/70 px-5 py-5 sm:px-7 sm:py-6">
-        <div className="grid gap-3 lg:grid-cols-[minmax(16rem,1fr)_auto] lg:items-center">
+      <section aria-labelledby="device-study-heading">
+        <div className="flex items-baseline justify-between gap-4 border-b border-border/70 px-5 py-4 sm:px-8">
+          <h4 className="font-serif text-2xl font-semibold tracking-tight text-foreground" id="device-study-heading">
+            From your devices
+          </h4>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            Latest reading
+          </span>
+        </div>
+        <ol>
+          {BIOMARKER_DEVICE_STUDIES.map((metric) => (
+            <li className="border-b border-border/70 last:border-b-0" key={metric.metricKey}>
+              <Link
+                className="group grid min-h-28 grid-cols-[2.5rem_minmax(0,1fr)] gap-4 px-5 py-5 transition-colors duration-200 hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-8 md:grid-cols-[2.5rem_8rem_minmax(0,1fr)_auto] md:items-center md:gap-5"
+                href={`/biomarkers/${metric.metricKey}`}
+              >
+                <BiomarkerIcon className="size-9" routeId={metric.metricKey} />
+                <div className="min-w-0">
+                  <p className="hidden font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground md:block">
+                    {metric.category}
+                  </p>
+                  <p className="text-base font-semibold text-foreground md:mt-1">{metric.name}</p>
+                </div>
+                <p className="col-span-2 line-clamp-2 max-w-[72ch] text-sm leading-relaxed text-muted-foreground md:col-span-1 md:line-clamp-none">
+                  {metric.summary}
+                </p>
+                <p className="col-span-2 min-w-24 text-left md:col-span-1 md:text-right">
+                  <span className="font-serif text-3xl font-semibold tabular-nums text-foreground">
+                    {metric.value}
+                  </span>{" "}
+                  <span className="text-xs text-muted-foreground">{metric.unit}</span>
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section aria-labelledby="lab-study-heading" className="border-t border-border/70">
+        <div className="px-5 pt-8 sm:px-8 sm:pt-10">
+          <h4 className="font-serif text-2xl font-semibold tracking-tight text-foreground" id="lab-study-heading">
+            From the lab
+          </h4>
+        </div>
+
+        <div className="grid gap-3 px-5 py-6 sm:px-8 lg:grid-cols-[minmax(18rem,1fr)_auto] lg:items-center">
           <label className="relative block">
-            <span className="sr-only">Search illustrative lab biomarkers</span>
+            <span className="sr-only">
+              Search biomarkers
+            </span>
             <Search
               aria-hidden="true"
-              className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
               strokeWidth={1.75}
             />
             <Input
-              className="bg-background/45 pl-9"
-              onChange={(event) => setQuery(event.target.value)}
+              className="h-12 rounded-full border-border/80 bg-background/45 pl-11 pr-5 shadow-none"
+              onInput={(event) => setQuery(event.currentTarget.value)}
               placeholder="Search biomarkers"
               type="search"
               value={query}
@@ -217,66 +172,58 @@ export function BiomarkerIndexStudy() {
           </label>
           <div aria-label="Filter illustrative lab biomarkers" className="flex flex-wrap gap-2" role="group">
             {FILTERS.map((option) => (
-              <Button
+              <button
                 aria-label={`${option.label}, ${counts[option.value]}`}
                 aria-pressed={filter === option.value}
                 className={cn(
-                  "rounded-full bg-card/40 px-6 text-base text-foreground hover:bg-muted/30",
+                  "inline-flex h-12 items-center justify-center gap-2 rounded-full border px-5 text-sm font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   filter === option.value
-                    ? "border-2 border-foreground"
-                    : "border border-border/90",
+                    ? "border-foreground bg-background text-foreground ring-1 ring-foreground"
+                    : "border-border/80 text-muted-foreground hover:border-foreground/40 hover:text-foreground",
                 )}
                 key={option.value}
                 onClick={() => setFilter(option.value)}
-                size="lg"
                 type="button"
-                variant="unstyled"
               >
                 {option.tone ? (
                   <span
                     aria-hidden="true"
                     className={cn(
                       "size-2.5 shrink-0 rounded-full",
-                      option.tone === "attention" ? "bg-destructive/80" : "bg-primary",
+                      option.tone === "review" ? "bg-destructive" : "bg-primary",
                     )}
                   />
                 ) : null}
-                <span className={cn(
-                  option.tone === "attention" && "text-destructive",
-                  option.tone === "in-range" && "text-primary",
-                )}>
-                  {option.label}
-                </span>
+                <span>{option.label}</span>
                 <span aria-hidden="true" className="text-muted-foreground">·</span>
-                <span className="text-sm font-normal tabular-nums text-muted-foreground">
+                <span className="inline-flex min-w-4 items-center justify-center self-center font-mono text-xs font-normal leading-none tabular-nums text-muted-foreground">
                   {counts[option.value]}
                 </span>
-              </Button>
+              </button>
             ))}
           </div>
         </div>
 
-      </div>
-
-      {visibleGroups.length > 0 ? (
-        <div className="border-t border-border/70">
-          {visibleGroups.map((group) => (
-            <BiomarkerStudyDisclosure
-              group={group}
-              key={group.id}
-              forcedOpen={normalizedQuery.length > 0}
-              onToggle={(open) => handleGroupToggle(group.id, open)}
-              open={normalizedQuery.length > 0 || openGroups.has(group.id)}
-            />
-          ))}
-        </div>
-      ) : (
-        <div className="border-t border-border/70 px-5 py-12 text-center sm:px-7">
-          <p className="font-serif text-xl font-semibold text-foreground">No matching biomarkers</p>
-          <p className="mt-1 text-sm text-muted-foreground">Try another name or status.</p>
-        </div>
-      )}
-    </section>
+        {visibleGroups.length > 0 ? (
+          <div className="border-t border-border/70">
+            {visibleGroups.map((group) => (
+              <BiomarkerStudyDisclosure
+                forcedOpen={normalizedQuery.length > 0}
+                group={group}
+                key={group.id}
+                onToggle={(open) => handleGroupToggle(group.id, open)}
+                open={normalizedQuery.length > 0 || openGroups.has(group.id)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="border-t border-border/70 px-5 py-14 text-center sm:px-8">
+            <p className="font-serif text-xl font-semibold text-foreground">No matching biomarkers</p>
+            <p className="mt-1 text-sm text-muted-foreground">Try another name or source status.</p>
+          </div>
+        )}
+      </section>
+    </article>
   );
 }
 
@@ -291,7 +238,6 @@ function BiomarkerStudyDisclosure({
   onToggle: (open: boolean) => void;
   open: boolean;
 }) {
-  const Icon = group.icon;
   const headingId = `biomarker-study-area-${group.id}`;
 
   return (
@@ -305,60 +251,76 @@ function BiomarkerStudyDisclosure({
       }}
       open={open}
     >
-      <summary className="flex min-h-20 cursor-pointer list-none items-center gap-3 px-5 py-4 transition-colors hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:gap-4 sm:px-7 [&::-webkit-details-marker]:hidden">
-        <Icon aria-hidden="true" className="size-5 shrink-0 text-foreground" />
-        <span className="min-w-0 flex-1">
-          <span
-            aria-level={4}
-            className="block font-serif text-xl font-semibold tracking-tight text-foreground"
-            id={headingId}
-            role="heading"
-          >
-            {group.label}
-          </span>
+      <summary className="flex min-h-16 cursor-pointer list-none items-center gap-4 bg-muted/10 px-5 py-3 transition-colors hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-8 [&::-webkit-details-marker]:hidden">
+        <span
+          aria-level={5}
+          className="min-w-0 flex-1 font-serif text-xl font-semibold tracking-tight text-foreground"
+          id={headingId}
+          role="heading"
+        >
+          {group.label}
         </span>
-        <ChevronRight
+        <ChevronDown
           aria-hidden="true"
-          className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-90"
+          className="size-4 shrink-0 -rotate-90 text-muted-foreground transition-transform duration-200 group-open:rotate-0"
           strokeWidth={1.75}
         />
       </summary>
-
-      <div className="flex flex-col">
+      <ol>
         {group.results.map((result) => (
-          <BiomarkerStudyRow
-            key={result.id}
-            result={result}
-          />
+          <li key={`${result.metricKey}:${result.name}`}>
+            <BiomarkerStudyRow result={result} />
+          </li>
         ))}
-      </div>
+      </ol>
     </details>
   );
 }
 
-function BiomarkerStudyRow({
-  result,
-}: {
-  result: BiomarkerStudyResult;
-}) {
-  const needsAttention = result.status === "attention";
-
+function BiomarkerStudyRow({ result }: { result: BiomarkerStudyResult }) {
   return (
     <Link
-      className="flex min-h-20 w-full cursor-pointer flex-col justify-center gap-1 border-t border-border/70 bg-card px-5 py-3 text-left transition-colors hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:min-h-24 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-7"
+      className="grid min-h-16 w-full gap-2 border-t border-border/60 px-5 py-3.5 transition-colors duration-200 hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-8 sm:px-8"
       href={`/biomarkers/results/${encodeURIComponent(result.metricKey)}`}
       prefetch={false}
     >
-      <span className="block min-w-0 break-words text-lg font-medium tracking-tight text-foreground">
-        {result.name}
+      <span className="flex min-w-0 items-center gap-3">
+        <span
+          aria-hidden="true"
+          className={cn(
+            "h-8 w-1 shrink-0 rounded-full",
+            result.status === "in-range" && "bg-primary",
+            result.status === "reported" && "bg-muted-foreground/50",
+            result.status === "review" && "bg-destructive",
+          )}
+        />
+        <span className="min-w-0 break-words text-[15px] font-medium text-foreground sm:text-base">
+          {result.name}
+        </span>
       </span>
-      <span className="block min-w-0 break-words text-sm sm:ml-auto sm:max-w-[50%] sm:text-right">
-        <strong className={needsAttention ? "text-destructive" : "text-primary"}>
+      <span className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 text-sm sm:justify-end sm:text-right">
+        <span className={cn(
+          "inline-flex items-center gap-1.5 font-medium",
+          result.status === "in-range" && "text-primary",
+          result.status === "reported" && "text-muted-foreground",
+          result.status === "review" && "text-destructive",
+        )}>
+          <span
+            aria-hidden="true"
+            className={cn(
+              "size-1.5 rounded-full",
+              result.status === "in-range" && "bg-primary",
+              result.status === "reported" && "bg-muted-foreground/60",
+              result.status === "review" && "bg-destructive",
+            )}
+          />
           {result.statusLabel}
-        </strong>
-        <span aria-hidden="true" className="text-muted-foreground"> · </span>
-        <strong className="tabular-nums text-foreground">{result.value}</strong>{" "}
-        <small className="text-xs text-muted-foreground">{result.unit}</small>
+        </span>
+        <span aria-hidden="true" className="text-border">/</span>
+        <span className="font-serif text-lg font-semibold tabular-nums text-foreground">
+          {result.value}
+        </span>
+        {result.unit ? <span className="text-xs text-muted-foreground">{result.unit}</span> : null}
       </span>
     </Link>
   );
@@ -368,55 +330,153 @@ export function BiomarkerDetailStudy() {
   return (
     <article
       aria-labelledby="biomarker-detail-study-heading"
-      className="border-y border-border/70 bg-card/40"
+      className="overflow-hidden rounded-xl border border-border/70 bg-card/70"
       data-design-study="biomarker-detail"
     >
-      <header className="px-5 py-8 sm:px-7 sm:py-10">
+      <header className="px-5 py-8 sm:px-8 sm:py-10">
+        <Link className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground" href="#biomarker-index-study-heading">
+          <ArrowLeft aria-hidden="true" className="size-4" />
+          Your biomarkers
+        </Link>
+        <p className="mt-10 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          Synthetic interface study / Blood
+        </p>
         <h3
-          className="scroll-mt-20 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl"
+          className="mt-2 scroll-mt-20 font-serif text-4xl font-semibold tracking-tight text-foreground sm:text-5xl"
           id="biomarker-detail-study-heading"
         >
           Hemoglobin
         </h3>
-        <p className="mt-3 max-w-3xl text-base leading-relaxed text-muted-foreground sm:text-lg">
-          A protein in red blood cells that carries oxygen through the body.
+        <p className="mt-3 max-w-[68ch] text-base leading-relaxed text-muted-foreground sm:text-lg">
+          The oxygen-carrying protein inside red blood cells, used with hematocrit and red-cell indices to understand oxygen transport and blood concentration.
         </p>
       </header>
 
-      <section aria-label="Latest illustrative result" className="border-t border-border/70 px-5 py-9 sm:px-7 sm:py-10">
-        <h4 className="text-2xl font-semibold tracking-tight text-destructive">Above range</h4>
-        <div className="mt-3 flex items-baseline gap-3">
-          <span aria-hidden="true" className="size-3 self-center rounded-full bg-destructive/80" />
-          <LabResultValue
-            presentation="hero"
-            result={{
-              comparator: null,
-              textValue: null,
-              unit: "g/dL",
-              value: 18,
-            }}
-          />
-        </div>
-        <time className="mt-4 block text-sm text-muted-foreground" dateTime="2026-01-01">
-          Jan 1, 2026
-        </time>
-
-        <div className="mt-9 min-w-0 border-y border-border/70 py-5">
-          <p
-            className="mb-3 text-xs text-muted-foreground"
-            id="illustrative-biomarker-chart-caption"
-          >
-            {HEMOGLOBIN_HISTORY.length} results plotted in g/dL · Shaded lab range: 13 to 17 g/dL
+      <section aria-labelledby="latest-reading-study-heading" className="grid border-t border-border/70 lg:grid-cols-[minmax(17rem,0.72fr)_minmax(0,1.28fr)]">
+        <div className="px-5 py-8 sm:px-8 sm:py-10 lg:border-r lg:border-border/70">
+          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground" id="latest-reading-study-heading">
+            Latest reading
           </p>
-          <LabBiomarkerHistoryChart
-            ariaDescribedBy="illustrative-biomarker-chart-caption"
-            displayName="Illustrative hemoglobin"
-            points={HEMOGLOBIN_HISTORY}
-            referenceRange={{ high: 17, low: 13 }}
-            unit="g/dL"
-          />
+          <p className="mt-4 text-xl font-semibold tracking-tight text-destructive">Above range</p>
+          <p className="mt-3 flex flex-wrap items-baseline gap-2">
+            <span className="font-serif text-5xl font-semibold tracking-tight tabular-nums text-foreground sm:text-6xl">18.0</span>
+            <span className="text-lg text-muted-foreground">g/dL</span>
+          </p>
+          <time className="mt-4 block text-sm text-muted-foreground" dateTime="2026-02-17">
+            Feb 17, 2026
+          </time>
+
+          <dl className="mt-8 border-t border-border/70 pt-5 text-sm">
+            <div className="grid grid-cols-[7rem_1fr] gap-3 py-1.5">
+              <dt className="text-muted-foreground">Lab range</dt>
+              <dd className="font-medium text-foreground">13.0 to 17.0 g/dL</dd>
+            </div>
+            <div className="grid grid-cols-[7rem_1fr] gap-3 py-1.5">
+              <dt className="text-muted-foreground">Source</dt>
+              <dd className="font-medium text-foreground">Example laboratory</dd>
+            </div>
+            <div className="grid grid-cols-[7rem_1fr] gap-3 py-1.5">
+              <dt className="text-muted-foreground">History</dt>
+              <dd className="font-medium text-foreground">4 comparable results</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="min-w-0 px-5 py-8 sm:px-8 sm:py-10">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <h4 className="font-serif text-2xl font-semibold tracking-tight text-foreground">
+              Results over time
+            </h4>
+            <div className="flex items-center gap-4 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-2"><span className="size-2 rounded-full bg-primary" />Result</span>
+              <span className="inline-flex items-center gap-2"><span className="h-2 w-5 bg-primary/10" />Lab range</span>
+            </div>
+          </div>
+          <div className="mt-4 min-w-0">
+            <LabBiomarkerHistoryChart
+              displayName="Illustrative hemoglobin"
+              points={HEMOGLOBIN_HISTORY}
+              referenceRange={{ high: 17, low: 13 }}
+              unit="g/dL"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="result-ledger-study-heading" className="border-t border-border/70 py-8 sm:py-10">
+        <div className="flex items-baseline justify-between gap-4 px-5 sm:px-8">
+          <h4 className="font-serif text-2xl font-semibold tracking-tight text-foreground" id="result-ledger-study-heading">
+            All results
+          </h4>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">2023 to 2026</span>
+        </div>
+        <div className="mt-5 overflow-hidden border-y border-border/70">
+          <div className="hidden grid-cols-[8rem_minmax(8rem,0.65fr)_minmax(12rem,1fr)_minmax(10rem,0.85fr)] gap-4 border-b border-border/70 bg-muted/15 px-4 py-2 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground sm:px-5 lg:grid">
+            <span>Date</span><span>Result</span><span>Reference range</span><span>Source</span>
+          </div>
+          <ol>
+            {[...HEMOGLOBIN_HISTORY].reverse().map((result) => (
+              <li className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-1.5 border-b border-border/60 px-4 py-3.5 last:border-b-0 sm:px-5 lg:grid-cols-[8rem_minmax(8rem,0.65fr)_minmax(12rem,1fr)_minmax(10rem,0.85fr)] lg:items-center lg:gap-4" key={result.id}>
+                <time className="order-2 text-xs text-muted-foreground lg:order-none lg:text-sm lg:text-foreground" dateTime={result.date}>{formatStudyDate(result.date)}</time>
+                <span className="order-1 font-serif text-lg font-semibold tabular-nums text-foreground lg:order-none">{result.displayValue} g/dL</span>
+                <span className="order-3 col-span-2 text-xs text-muted-foreground lg:col-span-1 lg:text-sm">13.0 to 17.0 g/dL</span>
+                <span className="order-4 col-span-2 text-xs text-muted-foreground lg:col-span-1 lg:text-sm">Example laboratory</span>
+              </li>
+            ))}
+          </ol>
         </div>
       </section>
     </article>
   );
+}
+
+export function BiomarkerBoundaryResultStudy() {
+  return (
+    <article className="overflow-hidden rounded-xl border border-border/70 bg-card/70" data-design-study="biomarker-boundary-result">
+      <header className="grid gap-6 px-5 py-8 sm:px-8 sm:py-10 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Synthetic boundary result</p>
+          <h3 className="mt-2 font-serif text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">Rheumatoid Factor</h3>
+          <p className="mt-3 max-w-[68ch] text-sm leading-relaxed text-muted-foreground sm:text-base">
+            An antibody test used as one piece of evidence when clinicians evaluate inflammatory autoimmune conditions, especially rheumatoid arthritis.
+          </p>
+        </div>
+        <div className="md:text-right">
+          <p className="font-medium text-primary">In range</p>
+          <p className="mt-1 font-serif text-4xl font-semibold tracking-tight text-foreground">&lt;10</p>
+          <p className="mt-1 text-xs text-muted-foreground">Feb 17, 2026</p>
+        </div>
+      </header>
+      <div className="grid gap-2 border-t border-border/70 px-5 py-4 text-sm sm:px-8 lg:grid-cols-[8rem_minmax(8rem,0.6fr)_minmax(12rem,1fr)_minmax(10rem,0.85fr)] lg:items-center lg:gap-4">
+        <time className="text-muted-foreground" dateTime="2026-02-17">Feb 17, 2026</time>
+        <span className="font-serif text-lg font-semibold text-foreground">&lt;10</span>
+        <span className="text-muted-foreground">Source range not listed</span>
+        <span className="text-muted-foreground">Example laboratory</span>
+      </div>
+    </article>
+  );
+}
+
+function formatStudyDate(date: string): string {
+  return new Intl.DateTimeFormat("en", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}
+
+function compareBiomarkerStudyResults(
+  left: BiomarkerStudyResult,
+  right: BiomarkerStudyResult,
+): number {
+  const rank: Readonly<Record<BiomarkerStudyStatus, number>> = {
+    review: 0,
+    "in-range": 1,
+    reported: 2,
+  };
+
+  return rank[left.status] - rank[right.status]
+    || left.name.localeCompare(right.name)
+    || left.metricKey.localeCompare(right.metricKey);
 }

--- a/apps/web/src/components/biomarkers/lab-biomarker-chat-action.tsx
+++ b/apps/web/src/components/biomarkers/lab-biomarker-chat-action.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import { MessageCircle } from "lucide-react";
+
+import { resolveHostedMurphContactOption } from "@/src/components/murph/hosted-murph-contact-action";
+import { MurphContactAuthButton } from "@/src/components/murph/murph-contact-auth-button";
+import { AuthButton } from "@/src/components/ui/auth-button";
+import { Button, buttonVariants } from "@/src/components/ui/button";
+
+interface LabBiomarkerChatActionProps {
+  authenticated: boolean;
+  displayName: string;
+}
+
+export function LabBiomarkerChatActionFallback() {
+  return (
+    <Button aria-busy="true" disabled size="lg" variant="outline">
+      <MessageCircle aria-hidden="true" />
+      Chat with Murph
+    </Button>
+  );
+}
+
+export async function LabBiomarkerChatAction({
+  authenticated,
+  displayName,
+}: LabBiomarkerChatActionProps) {
+  const option = await resolveHostedMurphContactOption({
+    message: {
+      body: `Let's chat about my ${displayName}.`,
+      subject: `My ${displayName} result`,
+    },
+  });
+
+  if (!option) {
+    if (authenticated) {
+      return (
+        <Button
+          aria-label="Link a contact method to chat with Murph"
+          nativeButton={false}
+          render={<Link href="/settings" />}
+          size="lg"
+          variant="outline"
+        >
+          <MessageCircle aria-hidden="true" />
+          Chat with Murph
+        </Button>
+      );
+    }
+
+    return (
+      <AuthButton aria-label="Sign in to chat with Murph" size="lg" variant="outline">
+        <MessageCircle aria-hidden="true" />
+        Chat with Murph
+      </AuthButton>
+    );
+  }
+
+  return (
+    <MurphContactAuthButton
+      actionLabel={`Chat with Murph about ${displayName}`}
+      className={buttonVariants({ size: "lg", variant: "outline" })}
+      option={option}
+    >
+      <MessageCircle aria-hidden="true" />
+      Chat with Murph
+    </MurphContactAuthButton>
+  );
+}

--- a/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
+++ b/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
@@ -24,6 +24,7 @@ import {
 
 export interface LabBiomarkerChartPoint {
   date: string;
+  displayValue?: string;
   id: string;
   value: number;
 }
@@ -69,6 +70,7 @@ export function LabBiomarkerHistoryChart({
 
         return [{
           date: point.date,
+          displayValue: point.displayValue,
           id: point.id,
           time,
           value: point.value,
@@ -111,8 +113,8 @@ export function LabBiomarkerHistoryChart({
           padding={range ? { bottom: 16, top: 16 } : undefined}
           tickFormatter={(value) => formatLabNumber(Number(value))}
           tickLine={false}
-          tickMargin={8}
-          width={72}
+          tickMargin={6}
+          width="auto"
         />
         {range && range.low !== null && range.high !== null ? (
           <ReferenceArea
@@ -147,14 +149,19 @@ export function LabBiomarkerHistoryChart({
                 const item = payload[0]?.payload as { date?: string } | undefined;
                 return item?.date ? formatFullDate(item.date) : "";
               }}
-              formatter={(value) => (
-                <div className="flex min-w-32 items-baseline justify-between gap-3">
-                  <span className="text-muted-foreground">Result</span>
-                  <span className="font-mono font-medium tabular-nums text-foreground">
-                    {formatLabNumber(Number(value))}{labUnitSuffix(unit)}
-                  </span>
-                </div>
-              )}
+              formatter={(value, _name, item) => {
+                const point = item?.payload as { displayValue?: string } | undefined;
+                const displayValue = point?.displayValue ?? formatLabNumber(Number(value));
+
+                return (
+                  <div className="flex min-w-32 items-baseline justify-between gap-3">
+                    <span className="text-muted-foreground">Result</span>
+                    <span className="font-mono font-medium tabular-nums text-foreground">
+                      {displayValue}{labUnitSuffix(unit)}
+                    </span>
+                  </div>
+                );
+              }}
             />
           }
         />

--- a/apps/web/test/biomarker-design-studies.test.tsx
+++ b/apps/web/test/biomarker-design-studies.test.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
 } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { resolveLabResultMetricDefinition } from "@murphai/health-metrics";
 import { beforeEach, expect, test, vi } from "vitest";
 
 import { renderClientComponent } from "./render-client-component";
@@ -67,9 +68,14 @@ vi.mock("@/src/components/biomarkers/lab-biomarker-history-chart", async () => {
 });
 
 import {
+  BiomarkerBoundaryResultStudy,
   BiomarkerDetailStudy,
   BiomarkerIndexStudy,
 } from "@/src/components/biomarkers/biomarker-design-studies";
+import {
+  BIOMARKER_DEVICE_STUDIES,
+  BIOMARKER_STUDY_GROUPS,
+} from "@/src/components/biomarkers/biomarker-design-data";
 import { DesignPage } from "@/app/design/design-page";
 
 beforeEach(() => {
@@ -83,8 +89,11 @@ test("design page routes the biomarker studies through the dedicated sections ta
   expect(sectionsMarkup).toContain(">Sections<");
   expect(sectionsMarkup).toContain("Biomarker index");
   expect(sectionsMarkup).toContain("Biomarker detail");
+  expect(sectionsMarkup).toContain("Boundary result detail");
   expect(sectionsMarkup).toContain('data-design-study="biomarker-index"');
   expect(sectionsMarkup).toContain('data-design-study="biomarker-detail"');
+  expect(sectionsMarkup).toContain('data-design-study="biomarker-boundary-result"');
+  expect(sectionsMarkup).toContain("max-w-7xl");
 
   navigationMocks.tab = "components";
   const componentsMarkup = renderToStaticMarkup(createElement(DesignPage));
@@ -92,35 +101,64 @@ test("design page routes the biomarker studies through the dedicated sections ta
   expect(componentsMarkup).toContain(">Components<");
   expect(componentsMarkup).not.toContain('data-design-study="biomarker-index"');
   expect(componentsMarkup).not.toContain('data-design-study="biomarker-detail"');
+  expect(componentsMarkup).not.toContain('data-design-study="biomarker-boundary-result"');
+  expect(componentsMarkup).toContain("max-w-5xl");
+  expect(componentsMarkup).not.toContain("max-w-7xl");
 });
 
-test("biomarker index study keeps status filters and native area disclosures explicit", () => {
+test("biomarker design data covers the full synthetic catalog", () => {
+  const results = BIOMARKER_STUDY_GROUPS.flatMap((group) => group.results);
+
+  expect(BIOMARKER_DEVICE_STUDIES).toHaveLength(5);
+  expect(BIOMARKER_STUDY_GROUPS).toHaveLength(13);
+  expect(results).toHaveLength(117);
+  expect(results.filter((result) => result.status === "review")).toHaveLength(20);
+  expect(results.filter((result) => result.status === "in-range")).toHaveLength(84);
+  expect(results.filter((result) => result.status === "reported")).toHaveLength(13);
+  for (const result of results) {
+    expect(resolveLabResultMetricDefinition(result.name)?.key).toBe(result.metricKey);
+  }
+});
+
+test("biomarker index study keeps device context, source flags, and area disclosures explicit", () => {
   const markup = renderToStaticMarkup(createElement(BiomarkerIndexStudy));
 
   expect(markup).toContain('data-design-study="biomarker-index"');
-  expect(markup).toContain("Biomarkers");
-  expect(markup).not.toContain("Illustrative data");
+  expect(markup).toContain("Your biomarkers");
+  expect(markup).toContain("From your devices");
+  expect(markup).toContain("From the lab");
+  expect(markup).toContain('class="font-serif text-2xl font-semibold tracking-tight text-foreground" id="device-study-heading"');
+  expect(markup).toContain('class="font-serif text-2xl font-semibold tracking-tight text-foreground" id="lab-study-heading"');
+  expect(markup).not.toContain("Saved lab biomarkers");
+  expect(markup).not.toContain("Status comes from the reporting lab");
+  expect(markup).toContain("Deep sleep");
+  expect(markup).toContain("HRV");
+  expect(markup).toContain("SpO₂");
+  expect(markup).toContain("growth-hormone release");
+  expect(markup).toContain('class="hidden font-mono text-[9px] uppercase');
+  expect(markup).toContain("md:block");
+  expect(markup).toContain("line-clamp-2");
+  expect(markup).toContain("md:line-clamp-none");
   expect(markup).toContain('type="search"');
   expect(markup).toContain('placeholder="Search biomarkers"');
   expect(markup).toContain("Review");
   expect(markup).not.toContain("Out of range");
   expect(markup).toContain('aria-pressed="true"');
-  expect(markup).not.toContain("From your devices");
-  expect(markup).not.toContain("From saved lab results");
-  expect(markup).not.toContain("Showing 7 of 7 saved lab biomarkers");
-  expect(markup).not.toContain("2 to review");
+  expect(markup).toContain("117 lab markers");
+  expect(markup).not.toContain("reported without a flag");
+  expect(markup).toContain('aria-label="All, 117"');
+  expect(markup).toContain('aria-label="Review, 20"');
+  expect(markup).toContain('aria-label="In range, 84"');
   expect(markup).toContain("Above range");
   expect(markup).toContain("In range");
-  expect(markup).not.toContain("4 results");
-  expect(markup).not.toContain("Jan 1, 2026");
   expect(markup).toContain('href="/biomarkers/results/hemoglobin"');
   expect(markup).toContain('href="/biomarkers/results/mean-corpuscular-hemoglobin"');
-  expect(markup).toContain("sm:flex-row");
-  expect(markup).toContain("sm:max-w-[50%]");
   expect(markup).not.toContain("md:grid-cols-2");
-  expect(markup.indexOf("Hemoglobin")).toBeLessThan(markup.indexOf("Mean corpuscular hemoglobin"));
-  expect(markup.match(/<details/g)).toHaveLength(3);
-  expect(markup.match(/<details[^>]*open=""/g) ?? []).toHaveLength(3);
+  expect(markup.indexOf('href="/biomarkers/results/eosinophil-percentage"')).toBeLessThan(
+    markup.indexOf('href="/biomarkers/results/basophil-percentage"'),
+  );
+  expect(markup.match(/<details/g)).toHaveLength(13);
+  expect(markup.match(/<details[^>]*open=""/g) ?? []).toHaveLength(13);
   expect(markup).not.toContain(">Other<");
 });
 
@@ -136,10 +174,52 @@ test("biomarker index study applies the status control to the visible rows", asy
 
     expect(reviewButton.getAttribute("aria-pressed")).toBe("true");
     expect(readResultLinks(rendered.container)).toEqual([
-      "/biomarkers/results/hemoglobin",
-      "/biomarkers/results/hematocrit",
+      "/biomarkers/results/c-peptide",
+      "/biomarkers/results/insulin",
+      "/biomarkers/results/hdl-c",
+      "/biomarkers/results/homocysteine",
+      "/biomarkers/results/ldl-chol-calc-nih",
+      "/biomarkers/results/egfr-ckd-epi",
+      "/biomarkers/results/total-bilirubin",
+      "/biomarkers/results/free-t4",
+      "/biomarkers/results/eosinophil-percentage",
+      "/biomarkers/results/absolute-immature-granulocytes",
+      "/biomarkers/results/lymphocyte-percentage",
+      "/biomarkers/results/mean-corpuscular-hemoglobin-concentration",
+      "/biomarkers/results/cortisol",
+      "/biomarkers/results/sex-hormone-binding-globulin",
+      "/biomarkers/results/epa",
+      "/biomarkers/results/iron-saturation",
+      "/biomarkers/results/omega-6-3-ratio",
+      "/biomarkers/results/chloride",
+      "/biomarkers/results/potassium",
+      "/biomarkers/results/psa-total",
+    ]);
+    expect(rendered.container.querySelectorAll("details")).toHaveLength(10);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("biomarker index study searches across marker names and health areas", async () => {
+  const rendered = await renderClientComponent(
+    createElement(BiomarkerIndexStudy),
+    { requireButton: false },
+  );
+
+  try {
+    const input = rendered.container.querySelector<HTMLInputElement>('input[type="search"]');
+    if (!input) {
+      throw new Error("Expected biomarker search input.");
+    }
+
+    await typeIntoInput(rendered.window, input, "rheumatoid");
+
+    expect(readResultLinks(rendered.container)).toEqual([
+      "/biomarkers/results/rheumatoid-factor",
     ]);
     expect(rendered.container.querySelectorAll("details")).toHaveLength(1);
+    expect(rendered.container.querySelector("details")?.hasAttribute("open")).toBe(true);
   } finally {
     await rendered.cleanup();
   }
@@ -150,20 +230,36 @@ test("biomarker detail study keeps the result and history concise", () => {
 
   expect(markup).toContain('data-design-study="biomarker-detail"');
   expect(markup).toContain("Hemoglobin");
-  expect(markup).toContain(">18<");
+  expect(markup).toContain(">18.0<");
+  expect(markup).toContain("18.0 g/dL");
+  expect(markup).toContain('href="#biomarker-index-study-heading"');
   expect(markup).toContain("Above range");
   expect(markup).not.toContain("Below range");
-  expect(markup).toContain("Jan 1, 2026");
-  expect(markup).not.toContain("Latest result");
-  expect(markup).not.toContain("Collected");
-  expect(markup).not.toContain("Why it matters");
-  expect(markup).not.toContain("Home");
-  expect(markup).toContain("4 results plotted in g/dL · Shaded lab range: 13 to 17 g/dL");
-  expect(markup).toContain('aria-describedby="illustrative-biomarker-chart-caption"');
+  expect(markup).toContain("Feb 17, 2026");
+  expect(markup).toContain("Latest reading");
+  expect(markup).toContain("Lab range");
+  expect(markup).toContain("Results over time");
+  expect(markup).not.toContain("Numeric history");
+  expect(markup).not.toContain("A steady rise");
+  expect(markup).not.toContain("exact results plotted");
+  expect(markup).not.toContain("shaded band");
+  expect(markup).not.toContain('aria-describedby="illustrative-biomarker-chart-caption"');
   expect(markup).toContain('aria-label="Illustrative hemoglobin results over time"');
   expect(markup).toContain('data-point-count="4"');
   expect(markup).toContain('data-low="13"');
   expect(markup).toContain('data-high="17"');
+});
+
+test("boundary result study keeps comparator data out of the numeric chart", () => {
+  const markup = renderToStaticMarkup(createElement(BiomarkerBoundaryResultStudy));
+
+  expect(markup).toContain('data-design-study="biomarker-boundary-result"');
+  expect(markup).toContain("Rheumatoid Factor");
+  expect(markup).toContain("&lt;10");
+  expect(markup).not.toContain("Why there is no line chart");
+  expect(markup).not.toContain("invented midpoint");
+  expect(markup).toContain("Source range not listed");
+  expect(markup).not.toContain('role="img"');
 });
 
 function getButton(container: HTMLElement, label: string): HTMLButtonElement {
@@ -182,6 +278,27 @@ async function click(
 ): Promise<void> {
   await act(async () => {
     button.dispatchEvent(new window.Event("click", { bubbles: true }));
+  });
+}
+
+async function typeIntoInput(
+  window: Window & typeof globalThis,
+  input: HTMLInputElement,
+  value: string,
+): Promise<void> {
+  await act(async () => {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    if (valueSetter) {
+      valueSetter.call(input, value);
+    } else {
+      input.value = value;
+    }
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    input.dispatchEvent(new window.Event("change", { bubbles: true }));
+    await Promise.resolve();
   });
 }
 

--- a/apps/web/test/biomarker-device-metrics.test.tsx
+++ b/apps/web/test/biomarker-device-metrics.test.tsx
@@ -131,16 +131,24 @@ test("only device-derived readings decide the latest card value without history 
     expect(link).not.toBeNull();
     expect(link?.querySelector("svg")).not.toBeNull();
     expect(link?.querySelector("time")).toBeNull();
-    expect(link?.querySelector("p")?.className).toContain("mb-5");
-    expect(link?.textContent).toContain("HEART HEALTH");
+    expect(link?.querySelector("p")?.className).toContain("hidden");
+    expect(link?.querySelector("p")?.className).toContain("md:block");
+    expect(link?.textContent).toContain("heart health");
     expect(link?.textContent).toContain("Resting heart rate reflects recovery load.");
+    const summary = [...(link?.querySelectorAll("p") ?? [])].find((paragraph) =>
+      paragraph.textContent?.includes("Resting heart rate reflects recovery load."),
+    );
+    expect(summary?.className).toContain("line-clamp-2");
+    expect(summary?.className).toContain("md:line-clamp-none");
     expect(link?.textContent).not.toContain("2 readings");
     expect(link?.textContent).not.toContain("Jul 14, 2026");
     expect(link?.textContent).not.toContain("2025 to 2026");
 
     const section = rendered.container.querySelector('[aria-labelledby="biomarker-devices-heading"]');
-    expect(section?.querySelector("ul")?.className).toContain("md:grid-cols-2");
-    expect(section?.querySelector("ul")?.className).toContain("xl:grid-cols-3");
+    const deviceHeading = rendered.container.querySelector("#biomarker-devices-heading");
+    expect(deviceHeading?.className).toContain("text-2xl");
+    expect(section?.querySelector("ul")?.className).not.toContain("grid-cols-");
+    expect(link?.className).toContain("md:grid-cols-");
 
     expect(text).toContain("1 metric");
     expect(text).not.toContain("No lab results yet");
@@ -173,20 +181,23 @@ test("device biomarkers remain first while lab sections start expanded", async (
     const deviceSection = rendered.container.querySelector(
       '[aria-labelledby="biomarker-devices-heading"]',
     );
+    const labRegion = rendered.container.querySelector(
+      'section[aria-labelledby="lab-biomarkers-heading"]',
+    );
+    const labHeading = rendered.container.querySelector("#lab-biomarkers-heading");
     const labSection = rendered.container.querySelector("details");
     expect(deviceSection).not.toBeNull();
+    expect(labRegion).not.toBeNull();
     expect(labSection).not.toBeNull();
-    if (!deviceSection || !labSection) {
+    expect(labHeading?.className).toContain("text-2xl");
+    if (!deviceSection || !labRegion || !labSection) {
       throw new Error("Expected device and lab sections");
     }
     expect(labSection.hasAttribute("open")).toBe(true);
-    const labGroupContainer = labSection.parentElement;
-    if (!labGroupContainer) {
-      throw new Error("Expected lab group container");
-    }
+    expect(labRegion.contains(labSection)).toBe(true);
     const pageSections = [...(deviceSection.parentElement?.children ?? [])];
     expect(pageSections.indexOf(deviceSection)).toBeLessThan(
-      pageSections.indexOf(labGroupContainer),
+      pageSections.indexOf(labRegion),
     );
   } finally {
     await rendered.cleanup();

--- a/apps/web/test/health-commons-biomarker-detail-page.test.ts
+++ b/apps/web/test/health-commons-biomarker-detail-page.test.ts
@@ -396,7 +396,7 @@ describe("BiomarkerPage", () => {
         biomarkerId: "resting-heart-rate",
       }),
     })).resolves.toEqual(expect.objectContaining({
-      description: expect.stringContaining("full rest"),
+      description: expect.stringContaining("quiet rest"),
       openGraph: expect.objectContaining({
         images: [
           expect.objectContaining({

--- a/apps/web/test/lab-biomarker-chat-action.test.tsx
+++ b/apps/web/test/lab-biomarker-chat-action.test.tsx
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+
+import {
+  cloneElement,
+  createElement,
+  isValidElement,
+  type ReactNode,
+} from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveHostedMurphContactOption: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default(props: { "aria-label"?: string; children?: ReactNode; href: string }) {
+    return createElement(
+      "a",
+      { "aria-label": props["aria-label"], href: props.href },
+      props.children,
+    );
+  },
+}));
+
+vi.mock("@/src/components/murph/hosted-murph-contact-action", () => ({
+  resolveHostedMurphContactOption: mocks.resolveHostedMurphContactOption,
+}));
+
+vi.mock("@/src/components/murph/murph-contact-auth-button", () => ({
+  MurphContactAuthButton(props: {
+    actionLabel: string;
+    children?: ReactNode;
+    option: { href: string };
+  }) {
+    return createElement(
+      "a",
+      { "aria-label": props.actionLabel, href: props.option.href },
+      props.children,
+    );
+  },
+}));
+
+vi.mock("@/src/components/ui/auth-button", () => ({
+  AuthButton(props: { "aria-label"?: string; children?: ReactNode }) {
+    return createElement(
+      "button",
+      { "aria-label": props["aria-label"], type: "button" },
+      props.children,
+    );
+  },
+}));
+
+vi.mock("@/src/components/ui/button", () => ({
+  Button(props: {
+    "aria-label"?: string;
+    children?: ReactNode;
+    render?: ReactNode;
+  }) {
+    if (isValidElement<{ "aria-label"?: string; children?: ReactNode }>(props.render)) {
+      return cloneElement(
+        props.render,
+        { "aria-label": props["aria-label"] },
+        props.children,
+      );
+    }
+
+    return createElement(
+      "button",
+      { "aria-label": props["aria-label"], type: "button" },
+      props.children,
+    );
+  },
+  buttonVariants: () => "button",
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveHostedMurphContactOption.mockResolvedValue({
+    href: "sms:+15550100001?body=Let%27s%20chat%20about%20my%20Hemoglobin.",
+    kind: "text",
+    label: "Messages",
+  });
+});
+
+test("biomarker chat action uses the existing contact route with a marker-specific draft", async () => {
+  const { LabBiomarkerChatAction } = await import(
+    "@/src/components/biomarkers/lab-biomarker-chat-action"
+  );
+  const markup = renderToStaticMarkup(await LabBiomarkerChatAction({
+    authenticated: true,
+    displayName: "Hemoglobin",
+  }));
+
+  assert.equal(mocks.resolveHostedMurphContactOption.mock.calls.length, 1);
+  assert.deepEqual(mocks.resolveHostedMurphContactOption.mock.calls[0]?.[0], {
+    message: {
+      body: "Let's chat about my Hemoglobin.",
+      subject: "My Hemoglobin result",
+    },
+  });
+  assert.match(markup, /href="sms:\+15550100001\?body=/u);
+  assert.match(markup, /aria-label="Chat with Murph about Hemoglobin"/u);
+  assert.match(markup, />Chat with Murph</u);
+});
+
+test("biomarker chat action routes a signed-in member without a channel to settings", async () => {
+  mocks.resolveHostedMurphContactOption.mockResolvedValue(null);
+  const { LabBiomarkerChatAction } = await import(
+    "@/src/components/biomarkers/lab-biomarker-chat-action"
+  );
+  const markup = renderToStaticMarkup(await LabBiomarkerChatAction({
+    authenticated: true,
+    displayName: "Hemoglobin",
+  }));
+
+  assert.match(markup, /href="\/settings"/u);
+  assert.match(markup, /Link a contact method to chat with Murph/u);
+});
+
+test("biomarker chat action asks a signed-out visitor to authenticate when no channel resolves", async () => {
+  mocks.resolveHostedMurphContactOption.mockResolvedValue(null);
+  const { LabBiomarkerChatAction } = await import(
+    "@/src/components/biomarkers/lab-biomarker-chat-action"
+  );
+  const markup = renderToStaticMarkup(await LabBiomarkerChatAction({
+    authenticated: false,
+    displayName: "Hemoglobin",
+  }));
+
+  assert.match(markup, /aria-label="Sign in to chat with Murph"/u);
+  assert.doesNotMatch(markup, /href="\/settings"/u);
+  assert.match(markup, />Chat with Murph</u);
+});

--- a/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
+++ b/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
@@ -8,11 +8,15 @@ const captured = vi.hoisted(() => ({
   lineChartProps: null as Record<string, unknown> | null,
   referenceAreas: [] as Record<string, unknown>[],
   referenceLines: [] as Record<string, unknown>[],
-  tooltipFormatter: null as ((value: unknown) => ReactNode) | null,
+  tooltipFormatter: null as ((
+    value: unknown,
+    name?: unknown,
+    item?: { payload?: unknown },
+  ) => ReactNode) | null,
   yAxisDomain: null as unknown,
   yAxisPadding: null as unknown,
   yAxisTickFormatter: null as ((value: unknown) => string) | null,
-  yAxisWidth: null as number | null,
+  yAxisWidth: null as number | "auto" | null,
 }));
 
 vi.mock("recharts", async () => {
@@ -43,7 +47,7 @@ vi.mock("recharts", async () => {
       domain?: unknown;
       padding?: unknown;
       tickFormatter?: (value: unknown) => string;
-      width?: number;
+      width?: number | "auto";
     }) {
       captured.yAxisDomain = props.domain ?? null;
       captured.yAxisPadding = props.padding ?? null;
@@ -67,7 +71,13 @@ vi.mock("@/src/components/ui/chart", async () => {
     ChartTooltip({ content }: { content?: ReactNode }) {
       return React.createElement(React.Fragment, null, content);
     },
-    ChartTooltipContent(props: { formatter?: (value: unknown) => ReactNode }) {
+    ChartTooltipContent(props: {
+      formatter?: (
+        value: unknown,
+        name?: unknown,
+        item?: { payload?: unknown },
+      ) => ReactNode;
+    }) {
       captured.tooltipFormatter = props.formatter ?? null;
       return null;
     },
@@ -101,7 +111,7 @@ test("lab chart keeps tiny values precise without adding a nested keyboard stop"
 
   expect(captured.lineChartProps?.accessibilityLayer).not.toBe(true);
   expect(captured.yAxisTickFormatter?.(0.0014)).toBe("0.0014");
-  expect(captured.yAxisWidth).toBe(72);
+  expect(captured.yAxisWidth).toBe("auto");
   expect(captured.chartConfig).toMatchObject({
     value: { color: "var(--chart-1)" },
   });
@@ -153,6 +163,23 @@ test("a single reference bound renders one dashed line and no band", () => {
 
   expect(captured.referenceAreas).toHaveLength(0);
   expect(captured.referenceLines.map((line) => line.y)).toEqual([99]);
+});
+
+test("a supplied display value preserves the lab's reported precision in the tooltip", () => {
+  renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
+    displayName: "Hemoglobin",
+    points: [
+      { date: "2026-02-17", displayValue: "18.0", id: "p1", value: 18 },
+    ],
+    unit: "g/dL",
+  }));
+
+  const tooltip = captured.tooltipFormatter?.(
+    18,
+    "value",
+    { payload: { displayValue: "18.0" } },
+  );
+  expect(renderToStaticMarkup(createElement("div", null, tooltip))).toContain("18.0 g/dL");
 });
 
 test("no reference range keeps the grid and default domain", () => {

--- a/apps/web/test/lab-biomarker-history-ui.test.tsx
+++ b/apps/web/test/lab-biomarker-history-ui.test.tsx
@@ -150,6 +150,9 @@ test("measured biomarkers are grouped by health area and link to private histori
     expect(hba1cLink?.textContent).toContain("HbA1c");
     expect(hba1cLink?.textContent).toContain("5.8%");
     expect(hba1cLink?.textContent).toContain("Above range");
+    expect(hba1cLink?.querySelector('[aria-hidden="true"]')?.className).toContain(
+      "bg-destructive",
+    );
     expect(hba1cLink?.getAttribute("role")).toBeNull();
     expect(hba1cLink?.parentElement).toBe(firstList);
     expect(hba1cLink?.className).toContain("cursor-pointer");
@@ -168,6 +171,21 @@ test("measured biomarkers are grouped by health area and link to private histori
       'a[href="/biomarkers/results/glucose"]',
     );
     expect(glucoseLink?.textContent).toContain("In range");
+    expect(glucoseLink?.querySelector('[aria-hidden="true"]')?.className).toContain(
+      "bg-primary",
+    );
+    const reportedLink = rendered.container.querySelector(
+      'a[href="/biomarkers/results/apob"]',
+    );
+    expect(reportedLink?.querySelector('[aria-hidden="true"]')?.className).toContain(
+      "bg-muted-foreground/50",
+    );
+    expect(
+      rendered.container
+        .querySelector('button[aria-label="In range, 1"]')
+        ?.querySelector('[aria-hidden="true"]')
+        ?.className,
+    ).toContain("bg-primary");
     expect((firstList?.textContent ?? "").indexOf("HbA1c")).toBeLessThan(
       (firstList?.textContent ?? "").indexOf("Glucose"),
     );
@@ -179,6 +197,9 @@ test("measured biomarkers are grouped by health area and link to private histori
       'button[aria-label="Review, 1"]',
     );
     expect(reviewFilter).not.toBeNull();
+    expect(
+      reviewFilter?.querySelector('[aria-hidden="true"]')?.className,
+    ).toContain("bg-destructive");
     await act(async () => {
       reviewFilter?.dispatchEvent(new rendered.window.Event("click", { bubbles: true }));
       await Promise.resolve();
@@ -378,7 +399,9 @@ test("a numeric result with source text remains plotted without a qualitative om
     expect(text).toContain("Reported");
     expect(text).toContain("5.6%");
     expect(text).not.toContain("comparable numeric results");
-    expect(text).toContain("2 results plotted in %");
+    expect(text).not.toContain("Numeric history");
+    expect(text).toContain("Results over time");
+    expect(text).not.toContain("results plotted");
     expect(text).not.toContain("qualitative result");
     expect(
       rendered.container.querySelector('[aria-label="HbA1c results over time"]'),
@@ -436,7 +459,8 @@ test("albumin uses one normalized unit across the overview, summary, ranges, and
   );
   try {
     const text = detail.container.textContent ?? "";
-    expect(text).toContain("2 results plotted in g/dL");
+    expect(text).not.toContain("Numeric history");
+    expect(text).not.toContain("results plotted");
     expect(text).toContain("4.9 g/dL");
     expect(text).toContain("5.1 g/dL");
     expect(text).toContain("3.4 to 5 g/dL");
@@ -495,7 +519,8 @@ test("a unitless latest result stays raw and is not compared as a canonical valu
   );
   try {
     const text = detail.container.textContent ?? "";
-    expect(text).toContain("1 result plotted in mg/dL");
+    expect(text).not.toContain("Numeric history");
+    expect(text).not.toContain("result plotted");
     expect(text).toContain("<6 mmol/L");
     expect(text).not.toContain("5.2 mg/dL");
     expect(text).not.toContain("since Feb 17, 2025");
@@ -591,12 +616,12 @@ test("detail charts comparable results across years and keeps excluded values in
     expect(text).toContain("HbA1c");
     expect(text).not.toContain("Change over time");
     expect(text).not.toContain("comparable numeric results");
-    expect(text).toContain("2 results plotted in %");
-    expect(text).not.toContain("5 results plotted");
-    expect(text).toContain("1 result was reported as a limit");
+    expect(text).not.toContain("Numeric history");
+    expect(text).not.toContain("results plotted");
+    expect(text).not.toContain("reported as a limit");
     expect(text).toContain("Less than 5.4%");
-    expect(text).toContain("1 qualitative result is shown in history");
-    expect(text).toContain("units that could not be compared");
+    expect(text).not.toContain("qualitative result is shown in history");
+    expect(text).not.toContain("units that could not be compared");
     expect(text).not.toContain("Latest comparable");
     expect(text).toContain("38 mmol/mol");
     expect(text).toContain("5.8%");
@@ -614,6 +639,31 @@ test("detail charts comparable results across years and keeps excluded values in
     expect(
       rendered.container.querySelector('[aria-label="HbA1c results over time"]'),
     ).not.toBeNull();
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("detail shows an authored biomarker summary without losing saved-history context", async () => {
+  browserVaultMock.value.client = clientWithRows([
+    labRow({ date: "2026-06-14", id: "hba1c-2026", value: 5.6 }),
+  ]);
+  browserVaultMock.value.status = "ready";
+
+  const rendered = await renderClientComponent(
+    <LabBiomarkerDetailClient
+      authenticated
+      metricKey="hba1c"
+      summary="HbA1c reflects average blood glucose exposure over roughly the previous two to three months."
+    />,
+    { requireButton: false },
+  );
+
+  try {
+    expect(rendered.container.textContent).toContain(
+      "HbA1c reflects average blood glucose exposure over roughly the previous two to three months.",
+    );
+    expect(rendered.container.textContent).toContain("1 saved result, 2026.");
   } finally {
     await rendered.cleanup();
   }
@@ -656,10 +706,8 @@ test("qualitative and comparator-only histories use a non-numeric fallback", asy
   try {
     const text = rendered.container.textContent ?? "";
     expect(text).toContain("Custom Screen");
-    expect(text).toContain("No comparable numeric trend");
-    expect(text).toContain(
-      "Qualitative results, boundary values, and units that cannot be compared remain in the history below.",
-    );
+    expect(text).not.toContain("No comparable numeric trend");
+    expect(text).not.toContain("boundary values");
     expect(text).toContain(">2 index");
     expect(text).toContain("Negative");
     expect(rendered.container.querySelector('[role="img"]')).toBeNull();
@@ -701,7 +749,7 @@ test("a latest comparator result keeps its visible and spoken boundary", async (
         .find((span) => span.textContent?.trim() === "Greater than or equal to 5.4%"),
     ).toBeDefined();
     expect(hero?.querySelector('[role="img"]')).toBeNull();
-    expect(hero?.textContent).toContain("No comparable numeric trend");
+    expect(hero?.textContent).not.toContain("No comparable numeric trend");
   } finally {
     await rendered.cleanup();
   }
@@ -1003,11 +1051,12 @@ test("a shared lab-reported range yields a chart band without summary tiles", as
     expect(text).not.toContain("Saved history");
     expect(text).not.toContain("Up 0.2% since Jun 3, 2025");
     expect(text).toContain("Range 4 to 5.6%");
-    expect(text).toContain("2 results plotted in % · Shaded lab range: 4 to 5.6%");
+    expect(text).not.toContain("results plotted");
+    expect(text).not.toContain("Shaded lab range");
     expect(
       rendered.container.querySelector('[aria-label="HbA1c results over time"]')
         ?.getAttribute("aria-describedby"),
-    ).toBe("biomarker-chart-caption");
+    ).toBeNull();
   } finally {
     await rendered.cleanup();
   }
@@ -1036,9 +1085,8 @@ test("a one-sided lab range explains the chart limit", async () => {
   );
 
   try {
-    expect(rendered.container.textContent).toContain(
-      "2 results plotted in % · Dashed lab limit: Up to 5.6%",
-    );
+    expect(rendered.container.textContent).toContain("Up to 5.6%");
+    expect(rendered.container.textContent).not.toContain("Dashed lab limit");
   } finally {
     await rendered.cleanup();
   }
@@ -1069,7 +1117,7 @@ test("an exact one-sided range stays in history without becoming an ambiguous ch
   try {
     const text = rendered.container.textContent ?? "";
     expect(text).toContain("<5.6%");
-    expect(text).toContain("2 results plotted in %");
+    expect(text).not.toContain("results plotted");
     expect(text).not.toContain("Dashed lab limit");
   } finally {
     await rendered.cleanup();
@@ -1134,7 +1182,7 @@ test("disagreeing or missing ranges withhold the band without adding summary til
 
   try {
     const text = rendered.container.textContent ?? "";
-    expect(text).toContain("2 results plotted in %");
+    expect(text).not.toContain("results plotted");
     expect(text).not.toContain("Shaded lab range");
     expect(text).not.toContain("Dashed lab limit");
     expect(text).not.toContain("Saved history");

--- a/apps/web/test/pitch-and-biomarkers-pages.test.tsx
+++ b/apps/web/test/pitch-and-biomarkers-pages.test.tsx
@@ -52,6 +52,7 @@ import BiomarkersPage, {
 import { BiomarkerLayoutClient } from "../app/(dashboard)/biomarkers/[biomarkerId]/biomarker-layout-client";
 import LabBiomarkerResultPage, {
   metadata as biomarkerResultMetadata,
+  resolveLabBiomarkerContext,
 } from "../app/(dashboard)/biomarkers/results/[metricKey]/page";
 import PitchPage, { metadata as pitchMetadata } from "../app/pitch/page";
 import { resolveHealthCommonsBiomarkerShell } from "../src/lib/health-commons/biomarker-projections";
@@ -223,6 +224,13 @@ test("Biomarker result route binds server auth and metric params to private hist
   assert.match(markup, /Your biomarkers/);
   assert.doesNotMatch(markup, /All biomarkers/);
   assert.ok(mocks.getHostedPageAuthSnapshot.mock.calls.length >= 1);
+});
+
+test("Biomarker result context follows explicit Health Commons entity mappings", () => {
+  const context = resolveLabBiomarkerContext("alt");
+
+  assert.equal(context.displayName, "ALT");
+  assert.match(context.summary ?? "", /^ALT measures alanine aminotransferase activity,/u);
 });
 
 test("legacy biomarker detail links back to the measured results page truthfully", () => {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -45,6 +45,9 @@
       "@murphai/health-commons": [
         "../../packages/health-commons/src/index.ts"
       ],
+      "@murphai/health-commons/biomarker-entity-mappings": [
+        "../../packages/health-commons/src/biomarker-entity-mappings.ts"
+      ],
       "@murphai/health-commons/runtime": [
         "../../packages/health-commons/src/runtime.ts"
       ],

--- a/packages/contracts/src/health-commons.ts
+++ b/packages/contracts/src/health-commons.ts
@@ -265,6 +265,42 @@ export const HEALTH_COMMONS_BIOMARKER_COMMUNITY_OUTCOME_STATES = [
 export type HealthCommonsBiomarkerCommunityOutcomeState =
   (typeof HEALTH_COMMONS_BIOMARKER_COMMUNITY_OUTCOME_STATES)[number];
 
+export const HEALTH_COMMONS_BIOMARKER_GUIDANCE_CLASSIFICATIONS = [
+  "generally_applicable_numeric",
+  "conditional_numeric",
+  "qualitative",
+  "calculated_or_method_specific",
+  "source_range_only",
+  "no_universal_range",
+] as const;
+
+export type HealthCommonsBiomarkerGuidanceClassification =
+  (typeof HEALTH_COMMONS_BIOMARKER_GUIDANCE_CLASSIFICATIONS)[number];
+
+export const HEALTH_COMMONS_BIOMARKER_GUIDANCE_ITEM_KINDS = [
+  "decision_limit",
+  "reference_interval",
+  "qualitative_interpretation",
+  "method_note",
+  "evidence_limit",
+] as const;
+
+export type HealthCommonsBiomarkerGuidanceItemKind =
+  (typeof HEALTH_COMMONS_BIOMARKER_GUIDANCE_ITEM_KINDS)[number];
+
+export const HEALTH_COMMONS_BIOMARKER_GUIDANCE_SOURCE_TYPES = [
+  "clinical_guideline",
+  "consensus_statement",
+  "primary_literature",
+  "systematic_review",
+  "academic_reference",
+  "assay_documentation",
+  "regulatory_guidance",
+] as const;
+
+export type HealthCommonsBiomarkerGuidanceSourceType =
+  (typeof HEALTH_COMMONS_BIOMARKER_GUIDANCE_SOURCE_TYPES)[number];
+
 const KEY_PATTERN = "^[a-z_]+:[A-Za-z0-9][A-Za-z0-9._:/-]*(?:@[A-Za-z0-9._:-]+)?$";
 const STABLE_ID_PATTERN = "^[a-zA-Z0-9][a-zA-Z0-9._:-]*$";
 const PATH_SEGMENT_PATTERN = "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._/-]+$";
@@ -1487,6 +1523,120 @@ export type HealthCommonsBiomarkerMeasurement = z.infer<
   typeof healthCommonsBiomarkerMeasurementSchema
 >;
 
+export const healthCommonsBiomarkerGuidanceBoundSchema = z
+  .object({
+    value: z.number().finite(),
+    inclusive: z.boolean(),
+  })
+  .strict();
+
+export type HealthCommonsBiomarkerGuidanceBound = z.infer<
+  typeof healthCommonsBiomarkerGuidanceBoundSchema
+>;
+
+export const healthCommonsBiomarkerGuidanceNumericValueSchema = z
+  .object({
+    label: shortStringSchema,
+    unit: shortStringSchema,
+    lowerBound: healthCommonsBiomarkerGuidanceBoundSchema.optional(),
+    upperBound: healthCommonsBiomarkerGuidanceBoundSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (!value.lowerBound && !value.upperBound) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Numeric guidance must preserve at least one explicit bound.",
+      });
+    }
+    if (
+      value.lowerBound
+      && value.upperBound
+      && value.lowerBound.value >= value.upperBound.value
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Numeric guidance lower bounds must be lower than upper bounds.",
+      });
+    }
+  });
+
+export type HealthCommonsBiomarkerGuidanceNumericValue = z.infer<
+  typeof healthCommonsBiomarkerGuidanceNumericValueSchema
+>;
+
+export const healthCommonsBiomarkerGuidanceSourceSchema = z
+  .object({
+    title: shortStringSchema,
+    organization: shortStringSchema,
+    year: z.number().int().min(1900).max(2100),
+    sourceType: z.enum(HEALTH_COMMONS_BIOMARKER_GUIDANCE_SOURCE_TYPES),
+    url: z.string().url().optional(),
+    doi: shortStringSchema.optional(),
+    pmid: z.string().regex(/^\d+$/u).optional(),
+  })
+  .strict()
+  .superRefine((source, context) => {
+    if (!source.url && !source.doi && !source.pmid) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Guidance sources require a URL, DOI, or PMID.",
+      });
+    }
+  });
+
+export type HealthCommonsBiomarkerGuidanceSource = z.infer<
+  typeof healthCommonsBiomarkerGuidanceSourceSchema
+>;
+
+export const healthCommonsBiomarkerGuidanceItemSchema = z
+  .object({
+    kind: z.enum(HEALTH_COMMONS_BIOMARKER_GUIDANCE_ITEM_KINDS),
+    guidance: longStringSchema,
+    applicability: longStringSchema,
+    numericValues: z.array(healthCommonsBiomarkerGuidanceNumericValueSchema).min(1).optional(),
+    source: healthCommonsBiomarkerGuidanceSourceSchema,
+  })
+  .strict();
+
+export type HealthCommonsBiomarkerGuidanceItem = z.infer<
+  typeof healthCommonsBiomarkerGuidanceItemSchema
+>;
+
+export const healthCommonsBiomarkerReferenceGuidanceSchema = z
+  .object({
+    classification: z.enum(HEALTH_COMMONS_BIOMARKER_GUIDANCE_CLASSIFICATIONS),
+    reviewStatus: z.literal("reviewed"),
+    use: z.literal("context_only"),
+    items: z.array(healthCommonsBiomarkerGuidanceItemSchema).min(1),
+  })
+  .strict()
+  .superRefine((guidance, context) => {
+    if (
+      (guidance.classification === "generally_applicable_numeric"
+        || guidance.classification === "conditional_numeric")
+      && !guidance.items.some((item) => item.numericValues && item.numericValues.length > 0)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Numeric guidance classifications require at least one bounded numeric value.",
+      });
+    }
+    if (
+      guidance.classification === "qualitative"
+      && guidance.items.some((item) => item.numericValues && item.numericValues.length > 0)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Qualitative guidance must not manufacture numeric values.",
+      });
+    }
+  });
+
+export type HealthCommonsBiomarkerReferenceGuidance = z.infer<
+  typeof healthCommonsBiomarkerReferenceGuidanceSchema
+>;
+
 export const healthCommonsBiomarkerDetailSchema = z
   .object({
     shortName: shortStringSchema.optional(),
@@ -1559,6 +1709,7 @@ export const healthCommonsPageFrontmatterSchema = z
     measurementContexts: z.array(shortStringSchema).optional(),
     interpretationFrame: healthCommonsInterpretationFrameSchema.optional(),
     biomarker: healthCommonsBiomarkerDetailSchema.optional(),
+    referenceGuidance: healthCommonsBiomarkerReferenceGuidanceSchema.optional(),
     measurementMethod: healthCommonsMeasurementMethodSchema.optional(),
     communityOutcomeSummary: healthCommonsBiomarkerCommunityOutcomeSummarySchema.optional(),
     testPlans: z.array(healthCommonsTestPlanSchema).optional(),
@@ -1653,6 +1804,14 @@ export const healthCommonsPageFrontmatterSchema = z
         code: z.ZodIssueCode.custom,
         message: "measurementMethod is only valid on measurement_method pages.",
         path: ["measurementMethod"],
+      });
+    }
+
+    if (page.entityType !== "biomarker" && page.referenceGuidance) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "referenceGuidance is only valid on biomarker pages.",
+        path: ["referenceGuidance"],
       });
     }
 

--- a/packages/contracts/test/health-commons.test.ts
+++ b/packages/contracts/test/health-commons.test.ts
@@ -12,6 +12,7 @@ import {
   HEALTH_COMMONS_SOURCE_INDEX_SCHEMA_VERSION,
   healthCommonsArtifactManifestSchema,
   healthCommonsArtifactPointerSchema,
+  healthCommonsBiomarkerReferenceGuidanceSchema,
   healthCommonsCatalogEntitySchema,
   healthCommonsCatalogSchema,
   healthCommonsChangeRecordSchema,
@@ -356,6 +357,35 @@ describe("@murphai/contracts health commons schemas", () => {
       success: true,
       data: validBiomarkerPage,
     });
+    const referenceGuidance = {
+      classification: "source_range_only",
+      reviewStatus: "reviewed",
+      use: "context_only",
+      items: [{
+        kind: "reference_interval",
+        guidance: "Use the reporting source's reference interval.",
+        applicability: "Applies to the named assay and reporting source.",
+        source: {
+          title: "Reference interval standard",
+          organization: "Example standards body",
+          year: 2026,
+          sourceType: "consensus_statement",
+          url: "https://example.com/reference-interval",
+        },
+      }],
+    } as const;
+    expect(
+      safeParseContract(healthCommonsPageFrontmatterSchema, {
+        ...validBiomarkerPage,
+        referenceGuidance,
+      }),
+    ).toMatchObject({ success: true });
+    expect(
+      safeParseContract(healthCommonsPageFrontmatterSchema, {
+        ...validSourceArtifactPage,
+        referenceGuidance,
+      }),
+    ).toMatchObject({ success: false });
     expect(
       safeParseContract(healthCommonsPageFrontmatterSchema, validMeasurementMethodPage),
     ).toEqual({
@@ -832,5 +862,59 @@ describe("@murphai/contracts health commons schemas", () => {
     ).toMatchObject({
       success: false,
     });
+  });
+
+  it("rejects contradictory or unsourced biomarker reference guidance", () => {
+    const source = {
+      title: "Reference guidance standard",
+      organization: "Example standards body",
+      year: 2026,
+      sourceType: "clinical_guideline",
+      url: "https://example.com/reference-guidance",
+    } as const;
+    const numericValue = {
+      label: "Example upper comparator",
+      unit: "example-unit",
+      upperBound: { inclusive: false, value: 10 },
+    } as const;
+    const baseItem = {
+      kind: "decision_limit",
+      guidance: "Use this decision limit only in its reviewed clinical context.",
+      applicability: "Applies only to the named assay and reviewed population.",
+      source,
+    } as const;
+
+    expect(
+      safeParseContract(healthCommonsBiomarkerReferenceGuidanceSchema, {
+        classification: "conditional_numeric",
+        reviewStatus: "reviewed",
+        use: "context_only",
+        items: [baseItem],
+      }),
+    ).toMatchObject({ success: false });
+    expect(
+      safeParseContract(healthCommonsBiomarkerReferenceGuidanceSchema, {
+        classification: "qualitative",
+        reviewStatus: "reviewed",
+        use: "context_only",
+        items: [{ ...baseItem, numericValues: [numericValue] }],
+      }),
+    ).toMatchObject({ success: false });
+    expect(
+      safeParseContract(healthCommonsBiomarkerReferenceGuidanceSchema, {
+        classification: "source_range_only",
+        reviewStatus: "reviewed",
+        use: "context_only",
+        items: [{
+          ...baseItem,
+          source: {
+            title: source.title,
+            organization: source.organization,
+            year: source.year,
+            sourceType: source.sourceType,
+          },
+        }],
+      }),
+    ).toMatchObject({ success: false });
   });
 });

--- a/packages/health-commons/content/biomarkers/absolute-basophils.md
+++ b/packages/health-commons/content/biomarkers/absolute-basophils.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:absolute-basophils
+slug: biomarkers/absolute-basophils
+title: "Basophils, absolute"
+summary: "Absolute basophils measure the number of basophils per blood volume, which can add differential-count context when interpreted with the full blood count and laboratory interval."
+status: reviewed
+quality: reviewed
+aliases:
+  - "basophils-absolute"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Basophils, absolute; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Basophils, absolute is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/absolute-eosinophils.md
+++ b/packages/health-commons/content/biomarkers/absolute-eosinophils.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:absolute-eosinophils
+slug: biomarkers/absolute-eosinophils
+title: "Eosinophils, absolute"
+summary: "Absolute eosinophils measure the number of eosinophils per blood volume, which can add immune context when interpreted with symptoms, exposures, medications, and the full blood count."
+status: reviewed
+quality: reviewed
+aliases:
+  - "eosinophils-absolute"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Eosinophils, absolute; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Eosinophils, absolute is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/absolute-immature-granulocytes.md
+++ b/packages/health-commons/content/biomarkers/absolute-immature-granulocytes.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:absolute-immature-granulocytes
+slug: biomarkers/absolute-immature-granulocytes
+title: "Immature granulocytes, absolute"
+summary: "Absolute immature granulocytes measure early granulocytes per blood volume, which can add marrow-response context when interpreted with the differential count and clinical setting."
+status: reviewed
+quality: reviewed
+aliases:
+  - "immature-grans-abs"
+  - "immature-granulocytes-absolute"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Immature granulocytes, absolute; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Immature granulocytes, absolute is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/absolute-lymphocytes.md
+++ b/packages/health-commons/content/biomarkers/absolute-lymphocytes.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:absolute-lymphocytes
+slug: biomarkers/absolute-lymphocytes
+title: "Lymphocytes, absolute"
+summary: "Absolute lymphocytes measure the number of lymphocytes per blood volume, which can add immune and marrow context when interpreted with the full differential count."
+status: reviewed
+quality: reviewed
+aliases:
+  - "absolute-lymphocytes"
+  - "lymphocytes-absolute"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Lymphocytes, absolute; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Lymphocytes, absolute is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/absolute-monocytes.md
+++ b/packages/health-commons/content/biomarkers/absolute-monocytes.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:absolute-monocytes
+slug: biomarkers/absolute-monocytes
+title: "Monocytes, absolute"
+summary: "Absolute monocytes measure the number of monocytes per blood volume, which can add immune and marrow context when interpreted with the full blood count."
+status: reviewed
+quality: reviewed
+aliases:
+  - "monocytes-absolute"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Monocytes, absolute; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Monocytes, absolute is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/absolute-neutrophils.md
+++ b/packages/health-commons/content/biomarkers/absolute-neutrophils.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:absolute-neutrophils
+slug: biomarkers/absolute-neutrophils
+title: "Neutrophils, absolute"
+summary: "Absolute neutrophils measure the number of neutrophils per blood volume, which can add context about innate immune and marrow activity when interpreted with the full blood count."
+status: reviewed
+quality: reviewed
+aliases:
+  - "absolute-neutrophil-count"
+  - "anc"
+  - "neutrophils-absolute"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Neutrophils, absolute; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Neutrophils, absolute is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/adjusted-calcium.md
+++ b/packages/health-commons/content/biomarkers/adjusted-calcium.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:adjusted-calcium
+slug: biomarkers/adjusted-calcium
+title: "Adjusted Calcium"
+summary: "Adjusted calcium estimates total calcium after applying an albumin-based correction, which can add context only within the named formula because it is not directly measured calcium."
+status: reviewed
+quality: reviewed
+aliases:
+  - "corrected-calcium"
+  - "albumin-adjusted-calcium"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Adjusted Calcium as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Adjusted Calcium is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/alanine-aminotransferase.md
+++ b/packages/health-commons/content/biomarkers/alanine-aminotransferase.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:alanine-aminotransferase"
 slug: "biomarkers/alanine-aminotransferase"
 title: "ALT"
-summary: "Safety lab for liver-enzyme monitoring when clinician guidance indicates it."
+summary: "ALT measures alanine aminotransferase activity, which can add liver-cell injury context while exercise, medications, metabolic factors, and the laboratory interval affect interpretation."
 status: "draft"
 quality: "usable"
 aliases:
@@ -63,5 +63,22 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Community outcome summaries will appear once enough opted-in experiment runs are available."
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for ALT; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "ACG Clinical Guideline: Evaluation of Abnormal Liver Chemistries"
+        organization: "American College of Gastroenterology; American Journal of Gastroenterology"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/27995906/"
+        doi: "10.1038/ajg.2016.517"
+        pmid: "27995906"
 ---
+
 Safety lab for liver-enzyme monitoring when clinician guidance indicates it.

--- a/packages/health-commons/content/biomarkers/albumin-globulin-ratio.md
+++ b/packages/health-commons/content/biomarkers/albumin-globulin-ratio.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:albumin-globulin-ratio
+slug: biomarkers/albumin-globulin-ratio
+title: "Albumin/Globulin Ratio"
+summary: "The albumin-to-globulin ratio compares two protein fractions, which can add context about their balance but inherits variation in both measured or calculated components."
+status: reviewed
+quality: reviewed
+aliases:
+  - "a-g-ratio"
+  - "albumin-to-globulin-ratio"
+categories:
+  - lab-metric
+  - liver
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Albumin/Globulin Ratio as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Albumin/Globulin Ratio is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/albumin.md
+++ b/packages/health-commons/content/biomarkers/albumin.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:albumin
+slug: biomarkers/albumin
+title: "Albumin"
+summary: "Albumin measures the main circulating blood protein, which can add context about liver synthesis, inflammation, nutrition, hydration, and protein loss."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-albumin"
+  - "serum_albumin"
+categories:
+  - lab-metric
+  - liver
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Albumin; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Albumin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/alkaline-phosphatase.md
+++ b/packages/health-commons/content/biomarkers/alkaline-phosphatase.md
@@ -1,0 +1,36 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:alkaline-phosphatase
+slug: biomarkers/alkaline-phosphatase
+title: "Alkaline phosphatase"
+summary: "Alkaline phosphatase measures enzyme activity from tissues including liver and bone, which can matter when interpreted with age, pregnancy, symptoms, and related laboratory results."
+status: reviewed
+quality: reviewed
+aliases:
+  - "alk-phos"
+  - "alkaline-phos"
+  - "alkaline_phosphatase"
+  - "alp"
+categories:
+  - lab-metric
+  - liver
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Alkaline phosphatase; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "ACG Clinical Guideline: Evaluation of Abnormal Liver Chemistries"
+        organization: "American College of Gastroenterology; American Journal of Gastroenterology"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/27995906/"
+        doi: "10.1038/ajg.2016.517"
+        pmid: "27995906"
+---
+
+Alkaline phosphatase is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ana-screen.md
+++ b/packages/health-commons/content/biomarkers/ana-screen.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ana-screen
+slug: biomarkers/ana-screen
+title: "ANA screen"
+summary: "An ANA screen reports whether antinuclear antibody reactivity is detected by the named method, which can add autoimmune context but is not a diagnosis by itself."
+status: reviewed
+quality: reviewed
+aliases:
+  - "antinuclear-antibody-screen"
+  - "antinuclear-antibodies-screen"
+categories:
+  - lab-metric
+  - inflammation-and-immune
+referenceGuidance:
+  classification: qualitative
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: qualitative_interpretation
+      guidance: "Preserve the reported category, titer, or narrative interpretation for ANA screen; Commons must not manufacture a numeric interval or translate an absent source flag into “in range.”"
+      applicability: "Applies with assay method, symptoms, acute illness, medications, pretest context, and the reporting laboratory’s qualitative or numeric interpretation retained."
+      source:
+        title: "Antinuclear Antibodies (ANA)"
+        organization: "American College of Rheumatology"
+        year: 2025
+        sourceType: "academic_reference"
+        url: "https://rheumatology.org/patients/antinuclear-antibodies-ana"
+---
+
+ANA screen is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/anion-gap.md
+++ b/packages/health-commons/content/biomarkers/anion-gap.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:anion-gap
+slug: biomarkers/anion-gap
+title: "Anion Gap"
+summary: "The anion gap is calculated from measured electrolytes, which can add acid-base context but depends on the laboratory formula, albumin, and the accuracy of its inputs."
+status: reviewed
+quality: reviewed
+aliases:
+  - "anion-gap-without-potassium"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Anion Gap as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Anion Gap is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/apolipoprotein-b.md
+++ b/packages/health-commons/content/biomarkers/apolipoprotein-b.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:apolipoprotein-b"
 slug: "biomarkers/apolipoprotein-b"
 title: "Apolipoprotein B"
-summary: "A blood marker reflecting the number of apoB-containing atherogenic lipoprotein particles; an optional higher-resolution secondary endpoint."
+summary: "ApoB measures the concentration of apolipoprotein B carried one per atherogenic particle, which can add particle-number context when standard cholesterol measures are discordant."
 status: "field-testing"
 hidden: true
 quality: "usable"
@@ -41,13 +41,13 @@ biomarker:
 
     -
       title: "Why people care"
-      body: "Each atherogenic lipoprotein carries exactly one ApoB molecule, making it a direct particle count and a stronger predictor of cardiovascular risk than LDL-C alone; in 20-30% of people LDL-C looks normal while ApoB is elevated."
+      body: "Each atherogenic lipoprotein particle carries one ApoB molecule, so ApoB can add particle-number context when it and LDL-C do not tell the same story."
     -
       title: "How to measure it"
-      body: "A standard blood draw (fasting not required); desirable is below 100 mg/dL, optimal for higher-risk individuals is below 80 mg/dL, and above 130 mg/dL is elevated. Track over 3-6 month intervals."
+      body: "ApoB is measured in blood; any decision limit or treatment goal depends on the person’s cardiovascular-risk setting, treatment status, assay, and the guidance being applied."
     -
       title: "What moves it"
-      body: "Saturated fat, excess body fat, refined sugar, inactivity, and poor sleep raise it; Mediterranean-style diet, fiber, weight loss, and exercise can lower it 5-15% over 12 weeks. Hypothyroidism, insulin resistance, and certain medications can confound readings."
+      body: "Diet, body composition, metabolic health, thyroid function, illness, and lipid-lowering medications can change ApoB, so comparisons should preserve that context."
   measurement:
     bestContext: "A blood lipid panel drawn before the intervention and repeated after the planned intervention window, ideally with similar lab and fasting conditions."
     howToMeasure:
@@ -73,5 +73,27 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Opted-in lipid experiment summaries will appear once enough comparable runs are available."
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "The 2026 dyslipidemia guideline lists persistent ApoB at or above 120 mg/dL among selected cardiovascular risk-enhancing lipid findings, while treatment goals depend on overall risk and clinical context."
+      applicability: "Use only in the cardiovascular risk context described by guideline-based assessment; assay, lipid treatment, diabetes, triglycerides, kidney disease, and discordance with LDL-C matter."
+      numericValues:
+        - label: "Risk-enhancing factor"
+          unit: "mg/dL"
+          lowerBound:
+            value: 120
+            inclusive: true
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
 ---
+
 Apolipoprotein B is used here as a lab-measured lipid marker. These cholesterol protocols treat LDL-C as the primary endpoint and use other lipid markers as supportive or contextual measures.

--- a/packages/health-commons/content/biomarkers/arachidonic-acid-epa-ratio.md
+++ b/packages/health-commons/content/biomarkers/arachidonic-acid-epa-ratio.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:arachidonic-acid-epa-ratio
+slug: biomarkers/arachidonic-acid-epa-ratio
+title: "Arachidonic Acid/EPA Ratio"
+summary: "The arachidonic-acid-to-EPA ratio compares two assay-defined fatty-acid fractions, which can add relative exposure context but inherits the method limits of both components."
+status: reviewed
+quality: reviewed
+aliases:
+  - "aa-epa-ratio"
+  - "arachidonic-acid-to-epa-ratio"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Arachidonic Acid/EPA Ratio as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+Arachidonic Acid/EPA Ratio is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/arachidonic-acid.md
+++ b/packages/health-commons/content/biomarkers/arachidonic-acid.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:arachidonic-acid
+slug: biomarkers/arachidonic-acid
+title: "Arachidonic Acid"
+summary: "Arachidonic acid reports an omega-6 fatty-acid fraction in the tested specimen, which can add dietary and membrane-fatty-acid context but varies by assay and specimen."
+status: reviewed
+quality: reviewed
+aliases:
+  - "aa-fatty-acid"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Arachidonic Acid; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+Arachidonic Acid is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/aspartate-aminotransferase.md
+++ b/packages/health-commons/content/biomarkers/aspartate-aminotransferase.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:aspartate-aminotransferase"
 slug: "biomarkers/aspartate-aminotransferase"
 title: "AST"
-summary: "Safety lab for liver-enzyme monitoring when clinician guidance indicates it."
+summary: "AST measures aspartate aminotransferase activity from liver, muscle, and other tissues, which can add tissue-injury context when interpreted with related markers and circumstances."
 status: "draft"
 quality: "usable"
 aliases:
@@ -63,5 +63,22 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Community outcome summaries will appear once enough opted-in experiment runs are available."
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for AST; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "ACG Clinical Guideline: Evaluation of Abnormal Liver Chemistries"
+        organization: "American College of Gastroenterology; American Journal of Gastroenterology"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/27995906/"
+        doi: "10.1038/ajg.2016.517"
+        pmid: "27995906"
 ---
+
 Safety lab for liver-enzyme monitoring when clinician guidance indicates it.

--- a/packages/health-commons/content/biomarkers/basophil-percentage.md
+++ b/packages/health-commons/content/biomarkers/basophil-percentage.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:basophil-percentage
+slug: biomarkers/basophil-percentage
+title: "Basophils"
+summary: "Basophil percentage measures basophils as a share of white blood cells, which can add differential-count context but can shift when other leukocyte populations change."
+status: reviewed
+quality: reviewed
+aliases:
+  - "basophils"
+  - "basophils-percent"
+  - "basophils-relative"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Basophils; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Basophils is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/bilirubin.md
+++ b/packages/health-commons/content/biomarkers/bilirubin.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:bilirubin
 slug: biomarkers/bilirubin
 title: Bilirubin
-summary: Optional liver-context safety lab interpreted by a clinician when relevant.
+summary: "Total bilirubin measures conjugated and unconjugated bilirubin together, which can add context about red-cell breakdown, liver processing, and bile flow."
 status: draft
 quality: usable
 categories:
@@ -22,6 +22,22 @@ biomarker:
   direction:
     desired: stable
     label: Stay within the lab reference range; large excursions should be reviewed with a clinician.
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Total bilirubin; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "ACG Clinical Guideline: Evaluation of Abnormal Liver Chemistries"
+        organization: "American College of Gastroenterology; American Journal of Gastroenterology"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/27995906/"
+        doi: "10.1038/ajg.2016.517"
+        pmid: "27995906"
 ---
 
 Optional liver-context safety lab interpreted by a clinician when relevant.

--- a/packages/health-commons/content/biomarkers/blood-glucose.md
+++ b/packages/health-commons/content/biomarkers/blood-glucose.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:blood-glucose
 slug: biomarkers/blood-glucose
 title: Blood Glucose
-summary: Sugar circulating in the blood, where insulin signals cells to pull it in for energy and how fast it clears after eating reflects how well that signaling works.
+summary: "Glucose measures sugar circulating in the blood, which matters because meals, fasting, hormones, illness, and medications can change how much fuel is available and regulated."
 status: field-testing
 hidden: true
 quality: usable
@@ -63,7 +63,7 @@ biomarker:
       body: "Shows fasting control, post-meal spikes, overnight stability, hypoglycemia risk, and how lifestyle, illness, or medications affect metabolism."
     -
       title: How to read it
-      body: "Fasting lab reference: <100 mg/dL; post-meal readings need separate timing. Treat lows as safety signals."
+      body: "Interpret a glucose value only in its measurement context—fasting laboratory, random, post-meal, capillary meter, or continuous sensor—and keep low readings visible as safety context."
     -
       title: What moves it
       body: "Carbohydrates, meal timing, activity, medications, illness, stress, sleep loss, alcohol, dehydration, sensor placement, and calibration changes."
@@ -206,6 +206,47 @@ communityOutcomeSummary:
   state: coming_soon
   minimumCohortSize: 30
   placeholder: Early glucose outcome summaries will appear once enough opted-in experiment runs include glucose samples with timing context.
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "For fasting plasma glucose, ADA decision guidance uses 100 through 125 mg/dL for increased diabetes risk and at least 126 mg/dL as a diabetes decision threshold, with confirmation unless hyperglycemia is unequivocal."
+      applicability: "For venous plasma after at least 8 hours without caloric intake in nonpregnant people; random, post-meal, gestational, capillary, and continuous-glucose results require different guidance."
+      numericValues:
+        - label: "Fasting increased-risk interval"
+          unit: "mg/dL"
+          lowerBound:
+            value: 100
+            inclusive: true
+          upperBound:
+            value: 125
+            inclusive: true
+        - label: "Fasting increased-risk interval"
+          unit: "mmol/L"
+          lowerBound:
+            value: 5.6
+            inclusive: true
+          upperBound:
+            value: 6.9
+            inclusive: true
+        - label: "Fasting diabetes decision threshold"
+          unit: "mg/dL"
+          lowerBound:
+            value: 126
+            inclusive: true
+        - label: "Fasting diabetes decision threshold"
+          unit: "mmol/L"
+          lowerBound:
+            value: 7.0
+            inclusive: true
+      source:
+        title: "2. Diagnosis and Classification of Diabetes: Standards of Care in Diabetes—2026"
+        organization: "American Diabetes Association; Diabetes Care"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://diabetesjournals.org/care/article/49/Supplement_1/S27/163926/2-Diagnosis-and-Classification-of-Diabetes"
 ---
 
 Blood glucose is one of the most useful and most easily misread biomarkers. It changes quickly enough to reveal meal, activity, sleep, stress, alcohol, illness, and medication effects. But the same number can mean different things depending on whether it came from a fasting laboratory draw, a waking finger-stick, a post-meal check, a CGM trace, an exercise window, or an illness day.

--- a/packages/health-commons/content/biomarkers/blood-oxygen-spo2.md
+++ b/packages/health-commons/content/biomarkers/blood-oxygen-spo2.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:blood-oxygen-spo2
 slug: biomarkers/blood-oxygen-spo2
 title: "Blood Oxygen Saturation (SpO₂)"
-summary: Percentage of hemoglobin carrying oxygen in the blood, where a consistently high reading means the lungs are loading red blood cells efficiently and tissue is getting the oxygen it needs.
+summary: "SpO₂ estimates the percentage of hemoglobin carrying oxygen, which can matter because sustained or repeated changes may reflect breathing, circulation, altitude, or measurement limitations."
 status: field-testing
 quality: usable
 aliases:
@@ -39,7 +39,7 @@ biomarker:
   valuePrecision: 1
   direction:
     desired: stable
-    label: "Stable in your normal range is usually the goal."
+    label: "Stable same-device patterns are more informative than chasing a higher number."
     nuance: "For many healthy sea-level adults, SpO₂ already sits near a physiological ceiling. Higher is not an experiment target; repeated lows, drops from baseline, or lows paired with shortness of breath, chest pain, confusion, bluish lips or nails, or unusual fatigue deserve medical context."
   privateMetricBindings:
     -
@@ -66,7 +66,7 @@ biomarker:
       body: "Contextualizes breathing during sleep, respiratory illness, altitude exposure, recovery strain, and symptom-matched low-oxygen warnings."
     -
       title: How to read it
-      body: "Typical sea-level range: 95-100%. Stable is expected; repeated drops or symptom-matched lows matter more than higher readings."
+      body: "No universal wearable target is encoded; repeated same-device changes, signal quality, altitude, symptoms, and any clinician-specific target matter more than maximizing the number."
     -
       title: What moves it
       body: "Altitude, illness, sleep apnea, perfusion, movement, sensor fit, nail polish, skin pigmentation, smoke exposure, and device limits."
@@ -79,7 +79,7 @@ biomarker:
       - "For overnight wearable data, separate the nightly median or average from desaturation events; a stable median can hide repeated dips, and a single dip can be movement artifact."
       - "Do not use consumer wearable SpO₂ alone to diagnose sleep apnea, pneumonia, COPD exacerbation, heart disease, or any other condition. Use it to decide whether a symptom pattern or repeated trend deserves clinical follow-up."
       - "Treat low readings that match concerning symptoms as safety context even if the wearable is imperfect; clinician-specific thresholds and emergency instructions override generic wellness ranges."
-      - "Do not try to optimize SpO₂ upward if it is already in your normal range. The practical goal is stable normal oxygenation and absence of repeated unexplained drops."
+      - "Do not treat SpO₂ as a score to maximize; interpret repeated unexplained changes against your usual pattern, symptoms, measurement quality, altitude, and any clinician-specific target."
     confounders:
       - device class
       - skin pigmentation
@@ -178,6 +178,20 @@ communityOutcomeSummary:
   state: coming_soon
   minimumCohortSize: 20
   placeholder: Early outcome summaries will appear here once enough opted-in experiment runs are available.
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Blood oxygen / SpO₂ (%); use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies with device class, signal quality, perfusion, skin pigmentation, movement, altitude, symptoms, and daytime-versus-overnight context recorded."
+      source:
+        title: "Pulse Oximeters"
+        organization: "US Food and Drug Administration"
+        year: 2025
+        sourceType: "regulatory_guidance"
+        url: "https://www.fda.gov/medical-devices/products-and-medical-procedures/pulse-oximeters"
 ---
 
 SpO₂ is the pulse-oximetry estimate of arterial oxygen saturation: the percentage of hemoglobin binding sites carrying oxygen at the moment of measurement. In consumer health tracking, it is best treated as a respiratory and sleep-context biomarker, not as a score to maximize.
@@ -186,7 +200,7 @@ SpO₂ is the pulse-oximetry estimate of arterial oxygen saturation: the percent
 
 Many healthy sea-level adults will usually see readings in the mid-to-high 90s. The exact acceptable range is contextual: altitude, chronic lung disease, congenital or cardiac conditions, medication effects, recent respiratory illness, and clinician-directed oxygen targets can all change what is normal for a specific person.
 
-The most useful pattern is not “highest possible SpO₂.” It is whether the value remains stable in your own normal range and whether there are repeated unexplained lows, especially overnight or during illness.
+The most useful pattern is not “highest possible SpO₂.” It is whether the value remains stable in your usual same-device pattern and whether there are repeated unexplained lows, especially overnight or during illness.
 
 ## Daytime spot checks versus overnight wearable trends
 

--- a/packages/health-commons/content/biomarkers/blood-urea-nitrogen.md
+++ b/packages/health-commons/content/biomarkers/blood-urea-nitrogen.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:blood-urea-nitrogen
 slug: biomarkers/blood-urea-nitrogen
 title: Blood Urea Nitrogen
-summary: Optional kidney and protein-metabolism context lab interpreted clinically when relevant.
+summary: "Blood urea nitrogen measures nitrogen from urea in blood, which can add kidney and protein-metabolism context but also changes with hydration, diet, catabolism, and medications."
 status: draft
 quality: usable
 categories:
@@ -22,6 +22,20 @@ biomarker:
   direction:
     desired: stable
     label: Stay within the lab reference range; large excursions should be reviewed with a clinician.
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Blood urea nitrogen; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
 ---
 
 Optional kidney and protein-metabolism context lab interpreted clinically when relevant.

--- a/packages/health-commons/content/biomarkers/bun-creatinine-ratio.md
+++ b/packages/health-commons/content/biomarkers/bun-creatinine-ratio.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:bun-creatinine-ratio
+slug: biomarkers/bun-creatinine-ratio
+title: "BUN/Creatinine Ratio"
+summary: "The BUN-to-creatinine ratio combines two blood measurements, which can add hydration and kidney context but inherits the limitations of both inputs and the reporting calculation."
+status: reviewed
+quality: reviewed
+aliases:
+  - "bun-creatinine-ratio"
+  - "blood-urea-nitrogen-creatinine-ratio"
+categories:
+  - lab-metric
+  - kidneys
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat BUN/Creatinine Ratio as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+BUN/Creatinine Ratio is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/c-peptide.md
+++ b/packages/health-commons/content/biomarkers/c-peptide.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:c-peptide
+slug: biomarkers/c-peptide
+title: "C-peptide"
+summary: "C-peptide reflects insulin released by the body because it is produced alongside endogenous insulin, which can help contextualize pancreatic insulin production when timing and glucose are considered."
+status: reviewed
+quality: reviewed
+aliases:
+  - "c peptide"
+  - "c_peptide"
+  - "serum-c-peptide"
+categories:
+  - lab-metric
+  - blood-sugar
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for C-peptide; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, collection timing, fasting status, concurrent glucose, medications, and assay method recorded; the saved laboratory range and flag remain authoritative."
+      source:
+        title: "2. Diagnosis and Classification of Diabetes: Standards of Care in Diabetes—2026"
+        organization: "American Diabetes Association; Diabetes Care"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://diabetesjournals.org/care/article/49/Supplement_1/S27/163926/2-Diagnosis-and-Classification-of-Diabetes"
+---
+
+C-peptide is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/calcium.md
+++ b/packages/health-commons/content/biomarkers/calcium.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:calcium
+slug: biomarkers/calcium
+title: "Calcium"
+summary: "Calcium measures total calcium in blood, which can add bone, parathyroid, kidney, and metabolic context while albumin, pH, medications, and assay range affect interpretation."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-calcium"
+  - "total-calcium"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Calcium; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Calcium is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/carbon-dioxide.md
+++ b/packages/health-commons/content/biomarkers/carbon-dioxide.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:carbon-dioxide
+slug: biomarkers/carbon-dioxide
+title: "Carbon Dioxide"
+summary: "Total carbon dioxide measures mainly bicarbonate in serum or plasma, which can add acid-base and respiratory context but depends on specimen handling and related electrolytes."
+status: reviewed
+quality: reviewed
+aliases:
+  - "CO2"
+  - "carbon-dioxide"
+  - "total-co2"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Carbon Dioxide; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Carbon Dioxide is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/chloride.md
+++ b/packages/health-commons/content/biomarkers/chloride.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:chloride
+slug: biomarkers/chloride
+title: "Chloride"
+summary: "Chloride measures a major extracellular electrolyte, which can add fluid and acid-base context when interpreted with sodium, bicarbonate, kidney function, and clinical circumstances."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-chloride"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Chloride; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Chloride is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/cholesterol-hdl-ratio.md
+++ b/packages/health-commons/content/biomarkers/cholesterol-hdl-ratio.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:cholesterol-hdl-ratio
+slug: biomarkers/cholesterol-hdl-ratio
+title: "Cholesterol/HDL ratio"
+summary: "The cholesterol-to-HDL ratio divides total cholesterol by HDL-C, which can summarize two lipid values but does not replace their individual interpretation or overall risk assessment."
+status: reviewed
+quality: reviewed
+aliases:
+  - "cholesterol-hdl-ratio"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Cholesterol/HDL ratio as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipid Measurements in the Management of Cardiovascular Diseases: Practical Recommendations"
+        organization: "National Lipid Association"
+        year: 2021
+        sourceType: "consensus_statement"
+        url: "https://www.lipid.org/nla/lipid-measurements-management-cardiovascular-diseases-scientific-statement"
+---
+
+Cholesterol/HDL ratio is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/cortisol.md
+++ b/packages/health-commons/content/biomarkers/cortisol.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:cortisol
+slug: biomarkers/cortisol
+title: "Cortisol"
+summary: "Cortisol measures a time-sensitive adrenal hormone concentration, which can add stress-axis context only when collection time, specimen, medications, sleep, and clinical purpose are known."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-cortisol"
+  - "plasma-cortisol"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Cortisol; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Cortisol is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/creatine-kinase.md
+++ b/packages/health-commons/content/biomarkers/creatine-kinase.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:creatine-kinase"
 slug: "biomarkers/creatine-kinase"
 title: "Creatine Kinase"
-summary: "Safety lab used when muscle symptoms or clinician guidance indicate monitoring."
+summary: "Creatine kinase measures enzyme activity released mainly from muscle, which can add muscle-injury and exertion context but varies with exercise, muscle mass, sex, ancestry, medications, and assay."
 status: "draft"
 quality: "usable"
 aliases:
@@ -64,5 +64,20 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Community outcome summaries will appear once enough opted-in experiment runs are available."
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Creatine Kinase; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay, exercise, muscle mass, symptoms, medications, hemolysis, and timing recorded; the reporting laboratory’s interval remains authoritative."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
 ---
+
 Safety lab used when muscle symptoms or clinician guidance indicate monitoring.

--- a/packages/health-commons/content/biomarkers/deep-sleep-minutes.md
+++ b/packages/health-commons/content/biomarkers/deep-sleep-minutes.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:deep-sleep-minutes
 slug: biomarkers/deep-sleep-minutes
 title: Deep Sleep
-summary: Time spent in slow-wave sleep each night, where the brain's deepest electrical slowdown drives growth-hormone release, tissue repair, and waste clearance that lighter stages do not match.
+summary: "Deep sleep minutes estimate time spent in the deepest non-REM sleep stage, which can add context to recovery and sleep continuity when viewed as a consistent same-device trend."
 status: field-testing
 quality: usable
 aliases:
@@ -56,7 +56,7 @@ biomarker:
       body: "Reflects sleep depth and recovery biology; useful for trends, not diagnosis or guaranteed cognitive improvement."
     -
       title: How to read it
-      body: "Typical range: about 45 minutes to 2 hours, or 10-20% of total sleep. Best when awakenings fall and recovery improves."
+      body: "There is no universal wearable target; compare same-device trends with total sleep, awakenings, and how restored you feel rather than treating one stage estimate as a verdict."
     -
       title: What moves it
       body: "Sleep opportunity, alcohol, illness, apnea, fragmentation, caffeine, late hard exercise, heat, stress, age, and device algorithms."
@@ -174,6 +174,20 @@ communityOutcomeSummary:
   state: coming_soon
   minimumCohortSize: 30
   placeholder: Early outcome summaries for deep sleep will appear once enough opted-in runs have same-device sleep-stage data and privacy thresholds are met.
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Deep sleep (minutes); use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to repeated same-device estimates under comparable wear, sleep-window, firmware, and signal-quality conditions; consumer staging is contextual rather than diagnostic."
+      source:
+        title: "Consumer Sleep Technology: An American Academy of Sleep Medicine Position Statement"
+        organization: "American Academy of Sleep Medicine; Journal of Clinical Sleep Medicine"
+        year: 2018
+        sourceType: "consensus_statement"
+        url: "https://aasm.org/advocacy/position-statements/consumer-sleep-technology/"
 ---
 
 Deep sleep minutes are useful when the measurement boundary is clear: this page is about a **consumer-wearable estimate** of N3 / slow-wave sleep duration, not a direct laboratory measurement of slow-wave activity or glymphatic clearance.

--- a/packages/health-commons/content/biomarkers/dha.md
+++ b/packages/health-commons/content/biomarkers/dha.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:dha
+slug: biomarkers/dha
+title: "DHA"
+summary: "DHA reports docosahexaenoic acid in the tested fatty-acid panel, which can add dietary and tissue-exposure context while specimen type and assay method determine comparability."
+status: reviewed
+quality: reviewed
+aliases:
+  - "docosahexaenoic-acid"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for DHA; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+DHA is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/dhea-sulfate.md
+++ b/packages/health-commons/content/biomarkers/dhea-sulfate.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:dhea-sulfate
+slug: biomarkers/dhea-sulfate
+title: "DHEA sulfate"
+summary: "DHEA sulfate measures a relatively stable adrenal androgen, which can add adrenal and androgen context while age, sex, pregnancy, medications, and assay range matter."
+status: reviewed
+quality: reviewed
+aliases:
+  - "dheas"
+  - "dhea-s"
+  - "dehydroepiandrosterone-sulfate"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for DHEA sulfate; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+DHEA sulfate is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/dpa.md
+++ b/packages/health-commons/content/biomarkers/dpa.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:dpa
+slug: biomarkers/dpa
+title: "DPA"
+summary: "DPA reports docosapentaenoic acid in the tested fatty-acid panel, which can add omega-3 exposure context while specimen type, fraction definition, and assay method matter."
+status: reviewed
+quality: reviewed
+aliases:
+  - "docosapentaenoic-acid"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for DPA; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+DPA is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/egfr-ckd-epi.md
+++ b/packages/health-commons/content/biomarkers/egfr-ckd-epi.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:egfr-ckd-epi
+slug: biomarkers/egfr-ckd-epi
+title: "eGFR (CKD-EPI)"
+summary: "eGFR using CKD-EPI estimates filtration from a named equation and patient variables, which can add kidney-function context while preserving the equation version and inputs."
+status: reviewed
+quality: reviewed
+aliases:
+  - "estimated-gfr-ckd-epi"
+  - "e-gfr-ckd-epi"
+categories:
+  - lab-metric
+  - kidneys
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat eGFR (CKD-EPI) as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "KDIGO 2024 Clinical Practice Guideline for the Evaluation and Management of Chronic Kidney Disease"
+        organization: "Kidney Disease: Improving Global Outcomes; Kidney International"
+        year: 2024
+        sourceType: "clinical_guideline"
+        url: "https://kdigo.org/guidelines/ckd-evaluation-and-management/"
+---
+
+eGFR (CKD-EPI) is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/egfr.md
+++ b/packages/health-commons/content/biomarkers/egfr.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:egfr"
 slug: "biomarkers/egfr"
 title: "eGFR"
-summary: "Kidney-function safety context for clinician-guided monitoring."
+summary: "eGFR estimates kidney filtration normalized to body surface area, which can support kidney-function assessment when equation, age, chronicity, and urine findings are considered."
 status: "draft"
 quality: "usable"
 aliases:
@@ -63,5 +63,26 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Community outcome summaries will appear once enough opted-in experiment runs are available."
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "KDIGO uses eGFR below 60 mL/min/1.73 m² as one chronic-kidney-disease criterion only when present for at least three months or accompanied by other markers of kidney damage."
+      applicability: "Applies to an adult eGFR from a validated named equation; acute kidney changes, extremes of muscle mass or diet, pregnancy, medications, and absent chronicity limit interpretation."
+      numericValues:
+        - label: "CKD filtration criterion when chronic or accompanied by kidney-damage markers"
+          unit: "mL/min/1.73 m²"
+          upperBound:
+            value: 60
+            inclusive: false
+      source:
+        title: "KDIGO 2024 Clinical Practice Guideline for the Evaluation and Management of Chronic Kidney Disease"
+        organization: "Kidney Disease: Improving Global Outcomes; Kidney International"
+        year: 2024
+        sourceType: "clinical_guideline"
+        url: "https://kdigo.org/guidelines/ckd-evaluation-and-management/"
 ---
+
 Kidney-function safety context for clinician-guided monitoring.

--- a/packages/health-commons/content/biomarkers/eosinophil-percentage.md
+++ b/packages/health-commons/content/biomarkers/eosinophil-percentage.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:eosinophil-percentage
+slug: biomarkers/eosinophil-percentage
+title: "Eosinophils"
+summary: "Eosinophil percentage measures eosinophils as a share of white blood cells, which can add allergy, parasite, medication, and immune context but depends on other leukocyte counts."
+status: reviewed
+quality: reviewed
+aliases:
+  - "eosinophils"
+  - "eosinophils-percent"
+  - "eosinophils-relative"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Eosinophils; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Eosinophils is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/epa.md
+++ b/packages/health-commons/content/biomarkers/epa.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:epa
+slug: biomarkers/epa
+title: "EPA"
+summary: "EPA reports eicosapentaenoic acid in the tested fatty-acid panel, which can add dietary and supplement exposure context while specimen type and assay method determine comparability."
+status: reviewed
+quality: reviewed
+aliases:
+  - "eicosapentaenoic-acid"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for EPA; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+EPA is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/estradiol.md
+++ b/packages/health-commons/content/biomarkers/estradiol.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:estradiol
+slug: biomarkers/estradiol
+title: "Estradiol"
+summary: "Estradiol measures a principal estrogen concentration, which can add reproductive, bone, and endocrine context but varies with sex, age, cycle stage, pregnancy, medications, and assay."
+status: reviewed
+quality: reviewed
+aliases:
+  - "estradiol-e2"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Estradiol; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Estradiol is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ferritin.md
+++ b/packages/health-commons/content/biomarkers/ferritin.md
@@ -1,0 +1,40 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ferritin
+slug: biomarkers/ferritin
+title: "Ferritin"
+summary: "Ferritin measures an iron-storage protein, which can add iron-status context but also rises with inflammation, infection, liver injury, and other conditions."
+status: reviewed
+quality: reviewed
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "WHO uses ferritin below 15 µg/L to indicate iron deficiency in apparently healthy adults, while inflammation can require higher decision limits and concurrent inflammatory assessment."
+      applicability: "Applies to serum or plasma ferritin in adults with inflammation, infection, liver disease, pregnancy, age, sex, and population context assessed; laboratory flags remain authoritative for the saved result."
+      numericValues:
+        - label: "Iron-deficiency decision limit in apparently healthy adults"
+          unit: "µg/L"
+          upperBound:
+            value: 15
+            inclusive: false
+        - label: "Iron-deficiency decision limit in adults with infection or inflammation"
+          unit: "µg/L"
+          upperBound:
+            value: 70
+            inclusive: false
+      source:
+        title: "WHO Guideline on Use of Ferritin Concentrations to Assess Iron Status in Individuals and Populations"
+        organization: "World Health Organization"
+        year: 2020
+        sourceType: "clinical_guideline"
+        url: "https://www.who.int/publications/i/item/9789240000124"
+---
+
+Ferritin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/fib4.md
+++ b/packages/health-commons/content/biomarkers/fib4.md
@@ -1,0 +1,62 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:fib4
+slug: biomarkers/fib4
+title: "FIB-4"
+summary: "FIB-4 combines age, AST, ALT, and platelet count to estimate liver-fibrosis risk, which can support triage only within the population and age limits of the calculation."
+status: reviewed
+quality: reviewed
+aliases:
+  - "fibrosis-score-fib4"
+  - "fibrosis-score-fib-4"
+  - "fib-4"
+categories:
+  - lab-metric
+  - liver
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat FIB-4 as the output of its named calculation, retain age, AST, ALT, platelet count, and formula provenance, and do not merge it with a measured fibrosis marker or differently calculated score."
+      applicability: "Applies only when the reported value uses the standard FIB-4 inputs and formula; acute illness and conditions that independently alter aminotransferases or platelets can distort the estimate."
+      source:
+        title: "AASLD Practice Guidance on the Clinical Assessment and Management of Nonalcoholic Fatty Liver Disease"
+        organization: "American Association for the Study of Liver Diseases; Hepatology"
+        year: 2023
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/36727674/"
+        doi: "10.1097/HEP.0000000000000323"
+        pmid: "36727674"
+    - kind: decision_limit
+      guidance: "In primary-care evaluation of adults ages 35 through 65 with suspected or established metabolic fatty liver disease, AASLD uses FIB-4 below 1.3 as a lower-risk triage result, at least 1.3 for secondary assessment, and above 2.67 as a reason to consider direct specialist referral."
+      applicability: "These are approximate care-pathway thresholds for the stated liver-risk population, not a general reference range; FIB-4 has low accuracy below age 35, uses different guidance above age 65, and should not be used during acute illness."
+      numericValues:
+        - label: "Lower-risk primary-care triage interval, ages 35–65"
+          unit: "index"
+          upperBound:
+            value: 1.3
+            inclusive: false
+        - label: "Secondary-assessment threshold, ages 35–65"
+          unit: "index"
+          lowerBound:
+            value: 1.3
+            inclusive: true
+        - label: "Direct-referral consideration threshold, ages 35–65"
+          unit: "index"
+          lowerBound:
+            value: 2.67
+            inclusive: false
+      source:
+        title: "AASLD Practice Guidance on the Clinical Assessment and Management of Nonalcoholic Fatty Liver Disease"
+        organization: "American Association for the Study of Liver Diseases; Hepatology"
+        year: 2023
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/36727674/"
+        doi: "10.1097/HEP.0000000000000323"
+        pmid: "36727674"
+---
+
+FIB-4 is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/follicle-stimulating-hormone.md
+++ b/packages/health-commons/content/biomarkers/follicle-stimulating-hormone.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:follicle-stimulating-hormone
+slug: biomarkers/follicle-stimulating-hormone
+title: "Follicle Stimulating Hormone"
+summary: "Follicle-stimulating hormone measures a pituitary signal to the ovaries or testes, which can add reproductive context but varies with sex, age, cycle stage, pregnancy, and treatment."
+status: reviewed
+quality: reviewed
+aliases:
+  - "fsh"
+  - "follicle-stimulating-hormone"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Follicle Stimulating Hormone; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Follicle Stimulating Hormone is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/free-t3.md
+++ b/packages/health-commons/content/biomarkers/free-t3.md
@@ -1,0 +1,34 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:free-t3
+slug: biomarkers/free-t3
+title: "Free T3"
+summary: "Free T3 estimates unbound triiodothyronine available in blood, which can add thyroid context but depends on assay performance, illness, medications, age, and pregnancy."
+status: reviewed
+quality: reviewed
+aliases:
+  - "triiodothyronine-free"
+  - "free-triiodothyronine"
+categories:
+  - lab-metric
+  - thyroid
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Free T3; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay, age, pregnancy or postpartum status, illness, medications, and the reporting laboratory’s population-specific interval retained."
+      source:
+        title: "2017 Guidelines of the American Thyroid Association for the Diagnosis and Management of Thyroid Disease During Pregnancy and the Postpartum"
+        organization: "American Thyroid Association; Thyroid"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/28056690/"
+        doi: "10.1089/thy.2016.0457"
+        pmid: "28056690"
+---
+
+Free T3 is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/free-t4.md
+++ b/packages/health-commons/content/biomarkers/free-t4.md
@@ -1,0 +1,34 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:free-t4
+slug: biomarkers/free-t4
+title: "Free T4"
+summary: "Free T4 estimates unbound thyroxine available in blood, which can add thyroid context when interpreted with TSH, assay method, age, illness, and pregnancy."
+status: reviewed
+quality: reviewed
+aliases:
+  - "thyroxine-free"
+  - "free-thyroxine"
+categories:
+  - lab-metric
+  - thyroid
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Free T4; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay, age, pregnancy or postpartum status, illness, medications, and the reporting laboratory’s population-specific interval retained."
+      source:
+        title: "2017 Guidelines of the American Thyroid Association for the Diagnosis and Management of Thyroid Disease During Pregnancy and the Postpartum"
+        organization: "American Thyroid Association; Thyroid"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/28056690/"
+        doi: "10.1089/thy.2016.0457"
+        pmid: "28056690"
+---
+
+Free T4 is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/free-testosterone.md
+++ b/packages/health-commons/content/biomarkers/free-testosterone.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:free-testosterone
+slug: biomarkers/free-testosterone
+title: "Free testosterone"
+summary: "Free testosterone estimates testosterone not tightly bound to proteins, which can add androgen context but depends on sex, age, timing, binding proteins, assay, and calculation method."
+status: reviewed
+quality: reviewed
+aliases:
+  - "testosterone-free"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Free testosterone; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Testosterone Therapy in Men With Hypogonadism: An Endocrine Society Clinical Practice Guideline"
+        organization: "Endocrine Society; Journal of Clinical Endocrinology & Metabolism"
+        year: 2018
+        sourceType: "clinical_guideline"
+        url: "https://www.endocrine.org/clinical-practice-guidelines/testosterone-therapy"
+        doi: "10.1210/jc.2018-00229"
+---
+
+Free testosterone is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/gfr-mdrd-af-amer.md
+++ b/packages/health-commons/content/biomarkers/gfr-mdrd-af-amer.md
@@ -1,0 +1,34 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:gfr-mdrd-af-amer
+slug: biomarkers/gfr-mdrd-af-amer
+title: "GFR MDRD Af Amer"
+summary: "GFR MDRD Af Amer is a historical race-coefficient MDRD estimate, which matters mainly for preserving the original calculation rather than treating it as interchangeable with race-free eGFR."
+status: reviewed
+quality: reviewed
+aliases:
+  - "gfr-mdrd-african-american"
+  - "mdrd-gfr-af-amer"
+categories:
+  - lab-metric
+  - kidneys
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat GFR MDRD Af Amer as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "A Unifying Approach for GFR Estimation: Recommendations of the NKF-ASN Task Force"
+        organization: "National Kidney Foundation and American Society of Nephrology; American Journal of Kidney Diseases"
+        year: 2021
+        sourceType: "consensus_statement"
+        url: "https://pubmed.ncbi.nlm.nih.gov/34563581/"
+        doi: "10.1053/j.ajkd.2021.08.003"
+        pmid: "34563581"
+---
+
+GFR MDRD Af Amer is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/gfr-mdrd-non-af-amer.md
+++ b/packages/health-commons/content/biomarkers/gfr-mdrd-non-af-amer.md
@@ -1,0 +1,34 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:gfr-mdrd-non-af-amer
+slug: biomarkers/gfr-mdrd-non-af-amer
+title: "GFR MDRD Non Af Amer"
+summary: "GFR MDRD Non Af Amer is a historical MDRD estimate without the African American coefficient, which matters mainly for preserving the original equation and report context."
+status: reviewed
+quality: reviewed
+aliases:
+  - "gfr-mdrd-non-african-american"
+  - "mdrd-gfr-non-af-amer"
+categories:
+  - lab-metric
+  - kidneys
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat GFR MDRD Non Af Amer as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "A Unifying Approach for GFR Estimation: Recommendations of the NKF-ASN Task Force"
+        organization: "National Kidney Foundation and American Society of Nephrology; American Journal of Kidney Diseases"
+        year: 2021
+        sourceType: "consensus_statement"
+        url: "https://pubmed.ncbi.nlm.nih.gov/34563581/"
+        doi: "10.1053/j.ajkd.2021.08.003"
+        pmid: "34563581"
+---
+
+GFR MDRD Non Af Amer is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ggt.md
+++ b/packages/health-commons/content/biomarkers/ggt.md
@@ -1,0 +1,34 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ggt
+slug: biomarkers/ggt
+title: "GGT"
+summary: "GGT measures gamma-glutamyl transferase activity, which can add hepatobiliary context but is influenced by alcohol, medications, metabolic factors, and assay range."
+status: reviewed
+quality: reviewed
+aliases:
+  - "gamma-glutamyl-transferase"
+  - "gamma_glutamyl_transferase"
+categories:
+  - lab-metric
+  - liver
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for GGT; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "ACG Clinical Guideline: Evaluation of Abnormal Liver Chemistries"
+        organization: "American College of Gastroenterology; American Journal of Gastroenterology"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/27995906/"
+        doi: "10.1038/ajg.2016.517"
+        pmid: "27995906"
+---
+
+GGT is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/hba1c.md
+++ b/packages/health-commons/content/biomarkers/hba1c.md
@@ -1,0 +1,59 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:hba1c
+slug: biomarkers/hba1c
+title: "HbA1c"
+summary: "HbA1c estimates average glucose exposure over roughly two to three months from glycated hemoglobin, which can add longer-term context while red-cell turnover and assay factors remain important."
+status: reviewed
+quality: reviewed
+aliases:
+  - "a1c"
+  - "hb-a1c"
+  - "hb-a1c-ngsp"
+  - "hb-a1c-si"
+  - "hba1c"
+  - "hba1c-ngsp"
+  - "hba1c-si"
+  - "hemoglobin-a-1c"
+  - "hemoglobin-a1c"
+  - "hemoglobin_a1c"
+categories:
+  - lab-metric
+  - blood-sugar
+referenceGuidance:
+  classification: generally_applicable_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "ADA decision guidance uses 5.7% through 6.4% for increased diabetes risk and at least 6.5% as a diabetes decision threshold, with confirmation unless hyperglycemia is unequivocal."
+      applicability: "For nonpregnant people using an NGSP-certified assay; altered red-cell turnover, hemoglobin variants, recent blood loss or transfusion, pregnancy, and kidney disease can make HbA1c discordant."
+      numericValues:
+        - label: "Increased-risk interval"
+          unit: "%"
+          lowerBound:
+            value: 5.7
+            inclusive: true
+          upperBound:
+            value: 6.4
+            inclusive: true
+        - label: "Diabetes decision threshold"
+          unit: "%"
+          lowerBound:
+            value: 6.5
+            inclusive: true
+        - label: "Diabetes decision threshold"
+          unit: "mmol/mol"
+          lowerBound:
+            value: 48
+            inclusive: true
+      source:
+        title: "2. Diagnosis and Classification of Diabetes: Standards of Care in Diabetes—2026"
+        organization: "American Diabetes Association; Diabetes Care"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://diabetesjournals.org/care/article/49/Supplement_1/S27/163926/2-Diagnosis-and-Classification-of-Diabetes"
+---
+
+HbA1c is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/hdl-c.md
+++ b/packages/health-commons/content/biomarkers/hdl-c.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:hdl-c"
 slug: "biomarkers/hdl-c"
 title: "HDL-C"
-summary: "High-density lipoprotein cholesterol from a lipid panel; a watch metric for cholesterol protocols rather than a promised response."
+summary: "HDL-C measures cholesterol carried within high-density lipoproteins, which adds lipid context but is not a stand-alone treatment target or direct measure of HDL function."
 status: "draft"
 quality: "usable"
 aliases:
@@ -70,5 +70,21 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Opted-in lipid experiment summaries will appear once enough comparable runs are available."
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for HDL-C; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
 ---
+
 HDL-C is used here as a lab-measured lipid marker. These cholesterol protocols treat LDL-C as the primary endpoint and use other lipid markers as supportive or contextual measures.

--- a/packages/health-commons/content/biomarkers/hematocrit.md
+++ b/packages/health-commons/content/biomarkers/hematocrit.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:hematocrit
+slug: biomarkers/hematocrit
+title: "Hematocrit"
+summary: "Hematocrit measures the fraction of blood volume occupied by red cells, which can add oxygen-carrying and hydration context alongside hemoglobin and red-cell indices."
+status: reviewed
+quality: reviewed
+aliases:
+  - "packed-cell-volume"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Hematocrit; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Hematocrit is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/hemoglobin.md
+++ b/packages/health-commons/content/biomarkers/hemoglobin.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:hemoglobin
+slug: biomarkers/hemoglobin
+title: "Hemoglobin"
+summary: "Hemoglobin measures the oxygen-carrying protein concentration in blood, which can add anemia, erythrocytosis, hydration, altitude, and blood-loss context."
+status: reviewed
+quality: reviewed
+aliases:
+  - "haemoglobin"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Hemoglobin; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Hemoglobin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/homocysteine.md
+++ b/packages/health-commons/content/biomarkers/homocysteine.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:homocysteine
+slug: biomarkers/homocysteine
+title: "Homocysteine"
+summary: "Homocysteine measures a sulfur-containing amino acid intermediate, which can matter as context for vitamin metabolism, kidney function, medications, and cardiovascular risk assessment."
+status: reviewed
+quality: reviewed
+aliases:
+  - "total-homocysteine"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Homocysteine; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Homocysteine is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/hrv-rmssd.md
+++ b/packages/health-commons/content/biomarkers/hrv-rmssd.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:hrv-rmssd
 slug: biomarkers/hrv-rmssd
 title: HRV / RMSSD
-summary: Beat-to-beat variation in heart timing measured at rest, where more variation signals stronger vagal brake on the heart and a nervous system with room to respond rather than one stuck in overdrive.
+summary: "RMSSD estimates short-term beat-to-beat heart-rate variation, which can add context about autonomic recovery and strain when compared with a person’s own consistent baseline."
 status: field-testing
 quality: reviewed
 aliases:
@@ -196,6 +196,22 @@ communityOutcomeSummary:
   state: coming_soon
   minimumCohortSize: 20
   placeholder: Early HRV outcome summaries will appear here once enough opted-in experiment runs are available with stable same-device baseline and intervention windows.
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for HRV / RMSSD (ms); use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the same HRV metric, device or ECG method, posture, time window, artifact handling, and personal baseline."
+      source:
+        title: "Heart Rate Variability: Standards of Measurement, Physiological Interpretation and Clinical Use"
+        organization: "Task Force of the European Society of Cardiology and the North American Society of Pacing and Electrophysiology; Circulation"
+        year: 1996
+        sourceType: "consensus_statement"
+        url: "https://pubmed.ncbi.nlm.nih.gov/8598068/"
+        doi: "10.1161/01.CIR.93.5.1043"
+        pmid: "8598068"
 ---
 
 ## Bottom line

--- a/packages/health-commons/content/biomarkers/hs-crp.md
+++ b/packages/health-commons/content/biomarkers/hs-crp.md
@@ -1,0 +1,43 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:hs-crp
+slug: biomarkers/hs-crp
+title: "hs-CRP"
+summary: "High-sensitivity CRP measures low concentrations of an inflammation-related protein, which can add cardiovascular risk context when acute illness and other inflammatory causes are considered."
+status: reviewed
+quality: reviewed
+aliases:
+  - "crp"
+  - "hscrp"
+  - "hs_crp"
+  - "high-sensitivity-crp"
+  - "high_sensitivity_crp"
+  - "c-reactive-protein"
+categories:
+  - lab-metric
+  - inflammation-and-immune
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "The 2026 dyslipidemia guideline lists hs-CRP at or above 2.0 mg/L on more than one occasion as a cardiovascular risk-enhancing factor in selected prevention discussions."
+      applicability: "Applies when repeat measurements are clinically appropriate and acute infection, injury, inflammatory disease, and recent strenuous exercise are not driving the result."
+      numericValues:
+        - label: "Cardiovascular risk-enhancing threshold"
+          unit: "mg/L"
+          lowerBound:
+            value: 2.0
+            inclusive: true
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
+---
+
+hs-CRP is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/immature-granulocyte-percentage.md
+++ b/packages/health-commons/content/biomarkers/immature-granulocyte-percentage.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:immature-granulocyte-percentage
+slug: biomarkers/immature-granulocyte-percentage
+title: "Immature granulocytes"
+summary: "Immature granulocyte percentage measures early granulocytes as a share of white blood cells, which can add marrow-response context but is analyzer and population dependent."
+status: reviewed
+quality: reviewed
+aliases:
+  - "immature-granulocytes"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Immature granulocytes; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Immature granulocytes is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/insulin.md
+++ b/packages/health-commons/content/biomarkers/insulin.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:insulin
+slug: biomarkers/insulin
+title: "Insulin"
+summary: "Insulin measures the hormone concentration at collection, which can help contextualize glucose handling but depends strongly on fasting state, timing, medications, and assay method."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-insulin"
+  - "fasting-insulin"
+categories:
+  - lab-metric
+  - blood-sugar
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Insulin; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, collection timing, fasting status, concurrent glucose, medications, and assay method recorded; the saved laboratory range and flag remain authoritative."
+      source:
+        title: "2. Diagnosis and Classification of Diabetes: Standards of Care in Diabetes—2026"
+        organization: "American Diabetes Association; Diabetes Care"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://diabetesjournals.org/care/article/49/Supplement_1/S27/163926/2-Diagnosis-and-Classification-of-Diabetes"
+---
+
+Insulin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/iron-saturation.md
+++ b/packages/health-commons/content/biomarkers/iron-saturation.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:iron-saturation
+slug: biomarkers/iron-saturation
+title: "Iron saturation"
+summary: "Iron saturation estimates the percentage of iron-binding sites occupied, which can add iron-status context but depends on serum iron, binding capacity, timing, and inflammation."
+status: reviewed
+quality: reviewed
+aliases:
+  - "iron-saturation"
+  - "transferrin-saturation"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Iron saturation as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Iron saturation is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/iron.md
+++ b/packages/health-commons/content/biomarkers/iron.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:iron
+slug: biomarkers/iron
+title: "Iron"
+summary: "Serum iron measures circulating iron bound mainly to transferrin at collection, which can add iron-status context but varies with time, fasting, recent intake, inflammation, and assay."
+status: reviewed
+quality: reviewed
+aliases:
+  - "iron-total"
+  - "serum-iron"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Iron; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Iron is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldh.md
+++ b/packages/health-commons/content/biomarkers/ldh.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldh
+slug: biomarkers/ldh
+title: "LDH"
+summary: "LDH measures lactate dehydrogenase activity from many tissues, which can add nonspecific tissue-injury context but is sensitive to hemolysis, exercise, illness, and assay range."
+status: reviewed
+quality: reviewed
+aliases:
+  - "lactate-dehydrogenase"
+  - "lactic-dehydrogenase"
+categories:
+  - lab-metric
+  - muscle-and-tissue
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for LDH; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay, exercise, muscle mass, symptoms, medications, hemolysis, and timing recorded; the reporting laboratory’s interval remains authoritative."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+LDH is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-c.md
+++ b/packages/health-commons/content/biomarkers/ldl-c.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:ldl-c"
 slug: "biomarkers/ldl-c"
 title: "LDL-C"
-summary: "Low-density lipoprotein cholesterol from a blood lipid panel; the primary lab endpoint for cholesterol protocols."
+summary: "LDL-C measures cholesterol carried within low-density lipoproteins, which matters because treatment goals depend on overall cardiovascular risk rather than one universal cutoff."
 status: "draft"
 quality: "usable"
 aliases:
@@ -67,5 +67,37 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Opted-in lipid experiment summaries will appear once enough comparable runs are available."
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "The 2026 dyslipidemia guideline uses LDL-C goals below 100 mg/dL for borderline or intermediate primary-prevention risk, below 70 mg/dL for high risk, and below 55 mg/dL for very-high-risk secondary prevention."
+      applicability: "These are risk- and treatment-specific goals, not a universal laboratory reference interval; the member’s clinical risk category and treatment plan determine which goal is relevant."
+      numericValues:
+        - label: "Borderline or intermediate primary-prevention goal"
+          unit: "mg/dL"
+          upperBound:
+            value: 100
+            inclusive: false
+        - label: "High-risk goal"
+          unit: "mg/dL"
+          upperBound:
+            value: 70
+            inclusive: false
+        - label: "Very-high-risk secondary-prevention goal"
+          unit: "mg/dL"
+          upperBound:
+            value: 55
+            inclusive: false
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
 ---
+
 LDL-C is used here as a lab-measured lipid marker. These cholesterol protocols treat LDL-C as the primary endpoint and use other lipid markers as supportive or contextual measures.

--- a/packages/health-commons/content/biomarkers/ldl-calculated.md
+++ b/packages/health-commons/content/biomarkers/ldl-calculated.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-calculated
+slug: biomarkers/ldl-calculated
+title: "LDL Calculated"
+summary: "LDL Calculated estimates LDL cholesterol from a lipid panel rather than measuring it directly, which matters because formula choice and triglyceride levels can change the result."
+status: reviewed
+quality: reviewed
+aliases:
+  - "calculated-ldl"
+  - "ldl-c-calculated"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat LDL Calculated as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
+---
+
+LDL Calculated is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-chol-calc-nih.md
+++ b/packages/health-commons/content/biomarkers/ldl-chol-calc-nih.md
@@ -1,0 +1,34 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-chol-calc-nih
+slug: biomarkers/ldl-chol-calc-nih
+title: "LDL CHOL CALC (NIH)"
+summary: "LDL CHOL CALC (NIH) estimates LDL cholesterol with the named NIH or Sampson equation, which matters because its formula-specific result is not interchangeable with other calculated LDL methods."
+status: reviewed
+quality: reviewed
+aliases:
+  - "ldl-cholesterol-calculated-nih"
+  - "ldl-calc-nih"
+  - "sampson-nih-ldl"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat LDL CHOL CALC (NIH) as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
+---
+
+LDL CHOL CALC (NIH) is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-large-particles.md
+++ b/packages/health-commons/content/biomarkers/ldl-large-particles.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-large-particles
+slug: biomarkers/ldl-large-particles
+title: "LDL large particles"
+summary: "LDL large particles measure a method-defined concentration or count of larger LDL particles, which can add advanced-lipid context without replacing standard risk assessment."
+status: reviewed
+quality: reviewed
+aliases:
+  - "large-ldl-particles"
+  - "ldl-large"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for LDL large particles; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipoprotein Fractionation, Cardio IQ"
+        organization: "HNL Lab Medicine and Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.hnl.com/test-directory/lipoprotein-fractionation-cardio-iq/carlf"
+---
+
+LDL large particles is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-medium-particles.md
+++ b/packages/health-commons/content/biomarkers/ldl-medium-particles.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-medium-particles
+slug: biomarkers/ldl-medium-particles
+title: "LDL medium particles"
+summary: "LDL medium particles measure a method-defined concentration or count of medium-sized LDL particles, which can add advanced-lipid context but varies by assay platform."
+status: reviewed
+quality: reviewed
+aliases:
+  - "medium-ldl-particles"
+  - "ldl-medium"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for LDL medium particles; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipoprotein Fractionation, Cardio IQ"
+        organization: "HNL Lab Medicine and Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.hnl.com/test-directory/lipoprotein-fractionation-cardio-iq/carlf"
+---
+
+LDL medium particles is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-particle-number.md
+++ b/packages/health-commons/content/biomarkers/ldl-particle-number.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-particle-number
+slug: biomarkers/ldl-particle-number
+title: "LDL particle number"
+summary: "LDL particle number estimates how many LDL particles are present, which can add risk context when cholesterol content and particle number are discordant."
+status: reviewed
+quality: reviewed
+aliases:
+  - "ldl-p"
+  - "ldl-particle-concentration"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for LDL particle number; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipoprotein Fractionation, Cardio IQ"
+        organization: "HNL Lab Medicine and Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.hnl.com/test-directory/lipoprotein-fractionation-cardio-iq/carlf"
+---
+
+LDL particle number is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-pattern.md
+++ b/packages/health-commons/content/biomarkers/ldl-pattern.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-pattern
+slug: biomarkers/ldl-pattern
+title: "LDL pattern"
+summary: "LDL pattern is a qualitative assay category describing the predominant LDL size distribution, which can add method-specific context without being converted into a numeric range."
+status: reviewed
+quality: reviewed
+aliases:
+  - "ldl-particle-pattern"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: qualitative
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: qualitative_interpretation
+      guidance: "Preserve the reported category, titer, or narrative interpretation for LDL pattern; Commons must not manufacture a numeric interval or translate an absent source flag into “in range.”"
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipoprotein Fractionation, Cardio IQ"
+        organization: "HNL Lab Medicine and Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.hnl.com/test-directory/lipoprotein-fractionation-cardio-iq/carlf"
+---
+
+LDL pattern is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-peak-size.md
+++ b/packages/health-commons/content/biomarkers/ldl-peak-size.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-peak-size
+slug: biomarkers/ldl-peak-size
+title: "LDL peak size"
+summary: "LDL peak size reports the dominant LDL particle diameter produced by a specific method, which can add context about particle distribution without serving as a stand-alone verdict."
+status: reviewed
+quality: reviewed
+aliases:
+  - "ldl-size"
+  - "ldl-peak-particle-size"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for LDL peak size; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipoprotein Fractionation, Cardio IQ"
+        organization: "HNL Lab Medicine and Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.hnl.com/test-directory/lipoprotein-fractionation-cardio-iq/carlf"
+---
+
+LDL peak size is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/ldl-small-particles.md
+++ b/packages/health-commons/content/biomarkers/ldl-small-particles.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:ldl-small-particles
+slug: biomarkers/ldl-small-particles
+title: "LDL small particles"
+summary: "LDL small particles measure a method-defined concentration or count of smaller LDL particles, which can add advanced-lipid context while remaining specific to the reporting assay."
+status: reviewed
+quality: reviewed
+aliases:
+  - "small-ldl-particles"
+  - "ldl-small"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for LDL small particles; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipoprotein Fractionation, Cardio IQ"
+        organization: "HNL Lab Medicine and Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.hnl.com/test-directory/lipoprotein-fractionation-cardio-iq/carlf"
+---
+
+LDL small particles is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/lead.md
+++ b/packages/health-commons/content/biomarkers/lead.md
@@ -1,0 +1,38 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:lead
+slug: biomarkers/lead
+title: "Lead"
+summary: "Blood lead measures recent circulating lead exposure, which matters because public-health action levels vary by age and context and are not boundaries of safety."
+status: reviewed
+quality: reviewed
+aliases:
+  - "blood-lead"
+  - "blood-lead-level"
+categories:
+  - lab-metric
+  - environmental-exposure
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "CDC uses 3.5 µg/dL as a blood lead reference value to identify children with levels higher than most US children; it is a population action reference, not a safe-versus-unsafe boundary."
+      applicability: "Applies specifically to blood lead in children ages 1 through 5 in US public-health guidance; adult occupational, pregnancy, capillary-screening, and confirmatory venous contexts use additional guidance."
+      numericValues:
+        - label: "CDC childhood blood lead reference value"
+          unit: "µg/dL"
+          lowerBound:
+            value: 3.5
+            inclusive: true
+      source:
+        title: "Guidelines and Recommendations: Childhood Lead Poisoning Prevention"
+        organization: "US Centers for Disease Control and Prevention"
+        year: 2025
+        sourceType: "regulatory_guidance"
+        url: "https://www.cdc.gov/lead-prevention/php/guidelines/index.html"
+---
+
+Lead is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/linoleic-acid.md
+++ b/packages/health-commons/content/biomarkers/linoleic-acid.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:linoleic-acid
+slug: biomarkers/linoleic-acid
+title: "Linoleic Acid"
+summary: "Linoleic acid reports an omega-6 fatty-acid fraction in the tested specimen, which can add dietary exposure context but varies with specimen type and assay method."
+status: reviewed
+quality: reviewed
+aliases:
+  - "la-fatty-acid"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Linoleic Acid; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+Linoleic Acid is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/lipoprotein-a.md
+++ b/packages/health-commons/content/biomarkers/lipoprotein-a.md
@@ -1,0 +1,45 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:lipoprotein-a
+slug: biomarkers/lipoprotein-a
+title: "Lipoprotein(a)"
+summary: "Lipoprotein(a) measures an inherited apoB-containing particle with apolipoprotein(a), which can add cardiovascular risk context when reported in assay-specific units."
+status: reviewed
+quality: reviewed
+aliases:
+  - "lp-a"
+  - "lpa"
+  - "lipoprotein(a)"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "The 2026 dyslipidemia guideline identifies at least 125 nmol/L or at least 50 mg/dL as risk-enhancing Lp(a) results; these are alternative assay-unit thresholds and must not be converted as exact equivalents."
+      applicability: "Applies to Lp(a) cardiovascular risk assessment with assay units preserved; nmol/L particle concentration and mg/dL mass are not directly interchangeable because apo(a) isoform size affects conversion."
+      numericValues:
+        - label: "Risk-enhancing threshold in particle concentration"
+          unit: "nmol/L"
+          lowerBound:
+            value: 125
+            inclusive: true
+        - label: "Risk-enhancing threshold in mass concentration"
+          unit: "mg/dL"
+          lowerBound:
+            value: 50
+            inclusive: true
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
+---
+
+Lipoprotein(a) is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/luteinizing-hormone.md
+++ b/packages/health-commons/content/biomarkers/luteinizing-hormone.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:luteinizing-hormone
+slug: biomarkers/luteinizing-hormone
+title: "Luteinizing Hormone"
+summary: "Luteinizing hormone measures a pituitary signal to the ovaries or testes, which can add reproductive context but varies with sex, age, cycle timing, pregnancy, and treatment."
+status: reviewed
+quality: reviewed
+aliases:
+  - "lh"
+  - "luteinizing-hormone"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Luteinizing Hormone; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Luteinizing Hormone is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/lymphocyte-percentage.md
+++ b/packages/health-commons/content/biomarkers/lymphocyte-percentage.md
@@ -1,0 +1,38 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:lymphocyte-percentage
+slug: biomarkers/lymphocyte-percentage
+title: "Lymphocytes"
+summary: "Lymphocyte percentage measures lymphocytes as a share of white blood cells, which can add immune context but may change when other leukocyte populations shift."
+status: reviewed
+quality: reviewed
+aliases:
+  - "lymphocyte"
+  - "lymphocyte-percent"
+  - "lymphocyte-pct"
+  - "lymphocyte_pct"
+  - "lymphocyte-percentage"
+  - "lymphocytes-percent"
+  - "lymphocytes-pct"
+  - "lymphocytes"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Lymphocytes; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Lymphocytes is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/magnesium-rbc.md
+++ b/packages/health-commons/content/biomarkers/magnesium-rbc.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:magnesium-rbc
+slug: biomarkers/magnesium-rbc
+title: "Magnesium RBC"
+summary: "RBC magnesium measures magnesium associated with red blood cells, which can add method-specific magnesium context but lacks a universally standardized clinical interval."
+status: reviewed
+quality: reviewed
+aliases:
+  - "rbc-magnesium"
+  - "magnesium-red-blood-cell"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Magnesium RBC; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Magnesium RBC is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/mean-corpuscular-hemoglobin-concentration.md
+++ b/packages/health-commons/content/biomarkers/mean-corpuscular-hemoglobin-concentration.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:mean-corpuscular-hemoglobin-concentration
+slug: biomarkers/mean-corpuscular-hemoglobin-concentration
+title: "Mean corpuscular hemoglobin concentration"
+summary: "Mean corpuscular hemoglobin concentration estimates hemoglobin concentration within red cells, which can help characterize red-cell patterns alongside other blood-count indices."
+status: reviewed
+quality: reviewed
+aliases:
+  - "mchc"
+  - "mean-corpuscular-hb-concentration"
+  - "mean-corpuscular-haemoglobin-concentration"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Mean corpuscular hemoglobin concentration; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Mean corpuscular hemoglobin concentration is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/mean-corpuscular-hemoglobin.md
+++ b/packages/health-commons/content/biomarkers/mean-corpuscular-hemoglobin.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:mean-corpuscular-hemoglobin
+slug: biomarkers/mean-corpuscular-hemoglobin
+title: "Mean corpuscular hemoglobin"
+summary: "Mean corpuscular hemoglobin estimates the average hemoglobin mass per red cell, which can help characterize red-cell patterns alongside MCV, MCHC, hemoglobin, and hematocrit."
+status: reviewed
+quality: reviewed
+aliases:
+  - "mch"
+  - "mean-cell-haemoglobin"
+  - "mean-corpuscular-haemoglobin"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Mean corpuscular hemoglobin; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Mean corpuscular hemoglobin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/mean-corpuscular-volume.md
+++ b/packages/health-commons/content/biomarkers/mean-corpuscular-volume.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:mean-corpuscular-volume
+slug: biomarkers/mean-corpuscular-volume
+title: "Mean corpuscular volume"
+summary: "Mean corpuscular volume estimates average red-cell size, which can help characterize red-cell patterns when interpreted with hemoglobin, RDW, and clinical context."
+status: reviewed
+quality: reviewed
+aliases:
+  - "mcv"
+  - "mean-cell-volume"
+  - "mean-corpuscular-volume"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Mean corpuscular volume; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Mean corpuscular volume is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/mean-platelet-volume.md
+++ b/packages/health-commons/content/biomarkers/mean-platelet-volume.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:mean-platelet-volume
+slug: biomarkers/mean-platelet-volume
+title: "Mean Platelet Volume"
+summary: "Mean platelet volume estimates average platelet size, which can add platelet-production context but varies materially by analyzer, sample handling, and time to analysis."
+status: reviewed
+quality: reviewed
+aliases:
+  - "MPV"
+  - "mean-platelet-volume"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Mean Platelet Volume; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Mean Platelet Volume is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/mercury.md
+++ b/packages/health-commons/content/biomarkers/mercury.md
@@ -1,0 +1,29 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:mercury
+slug: biomarkers/mercury
+title: "Mercury"
+summary: "Mercury measures mercury in a specified specimen, which can add exposure context only when chemical form, specimen, timing, and likely exposure source are considered."
+status: reviewed
+quality: reviewed
+categories:
+  - lab-metric
+  - environmental-exposure
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Mercury; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, chemical form, age, pregnancy, exposure source and timing, occupation, and jurisdiction-specific public-health guidance recorded."
+      source:
+        title: "Toxicological Profile for Mercury"
+        organization: "Agency for Toxic Substances and Disease Registry"
+        year: 2024
+        sourceType: "regulatory_guidance"
+        url: "https://www.atsdr.cdc.gov/peer-review-agenda/php/toxicological-profiles/mercury.html"
+---
+
+Mercury is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/methylmalonic-acid.md
+++ b/packages/health-commons/content/biomarkers/methylmalonic-acid.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:methylmalonic-acid
+slug: biomarkers/methylmalonic-acid
+title: "Methylmalonic Acid"
+summary: "Methylmalonic acid measures a metabolite that can rise when vitamin B12-dependent metabolism is impaired, which can add context but is also affected by kidney function and age."
+status: reviewed
+quality: reviewed
+aliases:
+  - "mma"
+  - "methylmalonate"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Methylmalonic Acid; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Methylmalonic Acid is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/monocyte-percentage.md
+++ b/packages/health-commons/content/biomarkers/monocyte-percentage.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:monocyte-percentage
+slug: biomarkers/monocyte-percentage
+title: "Monocytes"
+summary: "Monocyte percentage measures monocytes as a share of white blood cells, which can add differential-count context but can shift when other leukocyte populations change."
+status: reviewed
+quality: reviewed
+aliases:
+  - "monocytes"
+  - "monocytes-percent"
+  - "monocytes-relative"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Monocytes; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Monocytes is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/neutrophil-percentage.md
+++ b/packages/health-commons/content/biomarkers/neutrophil-percentage.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:neutrophil-percentage
+slug: biomarkers/neutrophil-percentage
+title: "Neutrophils"
+summary: "Neutrophil percentage measures neutrophils as a share of white blood cells, which can add immune context but may change when other leukocyte populations shift."
+status: reviewed
+quality: reviewed
+aliases:
+  - "neutrophils"
+  - "neutrophils-percent"
+  - "neutrophils-relative"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Neutrophils; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Neutrophils is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/non-hdl-cholesterol.md
+++ b/packages/health-commons/content/biomarkers/non-hdl-cholesterol.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:non-hdl-cholesterol"
 slug: "biomarkers/non-hdl-cholesterol"
 title: "Non-HDL Cholesterol"
-summary: "Total cholesterol minus HDL-C; secondary lipid-context endpoint for EPA/DHA experiments when a fasting lipid panel is used."
+summary: "Non-HDL cholesterol subtracts HDL-C from total cholesterol to estimate cholesterol carried by atherogenic particles, which can support risk-based lipid assessment."
 status: "draft"
 quality: "usable"
 aliases:
@@ -79,6 +79,37 @@ claims:
       - "source_artifact:pmid-26073395"
       - "source_artifact:pmid-26073397"
       - "source_artifact:pmid-36313109"
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "The 2026 dyslipidemia guideline uses non-HDL-C goals below 130 mg/dL for borderline or intermediate primary-prevention risk, below 100 mg/dL for high risk, and below 85 mg/dL for very-high-risk secondary prevention."
+      applicability: "These are risk- and treatment-specific goals rather than a universal reference interval, and they should remain linked to total cholesterol, HDL-C, treatment, and the member’s risk category."
+      numericValues:
+        - label: "Borderline or intermediate primary-prevention goal"
+          unit: "mg/dL"
+          upperBound:
+            value: 130
+            inclusive: false
+        - label: "High-risk goal"
+          unit: "mg/dL"
+          upperBound:
+            value: 100
+            inclusive: false
+        - label: "Very-high-risk secondary-prevention goal"
+          unit: "mg/dL"
+          upperBound:
+            value: 85
+            inclusive: false
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
 ---
 
 ## Role in this protocol

--- a/packages/health-commons/content/biomarkers/omega-3-total-omegacheck.md
+++ b/packages/health-commons/content/biomarkers/omega-3-total-omegacheck.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:omega-3-total-omegacheck
+slug: biomarkers/omega-3-total-omegacheck
+title: "Omega-3 Total / OmegaCheck"
+summary: "Omega-3 Total from an OmegaCheck-type panel reports the assay-defined combined omega-3 fraction, which can add dietary exposure context only within the named specimen and method."
+status: reviewed
+quality: reviewed
+aliases:
+  - "omega-3-total-omega-check"
+  - "omega3-total-omegacheck"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Omega-3 Total / OmegaCheck; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+Omega-3 Total / OmegaCheck is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/omega-6-3-ratio.md
+++ b/packages/health-commons/content/biomarkers/omega-6-3-ratio.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:omega-6-3-ratio
+slug: biomarkers/omega-6-3-ratio
+title: "Omega 6/3 Ratio"
+summary: "The omega-6-to-omega-3 ratio compares assay-defined fatty-acid totals, which can add relative dietary exposure context but changes with specimen and panel composition."
+status: reviewed
+quality: reviewed
+aliases:
+  - "omega-6-to-3-ratio"
+  - "omega6-omega3-ratio"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Omega 6/3 Ratio as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+Omega 6/3 Ratio is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/omega-6-total.md
+++ b/packages/health-commons/content/biomarkers/omega-6-total.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:omega-6-total
+slug: biomarkers/omega-6-total
+title: "Omega-6 total"
+summary: "Omega-6 total reports the assay-defined combined omega-6 fatty-acid fraction, which can add dietary exposure context only within the named specimen and panel method."
+status: reviewed
+quality: reviewed
+aliases:
+  - "total-omega-6"
+  - "omega6-total"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Omega-6 total; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+Omega-6 total is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/omegacheck-total.md
+++ b/packages/health-commons/content/biomarkers/omegacheck-total.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:omegacheck-total
+slug: biomarkers/omegacheck-total
+title: "OmegaCheck total"
+summary: "OmegaCheck total reports a laboratory-defined combined fatty-acid result, which can add exposure context only when the exact components, specimen, units, and method are preserved."
+status: reviewed
+quality: reviewed
+aliases:
+  - "omega-check-total"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for OmegaCheck total; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Metabolic Testing Portfolio: Omega-3 and Omega-6 Fatty Acids and OmegaCheck"
+        organization: "Quest Diagnostics"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.questdiagnostics.com/healthcare-professionals/about-our-tests/cardiovascular/metabolic-testing/portfolio"
+---
+
+OmegaCheck total is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/phosphate.md
+++ b/packages/health-commons/content/biomarkers/phosphate.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:phosphate
+slug: biomarkers/phosphate
+title: "Phosphate"
+summary: "Phosphate measures inorganic phosphorus in blood, which can add bone, kidney, parathyroid, nutrition, and cellular-shift context and varies with age and timing."
+status: reviewed
+quality: reviewed
+aliases:
+  - "phosphorus"
+  - "serum-phosphate"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Phosphate; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Phosphate is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/platelet-count.md
+++ b/packages/health-commons/content/biomarkers/platelet-count.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:platelet-count
+slug: biomarkers/platelet-count
+title: "Platelets"
+summary: "Platelets measure the number of circulating platelets, which can add clotting and marrow context while collection artifacts and the reporting interval remain important."
+status: reviewed
+quality: reviewed
+aliases:
+  - "platelet"
+  - "platelets"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Platelets; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Platelets is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/poc-troponin-i.md
+++ b/packages/health-commons/content/biomarkers/poc-troponin-i.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:poc-troponin-i
+slug: biomarkers/poc-troponin-i
+title: "POC Troponin I"
+summary: "Point-of-care troponin I measures cardiac troponin I with a specific rapid assay, which can matter when interpreted against that assay’s cutoff, timing, serial change, and clinical context."
+status: reviewed
+quality: reviewed
+aliases:
+  - "troponin-i-poc"
+  - "point-of-care-troponin-i"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Use the sex-specific 99th-percentile upper reference limit supplied for the exact point-of-care troponin I assay when available; values are not interchangeable across assays, and myocardial-infarction assessment requires a rise or fall pattern plus evidence of ischemia rather than one result alone."
+      applicability: "Applies only to the named assay, instrument, specimen, sampling time, and population for which its upper reference limit was established; serial sampling, symptoms, electrocardiography, kidney function, and the source laboratory flag remain part of interpretation."
+      source:
+        title: "Fourth Universal Definition of Myocardial Infarction (2018)"
+        organization: "ESC, ACC, AHA, and WHF; Journal of the American College of Cardiology"
+        year: 2018
+        sourceType: "consensus_statement"
+        url: "https://www.jacc.org/doi/10.1016/j.jacc.2018.08.1038"
+        doi: "10.1016/j.jacc.2018.08.1038"
+---
+
+POC Troponin I is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/potassium.md
+++ b/packages/health-commons/content/biomarkers/potassium.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:potassium
+slug: biomarkers/potassium
+title: "Potassium"
+summary: "Potassium measures a key intracellular electrolyte in blood, which can add cardiac, kidney, and medication context while collection hemolysis can create misleading results."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-potassium"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Potassium; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Potassium is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/prolactin.md
+++ b/packages/health-commons/content/biomarkers/prolactin.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:prolactin
+slug: biomarkers/prolactin
+title: "Prolactin"
+summary: "Prolactin measures a pituitary hormone concentration, which can add reproductive and pituitary context but changes with time, stress, sleep, pregnancy, medications, and assay interference."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-prolactin"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Prolactin; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Prolactin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/psa-free.md
+++ b/packages/health-commons/content/biomarkers/psa-free.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:psa-free
+slug: biomarkers/psa-free
+title: "PSA free"
+summary: "Free PSA measures the unbound fraction of prostate-specific antigen, which can add context alongside total PSA but depends on assay, age, prostate conditions, medications, and clinical purpose."
+status: reviewed
+quality: reviewed
+aliases:
+  - "free-psa"
+  - "prostate-specific-antigen-free"
+categories:
+  - lab-metric
+  - prostate-health
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for PSA free; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies with age, prostate history, symptoms, medications, recent procedures or infection, assay, and the clinical reason for testing recorded."
+      source:
+        title: "Early Detection of Prostate Cancer: AUA/SUO Guideline"
+        organization: "American Urological Association and Society of Urologic Oncology"
+        year: 2023
+        sourceType: "clinical_guideline"
+        url: "https://www.auanet.org/guidelines-and-quality/guidelines/early-detection-of-prostate-cancer-guidelines"
+---
+
+PSA free is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/psa-percent-free.md
+++ b/packages/health-commons/content/biomarkers/psa-percent-free.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:psa-percent-free
+slug: biomarkers/psa-percent-free
+title: "PSA percent free"
+summary: "Percent-free PSA calculates free PSA as a percentage of total PSA, which can add risk-stratification context in selected settings but has no universal standalone cutoff."
+status: reviewed
+quality: reviewed
+aliases:
+  - "percent-free-psa"
+  - "free-psa-percent"
+categories:
+  - lab-metric
+  - prostate-health
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat PSA percent free as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies with age, prostate history, symptoms, medications, recent procedures or infection, assay, and the clinical reason for testing recorded."
+      source:
+        title: "Early Detection of Prostate Cancer: AUA/SUO Guideline"
+        organization: "American Urological Association and Society of Urologic Oncology"
+        year: 2023
+        sourceType: "clinical_guideline"
+        url: "https://www.auanet.org/guidelines-and-quality/guidelines/early-detection-of-prostate-cancer-guidelines"
+---
+
+PSA percent free is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/psa-total.md
+++ b/packages/health-commons/content/biomarkers/psa-total.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:psa-total
+slug: biomarkers/psa-total
+title: "PSA total"
+summary: "Total PSA measures free plus protein-bound prostate-specific antigen, which can add prostate context but varies with age, prostate volume, inflammation, procedures, medications, and assay."
+status: reviewed
+quality: reviewed
+aliases:
+  - "total-psa"
+  - "prostate-specific-antigen-total"
+categories:
+  - lab-metric
+  - prostate-health
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for PSA total; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies with age, prostate history, symptoms, medications, recent procedures or infection, assay, and the clinical reason for testing recorded."
+      source:
+        title: "Early Detection of Prostate Cancer: AUA/SUO Guideline"
+        organization: "American Urological Association and Society of Urologic Oncology"
+        year: 2023
+        sourceType: "clinical_guideline"
+        url: "https://www.auanet.org/guidelines-and-quality/guidelines/early-detection-of-prostate-cancer-guidelines"
+---
+
+PSA total is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/red-blood-cell-count.md
+++ b/packages/health-commons/content/biomarkers/red-blood-cell-count.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:red-blood-cell-count
+slug: biomarkers/red-blood-cell-count
+title: "Red blood cells"
+summary: "Red blood cells measure the number of erythrocytes per blood volume, which can add oxygen-carrying and marrow context alongside hemoglobin, hematocrit, and cell indices."
+status: reviewed
+quality: reviewed
+aliases:
+  - "rbc"
+  - "red-blood-cell"
+  - "red-blood-cells"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Red blood cells; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Red blood cells is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/red-cell-distribution-width.md
+++ b/packages/health-commons/content/biomarkers/red-cell-distribution-width.md
@@ -1,0 +1,35 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:red-cell-distribution-width
+slug: biomarkers/red-cell-distribution-width
+title: "Red cell distribution width"
+summary: "Red cell distribution width measures variation in red-cell size, which can help characterize blood-count patterns when interpreted with MCV, hemoglobin, and clinical context."
+status: reviewed
+quality: reviewed
+aliases:
+  - "rdw"
+  - "rdw-cv"
+  - "red-cell-distribution-width"
+  - "red-cell-distribution-width-rdw"
+  - "red_cell_distribution_width"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Red cell distribution width; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+Red cell distribution width is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/rem-sleep-minutes.md
+++ b/packages/health-commons/content/biomarkers/rem-sleep-minutes.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:rem-sleep-minutes
 slug: biomarkers/rem-sleep-minutes
 title: REM Sleep
-summary: Time spent in rapid-eye-movement sleep each night, where the brain fires almost as actively as when awake to consolidate memory, process emotion, and rehearse learned patterns.
+summary: "REM sleep minutes estimate time spent in rapid-eye-movement sleep, which can add context to sleep architecture and continuity when tracked consistently with the same device."
 status: field-testing
 quality: usable
 aliases:
@@ -53,7 +53,7 @@ biomarker:
       body: "Tracks REM-related dreaming, emotion, memory, and autonomic physiology; useful as a trend, not an optimization target."
     -
       title: How to read it
-      body: "Typical range: about 90 minutes to 2 hours, or 20-25% of total sleep. Best with fewer awakenings and better daytime function."
+      body: "There is no universal wearable target; compare same-device trends with total sleep, continuity, and next-day function rather than treating one stage estimate as a verdict."
     -
       title: What moves it
       body: "Sleep duration, early alarms, alcohol, medications, apnea, CPAP changes, substance withdrawal, stress, circadian disruption, illness, and algorithms."
@@ -119,6 +119,20 @@ communityOutcomeSummary:
   state: coming_soon
   minimumCohortSize: 20
   placeholder: Early outcome summaries will appear here once enough opted-in runs include consistent REM sleep estimates and contextual sleep notes.
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for REM sleep (minutes); use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to repeated same-device estimates under comparable wear, sleep-window, firmware, and signal-quality conditions; consumer staging is contextual rather than diagnostic."
+      source:
+        title: "Consumer Sleep Technology: An American Academy of Sleep Medicine Position Statement"
+        organization: "American Academy of Sleep Medicine; Journal of Clinical Sleep Medicine"
+        year: 2018
+        sourceType: "consensus_statement"
+        url: "https://aasm.org/advocacy/position-statements/consumer-sleep-technology/"
 ---
 
 REM sleep minutes are useful because they give a simple view of one part of sleep architecture that many people already see in their wearable dashboards.

--- a/packages/health-commons/content/biomarkers/resting-heart-rate.md
+++ b/packages/health-commons/content/biomarkers/resting-heart-rate.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:resting-heart-rate
 slug: biomarkers/resting-heart-rate
 title: Resting Heart Rate
-summary: How many times the heart beats per minute at full rest, where a lower count usually means the heart pumps more blood per beat and needs fewer contractions to do the same job.
+summary: "Resting heart rate measures how often the heart beats during quiet rest, which can reflect fitness, recovery, illness, medication effects, and other changes over time."
 status: field-testing
 quality: usable
 aliases:
@@ -96,6 +96,29 @@ communityOutcomeSummary:
   state: coming_soon
   minimumCohortSize: 20
   placeholder: Early outcome summaries will appear here once enough opted-in experiment runs are available.
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "The American Heart Association describes 60 through 100 beats per minute as a typical resting range for most adults, while trained athletes, medications, illness, and rhythm conditions can shift what is expected."
+      applicability: "Applies to a resting measurement under comparable conditions while age, fitness, illness, medications, rhythm, and measurement method are considered."
+      numericValues:
+        - label: "Typical resting adult interval"
+          unit: "bpm"
+          lowerBound:
+            value: 60
+            inclusive: true
+          upperBound:
+            value: 100
+            inclusive: true
+      source:
+        title: "Target Heart Rates Chart"
+        organization: "American Heart Association"
+        year: 2024
+        sourceType: "academic_reference"
+        url: "https://www.heart.org/en/healthy-living/fitness/fitness-basics/target-heart-rates"
 ---
 
 Resting heart rate is useful because it is available on most consumer wearables and easier to explain than composite recovery scores.

--- a/packages/health-commons/content/biomarkers/rheumatoid-factor.md
+++ b/packages/health-commons/content/biomarkers/rheumatoid-factor.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:rheumatoid-factor
+slug: biomarkers/rheumatoid-factor
+title: "Rheumatoid Factor"
+summary: "Rheumatoid factor measures an antibody that can occur in rheumatoid arthritis and other settings, which can add immune context but is neither specific nor conclusive by itself."
+status: reviewed
+quality: reviewed
+aliases:
+  - "rf"
+  - "rheumatoid-factor"
+categories:
+  - lab-metric
+  - inflammation-and-immune
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Rheumatoid Factor; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay method, symptoms, acute illness, medications, pretest context, and the reporting laboratory’s qualitative or numeric interpretation retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Rheumatoid Factor is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/serum-25-hydroxyvitamin-d.md
+++ b/packages/health-commons/content/biomarkers/serum-25-hydroxyvitamin-d.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:serum-25-hydroxyvitamin-d
 slug: biomarkers/serum-25-hydroxyvitamin-d
 title: Serum 25-Hydroxyvitamin D
-summary: The primary lab marker for vitamin D status and the clearest measurable endpoint for daily vitamin D3 supplementation experiments, with thresholds and assay interpretation requiring context.
+summary: "Serum 25-hydroxyvitamin D measures the main circulating vitamin D status marker, which can add bone and nutrition context while testing indications and target thresholds differ across guidance."
 status: draft
 quality: usable
 aliases:
@@ -69,6 +69,40 @@ biomarker:
       - adherence
       - supplement stacking
       - kidney disease or calcium disorders
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Vitamin D; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Vitamin D for the Prevention of Disease: An Endocrine Society Clinical Practice Guideline"
+        organization: "Endocrine Society; Journal of Clinical Endocrinology & Metabolism"
+        year: 2024
+        sourceType: "clinical_guideline"
+        url: "https://www.endocrine.org/clinical-practice-guidelines/vitamin-d-for-prevention-of-disease"
+    - kind: decision_limit
+      guidance: "The National Academies concluded that 20 ng/mL, equivalent to 50 nmol/L, meets the needs of nearly all people for bone-health outcomes, while the 2024 Endocrine Society guideline found no outcome-specific threshold for routine testing in generally healthy populations."
+      applicability: "This records a real scope difference rather than choosing a false consensus: the National Academies threshold addresses population bone-health adequacy, while the Endocrine Society guidance addresses disease prevention and routine testing in generally healthy people."
+      numericValues:
+        - label: "National Academies concentration meeting needs of nearly all people for bone health"
+          unit: "ng/mL"
+          lowerBound:
+            value: 20
+            inclusive: true
+        - label: "National Academies concentration meeting needs of nearly all people for bone health"
+          unit: "nmol/L"
+          lowerBound:
+            value: 50
+            inclusive: true
+      source:
+        title: "Dietary Reference Intakes for Calcium and Vitamin D"
+        organization: "National Academies of Sciences, Engineering, and Medicine"
+        year: 2011
+        sourceType: "academic_reference"
+        url: "https://nap.nationalacademies.org/catalog/13050/dietary-reference-intakes-for-calcium-and-vitamin-d"
 ---
 
 Serum 25-hydroxyvitamin D is the main outcome for Daily Vitamin D3 Supplementation because direct daily-D3 trials repeatedly measure a change in this biomarker over weeks to months.

--- a/packages/health-commons/content/biomarkers/serum-creatinine.md
+++ b/packages/health-commons/content/biomarkers/serum-creatinine.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:serum-creatinine"
 slug: "biomarkers/serum-creatinine"
 title: "Serum Creatinine"
-summary: "Kidney-function safety context for clinician-guided monitoring."
+summary: "Creatinine measures a muscle-derived waste product in blood, which helps contextualize kidney filtration while muscle mass, diet, exercise, medications, and assay method can affect it."
 status: "draft"
 quality: "usable"
 aliases:
@@ -62,5 +62,20 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Community outcome summaries will appear once enough opted-in experiment runs are available."
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Creatinine; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
 ---
+
 Kidney-function safety context for clinician-guided monitoring.

--- a/packages/health-commons/content/biomarkers/serum-uric-acid.md
+++ b/packages/health-commons/content/biomarkers/serum-uric-acid.md
@@ -4,7 +4,7 @@ entityType: biomarker
 key: biomarker:serum-uric-acid
 slug: biomarkers/serum-uric-acid
 title: Serum Uric Acid
-summary: Optional gout and urate-context safety lab interpreted clinically when relevant.
+summary: "Uric acid measures circulating urate from purine metabolism, which can matter for gout, kidney, medication, and metabolic context without one value determining a condition."
 status: draft
 quality: usable
 categories:
@@ -22,6 +22,20 @@ biomarker:
   direction:
     desired: lower_or_stable
     label: Lower or stable uric acid within the healthy range reduces gout risk.
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Uric acid; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
 ---
 
 Optional gout and urate-context safety lab interpreted clinically when relevant.

--- a/packages/health-commons/content/biomarkers/sex-hormone-binding-globulin.md
+++ b/packages/health-commons/content/biomarkers/sex-hormone-binding-globulin.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:sex-hormone-binding-globulin
+slug: biomarkers/sex-hormone-binding-globulin
+title: "Sex Hormone Binding Globulin"
+summary: "Sex hormone-binding globulin measures a carrier protein for sex steroids, which can affect free-hormone estimates and varies with age, sex, liver, thyroid, metabolic, and medication factors."
+status: reviewed
+quality: reviewed
+aliases:
+  - "shbg"
+  - "sex-hormone-binding-globulin"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Sex Hormone Binding Globulin; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Sex Hormone Binding Globulin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/sodium.md
+++ b/packages/health-commons/content/biomarkers/sodium.md
@@ -1,0 +1,31 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:sodium
+slug: biomarkers/sodium
+title: "Sodium"
+summary: "Sodium measures the main extracellular electrolyte concentration, which primarily reflects water balance and can add hydration, kidney, endocrine, and medication context."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-sodium"
+categories:
+  - lab-metric
+  - electrolytes
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Sodium; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with specimen type and handling, hydration, albumin, kidney function, medications, acid-base context, calculation formula, and source laboratory interval retained."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Sodium is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/thyroglobulin-antibodies.md
+++ b/packages/health-commons/content/biomarkers/thyroglobulin-antibodies.md
@@ -1,0 +1,35 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:thyroglobulin-antibodies
+slug: biomarkers/thyroglobulin-antibodies
+title: "Thyroglobulin Antibodies"
+summary: "Thyroglobulin antibodies measure immune reactivity to thyroglobulin, which can add autoimmune-thyroid context and can interfere with some thyroglobulin assays."
+status: reviewed
+quality: reviewed
+aliases:
+  - "thyroglobulin-antibody"
+  - "tg-antibodies"
+  - "tgab"
+categories:
+  - lab-metric
+  - thyroid
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Thyroglobulin Antibodies; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay, age, pregnancy or postpartum status, illness, medications, and the reporting laboratory’s population-specific interval retained."
+      source:
+        title: "2017 Guidelines of the American Thyroid Association for the Diagnosis and Management of Thyroid Disease During Pregnancy and the Postpartum"
+        organization: "American Thyroid Association; Thyroid"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/28056690/"
+        doi: "10.1089/thy.2016.0457"
+        pmid: "28056690"
+---
+
+Thyroglobulin Antibodies is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/thyroid-peroxidase-antibodies.md
+++ b/packages/health-commons/content/biomarkers/thyroid-peroxidase-antibodies.md
@@ -1,0 +1,35 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:thyroid-peroxidase-antibodies
+slug: biomarkers/thyroid-peroxidase-antibodies
+title: "Thyroid Peroxidase Antibodies"
+summary: "Thyroid peroxidase antibodies measure immune reactivity to a thyroid enzyme, which can add autoimmune-thyroid context without determining thyroid function by themselves."
+status: reviewed
+quality: reviewed
+aliases:
+  - "thyroid-peroxidase-antibody"
+  - "tpo-antibodies"
+  - "tpoab"
+categories:
+  - lab-metric
+  - thyroid
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Thyroid Peroxidase Antibodies; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay, age, pregnancy or postpartum status, illness, medications, and the reporting laboratory’s population-specific interval retained."
+      source:
+        title: "2017 Guidelines of the American Thyroid Association for the Diagnosis and Management of Thyroid Disease During Pregnancy and the Postpartum"
+        organization: "American Thyroid Association; Thyroid"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/28056690/"
+        doi: "10.1089/thy.2016.0457"
+        pmid: "28056690"
+---
+
+Thyroid Peroxidase Antibodies is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/thyroid-stimulating-hormone.md
+++ b/packages/health-commons/content/biomarkers/thyroid-stimulating-hormone.md
@@ -1,0 +1,34 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:thyroid-stimulating-hormone
+slug: biomarkers/thyroid-stimulating-hormone
+title: "Thyroid-stimulating hormone"
+summary: "TSH measures the pituitary signal that regulates thyroid hormone production, which can add thyroid-function context while age, pregnancy, illness, medications, and assay ranges matter."
+status: reviewed
+quality: reviewed
+aliases:
+  - "thyrotropin"
+  - "tsh"
+categories:
+  - lab-metric
+  - thyroid
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Thyroid-stimulating hormone; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with assay, age, pregnancy or postpartum status, illness, medications, and the reporting laboratory’s population-specific interval retained."
+      source:
+        title: "2017 Guidelines of the American Thyroid Association for the Diagnosis and Management of Thyroid Disease During Pregnancy and the Postpartum"
+        organization: "American Thyroid Association; Thyroid"
+        year: 2017
+        sourceType: "clinical_guideline"
+        url: "https://pubmed.ncbi.nlm.nih.gov/28056690/"
+        doi: "10.1089/thy.2016.0457"
+        pmid: "28056690"
+---
+
+Thyroid-stimulating hormone is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/total-cholesterol.md
+++ b/packages/health-commons/content/biomarkers/total-cholesterol.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:total-cholesterol"
 slug: "biomarkers/total-cholesterol"
 title: "Total Cholesterol"
-summary: "Total cholesterol from a blood lipid panel; a supportive endpoint for cholesterol protocols, not the most specific marker."
+summary: "Total cholesterol measures cholesterol carried across the major lipoprotein classes, which can provide broad lipid context but does not distinguish particle type or overall risk by itself."
 status: "draft"
 quality: "usable"
 aliases:
@@ -69,5 +69,21 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Opted-in lipid experiment summaries will appear once enough comparable runs are available."
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Total cholesterol; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
 ---
+
 Total Cholesterol is used here as a lab-measured lipid marker. These cholesterol protocols treat LDL-C as the primary endpoint and use other lipid markers as supportive or contextual measures.

--- a/packages/health-commons/content/biomarkers/total-globulin.md
+++ b/packages/health-commons/content/biomarkers/total-globulin.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:total-globulin
+slug: biomarkers/total-globulin
+title: "Globulin"
+summary: "Globulin reports the non-albumin portion of measured serum protein, which can add context about immune proteins and protein balance but is often calculated."
+status: reviewed
+quality: reviewed
+aliases:
+  - "globulin"
+  - "globulin-total"
+categories:
+  - lab-metric
+  - liver
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Globulin; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Globulin is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/total-iron-binding-capacity.md
+++ b/packages/health-commons/content/biomarkers/total-iron-binding-capacity.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:total-iron-binding-capacity
+slug: biomarkers/total-iron-binding-capacity
+title: "Total Iron Binding Capacity"
+summary: "Total iron-binding capacity estimates how much iron transferrin can bind, which can add iron-status context when interpreted with iron, saturation, ferritin, inflammation, and assay method."
+status: reviewed
+quality: reviewed
+aliases:
+  - "tibc"
+  - "iron-binding-capacity-total"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Total Iron Binding Capacity; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Total Iron Binding Capacity is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/total-protein.md
+++ b/packages/health-commons/content/biomarkers/total-protein.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:total-protein
+slug: biomarkers/total-protein
+title: "Total Protein"
+summary: "Total protein measures albumin plus globulin in serum or plasma, which can add context about hydration, protein balance, inflammation, liver function, and protein loss."
+status: reviewed
+quality: reviewed
+aliases:
+  - "protein-total"
+  - "serum-total-protein"
+categories:
+  - lab-metric
+  - liver
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Total Protein; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies with the reporting assay, age, sex, symptoms, medications, alcohol, exercise, and related liver or blood-count results considered."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Total Protein is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/total-testosterone.md
+++ b/packages/health-commons/content/biomarkers/total-testosterone.md
@@ -1,0 +1,33 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:total-testosterone
+slug: biomarkers/total-testosterone
+title: "Total testosterone"
+summary: "Total testosterone measures bound plus unbound testosterone, which can add androgen context when collected and repeated under appropriate timing with an accurate assay."
+status: reviewed
+quality: reviewed
+aliases:
+  - "testosterone"
+  - "testosterone-total"
+categories:
+  - lab-metric
+  - hormones
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Total testosterone; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies only with specimen, sex, age, pregnancy or menopausal status, collection time or cycle stage, medications, binding proteins, and assay method recorded."
+      source:
+        title: "Testosterone Therapy in Men With Hypogonadism: An Endocrine Society Clinical Practice Guideline"
+        organization: "Endocrine Society; Journal of Clinical Endocrinology & Metabolism"
+        year: 2018
+        sourceType: "clinical_guideline"
+        url: "https://www.endocrine.org/clinical-practice-guidelines/testosterone-therapy"
+        doi: "10.1210/jc.2018-00229"
+---
+
+Total testosterone is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/triglycerides.md
+++ b/packages/health-commons/content/biomarkers/triglycerides.md
@@ -4,7 +4,7 @@ entityType: "biomarker"
 key: "biomarker:triglycerides"
 slug: "biomarkers/triglycerides"
 title: "Triglycerides"
-summary: "Blood triglycerides from a lipid panel; a context-sensitive watch metric for cholesterol protocols."
+summary: "Triglycerides measure circulating fats carried in lipoproteins, which can matter for metabolic and cardiovascular context and are sensitive to fasting, meals, alcohol, illness, and medications."
 status: "draft"
 quality: "usable"
 aliases:
@@ -67,5 +67,32 @@ communityOutcomeSummary:
   state: "coming_soon"
   minimumCohortSize: 20
   placeholder: "Opted-in lipid experiment summaries will appear once enough comparable runs are available."
+referenceGuidance:
+  classification: conditional_numeric
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: decision_limit
+      guidance: "Triglycerides at or above 500 mg/dL identify severe hypertriglyceridemia in guideline pathways where pancreatitis prevention becomes a specific management concern."
+      applicability: "Applies to a confirmed lipid result with fasting status, alcohol, diabetes, pregnancy, acute illness, and triglyceride-raising medications considered; this is not an “optimal” wellness boundary."
+      numericValues:
+        - label: "Severe hypertriglyceridemia decision threshold"
+          unit: "mg/dL"
+          lowerBound:
+            value: 500
+            inclusive: true
+        - label: "Severe hypertriglyceridemia decision threshold"
+          unit: "mmol/L"
+          lowerBound:
+            value: 5.7
+            inclusive: true
+      source:
+        title: "2026 ACC/AHA/Multisociety Guideline on the Management of Dyslipidemia"
+        organization: "American College of Cardiology, American Heart Association, and collaborating societies; Circulation"
+        year: 2026
+        sourceType: "clinical_guideline"
+        url: "https://www.ahajournals.org/doi/10.1161/CIR.0000000000001423"
+        doi: "10.1161/CIR.0000000000001423"
 ---
+
 Triglycerides is used here as a lab-measured lipid marker. These cholesterol protocols treat LDL-C as the primary endpoint and use other lipid markers as supportive or contextual measures.

--- a/packages/health-commons/content/biomarkers/urine-albumin-random-without-creatinine.md
+++ b/packages/health-commons/content/biomarkers/urine-albumin-random-without-creatinine.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:urine-albumin-random-without-creatinine
+slug: biomarkers/urine-albumin-random-without-creatinine
+title: "Urine albumin random without creatinine"
+summary: "Random urine albumin without creatinine measures albumin concentration in one specimen, which can add kidney context but is strongly affected by urine concentration."
+status: reviewed
+quality: reviewed
+aliases:
+  - "random-urine-albumin-without-creatinine"
+  - "urine-microalbumin-random-without-creatinine"
+categories:
+  - lab-metric
+  - kidneys
+referenceGuidance:
+  classification: no_universal_range
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: evidence_limit
+      guidance: "No universal numeric range is encoded for Urine albumin random without creatinine; use the named method, population, and source interpretation rather than a wellness “optimal” range."
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "KDIGO 2024 Clinical Practice Guideline for the Evaluation and Management of Chronic Kidney Disease"
+        organization: "Kidney Disease: Improving Global Outcomes; Kidney International"
+        year: 2024
+        sourceType: "clinical_guideline"
+        url: "https://kdigo.org/guidelines/ckd-evaluation-and-management/"
+---
+
+Urine albumin random without creatinine is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/urine-protein.md
+++ b/packages/health-commons/content/biomarkers/urine-protein.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:urine-protein
+slug: biomarkers/urine-protein
+title: "Urine protein"
+summary: "Urine protein reports whether or how much protein is detected in urine, which can add kidney context but may be qualitative, concentration-based, or method-specific."
+status: reviewed
+quality: reviewed
+aliases:
+  - "protein-urine"
+  - "urine-protein-qualitative"
+categories:
+  - lab-metric
+  - kidneys
+referenceGuidance:
+  classification: qualitative
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: qualitative_interpretation
+      guidance: "Preserve the reported category, titer, or narrative interpretation for Urine protein; Commons must not manufacture a numeric interval or translate an absent source flag into “in range.”"
+      applicability: "Applies with equation or assay, age, body-size context, hydration, medications, chronicity, and urine findings recorded; the source result range and flag remain authoritative."
+      source:
+        title: "KDIGO 2024 Clinical Practice Guideline for the Evaluation and Management of Chronic Kidney Disease"
+        organization: "Kidney Disease: Improving Global Outcomes; Kidney International"
+        year: 2024
+        sourceType: "clinical_guideline"
+        url: "https://kdigo.org/guidelines/ckd-evaluation-and-management/"
+---
+
+Urine protein is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/vldl-cholesterol-calculated.md
+++ b/packages/health-commons/content/biomarkers/vldl-cholesterol-calculated.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:vldl-cholesterol-calculated
+slug: biomarkers/vldl-cholesterol-calculated
+title: "Calculated VLDL cholesterol"
+summary: "Calculated VLDL cholesterol estimates cholesterol in very-low-density lipoproteins from other lipid values, which can add context only within the assumptions of the reporting formula."
+status: reviewed
+quality: reviewed
+aliases:
+  - "vldl-cholesterol-cal"
+  - "calculated-vldl-cholesterol"
+categories:
+  - lab-metric
+  - heart-and-lipids
+referenceGuidance:
+  classification: calculated_or_method_specific
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: method_note
+      guidance: "Treat Calculated VLDL cholesterol as the output of its named calculation or method, retain the formula and inputs, and do not merge it with a similarly named measured or differently calculated result."
+      applicability: "Applies to the named lipid analyte and method with fasting status, treatment, overall cardiovascular risk, and the source laboratory report retained."
+      source:
+        title: "Lipid Measurements in the Management of Cardiovascular Diseases: Practical Recommendations"
+        organization: "National Lipid Association"
+        year: 2021
+        sourceType: "consensus_statement"
+        url: "https://www.lipid.org/nla/lipid-measurements-management-cardiovascular-diseases-scientific-statement"
+---
+
+Calculated VLDL cholesterol is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/white-blood-cell-count.md
+++ b/packages/health-commons/content/biomarkers/white-blood-cell-count.md
@@ -1,0 +1,37 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:white-blood-cell-count
+slug: biomarkers/white-blood-cell-count
+title: "White blood cells"
+summary: "White blood cells measure the total number of circulating leukocytes, which can add immune and marrow context but changes with infection, inflammation, stress, medications, and physiology."
+status: reviewed
+quality: reviewed
+aliases:
+  - "leukocytes"
+  - "white-blood-cell"
+  - "white-blood-cell-count-wbc"
+  - "white-blood-cells"
+  - "white_blood_cells"
+  - "wbc"
+  - "wbc-count"
+categories:
+  - lab-metric
+  - blood
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for White blood cells; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies to venous whole-blood CBC results with age, sex, pregnancy, altitude, analyzer, specimen handling, and the local reference population considered."
+      source:
+        title: "Complete Blood Cell Count with Differential, Blood"
+        organization: "Mayo Clinic Laboratories"
+        year: 2026
+        sourceType: "assay_documentation"
+        url: "https://www.mayocliniclabs.com/test-catalog/overview/9109"
+---
+
+White blood cells is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/content/biomarkers/zinc.md
+++ b/packages/health-commons/content/biomarkers/zinc.md
@@ -1,0 +1,32 @@
+---
+schemaVersion: murph.commons.page.v1
+entityType: biomarker
+key: biomarker:zinc
+slug: biomarkers/zinc
+title: "Zinc"
+summary: "Zinc measures zinc concentration in the tested specimen, which can add nutrition context but is sensitive to specimen type, collection contamination, fasting, inflammation, and time of day."
+status: reviewed
+quality: reviewed
+aliases:
+  - "serum-zinc"
+  - "plasma-zinc"
+categories:
+  - lab-metric
+  - nutrients-and-fatty-acids
+referenceGuidance:
+  classification: source_range_only
+  reviewStatus: reviewed
+  use: context_only
+  items:
+    - kind: reference_interval
+      guidance: "Use the reporting laboratory’s reference interval for Zinc; Commons does not replace the source range because reference limits depend on assay, specimen, and reference population."
+      applicability: "Applies only to the named specimen, assay, units, collection conditions, supplements, diet, inflammation, kidney function, and source laboratory interpretation."
+      source:
+        title: "Defining, Establishing, and Verifying Reference Intervals in the Clinical Laboratory (EP28-A3c)"
+        organization: "Clinical and Laboratory Standards Institute and IFCC"
+        year: 2020
+        sourceType: "consensus_statement"
+        url: "https://clsi.org/shop/standards/ep28/"
+---
+
+Zinc is presented as contextual education only; the saved result’s source flag and per-result reference range remain authoritative for result display.

--- a/packages/health-commons/package.json
+++ b/packages/health-commons/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/runtime.js",
       "default": "./dist/runtime.js"
     },
+    "./biomarker-entity-mappings": {
+      "types": "./dist/biomarker-entity-mappings.d.ts",
+      "import": "./dist/biomarker-entity-mappings.js",
+      "default": "./dist/biomarker-entity-mappings.js"
+    },
     "./generated/*": "./generated/*"
   },
   "files": [

--- a/packages/health-commons/src/biomarker-entity-mappings.ts
+++ b/packages/health-commons/src/biomarker-entity-mappings.ts
@@ -1,0 +1,31 @@
+/**
+ * Explicit aliases from private metric biomarker identities to authored
+ * Health Commons entities. These mappings preserve stable metric keys while
+ * preventing duplicate Commons pages for the same analyte.
+ */
+export const HEALTH_COMMONS_BIOMARKER_ENTITY_MAPPINGS = {
+  "biomarker:alt": "biomarker:alanine-aminotransferase",
+  "biomarker:apob": "biomarker:apolipoprotein-b",
+  "biomarker:ast": "biomarker:aspartate-aminotransferase",
+  "biomarker:creatinine": "biomarker:serum-creatinine",
+  "biomarker:total-bilirubin": "biomarker:bilirubin",
+  "biomarker:vitamin-d": "biomarker:serum-25-hydroxyvitamin-d",
+} as const satisfies Readonly<Record<string, string>>;
+
+export function resolveHealthCommonsBiomarkerEntityKey(biomarkerKey: string): string {
+  let current = biomarkerKey.trim().toLowerCase();
+  const visited = new Set<string>();
+
+  while (!visited.has(current)) {
+    visited.add(current);
+    const mapped = HEALTH_COMMONS_BIOMARKER_ENTITY_MAPPINGS[
+      current as keyof typeof HEALTH_COMMONS_BIOMARKER_ENTITY_MAPPINGS
+    ];
+    if (!mapped) {
+      return current;
+    }
+    current = mapped;
+  }
+
+  throw new Error(`Health Commons biomarker entity mapping cycle detected at ${current}`);
+}

--- a/packages/health-commons/src/biomarker-web-artifacts.ts
+++ b/packages/health-commons/src/biomarker-web-artifacts.ts
@@ -3,6 +3,7 @@ import type {
   HealthCommonsBiomarkerExplainerCard,
   HealthCommonsBiomarkerPrivateMetricBinding,
   HealthCommonsBiomarkerProtocolExpectedDirection,
+  HealthCommonsBiomarkerReferenceGuidance,
   HealthCommonsBiomarkerTrendAggregation,
   HealthCommonsCatalogEntity,
   HealthCommonsClaim,
@@ -145,6 +146,7 @@ export interface HealthCommonsWebBiomarkerResearch {
   pageRevisionId: string;
   revision: HealthCommonsWebBiomarkerRevisionRef;
   route: HealthCommonsWebBiomarkerRoute;
+  referenceGuidance: HealthCommonsBiomarkerReferenceGuidance | null;
   routeId: string;
   schemaVersion: typeof HEALTH_COMMONS_WEB_BIOMARKER_RESEARCH_SCHEMA_VERSION;
   shortName: string;
@@ -278,6 +280,7 @@ export function buildHealthCommonsWebBiomarkerResearch(
     pageRevisionId: input.biomarker.revision.pageRevisionId,
     revision: input.biomarker.revision,
     route: biomarkerRoute(input),
+    referenceGuidance: input.biomarker.referenceGuidance ?? null,
     routeId: input.routeId,
     schemaVersion: HEALTH_COMMONS_WEB_BIOMARKER_RESEARCH_SCHEMA_VERSION,
     shortName: resolveHealthCommonsWebBiomarkerShortName(input.biomarker),

--- a/packages/health-commons/src/index.ts
+++ b/packages/health-commons/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./biomarker-entity-mappings.ts";
 export * from "./catalog.ts";
 export * from "./load.ts";
 export * from "./normalize.ts";

--- a/packages/health-commons/src/runtime.ts
+++ b/packages/health-commons/src/runtime.ts
@@ -19,6 +19,7 @@ import {
   resolveMetricDefinition,
   resolveMetricDefinitionForBiomarker,
 } from "@murphai/health-metrics";
+import { resolveHealthCommonsBiomarkerEntityKey } from "./biomarker-entity-mappings.ts";
 import {
   HEALTH_COMMONS_PROTOCOL_FAMILY_GRAPH_SCHEMA_VERSION,
   HEALTH_COMMONS_PROTOCOL_INDEX_SCHEMA_VERSION,
@@ -577,11 +578,11 @@ function resolveCanonicalBiomarkerKey(biomarkerKey: string): string {
   const normalizedBiomarkerKey = normalized.startsWith("biomarker:")
     ? normalized
     : `biomarker:${slug}`;
-  return (
+  const metricBiomarkerKey =
     resolveMetricDefinitionForBiomarker(normalizedBiomarkerKey)?.biomarkerKey ??
     resolveMetricDefinition(slug)?.biomarkerKey ??
-    normalizedBiomarkerKey
-  );
+    normalizedBiomarkerKey;
+  return resolveHealthCommonsBiomarkerEntityKey(metricBiomarkerKey);
 }
 
 export function loadGeneratedHealthCommonsWebRouteBundle(input: {

--- a/packages/health-commons/test/biomarker-web-artifacts.test.ts
+++ b/packages/health-commons/test/biomarker-web-artifacts.test.ts
@@ -1,11 +1,40 @@
 import { describe, expect, it } from "vitest";
 
-import type { HealthCommonsCatalogEntity } from "@murphai/contracts";
+import type {
+  HealthCommonsBiomarkerReferenceGuidance,
+  HealthCommonsCatalogEntity,
+} from "@murphai/contracts";
 import { buildHealthCommonsWebBiomarkerResearch } from "../src/biomarker-web-artifacts.ts";
 
 const TEST_PAGE_REVISION_ID = `sha256:${"1".repeat(64)}`;
 const TEST_CATALOG_HASH = `sha256:${"2".repeat(64)}`;
 const SOURCE_KEY = "source_artifact:test-source";
+const TEST_REFERENCE_GUIDANCE: HealthCommonsBiomarkerReferenceGuidance = {
+  classification: "conditional_numeric",
+  reviewStatus: "reviewed",
+  use: "context_only",
+  items: [
+    {
+      kind: "decision_limit",
+      guidance: "A test decision limit is preserved as contextual education only.",
+      applicability: "Applies only to the named test method and reviewed population.",
+      numericValues: [
+        {
+          label: "Example upper comparator",
+          unit: "example-unit",
+          upperBound: { inclusive: false, value: 10 },
+        },
+      ],
+      source: {
+        title: "Example guideline",
+        organization: "Example organization",
+        year: 2026,
+        sourceType: "clinical_guideline",
+        url: "https://example.test/guideline",
+      },
+    },
+  ],
+};
 
 describe("@murphai/health-commons biomarker web artifacts", () => {
   it("omits unsafe biomarker source urls from research links", () => {
@@ -30,6 +59,12 @@ describe("@murphai/health-commons biomarker web artifacts", () => {
 
     expect(research.sourceHighlights[0]?.externalUrl).toBe("https://example.test/source");
     expect(research.claims[0]?.sources[0]?.externalUrl).toBe("https://example.test/source");
+  });
+
+  it("projects structured reference guidance into the research artifact", () => {
+    const research = buildResearchWithSourceUrl("https://example.test/source");
+
+    expect(research.referenceGuidance).toEqual(TEST_REFERENCE_GUIDANCE);
   });
 });
 
@@ -68,6 +103,7 @@ function createBiomarkerEntity() {
         sourceKeys: [SOURCE_KEY],
       },
     ],
+    referenceGuidance: TEST_REFERENCE_GUIDANCE,
     relativePath: "biomarkers/test-biomarker.md",
     revision: {
       pageRevisionId: TEST_PAGE_REVISION_ID,

--- a/packages/health-commons/test/requested-biomarker-content.test.ts
+++ b/packages/health-commons/test/requested-biomarker-content.test.ts
@@ -1,0 +1,361 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  HEALTH_COMMONS_BIOMARKER_GUIDANCE_CLASSIFICATIONS,
+  healthCommonsBiomarkerGuidanceNumericValueSchema,
+} from "@murphai/contracts";
+import {
+  resolveIndexedLabHealthArea,
+  resolveLabResultMetricDefinition,
+  resolveMetricDefinition,
+  type LabHealthAreaId,
+} from "@murphai/health-metrics";
+import {
+  HEALTH_COMMONS_BIOMARKER_ENTITY_MAPPINGS,
+  resolveHealthCommonsBiomarkerEntityKey,
+} from "../src/biomarker-entity-mappings.ts";
+import { readHealthCommonsContent, type HealthCommonsSourcePage } from "../src/load.ts";
+
+type RequestedLabMarker = readonly [
+  label: string,
+  metricKey: string,
+  entityKey: string,
+  healthArea: LabHealthAreaId,
+];
+
+const REQUESTED_LAB_MARKERS = [
+  // blood-sugar
+  ["C-peptide", "c-peptide", "biomarker:c-peptide", "blood-sugar"],
+  ["Glucose", "glucose", "biomarker:blood-glucose", "blood-sugar"],
+  ["HbA1c", "hba1c", "biomarker:hba1c", "blood-sugar"],
+  ["Insulin", "insulin", "biomarker:insulin", "blood-sugar"],
+  // heart-and-lipids
+  ["Homocysteine", "homocysteine", "biomarker:homocysteine", "heart-lipids"],
+  ["LDL large particles", "ldl-large-particles", "biomarker:ldl-large-particles", "heart-lipids"],
+  ["LDL medium particles", "ldl-medium-particles", "biomarker:ldl-medium-particles", "heart-lipids"],
+  ["LDL particle number", "ldl-particle-number", "biomarker:ldl-particle-number", "heart-lipids"],
+  ["LDL peak size", "ldl-peak-size", "biomarker:ldl-peak-size", "heart-lipids"],
+  ["LDL small particles", "ldl-small-particles", "biomarker:ldl-small-particles", "heart-lipids"],
+  ["LDL-C", "ldl-c", "biomarker:ldl-c", "heart-lipids"],
+  ["Total cholesterol", "total-cholesterol", "biomarker:total-cholesterol", "heart-lipids"],
+  ["ApoB", "apob", "biomarker:apolipoprotein-b", "heart-lipids"],
+  ["Cholesterol/HDL ratio", "cholesterol-hdl-ratio", "biomarker:cholesterol-hdl-ratio", "heart-lipids"],
+  ["HDL-C", "hdl-c", "biomarker:hdl-c", "heart-lipids"],
+  ["LDL pattern", "ldl-pattern", "biomarker:ldl-pattern", "heart-lipids"],
+  ["Lipoprotein(a)", "lipoprotein-a", "biomarker:lipoprotein-a", "heart-lipids"],
+  ["Non-HDL cholesterol", "non-hdl-cholesterol", "biomarker:non-hdl-cholesterol", "heart-lipids"],
+  ["Triglycerides", "triglycerides", "biomarker:triglycerides", "heart-lipids"],
+  ["Calculated VLDL cholesterol", "vldl-cholesterol-calculated", "biomarker:vldl-cholesterol-calculated", "heart-lipids"],
+  ["LDL Calculated", "ldl-calculated", "biomarker:ldl-calculated", "heart-lipids"],
+  ["LDL CHOL CALC (NIH)", "ldl-chol-calc-nih", "biomarker:ldl-chol-calc-nih", "heart-lipids"],
+  ["POC Troponin I", "poc-troponin-i", "biomarker:poc-troponin-i", "heart-lipids"],
+  // kidneys
+  ["Creatinine", "creatinine", "biomarker:serum-creatinine", "kidneys"],
+  ["eGFR (CKD-EPI)", "egfr-ckd-epi", "biomarker:egfr-ckd-epi", "kidneys"],
+  ["Blood urea nitrogen", "blood-urea-nitrogen", "biomarker:blood-urea-nitrogen", "kidneys"],
+  ["eGFR", "egfr", "biomarker:egfr", "kidneys"],
+  ["Uric Acid", "uric-acid", "biomarker:serum-uric-acid", "kidneys"],
+  ["Urine protein", "urine-protein", "biomarker:urine-protein", "kidneys"],
+  ["BUN/Creatinine Ratio", "bun-creatinine-ratio", "biomarker:bun-creatinine-ratio", "kidneys"],
+  ["GFR MDRD Af Amer", "gfr-mdrd-af-amer", "biomarker:gfr-mdrd-af-amer", "kidneys"],
+  ["GFR MDRD Non Af Amer", "gfr-mdrd-non-af-amer", "biomarker:gfr-mdrd-non-af-amer", "kidneys"],
+  ["Urine albumin random without creatinine", "urine-albumin-random-without-creatinine", "biomarker:urine-albumin-random-without-creatinine", "kidneys"],
+  // liver
+  ["Albumin", "albumin", "biomarker:albumin", "liver"],
+  ["Albumin/Globulin Ratio", "albumin-globulin-ratio", "biomarker:albumin-globulin-ratio", "liver"],
+  ["Alkaline phosphatase", "alkaline-phosphatase", "biomarker:alkaline-phosphatase", "liver"],
+  ["ALT", "alt", "biomarker:alanine-aminotransferase", "liver"],
+  ["AST", "ast", "biomarker:aspartate-aminotransferase", "liver"],
+  ["FIB-4", "fib4", "biomarker:fib4", "liver"],
+  ["GGT", "ggt", "biomarker:ggt", "liver"],
+  ["Globulin", "total-globulin", "biomarker:total-globulin", "liver"],
+  ["Total bilirubin", "total-bilirubin", "biomarker:bilirubin", "liver"],
+  ["Total Protein", "total-protein", "biomarker:total-protein", "liver"],
+  // thyroid
+  ["Free T3", "free-t3", "biomarker:free-t3", "thyroid"],
+  ["Free T4", "free-t4", "biomarker:free-t4", "thyroid"],
+  ["Thyroglobulin Antibodies", "thyroglobulin-antibodies", "biomarker:thyroglobulin-antibodies", "thyroid"],
+  ["Thyroid Peroxidase Antibodies", "thyroid-peroxidase-antibodies", "biomarker:thyroid-peroxidase-antibodies", "thyroid"],
+  ["Thyroid-stimulating hormone", "thyroid-stimulating-hormone", "biomarker:thyroid-stimulating-hormone", "thyroid"],
+  // blood
+  ["Neutrophils, absolute", "absolute-neutrophils", "biomarker:absolute-neutrophils", "blood"],
+  ["White blood cells", "white-blood-cell-count", "biomarker:white-blood-cell-count", "blood"],
+  ["Basophils", "basophil-percentage", "biomarker:basophil-percentage", "blood"],
+  ["Basophils, absolute", "absolute-basophils", "biomarker:absolute-basophils", "blood"],
+  ["Eosinophils", "eosinophil-percentage", "biomarker:eosinophil-percentage", "blood"],
+  ["Eosinophils, absolute", "absolute-eosinophils", "biomarker:absolute-eosinophils", "blood"],
+  ["Hematocrit", "hematocrit", "biomarker:hematocrit", "blood"],
+  ["Hemoglobin", "hemoglobin", "biomarker:hemoglobin", "blood"],
+  ["Lymphocytes", "lymphocyte-percentage", "biomarker:lymphocyte-percentage", "blood"],
+  ["Lymphocytes, absolute", "absolute-lymphocytes", "biomarker:absolute-lymphocytes", "blood"],
+  ["Mean corpuscular hemoglobin", "mean-corpuscular-hemoglobin", "biomarker:mean-corpuscular-hemoglobin", "blood"],
+  ["Mean corpuscular hemoglobin concentration", "mean-corpuscular-hemoglobin-concentration", "biomarker:mean-corpuscular-hemoglobin-concentration", "blood"],
+  ["Mean corpuscular volume", "mean-corpuscular-volume", "biomarker:mean-corpuscular-volume", "blood"],
+  ["Mean Platelet Volume", "mean-platelet-volume", "biomarker:mean-platelet-volume", "blood"],
+  ["Monocytes", "monocyte-percentage", "biomarker:monocyte-percentage", "blood"],
+  ["Monocytes, absolute", "absolute-monocytes", "biomarker:absolute-monocytes", "blood"],
+  ["Neutrophils", "neutrophil-percentage", "biomarker:neutrophil-percentage", "blood"],
+  ["Platelets", "platelet-count", "biomarker:platelet-count", "blood"],
+  ["Red blood cells", "red-blood-cell-count", "biomarker:red-blood-cell-count", "blood"],
+  ["Red cell distribution width", "red-cell-distribution-width", "biomarker:red-cell-distribution-width", "blood"],
+  ["Immature granulocytes", "immature-granulocyte-percentage", "biomarker:immature-granulocyte-percentage", "blood"],
+  ["Immature granulocytes, absolute", "absolute-immature-granulocytes", "biomarker:absolute-immature-granulocytes", "blood"],
+  ["MPV", "mean-platelet-volume", "biomarker:mean-platelet-volume", "blood"],
+  // hormones
+  ["Free testosterone", "free-testosterone", "biomarker:free-testosterone", "hormones"],
+  ["Cortisol", "cortisol", "biomarker:cortisol", "hormones"],
+  ["DHEA sulfate", "dhea-sulfate", "biomarker:dhea-sulfate", "hormones"],
+  ["Sex Hormone Binding Globulin", "sex-hormone-binding-globulin", "biomarker:sex-hormone-binding-globulin", "hormones"],
+  ["Total testosterone", "total-testosterone", "biomarker:total-testosterone", "hormones"],
+  ["Estradiol", "estradiol", "biomarker:estradiol", "hormones"],
+  ["Follicle Stimulating Hormone", "follicle-stimulating-hormone", "biomarker:follicle-stimulating-hormone", "hormones"],
+  ["Luteinizing Hormone", "luteinizing-hormone", "biomarker:luteinizing-hormone", "hormones"],
+  ["Prolactin", "prolactin", "biomarker:prolactin", "hormones"],
+  // nutrients-and-fatty-acids
+  ["Omega-3 Total / OmegaCheck", "omega-3-total-omegacheck", "biomarker:omega-3-total-omegacheck", "nutrients"],
+  ["Arachidonic Acid", "arachidonic-acid", "biomarker:arachidonic-acid", "nutrients"],
+  ["Arachidonic Acid/EPA Ratio", "arachidonic-acid-epa-ratio", "biomarker:arachidonic-acid-epa-ratio", "nutrients"],
+  ["DHA", "dha", "biomarker:dha", "nutrients"],
+  ["DPA", "dpa", "biomarker:dpa", "nutrients"],
+  ["EPA", "epa", "biomarker:epa", "nutrients"],
+  ["Ferritin", "ferritin", "biomarker:ferritin", "nutrients"],
+  ["Iron", "iron", "biomarker:iron", "nutrients"],
+  ["Iron saturation", "iron-saturation", "biomarker:iron-saturation", "nutrients"],
+  ["Linoleic Acid", "linoleic-acid", "biomarker:linoleic-acid", "nutrients"],
+  ["Magnesium RBC", "magnesium-rbc", "biomarker:magnesium-rbc", "nutrients"],
+  ["Methylmalonic Acid", "methylmalonic-acid", "biomarker:methylmalonic-acid", "nutrients"],
+  ["Omega 6/3 Ratio", "omega-6-3-ratio", "biomarker:omega-6-3-ratio", "nutrients"],
+  ["Total Iron Binding Capacity", "total-iron-binding-capacity", "biomarker:total-iron-binding-capacity", "nutrients"],
+  ["Vitamin D", "vitamin-d", "biomarker:serum-25-hydroxyvitamin-d", "nutrients"],
+  ["Zinc", "zinc", "biomarker:zinc", "nutrients"],
+  ["Omega-6 total", "omega-6-total", "biomarker:omega-6-total", "nutrients"],
+  ["OmegaCheck total", "omegacheck-total", "biomarker:omegacheck-total", "nutrients"],
+  // inflammation-and-immune
+  ["ANA screen", "ana-screen", "biomarker:ana-screen", "inflammation"],
+  ["hs-CRP", "hs-crp", "biomarker:hs-crp", "inflammation"],
+  ["Rheumatoid Factor", "rheumatoid-factor", "biomarker:rheumatoid-factor", "inflammation"],
+  // electrolytes
+  ["Adjusted Calcium", "adjusted-calcium", "biomarker:adjusted-calcium", "electrolytes"],
+  ["Calcium", "calcium", "biomarker:calcium", "electrolytes"],
+  ["Carbon Dioxide", "carbon-dioxide", "biomarker:carbon-dioxide", "electrolytes"],
+  ["Chloride", "chloride", "biomarker:chloride", "electrolytes"],
+  ["Phosphate", "phosphate", "biomarker:phosphate", "electrolytes"],
+  ["Potassium", "potassium", "biomarker:potassium", "electrolytes"],
+  ["Sodium", "sodium", "biomarker:sodium", "electrolytes"],
+  ["Anion Gap", "anion-gap", "biomarker:anion-gap", "electrolytes"],
+  ["CO2", "carbon-dioxide", "biomarker:carbon-dioxide", "electrolytes"],
+  // muscle-and-tissue
+  ["Creatine Kinase", "creatine-kinase", "biomarker:creatine-kinase", "muscle-tissue"],
+  ["LDH", "ldh", "biomarker:ldh", "muscle-tissue"],
+  // environmental-exposure
+  ["Lead", "lead", "biomarker:lead", "environmental"],
+  ["Mercury", "mercury", "biomarker:mercury", "environmental"],
+  // prostate-health
+  ["PSA free", "psa-free", "biomarker:psa-free", "prostate"],
+  ["PSA percent free", "psa-percent-free", "biomarker:psa-percent-free", "prostate"],
+  ["PSA total", "psa-total", "biomarker:psa-total", "prostate"],
+] as const satisfies readonly RequestedLabMarker[];
+
+const REQUESTED_DEVICE_MARKERS = [
+  ["Deep sleep (minutes)", "deep-sleep-minutes", "biomarker:deep-sleep-minutes"],
+  ["HRV / RMSSD (ms)", "hrv-rmssd", "biomarker:hrv-rmssd"],
+  ["REM sleep (minutes)", "rem-sleep-minutes", "biomarker:rem-sleep-minutes"],
+  ["Resting heart rate / RHR (bpm)", "resting-heart-rate", "biomarker:resting-heart-rate"],
+  ["Blood oxygen / SpO₂ (%)", "spo2", "biomarker:blood-oxygen-spo2"],
+] as const;
+
+const EXPECTED_GUIDANCE_CLASSIFICATION_COUNTS = {
+  calculated_or_method_specific: 17,
+  conditional_numeric: 11,
+  generally_applicable_numeric: 1,
+  no_universal_range: 36,
+  qualitative: 3,
+  source_range_only: 52,
+} as const;
+
+const contentRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../content",
+);
+
+let pagesByKey: ReadonlyMap<string, HealthCommonsSourcePage>;
+
+beforeAll(async () => {
+  const content = await readHealthCommonsContent(contentRoot);
+  pagesByKey = new Map(content.pages.map((page) => [page.frontmatter.key, page]));
+});
+
+describe("requested biomarker Health Commons coverage", () => {
+  it("resolves every requested lab identity to the intended authored Commons entity", () => {
+    expect(REQUESTED_LAB_MARKERS).toHaveLength(117);
+
+    for (const [label, metricKey, entityKey, healthArea] of REQUESTED_LAB_MARKERS) {
+      const definition = resolveLabResultMetricDefinition(label);
+      if (!definition?.biomarkerKey) {
+        throw new Error(`Unresolved requested lab marker: ${label}`);
+      }
+
+      expect(definition.key).toBe(metricKey);
+      expect(resolveHealthCommonsBiomarkerEntityKey(definition.biomarkerKey)).toBe(entityKey);
+      expect(pagesByKey.has(entityKey)).toBe(true);
+      expect(resolveIndexedLabHealthArea(label)?.id).toBe(healthArea);
+    }
+
+    expect(new Set(REQUESTED_LAB_MARKERS.map(([, metricKey]) => metricKey)).size).toBe(115);
+    expect(new Set(REQUESTED_LAB_MARKERS.map(([, , entityKey]) => entityKey)).size).toBe(115);
+  });
+
+  it("keeps genuine aliases together and method- or specimen-specific identities apart", () => {
+    expect(resolveLabResultMetricDefinition("MPV")?.key).toBe(
+      resolveLabResultMetricDefinition("Mean Platelet Volume")?.key,
+    );
+    expect(resolveLabResultMetricDefinition("CO2")?.key).toBe(
+      resolveLabResultMetricDefinition("Carbon Dioxide")?.key,
+    );
+
+    expect(resolveLabResultMetricDefinition("LDL Calculated")?.key).not.toBe(
+      resolveLabResultMetricDefinition("LDL CHOL CALC (NIH)")?.key,
+    );
+    expect(resolveLabResultMetricDefinition("eGFR")?.key).not.toBe(
+      resolveLabResultMetricDefinition("eGFR (CKD-EPI)")?.key,
+    );
+    expect(resolveLabResultMetricDefinition("GFR MDRD Af Amer")?.key).not.toBe(
+      resolveLabResultMetricDefinition("GFR MDRD Non Af Amer")?.key,
+    );
+    expect(resolveLabResultMetricDefinition("Omega-3 Total / OmegaCheck")?.key).not.toBe(
+      resolveLabResultMetricDefinition("OmegaCheck total")?.key,
+    );
+    expect(resolveLabResultMetricDefinition("Neutrophils")?.key).not.toBe(
+      resolveLabResultMetricDefinition("Neutrophils, absolute")?.key,
+    );
+    expect(resolveLabResultMetricDefinition("blood mercury")).toBeNull();
+    expect(resolveLabResultMetricDefinition("urine mercury")).toBeNull();
+
+    const mercuryAliases = pagesByKey.get("biomarker:mercury")?.frontmatter.aliases ?? [];
+    expect(mercuryAliases).not.toContain("blood-mercury");
+    expect(mercuryAliases).not.toContain("urine-mercury");
+  });
+
+  it("backs all requested device metrics with authored Commons entities", () => {
+    for (const [label, metricKey, entityKey] of REQUESTED_DEVICE_MARKERS) {
+      const definition = resolveMetricDefinition(metricKey);
+      if (!definition?.biomarkerKey) {
+        throw new Error(`Unresolved requested device marker: ${label}`);
+      }
+
+      expect(resolveHealthCommonsBiomarkerEntityKey(definition.biomarkerKey)).toBe(entityKey);
+      expect(pagesByKey.has(entityKey)).toBe(true);
+    }
+  });
+
+  it("uses only explicit mappings whose authored targets exist", () => {
+    expect(Object.keys(HEALTH_COMMONS_BIOMARKER_ENTITY_MAPPINGS)).toHaveLength(6);
+
+    for (const [sourceKey, targetKey] of Object.entries(
+      HEALTH_COMMONS_BIOMARKER_ENTITY_MAPPINGS,
+    )) {
+      expect(sourceKey).not.toBe(targetKey);
+      expect(resolveHealthCommonsBiomarkerEntityKey(sourceKey)).toBe(targetKey);
+      expect(pagesByKey.has(targetKey)).toBe(true);
+    }
+  });
+
+  it("requires a reviewed one-sentence summary and structured guidance for every requested entity", () => {
+    const requestedEntityKeys = new Set([
+      ...REQUESTED_LAB_MARKERS.map(([, , entityKey]) => entityKey),
+      ...REQUESTED_DEVICE_MARKERS.map(([, , entityKey]) => entityKey),
+    ]);
+    expect(requestedEntityKeys.size).toBe(120);
+
+    const classificationCounts = new Map<string, number>();
+
+    for (const entityKey of requestedEntityKeys) {
+      const page = pagesByKey.get(entityKey);
+      if (!page) {
+        throw new Error(`Missing authored Commons page: ${entityKey}`);
+      }
+
+      const summary = page.frontmatter.summary?.trim() ?? "";
+      expect(summary.split(/\s+/u).length).toBeGreaterThanOrEqual(10);
+      expect(summary).toMatch(/^[^\r\n]+[.!?]$/u);
+      expect(summary.match(/[.!?](?=\s|$)/gu) ?? []).toHaveLength(1);
+      expect(summary).not.toMatch(/\b(?:todo|tbd|placeholder|coming soon|stub)\b/iu);
+
+      const guidance = page.frontmatter.referenceGuidance;
+      if (!guidance) {
+        throw new Error(`Missing reviewed reference guidance: ${entityKey}`);
+      }
+
+      expect(guidance.reviewStatus).toBe("reviewed");
+      expect(guidance.use).toBe("context_only");
+      expect(guidance.items.length).toBeGreaterThan(0);
+      classificationCounts.set(
+        guidance.classification,
+        (classificationCounts.get(guidance.classification) ?? 0) + 1,
+      );
+
+      for (const item of guidance.items) {
+        expect(item.guidance.split(/\s+/u).length).toBeGreaterThanOrEqual(8);
+        expect(item.applicability.split(/\s+/u).length).toBeGreaterThanOrEqual(8);
+        expect(item.source.title.length).toBeGreaterThan(0);
+        expect(item.source.organization.length).toBeGreaterThan(0);
+        expect(item.source.year).toBeGreaterThanOrEqual(1900);
+        expect(Boolean(item.source.url || item.source.doi || item.source.pmid)).toBe(true);
+
+        for (const numericValue of item.numericValues ?? []) {
+          expect(Boolean(numericValue.lowerBound || numericValue.upperBound)).toBe(true);
+          if (numericValue.lowerBound && numericValue.upperBound) {
+            expect(numericValue.lowerBound.value).toBeLessThanOrEqual(
+              numericValue.upperBound.value,
+            );
+            expect(numericValue.lowerBound.value).not.toBe(numericValue.upperBound.value);
+          }
+        }
+      }
+
+      if (guidance.classification === "qualitative") {
+        expect(guidance.items.every((item) => !item.numericValues)).toBe(true);
+      }
+    }
+
+    expect(Object.fromEntries([...classificationCounts].sort())).toEqual(
+      EXPECTED_GUIDANCE_CLASSIFICATION_COUNTS,
+    );
+    expect([...classificationCounts.keys()].sort()).toEqual(
+      [...HEALTH_COMMONS_BIOMARKER_GUIDANCE_CLASSIFICATIONS].sort(),
+    );
+  });
+
+  it("preserves comparator semantics instead of manufacturing exact points", () => {
+    const belowTen = healthCommonsBiomarkerGuidanceNumericValueSchema.parse({
+      label: "Below-ten comparator",
+      unit: "example-unit",
+      upperBound: { inclusive: false, value: 10 },
+    });
+
+    expect(belowTen).toEqual({
+      label: "Below-ten comparator",
+      unit: "example-unit",
+      upperBound: { inclusive: false, value: 10 },
+    });
+    expect(() => healthCommonsBiomarkerGuidanceNumericValueSchema.parse({
+      label: "Unbounded value",
+      unit: "example-unit",
+    })).toThrow();
+    expect(() => healthCommonsBiomarkerGuidanceNumericValueSchema.parse({
+      label: "Reversed interval",
+      lowerBound: { inclusive: true, value: 10 },
+      unit: "example-unit",
+      upperBound: { inclusive: true, value: 5 },
+    })).toThrow();
+    expect(() => healthCommonsBiomarkerGuidanceNumericValueSchema.parse({
+      label: "Collapsed exact point",
+      lowerBound: { inclusive: true, value: 10 },
+      unit: "example-unit",
+      upperBound: { inclusive: true, value: 10 },
+    })).toThrow();
+  });
+});

--- a/packages/health-metrics/src/definitions/labs.ts
+++ b/packages/health-metrics/src/definitions/labs.ts
@@ -1,5 +1,24 @@
 import type { MetricDefinition } from "../types.ts";
 
+interface SourceUnitLabMetricInput {
+  aliases: readonly string[];
+  biomarkerKey: string;
+  displayName: string;
+  key: string;
+  valuePrecision?: number;
+}
+
+function sourceUnitLabMetric(input: SourceUnitLabMetricInput): MetricDefinition {
+  return {
+    ...input,
+    canonicalUnit: null,
+    category: "lab",
+    displayUnit: null,
+    selectionPolicy: { kind: "latest-lab", preferCollectedAt: true, staleAfterDays: 365 },
+    valuePrecision: input.valuePrecision ?? 1,
+  };
+}
+
 export const LAB_RESULT_METRICS = [
   {
     aliases: ["serum-albumin", "serum_albumin"],
@@ -59,7 +78,7 @@ export const LAB_RESULT_METRICS = [
     valuePrecision: 0,
   },
   {
-    aliases: ["estimated-gfr-ckd-epi"],
+    aliases: ["estimated-gfr-ckd-epi", "e-gfr-ckd-epi"],
     biomarkerKey: "biomarker:egfr-ckd-epi",
     canonicalUnit: "mL/min/1.73m^2",
     category: "lab",
@@ -367,7 +386,7 @@ export const LAB_RESULT_METRICS = [
     valuePrecision: 1,
   },
   {
-    aliases: ["vldl-cholesterol-cal"],
+    aliases: ["vldl-cholesterol-cal", "calculated-vldl-cholesterol"],
     biomarkerKey: "biomarker:vldl-cholesterol-calculated",
     canonicalUnit: null,
     category: "lab",
@@ -400,7 +419,7 @@ export const LAB_RESULT_METRICS = [
     valuePrecision: 1,
   },
   {
-    aliases: ["fibrosis-score-fib4", "fibrosis-score-fib-4"],
+    aliases: ["fibrosis-score-fib4", "fibrosis-score-fib-4", "fib-4"],
     biomarkerKey: "biomarker:fib4",
     canonicalUnit: null,
     category: "lab",
@@ -641,6 +660,401 @@ export const LAB_RESULT_METRICS = [
     selectionPolicy: { kind: "latest-lab", preferCollectedAt: true, staleAfterDays: 365 },
     valuePrecision: 1,
   },
+  sourceUnitLabMetric({
+    aliases: ["c peptide", "c_peptide", "serum-c-peptide"],
+    biomarkerKey: "biomarker:c-peptide",
+    displayName: "C-peptide",
+    key: "c-peptide",
+    valuePrecision: 2,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-insulin", "fasting-insulin"],
+    biomarkerKey: "biomarker:insulin",
+    displayName: "Insulin",
+    key: "insulin",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["total-homocysteine"],
+    biomarkerKey: "biomarker:homocysteine",
+    displayName: "Homocysteine",
+    key: "homocysteine",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["large-ldl-particles", "ldl-large"],
+    biomarkerKey: "biomarker:ldl-large-particles",
+    displayName: "LDL large particles",
+    key: "ldl-large-particles",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["medium-ldl-particles", "ldl-medium"],
+    biomarkerKey: "biomarker:ldl-medium-particles",
+    displayName: "LDL medium particles",
+    key: "ldl-medium-particles",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["ldl-p", "ldl-particle-concentration"],
+    biomarkerKey: "biomarker:ldl-particle-number",
+    displayName: "LDL particle number",
+    key: "ldl-particle-number",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["ldl-size", "ldl-peak-particle-size"],
+    biomarkerKey: "biomarker:ldl-peak-size",
+    displayName: "LDL peak size",
+    key: "ldl-peak-size",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["small-ldl-particles", "ldl-small"],
+    biomarkerKey: "biomarker:ldl-small-particles",
+    displayName: "LDL small particles",
+    key: "ldl-small-particles",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["ldl-particle-pattern"],
+    biomarkerKey: "biomarker:ldl-pattern",
+    displayName: "LDL pattern",
+    key: "ldl-pattern",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["lp-a", "lpa", "lipoprotein(a)"],
+    biomarkerKey: "biomarker:lipoprotein-a",
+    displayName: "Lipoprotein(a)",
+    key: "lipoprotein-a",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["calculated-ldl", "ldl-c-calculated"],
+    biomarkerKey: "biomarker:ldl-calculated",
+    displayName: "LDL Calculated",
+    key: "ldl-calculated",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["ldl-cholesterol-calculated-nih", "ldl-calc-nih", "sampson-nih-ldl"],
+    biomarkerKey: "biomarker:ldl-chol-calc-nih",
+    displayName: "LDL CHOL CALC (NIH)",
+    key: "ldl-chol-calc-nih",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["troponin-i-poc", "point-of-care-troponin-i"],
+    biomarkerKey: "biomarker:poc-troponin-i",
+    displayName: "POC Troponin I",
+    key: "poc-troponin-i",
+    valuePrecision: 3,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-uric-acid", "urate"],
+    biomarkerKey: "biomarker:serum-uric-acid",
+    displayName: "Uric acid",
+    key: "uric-acid",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["protein-urine", "urine-protein-qualitative"],
+    biomarkerKey: "biomarker:urine-protein",
+    displayName: "Urine protein",
+    key: "urine-protein",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["bun-creatinine-ratio", "blood-urea-nitrogen-creatinine-ratio"],
+    biomarkerKey: "biomarker:bun-creatinine-ratio",
+    displayName: "BUN/Creatinine Ratio",
+    key: "bun-creatinine-ratio",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["gfr-mdrd-african-american", "mdrd-gfr-af-amer"],
+    biomarkerKey: "biomarker:gfr-mdrd-af-amer",
+    displayName: "GFR MDRD Af Amer",
+    key: "gfr-mdrd-af-amer",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["gfr-mdrd-non-african-american", "mdrd-gfr-non-af-amer"],
+    biomarkerKey: "biomarker:gfr-mdrd-non-af-amer",
+    displayName: "GFR MDRD Non Af Amer",
+    key: "gfr-mdrd-non-af-amer",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["random-urine-albumin-without-creatinine", "urine-microalbumin-random-without-creatinine"],
+    biomarkerKey: "biomarker:urine-albumin-random-without-creatinine",
+    displayName: "Urine albumin random without creatinine",
+    key: "urine-albumin-random-without-creatinine",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["a-g-ratio", "albumin-to-globulin-ratio"],
+    biomarkerKey: "biomarker:albumin-globulin-ratio",
+    displayName: "Albumin/Globulin Ratio",
+    key: "albumin-globulin-ratio",
+    valuePrecision: 2,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["protein-total", "serum-total-protein"],
+    biomarkerKey: "biomarker:total-protein",
+    displayName: "Total Protein",
+    key: "total-protein",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["triiodothyronine-free", "free-triiodothyronine"],
+    biomarkerKey: "biomarker:free-t3",
+    displayName: "Free T3",
+    key: "free-t3",
+    valuePrecision: 2,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["thyroxine-free", "free-thyroxine"],
+    biomarkerKey: "biomarker:free-t4",
+    displayName: "Free T4",
+    key: "free-t4",
+    valuePrecision: 2,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["thyroglobulin-antibody", "tg-antibodies", "tgab"],
+    biomarkerKey: "biomarker:thyroglobulin-antibodies",
+    displayName: "Thyroglobulin Antibodies",
+    key: "thyroglobulin-antibodies",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["thyroid-peroxidase-antibody", "tpo-antibodies", "tpoab"],
+    biomarkerKey: "biomarker:thyroid-peroxidase-antibodies",
+    displayName: "Thyroid Peroxidase Antibodies",
+    key: "thyroid-peroxidase-antibodies",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["mpv", "mean-platelet-volume"],
+    biomarkerKey: "biomarker:mean-platelet-volume",
+    displayName: "Mean Platelet Volume",
+    key: "mean-platelet-volume",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-cortisol", "plasma-cortisol"],
+    biomarkerKey: "biomarker:cortisol",
+    displayName: "Cortisol",
+    key: "cortisol",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["dheas", "dhea-s", "dehydroepiandrosterone-sulfate"],
+    biomarkerKey: "biomarker:dhea-sulfate",
+    displayName: "DHEA sulfate",
+    key: "dhea-sulfate",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["shbg", "sex-hormone-binding-globulin"],
+    biomarkerKey: "biomarker:sex-hormone-binding-globulin",
+    displayName: "Sex Hormone Binding Globulin",
+    key: "sex-hormone-binding-globulin",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["fsh", "follicle-stimulating-hormone"],
+    biomarkerKey: "biomarker:follicle-stimulating-hormone",
+    displayName: "Follicle Stimulating Hormone",
+    key: "follicle-stimulating-hormone",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["lh", "luteinizing-hormone"],
+    biomarkerKey: "biomarker:luteinizing-hormone",
+    displayName: "Luteinizing Hormone",
+    key: "luteinizing-hormone",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-prolactin"],
+    biomarkerKey: "biomarker:prolactin",
+    displayName: "Prolactin",
+    key: "prolactin",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["omega-3-total-omega-check", "omega3-total-omegacheck"],
+    biomarkerKey: "biomarker:omega-3-total-omegacheck",
+    displayName: "Omega-3 Total / OmegaCheck",
+    key: "omega-3-total-omegacheck",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["aa-fatty-acid"],
+    biomarkerKey: "biomarker:arachidonic-acid",
+    displayName: "Arachidonic Acid",
+    key: "arachidonic-acid",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["aa-epa-ratio", "arachidonic-acid-to-epa-ratio"],
+    biomarkerKey: "biomarker:arachidonic-acid-epa-ratio",
+    displayName: "Arachidonic Acid/EPA Ratio",
+    key: "arachidonic-acid-epa-ratio",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["docosahexaenoic-acid"],
+    biomarkerKey: "biomarker:dha",
+    displayName: "DHA",
+    key: "dha",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["docosapentaenoic-acid"],
+    biomarkerKey: "biomarker:dpa",
+    displayName: "DPA",
+    key: "dpa",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["eicosapentaenoic-acid"],
+    biomarkerKey: "biomarker:epa",
+    displayName: "EPA",
+    key: "epa",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["la-fatty-acid"],
+    biomarkerKey: "biomarker:linoleic-acid",
+    displayName: "Linoleic Acid",
+    key: "linoleic-acid",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["rbc-magnesium", "magnesium-red-blood-cell"],
+    biomarkerKey: "biomarker:magnesium-rbc",
+    displayName: "Magnesium RBC",
+    key: "magnesium-rbc",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["mma", "methylmalonate"],
+    biomarkerKey: "biomarker:methylmalonic-acid",
+    displayName: "Methylmalonic Acid",
+    key: "methylmalonic-acid",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["omega-6-to-3-ratio", "omega6-omega3-ratio"],
+    biomarkerKey: "biomarker:omega-6-3-ratio",
+    displayName: "Omega 6/3 Ratio",
+    key: "omega-6-3-ratio",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["tibc", "iron-binding-capacity-total"],
+    biomarkerKey: "biomarker:total-iron-binding-capacity",
+    displayName: "Total Iron Binding Capacity",
+    key: "total-iron-binding-capacity",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-zinc", "plasma-zinc"],
+    biomarkerKey: "biomarker:zinc",
+    displayName: "Zinc",
+    key: "zinc",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["total-omega-6", "omega6-total"],
+    biomarkerKey: "biomarker:omega-6-total",
+    displayName: "Omega-6 total",
+    key: "omega-6-total",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["omega-check-total"],
+    biomarkerKey: "biomarker:omegacheck-total",
+    displayName: "OmegaCheck total",
+    key: "omegacheck-total",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["antinuclear-antibody-screen", "antinuclear-antibodies-screen"],
+    biomarkerKey: "biomarker:ana-screen",
+    displayName: "ANA screen",
+    key: "ana-screen",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["rf", "rheumatoid-factor"],
+    biomarkerKey: "biomarker:rheumatoid-factor",
+    displayName: "Rheumatoid Factor",
+    key: "rheumatoid-factor",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["corrected-calcium", "albumin-adjusted-calcium"],
+    biomarkerKey: "biomarker:adjusted-calcium",
+    displayName: "Adjusted Calcium",
+    key: "adjusted-calcium",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-calcium", "total-calcium"],
+    biomarkerKey: "biomarker:calcium",
+    displayName: "Calcium",
+    key: "calcium",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["co2", "carbon-dioxide", "total-co2"],
+    biomarkerKey: "biomarker:carbon-dioxide",
+    displayName: "Carbon Dioxide",
+    key: "carbon-dioxide",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-chloride"],
+    biomarkerKey: "biomarker:chloride",
+    displayName: "Chloride",
+    key: "chloride",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["phosphorus", "serum-phosphate"],
+    biomarkerKey: "biomarker:phosphate",
+    displayName: "Phosphate",
+    key: "phosphate",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-potassium"],
+    biomarkerKey: "biomarker:potassium",
+    displayName: "Potassium",
+    key: "potassium",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["serum-sodium"],
+    biomarkerKey: "biomarker:sodium",
+    displayName: "Sodium",
+    key: "sodium",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["anion-gap-without-potassium"],
+    biomarkerKey: "biomarker:anion-gap",
+    displayName: "Anion Gap",
+    key: "anion-gap",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["ck", "total-ck", "creatine-phosphokinase", "cpk"],
+    biomarkerKey: "biomarker:creatine-kinase",
+    displayName: "Creatine Kinase",
+    key: "creatine-kinase",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["lactate-dehydrogenase", "lactic-dehydrogenase"],
+    biomarkerKey: "biomarker:ldh",
+    displayName: "LDH",
+    key: "ldh",
+    valuePrecision: 0,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["blood-lead", "blood-lead-level"],
+    biomarkerKey: "biomarker:lead",
+    displayName: "Lead",
+    key: "lead",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["total-mercury"],
+    biomarkerKey: "biomarker:mercury",
+    displayName: "Mercury",
+    key: "mercury",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["free-psa", "prostate-specific-antigen-free"],
+    biomarkerKey: "biomarker:psa-free",
+    displayName: "PSA free",
+    key: "psa-free",
+    valuePrecision: 2,
+  }),
+  sourceUnitLabMetric({
+    aliases: ["percent-free-psa", "free-psa-percent"],
+    biomarkerKey: "biomarker:psa-percent-free",
+    displayName: "PSA percent free",
+    key: "psa-percent-free",
+  }),
+  sourceUnitLabMetric({
+    aliases: ["total-psa", "prostate-specific-antigen-total"],
+    biomarkerKey: "biomarker:psa-total",
+    displayName: "PSA total",
+    key: "psa-total",
+    valuePrecision: 2,
+  }),
 ] satisfies readonly MetricDefinition[];
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@murphai/health-commons':
         specifier: workspace:*
         version: link:../../packages/health-commons
+      '@murphai/health-metrics':
+        specifier: workspace:*
+        version: link:../../packages/health-metrics
       '@murphai/hosted-execution':
         specifier: workspace:*
         version: link:../../packages/hosted-execution


### PR DESCRIPTION
## Why this PR exists

The biomarker index and result history were visually sparse, difficult to scan, and weak on comparator-safe chart behavior. The saved-lab experience also lacked reviewed plain-language descriptions and structured reference context for the complete requested marker inventory.

## User goal / user-visible behavior

Members can scan device and lab biomarkers in one calm, responsive index, filter or search lab results, open a precise result history, and start a prefilled “Chat with Murph” conversation about that marker. Individual biomarker pages can use one reviewed sentence and sourced contextual guidance without overriding the reporting lab’s flag or range.

## User experience

- `/biomarkers` presents device rows first, then “From the lab,” with matching section typography, compact status filters, source-status dots, and red/green/neutral row rails.
- Mobile keeps metric icons, removes redundant category eyebrows, clamps device descriptions to two lines, and stacks readings without horizontal clipping.
- `/biomarkers/results/[metricKey]` shows the exact latest value, source range, source, concise longitudinal chart, full-width history, and a marker-specific Chat with Murph action.
- Qualitative and comparator-only results remain exact history entries and are never plotted as invented numeric values.
- Empty, loading, stale, authentication, and retry behavior continue to use the existing browser-vault flow.

## Invariants

- Source-reported flags, exact display values, comparators, units, per-result ranges, and provenance remain authoritative.
- Reviewed Commons guidance is context-only and cannot relabel a saved result or manufacture a universal wellness range.
- Qualitative and boundary values never become numeric chart points.
- Member values, dates, flags, ranges, and sources are not placed in the Chat with Murph draft or committed design fixtures.
- Health Commons content stays authored source; generated catalog artifacts remain untracked build outputs.

## Non-obvious affected surfaces

- Health Commons frontmatter gains additive structured biomarker reference guidance. This is necessary to represent numeric, conditional, method-specific, qualitative, source-range-only, and no-universal-range outcomes; Contracts and deterministic catalog tests cover invalid combinations, locators, mappings, and all requested entities.
- The shared lab result definition catalog is expanded so production display names resolve to canonical metric and Commons identities. Health-metrics tests and the web route-context regression prove the mapping, including aliases.
- `apps/web` now declares its existing direct `@murphai/health-metrics` import instead of relying on a transitive workspace edge. Dependency-policy and workspace-boundary checks pass.

- The biomarker result route now consumes a narrow public `@murphai/health-commons/biomarker-entity-mappings` entrypoint because the package root barrel reaches the filesystem-backed runtime. The Health Commons package verify/build export check, Web production build, and route-context regression prove this boundary.
- Health Commons remains in the Cloudflare runner bundle. The reviewed mapping content increased the recorded Linux bundle by 217 bytes (9,424,731B); the single cross-platform total ceiling is ratcheted to the larger exact macOS measurement (9,460,571B) instead of adding platform-specific policy. Linux/macOS runner assembly and the focused 30-test budget-policy suite prove the guard.

## Change-shape breakdown

Classification rule: authored Health Commons biomarker Markdown is product source; test paths and `*.test.*` are tests/fixtures; `agent-docs/**` is docs; manifests and the lockfile are config/tooling; generated artifacts are separate. No binary files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5,356 | 484 |
| Tests/fixtures | 887 | 61 |
| Docs | 331 | 2 |
| Config/tooling | 4 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **6,578** | **547** |

ReviewGPT first-reviewed head: a3d2c30b9dbf1dbef7b4993c82bb00e29cd841e5

## Research coverage

- ReviewGPT covered 122 requested labels and resolved them to 120 authored entities; only MPV/Mean Platelet Volume and CO2/Carbon Dioxide are true alias pairs.
- Every entity has one reviewed sentence and sourced structured guidance.
- Numeric bounds exist only for the 14 entities where evidence supports them. Other pages retain assay, population, specimen, method, unit, or source-lab constraints rather than inventing an “optimal” range.
- Generic mercury lacks specimen/form specificity and POC troponin lacks an assay identity, so those pages deliberately remain context- or method-specific.

## Verification

- `pnpm test:diff ...` — passed affected typechecks, package tests, boundary checks, 6,044 web tests, web dev smoke/lint/production build, 1,848 Cloudflare node tests, and the Workers test.
- `pnpm verify:acceptance` — exit 0; workspace typechecks, doc gardening, artifact hygiene, coverage thresholds, web build, and Cloudflare verification passed.
- `pnpm --dir packages/health-commons verify` — 18 files / 85 tests, typecheck, deterministic generation check passed.
- Focused biomarker web suite — 51/51 passed; scoped web ESLint passed.
- Required frontend-review finished with zero actionable findings; coverage-write added and verified signed-out chat, status-rail/filter-dot, and invalid-guidance cases.
- Playwright captures at 1440×1000 and 390×844 were inspected after client rendering.

## Deployment skew / compatibility

No database migration or cross-runtime protocol change is introduced. Reference guidance is additive authored content and the web/shared-package changes ship together in the web build; older consumers ignore the optional field, so no tandem deploy or immediate container rollout is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787280487&installation_model_id=19880&pr_number=838&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F838&signature=77344116867f7b5771f894f4e4a6dad479aa271fe0c6288f39b514784c7281f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->