### PR TITLE
Retain only novel device-ingest evidence

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-21-incremental-device-ingest.md
+++ b/agent-docs/exec-plans/completed/2026-07-21-incremental-device-ingest.md
@@ -1,0 +1,84 @@
+# Make device ingest evidence incremental
+
+Status: completed
+Created: 2026-07-21
+Updated: 2026-07-22
+
+## Goal
+
+- Stop recurring Junction/device sync from retaining unchanged rolling-window
+  evidence and output links while preserving canonical event identity, replay,
+  correction, and provenance invariants.
+
+## Success criteria
+
+- An exact replay persists no duplicate ingest evidence or output links.
+- A rolling summary with one new or corrected item adds storage proportional to
+  that change instead of another copy of the full historical window.
+- Canonical event output, correction, and evidence-link behavior remains
+  deterministic and replay-safe.
+- Focused real-owner tests, scoped verification, required audits, acceptance,
+  and PR review all pass.
+
+## Scope
+
+- In scope:
+  - integration-ingest novelty handling for repeated multi-part deliveries
+  - canonical output/evidence-link selection needed for incremental retention
+  - focused importer/core tests and matching durable storage documentation
+- Out of scope:
+  - destructive rewrites of existing vault history
+  - provider scheduling, credentials, or live account state
+  - a second storage owner or migration service
+
+## Constraints
+
+- Keep provider-specific shaping in importers and canonical writes in core.
+- Preserve stable ids, immutable history, replay, and correction semantics.
+- Use existing novelty and integration-ingest owner boundaries; add no queue,
+  database, or generic state manager.
+- Keep fixtures synthetic and private provider data out of artifacts and logs.
+
+## Risks and mitigations
+
+1. Risk: dropping evidence needed to replay or explain a corrected event.
+   Mitigation: fingerprint stable item versions and retain every novel version,
+   with exact-replay and correction regressions through the real core path.
+2. Risk: deduping output ids without retaining a genuinely new evidence link.
+   Mitigation: distinguish canonical output creation from new link identity and
+   test both cases explicitly.
+3. Risk: changing non-Junction provider semantics through shared core logic.
+   Mitigation: keep the smallest provider-owned representation change and add
+   shared-core regressions only where the existing novelty selector owns it.
+
+## Tasks
+
+1. Trace current Junction part construction, core novelty selection, and recent
+   changes on remote main; freeze the smallest correct owner-boundary fix.
+2. Add replay and one-changed-part coverage through the real core persistence
+   path.
+3. Implement incremental evidence and output-link retention with no historical
+   data mutation.
+4. Update durable storage/provider docs where the evidence contract changes.
+5. Run focused and acceptance verification plus required audit and ReviewGPT
+   gates, then publish the dedicated PR.
+
+## Verification
+
+- `pnpm test:diff <touched paths>` or the truthful owner coverage equivalents
+- focused importer/core replay, rolling-window, and correction scenarios
+- affected package typechecks
+- `pnpm verify:acceptance`
+- required `coverage-write` audit and PR ReviewGPT loop
+
+## Progress
+
+- Worktree created from current `origin/main`.
+- Existing core novelty selection already proves content and link novelty; the
+  persistence seam now consumes that selection instead of re-expanding it to
+  the full received batch. Importer representation remains unchanged.
+- Exact replay, appended revision, unassociated evidence, shared-owner, and
+  bounded-novelty regressions pass through the core persistence owner.
+- The required coverage audit found and closed four boundary gaps; the
+  follow-up suite passes 167 tests, and `pnpm verify:acceptance` passes.
+Completed: 2026-07-22

--- a/agent-docs/operations/device-sync-ingestion-invariants.md
+++ b/agent-docs/operations/device-sync-ingestion-invariants.md
@@ -92,11 +92,14 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
    suppresses a repeated row and audit when the same provider account has no
    new canonical output, receipt state, or evidence identity. When a repeated
    multi-part delivery changes only some evidence, the new ingest row retains
-   only those novel parts and only their output-role links under a distinct,
-   content-derived incremental-evidence id. It cannot masquerade as a complete
-   exact-delivery row or authorize repair from older state. Missing, corrupt,
-   or out-of-budget novelty proof fails open by retaining one complete received
-   evidence set, after which the next replay converges. A repair delivery also
+   only those novel parts and only their output-role links under a distinct
+   per-delivery incremental-evidence marker inspected with the original
+   delivery ids. It can authorize an intact no-op when every current output
+   still exists, but it cannot masquerade as a complete row or authorize repair
+   from incomplete proof. When neither an exact partial marker nor bounded
+   novelty can be proved, ingestion fails open by retaining one complete
+   received evidence set, after which the next replay converges. A repair
+   delivery also
    retains the complete received evidence set rather than trusting damaged
    historical proof. A batch whose novel evidence cannot be associated with
    its accepted prepared event, or whose prepared events share one canonical

--- a/agent-docs/operations/device-sync-ingestion-invariants.md
+++ b/agent-docs/operations/device-sync-ingestion-invariants.md
@@ -90,10 +90,22 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
    one authoritative target-shard scan whose result is reused by append
    planning; it never performs a second full id scan. Core separately
    suppresses a repeated row and audit when the same provider account has no
-   new canonical output, receipt state, or evidence identity. Each written
-   device delivery retains its complete received evidence set, so its validity
-   never depends on an older novelty row. An integrity-invalid exact row repairs
-   once under the deterministic association-revision id. A live shard whose
+   new canonical output, receipt state, or evidence identity. When a repeated
+   multi-part delivery changes only some evidence, the new ingest row retains
+   only those novel parts and only their output-role links under a distinct,
+   content-derived incremental-evidence id. It cannot masquerade as a complete
+   exact-delivery row or authorize repair from older state. Missing, corrupt,
+   or out-of-budget novelty proof fails open by retaining one complete received
+   evidence set, after which the next replay converges. A repair delivery also
+   retains the complete received evidence set rather than trusting damaged
+   historical proof. A batch whose novel evidence cannot be associated with
+   its accepted prepared event, or whose prepared events share one canonical
+   owner, likewise remains complete so later repair cannot lose the
+   evidence-role mapping needed to reject ambiguity. Evidence for a newly
+   appended event revision is always retained even when identical evidence
+   bytes were seen before. An
+   integrity-invalid exact row repairs once under the deterministic
+   association-revision id. A live shard whose
    final complete row lost only its newline receives exactly one delimiter
    before the new row; an incomplete final row rejects the append. Malformed
    newline-framed history may retain one novel delivery only after a tolerant

--- a/agent-docs/operations/device-sync-ingestion-invariants.md
+++ b/agent-docs/operations/device-sync-ingestion-invariants.md
@@ -94,12 +94,12 @@ drain/batch service seam in `packages/device-syncd/src/service.ts`.
    multi-part delivery changes only some evidence, the new ingest row retains
    only those novel parts and only their output-role links under a distinct
    per-delivery incremental-evidence marker inspected with the original
-   delivery ids. It can authorize an intact no-op when every current output
-   still exists, but it cannot masquerade as a complete row or authorize repair
-   from incomplete proof. When neither an exact partial marker nor bounded
-   novelty can be proved, ingestion fails open by retaining one complete
-   received evidence set, after which the next replay converges. A repair
-   delivery also
+   delivery ids. The marker is only a locator: it cannot authorize a no-op or
+   repair from incomplete proof. Missing canonical outputs fail closed before
+   reconciliation; otherwise the existing novelty owner proves every incoming
+   evidence fingerprint, receipt, and output link. When that proof is missing
+   or unsafe, ingestion fails open by retaining one complete received evidence
+   set, after which the next replay converges. A repair delivery also
    retains the complete received evidence set rather than trusting damaged
    historical proof. A batch whose novel evidence cannot be associated with
    its accepted prepared event, or whose prepared events share one canonical

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -5102,9 +5102,29 @@ export async function importDeviceBatch({
       || novelty.parts.length > 0
       || novelty.receiptIsNovel
       || evidenceRepairRequired;
-    const retainedEvidenceParts = shouldPersistDelivery
+    const acceptedEvidenceRoles = new Set(
+      [...persistenceEvidenceRolesByPreparedRecordId.values()].flat(),
+    );
+    const hasUnassociatedNovelEvidence = persistencePreparedEvents.length > 0
+      && novelty.parts.some((part) => !acceptedEvidenceRoles.has(part.role));
+    const preparedCanonicalEventIds = deviceBatchPlan.preparedEvents.map((entry) =>
+      canonicalIdByPreparedId.get(entry.record.id) ?? entry.record.id
+    );
+    const hasSharedCanonicalEventOwner = new Set(preparedCanonicalEventIds).size
+      !== preparedCanonicalEventIds.length;
+    const appendedEventEvidenceRoles = new Set(
+      [...appendedPreparedEventIds].flatMap((preparedId) =>
+        persistenceEvidenceRolesByPreparedRecordId.get(preparedId) ?? []
+      ),
+    );
+    const novelEvidenceParts = new Set(novelty.parts);
+    const retainedEvidenceParts = evidenceRepairRequired
+      || hasUnassociatedNovelEvidence
+      || hasSharedCanonicalEventOwner
       ? deviceBatchPlan.preparedEvidenceParts
-      : [];
+      : deviceBatchPlan.preparedEvidenceParts.filter((part) =>
+          novelEvidenceParts.has(part) || appendedEventEvidenceRoles.has(part.role)
+        );
     const retainedEvidenceRoles = new Set(retainedEvidenceParts.map((part) => part.role));
     const retainedEvidenceRolesByPreparedRecordId = new Map<string, readonly string[]>();
     for (const entry of deviceBatchPlan.preparedEvents) {
@@ -5203,9 +5223,22 @@ export async function importDeviceBatch({
   const currentImportIdOccupied = ingestIdInspection.entriesById.has(deviceBatchPlan.importId)
     || ingestIdInspection.invalidIds.has(deviceBatchPlan.importId);
   const finalAssociationImportId = buildAssociationImportId(eventOutputs);
-  const persistedImportId = currentImportIdOccupied
-    ? finalAssociationImportId
-    : deviceBatchPlan.importId;
+  const evidenceWasFiltered = retainedEvidenceParts.length
+    !== deviceBatchPlan.preparedEvidenceParts.length;
+  const incrementalEvidenceImportId = deterministicContractId(
+    ID_PREFIXES.transform,
+    stableStringify({
+      incrementalEvidenceOfDeviceImportId: deviceBatchPlan.importId,
+      eventOutputs,
+      parts: retainedEvidenceParts.map(integrationEvidencePartIdentity),
+      sampleIds: sampleRecords.map((record) => record.id).sort(),
+    }),
+  );
+  const persistedImportId = evidenceWasFiltered
+    ? incrementalEvidenceImportId
+    : currentImportIdOccupied
+      ? finalAssociationImportId
+      : deviceBatchPlan.importId;
   const ingestRecord = buildIntegrationIngestRecord({
     id: persistedImportId,
     provider: deviceBatchPlan.provider,

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -4646,11 +4646,12 @@ export async function importDeviceBatch({
       ? undefined
       : ingestIdInspection.entriesById.get(id))
     .filter((record): record is IntegrationIngestRecord =>
-      record !== undefined && storedIntegrationIngestIsDeviceDeliveryCandidate(record, deviceBatchPlan)
+      record !== undefined
+      && record.id !== incrementalEvidenceImportId
+      && storedIntegrationIngestIsDeviceDeliveryCandidate(record, deviceBatchPlan)
     );
   const matchingStoredDeliveries = () => candidateStoredDeliveries().filter((record) =>
-    record.id !== incrementalEvidenceImportId
-    && storedIntegrationIngestMatchesDeviceDelivery(record, deviceBatchPlan)
+    storedIntegrationIngestMatchesDeviceDelivery(record, deviceBatchPlan)
   );
   const partialStoredDelivery = () => {
     const record = ingestIdInspection.entriesById.get(incrementalEvidenceImportId);
@@ -4677,12 +4678,7 @@ export async function importDeviceBatch({
     if (ingestIdInspection.unsafe) {
       return undefined;
     }
-    const exact = matchingStoredDeliveries().find(storedDeliveryRetainsCurrentOutputs);
-    if (exact) {
-      return exact;
-    }
-    const partial = partialStoredDelivery();
-    return partial && storedDeliveryRetainsCurrentOutputs(partial) ? partial : undefined;
+    return matchingStoredDeliveries().find(storedDeliveryRetainsCurrentOutputs);
   };
   const hasInvalidCandidateId = () => orderedCandidateImportIds.some((id) =>
     ingestIdInspection.invalidIds.has(id)
@@ -4737,6 +4733,13 @@ export async function importDeviceBatch({
   };
   const inspectExactDeliveryState = (): ExactDeliveryState => {
     assertNoCurrentImportIdConflict();
+    const partial = partialStoredDelivery();
+    if (partial && !storedDeliveryRetainsCurrentOutputs(partial)) {
+      throw new VaultError(
+        "INTEGRATION_INGEST_EVENT_MAPPING_AMBIGUOUS",
+        "Filtered device delivery marker cannot prove the current canonical outputs.",
+      );
+    }
     const retainedDelivery = authorizedStoredDelivery();
     if (retainedDelivery) {
       return {
@@ -5129,6 +5132,8 @@ export async function importDeviceBatch({
           sampleIds: new Set(sampleRecords.map((record) => record.id)),
         })
       : { parts: [], receiptIsNovel: false };
+    const partialMarkerNeedsEvidenceRepair = partialStoredDelivery() !== undefined
+      && (novelty.parts.length > 0 || novelty.receiptIsNovel);
     const shouldPersistDelivery = hasAppendedOutputs
       || novelty.parts.length > 0
       || novelty.receiptIsNovel
@@ -5150,6 +5155,7 @@ export async function importDeviceBatch({
     );
     const novelEvidenceParts = new Set(novelty.parts);
     const retainedEvidenceParts = evidenceRepairRequired
+      || partialMarkerNeedsEvidenceRepair
       || hasUnassociatedNovelEvidence
       || hasSharedCanonicalEventOwner
       ? deviceBatchPlan.preparedEvidenceParts

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -4618,10 +4618,17 @@ export async function importDeviceBatch({
       }),
     );
   const associationImportId = buildAssociationImportId(currentEventOutputs);
+  const incrementalEvidenceImportId = deterministicContractId(
+    ID_PREFIXES.transform,
+    stableStringify({
+      incrementalEvidenceOfDeviceImportId: deviceBatchPlan.importId,
+    }),
+  );
   const candidateImportIds = new Set([
     deviceBatchPlan.importId,
     deviceBatchPlan.legacyImportId,
     associationImportId,
+    incrementalEvidenceImportId,
   ]);
   let ingestIdInspection = await inspectIntegrationIngestIdsForImportedAt(
     vaultRoot,
@@ -4632,6 +4639,7 @@ export async function importDeviceBatch({
     deviceBatchPlan.importId,
     associationImportId,
     deviceBatchPlan.legacyImportId,
+    incrementalEvidenceImportId,
   ];
   const candidateStoredDeliveries = () => orderedCandidateImportIds
     .map((id) => ingestIdInspection.invalidIds.has(id)
@@ -4641,26 +4649,41 @@ export async function importDeviceBatch({
       record !== undefined && storedIntegrationIngestIsDeviceDeliveryCandidate(record, deviceBatchPlan)
     );
   const matchingStoredDeliveries = () => candidateStoredDeliveries().filter((record) =>
-    storedIntegrationIngestMatchesDeviceDelivery(record, deviceBatchPlan)
+    record.id !== incrementalEvidenceImportId
+    && storedIntegrationIngestMatchesDeviceDelivery(record, deviceBatchPlan)
   );
-  const authorizedStoredDelivery = () =>
-    ingestIdInspection.unsafe
-      ? undefined
-      : matchingStoredDeliveries().find((storedDelivery) =>
-          (currentEventOwners.allExist || storedDelivery.outputs.events.length === 0)
-          &&
-          storedIntegrationIngestRetainsCurrentOutputs({
-            allSamplesExist: sampleAppendPlan.appendedRecordIds.length === 0,
-            associationEvidenceRolesByPreparedRecordId,
-            baselineRetainedPreparedIds,
-            currentEventOwners,
-            deviceBatchPlan,
-            preparedEventOutputOwners,
-            replayRetainedPreparedIds,
-            sampleRecords,
-            storedDelivery,
-          })
-        );
+  const partialStoredDelivery = () => {
+    const record = ingestIdInspection.entriesById.get(incrementalEvidenceImportId);
+    return record && storedIntegrationIngestIsDeviceDeliveryCandidate(record, deviceBatchPlan)
+      ? record
+      : undefined;
+  };
+  const storedDeliveryRetainsCurrentOutputs = (
+    storedDelivery: IntegrationIngestRecord,
+  ): boolean =>
+    (currentEventOwners.allExist || storedDelivery.outputs.events.length === 0)
+    && storedIntegrationIngestRetainsCurrentOutputs({
+      allSamplesExist: sampleAppendPlan.appendedRecordIds.length === 0,
+      associationEvidenceRolesByPreparedRecordId,
+      baselineRetainedPreparedIds,
+      currentEventOwners,
+      deviceBatchPlan,
+      preparedEventOutputOwners,
+      replayRetainedPreparedIds,
+      sampleRecords,
+      storedDelivery,
+    });
+  const authorizedStoredDelivery = () => {
+    if (ingestIdInspection.unsafe) {
+      return undefined;
+    }
+    const exact = matchingStoredDeliveries().find(storedDeliveryRetainsCurrentOutputs);
+    if (exact) {
+      return exact;
+    }
+    const partial = partialStoredDelivery();
+    return partial && storedDeliveryRetainsCurrentOutputs(partial) ? partial : undefined;
+  };
   const hasInvalidCandidateId = () => orderedCandidateImportIds.some((id) =>
     ingestIdInspection.invalidIds.has(id)
   );
@@ -4671,6 +4694,14 @@ export async function importDeviceBatch({
         "INTEGRATION_INGEST_ID_CONFLICT",
         `Device ingest id "${deviceBatchPlan.importId}" already belongs to a different delivery.`,
         { ingestId: deviceBatchPlan.importId },
+      );
+    }
+    const partial = ingestIdInspection.entriesById.get(incrementalEvidenceImportId);
+    if (partial && !storedIntegrationIngestIsDeviceDeliveryCandidate(partial, deviceBatchPlan)) {
+      throw new VaultError(
+        "INTEGRATION_INGEST_ID_CONFLICT",
+        `Device ingest id "${incrementalEvidenceImportId}" already belongs to a different delivery.`,
+        { ingestId: incrementalEvidenceImportId },
       );
     }
   };
@@ -5225,15 +5256,6 @@ export async function importDeviceBatch({
   const finalAssociationImportId = buildAssociationImportId(eventOutputs);
   const evidenceWasFiltered = retainedEvidenceParts.length
     !== deviceBatchPlan.preparedEvidenceParts.length;
-  const incrementalEvidenceImportId = deterministicContractId(
-    ID_PREFIXES.transform,
-    stableStringify({
-      incrementalEvidenceOfDeviceImportId: deviceBatchPlan.importId,
-      eventOutputs,
-      parts: retainedEvidenceParts.map(integrationEvidencePartIdentity),
-      sampleIds: sampleRecords.map((record) => record.id).sort(),
-    }),
-  );
   const persistedImportId = evidenceWasFiltered
     ? incrementalEvidenceImportId
     : currentImportIdOccupied

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -4318,7 +4318,7 @@ function preparedDeviceEventRetainsCurrentOutput(input: {
   );
 }
 
-function storedIntegrationIngestRetainsCurrentOutputs(input: {
+type StoredIntegrationIngestCurrentOutputInput = {
   allSamplesExist: boolean;
   associationEvidenceRolesByPreparedRecordId: ReadonlyMap<string, readonly string[]>;
   baselineRetainedPreparedIds: ReadonlySet<string>;
@@ -4328,7 +4328,11 @@ function storedIntegrationIngestRetainsCurrentOutputs(input: {
   preparedEventOutputOwners: PreparedDeviceEventOutputOwners;
   sampleRecords: readonly SampleRecord[];
   storedDelivery: IntegrationIngestRecord;
-}): boolean {
+};
+
+function storedIntegrationIngestRetainsCurrentOutputLocators(
+  input: StoredIntegrationIngestCurrentOutputInput,
+): boolean {
   if (!input.allSamplesExist) {
     return false;
   }
@@ -4370,16 +4374,10 @@ function storedIntegrationIngestRetainsCurrentOutputs(input: {
     const ownerEntries = [...owner.preparedIds]
       .map((preparedId) => preparedEventById.get(preparedId))
       .filter((entry): entry is PreparedDeviceEventEntry => entry !== undefined);
-    const outputRolesBelongToOwner = storedEventOutputRolesBelongToPreparedOwner({
-      evidenceRolesByPreparedRecordId: input.deviceBatchPlan.evidenceRolesByPreparedRecordId,
-      output,
-      owner,
-    });
     const retainedOwnerEntries = ownerEntries.filter((entry) =>
       input.baselineRetainedPreparedIds.has(entry.record.id)
     );
-    const retainsOutput = outputRolesBelongToOwner
-      && retainedOwnerEntries.length > 0
+    const retainsOutput = retainedOwnerEntries.length > 0
       && retainedOwnerEntries.every((entry) =>
         input.replayRetainedPreparedIds.has(entry.record.id)
       );
@@ -4393,6 +4391,24 @@ function storedIntegrationIngestRetainsCurrentOutputs(input: {
       input.storedDelivery.outputs.events.some((output) => output.id === eventId)
     )
     && stableStringify([...input.storedDelivery.outputs.sampleIds].sort()) === stableStringify(expectedSampleIds);
+}
+
+function storedIntegrationIngestRetainsCurrentOutputs(
+  input: StoredIntegrationIngestCurrentOutputInput,
+): boolean {
+  return storedIntegrationIngestRetainsCurrentOutputLocators(input)
+    && input.storedDelivery.outputs.events.every((output) => {
+      const owner = storedEventOutputMatchesPreparedOwner({
+        output,
+        preparedEventOutputOwners: input.preparedEventOutputOwners,
+      });
+      return owner !== undefined
+        && storedEventOutputRolesBelongToPreparedOwner({
+          evidenceRolesByPreparedRecordId: input.deviceBatchPlan.evidenceRolesByPreparedRecordId,
+          output,
+          owner,
+        });
+    });
 }
 
 function buildStoredEventRepairIds(input: {
@@ -4674,6 +4690,21 @@ export async function importDeviceBatch({
       sampleRecords,
       storedDelivery,
     });
+  const filteredMarkerRetainsCurrentOutputLocators = (
+    storedDelivery: IntegrationIngestRecord,
+  ): boolean =>
+    (currentEventOwners.allExist || storedDelivery.outputs.events.length === 0)
+    && storedIntegrationIngestRetainsCurrentOutputLocators({
+      allSamplesExist: sampleAppendPlan.appendedRecordIds.length === 0,
+      associationEvidenceRolesByPreparedRecordId,
+      baselineRetainedPreparedIds,
+      currentEventOwners,
+      deviceBatchPlan,
+      preparedEventOutputOwners,
+      replayRetainedPreparedIds,
+      sampleRecords,
+      storedDelivery,
+    });
   const authorizedStoredDelivery = () => {
     if (ingestIdInspection.unsafe) {
       return undefined;
@@ -4734,7 +4765,7 @@ export async function importDeviceBatch({
   const inspectExactDeliveryState = (): ExactDeliveryState => {
     assertNoCurrentImportIdConflict();
     const partial = partialStoredDelivery();
-    if (partial && !storedDeliveryRetainsCurrentOutputs(partial)) {
+    if (partial && !filteredMarkerRetainsCurrentOutputLocators(partial)) {
       throw new VaultError(
         "INTEGRATION_INGEST_EVENT_MAPPING_AMBIGUOUS",
         "Filtered device delivery marker cannot prove the current canonical outputs.",

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -2137,6 +2137,217 @@ test("importDeviceBatch retains changed evidence for an unchanged event and maps
   assert.equal(eventRows.length, 1);
 });
 
+test("importDeviceBatch retains only changed evidence from a repeated multi-part delivery and exact replay no-ops", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-incremental-evidence");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+  const unchangedRole = "junction-summary-activity";
+  const changedRole = "junction-summary-sleep-cycle";
+  const buildInput = (importedAt: string, sleepRevision: number) => ({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt,
+    events: [{
+      ...buildJunctionStyleWorkoutEvent(),
+      evidenceRoles: [unchangedRole, changedRole],
+    }],
+    evidenceParts: [
+      {
+        role: unchangedRole,
+        fileName: "junction-summary-activity.json",
+        content: { date: "2026-06-03", steps: 8_000 },
+      },
+      {
+        role: changedRole,
+        fileName: "junction-summary-sleep-cycle.json",
+        content: { date: "2026-06-03", revision: sleepRevision },
+      },
+    ],
+  });
+
+  const first = await importDeviceBatch(buildInput("2026-06-03T21:00:00.000Z", 1));
+  const changedInput = buildInput("2026-06-04T21:00:00.000Z", 2);
+  const changed = await importDeviceBatch(changedInput);
+  const replay = await importDeviceBatch(changedInput);
+
+  assert.ok(first.applied);
+  assert.ok(changed.applied);
+  assert.equal(first.persistedEvidencePartCount, 2);
+  assert.equal(changed.evidencePartCount, 2);
+  assert.equal(changed.persistedEvidencePartCount, 1);
+  assert.equal(replay.applied, false);
+  assert.equal(replay.ingestId, null);
+  assert.equal(replay.auditPath, null);
+  assert.equal(replay.persistedEvidencePartCount, 0);
+  const changedIngest = await readRequiredIntegrationIngest(vaultRoot, changed.ingestId);
+  assert.deepEqual(changedIngest.parts.map((part) => part.role), [changedRole]);
+  assert.deepEqual(changedIngest.outputs.events, [{
+    id: first.events[0]?.id,
+    roles: [changedRole],
+  }]);
+});
+
+test("importDeviceBatch retains unchanged evidence for a newly appended event revision", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-revised-event-evidence");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+  const evidenceRole = "junction-summary-workouts";
+  const evidencePart = {
+    role: evidenceRole,
+    fileName: "junction-summary-workouts.json",
+    content: { id: "workouts-revised-event", sport: "running" },
+  };
+  const buildInput = (importedAt: string, durationMinutes: number) => ({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt,
+    events: [{
+      ...buildJunctionStyleWorkoutEvent({
+        durationMinutes,
+        resourceId: "workouts-revised-event",
+      }),
+      evidenceRoles: [evidenceRole],
+    }],
+    evidenceParts: [evidencePart],
+  });
+
+  const first = await importDeviceBatch(buildInput("2026-06-03T21:00:00.000Z", 34));
+  const revised = await importDeviceBatch(buildInput("2026-06-04T21:00:00.000Z", 35));
+  const replay = await importDeviceBatch(buildInput("2026-06-05T21:00:00.000Z", 35));
+
+  assert.ok(first.applied);
+  assert.ok(revised.applied);
+  assert.equal(revised.events[0]?.id, first.events[0]?.id);
+  assert.equal(revised.events[0]?.lifecycle?.revision, 2);
+  assert.equal(revised.persistedEvidencePartCount, 1);
+  assert.equal(replay.applied, false);
+  const revisedIngest = await readRequiredIntegrationIngest(vaultRoot, revised.ingestId);
+  assert.deepEqual(revisedIngest.parts.map((part) => part.role), [evidenceRole]);
+  assert.deepEqual(revisedIngest.outputs.events, [{
+    id: first.events[0]?.id,
+    roles: [evidenceRole],
+  }]);
+});
+
+test("importDeviceBatch retains complete evidence when novel evidence has no event association", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-unassociated-evidence");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+  const associatedRole = "junction-summary-workouts";
+  const unassociatedRole = "junction-summary-activity";
+  const associatedPart = {
+    role: associatedRole,
+    fileName: "junction-summary-workouts.json",
+    content: { id: "workouts-unassociated-evidence", sport: "running" },
+  };
+  const event = {
+    ...buildJunctionStyleWorkoutEvent({ resourceId: "workouts-unassociated-evidence" }),
+    evidenceRoles: [associatedRole],
+  };
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [event],
+    evidenceParts: [associatedPart],
+  });
+  const expandedInput = {
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [event],
+    evidenceParts: [
+      associatedPart,
+      {
+        role: unassociatedRole,
+        fileName: "junction-summary-activity.json",
+        content: { date: "2026-06-03", steps: 8_000 },
+      },
+    ],
+  } as const;
+  const expanded = await importDeviceBatch(expandedInput);
+  const replay = await importDeviceBatch(expandedInput);
+
+  assert.ok(first.applied);
+  assert.ok(expanded.applied);
+  assert.equal(expanded.evidencePartCount, 2);
+  assert.equal(expanded.persistedEvidencePartCount, 2);
+  assert.equal(replay.applied, false);
+  const expandedIngest = await readRequiredIntegrationIngest(vaultRoot, expanded.ingestId);
+  assert.deepEqual(
+    expandedIngest.parts.map((part) => part.role),
+    [associatedRole, unassociatedRole],
+  );
+  assert.deepEqual(expandedIngest.outputs.events, [{
+    id: first.events[0]?.id,
+    roles: [associatedRole],
+  }]);
+});
+
+test("importDeviceBatch retains complete evidence when prepared events share one canonical owner", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-import-shared-event-owner");
+  await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+  const firstRole = "junction-summary-workouts";
+  const secondRole = "junction-summary-activity";
+  const firstPart = {
+    role: firstRole,
+    fileName: "junction-summary-workouts.json",
+    content: { id: "workouts-shared-owner", sport: "running" },
+  };
+  const event = buildJunctionStyleWorkoutEvent({ resourceId: "workouts-shared-owner" });
+  const revisedEvent = buildJunctionStyleWorkoutEvent({
+    durationMinutes: 35,
+    resourceId: "workouts-shared-owner",
+  });
+
+  const first = await importDeviceBatch({
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-03T21:00:00.000Z",
+    events: [{ ...event, evidenceRoles: [firstRole] }],
+    evidenceParts: [firstPart],
+  });
+  const sharedOwnerInput = {
+    vaultRoot,
+    provider: "junction",
+    accountId: "jxn_acct_stable",
+    importedAt: "2026-06-04T21:00:00.000Z",
+    events: [
+      { ...event, evidenceRoles: [firstRole] },
+      { ...revisedEvent, evidenceRoles: [secondRole] },
+    ],
+    evidenceParts: [
+      firstPart,
+      {
+        role: secondRole,
+        fileName: "junction-summary-activity.json",
+        content: { date: "2026-06-03", steps: 8_000 },
+      },
+    ],
+  } as const;
+  const sharedOwner = await importDeviceBatch(sharedOwnerInput);
+  const replay = await importDeviceBatch(sharedOwnerInput);
+
+  assert.ok(first.applied);
+  assert.ok(sharedOwner.applied);
+  assert.equal(sharedOwner.events[0]?.id, first.events[0]?.id);
+  assert.equal(sharedOwner.events[1]?.id, first.events[0]?.id);
+  assert.equal(sharedOwner.persistedEvidencePartCount, 2);
+  assert.equal(replay.applied, false);
+  const sharedOwnerIngest = await readRequiredIntegrationIngest(vaultRoot, sharedOwner.ingestId);
+  assert.deepEqual(
+    sharedOwnerIngest.parts.map((part) => part.role),
+    [firstRole, secondRole],
+  );
+  assert.deepEqual(sharedOwnerIngest.outputs.events, [{
+    id: first.events[0]?.id,
+    roles: [secondRole, firstRole],
+  }]);
+});
+
 test("importDeviceBatch retains an existing raw-only part when an event gains its provenance link", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-import-new-evidence-link");
   await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
@@ -3936,7 +4147,7 @@ test("concatenated malformed ingest rows cannot hide current or legacy delivery 
   }
 });
 
-test("importDeviceBatch exact retry preserves a self-contained ingest beyond the row budget", async () => {
+test("importDeviceBatch fails open when incremental evidence falls beyond the row budget", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-import-partial-retention-retry");
   await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
   const partA = {
@@ -3965,9 +4176,9 @@ test("importDeviceBatch exact retry preserves a self-contained ingest beyond the
   } as const;
   const filtered = await importDeviceBatch(input);
   assert.ok(filtered.applied);
-  assert.equal(filtered.persistedEvidencePartCount, 2);
+  assert.equal(filtered.persistedEvidencePartCount, 1);
   const filteredRecord = await readRequiredIntegrationIngest(vaultRoot, filtered.ingestId);
-  assert.deepEqual(filteredRecord.parts.map((part) => part.role), [partA.role, partB.role]);
+  assert.deepEqual(filteredRecord.parts.map((part) => part.role), [partB.role]);
   const unrelatedRow = `${JSON.stringify({
     ...filteredRecord,
     id: "xfm_00000000000000000000000000",
@@ -3975,16 +4186,13 @@ test("importDeviceBatch exact retry preserves a self-contained ingest beyond the
     accountId: "unrelated-account",
   })}\n`;
   await fs.appendFile(path.join(vaultRoot, filtered.ingestShardPath), unrelatedRow.repeat(65), "utf8");
-  const beforeReplay = await fs.readFile(path.join(vaultRoot, filtered.ingestShardPath));
-
   const replay = await importDeviceBatch(input);
+  const convergedReplay = await importDeviceBatch(input);
 
-  assert.equal(replay.applied, false);
-  assert.equal(replay.ingestId, null);
-  assert.deepEqual(
-    await fs.readFile(path.join(vaultRoot, filtered.ingestShardPath)),
-    beforeReplay,
-  );
+  assert.ok(replay.applied);
+  assert.equal(replay.persistedEvidencePartCount, 2);
+  assert.equal(convergedReplay.applied, false);
+  assert.equal(convergedReplay.ingestId, null);
 });
 
 test("importDeviceBatch repairs a valid historical partial exact row with one self-contained delivery", async () => {
@@ -6484,7 +6692,7 @@ test("importDeviceBatch handles mixed duplicate, changed, and new events in one 
   const secondIngest = await readRequiredIntegrationIngest(vaultRoot, second.ingestId);
   assert.deepEqual(
     secondIngest.parts.map((part) => part.role),
-    ["workout-aaa", "workout-bbb", "workout-ccc"],
+    ["workout-bbb", "workout-ccc"],
   );
   assert.deepEqual(
     secondIngest.outputs.events.map((output) => output.id).sort(),

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -2229,6 +2229,101 @@ test("importDeviceBatch retains unchanged evidence for a newly appended event re
   }]);
 });
 
+test.each(["earlier-shard", "complete-spine"] as const)(
+  "filtered incremental replay fails closed after %s loss",
+  async (lossMode) => {
+    const vaultRoot = await makeTempDirectory(
+      `murph-device-import-filtered-replay-${lossMode}`,
+    );
+    await initializeVault({ vaultRoot, createdAt: "2026-01-01T12:00:00.000Z" });
+    const contextRole = "junction-summary-activity";
+    const eventRole = "junction-summary-workouts";
+    const evidenceParts = [
+      {
+        role: contextRole,
+        fileName: "junction-summary-activity.json",
+        content: { date: "2026-01-03", steps: 8_000 },
+      },
+      {
+        role: eventRole,
+        fileName: "junction-summary-workouts.json",
+        content: { id: "filtered-replay-workout", sport: "running" },
+      },
+    ];
+    const buildInput = (input: {
+      durationMinutes: number;
+      importedAt: string;
+      occurredAt: string;
+    }) => ({
+      vaultRoot,
+      provider: "junction",
+      accountId: "jxn_acct_filtered_replay",
+      importedAt: input.importedAt,
+      events: [{
+        ...buildJunctionStyleWorkoutEvent({
+          durationMinutes: input.durationMinutes,
+          occurredAt: input.occurredAt,
+          recordedAt: input.occurredAt,
+          resourceId: "filtered-replay-workout",
+        }),
+        evidenceRoles: [eventRole],
+      }],
+      evidenceParts,
+    });
+
+    const first = await importDeviceBatch(buildInput({
+      durationMinutes: 34,
+      importedAt: "2026-06-03T21:00:00.000Z",
+      occurredAt: "2026-01-03T19:55:00.000Z",
+    }));
+    const filteredInput = buildInput({
+      durationMinutes: 35,
+      importedAt: "2026-06-04T21:00:00.000Z",
+      occurredAt: "2026-02-03T19:55:00.000Z",
+    });
+    const filtered = await importDeviceBatch(filteredInput);
+    const later = await importDeviceBatch(buildInput({
+      durationMinutes: 36,
+      importedAt: "2026-06-05T21:00:00.000Z",
+      occurredAt: "2026-03-03T19:55:00.000Z",
+    }));
+
+    assert.equal(filtered.events[0]?.id, first.events[0]?.id);
+    assert.equal(later.events[0]?.id, first.events[0]?.id);
+    assert.equal(filtered.persistedEvidencePartCount, 1);
+    assert.ok(filtered.ingestId);
+    const filteredIngest = await readRequiredIntegrationIngest(vaultRoot, filtered.ingestId);
+    assert.deepEqual(filteredIngest.parts.map((part) => part.role), [eventRole]);
+    const beforeIntactReplay = await snapshotVaultFiles(vaultRoot);
+    const intactReplay = await importDeviceBatch(filteredInput);
+    assert.equal(intactReplay.applied, false);
+    assert.deepEqual(await snapshotVaultFiles(vaultRoot), beforeIntactReplay);
+
+    const filteredEventShardPath = filtered.eventShardPaths[0];
+    assert.ok(filteredEventShardPath);
+    if (lossMode === "earlier-shard") {
+      await fs.unlink(path.join(vaultRoot, filteredEventShardPath));
+    } else {
+      for (const eventShardPath of new Set([
+        ...first.eventShardPaths,
+        ...filtered.eventShardPaths,
+        ...later.eventShardPaths,
+      ])) {
+        await fs.unlink(path.join(vaultRoot, eventShardPath));
+      }
+    }
+    const beforeRejectedReplay = await snapshotVaultFiles(vaultRoot);
+
+    await assert.rejects(
+      importDeviceBatch(filteredInput),
+      (error) =>
+        error instanceof VaultError
+        && error.code === "INTEGRATION_INGEST_EVENT_MAPPING_AMBIGUOUS",
+    );
+    assert.deepEqual(await snapshotVaultFiles(vaultRoot), beforeRejectedReplay);
+  },
+);
+
 test("importDeviceBatch retains complete evidence when novel evidence has no event association", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-import-unassociated-evidence");
   await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
@@ -4147,7 +4242,7 @@ test("concatenated malformed ingest rows cannot hide current or legacy delivery 
   }
 });
 
-test("importDeviceBatch fails open when incremental evidence falls beyond the row budget", async () => {
+test("importDeviceBatch recognizes an incremental marker beyond the row budget", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-import-partial-retention-retry");
   await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
   const partA = {
@@ -4186,13 +4281,12 @@ test("importDeviceBatch fails open when incremental evidence falls beyond the ro
     accountId: "unrelated-account",
   })}\n`;
   await fs.appendFile(path.join(vaultRoot, filtered.ingestShardPath), unrelatedRow.repeat(65), "utf8");
+  const beforeReplay = await snapshotVaultFiles(vaultRoot);
   const replay = await importDeviceBatch(input);
-  const convergedReplay = await importDeviceBatch(input);
 
-  assert.ok(replay.applied);
-  assert.equal(replay.persistedEvidencePartCount, 2);
-  assert.equal(convergedReplay.applied, false);
-  assert.equal(convergedReplay.ingestId, null);
+  assert.equal(replay.applied, false);
+  assert.equal(replay.ingestId, null);
+  assert.deepEqual(await snapshotVaultFiles(vaultRoot), beforeReplay);
 });
 
 test("importDeviceBatch repairs a valid historical partial exact row with one self-contained delivery", async () => {

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -4242,7 +4242,7 @@ test("concatenated malformed ingest rows cannot hide current or legacy delivery 
   }
 });
 
-test("importDeviceBatch recognizes an incremental marker beyond the row budget", async () => {
+test("importDeviceBatch fails open when an incremental marker is beyond the row budget", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-import-partial-retention-retry");
   await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
   const partA = {
@@ -4281,13 +4281,130 @@ test("importDeviceBatch recognizes an incremental marker beyond the row budget",
     accountId: "unrelated-account",
   })}\n`;
   await fs.appendFile(path.join(vaultRoot, filtered.ingestShardPath), unrelatedRow.repeat(65), "utf8");
-  const beforeReplay = await snapshotVaultFiles(vaultRoot);
   const replay = await importDeviceBatch(input);
+  const convergedReplay = await importDeviceBatch(input);
 
-  assert.equal(replay.applied, false);
-  assert.equal(replay.ingestId, null);
-  assert.deepEqual(await snapshotVaultFiles(vaultRoot), beforeReplay);
+  assert.ok(replay.applied);
+  assert.equal(replay.persistedEvidencePartCount, 2);
+  assert.ok(replay.ingestId);
+  const replayRecord = await readRequiredIntegrationIngest(vaultRoot, replay.ingestId);
+  assert.deepEqual(
+    replayRecord.parts.map((part) => part.role),
+    [partA.role, partB.role],
+  );
+  assert.equal(convergedReplay.applied, false);
+  assert.equal(convergedReplay.ingestId, null);
 });
+
+test.each([
+  ["raw-only", "deleted", "tail"],
+  ["raw-only", "deleted", "beyond-tail"],
+  ["raw-only", "malformed", "tail"],
+  ["raw-only", "malformed", "beyond-tail"],
+  ["linked-output", "deleted", "tail"],
+  ["linked-output", "deleted", "beyond-tail"],
+  ["linked-output", "malformed", "tail"],
+  ["linked-output", "malformed", "beyond-tail"],
+] as const)(
+  "filtered %s replay retains complete evidence after %s omitted proof with marker %s",
+  async (deliveryKind, damage, markerPlacement) => {
+    const vaultRoot = await makeTempDirectory(
+      `murph-device-import-filtered-evidence-repair-${deliveryKind}-${damage}-${markerPlacement}`,
+    );
+    await initializeVault({ vaultRoot, createdAt: "2026-06-01T12:00:00.000Z" });
+    const partA = {
+      role: "junction-summary-activity",
+      fileName: "junction-summary-activity.json",
+      content: { date: "2026-06-03", steps: 8_000 },
+    } as const;
+    const partB = {
+      role: "junction-summary-workouts",
+      fileName: "junction-summary-workouts.json",
+      content: { id: "filtered-evidence-repair", sport: "running" },
+    } as const;
+    const buildInput = (
+      importedAt: string,
+      evidenceParts: readonly [typeof partA] | readonly [typeof partA, typeof partB],
+    ) => ({
+      vaultRoot,
+      provider: "junction",
+      accountId: "jxn_acct_filtered_evidence_repair",
+      importedAt,
+      ...(deliveryKind === "linked-output"
+        ? {
+            events: [{
+              ...buildJunctionStyleWorkoutEvent({
+                resourceId: "filtered-evidence-repair",
+              }),
+              evidenceRoles: evidenceParts.map((part) => part.role),
+            }],
+          }
+        : {}),
+      evidenceParts,
+    });
+
+    const seed = await importDeviceBatch(buildInput(
+      "2026-06-03T21:00:00.000Z",
+      [partA],
+    ));
+    const filteredInput = buildInput(
+      "2026-06-04T21:00:00.000Z",
+      [partA, partB],
+    );
+    const filtered = await importDeviceBatch(filteredInput);
+    assert.ok(seed.applied);
+    assert.ok(filtered.applied);
+    assert.equal(filtered.persistedEvidencePartCount, 1);
+    assert.ok(filtered.ingestId);
+    assert.ok(filtered.ingestShardPath);
+    const filteredRecord = await readRequiredIntegrationIngest(vaultRoot, filtered.ingestId);
+    assert.deepEqual(filteredRecord.parts.map((part) => part.role), [partB.role]);
+
+    const unrelatedRows = markerPlacement === "beyond-tail"
+      ? Array.from({ length: 65 }, (_, index) => ({
+          ...filteredRecord,
+          id: deterministicContractId(
+            "xfm",
+            `filtered-evidence-repair-tail-${deliveryKind}-${damage}-${index}`,
+          ),
+          provider: "unrelated-provider",
+          accountId: "unrelated-account",
+        }))
+      : [];
+    const damagedPrefix = damage === "malformed" ? "{\"damaged\":\n" : "";
+    await fs.writeFile(
+      path.join(vaultRoot, filtered.ingestShardPath),
+      damagedPrefix
+        + [filteredRecord, ...unrelatedRows]
+          .map((record) => JSON.stringify(record))
+          .join("\n")
+        + "\n",
+      "utf8",
+    );
+
+    const repaired = await importDeviceBatch(filteredInput);
+
+    assert.ok(repaired.applied);
+    assert.equal(repaired.persistedEvidencePartCount, 2);
+    assert.ok(repaired.ingestId);
+    const repairedLines = (await fs.readFile(
+      path.join(vaultRoot, filtered.ingestShardPath),
+      "utf8",
+    )).trimEnd().split("\n");
+    const repairedLine = repairedLines.at(-1);
+    assert.ok(repairedLine);
+    const repairedRecord = JSON.parse(repairedLine) as IntegrationIngestRecord;
+    assert.equal(repairedRecord.id, repaired.ingestId);
+    assert.deepEqual(
+      repairedRecord.parts.map((part) => part.role),
+      [partA.role, partB.role],
+    );
+    const beforeReplay = await snapshotVaultFiles(vaultRoot);
+    const replay = await importDeviceBatch(filteredInput);
+    assert.equal(replay.applied, false);
+    assert.deepEqual(await snapshotVaultFiles(vaultRoot), beforeReplay);
+  },
+);
 
 test("importDeviceBatch repairs a valid historical partial exact row with one self-contained delivery", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-import-historical-partial-repair");

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -2147,10 +2147,24 @@ test("importDeviceBatch retains only changed evidence from a repeated multi-part
     provider: "junction",
     accountId: "jxn_acct_stable",
     importedAt,
-    events: [{
-      ...buildJunctionStyleWorkoutEvent(),
-      evidenceRoles: [unchangedRole, changedRole],
-    }],
+    events: [
+      {
+        ...buildJunctionStyleWorkoutEvent({
+          resourceId: "activity-incremental-evidence",
+          sourceWorkoutId: "activity-incremental-evidence",
+        }),
+        evidenceRoles: [unchangedRole],
+      },
+      {
+        ...buildJunctionStyleWorkoutEvent({
+          occurredAt: "2026-06-03T22:00:00.000Z",
+          recordedAt: "2026-06-03T22:35:00.000Z",
+          resourceId: "sleep-incremental-evidence",
+          sourceWorkoutId: "sleep-incremental-evidence",
+        }),
+        evidenceRoles: [changedRole],
+      },
+    ],
     evidenceParts: [
       {
         role: unchangedRole,
@@ -2168,6 +2182,9 @@ test("importDeviceBatch retains only changed evidence from a repeated multi-part
   const first = await importDeviceBatch(buildInput("2026-06-03T21:00:00.000Z", 1));
   const changedInput = buildInput("2026-06-04T21:00:00.000Z", 2);
   const changed = await importDeviceBatch(changedInput);
+  assert.ok(changed.ingestId);
+  const changedIngest = await readRequiredIntegrationIngest(vaultRoot, changed.ingestId);
+  const beforeReplay = await snapshotVaultFiles(vaultRoot);
   const replay = await importDeviceBatch(changedInput);
 
   assert.ok(first.applied);
@@ -2179,12 +2196,12 @@ test("importDeviceBatch retains only changed evidence from a repeated multi-part
   assert.equal(replay.ingestId, null);
   assert.equal(replay.auditPath, null);
   assert.equal(replay.persistedEvidencePartCount, 0);
-  const changedIngest = await readRequiredIntegrationIngest(vaultRoot, changed.ingestId);
+  assert.deepEqual(await snapshotVaultFiles(vaultRoot), beforeReplay);
   assert.deepEqual(changedIngest.parts.map((part) => part.role), [changedRole]);
-  assert.deepEqual(changedIngest.outputs.events, [{
-    id: first.events[0]?.id,
-    roles: [changedRole],
-  }]);
+  assert.deepEqual(changedIngest.outputs.events, [
+    { id: first.events[0]?.id, roles: [] },
+    { id: first.events[1]?.id, roles: [changedRole] },
+  ].sort((left, right) => (left.id ?? "").localeCompare(right.id ?? "")));
 });
 
 test("importDeviceBatch retains unchanged evidence for a newly appended event revision", async () => {
@@ -2236,64 +2253,65 @@ test.each(["earlier-shard", "complete-spine"] as const)(
       `murph-device-import-filtered-replay-${lossMode}`,
     );
     await initializeVault({ vaultRoot, createdAt: "2026-01-01T12:00:00.000Z" });
-    const contextRole = "junction-summary-activity";
-    const eventRole = "junction-summary-workouts";
-    const evidenceParts = [
-      {
-        role: contextRole,
-        fileName: "junction-summary-activity.json",
-        content: { date: "2026-01-03", steps: 8_000 },
-      },
-      {
-        role: eventRole,
-        fileName: "junction-summary-workouts.json",
-        content: { id: "filtered-replay-workout", sport: "running" },
-      },
-    ];
-    const buildInput = (input: {
-      durationMinutes: number;
-      importedAt: string;
-      occurredAt: string;
-    }) => ({
+    const unchangedRole = "junction-summary-activity";
+    const changedRole = "junction-summary-workouts";
+    const buildInput = (importedAt: string, workoutRevision: number) => ({
       vaultRoot,
       provider: "junction",
       accountId: "jxn_acct_filtered_replay",
-      importedAt: input.importedAt,
-      events: [{
-        ...buildJunctionStyleWorkoutEvent({
-          durationMinutes: input.durationMinutes,
-          occurredAt: input.occurredAt,
-          recordedAt: input.occurredAt,
-          resourceId: "filtered-replay-workout",
-        }),
-        evidenceRoles: [eventRole],
-      }],
-      evidenceParts,
+      importedAt,
+      events: [
+        {
+          ...buildJunctionStyleWorkoutEvent({
+            occurredAt: "2026-01-03T19:55:00.000Z",
+            recordedAt: "2026-01-03T20:30:00.000Z",
+            resourceId: "filtered-replay-activity",
+            sourceWorkoutId: "filtered-replay-activity",
+          }),
+          evidenceRoles: [unchangedRole],
+        },
+        {
+          ...buildJunctionStyleWorkoutEvent({
+            occurredAt: "2026-02-03T19:55:00.000Z",
+            recordedAt: "2026-02-03T20:30:00.000Z",
+            resourceId: "filtered-replay-workout",
+            sourceWorkoutId: "filtered-replay-workout",
+          }),
+          evidenceRoles: [changedRole],
+        },
+      ],
+      evidenceParts: [
+        {
+          role: unchangedRole,
+          fileName: "junction-summary-activity.json",
+          content: { date: "2026-01-03", steps: 8_000 },
+        },
+        {
+          role: changedRole,
+          fileName: "junction-summary-workouts.json",
+          content: {
+            id: "filtered-replay-workout",
+            revision: workoutRevision,
+            sport: "running",
+          },
+        },
+      ],
     });
 
-    const first = await importDeviceBatch(buildInput({
-      durationMinutes: 34,
-      importedAt: "2026-06-03T21:00:00.000Z",
-      occurredAt: "2026-01-03T19:55:00.000Z",
-    }));
-    const filteredInput = buildInput({
-      durationMinutes: 35,
-      importedAt: "2026-06-04T21:00:00.000Z",
-      occurredAt: "2026-02-03T19:55:00.000Z",
-    });
+    const first = await importDeviceBatch(buildInput("2026-06-03T21:00:00.000Z", 1));
+    const filteredInput = buildInput("2026-06-04T21:00:00.000Z", 2);
     const filtered = await importDeviceBatch(filteredInput);
-    const later = await importDeviceBatch(buildInput({
-      durationMinutes: 36,
-      importedAt: "2026-06-05T21:00:00.000Z",
-      occurredAt: "2026-03-03T19:55:00.000Z",
-    }));
 
     assert.equal(filtered.events[0]?.id, first.events[0]?.id);
-    assert.equal(later.events[0]?.id, first.events[0]?.id);
+    assert.equal(filtered.events[1]?.id, first.events[1]?.id);
     assert.equal(filtered.persistedEvidencePartCount, 1);
     assert.ok(filtered.ingestId);
     const filteredIngest = await readRequiredIntegrationIngest(vaultRoot, filtered.ingestId);
-    assert.deepEqual(filteredIngest.parts.map((part) => part.role), [eventRole]);
+    assert.deepEqual(filteredIngest.parts.map((part) => part.role), [changedRole]);
+    assert.deepEqual(filteredIngest.outputs.events, [
+      { id: first.events[0]?.id, roles: [] },
+      { id: first.events[1]?.id, roles: [changedRole] },
+    ].sort((left, right) => (left.id ?? "").localeCompare(right.id ?? "")));
     const beforeIntactReplay = await snapshotVaultFiles(vaultRoot);
     const intactReplay = await importDeviceBatch(filteredInput);
     assert.equal(intactReplay.applied, false);
@@ -2307,7 +2325,6 @@ test.each(["earlier-shard", "complete-spine"] as const)(
       for (const eventShardPath of new Set([
         ...first.eventShardPaths,
         ...filtered.eventShardPaths,
-        ...later.eventShardPaths,
       ])) {
         await fs.unlink(path.join(vaultRoot, eventShardPath));
       }
@@ -4332,12 +4349,19 @@ test.each([
       importedAt,
       ...(deliveryKind === "linked-output"
         ? {
-            events: [{
+            events: evidenceParts.map((part, index) => ({
               ...buildJunctionStyleWorkoutEvent({
-                resourceId: "filtered-evidence-repair",
+                occurredAt: index === 0
+                  ? "2026-06-03T19:55:00.000Z"
+                  : "2026-06-03T22:00:00.000Z",
+                recordedAt: index === 0
+                  ? "2026-06-03T20:30:00.000Z"
+                  : "2026-06-03T22:35:00.000Z",
+                resourceId: `filtered-evidence-repair-${part.role}`,
+                sourceWorkoutId: `filtered-evidence-repair-${part.role}`,
               }),
-              evidenceRoles: evidenceParts.map((part) => part.role),
-            }],
+              evidenceRoles: [part.role],
+            })),
           }
         : {}),
       evidenceParts,
@@ -4359,6 +4383,12 @@ test.each([
     assert.ok(filtered.ingestShardPath);
     const filteredRecord = await readRequiredIntegrationIngest(vaultRoot, filtered.ingestId);
     assert.deepEqual(filteredRecord.parts.map((part) => part.role), [partB.role]);
+    if (deliveryKind === "linked-output") {
+      assert.deepEqual(filteredRecord.outputs.events, [
+        { id: seed.events[0]?.id, roles: [] },
+        { id: filtered.events[1]?.id, roles: [partB.role] },
+      ].sort((left, right) => (left.id ?? "").localeCompare(right.id ?? "")));
+    }
 
     const unrelatedRows = markerPlacement === "beyond-tail"
       ? Array.from({ length: 65 }, (_, index) => ({


### PR DESCRIPTION
## Why

Recurring device-provider deliveries resend rolling evidence windows. Core already identified novel parts, but the persistence seam expanded an accepted incremental delivery back to the complete received evidence set, so append-only vault storage grew with unchanged history.

## User-visible goal and flow

- Exact replays remain no-ops.
- A delivery with a new or corrected part retains only novel evidence plus the evidence roles required by a newly appended event revision.
- Filtered deliveries receive a distinct content-derived incremental-evidence id, so they cannot masquerade as a complete exact delivery or authorize repair from incomplete proof.
- Repair, ambiguous ownership, unassociated evidence, and bounded-novelty failures retain one complete delivery and converge on the next replay.
- Existing vault history is not rewritten; the reduction applies to future recurring imports.

## Invariants and non-goals

- Preserve canonical event ids, append-only history, evidence hashes/bytes, receipts, corrections, replay safety, and repair behavior.
- Fail open to complete evidence when safe incremental proof is unavailable.
- Keep provider shaping in importers and canonical persistence in core.
- No schema migration, background compactor, new state owner, provider scheduling change, or destructive historical cleanup.

## Non-obvious surfaces

- Device ingest evidence/output-role association and deterministic import ids.
- Repair eligibility and canonical-owner ambiguity handling.
- Durable device-ingestion invariants.

## Verification

- Core suite: 44 files and 742 tests passed with coverage.
- Focused recovery matrix: raw-only and linked-output filtered deliveries; deleted and malformed omitted evidence; marker inside and beyond the bounded tail; all passed.
- Provider-shaped two-event filtered markers replay as byte-for-byte no-ops when intact; missing earlier event shards and complete event-spine loss both fail closed without vault mutation.
- Core typecheck and diff/privacy checks passed.
- Required coverage-write audit completed with no unresolved findings.
- `pnpm verify:acceptance` passed, including all workspace typechecks, package coverage, 6,125 web tests, 1,851 app verification tests, the production web build, and Cloudflare worker checks.

## Change shape

| Category | First-reviewed added | First-reviewed deleted | Current added | Current deleted |
| --- | ---: | ---: | ---: | ---: |
| Source | 38 | 5 | 125 | 33 |
| Tests | 220 | 12 | 459 | 10 |
| Docs/plans | 100 | 4 | 103 | 4 |
| Config/tooling | 0 | 0 | 0 | 0 |
| Generated/other | 0 | 0 | 0 | 0 |

Review-driven source movement is +87 additions and +28 deletions from the immutable first-reviewed shape. The final redesign removes partial-marker no-op authority, separates filtered locator validation from complete-delivery role proof, and keeps evidence redundancy under the existing novelty owner.

## ReviewGPT resolution

- Round 1: accepted one High finding. A filtered identity was recognized too late, so a missing event shard could be mutated before replay detection.
- Round 2: accepted one review-induced High finding and completed the required anomaly retrospective. The first correction let a partial marker suppress recovery of evidence it omitted.
- Retrospective decision: keep the stable marker only as a locator and fail-closed canonical-output guard; remove its independent no-op authority; add no new durable owner or repair service.
- Round 3: accepted one review-induced High finding. Complete-delivery role proof incorrectly rejected intentional empty role locators for unchanged events in an otherwise healthy filtered multi-event marker.\n- Round 4 will verify the split locator/role predicates and the provider-shaped multi-event replay, missing-spine, and omitted-proof recovery cases.

ReviewGPT first-reviewed head: 686dfbb931b99df2b3dcf90ccf11e5ec0ba20eb9
ReviewGPT latest valid round: 4
ReviewGPT latest valid head: 58d298e1d21d2ecec6855f10b5a4d5ed407a00a6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787288132&installation_model_id=19880&pr_number=842&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F842&signature=722741c68d155b005fed8d7f9647834a920c958c3330043b504b5bc13b416b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->