### PR TITLE
Align mobile biomarker device labels

### DIFF
--- a/apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx
@@ -270,7 +270,7 @@ function DeviceMetricRow({ item }: { item: DeviceMetricListItem }) {
 
   return (
     <Link
-      className="group grid min-h-28 grid-cols-[2.5rem_minmax(0,1fr)] gap-4 px-5 py-5 transition-colors duration-200 hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-8 md:grid-cols-[2.5rem_8rem_minmax(0,1fr)_auto] md:items-center md:gap-5"
+      className="group grid min-h-28 grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-4 px-5 py-5 transition-colors duration-200 hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-8 md:grid-cols-[2.5rem_8rem_minmax(0,1fr)_auto] md:gap-5"
       href={`/biomarkers/${entry.routeId}`}
     >
       <BiomarkerIcon className="size-9" routeId={entry.routeId} />
@@ -278,7 +278,7 @@ function DeviceMetricRow({ item }: { item: DeviceMetricListItem }) {
         <p className="hidden font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground md:block">
           {category}
         </p>
-        <p className="text-base font-semibold text-foreground md:mt-1">{entry.shortName}</p>
+        <p className="text-lg font-semibold text-foreground md:mt-1 md:text-base">{entry.shortName}</p>
       </div>
       <p className="col-span-2 line-clamp-2 max-w-[72ch] text-sm leading-relaxed text-muted-foreground md:col-span-1 md:line-clamp-none">
         {entry.summary ?? "A device-derived health metric from your connected data."}

--- a/apps/web/test/biomarker-device-metrics.test.tsx
+++ b/apps/web/test/biomarker-device-metrics.test.tsx
@@ -149,6 +149,13 @@ test("only device-derived readings decide the latest card value without history 
     expect(deviceHeading?.className).toContain("text-2xl");
     expect(section?.querySelector("ul")?.className).not.toContain("grid-cols-");
     expect(link?.className).toContain("md:grid-cols-");
+    expect(link?.className.split(/\s+/u)).toContain("items-center");
+    const deviceName = [...(link?.querySelectorAll("p") ?? [])].find((paragraph) =>
+      paragraph.textContent === "Resting heart rate"
+    );
+    const deviceNameClassTokens = deviceName?.className.split(/\s+/u) ?? [];
+    expect(deviceNameClassTokens).toContain("text-lg");
+    expect(deviceNameClassTokens).toContain("md:text-base");
 
     expect(text).toContain("1 metric");
     expect(text).not.toContain("No lab results yet");


### PR DESCRIPTION
## Why this PR exists

Device metric names such as RHR and HRV were top-aligned against their biomarker SVGs on phones, which made the “From your devices” rows look visibly off.

## User goal / user-visible behavior

On mobile, every device metric name is now larger and vertically centered beside its icon. Desktop keeps its existing label size and row layout.

## User experience

Members open Biomarkers and see device-derived readings first. At phone widths, the icon and metric name now read as one centered visual unit; the summary and value remain in their existing rows and the whole row remains the navigation target. There is no state or error-flow change.

## Invariants

- Apply the same treatment to every device metric row, not one hard-coded metric.
- Preserve the existing desktop typography and grid.
- Preserve link, focus, route, value, summary, staleness, and data-selection behavior.
- Do not change biomarker data flow, state, auth, or authority boundaries.

## Non-obvious affected surfaces

None.

## Change-shape breakdown

Classification rule: authored component code is source; Vitest assertions are tests/fixtures; all other categories are classified by path. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 2 |
| Tests / fixtures | 7 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **9** | **2** |

## Verification

- `pnpm test:diff apps/web/app/(dashboard)/biomarkers/biomarkers-page-client.tsx apps/web/test/biomarker-device-metrics.test.tsx` passed in a Blacksmith Testbox: TypeScript, lint, 6,126 Web tests, dev smoke, and production build.
- The same canonical diff gate passed locally after the coverage audit tightened the class-token assertion.
- Focused Vitest passed: 1 file, 5 tests.
- `git diff --check` passed.
- Required `frontend-review`: no findings.
- Required `coverage-write`: tightened exact mobile/base class-token proof; no production change.
- Claude Fable UI double-check could not run because usage credits were exhausted; the required Codex frontend review served as the documented substitute.
- Rendered mobile browser proof remains unavailable because this session had no browser backend. Static class proof and the production build are green; no screenshot evidence is claimed.

ReviewGPT is not requested because this is minor responsive typography/alignment polish with no workflow, state, data, safety, or authority change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787324140&installation_model_id=19880&pr_number=844&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F844&signature=18e3aad45309dc4663b4aa551c4545d8203f72d06ba3662e1e98d589cbdc4831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->