### PR TITLE
Reduce runner bundle static closure

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-22-runner-static-closure.md
+++ b/agent-docs/exec-plans/completed/2026-07-22-runner-static-closure.md
@@ -1,0 +1,50 @@
+Goal (incl. success criteria):
+- Reduce the Cloudflare runner entrypoint bundle by removing proven dead or unnecessarily eager runtime imports.
+- Success means the packed runner no longer includes unused contract examples or query modules in its static boot closure, bundle budgets are re-tightened to measured values instead of raised, and canonical verification plus the PR ReviewGPT loop finish with no accepted findings.
+
+Constraints/Assumptions:
+- Preserve all hosted runtime behavior and product-critical flows; this is an import/ownership correction, not a feature deletion.
+- Preserve the existing public package entrypoints; avoid compatibility churn or new runtime boundaries when correct package purity metadata gives the bundler enough information.
+- Do not overlap the active runner dependency-prune lane's install/lockfile ownership unless evidence makes that necessary.
+- The PR lane uses ReviewGPT as its sole cross-cutting review gate; coverage proof still runs locally.
+
+Key decisions:
+- Prove each proposed boundary with an esbuild metafile measurement before retaining it.
+- Keep the contracts public API stable. A package-wide module-evaluation audit found no externally observable import-time effects in contracts or query, so declare both packages side-effect-free and let existing consumers tree-shake unused exports.
+- Do not add a dynamic query/browser boundary: the runner needs that work during foreground execution, so deferring it would shift cost into the first request without reducing the deployed graph.
+
+State:
+- Local implementation and verification complete; ready to commit and open the PR.
+
+Done:
+- Confirmed latest production total is within 16,246 bytes of the current ceiling.
+- Confirmed broad package roots retain unrelated modules and contract examples in the static closure.
+- Created an isolated worktree and branch from the latest `origin/main`.
+- Audited all contracts and query modules for side-effect-only imports and externally observable top-level effects; neither package relies on import-time registration or mutation.
+- Declared both packages side-effect-free without changing their public entrypoints or runtime call paths.
+- Rebuilt the packaged runner: total fell from 9,457,558B to 9,374,751B, static boot closure fell from 7,817,555B to 7,633,674B, and the entry chunk remained 1,588,744B.
+- Removed the 250KB operational allowance from the boot caps, ratcheted the baselines, retained 32KB of total-growth room, and added an explicit guard against contract examples re-entering the static closure.
+- Passed package typechecks/tests, the focused runner budget test, and the production bundle assembly/parity probes.
+- Coverage-write found one narrow proof gap and added exact-boundary acceptance plus one-byte-over rejection for the total bundle cap; the focused runner suite passes 32/32 tests.
+- Final canonical `pnpm test:diff` passed across all affected packages, reverse dependents, hosted web verification, and Cloudflare verification.
+- Scenario-manifest integrity passed for 204 scenarios, 11 sample inputs, and 28 golden-output directories.
+
+Now:
+- Close this plan through the scoped commit helper, push the branch, and open the PR.
+
+Next:
+- Commit, push, open the PR, start ReviewGPT alongside CI, and resolve both to completion.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- `packages/contracts/package.json`
+- `packages/query/package.json`
+- `apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts`
+- `apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts`
+- `pnpm --dir apps/cloudflare runner:bundle:assemble-only`
+- `pnpm test:diff <touched paths>`
+Status: completed
+Updated: 2026-07-22
+Completed: 2026-07-22

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -29,94 +29,17 @@ import {
 // (e.g. vault-cli PATH candidates) keeps landing on `<bundle>/node_modules`.
 export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 
-// Byte budgets over the esbuild metafile so import-graph creep in the boot
-// surface fails the assembly instead of silently regressing cold start.
-// Latest ratcheted baselines come from reviewed bundle measurements:
-// - entry container-entrypoint.js: 1,423,217B on CI Linux after the
-//   2026-07-13 mainline integration;
-// - static boot closure: 7,059,427B on CI Linux for the exact PR 608 head
-//   after the generic group newsletter reader and native-memory isolation.
-//   The forbidden-input guard below keeps clinical intake and other
-//   turn-scoped importer code out of this closure.
-// The tolerances below cover local emit jitter.
-//
-// The entry chunk gates cold-start parse, so its measured baseline stays
-// explicit. The guard combines the original emit-jitter tolerance with a
-// deliberate operational headroom allowance; growth past that combined cap
-// still fails assembly, and the fixed total-bundle ceiling remains a separate
-// backstop.
-//
-// Node parses the entry chunk plus every statically reachable chunk before
-// HTTP listen, so the static boot closure is ratcheted with the same reviewed
-// baseline discipline as the entry chunk. Its tolerance is wider than the
-// entry tolerance because the closure spans ~5x more bytes and many more
-// chunks, so path comments, content hashes, and platform-specific emit jitter
-// have more surface.
-//
-// PR #813's reviewed route-authority boundary, after merging current main,
-// measured 9,314,428B on CI Linux and 9,369,574B on local macOS after the
-// scheduled Telegram redirect authority correction. PR #750's
-// consented group-to-member ask path measures 9,402,536B on that merged base;
-// the scheduled-authority remediation measures 9,402,701B, and the combined
-// post-#827 head measures 9,405,369B. After merging current main's biomarker
-// unit normalization, the combined head measures 9,410,180B. Current main's
-// persona redesign adds 10,122B, producing 9,420,302B. PR #824's Epic query
-// expansion measures 9,388,733B on that mainline; the exact combined graph
-// measures 9,424,514B. PR #838's reviewed biomarker catalog produces
-// 9,424,731B on CI Linux (+217B) and 9,460,571B on local macOS. Ratchet the
-// fixed total backstop to the larger exact measurement. PR #841's automatic
-// approved-file continuation adds 2,752B, and its exact-owner review
-// remediation adds another 491B, and the final delivery-context ownership
-// correction adds 397B. The round-five consolidated outcome correction adds
-// 1,090B, producing 9,465,301B on local macOS; ratchet by those exact measured
-// increases;
-// dynamic chunk jitter still receives no extra margin or platform-specific
-// branch.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_465_301;
-// The exact PR #626 head after current-main exact-target reply handling adds
-// reviewed boot-critical batching recovery logic. Assembly measured
-// 1,486,467B on CI Linux (+699B over the prior budget) and 1,493,474B on local
-// macOS (+7,706B); advance only by the larger entry overage and preserve the
-// noise band. PR #678 then added 633B for runtime-owned approval-link delivery.
-// Post-delivery foreground release, mutation-scoped maintenance,
-// and indexed cron reconciliation on that merged base measure 1,497,825B on
-// local macOS, 4,351B over the resulting budget. Advance by that exact overage;
-// the review remediation deletes foreground terminal-evidence inspection and
-// leaves exact replyability policy with maintenance. Preserving the merged
-// base's precomputed boundary-tail retry added 233B; making the phase wake
-// authoritative across the complete local tail drain removes 179B. Explicit
-// invocation-local wake provenance adds 230B while preventing an inherited
-// reminder from suppressing pending-index repair.
-const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_450_742;
-// PR #631 added 913B for its reviewed Clinical Records crypto-lane labels and
-// another 872B for bounded checkpoint/resume handling. The exact PR #626 head
-// then measured a 7,190,569B local macOS closure (+33,357B over the prior
-// budget); advance only by that measured overage and preserve the separate
-// 96KB noise band.
-// On that merged base, indexed cron search, purpose-correlated artifact reads,
-// foreground cancellation, and delayed index repair measure a 7,192,498B local
-// static boot closure, 1,929B over the resulting budget. Advance by that exact
-// overage; boundary-tail retry preservation added the same measured 233B, and
-// complete-tail wake ownership later removes 179B. Explicit invocation-local
-// wake provenance adds 230B. Preserve the separate 96KB noise band.
-// The July 16 main merge (through PR #772) measured a 7,467,190B local macOS
-// closure; through the July 17 merges (Epic clinical records beta, onboarding
-// clarifiers, four-child hosted concurrency) it grew to ~7,489,000B local.
-// Rather than keep ratcheting this baseline by a few KB per merge on a
-// fast-moving shared main — which broke local dev:reset repeatedly because
-// local macOS runs ~40 KB heavier than the CI Linux measurement — use a round
-// 7.5 MB baseline. The variance tolerance and operational allowance below
-// provide the headroom. This intentionally loosens the boot-surface creep
-// guard; the forbidden-input markers below and fixed 9.3 MB total ceiling
-// remain the hard backstops. Re-tighten to a measured value if boot-closure
-// creep needs active policing again.
-const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 7_500_000;
-// Preserve the original emit-jitter bands and add one shared operational
-// allowance to both coupled boot-path caps. The static closure contains the
-// entry chunk, so applying the headroom to only one cap would be misleading.
+// Byte budgets over the esbuild metafile make import-graph growth fail the
+// assembly instead of silently regressing cold start. The baselines are the
+// clean packaged measurements after unused contracts and query exports became
+// tree-shakeable. Entry and static-closure caps retain their platform-jitter
+// tolerances; the total cap leaves 32KB for small reviewed additions without
+// restoring the former 250KB operational growth allowance.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_414_908;
+const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_591_691;
+const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 7_641_831;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES = 96_000;
-const RUNNER_ENTRYPOINT_BUNDLE_OPERATIONAL_HEADROOM_BYTES = 250_000;
 // The @murphai package markers are path suffixes, not node_modules-anchored:
 // workspace package inputs appear as `node_modules/@murphai/*/dist/...` in
 // the staged production assembly but as `packages/*/dist/...` when bundling
@@ -134,6 +57,7 @@ const RUNNER_ENTRYPOINT_FORBIDDEN_BOOT_INPUT_MARKERS = [
   "node_modules/@junction-api/sdk/",
   "/health-metrics/dist/murph-age.js",
   "/health-metrics/dist/murph-age-source-routes.js",
+  "/contracts/dist/examples.js",
   "/query/dist/murph-age.js",
   "/query/dist/browser-replica/murph-age.js",
 ] as const;
@@ -179,7 +103,7 @@ export async function bundleRunnerContainerEntrypoint(
     buildResult.metafile,
   );
   console.log(
-    `runner entrypoint bundle size: entry ${bundleBytes.entryBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES}B tolerance + ${RUNNER_ENTRYPOINT_BUNDLE_OPERATIONAL_HEADROOM_BYTES}B headroom), static boot closure ${bundleBytes.staticClosureBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES}B tolerance + ${RUNNER_ENTRYPOINT_BUNDLE_OPERATIONAL_HEADROOM_BYTES}B headroom), total ${bundleBytes.totalBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET}B budget`,
+    `runner entrypoint bundle size: entry ${bundleBytes.entryBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES}B tolerance), static boot closure ${bundleBytes.staticClosureBytes}B (baseline ${RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES}B + ${RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES}B tolerance), total ${bundleBytes.totalBytes}B of ${RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET}B budget`,
   );
   assertRunnerEntrypointBundleBoots({
     bundleDir,
@@ -192,8 +116,8 @@ export async function bundleRunnerContainerEntrypoint(
 }
 
 // Single source of truth for the production budgets: both boot-path caps use
-// their ratcheted baseline, emit-jitter tolerance, and shared operational
-// headroom; the total remains a fixed ceiling.
+// their measured baseline plus emit-jitter tolerance; the total remains a
+// fixed ceiling.
 // Exported so a unit test can lock these values (the assembly path calls
 // assertRunnerEntrypointBundleWithinBudgets with this as the default).
 export function resolveRunnerEntrypointBundleBudgets(): {
@@ -204,12 +128,10 @@ export function resolveRunnerEntrypointBundleBudgets(): {
   return {
     entryBytes:
       RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES
-      + RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES
-      + RUNNER_ENTRYPOINT_BUNDLE_OPERATIONAL_HEADROOM_BYTES,
+      + RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES,
     staticClosureBytes:
       RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES
-      + RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES
-      + RUNNER_ENTRYPOINT_BUNDLE_OPERATIONAL_HEADROOM_BYTES,
+      + RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES,
     totalBytes: RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET,
   };
 }

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -378,6 +378,11 @@ describe("runner bundle container-entrypoint esbuild step", () => {
       /node_modules\/@murphai\/health-metrics\/dist\/murph-age-source-routes\.js/,
     ],
     [
+      "staged contract examples",
+      ".deploy/runner-bundle/node_modules/@murphai/contracts/dist/examples.js",
+      /node_modules\/@murphai\/contracts\/dist\/examples\.js/,
+    ],
+    [
       "workspace Murph Age query runtime",
       "packages/query/dist/murph-age.js",
       /packages\/query\/dist\/murph-age\.js/,
@@ -527,15 +532,15 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     ]);
   });
 
-  it("resolves the production budgets with shared operational headroom", () => {
+  it("resolves the production budgets from measured baselines and jitter tolerances", () => {
     const budgets = resolveRunnerEntrypointBundleBudgets();
 
-    // Mirror the production baselines plus their variance and operational
-    // allowances so budget-policy changes remain explicit and reviewed.
+    // Mirror the production baselines plus their variance allowances so
+    // budget-policy changes remain explicit and reviewed.
     expect(budgets).toEqual({
-      entryBytes: 1_450_742 + 48_000 + 250_000,
-      staticClosureBytes: 7_500_000 + 96_000 + 250_000,
-      totalBytes: 9_465_301,
+      entryBytes: 1_591_691 + 48_000,
+      staticClosureBytes: 7_641_831 + 96_000,
+      totalBytes: 9_414_908,
     });
   });
 
@@ -577,6 +582,27 @@ describe("runner bundle container-entrypoint esbuild step", () => {
         staticBootClosureBytesMetafile(staticClosureBytes + 1),
       ),
     ).toThrow(/static boot closure .* exceeds budget/);
+  });
+
+  it("gates total output at the production ratchet boundary", () => {
+    const { totalBytes } = resolveRunnerEntrypointBundleBudgets();
+    const dynamicChunkBytesAtBudget = totalBytes - 1_000;
+
+    expect(
+      assertRunnerEntrypointBundleWithinBudgets(
+        dynamicOnlyChunkMetafile(dynamicChunkBytesAtBudget),
+      ),
+    ).toEqual({
+      entryBytes: 1_000,
+      staticClosureBytes: 1_000,
+      totalBytes,
+    });
+
+    expect(() =>
+      assertRunnerEntrypointBundleWithinBudgets(
+        dynamicOnlyChunkMetafile(dynamicChunkBytesAtBudget + 1),
+      ),
+    ).toThrow(/total output .* exceeds budget/);
   });
 
   it("does not count dynamic-only chunks toward the static boot closure budget", () => {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.4",
   "private": false,
   "type": "module",
+  "sideEffects": false,
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why this PR exists

The production runner bundle had crept to its byte ceiling because the contracts and query package barrels were retaining unused modules during bundling. This restores tree shaking at the package boundary and re-tightens the bundle guard without adding runtime indirection.

ReviewGPT first-reviewed head: b2de4a9c5b94950e34416c2efe74aaaa777f0941

## User goal / user-visible behavior

Keep hosted runner cold-start and deployment size from silently regressing as product code grows. There is no user-facing workflow or UI change; hosted behavior and public package entrypoints remain unchanged.

## Invariants

- Contracts and query modules remain free of externally observable import-time side effects.
- Existing package entrypoints and hosted execution behavior remain unchanged.
- Contract examples stay out of the static runner boot closure.
- Budget guards retain platform-jitter tolerance plus 32 KB of total growth room, and reject one-byte overages.

## Non-obvious affected surfaces

- Published `@murphai/contracts` package metadata: `sideEffects: false` lets downstream bundlers remove unused exports without changing the public API. Package tests, reverse-dependent verification, hosted web production build, and the production runner assembly all pass.
- Private `@murphai/query` package metadata: the same purity declaration removes unused barrel exports. Query tests, reverse-dependent verification, and production bundle assembly cover this boundary.
- Cloudflare runner assembly policy: entry/static baselines now match the rebased packaged graph, the former 250 KB operational allowance is removed, and the total cap retains 32 KB of requested headroom.

## Change shape

Classification: runtime bundle-build code and package manifests are config/tooling; Vitest is tests; the completed execution plan is docs; generated outputs are excluded.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 32 | 6 |
| Docs | 50 | 0 |
| Config / tooling | 17 | 93 |
| Generated / other | 0 | 0 |
| **Total** | **99** | **99** |

## ReviewGPT current head

| Round | Head | Scope |
| --- | --- | --- |
| 1 | `b2de4a9c5b94950e34416c2efe74aaaa777f0941` | Full patch |

## Verification

- `pnpm test:diff packages/contracts/package.json packages/query/package.json apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts`
- `pnpm test:scenario-integrity`
- `pnpm --dir apps/cloudflare runner:bundle`
- Focused runner budget suite: 32/32 tests passed.
- Final packaged measurement: entry 1,591,691 B; static boot closure 7,641,831 B; total 9,382,908 B of a 9,414,908 B cap.
- Required coverage-write audit: one boundary-test gap fixed; zero unresolved findings.

## Deployment skew / compatibility

No protocol, state, environment, or API shape changes. Old and new warm runner containers remain compatible with the same Worker and web versions; normal gradual container rollout is safe and no tandem deployment is required. Post-deploy, confirm the runner-bundle CI measurement and ordinary runner health smoke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787327467&installation_model_id=19880&pr_number=846&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F846&signature=3cbe5f05e20b9e4ba6a40b4b517c76d4c0d2fef7e0fe600aeebb07302d2de2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->