### PR TITLE
test(cloudflare): require runner tree shaking

### DIFF
--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -161,6 +161,10 @@ const ROOMY_TEST_BUDGETS = {
   staticClosureBytes: 10_000,
   totalBytes: 10_000,
 };
+const RUNNER_TREE_SHAKE_REQUIRED_PACKAGE_MANIFESTS = [
+  ["@murphai/contracts", "packages/contracts/package.json"],
+  ["@murphai/query", "packages/query/package.json"],
+] as const;
 
 afterEach(async () => {
   await Promise.all(
@@ -217,6 +221,26 @@ async function createFakeRunnerBundle(): Promise<string> {
 }
 
 describe("runner bundle container-entrypoint esbuild step", () => {
+  it.each(RUNNER_TREE_SHAKE_REQUIRED_PACKAGE_MANIFESTS)(
+    "requires %s to declare side-effect-free modules for tree shaking",
+    async (packageName, manifestPath) => {
+      const manifest: unknown = JSON.parse(
+        await readFile(
+          path.resolve(import.meta.dirname, "../../..", manifestPath),
+          "utf8",
+        ),
+      );
+      if (typeof manifest !== "object" || manifest === null) {
+        throw new Error(`${manifestPath} must contain a JSON object.`);
+      }
+
+      expect(
+        "sideEffects" in manifest ? manifest.sideEffects : undefined,
+        `${packageName} must declare \"sideEffects\": false so the runner bundle can remove unused exports.`,
+      ).toBe(false);
+    },
+  );
+
   it("bundles the staged entrypoint, resolves externals at boot, and passes the boot probe", async () => {
     const bundleDir = await createFakeRunnerBundle();
 


### PR DESCRIPTION
## Why this PR exists

PR #846 restored runner tree shaking by declaring the contracts and query packages side-effect-free, but the package metadata contract was only enforced indirectly by bundle-size caps. This adds a direct regression test so removing either declaration fails with an actionable message.

ReviewGPT first-reviewed head: b6905c39975b8b938ae894bff8d4347d04f90634

## User goal / user-visible behavior

Make tree shaking an explicit runner requirement while retaining the existing entry, static-closure, and total bundle caps. There is no runtime or user-facing behavior change.

## Invariants

- `@murphai/contracts` and `@murphai/query` must declare `"sideEffects": false` while the runner relies on their purity for dead-code elimination.
- The production bundle build remains the source of truth for actual tree-shaking effectiveness.
- Existing byte caps and forbidden-static-input checks continue to catch output regressions independently of package metadata.

## Non-obvious affected surfaces

- The guard reads the source package manifests, narrows parsed JSON without unsafe casts, and reports which package violated the runner requirement.
- This is test-only: no production code, package metadata, dependencies, or bundle budgets change.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 25 | 1 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **25** | **1** |

## ReviewGPT current head

| Round | Head | Scope | Outcome |
| --- | --- | --- | --- |
| 1 | `b6905c39975b8b938ae894bff8d4347d04f90634` | Full test-only patch | PASS; no qualifying findings |

## Verification

- Focused runner bundle suite: 34/34 tests passed.
- `pnpm test:diff apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts`: Cloudflare typecheck, 1,856 node tests, and 1 Workers test passed.
- Production runner bundle CI passed on the exact PR head.
- ReviewGPT round 1 passed with zero accepted or rejected findings.

## Deployment skew / compatibility

No production artifacts or runtime behavior change. No coordinated deployment is required.
