### PR TITLE
Clarify onboarding goal transition

### DIFF
--- a/agent-docs/product-specs/murph-onboarding.md
+++ b/agent-docs/product-specs/murph-onboarding.md
@@ -1,6 +1,6 @@
 # Murph New-Member Onboarding
 
-Last verified: 2026-07-20
+Last verified: 2026-07-22
 
 ## Product Decision
 
@@ -10,8 +10,8 @@ Murph first establishes a private relationship with a broad personal health
 assistant. It briefly learns what the member most wants from their health and
 asks only enough to name one or two open threads, then reflects, saves, and
 explicitly parks those threads. Murph asks once for a missing motivation and
-priority rather than inferring them; if the member does not know or declines,
-those fields remain explicitly unknown and onboarding continues. Murph gathers a
+does not infer it; if the member does not know or declines, the motivation
+remains explicitly unknown and onboarding continues. Murph gathers a
 finite health-context foundation over separate turns, returns to the earlier
 thread with that context, and collaborates on the first step.
 
@@ -137,15 +137,14 @@ A useful default is:
 
 Do not bundle this with additional intake questions. The broad anchor does not
 consume the clarification budget. After it, ask no more than three short
-clarifiers, one per message. Stop early when the outcome, motivation, and
-priority are known or explicitly unknown. Ask a missing motivation or priority
-question once, accept “I don't know” or a decline without pressure, and never
-infer an answer. The available
-clarifiers are:
+clarifiers, one per message. Stop early when the outcome and motivation are
+known or explicitly unknown. Ask a missing motivation once, accept “I don't
+know” or a decline without pressure, and never infer an answer. When the member
+names several threads, keep them all without asking which is the main priority;
+that choice belongs to the return step. The available clarifiers are:
 
 1. What would success look or feel like?
 2. Why would that matter?
-3. Is this the main priority or one of several?
 
 Keep the motivation question light. Do not excavate obstacles, failed attempts,
 diagnoses, baselines, schedules, equipment, treatment, or intervention design
@@ -165,15 +164,29 @@ who already feels healthy and has no goal is not a failed onboarding case.
 ### 4. Reflect, save, and park the threads
 
 Once one or two threads can be named and each attempted clarifier is answered
-or explicitly unknown, reflect them in the member's words and save each concrete goal or
-ongoing need to its existing canonical owner. Say naturally that Murph will
-keep the thread open. Do not label it as a permanent main direction or announce
-internal storage mechanics.
+or explicitly unknown, reflect the actual threads in the member's words and
+name them again in the parking reply. Keep a known motivation clearly
+subordinate to those threads instead of presenting it as another goal. Do not
+make the member recover the referent of “both,” “those,” or “them” from earlier
+messages.
 
-Then explain the ordering explicitly. The default meaning is:
+Save each concrete goal or ongoing need to its existing canonical owner. Say
+naturally that Murph will keep the thread open. Do not label it as a permanent
+main direction or announce internal storage mechanics.
 
-> I'm not going to jump into solving that yet. I want to learn enough about you
-> that when we return to it, the help actually fits.
+Then explain the ordering explicitly without foregrounding a refusal to help.
+For a casual member who named strength and sleep as the threads, confidence and
+energy as the reason, and has not resolved the data-source checkpoint, the
+complete reply may be:
+
+> got it — stronger and sleeping better, mainly for more confidence and energy.
+> before we decide where to start, i want to understand a bit more about what's
+> going on around your health so the advice actually fits. do you use a wearable
+> or health app?
+
+This is a worked example, not fixed copy. Murph substitutes the member's actual
+threads and reason, matches their register, and asks the first unresolved
+foundation question.
 
 This is not permission to diagnose, recommend, prescribe, design a plan, start
 an experiment, or create a support loop. Bridge directly into the first short

--- a/packages/assistant-engine/skills/murph-onboarding/SKILL.md
+++ b/packages/assistant-engine/skills/murph-onboarding/SKILL.md
@@ -299,17 +299,30 @@ problem; follow the skip and overall-decline rules below.
 ### 4. Reflect, save, and park the threads
 
 Once one or two threads can be named and each attempted clarifier is answered
-or explicitly unknown, reflect them back in one short sentence using the
-user's own language. Save each concrete health goal or ongoing need to its existing
-canonical owner. Describe it naturally as a thread Murph will keep open; do
-not announce internal storage or call it the user's permanent “main
-direction.”
+or explicitly unknown, reflect the actual threads back in one short sentence
+using the user's own language. Name the threads again in this reply instead of
+making the user recover them from earlier messages. When the reason is known,
+keep it clearly subordinate to the threads rather than turning it into another
+thread. Never rely on “both,” “those,” or “them” to carry the aspiration across
+messages.
 
-Then explicitly explain the ordering. Use this meaning, with natural wording:
+Save each concrete health goal or ongoing need to its existing canonical owner.
+Describe it naturally as a thread Murph will keep open; do not announce
+internal storage or call it the user's permanent “main direction.”
+
+Then explicitly explain the ordering without foregrounding a refusal to help.
+For a casual user who named strength and sleep as the threads, confidence and
+energy as the reason, and has not resolved the data-source checkpoint, a
+complete reply can be:
 
 ```text
-I'm not going to jump into solving that yet. I want to learn enough about you that when we return to it, the help actually fits.
+got it — stronger and sleeping better, mainly for more confidence and energy. before we decide where to start, i want to understand a bit more about what's going on around your health so the advice actually fits. do you use a wearable or health app?
 ```
+
+Treat this as a worked example, not fixed copy. Substitute the user's actual
+threads and reason, match their register, and ask the first unresolved
+foundation question rather than repeating the wearable question when that
+checkpoint is already known.
 
 This park is not a diagnosis, recommendation, plan, habit, experiment, support
 loop, or invitation to activate a domain-planning skill. Do not provide any of

--- a/packages/assistant-engine/test/assistant-skill-assets.test.ts
+++ b/packages/assistant-engine/test/assistant-skill-assets.test.ts
@@ -1983,8 +1983,18 @@ describe('assistant skill assets', () => {
     )
     expect(raw).toContain('### 4. Reflect, save, and park the threads')
     expect(compact).toContain(
-      'I\'m not going to jump into solving that yet. I want to learn enough about you that when we return to it, the help actually fits.',
+      "got it — stronger and sleeping better, mainly for more confidence and energy. before we decide where to start, i want to understand a bit more about what's going on around your health so the advice actually fits. do you use a wearable or health app?",
     )
+    expect(compact).toContain(
+      'When the reason is known, keep it clearly subordinate to the threads rather than turning it into another thread.',
+    )
+    expect(compact).toContain(
+      'Never rely on “both,” “those,” or “them” to carry the aspiration across messages.',
+    )
+    expect(compact).toContain(
+      'Treat this as a worked example, not fixed copy.',
+    )
+    expect(raw).not.toContain("I'm not going to jump into solving that yet.")
     expect(compact).toContain(
       'This park is not a diagnosis, recommendation, plan, habit, experiment, support loop, or invitation to activate a domain-planning skill.',
     )


### PR DESCRIPTION
## Why this PR exists

During first-run onboarding, the goal-parking reply could refer vaguely to “both threads” after several clarifying messages and lead with “I’m not going to jump into solving that yet.” That made the actual goals easy to confuse with the member’s stated motivation and made the transition sound withholding.

## User goal / user-visible behavior

Murph now restates the member’s actual goals in the parking reply, keeps the stated reason clearly subordinate to those goals, explains why it needs a little more context, and moves directly into the first unresolved foundation question.

## User experience

- The member names one or two goals and, when known, why they matter.
- Murph repeats the concrete goals in the same reply instead of relying on cross-message pronouns.
- Murph bridges into foundation context without refusal-first wording.
- The strength/sleep/confidence/energy sentence is a worked example only; Murph substitutes the member’s actual words and does not repeat the wearable question when that checkpoint is already resolved.
- Immediate health requests still take priority over onboarding.

## Invariants

- An aspiration answer is context, not authorization for an unsolicited diagnosis, plan, experiment, or support loop.
- Goals remain unranked until the member chooses a thread at the return step.
- The parking transition precedes foundation collection.
- Murph asks only the first unresolved foundation question and preserves existing persistence, privacy, safety, and authorization rules.

## Non-obvious affected surfaces

- The durable onboarding product spec now matches the live skill by removing a stale “main priority” clarifier.
- The prompt-contract test protects the worked-example boundary, goal-versus-motivation distinction, and removal of the old refusal-first sentence.
- No runtime, schema, API, deploy, auth, or persisted-state behavior changes.

## Verification

- `pnpm --dir packages/assistant-engine typecheck` — passed.
- `pnpm exec vitest run packages/assistant-engine/test/assistant-skill-assets.test.ts --config vitest.config.ts --no-coverage` — 29/29 tests passed.
- Required prompt-review pass against current official GPT-5.6 guidance — zero remaining findings.
- `pnpm test:diff ...` — affected typechecks and the assistant-engine suite passed (2,600 tests; 5 skipped). The untouched CLI reverse-dependent phase then hit widespread 60-second timeouts across unrelated experiment, intervention, workout, audit, and import tests, so the owned run was stopped after the failure pattern was established.

## Change shape

Classification: the skill is source, its contract test is tests, and the product specification is docs. No binary files.

- Source: +21 / -8
- Tests: +11 / -1
- Docs: +31 / -18
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
- Total: +63 / -27

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787334027&installation_model_id=19880&pr_number=853&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F853&signature=43249d0ffb0b8a617a97b8a6b064ac46097b774362691b2e0ddeec517a4fb0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->