### PR TITLE
Simplify onboarding follow-through copy

### DIFF
--- a/agent-docs/product-specs/murph-onboarding.md
+++ b/agent-docs/product-specs/murph-onboarding.md
@@ -132,7 +132,7 @@ and which mode fits now:
 
 A useful default is:
 
-> What would you most like from your health—something you want to change,
+> What would you most like from your health—something you want to improve,
 > understand, handle, or be able to do?
 
 Do not bundle this with additional intake questions. The broad anchor does not

--- a/packages/assistant-engine/skills/murph-onboarding/SKILL.md
+++ b/packages/assistant-engine/skills/murph-onboarding/SKILL.md
@@ -224,7 +224,7 @@ If the visible conversation has not already supplied one, ask one short
 question in this shape:
 
 ```text
-What would you most like from your health—something you want to change, understand, handle, or be able to do?
+What would you most like from your health—something you want to improve, understand, handle, or be able to do?
 ```
 
 When this question directly follows the user's minimal-identity answer, start
@@ -233,7 +233,7 @@ two- or three-sentence bridge on how Murph works before the question. Keep
 close to this wording, changing little more than the greeting:
 
 ```text
-Good to meet you. Here's how this works: whatever you want from your health, the hard part usually isn't knowing what to do. It's fitting it into your real life and following through. That's what I'm here for.
+Good to meet you. You might already know what you want to improve about your health. Following through is often the hard part. That's where I can help.
 ```
 
 Do not frame the bridge around getting healthy, as if the user is starting

--- a/packages/assistant-engine/test/assistant-skill-assets.test.ts
+++ b/packages/assistant-engine/test/assistant-skill-assets.test.ts
@@ -1940,13 +1940,13 @@ describe('assistant skill assets', () => {
     )
     expect(raw).toContain('If the user gives only a name, continue.')
     expect(raw).toContain(
-      'What would you most like from your health—something you want to change, understand, handle, or be able to do?',
+      'What would you most like from your health—something you want to improve, understand, handle, or be able to do?',
     )
     expect(compact).toContain(
       'start the same reply by greeting them by the name they just gave, then give a short two- or three-sentence bridge on how Murph works before the question',
     )
     expect(compact).toContain(
-      "the hard part usually isn't knowing what to do. It's fitting it into your real life and following through.",
+      "You might already know what you want to improve about your health. Following through is often the hard part. That's where I can help.",
     )
     expect(compact).toContain(
       'Do not frame the bridge around getting healthy, as if the user is starting from unhealthy.',


### PR DESCRIPTION
## Why this PR exists

The post-identity onboarding bridge said too much and made Murph's follow-through promise harder to parse. This keeps the same core idea while making the message shorter, clearer, and less absolute.

## User goal / user-visible behavior

After sharing their name, a new member sees a brief bridge:

> Good to meet you. You might already know what you want to improve about your health. Following through is often the hard part. That's where I can help.

Murph then asks:

> What would you most like from your health—something you want to improve, understand, handle, or be able to do?

## User experience

The existing onboarding sequence is unchanged: Murph greets the member by name, gives the short bridge, and asks one reply-oriented aspiration question. The wording remains open to improve, understand, handle, and explore entry modes without turning the answer into permission to prescribe or plan.

## Invariants

- Keep one clear question that encourages an early reply.
- Preserve all four onboarding entry modes, including members without a clear goal.
- Treat the answer as context, not authorization to begin an intervention.
- Keep the tone calm, conversational, and non-salesy.
- Do not change tools, privacy, safety, persistence, or runtime behavior.

## Non-obvious affected surfaces

None. The product spec and exact skill-asset assertion are updated only to stay synchronized with the prompt copy.

## Validation

- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-skill-assets.test.ts` — 29 passed.
- `pnpm --dir packages/assistant-engine typecheck` — passed.
- Required local `prompt-review` — one wording finding accepted and resolved; no remaining findings.
- `pnpm test:diff packages/assistant-engine/skills/murph-onboarding/SKILL.md packages/assistant-engine/test/assistant-skill-assets.test.ts agent-docs/product-specs/murph-onboarding.md` — the full Assistant Engine owner suite passed (2,600 tests; 5 skipped), as did affected typechecks and several reverse-dependent suites. The lane did not complete green because unrelated CLI session tests timed out and CLI experiment-expansion tests failed under concurrent host load; the final candidate was then rechecked with the focused test and owner typecheck above.

## Change-shape breakdown

Classification rule: the onboarding skill is source, the TypeScript assertion file is tests, and the onboarding product spec is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 2 |
| Tests / fixtures | 2 | 2 |
| Docs | 1 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **5** | **5** |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787334035&installation_model_id=19880&pr_number=854&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F854&signature=1e49f5954e881c6cfd4da78877e1dccf24c1e306fa4221ef66229974f19d5612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->