### PR TITLE
Add safe hosted usage reset ops surface

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-22-ops-usage-reset-review-remediation.md
+++ b/agent-docs/exec-plans/completed/2026-07-22-ops-usage-reset-review-remediation.md
@@ -1,0 +1,85 @@
+# Repair hosted usage reset completion semantics
+
+Status: completed
+Created: 2026-07-22
+Updated: 2026-07-22
+
+## Goal
+
+- Make the `/ops/usage` reset complete the real recovery path: select the
+  canonical allowance period, safely replenish it, wake already-accepted work,
+  and allow one fresh quota notice after the replenished allowance is spent.
+
+## Success criteria
+
+- The dashboard projects access and the exact current period through the
+  existing hosted allowance owner, including Family, trial, direct-billing,
+  thread-container, overlapping-period, and no-persisted-row cases.
+- Reset rejects a submitted period that is no longer canonical after locking
+  the member and preserves every noncanonical or historical period.
+- A committed reset signals the existing hosted runtime recheck; signal failure
+  is reported as a committed, retryable partial outcome without replaying spend
+  or losing the confirmation target.
+- Releasing the current logical notice claim permits one fresh durable delivery
+  attempt and fresh Linq provider idempotency identity while preserving old
+  delivery history and ordinary same-attempt retry idempotency.
+- Focused production-path regressions, required audits, canonical verification,
+  CI, and ReviewGPT correction verification pass on the final pushed head.
+
+## Constraints
+
+- Do not add schema, reset ledgers, queues, schedulers, lifecycle enums, or a
+  second allowance/runtime/delivery owner.
+- Preserve immutable usage, purchased credits and ledger version, mailbox work,
+  noncanonical usage periods, and delivery history.
+- Keep logical notice identity stable for the active capacity epoch; make only
+  the durable attempt row and external provider effect identity fresh after an
+  operator explicitly releases the prior claim.
+- Keep message-volume reporting on the disclosed retained mailbox source.
+
+## Tasks
+
+1. Add failing coverage for canonical period selection/rejection, reset wake
+   completion and retry, and same-epoch notice delivery after reset.
+2. Reuse the existing canonical gate per member inside one read transaction,
+   batch-load only exact period metadata, and consume it from the ops dashboard.
+3. Re-resolve the canonical gate in the reset transaction and signal the
+   existing runtime after commit with a truthful partial response on failure.
+4. Give claimed delivery attempts fresh durable IDs and use the usage-notice
+   attempt ID as Linq's provider idempotency identity.
+5. Run required verification, update the PR intent/change shape, commit, push,
+   and complete ReviewGPT round 2.
+
+## ReviewGPT round 1 evidence
+
+- Accepted: clearing usage state without `runtime_recheck_requested` leaves
+  already-accepted mailbox work asleep on its previous period-end timer.
+- Accepted: nulling the reusable lookup key while retaining the deterministic
+  delivery primary key makes the next same-epoch claim collide; reusing the raw
+  logical key also lets Linq deduplicate the genuinely new attempt.
+- Accepted: selecting the newest date-active persisted row disagrees with the
+  canonical allowance owner when no row exists, access is inactive, plan facts
+  changed, or Family and calendar-fallback periods overlap.
+
+## Remediation-growth retrospective
+
+- Trigger: the first set-based implementation added 617 production-source
+  lines and exceeded both the 500-line and 25-percent remediation thresholds.
+- The growth came almost entirely from duplicating the allowance owner's
+  direct/Family/thread access loading and projection shapes for a bulk ops
+  query. Although set-based, that shape created a second policy surface and was
+  larger than the feature needs.
+- Decision: delete the custom bulk policy. Resolve every row through the
+  existing canonical `readHostedAiUsageGate` inside one read transaction, then
+  batch-load only the exact persisted period metadata needed by the ops view.
+  The ops page is allowlisted and low-frequency; one transaction with canonical
+  per-member reads is preferable to hundreds of lines of duplicated policy.
+- Continue the same PR because the other two corrections reuse existing runtime
+  and delivery owners and add no new durable concepts. Re-measure source shape
+  before the correction-verification round.
+- Final re-measurement after deleting the duplicated policy: production source
+  is +391/-121 lines relative to the first reviewed head. The remaining growth
+  is the canonical projection, explicit wake-only partial retry, fresh delivery
+  attempt identity, and operator UX; no second policy owner or durable reset
+  state remains.
+Completed: 2026-07-22

--- a/agent-docs/exec-plans/completed/2026-07-22-ops-usage-reset-review-round-2.md
+++ b/agent-docs/exec-plans/completed/2026-07-22-ops-usage-reset-review-round-2.md
@@ -1,0 +1,92 @@
+# Resolve ops usage reset ReviewGPT round 2 findings
+
+Status: completed
+Created: 2026-07-22
+Updated: 2026-07-22
+
+## Goal
+
+- Close the three correction-verification gaps without adding a new policy,
+  delivery owner, runtime recovery mechanism, or persisted state.
+
+## Success criteria
+
+- The ops table derives blocked/available status only from the canonical gate
+  decision, including stale persisted `blocked_at` after plan changes.
+- Reset and wake-only recovery bound the existing runtime signal with the
+  repository's existing post-commit deadline and return the documented 202
+  partial state when the signal stalls.
+- Generic Linq provider fences retain deterministic delivery IDs and runtime
+  latency linkage; only a newly released usage-limit notice gets a fresh
+  durable attempt ID and provider idempotency identity.
+- Focused production-path regressions, required audits, canonical verification,
+  CI, and ReviewGPT round 3 pass on the final pushed head.
+
+## Constraints
+
+- Reuse the canonical allowance decision, bounded post-commit utility, and
+  existing Linq delivery claim owner.
+- Preserve reset serializability, logical notice lookup identity, ordinary
+  provider retry idempotency, immutable usage/history, credits, and mailbox
+  work.
+- Do not add schema, queues, schedulers, lifecycle state, repair passes, or a
+  second source of truth.
+
+## ReviewGPT round 2 evidence
+
+- Accepted: dashboard labels used raw persisted `blocked_at` even when the
+  canonical gate allowed or denied under a changed plan limit.
+- Accepted: an indefinitely pending runtime signal bypassed the rejected-promise
+  catch, preventing the committed-reset 202 and wake-only recovery journey.
+- Accepted: random IDs in the shared generic Linq fence path disagreed with the
+  deterministic ID returned by runtime outcome recording and could break the
+  latency foreign key.
+
+## Round 3 retrospective
+
+- Trigger: the next correction-verification pass is substantive round 3.
+- All three findings are review-induced and arise from corrections introduced
+  after the first reviewed head: one remaining raw projection field, one
+  unbounded call to an existing signal, and fresh identity placed at a shared
+  helper instead of the usage-notice caller.
+- Decision: continue the same PR with three owner-boundary reductions. Delete
+  raw block metadata from the dashboard projection, wrap the signal with the
+  existing bounded post-commit primitive, and restore deterministic identity
+  at the generic delivery helper while injecting freshness only from the usage
+  notice path. No new concepts or durable owners are necessary.
+
+## Tasks
+
+1. Add plan-change projection tests and remove raw blocked status from the ops
+   snapshot/UI contract.
+2. Add a never-settling signal test and apply the existing post-commit deadline
+   to reset and wake-only operations, forwarding its abort signal.
+3. Add the combined runtime-fence/outcome identity proof and scope fresh IDs to
+   usage-limit notice claims only.
+4. Run focused and database regressions, completion audits, canonical
+   verification, CI, and ReviewGPT round 3.
+
+## Completion-audit follow-up
+
+- Frontend review found that a historical notice claim still suppressed the
+  canonical Available badge. Admission and notice status now render
+  independently, with an increased-plan regression.
+- Coverage-write added the missing never-settling wake-only test, proving it
+  returns the committed-partial response at the shared deadline and never
+  replays reset.
+
+## Verification
+
+- Focused seven-file Vitest suite: 252 passed.
+- Web prepared typecheck: passed.
+- Local PostgreSQL reset/notice concurrency proof: passed.
+- `git diff --check`: passed.
+- Coverage-write and frontend-review: no unresolved findings; rendered browser
+  proof was unavailable because no browser backend was connected.
+- Canonical `pnpm test:diff`: passed in Blacksmith Testbox
+  `tbx_01ky5wpsf6m3ryfj3w6b1sm36b`.
+- Canonical `pnpm verify:acceptance`: all changed web paths passed, but the lane
+  remained non-green because the untouched CLI release audit expects an older
+  ReviewGPT-doc sentence that does not include `product-experience-review`.
+  Blacksmith Testbox: `tbx_01ky5wpsf6vjhfnzfpcv03evr9`.
+Completed: 2026-07-22

--- a/agent-docs/exec-plans/completed/2026-07-22-ops-usage-reset.md
+++ b/agent-docs/exec-plans/completed/2026-07-22-ops-usage-reset.md
@@ -1,0 +1,65 @@
+# Add safe hosted usage reset and reporting
+
+Status: completed
+Created: 2026-07-22
+Updated: 2026-07-22
+
+## Goal
+
+- Give allowlisted operators one safe place to inspect per-member and
+  per-container message volume and AI usage.
+- Let an operator reset the current included-usage period without leaving the
+  existing usage-limit notice claim attached to the replenished capacity.
+
+## Success criteria
+
+- `/ops` links to a usage surface listing every hosted member and synthetic
+  group container, with retained inbound message counts, seven-day volume,
+  seven-day daily average, all-time priced AI usage, current-period spend and
+  capacity, and blocked/notice state.
+- Reset is same-origin, ops-allowlisted, explicit, stale-safe, and atomic with
+  respect to usage accounting.
+- Reset preserves immutable usage rows and purchased-credit balance, clears
+  only current-period included spend/blocking, and releases only the current
+  capacity epoch's notice idempotency claim while retaining its delivery row.
+- Focused tests, diff-aware verification, browser proof, required audits, CI,
+  and ReviewGPT pass for the exact PR head.
+
+## Scope
+
+- Hosted Web `/ops` usage UI, its authenticated mutation route, and one
+  `hosted-ops` usage owner.
+- Focused ops usage service, route, and client tests.
+- Current hosted usage product and Web ownership documentation.
+
+## Constraints
+
+- Do not mutate the usage-credit ledger or purchased-credit balance.
+- Do not delete immutable AI usage or Linq delivery history.
+- Do not change the usage-limit notice dispatcher or its current idempotency
+  key construction; an active PR lane owns those internals.
+- Message totals must disclose the existing 30-day mailbox retention boundary
+  rather than introducing a second message-count source of truth.
+- Lock the member before the current usage period, matching usage-accounting
+  lock order, and reject a stale reset instead of discarding concurrent spend.
+
+## Tasks
+
+1. Add the read model for members, containers, retained messages, immutable AI
+   usage, current allowance, and current notice-claim state.
+2. Add an atomic current-period reset that nulls the current notice claim's
+   idempotency key while preserving the delivery record.
+3. Add the ops page, confirmation interaction, and `/ops` navigation entry.
+4. Add focused coverage and document the supported reset semantics.
+5. Complete verification, browser proof, audits, commit, PR, CI, and ReviewGPT.
+
+## Evidence
+
+- The live incident proved that resetting `spent_usd_micros` and `blocked_at`
+  alone leaves the current capacity epoch's accepted quota-notice claim in
+  place, so a later crossing resolves as `already_notified`.
+- Hosted mailbox conversation rows are retained for 30 days; daily global
+  snapshots are durable but do not preserve per-member history.
+- Immutable priced AI usage rows retain all-time allowance cost independently
+  from the mutable current-period allowance projection.
+Completed: 2026-07-22

--- a/agent-docs/product-specs/hosted-plan-usage.md
+++ b/agent-docs/product-specs/hosted-plan-usage.md
@@ -244,14 +244,27 @@ as lifetime history. The trailing seven-day total and daily average use the
 same mailbox source. All-time priced AI usage is derived from immutable counted
 `HostedAiUsage` rows.
 
-A reset targets exactly one current allowance period. The server locks the
-member and period in the same order as usage accounting, verifies the period
-timestamp and usage-credit ledger version shown to the operator, then clears
-current included spend and its blocked state. In the same serializable
+A reset targets exactly one current allowance period. The table and reset both
+resolve that period through the canonical allowance gate, so Family-sponsored,
+trial, direct-billing, thread-container, inactive-access, plan-change, and
+no-persisted-row behavior cannot drift from runtime admission. The server locks
+the member and period in the same order as usage accounting, verifies the
+period timestamp and usage-credit ledger version shown to the operator, then
+clears current included spend and its blocked state. In the same serializable
 transaction it releases only the matching period-and-credit-version notice
-idempotency claim by clearing that delivery row's unique claim key. The
-delivery row remains as history. A recent pre-provider dispatch makes the
-operation retryable instead of permitting a concurrent duplicate send.
+claim by clearing that delivery row's unique lookup key. The delivery row
+remains as history. A recent pre-provider dispatch makes the operation
+retryable instead of permitting a concurrent duplicate send.
+
+The table reads decision and concurrency-version facts from one repeatable
+database snapshot. After reset commit, the route signals the existing hosted
+runtime recheck so accepted mailbox work is reconsidered immediately. If that
+wake is not accepted, the route reports the reset as committed and exposes a
+wake-only retry instead of replaying the reset or claiming complete recovery.
+Reusing the logical notice key still permits only one active claim, while each
+explicitly re-released notice gets a fresh durable attempt ID and Linq provider
+idempotency key. This prevents a retained history row or provider deduplication
+from suppressing the next real limit crossing.
 
 Reset never deletes or rewrites immutable usage rows, purchased-credit entries,
 the purchased-credit balance or version, billing state, mailbox rows, or

--- a/agent-docs/product-specs/hosted-plan-usage.md
+++ b/agent-docs/product-specs/hosted-plan-usage.md
@@ -233,6 +233,31 @@ safe route and forbids lookup, claim, and send; an object permits only that
 exact target. Later counted usage may retry an uncompleted period claim, while
 the delivery owner permits at most one completed notice.
 
+### Operator usage recovery
+
+`/ops/usage` is the supported operator surface for inspecting and resetting
+hosted allowance state. It lists personal members and synthetic group
+containers from the existing hosted-member owner. Per-entity message totals
+come from retained canonical `conversation.message` mailbox rows, so the
+surface labels the 30-day retention boundary instead of presenting those rows
+as lifetime history. The trailing seven-day total and daily average use the
+same mailbox source. All-time priced AI usage is derived from immutable counted
+`HostedAiUsage` rows.
+
+A reset targets exactly one current allowance period. The server locks the
+member and period in the same order as usage accounting, verifies the period
+timestamp and usage-credit ledger version shown to the operator, then clears
+current included spend and its blocked state. In the same serializable
+transaction it releases only the matching period-and-credit-version notice
+idempotency claim by clearing that delivery row's unique claim key. The
+delivery row remains as history. A recent pre-provider dispatch makes the
+operation retryable instead of permitting a concurrent duplicate send.
+
+Reset never deletes or rewrites immutable usage rows, purchased-credit entries,
+the purchased-credit balance or version, billing state, mailbox rows, or
+delivery history. It creates no second usage ledger or message counter. A stale
+table row fails closed and must be refreshed before retrying.
+
 Every proactive billing action in Settings, Home, or `murph.plan_usage` comes
 only from the projection's thresholded `recommendedAction`. A notice code, plan
 label, incomplete billing row, or legacy state must not independently imply

--- a/agent-docs/product-specs/hosted-plan-usage.md
+++ b/agent-docs/product-specs/hosted-plan-usage.md
@@ -257,14 +257,20 @@ remains as history. A recent pre-provider dispatch makes the operation
 retryable instead of permitting a concurrent duplicate send.
 
 The table reads decision and concurrency-version facts from one repeatable
-database snapshot. After reset commit, the route signals the existing hosted
-runtime recheck so accepted mailbox work is reconsidered immediately. If that
-wake is not accepted, the route reports the reset as committed and exposes a
-wake-only retry instead of replaying the reset or claiming complete recovery.
-Reusing the logical notice key still permits only one active claim, while each
-explicitly re-released notice gets a fresh durable attempt ID and Linq provider
-idempotency key. This prevents a retained history row or provider deduplication
-from suppressing the next real limit crossing.
+database snapshot. Its blocked/available label comes from the canonical gate
+decision, never from the persisted `blocked_at` marker, because a plan change
+can make that storage marker stale until the mutating gate reconciles it. A
+historical notice claim is shown independently and never suppresses canonical
+availability. After reset commit, the route signals the existing hosted runtime
+recheck so accepted mailbox work is reconsidered immediately. That signal uses the
+existing bounded handoff deadline and forwards its abort signal. A rejection or
+timeout reports the reset as committed and exposes a wake-only retry instead of
+replaying the reset or claiming complete recovery. Reusing the logical notice
+key still permits only one active claim, while each explicitly re-released
+notice gets a fresh durable attempt ID and Linq provider idempotency key. Generic
+runtime and webhook delivery fences retain their deterministic durable IDs.
+This prevents a retained history row or provider deduplication from suppressing
+the next real limit crossing without changing unrelated delivery correlation.
 
 Reset never deletes or rewrites immutable usage rows, purchased-credit entries,
 the purchased-credit balance or version, billing state, mailbox rows, or

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1304,12 +1304,17 @@ Current hosted billing assumptions:
 - `/ops/usage` is the operator-only allowance inspection and recovery surface.
   It derives personal-member and synthetic-group message activity from retained
   canonical mailbox rows, derives all-time priced AI cost from immutable usage
-  rows, and labels the mailbox retention boundary. A row reset verifies the
-  displayed current-period and usage-credit versions, then atomically clears
-  current included spend and the block while releasing only that capacity
-  epoch's notice idempotency claim. It preserves immutable usage, purchased
-  credit, billing state, mailbox rows, and delivery history, and refuses to race
-  an in-flight notice dispatch.
+  rows, and labels the mailbox retention boundary. The table and reset reuse the
+  runtime's canonical allowance gate. A row reset verifies the displayed
+  current-period and usage-credit versions, then atomically clears current
+  included spend and the block while releasing only that capacity epoch's
+  logical notice claim. It preserves immutable usage, purchased credit, billing
+  state, mailbox rows, and delivery history, and refuses to race an in-flight
+  notice dispatch. After commit it signals the existing runtime recheck; a
+  failed wake is returned as a committed partial result with a wake-only retry.
+  The table reads its decision and reset version from one repeatable database
+  snapshot. A later crossing reuses the logical claim key but receives a fresh
+  durable delivery ID and provider idempotency key.
 - A live `trialing` Pulse Trial extends from its current Stripe trial end. A
   lapsed `paused` no-card Pulse Trial restarts for seven days from Preview time.
   The proof expires after 15 minutes. Active Family sponsorship and paid,

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1301,6 +1301,15 @@ Current hosted billing assumptions:
   mutation. Apply checks the same short-lived opaque proof under the shared
   hosted-member Stripe mutation lock, adds exactly seven days, and reconciles
   the local trial and usage-period window in that operation.
+- `/ops/usage` is the operator-only allowance inspection and recovery surface.
+  It derives personal-member and synthetic-group message activity from retained
+  canonical mailbox rows, derives all-time priced AI cost from immutable usage
+  rows, and labels the mailbox retention boundary. A row reset verifies the
+  displayed current-period and usage-credit versions, then atomically clears
+  current included spend and the block while releasing only that capacity
+  epoch's notice idempotency claim. It preserves immutable usage, purchased
+  credit, billing state, mailbox rows, and delivery history, and refuses to race
+  an in-flight notice dispatch.
 - A live `trialing` Pulse Trial extends from its current Stripe trial end. A
   lapsed `paused` no-card Pulse Trial restarts for seven days from Preview time.
   The proof expires after 15 minutes. Active Family sponsorship and paid,

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1311,10 +1311,15 @@ Current hosted billing assumptions:
   logical notice claim. It preserves immutable usage, purchased credit, billing
   state, mailbox rows, and delivery history, and refuses to race an in-flight
   notice dispatch. After commit it signals the existing runtime recheck; a
-  failed wake is returned as a committed partial result with a wake-only retry.
-  The table reads its decision and reset version from one repeatable database
-  snapshot. A later crossing reuses the logical claim key but receives a fresh
-  durable delivery ID and provider idempotency key.
+  rejected or bounded-timeout wake is returned as a committed partial result
+  with a wake-only retry. The table reads its decision and reset version from
+  one repeatable database snapshot, and derives blocked/available only from
+  that canonical decision rather than the potentially stale persisted marker.
+  Historical notice status is displayed independently from current admission.
+  A later crossing reuses the logical claim key but receives a fresh durable
+  delivery ID and provider idempotency key. Generic runtime and webhook
+  delivery fences keep deterministic durable IDs for latency and receipt
+  correlation.
 - A live `trialing` Pulse Trial extends from its current Stripe trial end. A
   lapsed `paused` no-card Pulse Trial restarts for seven days from Preview time.
   The proof expires after 15 minutes. Active Family sponsorship and paid,

--- a/apps/web/app/(dashboard)/ops/page.tsx
+++ b/apps/web/app/(dashboard)/ops/page.tsx
@@ -18,6 +18,12 @@ export const metadata: Metadata = {
 
 const OPS_TOOLS = [
   {
+    description:
+      "Inspect per-member and group-container inbound message volume, AI usage, and safely reset current included usage.",
+    href: "/ops/usage",
+    label: "Usage",
+  },
+  {
     description: "Review hosted growth, trial conversion, and daily revenue snapshots.",
     href: "/ops/growth",
     label: "Growth",

--- a/apps/web/app/(dashboard)/ops/usage/member-usage-client.tsx
+++ b/apps/web/app/(dashboard)/ops/usage/member-usage-client.tsx
@@ -1,0 +1,501 @@
+"use client";
+
+import { RotateCcwIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { Spinner } from "@/src/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
+import type {
+  HostedOpsMemberUsageDashboard,
+  HostedOpsMemberUsageResetResult,
+  HostedOpsMemberUsageRow,
+} from "@/src/lib/hosted-ops/member-usage";
+
+interface UsageResetMessage {
+  text: string;
+  tone: "error" | "success";
+}
+
+class UsageResetRequestError extends Error {
+  constructor(
+    message: string,
+    readonly code: string | null,
+  ) {
+    super(message);
+    this.name = "UsageResetRequestError";
+  }
+}
+
+export function MemberUsageClient({
+  dashboard,
+}: {
+  dashboard: HostedOpsMemberUsageDashboard;
+}) {
+  const router = useRouter();
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [resettingMemberId, setResettingMemberId] = useState<string | null>(
+    null,
+  );
+  const [message, setMessage] = useState<UsageResetMessage | null>(null);
+  const selectedRow = useMemo(
+    () => dashboard.rows.find((row) => row.memberId === selectedMemberId)
+      ?? null,
+    [dashboard.rows, selectedMemberId],
+  );
+  const isResetting = resettingMemberId !== null;
+
+  async function resetUsage(row: HostedOpsMemberUsageRow): Promise<void> {
+    if (!row.currentPeriod || isResetting) {
+      return;
+    }
+    setResettingMemberId(row.memberId);
+    setMessage(null);
+    try {
+      const result = await requestUsageReset(row);
+      setSelectedMemberId(null);
+      setMessage({
+        text: result.noticeClaimReleased
+          ? "Current included usage was reset and the quota notice claim was released."
+          : "Current included usage was reset. No quota notice claim was attached.",
+        tone: "success",
+      });
+      router.refresh();
+    } catch (error) {
+      setMessage({
+        text: error instanceof Error
+          ? error.message
+          : "Usage could not be reset. Refresh and try again.",
+        tone: "error",
+      });
+      setSelectedMemberId(null);
+      if (
+        error instanceof UsageResetRequestError
+        && error.code === "HOSTED_OPS_USAGE_RESET_STALE"
+      ) {
+        router.refresh();
+      }
+    } finally {
+      setResettingMemberId(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="border-b border-border/70 pb-6">
+        <div className="max-w-3xl">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-chart-5">
+            Ops notebook
+          </span>
+          <h1 className="mt-2 font-serif text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+            Usage
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Inbound message volume and priced AI usage for every hosted member
+            and synthetic group container. Reset restores the current included
+            allowance without changing immutable usage history or purchased
+            credits.
+          </p>
+        </div>
+      </header>
+
+      <section
+        aria-label="Usage summary"
+        className="grid border-y border-border/70 sm:grid-cols-2 lg:grid-cols-4"
+      >
+        <SummaryFinding
+          label="Members"
+          value={formatInteger(dashboard.summary.members)}
+        />
+        <SummaryFinding
+          label="Group containers"
+          value={formatInteger(dashboard.summary.groupContainers)}
+        />
+        <SummaryFinding
+          label="Active in 7 days"
+          value={formatInteger(dashboard.summary.activeEntitiesLast7Days)}
+        />
+        <SummaryFinding
+          label="All-time counted AI usage"
+          value={formatUsdMicros(
+            dashboard.summary.totalAllTimeUsageUsdMicros,
+          )}
+        />
+      </section>
+
+      {message ? (
+        <Alert variant={message.tone === "error" ? "destructive" : "default"}>
+          <AlertDescription>{message.text}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <section aria-labelledby="member-usage-table-title">
+        <div className="flex flex-col gap-1">
+          <h2
+            className="font-serif text-xl font-semibold tracking-tight text-foreground"
+            id="member-usage-table-title"
+          >
+            Members and containers
+          </h2>
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+            Retained inbound messages cover the canonical {dashboard.messageRetentionDays}-day
+            mailbox window. Last 7 days and daily average use the trailing seven
+            24-hour periods. AI usage is all-time counted priced cost from
+            immutable usage rows.
+          </p>
+          <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            Captured {formatTimestamp(dashboard.capturedAt)}
+          </p>
+        </div>
+
+        <div className="mt-5 overflow-hidden rounded-xl border border-border/70 bg-card/90">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Member or container</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead className="text-right">
+                  Inbound, {dashboard.messageRetentionDays} days
+                </TableHead>
+                <TableHead className="text-right">Inbound, 7 days</TableHead>
+                <TableHead className="text-right">Avg per day</TableHead>
+                <TableHead className="text-right">
+                  All-time counted AI usage
+                </TableHead>
+                <TableHead className="text-right">Current period</TableHead>
+                <TableHead className="text-right">Remaining</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {dashboard.rows.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    className="py-10 text-center text-muted-foreground"
+                    colSpan={10}
+                  >
+                    No hosted members or group containers were found.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                dashboard.rows.map((row) => (
+                  <UsageRow
+                    disabled={isResetting}
+                    key={row.memberId}
+                    onSelect={() => {
+                      setMessage(null);
+                      setSelectedMemberId(row.memberId);
+                    }}
+                    row={row}
+                  />
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+
+      <Dialog
+        onOpenChange={(open) => {
+          if (!open && !isResetting) {
+            setSelectedMemberId(null);
+          }
+        }}
+        open={selectedRow !== null}
+      >
+        <DialogContent showCloseButton={!isResetting}>
+          <DialogHeader>
+            <DialogTitle>Reset current included usage?</DialogTitle>
+            <DialogDescription>
+              This sets current-period included spend to $0, clears the blocked
+              state, and releases the current quota notice claim. Immutable AI
+              usage and purchased-credit balance stay unchanged.
+            </DialogDescription>
+          </DialogHeader>
+          {selectedRow?.currentPeriod ? (
+            <dl className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-2 border-y border-border/70 py-4 text-sm">
+              <dt className="text-muted-foreground">Target</dt>
+              <dd className="max-w-56 break-all text-right font-mono text-xs">
+                {selectedRow.memberId}
+              </dd>
+              <dt className="text-muted-foreground">Current spend</dt>
+              <dd className="font-serif font-semibold">
+                {formatUsdMicros(selectedRow.currentPeriod.spentUsdMicros)}
+              </dd>
+              <dt className="text-muted-foreground">Notice claim</dt>
+              <dd>
+                {selectedRow.currentPeriod.idempotencyClaimStatus
+                  ? "Will be released"
+                  : "None"}
+              </dd>
+            </dl>
+          ) : null}
+          <DialogFooter>
+            <Button
+              disabled={isResetting}
+              onClick={() => setSelectedMemberId(null)}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={!selectedRow?.currentPeriod || isResetting}
+              onClick={() => {
+                if (selectedRow) {
+                  void resetUsage(selectedRow);
+                }
+              }}
+              type="button"
+              variant="destructive"
+            >
+              {isResetting ? <Spinner data-icon="inline-start" /> : (
+                <RotateCcwIcon data-icon="inline-start" />
+              )}
+              {isResetting ? "Resetting" : "Reset usage"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function UsageRow(input: {
+  disabled: boolean;
+  onSelect: () => void;
+  row: HostedOpsMemberUsageRow;
+}) {
+  const period = input.row.currentPeriod;
+  const resettable = period !== null
+    && (
+      BigInt(period.spentUsdMicros) > 0n
+      || period.blockedAt !== null
+      || period.idempotencyClaimStatus !== null
+    );
+
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex max-w-64 flex-col gap-1">
+          <span
+            className="truncate font-mono text-xs text-foreground"
+            title={input.row.memberId}
+          >
+            {input.row.memberId}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {readEntitySecondaryLabel(input.row)}
+          </span>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge variant="outline">
+          {input.row.memberKind === "group_container" ? "Group" : "Member"}
+        </Badge>
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs tabular-nums">
+        {formatInteger(input.row.messagesRetained)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs tabular-nums">
+        {formatInteger(input.row.messagesLast7Days)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs tabular-nums">
+        {input.row.messagesDailyAverage7Days.toFixed(1)}
+      </TableCell>
+      <TableCell className="text-right font-serif font-semibold tabular-nums">
+        {formatUsdMicros(input.row.allTimeUsageUsdMicros)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs tabular-nums">
+        {period
+          ? `${formatUsdMicros(period.spentUsdMicros)} / ${
+            formatUsdMicros(period.limitUsdMicros)
+          }`
+          : "No period"}
+      </TableCell>
+      <TableCell className="text-right font-serif font-semibold tabular-nums">
+        {period ? formatUsdMicros(period.remainingUsdMicros) : "Not available"}
+      </TableCell>
+      <TableCell>
+        <div className="flex max-w-48 flex-wrap gap-1">
+          {input.row.suspended ? (
+            <Badge variant="destructive">Suspended</Badge>
+          ) : null}
+          {period?.blockedAt ? (
+            <Badge variant="destructive">Blocked</Badge>
+          ) : null}
+          {period?.idempotencyClaimStatus ? (
+            <Badge variant="secondary">Notice claimed</Badge>
+          ) : null}
+          {!period ? (
+            <Badge variant="secondary">No current period</Badge>
+          ) : null}
+          {period && !input.row.suspended && !period.blockedAt
+              && !period.idempotencyClaimStatus ? (
+            <Badge variant="outline">Available</Badge>
+          ) : null}
+        </div>
+      </TableCell>
+      <TableCell className="text-right">
+        <Button
+          aria-label={`Reset usage for ${input.row.memberId}`}
+          disabled={input.disabled || !resettable}
+          onClick={input.onSelect}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <RotateCcwIcon data-icon="inline-start" />
+          Reset
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function SummaryFinding(input: { label: string; value: string }) {
+  return (
+    <div className="border-border/70 px-4 py-4 sm:odd:border-r lg:not-last:border-r">
+      <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+        {input.label}
+      </div>
+      <div className="mt-2 font-serif text-2xl font-semibold tabular-nums text-foreground">
+        {input.value}
+      </div>
+    </div>
+  );
+}
+
+function readEntitySecondaryLabel(row: HostedOpsMemberUsageRow): string {
+  if (row.memberKind === "group_container") {
+    const participantLabel = row.participantCount === null
+      ? "Participants unavailable"
+      : `${formatInteger(row.participantCount)} participants`;
+    return row.containerOwnerMemberId
+      ? `${participantLabel}, owner ${row.containerOwnerMemberId}`
+      : participantLabel;
+  }
+  return row.maskedPhoneNumberHint ?? `Created ${formatDate(row.createdAt)}`;
+}
+
+async function requestUsageReset(
+  row: HostedOpsMemberUsageRow,
+): Promise<HostedOpsMemberUsageResetResult> {
+  const period = row.currentPeriod;
+  if (!period) {
+    throw new Error("This row has no current usage period to reset.");
+  }
+  const response = await fetch("/api/ops/usage-reset", {
+    body: JSON.stringify({
+      expectedPeriodUpdatedAt: period.updatedAt,
+      expectedUsageCreditLedgerVersion: period.usageCreditLedgerVersion,
+      memberId: row.memberId,
+      periodStart: period.periodStart,
+    }),
+    cache: "no-store",
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("Usage reset returned an unreadable response.");
+  }
+  if (!response.ok) {
+    throw new UsageResetRequestError(
+      readResponseErrorMessage(payload),
+      readResponseErrorCode(payload),
+    );
+  }
+  if (!isHostedOpsMemberUsageResetResult(payload)) {
+    throw new Error("Usage reset returned an invalid response.");
+  }
+  return payload;
+}
+
+function isHostedOpsMemberUsageResetResult(
+  value: unknown,
+): value is HostedOpsMemberUsageResetResult {
+  return Boolean(
+    value
+      && typeof value === "object"
+      && typeof Reflect.get(value, "memberId") === "string"
+      && typeof Reflect.get(value, "noticeClaimReleased") === "boolean"
+      && typeof Reflect.get(value, "outcome") === "string"
+      && typeof Reflect.get(value, "resetAt") === "string",
+  );
+}
+
+function readResponseErrorMessage(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
+    return "Usage could not be reset. Refresh and try again.";
+  }
+  const error = Reflect.get(payload, "error");
+  if (error && typeof error === "object") {
+    const message = Reflect.get(error, "message");
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+  return "Usage could not be reset. Refresh and try again.";
+}
+
+function readResponseErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const error = Reflect.get(payload, "error");
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatUsdMicros(value: string): string {
+  const cents = (BigInt(value) + 5_000n) / 10_000n;
+  return new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    style: "currency",
+  }).format(Number(cents) / 100);
+}
+
+function formatTimestamp(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+  }).format(new Date(value));
+}

--- a/apps/web/app/(dashboard)/ops/usage/member-usage-client.tsx
+++ b/apps/web/app/(dashboard)/ops/usage/member-usage-client.tsx
@@ -26,13 +26,22 @@ import {
 } from "@/src/components/ui/table";
 import type {
   HostedOpsMemberUsageDashboard,
-  HostedOpsMemberUsageResetResult,
+  HostedOpsMemberUsageResetResponse,
   HostedOpsMemberUsageRow,
 } from "@/src/lib/hosted-ops/member-usage";
 
 interface UsageResetMessage {
   text: string;
   tone: "error" | "success";
+}
+
+interface UsageResetRuntimeRetry {
+  memberId: string;
+}
+
+interface UsageRuntimeRecheckResponse {
+  memberId: string;
+  runtimeRecheckStatus: "accepted" | "pending";
 }
 
 class UsageResetRequestError extends Error {
@@ -56,6 +65,8 @@ export function MemberUsageClient({
     null,
   );
   const [message, setMessage] = useState<UsageResetMessage | null>(null);
+  const [runtimeRetry, setRuntimeRetry] =
+    useState<UsageResetRuntimeRetry | null>(null);
   const selectedRow = useMemo(
     () => dashboard.rows.find((row) => row.memberId === selectedMemberId)
       ?? null,
@@ -70,12 +81,46 @@ export function MemberUsageClient({
     setResettingMemberId(row.memberId);
     setMessage(null);
     try {
+      if (runtimeRetry?.memberId === row.memberId) {
+        const result = await requestRuntimeRecheck(row.memberId);
+        if (result.runtimeRecheckStatus === "pending") {
+          setMessage({
+            text:
+              "The runtime still has not accepted its recheck. The committed usage reset is unchanged; retry the runtime wake.",
+            tone: "error",
+          });
+          return;
+        }
+        setRuntimeRetry(null);
+        setSelectedMemberId(null);
+        setMessage({
+          text:
+            "The runtime recheck was accepted. The committed usage reset is unchanged.",
+          tone: "success",
+        });
+        router.refresh();
+        return;
+      }
+
       const result = await requestUsageReset(row);
+      if (result.runtimeRecheckStatus === "pending") {
+        setRuntimeRetry({
+          memberId: result.memberId,
+        });
+        setMessage({
+          text:
+            "Usage was reset, but the runtime did not accept its recheck yet. Retry the runtime wake; usage and credits will not be reset again.",
+          tone: "error",
+        });
+        router.refresh();
+        return;
+      }
+      setRuntimeRetry(null);
       setSelectedMemberId(null);
       setMessage({
         text: result.noticeClaimReleased
-          ? "Current included usage was reset and the quota notice claim was released."
-          : "Current included usage was reset. No quota notice claim was attached.",
+          ? "Current included usage was reset, the quota notice claim was released, and the runtime recheck was accepted."
+          : "Current included usage is clear and the runtime recheck was accepted.",
         tone: "success",
       });
       router.refresh();
@@ -86,12 +131,17 @@ export function MemberUsageClient({
           : "Usage could not be reset. Refresh and try again.",
         tone: "error",
       });
-      setSelectedMemberId(null);
       if (
         error instanceof UsageResetRequestError
         && error.code === "HOSTED_OPS_USAGE_RESET_STALE"
       ) {
+        setRuntimeRetry(null);
+        setSelectedMemberId(null);
         router.refresh();
+        return;
+      }
+      if (runtimeRetry?.memberId !== row.memberId) {
+        setSelectedMemberId(null);
       }
     } finally {
       setResettingMemberId(null);
@@ -203,6 +253,7 @@ export function MemberUsageClient({
                     key={row.memberId}
                     onSelect={() => {
                       setMessage(null);
+                      setRuntimeRetry(null);
                       setSelectedMemberId(row.memberId);
                     }}
                     row={row}
@@ -217,6 +268,7 @@ export function MemberUsageClient({
       <Dialog
         onOpenChange={(open) => {
           if (!open && !isResetting) {
+            setRuntimeRetry(null);
             setSelectedMemberId(null);
           }
         }}
@@ -224,42 +276,67 @@ export function MemberUsageClient({
       >
         <DialogContent showCloseButton={!isResetting}>
           <DialogHeader>
-            <DialogTitle>Reset current included usage?</DialogTitle>
+            <DialogTitle>
+              {runtimeRetry?.memberId === selectedRow?.memberId
+                ? "Retry runtime wake?"
+                : "Reset current included usage?"}
+            </DialogTitle>
             <DialogDescription>
-              This sets current-period included spend to $0, clears the blocked
-              state, and releases the current quota notice claim. Immutable AI
-              usage and purchased-credit balance stay unchanged.
+              {runtimeRetry?.memberId === selectedRow?.memberId
+                ? "The allowance reset is already committed. Retry only the runtime recheck so already-accepted work can continue."
+                : "This sets current-period included spend to $0, clears the blocked state, releases the current quota notice claim, and wakes already-accepted work. Immutable AI usage and purchased-credit balance stay unchanged."}
             </DialogDescription>
           </DialogHeader>
+          {runtimeRetry?.memberId === selectedRow?.memberId && message ? (
+            <Alert variant="destructive">
+              <AlertDescription>{message.text}</AlertDescription>
+            </Alert>
+          ) : null}
           {selectedRow?.currentPeriod ? (
             <dl className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-2 border-y border-border/70 py-4 text-sm">
               <dt className="text-muted-foreground">Target</dt>
               <dd className="max-w-56 break-all text-right font-mono text-xs">
                 {selectedRow.memberId}
               </dd>
-              <dt className="text-muted-foreground">Current spend</dt>
-              <dd className="font-serif font-semibold">
-                {formatUsdMicros(selectedRow.currentPeriod.spentUsdMicros)}
-              </dd>
-              <dt className="text-muted-foreground">Notice claim</dt>
-              <dd>
-                {selectedRow.currentPeriod.idempotencyClaimStatus
-                  ? "Will be released"
-                  : "None"}
-              </dd>
+              {runtimeRetry?.memberId !== selectedRow.memberId ? (
+                <>
+                  <dt className="text-muted-foreground">Current spend</dt>
+                  <dd className="font-serif font-semibold">
+                    {formatUsdMicros(selectedRow.currentPeriod.spentUsdMicros)}
+                  </dd>
+                  <dt className="text-muted-foreground">Notice claim</dt>
+                  <dd>
+                    {selectedRow.currentPeriod.idempotencyClaimStatus
+                      ? "Will be released"
+                      : "None"}
+                  </dd>
+                </>
+              ) : null}
             </dl>
           ) : null}
           <DialogFooter>
             <Button
               disabled={isResetting}
-              onClick={() => setSelectedMemberId(null)}
+              onClick={() => {
+                setRuntimeRetry(null);
+                setSelectedMemberId(null);
+              }}
               type="button"
               variant="outline"
             >
-              Cancel
+              {runtimeRetry?.memberId === selectedRow?.memberId
+                ? "Close"
+                : "Cancel"}
             </Button>
             <Button
-              disabled={!selectedRow?.currentPeriod || isResetting}
+              disabled={
+                !selectedRow?.currentPeriod
+                || (
+                  selectedRow.currentPeriod.updatedAt === null
+                  && runtimeRetry?.memberId !== selectedRow.memberId
+                )
+                || isResetting
+              }
               onClick={() => {
                 if (selectedRow) {
                   void resetUsage(selectedRow);
@@ -271,7 +348,11 @@ export function MemberUsageClient({
               {isResetting ? <Spinner data-icon="inline-start" /> : (
                 <RotateCcwIcon data-icon="inline-start" />
               )}
-              {isResetting ? "Resetting" : "Reset usage"}
+              {isResetting
+                ? "Working"
+                : runtimeRetry?.memberId === selectedRow?.memberId
+                ? "Retry runtime wake"
+                : "Reset usage"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -287,11 +368,8 @@ function UsageRow(input: {
 }) {
   const period = input.row.currentPeriod;
   const resettable = period !== null
-    && (
-      BigInt(period.spentUsdMicros) > 0n
-      || period.blockedAt !== null
-      || period.idempotencyClaimStatus !== null
-    );
+    && input.row.allowanceStatus === "available"
+    && period.updatedAt !== null;
 
   return (
     <TableRow>
@@ -346,10 +424,11 @@ function UsageRow(input: {
           {period?.idempotencyClaimStatus ? (
             <Badge variant="secondary">Notice claimed</Badge>
           ) : null}
-          {!period ? (
-            <Badge variant="secondary">No current period</Badge>
+          {input.row.allowanceStatus === "unavailable" ? (
+            <Badge variant="secondary">Unavailable</Badge>
           ) : null}
-          {period && !input.row.suspended && !period.blockedAt
+          {input.row.allowanceStatus === "available" && period
+              && !input.row.suspended && !period.blockedAt
               && !period.idempotencyClaimStatus ? (
             <Badge variant="outline">Available</Badge>
           ) : null}
@@ -399,14 +478,15 @@ function readEntitySecondaryLabel(row: HostedOpsMemberUsageRow): string {
 
 async function requestUsageReset(
   row: HostedOpsMemberUsageRow,
-): Promise<HostedOpsMemberUsageResetResult> {
+): Promise<HostedOpsMemberUsageResetResponse> {
   const period = row.currentPeriod;
-  if (!period) {
-    throw new Error("This row has no current usage period to reset.");
+  const expectedPeriodUpdatedAt = period?.updatedAt ?? null;
+  if (!period || !expectedPeriodUpdatedAt) {
+    throw new Error("This row has no persisted current usage to reset.");
   }
   const response = await fetch("/api/ops/usage-reset", {
     body: JSON.stringify({
-      expectedPeriodUpdatedAt: period.updatedAt,
+      expectedPeriodUpdatedAt,
       expectedUsageCreditLedgerVersion: period.usageCreditLedgerVersion,
       memberId: row.memberId,
       periodStart: period.periodStart,
@@ -434,16 +514,63 @@ async function requestUsageReset(
   return payload;
 }
 
+async function requestRuntimeRecheck(
+  memberId: string,
+): Promise<UsageRuntimeRecheckResponse> {
+  const response = await fetch("/api/ops/usage-reset", {
+    body: JSON.stringify({
+      memberId,
+      operation: "runtime_recheck",
+    }),
+    cache: "no-store",
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("Runtime recheck returned an unreadable response.");
+  }
+  if (!response.ok) {
+    throw new UsageResetRequestError(
+      readResponseErrorMessage(payload),
+      readResponseErrorCode(payload),
+    );
+  }
+  if (!isUsageRuntimeRecheckResponse(payload)) {
+    throw new Error("Runtime recheck returned an invalid response.");
+  }
+  return payload;
+}
+
 function isHostedOpsMemberUsageResetResult(
   value: unknown,
-): value is HostedOpsMemberUsageResetResult {
+): value is HostedOpsMemberUsageResetResponse {
   return Boolean(
     value
       && typeof value === "object"
       && typeof Reflect.get(value, "memberId") === "string"
       && typeof Reflect.get(value, "noticeClaimReleased") === "boolean"
       && typeof Reflect.get(value, "outcome") === "string"
-      && typeof Reflect.get(value, "resetAt") === "string",
+      && typeof Reflect.get(value, "resetAt") === "string"
+      && ["accepted", "pending"].includes(
+        String(Reflect.get(value, "runtimeRecheckStatus")),
+      )
+  );
+}
+
+function isUsageRuntimeRecheckResponse(
+  value: unknown,
+): value is UsageRuntimeRecheckResponse {
+  return Boolean(
+    value
+      && typeof value === "object"
+      && typeof Reflect.get(value, "memberId") === "string"
+      && ["accepted", "pending"].includes(
+        String(Reflect.get(value, "runtimeRecheckStatus")),
+      )
   );
 }
 

--- a/apps/web/app/(dashboard)/ops/usage/member-usage-client.tsx
+++ b/apps/web/app/(dashboard)/ops/usage/member-usage-client.tsx
@@ -418,7 +418,7 @@ function UsageRow(input: {
           {input.row.suspended ? (
             <Badge variant="destructive">Suspended</Badge>
           ) : null}
-          {period?.blockedAt ? (
+          {period?.blocked ? (
             <Badge variant="destructive">Blocked</Badge>
           ) : null}
           {period?.idempotencyClaimStatus ? (
@@ -427,9 +427,10 @@ function UsageRow(input: {
           {input.row.allowanceStatus === "unavailable" ? (
             <Badge variant="secondary">Unavailable</Badge>
           ) : null}
-          {input.row.allowanceStatus === "available" && period
-              && !input.row.suspended && !period.blockedAt
-              && !period.idempotencyClaimStatus ? (
+          {input.row.allowanceStatus === "available"
+              && period
+              && !input.row.suspended
+              && !period.blocked ? (
             <Badge variant="outline">Available</Badge>
           ) : null}
         </div>

--- a/apps/web/app/(dashboard)/ops/usage/page.tsx
+++ b/apps/web/app/(dashboard)/ops/usage/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+
+import { requireHostedOpsPageAccess } from "@/src/lib/hosted-ops/access";
+import { readHostedOpsMemberUsage } from "@/src/lib/hosted-ops/member-usage";
+import { getHostedDashboardPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
+
+import { MemberUsageClient } from "./member-usage-client";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  robots: {
+    follow: false,
+    index: false,
+  },
+  title: "Usage - Murph",
+};
+
+export default async function HostedOpsUsagePage() {
+  await getHostedDashboardPageAuthSnapshot();
+  await requireHostedOpsPageAccess();
+
+  return <MemberUsageClient dashboard={await readHostedOpsMemberUsage()} />;
+}

--- a/apps/web/app/api/ops/usage-reset/route.ts
+++ b/apps/web/app/api/ops/usage-reset/route.ts
@@ -5,6 +5,9 @@ import {
   HostedOpsMemberUsageResetStaleError,
   resetHostedOpsMemberUsage,
 } from "@/src/lib/hosted-ops/member-usage";
+import {
+  signalHostedRuntimeRecheckRuntime,
+} from "@/src/lib/hosted-orchestration/signal-runtime";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import {
   jsonOk,
@@ -28,6 +31,15 @@ export const POST = withJsonError(async (request: Request) => {
     tooLargeErrorCode: "HOSTED_OPS_USAGE_RESET_REQUEST_TOO_LARGE",
     tooLargeErrorMessage: "Hosted ops usage reset request body is too large.",
   });
+  const memberId = readMemberId(body.memberId);
+
+  if (body.operation === "runtime_recheck") {
+    const runtimeRecheckStatus = await trySignalHostedRuntimeRecheck(memberId);
+    return jsonOk({
+      memberId,
+      runtimeRecheckStatus,
+    }, runtimeRecheckStatus === "accepted" ? 200 : 202);
+  }
 
   try {
     const result = await resetHostedOpsMemberUsage({
@@ -39,7 +51,7 @@ export const POST = withJsonError(async (request: Request) => {
       expectedUsageCreditLedgerVersion: readLedgerVersion(
         body.expectedUsageCreditLedgerVersion,
       ),
-      memberId: readMemberId(body.memberId),
+      memberId,
       periodStart: readIsoDate(
         body.periodStart,
         "HOSTED_OPS_USAGE_RESET_PERIOD_INVALID",
@@ -47,12 +59,27 @@ export const POST = withJsonError(async (request: Request) => {
       ),
     });
 
+    const runtimeRecheckStatus = await trySignalHostedRuntimeRecheck(
+      result.memberId,
+      result.resetAt,
+    );
+    if (runtimeRecheckStatus === "pending") {
+      return jsonOk({
+        ...result,
+        runtimeRecheckStatus: "pending",
+      }, 202);
+    }
+
     console.info("Hosted ops current usage period reset completed.", {
       noticeClaimReleased: result.noticeClaimReleased,
       outcome: result.outcome,
+      runtimeRecheckStatus: "accepted",
       timestamp: result.resetAt,
     });
-    return jsonOk(result);
+    return jsonOk({
+      ...result,
+      runtimeRecheckStatus: "accepted",
+    });
   } catch (error) {
     if (error instanceof HostedOpsMemberUsageResetNotFoundError) {
       throw hostedOnboardingError({
@@ -82,6 +109,22 @@ export const POST = withJsonError(async (request: Request) => {
     throw error;
   }
 });
+
+async function trySignalHostedRuntimeRecheck(
+  memberId: string,
+  timestamp = new Date().toISOString(),
+): Promise<"accepted" | "pending"> {
+  try {
+    await signalHostedRuntimeRecheckRuntime({ userId: memberId });
+    return "accepted";
+  } catch (error) {
+    console.error("Hosted ops runtime recheck failed.", {
+      errorName: error instanceof Error ? error.name : "UnknownError",
+      timestamp,
+    });
+    return "pending";
+  }
+}
 
 function readMemberId(value: unknown): string {
   const memberId = typeof value === "string" ? value.trim() : "";

--- a/apps/web/app/api/ops/usage-reset/route.ts
+++ b/apps/web/app/api/ops/usage-reset/route.ts
@@ -1,0 +1,135 @@
+import { requireHostedOpsRequestAccess } from "@/src/lib/hosted-ops/access";
+import {
+  HostedOpsMemberUsageResetNotFoundError,
+  HostedOpsMemberUsageResetNoticeInFlightError,
+  HostedOpsMemberUsageResetStaleError,
+  resetHostedOpsMemberUsage,
+} from "@/src/lib/hosted-ops/member-usage";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import {
+  jsonOk,
+  readHostedOnboardingJsonObject,
+  withJsonError,
+} from "@/src/lib/hosted-onboarding/http";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const revalidate = 0;
+
+const REQUEST_BODY_LIMIT_BYTES = 2 * 1024;
+const MEMBER_ID_MAX_LENGTH = 128;
+
+export const POST = withJsonError(async (request: Request) => {
+  await requireHostedOpsRequestAccess(request, {
+    requireMutationOrigin: true,
+  });
+  const body = await readHostedOnboardingJsonObject(request, {
+    limitBytes: REQUEST_BODY_LIMIT_BYTES,
+    tooLargeErrorCode: "HOSTED_OPS_USAGE_RESET_REQUEST_TOO_LARGE",
+    tooLargeErrorMessage: "Hosted ops usage reset request body is too large.",
+  });
+
+  try {
+    const result = await resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: readIsoDate(
+        body.expectedPeriodUpdatedAt,
+        "HOSTED_OPS_USAGE_RESET_EXPECTED_UPDATE_INVALID",
+        "Refresh the usage table before resetting this row.",
+      ),
+      expectedUsageCreditLedgerVersion: readLedgerVersion(
+        body.expectedUsageCreditLedgerVersion,
+      ),
+      memberId: readMemberId(body.memberId),
+      periodStart: readIsoDate(
+        body.periodStart,
+        "HOSTED_OPS_USAGE_RESET_PERIOD_INVALID",
+        "Refresh the usage table before resetting this row.",
+      ),
+    });
+
+    console.info("Hosted ops current usage period reset completed.", {
+      noticeClaimReleased: result.noticeClaimReleased,
+      outcome: result.outcome,
+      timestamp: result.resetAt,
+    });
+    return jsonOk(result);
+  } catch (error) {
+    if (error instanceof HostedOpsMemberUsageResetNotFoundError) {
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_USAGE_RESET_NOT_FOUND",
+        httpStatus: 404,
+        message: error.message,
+        retryable: false,
+      });
+    }
+    if (error instanceof HostedOpsMemberUsageResetStaleError) {
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_USAGE_RESET_STALE",
+        httpStatus: 409,
+        message: error.message,
+        retryable: false,
+      });
+    }
+    if (error instanceof HostedOpsMemberUsageResetNoticeInFlightError) {
+      throw hostedOnboardingError({
+        code: "HOSTED_OPS_USAGE_RESET_NOTICE_IN_FLIGHT",
+        details: { retryAt: error.retryAt.toISOString() },
+        httpStatus: 409,
+        message: error.message,
+        retryable: true,
+      });
+    }
+    throw error;
+  }
+});
+
+function readMemberId(value: unknown): string {
+  const memberId = typeof value === "string" ? value.trim() : "";
+  if (
+    memberId.length > 0
+    && memberId.length <= MEMBER_ID_MAX_LENGTH
+    && /^hbm_[A-Za-z0-9_-]+$/u.test(memberId)
+  ) {
+    return memberId;
+  }
+  throw hostedOnboardingError({
+    code: "HOSTED_OPS_USAGE_RESET_MEMBER_ID_INVALID",
+    httpStatus: 400,
+    message: "Select a valid hosted member or container.",
+    retryable: false,
+  });
+}
+
+function readIsoDate(
+  value: unknown,
+  code: string,
+  message: string,
+): Date {
+  if (typeof value === "string" && value.length <= 64) {
+    const date = new Date(value);
+    if (
+      Number.isFinite(date.getTime())
+      && date.toISOString() === value
+    ) {
+      return date;
+    }
+  }
+  throw hostedOnboardingError({
+    code,
+    httpStatus: 400,
+    message,
+    retryable: false,
+  });
+}
+
+function readLedgerVersion(value: unknown): bigint {
+  if (typeof value === "string" && /^[0-9]{1,30}$/u.test(value)) {
+    return BigInt(value);
+  }
+  throw hostedOnboardingError({
+    code: "HOSTED_OPS_USAGE_RESET_LEDGER_VERSION_INVALID",
+    httpStatus: 400,
+    message: "Refresh the usage table before resetting this row.",
+    retryable: false,
+  });
+}

--- a/apps/web/app/api/ops/usage-reset/route.ts
+++ b/apps/web/app/api/ops/usage-reset/route.ts
@@ -8,6 +8,10 @@ import {
 import {
   signalHostedRuntimeRecheckRuntime,
 } from "@/src/lib/hosted-orchestration/signal-runtime";
+import {
+  createHostedPostCommitDeadline,
+  waitForHostedPostCommitOperation,
+} from "@/src/lib/hosted-onboarding/bounded-post-commit";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import {
   jsonOk,
@@ -115,7 +119,13 @@ async function trySignalHostedRuntimeRecheck(
   timestamp = new Date().toISOString(),
 ): Promise<"accepted" | "pending"> {
   try {
-    await signalHostedRuntimeRecheckRuntime({ userId: memberId });
+    await waitForHostedPostCommitOperation({
+      deadlineMs: createHostedPostCommitDeadline(undefined),
+      operation: (abortSignal) => signalHostedRuntimeRecheckRuntime({
+        abortSignal,
+        userId: memberId,
+      }),
+    });
     return "accepted";
   } catch (error) {
     console.error("Hosted ops runtime recheck failed.", {

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -134,6 +134,12 @@ export type HostedAiUsageGateDecisionWithSource =
     allowanceSource: HostedAiUsageAllowanceSourceKind;
   });
 
+export interface HostedAiUsageGateSnapshot {
+  decision: HostedAiUsageGateDecisionWithSource;
+  periodBlockedAt: Date | null;
+  periodPersistedAt: Date | null;
+}
+
 export interface HostedAiUsageGateUserNotice {
   code: HostedAiUsageGateNoticeCode;
   message: string;
@@ -1226,6 +1232,79 @@ export async function readHostedAiUsageGate(input: {
   });
 }
 
+/**
+ * Canonical read projection for low-frequency operator/reporting surfaces.
+ * All member decisions run through the ordinary gate owner in one transaction;
+ * only the exact resolved period metadata is batch-loaded afterward.
+ */
+export async function readHostedAiUsageGateSnapshots(input: {
+  memberIds: readonly string[];
+  now?: Date | string;
+  prisma?: HostedAiUsageAllowanceClient;
+}): Promise<Map<string, HostedAiUsageGateSnapshot>> {
+  const prisma = input.prisma ?? getPrisma();
+  const now = normalizeHostedAiUsageAllowanceDate(input.now ?? new Date());
+  const memberIds = [...new Set(input.memberIds.map((memberId) => memberId.trim()))]
+    .filter(Boolean);
+  if (memberIds.length === 0) {
+    return new Map();
+  }
+
+  return runHostedAiUsageAllowanceTransaction(prisma, async (tx) => {
+    const decisions = new Map<string, HostedAiUsageGateDecisionWithSource>();
+    for (const memberId of memberIds) {
+      decisions.set(memberId, await readHostedAiUsageGate({
+        memberId,
+        now,
+        prisma: tx,
+      }));
+    }
+    const currentPeriodKeys = [...decisions.values()].flatMap((decision) =>
+      decision.allowed || decision.reason === "ai_usage_limit_exceeded"
+        ? [{ memberId: decision.memberId, periodStart: decision.periodStart }]
+        : []
+    );
+    const persistedPeriods = currentPeriodKeys.length > 0
+      ? await tx.hostedAiUsagePeriod.findMany({
+          select: {
+            blockedAt: true,
+            memberId: true,
+            periodStart: true,
+            updatedAt: true,
+          },
+          where: {
+            OR: currentPeriodKeys,
+          },
+        })
+      : [];
+    const periodByKey = new Map(
+      persistedPeriods.map((period) => [
+        buildHostedAiUsagePeriodMapKey(period.memberId, period.periodStart),
+        period,
+      ]),
+    );
+
+    return new Map([...decisions].map(([memberId, decision]) => {
+      const persisted = periodByKey.get(buildHostedAiUsagePeriodMapKey(
+        memberId,
+        decision.periodStart,
+      )) ?? null;
+      return [memberId, {
+        decision,
+        periodBlockedAt: persisted?.blockedAt ?? null,
+        periodPersistedAt: persisted?.updatedAt ?? null,
+      }] as const;
+    }));
+  }, Prisma.TransactionIsolationLevel.RepeatableRead);
+}
+
+function buildHostedAiUsagePeriodMapKey(
+  memberId: string,
+  periodStart: Date,
+): string {
+  return `${memberId}\u0000${periodStart.toISOString()}`;
+}
+
 // Read-first gate for hot-path checks: denials are confirmed by the mutating
 // gate before callers act on them. The read path cannot lock or materialize
 // period rows or apply plan-change limit updates; spend accounting
@@ -2048,15 +2127,19 @@ async function lockHostedAiUsageAllowanceBeneficiaryTx(input: {
 async function runHostedAiUsageAllowanceTransaction<T>(
   prisma: HostedAiUsageAllowanceClient,
   run: (tx: Prisma.TransactionClient) => Promise<T>,
+  isolationLevel?: Prisma.TransactionIsolationLevel,
 ): Promise<T> {
   const maybeTransaction = prisma as {
     $transaction?: <R>(
       run: (tx: Prisma.TransactionClient) => Promise<R>,
+      options?: { isolationLevel?: Prisma.TransactionIsolationLevel },
     ) => Promise<R>;
   };
 
   if (typeof maybeTransaction.$transaction === "function") {
-    return maybeTransaction.$transaction(run);
+    return isolationLevel
+      ? maybeTransaction.$transaction(run, { isolationLevel })
+      : maybeTransaction.$transaction(run);
   }
 
   return run(prisma as Prisma.TransactionClient);

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -136,7 +136,6 @@ export type HostedAiUsageGateDecisionWithSource =
 
 export interface HostedAiUsageGateSnapshot {
   decision: HostedAiUsageGateDecisionWithSource;
-  periodBlockedAt: Date | null;
   periodPersistedAt: Date | null;
 }
 
@@ -1267,7 +1266,6 @@ export async function readHostedAiUsageGateSnapshots(input: {
     const persistedPeriods = currentPeriodKeys.length > 0
       ? await tx.hostedAiUsagePeriod.findMany({
           select: {
-            blockedAt: true,
             memberId: true,
             periodStart: true,
             updatedAt: true,
@@ -1291,7 +1289,6 @@ export async function readHostedAiUsageGateSnapshots(input: {
       )) ?? null;
       return [memberId, {
         decision,
-        periodBlockedAt: persisted?.blockedAt ?? null,
         periodPersistedAt: persisted?.updatedAt ?? null,
       }] as const;
     }));

--- a/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
@@ -67,6 +67,7 @@ const HOSTED_AI_USAGE_TELEGRAM_NOTICE_DELIVERY_SOURCE =
 export type HostedAiUsageLimitNoticeDeliveryClaim =
   | {
     idempotencyKey: string;
+    providerIdempotencyKey: string;
     status: "claimed";
   }
   | {
@@ -313,7 +314,7 @@ export async function claimHostedLinqDeliveryProviderDispatchTx(input: {
   } satisfies HostedLinqDeliveryProviderDispatchData;
   const createData = {
     ...data,
-    id: buildHostedLinqDeliveryId(idempotencyKey),
+    id: generateHostedRandomPrefixedId("hld"),
     idempotencyKey,
   };
   const existing = await input.prisma.hostedLinqDelivery.findUnique({
@@ -455,8 +456,13 @@ export async function startHostedAiUsageLimitNoticeDispatchTx(input: {
       template: "ai_usage_quota",
     });
     if (claim.claimed) {
+      if (!claim.id) {
+        throw new Error("Hosted AI usage notice claim is missing its attempt id.");
+      }
       return {
         idempotencyKey,
+        providerIdempotencyKey:
+          buildHostedAiUsageNoticeProviderIdempotencyKey(claim.id),
         status: "claimed",
       };
     }
@@ -521,6 +527,16 @@ export function buildHostedAiUsageGateNoticeIdempotencyKey(input: {
         usageCreditLedgerVersion: input.usageCreditLedgerVersion.toString(),
       };
   return `ai-usage-gate:${sha256Hex(JSON.stringify(capacityEpoch)).slice(0, 32)}`;
+}
+
+export function buildHostedAiUsageNoticeProviderIdempotencyKey(
+  deliveryId: string,
+): string {
+  const normalized = deliveryId.trim();
+  if (!normalized) {
+    throw new TypeError("Hosted AI usage notice delivery id is required.");
+  }
+  return `ai-usage-attempt:${normalized}`;
 }
 
 function normalizeHostedAiUsageNoticePeriodStart(value: Date | string): Date {

--- a/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
@@ -262,7 +262,7 @@ export async function resolveHostedLinqInviteSignupDispatchEffectIdTx(input: {
   return null;
 }
 
-export async function claimHostedLinqDeliveryProviderDispatchTx(input: {
+type HostedLinqDeliveryProviderDispatchClaimInput = {
   attemptedAt?: Date;
   idempotencyKey?: string | null;
   linqChatId?: string | null;
@@ -274,7 +274,21 @@ export async function claimHostedLinqDeliveryProviderDispatchTx(input: {
   status?: HostedLinqDeliveryProviderDispatchData["status"];
   targetKind?: string | null;
   template?: string | null;
-}): Promise<{ claimed: boolean; id: string | null; retryAt?: Date }> {
+};
+
+export async function claimHostedLinqDeliveryProviderDispatchTx(
+  input: HostedLinqDeliveryProviderDispatchClaimInput,
+): Promise<{ claimed: boolean; id: string | null; retryAt?: Date }> {
+  return claimHostedLinqDeliveryProviderDispatchWithIdTx(
+    input,
+    buildHostedLinqDeliveryId,
+  );
+}
+
+async function claimHostedLinqDeliveryProviderDispatchWithIdTx(
+  input: HostedLinqDeliveryProviderDispatchClaimInput,
+  buildDeliveryId: (idempotencyKey: string) => string,
+): Promise<{ claimed: boolean; id: string | null; retryAt?: Date }> {
   const attemptedAt = input.attemptedAt ?? new Date();
   const idempotencyKey = createHostedLinqDeliveryIdempotencyLookupKey(
     normalizeNullable(input.idempotencyKey),
@@ -314,7 +328,7 @@ export async function claimHostedLinqDeliveryProviderDispatchTx(input: {
   } satisfies HostedLinqDeliveryProviderDispatchData;
   const createData = {
     ...data,
-    id: generateHostedRandomPrefixedId("hld"),
+    id: buildDeliveryId(idempotencyKey),
     idempotencyKey,
   };
   const existing = await input.prisma.hostedLinqDelivery.findUnique({
@@ -442,19 +456,22 @@ export async function startHostedAiUsageLimitNoticeDispatchTx(input: {
       return { status: "already_notified" };
     }
 
-    const claim = await claimHostedLinqDeliveryProviderDispatchTx({
-      attemptedAt: input.attemptedAt,
-      idempotencyKey,
-      linqChatId: input.linqChatId,
-      phoneNumber: input.phoneNumber,
-      prisma,
-      reclaimStalePreProviderAttempt: true,
-      source: input.source,
-      sourceRef: input.sourceRef,
-      status: HOSTED_LINQ_DELIVERY_PROVIDER_DISPATCH_STARTED_STATUS,
-      targetKind: input.targetKind,
-      template: "ai_usage_quota",
-    });
+    const claim = await claimHostedLinqDeliveryProviderDispatchWithIdTx(
+      {
+        attemptedAt: input.attemptedAt,
+        idempotencyKey,
+        linqChatId: input.linqChatId,
+        phoneNumber: input.phoneNumber,
+        prisma,
+        reclaimStalePreProviderAttempt: true,
+        source: input.source,
+        sourceRef: input.sourceRef,
+        status: HOSTED_LINQ_DELIVERY_PROVIDER_DISPATCH_STARTED_STATUS,
+        targetKind: input.targetKind,
+        template: "ai_usage_quota",
+      },
+      () => generateHostedRandomPrefixedId("hld"),
+    );
     if (claim.claimed) {
       if (!claim.id) {
         throw new Error("Hosted AI usage notice claim is missing its attempt id.");

--- a/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
@@ -463,6 +463,7 @@ async function sendHostedLinqSideEffect(
         startedAtMs,
       });
   let deliveryEffect = effect;
+  let providerIdempotencyKey = effect.effectId;
   let usageLimitDispatchClaimed = false;
 
   try {
@@ -534,6 +535,7 @@ async function sendHostedLinqSideEffect(
             };
       }
       usageLimitDispatchClaimed = true;
+      providerIdempotencyKey = dispatch.providerIdempotencyKey;
       deliveryEffect = dispatch.idempotencyKey === effect.effectId
         ? effect
         : { ...effect, effectId: dispatch.idempotencyKey };
@@ -541,7 +543,7 @@ async function sendHostedLinqSideEffect(
 
     const result = await sendHostedLinqChatMessage({
       chatId: effect.payload.chatId,
-      idempotencyKey: deliveryEffect.effectId,
+      idempotencyKey: providerIdempotencyKey,
       message,
       replyToMessageId: effect.payload.replyToMessageId,
       signal: options.signal,

--- a/apps/web/src/lib/hosted-ops/member-usage.ts
+++ b/apps/web/src/lib/hosted-ops/member-usage.ts
@@ -1,0 +1,553 @@
+import "server-only";
+
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+import {
+  HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_STALE_MS,
+  buildHostedAiUsageGateNoticeIdempotencyKey,
+} from "../hosted-onboarding/linq-delivery-store";
+import {
+  createHostedLinqDeliveryIdempotencyLookupKey,
+} from "../hosted-onboarding/linq-observability-identifiers";
+import {
+  HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+} from "../hosted-onboarding/shared";
+import { getPrisma } from "../prisma";
+
+const HOSTED_CONVERSATION_MESSAGE_KIND = "conversation.message";
+const HOSTED_MESSAGE_RETENTION_DAYS = 30;
+const HOSTED_USAGE_REPORTING_WINDOW_DAYS = 7;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface HostedOpsMemberUsageRow {
+  allTimeUsageUsdMicros: string;
+  billingStatus: string;
+  containerOwnerMemberId: string | null;
+  createdAt: string;
+  currentPeriod: HostedOpsMemberUsagePeriod | null;
+  maskedPhoneNumberHint: string | null;
+  memberId: string;
+  memberKind: "group_container" | "member";
+  messagesDailyAverage7Days: number;
+  messagesLast7Days: number;
+  messagesRetained: number;
+  participantCount: number | null;
+  suspended: boolean;
+}
+
+export interface HostedOpsMemberUsagePeriod {
+  blockedAt: string | null;
+  idempotencyClaimStatus: string | null;
+  limitUsdMicros: string;
+  periodEnd: string;
+  periodStart: string;
+  remainingUsdMicros: string;
+  spentUsdMicros: string;
+  updatedAt: string;
+  usageCreditBalanceUsdMicros: string;
+  usageCreditLedgerVersion: string;
+}
+
+export interface HostedOpsMemberUsageDashboard {
+  capturedAt: string;
+  messageRetentionDays: number;
+  rows: HostedOpsMemberUsageRow[];
+  summary: {
+    activeEntitiesLast7Days: number;
+    groupContainers: number;
+    members: number;
+    totalAllTimeUsageUsdMicros: string;
+  };
+}
+
+export interface HostedOpsMemberUsageResetInput {
+  expectedPeriodUpdatedAt: Date;
+  expectedUsageCreditLedgerVersion: bigint;
+  memberId: string;
+  now?: Date;
+  periodStart: Date;
+}
+
+export interface HostedOpsMemberUsageResetResult {
+  memberId: string;
+  noticeClaimReleased: boolean;
+  outcome: "reset" | "unchanged";
+  periodStart: string;
+  previousSpentUsdMicros: string;
+  resetAt: string;
+  updatedAt: string;
+}
+
+export class HostedOpsMemberUsageResetNotFoundError extends Error {
+  constructor() {
+    super("The hosted member or current usage period no longer exists.");
+    this.name = "HostedOpsMemberUsageResetNotFoundError";
+  }
+}
+
+export class HostedOpsMemberUsageResetStaleError extends Error {
+  constructor() {
+    super("Usage changed after this table loaded. Refresh and review the current row before resetting it.");
+    this.name = "HostedOpsMemberUsageResetStaleError";
+  }
+}
+
+export class HostedOpsMemberUsageResetNoticeInFlightError extends Error {
+  readonly retryAt: Date;
+
+  constructor(retryAt: Date) {
+    super("A usage-limit notice is currently being sent. Retry after that dispatch settles.");
+    this.name = "HostedOpsMemberUsageResetNoticeInFlightError";
+    this.retryAt = retryAt;
+  }
+}
+
+export async function readHostedOpsMemberUsage(
+  now = new Date(),
+  prisma: PrismaClient = getPrisma(),
+): Promise<HostedOpsMemberUsageDashboard> {
+  assertValidDate(now, "Hosted ops usage reporting timestamp is invalid.");
+  const last7DaysStart = new Date(
+    now.getTime() - HOSTED_USAGE_REPORTING_WINDOW_DAYS * DAY_MS,
+  );
+  const retentionWindowStart = new Date(
+    now.getTime() - HOSTED_MESSAGE_RETENTION_DAYS * DAY_MS,
+  );
+
+  const [members, retainedMessageCounts, last7DayMessageCounts, usageTotals] =
+    await Promise.all([
+      prisma.hostedMember.findMany({
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        select: {
+          billingStatus: true,
+          createdAt: true,
+          hostedAiUsagePeriods: {
+            orderBy: { periodStart: "desc" },
+            select: {
+              blockedAt: true,
+              limitUsdMicros: true,
+              periodEnd: true,
+              periodStart: true,
+              spentUsdMicros: true,
+              updatedAt: true,
+            },
+            take: 1,
+            where: {
+              periodEnd: { gt: now },
+              periodStart: { lte: now },
+            },
+          },
+          hostedGroupRuntime: {
+            select: {
+              ownerMemberId: true,
+              _count: {
+                select: { members: true },
+              },
+            },
+          },
+          id: true,
+          identity: {
+            select: { maskedPhoneNumberHint: true },
+          },
+          suspendedAt: true,
+          threadContainer: {
+            select: {
+              ownerMemberId: true,
+              _count: {
+                select: {
+                  participants: {
+                    where: { removedAt: null },
+                  },
+                },
+              },
+            },
+          },
+          usageCreditBalanceUsdMicros: true,
+          usageCreditLedgerVersion: true,
+        },
+      }),
+      prisma.hostedMailboxItem.groupBy({
+        by: ["userId"],
+        _count: { _all: true },
+        where: {
+          kind: HOSTED_CONVERSATION_MESSAGE_KIND,
+          occurredAt: { gte: retentionWindowStart, lt: now },
+        },
+      }),
+      prisma.hostedMailboxItem.groupBy({
+        by: ["userId"],
+        _count: { _all: true },
+        where: {
+          kind: HOSTED_CONVERSATION_MESSAGE_KIND,
+          occurredAt: { gte: last7DaysStart, lt: now },
+        },
+      }),
+      prisma.hostedAiUsage.groupBy({
+        by: ["memberId"],
+        _sum: { allowanceCostUsdMicros: true },
+        where: { allowanceCounted: true },
+      }),
+    ]);
+
+  const retainedByMember = new Map(
+    retainedMessageCounts.map((row) => [row.userId, row._count._all]),
+  );
+  const last7DaysByMember = new Map(
+    last7DayMessageCounts.map((row) => [row.userId, row._count._all]),
+  );
+  const usageByMember = new Map(
+    usageTotals.map((row) => [
+      row.memberId,
+      row._sum.allowanceCostUsdMicros ?? 0n,
+    ]),
+  );
+
+  const claimLookupKeys = members.flatMap((member) => {
+    const period = member.hostedAiUsagePeriods[0];
+    if (!period) {
+      return [];
+    }
+    const key = buildHostedUsageNoticeLookupKey({
+      memberId: member.id,
+      periodStart: period.periodStart,
+      usageCreditLedgerVersion: normalizeNonNegativeBigInt(
+        member.usageCreditLedgerVersion,
+      ),
+    });
+    return key ? [key] : [];
+  });
+  const noticeClaims = claimLookupKeys.length > 0
+    ? await prisma.hostedLinqDelivery.findMany({
+        select: {
+          idempotencyKey: true,
+          status: true,
+        },
+        where: {
+          idempotencyKey: { in: claimLookupKeys },
+        },
+      })
+    : [];
+  const noticeStatusByLookupKey = new Map(
+    noticeClaims.flatMap((claim) => claim.idempotencyKey
+      ? [[claim.idempotencyKey, claim.status] as const]
+      : []),
+  );
+
+  const rows = members.map((member): HostedOpsMemberUsageRow => {
+    const retained = retainedByMember.get(member.id) ?? 0;
+    const last7Days = last7DaysByMember.get(member.id) ?? 0;
+    const usageCreditBalanceUsdMicros = normalizeNonNegativeBigInt(
+      member.usageCreditBalanceUsdMicros,
+    );
+    const usageCreditLedgerVersion = normalizeNonNegativeBigInt(
+      member.usageCreditLedgerVersion,
+    );
+    const period = member.hostedAiUsagePeriods[0] ?? null;
+    const noticeLookupKey = period
+      ? buildHostedUsageNoticeLookupKey({
+          memberId: member.id,
+          periodStart: period.periodStart,
+          usageCreditLedgerVersion,
+        })
+      : null;
+    const threadContainer = member.threadContainer;
+    const legacyGroupContainer = member.hostedGroupRuntime;
+    const isContainer = threadContainer !== null || legacyGroupContainer !== null;
+
+    return {
+      allTimeUsageUsdMicros: (usageByMember.get(member.id) ?? 0n).toString(),
+      billingStatus: member.billingStatus,
+      containerOwnerMemberId:
+        threadContainer?.ownerMemberId
+        ?? legacyGroupContainer?.ownerMemberId
+        ?? null,
+      createdAt: member.createdAt.toISOString(),
+      currentPeriod: period
+        ? {
+            blockedAt: period.blockedAt?.toISOString() ?? null,
+            idempotencyClaimStatus: noticeLookupKey
+              ? noticeStatusByLookupKey.get(noticeLookupKey) ?? null
+              : null,
+            limitUsdMicros: period.limitUsdMicros.toString(),
+            periodEnd: period.periodEnd.toISOString(),
+            periodStart: period.periodStart.toISOString(),
+            remainingUsdMicros: calculateRemainingUsdMicros({
+              credit: usageCreditBalanceUsdMicros,
+              limit: period.limitUsdMicros,
+              spent: period.spentUsdMicros,
+            }).toString(),
+            spentUsdMicros: period.spentUsdMicros.toString(),
+            updatedAt: period.updatedAt.toISOString(),
+            usageCreditBalanceUsdMicros:
+              usageCreditBalanceUsdMicros.toString(),
+            usageCreditLedgerVersion: usageCreditLedgerVersion.toString(),
+          }
+        : null,
+      maskedPhoneNumberHint: member.identity?.maskedPhoneNumberHint ?? null,
+      memberId: member.id,
+      memberKind: isContainer ? "group_container" : "member",
+      messagesDailyAverage7Days: last7Days /
+        HOSTED_USAGE_REPORTING_WINDOW_DAYS,
+      messagesLast7Days: last7Days,
+      messagesRetained: retained,
+      participantCount: threadContainer?._count.participants
+        ?? legacyGroupContainer?._count.members
+        ?? null,
+      suspended: member.suspendedAt !== null,
+    };
+  }).sort(compareHostedOpsUsageRows);
+
+  const totalAllTimeUsageUsdMicros = rows.reduce(
+    (total, row) => total + BigInt(row.allTimeUsageUsdMicros),
+    0n,
+  );
+
+  return {
+    capturedAt: now.toISOString(),
+    messageRetentionDays: HOSTED_MESSAGE_RETENTION_DAYS,
+    rows,
+    summary: {
+      activeEntitiesLast7Days: rows.filter((row) => row.messagesLast7Days > 0)
+        .length,
+      groupContainers: rows.filter((row) => row.memberKind === "group_container")
+        .length,
+      members: rows.filter((row) => row.memberKind === "member").length,
+      totalAllTimeUsageUsdMicros: totalAllTimeUsageUsdMicros.toString(),
+    },
+  };
+}
+
+export async function resetHostedOpsMemberUsage(
+  input: HostedOpsMemberUsageResetInput,
+  prisma: PrismaClient = getPrisma(),
+): Promise<HostedOpsMemberUsageResetResult> {
+  const now = input.now ?? new Date();
+  assertValidDate(now, "Hosted ops usage reset timestamp is invalid.");
+  assertValidDate(
+    input.periodStart,
+    "Hosted ops usage reset period start is invalid.",
+  );
+  assertValidDate(
+    input.expectedPeriodUpdatedAt,
+    "Hosted ops usage reset expected update timestamp is invalid.",
+  );
+  if (input.expectedUsageCreditLedgerVersion < 0n) {
+    throw new TypeError("Hosted ops usage reset ledger version is invalid.");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const memberRows = await tx.$queryRaw<Array<{
+      usageCreditLedgerVersion: bigint | null;
+    }>>`
+      SELECT
+        "usage_credit_ledger_version" AS "usageCreditLedgerVersion"
+      FROM "hosted_member"
+      WHERE "id" = ${input.memberId}
+      FOR UPDATE
+    `;
+    const member = memberRows[0];
+    if (!member) {
+      throw new HostedOpsMemberUsageResetNotFoundError();
+    }
+    const usageCreditLedgerVersion = normalizeNonNegativeBigInt(
+      member.usageCreditLedgerVersion,
+    );
+    if (
+      usageCreditLedgerVersion !== input.expectedUsageCreditLedgerVersion
+    ) {
+      throw new HostedOpsMemberUsageResetStaleError();
+    }
+
+    const periodRows = await tx.$queryRaw<Array<{
+      blockedAt: Date | null;
+      periodEnd: Date;
+      spentUsdMicros: bigint;
+      updatedAt: Date;
+    }>>`
+      SELECT
+        "blocked_at" AS "blockedAt",
+        "period_end" AS "periodEnd",
+        "spent_usd_micros" AS "spentUsdMicros",
+        "updated_at" AS "updatedAt"
+      FROM "hosted_ai_usage_period"
+      WHERE "member_id" = ${input.memberId}
+        AND "period_start" = ${input.periodStart}
+      FOR UPDATE
+    `;
+    const period = periodRows[0];
+    if (!period) {
+      throw new HostedOpsMemberUsageResetNotFoundError();
+    }
+    if (
+      input.periodStart.getTime() > now.getTime()
+      || period.periodEnd.getTime() <= now.getTime()
+      || period.updatedAt.getTime() !== input.expectedPeriodUpdatedAt.getTime()
+    ) {
+      throw new HostedOpsMemberUsageResetStaleError();
+    }
+
+    const noticeLookupKey = buildHostedUsageNoticeLookupKey({
+      memberId: input.memberId,
+      periodStart: input.periodStart,
+      usageCreditLedgerVersion,
+    });
+    const deliveryRows = noticeLookupKey
+      ? await tx.$queryRaw<Array<{
+          acceptedAt: Date | null;
+          attemptedAt: Date;
+          deliveredAt: Date | null;
+          failedAt: Date | null;
+          id: string;
+          lastReceiptAt: Date | null;
+          messageLookupKey: string | null;
+          skippedAt: Date | null;
+          status: string;
+        }>>`
+          SELECT
+            "accepted_at" AS "acceptedAt",
+            "attempted_at" AS "attemptedAt",
+            "delivered_at" AS "deliveredAt",
+            "failed_at" AS "failedAt",
+            "id",
+            "last_receipt_at" AS "lastReceiptAt",
+            "message_lookup_key" AS "messageLookupKey",
+            "skipped_at" AS "skippedAt",
+            "status"
+          FROM "hosted_linq_delivery"
+          WHERE "idempotency_key" = ${noticeLookupKey}
+          FOR UPDATE
+        `
+      : [];
+    const delivery = deliveryRows[0] ?? null;
+    if (delivery && isHostedUsageNoticeDispatchInFlight({ delivery, now })) {
+      throw new HostedOpsMemberUsageResetNoticeInFlightError(
+        new Date(
+          delivery.attemptedAt.getTime()
+            + HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_STALE_MS,
+        ),
+      );
+    }
+
+    if (delivery) {
+      await tx.hostedLinqDelivery.update({
+        data: { idempotencyKey: null },
+        where: { id: delivery.id },
+      });
+    }
+
+    const outcome = period.spentUsdMicros === 0n
+        && period.blockedAt === null
+        && delivery === null
+      ? "unchanged"
+      : "reset";
+    if (outcome === "reset") {
+      const updated = await tx.hostedAiUsagePeriod.updateMany({
+        data: {
+          blockedAt: null,
+          spentUsdMicros: 0n,
+          updatedAt: now,
+        },
+        where: {
+          memberId: input.memberId,
+          periodStart: input.periodStart,
+          updatedAt: period.updatedAt,
+        },
+      });
+      if (updated.count !== 1) {
+        throw new HostedOpsMemberUsageResetStaleError();
+      }
+    }
+
+    return {
+      memberId: input.memberId,
+      noticeClaimReleased: delivery !== null,
+      outcome,
+      periodStart: input.periodStart.toISOString(),
+      previousSpentUsdMicros: period.spentUsdMicros.toString(),
+      resetAt: now.toISOString(),
+      updatedAt: outcome === "reset"
+        ? now.toISOString()
+        : period.updatedAt.toISOString(),
+    };
+  }, {
+    ...HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  });
+}
+
+function buildHostedUsageNoticeLookupKey(input: {
+  memberId: string;
+  periodStart: Date;
+  usageCreditLedgerVersion: bigint;
+}): string | null {
+  return createHostedLinqDeliveryIdempotencyLookupKey(
+    buildHostedAiUsageGateNoticeIdempotencyKey(input),
+  );
+}
+
+function calculateRemainingUsdMicros(input: {
+  credit: bigint;
+  limit: bigint;
+  spent: bigint;
+}): bigint {
+  const includedRemaining = input.limit > input.spent
+    ? input.limit - input.spent
+    : 0n;
+  return includedRemaining + input.credit;
+}
+
+function normalizeNonNegativeBigInt(value: bigint | null): bigint {
+  const normalized = value ?? 0n;
+  if (normalized < 0n) {
+    throw new TypeError("Hosted usage projection cannot be negative.");
+  }
+  return normalized;
+}
+
+function compareHostedOpsUsageRows(
+  left: HostedOpsMemberUsageRow,
+  right: HostedOpsMemberUsageRow,
+): number {
+  if (left.memberKind !== right.memberKind) {
+    return left.memberKind === "group_container" ? -1 : 1;
+  }
+  if (left.messagesLast7Days !== right.messagesLast7Days) {
+    return right.messagesLast7Days - left.messagesLast7Days;
+  }
+  return left.memberId.localeCompare(right.memberId);
+}
+
+function isHostedUsageNoticeDispatchInFlight(input: {
+  delivery: {
+    acceptedAt: Date | null;
+    attemptedAt: Date;
+    deliveredAt: Date | null;
+    failedAt: Date | null;
+    lastReceiptAt: Date | null;
+    messageLookupKey: string | null;
+    skippedAt: Date | null;
+    status: string;
+  };
+  now: Date;
+}): boolean {
+  const delivery = input.delivery;
+  const preProvider = delivery.acceptedAt === null
+    && delivery.deliveredAt === null
+    && delivery.failedAt === null
+    && delivery.lastReceiptAt === null
+    && delivery.messageLookupKey === null
+    && delivery.skippedAt === null
+    && (
+      delivery.status === "attempted"
+      || delivery.status === "provider_dispatch_started"
+    );
+  return preProvider
+    && delivery.attemptedAt.getTime()
+      > input.now.getTime() - HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_STALE_MS;
+}
+
+function assertValidDate(value: Date, message: string): void {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new TypeError(message);
+  }
+}

--- a/apps/web/src/lib/hosted-ops/member-usage.ts
+++ b/apps/web/src/lib/hosted-ops/member-usage.ts
@@ -3,6 +3,10 @@ import "server-only";
 import { Prisma, type PrismaClient } from "@prisma/client";
 
 import {
+  readHostedAiUsageGate,
+  readHostedAiUsageGateSnapshots,
+} from "../hosted-execution/usage-allowance";
+import {
   HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_STALE_MS,
   buildHostedAiUsageGateNoticeIdempotencyKey,
 } from "../hosted-onboarding/linq-delivery-store";
@@ -20,6 +24,7 @@ const HOSTED_USAGE_REPORTING_WINDOW_DAYS = 7;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 export interface HostedOpsMemberUsageRow {
+  allowanceStatus: "available" | "unavailable";
   allTimeUsageUsdMicros: string;
   billingStatus: string;
   containerOwnerMemberId: string | null;
@@ -43,7 +48,7 @@ export interface HostedOpsMemberUsagePeriod {
   periodStart: string;
   remainingUsdMicros: string;
   spentUsdMicros: string;
-  updatedAt: string;
+  updatedAt: string | null;
   usageCreditBalanceUsdMicros: string;
   usageCreditLedgerVersion: string;
 }
@@ -76,6 +81,11 @@ export interface HostedOpsMemberUsageResetResult {
   previousSpentUsdMicros: string;
   resetAt: string;
   updatedAt: string;
+}
+
+export interface HostedOpsMemberUsageResetResponse
+  extends HostedOpsMemberUsageResetResult {
+  runtimeRecheckStatus: "accepted" | "pending";
 }
 
 export class HostedOpsMemberUsageResetNotFoundError extends Error {
@@ -114,58 +124,44 @@ export async function readHostedOpsMemberUsage(
     now.getTime() - HOSTED_MESSAGE_RETENTION_DAYS * DAY_MS,
   );
 
-  const [members, retainedMessageCounts, last7DayMessageCounts, usageTotals] =
-    await Promise.all([
-      prisma.hostedMember.findMany({
-        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  const members = await prisma.hostedMember.findMany({
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    select: {
+      billingStatus: true,
+      createdAt: true,
+      hostedGroupRuntime: {
         select: {
-          billingStatus: true,
-          createdAt: true,
-          hostedAiUsagePeriods: {
-            orderBy: { periodStart: "desc" },
-            select: {
-              blockedAt: true,
-              limitUsdMicros: true,
-              periodEnd: true,
-              periodStart: true,
-              spentUsdMicros: true,
-              updatedAt: true,
-            },
-            take: 1,
-            where: {
-              periodEnd: { gt: now },
-              periodStart: { lte: now },
-            },
+          ownerMemberId: true,
+          _count: {
+            select: { members: true },
           },
-          hostedGroupRuntime: {
-            select: {
-              ownerMemberId: true,
-              _count: {
-                select: { members: true },
-              },
-            },
-          },
-          id: true,
-          identity: {
-            select: { maskedPhoneNumberHint: true },
-          },
-          suspendedAt: true,
-          threadContainer: {
-            select: {
-              ownerMemberId: true,
-              _count: {
-                select: {
-                  participants: {
-                    where: { removedAt: null },
-                  },
-                },
-              },
-            },
-          },
-          usageCreditBalanceUsdMicros: true,
-          usageCreditLedgerVersion: true,
         },
-      }),
+      },
+      id: true,
+      identity: {
+        select: { maskedPhoneNumberHint: true },
+      },
+      suspendedAt: true,
+      threadContainer: {
+        select: {
+          ownerMemberId: true,
+          _count: {
+            select: {
+              participants: {
+                where: { removedAt: null },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  const [
+    retainedMessageCounts,
+    last7DayMessageCounts,
+    usageTotals,
+    usageGateSnapshots,
+  ] = await Promise.all([
       prisma.hostedMailboxItem.groupBy({
         by: ["userId"],
         _count: { _all: true },
@@ -187,6 +183,11 @@ export async function readHostedOpsMemberUsage(
         _sum: { allowanceCostUsdMicros: true },
         where: { allowanceCounted: true },
       }),
+      readHostedAiUsageGateSnapshots({
+        memberIds: members.map((member) => member.id),
+        now,
+        prisma,
+      }),
     ]);
 
   const retainedByMember = new Map(
@@ -203,16 +204,19 @@ export async function readHostedOpsMemberUsage(
   );
 
   const claimLookupKeys = members.flatMap((member) => {
-    const period = member.hostedAiUsagePeriods[0];
-    if (!period) {
+    const snapshot = usageGateSnapshots.get(member.id);
+    const decision = snapshot?.decision;
+    if (
+      !snapshot?.periodPersistedAt
+      || !decision
+      || (!decision.allowed && decision.reason !== "ai_usage_limit_exceeded")
+    ) {
       return [];
     }
     const key = buildHostedUsageNoticeLookupKey({
       memberId: member.id,
-      periodStart: period.periodStart,
-      usageCreditLedgerVersion: normalizeNonNegativeBigInt(
-        member.usageCreditLedgerVersion,
-      ),
+      periodStart: decision.periodStart,
+      usageCreditLedgerVersion: decision.usageCreditLedgerVersion,
     });
     return key ? [key] : [];
   });
@@ -236,18 +240,16 @@ export async function readHostedOpsMemberUsage(
   const rows = members.map((member): HostedOpsMemberUsageRow => {
     const retained = retainedByMember.get(member.id) ?? 0;
     const last7Days = last7DaysByMember.get(member.id) ?? 0;
-    const usageCreditBalanceUsdMicros = normalizeNonNegativeBigInt(
-      member.usageCreditBalanceUsdMicros,
+    const snapshot = usageGateSnapshots.get(member.id) ?? null;
+    const decision = snapshot?.decision ?? null;
+    const allowanceAvailable = decision !== null && (
+      decision.allowed || decision.reason === "ai_usage_limit_exceeded"
     );
-    const usageCreditLedgerVersion = normalizeNonNegativeBigInt(
-      member.usageCreditLedgerVersion,
-    );
-    const period = member.hostedAiUsagePeriods[0] ?? null;
-    const noticeLookupKey = period
+    const noticeLookupKey = allowanceAvailable && snapshot?.periodPersistedAt
       ? buildHostedUsageNoticeLookupKey({
           memberId: member.id,
-          periodStart: period.periodStart,
-          usageCreditLedgerVersion,
+          periodStart: decision.periodStart,
+          usageCreditLedgerVersion: decision.usageCreditLedgerVersion,
         })
       : null;
     const threadContainer = member.threadContainer;
@@ -255,6 +257,7 @@ export async function readHostedOpsMemberUsage(
     const isContainer = threadContainer !== null || legacyGroupContainer !== null;
 
     return {
+      allowanceStatus: allowanceAvailable ? "available" : "unavailable",
       allTimeUsageUsdMicros: (usageByMember.get(member.id) ?? 0n).toString(),
       billingStatus: member.billingStatus,
       containerOwnerMemberId:
@@ -262,25 +265,22 @@ export async function readHostedOpsMemberUsage(
         ?? legacyGroupContainer?.ownerMemberId
         ?? null,
       createdAt: member.createdAt.toISOString(),
-      currentPeriod: period
+      currentPeriod: allowanceAvailable && decision && snapshot
         ? {
-            blockedAt: period.blockedAt?.toISOString() ?? null,
+            blockedAt: snapshot.periodBlockedAt?.toISOString() ?? null,
             idempotencyClaimStatus: noticeLookupKey
               ? noticeStatusByLookupKey.get(noticeLookupKey) ?? null
               : null,
-            limitUsdMicros: period.limitUsdMicros.toString(),
-            periodEnd: period.periodEnd.toISOString(),
-            periodStart: period.periodStart.toISOString(),
-            remainingUsdMicros: calculateRemainingUsdMicros({
-              credit: usageCreditBalanceUsdMicros,
-              limit: period.limitUsdMicros,
-              spent: period.spentUsdMicros,
-            }).toString(),
-            spentUsdMicros: period.spentUsdMicros.toString(),
-            updatedAt: period.updatedAt.toISOString(),
+            limitUsdMicros: decision.limitUsdMicros.toString(),
+            periodEnd: decision.periodEnd.toISOString(),
+            periodStart: decision.periodStart.toISOString(),
+            remainingUsdMicros: decision.remainingUsdMicros.toString(),
+            spentUsdMicros: decision.spentUsdMicros.toString(),
+            updatedAt: snapshot.periodPersistedAt?.toISOString() ?? null,
             usageCreditBalanceUsdMicros:
-              usageCreditBalanceUsdMicros.toString(),
-            usageCreditLedgerVersion: usageCreditLedgerVersion.toString(),
+              decision.usageCreditBalanceUsdMicros.toString(),
+            usageCreditLedgerVersion:
+              decision.usageCreditLedgerVersion.toString(),
           }
         : null,
       maskedPhoneNumberHint: member.identity?.maskedPhoneNumberHint ?? null,
@@ -358,6 +358,21 @@ export async function resetHostedOpsMemberUsage(
       throw new HostedOpsMemberUsageResetStaleError();
     }
 
+    const canonicalGate = await readHostedAiUsageGate({
+      memberId: input.memberId,
+      now,
+      prisma: tx,
+    });
+    if (
+      (!canonicalGate.allowed
+        && canonicalGate.reason !== "ai_usage_limit_exceeded")
+      || canonicalGate.periodStart.getTime() !== input.periodStart.getTime()
+      || canonicalGate.usageCreditLedgerVersion
+        !== input.expectedUsageCreditLedgerVersion
+    ) {
+      throw new HostedOpsMemberUsageResetStaleError();
+    }
+
     const periodRows = await tx.$queryRaw<Array<{
       blockedAt: Date | null;
       periodEnd: Date;
@@ -379,9 +394,7 @@ export async function resetHostedOpsMemberUsage(
       throw new HostedOpsMemberUsageResetNotFoundError();
     }
     if (
-      input.periodStart.getTime() > now.getTime()
-      || period.periodEnd.getTime() <= now.getTime()
-      || period.updatedAt.getTime() !== input.expectedPeriodUpdatedAt.getTime()
+      period.updatedAt.getTime() !== input.expectedPeriodUpdatedAt.getTime()
     ) {
       throw new HostedOpsMemberUsageResetStaleError();
     }
@@ -483,17 +496,6 @@ function buildHostedUsageNoticeLookupKey(input: {
   return createHostedLinqDeliveryIdempotencyLookupKey(
     buildHostedAiUsageGateNoticeIdempotencyKey(input),
   );
-}
-
-function calculateRemainingUsdMicros(input: {
-  credit: bigint;
-  limit: bigint;
-  spent: bigint;
-}): bigint {
-  const includedRemaining = input.limit > input.spent
-    ? input.limit - input.spent
-    : 0n;
-  return includedRemaining + input.credit;
 }
 
 function normalizeNonNegativeBigInt(value: bigint | null): bigint {

--- a/apps/web/src/lib/hosted-ops/member-usage.ts
+++ b/apps/web/src/lib/hosted-ops/member-usage.ts
@@ -41,7 +41,7 @@ export interface HostedOpsMemberUsageRow {
 }
 
 export interface HostedOpsMemberUsagePeriod {
-  blockedAt: string | null;
+  blocked: boolean;
   idempotencyClaimStatus: string | null;
   limitUsdMicros: string;
   periodEnd: string;
@@ -267,7 +267,8 @@ export async function readHostedOpsMemberUsage(
       createdAt: member.createdAt.toISOString(),
       currentPeriod: allowanceAvailable && decision && snapshot
         ? {
-            blockedAt: snapshot.periodBlockedAt?.toISOString() ?? null,
+            blocked: !decision.allowed
+              && decision.reason === "ai_usage_limit_exceeded",
             idempotencyClaimStatus: noticeLookupKey
               ? noticeStatusByLookupKey.get(noticeLookupKey) ?? null
               : null,

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -25,6 +25,7 @@ import {
   checkHostedAiUsageGate,
   priceHostedAiUsageForAllowance,
   readHostedAiUsageGate,
+  readHostedAiUsageGateSnapshots,
   reconcileHostedAiUsageAllowancePeriodForMemberTx,
   resolveHostedAiUsageGate,
 } from "@/src/lib/hosted-execution/usage-allowance";
@@ -3136,6 +3137,74 @@ describe("readHostedAiUsageGate", () => {
 
     expect(prisma.hostedAiUsagePeriod.update).not.toHaveBeenCalled();
     expect(aggregate).not.toHaveBeenCalled();
+  });
+});
+
+describe("readHostedAiUsageGateSnapshots", () => {
+  it("uses the canonical gate decision and attaches exact persisted metadata", async () => {
+    const now = new Date("2026-07-22T18:00:00.000Z");
+    const periodStart = new Date("2026-07-05T00:00:00.000Z");
+    const periodEnd = new Date("2026-08-05T00:00:00.000Z");
+    const periodUpdatedAt = new Date("2026-07-22T17:00:00.000Z");
+    const prisma = createGatePrisma({
+      findUniquePeriod: {
+        billingPlanCode: "launch_monthly",
+        blockedAt: new Date("2026-07-22T16:55:00.000Z"),
+        limitUsdMicros: 10_000_000n,
+        periodEnd,
+        periodStart,
+        spentUsdMicros: 10_000_000n,
+      },
+      periodEnd,
+      periodStart,
+      spentUsdMicros: 10_000_000n,
+    });
+    const findPeriods = vi.fn(async () => [{
+      billingPlanCode: "launch_monthly",
+      blockedAt: new Date("2026-07-22T16:55:00.000Z"),
+      limitUsdMicros: 10_000_000n,
+      memberId: "member_123",
+      periodEnd,
+      periodStart,
+      spentUsdMicros: 10_000_000n,
+      updatedAt: periodUpdatedAt,
+    }]);
+    Object.assign(prisma.hostedAiUsagePeriod, { findMany: findPeriods });
+    const transaction = vi.fn(async (
+      run: (tx: typeof prisma) => Promise<unknown>,
+      _options?: { isolationLevel?: string },
+    ) => run(prisma));
+
+    const snapshots = await readHostedAiUsageGateSnapshots({
+      memberIds: ["member_123"],
+      now,
+      prisma: { $transaction: transaction } as never,
+    });
+
+    expect(snapshots.get("member_123")).toMatchObject({
+      decision: {
+        allowed: false,
+        allowanceSource: "direct_paid_member_plan",
+        periodEnd,
+        periodStart,
+        reason: "ai_usage_limit_exceeded",
+        spentUsdMicros: 10_000_000n,
+      },
+      periodPersistedAt: periodUpdatedAt,
+    });
+    expect(findPeriods).toHaveBeenCalledWith({
+      select: expect.any(Object),
+      where: {
+        OR: [{
+          memberId: "member_123",
+          periodStart,
+        }],
+      },
+    });
+    expect(transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { isolationLevel: "RepeatableRead" },
+    );
   });
 });
 

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -3193,7 +3193,11 @@ describe("readHostedAiUsageGateSnapshots", () => {
       periodPersistedAt: periodUpdatedAt,
     });
     expect(findPeriods).toHaveBeenCalledWith({
-      select: expect.any(Object),
+      select: {
+        memberId: true,
+        periodStart: true,
+        updatedAt: true,
+      },
       where: {
         OR: [{
           memberId: "member_123",
@@ -3205,6 +3209,96 @@ describe("readHostedAiUsageGateSnapshots", () => {
       expect.any(Function),
       { isolationLevel: "RepeatableRead" },
     );
+  });
+
+  it("derives admission from the current plan instead of stale block metadata", async () => {
+    const now = new Date("2026-07-22T18:00:00.000Z");
+    const periodStart = new Date("2026-07-05T00:00:00.000Z");
+    const periodEnd = new Date("2026-08-05T00:00:00.000Z");
+    const periodUpdatedAt = new Date("2026-07-22T17:00:00.000Z");
+
+    const increasedPlan = createGatePrisma({
+      billingPlanCode: "launch_edge_monthly",
+      findUniquePeriod: {
+        billingPlanCode: "launch_monthly",
+        blockedAt: new Date("2026-07-22T16:55:00.000Z"),
+        limitUsdMicros: 10_000_000n,
+        periodEnd,
+        periodStart,
+        spentUsdMicros: 10_000_000n,
+      },
+      periodEnd,
+      periodStart,
+      spentUsdMicros: 10_000_000n,
+    });
+    Object.assign(increasedPlan.hostedAiUsagePeriod, {
+      findMany: vi.fn(async () => [{
+        memberId: "member_123",
+        periodStart,
+        updatedAt: periodUpdatedAt,
+      }]),
+    });
+    const increasedTransaction = vi.fn(async (
+      run: (tx: typeof increasedPlan) => Promise<unknown>,
+      _options?: { isolationLevel?: string },
+    ) => run(increasedPlan));
+
+    const increasedSnapshots = await readHostedAiUsageGateSnapshots({
+      memberIds: ["member_123"],
+      now,
+      prisma: { $transaction: increasedTransaction } as never,
+    });
+
+    expect(increasedSnapshots.get("member_123")).toMatchObject({
+      decision: {
+        allowed: true,
+        limitUsdMicros: 25_000_000n,
+        remainingUsdMicros: 15_000_000n,
+      },
+      periodPersistedAt: periodUpdatedAt,
+    });
+
+    const decreasedPlan = createGatePrisma({
+      billingPlanCode: "launch_monthly",
+      findUniquePeriod: {
+        billingPlanCode: "launch_edge_monthly",
+        blockedAt: null,
+        limitUsdMicros: 25_000_000n,
+        periodEnd,
+        periodStart,
+        spentUsdMicros: 11_000_000n,
+      },
+      periodEnd,
+      periodStart,
+      spentUsdMicros: 11_000_000n,
+    });
+    Object.assign(decreasedPlan.hostedAiUsagePeriod, {
+      findMany: vi.fn(async () => [{
+        memberId: "member_123",
+        periodStart,
+        updatedAt: periodUpdatedAt,
+      }]),
+    });
+    const decreasedTransaction = vi.fn(async (
+      run: (tx: typeof decreasedPlan) => Promise<unknown>,
+      _options?: { isolationLevel?: string },
+    ) => run(decreasedPlan));
+
+    const decreasedSnapshots = await readHostedAiUsageGateSnapshots({
+      memberIds: ["member_123"],
+      now,
+      prisma: { $transaction: decreasedTransaction } as never,
+    });
+
+    expect(decreasedSnapshots.get("member_123")).toMatchObject({
+      decision: {
+        allowed: false,
+        limitUsdMicros: 10_000_000n,
+        reason: "ai_usage_limit_exceeded",
+        remainingUsdMicros: 0n,
+      },
+      periodPersistedAt: periodUpdatedAt,
+    });
   });
 });
 

--- a/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
+++ b/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
@@ -64,6 +64,7 @@ describe("hosted usage-limit notice claim authority", () => {
         await input.assertDispatchAuthority?.(input.prisma);
         return {
           idempotencyKey: "usage_notice_claim_1",
+          providerIdempotencyKey: "usage_notice_provider_attempt_1",
           status: "claimed",
         };
       },
@@ -92,6 +93,7 @@ describe("hosted usage-limit notice claim authority", () => {
       usageCreditLedgerVersion: 4n,
     })).resolves.toEqual({
       idempotencyKey: "usage_notice_claim_1",
+      providerIdempotencyKey: "usage_notice_provider_attempt_1",
       status: "claimed",
     });
 
@@ -244,6 +246,7 @@ describe("hosted usage-limit notice claim authority", () => {
       usageCreditLedgerVersion: 6n,
     })).resolves.toEqual({
       idempotencyKey: "usage_notice_claim_1",
+      providerIdempotencyKey: "usage_notice_provider_attempt_1",
       status: "claimed",
     });
   });

--- a/apps/web/test/hosted-execution-usage-limit-notice.test.ts
+++ b/apps/web/test/hosted-execution-usage-limit-notice.test.ts
@@ -55,6 +55,7 @@ describe("hosted usage-limit notice delivery", () => {
     });
     deliveryMocks.startHostedAiUsageLimitNoticeDispatchTx.mockResolvedValue({
       idempotencyKey: "usage_notice_claim_1",
+      providerIdempotencyKey: "usage_notice_provider_attempt_1",
       status: "claimed",
     });
     deliveryMocks.markHostedLinqDeliveryAcceptedTx.mockResolvedValue(true);

--- a/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
@@ -1298,7 +1298,7 @@ describe("hosted Linq observability stores", () => {
       targetKind: "thread",
     })).resolves.toEqual({
       claimed: true,
-      id: expect.stringMatching(/^hld_[a-f0-9]{32}$/u),
+      id: expect.stringMatching(/^hld_[A-Za-z0-9_-]{16}$/u),
     });
 
     expect(fixture.hostedLinqDeliveryCreateMany).toHaveBeenCalledWith({
@@ -1353,7 +1353,7 @@ describe("hosted Linq observability stores", () => {
       template: "invite_signup",
     })).resolves.toEqual({
       claimed: true,
-      id: expect.stringMatching(/^hld_[a-f0-9]{32}$/u),
+      id: expect.stringMatching(/^hld_[A-Za-z0-9_-]{16}$/u),
     });
 
     expect(fixture.hostedLinqDeliveryFindUnique).toHaveBeenCalledWith({
@@ -1946,6 +1946,9 @@ describe("hosted Linq observability stores", () => {
       usageCreditLedgerVersion: 0n,
     })).resolves.toEqual({
       idempotencyKey: currentIdempotencyKey,
+      providerIdempotencyKey: expect.stringMatching(
+        /^ai-usage-attempt:hld_[A-Za-z0-9_-]{16}$/u,
+      ),
       status: "claimed",
     });
 
@@ -2133,6 +2136,8 @@ describe("hosted Linq observability stores", () => {
       usageCreditLedgerVersion: 0n,
     })).resolves.toEqual({
       idempotencyKey: currentIdempotencyKey,
+      providerIdempotencyKey:
+        "ai-usage-attempt:hld_stale_current_usage_notice",
       status: "claimed",
     });
 

--- a/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
@@ -1289,16 +1289,17 @@ describe("hosted Linq observability stores", () => {
     const fixture = createObservabilityPrismaFixture();
     const attemptedAt = new Date("2026-03-26T12:00:00.000Z");
 
-    await expect(recordHostedLinqRuntimeProviderDispatchFenceTx({
+    const fence = await recordHostedLinqRuntimeProviderDispatchFenceTx({
       attemptedAt,
       idempotencyKey: "assistant-outbox:intent-123",
       linqChatId: "chat_123",
       prisma: fixture.prisma as never,
       sourceRef: "intent-123",
       targetKind: "thread",
-    })).resolves.toEqual({
+    });
+    expect(fence).toEqual({
       claimed: true,
-      id: expect.stringMatching(/^hld_[A-Za-z0-9_-]{16}$/u),
+      id: expect.stringMatching(/^hld_[a-f0-9]{32}$/u),
     });
 
     expect(fixture.hostedLinqDeliveryCreateMany).toHaveBeenCalledWith({
@@ -1310,6 +1311,37 @@ describe("hosted Linq observability stores", () => {
         targetKind: "thread",
       })],
       skipDuplicates: true,
+    });
+
+    fixture.hostedLinqDeliveryFindUnique.mockResolvedValueOnce({
+      acceptedAt: null,
+      attemptedAt,
+      deliveredAt: null,
+      failedAt: null,
+      id: fence.id,
+      lastReceiptAt: null,
+      messageLookupKey: null,
+      phoneNumberLookupKey: null,
+      retryAfterAt: null,
+      skippedAt: null,
+      source: "hosted_runtime_linq_delivery",
+      status: "provider_dispatch_started",
+    });
+    const outcome = await recordHostedLinqRuntimeDeliveryOutcomeTx({
+      acceptedAt: new Date("2026-03-26T12:00:01.000Z"),
+      attemptedAt,
+      idempotencyKey: "assistant-outbox:intent-123",
+      linqChatId: "chat_123",
+      messageId: "provider_message_123",
+      prisma: fixture.prisma as never,
+      sourceRef: "intent-123",
+      targetKind: "thread",
+      userId: "member_123",
+    });
+
+    expect(outcome).toMatchObject({
+      deliveryId: fence.id,
+      recorded: true,
     });
   });
 
@@ -1353,7 +1385,7 @@ describe("hosted Linq observability stores", () => {
       template: "invite_signup",
     })).resolves.toEqual({
       claimed: true,
-      id: expect.stringMatching(/^hld_[A-Za-z0-9_-]{16}$/u),
+      id: expect.stringMatching(/^hld_[a-f0-9]{32}$/u),
     });
 
     expect(fixture.hostedLinqDeliveryFindUnique).toHaveBeenCalledWith({

--- a/apps/web/test/hosted-onboarding-linq-participant-addition-concurrency.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-participant-addition-concurrency.test.ts
@@ -424,6 +424,9 @@ describe.skipIf(!runPostgresConcurrencyProof)(
         releaseUsageAuthorityCheck.resolve();
         await expect(usageTransaction).resolves.toEqual({
           idempotencyKey: usageIdempotencyKey,
+          providerIdempotencyKey: expect.stringMatching(
+            /^ai-usage-attempt:hld_[A-Za-z0-9_-]{16}$/u,
+          ),
           status: "claimed",
         });
         await expect(consumerTransaction).resolves.toBe(true);
@@ -605,6 +608,9 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           usageCreditLedgerVersion: 0n,
         })).resolves.toEqual({
           idempotencyKey: usageIdempotencyKey,
+          providerIdempotencyKey: expect.stringMatching(
+            /^ai-usage-attempt:hld_[A-Za-z0-9_-]{16}$/u,
+          ),
           status: "claimed",
         });
         await expect(markHostedAiUsageLimitNoticeDeliveryRetryableTx({
@@ -655,6 +661,9 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           usageCreditLedgerVersion: 2n,
         })).resolves.toEqual({
           idempotencyKey: reexhaustionIdempotencyKey,
+          providerIdempotencyKey: expect.stringMatching(
+            /^ai-usage-attempt:hld_[A-Za-z0-9_-]{16}$/u,
+          ),
           status: "claimed",
         });
         expect(reexhaustionIdempotencyKey).not.toBe(usageIdempotencyKey);

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -113,6 +113,7 @@ vi.mock("@/src/lib/hosted-execution/usage-limit-notice-claim", async () => {
         usageCreditLedgerVersion: bigint;
       }) => ({
         idempotencyKey: actual.buildHostedAiUsageGateNoticeIdempotencyKey(input),
+        providerIdempotencyKey: "ai-usage-attempt:hld_usage_notice",
         status: "claimed" as const,
       }),
     ),
@@ -189,6 +190,7 @@ describe("hosted Linq webhook transport", () => {
         });
         return {
           idempotencyKey: buildHostedAiUsageGateNoticeIdempotencyKey(input),
+          providerIdempotencyKey: "ai-usage-attempt:hld_usage_notice",
           status: "claimed",
         };
       });
@@ -765,7 +767,7 @@ describe("hosted Linq webhook transport", () => {
     expect(sendHostedLinqChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: "chat-1",
-        idempotencyKey: expectedIdempotencyKey,
+        idempotencyKey: "ai-usage-attempt:hld_usage_notice",
         message: "usage-limit",
         replyToMessageId: "message-1",
       }),

--- a/apps/web/test/hosted-ops-member-usage.test.ts
+++ b/apps/web/test/hosted-ops-member-usage.test.ts
@@ -1,0 +1,414 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  HostedOpsMemberUsageResetNotFoundError,
+  HostedOpsMemberUsageResetNoticeInFlightError,
+  HostedOpsMemberUsageResetStaleError,
+  readHostedOpsMemberUsage,
+  resetHostedOpsMemberUsage,
+} from "../src/lib/hosted-ops/member-usage";
+import {
+  buildHostedAiUsageGateNoticeIdempotencyKey,
+} from "../src/lib/hosted-onboarding/linq-delivery-store";
+import {
+  createHostedLinqDeliveryIdempotencyLookupKey,
+} from "../src/lib/hosted-onboarding/linq-observability-identifiers";
+
+const NOW = new Date("2026-07-22T18:00:00.000Z");
+const PERIOD_START = new Date("2026-07-01T00:00:00.000Z");
+const PERIOD_END = new Date("2026-08-01T00:00:00.000Z");
+const PERIOD_UPDATED_AT = new Date("2026-07-22T17:30:00.000Z");
+
+describe("hosted ops member usage", () => {
+  test("reports members and containers from canonical retained and immutable rows", async () => {
+    const groupMessages = vi.fn()
+      .mockResolvedValueOnce([{
+        _count: { _all: 18 },
+        userId: "hbm_container",
+      }, {
+        _count: { _all: 4 },
+        userId: "hbm_person",
+      }])
+      .mockResolvedValueOnce([{
+        _count: { _all: 7 },
+        userId: "hbm_container",
+      }]);
+    const findDeliveries = vi.fn(async (input: {
+      where: { idempotencyKey: { in: string[] } };
+    }) => [{
+      idempotencyKey: input.where.idempotencyKey.in[0] ?? null,
+      status: "accepted",
+    }]);
+    const groupUsage = vi.fn(async () => [{
+      _sum: { allowanceCostUsdMicros: 7_250_000n },
+      memberId: "hbm_container",
+    }, {
+      _sum: { allowanceCostUsdMicros: 1_250_000n },
+      memberId: "hbm_person",
+    }]);
+    const findMembers = vi.fn(async () => [
+      makeMember({
+        hostedAiUsagePeriods: [makePeriod()],
+        id: "hbm_container",
+        identity: null,
+        threadContainer: {
+          _count: { participants: 2 },
+          ownerMemberId: "hbm_person",
+        },
+        usageCreditBalanceUsdMicros: 500_000n,
+        usageCreditLedgerVersion: 3n,
+      }),
+      makeMember({ id: "hbm_person" }),
+    ]);
+    const prisma = asPrismaClientForHostedOpsTest({
+      hostedAiUsage: {
+        groupBy: groupUsage,
+      },
+      hostedLinqDelivery: { findMany: findDeliveries },
+      hostedMailboxItem: {
+        groupBy: groupMessages,
+      },
+      hostedMember: {
+        findMany: findMembers,
+      },
+    });
+
+    const dashboard = await readHostedOpsMemberUsage(NOW, prisma);
+
+    expect(dashboard.rows.map((row) => row.memberId)).toEqual([
+      "hbm_container",
+      "hbm_person",
+    ]);
+    expect(dashboard.rows[0]).toMatchObject({
+      allTimeUsageUsdMicros: "7250000",
+      containerOwnerMemberId: "hbm_person",
+      memberKind: "group_container",
+      messagesDailyAverage7Days: 1,
+      messagesLast7Days: 7,
+      messagesRetained: 18,
+      participantCount: 2,
+    });
+    expect(dashboard.rows[0]?.currentPeriod).toMatchObject({
+      idempotencyClaimStatus: "accepted",
+      remainingUsdMicros: "500000",
+      usageCreditBalanceUsdMicros: "500000",
+      usageCreditLedgerVersion: "3",
+    });
+    expect(dashboard.rows[1]).toMatchObject({
+      allTimeUsageUsdMicros: "1250000",
+      memberKind: "member",
+      messagesDailyAverage7Days: 0,
+      messagesLast7Days: 0,
+      messagesRetained: 4,
+    });
+    expect(dashboard.summary).toEqual({
+      activeEntitiesLast7Days: 1,
+      groupContainers: 1,
+      members: 1,
+      totalAllTimeUsageUsdMicros: "8500000",
+    });
+    expect(groupMessages).toHaveBeenNthCalledWith(1, {
+      by: ["userId"],
+      _count: { _all: true },
+      where: {
+        kind: "conversation.message",
+        occurredAt: {
+          gte: new Date("2026-06-22T18:00:00.000Z"),
+          lt: NOW,
+        },
+      },
+    });
+    expect(groupMessages).toHaveBeenNthCalledWith(2, {
+      by: ["userId"],
+      _count: { _all: true },
+      where: {
+        kind: "conversation.message",
+        occurredAt: {
+          gte: new Date("2026-07-15T18:00:00.000Z"),
+          lt: NOW,
+        },
+      },
+    });
+    expect(groupUsage).toHaveBeenCalledWith({
+      by: ["memberId"],
+      _sum: { allowanceCostUsdMicros: true },
+      where: { allowanceCounted: true },
+    });
+    expect(findMembers).toHaveBeenCalledWith(expect.objectContaining({
+      select: expect.objectContaining({
+        threadContainer: {
+          select: {
+            ownerMemberId: true,
+            _count: {
+              select: {
+                participants: {
+                  where: { removedAt: null },
+                },
+              },
+            },
+          },
+        },
+      }),
+    }));
+    expect(findDeliveries).toHaveBeenCalledTimes(1);
+  });
+
+  test("atomically clears included spend and releases only the current notice claim", async () => {
+    const tx = createResetTransactionFixture({
+      delivery: makeDelivery({ status: "accepted" }),
+    });
+    const prisma = asPrismaClientForHostedOpsTest({
+      $transaction: vi.fn(async (run: (client: typeof tx) => Promise<unknown>) =>
+        run(tx)),
+    });
+
+    const result = await resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: "hbm_container",
+      now: NOW,
+      periodStart: PERIOD_START,
+    }, prisma);
+
+    expect(result).toEqual({
+      memberId: "hbm_container",
+      noticeClaimReleased: true,
+      outcome: "reset",
+      periodStart: PERIOD_START.toISOString(),
+      previousSpentUsdMicros: "4522964",
+      resetAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+    });
+    expect(tx.hostedLinqDelivery.update).toHaveBeenCalledWith({
+      data: { idempotencyKey: null },
+      where: { id: "delivery_1" },
+    });
+    expect(tx.hostedAiUsagePeriod.updateMany).toHaveBeenCalledWith({
+      data: {
+        blockedAt: null,
+        spentUsdMicros: 0n,
+        updatedAt: NOW,
+      },
+      where: {
+        memberId: "hbm_container",
+        periodStart: PERIOD_START,
+        updatedAt: PERIOD_UPDATED_AT,
+      },
+    });
+    const expectedNoticeLookupKey = createHostedLinqDeliveryIdempotencyLookupKey(
+      buildHostedAiUsageGateNoticeIdempotencyKey({
+        memberId: "hbm_container",
+        periodStart: PERIOD_START,
+        usageCreditLedgerVersion: 4n,
+      }),
+    );
+    expect(tx.$queryRaw.mock.calls[2]?.[1]).toBe(expectedNoticeLookupKey);
+  });
+
+  test("rejects a stale credit epoch before reading or releasing a notice claim", async () => {
+    const tx = createResetTransactionFixture({
+      usageCreditLedgerVersion: 5n,
+    });
+    const prisma = asPrismaClientForHostedOpsTest({
+      $transaction: vi.fn(async (run: (client: typeof tx) => Promise<unknown>) =>
+        run(tx)),
+    });
+
+    await expect(resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: "hbm_container",
+      now: NOW,
+      periodStart: PERIOD_START,
+    }, prisma)).rejects.toBeInstanceOf(HostedOpsMemberUsageResetStaleError);
+    expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(tx.hostedLinqDelivery.update).not.toHaveBeenCalled();
+    expect(tx.hostedAiUsagePeriod.updateMany).not.toHaveBeenCalled();
+  });
+
+  test("rejects a stale row before releasing its notice claim", async () => {
+    const tx = createResetTransactionFixture({
+      periodUpdatedAt: new Date(PERIOD_UPDATED_AT.getTime() + 1_000),
+    });
+    const prisma = asPrismaClientForHostedOpsTest({
+      $transaction: vi.fn(async (run: (client: typeof tx) => Promise<unknown>) =>
+        run(tx)),
+    });
+
+    await expect(resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: "hbm_container",
+      now: NOW,
+      periodStart: PERIOD_START,
+    }, prisma)).rejects.toBeInstanceOf(HostedOpsMemberUsageResetStaleError);
+    expect(tx.hostedLinqDelivery.update).not.toHaveBeenCalled();
+    expect(tx.hostedAiUsagePeriod.updateMany).not.toHaveBeenCalled();
+  });
+
+  test("does not reset while the current quota notice is still dispatching", async () => {
+    const tx = createResetTransactionFixture({
+      delivery: makeDelivery({
+        acceptedAt: null,
+        attemptedAt: new Date(NOW.getTime() - 60_000),
+        messageLookupKey: null,
+        status: "provider_dispatch_started",
+      }),
+    });
+    const prisma = asPrismaClientForHostedOpsTest({
+      $transaction: vi.fn(async (run: (client: typeof tx) => Promise<unknown>) =>
+        run(tx)),
+    });
+
+    await expect(resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: "hbm_container",
+      now: NOW,
+      periodStart: PERIOD_START,
+    }, prisma)).rejects.toBeInstanceOf(
+      HostedOpsMemberUsageResetNoticeInFlightError,
+    );
+    expect(tx.hostedLinqDelivery.update).not.toHaveBeenCalled();
+    expect(tx.hostedAiUsagePeriod.updateMany).not.toHaveBeenCalled();
+  });
+
+  test("returns unchanged without rewriting an already clear period", async () => {
+    const tx = createResetTransactionFixture({
+      blockedAt: null,
+      delivery: null,
+      spentUsdMicros: 0n,
+    });
+    const prisma = asPrismaClientForHostedOpsTest({
+      $transaction: vi.fn(async (run: (client: typeof tx) => Promise<unknown>) =>
+        run(tx)),
+    });
+
+    const result = await resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: "hbm_container",
+      now: NOW,
+      periodStart: PERIOD_START,
+    }, prisma);
+
+    expect(result).toMatchObject({
+      noticeClaimReleased: false,
+      outcome: "unchanged",
+      previousSpentUsdMicros: "0",
+      updatedAt: PERIOD_UPDATED_AT.toISOString(),
+    });
+    expect(tx.hostedLinqDelivery.update).not.toHaveBeenCalled();
+    expect(tx.hostedAiUsagePeriod.updateMany).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when the selected member no longer exists", async () => {
+    const tx = createResetTransactionFixture({ memberExists: false });
+    const prisma = asPrismaClientForHostedOpsTest({
+      $transaction: vi.fn(async (run: (client: typeof tx) => Promise<unknown>) =>
+        run(tx)),
+    });
+
+    await expect(resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: "hbm_container",
+      now: NOW,
+      periodStart: PERIOD_START,
+    }, prisma)).rejects.toBeInstanceOf(HostedOpsMemberUsageResetNotFoundError);
+    expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(tx.hostedLinqDelivery.update).not.toHaveBeenCalled();
+    expect(tx.hostedAiUsagePeriod.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+function makeMember(overrides: Record<string, unknown> = {}) {
+  return {
+    billingStatus: "active",
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    hostedAiUsagePeriods: [],
+    hostedGroupRuntime: null,
+    id: "hbm_person",
+    identity: { maskedPhoneNumberHint: "••• 0101" },
+    suspendedAt: null,
+    threadContainer: null,
+    usageCreditBalanceUsdMicros: 0n,
+    usageCreditLedgerVersion: 0n,
+    ...overrides,
+  };
+}
+
+function makePeriod() {
+  return {
+    blockedAt: new Date("2026-07-22T17:25:30.000Z"),
+    limitUsdMicros: 4_500_000n,
+    periodEnd: PERIOD_END,
+    periodStart: PERIOD_START,
+    spentUsdMicros: 4_522_964n,
+    updatedAt: PERIOD_UPDATED_AT,
+  };
+}
+
+function makeDelivery(overrides: Record<string, unknown> = {}) {
+  return {
+    acceptedAt: NOW,
+    attemptedAt: new Date(NOW.getTime() - 60 * 60 * 1000),
+    deliveredAt: null,
+    failedAt: null,
+    id: "delivery_1",
+    lastReceiptAt: null,
+    messageLookupKey: "message_lookup",
+    skippedAt: null,
+    status: "accepted",
+    ...overrides,
+  };
+}
+
+function createResetTransactionFixture(input: {
+  blockedAt?: Date | null;
+  delivery?: ReturnType<typeof makeDelivery> | null;
+  memberExists?: boolean;
+  periodUpdatedAt?: Date;
+  spentUsdMicros?: bigint;
+  usageCreditLedgerVersion?: bigint;
+} = {}) {
+  const rows = [
+    input.memberExists === false
+      ? []
+      : [{
+          usageCreditLedgerVersion: input.usageCreditLedgerVersion ?? 4n,
+        }],
+    [{
+      blockedAt: input.blockedAt === undefined
+        ? new Date("2026-07-22T17:25:30.000Z")
+        : input.blockedAt,
+      periodEnd: PERIOD_END,
+      spentUsdMicros: input.spentUsdMicros ?? 4_522_964n,
+      updatedAt: input.periodUpdatedAt ?? PERIOD_UPDATED_AT,
+    }],
+    input.delivery === null ? [] : [input.delivery ?? makeDelivery()],
+  ];
+  return {
+    $queryRaw: vi.fn()
+      .mockResolvedValueOnce(rows[0])
+      .mockResolvedValueOnce(rows[1])
+      .mockResolvedValueOnce(rows[2]),
+    hostedAiUsagePeriod: {
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
+    hostedLinqDelivery: {
+      update: vi.fn(async () => ({ id: "delivery_1" })),
+    },
+  };
+}
+
+/**
+ * This fixture assertion is limited to the delegates exercised by this file.
+ * The production queries remain checked against the generated Prisma client.
+ */
+function asPrismaClientForHostedOpsTest(value: object): PrismaClient {
+  return value as PrismaClient;
+}

--- a/apps/web/test/hosted-ops-member-usage.test.ts
+++ b/apps/web/test/hosted-ops-member-usage.test.ts
@@ -96,7 +96,6 @@ describe("hosted ops member usage", () => {
       new Map([
         ["hbm_container", {
           decision: makeUsageGateDecision({ allowed: true }),
-          periodBlockedAt: new Date("2026-07-22T17:25:30.000Z"),
           periodPersistedAt: PERIOD_UPDATED_AT,
         }],
         ["hbm_person", {
@@ -107,7 +106,6 @@ describe("hosted ops member usage", () => {
             spentUsdMicros: 0n,
             usageCreditLedgerVersion: 0n,
           }),
-          periodBlockedAt: null,
           periodPersistedAt: null,
         }],
       ]),
@@ -142,10 +140,14 @@ describe("hosted ops member usage", () => {
       participantCount: 2,
     });
     expect(dashboard.rows[0]?.currentPeriod).toMatchObject({
+      blocked: false,
       idempotencyClaimStatus: "accepted",
       remainingUsdMicros: "500000",
       usageCreditBalanceUsdMicros: "500000",
       usageCreditLedgerVersion: "3",
+    });
+    expect(dashboard.rows[1]?.currentPeriod).toMatchObject({
+      blocked: false,
     });
     expect(dashboard.rows[1]).toMatchObject({
       allTimeUsageUsdMicros: "1250000",
@@ -204,6 +206,29 @@ describe("hosted ops member usage", () => {
       }),
     }));
     expect(findDeliveries).toHaveBeenCalledTimes(1);
+  });
+
+  test("projects blocked status from the canonical decision", async () => {
+    usageAllowanceMocks.readHostedAiUsageGateSnapshots.mockResolvedValue(
+      new Map([["hbm_person", {
+        decision: makeUsageGateDecision({ memberId: "hbm_person" }),
+        periodPersistedAt: PERIOD_UPDATED_AT,
+      }]]),
+    );
+    const prisma = asPrismaClientForHostedOpsTest({
+      hostedAiUsage: { groupBy: vi.fn(async () => []) },
+      hostedLinqDelivery: { findMany: vi.fn(async () => []) },
+      hostedMailboxItem: { groupBy: vi.fn(async () => []) },
+      hostedMember: {
+        findMany: vi.fn(async () => [makeMember({ id: "hbm_person" })]),
+      },
+    });
+
+    const dashboard = await readHostedOpsMemberUsage(NOW, prisma);
+
+    expect(dashboard.rows[0]?.currentPeriod).toMatchObject({
+      blocked: true,
+    });
   });
 
   test("atomically clears included spend and releases only the current notice claim", async () => {

--- a/apps/web/test/hosted-ops-member-usage.test.ts
+++ b/apps/web/test/hosted-ops-member-usage.test.ts
@@ -1,7 +1,24 @@
 import type { PrismaClient } from "@prisma/client";
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
+
+const usageAllowanceMocks = vi.hoisted(() => ({
+  readHostedAiUsageGate: vi.fn(),
+  readHostedAiUsageGateSnapshots: vi.fn(),
+}));
+
+vi.mock("../src/lib/hosted-execution/usage-allowance", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/hosted-execution/usage-allowance")
+  >("../src/lib/hosted-execution/usage-allowance");
+  return {
+    ...actual,
+    readHostedAiUsageGate: usageAllowanceMocks.readHostedAiUsageGate,
+    readHostedAiUsageGateSnapshots:
+      usageAllowanceMocks.readHostedAiUsageGateSnapshots,
+  };
+});
 
 import {
   HostedOpsMemberUsageResetNotFoundError,
@@ -23,6 +40,19 @@ const PERIOD_END = new Date("2026-08-01T00:00:00.000Z");
 const PERIOD_UPDATED_AT = new Date("2026-07-22T17:30:00.000Z");
 
 describe("hosted ops member usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usageAllowanceMocks.readHostedAiUsageGate.mockResolvedValue(
+      makeUsageGateDecision({
+        usageCreditBalanceUsdMicros: 0n,
+        usageCreditLedgerVersion: 4n,
+      }),
+    );
+    usageAllowanceMocks.readHostedAiUsageGateSnapshots.mockResolvedValue(
+      new Map(),
+    );
+  });
+
   test("reports members and containers from canonical retained and immutable rows", async () => {
     const groupMessages = vi.fn()
       .mockResolvedValueOnce([{
@@ -51,7 +81,6 @@ describe("hosted ops member usage", () => {
     }]);
     const findMembers = vi.fn(async () => [
       makeMember({
-        hostedAiUsagePeriods: [makePeriod()],
         id: "hbm_container",
         identity: null,
         threadContainer: {
@@ -63,6 +92,26 @@ describe("hosted ops member usage", () => {
       }),
       makeMember({ id: "hbm_person" }),
     ]);
+    usageAllowanceMocks.readHostedAiUsageGateSnapshots.mockResolvedValue(
+      new Map([
+        ["hbm_container", {
+          decision: makeUsageGateDecision({ allowed: true }),
+          periodBlockedAt: new Date("2026-07-22T17:25:30.000Z"),
+          periodPersistedAt: PERIOD_UPDATED_AT,
+        }],
+        ["hbm_person", {
+          decision: makeUsageGateDecision({
+            allowed: true,
+            memberId: "hbm_person",
+            remainingUsdMicros: 4_500_000n,
+            spentUsdMicros: 0n,
+            usageCreditLedgerVersion: 0n,
+          }),
+          periodBlockedAt: null,
+          periodPersistedAt: null,
+        }],
+      ]),
+    );
     const prisma = asPrismaClientForHostedOpsTest({
       hostedAiUsage: {
         groupBy: groupUsage,
@@ -83,6 +132,7 @@ describe("hosted ops member usage", () => {
       "hbm_person",
     ]);
     expect(dashboard.rows[0]).toMatchObject({
+      allowanceStatus: "available",
       allTimeUsageUsdMicros: "7250000",
       containerOwnerMemberId: "hbm_person",
       memberKind: "group_container",
@@ -229,6 +279,33 @@ describe("hosted ops member usage", () => {
     expect(tx.hostedAiUsagePeriod.updateMany).not.toHaveBeenCalled();
   });
 
+  test("rejects a date-active row that is no longer the canonical period", async () => {
+    usageAllowanceMocks.readHostedAiUsageGate.mockResolvedValueOnce(
+      makeUsageGateDecision({
+        periodEnd: new Date("2026-07-25T00:00:00.000Z"),
+        periodStart: new Date("2026-06-25T00:00:00.000Z"),
+        usageCreditBalanceUsdMicros: 0n,
+        usageCreditLedgerVersion: 4n,
+      }),
+    );
+    const tx = createResetTransactionFixture();
+    const prisma = asPrismaClientForHostedOpsTest({
+      $transaction: vi.fn(async (run: (client: typeof tx) => Promise<unknown>) =>
+        run(tx)),
+    });
+
+    await expect(resetHostedOpsMemberUsage({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: "hbm_container",
+      now: NOW,
+      periodStart: PERIOD_START,
+    }, prisma)).rejects.toBeInstanceOf(HostedOpsMemberUsageResetStaleError);
+    expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(tx.hostedLinqDelivery.update).not.toHaveBeenCalled();
+    expect(tx.hostedAiUsagePeriod.updateMany).not.toHaveBeenCalled();
+  });
+
   test("rejects a stale row before releasing its notice claim", async () => {
     const tx = createResetTransactionFixture({
       periodUpdatedAt: new Date(PERIOD_UPDATED_AT.getTime() + 1_000),
@@ -329,7 +406,6 @@ function makeMember(overrides: Record<string, unknown> = {}) {
   return {
     billingStatus: "active",
     createdAt: new Date("2026-06-01T00:00:00.000Z"),
-    hostedAiUsagePeriods: [],
     hostedGroupRuntime: null,
     id: "hbm_person",
     identity: { maskedPhoneNumberHint: "••• 0101" },
@@ -341,14 +417,26 @@ function makeMember(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makePeriod() {
+function makeUsageGateDecision(overrides: Record<string, unknown> = {}) {
   return {
-    blockedAt: new Date("2026-07-22T17:25:30.000Z"),
+    allowed: false,
+    allowanceSource: "thread_container",
+    billingPlanCode: "launch_monthly",
     limitUsdMicros: 4_500_000n,
+    memberId: "hbm_container",
     periodEnd: PERIOD_END,
     periodStart: PERIOD_START,
+    reason: "ai_usage_limit_exceeded",
+    remainingUsdMicros: 500_000n,
+    retryAfter: PERIOD_END,
     spentUsdMicros: 4_522_964n,
-    updatedAt: PERIOD_UPDATED_AT,
+    usageCreditBalanceUsdMicros: 500_000n,
+    usageCreditLedgerVersion: 3n,
+    userNotice: {
+      code: "thread_usage_limit_reached",
+      message: "Usage limit reached.",
+    },
+    ...overrides,
   };
 }
 

--- a/apps/web/test/hosted-ops-usage-reset-postgres.test.ts
+++ b/apps/web/test/hosted-ops-usage-reset-postgres.test.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from "node:crypto";
+
+import { HostedBillingStatus } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { resetHostedOpsMemberUsage } from "@/src/lib/hosted-ops/member-usage";
+import { getHostedAiUsageMonthlyAllowanceUsdMicros } from "@/src/lib/hosted-onboarding/billing-plans";
+import {
+  startHostedAiUsageLimitNoticeDispatchTx,
+} from "@/src/lib/hosted-onboarding/linq-delivery-store";
+import {
+  createHostedLinqDeliveryIdempotencyLookupKey,
+} from "@/src/lib/hosted-onboarding/linq-observability-identifiers";
+import { createPrismaClient } from "@/src/lib/prisma";
+
+const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
+const runPostgresProof =
+  process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+
+if (runPostgresProof && (!databaseUrl || !isClearlyLocalPostgresUrl(databaseUrl))) {
+  throw new Error(
+    "The hosted ops usage reset PostgreSQL proof requires a local DATABASE_URL.",
+  );
+}
+
+describe.skipIf(!runPostgresProof)(
+  "hosted ops usage reset PostgreSQL completion",
+  () => {
+    it("retains history and creates one fresh same-epoch notice attempt after reset", async () => {
+      const fixtureId = randomUUID();
+      const memberId = `member_ops_usage_reset_${fixtureId}`;
+      const usageId = `usage_ops_reset_${fixtureId}`;
+      const periodStart = new Date("2026-07-01T00:00:00.000Z");
+      const periodEnd = new Date("2026-08-01T00:00:00.000Z");
+      const historicalPeriodStart = new Date("2026-06-01T00:00:00.000Z");
+      const historicalPeriodEnd = periodStart;
+      const firstAttemptedAt = new Date("2026-07-22T17:00:00.000Z");
+      const resetAt = new Date("2026-07-22T18:00:00.000Z");
+      const reblockedAt = new Date("2026-07-22T18:01:00.000Z");
+      const secondAttemptedAt = new Date("2026-07-22T18:02:00.000Z");
+      const limitUsdMicros =
+        getHostedAiUsageMonthlyAllowanceUsdMicros("launch_monthly");
+      const usageCreditBalanceUsdMicros = 1_250_000n;
+      const usageCreditLedgerVersion = 7n;
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      let firstDeliveryId: string | null = null;
+      let noticeLookupKey: string | null = null;
+
+      try {
+        await prisma.hostedMember.create({
+          data: {
+            billingRef: {
+              create: {
+                currentBillingPhase: "paid",
+                currentBillingPlanCode: "launch_monthly",
+                currentPeriodEnd: periodEnd,
+                currentPeriodStart: periodStart,
+              },
+            },
+            billingStatus: HostedBillingStatus.active,
+            hostedAiUsagePeriods: {
+              create: [{
+                billingPlanCode: "launch_monthly",
+                blockedAt: firstAttemptedAt,
+                limitUsdMicros,
+                periodEnd,
+                periodStart,
+                spentUsdMicros: limitUsdMicros,
+              }, {
+                billingPlanCode: "launch_monthly",
+                limitUsdMicros,
+                periodEnd: historicalPeriodEnd,
+                periodStart: historicalPeriodStart,
+                spentUsdMicros: 1_200_000n,
+              }],
+            },
+            id: memberId,
+            usageCreditBalanceUsdMicros,
+            usageCreditLedgerVersion,
+          },
+        });
+        await prisma.hostedAiUsage.create({
+          data: {
+            allowanceAccountedAt: firstAttemptedAt,
+            allowanceCostUsdMicros: limitUsdMicros,
+            allowanceCounted: true,
+            allowancePeriodEnd: periodEnd,
+            allowancePeriodStart: periodStart,
+            attemptCount: 1,
+            id: usageId,
+            memberId,
+            occurredAt: firstAttemptedAt,
+            provider: "codex-cli",
+            sessionId: `session_${fixtureId}`,
+            turnId: `turn_${fixtureId}`,
+          },
+        });
+        const immutableUsageBefore = await prisma.hostedAiUsage.findUniqueOrThrow({
+          select: {
+            allowanceCostUsdMicros: true,
+            allowanceCounted: true,
+            memberId: true,
+            occurredAt: true,
+          },
+          where: { id: usageId },
+        });
+        const historicalPeriodBefore =
+          await prisma.hostedAiUsagePeriod.findUniqueOrThrow({
+            where: {
+              memberId_periodStart: { memberId, periodStart: historicalPeriodStart },
+            },
+          });
+        const firstClaim = await startHostedAiUsageLimitNoticeDispatchTx({
+          attemptedAt: firstAttemptedAt,
+          memberId,
+          periodStart,
+          prisma,
+          source: "hosted_webhook_side_effect",
+          sourceRef: `source_first_${fixtureId}`,
+          targetKind: "thread",
+          usageCreditLedgerVersion,
+        });
+        if (firstClaim.status !== "claimed") {
+          throw new Error("Expected the first usage notice claim.");
+        }
+        noticeLookupKey = createHostedLinqDeliveryIdempotencyLookupKey(
+          firstClaim.idempotencyKey,
+        );
+        if (!noticeLookupKey) {
+          throw new Error("Expected the usage notice lookup key.");
+        }
+        const firstDelivery = await prisma.hostedLinqDelivery.findUniqueOrThrow({
+          select: { id: true },
+          where: { idempotencyKey: noticeLookupKey },
+        });
+        firstDeliveryId = firstDelivery.id;
+        await prisma.hostedLinqDelivery.update({
+          data: {
+            acceptedAt: firstAttemptedAt,
+            status: "accepted",
+          },
+          where: { id: firstDelivery.id },
+        });
+        const periodBeforeReset = await prisma.hostedAiUsagePeriod.findUniqueOrThrow({
+          select: { updatedAt: true },
+          where: {
+            memberId_periodStart: { memberId, periodStart },
+          },
+        });
+
+        await expect(resetHostedOpsMemberUsage({
+          expectedPeriodUpdatedAt: periodBeforeReset.updatedAt,
+          expectedUsageCreditLedgerVersion: usageCreditLedgerVersion,
+          memberId,
+          now: resetAt,
+          periodStart,
+        }, prisma)).resolves.toMatchObject({
+          noticeClaimReleased: true,
+          outcome: "reset",
+          previousSpentUsdMicros: limitUsdMicros.toString(),
+        });
+        await expect(prisma.hostedLinqDelivery.findUnique({
+          where: { id: firstDelivery.id },
+        })).resolves.toMatchObject({
+          id: firstDelivery.id,
+          idempotencyKey: null,
+          status: "accepted",
+        });
+        await expect(prisma.hostedAiUsage.findUniqueOrThrow({
+          select: {
+            allowanceCostUsdMicros: true,
+            allowanceCounted: true,
+            memberId: true,
+            occurredAt: true,
+          },
+          where: { id: usageId },
+        })).resolves.toEqual(immutableUsageBefore);
+        await expect(prisma.hostedMember.findUniqueOrThrow({
+          select: {
+            usageCreditBalanceUsdMicros: true,
+            usageCreditLedgerVersion: true,
+          },
+          where: { id: memberId },
+        })).resolves.toEqual({
+          usageCreditBalanceUsdMicros,
+          usageCreditLedgerVersion,
+        });
+        await expect(prisma.hostedAiUsagePeriod.findUniqueOrThrow({
+          where: {
+            memberId_periodStart: { memberId, periodStart: historicalPeriodStart },
+          },
+        })).resolves.toEqual(historicalPeriodBefore);
+
+        await prisma.hostedAiUsagePeriod.update({
+          data: {
+            blockedAt: reblockedAt,
+            spentUsdMicros: limitUsdMicros,
+            updatedAt: reblockedAt,
+          },
+          where: {
+            memberId_periodStart: { memberId, periodStart },
+          },
+        });
+        const claimInput = {
+          attemptedAt: secondAttemptedAt,
+          memberId,
+          periodStart,
+          prisma,
+          source: "hosted_webhook_side_effect" as const,
+          sourceRef: `source_second_${fixtureId}`,
+          targetKind: "thread",
+          usageCreditLedgerVersion,
+        };
+        const concurrentClaims = await Promise.all([
+          startHostedAiUsageLimitNoticeDispatchTx(claimInput),
+          startHostedAiUsageLimitNoticeDispatchTx(claimInput),
+        ]);
+        const claimed = concurrentClaims.filter((claim) =>
+          claim.status === "claimed"
+        );
+        expect(claimed).toHaveLength(1);
+        expect(concurrentClaims.some((claim) =>
+          claim.status === "in_flight" || claim.status === "already_notified"
+        )).toBe(true);
+        const secondClaim = claimed[0];
+        if (!secondClaim || secondClaim.status !== "claimed") {
+          throw new Error("Expected one fresh usage notice attempt.");
+        }
+        expect(secondClaim.idempotencyKey).toBe(firstClaim.idempotencyKey);
+        expect(secondClaim.providerIdempotencyKey).not.toBe(
+          firstClaim.providerIdempotencyKey,
+        );
+        const deliveries = await prisma.hostedLinqDelivery.findMany({
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            idempotencyKey: true,
+          },
+          where: {
+            OR: [
+              { id: firstDelivery.id },
+              { idempotencyKey: noticeLookupKey },
+            ],
+          },
+        });
+        expect(deliveries).toHaveLength(2);
+        expect(new Set(deliveries.map((delivery) => delivery.id)).size).toBe(2);
+        expect(deliveries.filter((delivery) =>
+          delivery.idempotencyKey === noticeLookupKey
+        )).toHaveLength(1);
+      } finally {
+        if (noticeLookupKey || firstDeliveryId) {
+          await prisma.hostedLinqDelivery.deleteMany({
+            where: {
+              OR: [
+                ...(firstDeliveryId ? [{ id: firstDeliveryId }] : []),
+                ...(noticeLookupKey
+                  ? [{ idempotencyKey: noticeLookupKey }]
+                  : []),
+              ],
+            },
+          });
+        }
+        await prisma.hostedMember.deleteMany({ where: { id: memberId } });
+        await prisma.$disconnect();
+      }
+    });
+  },
+);
+
+function isClearlyLocalPostgresUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  if (!["postgres:", "postgresql:"].includes(parsed.protocol)) {
+    return false;
+  }
+  const hostOverrides = parsed.searchParams.getAll("host");
+  if (hostOverrides.length > 1) {
+    return false;
+  }
+  const effectiveHost = (hostOverrides[0] || parsed.hostname).toLowerCase();
+  return ["127.0.0.1", "::1", "[::1]", "localhost"].includes(effectiveHost)
+    || effectiveHost.startsWith("/");
+}

--- a/apps/web/test/hosted-ops-usage-reset-route.test.ts
+++ b/apps/web/test/hosted-ops-usage-reset-route.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  assertHostedOnboardingMutationOrigin: vi.fn(),
+  requireActiveHostedAppSessionFromRequest: vi.fn(),
+  resetHostedOpsMemberUsage: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
+  requireActiveHostedAppSessionFromRequest:
+    mocks.requireActiveHostedAppSessionFromRequest,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/csrf", () => ({
+  assertHostedOnboardingMutationOrigin:
+    mocks.assertHostedOnboardingMutationOrigin,
+}));
+
+vi.mock("@/src/lib/hosted-ops/member-usage", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-ops/member-usage")
+  >("@/src/lib/hosted-ops/member-usage");
+  return {
+    ...actual,
+    resetHostedOpsMemberUsage: mocks.resetHostedOpsMemberUsage,
+  };
+});
+
+import {
+  HostedOpsMemberUsageResetNotFoundError,
+  HostedOpsMemberUsageResetNoticeInFlightError,
+  HostedOpsMemberUsageResetStaleError,
+} from "@/src/lib/hosted-ops/member-usage";
+
+type RouteModule = typeof import("../app/api/ops/usage-reset/route");
+
+const NOW = new Date("2026-07-22T18:00:00.000Z");
+const PERIOD_START = "2026-07-01T00:00:00.000Z";
+const PERIOD_UPDATED_AT = "2026-07-22T17:30:00.000Z";
+const OPERATOR_MEMBER_ID = "hbm_operator";
+const TARGET_MEMBER_ID = "hbm_target";
+const originalOpsMemberIds = process.env.HOSTED_OPS_MEMBER_IDS;
+let route: RouteModule;
+let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+
+describe("hosted ops usage reset route", () => {
+  beforeAll(async () => {
+    route = await import("../app/api/ops/usage-reset/route");
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
+    process.env.HOSTED_OPS_MEMBER_IDS = OPERATOR_MEMBER_ID;
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
+      member: { id: OPERATOR_MEMBER_ID },
+    });
+    mocks.resetHostedOpsMemberUsage.mockResolvedValue(makeResult());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    consoleInfoSpy.mockRestore();
+    if (originalOpsMemberIds === undefined) {
+      delete process.env.HOSTED_OPS_MEMBER_IDS;
+    } else {
+      process.env.HOSTED_OPS_MEMBER_IDS = originalOpsMemberIds;
+    }
+  });
+
+  test("requires allowlisted same-origin access and applies the exact row version", async () => {
+    const response = await route.POST(makeRequest());
+
+    assert.equal(response.status, 200);
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledTimes(1);
+    expect(mocks.resetHostedOpsMemberUsage).toHaveBeenCalledWith({
+      expectedPeriodUpdatedAt: new Date(PERIOD_UPDATED_AT),
+      expectedUsageCreditLedgerVersion: 4n,
+      memberId: TARGET_MEMBER_ID,
+      periodStart: new Date(PERIOD_START),
+    });
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      "Hosted ops current usage period reset completed.",
+      {
+        noticeClaimReleased: true,
+        outcome: "reset",
+        timestamp: NOW.toISOString(),
+      },
+    );
+    expect(JSON.stringify(consoleInfoSpy.mock.calls)).not.toContain(
+      TARGET_MEMBER_ID,
+    );
+  });
+
+  test("hides the route from members outside the ops allowlist", async () => {
+    mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
+      member: { id: "hbm_other" },
+    });
+
+    const response = await route.POST(makeRequest());
+
+    assert.equal(response.status, 404);
+    expect(mocks.resetHostedOpsMemberUsage).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["member", { memberId: "member_target" }],
+    ["period", { periodStart: "July" }],
+    ["updated timestamp", { expectedPeriodUpdatedAt: "now" }],
+    ["ledger version", { expectedUsageCreditLedgerVersion: -1 }],
+  ])("rejects an invalid %s field", async (_label, override) => {
+    const response = await route.POST(makeRequest(override));
+
+    assert.equal(response.status, 400);
+    expect(mocks.resetHostedOpsMemberUsage).not.toHaveBeenCalled();
+  });
+
+  test("maps stale and in-flight resets to retryable-safe conflicts", async () => {
+    mocks.resetHostedOpsMemberUsage
+      .mockRejectedValueOnce(new HostedOpsMemberUsageResetStaleError())
+      .mockRejectedValueOnce(new HostedOpsMemberUsageResetNoticeInFlightError(
+        new Date(NOW.getTime() + 60_000),
+      ));
+
+    const stale = await route.POST(makeRequest());
+    const inFlight = await route.POST(makeRequest());
+
+    assert.equal(stale.status, 409);
+    assert.equal(inFlight.status, 409);
+    assert.deepEqual(await stale.json(), {
+      error: {
+        code: "HOSTED_OPS_USAGE_RESET_STALE",
+        message:
+          "Usage changed after this table loaded. Refresh and review the current row before resetting it.",
+        retryable: false,
+      },
+    });
+    assert.deepEqual(await inFlight.json(), {
+      error: {
+        code: "HOSTED_OPS_USAGE_RESET_NOTICE_IN_FLIGHT",
+        details: {
+          retryAt: "2026-07-22T18:01:00.000Z",
+        },
+        message:
+          "A usage-limit notice is currently being sent. Retry after that dispatch settles.",
+        retryable: true,
+      },
+    });
+  });
+
+  test("maps a removed member or period to a non-retryable not-found response", async () => {
+    mocks.resetHostedOpsMemberUsage.mockRejectedValueOnce(
+      new HostedOpsMemberUsageResetNotFoundError(),
+    );
+
+    const response = await route.POST(makeRequest());
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), {
+      error: {
+        code: "HOSTED_OPS_USAGE_RESET_NOT_FOUND",
+        message: "The hosted member or current usage period no longer exists.",
+        retryable: false,
+      },
+    });
+  });
+});
+
+function makeRequest(overrides: Record<string, unknown> = {}): Request {
+  return new Request("http://localhost/api/ops/usage-reset", {
+    body: JSON.stringify({
+      expectedPeriodUpdatedAt: PERIOD_UPDATED_AT,
+      expectedUsageCreditLedgerVersion: "4",
+      memberId: TARGET_MEMBER_ID,
+      periodStart: PERIOD_START,
+      ...overrides,
+    }),
+    headers: {
+      "content-type": "application/json",
+      origin: "http://localhost",
+    },
+    method: "POST",
+  });
+}
+
+function makeResult() {
+  return {
+    memberId: TARGET_MEMBER_ID,
+    noticeClaimReleased: true,
+    outcome: "reset",
+    periodStart: PERIOD_START,
+    previousSpentUsdMicros: "4522964",
+    resetAt: NOW.toISOString(),
+    updatedAt: NOW.toISOString(),
+  };
+}

--- a/apps/web/test/hosted-ops-usage-reset-route.test.ts
+++ b/apps/web/test/hosted-ops-usage-reset-route.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   assertHostedOnboardingMutationOrigin: vi.fn(),
   requireActiveHostedAppSessionFromRequest: vi.fn(),
   resetHostedOpsMemberUsage: vi.fn(),
+  signalHostedRuntimeRecheckRuntime: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
@@ -28,6 +29,11 @@ vi.mock("@/src/lib/hosted-ops/member-usage", async () => {
     resetHostedOpsMemberUsage: mocks.resetHostedOpsMemberUsage,
   };
 });
+
+vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
+  signalHostedRuntimeRecheckRuntime:
+    mocks.signalHostedRuntimeRecheckRuntime,
+}));
 
 import {
   HostedOpsMemberUsageResetNotFoundError,
@@ -61,6 +67,10 @@ describe("hosted ops usage reset route", () => {
       member: { id: OPERATOR_MEMBER_ID },
     });
     mocks.resetHostedOpsMemberUsage.mockResolvedValue(makeResult());
+    mocks.signalHostedRuntimeRecheckRuntime.mockResolvedValue({
+      signalAccepted: true,
+      workflowId: "hosted-user-runtime:hbm_target",
+    });
   });
 
   afterEach(() => {
@@ -84,17 +94,71 @@ describe("hosted ops usage reset route", () => {
       memberId: TARGET_MEMBER_ID,
       periodStart: new Date(PERIOD_START),
     });
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
+      userId: TARGET_MEMBER_ID,
+    });
+    expect(
+      mocks.resetHostedOpsMemberUsage.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      Number(mocks.signalHostedRuntimeRecheckRuntime.mock.invocationCallOrder[0]),
+    );
     expect(consoleInfoSpy).toHaveBeenCalledWith(
       "Hosted ops current usage period reset completed.",
       {
         noticeClaimReleased: true,
         outcome: "reset",
+        runtimeRecheckStatus: "accepted",
         timestamp: NOW.toISOString(),
       },
     );
     expect(JSON.stringify(consoleInfoSpy.mock.calls)).not.toContain(
       TARGET_MEMBER_ID,
     );
+  });
+
+  test("reports a committed reset as retryable when the runtime recheck fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.signalHostedRuntimeRecheckRuntime.mockRejectedValueOnce(
+      new Error("Temporal unavailable"),
+    );
+
+    try {
+      const response = await route.POST(makeRequest());
+
+      assert.equal(response.status, 202);
+      assert.deepEqual(await response.json(), {
+        ...makeResult(),
+        runtimeRecheckStatus: "pending",
+      });
+      expect(mocks.resetHostedOpsMemberUsage).toHaveBeenCalledTimes(1);
+      expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Hosted ops runtime recheck failed.",
+        {
+          errorName: "Error",
+          timestamp: NOW.toISOString(),
+        },
+      );
+      expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toContain(
+        TARGET_MEMBER_ID,
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test("retries only the runtime wake after a committed reset", async () => {
+    const response = await route.POST(makeRuntimeRecheckRequest());
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      memberId: TARGET_MEMBER_ID,
+      runtimeRecheckStatus: "accepted",
+    });
+    expect(mocks.resetHostedOpsMemberUsage).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
+      userId: TARGET_MEMBER_ID,
+    });
   });
 
   test("hides the route from members outside the ops allowlist", async () => {
@@ -179,6 +243,20 @@ function makeRequest(overrides: Record<string, unknown> = {}): Request {
       memberId: TARGET_MEMBER_ID,
       periodStart: PERIOD_START,
       ...overrides,
+    }),
+    headers: {
+      "content-type": "application/json",
+      origin: "http://localhost",
+    },
+    method: "POST",
+  });
+}
+
+function makeRuntimeRecheckRequest(): Request {
+  return new Request("http://localhost/api/ops/usage-reset", {
+    body: JSON.stringify({
+      memberId: TARGET_MEMBER_ID,
+      operation: "runtime_recheck",
     }),
     headers: {
       "content-type": "application/json",

--- a/apps/web/test/hosted-ops-usage-reset-route.test.ts
+++ b/apps/web/test/hosted-ops-usage-reset-route.test.ts
@@ -40,6 +40,9 @@ import {
   HostedOpsMemberUsageResetNoticeInFlightError,
   HostedOpsMemberUsageResetStaleError,
 } from "@/src/lib/hosted-ops/member-usage";
+import {
+  HOSTED_POST_COMMIT_TIMEOUT_MS,
+} from "@/src/lib/hosted-onboarding/bounded-post-commit";
 
 type RouteModule = typeof import("../app/api/ops/usage-reset/route");
 
@@ -95,6 +98,7 @@ describe("hosted ops usage reset route", () => {
       periodStart: new Date(PERIOD_START),
     });
     expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       userId: TARGET_MEMBER_ID,
     });
     expect(
@@ -147,6 +151,40 @@ describe("hosted ops usage reset route", () => {
     }
   });
 
+  test("bounds a stalled post-commit wake and exposes wake-only recovery", async () => {
+    mocks.signalHostedRuntimeRecheckRuntime.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    const responsePromise = route.POST(makeRequest());
+    await vi.waitFor(() => {
+      expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(1);
+    });
+    await vi.advanceTimersByTimeAsync(HOSTED_POST_COMMIT_TIMEOUT_MS);
+    const response = await responsePromise;
+
+    assert.equal(response.status, 202);
+    assert.deepEqual(await response.json(), {
+      ...makeResult(),
+      runtimeRecheckStatus: "pending",
+    });
+    expect(mocks.resetHostedOpsMemberUsage).toHaveBeenCalledTimes(1);
+    const observedAbortSignal = mocks.signalHostedRuntimeRecheckRuntime
+      .mock.calls[0]?.[0]?.abortSignal;
+    expect(observedAbortSignal).toBeInstanceOf(AbortSignal);
+    expect(observedAbortSignal.aborted).toBe(true);
+
+    mocks.signalHostedRuntimeRecheckRuntime.mockResolvedValueOnce({
+      signalAccepted: true,
+      workflowId: "hosted-user-runtime:hbm_target",
+    });
+    const retry = await route.POST(makeRuntimeRecheckRequest());
+
+    assert.equal(retry.status, 200);
+    expect(mocks.resetHostedOpsMemberUsage).toHaveBeenCalledTimes(1);
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(2);
+  });
+
   test("retries only the runtime wake after a committed reset", async () => {
     const response = await route.POST(makeRuntimeRecheckRequest());
 
@@ -157,8 +195,33 @@ describe("hosted ops usage reset route", () => {
     });
     expect(mocks.resetHostedOpsMemberUsage).not.toHaveBeenCalled();
     expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       userId: TARGET_MEMBER_ID,
     });
+  });
+
+  test("bounds a stalled wake-only retry without replaying the reset", async () => {
+    mocks.signalHostedRuntimeRecheckRuntime.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    const responsePromise = route.POST(makeRuntimeRecheckRequest());
+    await vi.waitFor(() => {
+      expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(1);
+    });
+    await vi.advanceTimersByTimeAsync(HOSTED_POST_COMMIT_TIMEOUT_MS);
+    const response = await responsePromise;
+
+    assert.equal(response.status, 202);
+    assert.deepEqual(await response.json(), {
+      memberId: TARGET_MEMBER_ID,
+      runtimeRecheckStatus: "pending",
+    });
+    expect(mocks.resetHostedOpsMemberUsage).not.toHaveBeenCalled();
+    const observedAbortSignal = mocks.signalHostedRuntimeRecheckRuntime
+      .mock.calls[0]?.[0]?.abortSignal;
+    expect(observedAbortSignal).toBeInstanceOf(AbortSignal);
+    expect(observedAbortSignal.aborted).toBe(true);
   });
 
   test("hides the route from members outside the ops allowlist", async () => {

--- a/apps/web/test/ops-member-usage-client.test.tsx
+++ b/apps/web/test/ops-member-usage-client.test.tsx
@@ -131,7 +131,7 @@ describe("MemberUsageClient", () => {
     if (!period) {
       throw new Error("Expected a usage fixture period.");
     }
-    period.blockedAt = null;
+    period.blocked = false;
     period.idempotencyClaimStatus = null;
     period.remainingUsdMicros = "4500000";
     period.spentUsdMicros = "0";
@@ -146,13 +146,33 @@ describe("MemberUsageClient", () => {
     expect(getButton(rendered.container, "Reset").disabled).toBe(true);
   });
 
+  test("shows canonical availability independently from a notice claim", async () => {
+    const dashboard = makeDashboard();
+    const period = dashboard.rows[0]?.currentPeriod;
+    if (!period) {
+      throw new Error("Expected a usage fixture period.");
+    }
+    period.blocked = false;
+    period.limitUsdMicros = "25000000";
+    period.remainingUsdMicros = "15000000";
+    period.spentUsdMicros = "10000000";
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    expect(rendered.container.textContent).toContain("Notice claimed");
+    expect(rendered.container.textContent).toContain("Available");
+    expect(rendered.container.textContent).not.toContain("Blocked");
+  });
+
   test("keeps a clear persisted period actionable for a later runtime wake", async () => {
     const dashboard = makeDashboard();
     const period = dashboard.rows[0]?.currentPeriod;
     if (!period) {
       throw new Error("Expected a usage fixture period.");
     }
-    period.blockedAt = null;
+    period.blocked = false;
     period.idempotencyClaimStatus = null;
     period.spentUsdMicros = "0";
     const rendered = await renderClientComponent(
@@ -309,7 +329,7 @@ function makeDashboard(): HostedOpsMemberUsageDashboard {
       containerOwnerMemberId: "hbm_owner",
       createdAt: "2026-06-01T00:00:00.000Z",
       currentPeriod: {
-        blockedAt: "2026-07-22T17:25:30.000Z",
+        blocked: true,
         idempotencyClaimStatus: "accepted",
         limitUsdMicros: "4500000",
         periodEnd: "2026-08-01T00:00:00.000Z",

--- a/apps/web/test/ops-member-usage-client.test.tsx
+++ b/apps/web/test/ops-member-usage-client.test.tsx
@@ -1,0 +1,272 @@
+import { act, createElement, type ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const routerRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: routerRefresh }),
+}));
+
+vi.mock("lucide-react", () => ({
+  RotateCcwIcon: () => createElement("svg"),
+}));
+
+vi.mock("@/src/components/ui/alert", () => ({
+  Alert: ({ variant, ...props }: ComponentProps<"div"> & { variant?: string }) => {
+    void variant;
+    return createElement("div", { role: "alert", ...props });
+  },
+  AlertDescription: (props: ComponentProps<"div">) =>
+    createElement("div", props),
+}));
+
+vi.mock("@/src/components/ui/badge", () => ({
+  Badge: ({ variant, ...props }: ComponentProps<"span"> & { variant?: string }) => {
+    void variant;
+    return createElement("span", props);
+  },
+}));
+
+vi.mock("@/src/components/ui/button", () => ({
+  Button: ({ size, variant, ...props }: ComponentProps<"button"> & {
+    size?: string;
+    variant?: string;
+  }) => {
+    void size;
+    void variant;
+    return createElement("button", props);
+  },
+}));
+
+vi.mock("@/src/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: ComponentProps<"div"> & { open?: boolean }) =>
+    open ? createElement("div", null, children) : null,
+  DialogContent: ({ showCloseButton, ...props }: ComponentProps<"div"> & {
+    showCloseButton?: boolean;
+  }) => {
+    void showCloseButton;
+    return createElement("div", props);
+  },
+  DialogDescription: (props: ComponentProps<"p">) => createElement("p", props),
+  DialogFooter: (props: ComponentProps<"div">) => createElement("div", props),
+  DialogHeader: (props: ComponentProps<"div">) => createElement("div", props),
+  DialogTitle: (props: ComponentProps<"h2">) => createElement("h2", props),
+}));
+
+vi.mock("@/src/components/ui/spinner", () => ({
+  Spinner: (props: ComponentProps<"span">) => createElement("span", props),
+}));
+
+vi.mock("@/src/components/ui/table", () => ({
+  Table: (props: ComponentProps<"table">) => createElement("table", props),
+  TableBody: (props: ComponentProps<"tbody">) => createElement("tbody", props),
+  TableCell: (props: ComponentProps<"td">) => createElement("td", props),
+  TableHead: (props: ComponentProps<"th">) => createElement("th", props),
+  TableHeader: (props: ComponentProps<"thead">) => createElement("thead", props),
+  TableRow: (props: ComponentProps<"tr">) => createElement("tr", props),
+}));
+
+import { MemberUsageClient } from "../app/(dashboard)/ops/usage/member-usage-client";
+import type { HostedOpsMemberUsageDashboard } from "../src/lib/hosted-ops/member-usage";
+import { renderClientComponent } from "./render-client-component";
+
+const fetchMock = vi.fn<typeof fetch>();
+let cleanupRender: (() => Promise<void>) | null = null;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  routerRefresh.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(async () => {
+  if (cleanupRender) {
+    await cleanupRender();
+    cleanupRender = null;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("MemberUsageClient", () => {
+  test("shows members, containers, retained-message scope, and usage totals", async () => {
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard: makeDashboard() }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    expect(rendered.container.textContent).toContain("Members and containers");
+    expect(rendered.container.textContent).toContain("30-day mailbox window");
+    expect(rendered.container.textContent).toContain("hbm_container");
+    expect(rendered.container.textContent).toContain("2 participants");
+    expect(rendered.container.textContent).toContain("$7.25");
+    expect(rendered.container.textContent).toContain("Notice claimed");
+    expect(rendered.container.querySelectorAll("table")).toHaveLength(1);
+  });
+
+  test("labels a row without a current period without calling it available", async () => {
+    const dashboard = makeDashboard();
+    const row = dashboard.rows[0];
+    if (!row) {
+      throw new Error("Expected a usage fixture row.");
+    }
+    row.currentPeriod = null;
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    expect(rendered.container.textContent).toContain("No current period");
+    expect(rendered.container.textContent).not.toContain("Available");
+    const resetButton = getButton(rendered.container, "Reset");
+    expect(resetButton.getAttribute("aria-label")).toBe(
+      "Reset usage for hbm_container",
+    );
+    expect(resetButton.disabled).toBe(true);
+  });
+
+  test("shows an explicit empty state", async () => {
+    const dashboard = makeDashboard();
+    dashboard.rows = [];
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard }),
+      { requireButton: false },
+    );
+    cleanupRender = rendered.cleanup;
+
+    expect(rendered.container.textContent).toContain(
+      "No hosted members or group containers were found.",
+    );
+  });
+
+  test("confirms and submits the exact period version before refreshing", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      memberId: "hbm_container",
+      noticeClaimReleased: true,
+      outcome: "reset",
+      periodStart: "2026-07-01T00:00:00.000Z",
+      previousSpentUsdMicros: "4522964",
+      resetAt: "2026-07-22T18:00:00.000Z",
+      updatedAt: "2026-07-22T18:00:00.000Z",
+    }));
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard: makeDashboard() }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    await clickButton(rendered.window, getButton(rendered.container, "Reset"));
+    expect(rendered.container.textContent).toContain(
+      "Reset current included usage?",
+    );
+    expect(rendered.container.textContent).toContain("Will be released");
+
+    await clickButton(
+      rendered.window,
+      getButton(rendered.container, "Reset usage"),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/ops/usage-reset", {
+      body: JSON.stringify({
+        expectedPeriodUpdatedAt: "2026-07-22T17:30:00.000Z",
+        expectedUsageCreditLedgerVersion: "4",
+        memberId: "hbm_container",
+        periodStart: "2026-07-01T00:00:00.000Z",
+      }),
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(rendered.container.querySelector('[role="alert"]')?.textContent)
+      .toContain("quota notice claim was released");
+    expect(routerRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("surfaces a stale reset without claiming success", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      error: {
+        code: "HOSTED_OPS_USAGE_RESET_STALE",
+        message: "Usage changed after this table loaded.",
+      },
+    }, 409));
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard: makeDashboard() }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    await clickButton(rendered.window, getButton(rendered.container, "Reset"));
+    await clickButton(
+      rendered.window,
+      getButton(rendered.container, "Reset usage"),
+    );
+
+    expect(rendered.container.querySelector('[role="alert"]')?.textContent)
+      .toContain("Usage changed after this table loaded");
+    expect(routerRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+function makeDashboard(): HostedOpsMemberUsageDashboard {
+  return {
+    capturedAt: "2026-07-22T18:00:00.000Z",
+    messageRetentionDays: 30,
+    rows: [{
+      allTimeUsageUsdMicros: "7250000",
+      billingStatus: "active",
+      containerOwnerMemberId: "hbm_owner",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      currentPeriod: {
+        blockedAt: "2026-07-22T17:25:30.000Z",
+        idempotencyClaimStatus: "accepted",
+        limitUsdMicros: "4500000",
+        periodEnd: "2026-08-01T00:00:00.000Z",
+        periodStart: "2026-07-01T00:00:00.000Z",
+        remainingUsdMicros: "0",
+        spentUsdMicros: "4522964",
+        updatedAt: "2026-07-22T17:30:00.000Z",
+        usageCreditBalanceUsdMicros: "0",
+        usageCreditLedgerVersion: "4",
+      },
+      maskedPhoneNumberHint: null,
+      memberId: "hbm_container",
+      memberKind: "group_container",
+      messagesDailyAverage7Days: 1,
+      messagesLast7Days: 7,
+      messagesRetained: 18,
+      participantCount: 2,
+      suspended: false,
+    }],
+    summary: {
+      activeEntitiesLast7Days: 1,
+      groupContainers: 1,
+      members: 0,
+      totalAllTimeUsageUsdMicros: "7250000",
+    },
+  };
+}
+
+function getButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")]
+    .find((candidate) => candidate.textContent?.trim() === label);
+  if (!button) {
+    throw new Error(`Button not found: ${label}`);
+  }
+  return button;
+}
+
+async function clickButton(
+  window: Window,
+  button: HTMLButtonElement,
+): Promise<void> {
+  await act(async () => {
+    const event = window.document.createEvent("Event");
+    event.initEvent("click", true, true);
+    button.dispatchEvent(event);
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}

--- a/apps/web/test/ops-member-usage-client.test.tsx
+++ b/apps/web/test/ops-member-usage-client.test.tsx
@@ -110,18 +110,57 @@ describe("MemberUsageClient", () => {
       throw new Error("Expected a usage fixture row.");
     }
     row.currentPeriod = null;
+    row.allowanceStatus = "unavailable";
     const rendered = await renderClientComponent(
       createElement(MemberUsageClient, { dashboard }),
     );
     cleanupRender = rendered.cleanup;
 
-    expect(rendered.container.textContent).toContain("No current period");
+    expect(rendered.container.textContent).toContain("Unavailable");
     expect(rendered.container.textContent).not.toContain("Available");
     const resetButton = getButton(rendered.container, "Reset");
     expect(resetButton.getAttribute("aria-label")).toBe(
       "Reset usage for hbm_container",
     );
     expect(resetButton.disabled).toBe(true);
+  });
+
+  test("keeps a synthetic available period visible but not resettable", async () => {
+    const dashboard = makeDashboard();
+    const period = dashboard.rows[0]?.currentPeriod;
+    if (!period) {
+      throw new Error("Expected a usage fixture period.");
+    }
+    period.blockedAt = null;
+    period.idempotencyClaimStatus = null;
+    period.remainingUsdMicros = "4500000";
+    period.spentUsdMicros = "0";
+    period.updatedAt = null;
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    expect(rendered.container.textContent).toContain("Available");
+    expect(rendered.container.textContent).toContain("$0.00 / $4.50");
+    expect(getButton(rendered.container, "Reset").disabled).toBe(true);
+  });
+
+  test("keeps a clear persisted period actionable for a later runtime wake", async () => {
+    const dashboard = makeDashboard();
+    const period = dashboard.rows[0]?.currentPeriod;
+    if (!period) {
+      throw new Error("Expected a usage fixture period.");
+    }
+    period.blockedAt = null;
+    period.idempotencyClaimStatus = null;
+    period.spentUsdMicros = "0";
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    expect(getButton(rendered.container, "Reset").disabled).toBe(false);
   });
 
   test("shows an explicit empty state", async () => {
@@ -146,6 +185,7 @@ describe("MemberUsageClient", () => {
       periodStart: "2026-07-01T00:00:00.000Z",
       previousSpentUsdMicros: "4522964",
       resetAt: "2026-07-22T18:00:00.000Z",
+      runtimeRecheckStatus: "accepted",
       updatedAt: "2026-07-22T18:00:00.000Z",
     }));
     const rendered = await renderClientComponent(
@@ -177,8 +217,61 @@ describe("MemberUsageClient", () => {
       method: "POST",
     });
     expect(rendered.container.querySelector('[role="alert"]')?.textContent)
-      .toContain("quota notice claim was released");
+      .toContain("runtime recheck was accepted");
     expect(routerRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps a committed reset open and retries only the runtime wake", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        memberId: "hbm_container",
+        noticeClaimReleased: true,
+        outcome: "reset",
+        periodStart: "2026-07-01T00:00:00.000Z",
+        previousSpentUsdMicros: "4522964",
+        resetAt: "2026-07-22T18:00:00.000Z",
+        runtimeRecheckStatus: "pending",
+        updatedAt: "2026-07-22T18:00:00.000Z",
+      }, 202))
+      .mockResolvedValueOnce(jsonResponse({
+        memberId: "hbm_container",
+        runtimeRecheckStatus: "accepted",
+      }));
+    const rendered = await renderClientComponent(
+      createElement(MemberUsageClient, { dashboard: makeDashboard() }),
+    );
+    cleanupRender = rendered.cleanup;
+
+    await clickButton(rendered.window, getButton(rendered.container, "Reset"));
+    await clickButton(rendered.window, getButton(rendered.container, "Reset usage"));
+
+    expect(rendered.container.textContent).toContain(
+      "Usage was reset, but the runtime did not accept its recheck yet.",
+    );
+    expect(rendered.container.textContent).toContain("Retry runtime wake?");
+    expect(rendered.container.textContent).toContain("Target");
+    expect(rendered.container.textContent).not.toContain("Current spend");
+    expect(rendered.container.textContent).not.toContain("Will be released");
+    expect(getButton(rendered.container, "Close").disabled).toBe(false);
+    expect(getButton(rendered.container, "Retry runtime wake").disabled).toBe(false);
+
+    await clickButton(
+      rendered.window,
+      getButton(rendered.container, "Retry runtime wake"),
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/ops/usage-reset", {
+      body: JSON.stringify({
+        memberId: "hbm_container",
+        operation: "runtime_recheck",
+      }),
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(rendered.container.querySelector('[role="alert"]')?.textContent)
+      .toContain("runtime recheck was accepted");
   });
 
   test("surfaces a stale reset without claiming success", async () => {
@@ -210,6 +303,7 @@ function makeDashboard(): HostedOpsMemberUsageDashboard {
     capturedAt: "2026-07-22T18:00:00.000Z",
     messageRetentionDays: 30,
     rows: [{
+      allowanceStatus: "available",
       allTimeUsageUsdMicros: "7250000",
       billingStatus: "active",
       containerOwnerMemberId: "hbm_owner",


### PR DESCRIPTION
## Why

The existing manual allowance replenishment could clear spend while leaving two recovery gaps. Work already accepted by the hosted runtime remained asleep on its previous period-end timer, and releasing only the logical usage-notice claim could collide with the old durable delivery row or reuse Linq's provider idempotency identity. The ops view also selected a date-active row independently of the canonical allowance gate, so it could display or reset the wrong period.

## User-visible goal and flow

- Add `/ops/usage` for allowlisted operators.
- Show every hosted member and synthetic group container with retained 30-day inbound volume, trailing 7-day volume and daily average, all-time counted AI usage, current spend/capacity, and block/notice status.
- Let an operator review the exact target in a destructive confirmation dialog and reset the canonical current included-usage period.
- Wake the existing hosted runtime after the reset so accepted work can resume immediately.
- If that wake rejects or stalls after the reset commits, keep a truthful partial-success dialog whose retry performs only the bounded runtime wake.
- Refresh stale rows instead of applying a reset against changed accounting state.

## Invariants

- The reset is ops-allowlisted, same-origin protected, stale-safe, and serializable.
- Dashboard projection and reset both delegate period/access selection to the existing canonical hosted allowance gate.
- The read projection uses one repeatable-read snapshot, and the reset rechecks the exact canonical period after locking the member.
- Current blocked/available state comes only from the canonical decision; historical notice state is displayed independently.
- Purchased credit balance and ledger version are never changed.
- Immutable AI usage rows, historical/noncanonical periods, mailbox work, and Linq delivery history are never deleted.
- Only the exact current capacity-epoch logical notice claim is released; recent pre-provider dispatches still fail closed until they settle or become stale.
- A post-reset notice keeps the stable logical lookup identity but receives a fresh durable delivery ID and fresh Linq provider idempotency key.
- Generic Linq runtime/webhook fences retain deterministic IDs so delivery outcomes and latency traces keep their existing correlation identity.
- Message reporting discloses and uses the existing 30-day mailbox retention window rather than introducing a second durable counter.

## Non-obvious affected surfaces

- The shared generic Linq runtime/webhook dispatch-claim surface must keep deterministic delivery IDs: runtime outcome persistence derives the same row ID, and ingress-latency traces reference that row. Only explicitly released usage-limit notices inject fresh attempt/provider identity. The focused runtime provider-dispatch regression asserts fence/outcome delivery-ID equality, and the generic webhook/provider-dispatch claim regression asserts deterministic identity.
- Runtime recovery reuses the existing `runtime_recheck_requested` signal and bounded post-commit helper; no queue, scheduler, reset ledger, or second state owner was added.
- Group-container classification supports both current thread containers and legacy group runtimes; participant counts include only active thread participants.
- Synthetic no-row periods are visible but not resettable because there is no persisted accounting row to mutate.

## ReviewGPT round 1 findings and dispositions

1. **Accepted — reset did not wake accepted runtime work.** The route now signals the existing runtime recheck after commit. A failed signal returns committed HTTP 202 state, and the retry branch performs only that wake rather than replaying the reset.
2. **Accepted — released claims could collide with the old delivery/provider identity.** Claimed usage-notice attempts now receive a fresh durable row ID and a provider idempotency key derived from that attempt; the stable logical key remains the active-claim lookup.
3. **Accepted — the dashboard duplicated and could disagree with canonical period policy.** The custom bulk policy was deleted. Dashboard rows resolve through the existing gate inside one repeatable-read transaction, and reset verifies that canonical result inside its serializable transaction.

## ReviewGPT round 2 findings and dispositions

1. **Accepted — raw `blocked_at` could contradict the current plan.** The raw marker was deleted from the ops projection. The UI receives only the canonical decision-derived blocked boolean, with both plan-increase and plan-decrease regressions.
2. **Accepted — a never-settling runtime signal could hang the committed reset response.** Reset and wake-only branches now reuse the existing five-second bounded post-commit helper and forward its abort signal. Both stalled paths return HTTP 202 without replaying reset.
3. **Accepted — fresh IDs were applied to the shared generic Linq fence path.** Generic fences again use their deterministic delivery ID, preserving runtime outcome/latency linkage. Fresh IDs are injected only by the usage-limit notice caller after an explicit release.

## Remediation-growth retrospective

The first remediation approach added 617 production-source lines by duplicating direct, Family, thread, and overlapping-period allowance policy in a custom bulk reader. That crossed the review-growth threshold and created a second policy surface. It was deleted.

Round 2 exposed three review-induced placement errors in the first correction: one remaining raw projection field, one unbounded call to an existing signal, and fresh identity placed at a shared helper instead of the usage-notice caller. Round 3 continues the same PR with owner-boundary reductions: delete the raw state, reuse the bounded helper, and restore deterministic generic identity. No new durable owner, queue, lifecycle, schema, or reconciliation process was added.

The current correction is +447/-148 production-source lines relative to the immutable first-reviewed head. The additional round-3 delta is +44/-18 and consists of the three scoped corrections above.

## Verification

- Focused Web regression suite: 252 passed.
- Direct PostgreSQL regression: passed. It proves canonical period reset, preservation of nonzero credits/version and historical data, immutable usage/history preservation, and exactly one fresh same-epoch delivery claim under a concurrent race.
- `pnpm test:diff`: passed on the final content (`tbx_01ky5wpsf6m3ryfj3w6b1sm36b`), including 6,164 Web tests, lint, typecheck, smoke, and production build.
- `pnpm verify:acceptance`: all changed Web paths passed. The workspace-wide run was non-green only because an untouched CLI release audit expects an older ReviewGPT-doc sentence that omits `product-experience-review` (`tbx_01ky5wpsf6vjhfnzfpcv03evr9`).
- Coverage-write and frontend-review completion audits: no unresolved findings. They added the missing stalled wake-only proof and separated canonical availability from historical notice status.
- Rendered browser proof was unavailable because no browser backend was connected.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1,538 | 18 |
| Tests | 1,761 | 3 |
| Docs | 305 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 5aa49ae50d4f4383a5bfa2d12ce9fe58223b14f8

| Review round | Current head | Production-source delta from first head |
| --- | --- | ---: |
| 1 | `5aa49ae50d4f4383a5bfa2d12ce9fe58223b14f8` | 0 |
| 2 | `6a527d7bf540efd4e1865cc54e91f7e820efbbb4` | +403/-130 |
| 3 | `5c3b2bda73c936fcb90b574d5b474f346258a613` | +447/-148 |
