### PR TITLE
Remove persona card inset outlines

### DIFF
--- a/apps/web/src/components/murph/murph-persona-picker.tsx
+++ b/apps/web/src/components/murph/murph-persona-picker.tsx
@@ -553,7 +553,7 @@ function PersonaMatchCard({
     <div
       style={{ position: "relative" }}
       className={cn(
-        "relative flex min-h-28 items-center gap-4 rounded-xl border p-4 transition-[border-color,background-color]",
+        "relative flex min-h-28 items-center gap-4 rounded-xl border p-4 transition-[border-color,background-color] has-[:focus-visible]:border-2 has-[:focus-visible]:border-primary",
         selected
           ? "border-primary bg-primary/10"
           : "border-border bg-background hover:border-primary/45",
@@ -574,7 +574,7 @@ function PersonaMatchCard({
       <label
         htmlFor={inputId}
         onClick={onSelect}
-        className="absolute inset-0 cursor-pointer rounded-xl peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-inset"
+        className="absolute inset-0 cursor-pointer rounded-xl"
       >
         <span className="sr-only">Select {option.label}</span>
       </label>
@@ -629,7 +629,7 @@ function SupportingPersonaChoice({
   return (
     <div
       className={cn(
-        "relative grid min-h-16 grid-cols-[2.5rem_minmax(0,1fr)_1.25rem] items-center gap-3 rounded-xl border px-3.5 py-2.5 transition-[border-color,background-color]",
+        "relative grid min-h-16 grid-cols-[2.5rem_minmax(0,1fr)_1.25rem] items-center gap-3 rounded-xl border px-3.5 py-2.5 transition-[border-color,background-color] has-[:focus-visible]:border-2 has-[:focus-visible]:border-primary",
         selected
           ? "border-primary bg-primary/10"
           : "border-border bg-background hover:border-primary/45",
@@ -650,7 +650,7 @@ function SupportingPersonaChoice({
       <label
         htmlFor={inputId}
         onClick={onSelect}
-        className="absolute inset-0 cursor-pointer rounded-xl peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-inset"
+        className="absolute inset-0 cursor-pointer rounded-xl"
       >
         <span className="sr-only">Select {label}</span>
       </label>
@@ -704,7 +704,7 @@ function ToneChoiceCard({
   return (
     <div
       className={cn(
-        "relative flex min-h-28 items-start rounded-xl border p-5 transition-[border-color,background-color]",
+        "relative flex min-h-28 items-start rounded-xl border p-5 transition-[border-color,background-color] has-[:focus-visible]:border-2 has-[:focus-visible]:border-primary",
         selected
           ? "border-primary bg-primary/10"
           : "border-border bg-background hover:border-primary/45",
@@ -726,7 +726,7 @@ function ToneChoiceCard({
       <label
         htmlFor={inputId}
         onClick={onSelect}
-        className="absolute inset-0 cursor-pointer rounded-xl peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-inset"
+        className="absolute inset-0 cursor-pointer rounded-xl"
       >
         <span className="sr-only">Select {label}</span>
       </label>
@@ -773,7 +773,7 @@ function PersonaVoiceChoice({
   return (
     <div
       className={cn(
-        "relative flex cursor-pointer flex-col gap-3 rounded-xl border p-4 transition-colors",
+        "relative flex cursor-pointer flex-col gap-3 rounded-xl border p-4 transition-colors has-[:focus-visible]:border-2 has-[:focus-visible]:border-primary",
         selected
           ? "border-primary bg-primary/10"
           : "border-border bg-background hover:border-primary/45",
@@ -797,7 +797,7 @@ function PersonaVoiceChoice({
       />
       <label
         htmlFor={inputId}
-        className="absolute inset-0 cursor-pointer rounded-xl peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-inset"
+        className="absolute inset-0 cursor-pointer rounded-xl"
       >
         <span className="sr-only">Select {option.label}</span>
       </label>

--- a/apps/web/test/murph-persona-picker.test.tsx
+++ b/apps/web/test/murph-persona-picker.test.tsx
@@ -227,7 +227,7 @@ test("MurphPersonaPicker chooses a main personality and an optional supporting p
         ?? [],
     );
     assert.equal(mainRadios.length, 6);
-    assertCardFocusRingsStayInside(mainRadios);
+    assertCardFocusUsesSingleBorder(mainRadios);
     assert.equal(mainRadios.filter((radio) => radio.checked).length, 1);
     assert.equal(new Set(mainRadios.map((radio) => radio.name)).size, 1);
     assert.match(rendered.container.textContent ?? "", /Classic/u);
@@ -260,7 +260,7 @@ test("MurphPersonaPicker chooses a main personality and an optional supporting p
         ?? [],
     );
     assert.equal(supportRadios.length, 6);
-    assertCardFocusRingsStayInside(supportRadios);
+    assertCardFocusUsesSingleBorder(supportRadios);
     assert.equal(supportRadios.filter((radio) => radio.checked).length, 1);
     assert.equal(new Set(supportRadios.map((radio) => radio.name)).size, 1);
     assert.notEqual(mainRadios[0]?.name, supportRadios[0]?.name);
@@ -301,7 +301,7 @@ test("MurphPersonaPicker chooses a main personality and an optional supporting p
       voiceFieldset?.querySelectorAll<HTMLInputElement>("input[type='radio']") ?? [],
     );
     assert.equal(voiceRadios.length, 22);
-    assertCardFocusRingsStayInside(voiceRadios);
+    assertCardFocusUsesSingleBorder(voiceRadios);
     assert.equal(voiceRadios.filter((radio) => radio.checked).length, 1);
     assert.equal(
       voiceRadios.find((radio) => radio.checked)?.value,
@@ -330,7 +330,7 @@ test("MurphPersonaPicker chooses a main personality and an optional supporting p
         ?? [],
     );
     assert.equal(toneRadios.length, 2);
-    assertCardFocusRingsStayInside(toneRadios);
+    assertCardFocusUsesSingleBorder(toneRadios);
     assert.equal(
       toneRadios.find((radio) => radio.checked)?.value,
       "formal",
@@ -542,17 +542,19 @@ test("MurphPersonaPicker retains choices after an error and retries them", async
   }
 });
 
-function assertCardFocusRingsStayInside(
+function assertCardFocusUsesSingleBorder(
   radios: readonly HTMLInputElement[],
 ): void {
   for (const radio of radios) {
+    const card = radio.parentElement;
     const label = radio.ownerDocument.querySelector(
       `label[for='${radio.id}']`,
     );
-    assert.match(label?.className ?? "", /peer-focus-visible:ring-inset/u);
+    assert.match(card?.className ?? "", /has-\[:focus-visible\]:border-primary/u);
+    assert.match(card?.className ?? "", /has-\[:focus-visible\]:border-2/u);
     assert.doesNotMatch(
       label?.className ?? "",
-      /peer-focus-visible:ring-offset/u,
+      /peer-focus-visible:(?:outline|ring)/u,
     );
   }
 }


### PR DESCRIPTION
## Why this PR exists

Persona cards in onboarding can show an inset focus ring that reads as a second border. This removes that inset treatment from the card component.

## User goal / user-visible behavior

Onboarding persona cards keep one clean border in every state. Keyboard focus remains visible by thickening that same outer border to 2px; no inner ring or outline is added.

## User experience

The existing onboarding flow, wording, choices, and timing are unchanged. Main personality, supporting personality, voice, and tone cards all receive the same immediate single-border focus treatment while preserving the full-card click target. There is no asynchronous continuation or new recovery path.

Reference evidence: `.artifacts/review-gpt/persona-picker-reference-desktop.png` is the redacted 898x586 screenshot supplied with the report and shows the affected component in its ordinary desktop state. Post-change desktop and mobile capture is blocked because the in-app browser reported `No browser is available`; no rendered-quality claim is inferred from source alone.

## Invariants the PR must preserve

- Native radio selection, grouping, names, labels, and saved preference values remain unchanged.
- The whole card remains clickable and keyboard focus remains visible.
- Selected colors and check indicators remain unchanged.
- No onboarding state, data flow, persistence, auth, or authority boundary changes.

## Non-obvious affected surfaces

None.

## Preliminary specialist lenses

- Prompt: **not applicable** — no prompts or instruction stacks changed.
- Frontend: **applicable** — the supplied desktop reference is available locally as `.artifacts/review-gpt/persona-picker-reference-desktop.png`; post-change desktop/mobile rendered evidence is unavailable due to the browser-service blocker stated above.
- Coverage: **applicable** — `pnpm test:diff apps/web/src/components/murph/murph-persona-picker.tsx apps/web/test/murph-persona-picker.test.tsx` passed on Blacksmith Testbox `tbx_01ky5tekspnqvvpdw9qb821492` ([run evidence](https://github.com/cobuildwithus/murph/actions/runs/29957938348)); the web owner lane typechecked, built, linted, and reported 490 passing test files / 6,139 passing tests. Focused Vitest: 7/7 passed.

## Change shape

Classification rule: authored component code under `apps/web/src` is source; the matching file under `apps/web/test` is tests/fixtures. No binary file is part of the Git diff; the ignored screenshot is review evidence only.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 8 | 8 |
| Tests/fixtures | 9 | 7 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **17** | **15** |

## Review routing

- Product-experience review: not applicable; this is implementation-only presentation with no product-owned dimension change.
- Final ReviewGPT gate: exempt as minor frontend presentation polish with no workflow, UI state-model, data-flow, product-critical-flow, or authority-boundary change. The preliminary frontend and coverage lenses still apply.

## Completion gate status

- GitHub CI is green on the exact pushed head.
- The required preliminary specialist pass is **blocked**. Its trusted exact-head attempt returned `SPECIALIST_OUTCOME: INVALID`: the guarded ZIP omitted required frontend/design guidance and the named reference image, and no post-change desktop/mobile focus-state captures were available.
- The in-app browser reported `No browser is available`; the separate Fable UI check ended at explicit usage-credit exhaustion.
- Do not merge until the evidence packet is repaired, post-change desktop/mobile focus states are captured, and the same preliminary pass returns a substantive outcome whose findings are resolved.
