### PR TITLE
Add homepage Consumer Health Data notice link

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -5,6 +5,10 @@ import {
   BiomarkerPreparingStateStudy,
   BiomarkerReferenceContextStudy,
 } from "@/src/components/biomarkers/biomarker-design-studies";
+import { HowItWorksSection } from "@/src/components/homepage/how-it-works-section";
+import { DEFAULT_MURPH_HEADSHOT } from "@/src/components/homepage/murph-headshot-avatar";
+import { PersonasSection } from "@/src/components/homepage/personas-section";
+import { SecurityTeaserSection } from "@/src/components/homepage/security-teaser-section";
 import { Separator } from "@/src/components/ui/separator";
 import { ConnectSourceCardStudy } from "./connect-source-card-study";
 import { PersonaOnboardingStudy } from "./persona-onboarding-study";
@@ -36,6 +40,24 @@ export function SectionsContent() {
       <h1 className="font-serif text-4xl font-semibold tracking-tight text-foreground">
         Sections
       </h1>
+
+      <Separator />
+
+      <StudySection title="Homepage security and privacy">
+        <SecurityTeaserSection />
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Homepage experiment flow">
+        <HowItWorksSection />
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Homepage personas">
+        <PersonasSection murphHeadshotSrc={DEFAULT_MURPH_HEADSHOT} />
+      </StudySection>
 
       <Separator />
 

--- a/apps/web/src/components/homepage/how-it-works-section.tsx
+++ b/apps/web/src/components/homepage/how-it-works-section.tsx
@@ -49,6 +49,11 @@ export function HowItWorksSection() {
           <RunCard />
           <LearnCard />
         </div>
+
+        <p className="mx-auto mt-8 max-w-[72ch] text-center text-xs leading-[1.6] text-[#736a58]">
+          Illustrative examples. Changes in personal data can have many causes
+          and do not establish that an intervention produced the result.
+        </p>
       </div>
     </section>
   );

--- a/apps/web/src/components/homepage/personas-section.tsx
+++ b/apps/web/src/components/homepage/personas-section.tsx
@@ -223,6 +223,11 @@ export function PersonasSection({
             </article>
           ))}
         </div>
+
+        <p className="mx-auto mt-10 max-w-[72ch] text-center text-xs leading-[1.6] text-[#f5f0e8]/50">
+          Illustrative examples. Changes in personal data can have many causes
+          and do not establish that an intervention produced the result.
+        </p>
       </div>
     </section>
   );

--- a/apps/web/src/components/homepage/security-teaser-section.tsx
+++ b/apps/web/src/components/homepage/security-teaser-section.tsx
@@ -51,6 +51,16 @@ export function SecurityTeaserSection() {
               <span aria-hidden="true">→</span>
             </Link>
           </div>
+
+          <div className="mt-6 border-t border-[#3a4a1e]/20 pt-5">
+            <Link
+              className="inline-flex items-center gap-2 text-[0.875rem] font-medium text-[#2d3436] underline decoration-[#3a4a1e]/30 underline-offset-4 transition-colors hover:text-[#3a4a1e] hover:decoration-[#3a4a1e]"
+              href="/consumer-health-data-privacy-policy"
+            >
+              Consumer Health Data Privacy Notice
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
         </div>
 
         <TeaserVaultGlyph className="mx-auto w-full max-w-[360px] text-[#2d3436]" />

--- a/apps/web/src/components/homepage/security-teaser-section.tsx
+++ b/apps/web/src/components/homepage/security-teaser-section.tsx
@@ -54,7 +54,7 @@ export function SecurityTeaserSection() {
 
           <div className="mt-6 border-t border-[#3a4a1e]/20 pt-5">
             <Link
-              className="inline-flex items-center gap-2 text-[0.875rem] font-medium text-[#2d3436] underline decoration-[#3a4a1e]/30 underline-offset-4 transition-colors hover:text-[#3a4a1e] hover:decoration-[#3a4a1e]"
+              className="inline-flex items-center gap-2 text-[0.875rem] font-medium text-[#2d3436] underline decoration-[#3a4a1e]/30 underline-offset-4 transition-colors hover:text-[#3a4a1e] hover:decoration-[#3a4a1e] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:[outline-color:#3a4a1e]"
               href="/consumer-health-data-privacy-policy"
             >
               Consumer Health Data Privacy Notice

--- a/apps/web/test/biomarker-design-studies.test.tsx
+++ b/apps/web/test/biomarker-design-studies.test.tsx
@@ -96,6 +96,14 @@ test("design page routes the biomarker studies through the dedicated sections ta
   const sectionsMarkup = renderToStaticMarkup(createElement(DesignPage));
 
   expect(sectionsMarkup).toContain(">Sections<");
+  expect(sectionsMarkup).toContain("Homepage security and privacy");
+  expect(sectionsMarkup).toContain("Consumer Health Data Privacy Notice");
+  expect(sectionsMarkup).toContain(
+    'href="/consumer-health-data-privacy-policy"',
+  );
+  expect(sectionsMarkup).toContain("Homepage experiment flow");
+  expect(sectionsMarkup).toContain("Homepage personas");
+  expect(sectionsMarkup.match(/Illustrative examples\./g)).toHaveLength(2);
   expect(sectionsMarkup).toContain("Biomarker preparing state");
   expect(sectionsMarkup).toContain("Biomarker index");
   expect(sectionsMarkup).toContain("Group usage funding");

--- a/apps/web/test/page.test.ts
+++ b/apps/web/test/page.test.ts
@@ -231,6 +231,18 @@ test("HomePage renders the canonical landing page at the root route", async () =
   );
   assert.match(markup, /What does the group actually see\?/);
   assert.match(markup, /Everything else stays private by default\./);
+  assert.match(
+    markup,
+    /See how we protect your data.*href="\/consumer-health-data-privacy-policy"[^>]*>Consumer Health Data Privacy Notice<span aria-hidden="true">→<\/span><\/a>/s,
+  );
+  assert.equal(
+    (
+      markup.match(
+        /Illustrative examples\. Changes in personal data can have many causes and do not establish that an intervention produced the result\./g,
+      ) ?? []
+    ).length,
+    2,
+  );
   assert.match(markup, /Murph uses AI-assisted review of published studies/);
   assert.match(markup, /Research may be incomplete, mixed, or not applicable to your situation/);
   assert.doesNotMatch(markup, /GPT-5\.5 Pro/);


### PR DESCRIPTION
## Why this PR exists

Washington consumer-health-data guidance calls for a separate, distinct homepage link to the applicable notice. The homepage also needs a concise causality disclaimer directly beneath its experiment and persona examples.

## User goal / user-visible behavior

Homepage visitors can find **Consumer Health Data Privacy Notice →** as a noticeable, subordinate standalone link within **Security & Privacy**. The experiment and persona example groups each end with: “Illustrative examples. Changes in personal data can have many causes and do not establish that an intervention produced the result.”

## User experience

The anonymous visitor enters at `/`, reads the existing static homepage, and can open the existing `/consumer-health-data-privacy-policy` route directly from Security & Privacy. The link and captions render immediately; there is no authentication, permission check, asynchronous continuation, wait, or recovery state. The path adds one link and one repeated explanatory caption without adding a new screen or changing the legal notice.

The production sections are cataloged at `/design?tab=sections`. Playwright captured and verified all three sections at desktop and mobile widths. Hosted screenshot packaging remains blocked because Cloudflare Images write authorization is unavailable, so the proof files stay local and ignored.

## Invariants

- Keep the consumer-health-data notice route and legal content unchanged.
- Keep the notice link separate from the footer and inside the homepage Security & Privacy section.
- Preserve the existing homepage examples and upstream security-copy corrections.
- Do not add data collection, persistence, auth, runtime, or deployment behavior.

## Non-obvious affected surfaces

- `/design?tab=sections`: renders the three real production homepage sections so the UI change has a stable catalog surface. Regression proof: `apps/web/test/biomarker-design-studies.test.tsx`.

## Preliminary specialist lenses

- Prompt: **not applicable** — no prompts or instruction stacks changed.
- Frontend: **applicable** — static homepage hierarchy and explanatory copy changed. Playwright proof files: `audit-packages/pr-884-security-desktop.png`, `audit-packages/pr-884-experiment-desktop.png`, `audit-packages/pr-884-personas-desktop.png`, `audit-packages/pr-884-security-mobile.png`, `audit-packages/pr-884-experiment-mobile.png`, and `audit-packages/pr-884-personas-mobile.png`.
- Coverage: **applicable** — `pnpm test:diff apps/web/src/components/homepage/security-teaser-section.tsx apps/web/src/components/homepage/how-it-works-section.tsx apps/web/src/components/homepage/personas-section.tsx apps/web/app/design/sections-content.tsx apps/web/test/page.test.ts apps/web/test/biomarker-design-studies.test.tsx` passed on the final remediation head: 494 files and 6,228 tests, TypeScript, lint with 0 errors, dev smoke, and production build.

## Change shape

Classification: production components and design-catalog composition are source; assertions are tests; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 42 | 0 |
| Tests / fixtures | 20 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **62** | **0** |

## Design proof

- Design page: [Homepage security, experiment, and persona sections](/design?tab=sections)
- Desktop screenshot: captured with Playwright at 1440px in the three desktop proof files listed above; hosting remains blocked because Cloudflare Images write authorization is unavailable.
- Mobile screenshot: captured with Playwright at 390px in the three mobile proof files listed above; hosting remains blocked because Cloudflare Images write authorization is unavailable.

## Verification

- Playwright rendered proof: all three production sections captured at 1440px and 390px; the notice link appears once and the exact disclaimer appears twice, with no observed horizontal overflow.
- Focused homepage/design tests after rebasing onto current `main`: 2 files, 13 tests passed.
- `pnpm test:frontend-design-proof`: 9 tests passed.
- `pnpm test:diff ...`: passed, including full web tests, typecheck, lint (0 errors; 11 unrelated existing warnings), dev smoke, and Next production build.
- Preliminary specialist ReviewGPT: `FINDINGS` on `7b07ef63b0`; one valid medium keyboard-focus finding. Resolved in `b96a094a80` with a solid 2px `#3a4a1e` outline at 2px offset. Playwright confirmed the notice link receives that computed style after two Tab presses at both widths; no patch artifact was returned.
- Final ReviewGPT round 1: `PASS` with no findings on immutable exact head `b96a094a80207cc85dfcae4a423083d9595efaaa` (Hercules, GPT-5.6 Pro; exact-head ZIP and marker verified). The final ZIP did not include local rendered files; the preliminary specialist pass reviewed all six Playwright screenshots.
- Local product-experience review: `NO FINDINGS`; the initial rendered-proof gap was subsequently closed with the six Playwright captures.
- Independent Claude UI double-check was attempted once and stopped because the reviewer account is out of usage credits.
- `pnpm verify:acceptance`: all web checks passed, but repository-wide acceptance exited 1 because three unrelated `packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-diagnostics.test.ts` tests encounter a pre-existing pending-input schema mismatch. A focused rerun reproduced those three failures; this PR changes no assistant-runtime or persisted-state code.
- Exact-head GitHub checks: Vercel, Repo Hygiene, Web Viewport Overflow, Murph Host Support, and Cloudflare Hosted E2E passed. Frontend Design Proof fails only because it requires hosted desktop/mobile screenshot URLs; the completed local Playwright proof cannot satisfy that gate without image-host write authorization.

## Deployment skew / compatibility

Not applicable. This is a single web-only static-content change with no deploy-boundary, runtime, schema, or persisted-state coupling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787370432&installation_model_id=19880&pr_number=884&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F884&signature=dbe8bd79d363d3e1073df112d82f91a612b11317e0792757f8182e4d0dd824d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

ReviewGPT first-reviewed head: b96a094a80207cc85dfcae4a423083d9595efaaa
