### PR TITLE
Raise the group-chat daily text cap to 200

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/linq-daily-state.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-daily-state.ts
@@ -4,6 +4,7 @@ import type { Prisma } from "@prisma/client";
 type HostedLinqDailyStateClient = PrismaClient | Prisma.TransactionClient;
 
 export const HOSTED_LINQ_DAILY_TEXT_LIMIT = 100;
+export const HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT = 200;
 export const HOSTED_AUTOMATION_ENGAGEMENT_WINDOW_DAYS = 28;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;

--- a/apps/web/src/lib/hosted-onboarding/linq-replies.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-replies.ts
@@ -16,14 +16,17 @@ export function buildHostedInviteReply(input: {
 }
 
 export function buildHostedDailyQuotaReply(input: {
+  dailyTextLimit?: number;
   seed?: string | null;
 } = {}): string {
+  const dailyTextLimit = input.dailyTextLimit ?? HOSTED_LINQ_DAILY_TEXT_LIMIT;
+
   return renderUserFacingMessage({
     context: {
-      dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
+      dailyTextLimit,
     },
     key: "linq.daily_quota",
-    seed: input.seed ?? `daily-quota:${HOSTED_LINQ_DAILY_TEXT_LIMIT}`,
+    seed: input.seed ?? `daily-quota:${dailyTextLimit}`,
   }).text;
 }
 

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq-shared.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq-shared.ts
@@ -258,6 +258,7 @@ export function buildConversationHomeRedirectResponse(input: {
 
 export function buildQuotaReplyResponse(input: {
   chatId: string;
+  dailyTextLimit: number;
   memberId: string;
   messageId: string;
   occurredAt: string;
@@ -268,6 +269,7 @@ export function buildQuotaReplyResponse(input: {
     desiredSideEffects: [
       createHostedWebhookLinqMessageSideEffect({
         chatId: input.chatId,
+        dailyTextLimit: input.dailyTextLimit,
         memberId: input.memberId,
         occurredAt: input.occurredAt,
         replyToMessageId: input.messageId,

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -44,6 +44,7 @@ import {
 } from "./logging";
 import {
   HOSTED_LINQ_DAILY_TEXT_LIMIT,
+  HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
   incrementHostedLinqInboundDailyState,
   incrementHostedLinqOutboundDailyState,
   readHostedLinqDailyState,
@@ -620,6 +621,7 @@ export async function planHostedOnboardingLinqWebhook(input: {
     const admissionPlan = await planHostedLinqDailyQuotaAdmissionDenied({
       context,
       dailyState,
+      dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
       event: input.event,
       logDetails: {
         existingMemberActive: true,
@@ -1270,9 +1272,12 @@ async function planHostedLinqExplicitThreadRouteWebhook(input: {
 
   // Subscription/AI usage and its limit notice are gated after mailbox append,
   // so pending user input survives upgrades and allowance resets.
+  // Group threads share one daily bucket across every participant, so they get
+  // a higher cap than a 1:1 direct chat.
   const admissionPlan = await planHostedLinqDailyQuotaAdmissionDenied({
     context: input.context,
     dailyState,
+    dailyTextLimit: HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
     event: input.event,
     logDetails: {
       existingMemberActive: true,
@@ -1525,6 +1530,7 @@ async function planHostedLinqGroupChatWebhook(input: {
 async function planHostedLinqDailyQuotaAdmissionDenied(input: {
   context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
   dailyState: HostedLinqDailyState | null;
+  dailyTextLimit: number;
   event: HostedLinqWebhookEvent;
   logDetails: HostedOnboardingStructuredLogDetails;
   memberId: string;
@@ -1539,7 +1545,7 @@ async function planHostedLinqDailyQuotaAdmissionDenied(input: {
     return null;
   }
 
-  if (dailyState.inboundCount > HOSTED_LINQ_DAILY_TEXT_LIMIT) {
+  if (dailyState.inboundCount > input.dailyTextLimit) {
     if (dailyState.quotaReplySentAt) {
       return logHostedLinqWebhookPlannerDecisionAndReturn(
         buildIgnoredLinqWebhookPlan("daily-quota-reached"),
@@ -1555,6 +1561,7 @@ async function planHostedLinqDailyQuotaAdmissionDenied(input: {
     return logHostedLinqWebhookPlannerDecisionAndReturn(
       buildQuotaReplyResponse({
         chatId: input.context.summary.chatId,
+        dailyTextLimit: input.dailyTextLimit,
         memberId: input.memberId,
         messageId: input.context.summary.messageId,
         occurredAt: input.context.occurredAt,

--- a/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
@@ -72,6 +72,9 @@ export type HostedLinqConversationHomeRedirectPayload = {
 
 export type HostedLinqDailyQuotaPayload = {
   chatId: string;
+  // Optional for payloads persisted before per-thread limits existed; render
+  // falls back to the direct-chat limit.
+  dailyTextLimit?: number;
   memberId: string;
   occurredAt: string;
   replyToMessageId: string | null;
@@ -209,6 +212,7 @@ export type CreateHostedWebhookLinqMessageSideEffectInput =
     }
   | {
       chatId: string;
+      dailyTextLimit: number;
       memberId: string;
       occurredAt: string;
       replyToMessageId?: string | null;
@@ -988,6 +992,9 @@ async function buildHostedLinqSideEffectMessage(
       return effect.payload.message;
     case "daily_quota":
       return buildHostedDailyQuotaReply({
+        ...(effect.payload.dailyTextLimit === undefined
+          ? {}
+          : { dailyTextLimit: effect.payload.dailyTextLimit }),
         seed: effect.effectId,
       });
     case "family_invite_reply":
@@ -1115,6 +1122,7 @@ function buildHostedWebhookLinqMessagePayload(
     case "daily_quota":
       return {
         chatId: input.chatId,
+        dailyTextLimit: input.dailyTextLimit,
         memberId: input.memberId,
         occurredAt: input.occurredAt,
         replyToMessageId,

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -1923,7 +1923,7 @@ describe("Linq explicit external-thread routing", () => {
     vi.mocked(mailboxStore.readHostedMailboxItemByDedupeKey).mockResolvedValueOnce(null);
     vi.mocked(linqDailyState.incrementHostedLinqInboundDailyState).mockResolvedValueOnce({
       dayUtc: new Date("2026-06-24T00:00:00.000Z"),
-      inboundCount: linqDailyState.HOSTED_LINQ_DAILY_TEXT_LIMIT + 1,
+      inboundCount: linqDailyState.HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT + 1,
       memberId: "member_thread_container_123",
       outboundCount: 0,
       quotaReplySentAt: null,
@@ -1954,6 +1954,7 @@ describe("Linq explicit external-thread routing", () => {
     expect(plan.desiredSideEffects).toHaveLength(1);
     expect(plan.desiredSideEffects[0]?.payload).toMatchObject({
       chatId: "chat_group_123",
+      dailyTextLimit: linqDailyState.HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
       memberId: "member_thread_container_123",
       routeAuthority: {
         accountLookupKey: createHostedPhoneLookupKey("+15550000000"),
@@ -1977,6 +1978,41 @@ describe("Linq explicit external-thread routing", () => {
       groupParticipantAdded: true,
     });
     expect(prisma.readPendingParticipantAddition()).toBe(false);
+  });
+
+  it("admits routed thread traffic past the direct-chat daily limit up to the group limit", async () => {
+    const prisma = createPrisma({
+      routeContainerMemberId: "member_thread_container_123",
+    });
+    vi.mocked(mailboxStore.readHostedMailboxItemByDedupeKey).mockResolvedValueOnce(null);
+    vi.mocked(linqDailyState.incrementHostedLinqInboundDailyState).mockResolvedValueOnce({
+      dayUtc: new Date("2026-06-24T00:00:00.000Z"),
+      inboundCount: linqDailyState.HOSTED_LINQ_DAILY_TEXT_LIMIT + 1,
+      memberId: "member_thread_container_123",
+      outboundCount: 0,
+      quotaReplySentAt: null,
+    } as Awaited<ReturnType<typeof linqDailyState.incrementHostedLinqInboundDailyState>>);
+    vi.mocked(mailboxStore.appendHostedMailboxEnvelopeTx).mockResolvedValueOnce({
+      dedupeConflict: false,
+      duplicate: false,
+      inserted: true,
+      item: buildHostedMailboxItem({
+        id: "mailbox_group_over_direct_limit_123",
+        userId: "member_thread_container_123",
+      }),
+    });
+
+    const plan = await planHostedOnboardingLinqWebhook({
+      event: buildLinqMessageReceivedEvent({}),
+      prisma: prisma as never,
+    });
+
+    expect(plan.response).toMatchObject({
+      ignored: false,
+      ok: true,
+      reason: "wake-appended-thread-route",
+    });
+    expect(plan.desiredSideEffects).toHaveLength(0);
   });
 
   it("appends routed thread traffic even when the AI usage gate would deny", async () => {

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -134,6 +134,8 @@ import {
 import {
   claimHostedLinqOnboardingLinkNotice,
   claimHostedLinqQuotaReplyNotice,
+  HOSTED_LINQ_DAILY_TEXT_LIMIT,
+  HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
   markHostedLinqOnboardingLinkNoticeSent,
   releaseHostedLinqOnboardingLinkNoticeClaim,
   releaseHostedLinqQuotaReplyNoticeClaim,
@@ -359,6 +361,7 @@ describe("hosted Linq webhook transport", () => {
     });
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
+      dailyTextLimit: HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
       memberId: "member-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -412,6 +415,7 @@ describe("hosted Linq webhook transport", () => {
     });
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
+      dailyTextLimit: HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
       memberId: "member-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -446,6 +450,7 @@ describe("hosted Linq webhook transport", () => {
     });
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
+      dailyTextLimit: HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
       memberId: "member-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -488,6 +493,7 @@ describe("hosted Linq webhook transport", () => {
     });
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
+      dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
       memberId: "member-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -647,6 +653,7 @@ describe("hosted Linq webhook transport", () => {
     const prisma = {};
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
+      dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
       memberId: "member-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -1496,6 +1503,7 @@ describe("hosted Linq webhook transport", () => {
     ));
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
+      dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
       memberId: "member-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -1559,6 +1567,7 @@ describe("hosted Linq webhook transport", () => {
     };
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-group-1",
+      dailyTextLimit: HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
       memberId: "member-thread-container-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -1608,6 +1617,7 @@ describe("hosted Linq webhook transport", () => {
     };
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-group-1",
+      dailyTextLimit: HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
       memberId: "member-thread-container-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -1657,6 +1667,7 @@ describe("hosted Linq webhook transport", () => {
     };
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-group-b",
+      dailyTextLimit: HOSTED_LINQ_GROUP_DAILY_TEXT_LIMIT,
       memberId: "member-thread-container-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",
@@ -1738,6 +1749,7 @@ describe("hosted Linq webhook transport", () => {
     vi.mocked(claimHostedLinqQuotaReplyNotice).mockResolvedValueOnce(false);
     const effect = createHostedWebhookLinqMessageSideEffect({
       chatId: "chat-1",
+      dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
       memberId: "member-1",
       occurredAt: "2026-03-26T12:00:00.000Z",
       replyToMessageId: "message-1",


### PR DESCRIPTION
## Why

Group iMessage threads share a single hosted Linq daily inbound bucket for the whole thread (every participant's messages count against the thread container's `HostedLinqDailyState` row), so the 100/day cap sized for a 1:1 direct chat was too tight for group chats.

## Intent contract

- **User-visible goal:** a group chat with Murph can send up to 200 texts per UTC day before hitting the daily cap; 1:1 direct chats keep the existing 100/day cap. The smallest complete flow: a group thread sends its 101st message of the day and Murph still answers; at 201 the thread gets the once-per-day quota reply quoting 200.
- **Immediate feedback:** unchanged — messages under the cap flow to the runtime; the first message over the cap gets the existing quota reply, now rendering the limit that actually applied to that thread (200 for group threads, 100 for direct chats).
- **Timing and continuation:** unchanged — the cap resets per UTC day; quota replies stay suppressed to once per day via the existing `quotaReplySentAt` claim.
- **Terminal delivery or recovery:** unchanged — over-cap messages are ignored with the existing `daily-quota-reached` plan; no new failure modes.
- **Invariants preserved:** quota suppression stays ahead of route binding and mailbox append; webhook idempotency and the once-per-day notice claims are untouched; the daily-state store schema is unchanged. `dailyTextLimit` is optional on the persisted `daily_quota` side-effect payload so pre-deploy rows still render (falling back to the direct-chat limit, which is what produced them).
- **Non-obvious affected surfaces:** the `daily_quota` Linq side-effect payload gains an optional `dailyTextLimit` field carried through `buildQuotaReplyResponse` → `createHostedWebhookLinqMessageSideEffect` → `buildHostedDailyQuotaReply`, so the quota reply template renders the applicable limit. Linq thread routes are created only by group-chat provisioning (`ensureHostedThreadContainerRouteTx` callers), so the 200 cap lands exactly on group threads.

## Preliminary specialist lenses

- prompt: not applicable (no prompt text, instruction stacks, or tool descriptions changed)
- frontend: not applicable (no `apps/web` UI changed; the only copy surface is the existing SMS quota template, which already interpolated `{dailyTextLimit}`)
- coverage: not applicable (verification used the owner's focused vitest files, not `pnpm test:diff`; commands and outcomes below)

## Verification

- `pnpm typecheck` (apps/web) — pass
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts apps/web/test/hosted-onboarding-linq-thread-route.test.ts apps/web/test/hosted-onboarding-linq-dispatch.test.ts apps/web/test/hosted-onboarding-linq-transport.test.ts apps/web/test/hosted-onboarding-linq-daily-state.test.ts` — 216 tests pass, including a new case that a group thread at 101 inbound is still admitted and the existing group quota test now tripping at 201
- `eslint` on all changed files — pass

## Change shape

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 24 | 3 |
| Tests | 49 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT first-reviewed head: 1d18bfcd2a62e1cddf0978a855fa70c19890762d

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787428359&installation_model_id=19880&pr_number=900&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F900&signature=fa13a401cc6280394dbd44bc299d6d48484756298ba748a9c4354b50e86aadd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->