### PR TITLE
Deflake the onboarding follow-up archive assertion

### DIFF
--- a/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
@@ -121,8 +121,16 @@ describe("hosted local onboarding follow-up e2e", () => {
     });
     expect(requireLinqStub().readObservedMessageText(completionReply))
       .toBe(onboardingCompleteReplyText);
-    const completionStatus = await requireScenario().waitForHostedCompletion(userId);
+    let completionStatus = await requireScenario().waitForHostedCompletion(userId);
     expect(completionStatus.lastErrorCode ?? null).toBeNull();
+    // The follow-up archive commits in a post-checkpoint managed-automation
+    // pass that may land one checkpoint (or one deferred wake) after the
+    // completion reply, so re-sample completions until the sticky
+    // murphManagedAutomationUpdated counter appears.
+    while (completionStatus.workspace?.redactedStatus?.murphManagedAutomationUpdated !== 1) {
+      completionStatus = await requireScenario().waitForHostedCompletion(userId);
+      expect(completionStatus.lastErrorCode ?? null).toBeNull();
+    }
     expect(completionStatus.workspace?.redactedStatus).toMatchObject({
       murphManagedAutomationUpdated: 1,
     });


### PR DESCRIPTION
## Why

`hosted-local-onboarding-followup-e2e.test.ts` failed twice on `main` on 2026-07-23 (runs 29992404188 and 30045066131) and passed on reruns with no source change. The test asserted `murphManagedAutomationUpdated: 1` on the first completed status sampled after the completion reply, but the follow-up archive commits in a post-checkpoint managed-automation pass that can land one checkpoint later, or defer to the next wake when background maintenance yields. The workspace `redactedStatus` merges across checkpoints, so the poll could observe the creation pass's stale `updated: 0` in that window.

## Change

Test-only. Re-sample `waitForHostedCompletion` until the counter appears. Once written the counter is sticky: later no-op automation passes return `null` and write no status, so nothing can reset it and the loop converges exactly when the archive lands. If the archive never happens, the harness progress-wait timeout still fails the test, so the deterministic-archive guarantee stays covered.

## Verification

- `tsc --noEmit -p apps/cloudflare/tsconfig.typecheck.json`: clean.
- The "Linq reminder + onboarding follow-up E2E" lane on this PR runs the exact scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787439740&installation_model_id=19880&pr_number=910&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F910&signature=d89975ef521c7114f6a89053c220756931b89d628c3f15a4f9cd0c5f0208d4b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->