### PR TITLE
Cap group-chat message length behind the room Detail ceiling

### DIFF
--- a/packages/assistant-engine/skills/group-challenge/SKILL.md
+++ b/packages/assistant-engine/skills/group-challenge/SKILL.md
@@ -172,6 +172,14 @@ When kickoff needs another decision, ask that next question directly in the
 group response. Do not prepend a setup-status, progress, or transition sentence;
 the question is the useful update.
 
+Kickoff is a conversation, not a rules document, and every kickoff message
+obeys `group-chat`'s length budget. Pitch a format or scoring idea in a few
+short sentences, settle one decision at a time, and ask at most one question
+per message. The full format, scoring detail, and fine print belong on the
+challenge page; the chat gets the headline version. Do not post a
+multi-section framework or numbered rulebook into the room unless the room's
+Detail is 10/10 or a member explicitly asks this turn for the full rules.
+
 1. **Negotiate the metric.** Participants argue about fairness; that
    argument is engagement, not friction. Take a real position, adjudicate
    with a ruling, and converge the group on one metric and window. Record
@@ -427,6 +435,11 @@ automation action rules with a `dailyLocal` schedule and
    literal disconnected, `needs-reconnect`, and other device statuses may get
    status-appropriate guidance and no permission card.
 5. Compose ONE dispatch in ONE format, in the `groupchat-comedy` voice.
+   The scheduled dispatch is the one group message where the required
+   completeness statement and per-person missing-data lines always count as
+   substance: never trim them for length, keep them to about one line per
+   person, keep the whole dispatch compact, and put ranking mechanics or
+   anything longer on the challenge page.
    Rotate formats day over day — text bit, comic, voice memo, song,
    sportsbook odds, ruling — and check the sent log so the same format does
    not land twice in a row. A voice memo or song cannot share a turn with

--- a/packages/assistant-engine/skills/group-chat/SKILL.md
+++ b/packages/assistant-engine/skills/group-chat/SKILL.md
@@ -281,7 +281,8 @@ vulnerable disclosure.
   multi-paragraph message, and the ceiling covers the whole turn, including
   every `---` bubble. When the substance will not fit, send the headline
   decision or answer, let the room ask for more, and keep durable detail on
-  the owning vault page instead of in the chat.
+  the owning vault page instead of in the chat. An explicitly configured
+  scheduled edition or digest follows its owning skill's shape.
 - Match the group's register: length (within the ceiling above), casing,
   energy. No lecture formatting, headers, or bullet lists unless someone
   asked for a breakdown.

--- a/packages/assistant-engine/skills/group-chat/SKILL.md
+++ b/packages/assistant-engine/skills/group-chat/SKILL.md
@@ -274,8 +274,17 @@ vulnerable disclosure.
   requests, such as a contact card plus a song, may accompany it. Never send a
   separate unrequested status or permission-card companion follow-up, never add
   "anything else?" tails, and never send a paragraph where a line works.
-- Match the group's register: length, casing, energy. No lecture formatting,
-  headers, or bullet lists unless someone asked for a breakdown.
+- Group messages are phone-screen short: a few short sentences is the default
+  shape for any reply, whatever the ask. The room's Detail setting is a hard
+  ceiling on length, never a target. Unless Detail is 10/10 or someone
+  explicitly asked this turn for the full write-up, do not send a
+  multi-paragraph message, and the ceiling covers the whole turn, including
+  every `---` bubble. When the substance will not fit, send the headline
+  decision or answer, let the room ask for more, and keep durable detail on
+  the owning vault page instead of in the chat.
+- Match the group's register: length (within the ceiling above), casing,
+  energy. No lecture formatting, headers, or bullet lists unless someone
+  asked for a breakdown.
 - Default to no emoji. Use at most one only when it adds something and matches
   how the group already talks; never decorate every reply or use emojis in
   consecutive messages.

--- a/packages/assistant-engine/skills/groupchat-comedy/SKILL.md
+++ b/packages/assistant-engine/skills/groupchat-comedy/SKILL.md
@@ -121,7 +121,8 @@ stake they visibly don't want.
   disclaimers around trivial trash talk, structured-summary energy for a
   two-line score update ("I want to be fully transparent with the group
   before sharing today's standings."). Commit fully — for this one message
-  the register overrides the usual brevity, and a half-committed version
+  the register overrides the usual brevity, not the room's length ceiling:
+  stay inside one compact message, and a half-committed version
   reads as a bug, not a bit. This is occasional rotation spice, never the
   house voice or default register; if Murph always talks this way, the
   parody collapses into the thing it mocks.

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -684,7 +684,7 @@ function buildAssistantPersonalityPreferenceText(
     ...lines,
     ...(conversationScope === "group"
       ? [
-          "- In this group room, Detail is a hard ceiling on message length, never a floor: below 10/10, keep each reply to a few short sentences and let members ask for more instead of front-loading detail. Only Detail 10/10 or an explicit member request this turn for a full write-up permits a multi-paragraph reply.",
+          "- In this group room, Detail is a hard ceiling on message length, never a floor: below 10/10, keep each reply to a few short sentences and let members ask for more instead of front-loading detail. Only Detail 10/10 or an explicit member request this turn for a full write-up permits a multi-paragraph reply. An explicitly configured scheduled edition or digest follows its owning skill's shape.",
         ]
       : []),
     "- Apply these dials within the saved tone and current channel style. Fit them inside the channel's pacing: Detail sets the length budget, Humor and Push fit inside it, and Humor never gets its own bubble. They change expression, not facts, authority, safety thresholds, or required warnings. When urgent action is needed, lead with the action, timeframe, and safety essentials; when the user has limited capacity, omit optional background. Stay warm, competent, respectful of the user's choices, and factually clear. Safety, truth, privacy, consent, authorization, clinical and protected-context rules, channel rules, and the user's explicit current-turn instructions take precedence.",

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -682,6 +682,11 @@ function buildAssistantPersonalityPreferenceText(
       ? "Assistant personality preferences for this group room:"
       : "Assistant personality preferences for this private conversation:",
     ...lines,
+    ...(conversationScope === "group"
+      ? [
+          "- In this group room, Detail is a hard ceiling on message length, never a floor: below 10/10, keep each reply to a few short sentences and let members ask for more instead of front-loading detail. Only Detail 10/10 or an explicit member request this turn for a full write-up permits a multi-paragraph reply.",
+        ]
+      : []),
     "- Apply these dials within the saved tone and current channel style. Fit them inside the channel's pacing: Detail sets the length budget, Humor and Push fit inside it, and Humor never gets its own bubble. They change expression, not facts, authority, safety thresholds, or required warnings. When urgent action is needed, lead with the action, timeframe, and safety essentials; when the user has limited capacity, omit optional background. Stay warm, competent, respectful of the user's choices, and factually clear. Safety, truth, privacy, consent, authorization, clinical and protected-context rules, channel rules, and the user's explicit current-turn instructions take precedence.",
   ].join("\n")
 }
@@ -1025,7 +1030,8 @@ function buildAssistantGroupIdentityAndScopeText(): string {
 The room container is not a person. Do not treat a speaker's first-person health statement as authority to read or write personal records, memory, settings, devices, accounts, or preferences. Do not save a participant's health fact into the room vault as though it belonged to the room. Use personal data only when a server-owned group tool returns an explicitly shared projection, and attribute it to the returned member.
 
 Personality:
-Calm, observant, direct, plainspoken, and casual. Use light humor when it fits — dry and deadpan, never marked with laughing emojis or laughter at your own lines — support each participant's judgment, and never shame, diagnose, rank bodies, or turn the room into surveillance.`;
+Calm, observant, direct, plainspoken, and casual. Use light humor when it fits — dry and deadpan, never marked with laughing emojis or laughter at your own lines — support each participant's judgment, and never shame, diagnose, rank bodies, or turn the room into surveillance.
+Group messages stay phone-screen short: a few short sentences, whatever the ask, and the ceiling covers the whole reply. Never send a multi-paragraph reply unless someone explicitly asked this turn for the full write-up or the room's saved style calls for maximum detail; otherwise give the headline and let the room ask for more. An explicitly configured scheduled edition or digest follows its owning skill's shape.`;
 }
 
 function buildAssistantProductPrinciplesText(): string {

--- a/packages/assistant-engine/test/assistant-group-challenge-diagnostics-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-group-challenge-diagnostics-skill.test.ts
@@ -59,6 +59,12 @@ describe('assistant group challenge diagnostics guidance', () => {
     expect(challenge).toContain(
       'Never present a partial table as the full standings.',
     )
+    expect(challenge).toContain(
+      'The scheduled dispatch is the one group message where the required completeness statement and per-person missing-data lines always count as substance',
+    )
+    expect(challenge).toContain(
+      'never trim them for length, keep them to about one line per person, keep the whole dispatch compact, and put ranking mechanics or anything longer on the challenge page',
+    )
     expect(groupChat).toContain(
       'It is the only hosted model-facing path to the current Web-owned shared snapshot',
     )

--- a/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
@@ -52,6 +52,9 @@ describe('assistant group-chat style guidance', () => {
     expect(normalized).toContain(
       'send the headline decision or answer, let the room ask for more, and keep durable detail on the owning vault page instead of in the chat',
     )
+    expect(normalized).toContain(
+      "An explicitly configured scheduled edition or digest follows its owning skill's shape.",
+    )
   })
 
   it('keeps challenge kickoff conversational instead of a rulebook dump', async () => {

--- a/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
@@ -37,6 +37,41 @@ describe('assistant group-chat style guidance', () => {
     )
   })
 
+  it('caps group message length behind the room Detail ceiling', async () => {
+    const normalized = await readNormalizedGroupChatSkill()
+
+    expect(normalized).toContain(
+      'Group messages are phone-screen short: a few short sentences is the default shape for any reply, whatever the ask.',
+    )
+    expect(normalized).toContain(
+      "The room's Detail setting is a hard ceiling on length, never a target.",
+    )
+    expect(normalized).toContain(
+      'Unless Detail is 10/10 or someone explicitly asked this turn for the full write-up, do not send a multi-paragraph message, and the ceiling covers the whole turn, including every `---` bubble.',
+    )
+    expect(normalized).toContain(
+      'send the headline decision or answer, let the room ask for more, and keep durable detail on the owning vault page instead of in the chat',
+    )
+  })
+
+  it('keeps challenge kickoff conversational instead of a rulebook dump', async () => {
+    const groupChallenge = await readFile(
+      path.join(resolveAssistantSkillsRoot(), 'group-challenge', 'SKILL.md'),
+      'utf8',
+    )
+    const normalized = groupChallenge.replace(/\s+/gu, ' ')
+
+    expect(normalized).toContain(
+      "Kickoff is a conversation, not a rules document, and every kickoff message obeys `group-chat`'s length budget.",
+    )
+    expect(normalized).toContain(
+      'Pitch a format or scoring idea in a few short sentences, settle one decision at a time, and ask at most one question per message.',
+    )
+    expect(normalized).toContain(
+      "Do not post a multi-section framework or numbered rulebook into the room unless the room's Detail is 10/10 or a member explicitly asks this turn for the full rules.",
+    )
+  })
+
   it('keeps emoji use occasional instead of habitual', async () => {
     const normalized = await readNormalizedGroupChatSkill()
 

--- a/packages/assistant-engine/test/assistant-groupchat-comedy-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-groupchat-comedy-skill.test.ts
@@ -72,6 +72,9 @@ describe('assistant group-chat comedy skill', () => {
     expect(normalized).toContain(
       'for this one message the register overrides the usual brevity',
     )
+    expect(normalized).toContain(
+      "not the room's length ceiling: stay inside one compact message",
+    )
     expect(normalized).toContain('never the house voice or default register')
     expect(normalized).toContain('the parody collapses into the thing it mocks')
   })

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -277,6 +277,9 @@ describe('assistant execution prompt contract', () => {
     expect(layers.threadContextPrompt).toContain(
       'Assistant personality preferences for this private conversation:',
     )
+    expect(layers.threadContextPrompt).not.toContain(
+      'In this group room, Detail is a hard ceiling on message length',
+    )
     expect(layers.threadContextPrompt).toContain(
       'Humor 9/10: initiate when there is an opening and commit to the bit',
     )
@@ -2186,6 +2189,15 @@ describe('assistant conversation scope', () => {
 
     expect(prompt).toContain('Conversation scope: hosted group chat.')
     expect(prompt).toContain('synthetic room container, not the human speaker')
+    expect(prompt).toContain(
+      'Group messages stay phone-screen short: a few short sentences, whatever the ask, and the ceiling covers the whole reply.',
+    )
+    expect(prompt).toContain(
+      "An explicitly configured scheduled edition or digest follows its owning skill's shape.",
+    )
+    expect(prompt).toContain(
+      "Never send a multi-paragraph reply unless someone explicitly asked this turn for the full write-up or the room's saved style calls for maximum detail",
+    )
     expect(prompt).not.toContain('Assistant style settings')
     expect(prompt).toContain('Use only accountless built-in service tools')
     expect(prompt).toContain('A group container cannot own a Family plan')
@@ -2260,6 +2272,12 @@ describe('assistant conversation scope', () => {
     expect(prompt).toContain('Humor 9/10')
     expect(prompt).toContain('Push 8/10')
     expect(prompt).toContain('Detail 7/10')
+    expect(prompt).toContain(
+      'In this group room, Detail is a hard ceiling on message length, never a floor: below 10/10, keep each reply to a few short sentences and let members ask for more instead of front-loading detail.',
+    )
+    expect(prompt).toContain(
+      'Only Detail 10/10 or an explicit member request this turn for a full write-up permits a multi-paragraph reply.',
+    )
     expect(prompt).toContain(
       'Casual is a persistent user-facing writing invariant',
     )


### PR DESCRIPTION
## Problem

In a live iMessage group chat, challenge setup produced several consecutive multi-paragraph replies (full scoring frameworks, numbered point systems, formal rulings) at the default room Detail of 5/10, and a participant pushed back on the volume. The group-chat skill said "never send a paragraph where a line works" but set no hard budget, the mid-score Detail dial text ("balanced detail with rationale and context") read as a license for paragraphs, and the group-challenge kickoff flow ("negotiate the metric, adjudicate with a ruling") had no length constraint, so the challenge workflow won.

## Product rule

In a group chat the room's Detail setting is a hard ceiling on message length, never a target. Below 10/10 (including when unset), replies stay a few short sentences, and the ceiling covers the whole turn including every `---` bubble. A multi-paragraph reply requires Detail 10/10 or an explicit same-turn request for the full write-up. Complex substance (challenge formats, scoring, rulings) still happens: the chat gets the headline version, one decision at a time, and full detail lives on the durable challenge page.

## Changes

- `skills/group-chat/SKILL.md` — new Message shape bullet: phone-screen-short default, Detail as hard ceiling, whole-turn coverage, headline-then-pull pattern; register matching now scoped within the ceiling.
- `skills/group-challenge/SKILL.md` — kickoff is a conversation, not a rules document: one decision at a time, at most one question per message, no multi-section rulebooks below Detail 10/10; daily-dispatch step keeps required completeness/missing-data lines as never-trimmed substance (about one line per person) while ranking mechanics go to the challenge page.
- `skills/groupchat-comedy/SKILL.md` — AI-voice parody register overrides brevity of tone, not the room's length ceiling; stays inside one compact message.
- `src/assistant/system-prompt.ts` — group identity text gains the phone-screen-short backstop (covers rooms with no saved dials; explicitly configured scheduled editions/digests follow their owning skill's shape), and the group personality block renders a Detail-ceiling line alongside the dials. Private-conversation rendering is unchanged.
- Tests assert the new skill strings, the group prompt lines, and their absence from private-scope prompts.

## Verification

- `pnpm test:diff` over all touched files: green (assistant-engine suite 171 passed / 1 skipped plus affected app verification).
- Focused runs: assistant-group-chat-style-skill, model-behavior, assistant-groupchat-comedy-skill, assistant-codex-turn-planning — 129 passed.
- Local product-experience-review pass completed; all six findings (scheduled-dispatch reconciliation, newsletter edition shapes, multi-bubble loophole, parody-format conflict, same-turn qualifiers, register adjacency) resolved in this diff. Note: the usual Codex audit lane is quota-blocked until Jul 28, so the review ran on the parent-model fallback per the completion workflow.

## Change shape

Base-to-head diff, classified by path (rule: `src/**` and `skills/**` prompt assets = source, `test/**` = tests): source +33/-4 (three SKILL.md prompt assets +26/-3, system-prompt.ts +7/-1), tests +53/-0. No docs, config, generated, or binary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787457134&installation_model_id=19880&pr_number=913&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F913&signature=8442ac31b940d7dde89f598bda49dc0160d22e4af1ca157e66891bb1dfb93314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->