### PR TITLE
fix(web): detect in-app browsers on the contact-card add flow

### DIFF
--- a/apps/web/app/api/murph-contact-card/route.ts
+++ b/apps/web/app/api/murph-contact-card/route.ts
@@ -11,6 +11,11 @@ import {
 } from "@/src/lib/hosted-onboarding/linq-contact-card";
 import { readHostedMemberRoutingState } from "@/src/lib/hosted-onboarding/hosted-member-routing-store";
 import {
+  sanitizeHostedOnboardingStructuredLogDetails,
+  toHostedOnboardingLogIdSuffix,
+} from "@/src/lib/hosted-onboarding/logging";
+import { detectInAppBrowser } from "@/src/lib/in-app-browser";
+import {
   DEFAULT_MURPH_CONTACT_AVATAR_ID,
   findMurphContactAvatarOption,
 } from "@/src/lib/murph-contact-avatars";
@@ -28,6 +33,18 @@ export const GET = withJsonError(async (request: Request) => {
   // plus the active-access entitlement check, like the other member-bound
   // settings GET routes.
   const session = await requireActiveHostedAppSessionFromRequest(request);
+  const avatarId = new URL(request.url).searchParams.get("avatar")
+    ?? DEFAULT_MURPH_CONTACT_AVATAR_ID;
+  const avatar = findMurphContactAvatarOption(avatarId);
+  const browser = detectInAppBrowser(request.headers.get("user-agent") ?? "");
+  console.info("Hosted Murph contact-card request.", {
+    app: browser.app,
+    ...sanitizeHostedOnboardingStructuredLogDetails({
+      avatarId: avatar.id,
+      memberIdSuffix: toHostedOnboardingLogIdSuffix(session.member.id),
+      webview: browser.inAppBrowser,
+    }),
+  });
   const prisma = getPrisma();
 
   const routing = await readHostedMemberRoutingState({
@@ -47,10 +64,6 @@ export const GET = withJsonError(async (request: Request) => {
       retryable: true,
     });
   }
-
-  const avatarId = new URL(request.url).searchParams.get("avatar")
-    ?? DEFAULT_MURPH_CONTACT_AVATAR_ID;
-  const avatar = findMurphContactAvatarOption(avatarId);
 
   const [photo, backupPhoneNumber] = await Promise.all([
     avatar.src

--- a/apps/web/app/api/murph-contact-card/route.ts
+++ b/apps/web/app/api/murph-contact-card/route.ts
@@ -1,6 +1,18 @@
 import { requireActiveHostedAppSessionFromRequest } from "@/src/lib/hosted-onboarding/app-session";
-import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
-import { withJsonError } from "@/src/lib/hosted-onboarding/http";
+import {
+  issueMurphContactCardHandoffClaim,
+  requireMurphContactCardHandoffClaim,
+} from "@/src/lib/hosted-onboarding/contact-card-handoff";
+import { assertHostedOnboardingMutationOrigin } from "@/src/lib/hosted-onboarding/csrf";
+import {
+  hostedOnboardingError,
+  isHostedOnboardingError,
+} from "@/src/lib/hosted-onboarding/errors";
+import {
+  jsonOk,
+  readJsonObject,
+  withJsonError,
+} from "@/src/lib/hosted-onboarding/http";
 import {
   buildMurphHostedLinqContactCardVcf,
   fetchMurphHostedLinqContactCardVcfPhoto,
@@ -14,12 +26,24 @@ import {
   sanitizeHostedOnboardingStructuredLogDetails,
   toHostedOnboardingLogIdSuffix,
 } from "@/src/lib/hosted-onboarding/logging";
+import { assertActiveHostedMemberAccessAllowed } from "@/src/lib/hosted-onboarding/member-access";
 import { detectInAppBrowser } from "@/src/lib/in-app-browser";
 import {
   DEFAULT_MURPH_CONTACT_AVATAR_ID,
   findMurphContactAvatarOption,
+  type MurphContactAvatarOption,
 } from "@/src/lib/murph-contact-avatars";
 import { getPrisma } from "@/src/lib/prisma";
+
+const MURPH_CONTACT_CARD_HANDOFF_BODY_LIMIT_BYTES = 512;
+
+type MurphContactCardAuthoritySource = "handoff" | "session";
+
+interface MurphContactCardAuthority {
+  avatar: MurphContactAvatarOption;
+  memberId: string;
+  source: MurphContactCardAuthoritySource;
+}
 
 /**
  * Downloadable Murph vCard with the member-chosen avatar embedded as the
@@ -29,26 +53,42 @@ import { getPrisma } from "@/src/lib/prisma";
  * headshot; the no-photo option omits `PHOTO` entirely.
  */
 export const GET = withJsonError(async (request: Request) => {
-  // Hosted app session (the same authority that rendered the picker UI),
-  // plus the active-access entitlement check, like the other member-bound
-  // settings GET routes.
-  const session = await requireActiveHostedAppSessionFromRequest(request);
-  const avatarId = new URL(request.url).searchParams.get("avatar")
-    ?? DEFAULT_MURPH_CONTACT_AVATAR_ID;
-  const avatar = findMurphContactAvatarOption(avatarId);
+  const url = new URL(request.url);
   const browser = detectInAppBrowser(request.headers.get("user-agent") ?? "");
-  console.info("Hosted Murph contact-card request.", {
-    app: browser.app,
-    ...sanitizeHostedOnboardingStructuredLogDetails({
-      avatarId: avatar.id,
-      memberIdSuffix: toHostedOnboardingLogIdSuffix(session.member.id),
-      webview: browser.inAppBrowser,
-    }),
-  });
-  const prisma = getPrisma();
+  const source: MurphContactCardAuthoritySource =
+    url.searchParams.has("handoff") ? "handoff" : "session";
 
+  let authority: MurphContactCardAuthority;
+  try {
+    authority = await requireMurphContactCardAuthority({ request, url });
+  } catch (error) {
+    logMurphContactCardRequest({
+      app: browser.app,
+      authOutcome: "rejected",
+      avatarId: source === "session"
+        ? resolveRequestedAvatar(url).id
+        : null,
+      errorCode: classifyMurphContactCardAuthorizationError(error),
+      memberId: null,
+      source,
+      webview: browser.inAppBrowser,
+    });
+    throw error;
+  }
+
+  logMurphContactCardRequest({
+    app: browser.app,
+    authOutcome: "authorized",
+    avatarId: authority.avatar.id,
+    errorCode: null,
+    memberId: authority.memberId,
+    source: authority.source,
+    webview: browser.inAppBrowser,
+  });
+
+  const prisma = getPrisma();
   const routing = await readHostedMemberRoutingState({
-    memberId: session.member.id,
+    memberId: authority.memberId,
     prisma,
   });
   // Same phone authority as the invite/home surfaces that show the CTA: a
@@ -66,9 +106,9 @@ export const GET = withJsonError(async (request: Request) => {
   }
 
   const [photo, backupPhoneNumber] = await Promise.all([
-    avatar.src
+    authority.avatar.src
       ? fetchMurphHostedLinqContactCardVcfPhoto({
-          imageUrl: resolveMurphContactCardAssetUrl(avatar.src),
+          imageUrl: resolveMurphContactCardAssetUrl(authority.avatar.src),
         })
       : Promise.resolve(null),
     resolveMurphHostedLinqContactCardBackupPhoneNumber({
@@ -95,3 +135,102 @@ export const GET = withJsonError(async (request: Request) => {
     },
   });
 });
+
+export const POST = withJsonError(async (request: Request) => {
+  assertHostedOnboardingMutationOrigin(request);
+  const session = await requireActiveHostedAppSessionFromRequest(request);
+  const payload = await readJsonObject(request, {
+    limitBytes: MURPH_CONTACT_CARD_HANDOFF_BODY_LIMIT_BYTES,
+  });
+  const avatarId = requireRequestedHandoffAvatarId(payload.avatar);
+
+  return jsonOk({
+    claim: issueMurphContactCardHandoffClaim({
+      avatarId,
+      memberId: session.member.id,
+      sessionId: session.sessionId,
+    }),
+  });
+});
+
+async function requireMurphContactCardAuthority(input: {
+  request: Request;
+  url: URL;
+}): Promise<MurphContactCardAuthority> {
+  const handoff = input.url.searchParams.get("handoff");
+  if (handoff !== null) {
+    const claim = requireMurphContactCardHandoffClaim(handoff);
+    await assertActiveHostedMemberAccessAllowed({ memberId: claim.memberId });
+    return {
+      avatar: findMurphContactAvatarOption(claim.avatarId),
+      memberId: claim.memberId,
+      source: "handoff",
+    };
+  }
+
+  const session = await requireActiveHostedAppSessionFromRequest(input.request);
+  return {
+    avatar: resolveRequestedAvatar(input.url),
+    memberId: session.member.id,
+    source: "session",
+  };
+}
+
+function resolveRequestedAvatar(url: URL): MurphContactAvatarOption {
+  return findMurphContactAvatarOption(
+    url.searchParams.get("avatar") ?? DEFAULT_MURPH_CONTACT_AVATAR_ID,
+  );
+}
+
+function requireRequestedHandoffAvatarId(value: unknown): string {
+  if (typeof value !== "string") {
+    throw invalidHandoffAvatarError();
+  }
+
+  const avatar = findMurphContactAvatarOption(value);
+  if (avatar.id !== value) {
+    throw invalidHandoffAvatarError();
+  }
+
+  return avatar.id;
+}
+
+function invalidHandoffAvatarError(): Error {
+  return hostedOnboardingError({
+    code: "MURPH_CONTACT_CARD_AVATAR_INVALID",
+    httpStatus: 400,
+    message: "Choose a valid Murph contact photo.",
+  });
+}
+
+function classifyMurphContactCardAuthorizationError(error: unknown): string {
+  if (isHostedOnboardingError(error)) {
+    return error.code;
+  }
+
+  return error instanceof Error && error.name
+    ? error.name
+    : "UNKNOWN_ERROR";
+}
+
+function logMurphContactCardRequest(input: {
+  app: string | null;
+  authOutcome: "authorized" | "rejected";
+  avatarId: string | null;
+  errorCode: string | null;
+  memberId: string | null;
+  source: MurphContactCardAuthoritySource;
+  webview: boolean;
+}): void {
+  console.info("Hosted Murph contact-card request.", {
+    app: input.app,
+    ...sanitizeHostedOnboardingStructuredLogDetails({
+      authOutcome: input.authOutcome,
+      authority: input.source,
+      avatarId: input.avatarId,
+      errorCode: input.errorCode,
+      memberIdSuffix: toHostedOnboardingLogIdSuffix(input.memberId),
+      webview: input.webview,
+    }),
+  });
+}

--- a/apps/web/app/api/murph-contact-card/route.ts
+++ b/apps/web/app/api/murph-contact-card/route.ts
@@ -213,7 +213,7 @@ function classifyMurphContactCardAuthorizationError(error: unknown): string {
     : "UNKNOWN_ERROR";
 }
 
-function logMurphContactCardRequest(input: {
+function logMurphContactCardRequest(details: {
   app: string | null;
   authOutcome: "authorized" | "rejected";
   avatarId: string | null;
@@ -223,14 +223,14 @@ function logMurphContactCardRequest(input: {
   webview: boolean;
 }): void {
   console.info("Hosted Murph contact-card request.", {
-    app: input.app,
+    app: details.app,
     ...sanitizeHostedOnboardingStructuredLogDetails({
-      authOutcome: input.authOutcome,
-      authority: input.source,
-      avatarId: input.avatarId,
-      errorCode: input.errorCode,
-      memberIdSuffix: toHostedOnboardingLogIdSuffix(input.memberId),
-      webview: input.webview,
+      authOutcome: details.authOutcome,
+      authority: details.source,
+      avatarId: details.avatarId,
+      errorCode: details.errorCode,
+      memberIdSuffix: toHostedOnboardingLogIdSuffix(details.memberId),
+      webview: details.webview,
     }),
   });
 }

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CheckCircle2, Monitor } from "lucide-react";
+import { CheckCircle2, ContactRound, Monitor } from "lucide-react";
 import { SourceCard } from "@/app/(dashboard)/connect/connect-source-card";
 import type { ConnectSource } from "@/app/(dashboard)/connect/connect-page-types";
 import {
@@ -36,7 +36,7 @@ import { HOSTED_PHONE_COUNTRY_OPTIONS } from "@/src/components/hosted-onboarding
 import { ContactSupportAction } from "@/src/components/support/contact-support-action";
 import { AuthButton } from "@/src/components/ui/auth-button";
 import { MurphPulseLoader } from "@/src/components/ui/murph-pulse-loader";
-import { Button } from "@/src/components/ui/button";
+import { Button, buttonVariants } from "@/src/components/ui/button";
 import { ChoiceCard } from "@/src/components/ui/choice-card";
 import { PaymentButton } from "@/src/components/ui/payment-button";
 import { Badge } from "@/src/components/ui/badge";
@@ -77,6 +77,8 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/src/components/ui/card";
 import { PlanVisual } from "@/src/components/ui/plan-visual";
 import {
+  IN_APP_BROWSER_DESCRIPTION,
+  IN_APP_BROWSER_PRIMARY_ACTION,
   MURPH_CONTACT_AVATAR_OPTIONS,
   MurphContactAvatarArt,
   MurphContactAvatarGrid,
@@ -1120,6 +1122,30 @@ export function ComponentsContent() {
               onChange={setInlineContactAvatarId}
               value={inlineContactAvatarId}
             />
+          </div>
+          <div className="max-w-sm rounded-xl border border-border bg-card p-5">
+            <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              In-app browser CTA
+            </p>
+            <p className="mb-4 text-sm leading-6 text-muted-foreground">
+              On an iOS in-app browser (X, Instagram, Facebook, TikTok, and the
+              like) the WebKit view fetches the vCard but never hands it to the
+              contact importer, so the normal add silently does nothing. There
+              the primary action becomes a Safari escape instead.
+            </p>
+            <div className="flex flex-col gap-2">
+              <a
+                className={buttonVariants({ className: "w-full", size: "xl" })}
+                href="#in-app-browser-cta-preview"
+                onClick={(event) => event.preventDefault()}
+              >
+                <ContactRound data-icon="inline-start" />
+                {IN_APP_BROWSER_PRIMARY_ACTION}
+              </a>
+              <p className="px-2 text-center text-xs leading-5 text-muted-foreground">
+                {IN_APP_BROWSER_DESCRIPTION}
+              </p>
+            </div>
           </div>
         </Section>
 

--- a/apps/web/src/components/murph/murph-contact-card-picker.tsx
+++ b/apps/web/src/components/murph/murph-contact-card-picker.tsx
@@ -197,8 +197,8 @@ export function MurphAddToContactsButton({
 const PICKER_TITLE = "Add Murph to your contacts";
 const PICKER_DESCRIPTION =
   "Pick the photo Murph shows up with in your contacts. Same Murph either way.";
-const IN_APP_BROWSER_PRIMARY_ACTION = "Open in Safari to add Murph";
-const IN_APP_BROWSER_DESCRIPTION =
+export const IN_APP_BROWSER_PRIMARY_ACTION = "Open in Safari to add Murph";
+export const IN_APP_BROWSER_DESCRIPTION =
   "You're in an in-app browser, which can't save contacts. This opens Safari instead.";
 const DEFAULT_PICKER_COPY = {
   description: PICKER_DESCRIPTION,

--- a/apps/web/src/components/murph/murph-contact-card-picker.tsx
+++ b/apps/web/src/components/murph/murph-contact-card-picker.tsx
@@ -408,9 +408,11 @@ export function MurphContactCardPicker({
 }
 
 /**
- * Resolves true only once this document goes away, which is the sole
- * observable acknowledgement that the host accepted the Safari scheme
- * navigation. A suppressed or declined launch resolves false instead.
+ * Resolves true only once this document is being unloaded, which is the
+ * closest observable acknowledgement that the host accepted the Safari
+ * scheme navigation. `visibilitychange` is deliberately not accepted: it
+ * fires for any backgrounding, so an app switch or screen lock during the
+ * launch window would otherwise be misread as a successful launch.
  */
 function waitForMurphContactCardLaunch(signal: AbortSignal): Promise<boolean> {
   if (signal.aborted) return Promise.resolve(false);
@@ -421,7 +423,6 @@ function waitForMurphContactCardLaunch(signal: AbortSignal): Promise<boolean> {
     function settle(launched: boolean) {
       clearTimeout(deadline);
       window.removeEventListener("pagehide", onPageHide);
-      document.removeEventListener("visibilitychange", onVisibilityChange);
       signal.removeEventListener("abort", onAbort);
       resolve(launched);
     }
@@ -430,17 +431,12 @@ function waitForMurphContactCardLaunch(signal: AbortSignal): Promise<boolean> {
       settle(true);
     }
 
-    function onVisibilityChange() {
-      if (document.visibilityState === "hidden") settle(true);
-    }
-
     function onAbort() {
       settle(false);
     }
 
     deadline = setTimeout(() => settle(false), MURPH_CONTACT_CARD_LAUNCH_TIMEOUT_MS);
     window.addEventListener("pagehide", onPageHide);
-    document.addEventListener("visibilitychange", onVisibilityChange);
     signal.addEventListener("abort", onAbort);
   });
 }

--- a/apps/web/src/components/murph/murph-contact-card-picker.tsx
+++ b/apps/web/src/components/murph/murph-contact-card-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useState, useSyncExternalStore } from "react";
+import { useId, useRef, useState, useSyncExternalStore } from "react";
 import { ContactRoundIcon } from "lucide-react";
 
 import { Button, buttonVariants } from "@/src/components/ui/button";
@@ -41,10 +41,6 @@ export {
 
 export function murphContactCardDownloadHref(avatarId: string): string {
   return `/api/murph-contact-card?avatar=${encodeURIComponent(avatarId)}`;
-}
-
-function murphContactCardHandoffHref(claim: string): string {
-  return `/api/murph-contact-card?handoff=${encodeURIComponent(claim)}`;
 }
 
 function subscribeToBrowserSnapshot() {
@@ -95,9 +91,11 @@ export function MurphContactAvatarArt({
 }
 
 export function MurphContactAvatarGrid({
+  disabled = false,
   onChange,
   value,
 }: {
+  disabled?: boolean;
   onChange: (id: string) => void;
   value: string;
 }) {
@@ -113,12 +111,13 @@ export function MurphContactAvatarGrid({
         const selected = option.id === value;
         return (
           <label
-            className="group flex cursor-pointer flex-col items-center gap-2 rounded-xl px-1 py-1.5 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring"
+            className="group flex cursor-pointer flex-col items-center gap-2 rounded-xl px-1 py-1.5 has-[:disabled]:pointer-events-none has-[:disabled]:cursor-default has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring"
             key={option.id}
           >
             <input
               checked={selected}
               className="sr-only"
+              disabled={disabled}
               name={groupName}
               onChange={() => onChange(option.id)}
               type="radio"
@@ -171,11 +170,6 @@ export function MurphContactCardPreview({
   );
 }
 
-/**
- * Self-contained "Add Murph to Contacts" button that opens the picker.
- * Drop-in for server components (signup success, settings) that just need
- * the entry point.
- */
 export function MurphAddToContactsButton({
   size = "lg",
   variant = "outline",
@@ -205,8 +199,7 @@ const PICKER_DESCRIPTION =
 export const IN_APP_BROWSER_PRIMARY_ACTION = "Open in Safari to add Murph";
 export const IN_APP_BROWSER_DESCRIPTION =
   "You're in an in-app browser, which can't save contacts. This opens Safari instead.";
-const IN_APP_BROWSER_HANDOFF_ERROR =
-  "Couldn't open Safari. Check your connection and try again.";
+const MURPH_CONTACT_CARD_HANDOFF_TIMEOUT_MS = 10_000;
 const DEFAULT_PICKER_COPY = {
   description: PICKER_DESCRIPTION,
   primaryAction: "Add Murph to Contacts",
@@ -226,7 +219,7 @@ export function MurphContactCardPicker({
 }: {
   copy?: MurphContactCardPickerCopy;
   initialAvatarId?: string;
-  onAddToContacts?: (option: MurphContactAvatarOption) => void;
+  onAddToContacts: (option: MurphContactAvatarOption) => void;
   onOpenChange: (open: boolean) => void;
   onSkip?: () => void;
   open: boolean;
@@ -238,15 +231,43 @@ export function MurphContactCardPicker({
     readBrowserServerSnapshot,
   );
   const [selectedId, setSelectedId] = useState(initialAvatarId);
-  const [handoffPending, setHandoffPending] = useState(false);
-  const [handoffError, setHandoffError] = useState<string | null>(null);
+  const [handoffStatus, setHandoffStatus] = useState<"error" | "pending" | null>(null);
+  const handoffController = useRef<AbortController | null>(null);
   const selected = findMurphContactAvatarOption(selectedId);
   const browser = detectInAppBrowser(userAgent);
   const opensInSafari = browser.inAppBrowser && browser.isIos;
-  const pickerCopy = {
-    ...DEFAULT_PICKER_COPY,
-    ...copy,
-  };
+  const pickerCopy = { ...DEFAULT_PICKER_COPY, ...copy };
+
+  function handleOpenChange(nextOpen: boolean) {
+    const controller = handoffController.current;
+    if (!nextOpen && controller) {
+      handoffController.current = null;
+      controller.abort();
+      setHandoffStatus("error");
+      return;
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSafariHandoff() {
+    if (handoffController.current) return;
+    const controller = new AbortController();
+    handoffController.current = controller;
+    setHandoffStatus("pending");
+    try {
+      const claim = await issueMurphContactCardHandoff(selected.id, controller.signal);
+      window.location.assign(
+        `x-safari-https://${window.location.host}/api/murph-contact-card?handoff=${encodeURIComponent(claim)}`,
+      );
+    } catch {
+      if (handoffController.current === controller) setHandoffStatus("error");
+      return;
+    } finally {
+      if (handoffController.current === controller) handoffController.current = null;
+    }
+    setHandoffStatus(null);
+    onAddToContacts(selected);
+  }
 
   const actions = (
     <div className="flex flex-col gap-2">
@@ -254,62 +275,43 @@ export function MurphContactCardPicker({
         <>
           <Button
             className="w-full"
-            disabled={handoffPending}
-            onClick={() => {
-              setHandoffError(null);
-              setHandoffPending(true);
-              void issueMurphContactCardHandoff(selected.id)
-                .then((claim) => {
-                  window.location.assign(
-                    `x-safari-https://${window.location.host}${murphContactCardHandoffHref(claim)}`,
-                  );
-                })
-                .catch(() => {
-                  setHandoffError(IN_APP_BROWSER_HANDOFF_ERROR);
-                })
-                .finally(() => {
-                  setHandoffPending(false);
-                });
-            }}
+            disabled={handoffStatus === "pending"}
+            onClick={() => void handleSafariHandoff()}
             size="xl"
             type="button"
           >
             <ContactRoundIcon data-icon="inline-start" />
-            {handoffPending ? "Opening Safari…" : IN_APP_BROWSER_PRIMARY_ACTION}
+            {handoffStatus === "pending" ? "Opening Safari…" : IN_APP_BROWSER_PRIMARY_ACTION}
           </Button>
           <p className="px-2 text-center text-xs leading-5 text-muted-foreground">
             {IN_APP_BROWSER_DESCRIPTION}
           </p>
-          {handoffError ? (
+          {handoffStatus === "error" ? (
             <p
               className="px-2 text-center text-sm leading-5 text-destructive"
               role="alert"
             >
-              {handoffError}
+              Couldn't open Safari. Check your connection and try again.
             </p>
           ) : null}
         </>
       ) : (
-        <>
-          {/* No `download` attribute: the route serves the vCard inline so iOS
-              Safari opens its native contact preview; a download hint would
-              route it into Files instead. */}
-          <a
-            className={buttonVariants({ className: "w-full", size: "xl" })}
-            href={murphContactCardDownloadHref(selected.id)}
-            onClick={() => onAddToContacts?.(selected)}
-          >
-            <ContactRoundIcon data-icon="inline-start" />
-            {pickerCopy.primaryAction}
-          </a>
-        </>
+        /* Keep the vCard inline so iOS opens its contact preview instead of Files. */
+        <a
+          className={buttonVariants({ className: "w-full", size: "xl" })}
+          href={murphContactCardDownloadHref(selected.id)}
+          onClick={() => onAddToContacts(selected)}
+        >
+          <ContactRoundIcon data-icon="inline-start" />
+          {pickerCopy.primaryAction}
+        </a>
       )}
       <Button
         className="w-full"
-        disabled={opensInSafari && handoffPending}
+        disabled={handoffStatus === "pending"}
         onClick={() => {
           onSkip?.();
-          onOpenChange(false);
+          handleOpenChange(false);
         }}
         size="xl"
         type="button"
@@ -322,7 +324,7 @@ export function MurphContactCardPicker({
 
   if (isMobile) {
     return (
-      <Drawer onOpenChange={onOpenChange} open={open}>
+      <Drawer onOpenChange={handleOpenChange} open={open}>
         <DrawerContent className="h-dvh data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-dvh data-[vaul-drawer-direction=bottom]:rounded-t-none">
           <DrawerHeader className="items-center text-center">
             <DrawerTitle className="font-serif text-2xl/7 font-semibold tracking-normal text-foreground">
@@ -335,7 +337,7 @@ export function MurphContactCardPicker({
           <div className="min-h-0 flex-1 overflow-y-auto px-4 py-1">
             <div className="flex flex-col gap-6">
               <MurphContactCardPreview option={selected} />
-              <MurphContactAvatarGrid onChange={setSelectedId} value={selectedId} />
+              <MurphContactAvatarGrid disabled={handoffStatus === "pending"} onChange={setSelectedId} value={selectedId} />
             </div>
           </div>
           <DrawerFooter className="border-t border-border px-4 pb-[max(env(safe-area-inset-bottom),1.5rem)] pt-3">
@@ -346,18 +348,8 @@ export function MurphContactCardPicker({
     );
   }
 
-  const body = (
-    <div className="flex flex-col gap-6">
-      <MurphContactCardPreview option={selected} />
-      <div className="-mx-1 max-h-[42dvh] overflow-y-auto px-1 py-1">
-        <MurphContactAvatarGrid onChange={setSelectedId} value={selectedId} />
-      </div>
-      {actions}
-    </div>
-  );
-
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
+    <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent
         className="max-h-[calc(100dvh-2rem)] max-w-xl gap-6 overflow-y-auto rounded-2xl border border-border bg-popover p-6 text-popover-foreground ring-border md:p-7"
         showCloseButton={false}
@@ -370,13 +362,20 @@ export function MurphContactCardPicker({
             {pickerCopy.description}
           </DialogDescription>
         </DialogHeader>
-        {body}
+        <div className="flex flex-col gap-6">
+          <MurphContactCardPreview option={selected} />
+          <div className="-mx-1 max-h-[42dvh] overflow-y-auto px-1 py-1">
+            <MurphContactAvatarGrid disabled={handoffStatus === "pending"} onChange={setSelectedId} value={selectedId} />
+          </div>
+          {actions}
+        </div>
       </DialogContent>
     </Dialog>
   );
 }
 
-async function issueMurphContactCardHandoff(avatarId: string): Promise<string> {
+async function issueMurphContactCardHandoff(avatarId: string, cancellationSignal: AbortSignal): Promise<string> {
+  const signal = AbortSignal.any([cancellationSignal, AbortSignal.timeout(MURPH_CONTACT_CARD_HANDOFF_TIMEOUT_MS)]);
   const response = await fetch("/api/murph-contact-card", {
     body: JSON.stringify({ avatar: avatarId }),
     credentials: "same-origin",
@@ -385,6 +384,7 @@ async function issueMurphContactCardHandoff(avatarId: string): Promise<string> {
       "Content-Type": "application/json",
     },
     method: "POST",
+    signal,
   });
 
   if (!response.ok) {
@@ -392,13 +392,10 @@ async function issueMurphContactCardHandoff(avatarId: string): Promise<string> {
   }
 
   const payload: unknown = await response.json();
-  if (
-    !isRecord(payload)
-    || typeof payload.claim !== "string"
-    || payload.claim.length === 0
-  ) {
+  if (!isRecord(payload) || typeof payload.claim !== "string" || !payload.claim) {
     throw new Error("Murph contact-card handoff response was invalid.");
   }
 
+  signal.throwIfAborted();
   return payload.claim;
 }

--- a/apps/web/src/components/murph/murph-contact-card-picker.tsx
+++ b/apps/web/src/components/murph/murph-contact-card-picker.tsx
@@ -200,6 +200,9 @@ export const IN_APP_BROWSER_PRIMARY_ACTION = "Open in Safari to add Murph";
 export const IN_APP_BROWSER_DESCRIPTION =
   "You're in an in-app browser, which can't save contacts. This opens Safari instead.";
 const MURPH_CONTACT_CARD_HANDOFF_TIMEOUT_MS = 10_000;
+// Long enough that a host "Open in Safari?" confirmation can still be tapped
+// before the attempt is treated as never launched.
+export const MURPH_CONTACT_CARD_LAUNCH_TIMEOUT_MS = 5_000;
 const DEFAULT_PICKER_COPY = {
   description: PICKER_DESCRIPTION,
   primaryAction: "Add Murph to Contacts",
@@ -249,22 +252,52 @@ export function MurphContactCardPicker({
     onOpenChange(nextOpen);
   }
 
+  function failHandoff(controller: AbortController) {
+    // Aborting settles any launch wait so its listeners cannot outlive the attempt.
+    controller.abort();
+    if (handoffController.current !== controller) return;
+    handoffController.current = null;
+    setHandoffStatus("error");
+  }
+
   async function handleSafariHandoff() {
     if (handoffController.current) return;
     const controller = new AbortController();
     handoffController.current = controller;
     setHandoffStatus("pending");
+    const issuanceDeadline = setTimeout(
+      () => controller.abort(),
+      MURPH_CONTACT_CARD_HANDOFF_TIMEOUT_MS,
+    );
+
+    let claim: string;
     try {
-      const claim = await issueMurphContactCardHandoff(selected.id, controller.signal);
+      claim = await issueMurphContactCardHandoff(selected.id, controller.signal);
+    } catch {
+      failHandoff(controller);
+      return;
+    } finally {
+      clearTimeout(issuanceDeadline);
+    }
+
+    // `assign` returns void whether or not the host accepted the scheme
+    // navigation, so completion waits for this document to actually go away.
+    const launched = waitForMurphContactCardLaunch(controller.signal);
+    try {
       window.location.assign(
         `x-safari-https://${window.location.host}/api/murph-contact-card?handoff=${encodeURIComponent(claim)}`,
       );
     } catch {
-      if (handoffController.current === controller) setHandoffStatus("error");
+      failHandoff(controller);
       return;
-    } finally {
-      if (handoffController.current === controller) handoffController.current = null;
     }
+    if (!(await launched)) {
+      failHandoff(controller);
+      return;
+    }
+
+    if (handoffController.current !== controller) return;
+    handoffController.current = null;
     setHandoffStatus(null);
     onAddToContacts(selected);
   }
@@ -374,8 +407,45 @@ export function MurphContactCardPicker({
   );
 }
 
-async function issueMurphContactCardHandoff(avatarId: string, cancellationSignal: AbortSignal): Promise<string> {
-  const signal = AbortSignal.any([cancellationSignal, AbortSignal.timeout(MURPH_CONTACT_CARD_HANDOFF_TIMEOUT_MS)]);
+/**
+ * Resolves true only once this document goes away, which is the sole
+ * observable acknowledgement that the host accepted the Safari scheme
+ * navigation. A suppressed or declined launch resolves false instead.
+ */
+function waitForMurphContactCardLaunch(signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) return Promise.resolve(false);
+
+  return new Promise((resolve) => {
+    let deadline: ReturnType<typeof setTimeout>;
+
+    function settle(launched: boolean) {
+      clearTimeout(deadline);
+      window.removeEventListener("pagehide", onPageHide);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      signal.removeEventListener("abort", onAbort);
+      resolve(launched);
+    }
+
+    function onPageHide() {
+      settle(true);
+    }
+
+    function onVisibilityChange() {
+      if (document.visibilityState === "hidden") settle(true);
+    }
+
+    function onAbort() {
+      settle(false);
+    }
+
+    deadline = setTimeout(() => settle(false), MURPH_CONTACT_CARD_LAUNCH_TIMEOUT_MS);
+    window.addEventListener("pagehide", onPageHide);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    signal.addEventListener("abort", onAbort);
+  });
+}
+
+async function issueMurphContactCardHandoff(avatarId: string, signal: AbortSignal): Promise<string> {
   const response = await fetch("/api/murph-contact-card", {
     body: JSON.stringify({ avatar: avatarId }),
     credentials: "same-origin",
@@ -396,6 +466,9 @@ async function issueMurphContactCardHandoff(avatarId: string, cancellationSignal
     throw new Error("Murph contact-card handoff response was invalid.");
   }
 
-  signal.throwIfAborted();
+  if (signal.aborted) {
+    throw new Error("Murph contact-card handoff was cancelled.");
+  }
+
   return payload.claim;
 }

--- a/apps/web/src/components/murph/murph-contact-card-picker.tsx
+++ b/apps/web/src/components/murph/murph-contact-card-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useId, useState, useSyncExternalStore } from "react";
 import { ContactRoundIcon } from "lucide-react";
 
 import { Button, buttonVariants } from "@/src/components/ui/button";
@@ -27,6 +27,7 @@ import {
   type MurphContactAvatarKind,
   type MurphContactAvatarOption,
 } from "@/src/lib/murph-contact-avatars";
+import { detectInAppBrowser } from "@/src/lib/in-app-browser";
 import { cn } from "@/src/lib/utils";
 
 export {
@@ -39,6 +40,18 @@ export {
 
 export function murphContactCardDownloadHref(avatarId: string): string {
   return `/api/murph-contact-card?avatar=${encodeURIComponent(avatarId)}`;
+}
+
+function subscribeToBrowserSnapshot() {
+  return () => {};
+}
+
+function readBrowserServerSnapshot(): string {
+  return "";
+}
+
+function readBrowserUserAgentSnapshot(): string {
+  return navigator.userAgent;
 }
 
 export function MurphContactAvatarArt({
@@ -184,6 +197,9 @@ export function MurphAddToContactsButton({
 const PICKER_TITLE = "Add Murph to your contacts";
 const PICKER_DESCRIPTION =
   "Pick the photo Murph shows up with in your contacts. Same Murph either way.";
+const IN_APP_BROWSER_PRIMARY_ACTION = "Open in Safari to add Murph";
+const IN_APP_BROWSER_DESCRIPTION =
+  "You're in an in-app browser, which can't save contacts. This opens Safari instead.";
 const DEFAULT_PICKER_COPY = {
   description: PICKER_DESCRIPTION,
   primaryAction: "Add Murph to Contacts",
@@ -209,8 +225,15 @@ export function MurphContactCardPicker({
   open: boolean;
 }) {
   const isMobile = useIsMobile();
+  const userAgent = useSyncExternalStore(
+    subscribeToBrowserSnapshot,
+    readBrowserUserAgentSnapshot,
+    readBrowserServerSnapshot,
+  );
   const [selectedId, setSelectedId] = useState(initialAvatarId);
   const selected = findMurphContactAvatarOption(selectedId);
+  const browser = detectInAppBrowser(userAgent);
+  const opensInSafari = browser.inAppBrowser && browser.isIos;
   const pickerCopy = {
     ...DEFAULT_PICKER_COPY,
     ...copy,
@@ -223,12 +246,23 @@ export function MurphContactCardPicker({
           route it into Files instead. */}
       <a
         className={buttonVariants({ className: "w-full", size: "xl" })}
-        href={murphContactCardDownloadHref(selected.id)}
+        href={
+          opensInSafari
+            ? `x-safari-https://${window.location.host}${murphContactCardDownloadHref(selected.id)}`
+            : murphContactCardDownloadHref(selected.id)
+        }
         onClick={() => onAddToContacts?.(selected)}
       >
         <ContactRoundIcon data-icon="inline-start" />
-        {pickerCopy.primaryAction}
+        {opensInSafari
+          ? IN_APP_BROWSER_PRIMARY_ACTION
+          : pickerCopy.primaryAction}
       </a>
+      {opensInSafari ? (
+        <p className="px-2 text-center text-xs leading-5 text-muted-foreground">
+          {IN_APP_BROWSER_DESCRIPTION}
+        </p>
+      ) : null}
       <Button
         className="w-full"
         onClick={() => {

--- a/apps/web/src/components/murph/murph-contact-card-picker.tsx
+++ b/apps/web/src/components/murph/murph-contact-card-picker.tsx
@@ -199,6 +199,8 @@ const PICKER_DESCRIPTION =
 export const IN_APP_BROWSER_PRIMARY_ACTION = "Open in Safari to add Murph";
 export const IN_APP_BROWSER_DESCRIPTION =
   "You're in an in-app browser, which can't save contacts. This opens Safari instead.";
+const IN_APP_BROWSER_HANDOFF_ERROR =
+  "Couldn't open Safari. Check your connection and try again.";
 const MURPH_CONTACT_CARD_HANDOFF_TIMEOUT_MS = 10_000;
 // Long enough that a host "Open in Safari?" confirmation can still be tapped
 // before the attempt is treated as never launched.
@@ -324,7 +326,7 @@ export function MurphContactCardPicker({
               className="px-2 text-center text-sm leading-5 text-destructive"
               role="alert"
             >
-              Couldn't open Safari. Check your connection and try again.
+              {IN_APP_BROWSER_HANDOFF_ERROR}
             </p>
           ) : null}
         </>
@@ -418,8 +420,6 @@ function waitForMurphContactCardLaunch(signal: AbortSignal): Promise<boolean> {
   if (signal.aborted) return Promise.resolve(false);
 
   return new Promise((resolve) => {
-    let deadline: ReturnType<typeof setTimeout>;
-
     function settle(launched: boolean) {
       clearTimeout(deadline);
       window.removeEventListener("pagehide", onPageHide);
@@ -435,7 +435,7 @@ function waitForMurphContactCardLaunch(signal: AbortSignal): Promise<boolean> {
       settle(false);
     }
 
-    deadline = setTimeout(() => settle(false), MURPH_CONTACT_CARD_LAUNCH_TIMEOUT_MS);
+    const deadline = setTimeout(() => settle(false), MURPH_CONTACT_CARD_LAUNCH_TIMEOUT_MS);
     window.addEventListener("pagehide", onPageHide);
     signal.addEventListener("abort", onAbort);
   });

--- a/apps/web/src/components/murph/murph-contact-card-picker.tsx
+++ b/apps/web/src/components/murph/murph-contact-card-picker.tsx
@@ -28,6 +28,7 @@ import {
   type MurphContactAvatarOption,
 } from "@/src/lib/murph-contact-avatars";
 import { detectInAppBrowser } from "@/src/lib/in-app-browser";
+import { isRecord } from "@/src/lib/primitives";
 import { cn } from "@/src/lib/utils";
 
 export {
@@ -40,6 +41,10 @@ export {
 
 export function murphContactCardDownloadHref(avatarId: string): string {
   return `/api/murph-contact-card?avatar=${encodeURIComponent(avatarId)}`;
+}
+
+function murphContactCardHandoffHref(claim: string): string {
+  return `/api/murph-contact-card?handoff=${encodeURIComponent(claim)}`;
 }
 
 function subscribeToBrowserSnapshot() {
@@ -200,6 +205,8 @@ const PICKER_DESCRIPTION =
 export const IN_APP_BROWSER_PRIMARY_ACTION = "Open in Safari to add Murph";
 export const IN_APP_BROWSER_DESCRIPTION =
   "You're in an in-app browser, which can't save contacts. This opens Safari instead.";
+const IN_APP_BROWSER_HANDOFF_ERROR =
+  "Couldn't open Safari. Check your connection and try again.";
 const DEFAULT_PICKER_COPY = {
   description: PICKER_DESCRIPTION,
   primaryAction: "Add Murph to Contacts",
@@ -231,6 +238,8 @@ export function MurphContactCardPicker({
     readBrowserServerSnapshot,
   );
   const [selectedId, setSelectedId] = useState(initialAvatarId);
+  const [handoffPending, setHandoffPending] = useState(false);
+  const [handoffError, setHandoffError] = useState<string | null>(null);
   const selected = findMurphContactAvatarOption(selectedId);
   const browser = detectInAppBrowser(userAgent);
   const opensInSafari = browser.inAppBrowser && browser.isIos;
@@ -241,30 +250,63 @@ export function MurphContactCardPicker({
 
   const actions = (
     <div className="flex flex-col gap-2">
-      {/* No `download` attribute: the route serves the vCard inline so iOS
-          Safari opens its native contact preview; a download hint would
-          route it into Files instead. */}
-      <a
-        className={buttonVariants({ className: "w-full", size: "xl" })}
-        href={
-          opensInSafari
-            ? `x-safari-https://${window.location.host}${murphContactCardDownloadHref(selected.id)}`
-            : murphContactCardDownloadHref(selected.id)
-        }
-        onClick={() => onAddToContacts?.(selected)}
-      >
-        <ContactRoundIcon data-icon="inline-start" />
-        {opensInSafari
-          ? IN_APP_BROWSER_PRIMARY_ACTION
-          : pickerCopy.primaryAction}
-      </a>
       {opensInSafari ? (
-        <p className="px-2 text-center text-xs leading-5 text-muted-foreground">
-          {IN_APP_BROWSER_DESCRIPTION}
-        </p>
-      ) : null}
+        <>
+          <Button
+            className="w-full"
+            disabled={handoffPending}
+            onClick={() => {
+              setHandoffError(null);
+              setHandoffPending(true);
+              void issueMurphContactCardHandoff(selected.id)
+                .then((claim) => {
+                  window.location.assign(
+                    `x-safari-https://${window.location.host}${murphContactCardHandoffHref(claim)}`,
+                  );
+                })
+                .catch(() => {
+                  setHandoffError(IN_APP_BROWSER_HANDOFF_ERROR);
+                })
+                .finally(() => {
+                  setHandoffPending(false);
+                });
+            }}
+            size="xl"
+            type="button"
+          >
+            <ContactRoundIcon data-icon="inline-start" />
+            {handoffPending ? "Opening Safari…" : IN_APP_BROWSER_PRIMARY_ACTION}
+          </Button>
+          <p className="px-2 text-center text-xs leading-5 text-muted-foreground">
+            {IN_APP_BROWSER_DESCRIPTION}
+          </p>
+          {handoffError ? (
+            <p
+              className="px-2 text-center text-sm leading-5 text-destructive"
+              role="alert"
+            >
+              {handoffError}
+            </p>
+          ) : null}
+        </>
+      ) : (
+        <>
+          {/* No `download` attribute: the route serves the vCard inline so iOS
+              Safari opens its native contact preview; a download hint would
+              route it into Files instead. */}
+          <a
+            className={buttonVariants({ className: "w-full", size: "xl" })}
+            href={murphContactCardDownloadHref(selected.id)}
+            onClick={() => onAddToContacts?.(selected)}
+          >
+            <ContactRoundIcon data-icon="inline-start" />
+            {pickerCopy.primaryAction}
+          </a>
+        </>
+      )}
       <Button
         className="w-full"
+        disabled={opensInSafari && handoffPending}
         onClick={() => {
           onSkip?.();
           onOpenChange(false);
@@ -332,4 +374,31 @@ export function MurphContactCardPicker({
       </DialogContent>
     </Dialog>
   );
+}
+
+async function issueMurphContactCardHandoff(avatarId: string): Promise<string> {
+  const response = await fetch("/api/murph-contact-card", {
+    body: JSON.stringify({ avatar: avatarId }),
+    credentials: "same-origin",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error("Murph contact-card handoff issuance failed.");
+  }
+
+  const payload: unknown = await response.json();
+  if (
+    !isRecord(payload)
+    || typeof payload.claim !== "string"
+    || payload.claim.length === 0
+  ) {
+    throw new Error("Murph contact-card handoff response was invalid.");
+  }
+
+  return payload.claim;
 }

--- a/apps/web/src/lib/hosted-onboarding/contact-card-handoff.ts
+++ b/apps/web/src/lib/hosted-onboarding/contact-card-handoff.ts
@@ -1,0 +1,227 @@
+import "server-only";
+
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+import { findMurphContactAvatarOption } from "../murph-contact-avatars";
+import { isRecord } from "../primitives";
+import { readHostedContactPrivacyKeyring } from "./env";
+import { hostedOnboardingError } from "./errors";
+
+const MURPH_CONTACT_CARD_HANDOFF_TOKEN_PREFIX =
+  "murph-contact-card-handoff-v1";
+const MURPH_CONTACT_CARD_HANDOFF_HMAC_CONTEXT =
+  "hosted-murph-contact-card-handoff-v1";
+const MURPH_CONTACT_CARD_HANDOFF_TTL_SECONDS = 5 * 60;
+const MURPH_CONTACT_CARD_HANDOFF_CLOCK_SKEW_SECONDS = 30;
+const MURPH_CONTACT_CARD_HANDOFF_ID_MAX_LENGTH = 256;
+const MURPH_CONTACT_CARD_HANDOFF_TOKEN_PATTERN =
+  /^murph-contact-card-handoff-v1\.(v[0-9]+)\.([A-Za-z0-9_-]{1,1366})\.([A-Za-z0-9_-]{43})$/u;
+
+interface MurphContactCardHandoffPayload {
+  avatarId: string;
+  exp: number;
+  iat: number;
+  memberId: string;
+  sessionId: string;
+}
+
+export interface MurphContactCardHandoffClaim {
+  avatarId: string;
+  memberId: string;
+  sessionId: string;
+}
+
+class MurphContactCardHandoffInvalidError extends Error {
+  constructor() {
+    super("Murph contact-card handoff is invalid.");
+    this.name = "MurphContactCardHandoffInvalidError";
+  }
+}
+
+export function issueMurphContactCardHandoffClaim(input: {
+  avatarId: string;
+  memberId: string;
+  now?: Date;
+  sessionId: string;
+}): string {
+  const issuedAt = toUnixSeconds(input.now ?? new Date());
+  const payload = encodePayload({
+    avatarId: requireAvatarId(input.avatarId),
+    exp: issuedAt + MURPH_CONTACT_CARD_HANDOFF_TTL_SECONDS,
+    iat: issuedAt,
+    memberId: requireClaimId(input.memberId),
+    sessionId: requireClaimId(input.sessionId),
+  });
+  const keyring = readHostedContactPrivacyKeyring(process.env);
+  const keyVersion = keyring.currentVersion;
+  const sourceKey = keyring.keysByVersion[keyVersion];
+
+  if (!sourceKey) {
+    throw new TypeError(
+      `Hosted contact privacy keyring is missing ${keyVersion}.`,
+    );
+  }
+
+  const signingInput = buildSigningInput(keyVersion, payload);
+  return `${signingInput}.${signMurphContactCardHandoff(signingInput, sourceKey)}`;
+}
+
+export function requireMurphContactCardHandoffClaim(
+  value: string | null | undefined,
+  options: { now?: Date } = {},
+): MurphContactCardHandoffClaim {
+  try {
+    return readMurphContactCardHandoffClaim(value, options.now ?? new Date());
+  } catch (error) {
+    if (error instanceof MurphContactCardHandoffInvalidError) {
+      throw hostedOnboardingError({
+        code: "MURPH_CONTACT_CARD_HANDOFF_INVALID",
+        httpStatus: 401,
+        message: "This contact-card handoff is invalid or expired. Try again from Murph.",
+        retryable: true,
+      });
+    }
+
+    throw error;
+  }
+}
+
+function readMurphContactCardHandoffClaim(
+  value: string | null | undefined,
+  now: Date,
+): MurphContactCardHandoffClaim {
+  const match = typeof value === "string"
+    ? MURPH_CONTACT_CARD_HANDOFF_TOKEN_PATTERN.exec(value)
+    : null;
+  const keyVersion = match?.[1];
+  const payloadEncoded = match?.[2];
+  const signature = match?.[3];
+  if (!keyVersion || !payloadEncoded || !signature) {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  const keyring = readHostedContactPrivacyKeyring(process.env);
+  const sourceKey = keyring.keysByVersion[keyVersion];
+  if (!sourceKey) {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  const signingInput = buildSigningInput(keyVersion, payloadEncoded);
+  const expectedSignature = signMurphContactCardHandoff(signingInput, sourceKey);
+  if (!secureEqual(signature, expectedSignature)) {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(
+      Buffer.from(payloadEncoded, "base64url").toString("utf8"),
+    );
+  } catch {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  const payload = requirePayload(parsed);
+  const nowSeconds = toUnixSeconds(now);
+  if (
+    payload.exp <= payload.iat
+    || payload.exp - payload.iat > MURPH_CONTACT_CARD_HANDOFF_TTL_SECONDS
+    || payload.iat > nowSeconds + MURPH_CONTACT_CARD_HANDOFF_CLOCK_SKEW_SECONDS
+    || payload.exp <= nowSeconds
+  ) {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  return {
+    avatarId: payload.avatarId,
+    memberId: payload.memberId,
+    sessionId: payload.sessionId,
+  };
+}
+
+function requirePayload(value: unknown): MurphContactCardHandoffPayload {
+  if (
+    !isRecord(value)
+    || Object.keys(value).sort().join("|") !==
+      "avatarId|exp|iat|memberId|sessionId"
+    || typeof value.iat !== "number"
+    || typeof value.exp !== "number"
+    || !Number.isSafeInteger(value.iat)
+    || !Number.isSafeInteger(value.exp)
+  ) {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  return {
+    avatarId: requireAvatarId(value.avatarId),
+    exp: value.exp,
+    iat: value.iat,
+    memberId: requireClaimId(value.memberId),
+    sessionId: requireClaimId(value.sessionId),
+  };
+}
+
+function encodePayload(payload: MurphContactCardHandoffPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function buildSigningInput(keyVersion: string, payload: string): string {
+  return `${MURPH_CONTACT_CARD_HANDOFF_TOKEN_PREFIX}.${keyVersion}.${payload}`;
+}
+
+function signMurphContactCardHandoff(
+  signingInput: string,
+  sourceKey: Buffer,
+): string {
+  const signingKey = createHash("sha256")
+    .update(MURPH_CONTACT_CARD_HANDOFF_HMAC_CONTEXT, "utf8")
+    .update("\0", "utf8")
+    .update(sourceKey)
+    .digest();
+
+  return createHmac("sha256", signingKey)
+    .update(signingInput, "utf8")
+    .digest("base64url");
+}
+
+function secureEqual(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, "utf8");
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  return actualBuffer.length === expectedBuffer.length
+    && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function requireAvatarId(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  const avatar = findMurphContactAvatarOption(value);
+  if (avatar.id !== value) {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  return avatar.id;
+}
+
+function requireClaimId(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.length > MURPH_CONTACT_CARD_HANDOFF_ID_MAX_LENGTH
+    || value !== value.trim()
+  ) {
+    throw new MurphContactCardHandoffInvalidError();
+  }
+
+  return value;
+}
+
+function toUnixSeconds(value: Date): number {
+  const timestamp = value.getTime();
+  if (!Number.isFinite(timestamp)) {
+    throw new TypeError("Murph contact-card handoff time is invalid.");
+  }
+
+  return Math.floor(timestamp / 1_000);
+}

--- a/apps/web/src/lib/in-app-browser.ts
+++ b/apps/web/src/lib/in-app-browser.ts
@@ -1,0 +1,41 @@
+export type InAppBrowserApp =
+  | "Facebook"
+  | "Google"
+  | "Instagram"
+  | "Line"
+  | "LinkedIn"
+  | "Snapchat"
+  | "TikTok"
+  | "Twitter";
+
+export type InAppBrowserDetection = {
+  app: InAppBrowserApp | null;
+  inAppBrowser: boolean;
+  isIos: boolean;
+};
+
+const IN_APP_BROWSER_TOKENS: ReadonlyArray<{
+  app: InAppBrowserApp;
+  pattern: RegExp;
+}> = [
+  { app: "Instagram", pattern: /\bInstagram\b/iu },
+  { app: "Facebook", pattern: /\b(?:FBAN|FBAV|FB_IAB)\b/iu },
+  { app: "TikTok", pattern: /musical_ly|Bytedance/iu },
+  { app: "LinkedIn", pattern: /\bLinkedInApp\b/iu },
+  { app: "Snapchat", pattern: /\bSnapchat\b/iu },
+  { app: "Line", pattern: /\bLine\b/iu },
+  { app: "Twitter", pattern: /\bTwitter\b/iu },
+  { app: "Google", pattern: /\bGSA\b/iu },
+];
+
+export function detectInAppBrowser(userAgent: string): InAppBrowserDetection {
+  const isIos = /iPhone|iPad|iPod/iu.test(userAgent);
+  const app = IN_APP_BROWSER_TOKENS.find(({ pattern }) => pattern.test(userAgent))
+    ?.app ?? null;
+
+  return {
+    app,
+    inAppBrowser: app !== null || (isIos && !/Safari\//iu.test(userAgent)),
+    isIos,
+  };
+}

--- a/apps/web/test/customize-murph-settings.test.tsx
+++ b/apps/web/test/customize-murph-settings.test.tsx
@@ -430,7 +430,7 @@ describe("CustomizeMurphSettings", () => {
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=settings.current-member.claim",
     );
     expect(rendered.container.querySelector("[data-drawer-open='true']"))
-      .not.toBeNull();
+      .toBeNull();
 
     await rendered.cleanup();
   });

--- a/apps/web/test/customize-murph-settings.test.tsx
+++ b/apps/web/test/customize-murph-settings.test.tsx
@@ -38,12 +38,25 @@ vi.mock("@/src/components/murph/murph-assistant-style-picker", () => ({
   },
 }));
 
-vi.mock("@/src/components/murph/murph-contact-card-picker", () => ({
-  MurphContactCardPicker(props: { open?: boolean }) {
-    return props.open
-      ? React.createElement("div", { "data-contact-card-picker": "true" }, "contact card picker")
-      : null;
-  },
+vi.mock("@/src/components/ui/drawer", () => ({
+  Drawer: ({ children, open }: { children?: React.ReactNode; open?: boolean }) =>
+    open
+      ? React.createElement("div", { "data-drawer-open": "true" }, children)
+      : null,
+  DrawerContent: (props: React.HTMLAttributes<HTMLDivElement>) =>
+    React.createElement("div", { ...props, "data-drawer-content": "true" }),
+  DrawerDescription: (props: React.HTMLAttributes<HTMLParagraphElement>) =>
+    React.createElement("p", props),
+  DrawerFooter: (props: React.HTMLAttributes<HTMLDivElement>) =>
+    React.createElement("div", props),
+  DrawerHeader: (props: React.HTMLAttributes<HTMLDivElement>) =>
+    React.createElement("div", props),
+  DrawerTitle: (props: React.HTMLAttributes<HTMLHeadingElement>) =>
+    React.createElement("h2", props),
+}));
+
+vi.mock("@/src/hooks/use-mobile", () => ({
+  useIsMobile: () => true,
 }));
 
 // Stub the editor but keep the real summary resolver so the row still shows the
@@ -323,7 +336,100 @@ describe("CustomizeMurphSettings", () => {
     await React.act(async () => {
       contactRow?.querySelector("button")?.click();
     });
-    expect(rendered.container.querySelector("[data-contact-card-picker]"))
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+    expect(rendered.container.textContent).toContain("Pick a new look");
+
+    await rendered.cleanup();
+  });
+
+  test("keeps Settings contact-card handoff understandable and recoverable", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ claim: "settings.current-member.claim" }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const element = React.createElement(CustomizeMurphSettings, {
+      assistant: null,
+      murphPhoneNumber: "+15550100001",
+    });
+    const rendered = await renderClientComponent(element, {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/settings",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    });
+
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+    });
+    await rendered.rerender(element);
+
+    const contactRow = findSettingsRow(rendered.container, "Contact card");
+    await React.act(async () => {
+      contactRow?.querySelector("button")?.click();
+    });
+
+    expect(rendered.container.textContent).toContain("Pick a new look");
+    expect(rendered.container.textContent).toContain(
+      "Delete your current Murph contact first, then save this one fresh.",
+    );
+    expect(rendered.container.textContent).toContain(
+      "You're in an in-app browser, which can't save contacts. This opens Safari instead.",
+    );
+    expect(rendered.container.textContent).toContain("Close");
+
+    const gremlinInput = rendered.container.querySelector<HTMLInputElement>(
+      'input[type="radio"][value="gremlin"]',
+    );
+    expect(gremlinInput).toBeInstanceOf(rendered.window.HTMLInputElement);
+    await React.act(async () => {
+      gremlinInput?.click();
+    });
+
+    const firstAttempt = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    expect(firstAttempt).not.toBeNull();
+    await React.act(async () => {
+      firstAttempt?.click();
+      await flushPromises();
+    });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      avatar: "gremlin",
+    });
+    expect(rendered.container.querySelector("[role='alert']")?.textContent)
+      .toContain("Couldn't open Safari");
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+
+    const retry = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    expect(retry?.disabled).toBe(false);
+    await React.act(async () => {
+      retry?.click();
+      await flushPromises();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+      avatar: "gremlin",
+    });
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=settings.current-member.claim",
+    );
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
       .not.toBeNull();
 
     await rendered.cleanup();
@@ -424,6 +530,23 @@ function makeVoiceTestOption(): MurphContactOption {
     kind: "text",
     label: "Messages",
   };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function findButton(
+  container: Element,
+  label: string,
+): HTMLButtonElement | null {
+  const ButtonElement = container.ownerDocument.defaultView?.HTMLButtonElement;
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent === label,
+  );
+  return ButtonElement && button instanceof ButtonElement ? button : null;
 }
 
 function findSettingsRow(container: Element, label: string): HTMLElement | null {

--- a/apps/web/test/customize-murph-settings.test.tsx
+++ b/apps/web/test/customize-murph-settings.test.tsx
@@ -429,6 +429,7 @@ describe("CustomizeMurphSettings", () => {
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=settings.current-member.claim",
     );
+    await acknowledgeSafariLaunch();
     expect(rendered.container.querySelector("[data-drawer-open='true']"))
       .toBeNull();
 
@@ -530,6 +531,14 @@ function makeVoiceTestOption(): MurphContactOption {
     kind: "text",
     label: "Messages",
   };
+}
+
+/** The picker completes only once this document goes away. */
+async function acknowledgeSafariLaunch(): Promise<void> {
+  await React.act(async () => {
+    window.dispatchEvent(new Event("pagehide"));
+    await flushPromises();
+  });
 }
 
 async function flushPromises(): Promise<void> {

--- a/apps/web/test/home-initial-visit-contact-handoff.test.tsx
+++ b/apps/web/test/home-initial-visit-contact-handoff.test.tsx
@@ -98,6 +98,11 @@ test("initial-visit contact handoff advances to persona setup after Safari launc
     assert.deepEqual(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)), {
       avatar: "classic",
     });
+    await act(async () => {
+      window.dispatchEvent(new Event("pagehide"));
+      await flushPromises();
+    });
+
     assert.equal(
       rendered.assign.mock.calls[0]?.[0],
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=initial-visit.claim",

--- a/apps/web/test/home-initial-visit-contact-handoff.test.tsx
+++ b/apps/web/test/home-initial-visit-contact-handoff.test.tsx
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+
+import { act, createElement, type HTMLAttributes, type ReactNode } from "react";
+import { test, vi } from "vitest";
+
+import { renderClientComponent } from "./render-client-component";
+
+vi.mock("@/src/components/murph/murph-persona-picker", () => ({
+  MurphPersonaPicker({ open }: { open: boolean }) {
+    return open
+      ? createElement("section", { "data-murph-persona-picker": "open" })
+      : null;
+  },
+}));
+
+vi.mock("@/src/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
+    open ? createElement("div", null, children) : null,
+  DialogContent: (props: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props),
+  DialogDescription: (props: HTMLAttributes<HTMLParagraphElement>) =>
+    createElement("p", props),
+  DialogHeader: (props: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props),
+  DialogTitle: (props: HTMLAttributes<HTMLHeadingElement>) =>
+    createElement("h2", props),
+}));
+
+vi.mock("@/src/components/ui/drawer", () => ({
+  Drawer: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
+    open
+      ? createElement("div", { "data-drawer-open": "true" }, children)
+      : null,
+  DrawerContent: (props: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props),
+  DrawerDescription: (props: HTMLAttributes<HTMLParagraphElement>) =>
+    createElement("p", props),
+  DrawerFooter: (props: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props),
+  DrawerHeader: (props: HTMLAttributes<HTMLDivElement>) =>
+    createElement("div", props),
+  DrawerTitle: (props: HTMLAttributes<HTMLHeadingElement>) =>
+    createElement("h2", props),
+}));
+
+vi.mock("@/src/hooks/use-mobile", () => ({
+  useIsMobile: () => true,
+}));
+
+test("initial-visit contact handoff advances to persona setup after Safari launches", async () => {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(JSON.stringify({ claim: "initial-visit.claim" }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  const { HomeInitialVisitPersonaPickerClient } = await import(
+    "../app/(dashboard)/home/initial-visit-persona-picker-client"
+  );
+  const createInitialVisitElement = () =>
+    createElement(HomeInitialVisitPersonaPickerClient, {
+      contactAction: {
+        href: "sms:+15550100001",
+        kind: "text",
+        label: "Messages",
+      },
+    });
+  const rendered = await renderClientComponent(createInitialVisitElement(), {
+    location: {
+      hash: "",
+      host: "app.example.com",
+      href: "https://app.example.com/home?initialVisit=true",
+      origin: "https://app.example.com",
+      pathname: "/home",
+      search: "?initialVisit=true",
+    },
+    requireButton: false,
+  });
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(createInitialVisitElement());
+
+  try {
+    const launch = Array.from(rendered.container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent === "Open in Safari to add Murph",
+    );
+    assert.ok(launch);
+
+    await act(async () => {
+      launch.click();
+      await flushPromises();
+    });
+
+    assert.deepEqual(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)), {
+      avatar: "classic",
+    });
+    assert.equal(
+      rendered.assign.mock.calls[0]?.[0],
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=initial-visit.claim",
+    );
+    assert.equal(
+      rendered.container.querySelector("[data-drawer-open='true']"),
+      null,
+    );
+    assert.ok(
+      rendered.container.querySelector("[data-murph-persona-picker='open']"),
+    );
+    assert.doesNotMatch(rendered.container.textContent ?? "", /Skip for now/u);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/apps/web/test/in-app-browser.test.ts
+++ b/apps/web/test/in-app-browser.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { detectInAppBrowser } from "@/src/lib/in-app-browser";
+
+const IOS_SAFARI_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+const IOS_CHROME_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.108 Mobile/15E148 Safari/604.1";
+const DESKTOP_CHROME_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const DESKTOP_SAFARI_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15";
+const X_IOS_WEBVIEW_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+const INSTAGRAM_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 326.0.0.42.90 (iPhone15,4; iOS 17_4_1; en_US; en; scale=3.00; 1179x2556; IABMV/1)";
+const FACEBOOK_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/456.0.0.45.101;FBDV/iPhone15,2;FBSV/17.4]";
+const TIKTOK_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 musical_ly_30.7.0 JsSdk/2.0 NetType/WIFI Channel/App Store ByteLocale/en Region/US WKWebView/1";
+const LINKEDIN_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LinkedInApp/9.1.348";
+const ANDROID_CHROME_USER_AGENT =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro Build/AP1A.240505.005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36";
+const ANDROID_FACEBOOK_USER_AGENT =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro Build/AP1A.240505.005; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/125.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/466.0.0.55.109;]";
+
+describe("detectInAppBrowser", () => {
+  it.each([
+    ["iOS Safari", IOS_SAFARI_USER_AGENT, true],
+    ["Chrome on iOS", IOS_CHROME_USER_AGENT, true],
+    ["desktop Chrome", DESKTOP_CHROME_USER_AGENT, false],
+    ["desktop Safari", DESKTOP_SAFARI_USER_AGENT, false],
+    ["Android Chrome", ANDROID_CHROME_USER_AGENT, false],
+  ] as const)("does not flag %s", (_name, userAgent, isIos) => {
+    expect(detectInAppBrowser(userAgent)).toEqual({
+      app: null,
+      inAppBrowser: false,
+      isIos,
+    });
+  });
+
+  it("flags an X/Twitter iOS webview without requiring an app token", () => {
+    expect(detectInAppBrowser(X_IOS_WEBVIEW_USER_AGENT)).toEqual({
+      app: null,
+      inAppBrowser: true,
+      isIos: true,
+    });
+  });
+
+  it.each([
+    ["Instagram", INSTAGRAM_USER_AGENT, "Instagram"],
+    ["Facebook", FACEBOOK_USER_AGENT, "Facebook"],
+    ["TikTok", TIKTOK_USER_AGENT, "TikTok"],
+    [
+      "TikTok Bytedance",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 BytedanceWebview/30.7.0",
+      "TikTok",
+    ],
+    ["LinkedIn", LINKEDIN_USER_AGENT, "LinkedIn"],
+    [
+      "Snapchat",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Snapchat/12.81.0.41",
+      "Snapchat",
+    ],
+    [
+      "Line",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Line/14.10.0",
+      "Line",
+    ],
+    [
+      "Twitter",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Twitter for iPhone/9.59",
+      "Twitter",
+    ],
+    [
+      "Google app",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/317.0.656428447 Mobile/15E148 Safari/604.1",
+      "Google",
+    ],
+  ] as const)("recognizes %s", (_name, userAgent, app) => {
+    expect(detectInAppBrowser(userAgent)).toEqual({
+      app,
+      inAppBrowser: true,
+      isIos: true,
+    });
+  });
+
+  it("flags an Android Facebook webview through its app token", () => {
+    expect(detectInAppBrowser(ANDROID_FACEBOOK_USER_AGENT)).toEqual({
+      app: "Facebook",
+      inAppBrowser: true,
+      isIos: false,
+    });
+  });
+});

--- a/apps/web/test/murph-contact-card-picker.test.tsx
+++ b/apps/web/test/murph-contact-card-picker.test.tsx
@@ -14,6 +14,7 @@ import {
   DEFAULT_MURPH_CONTACT_AVATAR_ID,
   findMurphContactAvatarOption,
   MURPH_CONTACT_AVATAR_OPTIONS,
+  MURPH_CONTACT_CARD_LAUNCH_TIMEOUT_MS,
   MurphContactAvatarArt,
   MurphContactAvatarGrid,
   MurphAddToContactsButton,
@@ -246,6 +247,7 @@ test("contact card picker issues a bound handoff and keeps launch failures retry
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=claim.for.gremlin",
     );
+    await expireSafariLaunchWindow();
     expect(rendered.container.querySelector("[role='alert']")?.textContent)
       .toContain("Couldn't open Safari");
     expect(findButton(rendered.container, "Open in Safari to add Murph")?.disabled)
@@ -333,6 +335,7 @@ test("contact card picker keeps an issuance denial open and retryable", async ()
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=retry.claim",
     );
+    await acknowledgeSafariLaunch();
     expect(onAddToContacts).toHaveBeenCalledWith(
       findMurphContactAvatarOption("gremlin"),
     );
@@ -389,6 +392,7 @@ test("hosted-onboarding add-to-contacts caller closes after a successful Safari 
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=standalone.claim",
     );
+    await acknowledgeSafariLaunch();
     expect(rendered.container.querySelector("[data-drawer-open='true']"))
       .toBeNull();
     expect(rendered.container.textContent).not.toContain("Skip for now");
@@ -406,11 +410,15 @@ test("hosted-onboarding add-to-contacts caller closes after a successful Safari 
 });
 
 test("contact card picker times out issuance and stays open for retry", async () => {
-  const timeoutController = new AbortController();
-  const retryTimeoutController = new AbortController();
-  const timeoutSpy = vi.spyOn(AbortSignal, "timeout")
-    .mockReturnValueOnce(timeoutController.signal)
-    .mockReturnValue(retryTimeoutController.signal);
+  // The deadline is an owned setTimeout, not AbortSignal.timeout, so that older
+  // iOS WebKit builds without the static combinators still reach the network.
+  const scheduled: Array<() => void> = [];
+  const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(
+    ((handler: () => void) => {
+      scheduled.push(handler);
+      return scheduled.length as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout,
+  );
   const fetchMock = vi.fn<typeof fetch>()
     .mockImplementationOnce((_url, init) => rejectOnAbort(init?.signal))
     .mockResolvedValueOnce(
@@ -457,7 +465,7 @@ test("contact card picker times out issuance and stays open for retry", async ()
       await Promise.resolve();
     });
 
-    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000);
     expect(findButton(rendered.container, "Opening Safari…")?.disabled).toBe(true);
     expect(findButton(rendered.container, "Skip for now")?.disabled).toBe(true);
     expect(
@@ -467,7 +475,7 @@ test("contact card picker times out issuance and stays open for retry", async ()
     ).toBe(true);
 
     await act(async () => {
-      timeoutController.abort(new Error("Handoff timed out."));
+      scheduled.forEach((fire) => fire());
       await flushPromises();
     });
 
@@ -493,6 +501,7 @@ test("contact card picker times out issuance and stays open for retry", async ()
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=timeout.retry.claim",
     );
+    await acknowledgeSafariLaunch();
     expect(onAddToContacts).toHaveBeenCalledWith(
       findMurphContactAvatarOption("gremlin"),
     );
@@ -600,6 +609,7 @@ test("contact card picker aborts dismissal during issuance and stays retryable",
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=dismissal.retry.claim",
     );
+    await acknowledgeSafariLaunch();
     expect(onAddToContacts).toHaveBeenCalledWith(
       findMurphContactAvatarOption("gremlin"),
     );
@@ -700,6 +710,7 @@ test("contact card picker freezes the selected avatar during issuance", async ()
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=gremlin.claim",
     );
+    await acknowledgeSafariLaunch();
     expect(onAddToContacts).toHaveBeenCalledWith(
       findMurphContactAvatarOption("gremlin"),
     );
@@ -763,6 +774,26 @@ test("contact card picker keeps the normal download action in Android webviews",
     await rendered.cleanup();
   }
 });
+
+/**
+ * The picker treats a launch as real only once this document goes away, so
+ * tests must supply that acknowledgement rather than relying on `assign`.
+ */
+async function acknowledgeSafariLaunch(): Promise<void> {
+  await act(async () => {
+    window.dispatchEvent(new Event("pagehide"));
+    await flushPromises();
+  });
+}
+
+async function expireSafariLaunchWindow(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, MURPH_CONTACT_CARD_LAUNCH_TIMEOUT_MS + 250);
+    });
+    await flushPromises();
+  });
+}
 
 async function flushPromises(): Promise<void> {
   await Promise.resolve();

--- a/apps/web/test/murph-contact-card-picker.test.tsx
+++ b/apps/web/test/murph-contact-card-picker.test.tsx
@@ -16,6 +16,7 @@ import {
   MURPH_CONTACT_AVATAR_OPTIONS,
   MurphContactAvatarArt,
   MurphContactAvatarGrid,
+  MurphAddToContactsButton,
   MurphContactCardPreview,
   MurphContactCardPicker,
 } from "@/src/components/murph/murph-contact-card-picker";
@@ -23,8 +24,31 @@ import {
 import { renderClientComponent } from "./render-client-component";
 
 vi.mock("@/src/components/ui/drawer", () => ({
-  Drawer: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
-    open ? createElement("div", { "data-drawer-open": "true" }, children) : null,
+  Drawer: ({
+    children,
+    onOpenChange,
+    open,
+  }: {
+    children?: ReactNode;
+    onOpenChange?: (open: boolean) => void;
+    open?: boolean;
+  }) =>
+    open
+      ? createElement(
+          "div",
+          { "data-drawer-open": "true" },
+          children,
+          createElement(
+            "button",
+            {
+              "data-dismiss-drawer": "true",
+              onClick: () => onOpenChange?.(false),
+              type: "button",
+            },
+            "Dismiss drawer",
+          ),
+        )
+      : null,
   DrawerContent: ({ children, className }: HTMLAttributes<HTMLDivElement>) =>
     createElement("div", { className, "data-drawer-content": "true" }, children),
   DrawerDescription: (props: HTMLAttributes<HTMLParagraphElement>) =>
@@ -139,7 +163,11 @@ test("contact card preview shows Murph with the selected avatar", () => {
 
 test("contact card picker fills the mobile viewport and keeps safe-area actions", () => {
   const markup = renderToStaticMarkup(
-    <MurphContactCardPicker onOpenChange={() => {}} open />,
+    <MurphContactCardPicker
+      onAddToContacts={() => {}}
+      onOpenChange={() => {}}
+      open
+    />,
   );
 
   expect(markup).toContain('data-drawer-content="true"');
@@ -202,15 +230,19 @@ test("contact card picker issues a bound handoff and keeps launch failures retry
       await flushPromises();
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/murph-contact-card", {
-      body: JSON.stringify({ avatar: "gremlin" }),
-      credentials: "same-origin",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-      method: "POST",
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/murph-contact-card",
+      expect.objectContaining({
+        body: JSON.stringify({ avatar: "gremlin" }),
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      }),
+    );
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=claim.for.gremlin",
     );
@@ -227,9 +259,9 @@ test("contact card picker issues a bound handoff and keeps launch failures retry
   }
 });
 
-test("contact card picker keeps an issuance failure open and retryable", async () => {
+test("contact card picker keeps an issuance denial open and retryable", async () => {
   const fetchMock = vi.fn<typeof fetch>()
-    .mockResolvedValueOnce(new Response(null, { status: 503 }))
+    .mockResolvedValueOnce(new Response(null, { status: 403 }))
     .mockResolvedValueOnce(
       new Response(JSON.stringify({ claim: "retry.claim" }), {
         headers: { "content-type": "application/json" },
@@ -239,10 +271,12 @@ test("contact card picker keeps an issuance failure open and retryable", async (
   vi.stubGlobal("fetch", fetchMock);
   const onAddToContacts = vi.fn();
   const onOpenChange = vi.fn();
+  const onSkip = vi.fn();
   const props = {
     initialAvatarId: "gremlin",
     onAddToContacts,
     onOpenChange,
+    onSkip,
     open: true,
   };
   const rendered = await renderClientComponent(
@@ -299,6 +333,378 @@ test("contact card picker keeps an issuance failure open and retryable", async (
     expect(rendered.assign).toHaveBeenCalledWith(
       "x-safari-https://app.example.com/api/murph-contact-card?handoff=retry.claim",
     );
+    expect(onAddToContacts).toHaveBeenCalledWith(
+      findMurphContactAvatarOption("gremlin"),
+    );
+    expect(onSkip).not.toHaveBeenCalled();
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("hosted-onboarding add-to-contacts caller closes after a successful Safari handoff", async () => {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(JSON.stringify({ claim: "standalone.claim" }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  const element = <MurphAddToContactsButton />;
+  const rendered = await renderClientComponent(element, {
+    location: {
+      host: "app.example.com",
+      href: "https://app.example.com/join",
+      origin: "https://app.example.com",
+    },
+    requireButton: false,
+  });
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(element);
+
+  try {
+    const openPicker = findButton(rendered.container, "Add Murph to Contacts");
+    assert.ok(openPicker);
+    await act(async () => {
+      openPicker.click();
+    });
+
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+    const launch = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(launch);
+
+    await act(async () => {
+      launch.click();
+      await flushPromises();
+    });
+
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=standalone.claim",
+    );
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .toBeNull();
+    expect(rendered.container.textContent).not.toContain("Skip for now");
+
+    const reopenPicker = findButton(rendered.container, "Add Murph to Contacts");
+    assert.ok(reopenPicker);
+    await act(async () => {
+      reopenPicker.click();
+    });
+    expect(findButton(rendered.container, "Open in Safari to add Murph")?.disabled)
+      .toBe(false);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("contact card picker times out issuance and stays open for retry", async () => {
+  const timeoutController = new AbortController();
+  const retryTimeoutController = new AbortController();
+  const timeoutSpy = vi.spyOn(AbortSignal, "timeout")
+    .mockReturnValueOnce(timeoutController.signal)
+    .mockReturnValue(retryTimeoutController.signal);
+  const fetchMock = vi.fn<typeof fetch>()
+    .mockImplementationOnce((_url, init) => rejectOnAbort(init?.signal))
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ claim: "timeout.retry.claim" }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const onAddToContacts = vi.fn();
+  const onOpenChange = vi.fn();
+  const props = {
+    initialAvatarId: "gremlin",
+    onAddToContacts,
+    onOpenChange,
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const launch = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(launch);
+    await act(async () => {
+      launch.click();
+      await Promise.resolve();
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(findButton(rendered.container, "Opening Safari…")?.disabled).toBe(true);
+    expect(findButton(rendered.container, "Skip for now")?.disabled).toBe(true);
+    expect(
+      Array.from(
+        rendered.container.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+      ).every((input) => input.disabled),
+    ).toBe(true);
+
+    await act(async () => {
+      timeoutController.abort(new Error("Handoff timed out."));
+      await flushPromises();
+    });
+
+    expect(rendered.container.querySelector("[role='alert']")?.textContent)
+      .toContain("Couldn't open Safari");
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+    expect(findButton(rendered.container, "Open in Safari to add Murph")?.disabled)
+      .toBe(false);
+    expect(onAddToContacts).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    const retry = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(retry);
+    await act(async () => {
+      retry.click();
+      await flushPromises();
+    });
+
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=timeout.retry.claim",
+    );
+    expect(onAddToContacts).toHaveBeenCalledWith(
+      findMurphContactAvatarOption("gremlin"),
+    );
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("contact card picker aborts dismissal during issuance and stays retryable", async () => {
+  let issuedSignal: AbortSignal | null | undefined;
+  let resolveCancelledIssuance: ((response: Response) => void) | undefined;
+  const fetchMock = vi.fn<typeof fetch>()
+    .mockImplementationOnce((_url, init) => {
+      issuedSignal = init?.signal;
+      return new Promise<Response>((resolve) => {
+        resolveCancelledIssuance = resolve;
+      });
+    })
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ claim: "dismissal.retry.claim" }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const onAddToContacts = vi.fn();
+  const onOpenChange = vi.fn();
+  const props = {
+    initialAvatarId: "gremlin",
+    onAddToContacts,
+    onOpenChange,
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const launch = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(launch);
+    await act(async () => {
+      launch.click();
+      await Promise.resolve();
+    });
+
+    expect(issuedSignal?.aborted).toBe(false);
+    const dismiss = rendered.container.querySelector<HTMLButtonElement>(
+      "[data-dismiss-drawer='true']",
+    );
+    assert.ok(dismiss);
+    await act(async () => {
+      dismiss.click();
+      await flushPromises();
+    });
+
+    expect(issuedSignal?.aborted).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(onAddToContacts).not.toHaveBeenCalled();
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+    expect(rendered.container.querySelector("[role='alert']")?.textContent)
+      .toContain("Couldn't open Safari");
+
+    assert.ok(resolveCancelledIssuance);
+    await act(async () => {
+      resolveCancelledIssuance?.(
+        new Response(JSON.stringify({ claim: "cancelled.claim" }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      );
+      await flushPromises();
+    });
+    expect(rendered.assign).not.toHaveBeenCalled();
+    expect(onAddToContacts).not.toHaveBeenCalled();
+
+    const retry = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(retry);
+    expect(retry.disabled).toBe(false);
+    await act(async () => {
+      retry.click();
+      await flushPromises();
+    });
+
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=dismissal.retry.claim",
+    );
+    expect(onAddToContacts).toHaveBeenCalledWith(
+      findMurphContactAvatarOption("gremlin"),
+    );
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("contact card picker freezes the selected avatar during issuance", async () => {
+  let resolveIssuance: ((response: Response) => void) | undefined;
+  const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+    const signal = init?.signal;
+    assert.ok(signal);
+    return new Promise<Response>((resolve, reject) => {
+      resolveIssuance = resolve;
+      signal.addEventListener(
+        "abort",
+        () => reject(signal.reason ?? new Error("Handoff aborted.")),
+        { once: true },
+      );
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  const onAddToContacts = vi.fn();
+  const onOpenChange = vi.fn();
+  const onSkip = vi.fn();
+  const props = {
+    initialAvatarId: "gremlin",
+    onAddToContacts,
+    onOpenChange,
+    onSkip,
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const launch = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(launch);
+    await act(async () => {
+      launch.click();
+      await Promise.resolve();
+    });
+
+    const gremlinInput = rendered.container.querySelector<HTMLInputElement>(
+      'input[type="radio"][value="gremlin"]',
+    );
+    const hoodedInput = rendered.container.querySelector<HTMLInputElement>(
+      'input[type="radio"][value="hooded"]',
+    );
+    assert.ok(gremlinInput);
+    assert.ok(hoodedInput);
+    expect(gremlinInput.disabled).toBe(true);
+    expect(hoodedInput.disabled).toBe(true);
+    expect(gremlinInput.checked).toBe(true);
+    expect(hoodedInput.checked).toBe(false);
+    const hoodedOption = hoodedInput.closest("label");
+    assert.ok(hoodedOption);
+
+    await act(async () => {
+      hoodedOption.click();
+    });
+
+    expect(gremlinInput.checked).toBe(true);
+    expect(hoodedInput.checked).toBe(false);
+    assert.ok(resolveIssuance);
+    await act(async () => {
+      resolveIssuance?.(
+        new Response(JSON.stringify({ claim: "gremlin.claim" }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      );
+      await flushPromises();
+    });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      avatar: "gremlin",
+    });
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=gremlin.claim",
+    );
+    expect(onAddToContacts).toHaveBeenCalledWith(
+      findMurphContactAvatarOption("gremlin"),
+    );
+    expect(onSkip).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   } finally {
     await rendered.cleanup();
   }
@@ -362,6 +768,22 @@ async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function rejectOnAbort(
+  signal: AbortSignal | null | undefined,
+): Promise<Response> {
+  assert.ok(signal);
+  return new Promise<Response>((_resolve, reject) => {
+    const rejectAborted = () => {
+      reject(signal.reason ?? new Error("Handoff aborted."));
+    };
+    if (signal.aborted) {
+      rejectAborted();
+      return;
+    }
+    signal.addEventListener("abort", rejectAborted, { once: true });
+  });
 }
 
 function findButton(

--- a/apps/web/test/murph-contact-card-picker.test.tsx
+++ b/apps/web/test/murph-contact-card-picker.test.tsx
@@ -149,12 +149,100 @@ test("contact card picker fills the mobile viewport and keeps safe-area actions"
   expect(markup).toContain("safe-area-inset-bottom");
 });
 
-test("contact card picker opens iOS webviews in Safari", async () => {
+test("contact card picker issues a bound handoff and keeps launch failures retryable", async () => {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(JSON.stringify({ claim: "claim.for.gremlin" }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
   const onAddToContacts = vi.fn();
+  const onOpenChange = vi.fn();
   const props = {
     initialAvatarId: "gremlin",
     onAddToContacts,
-    onOpenChange: () => {},
+    onOpenChange,
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  rendered.assign.mockImplementationOnce(() => {
+    throw new Error("Safari scheme launch failed.");
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const button = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(button);
+    expect(rendered.container.textContent).toContain(
+      "You're in an in-app browser, which can't save contacts. This opens Safari instead.",
+    );
+    expect(rendered.container.textContent).toContain("Skip for now");
+
+    await act(async () => {
+      button.click();
+      await flushPromises();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/murph-contact-card", {
+      body: JSON.stringify({ avatar: "gremlin" }),
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=claim.for.gremlin",
+    );
+    expect(rendered.container.querySelector("[role='alert']")?.textContent)
+      .toContain("Couldn't open Safari");
+    expect(findButton(rendered.container, "Open in Safari to add Murph")?.disabled)
+      .toBe(false);
+    expect(onAddToContacts).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("contact card picker keeps an issuance failure open and retryable", async () => {
+  const fetchMock = vi.fn<typeof fetch>()
+    .mockResolvedValueOnce(new Response(null, { status: 503 }))
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ claim: "retry.claim" }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const onAddToContacts = vi.fn();
+  const onOpenChange = vi.fn();
+  const props = {
+    initialAvatarId: "gremlin",
+    onAddToContacts,
+    onOpenChange,
     open: true,
   };
   const rendered = await renderClientComponent(
@@ -176,27 +264,40 @@ test("contact card picker opens iOS webviews in Safari", async () => {
   await rendered.rerender(<MurphContactCardPicker {...props} />);
 
   try {
-    const link = rendered.container.querySelector("a");
-    assert.ok(link);
-    expect(link.getAttribute("href")).toBe(
-      "x-safari-https://app.example.com/api/murph-contact-card?avatar=gremlin",
+    const firstAttempt = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
     );
-    expect(link.textContent).toContain("Open in Safari to add Murph");
-    expect(rendered.container.textContent).toContain(
-      "You're in an in-app browser, which can't save contacts. This opens Safari instead.",
-    );
-    expect(rendered.container.textContent).toContain("Skip for now");
+    assert.ok(firstAttempt);
 
     await act(async () => {
-      const clickEvent = new rendered.window.Event("click", {
-        bubbles: true,
-        cancelable: true,
-      });
-      clickEvent.preventDefault();
-      link.dispatchEvent(clickEvent);
+      firstAttempt.click();
+      await flushPromises();
     });
-    expect(onAddToContacts).toHaveBeenCalledWith(
-      findMurphContactAvatarOption("gremlin"),
+
+    expect(rendered.container.querySelector("[role='alert']")?.textContent)
+      .toContain("Couldn't open Safari");
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+    expect(onAddToContacts).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(rendered.assign).not.toHaveBeenCalled();
+
+    const retry = findButton(
+      rendered.container,
+      "Open in Safari to add Murph",
+    );
+    assert.ok(retry);
+    expect(retry.disabled).toBe(false);
+
+    await act(async () => {
+      retry.click();
+      await flushPromises();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=retry.claim",
     );
   } finally {
     await rendered.cleanup();
@@ -204,8 +305,10 @@ test("contact card picker opens iOS webviews in Safari", async () => {
 });
 
 test("contact card picker keeps the normal download action in Android webviews", async () => {
+  const onAddToContacts = vi.fn();
   const props = {
     initialAvatarId: "gremlin",
+    onAddToContacts,
     onOpenChange: () => {},
     open: true,
   };
@@ -238,7 +341,36 @@ test("contact card picker keeps the normal download action in Android webviews",
       "You're in an in-app browser",
     );
     expect(rendered.container.textContent).toContain("Skip for now");
+
+    await act(async () => {
+      const clickEvent = new rendered.window.Event("click", {
+        bubbles: true,
+        cancelable: true,
+      });
+      clickEvent.preventDefault();
+      link.dispatchEvent(clickEvent);
+    });
+    expect(onAddToContacts).toHaveBeenCalledWith(
+      findMurphContactAvatarOption("gremlin"),
+    );
   } finally {
     await rendered.cleanup();
   }
 });
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function findButton(
+  container: Element,
+  label: string,
+): HTMLButtonElement | null {
+  const ButtonElement = container.ownerDocument.defaultView?.HTMLButtonElement;
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent === label,
+  );
+  return ButtonElement && button instanceof ButtonElement ? button : null;
+}

--- a/apps/web/test/murph-contact-card-picker.test.tsx
+++ b/apps/web/test/murph-contact-card-picker.test.tsx
@@ -775,6 +775,126 @@ test("contact card picker keeps the normal download action in Android webviews",
   }
 });
 
+test("contact card picker ignores backgrounding and times out an unacknowledged launch", async () => {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(JSON.stringify({ claim: "claim.for.gremlin" }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  const onAddToContacts = vi.fn();
+  const onOpenChange = vi.fn();
+  const props = {
+    initialAvatarId: "gremlin",
+    onAddToContacts,
+    onOpenChange,
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const launch = findButton(rendered.container, "Open in Safari to add Murph");
+    assert.ok(launch);
+    await act(async () => {
+      launch.click();
+      await flushPromises();
+    });
+
+    // `assign` returned normally, so only a real unload may complete the handoff.
+    expect(rendered.assign).toHaveBeenCalledWith(
+      "x-safari-https://app.example.com/api/murph-contact-card?handoff=claim.for.gremlin",
+    );
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("blur"));
+      await flushPromises();
+    });
+    expect(onAddToContacts).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(rendered.container.querySelector("[role='alert']")).toBeNull();
+
+    await expireSafariLaunchWindow();
+
+    expect(onAddToContacts).not.toHaveBeenCalled();
+    expect(rendered.container.querySelector("[role='alert']")?.textContent)
+      .toContain("Couldn't open Safari");
+    expect(findButton(rendered.container, "Open in Safari to add Murph")?.disabled)
+      .toBe(false);
+    expect(rendered.container.querySelector("[data-drawer-open='true']"))
+      .not.toBeNull();
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("contact card picker completes an acknowledged launch exactly once", async () => {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(JSON.stringify({ claim: "claim.for.gremlin" }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  const onAddToContacts = vi.fn();
+  const props = {
+    initialAvatarId: "gremlin",
+    onAddToContacts,
+    onOpenChange: vi.fn(),
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const launch = findButton(rendered.container, "Open in Safari to add Murph");
+    assert.ok(launch);
+    await act(async () => {
+      launch.click();
+      await flushPromises();
+    });
+
+    await acknowledgeSafariLaunch();
+    await acknowledgeSafariLaunch();
+
+    expect(onAddToContacts).toHaveBeenCalledTimes(1);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
 /**
  * The picker treats a launch as real only once this document goes away, so
  * tests must supply that acknowledgement rather than relying on `assign`.

--- a/apps/web/test/murph-contact-card-picker.test.tsx
+++ b/apps/web/test/murph-contact-card-picker.test.tsx
@@ -1,6 +1,12 @@
+import assert from "node:assert/strict";
 import { existsSync, statSync } from "node:fs";
 
-import { createElement, type HTMLAttributes, type ReactNode } from "react";
+import {
+  act,
+  createElement,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { expect, test, vi } from "vitest";
 
@@ -13,6 +19,8 @@ import {
   MurphContactCardPreview,
   MurphContactCardPicker,
 } from "@/src/components/murph/murph-contact-card-picker";
+
+import { renderClientComponent } from "./render-client-component";
 
 vi.mock("@/src/components/ui/drawer", () => ({
   Drawer: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
@@ -139,4 +147,98 @@ test("contact card picker fills the mobile viewport and keeps safe-area actions"
   expect(markup).toContain("max-h-dvh");
   expect(markup).not.toContain("92dvh");
   expect(markup).toContain("safe-area-inset-bottom");
+});
+
+test("contact card picker opens iOS webviews in Safari", async () => {
+  const onAddToContacts = vi.fn();
+  const props = {
+    initialAvatarId: "gremlin",
+    onAddToContacts,
+    onOpenChange: () => {},
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const link = rendered.container.querySelector("a");
+    assert.ok(link);
+    expect(link.getAttribute("href")).toBe(
+      "x-safari-https://app.example.com/api/murph-contact-card?avatar=gremlin",
+    );
+    expect(link.textContent).toContain("Open in Safari to add Murph");
+    expect(rendered.container.textContent).toContain(
+      "You're in an in-app browser, which can't save contacts. This opens Safari instead.",
+    );
+    expect(rendered.container.textContent).toContain("Skip for now");
+
+    await act(async () => {
+      const clickEvent = new rendered.window.Event("click", {
+        bubbles: true,
+        cancelable: true,
+      });
+      clickEvent.preventDefault();
+      link.dispatchEvent(clickEvent);
+    });
+    expect(onAddToContacts).toHaveBeenCalledWith(
+      findMurphContactAvatarOption("gremlin"),
+    );
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("contact card picker keeps the normal download action in Android webviews", async () => {
+  const props = {
+    initialAvatarId: "gremlin",
+    onOpenChange: () => {},
+    open: true,
+  };
+  const rendered = await renderClientComponent(
+    <MurphContactCardPicker {...props} />,
+    {
+      location: {
+        host: "app.example.com",
+        href: "https://app.example.com/onboarding",
+        origin: "https://app.example.com",
+      },
+      requireButton: false,
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro Build/AP1A.240505.005; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/125.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/466.0.0.55.109;]",
+  });
+  await rendered.rerender(<MurphContactCardPicker {...props} />);
+
+  try {
+    const link = rendered.container.querySelector("a");
+    assert.ok(link);
+    expect(link.getAttribute("href")).toBe(
+      "/api/murph-contact-card?avatar=gremlin",
+    );
+    expect(link.textContent).toContain("Add Murph to Contacts");
+    expect(rendered.container.textContent).not.toContain(
+      "You're in an in-app browser",
+    );
+    expect(rendered.container.textContent).toContain("Skip for now");
+  } finally {
+    await rendered.cleanup();
+  }
 });

--- a/apps/web/test/murph-contact-card-route.test.ts
+++ b/apps/web/test/murph-contact-card-route.test.ts
@@ -1,8 +1,30 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { issueMurphContactCardHandoffClaim } from "@/src/lib/hosted-onboarding/contact-card-handoff";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import { isRecord } from "@/src/lib/primitives";
+
+const INITIATING_MEMBER_ID = "member_123456789";
+const INITIATING_SESSION_ID = "hws_initiating";
+const INITIATING_PHONE_NUMBER = "+14045550100";
+const OTHER_MEMBER_ID = "member_987654321";
+const OTHER_PHONE_NUMBER = "+14045550999";
+const IOS_WEBVIEW_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+const IOS_SAFARI_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+
+interface TestMurphContactCardHandoffPayload {
+  avatarId: string;
+  exp: number;
+  iat: number;
+  memberId: string;
+  sessionId: string;
+}
 
 const mocks = vi.hoisted(() => ({
+  assertActiveHostedMemberAccessAllowed: vi.fn(),
+  assertHostedOnboardingMutationOrigin: vi.fn(),
   fetchMurphHostedLinqContactCardVcfPhoto: vi.fn(),
   getPrisma: vi.fn(),
   readHostedMemberRoutingState: vi.fn(),
@@ -13,6 +35,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
   requireActiveHostedAppSessionFromRequest:
     mocks.requireActiveHostedAppSessionFromRequest,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/csrf", () => ({
+  assertHostedOnboardingMutationOrigin:
+    mocks.assertHostedOnboardingMutationOrigin,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-member-routing-store", () => ({
@@ -32,6 +59,11 @@ vi.mock("@/src/lib/hosted-onboarding/linq-contact-card", async (importOriginal) 
   };
 });
 
+vi.mock("@/src/lib/hosted-onboarding/member-access", () => ({
+  assertActiveHostedMemberAccessAllowed:
+    mocks.assertActiveHostedMemberAccessAllowed,
+}));
+
 vi.mock("@/src/lib/prisma", () => ({
   getPrisma: mocks.getPrisma,
 }));
@@ -41,11 +73,72 @@ type MurphContactCardRouteModule =
 
 let route: MurphContactCardRouteModule;
 
-function buildRequest(query: string = "", userAgent?: string): Request {
+function buildRequest(
+  query: string = "",
+  options: { cookie?: string; userAgent?: string } = {},
+): Request {
+  const headers = new Headers();
+  if (options.cookie) {
+    headers.set("cookie", options.cookie);
+  }
+  if (options.userAgent) {
+    headers.set("user-agent", options.userAgent);
+  }
+
   return new Request(
     `https://app.example.com/api/murph-contact-card${query}`,
-    userAgent ? { headers: { "user-agent": userAgent } } : undefined,
+    { headers },
   );
+}
+
+function buildIssuanceRequest(avatar: string): Request {
+  return new Request("https://app.example.com/api/murph-contact-card", {
+    body: JSON.stringify({ avatar }),
+    headers: {
+      "content-type": "application/json",
+      cookie: "murph-session=webview-only",
+      origin: "https://app.example.com",
+      "user-agent": IOS_WEBVIEW_USER_AGENT,
+    },
+    method: "POST",
+  });
+}
+
+async function readHandoffClaim(response: Response): Promise<string> {
+  const payload: unknown = await response.json();
+  if (!isRecord(payload) || typeof payload.claim !== "string") {
+    throw new Error("Expected a contact-card handoff claim.");
+  }
+  return payload.claim;
+}
+
+function readHandoffPayload(claim: string): TestMurphContactCardHandoffPayload {
+  const payloadEncoded = claim.split(".")[2];
+  if (!payloadEncoded) {
+    throw new Error("Expected a contact-card handoff payload.");
+  }
+
+  const payload: unknown = JSON.parse(
+    Buffer.from(payloadEncoded, "base64url").toString("utf8"),
+  );
+  if (
+    !isRecord(payload)
+    || typeof payload.avatarId !== "string"
+    || typeof payload.exp !== "number"
+    || typeof payload.iat !== "number"
+    || typeof payload.memberId !== "string"
+    || typeof payload.sessionId !== "string"
+  ) {
+    throw new Error("Expected a contact-card handoff payload object.");
+  }
+
+  return {
+    avatarId: payload.avatarId,
+    exp: payload.exp,
+    iat: payload.iat,
+    memberId: payload.memberId,
+    sessionId: payload.sessionId,
+  };
 }
 
 describe("murph contact card route", () => {
@@ -58,12 +151,18 @@ describe("murph contact card route", () => {
     vi.spyOn(console, "info").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     mocks.getPrisma.mockReturnValue({});
+    mocks.assertActiveHostedMemberAccessAllowed.mockResolvedValue(undefined);
     mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
-      member: { id: "member_123456789" },
+      member: { id: INITIATING_MEMBER_ID },
+      sessionId: INITIATING_SESSION_ID,
     });
-    mocks.readHostedMemberRoutingState.mockResolvedValue({
-      linqRecipientPhone: "+14045550100",
-    });
+    mocks.readHostedMemberRoutingState.mockImplementation(
+      async ({ memberId }: { memberId: string }) => ({
+        linqRecipientPhone: memberId === OTHER_MEMBER_ID
+          ? OTHER_PHONE_NUMBER
+          : INITIATING_PHONE_NUMBER,
+      }),
+    );
     mocks.resolveMurphHostedLinqContactCardBackupPhoneNumber.mockResolvedValue(
       "+14045550111",
     );
@@ -84,7 +183,7 @@ describe("murph contact card route", () => {
 
     const body = await response.text();
     expect(body).toContain("FN:Murph");
-    expect(body).toContain("TEL;TYPE=CELL:+14045550100");
+    expect(body).toContain(`TEL;TYPE=CELL:${INITIATING_PHONE_NUMBER}`);
     expect(body).toContain("item1.TEL:+14045550111");
     expect(body).toContain("item1.X-ABLabel:backup");
     expect(body).toContain("PHOTO;ENCODING=b;TYPE=PNG:cGhvdG8=");
@@ -95,9 +194,155 @@ describe("murph contact card route", () => {
     expect(
       mocks.resolveMurphHostedLinqContactCardBackupPhoneNumber,
     ).toHaveBeenCalledWith({
-      excludePhoneNumber: "+14045550100",
+      excludePhoneNumber: INITIATING_PHONE_NUMBER,
       prisma: {},
     });
+  });
+
+  it("issues in the webview context and redeems in a cookie-empty Safari context", async () => {
+    const webviewRequest = buildIssuanceRequest("gremlin");
+    expect(webviewRequest.headers.get("cookie")).toBe(
+      "murph-session=webview-only",
+    );
+
+    const issuanceResponse = await route.POST(webviewRequest);
+    expect(issuanceResponse.status).toBe(200);
+    const claim = await readHandoffClaim(issuanceResponse);
+    const claimPayload = readHandoffPayload(claim);
+    expect(claimPayload).toMatchObject({
+      avatarId: "gremlin",
+      memberId: INITIATING_MEMBER_ID,
+      sessionId: INITIATING_SESSION_ID,
+    });
+    expect(claimPayload.exp - claimPayload.iat).toBe(5 * 60);
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledWith(
+      webviewRequest,
+    );
+    expect(mocks.requireActiveHostedAppSessionFromRequest).toHaveBeenCalledWith(
+      webviewRequest,
+    );
+
+    mocks.requireActiveHostedAppSessionFromRequest.mockClear();
+    const safariRequest = buildRequest(
+      `?handoff=${encodeURIComponent(claim)}`,
+      { userAgent: IOS_SAFARI_USER_AGENT },
+    );
+    expect(safariRequest.headers.get("cookie")).toBeNull();
+
+    const safariResponse = await route.GET(safariRequest);
+    expect(safariResponse.status).toBe(200);
+    expect(mocks.requireActiveHostedAppSessionFromRequest).not.toHaveBeenCalled();
+    expect(mocks.assertActiveHostedMemberAccessAllowed).toHaveBeenCalledWith({
+      memberId: INITIATING_MEMBER_ID,
+    });
+    expect(mocks.readHostedMemberRoutingState).toHaveBeenCalledWith({
+      memberId: INITIATING_MEMBER_ID,
+      prisma: {},
+    });
+    expect(await safariResponse.text()).toContain(
+      `TEL;TYPE=CELL:${INITIATING_PHONE_NUMBER}`,
+    );
+    expect(mocks.fetchMurphHostedLinqContactCardVcfPhoto).toHaveBeenCalledWith({
+      imageUrl: "https://www.withmurph.ai/murph-headshots/murph-headshot-03-sm.png",
+    });
+  });
+
+  it("keeps the handoff member and avatar when Safari has another member's cookie", async () => {
+    const claim = issueMurphContactCardHandoffClaim({
+      avatarId: "gremlin",
+      memberId: INITIATING_MEMBER_ID,
+      sessionId: INITIATING_SESSION_ID,
+    });
+    mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
+      member: { id: OTHER_MEMBER_ID },
+      sessionId: "hws_other",
+    });
+
+    const response = await route.GET(buildRequest(
+      `?handoff=${encodeURIComponent(claim)}&avatar=hooded`,
+      { cookie: "murph-session=other-safari-session" },
+    ));
+
+    expect(response.status).toBe(200);
+    expect(mocks.requireActiveHostedAppSessionFromRequest).not.toHaveBeenCalled();
+    expect(mocks.readHostedMemberRoutingState).toHaveBeenCalledWith({
+      memberId: INITIATING_MEMBER_ID,
+      prisma: {},
+    });
+    const body = await response.text();
+    expect(body).toContain(`TEL;TYPE=CELL:${INITIATING_PHONE_NUMBER}`);
+    expect(body).not.toContain(OTHER_PHONE_NUMBER);
+    expect(mocks.fetchMurphHostedLinqContactCardVcfPhoto).toHaveBeenCalledWith({
+      imageUrl: "https://www.withmurph.ai/murph-headshots/murph-headshot-03-sm.png",
+    });
+  });
+
+  it("rejects a missing handoff claim without falling back to a Safari session", async () => {
+    const response = await route.GET(buildRequest(
+      "?handoff=",
+      { cookie: "murph-session=other-safari-session" },
+    ));
+
+    expect(response.status).toBe(401);
+    expect((await response.json()).error.code).toBe(
+      "MURPH_CONTACT_CARD_HANDOFF_INVALID",
+    );
+    expect(mocks.requireActiveHostedAppSessionFromRequest).not.toHaveBeenCalled();
+    expect(mocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith(
+      "Hosted Murph contact-card request.",
+      {
+        app: null,
+        authOutcome: "rejected",
+        authority: "handoff",
+        errorCode: "MURPH_CONTACT_CARD_HANDOFF_INVALID",
+        webview: false,
+      },
+    );
+  });
+
+  it("rejects expired handoff claims", async () => {
+    const claim = issueMurphContactCardHandoffClaim({
+      avatarId: "gremlin",
+      memberId: INITIATING_MEMBER_ID,
+      now: new Date("2020-01-01T00:00:00.000Z"),
+      sessionId: INITIATING_SESSION_ID,
+    });
+
+    const response = await route.GET(buildRequest(
+      `?handoff=${encodeURIComponent(claim)}`,
+    ));
+
+    expect(response.status).toBe(401);
+    expect((await response.json()).error.code).toBe(
+      "MURPH_CONTACT_CARD_HANDOFF_INVALID",
+    );
+    expect(mocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+  });
+
+  it("rejects tampered handoff claims", async () => {
+    const claim = issueMurphContactCardHandoffClaim({
+      avatarId: "gremlin",
+      memberId: INITIATING_MEMBER_ID,
+      sessionId: INITIATING_SESSION_ID,
+    });
+    const claimParts = claim.split(".");
+    const payload = readHandoffPayload(claim);
+    payload.avatarId = "hooded";
+    payload.memberId = OTHER_MEMBER_ID;
+    claimParts[2] = Buffer.from(JSON.stringify(payload), "utf8")
+      .toString("base64url");
+    const tamperedClaim = claimParts.join(".");
+
+    const response = await route.GET(buildRequest(
+      `?handoff=${encodeURIComponent(tamperedClaim)}`,
+    ));
+
+    expect(response.status).toBe(401);
+    expect((await response.json()).error.code).toBe(
+      "MURPH_CONTACT_CARD_HANDOFF_INVALID",
+    );
+    expect(mocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
   });
 
   it("embeds the chosen logo avatar", async () => {
@@ -134,11 +379,13 @@ describe("murph contact card route", () => {
     });
   });
 
-  it("logs an iOS webview contact-card request", async () => {
+  it("logs an authorized iOS webview contact-card request", async () => {
     await route.GET(
       buildRequest(
         "?avatar=hooded",
-        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+        {
+          userAgent: IOS_WEBVIEW_USER_AGENT,
+        },
       ),
     );
 
@@ -146,6 +393,8 @@ describe("murph contact card route", () => {
       "Hosted Murph contact-card request.",
       {
         app: null,
+        authOutcome: "authorized",
+        authority: "session",
         avatarId: "hooded",
         memberIdSuffix: "456789",
         webview: true,
@@ -153,11 +402,18 @@ describe("murph contact card route", () => {
     );
   });
 
-  it("logs a Safari contact-card request as outside a webview", async () => {
+  it("logs an authorized Safari handoff request as outside a webview", async () => {
+    const claim = issueMurphContactCardHandoffClaim({
+      avatarId: "hooded",
+      memberId: INITIATING_MEMBER_ID,
+      sessionId: INITIATING_SESSION_ID,
+    });
     await route.GET(
       buildRequest(
-        "?avatar=hooded",
-        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+        `?handoff=${encodeURIComponent(claim)}`,
+        {
+          userAgent: IOS_SAFARI_USER_AGENT,
+        },
       ),
     );
 
@@ -165,6 +421,8 @@ describe("murph contact card route", () => {
       "Hosted Murph contact-card request.",
       {
         app: null,
+        authOutcome: "authorized",
+        authority: "handoff",
         avatarId: "hooded",
         memberIdSuffix: "456789",
         webview: false,
@@ -198,7 +456,7 @@ describe("murph contact card route", () => {
     expect(payload.error.code).toBe("MURPH_TEXT_LINE_NOT_READY");
   });
 
-  it("propagates auth failures without building a card", async () => {
+  it("logs and propagates unauthenticated Safari requests before card lookup", async () => {
     mocks.requireActiveHostedAppSessionFromRequest.mockRejectedValue(
       hostedOnboardingError({
         code: "APP_SESSION_REQUIRED",
@@ -207,8 +465,23 @@ describe("murph contact card route", () => {
       }),
     );
 
-    const response = await route.GET(buildRequest());
+    const response = await route.GET(buildRequest(
+      "?avatar=hooded",
+      { userAgent: IOS_SAFARI_USER_AGENT },
+    ));
+
     expect(response.status).toBe(401);
     expect(mocks.readHostedMemberRoutingState).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith(
+      "Hosted Murph contact-card request.",
+      {
+        app: null,
+        authOutcome: "rejected",
+        authority: "session",
+        avatarId: "hooded",
+        errorCode: "APP_SESSION_REQUIRED",
+        webview: false,
+      },
+    );
   });
 });

--- a/apps/web/test/murph-contact-card-route.test.ts
+++ b/apps/web/test/murph-contact-card-route.test.ts
@@ -41,8 +41,11 @@ type MurphContactCardRouteModule =
 
 let route: MurphContactCardRouteModule;
 
-function buildRequest(query: string = ""): Request {
-  return new Request(`https://app.example.com/api/murph-contact-card${query}`);
+function buildRequest(query: string = "", userAgent?: string): Request {
+  return new Request(
+    `https://app.example.com/api/murph-contact-card${query}`,
+    userAgent ? { headers: { "user-agent": userAgent } } : undefined,
+  );
 }
 
 describe("murph contact card route", () => {
@@ -52,10 +55,11 @@ describe("murph contact card route", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(console, "info").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     mocks.getPrisma.mockReturnValue({});
     mocks.requireActiveHostedAppSessionFromRequest.mockResolvedValue({
-      member: { id: "member_1" },
+      member: { id: "member_123456789" },
     });
     mocks.readHostedMemberRoutingState.mockResolvedValue({
       linqRecipientPhone: "+14045550100",
@@ -128,6 +132,44 @@ describe("murph contact card route", () => {
     expect(mocks.fetchMurphHostedLinqContactCardVcfPhoto).toHaveBeenCalledWith({
       imageUrl: "https://www.withmurph.ai/murph-headshots/murph-headshot-02-sm.png",
     });
+  });
+
+  it("logs an iOS webview contact-card request", async () => {
+    await route.GET(
+      buildRequest(
+        "?avatar=hooded",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+      ),
+    );
+
+    expect(console.info).toHaveBeenCalledWith(
+      "Hosted Murph contact-card request.",
+      {
+        app: null,
+        avatarId: "hooded",
+        memberIdSuffix: "456789",
+        webview: true,
+      },
+    );
+  });
+
+  it("logs a Safari contact-card request as outside a webview", async () => {
+    await route.GET(
+      buildRequest(
+        "?avatar=hooded",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      ),
+    );
+
+    expect(console.info).toHaveBeenCalledWith(
+      "Hosted Murph contact-card request.",
+      {
+        app: null,
+        avatarId: "hooded",
+        memberIdSuffix: "456789",
+        webview: false,
+      },
+    );
   });
 
   it("uses the pending line while the member's line commit is in flight", async () => {


### PR DESCRIPTION
## Problem

A member who opens web onboarding inside a social app's in-app browser (X/Twitter, Instagram, Facebook, TikTok, LinkedIn, Snapchat, …) can tap **Add Murph to Contacts**, but the webview fetches the vCard (HTTP 200 server-side) and never hands it to the iOS contact importer. Nothing visibly happens, the picker has already optimistically advanced, and the download request logged nothing that distinguished the case — so the failure was silent and un-diagnosable.

Confirmed in production: the reporting member was in the X in-app browser. Reproduced end-to-end on the iOS Simulator — a real Safari session opens the native contact preview and imports cleanly; the served vCard bytes parse fine via `CNContactVCardSerialization`. The only failing variable is the webview.

## Change

New shared `apps/web/src/lib/in-app-browser.ts` → `detectInAppBrowser(ua)` returning `{ app, inAppBrowser, isIos }`:
- iOS in-app-browser rule: iOS WebKit UA with **no `Safari/` token** (every real iOS browser — Safari, CriOS, FxiOS — carries it; WKWebViews do not). This catches X, which announces no app token of its own.
- Explicit app tokens: Instagram, Facebook (`FBAN`/`FBAV`/`FB_IAB`), TikTok (`musical_ly`/`Bytedance`), LinkedIn, Snapchat, Line, Twitter, Google app (`GSA`).

Used in two places:
- **Picker** (`murph-contact-card-picker.tsx`): on a detected iOS webview the primary CTA becomes an `x-safari-https://` Safari-escape link with a short plain-language explainer; Android and real browsers are unchanged; the existing `onAddToContacts` callback still fires so onboarding advances identically.
- **Route** (`/api/murph-contact-card`): one structured log line per download carrying the `webview` flag, detected app token, avatar id, and member-id **suffix** only (existing sanitize/suffix logging conventions) — turns a future incident from an hour of forensics into a one-line query.

## Tests

Three new/updated files, 36 assertions: UA fixtures (iOS Safari, CriOS, X webview, Instagram, Facebook, TikTok, LinkedIn, Android Chrome negative), the CTA-swap logic, and the route log assertions.

- `pnpm --filter @murphai/hosted-web exec vitest run --config vitest.workspace.ts --no-coverage test/in-app-browser.test.ts test/murph-contact-card-picker.test.tsx test/murph-contact-card-route.test.ts` → 36 passed
- `pnpm --dir apps/web typecheck` → clean

## Notes

- No behavior change to the download response, and the native Linq share path / group vCard tool are untouched.
- The Safari-escape URL uses `window.location.host`, so it carries a non-default port in local dev; correct in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787461143&installation_model_id=19880&pr_number=917&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F917&signature=492e4d93daa34231e1cb80b53d1133b07696262e3028efd2f3b9ba4913e65fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## User goal / user-visible behavior

A member who opens onboarding inside an iOS in-app browser can add Murph's contact card and have onboarding continue, instead of tapping a button that silently does nothing.

## User experience

Irreducible user purpose: get Murph's number into the member's contacts, once, without the member having to understand why their browser is unusual.

- **Entry point.** The contact-card picker, reached from initial-visit onboarding, Settings contact-card customization, or the standalone add button in the join-invite flow.
- **Fewest necessary steps.** The in-app-browser branch changes one button's label and destination and adds one line of explanation. No extra screen, no extra choice, no confirmation step, and no second gesture.
- **Immediate feedback.** The button becomes "Opening Safari…" and is disabled; the avatar grid is frozen so a late response cannot launch a superseded selection.
- **Timing class.** Sub-second in the normal case. Longest normal wait is the 10s claim-issuance deadline; the launch acknowledgement window is 5s, chosen so a host "Open in Safari?" confirmation can still be tapped.
- **Asynchronous continuation owner.** The picker itself, via one `AbortController` per attempt. No durable store, queue, scheduler, or reconciliation path.
- **Final destination and audience.** Safari opens the member's own member-bound vCard; the audience is that member only.
- **Failure and recovery.** Issuance failure, timeout, dismissal, a synchronous launch throw, or an unacknowledged launch all leave the picker open with a legible retry. Only an acknowledged launch advances or closes the originating surface.
- **What happens next without a new inbound action.** On success the originating surface advances to persona setup or closes, so the member returns to the next step rather than to a finished task.
- **Local rendered evidence.** Desktop 1440x1000 and mobile 390x844 captures of the design-catalog CTA states, packaged for ReviewGPT and linked under Design proof. Gap stated honestly: those renders show the idle CTA states, not the pending/error/disabled-avatar states, and no device-level webview capture exists yet.

## Invariants the PR must preserve

- A contact card is only ever served for the member who initiated the request; an unrelated Safari session must not be able to rebind it.
- The handoff claim is short-lived, signed, and fails closed on malformed, tampered, expired, or unknown-key-version input.
- No new secret, dependency, durable token store, or lifecycle owner is introduced; the existing contact-privacy keyring is reused.
- Logs carry a member-id suffix only, never a full member id or the claim itself.
- The non-webview download path is byte-for-byte unchanged.
- Completion is reported only for an acknowledged launch; backgrounding is not completion.

## Preliminary specialist lenses

- **Prompt:** not applicable. No assistant prompt, skill, or model-facing text changes.
- **Frontend:** applicable. Rendered evidence packaged for ReviewGPT: `audit-packages/wv-desktop.png` (1440x1000) and `audit-packages/wv-mobile.png` (390x844), proving the default and in-app-browser CTA states from the `/design?tab=components` Contact Card Picker catalog entry.
- **Coverage:** applicable. Canonical command `pnpm --filter @murphai/hosted-web exec vitest run --config vitest.workspace.ts --no-coverage` — current outcome: 509 files / 6,534 tests passing in CI app verification.

## Change-shape breakdown

Classification rule: anything under `apps/web/test/` is tests; `.md` is docs; JSON/YAML/config files are config/tooling; everything else under `apps/web/src/` and `apps/web/app/` is authored source. No binary files and no generated code are in this diff (the design-proof screenshots are hosted externally and deliberately not committed).

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 669 | 54 |
| Tests/fixtures | 1498 | 21 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **2167** | **75** |

Authored-source churn is 723 lines; roughly two thirds of the diff is tests. The single largest source file is the 227-line stateless claim module, which review round 2 cleared on forgery, replay, rebinding, endpoint abuse, and key rotation.

## Deployment skew / compatibility

Web-only; no Cloudflare Worker, runner bundle, runtime env, or persisted-state change. The claim is stateless and verified by the same deployment that issued it, so there is no cross-version token to strand. During a rolling deploy an old page bundle can still `POST` to the new route (session path unchanged) and a new page bundle can only reach a new route, so both directions are compatible. Per the contact-card ordering, deploy web before Cloudflare. `container_rollout=immediate` is not required.

## Design proof

The Contact Card Picker catalog entry now renders the new Safari-escape CTA state alongside the default.

- Design page: [/design?tab=components](https://www.withmurph.ai/design?tab=components) — "Contact Card Picker" section
- Desktop screenshot: ![Contact card picker CTA states, desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/3641d6c6-4b45-4826-6c2a-446670748200/public)
- Mobile screenshot: ![Contact card picker CTA states, mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/2bdb58ab-7036-434f-d711-1e9c6bed5200/public)


## Non-obvious affected surfaces

- **Settings contact-card customization (`CustomizeMurphSettings`)** — This surface uses the shared `MurphContactCardPicker`, so iOS in-app browsers hit the same cookie-jar boundary as onboarding. The shared Safari handoff therefore applies here as well: Settings keeps its own instructions, issues a member- and avatar-bound handoff before leaving the webview, and stays open on issuance or launch failure so the member can retry. Regression proof: `apps/web/test/customize-murph-settings.test.tsx` exercises the real picker (not a mock) for the Settings copy, selected avatar, failure, and retry behavior; `apps/web/test/murph-contact-card-route.test.ts` proves the resulting handoff returns the initiating member's selected vCard with no Safari cookie and cannot be rebound by an unrelated Safari session.

ReviewGPT first-reviewed head: 335f6c3608704ddaf51fd5cff20cce89990386d2


