### PR TITLE
fix(assistant): shorten group contact-card re-share throttle to 90s

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-24-contact-card-reshare-throttle-window.md
+++ b/agent-docs/exec-plans/completed/2026-07-24-contact-card-reshare-throttle-window.md
@@ -1,0 +1,40 @@
+# Shorten the group contact-card re-share throttle window
+
+## Problem
+
+PR #912 fixed group contact-card re-share but left the per-chat share throttle
+at 10 minutes. That window is far longer than anything it needs to guard and
+still reproduces a slice of the original friction: a genuine "resend, he didn't
+get it" request inside 10 minutes silently returns `already_shared` and posts no
+new card.
+
+## Why the throttle exists (verified, not removed)
+
+The `share_contact_card` side effect runs live inside the model turn and is not
+journaled. The hosted turn retries up to 6 times
+(`hosted-user-runtime.ts`, `maximumAttempts: 6`), and the provider idempotency
+key is derived from the reservation instant, so it differs on every firing.
+The durable `hostedLinqContactCardShare` reservation row is therefore the only
+thing that collapses a duplicate `share_contact_card` firing across a
+retried/replayed turn or a coalesced wake burst. Removing it would post
+duplicate vCards on the retry path — a line-health risk for a group of mostly
+non-users. The group tool is the reservation seam's only caller.
+
+## Fix
+
+`apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts`:
+`HOSTED_LINQ_CONTACT_CARD_SHARE_THROTTLE_MS` drops from `10 * 60 * 1000` to
+`90 * 1000`. 90s covers the retry-backoff / burst horizon while being
+imperceptible to a genuine human re-request (which arrives minutes later, after
+the card is already visible in the chat). Docstring and the two window-dependent
+test cases in `hosted-onboarding-linq-contact-card-share.test.ts` updated.
+
+## Invariants
+
+- The reservation remains the durable retry/burst dedup guard; only its window
+  shrinks.
+- Authority, eligibility, roster, and failed-send release paths are unchanged.
+- No new persisted state.
+Status: completed
+Updated: 2026-07-24
+Completed: 2026-07-24

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts
@@ -46,7 +46,13 @@ type HostedLinqContactCardShareFindManyInput = {
   };
 };
 
-const HOSTED_LINQ_CONTACT_CARD_SHARE_THROTTLE_MS = 10 * 60 * 1000;
+// Sized to the runtime turn-retry horizon, not a user-visible cooldown. The
+// hosted turn retries up to 6 times and this send is not journaled, so a
+// duplicate `share_contact_card` firing (a retried/replayed turn, or a
+// coalesced wake burst) must collapse to one card. A genuine human re-request
+// arrives minutes later, after the card is already in the chat, so 90s is
+// imperceptible to it while still covering the retry backoff.
+const HOSTED_LINQ_CONTACT_CARD_SHARE_THROTTLE_MS = 90 * 1000;
 
 type HostedLinqContactCardShareSkipReason =
   | "missing_chat_id"
@@ -68,7 +74,7 @@ type HostedLinqContactCardShareReserveDecision =
 /**
  * Shared per-chat share throttle. Callers own their eligibility/authority
  * checks; this only dedupes duplicate attempts within one turn/wake (one per
- * chat per 10 minutes). Every share is an intentional assistant decision, so
+ * chat per 90 seconds). Every share is an intentional assistant decision, so
  * a requested re-share outside that window must go through.
  */
 export async function reserveHostedLinqContactCardShareAttempt(input: {

--- a/apps/web/test/hosted-onboarding-linq-contact-card-share.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card-share.test.ts
@@ -52,7 +52,7 @@ describe("hosted Linq contact-card share reservations", () => {
     expect(prisma.rows[0]?.linqChatLookupKey).not.toContain("chat_123");
   });
 
-  it("throttles repeat vCard shares for 10 minutes, then allows a re-share", async () => {
+  it("throttles repeat vCard shares for 90 seconds, then allows a re-share", async () => {
     const prisma = createContactCardSharePrismaStub();
     const now = new Date("2026-06-27T12:00:00.000Z");
 
@@ -66,14 +66,14 @@ describe("hosted Linq contact-card share reservations", () => {
     await expect(reserveHostedLinqContactCardShareAttempt({
       chatId: "chat_123",
       memberId: "member_123",
-      now: new Date("2026-06-27T12:09:59.000Z"),
+      now: new Date("2026-06-27T12:01:29.000Z"),
       prisma: prisma.client,
     })).resolves.toEqual({
       action: "skip",
       reason: "recent_attempt",
     });
 
-    const nextAttempt = new Date("2026-06-27T12:10:00.000Z");
+    const nextAttempt = new Date("2026-06-27T12:01:30.000Z");
     await expect(reserveHostedLinqContactCardShareAttempt({
       chatId: "chat_123",
       memberId: "member_123",
@@ -96,7 +96,7 @@ describe("hosted Linq contact-card share reservations", () => {
       entries: { ...TEST_KEYRING_ENTRIES },
     });
     prisma.rows.push(createContactCardShareRow({
-      lastContactCardShareAttemptedAt: new Date("2026-06-27T11:55:00.000Z"),
+      lastContactCardShareAttemptedAt: new Date("2026-06-27T11:59:30.000Z"),
       linqChatLookupKey: oldLookupKey,
     }));
 


### PR DESCRIPTION
## Why

Follow-up to #912. That PR fixed group contact-card re-share but left the per-chat share throttle at 10 minutes — far longer than anything it needs to guard, and long enough to still reproduce a slice of the original friction: a genuine "resend, he didn't get it" request inside 10 minutes silently returns `already_shared` and posts no new card.

## The throttle is kept, not removed — here's why

The `share_contact_card` side effect runs live inside the model turn and is **not** journaled (unlike `webhook-transport.ts`, which sends from a durable outbox keyed by a stable `effectId`). The hosted turn retries up to 6 times (`hosted-user-runtime.ts`, `maximumAttempts: 6`), and the provider idempotency key is derived from the reservation instant, so it differs on every firing. The durable `hostedLinqContactCardShare` reservation row is therefore the **only** thing that collapses a duplicate `share_contact_card` firing across a retried/replayed turn or a coalesced wake burst. Removing it would post duplicate vCards on the retry path — a line-health risk for a group of mostly non-users. The group tool is the reservation seam's only caller.

## Change

`HOSTED_LINQ_CONTACT_CARD_SHARE_THROTTLE_MS`: `10 * 60 * 1000` → `90 * 1000`. 90s covers the retry-backoff / burst horizon while being imperceptible to a genuine human re-request (which arrives minutes later, after the card is already sitting in the chat). Docstring and the two window-dependent reservation tests updated to the new boundary.

## Invariants

- The reservation remains the durable retry/burst dedup guard; only its window shrinks.
- Authority, eligibility, roster, and failed-send release paths are unchanged.
- No new persisted state.

## Review lenses

- prompt: not applicable (no prompt/skill/tool-description change; the SKILL.md "in the last few minutes" copy stays accurate).
- frontend: not applicable (no `apps/web` UI change).
- coverage: applicable. `pnpm test:diff apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts` — green (504 test files / 6,338 tests passed, full apps/web verification EXIT=0). Focused reservation file 4/4 pass; window boundary asserted at 89s (skip) vs 90s (share).

## Change shape (base→head diff; classified by path)

- Source: +8 / −2 (`apps/web/src/lib/hosted-onboarding/linq-contact-card-share.ts` — one constant + explanatory comment)
- Tests: +4 / −4 (`apps/web/test/hosted-onboarding-linq-contact-card-share.test.ts` — window boundary timestamps)
- Docs: +40 / −0 (completed exec-plan snapshot)
- Config/tooling: 0
- Generated/other: 0
- No binary files. Counts from `git diff --numstat origin/main...HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787462775&installation_model_id=19880&pr_number=918&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F918&signature=f8c9574b820151c06b987cd67061712879afb7f4516769847bfb43494d498ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->