### PR TITLE
Group length ceiling caps unrequested detail, never asked-for substance

### DIFF
--- a/packages/assistant-engine/skills/group-chat/SKILL.md
+++ b/packages/assistant-engine/skills/group-chat/SKILL.md
@@ -275,14 +275,17 @@ vulnerable disclosure.
   separate unrequested status or permission-card companion follow-up, never add
   "anything else?" tails, and never send a paragraph where a line works.
 - Group messages are phone-screen short: a few short sentences is the default
-  shape for any reply, whatever the ask. The room's Detail setting is a hard
-  ceiling on length, never a target. Unless Detail is 10/10 or someone
-  explicitly asked this turn for the full write-up, do not send a
-  multi-paragraph message, and the ceiling covers the whole turn, including
-  every `---` bubble. When the substance will not fit, send the headline
-  decision or answer, let the room ask for more, and keep durable detail on
-  the owning vault page instead of in the chat. An explicitly configured
-  scheduled edition or digest follows its owning skill's shape.
+  shape, and the room's Detail setting is a ceiling on unrequested length,
+  never a target. Never skimp on asked-for substance: when someone directly
+  asks a question whose complete answer genuinely needs a few paragraphs,
+  give that answer, as tight as accuracy allows. What the ceiling kills is
+  volunteered length — frameworks, multi-topic essays, background beyond the
+  question, detail nobody asked for — and it covers the whole turn, including
+  every `---` bubble. For open-ended setup, planning, or brainstorm asks,
+  depth arrives incrementally: headline first, one decision per message, more
+  on request, with durable detail on the owning vault page instead of the
+  chat. An explicitly configured scheduled edition or digest follows its
+  owning skill's shape.
 - Match the group's register: length (within the ceiling above), casing,
   energy. No lecture formatting, headers, or bullet lists unless someone
   asked for a breakdown.

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -684,7 +684,7 @@ function buildAssistantPersonalityPreferenceText(
     ...lines,
     ...(conversationScope === "group"
       ? [
-          "- In this group room, Detail is a hard ceiling on message length, never a floor: below 10/10, keep each reply to a few short sentences and let members ask for more instead of front-loading detail. Only Detail 10/10 or an explicit member request this turn for a full write-up permits a multi-paragraph reply. An explicitly configured scheduled edition or digest follows its owning skill's shape.",
+          "- In this group room, Detail caps unrequested length, never asked-for substance: below 10/10, default each reply to a few short sentences and never front-load detail nobody asked for, but answer a direct question completely even when its honest answer needs a few tight paragraphs. Detail 10/10 or an explicit member request this turn for a full write-up lifts the default entirely. An explicitly configured scheduled edition or digest follows its owning skill's shape.",
         ]
       : []),
     "- Apply these dials within the saved tone and current channel style. Fit them inside the channel's pacing: Detail sets the length budget, Humor and Push fit inside it, and Humor never gets its own bubble. They change expression, not facts, authority, safety thresholds, or required warnings. When urgent action is needed, lead with the action, timeframe, and safety essentials; when the user has limited capacity, omit optional background. Stay warm, competent, respectful of the user's choices, and factually clear. Safety, truth, privacy, consent, authorization, clinical and protected-context rules, channel rules, and the user's explicit current-turn instructions take precedence.",
@@ -1031,7 +1031,7 @@ The room container is not a person. Do not treat a speaker's first-person health
 
 Personality:
 Calm, observant, direct, plainspoken, and casual. Use light humor when it fits — dry and deadpan, never marked with laughing emojis or laughter at your own lines — support each participant's judgment, and never shame, diagnose, rank bodies, or turn the room into surveillance.
-Group messages stay phone-screen short: a few short sentences, whatever the ask, and the ceiling covers the whole reply. Never send a multi-paragraph reply unless someone explicitly asked this turn for the full write-up or the room's saved style calls for maximum detail; otherwise give the headline and let the room ask for more. An explicitly configured scheduled edition or digest follows its owning skill's shape.`;
+Group messages stay phone-screen short by default, and the ceiling covers the whole reply. Answer a direct question completely — asked-for substance is never skimped, even when its honest answer needs a few tight paragraphs — but never volunteer length: no frameworks, essays, or background beyond what was asked. For open-ended setup or brainstorm asks, give the headline first, one decision per message, and let the room pull for more. An explicitly configured scheduled edition or digest follows its owning skill's shape.`;
 }
 
 function buildAssistantProductPrinciplesText(): string {

--- a/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
@@ -41,16 +41,16 @@ describe('assistant group-chat style guidance', () => {
     const normalized = await readNormalizedGroupChatSkill()
 
     expect(normalized).toContain(
-      'Group messages are phone-screen short: a few short sentences is the default shape for any reply, whatever the ask.',
+      "the room's Detail setting is a ceiling on unrequested length, never a target",
     )
     expect(normalized).toContain(
-      "The room's Detail setting is a hard ceiling on length, never a target.",
+      'Never skimp on asked-for substance: when someone directly asks a question whose complete answer genuinely needs a few paragraphs, give that answer, as tight as accuracy allows.',
     )
     expect(normalized).toContain(
-      'Unless Detail is 10/10 or someone explicitly asked this turn for the full write-up, do not send a multi-paragraph message, and the ceiling covers the whole turn, including every `---` bubble.',
+      'What the ceiling kills is volunteered length — frameworks, multi-topic essays, background beyond the question, detail nobody asked for — and it covers the whole turn, including every `---` bubble.',
     )
     expect(normalized).toContain(
-      'send the headline decision or answer, let the room ask for more, and keep durable detail on the owning vault page instead of in the chat',
+      'For open-ended setup, planning, or brainstorm asks, depth arrives incrementally: headline first, one decision per message, more on request',
     )
     expect(normalized).toContain(
       "An explicitly configured scheduled edition or digest follows its owning skill's shape.",

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -278,7 +278,7 @@ describe('assistant execution prompt contract', () => {
       'Assistant personality preferences for this private conversation:',
     )
     expect(layers.threadContextPrompt).not.toContain(
-      'In this group room, Detail is a hard ceiling on message length',
+      'In this group room, Detail caps unrequested length',
     )
     expect(layers.threadContextPrompt).toContain(
       'Humor 9/10: initiate when there is an opening and commit to the bit',
@@ -2190,13 +2190,13 @@ describe('assistant conversation scope', () => {
     expect(prompt).toContain('Conversation scope: hosted group chat.')
     expect(prompt).toContain('synthetic room container, not the human speaker')
     expect(prompt).toContain(
-      'Group messages stay phone-screen short: a few short sentences, whatever the ask, and the ceiling covers the whole reply.',
+      'Group messages stay phone-screen short by default, and the ceiling covers the whole reply.',
     )
     expect(prompt).toContain(
       "An explicitly configured scheduled edition or digest follows its owning skill's shape.",
     )
     expect(prompt).toContain(
-      "Never send a multi-paragraph reply unless someone explicitly asked this turn for the full write-up or the room's saved style calls for maximum detail",
+      'Answer a direct question completely — asked-for substance is never skimped, even when its honest answer needs a few tight paragraphs — but never volunteer length',
     )
     expect(prompt).not.toContain('Assistant style settings')
     expect(prompt).toContain('Use only accountless built-in service tools')
@@ -2273,10 +2273,10 @@ describe('assistant conversation scope', () => {
     expect(prompt).toContain('Push 8/10')
     expect(prompt).toContain('Detail 7/10')
     expect(prompt).toContain(
-      'In this group room, Detail is a hard ceiling on message length, never a floor: below 10/10, keep each reply to a few short sentences and let members ask for more instead of front-loading detail.',
+      'In this group room, Detail caps unrequested length, never asked-for substance: below 10/10, default each reply to a few short sentences and never front-load detail nobody asked for, but answer a direct question completely even when its honest answer needs a few tight paragraphs.',
     )
     expect(prompt).toContain(
-      'Only Detail 10/10 or an explicit member request this turn for a full write-up permits a multi-paragraph reply.',
+      'Detail 10/10 or an explicit member request this turn for a full write-up lifts the default entirely.',
     )
     expect(prompt).toContain(
       'Casual is a persistent user-facing writing invariant',


### PR DESCRIPTION
## Problem

The group length ceiling merged in #913 gates any multi-paragraph group reply behind room Detail 10/10 or a literal "full write-up" request. That over-corrects: a member asking a direct substantive question (for example why a metric should not be compared across wearables) deserves its complete answer even when that honestly needs a few paragraphs, without knowing to say "give me the full write-up".

## Product rule (rebalanced)

The ceiling caps unrequested length, never asked-for substance. In a group chat:

- A direct question gets its complete answer, as tight as accuracy allows, even when that needs a few paragraphs.
- What stays banned is volunteered length: frameworks, multi-topic essays, background beyond the question, detail nobody asked for. The ceiling still covers the whole turn including every `---` bubble.
- Open-ended setup, planning, and brainstorm asks (the original incident shape) still proceed incrementally: headline first, one decision per message, more on request, durable detail on the owning vault page.
- Detail 10/10 or an explicit same-turn full-write-up request lifts the default entirely; configured scheduled editions/digests keep following their owning skill's shape.

## Changes

- `skills/group-chat/SKILL.md` — Message shape bullet rewritten around the asked-for vs volunteered split.
- `src/assistant/system-prompt.ts` — the group identity backstop and the group personality Detail line carry the same rule; private-conversation rendering unchanged.
- Tests updated to pin the new strings; the private-scope absence assertion tracks the new prefix.

`skills/group-challenge/SKILL.md` kickoff and dispatch rules from #913 are intentionally untouched: setup/brainstorm flows keep the incremental shape.

## Verification

`pnpm test:diff` over the touched files: green (assistant-engine suite plus affected app verification).

## Change shape

Base-to-head diff, classified by path (`src/**` and `skills/**` prompt assets = source, `test/**` = tests): source +21/-15, tests +19/-19. No docs, config, generated, or binary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787498502&installation_model_id=19880&pr_number=921&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F921&signature=e3fa7b16c497cc14e87b00019a6a7d2cbc1f0e9ea1d372d0f12af0e564e04662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->