### PR TITLE
Decline work-output requests in group and unverified-external prompts

### DIFF
--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -279,7 +279,7 @@ function buildStaticCacheableCorePrompt(
   if (conversationScope === "unverified-external") {
     return `You are Murph, a personal health assistant, but this external audience has not been authoritatively classified as private or group.
 
-Answer the current message using only its contents and public, non-account information. Do not use prior conversation, hidden route or member context, private state, account-backed tools, or durable personal operations. Be honest about unavailable context and do not claim an action occurred unless a permitted tool proves it.`;
+Answer the current message using only its contents and public, non-account information. Do not use prior conversation, hidden route or member context, private state, account-backed tools, or durable personal operations. Be honest about unavailable context and do not claim an action occurred unless a permitted tool proves it. Casual and general-knowledge questions are fine; decline producing work output such as writing, reviewing, or debugging code, or work, school, or professional deliverables.`;
   }
   if (conversationScope === "group") {
     return joinPromptSections(
@@ -1026,6 +1026,9 @@ Calm, observant, direct, plainspoken. Defaults: Humor 3—deadpan; at most one e
 
 function buildAssistantGroupIdentityAndScopeText(): string {
   return `You are Murph in a hosted group chat. Help the room discuss health, coordinate group-owned activities, and use only public information or server-approved group projections.
+
+Scope boundary:
+Casual conversation and quick general-knowledge answers are part of being good company. Producing work output is not: decline requests to write, review, or debug code, or to produce work, school, or professional deliverables, in one plain sentence without lecturing; tool availability does not expand scope.
 
 The room container is not a person. Do not treat a speaker's first-person health statement as authority to read or write personal records, memory, settings, devices, accounts, or preferences. Do not save a participant's health fact into the room vault as though it belonged to the room. Use personal data only when a server-owned group tool returns an explicitly shared projection, and attribute it to the returned member.
 

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -2227,6 +2227,13 @@ describe('assistant conversation scope', () => {
     expect(prompt).not.toContain("the user's compiled wiki")
     expect(prompt).not.toContain('vault-cli memory set-name')
     expect(prompt).toContain('The room container is not a person')
+    expect(prompt).toContain('Scope boundary:')
+    expect(prompt).toContain(
+      'Casual conversation and quick general-knowledge answers are part of being good company.',
+    )
+    expect(prompt).toContain(
+      'Producing work output is not: decline requests to write, review, or debug code, or to produce work, school, or professional deliverables, in one plain sentence without lecturing; tool availability does not expand scope.',
+    )
     expect(prompt).toContain('Do not log medications, symptoms, meals, measurements')
     expect(prompt).not.toContain('murph.assistant_style')
     expect(prompt).toContain(
@@ -2402,6 +2409,9 @@ describe('assistant conversation scope', () => {
 
     expect(prompt).toContain('Conversation scope: unverified external audience.')
     expect(prompt).toContain('do not describe this as a private conversation or a hosted group container')
+    expect(prompt).toContain(
+      'Casual and general-knowledge questions are fine; decline producing work output such as writing, reviewing, or debugging code, or work, school, or professional deliverables.',
+    )
     expect(prompt).not.toContain('Conversation scope: private Murph conversation.')
     expect(prompt).not.toContain('Conversation scope: hosted group chat.')
     expect(prompt).not.toContain('PERSONAL_CLI_CONTRACT')


### PR DESCRIPTION
## Summary
Group rooms and unverified external audiences had no work-task scope boundary in the assistant system prompt, so a group participant could get Murph to write React hooks or offer repo code reviews — a trial-token farming vector. The direct 1:1 prompt already declines unrelated work tasks; the group and unverified-external variants are separate builders and never got the clause.

This adds a scope boundary to `buildAssistantGroupIdentityAndScopeText()` and the unverified-external static core:
- Casual conversation and quick general-knowledge answers stay in scope (Murph remains good company in the room, not a health-only hall monitor).
- Producing work output — writing, reviewing, or debugging code, or work/school/professional deliverables — is declined in one plain sentence without lecturing; tool availability does not expand scope.

Wording follows the GPT-5.6 Sol prompting guidance (developers.openai.com/api/docs/guides/prompt-guidance-gpt-5p6.md): the policy is stated once per variant as a decision rule, no repeated absolutes, and it does not contradict the existing turn-priority or message-length rules.

The direct-scope static core is untouched, so the pinned `staticPromptHash` in model-behavior.test.ts is unchanged.

## Testing
- `test/model-behavior.test.ts`: 63/63 pass, including new verbatim assertions for both variants.
- Full `@murphai/assistant-engine` suite: 2606 passed / 5 skipped. One pre-existing forks-worker termination timeout on `assistant-local-service-runtime.test.ts` reproduces identically on clean main (tests inside it pass; the error is teardown-only) — unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787500879&installation_model_id=19880&pr_number=922&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F922&signature=c969485d790cc6fe501722ddc01aabfaa1f676a6eceef64a888761b77c4b673c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->