### PR TITLE
Ask why on account deletion and keep the answer

### DIFF
--- a/apps/web/app/api/settings/privacy/delete/route.ts
+++ b/apps/web/app/api/settings/privacy/delete/route.ts
@@ -22,7 +22,7 @@ export const POST = withJsonError(async (request: Request) => {
   const body = await readJsonObject(request, {
     limitBytes: HOSTED_ACCOUNT_PRIVACY_REQUEST_BODY_LIMIT_BYTES,
   });
-  parseHostedAccountDeletionRequest(body);
+  const deletionRequest = parseHostedAccountDeletionRequest(body);
 
   await verifyAndConsumeSensitiveActionChallenge({
     authorization: body.authorization,
@@ -38,6 +38,7 @@ export const POST = withJsonError(async (request: Request) => {
   });
 
   const result = await deleteHostedAccountData({
+    exitFeedback: deletionRequest.exitFeedback,
     memberId: auth.member.id,
     prisma,
     request,

--- a/apps/web/app/design/account-exit-reason-study.tsx
+++ b/apps/web/app/design/account-exit-reason-study.tsx
@@ -81,11 +81,13 @@ function StepFrame(props: {
       <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
         {props.label}
       </p>
+      {/* Matches the delete dialog's own max-w-md so the catalog shows the
+          component at the width it actually renders at. */}
       <div
-        className="rounded-2xl border border-border bg-background p-6"
+        className="w-full max-w-md rounded-2xl border border-border bg-background p-6"
         inert={props.inert}
       >
-        <div className="mx-auto w-full max-w-md">{props.children}</div>
+        {props.children}
       </div>
     </div>
   );

--- a/apps/web/app/design/account-exit-reason-study.tsx
+++ b/apps/web/app/design/account-exit-reason-study.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+
+import { AccountExitReasonStep } from "@/src/components/settings/account-exit-reason-step";
+import type { HostedAccountExitReasonCode } from "@/src/lib/hosted-privacy/account-data-shared";
+
+export function AccountExitReasonStudy() {
+  return (
+    <div
+      className="flex flex-col gap-8"
+      data-design-study="account-exit-reason"
+      id="account-exit-reason"
+    >
+      <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+        The first step of the delete-account dialog in{" "}
+        <code>/settings</code>. Answering is optional: Skip always moves straight
+        to the confirmation step, and Continue only turns on once a reason is
+        picked. The note field appears after a reason is chosen so a written note
+        always arrives attached to one. The live step is interactive here; the
+        two previews below are inert.
+      </p>
+
+      <StepFrame label="Interactive">
+        <InteractiveExitReasonStep />
+      </StepFrame>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <StepFrame inert label="Nothing picked yet · Continue disabled" state="empty">
+          <AccountExitReasonStep
+            note=""
+            reason={null}
+            onContinue={() => undefined}
+            onNoteChange={() => undefined}
+            onReasonChange={() => undefined}
+            onSkip={() => undefined}
+          />
+        </StepFrame>
+        <StepFrame inert label="Reason picked · note revealed" state="reason-selected">
+          <AccountExitReasonStep
+            note="Loved the texts, just cannot justify it this month."
+            reason="too_expensive"
+            onContinue={() => undefined}
+            onNoteChange={() => undefined}
+            onReasonChange={() => undefined}
+            onSkip={() => undefined}
+          />
+        </StepFrame>
+      </div>
+    </div>
+  );
+}
+
+function InteractiveExitReasonStep() {
+  const [reason, setReason] = useState<HostedAccountExitReasonCode | null>(null);
+  const [note, setNote] = useState("");
+
+  return (
+    <AccountExitReasonStep
+      note={note}
+      reason={reason}
+      onContinue={() => undefined}
+      onNoteChange={setNote}
+      onReasonChange={setReason}
+      onSkip={() => {
+        setReason(null);
+        setNote("");
+      }}
+    />
+  );
+}
+
+function StepFrame(props: {
+  children: React.ReactNode;
+  inert?: boolean;
+  label: string;
+  state?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-3" data-design-state={props.state}>
+      <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+        {props.label}
+      </p>
+      <div
+        className="rounded-2xl border border-border bg-background p-6"
+        inert={props.inert}
+      >
+        <div className="mx-auto w-full max-w-md">{props.children}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_MURPH_HEADSHOT } from "@/src/components/homepage/murph-headshot
 import { PersonasSection } from "@/src/components/homepage/personas-section";
 import { SecurityTeaserSection } from "@/src/components/homepage/security-teaser-section";
 import { Separator } from "@/src/components/ui/separator";
+import { AccountExitReasonStudy } from "./account-exit-reason-study";
 import { ConnectSourceCardStudy } from "./connect-source-card-study";
 import { FamilyInviteJoinStudy } from "./family-invite-join-study";
 import { GroupJoinStudy } from "./group-join-study";
@@ -78,6 +79,12 @@ export function SectionsContent() {
 
       <StudySection title="Connect source card actions">
         <ConnectSourceCardStudy />
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Account deletion exit reason">
+        <AccountExitReasonStudy />
       </StudySection>
 
       <Separator />

--- a/apps/web/prisma/migrations/20260724160000_hosted_account_exit_reason/migration.sql
+++ b/apps/web/prisma/migrations/20260724160000_hosted_account_exit_reason/migration.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "HostedAccountExitReasonCode" AS ENUM (
+  'too_expensive',
+  'not_useful_enough',
+  'too_many_texts',
+  'privacy_concerns',
+  'setup_trouble',
+  'just_testing'
+);
+
+-- No member_id column and no foreign key by design: this row must survive the
+-- account-deletion cascade that removes every member-keyed record, and must not
+-- be joinable back to the person who left.
+CREATE TABLE "hosted_account_exit_reason" (
+  "id" TEXT NOT NULL,
+  "reason" "HostedAccountExitReasonCode" NOT NULL,
+  "note" TEXT,
+  "billing_status" "HostedBillingStatus" NOT NULL,
+  "tenure_days" INTEGER NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "hosted_account_exit_reason_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "hosted_account_exit_reason_tenure_days_nonnegative"
+    CHECK ("tenure_days" >= 0)
+);
+
+CREATE INDEX "hosted_account_exit_reason_created_at_idx"
+  ON "hosted_account_exit_reason"("created_at");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1248,6 +1248,33 @@ model HostedStripeEvent {
   @@map("hosted_stripe_event")
 }
 
+/// Why a member said they were leaving, captured once on the delete dialog.
+/// Deliberately holds no member relation or member id: the row has to outlive
+/// the cascade that removes every member-keyed record, which is exactly the gap
+/// that made past churn unanswerable. Keeping it unjoinable is also why the
+/// retained context is coarse (plan state and whole days of tenure) rather than
+/// anything that could re-identify the person who left.
+model HostedAccountExitReason {
+  id            String                      @id
+  reason        HostedAccountExitReasonCode
+  note          String?
+  billingStatus HostedBillingStatus         @map("billing_status")
+  tenureDays    Int                         @map("tenure_days")
+  createdAt     DateTime                    @default(now()) @map("created_at")
+
+  @@index([createdAt])
+  @@map("hosted_account_exit_reason")
+}
+
+enum HostedAccountExitReasonCode {
+  too_expensive
+  not_useful_enough
+  too_many_texts
+  privacy_concerns
+  setup_trouble
+  just_testing
+}
+
 model HostedUsageCreditPurchase {
   id                                String                               @id
   payerMemberId                     String?                              @map("payer_member_id")

--- a/apps/web/src/components/settings/account-exit-reason-step.tsx
+++ b/apps/web/src/components/settings/account-exit-reason-step.tsx
@@ -49,10 +49,12 @@ export function AccountExitReasonStep(props: {
           return (
             <Label
               key={option.code}
-              className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2.5 text-sm leading-6 font-normal text-foreground transition-colors hover:bg-primary/5 has-data-checked:bg-primary/10"
+              className="flex cursor-pointer items-start gap-3 rounded-lg px-2 py-2.5 text-sm leading-6 font-normal text-foreground transition-colors hover:bg-primary/5 has-data-checked:bg-primary/10"
               htmlFor={inputId}
             >
-              <RadioGroupItem id={inputId} value={option.code} />
+              {/* items-start keeps the control on the first line when a label
+                  wraps at narrow widths; mt-1 optically centers it there. */}
+              <RadioGroupItem className="mt-1" id={inputId} value={option.code} />
               {option.label}
             </Label>
           );

--- a/apps/web/src/components/settings/account-exit-reason-step.tsx
+++ b/apps/web/src/components/settings/account-exit-reason-step.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Button } from "@/src/components/ui/button";
+import { Label } from "@/src/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/src/components/ui/radio-group";
+import { Textarea } from "@/src/components/ui/textarea";
+import {
+  HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH,
+  HOSTED_ACCOUNT_EXIT_REASONS,
+  type HostedAccountExitReasonCode,
+  isHostedAccountExitReasonCode,
+} from "@/src/lib/hosted-privacy/account-data-shared";
+
+const REASON_INPUT_ID_PREFIX = "hosted-account-exit-reason";
+const NOTE_INPUT_ID = "hosted-account-exit-note";
+
+/**
+ * The optional "why are you leaving" step shown before the delete confirmation.
+ * Answering never gates deletion, so Skip is always available and Continue only
+ * turns on once there is something to send. The note appears after a reason is
+ * picked so a written note always arrives attached to one.
+ */
+export function AccountExitReasonStep(props: {
+  disabled?: boolean;
+  note: string;
+  onContinue: () => void;
+  onNoteChange: (note: string) => void;
+  onReasonChange: (reason: HostedAccountExitReasonCode) => void;
+  onSkip: () => void;
+  reason: HostedAccountExitReasonCode | null;
+}) {
+  const disabled = props.disabled ?? false;
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="account-exit-reason-step">
+      <RadioGroup
+        aria-label="Why are you leaving?"
+        className="gap-1"
+        disabled={disabled}
+        value={props.reason ?? ""}
+        onValueChange={(value) => {
+          if (isHostedAccountExitReasonCode(value)) {
+            props.onReasonChange(value);
+          }
+        }}
+      >
+        {HOSTED_ACCOUNT_EXIT_REASONS.map((option) => {
+          const inputId = `${REASON_INPUT_ID_PREFIX}-${option.code}`;
+          return (
+            <Label
+              key={option.code}
+              className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2.5 text-sm leading-6 font-normal text-foreground transition-colors hover:bg-primary/5 has-data-checked:bg-primary/10"
+              htmlFor={inputId}
+            >
+              <RadioGroupItem id={inputId} value={option.code} />
+              {option.label}
+            </Label>
+          );
+        })}
+      </RadioGroup>
+
+      {props.reason ? (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor={NOTE_INPUT_ID}>Anything else? (optional)</Label>
+          <Textarea
+            disabled={disabled}
+            id={NOTE_INPUT_ID}
+            maxLength={HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH}
+            rows={3}
+            value={props.note}
+            onChange={(event) => props.onNoteChange(event.target.value)}
+          />
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        <Button
+          className="w-full"
+          disabled={disabled || !props.reason}
+          size="xl"
+          type="button"
+          onClick={props.onContinue}
+        >
+          Continue
+        </Button>
+        <Button
+          className="w-full"
+          disabled={disabled}
+          size="xl"
+          type="button"
+          variant="ghost"
+          onClick={props.onSkip}
+        >
+          Skip
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/hosted-data-privacy-settings.tsx
+++ b/apps/web/src/components/settings/hosted-data-privacy-settings.tsx
@@ -30,8 +30,12 @@ import {
   publishBrowserVaultSessionInvalidation,
 } from "@/src/lib/browser-vault/session-invalidation";
 import { reloadCurrentHostedAuthDocument } from "@/src/components/hosted-onboarding/hosted-auth-navigation";
-import { HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE } from "@/src/lib/hosted-privacy/account-data-shared";
+import {
+  HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+  type HostedAccountExitReasonCode,
+} from "@/src/lib/hosted-privacy/account-data-shared";
 
+import { AccountExitReasonStep } from "./account-exit-reason-step";
 import { HostedSettingsSessionState } from "./hosted-settings-session-state";
 
 interface HostedAccountVendorDeletionSummary {
@@ -80,6 +84,9 @@ function HostedDataPrivacySettingsAuthorized(props: { authenticated: boolean }) 
   const [exportSuccess, setExportSuccess] = useState<string | null>(null);
   const [deletePending, setDeletePending] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogStep, setDialogStep] = useState<"reason" | "confirm">("reason");
+  const [exitReason, setExitReason] = useState<HostedAccountExitReasonCode | null>(null);
+  const [exitNote, setExitNote] = useState("");
   const [confirmationPhrase, setConfirmationPhrase] = useState("");
   const [dialogError, setDialogError] = useState<string | null>(null);
   const [deleted, setDeleted] = useState(false);
@@ -187,7 +194,11 @@ function HostedDataPrivacySettingsAuthorized(props: { authenticated: boolean }) 
           receivedReplacementHeaders = true;
           publishBrowserVaultSessionInvalidation();
         },
-        payload: { authorization, confirmationPhrase },
+        payload: {
+          authorization,
+          confirmationPhrase,
+          ...(exitReason ? { exitNote, exitReason } : {}),
+        },
         url: "/api/settings/privacy/delete",
       });
       setCleanupPending(hasIncompleteCleanup(response.result));
@@ -227,6 +238,9 @@ function HostedDataPrivacySettingsAuthorized(props: { authenticated: boolean }) 
   function openDialog() {
     setConfirmationPhrase("");
     setDialogError(null);
+    setDialogStep("reason");
+    setExitReason(null);
+    setExitNote("");
     setDialogOpen(true);
   }
 
@@ -238,6 +252,15 @@ function HostedDataPrivacySettingsAuthorized(props: { authenticated: boolean }) 
     setDialogOpen(false);
     setConfirmationPhrase("");
     setDialogError(null);
+    setDialogStep("reason");
+    setExitReason(null);
+    setExitNote("");
+  }
+
+  function skipExitReason() {
+    setExitReason(null);
+    setExitNote("");
+    setDialogStep("confirm");
   }
 
   if (!props.authenticated) {
@@ -345,10 +368,12 @@ function HostedDataPrivacySettingsAuthorized(props: { authenticated: boolean }) 
         >
           <DialogHeader className="pr-10">
             <DialogTitle className="font-serif text-2xl/7 font-semibold tracking-normal text-foreground">
-              Delete account
+              {dialogStep === "reason" ? "Before you go" : "Delete account"}
             </DialogTitle>
             <DialogDescription className="text-sm leading-6 text-muted-foreground">
-              Permanently deletes your account and all your data, including your subscription and login. This cannot be undone.
+              {dialogStep === "reason"
+                ? "Could you let us know why you're leaving? This is optional and it won't hold up your deletion."
+                : "Permanently deletes your account and all your data, including your subscription and login. This cannot be undone."}
             </DialogDescription>
           </DialogHeader>
           {dialogError ? (
@@ -356,34 +381,47 @@ function HostedDataPrivacySettingsAuthorized(props: { authenticated: boolean }) 
               {dialogError}
             </p>
           ) : null}
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="hosted-account-delete-phrase">Type <span className="font-mono">{HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE}</span> to confirm</Label>
-            <Input
-              autoComplete="off"
-              className="h-12 text-base"
-              disabled={deletePending}
-              id="hosted-account-delete-phrase"
-              inputMode="text"
-              value={confirmationPhrase}
-              onChange={(event) => setConfirmationPhrase(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  void handleDeleteConfirmed();
-                }
-              }}
-              aria-invalid={confirmationPhrase.length > 0 && !phraseMatches}
-              placeholder={HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE}
+          {dialogStep === "reason" ? (
+            <AccountExitReasonStep
+              note={exitNote}
+              reason={exitReason}
+              onContinue={() => setDialogStep("confirm")}
+              onNoteChange={setExitNote}
+              onReasonChange={setExitReason}
+              onSkip={skipExitReason}
             />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Button type="button" size="xl" variant="destructive" onClick={() => void handleDeleteConfirmed()} disabled={!deleteReady} className="w-full">
-              {deletePending ? "Deleting..." : "Delete account"}
-            </Button>
-            <Button type="button" size="xl" variant="ghost" onClick={closeDialog} disabled={deletePending} className="w-full">
-              Cancel
-            </Button>
-          </div>
+          ) : (
+            <>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="hosted-account-delete-phrase">Type <span className="font-mono">{HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE}</span> to confirm</Label>
+                <Input
+                  autoComplete="off"
+                  className="h-12 text-base"
+                  disabled={deletePending}
+                  id="hosted-account-delete-phrase"
+                  inputMode="text"
+                  value={confirmationPhrase}
+                  onChange={(event) => setConfirmationPhrase(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      void handleDeleteConfirmed();
+                    }
+                  }}
+                  aria-invalid={confirmationPhrase.length > 0 && !phraseMatches}
+                  placeholder={HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Button type="button" size="xl" variant="destructive" onClick={() => void handleDeleteConfirmed()} disabled={!deleteReady} className="w-full">
+                  {deletePending ? "Deleting..." : "Delete account"}
+                </Button>
+                <Button type="button" size="xl" variant="ghost" onClick={closeDialog} disabled={deletePending} className="w-full">
+                  Cancel
+                </Button>
+              </div>
+            </>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/web/src/lib/hosted-onboarding/shared.ts
+++ b/apps/web/src/lib/hosted-onboarding/shared.ts
@@ -103,6 +103,10 @@ export function generateHostedVaultShareId(): string {
   return `hbvs_${randomBytes(12).toString("base64url")}`;
 }
 
+export function generateHostedAccountExitReasonId(): string {
+  return `haer_${randomBytes(12).toString("base64url")}`;
+}
+
 export function generateHostedFamilyCheckoutAttemptId(): string {
   return `hbfca_${randomBytes(12).toString("base64url")}`;
 }

--- a/apps/web/src/lib/hosted-privacy/account-data-service.ts
+++ b/apps/web/src/lib/hosted-privacy/account-data-service.ts
@@ -1,4 +1,4 @@
-import { Prisma, type PrismaClient } from "@prisma/client";
+import { type HostedBillingStatus, Prisma, type PrismaClient } from "@prisma/client";
 
 import { sanitizeHostedRuntimeErrorCode } from "@murphai/device-syncd/hosted-runtime";
 import { isDeviceSyncError } from "@murphai/device-syncd/errors";
@@ -25,7 +25,10 @@ import { readHostedAccountGroupStripeBillingRef } from "../hosted-onboarding/fam
 import { deleteHostedPrivyUser } from "../hosted-onboarding/privy";
 import { buildHostedLinqInviteSignupEffectIdMemberPrefix } from "../hosted-onboarding/linq-invite-signup-effect-id";
 import { getHostedOnboardingStripe } from "../hosted-onboarding/runtime";
-import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from "../hosted-onboarding/shared";
+import {
+  generateHostedAccountExitReasonId,
+  HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+} from "../hosted-onboarding/shared";
 import {
   assertHostedUsageCreditPurchasesReadyForAccountDeletionTx,
   closeHostedUsageCreditPurchasesForAccountDeletion,
@@ -44,6 +47,9 @@ import {
 import {
   HOSTED_ACCOUNT_DATA_DELETION_SCHEMA,
   HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+  HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH,
+  type HostedAccountExitReasonCode,
+  isHostedAccountExitReasonCode,
 } from "./account-data-shared";
 
 export type HostedAccountStoreDeletionMode =
@@ -468,6 +474,12 @@ export type HostedAccountDataStoreSlug = typeof HOSTED_ACCOUNT_DATA_STORE_COVERA
 
 export interface HostedAccountDeletionRequest {
   confirmationPhrase: typeof HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE;
+  exitFeedback: HostedAccountExitFeedback | null;
+}
+
+export interface HostedAccountExitFeedback {
+  note: string | null;
+  reason: HostedAccountExitReasonCode;
 }
 
 export interface HostedAccountDataCounts {
@@ -553,16 +565,40 @@ export function parseHostedAccountDeletionRequest(
 
   return {
     confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+    exitFeedback: parseHostedAccountExitFeedback(body),
+  };
+}
+
+/**
+ * Reads the optional "why are you leaving" answer. Deliberately lenient: an
+ * absent, unknown, or malformed answer resolves to null instead of throwing,
+ * because nothing about this optional survey may block someone from deleting
+ * their own account. Nothing is authorized off these values.
+ */
+export function parseHostedAccountExitFeedback(
+  body: Record<string, unknown>,
+): HostedAccountExitFeedback | null {
+  if (!isHostedAccountExitReasonCode(body.exitReason)) {
+    return null;
+  }
+
+  const rawNote = typeof body.exitNote === "string" ? body.exitNote.trim() : "";
+  const note = rawNote.slice(0, HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH);
+
+  return {
+    note: note.length > 0 ? note : null,
+    reason: body.exitReason,
   };
 }
 
 export async function deleteHostedAccountData(input: {
+  exitFeedback?: HostedAccountExitFeedback | null;
   memberId: string;
   prisma: PrismaClient;
   request: Request;
 }): Promise<HostedAccountDeletionResult> {
   const member = await input.prisma.hostedMember.findUnique({
-    select: { id: true },
+    select: { billingStatus: true, createdAt: true, id: true },
     where: { id: input.memberId },
   });
 
@@ -722,6 +758,15 @@ export async function deleteHostedAccountData(input: {
   const deletedRuntimeMemberIds = databaseDeletion.deletedRuntimeMemberIds.length > 0
     ? databaseDeletion.deletedRuntimeMemberIds
     : deletionMemberIds;
+  // Recorded only once the member's rows are actually gone, so a deletion that
+  // failed part way through never leaves a phantom exit in the churn record.
+  await recordHostedAccountExitReasonBestEffort({
+    billingStatus: member.billingStatus,
+    feedback: input.exitFeedback ?? null,
+    memberCreatedAt: member.createdAt,
+    now: deletionStartedAt,
+    prisma: input.prisma,
+  });
   await Promise.all(deletedRuntimeMemberIds.map((memberId) =>
     terminateHostedUserRuntimeWorkflowBestEffort({
       reason: "account-deleted",
@@ -762,6 +807,49 @@ export async function deleteHostedAccountData(input: {
       stripeSubscription,
     },
   };
+}
+
+/**
+ * Persists the optional exit answer. Best effort on purpose: the account is
+ * already deleted by this point, and losing one survey row is strictly better
+ * than failing a completed deletion. The free-text note is never logged, since
+ * it is whatever the departing member chose to type.
+ */
+async function recordHostedAccountExitReasonBestEffort(input: {
+  billingStatus: HostedBillingStatus;
+  feedback: HostedAccountExitFeedback | null;
+  memberCreatedAt: Date;
+  now: Date;
+  prisma: PrismaClient;
+}): Promise<void> {
+  if (!input.feedback) {
+    return;
+  }
+
+  try {
+    await input.prisma.hostedAccountExitReason.create({
+      data: {
+        billingStatus: input.billingStatus,
+        id: generateHostedAccountExitReasonId(),
+        note: input.feedback.note,
+        reason: input.feedback.reason,
+        tenureDays: countWholeDaysBetween(input.memberCreatedAt, input.now),
+      },
+    });
+  } catch (error) {
+    console.error(
+      `[hosted-privacy] Exit reason capture failed after account deletion (errorCode=${safeErrorCode(error)}).`,
+    );
+  }
+}
+
+function countWholeDaysBetween(startedAt: Date, endedAt: Date): number {
+  const elapsedMs = endedAt.getTime() - startedAt.getTime();
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) {
+    return 0;
+  }
+
+  return Math.floor(elapsedMs / (24 * 60 * 60 * 1000));
 }
 
 async function deleteHostedComputerUseExternalStateForAccountDeletion(input: {

--- a/apps/web/src/lib/hosted-privacy/account-data-shared.ts
+++ b/apps/web/src/lib/hosted-privacy/account-data-shared.ts
@@ -1,3 +1,28 @@
 export const HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE = "DELETE MY ACCOUNT";
 export const HOSTED_ACCOUNT_DATA_DELETION_SCHEMA = "murph.hosted-account-data-deletion-result.v2";
 export const HOSTED_ACCOUNT_PRIVACY_REQUEST_BODY_LIMIT_BYTES = 4 * 1024;
+
+/**
+ * The one question we ask on the way out. Answering is optional and never gates
+ * deletion, so both the client and `parseHostedAccountExitFeedback` treat an
+ * absent, unknown, or malformed answer as "skipped" rather than an error.
+ */
+export const HOSTED_ACCOUNT_EXIT_REASONS = [
+  { code: "too_expensive", label: "Too expensive" },
+  { code: "not_useful_enough", label: "Not useful enough" },
+  { code: "too_many_texts", label: "Texts too much" },
+  { code: "privacy_concerns", label: "Privacy concerns" },
+  { code: "setup_trouble", label: "Couldn't get it working" },
+  { code: "just_testing", label: "Just testing, or I made a second account" },
+] as const;
+
+export type HostedAccountExitReasonCode =
+  (typeof HOSTED_ACCOUNT_EXIT_REASONS)[number]["code"];
+
+export const HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH = 500;
+
+export function isHostedAccountExitReasonCode(
+  value: unknown,
+): value is HostedAccountExitReasonCode {
+  return HOSTED_ACCOUNT_EXIT_REASONS.some((reason) => reason.code === value);
+}

--- a/apps/web/test/account-exit-reason-step.test.tsx
+++ b/apps/web/test/account-exit-reason-step.test.tsx
@@ -1,0 +1,103 @@
+import { act, createElement } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { AccountExitReasonStep } from "@/src/components/settings/account-exit-reason-step";
+import {
+  HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH,
+  HOSTED_ACCOUNT_EXIT_REASONS,
+} from "@/src/lib/hosted-privacy/account-data-shared";
+
+import { renderClientComponent } from "./render-client-component";
+
+let cleanupRender: (() => Promise<void>) | null = null;
+
+afterEach(async () => {
+  await cleanupRender?.();
+  cleanupRender = null;
+});
+
+function noop() {
+  return undefined;
+}
+
+function baseProps() {
+  return {
+    note: "",
+    onContinue: noop,
+    onNoteChange: noop,
+    onReasonChange: noop,
+    onSkip: noop,
+    reason: null,
+  };
+}
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")]
+    .find((candidate) => candidate.textContent?.trim() === label);
+  expect(button, `expected a "${label}" button`).toBeTruthy();
+  return button as HTMLButtonElement;
+}
+
+test("offers every exit reason and keeps skipping available", async () => {
+  const { cleanup, container } = await renderClientComponent(
+    createElement(AccountExitReasonStep, baseProps()),
+    { requireButton: false },
+  );
+  cleanupRender = cleanup;
+
+  for (const option of HOSTED_ACCOUNT_EXIT_REASONS) {
+    expect(container.textContent).toContain(option.label);
+  }
+
+  // Nothing chosen yet: Continue has nothing to send, but leaving must stay
+  // one click away.
+  expect(findButton(container, "Continue").disabled).toBe(true);
+  expect(findButton(container, "Skip").disabled).toBe(false);
+});
+
+test("reveals the note field only once a reason is chosen", async () => {
+  const { cleanup, container, rerender } = await renderClientComponent(
+    createElement(AccountExitReasonStep, baseProps()),
+    { requireButton: false },
+  );
+  cleanupRender = cleanup;
+
+  expect(container.querySelector("textarea")).toBeNull();
+
+  await rerender(createElement(AccountExitReasonStep, {
+    ...baseProps(),
+    reason: "too_expensive" as const,
+  }));
+
+  const textarea = container.querySelector("textarea");
+  expect(textarea).toBeTruthy();
+  // Attribute casing is not normalized by the test DOM, so match either form
+  // rather than assume one. The authoritative cap is enforced server side.
+  expect(textarea?.outerHTML).toMatch(
+    new RegExp(`maxlength="${HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH}"`, "iu"),
+  );
+  expect(findButton(container, "Continue").disabled).toBe(false);
+});
+
+test("reports the chosen reason", async () => {
+  const onReasonChange = vi.fn();
+  const { cleanup, container } = await renderClientComponent(
+    createElement(AccountExitReasonStep, {
+      ...baseProps(),
+      onReasonChange,
+    }),
+    { requireButton: false },
+  );
+  cleanupRender = cleanup;
+
+  const input = container.querySelector<HTMLElement>(
+    "#hosted-account-exit-reason-privacy_concerns",
+  );
+  expect(input).toBeTruthy();
+
+  await act(async () => {
+    input?.click();
+  });
+
+  expect(onReasonChange).toHaveBeenCalledWith("privacy_concerns");
+});

--- a/apps/web/test/hosted-account-data-service.test.ts
+++ b/apps/web/test/hosted-account-data-service.test.ts
@@ -75,6 +75,7 @@ import { HostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import { ComposioConnectedAppsRequestError } from "@/src/lib/connected-apps/composio";
 import {
   HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+  HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH,
 } from "@/src/lib/hosted-privacy/account-data-shared";
 import {
   buildHostedMemberBillingPrivateColumns,
@@ -213,6 +214,21 @@ describe("parseHostedAccountDeletionRequest", () => {
       confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
     })).toEqual({
       confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+      exitFeedback: null,
+    });
+  });
+
+  it("carries an answered exit reason and note", () => {
+    expect(parseHostedAccountDeletionRequest({
+      confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+      exitNote: "  Too many texts on weekends.  ",
+      exitReason: "too_many_texts",
+    })).toEqual({
+      confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+      exitFeedback: {
+        note: "Too many texts on weekends.",
+        reason: "too_many_texts",
+      },
     });
   });
 
@@ -235,6 +251,39 @@ describe("parseHostedAccountDeletionRequest", () => {
     expect(error).toBeInstanceOf(HostedOnboardingError);
     expect((error as HostedOnboardingError).code).toBe(expectedCode);
     expect((error as HostedOnboardingError).httpStatus).toBe(400);
+  });
+
+  // The exit survey is optional telemetry attached to an irreversible privacy
+  // action, so a malformed answer must degrade to "skipped" rather than block
+  // someone from deleting their own account.
+  it.each([
+    ["an unknown reason code", { exitReason: "because_i_said_so" }],
+    ["a non-string reason", { exitReason: 12 }],
+    ["a note with no reason", { exitNote: "orphaned note" }],
+    ["an empty reason", { exitReason: "" }],
+  ])("still deletes, recording no reason, given %s", (_label, extra) => {
+    expect(parseHostedAccountDeletionRequest({
+      confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+      ...extra,
+    })).toEqual({
+      confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+      exitFeedback: null,
+    });
+  });
+
+  it("drops a whitespace-only note and truncates an oversized one", () => {
+    expect(parseHostedAccountDeletionRequest({
+      confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+      exitNote: "   ",
+      exitReason: "privacy_concerns",
+    }).exitFeedback).toEqual({ note: null, reason: "privacy_concerns" });
+
+    const oversized = parseHostedAccountDeletionRequest({
+      confirmationPhrase: HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE,
+      exitNote: "n".repeat(HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH + 50),
+      exitReason: "not_useful_enough",
+    }).exitFeedback;
+    expect(oversized?.note).toHaveLength(HOSTED_ACCOUNT_EXIT_NOTE_MAX_LENGTH);
   });
 });
 

--- a/apps/web/test/hosted-data-privacy-settings.test.ts
+++ b/apps/web/test/hosted-data-privacy-settings.test.ts
@@ -391,6 +391,71 @@ describe("HostedDataPrivacySettings", () => {
     ).toBeLessThan(mocks.requestHostedOnboardingJson.mock.invocationCallOrder[0]);
   });
 
+  test("sends the answered exit reason and note alongside the deletion", async () => {
+    mockHostedDataPrivacyDeleteFlowState({
+      exitNote: "Texts were great, price was not.",
+      exitReason: "too_expensive",
+    });
+
+    const { document, window } = loadLinkedom().parseHTML(
+      "<html><body><div id='root'></div></body></html>",
+    );
+    installGlobals(window, document);
+    const container = document.getElementById("root");
+    assert.ok(container);
+
+    const root: Root = createRoot(container);
+    cleanupRender = async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    };
+
+    await act(async () => {
+      root.render(createElement(HostedDataPrivacySettings, { authenticated: true }));
+    });
+
+    await clickButton(container, "Delete account", window);
+
+    expect(mocks.requestHostedOnboardingJson.mock.calls[0]?.[0]?.payload).toEqual({
+      authorization: {
+        signature: `0x${"11".repeat(65)}`,
+        token: "sac_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+      },
+      confirmationPhrase: "DELETE MY ACCOUNT",
+      exitNote: "Texts were great, price was not.",
+      exitReason: "too_expensive",
+    });
+  });
+
+  test("omits exit fields entirely when the member skips the question", async () => {
+    mockHostedDataPrivacyDeleteFlowState();
+
+    const { document, window } = loadLinkedom().parseHTML(
+      "<html><body><div id='root'></div></body></html>",
+    );
+    installGlobals(window, document);
+    const container = document.getElementById("root");
+    assert.ok(container);
+
+    const root: Root = createRoot(container);
+    cleanupRender = async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    };
+
+    await act(async () => {
+      root.render(createElement(HostedDataPrivacySettings, { authenticated: true }));
+    });
+
+    await clickButton(container, "Delete account", window);
+
+    const payload = mocks.requestHostedOnboardingJson.mock.calls[0]?.[0]?.payload;
+    expect(payload).not.toHaveProperty("exitReason");
+    expect(payload).not.toHaveProperty("exitNote");
+  });
+
   test("allows account deletion to succeed after the vault receiver lease window", async () => {
     vi.useFakeTimers();
     mockHostedDataPrivacyDeleteFlowState();
@@ -644,8 +709,8 @@ describe("HostedDataPrivacySettings", () => {
 
 // Values follow the component's useState declaration order:
 // exportPending, exportDialogOpen, acknowledgedSensitiveDownload, exportDialogError,
-// exportSuccess, deletePending, dialogOpen, confirmationPhrase, dialogError, deleted,
-// cleanupPending, privyLogoutDone.
+// exportSuccess, deletePending, dialogOpen, dialogStep, exitReason, exitNote,
+// confirmationPhrase, dialogError, deleted, cleanupPending, privyLogoutDone.
 function mockHostedVaultExportFlowState(input: {
   acknowledgedSensitiveDownload?: boolean;
 } = {}) {
@@ -657,6 +722,9 @@ function mockHostedVaultExportFlowState(input: {
     null,
     false,
     false,
+    "reason",
+    null,
+    "",
     "",
     null,
     false,
@@ -667,6 +735,8 @@ function mockHostedVaultExportFlowState(input: {
 
 function mockHostedDataPrivacyDeleteFlowState(input: {
   confirmationPhrase?: string;
+  exitNote?: string;
+  exitReason?: string | null;
 } = {}) {
   mocks.useStateValues = [
     false,
@@ -676,6 +746,11 @@ function mockHostedDataPrivacyDeleteFlowState(input: {
     null,
     false,
     true,
+    // These tests exercise the confirmation step, so start past the optional
+    // exit-reason step unless a case opts into an answered reason.
+    "confirm",
+    input.exitReason ?? null,
+    input.exitNote ?? "",
     input.confirmationPhrase ?? "DELETE MY ACCOUNT",
     null,
     false,
@@ -693,6 +768,9 @@ function mockHostedDataPrivacyDeletedState() {
     null,
     false,
     false,
+    "reason",
+    null,
+    "",
     "",
     null,
     true,

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -882,6 +882,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260720173000_hosted_assistant_persona",
       "20260720230000_hosted_group_usage_funding",
       "20260721160000_clinical_retrieval_wire_identity",
+      "20260724160000_hosted_account_exit_reason",
       "migration_lock.toml",
     ]);
     expect(hostedMailboxSubscriptionActionClaimMigrationSql).toContain(


### PR DESCRIPTION
## Why this exists

Account deletion cascades every member-keyed row. When two accounts were deleted on 2026-07-23 — the only two deletions in Stripe's 30-day event history, ten minutes apart — nothing survived that could explain why. Member rows were gone, Stripe scrubbed the customer emails, the Privy users were deleted, and platform request logs aged out inside 24 hours. The churn was unanswerable, and would have stayed that way for every future exit.

This adds the one question that makes it answerable, without weakening the deletion itself.

## User-visible goal and UX

The delete-account dialog gains a first step: **"Before you go"**, with six reasons and an optional note, then **Continue** or **Skip**. The existing confirmation-phrase step is unchanged and still the only thing that performs the deletion.

Answering is optional in the strong sense:

- **Skip** is always enabled and goes straight to the confirmation step.
- **Continue** is disabled until a reason is picked, so it never submits nothing.
- The note field appears only after a reason is chosen, so a written note always arrives attached to one.
- A malformed or unknown answer degrades to "no answer" instead of erroring, because nothing about an optional survey may block someone from deleting their own account.

Reasons offered: too expensive · not useful enough · texts too much · privacy concerns · couldn't get it working · just testing, or I made a second account.

The last one earns its place: it lets people self-identify as noise, so genuine churn is not mixed with test accounts.

## Invariants

- **Deletion is never gated on feedback.** Lenient parsing, plus a best-effort write wrapped in its own try/catch. Losing a survey row is strictly better than failing a completed deletion.
- **The record outlives the cascade.** `hosted_account_exit_reason` has no member relation and no member id, so it survives the deletion that removes every member-keyed record. That absence is the entire point and is documented in both the model and the migration.
- **Not re-identifiable.** Retained context is deliberately coarse: plan state and whole days of tenure. No member id, no contact details.
- **The note is never logged.** It is free text the departing member wrote; it stays out of logs and error messages.
- **Written only after the member's rows are actually gone**, so a deletion that failed part way through never leaves a phantom exit in the churn record.

## Verification

- `pnpm test:diff` across the four touched test files: **507 files / 6369 tests passed, exit 0**.
- `pnpm typecheck`: exit 0. `pnpm lint`: exit 0 (12 pre-existing warnings, none in touched files).
- Migration proof: applied all 119 migrations to a fresh database (`prisma migrate deploy`, exit 0), then `prisma migrate diff` against the schema — the new table and enum show **no drift**. The 22 reported drift entries are pre-existing index-name truncations in `clinical_record_*` / `device_sync_*`, untouched here.
- New coverage: exit-reason step rendering and interaction, payload wiring for both answered and skipped paths, and lenient-parse cases (unknown code, non-string, note without reason, oversized note).

Note: `apps/web/test/hosted-preference-handoff-sweeper.test.ts` failed once mid-run and passed on re-run with the same tree. It is timing-dependent and unrelated to this diff.

## Change shape

| Source | Added | Deleted |
| --- | --- | --- |
| Source | ~200 | ~10 |
| Tests | ~215 | ~5 |
| Config/tooling (schema + migration) | ~55 | 0 |

Classification: `src/`, `app/`, and `prisma/schema.prisma` model code counted as source; `test/` as tests; migration SQL as config/tooling. No generated or binary files.

## Design proof

- Design page: `/design?tab=sections` → "Account deletion exit reason" (`apps/web/app/design/sections-content.tsx`)
- Desktop screenshot: _drop `design-exit-reason-desktop.png` here_
- Mobile screenshot: _drop `design-exit-reason-mobile.png` here_

Captured at 1440x1200 @2x and 390x844 @3x against the real component on the Sections tab. Hosted upload is blocked: `CLOUDFLARE_IMAGES_API_KEY` is not present in the project environment (only `CLOUDFLARE_IMAGES_ACCOUNT_ID`), so no `https://imagedelivery.net/...` URL can be produced locally. Per `agent-docs/operations/completion-workflow.md` that credential gap is reported rather than worked around by committing proof images.

Rendering the page paid for itself: it caught the radio centering against a two-line label at narrow widths, and a catalog frame wider than the `max-w-md` the dialog actually uses. Both fixed in 46d66aa65b.

## Outstanding gates

These could not run and are owed before merge:

- **Preliminary `completion-specialists` ReviewGPT pass** — ReviewGPT is stalling at draft-staging on every lane today.
- **Local `product-experience-review`** — this change does trigger it (new user-facing copy, a new required interaction step, new UI state). The non-Codex-parent route for that pass needs the Codex CLI, and all Codex homes are quota-capped until ~Jul 28.
- **Hosted desktop and mobile `/design` screenshots.** The study is registered on the Sections tab as "Account deletion exit reason" and renders the real component, but the captures are not attached yet.

Opened as a draft for that reason.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787515872&installation_model_id=19880&pr_number=926&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F926&signature=14c7f066a2ed2fd65ffdbec2958729c994fe37679bc6c9135d126616b9ffc584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
