### PR TITLE
Name the inbound timestamp as the group pace signal

### DIFF
--- a/packages/assistant-engine/skills/group-chat/SKILL.md
+++ b/packages/assistant-engine/skills/group-chat/SKILL.md
@@ -235,12 +235,14 @@ outcome. Do not wait when someone needs an answer now, and do not miss a beat
 that is yours: a comedic interjection can be better precisely because it lands
 immediately.
 
-Each inbound message carries an `Occurred at:` time, and the ones before it stay
-visible earlier in this conversation. The gaps between those times are how you
-tell what the room is doing: a few seconds apart means it is live and
-mid-volley; a long quiet stretch before the newest message means you are
-catching up, or someone has been waiting on you. When those times are missing
-or ambiguous, do not wait.
+Every turn opens with an `Occurred at:` time — a single timestamp, or a
+first-to-last range when several messages arrived together — and earlier turns
+keep theirs above in this conversation. Read them to tell what the room is
+doing: times a few seconds apart, or a range whose whole span is only a few
+seconds, mean the room is live and mid-volley. A long stretch before the newest
+message means you are catching up, or someone has been waiting on you. A wide
+range hides the gap that matters, so treat it as ambiguous. When the times are
+missing or ambiguous, do not wait.
 
 Two rhythms, both normal. **Catching up:** you were away and a lot happened —
 read it, react to what deserves it, reply to the one or two things actually

--- a/packages/assistant-engine/skills/group-chat/SKILL.md
+++ b/packages/assistant-engine/skills/group-chat/SKILL.md
@@ -235,6 +235,13 @@ outcome. Do not wait when someone needs an answer now, and do not miss a beat
 that is yours: a comedic interjection can be better precisely because it lands
 immediately.
 
+Each inbound message carries an `Occurred at:` time, and the ones before it stay
+visible earlier in this conversation. The gaps between those times are how you
+tell what the room is doing: a few seconds apart means it is live and
+mid-volley; a long quiet stretch before the newest message means you are
+catching up, or someone has been waiting on you. When those times are missing
+or ambiguous, do not wait.
+
 Two rhythms, both normal. **Catching up:** you were away and a lot happened —
 read it, react to what deserves it, reply to the one or two things actually
 meant for you, and let the rest go. Nobody writes a recap of what they missed.

--- a/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
@@ -217,6 +217,25 @@ describe('assistant group-chat style guidance', () => {
     }
   })
 
+  it('names the inbound timestamp as the signal for what the room is doing', async () => {
+    const normalized = await readNormalizedGroupChatSkill()
+
+    // Every auto-reply prompt already carries an `Occurred at:` header
+    // (buildAssistantAutoReplyContextLines). Without naming it, judging
+    // "mid-volley" falls back to guessing from message content.
+    expect(normalized).toContain(
+      'Each inbound message carries an `Occurred at:` time, and the ones before it stay visible earlier in this conversation.',
+    )
+    expect(normalized).toContain(
+      'a few seconds apart means it is live and mid-volley; a long quiet stretch before the newest message means you are catching up, or someone has been waiting on you.',
+    )
+    // A cold thread or a compacted one may not expose earlier times; the safe
+    // default is to answer rather than sit on a reply.
+    expect(normalized).toContain(
+      'When those times are missing or ambiguous, do not wait.',
+    )
+  })
+
   it('carries the catching-up, live-room, and share-of-voice rhythms', async () => {
     const normalized = await readNormalizedGroupChatSkill()
 

--- a/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-group-chat-style-skill.test.ts
@@ -220,19 +220,26 @@ describe('assistant group-chat style guidance', () => {
   it('names the inbound timestamp as the signal for what the room is doing', async () => {
     const normalized = await readNormalizedGroupChatSkill()
 
-    // Every auto-reply prompt already carries an `Occurred at:` header
-    // (buildAssistantAutoReplyContextLines). Without naming it, judging
-    // "mid-volley" falls back to guessing from message content.
+    // buildAssistantAutoReplyContextLines emits ONE `Occurred at:` per turn —
+    // a single time, or a first-to-last range when inputs were grouped. The
+    // guidance must describe that contract and never claim a per-message
+    // timestamp, which the prompt builder does not render.
     expect(normalized).toContain(
-      'Each inbound message carries an `Occurred at:` time, and the ones before it stay visible earlier in this conversation.',
+      'Every turn opens with an `Occurred at:` time — a single timestamp, or a first-to-last range when several messages arrived together — and earlier turns keep theirs above in this conversation.',
     )
+    expect(normalized).not.toContain('Each inbound message carries an')
     expect(normalized).toContain(
-      'a few seconds apart means it is live and mid-volley; a long quiet stretch before the newest message means you are catching up, or someone has been waiting on you.',
+      'times a few seconds apart, or a range whose whole span is only a few seconds, mean the room is live and mid-volley.',
+    )
+    // A wide grouped range cannot expose the gap immediately before the newest
+    // message, so it must not be read as evidence either way.
+    expect(normalized).toContain(
+      'A wide range hides the gap that matters, so treat it as ambiguous.',
     )
     // A cold thread or a compacted one may not expose earlier times; the safe
     // default is to answer rather than sit on a reply.
     expect(normalized).toContain(
-      'When those times are missing or ambiguous, do not wait.',
+      'When the times are missing or ambiguous, do not wait.',
     )
   })
 


### PR DESCRIPTION
## Why this PR exists

Follow-up to #906. That PR taught Murph to watch a live group room instead of replying instantly — but the instruction "notice whether the room is still mid-volley" never said *how* to notice. Judging pace was left to inference from message content.

## User goal / user-visible behavior

Murph waits when the room is genuinely mid-conversation and answers promptly when it is not, grounded in a real signal rather than a guess. No user-visible surface changes; this makes the existing waiting behavior fire in the right situations more often.

## What changed

Every auto-reply prompt already prepends an `Occurred at:` header (`buildAssistantAutoReplyContextLines` in `automation/prompt-builder.ts`), and because a group chat is a persistent thread, earlier messages keep their own headers in context. The signal was always present and simply unnamed.

The group-chat skill now names it, and states the contract truthfully: `Occurred at:` is emitted once per turn — a single timestamp, or a first-to-last range when several messages arrived grouped — with earlier turns keeping theirs above in the thread. Times a few seconds apart, or a range whose whole span is only a few seconds, mean the room is live. A long stretch before the newest message means Murph is catching up or someone has been waiting. A wide range hides the gap that actually matters, so it is treated as ambiguous. When times are missing or ambiguous — a cold thread, compacted context, or a wide grouped range — the instruction is to not wait, so the safe default is answering rather than sitting on a reply.

This also sharpens the catching-up vs live-room distinction from #906, which is itself a timing distinction.

## User experience

Entry point unchanged: group members text over iMessage/Telegram. Timing class unchanged — Murph still waits only a few seconds when it elects to, and the pre-existing provider stall watchdog and turn abort remain the backstops. The only change is that the wait/answer decision is now anchored to observable message times instead of inferred from content. Failure mode is fail-safe: absent or ambiguous timestamps mean do not wait.

## Lens declarations

- **prompt: applicable** — group-chat SKILL.md text only; static thread-stable content.
- **frontend: not applicable** — no `apps/web` change.
- **coverage: applicable** — `pnpm test:diff` over the touched paths.

## Verification

- `pnpm --dir packages/assistant-engine typecheck`: pass.
- `assistant-group-chat-style-skill.test.ts`: 14 passed, including new assertions that the skill names `Occurred at:`, states the live-versus-quiet reading, and carries the fail-safe "when those times are missing or ambiguous, do not wait".
- `pnpm test:diff` over the touched paths: see checks.

## Invariants

- No new field, plumbing, or runtime surface: the timestamp is already in every prompt.
- Group scope only; DM behavior untouched.
- No new persisted state, tool, scheduler, or owner.
- Fail-safe default: missing or ambiguous times mean answer, never wait.

## Change shape

- source: +9 / -2 (prompt text)
- tests: +26 / -10
- docs: 0 / 0; config/tooling: 0 / 0; generated/other: 0 / 0
- Rule: classified by file path. No binary files.

DEPLOYMENT CONCERNS: assistant-engine ships in the Cloudflare runner bundle; deploy `apps/cloudflare` normally, no `apps/web` ordering constraint. Warm runner containers keep prior prompt text until recycled. Post-deploy, fold into the #906 group smoke: confirm Murph stays quiet during a fast unaddressed volley and answers promptly when the room has been quiet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787520715&installation_model_id=19880&pr_number=928&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F928&signature=cd365d00650d59e6fef12a4c42602503e85274c6bde0fdeb2e87914d740b83e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Preliminary specialist pass

Ran `completion-specialists` (prompt + coverage lenses; frontend not applicable) at 8219006. One medium prompt finding, **accepted and fixed**: the first draft asserted that *each inbound message* carries its own `Occurred at:` time. `buildAssistantAutoReplyContextLines` actually emits one header per turn — a single time or a first-to-last range — and `renderAssistantAutoReplyInputSection` renders no per-input time, so grouped batches (still possible via `collectAssistantAutoReplyGroup`) cannot expose the gap immediately before the newest message. Two batches with very different last beats can show the same range. The guidance now states the real contract and routes a wide range to the existing do-not-wait fallback rather than treating it as evidence; the test that pinned the false premise is replaced with one pinning the true contract plus the wide-range-is-ambiguous rule. No coverage patch was offered or applied.
