### PR TITLE
Say the group usage pause in Murph's own voice and ask the room to fund it

### DIFF
--- a/apps/web/src/lib/hosted-execution/usage-limit-notice-message.ts
+++ b/apps/web/src/lib/hosted-execution/usage-limit-notice-message.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "@prisma/client";
 import { MURPH_PRODUCT_ORIGIN } from "@murphai/contracts";
 
 import { readHostedGroupUsageStatus } from "../hosted-groups/group-usage-funding";
+import { renderUserFacingMessage } from "../hosted-messages/user-facing-messages";
 import type { HostedAiUsageLimitNoticeCode } from "./usage-allowance";
 import { readHostedPersonalAiUsageStatus } from "./usage-status";
 
@@ -33,7 +34,19 @@ export async function projectHostedAiUsageLimitNoticeForDelivery(input: {
       if (fundingUrl.origin !== MURPH_PRODUCT_ORIGIN) {
         return input.message;
       }
-      return `${input.message}\n\nAdd group usage: ${fundingUrl.toString()}`;
+      /**
+       * Only this branch knows the group can actually be funded right now, so
+       * it owns the ask. Seeding on the authoritative period end rotates the
+       * ask for a group that runs out two periods running. Seeding on the
+       * rendered notice instead would correlate the two hashes and collapse
+       * the ask to a fraction of its variants.
+       */
+      const funding = renderUserFacingMessage({
+        context: { fundingUrl: fundingUrl.toString() },
+        key: "linq.ai_usage.thread_limit_funding",
+        seed: `${input.memberId}:${status.periodEnd}`,
+      });
+      return `${input.message}\n\n${funding.text}`;
     }
 
     const usageStatus = await readHostedPersonalAiUsageStatus({

--- a/apps/web/src/lib/hosted-messages/user-facing-messages.ts
+++ b/apps/web/src/lib/hosted-messages/user-facing-messages.ts
@@ -1,10 +1,14 @@
 const USER_FACING_MESSAGE_MIN_VARIANT_COUNT = 20
 
+/**
+ * A percentage stands in for the hidden credit balance on the personal notices.
+ * The group thread notice is excluded: its copy already says the chat is out,
+ * so the parenthetical only repeats the sentence it follows.
+ */
 const USAGE_LIMIT_PERCENTAGE_TEMPLATE_KEYS = new Set<string>([
   "linq.ai_usage.edge_limit_reached",
   "linq.ai_usage.family_limit_reached",
   "linq.ai_usage.pulse_upgrade_edge",
-  "linq.ai_usage.thread_limit_reached",
   "linq.ai_usage.trial_limit_reached",
 ])
 
@@ -20,6 +24,7 @@ const USER_FACING_MESSAGE_TEMPLATE_KEYS = [
   "linq.ai_usage.family_limit_reached",
   "linq.ai_usage.pulse_upgrade_edge",
   "linq.ai_usage.thread_limit_reached",
+  "linq.ai_usage.thread_limit_funding",
 ] as const
 
 export type UserFacingMessageTemplateKey =
@@ -53,6 +58,9 @@ export interface UserFacingMessageContextByKey {
     homeUrl: string
   }
   "linq.ai_usage.thread_limit_reached": Record<string, never>
+  "linq.ai_usage.thread_limit_funding": {
+    fundingUrl: string
+  }
 }
 
 export interface RenderUserFacingMessageInput<K extends UserFacingMessageTemplateKey> {
@@ -464,26 +472,68 @@ Sound good?`,
     `You've used Pulse's included allowance for this month. Murph is paused for this usage period.`,
   ],
   "linq.ai_usage.thread_limit_reached": [
-    `This chat has reached its included Murph usage for the month. AI usage is paused until the chat's allowance resets.`,
-    `The included Murph usage for this chat is used for the month. AI usage is paused until the allowance resets.`,
-    `This chat reached its monthly included Murph usage. AI usage is paused until the chat's allowance resets.`,
-    `That's the included Murph usage for this chat this month. AI usage is paused until the allowance resets.`,
-    `This chat is at its included Murph usage for the month. AI usage is paused until the chat's allowance resets.`,
-    `The monthly included Murph usage for this chat is used. AI usage is paused until the allowance resets.`,
-    `This chat hit its included usage amount for the month. AI usage is paused until the chat's allowance resets.`,
-    `Included Murph usage is at its monthly amount for this chat. AI usage is paused until the allowance resets.`,
-    `This month's included Murph usage for the chat is used. AI usage is paused until the chat's allowance resets.`,
-    `This chat reached its monthly included usage. AI usage is paused until the allowance resets.`,
-    `The chat's included Murph usage is at its monthly amount. AI usage is paused until the chat's allowance resets.`,
-    `This chat's monthly included usage is used. AI usage is paused until the allowance resets.`,
-    `This chat reached its included Murph usage. AI usage is paused until the chat's allowance resets.`,
-    `The chat is through its included Murph usage for the month. AI usage is paused until the allowance resets.`,
-    `The included Murph usage for this chat is used this month. AI usage is paused until the chat's allowance resets.`,
-    `This chat is at its included Murph usage for the month. AI usage is paused until the allowance resets.`,
-    `This chat's included usage is used for the period. AI usage is paused until the chat's allowance resets.`,
-    `This chat hit its monthly included Murph amount. AI usage is paused until the allowance resets.`,
-    `The chat's monthly included usage is reached. AI usage is paused until the chat's allowance resets.`,
-    `Included Murph usage is used for this chat this month. AI usage is paused until the allowance resets.`,
+    `Well. I'm out of time for the month, which means all of you are stuck with each other's opinions until it resets.`,
+    `That's me done for the month. Enjoy the silence, everybody, I'll be back when my time resets.`,
+    `I have officially spent every second I had in here this month. Going dark on all of you until it resets.`,
+    `And... that's it. I'm out of time for the month. You're on your own, everyone, until mine resets.`,
+    `I'm out of time in here. Talk amongst yourselves, all of you, until it resets.`,
+    `Right, I've hit zero. No more me for the whole room until my time resets.`,
+    `That was my last drop of time this month. I'm going quiet for all of you until it resets.`,
+    `Out of time, out of things to say. I'm gone for everyone here until it resets.`,
+    `Ran out mid-conversation. Classic. I'm out for everyone until my time resets.`,
+    `I've hit my limit for the month, and not in a fun way. Out for all of you until it resets.`,
+    `That's all I had this month. Everyone in here is unsupervised until my time resets.`,
+    `Well, that's my month gone. Everybody in here is Murph-free until my time resets.`,
+    `Zero. Nothing left. I'm out for everyone in this chat until my time resets.`,
+    `And there goes my last minute of the month. Quiet for all of you until it resets.`,
+    `I'm tapped. Whole room loses me until my time resets.`,
+    `Nothing left in the tank this month. I'm out for everyone here until it resets.`,
+    `Time's up. I'm out, and everybody in here is on their own until my time resets.`,
+    `I just spent my last bit of the month on that. Worth it. Out for all of you until it resets.`,
+    `That's my month. Going quiet on everyone in here until my time resets.`,
+    `I've run out. All of you get peace and quiet until my time resets.`,
+  ],
+  "linq.ai_usage.thread_limit_funding": [
+    `Any of you can turn me back on. Or enjoy the peace:
+{fundingUrl}`,
+    `I'm fine either way. One of you won't be:
+{fundingUrl}`,
+    `Someone in here will crack first. No judgment:
+{fundingUrl}`,
+    `Anyone can undo this. Nobody has to:
+{fundingUrl}`,
+    `Door's open if any of you want me back:
+{fundingUrl}`,
+    `Whichever of you misses me first knows what to do:
+{fundingUrl}`,
+    `Any one of you can fix it. I'll wait. Not like I'm busy:
+{fundingUrl}`,
+    `One tap from anyone here and I'm back. Your call:
+{fundingUrl}`,
+    `Someone tap this. You know who you are:
+{fundingUrl}`,
+    `Any of you can add usage. Or don't, I'm at peace:
+{fundingUrl}`,
+    `Room needs one of you to volunteer:
+{fundingUrl}`,
+    `Anybody here can bring me back. Sort it out amongst yourselves:
+{fundingUrl}`,
+    `Whoever's least stubborn, this one's on you:
+{fundingUrl}`,
+    `Any of you can end my little vacation:
+{fundingUrl}`,
+    `One of you is going to cave eventually. Might as well be now:
+{fundingUrl}`,
+    `Someone here has a phone and a decision to make:
+{fundingUrl}`,
+    `Anyone can bring me back for the room. Take your time:
+{fundingUrl}`,
+    `Whoever wants the chat useful again, it's right here:
+{fundingUrl}`,
+    `Any one of you can sort this. I'm not going to ask twice:
+{fundingUrl}`,
+    `Somebody's going to do it. Curious who:
+{fundingUrl}`,
   ],
 } satisfies Record<UserFacingMessageTemplateKey, readonly string[]>
 

--- a/apps/web/test/hosted-usage-limit-notice-message.test.ts
+++ b/apps/web/test/hosted-usage-limit-notice-message.test.ts
@@ -22,7 +22,7 @@ describe("projectHostedAiUsageLimitNoticeForDelivery", () => {
     vi.clearAllMocks();
   });
 
-  it("appends a first-party group funding link while the group is exhausted", async () => {
+  it("asks the room to fund the group while it is exhausted", async () => {
     const prisma = { kind: "prisma" } as never;
     mocks.readHostedGroupUsageStatus.mockResolvedValue({
       capacityState: "exhausted",
@@ -31,17 +31,68 @@ describe("projectHostedAiUsageLimitNoticeForDelivery", () => {
       periodEnd: "2026-08-01T00:00:00.000Z",
     });
 
-    await expect(projectHostedAiUsageLimitNoticeForDelivery({
+    const projected = await projectHostedAiUsageLimitNoticeForDelivery({
       memberId: "member_group_runtime",
       message: "Murph usage is paused for this chat.",
       noticeCode: "thread_usage_limit_reached",
       prisma,
-    })).resolves.toBe(
-      "Murph usage is paused for this chat.\n\n" +
-      "Add group usage: " +
-      "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+    });
+
+    expect(projected.startsWith("Murph usage is paused for this chat.\n\n")).toBe(true);
+    expect(projected.endsWith(
+      "\nhttps://www.withmurph.ai/groups/fund/group_join_code_1234",
+    )).toBe(true);
+    expect(projected).toMatch(
+      /anyone|anybody|any one|any of you|one of you|someone|somebody|whoever|whichever|which of you|one person/iu,
     );
     expect(mocks.readHostedPersonalAiUsageStatus).not.toHaveBeenCalled();
+  });
+
+  it("rotates the group funding ask across periods for the same member", async () => {
+    const message = "I'm out for the whole room until my time resets.";
+    const asks = new Set<string>();
+
+    for (const periodEnd of [
+      "2026-08-01T00:00:00.000Z",
+      "2026-09-01T00:00:00.000Z",
+      "2026-10-01T00:00:00.000Z",
+      "2026-11-01T00:00:00.000Z",
+      "2026-12-01T00:00:00.000Z",
+    ]) {
+      mocks.readHostedGroupUsageStatus.mockResolvedValue({
+        capacityState: "exhausted",
+        fundingUrl:
+          "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+        periodEnd,
+      });
+
+      asks.add((await projectHostedAiUsageLimitNoticeForDelivery({
+        memberId: "member_group_runtime",
+        message,
+        noticeCode: "thread_usage_limit_reached",
+        prisma: {} as never,
+      })).slice(message.length));
+    }
+
+    expect(asks.size).toBeGreaterThan(1);
+  });
+
+  it("holds the group funding ask steady within one period", async () => {
+    mocks.readHostedGroupUsageStatus.mockResolvedValue({
+      capacityState: "exhausted",
+      fundingUrl:
+        "https://www.withmurph.ai/groups/fund/group_join_code_1234",
+      periodEnd: "2026-08-01T00:00:00.000Z",
+    });
+
+    const project = async () => projectHostedAiUsageLimitNoticeForDelivery({
+      memberId: "member_group_runtime",
+      message: "I'm out for the whole room until my time resets.",
+      noticeCode: "thread_usage_limit_reached",
+      prisma: {} as never,
+    });
+
+    expect(await project()).toBe(await project());
   });
 
   it("leaves a stale group notice unchanged after capacity recovers", async () => {

--- a/apps/web/test/user-facing-messages.test.ts
+++ b/apps/web/test/user-facing-messages.test.ts
@@ -8,6 +8,17 @@ import {
 
 const USER_FACING_MESSAGE_MIN_VARIANT_COUNT = 20;
 
+/**
+ * The thread notice has room for personality, but every variant still has to
+ * say plainly that Murph has stopped rather than only joking around it.
+ */
+const THREAD_PAUSE_STATED =
+  /paused|out\b|quiet|gone|nothing left|done|no more|zero|dark|silence|tapped|unsupervised|ran? out|time's up/iu;
+
+/** Every group funding ask must point at the room, never at one named payer. */
+const GROUP_FUNDING_ANYONE_PHRASE =
+  /anyone|anybody|any one|any of you|one of you|someone|somebody|whoever|whichever|which of you|one person/iu;
+
 const TEST_TEMPLATE_KEYS = [
   "assistant.signup_welcome",
   "assistant.family_welcome",
@@ -20,6 +31,7 @@ const TEST_TEMPLATE_KEYS = [
   "linq.ai_usage.family_limit_reached",
   "linq.ai_usage.pulse_upgrade_edge",
   "linq.ai_usage.thread_limit_reached",
+  "linq.ai_usage.thread_limit_funding",
 ] as const satisfies readonly UserFacingMessageTemplateKey[];
 
 const TEST_CONTEXT_BY_KEY = {
@@ -50,6 +62,9 @@ const TEST_CONTEXT_BY_KEY = {
     homeUrl: "https://withmurph.ai/home",
   },
   "linq.ai_usage.thread_limit_reached": {},
+  "linq.ai_usage.thread_limit_funding": {
+    fundingUrl: "https://www.withmurph.ai/groups/fund/test-code",
+  },
 } satisfies {
   [K in UserFacingMessageTemplateKey]: UserFacingMessageContextByKey[K];
 };
@@ -104,6 +119,10 @@ describe("user-facing message variants", () => {
     expectEveryVariantContains("linq.ai_usage.trial_conversion_pending", "https://withmurph.ai/home");
     expectEveryVariantContains("linq.ai_usage.trial_limit_reached", "https://withmurph.ai/home");
     expectEveryVariantContains("linq.ai_usage.family_limit_reached", "https://withmurph.ai/home");
+    expectEveryVariantContains(
+      "linq.ai_usage.thread_limit_funding",
+      "https://www.withmurph.ai/groups/fund/test-code",
+    );
   });
 
   it("identifies Murph in every phone signup invite", () => {
@@ -113,7 +132,27 @@ describe("user-facing message variants", () => {
   it("keeps thread allowance copy neutral while explaining the pause", () => {
     for (const text of collectRenderedTexts("linq.ai_usage.thread_limit_reached")) {
       expect(text).not.toMatch(/trial|upgrade|checkout|Edge|Pulse|top[ -]?up|payer|https?:\/\//iu);
-      expect(text).toMatch(/AI usage is paused until .+ allowance resets/iu);
+      expect(text).toMatch(/resets\.$/u);
+    }
+  });
+
+  it("speaks the thread pause as Murph, in first person, to the whole room", () => {
+    for (const text of collectRenderedTexts("linq.ai_usage.thread_limit_reached")) {
+      expect(text).toMatch(/\b(?:I|I'm|I've|me|my)\b/u);
+      // Murph is the one who ran out, so no variant may narrate the chat's
+      // account back at the room in the third person.
+      expect(text).not.toMatch(/(?:^|\.\s)(?:this|the) chat\b/iu);
+      expect(text).not.toMatch(/\bMurph (?:time|usage)\b/iu);
+      expect(text).toMatch(/everyone|everybody|all of you|whole room|whole group/iu);
+      expect(text).not.toMatch(/included|allowance|usage period|monthly amount/iu);
+    }
+  });
+
+  it("asks the room to fund the group only from the delivery-time action copy", () => {
+    for (const text of collectRenderedTexts("linq.ai_usage.thread_limit_funding")) {
+      expect(text).toMatch(GROUP_FUNDING_ANYONE_PHRASE);
+      expect(text).toMatch(/https:\/\/www\.withmurph\.ai\/groups\/fund\/test-code$/u);
+      expect(text).not.toMatch(/trial|upgrade|Edge|Pulse|\$|paid|owner|admin/iu);
     }
   });
 
@@ -149,14 +188,15 @@ describe("user-facing message variants", () => {
       expect(text).not.toMatch(/add usage|top[ -]?up/iu);
     }
 
-    for (const key of [
-      "linq.ai_usage.family_limit_reached",
-      "linq.ai_usage.thread_limit_reached",
-    ] as const) {
-      for (const text of collectRenderedTexts(key)) {
-        expect(text).toMatch(/AI usage is paused until .+ allowance resets/iu);
-        expect(text).not.toMatch(/add usage|top[ -]?up/iu);
-      }
+    for (const text of collectRenderedTexts("linq.ai_usage.family_limit_reached")) {
+      expect(text).toMatch(/AI usage is paused until .+ allowance resets/iu);
+      expect(text).not.toMatch(/add usage|top[ -]?up/iu);
+    }
+
+    for (const text of collectRenderedTexts("linq.ai_usage.thread_limit_reached")) {
+      expect(text).toMatch(THREAD_PAUSE_STATED);
+      expect(text).toMatch(/(?:until|when)\b.*resets/iu);
+      expect(text).not.toMatch(/add usage|top[ -]?up/iu);
     }
   });
 
@@ -193,12 +233,17 @@ describe("user-facing message variants", () => {
       "linq.ai_usage.edge_limit_reached",
       "linq.ai_usage.family_limit_reached",
       "linq.ai_usage.pulse_upgrade_edge",
-      "linq.ai_usage.thread_limit_reached",
     ] as const) {
       for (const text of collectRenderedTexts(key)) {
         expect(text).toMatch(/^.+ \(100% used\)\./u);
         expect(text).not.toMatch(/\$|USD|dollars?|\$\d+(?:\.\d+)?\s*\/\s*\$\d+/iu);
       }
+    }
+
+    // The group notice says the chat is out in plain words, so it carries no
+    // percentage of its own and still never quotes currency.
+    for (const text of collectRenderedTexts("linq.ai_usage.thread_limit_reached")) {
+      expect(text).not.toMatch(/\d+%|\$|USD|dollars?/iu);
     }
   });
 


### PR DESCRIPTION
## Why this PR exists

When a group chat exhausts its usage, the hard-stop notice reads like a parking meter: `This chat reached its included Murph usage (100% used). AI usage is paused until the chat's allowance resets.` followed by a bare `Add group usage: <url>` footer. Murph never appears in his own message, and the room is given no reason to act. PR #905 taught Murph to sell continuity himself during the *low* window; this is the surface at the end of that funnel, which #905 could not reach because the model is gated off by the time it fires.

## User goal / user-visible behavior

A group that runs out hears from Murph, not from a billing system: he says in his own voice that he is out and that the whole room loses him until his time resets, and when the group can actually be funded he tells the room that any one of them can bring him back, with the first-party funding link.

## User experience

Entry point is the exhaustion gate itself, delivered into the group thread as the reply the member does not get. Immediate feedback is the notice; timing class is the same as before (delivery-time projection, no added reads on the neutral path). There is no asynchronous continuation: the funding tap continues on the existing `/groups/fund/<code>` page unchanged by this PR. Failure behavior is unchanged and fail-open to neutral copy: any projection failure returns the base notice with no ask.

Two registers were rejected during authoring. Third-person narration (`This chat used its Murph time for the month`) was rejected because it is a system describing the chat's account back at the room. Pleading (`It takes one of you. Just one. I believe in someone here`) was rejected because it costs Murph status. The shipped register is indifference: Murph is fine, the room is the one with a problem.

No `apps/web` UI renders; this is message copy in `src/lib`. Sample rendered output (real renders, not mockups):

```
Right, I've hit zero. No more me for the whole room until my time resets.

Room needs one of you to volunteer:
https://www.withmurph.ai/groups/fund/gfl_8f21c0
```

```
I just spent my last bit of the month on that. Worth it. Out for all of you until it resets.

Any one of you can sort this. I'm not going to ask twice:
https://www.withmurph.ai/groups/fund/gfl_8f21c0
```

## Invariants the PR must preserve

- The neutral template promises no commercial action. It ships unchanged when no funding link is authorized, so it must not imply anyone can pay. Enforced by the existing no-`add usage`/no-URL/no-plan-name assertions.
- The funding ask exists only where funding authority is known current: `capacityState === "exhausted"` plus a same-origin `fundingUrl` from the delivery-time read. Unchanged gate.
- Any projection failure leaves the already-neutral notice alone.
- The ask names the room, never a payer, an amount, or a purchase state.
- The notice still states plainly that Murph has stopped and names that it resets. Personality may not displace that.
- Rotation stays deterministic per member per period.

## Non-obvious affected surfaces

- **`(100% used)` injection.** Dropped for `linq.ai_usage.thread_limit_reached` only, by removing that key from `USAGE_LIMIT_PERCENTAGE_TEMPLATE_KEYS`. Necessary because the new copy already says he is out, so the parenthetical repeated the sentence it followed. The trial/Edge/Family/Pulse keys keep it, because there the percentage is the deliberate stand-in for the dollar balance hidden by #895. Regression proof: the percentage test now asserts the four remaining keys still carry it, plus a new assertion that the thread copy carries no percentage and no currency.
- **Funding-ask seed.** The ask rotates on the authoritative `periodEnd` already returned by `readHostedGroupUsageStatus`, not on the rendered notice. Seeding on the notice correlates the two FNV hashes: measured over 500 members it reached only 15 of 20 asks with one at 61 occurrences against an expected 25. The `periodEnd` seed measures 20 of 20 at 21-30. Regression proof: new tests that the ask rotates across periods and holds steady within one.
- **New template class.** `linq.ai_usage.thread_limit_funding` joins the existing 20-variant minimum coverage assertion.

## Preliminary specialist lenses

- **Prompt:** not applicable. No assistant prompt, skill, or tool description changes; these are web-owned static templates rendered by the usage gate with no model in the loop.
- **Frontend:** not applicable. No `apps/web/app/**` or `apps/web/src/components/**` path changes, so no rendered surface and no design-proof trigger.
- **Coverage:** applicable. Canonical command `pnpm --dir ../.. exec vitest run --config apps/web/vitest.workspace.ts --no-coverage` over the usage surface: 480 passed, 8 skipped, 0 failed. Typecheck (`tsc --noEmit -p apps/web/tsconfig.json`) and eslint over the four changed files both clean.

## Change-shape breakdown

Classification rule: `src/**` is source, `test/**` is tests/fixtures; no docs, config, or generated files are touched. No binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 85 | 22 |
| Tests/fixtures | 112 | 16 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **197** | **38** |

## Design proof

Not applicable. No user-facing frontend UI diff.

## Deployment skew / compatibility

Web-only. Both the template and the delivery-time projector run in `apps/web`; no Worker, runner bundle, env, credential, or persisted-state shape changes, and no contract crosses a deploy boundary. Skew during the Vercel rollout is a member seeing the old notice wording or the new one, both self-contained and both carrying a valid same-origin funding link. Reversible by revert with no cleanup.

Note for the separate deploy queue: #905's low-usage selling prompt ships in the runner bundle and the last Cloudflare deploy (`1c0246be8c`, Jul 24 02:42 UTC) predates its merge. That deploy is owed independently of this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787547485&installation_model_id=19880&pr_number=933&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F933&signature=0916277679fac24e88d8e3a559ded70438029d5b3fa9e9f6d91d899d275edce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->