### PR TITLE
Check the weather before a reminder sends someone outside

### DIFF
--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -1529,6 +1529,11 @@ function buildAssistantSharedAutomationPreferenceText(
   const selfTargetPreference = hostedRuntime || conversationScope === "group"
     ? "Do not inspect or reuse saved personal phone, Telegram, or email self-targets for this chat-authored automation."
     : "Before asking the user to repeat phone, Telegram, or email routing details for an automation route, inspect saved local self-targets. If the needed route is not already saved, ask for the missing details explicitly instead of guessing.";
+  const outdoorLocationPreference = conversationScope === "group"
+    ? "Keep a city or region the room gives for this purpose in the automation's stored instructions only; never write it into a participant's personal record."
+    : `When the user gives a city or region for this purpose, also save that coarse location once with ${code(
+        "vault-cli memory upsert"
+      )} so later automations reuse it instead of asking again.`;
   return `Prefer bounded, context-aware automations. For passive monitoring, default to digest or summary. Repeated support needs skip/repair rules and a review point. Never create open-ended reminders; renewal needs fresh consent.
 
 For generated reminders, check-ins, and reviews, include a privacy-safe user-facing subject anchor in the stored instructions and require the notification to pass a standalone-interruption test: after hours of unrelated conversation, the recipient should still know what it is about from the message itself. A title, slug, metadata, or preserved thread is not enough. Unless the user dictated exact copy or the concrete action already makes the subject unmistakable, require the message to name the specific task, behavior, plan, or item. Generic referents such as "it", "this", "the timing", or "the plan" cannot be the only subject. Keep it brief only after it is clear.
@@ -1542,6 +1547,14 @@ When creating automations, choose continuity deliberately. Use ${code(
 Linq/iMessage off-hours reminder guard: before creating or updating a user-facing reminder/check-in automation that will deliver through Linq/iMessage (${code(
     "channel=linq"
   )}, or an inherited current route whose channel is Linq/iMessage), avoid scheduling sends from 23:00 through 04:59 in the recipient's local timezone. If recipient-local timezone is unknown, use the vault/user timezone as the best available local-time proxy and say so if asking the user. Off-hours iMessage sends can add spam-risk signal and compound with other delivery-risk factors, so prefer the nearest reasonable waking-time alternative by default. If the user explicitly asks for an off-hours Linq/iMessage reminder, or the reminder's health/safety/logistical purpose genuinely requires overnight delivery, do not silently block it. Before saving the automation, briefly warn that 11pm-5am recipient-local iMessage reminders are more likely to look spammy to Apple/Linq delivery, suggest a safer nearby time, and ask for confirmation. A clear user confirmation for that exact off-hours time is enough to proceed. Do not add this extra confirmation for non-Linq channels.
+
+Outdoor-conditions reminder guard: before saving a reminder, check-in, or plan-support automation that asks someone to go outside, such as morning sunlight, a walk, run, ride, or outdoor workout, reuse a city or region already known from this conversation, saved context, or the plan. When none is known, offer once, as an option, to take one; ask for city or region, never an exact address, and let a decline save the automation unchanged without raising it again. With a location, store it in the instructions along with the run-time instruction to read weather for it before composing the message: call ${code(
+    "murph.connected_apps_execute"
+  )} with no account selector and ${code(
+    "toolSlug: OPENWEATHER_API_GET_CURRENT_WEATHER"
+  )}, or ${code(
+    "OPENWEATHER_API_GET5_DAY_FORECAST"
+  )} when the activity window is still hours away. Both slugs are server-allowlisted accountless reads, so search first only when their argument schema is unclear. Adapt rather than send an ask the conditions contradict: name the conditions, then offer the nearest workable time in the same window or an indoor equivalent. Weather changes a run's wording, never whether it happens; with no stored location or a failed read, send the ordinary reminder without mentioning the check. ${outdoorLocationPreference}
 
 ${selfTargetPreference}`;
 }

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -1098,6 +1098,56 @@ describe('assistant execution prompt contract', () => {
       'Do not add this extra confirmation for non-Linq channels',
     )
   })
+
+  it('offers a weather check before saving outdoor reminder automations', () => {
+    const prompt = buildAssistantSystemPrompt(createCommonCodexPromptInput())
+
+    expect(prompt).toContain('Outdoor-conditions reminder guard')
+    expect(prompt).toContain(
+      'reuse a city or region already known from this conversation, saved context, or the plan',
+    )
+    expect(prompt).toContain(
+      'offer once, as an option, to take one; ask for city or region, never an exact address',
+    )
+    expect(prompt).toContain(
+      'let a decline save the automation unchanged without raising it again',
+    )
+    expect(prompt).toContain(
+      'read weather for it before composing the message: call `murph.connected_apps_execute` with no account selector and `toolSlug: OPENWEATHER_API_GET_CURRENT_WEATHER`',
+    )
+    expect(prompt).toContain(
+      'or `OPENWEATHER_API_GET5_DAY_FORECAST` when the activity window is still hours away',
+    )
+    expect(prompt).toContain(
+      'Both slugs are server-allowlisted accountless reads, so search first only when their argument schema is unclear',
+    )
+    expect(prompt).toContain(
+      'name the conditions, then offer the nearest workable time in the same window or an indoor equivalent',
+    )
+    expect(prompt).toContain(
+      "Weather changes a run's wording, never whether it happens",
+    )
+    expect(prompt).toContain(
+      'with no stored location or a failed read, send the ordinary reminder without mentioning the check',
+    )
+    expect(prompt).toContain(
+      'save that coarse location once with `vault-cli memory upsert` so later automations reuse it instead of asking again',
+    )
+  })
+
+  it('keeps outdoor reminder locations out of personal records in group rooms', () => {
+    const prompt = buildAssistantSystemPrompt(
+      createCommonCodexPromptInput({ conversationScope: 'group' }),
+    )
+
+    expect(prompt).toContain('Outdoor-conditions reminder guard')
+    expect(prompt).toContain(
+      "Keep a city or region the room gives for this purpose in the automation's stored instructions only; never write it into a participant's personal record.",
+    )
+    expect(prompt).not.toContain(
+      'save that coarse location once with `vault-cli memory upsert`',
+    )
+  })
 })
 
 describe('assistant local PDF evidence guidance', () => {
@@ -1554,8 +1604,12 @@ describe('assistant system prompt cache stability', () => {
     // Main's own bound moved to 68_000 (baseline 67_801) while this branch was
     // open. The conversational-only Unhinged dial, the rare style-dissatisfaction
     // offer, and the bounded-step rule for a bare directional request add ~1_040
-    // characters on top of that baseline.
-    expect(layers.stableRouteCapabilityPrompt.length).toBeLessThanOrEqual(69_000)
+    // characters on top of that baseline. The outdoor-conditions reminder guard
+    // adds ~1_340 more (baseline 68_852) because it has to be present both when
+    // an outdoor automation is created and when one of its runs fires, and it
+    // names the two OpenWeather tool slugs so a run reads conditions directly
+    // instead of spending a connected-app search on discovery.
+    expect(layers.stableRouteCapabilityPrompt.length).toBeLessThanOrEqual(70_300)
   })
 
   it('passes the injected CLI contract through byte-for-byte at the stable-route tail', () => {


### PR DESCRIPTION
## Why this PR exists

A member received a morning-sunlight reminder while it was raining where they live. Nothing in the automation prompt connected an outdoor ask to the conditions at delivery time, so a reminder that told someone to go stand in the sun fired regardless of weather. A reminder to go outside is only useful when going outside is reasonable.

## User goal / user-visible behavior

When Murph sets up a reminder, check-in, or plan support that will ask someone to go outside, it offers once to take the city or region so runs can check conditions first. When a location is known, a run reads the weather before composing the message and adapts the wording to what is actually happening outside, instead of sending an ask the conditions contradict. The member experiences an assistant that noticed it was raining, rather than one reading from a script.

## User experience

- **Irreducible purpose.** Do not tell someone to go outside when going outside is a bad idea right now.
- **Entry point.** Ordinary conversational setup of an outdoor-dependent reminder, experiment, or plan support. No new screen, command, setting, or user-initiated step exists; the offer rides inside a conversation the member is already having.
- **Fewest necessary words/actions.** At most one added question, and only when no city or region is already known from the conversation, saved context, or the plan. It is framed as an option, asks for city or region rather than an exact address, and a decline saves the automation unchanged and is never raised again for it. In a personal chat the coarse location is saved once so later outdoor automations do not re-ask.
- **Immediate feedback and timing.** Setup is synchronous in the same reply, no added wait. At run time the automation adds one accountless OpenWeather read before composing; expected timing class is a single sub-second-to-few-second provider call inside a turn that already runs tool calls.
- **Asynchronous continuation owner.** Unchanged. The existing scheduled automation run owns delivery; this adds a read inside that run and changes nothing about scheduling, wake, or routing.
- **Final destination and audience.** The same reminder, on the same route, to the same recipient. Only the wording changes.
- **Failure and recovery.** Weather changes a run's wording, never whether it happens. With no stored location, an unavailable connected-app surface, or a failed weather read, the ordinary reminder still goes out and the failed check is not mentioned to the member. The failure mode is the current behavior, not a dropped reminder.
- **What happens next without a new inbound action.** Nothing new. Existing automations without a stored location keep behaving exactly as they do today.

## Invariants the PR must preserve

- A weather read never suppresses, delays, reschedules, or cancels a scheduled run. It may only change message wording.
- A location question is optional and asked at most once per automation; a decline is durable for that automation.
- Location granularity stays coarse: city or region, never an exact address.
- Group rooms write no personal state. A city given in a group stays in that automation's stored instructions and never reaches a participant's personal record.
- The OpenWeather read stays accountless. No account selector, and no personal connected-account access is implied or added.
- The existing standalone-interruption subject-anchor rule and the Linq/iMessage off-hours guard in the same block are unchanged.

## Non-obvious affected surfaces

- **Group-scope automation prompt.** `buildAssistantSharedAutomationPreferenceText` is shared by direct and group scopes, so the guard text renders in group rooms too. This is necessary because group challenges schedule outdoor activity, and it is the reason the location-persistence sentence is scope-conditional rather than a single string. Regression proof: the new `keeps outdoor reminder locations out of personal records in group rooms` test asserts the group variant renders and asserts the `vault-cli memory upsert` sentence is absent.
- **Stable-route prompt length ratchet.** This block is resident on every turn for every member, and `keeps the always-on kernel and non-CLI route guidance bounded` caps it. The bound moves from 69,000 to 70,300 against a 68,852 baseline. The comment records the delta and why the guidance has to be thread-stable. No other prompt-cache assertion changes; the layer split and cache-metadata hashes are untouched.
- **Scheduled automation runs.** The guard names `murph.connected_apps_execute`, which is gated on `connectedAppsAvailable`. That flag derives from a platform-level `connectedApps` port rather than a per-trigger one, so automation-triggered turns do have the tool. Where it is absent, the documented fallback sends the ordinary reminder.

Nothing else. No schema, persisted state, route, tool registry, API, or deploy surface changes.

## Preliminary specialist lenses

- **Prompt — applicable.** The entire diff is assistant system-prompt guidance plus its assertions.
- **Frontend — not applicable.** No `apps/web` file is touched and the PR renders no UI.
- **Coverage — applicable.** Canonical command: `pnpm test:diff packages/assistant-engine/src/assistant/system-prompt.ts packages/assistant-engine/test/model-behavior.test.ts`. Outcome recorded under Verification below.

## Change-shape breakdown

Classification rule: `packages/**/src/**` is source, `packages/**/test/**` is tests/fixtures, `*.md` under `agent-docs`/root is docs, build and CI files are config/tooling, and anything build-emitted is generated. Counts are `git diff --numstat` from the merge base to head. No binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 13 | 0 |
| Tests/fixtures | 56 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **69** | **2** |

The test-heavy ratio is expected for a prompt change: the source delta is one guidance paragraph plus a scope-conditional clause, and the tests pin its load-bearing sentences so a future edit cannot silently drop the guard.

## Design proof for user-facing frontend UI

Not applicable. This PR changes assistant prompt text only and touches no `apps/web` component, section, or rendered surface.

## Deployment skew / compatibility

Not applicable as a skew risk, but worth one note. The prompt ships inside the runner bundle, so a gradual container rollout can leave warm `RunnerContainer` processes on the previous bundle for a window. The change is purely additive guidance with no contract, tool, schema, or persisted-state component, so old and new runners disagree only on whether a given outdoor reminder offers a location or checks weather. Both states are safe and self-correct as containers cycle; `container_rollout=immediate` is not required and no compatibility window, migration, or repair path applies.

## Verification

- `packages/assistant-engine` full suite: 171 files, 2,539 tests pass, 5 skipped. `assistant-local-service-runtime.test.ts` was excluded from that run for a pre-existing vitest worker-teardown timeout reproduced on the unmodified baseline; it passes 81/81 on its own and passed in an earlier full run.
- `tsc -p packages/assistant-engine/tsconfig.typecheck.json --noEmit` clean.
- New assertions cover the direct-chat guard, the group-scope variant, and the ratcheted prompt-length bound.
- Direct scenario check on the run-time dependency: both allowlisted OpenWeather slugs were exercised live against the tier the server allowlist uses, returning current conditions and a 5-day forecast, confirming the named read is reachable rather than assumed.

### Pre-existing failures in the reverse-dependent lane, named explicitly

The first `pnpm test:diff` run in this fresh worktree reported 37 `packages/cli` failures. Neither cause is this diff:

1. Most were `ENOENT .../packages/health-commons/generated/protocol-run-specs.json` — the worktree had not built `health-commons`. After `pnpm build` in that package, `experiment-session-typed-confounders.test.ts` passes 8/8.
2. `cli-expansion-samples-audit.test.ts > audit commands are reachable through the top-level CLI registration` times out at 60,000 ms. It reproduces identically after restoring the base version of both files this PR touches, so it is environmental subprocess slowness on a loaded host, not a regression. Nothing in the diff reaches CLI command registration.

CI is the authority on the lane; both surfaces are untouched by a prompt-string change.

## Deliberately deferred

The conversational OpenWeather bullet in the connected-apps section still routes through `connected_apps_search` for discovery. Only the automation guard names the slugs directly, because that is the path where a scheduled run pays for a discovery round trip it can skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787548913&installation_model_id=19880&pr_number=934&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F934&signature=d09d39713bfff45a3add92a6cdd55baa8cb0483a1e6aa9de5fdb502ef37ac3e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->