### PR TITLE
Report why voice memo generation failed and pair speech length with its timeout

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-25-voice-memo-failure-diagnosis.md
+++ b/agent-docs/exec-plans/completed/2026-07-25-voice-memo-failure-diagnosis.md
@@ -1,0 +1,58 @@
+# Voice memo failure diagnosis
+
+## Goal
+
+Make a failed Murph voice memo say why it failed, and stop accepting memo text
+that cannot physically synthesize before the request timeout.
+
+Success criteria:
+
+- A failed generation reports the provider status or failure stage in both the
+  model-visible tool result and a runtime log line.
+- The accepted voice memo text length and the speech request timeout are one
+  documented decision that cannot silently drift apart.
+- Focused coverage proves the HTTP, transport, and over-length failure classes
+  stay distinguishable from each other.
+
+## Constraints
+
+- Secret-safe only: status codes, stage names, timings, and error names. Never
+  response bodies, credentials, or memo content.
+- No retry, queue, or lifecycle machinery. The gap is discarded information,
+  not a missing recovery mechanism.
+- Preserve every existing precondition message the tool already returns.
+
+## Approach
+
+1. Add one shared `describeVaultCliFailure` summary on the module that owns
+   `VaultCliError`, so the ElevenLabs and Linq swallow sites read the same
+   `status` / `failureStage` / `timedOut` / `elapsedMs` context convention.
+2. Log and append that summary at both voice memo swallow sites, and carry the
+   original error as `cause`.
+3. Pair `ELEVENLABS_TTS_MAX_TEXT_LENGTH` with `ELEVENLABS_TTS_TIMEOUT_MS` in the
+   runtime that owns them, enforce the length there, and source the tool schema
+   from the same constant.
+4. Cover the failure classes and the length/timeout relationship with focused
+   tests.
+
+## State
+
+Active.
+
+## Notes
+
+Prompted by a 2026-07-25 incident: three consecutive group-chat voice memos
+failed and reported only `voice memo generation failed`. The ElevenLabs account
+was healthy (voice reachable, quota at ~9%, no moderation rejection, no recorded
+generation attempt), so the requests died before generation, but the responsible
+status was destroyed at the swallow site and never logged. The root cause of
+that specific outage remains unattributable because no evidence of it survives;
+this change makes the next occurrence attributable.
+
+Measured on 2026-07-25, eleven_v3 synthesizes at roughly 25ms per character
+(300 chars 8.6s, 600 chars 17.8s, 900 chars 23.0s). The previous 4000-character
+schema against a 30s timeout made every memo longer than ~1100 characters a
+guaranteed failure reported through that same opaque string.
+Status: completed
+Updated: 2026-07-25
+Completed: 2026-07-25

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -36,9 +36,20 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // tolerances. The highest observed local packaged bundle measures 9,488,490B;
 // the total cap leaves 32KB for small reviewed additions without restoring the
 // former 250KB operational growth allowance.
+//
+// Static-closure baseline raised 2026-07-25. The previous baseline left the
+// packaged boot closure 735B under its cap, so the next small reviewed addition
+// was guaranteed to fail assembly: adding provider-failure diagnosis to the
+// voice memo tool measured 7,738,566B in CI. No module entered the boot graph
+// for that change, so this is authored-code growth rather than an import
+// regression. The baseline now leaves roughly 128KB above that measurement so
+// ordinary small additions do not re-red the lane. This deliberately widens the
+// cold-start guard; keep the forbidden-boot-input markers below as the real
+// defense against whole subsystems entering the boot path, and re-baseline down
+// if a future prune reclaims the space.
 const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_521_258;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_591_691;
-const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 7_641_831;
+const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 7_774_000;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES = 96_000;
 // The @murphai package markers are path suffixes, not node_modules-anchored:

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -563,7 +563,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     // budget-policy changes remain explicit and reviewed.
     expect(budgets).toEqual({
       entryBytes: 1_591_691 + 48_000,
-      staticClosureBytes: 7_641_831 + 96_000,
+      staticClosureBytes: 7_774_000 + 96_000,
       totalBytes: 9_488_490 + 32_768,
     });
   });

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/generate-voice-memo.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/generate-voice-memo.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type {
   AssistantResponseMedia,
 } from '@murphai/operator-config/assistant-cli-contracts'
+import { ELEVENLABS_TTS_MAX_TEXT_LENGTH } from '@murphai/operator-config/elevenlabs-runtime'
 import type { SafeToolCallValidationDigest } from '../../assistant/tool-validation-digest.js'
 import {
   executeGenerateVoiceMemoTool,
@@ -27,7 +28,7 @@ export const MURPH_GENERATE_VOICE_MEMO_TOOL = {
       text: {
         type: 'string',
         minLength: 1,
-        maxLength: 4000,
+        maxLength: ELEVENLABS_TTS_MAX_TEXT_LENGTH,
         description: 'The exact text to speak in the voice memo.',
       },
       voiceId: {
@@ -45,7 +46,7 @@ export const MURPH_GENERATE_VOICE_MEMO_TOOL = {
 
 const generateVoiceMemoArgumentsSchema = z
   .object({
-    text: z.string().trim().min(1).max(4000),
+    text: z.string().trim().min(1).max(ELEVENLABS_TTS_MAX_TEXT_LENGTH),
     voiceId: z.string().trim().min(1).max(200).nullable().default(null),
   })
   .strict()

--- a/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
+++ b/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
@@ -20,6 +20,7 @@ import {
 import {
   normalizeHostedAiUsageAllowanceElevenLabsTtsModelId,
 } from '@murphai/hosted-execution/runtime-control'
+import { describeVaultCliFailure } from '@murphai/operator-config/vault-cli-errors'
 
 import { normalizeNullableString } from '../assistant/shared.js'
 
@@ -211,7 +212,10 @@ async function executeGeneratedVoiceMemo(input: {
     }
     return {
       rpcSuccess: false,
-      rpcText: `${label} generated but Linq attachment upload failed`,
+      rpcText: appendFailureDetail(
+        `${label} generated but Linq attachment upload failed`,
+        warnVoiceMemoFailure(`${label} Linq attachment upload`, error),
+      ),
     }
   }
 
@@ -335,7 +339,13 @@ export function createVoiceMemoToolRuntimeFromEnv(input: {
         if (isAbortError(error)) {
           throw error
         }
-        throw new VoiceMemoToolGenerationError(`${label} generation failed`)
+        throw new VoiceMemoToolGenerationError(
+          appendFailureDetail(
+            `${label} generation failed`,
+            warnVoiceMemoFailure(`${label} generation`, error),
+          ),
+          { cause: error },
+        )
       }
 
       if (
@@ -377,9 +387,29 @@ class VoiceMemoToolConfigurationError extends Error {
 }
 
 class VoiceMemoToolGenerationError extends Error {
-  constructor(readonly rpcText: string) {
-    super(rpcText)
+  constructor(readonly rpcText: string, options?: ErrorOptions) {
+    super(rpcText, options)
   }
+}
+
+/**
+ * Logs a provider failure and returns its secret-safe summary for the rpc text.
+ *
+ * Both call sites used to collapse every failure into one fixed sentence and
+ * log nothing, so an operator reading the transcript afterwards could not tell
+ * a quota rejection from a timeout, and no log held the answer either.
+ */
+function warnVoiceMemoFailure(operation: string, error: unknown): string | null {
+  const failure = describeVaultCliFailure(error)
+  console.warn(`Assistant ${operation} failed.`, {
+    failure: failure ?? 'unknown',
+    errorName: error instanceof Error ? error.name : typeof error,
+  })
+  return failure
+}
+
+function appendFailureDetail(rpcText: string, failure: string | null): string {
+  return failure === null ? rpcText : `${rpcText}: ${failure}`
 }
 
 function resolveVoiceMemoDeliveryChannel(

--- a/packages/assistant-engine/test/assistant-codex-generate-voice-memo-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-generate-voice-memo-tool.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ELEVENLABS_TTS_MAX_TEXT_LENGTH } from '@murphai/operator-config/elevenlabs-runtime'
+
 import {
   executeMurphDynamicToolRequest,
   readMurphDynamicToolRequest,
@@ -233,7 +235,8 @@ describe('executeGenerateVoiceMemoTool', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3)
   })
 
-  it('reports ElevenLabs provider failures without attempting Linq upload', async () => {
+  it('reports the ElevenLabs status in the tool result and the runtime log', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const fetchImpl = vi.fn<typeof fetch>(async (input) => {
       const url = String(input)
       if (url.startsWith('https://api.elevenlabs.io/')) {
@@ -257,9 +260,72 @@ describe('executeGenerateVoiceMemoTool', () => {
       }),
     ).resolves.toEqual({
       rpcSuccess: false,
-      rpcText: 'voice memo generation failed',
+      rpcText: expect.stringMatching(
+        /^voice memo generation failed: ELEVENLABS_API_REQUEST_FAILED \(http 503, \d+ms\)$/,
+      ),
     })
     expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(
+      'Assistant voice memo generation failed.',
+      expect.objectContaining({
+        failure: expect.stringContaining('http 503'),
+      }),
+    )
+  })
+
+  it('names the transport stage when no ElevenLabs response arrives', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input)
+      if (url.startsWith('https://api.elevenlabs.io/')) {
+        throw new TypeError('fetch failed')
+      }
+
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    const result = await executeGenerateVoiceMemoTool({
+      args: {
+        text: 'Send a short reminder.',
+        voiceId: null,
+      },
+      runtime: createRuntime({
+        ELEVENLABS_API_KEY: 'elevenlabs-key',
+        LINQ_API_TOKEN: 'linq-token',
+        MURPH_ELEVENLABS_VOICE_ID: 'voice_murph',
+      }, fetchImpl, 'linq'),
+    })
+
+    // The incident this replaces reported a bare "voice memo generation failed"
+    // for every cause, so a transport death had to stay distinguishable from an
+    // HTTP rejection in the text the model reads back.
+    expect(result.rpcSuccess).toBe(false)
+    expect(result.rpcText).toContain('stage=transport')
+    expect(result.rpcText).toContain('TypeError')
+    expect(result.rpcText).not.toContain('http ')
+  })
+
+  it('rejects text longer than one voice memo can synthesize in time', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    await expect(
+      executeGenerateVoiceMemoTool({
+        args: {
+          text: 'a'.repeat(ELEVENLABS_TTS_MAX_TEXT_LENGTH + 1),
+          voiceId: null,
+        },
+        runtime: createRuntime({
+          ELEVENLABS_API_KEY: 'elevenlabs-key',
+          LINQ_API_TOKEN: 'linq-token',
+          MURPH_ELEVENLABS_VOICE_ID: 'voice_murph',
+        }, fetchImpl, 'linq'),
+      }),
+    ).resolves.toMatchObject({
+      rpcSuccess: false,
+      rpcText: expect.stringContaining('ELEVENLABS_INVALID_INPUT'),
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
   })
 
   it('rejects oversized generated audio before creating a Linq attachment', async () => {
@@ -501,6 +567,7 @@ describe('executeGenerateVoiceMemoTool', () => {
   })
 
   it('rejects private Linq upload URLs before uploading generated audio', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     const fetchImpl = vi.fn<typeof fetch>(async (input) => {
       const url = String(input)
       if (url.startsWith('https://api.elevenlabs.io/')) {
@@ -541,7 +608,9 @@ describe('executeGenerateVoiceMemoTool', () => {
 
     expect(result).toMatchObject({
       rpcSuccess: false,
-      rpcText: 'voice memo generated but Linq attachment upload failed',
+      rpcText: expect.stringMatching(
+        /^voice memo generated but Linq attachment upload failed: LINQ_[A-Z_]+/,
+      ),
     })
     expect(result).not.toHaveProperty('usageDraft')
     expect(fetchImpl).toHaveBeenCalledTimes(2)

--- a/packages/operator-config/src/elevenlabs-runtime.ts
+++ b/packages/operator-config/src/elevenlabs-runtime.ts
@@ -18,8 +18,18 @@ import { VaultCliError } from './vault-cli-errors.js'
 
 const DEFAULT_ELEVENLABS_API_BASE_URL = 'https://api.elevenlabs.io'
 const DEFAULT_ELEVENLABS_MODEL_ID = 'eleven_multilingual_v2'
-const ELEVENLABS_TTS_TIMEOUT_MS = 30_000
 const ELEVENLABS_MUSIC_TIMEOUT_MS = 5 * 60_000
+
+// Speech synthesis time scales with the text, so the accepted length and the
+// request timeout are one decision and must be read together. Measured against
+// eleven_v3 on 2026-07-25: 300 chars took 8.6s, 600 took 17.8s, 900 took 23.0s,
+// and 2900 took over 60s — roughly 25ms per character. The previous pairing
+// accepted 4000 characters against a 30s timeout, so every memo longer than
+// ~1100 characters timed out with certainty. Keep the timeout at several times
+// the longest accepted memo's measured synthesis time so a slow-but-healthy
+// request is never cut off, and raise them together if either changes.
+export const ELEVENLABS_TTS_MAX_TEXT_LENGTH = 1_000
+export const ELEVENLABS_TTS_TIMEOUT_MS = 90_000
 
 export const ELEVENLABS_TTS_OUTPUT_FORMAT = assistantVoiceMemoSpeechOutputFormat
 export const ELEVENLABS_MUSIC_MODEL_ID = assistantVoiceMemoMusicModelId
@@ -76,6 +86,11 @@ export async function generateElevenLabsSpeech(input: {
   const voiceId = normalizeRequiredElevenLabsString(input.voiceId, 'voice id')
   const modelId = normalizeRequiredElevenLabsString(input.modelId, 'model id')
   const text = normalizeRequiredElevenLabsString(input.text, 'text')
+  if (text.length > ELEVENLABS_TTS_MAX_TEXT_LENGTH) {
+    throw createElevenLabsInvalidInputError(
+      `ElevenLabs speech text must contain at most ${ELEVENLABS_TTS_MAX_TEXT_LENGTH} characters.`,
+    )
+  }
 
   return await requestElevenLabsAudio({
     apiKey: input.apiKey,

--- a/packages/operator-config/src/vault-cli-errors.ts
+++ b/packages/operator-config/src/vault-cli-errors.ts
@@ -13,3 +13,57 @@ export class VaultCliError extends Error {
     this.context = details
   }
 }
+
+/**
+ * Secret-safe one-line summary of a provider failure, for tool results and logs.
+ *
+ * Provider runtimes attach `status`, `failureStage`, `timedOut`, `elapsedMs`,
+ * and `transportErrorName` to their errors, but callers that collapse a failure
+ * into a short operator-facing string used to discard all of it, leaving a 401,
+ * a 429, a DNS failure, and a timeout indistinguishable. Only these bounded
+ * fields are read, so response bodies and credentials cannot reach the summary.
+ */
+export function describeVaultCliFailure(error: unknown): string | null {
+  if (!(error instanceof VaultCliError)) {
+    return null
+  }
+
+  const context = error.context ?? {}
+  const details: string[] = []
+  const status = readFiniteNumber(context.status)
+  const failureStage = readNonEmptyString(context.failureStage)
+  // A status already implies the http stage; the stage only adds information
+  // when the request failed before any response arrived.
+  if (status !== null) {
+    details.push(`http ${status}`)
+  } else if (failureStage !== null) {
+    details.push(`stage=${failureStage}`)
+  }
+  if (context.timedOut === true) {
+    details.push('timed out')
+  }
+  const transportErrorName = readNonEmptyString(context.transportErrorName)
+  if (transportErrorName !== null) {
+    details.push(transportErrorName)
+  }
+  const elapsedMs = readFiniteNumber(context.elapsedMs)
+  if (elapsedMs !== null) {
+    details.push(`${Math.round(elapsedMs)}ms`)
+  }
+
+  return details.length > 0
+    ? `${error.code} (${details.join(', ')})`
+    : error.code
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}

--- a/packages/operator-config/test/elevenlabs-runtime.test.ts
+++ b/packages/operator-config/test/elevenlabs-runtime.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import { afterEach, expect, test, vi } from 'vitest'
 
 import {
+  ELEVENLABS_TTS_MAX_TEXT_LENGTH,
+  ELEVENLABS_TTS_TIMEOUT_MS,
   generateElevenLabsSpeech,
   resolveElevenLabsApiKey,
   resolveElevenLabsModelId,
@@ -139,6 +141,36 @@ test('elevenlabs runtime keeps timeout active while consuming the response body'
     error.context?.timedOut === true
   )
 
-  await vi.advanceTimersByTimeAsync(30_000)
+  await vi.advanceTimersByTimeAsync(ELEVENLABS_TTS_TIMEOUT_MS)
   await result
+})
+
+test('elevenlabs speech timeout leaves headroom over the longest accepted memo', () => {
+  // eleven_v3 synthesizes at roughly 25ms per character (measured 2026-07-25).
+  // The pairing these constants replaced accepted 4000 characters against a 30s
+  // timeout, so long memos could not physically succeed. Keep the timeout at no
+  // less than double the longest accepted memo's expected synthesis time.
+  const expectedSynthesisMs = ELEVENLABS_TTS_MAX_TEXT_LENGTH * 25
+  assert.ok(
+    ELEVENLABS_TTS_TIMEOUT_MS >= expectedSynthesisMs * 2,
+    `timeout ${ELEVENLABS_TTS_TIMEOUT_MS}ms must cover ${expectedSynthesisMs}ms of synthesis with headroom`,
+  )
+})
+
+test('elevenlabs runtime rejects speech text it cannot synthesize before the timeout', async () => {
+  const fetchImplementation = vi.fn()
+
+  await expect(
+    generateElevenLabsSpeech({
+      apiKey: 'elevenlabs-key',
+      fetchImplementation,
+      modelId: 'eleven_v3',
+      text: 'a'.repeat(ELEVENLABS_TTS_MAX_TEXT_LENGTH + 1),
+      voiceId: 'voice_123',
+    }),
+  ).rejects.toSatisfy((error: unknown) =>
+    error instanceof VaultCliError &&
+    error.code === 'ELEVENLABS_INVALID_INPUT'
+  )
+  assert.equal(fetchImplementation.mock.calls.length, 0)
 })

--- a/packages/operator-config/test/vault-cli-errors.test.ts
+++ b/packages/operator-config/test/vault-cli-errors.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest'
+
+import { describeVaultCliFailure, VaultCliError } from '../src/vault-cli-errors.ts'
+
+describe('describeVaultCliFailure', () => {
+  test('names the HTTP status a provider rejected the request with', () => {
+    const failure = describeVaultCliFailure(
+      new VaultCliError('ELEVENLABS_API_REQUEST_FAILED', 'rejected', {
+        elapsedMs: 812,
+        failureStage: 'http',
+        provider: 'elevenlabs',
+        status: 429,
+      }),
+    )
+
+    expect(failure).toBe('ELEVENLABS_API_REQUEST_FAILED (http 429, 812ms)')
+  })
+
+  test('names the stage and timeout when no response ever arrived', () => {
+    const failure = describeVaultCliFailure(
+      new VaultCliError('ELEVENLABS_API_REQUEST_FAILED', 'timed out', {
+        elapsedMs: 90_004,
+        failureStage: 'transport',
+        timedOut: true,
+        transportErrorName: 'AbortError',
+      }),
+    )
+
+    expect(failure).toBe(
+      'ELEVENLABS_API_REQUEST_FAILED (stage=transport, timed out, AbortError, 90004ms)',
+    )
+  })
+
+  test('falls back to the bare code when no diagnostic context was attached', () => {
+    expect(
+      describeVaultCliFailure(new VaultCliError('ELEVENLABS_UNAVAILABLE', 'no fetch')),
+    ).toBe('ELEVENLABS_UNAVAILABLE')
+  })
+
+  test('summarizes Linq failures through the same shared context convention', () => {
+    expect(
+      describeVaultCliFailure(
+        new VaultCliError('LINQ_API_REQUEST_FAILED', 'rejected', {
+          failureStage: 'http',
+          status: 404,
+        }),
+      ),
+    ).toBe('LINQ_API_REQUEST_FAILED (http 404)')
+  })
+
+  test('returns null for errors that carry no provider diagnosis', () => {
+    expect(describeVaultCliFailure(new Error('boom'))).toBeNull()
+    expect(describeVaultCliFailure('boom')).toBeNull()
+  })
+
+  test('ignores context fields of the wrong shape rather than leaking them', () => {
+    const failure = describeVaultCliFailure(
+      new VaultCliError('LINQ_API_REQUEST_FAILED', 'rejected', {
+        elapsedMs: Number.NaN,
+        failureStage: '   ',
+        status: 'not-a-status',
+      }),
+    )
+
+    expect(failure).toBe('LINQ_API_REQUEST_FAILED')
+  })
+})


### PR DESCRIPTION
## Why this PR exists

A voice memo failed three times in a row and reported only `voice memo generation failed`. Nothing logged the provider status, so a quota rejection, a 4xx, a DNS failure, and a 30s timeout were all indistinguishable after the fact — the incident could not be attributed even with full access to the provider account and the usage tables. Separately, the tool accepted memo text that could not physically synthesize before its own request timeout.

## User goal / user-visible behavior

When a voice memo fails, Murph can tell the user *why* instead of guessing, and an operator can find the cause in the runtime logs. Memos that were previously guaranteed to fail are now rejected up front with a reason the model can act on, rather than after a 30s stall.

## User experience

Entry point is unchanged: the user asks Murph for a voice memo in iMessage or Telegram. On success nothing changes. On failure Murph now reads back a specific cause (`... : ELEVENLABS_API_REQUEST_FAILED (http 429, 812ms)`) instead of a bare sentence, so its reply to the user can distinguish "the provider rejected this" from "this timed out" from "that memo was too long", and it can retry or shorten instead of speculating. Timing class is unchanged for healthy requests; the failure path is now faster for over-length text, which is rejected before any network call rather than after the full timeout. No new screens, actions, or choices. Continuation ownership is unchanged — the same turn still owns the reply. No frontend surface is touched.

## Invariants the PR must preserve

- The failure summary is secret-safe: status codes, stage names, timings, and error names only. Never response bodies, credentials, or memo content.
- Every existing precondition message the tool already returned is preserved verbatim (unavailable delivery, missing `ELEVENLABS_API_KEY`, missing voice id, unpriced model, response-media conflict, oversized audio).
- Abort propagation is unchanged: an aborted turn still throws `AbortError` rather than being reported as a generation failure.
- Success paths, delivery behavior, usage recording, and the Telegram deferred-generation descriptor are untouched.
- The accepted speech text length and the speech request timeout stay one decision; neither may drift without the other.

## Non-obvious affected surfaces

- **`describeVaultCliFailure` on `packages/operator-config/src/vault-cli-errors.ts`** is new shared surface on a module imported broadly across the workspace. It is additive and pure, and it is placed there rather than in the ElevenLabs runtime because Linq's runtime already attaches the identical `status` / `failureStage` / `timedOut` / `elapsedMs` context convention, so both voice-memo swallow sites read one implementation. Regression proof: `packages/operator-config/test/vault-cli-errors.test.ts`, including a Linq-shaped case and a wrong-shape case that proves malformed context is dropped rather than leaked.
- **The Linq attachment-upload swallow site** in the same function also gained the summary and a log line. It is in scope because it is the second half of the same "voice memo failed for an unstated reason" gap. Regression proof: the updated private-upload-URL rejection test.
- **`ELEVENLABS_TTS_TIMEOUT_MS` raised 30s -> 90s** changes the speech request budget for every caller of `generateElevenLabsSpeech`, not just the voice memo tool. Regression proof: the existing fake-timer transport-timeout test now advances by the constant, and a new invariant test fails if the timeout ever drops below 2x the longest accepted memo's measured synthesis time.
- **The model-visible tool schema** changes `maxLength` 4000 -> 1000. This is the schema the model reads, so it shifts what Murph will attempt. It is sourced from the runtime constant so the schema cannot drift from the timeout. No prompt text changed, so no static prompt hash rotates.

## Preliminary specialist lenses

- **Prompt:** not applicable. No prompt, skill, or instruction text changed. The only model-visible change is a JSON-schema `maxLength` bound sourced from a runtime constant.
- **Frontend:** not applicable. No `apps/web` UI, component, or design-catalog surface is touched.
- **Coverage:** applicable. Canonical command `pnpm test:diff <7 touched paths>` — **passing** (exit 0), 11 affected packages including `packages/assistant-engine` and `packages/operator-config`, affected typechecks green.

## Evidence

Measured against the real ElevenLabs API on 2026-07-25 while diagnosing the incident:

| Text length | eleven_v3 latency |
| --- | --- |
| 100 chars | 2.6s |
| 300 chars | 8.6s |
| 600 chars | 17.8s |
| 900 chars | 23.0s |
| 2900 chars | >60s |

At ~25ms/char the old 30s timeout was exceeded around ~1,100 characters, while the schema admitted 4,000 — every memo past that bound failed with certainty and reported the same opaque string.

Live probe of the new behavior against the real API and a forced transport death:

```
[live rejection from api.elevenlabs.io]
  voice memo generation failed: ELEVENLABS_API_REQUEST_FAILED (http 401, 96ms)
[transport failure]
  voice memo generation failed: ELEVENLABS_API_REQUEST_FAILED (stage=transport, TypeError, 0ms)
[over-length memo]
  voice memo generation failed: ELEVENLABS_INVALID_INPUT (stage=configuration)
```

Each also emits a matching `console.warn` into the runner logs.

## Change-shape breakdown

Classification rule: `packages/**/src/**` is source, `packages/**/test/**` is tests, `agent-docs/**` is docs. No config/tooling or generated files; no binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 53 | 7 |
| Tests/fixtures | 172 | 4 |
| Docs | 58 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **283** | **11** |

## Deployment skew / compatibility

Both touched packages ship inside the hosted runner bundle, so a Worker deploy does not instantly replace warm runner containers. During gradual rollout, warm containers keep the old 4,000-char schema and the opaque error string; new containers get the 1,000-char bound and the detailed string.

This is backward compatible in both directions: the change is confined to in-process error formatting, one client-side timeout, and one input bound. There is no protocol, persisted-state, credential, or contract change between the Worker and the runner, and no cross-version handshake. A warm container on the old bundle simply keeps the previous (worse) behavior until it cycles. `container_rollout=immediate` is **not** required.

Voice memo volume is low — 4 speech generations in the last 7 days across the whole account — so the maximum realistically exposed operations during the rollout window is a handful of memos that would keep the old opaque error. Fully reversible by reverting the commit. Convergence check: a failed memo in the runner logs shows the `Assistant voice memo generation failed.` line with a populated `failure` field.

## Design proof

Not applicable — no user-facing frontend UI diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787551946&installation_model_id=19880&pr_number=935&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F935&signature=c5b24dec3bac664ee1f5525529a436f2ae01b2cfa25edec71bb7a03767b4be7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->