### PR TITLE
Tolerate non-document residue in experiment lifecycle reads

### DIFF
--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -623,9 +623,13 @@ export async function applyMurphManagedAutomations(
       ...MURPH_MANAGED_AUTOMATIONS,
       ...(experimentLifecycle?.seeds ?? []),
     ])
-  const desiredExperimentSupportSeries = input.seeds === undefined
-    ? buildDesiredExperimentSupportSeries(rawSeeds)
-    : null
+  // A failed experiment scan leaves the desired experiment state *unknown*, not
+  // empty. Reconciling an empty desired set against live records archives every
+  // active experiment automation, so skip that namespace entirely instead.
+  const desiredExperimentSupportSeries =
+    input.seeds === undefined && experimentLifecycleFailure === null
+      ? buildDesiredExperimentSupportSeries(rawSeeds)
+      : null
   const seeds = rawSeeds.filter((seed) =>
     murphManagedAutomationAppliesToRuntime(seed, input.runtimeEnv)
   )

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -86,6 +86,7 @@ export interface MurphManagedAutomationDiagnosticStage {
 
 export interface ApplyMurphManagedAutomationsResult {
   created: number
+  experimentLifecycleFailure?: unknown
   skipped: number
   stableKeyFailure?: unknown
   stableKeyRetryNeeded?: true
@@ -588,15 +589,27 @@ export async function applyMurphManagedAutomations(
   let experimentLifecycle: Awaited<ReturnType<
     typeof prepareExperimentLifecycleAutomations
   >> | null = null
+  let experimentLifecycleFailure: unknown = null
   if (input.seeds === undefined) {
     reportMurphManagedAutomationDiagnosticStage(input, {
       stage: 'experiment_lifecycle',
     })
-    experimentLifecycle = await prepareExperimentLifecycleAutomations({
-      now,
-      shouldYield: input.shouldYield ?? null,
-      vaultRoot: input.vaultRoot,
-    })
+    try {
+      experimentLifecycle = await prepareExperimentLifecycleAutomations({
+        now,
+        shouldYield: input.shouldYield ?? null,
+        vaultRoot: input.vaultRoot,
+      })
+    } catch (error) {
+      // Experiment seeds are one contributor to this pass, not a precondition
+      // for it. Letting this stage abort the whole call took every unrelated
+      // managed automation down with it, so record the failure and compose the
+      // seeds that do not depend on the experiment scan.
+      experimentLifecycleFailure = error
+    }
+  }
+  if (experimentLifecycleFailure !== null) {
+    result.experimentLifecycleFailure = experimentLifecycleFailure
   }
   if (experimentLifecycle?.yielded === true || input.shouldYield?.() === true) {
     return { ...result, yielded: true }

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -1,4 +1,5 @@
-import { rm } from 'node:fs/promises'
+import { rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 
 import {
   initializeVault,
@@ -128,6 +129,34 @@ describe('applyMurphManagedAutomations core integration', () => {
       skipped: 0,
       updated: 0,
     })
+  })
+
+  it('still creates unrelated automations when experiment lifecycle staging fails', async () => {
+    const vaultRoot = await createVaultRoot()
+    // A stray Markdown document is the one entry the experiment scan still
+    // refuses, and it must not take the rest of the pass down with it.
+    await writeFile(
+      join(vaultRoot, 'bank/experiments/Stray Copy.md'),
+      '---\nslug: stray\n---\n',
+      'utf8',
+    )
+
+    const result = await applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-09T12:00:00.000Z'),
+      vaultRoot,
+    })
+
+    expect(result.created).toBe(5)
+    expect(result.experimentLifecycleFailure).toMatchObject({
+      code: 'EXPERIMENT_STORAGE_INVALID',
+    })
+    expect(
+      await showAutomation({
+        automationId: MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
+        vaultRoot,
+      }),
+    ).toMatchObject({ status: 'active' })
   })
 
   it('creates managed health automations through the canonical automation registry', async () => {

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -7,6 +7,7 @@ import {
   showAutomation,
   upsertAutomation,
 } from '@murphai/core'
+import { buildAutomationSupportSeriesTag } from '@murphai/contracts'
 import {
   HOSTED_RUNTIME_PROCESS_ENV,
 } from '@murphai/hosted-execution/env'
@@ -156,6 +157,50 @@ describe('applyMurphManagedAutomations core integration', () => {
         automationId: MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
         vaultRoot,
       }),
+    ).toMatchObject({ status: 'active' })
+  })
+
+  it('never archives live experiment automations when the experiment scan fails', async () => {
+    const vaultRoot = await createVaultRoot()
+    // An existing, active experiment support-series automation. A failed scan
+    // leaves desired experiment state unknown, so this must survive untouched:
+    // reconciling an empty desired set here would archive the user's live
+    // experiment check-ins and they cannot all be recovered afterwards.
+    const supportSeriesTag = buildAutomationSupportSeriesTag(
+      'experiment-lifecycle:sleep-reset',
+    )
+    const experimentAutomationId = 'automation_01K2WKKY3F8Q4R5S6T7V8W9XAC'
+    await upsertAutomation({
+      automationId: experimentAutomationId,
+      continuityPolicy: 'fresh',
+      instructions: 'Existing experiment check-in.',
+      route: defaultRoute,
+      schedule: { kind: 'every', everyMs: 24 * 60 * 60 * 1000 },
+      slug: 'experiment-check-in',
+      status: 'active',
+      tags: [supportSeriesTag],
+      title: 'Experiment check-in',
+      vaultRoot,
+    })
+
+    await writeFile(
+      join(vaultRoot, 'bank/experiments/Stray Copy.md'),
+      '---\nslug: stray\n---\n',
+      'utf8',
+    )
+
+    const result = await applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-06-09T12:00:00.000Z'),
+      vaultRoot,
+    })
+
+    expect(result.experimentLifecycleFailure).toMatchObject({
+      code: 'EXPERIMENT_STORAGE_INVALID',
+    })
+    expect(result.created).toBe(5)
+    expect(
+      await showAutomation({ automationId: experimentAutomationId, vaultRoot }),
     ).toMatchObject({ status: 'active' })
   })
 

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2303,6 +2303,38 @@ async function applyHostedManagedAutomationsBestEffort(input: {
     });
   }
 
+  if (result.experimentLifecycleFailure !== undefined) {
+    // The pass still delivered every automation that does not depend on the
+    // experiment scan, so this is reported and not treated as a failed setup.
+    const failure = buildHostedRuntimeFailureDiagnostics(
+      result.experimentLifecycleFailure,
+      "Hosted managed automation experiment lifecycle staging failed.",
+      { includeSafeIdentity: true },
+    );
+    await writeHostedRuntimeLogBestEffort({
+      entry: {
+        ...buildHostedRuntimeLogContextFields({
+          attemptId: input.input.request.attemptId,
+          leaseGeneration: input.input.request.leaseGeneration,
+          workspaceVersion: input.input.request.workspaceVersion,
+        }),
+        component: "runtime",
+        errorCode: failure.errorCode,
+        eventCode: "runner.error",
+        level: "warn",
+        phase: "error",
+        redactedJson: {
+          ...failure.redactedJson,
+          ...buildHostedManagedAutomationStageDiagnostics({
+            stage: "experiment_lifecycle",
+          }),
+          murphManagedAutomationExperimentLifecycleFailed: true,
+        },
+      },
+      platform: input.input.runtime.platform,
+    });
+  }
+
   if (result.yielded === true) {
     return {
       checkpointReason: "assistant_runtime_commit",

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2333,6 +2333,25 @@ async function applyHostedManagedAutomationsBestEffort(input: {
       },
       platform: input.input.runtime.platform,
     });
+
+    // A transient filesystem or lock failure is still owned by the existing
+    // bounded setup-retry ladder. Degrading the stage must not swallow those
+    // and report a successful pass, or a time-bound experiment seed is never
+    // installed and its one-shot goes stale unrecoverably.
+    if (
+      isHostedManagedAutomationSetupRetryableError(result.experimentLifecycleFailure)
+    ) {
+      return buildHostedManagedAutomationFailureResult({
+        error: result.experimentLifecycleFailure,
+        input: input.input,
+        redactedStatus: {
+          murphManagedAutomationCreated: result.created,
+          murphManagedAutomationExperimentLifecycleFailed: true,
+          murphManagedAutomationSkipped: result.skipped,
+          murphManagedAutomationUpdated: result.updated,
+        },
+      });
+    }
   }
 
   if (result.yielded === true) {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -2952,6 +2952,69 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     );
   });
 
+  it("keeps the bounded retry ladder for a transient experiment lifecycle failure", async () => {
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const transient = Object.assign(new Error("experiment snapshot busy"), {
+      code: "EBUSY",
+    });
+    mocks.applyMurphManagedAutomations.mockResolvedValueOnce({
+      created: 2,
+      experimentLifecycleFailure: transient,
+      skipped: 0,
+      updated: 0,
+    });
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      logRequests,
+      now: () => "2026-04-27T00:00:00.000Z",
+    }));
+
+    // First rung of the existing 30s / 2m / 10m ladder, with the unrelated
+    // automations that already landed preserved in the status.
+    expect(result).toEqual(expect.objectContaining({
+      nextWakeAt: "2026-04-27T00:00:30.000Z",
+      progressed: true,
+      redactedStatus: expect.objectContaining({
+        murphManagedAutomationCreated: 2,
+        murphManagedAutomationExperimentLifecycleFailed: true,
+        murphManagedAutomationSetupRetryAttempt: 1,
+        murphManagedAutomationSetupRetryable: true,
+      }),
+    }));
+    // It must not also report the pass as a clean success.
+    expect(result.redactedStatus).not.toEqual(expect.objectContaining({
+      murphManagedAutomationFailed: false,
+    }));
+  });
+
+  it("does not retry a deterministic experiment storage failure", async () => {
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    mocks.applyMurphManagedAutomations.mockResolvedValueOnce({
+      created: 2,
+      experimentLifecycleFailure: Object.assign(
+        new Error("Experiment storage contains an entry that could hold an experiment document."),
+        { code: "EXPERIMENT_STORAGE_INVALID" },
+      ),
+      skipped: 0,
+      updated: 0,
+    });
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      logRequests,
+      now: () => "2026-04-27T00:00:00.000Z",
+    }));
+
+    // Retrying an unchanged vault every 30 seconds would buy nothing.
+    expect(result).not.toEqual(expect.objectContaining({
+      nextWakeAt: "2026-04-27T00:00:30.000Z",
+    }));
+    expect(result).toEqual(expect.objectContaining({
+      redactedStatus: expect.objectContaining({
+        murphManagedAutomationCreated: 2,
+      }),
+    }));
+  });
+
   it("logs stable-key metadata failures when background setup stays idle", async () => {
     const logRequests: HostedRuntimeLogRequest[] = [];
     const stableKeyFailure = new Error("metadata unavailable");

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -2916,6 +2916,42 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     );
   });
 
+  it("reports a degraded experiment lifecycle stage without failing the pass", async () => {
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    mocks.applyMurphManagedAutomations.mockResolvedValueOnce({
+      created: 2,
+      experimentLifecycleFailure: new Error("Experiment storage rejected an entry."),
+      skipped: 0,
+      updated: 0,
+    });
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      logRequests,
+      now: () => "2026-04-27T00:00:00.000Z",
+    }));
+
+    // The automations that do not depend on the experiment scan still landed.
+    expect(result).toEqual(expect.objectContaining({
+      progressed: true,
+      redactedStatus: expect.objectContaining({
+        murphManagedAutomationCreated: 2,
+        murphManagedAutomationFailed: false,
+      }),
+    }));
+    expect(logRequests.flatMap((request) => request.entries)).toContainEqual(
+      expect.objectContaining({
+        component: "runtime",
+        eventCode: "runner.error",
+        level: "warn",
+        phase: "error",
+        redactedJson: expect.objectContaining({
+          murphManagedAutomationExperimentLifecycleFailed: true,
+          murphManagedAutomationStage: "experiment_lifecycle",
+        }),
+      }),
+    );
+  });
+
   it("logs stable-key metadata failures when background setup stays idle", async () => {
     const logRequests: HostedRuntimeLogRequest[] = [];
     const stableKeyFailure = new Error("metadata unavailable");

--- a/packages/core/src/experiment-media-repair.ts
+++ b/packages/core/src/experiment-media-repair.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
 import path from "node:path";
 
 import {
+  EXPERIMENTS_DIRECTORY,
   ID_PREFIXES,
   rawImportManifestSchema,
   safeParseContract,
@@ -899,6 +901,40 @@ async function createAndVerifyCapture(
   return verified;
 }
 
+/**
+ * Removes the legacy directories a promotion just emptied, deepest first.
+ *
+ * Promotion deletes files but the directories that held them are not vault
+ * content, so nothing else ever reclaims them. Leaving them behind is what
+ * turned a completed repair into residue that later readers had to tolerate.
+ * `rmdir` succeeds only on an empty directory, so a directory that still holds
+ * anything is left exactly as it is.
+ */
+async function removeEmptiedLegacyDirectories(
+  vaultRoot: string,
+  deletedRelativePaths: readonly string[],
+): Promise<void> {
+  const directories = new Set<string>();
+  for (const deletedRelativePath of deletedRelativePaths) {
+    let current = path.posix.dirname(deletedRelativePath);
+    while (current.startsWith(`${EXPERIMENTS_DIRECTORY}/`)) {
+      directories.add(current);
+      current = path.posix.dirname(current);
+    }
+  }
+
+  const depth = (relativePath: string): number => relativePath.split("/").length;
+  for (const relativePath of [...directories].sort((left, right) =>
+    depth(right) - depth(left)
+  )) {
+    try {
+      await fs.rmdir(resolveVaultPath(vaultRoot, relativePath).absolutePath);
+    } catch {
+      // Still populated, already gone, or concurrently reused.
+    }
+  }
+}
+
 function summarizeBlockers(
   blockers: readonly ExperimentMediaRepairBlocker[],
 ): Record<string, number> {
@@ -1076,6 +1112,11 @@ export async function repairExperimentMediaInternal(
     summary: "Promote misplaced experiment media and remove verified legacy copies",
     vaultRoot: input.vaultRoot,
   });
+
+  await removeEmptiedLegacyDirectories(
+    input.vaultRoot,
+    detection.candidates.map((candidate) => candidate.relativePath),
+  );
 
   return resultFromDetection({
     auditPaths: [deletion.auditPath],

--- a/packages/core/src/experiment-storage.ts
+++ b/packages/core/src/experiment-storage.ts
@@ -4,6 +4,7 @@ import { promises as fs } from "node:fs";
 import {
   classifyExperimentStorageFile,
   EXPERIMENTS_DIRECTORY,
+  EXPERIMENT_OUTCOMES_DIRECTORY,
   isExperimentDocumentRelativePath,
   type ExperimentStorageFileKind,
 } from "@murphai/contracts";
@@ -31,6 +32,62 @@ export interface CanonicalExperimentDocumentPathPage {
 
 function isMarkdownFileName(name: string): boolean {
   return path.extname(name).toLowerCase() === ".md";
+}
+
+/**
+ * Bounds the residue inspection below one direct experiment subdirectory.
+ *
+ * Reclaimed legacy trees are a handful of empty directories, so this only has
+ * to be large enough to prove that shape inert while keeping the lifecycle
+ * reader's work bounded.
+ */
+const MAX_EXPERIMENT_RESIDUE_ENTRIES = 4_096;
+
+const EXPERIMENT_OUTCOMES_DIRECTORY_NAME =
+  EXPERIMENT_OUTCOMES_DIRECTORY.split("/").at(-1);
+
+/**
+ * Proves a direct subdirectory cannot hide a canonical experiment document.
+ *
+ * A directory is never a document, but it can *contain* one, and a reader that
+ * skipped it unconditionally would hand back a complete-looking snapshot that
+ * silently omits that experiment. Callers archive support automations and
+ * resolve due one-shots from this snapshot, so absence has to mean absence.
+ * Anything this cannot prove inert — a Markdown file at any depth, a symlink,
+ * a non-regular file, or a tree larger than the bound — returns false so the
+ * caller fails closed instead.
+ */
+async function experimentDirectoryIsDocumentFree(
+  absoluteDirectory: string,
+): Promise<boolean> {
+  const pending = [absoluteDirectory];
+  let inspected = 0;
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined) {
+      break;
+    }
+
+    for (const child of await fs.readdir(current, { withFileTypes: true })) {
+      inspected += 1;
+      if (inspected > MAX_EXPERIMENT_RESIDUE_ENTRIES) {
+        return false;
+      }
+      if (child.isSymbolicLink() || (!child.isDirectory() && !child.isFile())) {
+        return false;
+      }
+      if (child.isDirectory()) {
+        pending.push(path.join(current, child.name));
+        continue;
+      }
+      if (isMarkdownFileName(child.name)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 export function assertExperimentDocumentRelativePath(relativePath: string): void {
@@ -116,6 +173,21 @@ export async function listCanonicalExperimentDocumentPaths(
     .map((entry) => entry.relativePath);
 }
 
+/** Classifies one direct experiment-root entry the lifecycle reader may skip. */
+async function experimentStorageEntryIsProvenInert(
+  entry: { isDirectory: () => boolean; isFile: () => boolean; isSymbolicLink: () => boolean; name: string },
+  absolutePath: string,
+): Promise<boolean> {
+  if (entry.isSymbolicLink()) {
+    return false;
+  }
+  if (entry.isDirectory()) {
+    return entry.name === EXPERIMENT_OUTCOMES_DIRECTORY_NAME
+      || await experimentDirectoryIsDocumentFree(absolutePath);
+  }
+  return entry.isFile() && !isMarkdownFileName(entry.name);
+}
+
 /**
  * Lists only direct experiment documents without walking the outcomes tree.
  *
@@ -123,13 +195,18 @@ export async function listCanonicalExperimentDocumentPaths(
  * scan so foreground work can interrupt directory enumeration and so one
  * maintenance pass can never admit an unbounded number of documents.
  *
- * Residue that cannot be a canonical document is skipped rather than fatal.
- * Directories, symlinks, and non-Markdown files are inert here, and
- * `validateVault` already reports them as storage issues, so refusing to list
- * anything because one is present only costs the caller its whole pass. A
- * stray Markdown file is the one case still worth failing closed on: it may be
- * a mis-named experiment document, and silently dropping it would take that
- * experiment out of lifecycle care without anyone noticing.
+ * Residue that is *proven* unable to hold a canonical document is skipped
+ * rather than fatal: non-Markdown regular files, and directories whose subtree
+ * contains no Markdown at all. Reclaimed legacy media trees are that shape, and
+ * `validateVault` already reports them, so refusing to list anything because one
+ * is present only costs the caller its whole pass.
+ *
+ * Everything else still fails closed, because callers treat this snapshot as
+ * authoritative absence — they archive support automations and resolve due
+ * one-shots from it. Silently omitting a document that exists would delete the
+ * user's experiment work. So a stray Markdown file, a directory holding Markdown
+ * at any depth, a symlink, and a non-regular file all remain
+ * `EXPERIMENT_STORAGE_INVALID`.
  */
 export async function listCanonicalExperimentDocumentPathsInterruptible(input: {
   vaultRoot: string;
@@ -167,14 +244,20 @@ export async function listCanonicalExperimentDocumentPathsInterruptible(input: {
 
     const relativePath = `${EXPERIMENTS_DIRECTORY}/${entry.name}`;
     if (!entry.isFile() || !isExperimentDocumentRelativePath(relativePath)) {
-      if (entry.isFile() && isMarkdownFileName(entry.name)) {
-        throw new VaultError(
-          "EXPERIMENT_STORAGE_INVALID",
-          "Experiment storage contains an unsupported direct Markdown entry.",
-          { relativePath },
-        );
+      if (
+        await experimentStorageEntryIsProvenInert(
+          entry,
+          path.join(experimentRoot.absolutePath, entry.name),
+        )
+      ) {
+        continue;
       }
-      continue;
+
+      throw new VaultError(
+        "EXPERIMENT_STORAGE_INVALID",
+        "Experiment storage contains an entry that could hold an experiment document.",
+        { relativePath },
+      );
     }
 
     if (relativePaths.length >= input.maxDocuments) {

--- a/packages/core/src/experiment-storage.ts
+++ b/packages/core/src/experiment-storage.ts
@@ -4,7 +4,6 @@ import { promises as fs } from "node:fs";
 import {
   classifyExperimentStorageFile,
   EXPERIMENTS_DIRECTORY,
-  EXPERIMENT_OUTCOMES_DIRECTORY,
   isExperimentDocumentRelativePath,
   type ExperimentStorageFileKind,
 } from "@murphai/contracts";
@@ -28,6 +27,10 @@ export interface ExperimentStorageEntry {
 export interface CanonicalExperimentDocumentPathPage {
   relativePaths: string[];
   yielded: boolean;
+}
+
+function isMarkdownFileName(name: string): boolean {
+  return path.extname(name).toLowerCase() === ".md";
 }
 
 export function assertExperimentDocumentRelativePath(relativePath: string): void {
@@ -119,6 +122,14 @@ export async function listCanonicalExperimentDocumentPaths(
  * Lifecycle maintenance uses this boundary instead of the general storage
  * scan so foreground work can interrupt directory enumeration and so one
  * maintenance pass can never admit an unbounded number of documents.
+ *
+ * Residue that cannot be a canonical document is skipped rather than fatal.
+ * Directories, symlinks, and non-Markdown files are inert here, and
+ * `validateVault` already reports them as storage issues, so refusing to list
+ * anything because one is present only costs the caller its whole pass. A
+ * stray Markdown file is the one case still worth failing closed on: it may be
+ * a mis-named experiment document, and silently dropping it would take that
+ * experiment out of lifecycle care without anyone noticing.
  */
 export async function listCanonicalExperimentDocumentPathsInterruptible(input: {
   vaultRoot: string;
@@ -148,24 +159,22 @@ export async function listCanonicalExperimentDocumentPathsInterruptible(input: {
     return { relativePaths: [], yielded: true };
   }
   const relativePaths: string[] = [];
-  const outcomesDirectoryName = EXPERIMENT_OUTCOMES_DIRECTORY.split("/").at(-1);
 
   for await (const entry of await fs.opendir(experimentRoot.absolutePath)) {
     if (input.shouldYield?.() === true) {
       return { relativePaths: [], yielded: true };
     }
 
-    if (entry.isDirectory() && entry.name === outcomesDirectoryName) {
-      continue;
-    }
-
     const relativePath = `${EXPERIMENTS_DIRECTORY}/${entry.name}`;
     if (!entry.isFile() || !isExperimentDocumentRelativePath(relativePath)) {
-      throw new VaultError(
-        "EXPERIMENT_STORAGE_INVALID",
-        "Experiment storage contains an unsupported direct entry.",
-        { relativePath },
-      );
+      if (entry.isFile() && isMarkdownFileName(entry.name)) {
+        throw new VaultError(
+          "EXPERIMENT_STORAGE_INVALID",
+          "Experiment storage contains an unsupported direct Markdown entry.",
+          { relativePath },
+        );
+      }
+      continue;
     }
 
     if (relativePaths.length >= input.maxDocuments) {

--- a/packages/core/src/experiment-storage.ts
+++ b/packages/core/src/experiment-storage.ts
@@ -4,7 +4,6 @@ import { promises as fs } from "node:fs";
 import {
   classifyExperimentStorageFile,
   EXPERIMENTS_DIRECTORY,
-  EXPERIMENT_OUTCOMES_DIRECTORY,
   isExperimentDocumentRelativePath,
   type ExperimentStorageFileKind,
 } from "@murphai/contracts";
@@ -35,60 +34,13 @@ function isMarkdownFileName(name: string): boolean {
 }
 
 /**
- * Bounds the residue inspection below one direct experiment subdirectory.
+ * Bounds one lifecycle enumeration so a pathological tree cannot run unbounded.
  *
- * Reclaimed legacy trees are a handful of empty directories, so this only has
- * to be large enough to prove that shape inert while keeping the lifecycle
- * reader's work bounded.
+ * Experiment storage holds one document per experiment plus one JSON record per
+ * completed outcome, so this sits far above any real vault and exists only as a
+ * ceiling.
  */
-const MAX_EXPERIMENT_RESIDUE_ENTRIES = 4_096;
-
-const EXPERIMENT_OUTCOMES_DIRECTORY_NAME =
-  EXPERIMENT_OUTCOMES_DIRECTORY.split("/").at(-1);
-
-/**
- * Proves a direct subdirectory cannot hide a canonical experiment document.
- *
- * A directory is never a document, but it can *contain* one, and a reader that
- * skipped it unconditionally would hand back a complete-looking snapshot that
- * silently omits that experiment. Callers archive support automations and
- * resolve due one-shots from this snapshot, so absence has to mean absence.
- * Anything this cannot prove inert — a Markdown file at any depth, a symlink,
- * a non-regular file, or a tree larger than the bound — returns false so the
- * caller fails closed instead.
- */
-async function experimentDirectoryIsDocumentFree(
-  absoluteDirectory: string,
-): Promise<boolean> {
-  const pending = [absoluteDirectory];
-  let inspected = 0;
-
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (current === undefined) {
-      break;
-    }
-
-    for (const child of await fs.readdir(current, { withFileTypes: true })) {
-      inspected += 1;
-      if (inspected > MAX_EXPERIMENT_RESIDUE_ENTRIES) {
-        return false;
-      }
-      if (child.isSymbolicLink() || (!child.isDirectory() && !child.isFile())) {
-        return false;
-      }
-      if (child.isDirectory()) {
-        pending.push(path.join(current, child.name));
-        continue;
-      }
-      if (isMarkdownFileName(child.name)) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
+const MAX_EXPERIMENT_STORAGE_ENTRIES = 16_384;
 
 export function assertExperimentDocumentRelativePath(relativePath: string): void {
   if (isExperimentDocumentRelativePath(relativePath)) {
@@ -173,40 +125,27 @@ export async function listCanonicalExperimentDocumentPaths(
     .map((entry) => entry.relativePath);
 }
 
-/** Classifies one direct experiment-root entry the lifecycle reader may skip. */
-async function experimentStorageEntryIsProvenInert(
-  entry: { isDirectory: () => boolean; isFile: () => boolean; isSymbolicLink: () => boolean; name: string },
-  absolutePath: string,
-): Promise<boolean> {
-  if (entry.isSymbolicLink()) {
-    return false;
-  }
-  if (entry.isDirectory()) {
-    return entry.name === EXPERIMENT_OUTCOMES_DIRECTORY_NAME
-      || await experimentDirectoryIsDocumentFree(absolutePath);
-  }
-  return entry.isFile() && !isMarkdownFileName(entry.name);
-}
-
 /**
- * Lists only direct experiment documents without walking the outcomes tree.
+ * Lists the canonical experiment documents, bounded and interruptible.
  *
- * Lifecycle maintenance uses this boundary instead of the general storage
- * scan so foreground work can interrupt directory enumeration and so one
- * maintenance pass can never admit an unbounded number of documents.
+ * Callers treat this snapshot as *authoritative absence*: support-series
+ * reconciliation archives automations for experiments it does not name, and
+ * fire-time one-shot lookup consumes an occurrence whose owner it cannot find.
+ * Completeness is therefore the contract, and one rule enforces it at every
+ * depth — the same `classifyExperimentStorageFile` the write policy and
+ * `validateVault` already use, so there is no second notion of what belongs
+ * here to drift apart from.
  *
- * Residue that is *proven* unable to hold a canonical document is skipped
- * rather than fatal: non-Markdown regular files, and directories whose subtree
- * contains no Markdown at all. Reclaimed legacy media trees are that shape, and
- * `validateVault` already reports them, so refusing to list anything because one
- * is present only costs the caller its whole pass.
+ * Every regular file is classified by its own path. A document is listed, an
+ * outcome record is ignored, and anything else is fatal only when it could
+ * itself be a document — that is, when it is Markdown. That single rule covers
+ * the reserved outcomes subtree without naming it, so a document hidden there
+ * fails closed like any other.
  *
- * Everything else still fails closed, because callers treat this snapshot as
- * authoritative absence — they archive support automations and resolve due
- * one-shots from it. Silently omitting a document that exists would delete the
- * user's experiment work. So a stray Markdown file, a directory holding Markdown
- * at any depth, a symlink, and a non-regular file all remain
- * `EXPERIMENT_STORAGE_INVALID`.
+ * Directories are pure containers and are walked, never trusted by name, which
+ * is what makes the reclaimed legacy media trees this reader must tolerate
+ * (nested but holding no Markdown) inert without an exemption. Symlinks and
+ * non-regular entries can stand in for a document and stay fatal.
  */
 export async function listCanonicalExperimentDocumentPathsInterruptible(input: {
   vaultRoot: string;
@@ -236,38 +175,75 @@ export async function listCanonicalExperimentDocumentPathsInterruptible(input: {
     return { relativePaths: [], yielded: true };
   }
   const relativePaths: string[] = [];
+  const pending: Array<{ absolutePath: string; relativePath: string }> = [{
+    absolutePath: experimentRoot.absolutePath,
+    relativePath: EXPERIMENTS_DIRECTORY,
+  }];
+  let inspected = 0;
 
-  for await (const entry of await fs.opendir(experimentRoot.absolutePath)) {
-    if (input.shouldYield?.() === true) {
-      return { relativePaths: [], yielded: true };
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    if (directory === undefined) {
+      break;
     }
 
-    const relativePath = `${EXPERIMENTS_DIRECTORY}/${entry.name}`;
-    if (!entry.isFile() || !isExperimentDocumentRelativePath(relativePath)) {
-      if (
-        await experimentStorageEntryIsProvenInert(
-          entry,
-          path.join(experimentRoot.absolutePath, entry.name),
-        )
-      ) {
+    for (
+      const entry of await fs.readdir(directory.absolutePath, { withFileTypes: true })
+    ) {
+      if (input.shouldYield?.() === true) {
+        return { relativePaths: [], yielded: true };
+      }
+
+      inspected += 1;
+      if (inspected > MAX_EXPERIMENT_STORAGE_ENTRIES) {
+        throw new VaultError(
+          "EXPERIMENT_LIFECYCLE_LIMIT_EXCEEDED",
+          "Experiment lifecycle maintenance exceeded its bounded storage limit.",
+          { maxEntries: MAX_EXPERIMENT_STORAGE_ENTRIES },
+        );
+      }
+
+      const relativePath = `${directory.relativePath}/${entry.name}`;
+      if (entry.isSymbolicLink() || (!entry.isDirectory() && !entry.isFile())) {
+        throw new VaultError(
+          "EXPERIMENT_STORAGE_INVALID",
+          "Experiment storage contains an entry that could stand in for a document.",
+          { relativePath },
+        );
+      }
+
+      if (entry.isDirectory()) {
+        pending.push({
+          absolutePath: path.join(directory.absolutePath, entry.name),
+          relativePath,
+        });
         continue;
       }
 
-      throw new VaultError(
-        "EXPERIMENT_STORAGE_INVALID",
-        "Experiment storage contains an entry that could hold an experiment document.",
-        { relativePath },
-      );
-    }
+      const fileKind = classifyExperimentStorageFile(relativePath);
+      if (fileKind === "outcome") {
+        continue;
+      }
+      if (fileKind === "unsupported") {
+        if (isMarkdownFileName(entry.name)) {
+          throw new VaultError(
+            "EXPERIMENT_STORAGE_INVALID",
+            "Experiment storage contains a Markdown file that is not a canonical document.",
+            { relativePath },
+          );
+        }
+        continue;
+      }
 
-    if (relativePaths.length >= input.maxDocuments) {
-      throw new VaultError(
-        "EXPERIMENT_LIFECYCLE_LIMIT_EXCEEDED",
-        "Experiment lifecycle maintenance exceeded its bounded document limit.",
-        { maxDocuments: input.maxDocuments },
-      );
+      if (relativePaths.length >= input.maxDocuments) {
+        throw new VaultError(
+          "EXPERIMENT_LIFECYCLE_LIMIT_EXCEEDED",
+          "Experiment lifecycle maintenance exceeded its bounded document limit.",
+          { maxDocuments: input.maxDocuments },
+        );
+      }
+      relativePaths.push(relativePath);
     }
-    relativePaths.push(relativePath);
   }
 
   if (input.shouldYield?.() === true) {

--- a/packages/core/test/experiment-lifecycle-read.test.ts
+++ b/packages/core/test/experiment-lifecycle-read.test.ts
@@ -78,9 +78,11 @@ test("experiment lifecycle reads skip residue that cannot be a document", async 
     // Residue a synced filesystem adds on its own.
     await fs.writeFile(path.join(experimentRoot, ".DS_Store"), "finder", "utf8");
     await fs.writeFile(path.join(experimentRoot, "scratch.txt"), "notes", "utf8");
-    await fs.symlink(
-      path.join(experimentRoot, "sleep-reset.md"),
-      path.join(experimentRoot, "alias-link.md"),
+    // Un-promoted legacy media is inert for document listing too.
+    await fs.writeFile(
+      path.join(experimentRoot, "media/sleep-reset/2026-06-26/baseline.webp"),
+      "image-bytes",
+      "utf8",
     );
 
     const result = await readExperimentLifecycleFrontmatterDocuments({ vaultRoot });
@@ -110,6 +112,59 @@ test("experiment lifecycle reads still fail closed on a stray Markdown document"
         // The rejected path is what makes this diagnosable in production.
         && (error.details as { relativePath?: string }).relativePath
           === "bank/experiments/Sleep Reset Copy.md",
+    );
+  } finally {
+    await fs.rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("experiment lifecycle reads never report a document hidden below the root as absent", async () => {
+  for (const hidden of [
+    "recovered/sleep-reset.md",
+    "recovered/deeper/still/sleep-reset.md",
+  ]) {
+    const vaultRoot = await makeVault("murph-experiment-lifecycle-hidden-md");
+    const experimentRoot = path.join(vaultRoot, "bank/experiments");
+
+    try {
+      await createExperiment({ slug: "other", title: "Other", vaultRoot });
+      const hiddenPath = path.join(experimentRoot, hidden);
+      await fs.mkdir(path.dirname(hiddenPath), { recursive: true });
+      await fs.writeFile(hiddenPath, "---\nslug: sleep-reset\n---\n", "utf8");
+
+      // Reporting `other` alone would be authoritative absence for sleep-reset,
+      // and callers archive that experiment's automations from this snapshot.
+      await assert.rejects(
+        readExperimentLifecycleFrontmatterDocuments({ vaultRoot }),
+        (error: unknown) =>
+          error instanceof VaultError
+          && error.code === "EXPERIMENT_STORAGE_INVALID"
+          && (error.details as { relativePath?: string }).relativePath
+            === "bank/experiments/recovered",
+        `hidden document ${hidden}`,
+      );
+    } finally {
+      await fs.rm(vaultRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test("experiment lifecycle reads fail closed on an entry they cannot prove inert", async () => {
+  const vaultRoot = await makeVault("murph-experiment-lifecycle-symlink");
+  const experimentRoot = path.join(vaultRoot, "bank/experiments");
+
+  try {
+    await createExperiment({ slug: "sleep-reset", title: "Sleep Reset", vaultRoot });
+    // A symlink can stand in for a Markdown document or a directory holding one.
+    await fs.symlink(
+      path.join(experimentRoot, "sleep-reset.md"),
+      path.join(experimentRoot, "alias-link.md"),
+    );
+
+    await assert.rejects(
+      readExperimentLifecycleFrontmatterDocuments({ vaultRoot }),
+      (error: unknown) =>
+        error instanceof VaultError && error.code === "EXPERIMENT_STORAGE_INVALID",
     );
   } finally {
     await fs.rm(vaultRoot, { recursive: true, force: true });

--- a/packages/core/test/experiment-lifecycle-read.test.ts
+++ b/packages/core/test/experiment-lifecycle-read.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { test } from "vitest";
 
 import {
+  createExperiment,
   initializeVault,
   MAX_EXPERIMENT_LIFECYCLE_DOCUMENTS,
   readExperimentLifecycleFrontmatterDocuments,
@@ -58,6 +59,57 @@ test("experiment lifecycle reads never traverse the outcomes tree", async () => 
     assert.deepEqual(
       await readExperimentLifecycleFrontmatterDocuments({ vaultRoot }),
       { items: [], yielded: false },
+    );
+  } finally {
+    await fs.rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("experiment lifecycle reads skip residue that cannot be a document", async () => {
+  const vaultRoot = await makeVault("murph-experiment-lifecycle-residue");
+  const experimentRoot = path.join(vaultRoot, "bank/experiments");
+
+  try {
+    await createExperiment({ slug: "sleep-reset", title: "Sleep Reset", vaultRoot });
+    // Empty directories left behind by a completed media promotion.
+    await fs.mkdir(path.join(experimentRoot, "media/sleep-reset/2026-06-26"), {
+      recursive: true,
+    });
+    // Residue a synced filesystem adds on its own.
+    await fs.writeFile(path.join(experimentRoot, ".DS_Store"), "finder", "utf8");
+    await fs.writeFile(path.join(experimentRoot, "scratch.txt"), "notes", "utf8");
+    await fs.symlink(
+      path.join(experimentRoot, "sleep-reset.md"),
+      path.join(experimentRoot, "alias-link.md"),
+    );
+
+    const result = await readExperimentLifecycleFrontmatterDocuments({ vaultRoot });
+    assert.equal(result.yielded, false);
+    assert.deepEqual(result.items.map((item) => item.slug), ["sleep-reset"]);
+  } finally {
+    await fs.rm(vaultRoot, { recursive: true, force: true });
+  }
+});
+
+test("experiment lifecycle reads still fail closed on a stray Markdown document", async () => {
+  const vaultRoot = await makeVault("murph-experiment-lifecycle-stray-md");
+  const experimentRoot = path.join(vaultRoot, "bank/experiments");
+
+  try {
+    await fs.writeFile(
+      path.join(experimentRoot, "Sleep Reset Copy.md"),
+      "---\nslug: sleep-reset\n---\n",
+      "utf8",
+    );
+
+    await assert.rejects(
+      readExperimentLifecycleFrontmatterDocuments({ vaultRoot }),
+      (error: unknown) =>
+        error instanceof VaultError
+        && error.code === "EXPERIMENT_STORAGE_INVALID"
+        // The rejected path is what makes this diagnosable in production.
+        && (error.details as { relativePath?: string }).relativePath
+          === "bank/experiments/Sleep Reset Copy.md",
     );
   } finally {
     await fs.rm(vaultRoot, { recursive: true, force: true });

--- a/packages/core/test/experiment-lifecycle-read.test.ts
+++ b/packages/core/test/experiment-lifecycle-read.test.ts
@@ -43,13 +43,18 @@ test("experiment lifecycle reads discard a partially enumerated snapshot when as
   }
 });
 
-test("experiment lifecycle reads never traverse the outcomes tree", async () => {
+test("experiment lifecycle reads never list anything from the outcomes tree", async () => {
   const vaultRoot = await makeVault("murph-experiment-lifecycle-outcomes");
 
   try {
     await fs.mkdir(path.join(vaultRoot, "bank/experiments/outcomes"), {
       recursive: true,
     });
+    await fs.writeFile(
+      path.join(vaultRoot, "bank/experiments/outcomes/completed-2026-04-01.json"),
+      "{}\n",
+      "utf8",
+    );
     await fs.writeFile(
       path.join(vaultRoot, "bank/experiments/outcomes/not-an-outcome.txt"),
       "ignored by lifecycle frontmatter reads",
@@ -122,6 +127,10 @@ test("experiment lifecycle reads never report a document hidden below the root a
   for (const hidden of [
     "recovered/sleep-reset.md",
     "recovered/deeper/still/sleep-reset.md",
+    // The reserved outcomes subtree is not exempt from this: it is walked by
+    // the same rule as any other directory.
+    "outcomes/sleep-reset.md",
+    "outcomes/nested/sleep-reset.md",
   ]) {
     const vaultRoot = await makeVault("murph-experiment-lifecycle-hidden-md");
     const experimentRoot = path.join(vaultRoot, "bank/experiments");
@@ -139,8 +148,9 @@ test("experiment lifecycle reads never report a document hidden below the root a
         (error: unknown) =>
           error instanceof VaultError
           && error.code === "EXPERIMENT_STORAGE_INVALID"
+          // The rejected path names the hidden document itself.
           && (error.details as { relativePath?: string }).relativePath
-            === "bank/experiments/recovered",
+            === `bank/experiments/${hidden}`,
         `hidden document ${hidden}`,
       );
     } finally {

--- a/packages/core/test/experiment-media-repair.test.ts
+++ b/packages/core/test/experiment-media-repair.test.ts
@@ -20,6 +20,7 @@ import {
   applyCanonicalWriteBatch,
   createExperiment,
   initializeVault,
+  readExperimentLifecycleFrontmatterDocuments,
   repairExperimentMedia,
   validateVault,
   walkVaultFiles,
@@ -112,7 +113,13 @@ test("experiment media repair is dry-run first and copy-verifies before exact li
   assert.equal(repairedMarkdown.includes(legacyRelativePath), false);
   assert.equal(repairedMarkdown.split(capturedMediaPath).length - 1, 2);
   assert.equal((await validateVault({ vaultRoot })).valid, true);
+  // Promotion reclaims the directory it emptied, so nothing is left under the
+  // experiments root for later readers to tolerate.
+  await assert.rejects(readFile(path.dirname(legacyPath), "utf8"), {
+    code: "ENOENT",
+  });
 
+  await mkdir(path.dirname(legacyPath), { recursive: true });
   await writeFile(legacyPath, "legacy-image-bytes", "utf8");
   await writeFile(
     experimentPath,
@@ -128,6 +135,7 @@ test("experiment media repair is dry-run first and copy-verifies before exact li
     canonicalCapturePaths,
   );
 
+  await mkdir(path.dirname(legacyPath), { recursive: true });
   await writeFile(legacyPath, "legacy-image-bytes", "utf8");
   await writeFile(
     experimentPath,
@@ -719,4 +727,54 @@ test("vault validation and supported text writes enforce the direct experiment a
     ),
     true,
   );
+});
+
+test("experiment media repair reclaims the nested directories it empties", async () => {
+  const vaultRoot = await createTempVault();
+  const experiment = await createExperiment({
+    slug: "face-photo-check",
+    title: "Face Photo Check",
+    vaultRoot,
+  });
+
+  // The shape a legacy media folder actually takes: media/<slug>/<date>/.
+  const legacyDirectory =
+    `${VAULT_LAYOUT.experimentsDirectory}/media/face-photo-check/2026-06-26`;
+  const legacyRelativePaths = [
+    `${legacyDirectory}/baseline-front.webp`,
+    `${legacyDirectory}/baseline-left-profile.webp`,
+  ];
+  await mkdir(path.join(vaultRoot, legacyDirectory), { recursive: true });
+  for (const relativePath of legacyRelativePaths) {
+    await writeFile(path.join(vaultRoot, relativePath), relativePath, "utf8");
+  }
+
+  const experimentPath = path.join(vaultRoot, experiment.experiment.relativePath);
+  await writeFile(
+    experimentPath,
+    `${await readFile(experimentPath, "utf8")}\n${
+      legacyRelativePaths.map((relativePath) => `Photo: ${relativePath}`).join("\n")
+    }\n`,
+    "utf8",
+  );
+
+  const applied = await repairExperimentMedia({ apply: true, vaultRoot });
+  assert.equal(applied.mutated, true);
+  assert.equal(applied.deletedFileCount, legacyRelativePaths.length);
+
+  // Every level of the emptied tree is gone, and the experiments root is not.
+  for (const removed of [
+    legacyDirectory,
+    `${VAULT_LAYOUT.experimentsDirectory}/media/face-photo-check`,
+    `${VAULT_LAYOUT.experimentsDirectory}/media`,
+  ]) {
+    await assert.rejects(readFile(path.join(vaultRoot, removed), "utf8"), {
+      code: "ENOENT",
+    });
+  }
+  assert.equal((await validateVault({ vaultRoot })).valid, true);
+
+  // And the lifecycle read the incident broke now succeeds.
+  const lifecycle = await readExperimentLifecycleFrontmatterDocuments({ vaultRoot });
+  assert.deepEqual(lifecycle.items.map((item) => item.slug), ["face-photo-check"]);
 });


### PR DESCRIPTION
## Why this PR exists

A completed experiment-media promotion deletes the files it promotes but never reclaims the directories that held them. One such leftover directory then made the experiment-lifecycle read refuse to return anything, which took down **every** managed automation for the affected user — not just experiments — for three days, behind a generic runtime-failure message.

## User goal / user-visible behavior

A user's scheduled Murph automations (memory consolidation, weekly coach, experiment check-ins) keep running even when their vault's experiments folder contains residue that is not a canonical experiment document. Residue is inert, not fatal.

## User experience

No new surface. The user-visible change is the absence of a silent outage: automations that previously stopped firing continue to fire. There is no entry point, no new screen, and no new inbound action — the failure and the recovery are both invisible to the user by design. Operationally, the failure is now reported as a degraded stage rather than a failed setup pass, and `validateVault` remains the on-demand channel that names the offending path.

Not a frontend change; no rendered evidence applies.

## Invariants the PR must preserve

- Experiment-lifecycle maintenance never operates on a **partial** document set. The snapshot is treated as authoritative absence by support-series reconciliation and by fire-time one-shot owner resolution, so anything that could hold or stand in for a document must fail closed — not just at the root, but at any depth.
- A stray Markdown file remains fail-closed: it may be a mis-named experiment document, and silently skipping it would remove that experiment from lifecycle care unnoticed.
- Transient failures keep their existing bounded retry owner; only deterministic storage-invalid failures take the no-retry degraded path.
- Directory reclamation only ever removes **empty** directories, never the experiments root, and never anything holding content.
- No vault-relative experiment path enters production logs. Experiment slugs are user-authored health topics; the existing redaction posture is deliberate and unchanged here.
- A degraded experiment stage must not be reported as a successful pass, nor as a failed setup that suppresses unrelated automations.

## Non-obvious affected surfaces

- **`repairExperimentMedia` post-commit behavior** (`packages/core/src/experiment-media-repair.ts`). Promotion now performs directory reclamation after the audited write commits. Necessary because the repair is the mechanism that created the outage condition; without it the condition returns on the next promotion. `rmdir` succeeds only on empty directories, so this cannot remove content. Regression proof: `experiment media repair reclaims the nested directories it empties`, plus two updated assertions in the existing dry-run/idempotency test that now re-create the pruned parent.
- **`applyMurphManagedAutomations` result contract** (`packages/assistant-engine`). Adds `experimentLifecycleFailure?: unknown`, following the existing `stableKeyFailure` idiom rather than introducing a new degradation mechanism. Changes the failure mode of the whole managed-automation pass from abort to degrade. Regression proof: `still creates unrelated automations when experiment lifecycle staging fails`.
- **Hosted runtime log stream** (`packages/assistant-runtime`). Emits one new `runner.error` warn entry carrying `murphManagedAutomationExperimentLifecycleFailed` and stage `experiment_lifecycle`, on a path that previously produced a setup failure. Regression proof: `reports a degraded experiment lifecycle stage without failing the pass`.
- **`experimentLookupForProgressMilestone`** (`packages/assistant-engine/src/assistant/experiment-support-automations.ts:957`) is a second, fire-time caller of the same reader. Its own comment requires read/parse failures to *propagate* so cron retries rather than consuming a due legacy one-shot. That is why the reader must fail closed on anything it cannot prove inert: a partial snapshot makes this lookup return no owner, which produces `skip` and permanently consumes the occurrence. Regression proof: `experiment lifecycle reads never report a document hidden below the root as absent`.
- **Managed-automation setup retry ladder** (`packages/assistant-runtime`). A transient experiment-lifecycle failure is routed back through `isHostedManagedAutomationSetupRetryableError` and `buildHostedManagedAutomationFailureResult`, so the existing 30s / 2m / 10m ladder still owns it. Necessary because degrading the stage would otherwise report a clean pass and reset retry state, stranding a time-bound seed until `isStaleMurphManagedOneShotSeed` drops it. Regression proofs: `keeps the bounded retry ladder for a transient experiment lifecycle failure` and `does not retry a deterministic experiment storage failure`.

## Preliminary specialist lenses

- **Prompt:** not applicable. No prompt, instruction, or model-facing text changes.
- **Frontend:** not applicable. No `apps/web` diff and no user-facing UI surface.
- **Coverage:** applicable. Canonical commands and outcomes:
  - `pnpm -F @murphai/core test` → **759 passed / 44 files, exit 0**
  - `pnpm -F @murphai/assistant-runtime test` → **1842 passed, 2 skipped / 76 files, exit 0**
  - `pnpm -F @murphai/assistant-engine test` → **2642 passed, 5 skipped / 172 files pass**, with one pre-existing vitest worker-teardown error on the untouched `assistant-local-service-runtime.test.ts`. Reproduced on a clean stash of `origin/main` at the same commit (`BASELINE_EXIT=1`, identical `Timeout terminating forks worker` message), so it is not introduced here.
  - `pnpm -F @murphai/core -F @murphai/assistant-engine -F @murphai/assistant-runtime typecheck` → clean.

  Preliminary specialist pass returned `SPECIALIST_OUTCOME: FINDINGS` (1 high, coverage lens) at `5b855ed190`. Accepted and fixed in `58e841189c` — see below.

## Change-shape breakdown

Classification rule: files under `test/` are tests/fixtures; files under `src/` are source; nothing here is generated, docs, or config. No binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 213 | 36 |
| Tests/fixtures | 350 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **563** | **38** |

## Design proof for user-facing frontend UI

Not applicable — no user-facing frontend UI diff.

## Deployment skew / compatibility

`packages/core` and `packages/assistant-engine` ship inside the runner bundle; `packages/assistant-runtime` spans the hosted runtime. During gradual container rollout, warm containers keep the old strict lister and continue failing the same way they do today, while new containers tolerate the residue — both states are safe and neither writes anything new. The `experimentLifecycleFailure` field is additive and optional, so an old runtime reading a new engine result simply ignores it, and a new runtime reading an old result sees `undefined` and takes the existing path. No persisted state shape changes, so there is nothing to migrate and nothing to reconcile.

Reversibility is a plain revert. Exposure is bounded: the change only affects passes that would otherwise have thrown, which is currently a small number of vaults holding experiment residue. `container_rollout=immediate` is not required; convergence is visible as the disappearance of `EXPERIMENT_STORAGE_INVALID` at the `experiment_lifecycle` stage in runner logs.

## Preliminary review finding, accepted and fixed

The preliminary specialist pass found that the degrade path introduced a **destructive** regression, and it was right. With `experimentLifecycle` null, `buildDesiredExperimentSupportSeries` still ran over the base seeds and produced an *empty* experiment desired set; `reconcileAutomationSupportSeriesNamespace` then treated every active automation in the `experiment-lifecycle:` namespace as stale and archived it (`packages/core/src/automation.ts:1245-1259`). So degrading the stage traded a total abort for silently archiving the user's live experiment check-ins, which `canReactivateReconciledLifecycleOneShot` cannot always restore once the scheduled time has passed.

Fixed in `58e841189c` by treating the desired experiment state as *unavailable* rather than empty — the namespace is skipped when `experimentLifecycleFailure` is present, reusing the existing `null`-means-skip gate rather than adding a branch. The new boundary test pre-creates an active experiment support-series automation and **fails without the fix** (verified by reverting the one-line change and re-running).

## Final gate round 1 findings, both accepted and fixed

Round 1 at `58e841189c` returned two findings; both were real and both are fixed in `3b2d78c9bd`.

**High — a skipped non-empty directory became destructive evidence of absence.** Skipping *every* directory meant a document moved to `bank/experiments/recovered/sleep-reset.md` yielded a complete-looking snapshot omitting it, so reconciliation archived its automations and the legacy progress lookup resolved no owner and consumed its one-shot. Fixed by proving inertness instead of assuming it: a directory is skipped only when its subtree contains no Markdown at all; symlinks and non-regular entries stay fatal.

One correction to the suggested fix: "verified-empty" directories would not have covered the original incident, whose residue was `media/` → `<slug>/` → `<date>/` — `media/` is non-empty because it holds a subdirectory. The subtree-Markdown-free rule covers both that shape and un-promoted legacy media, without a durable-state or recursive-scan mechanism (bounded at 4096 entries, fail-closed above it).

**Material UX — retryable failures were downgraded to a non-retrying success.** The new catch intercepted transient `EBUSY`/`EMFILE`/`EAGAIN` failures before the existing retry ladder saw them, so experiment seeds lost bounded retry and a time-bound one-shot could be permanently lost. Fixed by classifying the captured failure and returning `buildHostedManagedAutomationFailureResult` when retryable, keeping deterministic storage-invalid failures on the degraded no-retry path.

Both new tests were verified to **fail without their fix** by reverting each change and re-running.

## Round 2 retrospective (RETROSPECTIVE_REQUIRED)

Round 2 correctly refused another tactical patch. The round-1 fix asserted two positions at once: "Markdown at any depth fails closed" *and* a blanket `outcomes/` exemption skipped by directory name. A document at `bank/experiments/outcomes/sleep-reset.md` therefore still produced authoritative absence — the identical mechanism from round 1, preserved under a different name. That is why the repeated-mechanism trigger fired, and it was right.

**Governing requirement, reconciled to one position.** Experiment storage has exactly one notion of what belongs in it, and it already exists: `classifyExperimentStorageFile`, shared by the write policy and `validateVault`. The lifecycle reader now uses that same classifier at every depth instead of a private rule. No subtree is exempt.

**Ownership boundary.** The reader itself establishes snapshot completeness before any consumer runs. There is no new owner, queue, reconciliation state, or compatibility layer — the two destructive consumers (support-series reconciliation and fire-time one-shot lookup) are unchanged and simply never receive a partial snapshot.

**Direction chosen: shrink by deletion.** Round 1's remediation had accumulated four mechanisms — a recursive inertness prover, a 4096-entry residue bound, a separate direct-entry classifier, and a named exemption. All four are deleted. What replaces them is one pass: classify each regular file by its own path; list `document`, ignore `outcome`, and fail closed on any other Markdown. Directories are walked rather than trusted by name, which is *why* the original inert media residue is tolerated — those trees hold no Markdown — without an exemption existing at all. Symlinks and non-regular entries stay fatal because they can stand in for a document. This is the smallest shape that tolerates the residue without permitting an unchecked subtree, because the tolerance now falls out of the contract rather than being carved out beside it.

**Regression proof added across the storage boundary.** `experiment lifecycle reads never report a document hidden below the root as absent` now covers `recovered/sleep-reset.md`, a deeper nested path, and — closing the round-2 finding — `outcomes/sleep-reset.md` and `outcomes/nested/sleep-reset.md`, asserting the rejected path names the hidden document itself. Markdown-free media residue remains tolerated, the existing bounded-yield test still passes unchanged, an active support-series automation is proven preserved, and the transient-retry ladder keeps its two proofs.

Round 2 also confirmed the transient-failure correction is effective and found no `REVIEW_INDUCED` issue in that path; it is unchanged here.

## Deliberately deferred

- **Logging the rejected path.** Originally scoped, then dropped on review: an experiment slug is user-authored health content, so putting it in the production log stream would be a privacy regression. `validateVault` already reports the exact path through an operator-initiated channel, which is the right place for it.
- **Suppressing repeated deterministic failures.** The observed ~10-minute cadence is not a retry ladder — `EXPERIMENT_STORAGE_INVALID` is not in the transient set, so no `nextWakeAt` is scheduled. It is ordinary runner wakes re-running setup with no memo of deterministic failures. Worth fixing, but it is a scheduling-policy design question rather than part of this outage fix.

ReviewGPT first-reviewed head: 58e841189cddf3b63c368296509896e918edf399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
