### PR TITLE
Give each deploy smoke retry a fresh runner container and a wall-clock budget

### DIFF
--- a/.github/workflows/deploy-cloudflare-hosted.yml
+++ b/.github/workflows/deploy-cloudflare-hosted.yml
@@ -603,6 +603,9 @@ jobs:
       HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER: "true"
       HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS: "300"
       HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS: "3000"
+      # Must stay under this job's timeout-minutes so a rollout that never surfaces
+      # the new bundle fails here with a named reason instead of being cancelled.
+      HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS: "1200000"
       HOSTED_EXECUTION_SMOKE_USER_ID: ${{ inputs.smoke_user_id }}
       MURPH_RUNNER_BUNDLE_BUILD_CONCURRENCY: 1
       MURPH_RUNNER_BUNDLE_PACK_CONCURRENCY: 4

--- a/agent-docs/exec-plans/completed/2026-07-25-deploy-smoke-container-rollout-gate.md
+++ b/agent-docs/exec-plans/completed/2026-07-25-deploy-smoke-container-rollout-gate.md
@@ -1,0 +1,77 @@
+# Deploy Smoke Container Rollout Gate
+
+## Goal
+
+Make the deployed-endpoint runner-bundle smoke converge during a normal Cloudflare
+container rollout, and fail attributably inside the deploy job timeout when it does
+not.
+
+## Background
+
+Production deploy run `30149505443` deployed the Worker successfully, then spent 46
+minutes and 119 retries asserting that the managed container ran the new runner
+bundle. Every attempt reported the previous deploy's bundle, and the job was
+cancelled at its 60-minute timeout before the retry budget was reached.
+
+Cloudflare documents the underlying model: worker code updates immediately while
+containers roll out gradually, so a newly deployed Worker version legitimately
+coexists with old-image container instances until the rollout completes
+(`/containers/platform-details/rollouts/`).
+
+Two defects made that window fatal instead of transient:
+
+1. The smoke pins one Worker version for the whole run, and the smoke container's
+   Durable Object name is derived from that version
+   (`resolveDeployContainerSmokeObjectName`). Every retry therefore addressed one
+   Durable Object, hence one container instance. Once that instance was provisioned
+   from the pre-rollout image it stayed stale, and the smoke's own ~24s polling kept
+   it below the 20-minute idle TTL that would otherwise have reaped it. Retrying
+   could not reach a different instance.
+2. The retry budget is an attempt count with no wall-clock bound. At 300 attempts and
+   ~24s per attempt the budget is ~118 minutes against a 60-minute job timeout, so a
+   real convergence failure can never exhaust its own budget. It always surfaces as
+   an opaque cancelled job, and `Publish deployment summary` never runs.
+
+## Scope
+
+- `apps/cloudflare/scripts/smoke-hosted-deploy.shared.ts`
+- `apps/cloudflare/src/worker/route-handlers/deploy-smoke.ts`
+- `apps/cloudflare/test/smoke-hosted-deploy.test.ts`
+- `apps/cloudflare/test/index.test.ts`
+- `.github/workflows/deploy-cloudflare-hosted.yml`
+- `apps/cloudflare/DEPLOY.md`
+
+## Constraints
+
+- Do not weaken the bundle-identity assertion. A converged smoke must still prove the
+  deployed bundle actually boots and serves.
+- Keep the production per-user runner container lifecycle unchanged; this is
+  deploy-smoke-only.
+- Keep the existing attempt ceiling so retry tests stay deterministic without
+  injecting a clock.
+- No new persisted state, manager, or lifecycle machinery.
+
+## Plan
+
+1. Thread the retry attempt into the smoke request so each attempt addresses a fresh
+   smoke Durable Object, and therefore a fresh container-provisioning decision. Set
+   the attempt search param before signing so it is covered by the callback
+   signature.
+2. Accept the attempt segment in `resolveDeployContainerSmokeObjectName` and append it
+   to the object name, leaving the existing identity precedence intact.
+3. Add a wall-clock deadline to the runner-container smoke retry policy. On expiry,
+   throw a non-retryable error naming elapsed time, attempts, and the last failure.
+4. Set the deadline in the deploy workflow below the job timeout and above
+   Cloudflare's documented 15-minute forced-kill window.
+5. Cover: attempt-scoped object naming, per-attempt URL variation, deadline expiry,
+   and preserved convergence/assertion behavior.
+6. Document the deadline knob in `DEPLOY.md`.
+
+## Verification
+
+- Focused `apps/cloudflare` smoke and worker-index tests.
+- `pnpm test:diff` over the touched paths.
+- Typecheck.
+Status: completed
+Updated: 2026-07-25
+Completed: 2026-07-25

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -757,6 +757,7 @@ Optional smoke env:
 - `HOSTED_EXECUTION_SMOKE_LIVE_MODEL_TURN=true` to extend the managed-container smoke with one real `gpt-5.6-terra` turn; requires `HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER=true`
 - `HOSTED_EXECUTION_SMOKE_VERSION_ID` to pin smoke requests to a version in the active deployment; the deploy workflow passes the freshly deployed version
 - `HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS` and `HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS` to override the managed-container rollout wait
+- `HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS` to bound that wait by wall clock (default 20 minutes). Keep it under the deploy job timeout: the attempt ceiling alone can outlast the job, which makes a non-converging rollout surface as a cancelled job with no reason instead of a named smoke failure. Each attempt addresses its own smoke Durable Object, so retries get a fresh container instead of re-reading one pre-rollout container for the whole run.
 
 If neither managed-container smoke nor `HOSTED_EXECUTION_SMOKE_USER_ID` is configured, smoke stops after the public banner and health checks.
 

--- a/apps/cloudflare/scripts/smoke-hosted-deploy.shared.ts
+++ b/apps/cloudflare/scripts/smoke-hosted-deploy.shared.ts
@@ -46,6 +46,11 @@ const WORKER_VERSION_SMOKE_MAX_ATTEMPTS = 5;
 const WORKER_VERSION_SMOKE_RETRY_DELAY_MS = 2_000;
 const DEFAULT_RUNNER_CONTAINER_SMOKE_MAX_ATTEMPTS = 120;
 const DEFAULT_RUNNER_CONTAINER_SMOKE_RETRY_DELAY_MS = 10_000;
+// Cloudflare gives a rolling container 15 minutes after SIGTERM before it is
+// force-killed, so a rollout that has not surfaced the new bundle by then is not
+// going to. Keep this under the deploy job timeout so the gate reports its own
+// failure instead of dying as a cancelled job.
+const DEFAULT_RUNNER_CONTAINER_SMOKE_MAX_WAIT_MS = 20 * 60 * 1000;
 interface SmokeControlRequest {
   authorizationHeader: string;
   boundUserId: string;
@@ -90,6 +95,7 @@ interface SmokeLiveModelTurnResult {
 
 interface SmokeRunnerRetryPolicy {
   maxAttempts: number;
+  maxWaitMs: number;
   retryDelayMs: number;
 }
 
@@ -270,14 +276,23 @@ async function assertRunnerContainerSmoke(input: {
   url: string;
   versionOverrideHeaders: Record<string, string> | undefined;
 }): Promise<void> {
-  const expectedManifest = await readExpectedRunnerBundleManifest(input.source);
+  // Validate retry configuration before touching the filesystem so a bad knob
+  // reports itself rather than surfacing as a missing-manifest error.
   const retryPolicy = readRunnerContainerSmokeRetryPolicy(input.source);
+  const expectedManifest = await readExpectedRunnerBundleManifest(input.source);
   const retryableFailures = input.expectLiveModelTurnModel === null;
+  const startedAtMs = Date.now();
 
   for (let attempt = 1; attempt <= retryPolicy.maxAttempts; attempt += 1) {
     try {
       assertSmokeRunnerBundleManifest(
-        await readRunnerContainerSmoke(input),
+        // Each attempt addresses its own smoke Durable Object, so a retry gets a
+        // fresh container-provisioning decision instead of re-reading the one
+        // instance this run already pinned. Worker code updates immediately while
+        // containers roll out gradually, so the first instance can legitimately be
+        // pre-rollout, and polling it keeps it below the idle TTL that would
+        // otherwise replace it.
+        await readRunnerContainerSmoke({ ...input, attempt }),
         expectedManifest,
         {
           retryable: retryableFailures,
@@ -285,12 +300,20 @@ async function assertRunnerContainerSmoke(input: {
       );
       return;
     } catch (error) {
+      const elapsedMs = Date.now() - startedAtMs;
       if (
         !retryableFailures ||
         attempt >= retryPolicy.maxAttempts ||
         !(error instanceof RunnerContainerSmokeRetryableError)
       ) {
         throw error;
+      }
+
+      if (elapsedMs + retryPolicy.retryDelayMs >= retryPolicy.maxWaitMs) {
+        throw new Error(
+          `runner container smoke did not converge within ${retryPolicy.maxWaitMs}ms `
+            + `(${attempt} attempts, ${elapsedMs}ms elapsed). Last failure: ${error.message}`,
+        );
       }
 
       input.log(
@@ -303,6 +326,7 @@ async function assertRunnerContainerSmoke(input: {
 }
 
 async function readRunnerContainerSmoke(input: {
+  attempt: number;
   expectDirectR2PresignedPut: boolean;
   expectLiveModelTurnModel: string | null;
   fetchImpl: FetchLike;
@@ -311,6 +335,8 @@ async function readRunnerContainerSmoke(input: {
   versionOverrideHeaders: Record<string, string> | undefined;
 }): Promise<SmokeRunnerBundleManifest | null> {
   const url = new URL(input.url);
+  // Set before signing so the attempt is covered by the callback signature.
+  url.searchParams.set("attempt", String(input.attempt));
   const payload = "";
   const signatureHeaders = await createHostedWebCallbackSignatureHeaders({
     environment: readHostedWebCallbackSigningEnvironment(input.source),
@@ -563,6 +589,11 @@ function readRunnerContainerSmokeRetryPolicy(source: EnvSource): SmokeRunnerRetr
     "HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS must be a non-negative integer.",
   ) ?? DEFAULT_RUNNER_CONTAINER_SMOKE_RETRY_DELAY_MS;
 
+  const maxWaitMs = parseOptionalStrictInteger(
+    source.HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS,
+    "HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS must be a non-negative integer.",
+  ) ?? DEFAULT_RUNNER_CONTAINER_SMOKE_MAX_WAIT_MS;
+
   if (maxAttempts < 1) {
     throw new Error("HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS must be a positive integer.");
   }
@@ -571,8 +602,13 @@ function readRunnerContainerSmokeRetryPolicy(source: EnvSource): SmokeRunnerRetr
     throw new Error("HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS must be a non-negative integer.");
   }
 
+  if (maxWaitMs < 0) {
+    throw new Error("HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS must be a non-negative integer.");
+  }
+
   return {
     maxAttempts,
+    maxWaitMs,
     retryDelayMs,
   };
 }

--- a/apps/cloudflare/scripts/smoke-hosted-deploy.shared.ts
+++ b/apps/cloudflare/scripts/smoke-hosted-deploy.shared.ts
@@ -214,7 +214,7 @@ export async function runSmokeHostedDeploy(input: {
     : null;
 
   if (shouldSmokeRunnerContainer) {
-    await assertRunnerContainerSmoke({
+    const convergedAttempt = await assertRunnerContainerSmoke({
       fetchImpl,
       log,
       source,
@@ -234,6 +234,10 @@ export async function runSmokeHostedDeploy(input: {
         fetchImpl,
         log,
         source,
+        // Stay on the container the bundle phase proved current. Live model turn
+        // failures are non-retryable, so restarting the attempt counter here would
+        // send this phase back to a pre-rollout container.
+        pinnedAttempt: convergedAttempt,
         url: buildRunnerContainerSmokeUrl({
           directR2PresignedPut: false,
           liveModelTurn: true,
@@ -267,23 +271,28 @@ export async function runSmokeHostedDeploy(input: {
   log("Cloudflare hosted execution smoke checks passed.");
 }
 
+// Returns the attempt whose container satisfied the assertion, so a later phase can
+// address that same proven container instead of restarting the attempt counter.
 async function assertRunnerContainerSmoke(input: {
   expectDirectR2PresignedPut: boolean;
   expectLiveModelTurnModel: string | null;
   fetchImpl: FetchLike;
   log: (message: string) => void;
+  pinnedAttempt?: number;
   source: EnvSource;
   url: string;
   versionOverrideHeaders: Record<string, string> | undefined;
-}): Promise<void> {
+}): Promise<number> {
   // Validate retry configuration before touching the filesystem so a bad knob
   // reports itself rather than surfacing as a missing-manifest error.
   const retryPolicy = readRunnerContainerSmokeRetryPolicy(input.source);
   const expectedManifest = await readExpectedRunnerBundleManifest(input.source);
   const retryableFailures = input.expectLiveModelTurnModel === null;
   const startedAtMs = Date.now();
+  const firstAttempt = input.pinnedAttempt ?? 1;
+  const lastAttempt = input.pinnedAttempt ?? retryPolicy.maxAttempts;
 
-  for (let attempt = 1; attempt <= retryPolicy.maxAttempts; attempt += 1) {
+  for (let attempt = firstAttempt; attempt <= lastAttempt; attempt += 1) {
     try {
       assertSmokeRunnerBundleManifest(
         // Each attempt addresses its own smoke Durable Object, so a retry gets a
@@ -298,12 +307,12 @@ async function assertRunnerContainerSmoke(input: {
           retryable: retryableFailures,
         },
       );
-      return;
+      return attempt;
     } catch (error) {
       const elapsedMs = Date.now() - startedAtMs;
       if (
         !retryableFailures ||
-        attempt >= retryPolicy.maxAttempts ||
+        attempt >= lastAttempt ||
         !(error instanceof RunnerContainerSmokeRetryableError)
       ) {
         throw error;
@@ -323,6 +332,8 @@ async function assertRunnerContainerSmoke(input: {
       await sleep(retryPolicy.retryDelayMs);
     }
   }
+
+  throw new Error("runner container smoke exhausted its attempts without a verdict.");
 }
 
 async function readRunnerContainerSmoke(input: {

--- a/apps/cloudflare/src/worker/route-handlers/deploy-smoke.ts
+++ b/apps/cloudflare/src/worker/route-handlers/deploy-smoke.ts
@@ -68,8 +68,17 @@ export async function handleDeployContainerSmokeRoute(
       ok: false,
     }, 400);
   }
+  let attempt: number | null;
+  try {
+    attempt = readDeployContainerSmokeAttempt(context.url);
+  } catch {
+    return json({
+      error: "Unsupported deploy container smoke attempt.",
+      ok: false,
+    }, 400);
+  }
   const container = context.env.RUNNER_CONTAINER_SMOKE
-    .getByName(resolveDeployContainerSmokeObjectName(context.env));
+    .getByName(resolveDeployContainerSmokeObjectName(context.env, attempt));
   const directR2Smoke = directR2PresignedPut
     ? await createDeployContainerDirectR2PresignedPutSmoke(context)
     : null;
@@ -228,6 +237,19 @@ export function readDeployContainerSmokeLiveModelTurnModel(url: URL): string | n
   return DEPLOY_LIVE_MODEL_TURN_SMOKE_MODEL;
 }
 
+// Retry attempt: scopes the smoke Durable Object so each attempt gets its own
+// container instance. Absent means the caller wants the unscoped object name.
+export function readDeployContainerSmokeAttempt(url: URL): number | null {
+  const normalized = normalizeDeployContainerSmokeQueryValue(url.searchParams.get("attempt"));
+  if (!normalized) {
+    return null;
+  }
+  if (!/^[1-9][0-9]{0,3}$/u.test(normalized)) {
+    throw new RangeError("Unsupported deploy container smoke attempt.");
+  }
+  return Number(normalized);
+}
+
 function normalizeDeployContainerSmokeQueryValue(value: string | null): string | null {
   const normalized = typeof value === "string" ? value.trim() : "";
   return normalized.length > 0 ? normalized : null;
@@ -240,15 +262,21 @@ export function resolveDeployContainerSmokeObjectName(
     | "MURPH_HOSTED_LOCAL_DEPLOY_SMOKE_USE_BUILD_ID"
     | "MURPH_HOSTED_RUNNER_LOCAL_BUILD_ID"
   >,
+  attempt: number | null = null,
 ): string {
   const hostedLocalObjectIdentity = shouldUseHostedLocalDeploySmokeBuildId(env)
     ? readHostedLocalRunnerBuildIdSegment(env)
     : null;
   const objectIdentity = hostedLocalObjectIdentity
     ?? readWorkerVersionId(env);
-  return objectIdentity
+  const baseName = objectIdentity
     ? `__deploy-smoke-${objectIdentity}`
     : "__deploy-smoke";
+  // The worker version is fixed for a whole smoke run, so without the attempt every
+  // retry would reuse one Durable Object and therefore one container instance. A
+  // container provisioned before the rollout surfaced the new image would then stay
+  // stale for the entire run.
+  return attempt === null ? baseName : `${baseName}-attempt-${attempt}`;
 }
 
 function shouldUseHostedLocalDeploySmokeBuildId(

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -569,6 +569,7 @@ describe("hosted deploy automation helpers", () => {
       "description: Run one real gpt-5.6-terra turn in the deployed container smoke",
       'HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS: "300"',
       'HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS: "3000"',
+      'HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS: "1200000"',
       "HOSTED_CRYPTO_CLOUDFLARE_AUTOMATION_KEY_ID: ${{ vars.HOSTED_CRYPTO_CLOUDFLARE_AUTOMATION_KEY_ID }}",
       "HOSTED_CRYPTO_CLOUDFLARE_AUTOMATION_PRIVATE_JWK: ${{ secrets.HOSTED_CRYPTO_CLOUDFLARE_AUTOMATION_PRIVATE_JWK }}",
       "HOSTED_WEB_PRODUCTION_BASE_URL: ${{ vars.HOSTED_WEB_PRODUCTION_BASE_URL }}",
@@ -649,6 +650,21 @@ describe("hosted deploy automation helpers", () => {
     ]) {
       expect(workflow).toContain(expectedLine);
     }
+
+    // The smoke's wall-clock budget only makes a stalled rollout attributable if it
+    // expires before the deploy job is cancelled. Guard the relationship, not just
+    // the literal values: a job-timeout reduction is exactly the drift that would
+    // silently restore an unattributed cancelled-job failure.
+    const deployJob = readWorkflowJobBlock(workflow, "deploy");
+    const deployTimeoutMinutes = Number(
+      /^\s*timeout-minutes:\s*(\d+)\s*$/mu.exec(deployJob)?.[1] ?? "",
+    );
+    const smokeMaxWaitMs = Number(
+      /^\s*HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS:\s*"(\d+)"\s*$/mu.exec(deployJob)?.[1] ?? "",
+    );
+    expect(Number.isInteger(deployTimeoutMinutes)).toBe(true);
+    expect(Number.isInteger(smokeMaxWaitMs)).toBe(true);
+    expect(smokeMaxWaitMs).toBeLessThan(deployTimeoutMinutes * 60 * 1000);
 
     expect(readWorkflowJobBlock(workflow, "codex-cache-prefix-gate")).toContain(
       'MURPH_HOSTED_LOCAL_E2E_FAST_GATE: "1"',

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -27,6 +27,7 @@ import { hostedLocalTestInternalRoutes } from "../src/worker/hosted-local-test-r
 import { workerInternalRoutes } from "../src/worker/internal-routes.ts";
 import { workerPublicRoutes } from "../src/worker/public-routes.ts";
 import {
+  readDeployContainerSmokeAttempt,
   resolveDeployContainerSmokeObjectName,
 } from "../src/worker/route-handlers/deploy-smoke.ts";
 import {
@@ -788,6 +789,38 @@ describe("cloudflare worker routes", () => {
       },
       MURPH_HOSTED_RUNNER_LOCAL_BUILD_ID: "local build/123",
     })).toBe("__deploy-smoke-version-123");
+  });
+
+  it("scopes the deploy smoke Durable Object name to the retry attempt", () => {
+    const env = {
+      CF_VERSION_METADATA: {
+        id: "version-123",
+        tag: "test",
+        timestamp: "2026-04-24T00:00:00.000Z",
+      },
+    } as const;
+
+    // The worker version is constant for a whole smoke run, so the attempt is the
+    // only thing that moves a retry onto a fresh container instance.
+    expect(resolveDeployContainerSmokeObjectName(env, 1))
+      .toBe("__deploy-smoke-version-123-attempt-1");
+    expect(resolveDeployContainerSmokeObjectName(env, 2))
+      .toBe("__deploy-smoke-version-123-attempt-2");
+    expect(resolveDeployContainerSmokeObjectName(env)).toBe("__deploy-smoke-version-123");
+  });
+
+  it("reads a positive deploy smoke attempt and rejects malformed ones", () => {
+    const read = (search: string) =>
+      readDeployContainerSmokeAttempt(
+        new URL(`https://worker.example.test/internal/deploy/container-smoke${search}`),
+      );
+
+    expect(read("")).toBeNull();
+    expect(read("?attempt=1")).toBe(1);
+    expect(read("?attempt=300")).toBe(300);
+    for (const search of ["?attempt=0", "?attempt=-1", "?attempt=1.5", "?attempt=abc", "?attempt=10000"]) {
+      expect(() => read(search)).toThrow(RangeError);
+    }
   });
 
   it("uses a local-build-specific deploy smoke Durable Object name in hosted-local mode", async () => {

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -768,6 +768,78 @@ describe("cloudflare worker routes", () => {
     expect(runnerGetByName).not.toHaveBeenCalled();
   });
 
+  it("routes a signed attempt-scoped deploy smoke request to its own container", async () => {
+    const baseEnv = createWorkerEnv();
+    const smokeGetByName = vi.fn(createRunnerContainerNamespace().getByName);
+    const env = {
+      ...baseEnv,
+      CF_VERSION_METADATA: {
+        id: "version-123",
+        tag: "test",
+        timestamp: "2026-04-24T00:00:00.000Z",
+      },
+      RUNNER_CONTAINER_SMOKE: {
+        getByName: smokeGetByName,
+      },
+    };
+    const url = new URL("https://runner.example.test/internal/deploy/container-smoke?attempt=2");
+    const callbackSigning = readHostedExecutionEnvironment(asWorkerStringEnvironment(env)).webCallbackSigning;
+    const request = new Request(url, {
+      // Signing over the attempt-bearing search proves the smoke's attempt is
+      // covered by the signature rather than an unauthenticated tack-on.
+      headers: await createHostedWebCallbackSignatureHeaders({
+        environment: callbackSigning,
+        method: "POST",
+        path: url.pathname,
+        payload: "",
+        search: url.search,
+      }),
+      method: "POST",
+    });
+
+    const response = await worker.fetch(request, env);
+
+    expect(response.status).toBe(200);
+    expect(smokeGetByName).toHaveBeenCalledWith("__deploy-smoke-version-123-attempt-2");
+  });
+
+  it("rejects a signed deploy smoke request with a malformed attempt before starting a container", async () => {
+    const baseEnv = createWorkerEnv();
+    const smokeGetByName = vi.fn(createRunnerContainerNamespace().getByName);
+    const env = {
+      ...baseEnv,
+      CF_VERSION_METADATA: {
+        id: "version-123",
+        tag: "test",
+        timestamp: "2026-04-24T00:00:00.000Z",
+      },
+      RUNNER_CONTAINER_SMOKE: {
+        getByName: smokeGetByName,
+      },
+    };
+    const url = new URL("https://runner.example.test/internal/deploy/container-smoke?attempt=0");
+    const callbackSigning = readHostedExecutionEnvironment(asWorkerStringEnvironment(env)).webCallbackSigning;
+    const request = new Request(url, {
+      headers: await createHostedWebCallbackSignatureHeaders({
+        environment: callbackSigning,
+        method: "POST",
+        path: url.pathname,
+        payload: "",
+        search: url.search,
+      }),
+      method: "POST",
+    });
+
+    const response = await worker.fetch(request, env);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unsupported deploy container smoke attempt.",
+      ok: false,
+    });
+    expect(smokeGetByName).not.toHaveBeenCalled();
+  });
+
   it("uses the local build deploy smoke Durable Object name before version metadata", () => {
     expect(resolveDeployContainerSmokeObjectName({
       CF_VERSION_METADATA: {

--- a/apps/cloudflare/test/smoke-hosted-deploy.test.ts
+++ b/apps/cloudflare/test/smoke-hosted-deploy.test.ts
@@ -49,6 +49,23 @@ describe("resolveSmokeWorkerBaseUrl", () => {
   });
 });
 
+const CONTAINER_SMOKE_PATH = "/internal/deploy/container-smoke";
+
+// The smoke appends a per-attempt query param, so match on pathname rather than
+// suffix.
+function isContainerSmokeRequest(url: string): boolean {
+  return new URL(url).pathname === CONTAINER_SMOKE_PATH;
+}
+
+// The bundle-identity phase carries no feature flags; the direct R2 and live model
+// turn phases are separate later requests that must not be answered by it.
+function isBundleOnlyContainerSmokeRequest(url: string): boolean {
+  const parsed = new URL(url);
+  return parsed.pathname === CONTAINER_SMOKE_PATH
+    && parsed.searchParams.get("directR2PresignedPut") !== "1"
+    && parsed.searchParams.get("liveModelTurn") !== "1";
+}
+
 function createCodexShellSmokeResult() {
   return {
     cliSurfaceContractBytes: 37282,
@@ -439,7 +456,7 @@ describe("runSmokeHostedDeploy", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
 
-      if (String(url).endsWith("/internal/deploy/container-smoke")) {
+      if (isBundleOnlyContainerSmokeRequest(String(url))) {
         return new Response(JSON.stringify({
           ok: true,
           runnerContainer: {
@@ -469,9 +486,7 @@ describe("runSmokeHostedDeploy", () => {
       },
     });
 
-    const containerCall = fetchCalls.find((entry) =>
-      entry.url === "https://worker.example.test/internal/deploy/container-smoke"
-    );
+    const containerCall = fetchCalls.find((entry) => isContainerSmokeRequest(entry.url));
     expect(containerCall).toBeDefined();
     expect(containerCall?.method).toBe("POST");
     const headers = new Headers(containerCall?.headers);
@@ -506,7 +521,7 @@ describe("runSmokeHostedDeploy", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
 
-      if (String(url).endsWith("/internal/deploy/container-smoke?directR2PresignedPut=1")) {
+      if (new URL(String(url)).searchParams.get("directR2PresignedPut") === "1") {
         return new Response(JSON.stringify({
           ok: true,
           runnerContainer: {
@@ -543,9 +558,10 @@ describe("runSmokeHostedDeploy", () => {
       },
     });
 
-    expect(fetchCalls).toContain(
-      "https://worker.example.test/internal/deploy/container-smoke?directR2PresignedPut=1",
-    );
+    expect(fetchCalls.some((entry) =>
+      isContainerSmokeRequest(entry)
+      && new URL(entry).searchParams.get("directR2PresignedPut") === "1"
+    )).toBe(true);
   });
 
   it("can request the deployed runner live model turn smoke", async () => {
@@ -575,7 +591,7 @@ describe("runSmokeHostedDeploy", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
 
-      if (String(url).endsWith("/internal/deploy/container-smoke")) {
+      if (isBundleOnlyContainerSmokeRequest(String(url))) {
         return new Response(JSON.stringify({
           ok: true,
           runnerContainer: {
@@ -632,9 +648,7 @@ describe("runSmokeHostedDeploy", () => {
       },
     });
 
-    expect(fetchCalls).toContain(
-      "https://worker.example.test/internal/deploy/container-smoke",
-    );
+    expect(fetchCalls.some((entry) => isBundleOnlyContainerSmokeRequest(entry))).toBe(true);
     const liveCall = fetchCalls
       .map((entry) => new URL(entry))
       .find((entry) => entry.searchParams.get("liveModelTurn") === "1");
@@ -667,7 +681,7 @@ describe("runSmokeHostedDeploy", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
 
-      if (String(url).endsWith("/internal/deploy/container-smoke")) {
+      if (isBundleOnlyContainerSmokeRequest(String(url))) {
         return new Response(JSON.stringify({
           ok: true,
           runnerContainer: {
@@ -862,6 +876,162 @@ describe("runSmokeHostedDeploy", () => {
     );
   });
 
+  it("scopes each runner container smoke attempt to its own container instance", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "cloudflare-smoke-attempt-scope-"));
+    const manifestPath = path.join(root, ".deploy", "runner-bundle", ".murph-runner-bundle-manifest.json");
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify({
+        buildSkipped: false,
+        bundleFingerprint: "expected-bundle",
+        sourceFingerprint: "expected-source",
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const smokeAttempts: (string | null)[] = [];
+    const fetchImpl = async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/")) {
+        return new Response(JSON.stringify({ ok: true, service: "cloudflare-hosted-runner" }), {
+          status: 200,
+        });
+      }
+      if (String(url).endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (isContainerSmokeRequest(String(url))) {
+        const attempt = new URL(String(url)).searchParams.get("attempt");
+        smokeAttempts.push(attempt);
+        return new Response(JSON.stringify({
+          ok: true,
+          runnerContainer: {
+            codexShell: createCodexShellSmokeResult(),
+            ok: true,
+            runnerBundle: smokeAttempts.length < 3
+              ? {
+                  buildSkipped: false,
+                  bundleFingerprint: "stale-bundle",
+                  sourceFingerprint: "stale-source",
+                }
+              : {
+                  buildSkipped: false,
+                  bundleFingerprint: "expected-bundle",
+                  sourceFingerprint: "expected-source",
+                },
+            service: "cloudflare-hosted-runner-node",
+          },
+        }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected smoke request: ${String(url)}`);
+    };
+
+    await runSmokeHostedDeploy({
+      fetchImpl,
+      log() {},
+      source: {
+        HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER: "true",
+        HOSTED_EXECUTION_SMOKE_RUNNER_MANIFEST_PATH: manifestPath,
+        HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS: "3",
+        HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS: "0",
+        HOSTED_EXECUTION_SMOKE_WORKER_BASE_URL: "https://worker.example.test",
+        HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: TEST_HOSTED_WEB_CALLBACK_PRIVATE_JWK_JSON,
+      },
+    });
+
+    // Distinct attempt values are what give each retry a fresh smoke Durable
+    // Object, so a pre-rollout container cannot be re-read for the whole run.
+    expect(smokeAttempts).toEqual(["1", "2", "3"]);
+  });
+
+  it("stops waiting for the runner container rollout once the wall-clock budget is spent", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "cloudflare-smoke-max-wait-"));
+    const manifestPath = path.join(root, ".deploy", "runner-bundle", ".murph-runner-bundle-manifest.json");
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify({
+        buildSkipped: false,
+        bundleFingerprint: "expected-bundle",
+        sourceFingerprint: "expected-source",
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    let smokeCalls = 0;
+    const fetchImpl = async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/")) {
+        return new Response(JSON.stringify({ ok: true, service: "cloudflare-hosted-runner" }), {
+          status: 200,
+        });
+      }
+      if (String(url).endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (isContainerSmokeRequest(String(url))) {
+        smokeCalls += 1;
+        return new Response(JSON.stringify({
+          ok: true,
+          runnerContainer: {
+            codexShell: createCodexShellSmokeResult(),
+            ok: true,
+            runnerBundle: {
+              buildSkipped: false,
+              bundleFingerprint: "stale-bundle",
+              sourceFingerprint: "stale-source",
+            },
+            service: "cloudflare-hosted-runner-node",
+          },
+        }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected smoke request: ${String(url)}`);
+    };
+
+    // A zero budget makes the deadline unreachable on the first retry decision, so
+    // the gate reports its own failure instead of outliving the deploy job.
+    await expect(runSmokeHostedDeploy({
+      fetchImpl,
+      log() {},
+      source: {
+        HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER: "true",
+        HOSTED_EXECUTION_SMOKE_RUNNER_MANIFEST_PATH: manifestPath,
+        HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS: "300",
+        HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS: "0",
+        HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS: "0",
+        HOSTED_EXECUTION_SMOKE_WORKER_BASE_URL: "https://worker.example.test",
+        HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: TEST_HOSTED_WEB_CALLBACK_PRIVATE_JWK_JSON,
+      },
+    })).rejects.toThrow("runner container smoke did not converge within 0ms");
+
+    expect(smokeCalls).toBe(1);
+  });
+
+  it("rejects a negative runner container smoke wall-clock budget", async () => {
+    const fetchImpl = async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/")) {
+        return new Response(JSON.stringify({ ok: true, service: "cloudflare-hosted-runner" }), {
+          status: 200,
+        });
+      }
+      if (String(url).endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      throw new Error(`Invalid wall-clock budget should fail before ${String(url)}.`);
+    };
+
+    await expect(runSmokeHostedDeploy({
+      fetchImpl,
+      log() {},
+      source: {
+        HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER: "true",
+        HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS: "-1",
+        HOSTED_EXECUTION_SMOKE_WORKER_BASE_URL: "https://worker.example.test",
+      },
+    })).rejects.toThrow("HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS must be a non-negative integer.");
+  });
+
   it("retries the deploy-signed runner container smoke until the expected bundle is active", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "cloudflare-smoke-retry-manifest-"));
     const manifestPath = path.join(root, ".deploy", "runner-bundle", ".murph-runner-bundle-manifest.json");
@@ -890,9 +1060,9 @@ describe("runSmokeHostedDeploy", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
 
-      if (String(url).endsWith("/internal/deploy/container-smoke")) {
+      if (isContainerSmokeRequest(String(url))) {
         const smokeAttempt = fetchCalls.filter((entry) =>
-          entry.endsWith("/internal/deploy/container-smoke")
+          isContainerSmokeRequest(entry)
         ).length;
         return new Response(JSON.stringify({
           ok: true,
@@ -934,7 +1104,7 @@ describe("runSmokeHostedDeploy", () => {
     });
 
     expect(fetchCalls.filter((entry) =>
-      entry.endsWith("/internal/deploy/container-smoke")
+      isContainerSmokeRequest(entry)
     )).toHaveLength(2);
     expect(logs.some((message) =>
       message.startsWith("Runner container smoke attempt 1/2 failed (")
@@ -970,9 +1140,9 @@ describe("runSmokeHostedDeploy", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
 
-      if (String(url).endsWith("/internal/deploy/container-smoke")) {
+      if (isContainerSmokeRequest(String(url))) {
         const smokeAttempt = fetchCalls.filter((entry) =>
-          entry.endsWith("/internal/deploy/container-smoke")
+          isContainerSmokeRequest(entry)
         ).length;
         if (smokeAttempt === 1) {
           return new Response(JSON.stringify({ error: "Invalid request." }), { status: 400 });
@@ -1010,7 +1180,7 @@ describe("runSmokeHostedDeploy", () => {
     });
 
     expect(fetchCalls.filter((entry) =>
-      entry.endsWith("/internal/deploy/container-smoke")
+      isContainerSmokeRequest(entry)
     )).toHaveLength(2);
   });
 
@@ -1038,7 +1208,7 @@ describe("runSmokeHostedDeploy", () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
 
-      if (String(url).endsWith("/internal/deploy/container-smoke")) {
+      if (isContainerSmokeRequest(String(url))) {
         return new Response(
           JSON.stringify({
             access_key: "fixture-access-value",

--- a/apps/cloudflare/test/smoke-hosted-deploy.test.ts
+++ b/apps/cloudflare/test/smoke-hosted-deploy.test.ts
@@ -945,6 +945,94 @@ describe("runSmokeHostedDeploy", () => {
     expect(smokeAttempts).toEqual(["1", "2", "3"]);
   });
 
+  it("runs the live model turn against the container the bundle phase proved current", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "cloudflare-smoke-live-after-retry-"));
+    const manifestPath = path.join(root, ".deploy", "runner-bundle", ".murph-runner-bundle-manifest.json");
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify({
+        buildSkipped: false,
+        bundleFingerprint: "expected-bundle",
+        sourceFingerprint: "expected-source",
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    // Attempt 1 is the pre-rollout container. Once the bundle phase converges on
+    // attempt 2, the live model turn must stay on attempt 2: its failures are
+    // non-retryable, so returning to the stale attempt-1 container would hard-fail
+    // the deploy in exactly the rollout window this is meant to survive.
+    const staleAttempts = new Set(["1"]);
+    const liveAttempts: (string | null)[] = [];
+    const fetchImpl = async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/")) {
+        return new Response(JSON.stringify({ ok: true, service: "cloudflare-hosted-runner" }), {
+          status: 200,
+        });
+      }
+      if (String(url).endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (isContainerSmokeRequest(String(url))) {
+        const parsed = new URL(String(url));
+        const attempt = parsed.searchParams.get("attempt");
+        const liveModelTurn = parsed.searchParams.get("liveModelTurn") === "1";
+        if (liveModelTurn) {
+          liveAttempts.push(attempt);
+        }
+        const stale = attempt !== null && staleAttempts.has(attempt);
+        return new Response(JSON.stringify({
+          ok: true,
+          runnerContainer: {
+            codexShell: createCodexShellSmokeResult(),
+            ...(liveModelTurn
+              ? {
+                  liveModelTurn: {
+                    durationMs: 1234,
+                    egressGrantConsumed: true,
+                    model: DEPLOY_LIVE_MODEL_TURN_SMOKE_MODEL,
+                    stdoutBytes: 128,
+                  },
+                }
+              : {}),
+            ok: true,
+            runnerBundle: stale
+              ? {
+                  buildSkipped: false,
+                  bundleFingerprint: "stale-bundle",
+                  sourceFingerprint: "stale-source",
+                }
+              : {
+                  buildSkipped: false,
+                  bundleFingerprint: "expected-bundle",
+                  sourceFingerprint: "expected-source",
+                },
+            service: "cloudflare-hosted-runner-node",
+          },
+        }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected smoke request: ${String(url)}`);
+    };
+
+    await runSmokeHostedDeploy({
+      fetchImpl,
+      log() {},
+      source: {
+        HOSTED_EXECUTION_SMOKE_LIVE_MODEL_TURN: "true",
+        HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER: "true",
+        HOSTED_EXECUTION_SMOKE_RUNNER_MANIFEST_PATH: manifestPath,
+        HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS: "3",
+        HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS: "0",
+        HOSTED_EXECUTION_SMOKE_WORKER_BASE_URL: "https://worker.example.test",
+        HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: TEST_HOSTED_WEB_CALLBACK_PRIVATE_JWK_JSON,
+      },
+    });
+
+    expect(liveAttempts).toEqual(["2"]);
+  });
+
   it("stops waiting for the runner container rollout once the wall-clock budget is spent", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "cloudflare-smoke-max-wait-"));
     const manifestPath = path.join(root, ".deploy", "runner-bundle", ".murph-runner-bundle-manifest.json");
@@ -1006,6 +1094,82 @@ describe("runSmokeHostedDeploy", () => {
     })).rejects.toThrow("runner container smoke did not converge within 0ms");
 
     expect(smokeCalls).toBe(1);
+  });
+
+  it("lets the wall-clock budget preempt a much larger attempt ceiling", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "cloudflare-smoke-budget-preempt-"));
+    const manifestPath = path.join(root, ".deploy", "runner-bundle", ".murph-runner-bundle-manifest.json");
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify({
+        buildSkipped: false,
+        bundleFingerprint: "expected-bundle",
+        sourceFingerprint: "expected-source",
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    let smokeCalls = 0;
+    // Drive elapsed time off the smoke-call count rather than real sleeping or a
+    // fixed call sequence, so the assertion does not depend on how many times
+    // Date.now happens to be read. The budget must stop the loop long before the
+    // 300-attempt ceiling, which is the relationship that let a stalled rollout
+    // outlive the deploy job.
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => smokeCalls * 5_000);
+    const fetchImpl = async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/")) {
+        return new Response(JSON.stringify({ ok: true, service: "cloudflare-hosted-runner" }), {
+          status: 200,
+        });
+      }
+      if (String(url).endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (isContainerSmokeRequest(String(url))) {
+        smokeCalls += 1;
+        return new Response(JSON.stringify({
+          ok: true,
+          runnerContainer: {
+            codexShell: createCodexShellSmokeResult(),
+            ok: true,
+            runnerBundle: {
+              buildSkipped: false,
+              bundleFingerprint: "stale-bundle",
+              sourceFingerprint: "stale-source",
+            },
+            service: "cloudflare-hosted-runner-node",
+          },
+        }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected smoke request: ${String(url)}`);
+    };
+
+    try {
+      const error = await runSmokeHostedDeploy({
+        fetchImpl,
+        log() {},
+        source: {
+          HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER: "true",
+          HOSTED_EXECUTION_SMOKE_RUNNER_MANIFEST_PATH: manifestPath,
+          HOSTED_EXECUTION_SMOKE_RUNNER_MAX_ATTEMPTS: "300",
+          HOSTED_EXECUTION_SMOKE_RUNNER_MAX_WAIT_MS: "10000",
+          HOSTED_EXECUTION_SMOKE_RUNNER_RETRY_DELAY_MS: "1000",
+          HOSTED_EXECUTION_SMOKE_WORKER_BASE_URL: "https://worker.example.test",
+          HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: TEST_HOSTED_WEB_CALLBACK_PRIVATE_JWK_JSON,
+        },
+      }).then(() => null, (reason: unknown) => reason as Error);
+
+      // One retry is allowed under budget, then the deadline stops the loop and the
+      // failure names attempts, elapsed time, and the underlying mismatch.
+      expect(smokeCalls).toBe(2);
+      expect(error?.message).toContain("runner container smoke did not converge within 10000ms");
+      expect(error?.message).toContain("(2 attempts, 10000ms elapsed)");
+      expect(error?.message).toContain("did not run the expected runner bundle");
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("rejects a negative runner container smoke wall-clock budget", async () => {


### PR DESCRIPTION
ReviewGPT first-reviewed head: 46e77c411ec56f1d22a0a9837287d25dfed54b18

## Why this PR exists

Production deploy run [30149505443](https://github.com/cobuildwithus/murph/actions/runs/30149505443) deployed the Worker successfully, then spent 46 minutes and 119 retries asserting that the managed container ran the new runner bundle. Every attempt reported the previous deploy's bundle, and the job was cancelled at its 60-minute timeout before the retry budget was reached. `Publish deployment summary` never ran, so the deploy reported no reason for the failure.

The deploy itself was fine. Production was on the new bundle the whole time: `assertRunnerContainerHealthy` throws `HostedRunnerContainerBundleMismatchError` whenever a container's bundle does not match the Worker's `HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT`, prod logged zero such errors, and 7 runner turns across 3 members succeeded during the window. The gate was a false negative.

Two defects made a normal rollout window fatal.

**The retry loop could not reach a different container.** The smoke pins one Worker version for the whole run via `Cloudflare-Workers-Version-Overrides`, and the smoke container's Durable Object name was derived from that version, so all 119 retries addressed one Durable Object and therefore one container instance. Cloudflare documents the model plainly: worker code updates immediately while containers roll out gradually, so a newly deployed Worker version legitimately coexists with old-image containers until the rollout completes. Once that single instance was provisioned pre-rollout it stayed stale, and the smoke's own ~24s polling kept it below the 20-minute idle TTL that would otherwise have reaped and replaced it. The retry traffic prevented the only mechanism that could have made the retry succeed.

**The gate could not report its own failure.** The budget was attempt-only: 300 attempts at ~24s each is ~118 minutes against a 60-minute job timeout, so a real convergence failure could never exhaust its own budget and always surfaced as an opaque cancelled job.

## User goal

None directly user-facing. This restores a truthful deploy gate so runner-bundle regressions are caught and reported, and so a healthy deploy is not reported as a failure.

## User experience

Not applicable. No user-facing surface, copy, or interaction changes.

## Invariants

- The bundle-identity assertion is unchanged. A converged smoke still proves the deployed bundle boots and serves; nothing was weakened or made advisory to get a green gate.
- Both smoke phases must observe the same proven-current container. The bundle phase returns the attempt that converged and the live model turn is pinned to it, because live-turn failures are deliberately non-retryable.
- The production per-user runner container lifecycle is untouched. This is deploy-smoke-only, on the separate `RUNNER_CONTAINER_SMOKE` binding.
- `resolveDeployContainerSmokeObjectName` identity precedence is preserved: hosted-local build id still wins over version metadata, and the unscoped name is still produced when no attempt is supplied.
- The attempt is set before signing, so it is covered by the callback signature rather than being an unauthenticated input.
- The attempt is bounded (`1`–`9999`) and a malformed value fails closed with HTTP 400 before any container starts.
- The smoke's wall-clock budget must expire before the deploy job's timeout, otherwise the failure is unattributable again. This relationship is now asserted, not just the literal values.

## Non-obvious affected surfaces

- `apps/cloudflare/src/worker/route-handlers/test-direct-r2.ts` also calls `resolveDeployContainerSmokeObjectName`. It passes no attempt and keeps the existing unscoped object name; the new parameter defaults to `null`.
- Retry cost changes shape. Each attempt now boots a fresh container instead of re-reading a warm one, so attempts are individually slower and the run performs more container starts. The wall-clock budget bounds this, and a rollout that normally converges in 2–12 attempts stays well inside it.
- The retry policy is now validated before the manifest is read, so a bad knob reports itself instead of surfacing as a missing-manifest `ENOENT`.
- Tests previously matched the smoke request by URL suffix. Since the URL now carries a query param, they match on pathname, with a separate predicate for the bundle-only phase so it cannot answer the direct-R2 or live-model-turn requests.

## Preliminary specialist lenses

Coverage was the applicable lens; prompt and frontend do not apply (no assistant prompt text, no `apps/web` UI). The pass returned three findings, all accepted and fixed in `46e77c4`:

- **high — the live model turn returned to the stale container.** Both smoke phases call `assertRunnerContainerSmoke` and each call restarted the attempt counter at 1, so once the bundle phase converged on attempt 2 the live turn went back to the attempt-1 container. Because live-turn failures are non-retryable, this would have hard-failed deploys in exactly the rollout window the PR exists to survive — a regression introduced by the first commit. Proven with a failing test before fixing, then fixed by returning the converged attempt and pinning the live turn to it.
- **medium — attempt signing and route wiring were only proven in disconnected units.** Added route-level signed tests: a valid `attempt=2` reaching `__deploy-smoke-version-123-attempt-2`, and a malformed attempt returning 400 without calling `getByName`. Signing over the attempt-bearing search is now asserted at the route.
- **low — the deadline was only covered by a zero-budget degenerate case.** Added a positive-budget case proving the wall clock preempts the much larger attempt ceiling and that the message names attempts, elapsed time, and the last failure. Extended the deploy-workflow guard to assert the budget is under the job timeout; verified that guard fails when the relationship is violated.

## Change shape

Base-to-head diff, classified by path: `apps/cloudflare/{scripts,src}` as source, `apps/cloudflare/test` as tests, `*.md` as docs, `.github/workflows` as config/tooling. No binary files.

| Class | Added | Deleted |
| --- | --- | --- |
| Source | 84 | 9 |
| Tests | 475 | 20 |
| Docs | 78 | 0 |
| Config/tooling | 3 | 0 |
| Generated/other | 0 | 0 |

Tests dominate roughly 5:1 over source. The fix is deliberately small; the volume is existing smoke tests being made param-aware plus the review-driven coverage above. Counts are for reviewer orientation, not a quality target.

## Design proof

Not applicable. No `apps/web` UI paths are touched, so `scripts/check-frontend-design-proof.mjs` reports the gate as not required, and the `Frontend design proof` check passes.

## Verification

- `pnpm test:diff` over all seven touched paths: 106 files, 1898 tests, exit 0.
- Focused: `smoke-hosted-deploy.test.ts` 36/36, `index.test.ts` 94/94, `deploy-automation.test.ts` 25/25.
- `pnpm --dir apps/cloudflare typecheck` exit 0.

Three CI E2E lanes are red for reasons that predate this branch: `Hosted E2E required gate`, `Hosted device-sync E2E required gate`, and `Runtime checkpoint durability E2E` all failed on `main` at this PR's base commit `75adaae338` in run [30151308115](https://github.com/cobuildwithus/murph/actions/runs/30151308115). The failing assertion is a snapshot-publication timeout in `hosted-local-snapshot-publication-fallback-e2e.test.ts`, which this diff does not touch; the change is deploy-smoke-only and inert unless an `attempt` param is sent, which those lanes never send.

## DEPLOYMENT CONCERNS

This changes the deploy workflow and a Worker route together, but the two halves are independently compatible, so no tandem deploy or compatibility window is required:

- A new smoke script against an old Worker: the old route ignores the unknown `attempt` param and reuses one Durable Object, which is exactly today's behavior.
- A new Worker against an old smoke script: no `attempt` is sent, `readDeployContainerSmokeAttempt` returns `null`, and the unscoped object name is used, again today's behavior.

In practice both ship in the same commit and the smoke runs from the same checkout it deployed.

Post-deploy check: the next `pnpm cf:deploy` should show `Smoke test deployed endpoints` converging within a few attempts and `Publish deployment summary` running. If a rollout genuinely stalls, expect a named `runner container smoke did not converge within 1200000ms` failure inside the job timeout instead of a cancelled job.

## ReviewGPT

**Round 1 (final gate) — `ROUND_OUTCOME: PASS`, zero findings**, on head `46e77c411ec56f1d22a0a9837287d25dfed54b18` (the immutable first-reviewed head above). Elapsed ~20 minutes, well above the trust floor. The round independently validated its own evidence: `review-round.json` naming the correct first/current head, changed-file inventory matching the diff, both later-round remediation deltas correctly empty for a round-1 full audit, reverse-applied `pr.diff` confirming the packaged source is the reviewed head, and clean YAML/TypeScript parses. It independently arrived at 84 additions / 9 deletions of authored source, matching the change-shape table above.

**Model substitution, disclosed:** the round ran on `gpt-5-6-pro` rather than the requested `gpt-5.6-sol`, and reports `MODEL_CONFIRMATION: UNKNOWN`. `gpt-5.6-sol` is unavailable service-side right now, not a profile misconfiguration: the Mountain lane fails the availability probe outright with `Requested ChatGPT model is not available (gpt-5.6-sol): Failed to load subscription: Service Unavailable`, and an Eragon attempt on this exact head produced a full Pro response that the gate then correctly rejected for missing `MODEL_CONFIRMATION` for `sol`. Five attempts across four lanes reproduced this. Pro is not a downgrade from `sol`, so this round is accepted with the substitution recorded here rather than discarded; per the loop contract those model/browser failures never advanced the round counter, so this is still round 1. Lane pinned to `hercules` as a temporary override.
