### PR TITLE
Mirror the hosted-local MinIO image into GHCR

### DIFF
--- a/.github/workflows/hosted-local-minio-image.yml
+++ b/.github/workflows/hosted-local-minio-image.yml
@@ -1,0 +1,64 @@
+name: Hosted Local MinIO Mirror
+
+# Hosted E2E pulls the MinIO sidecar on every run. Docker Hub rate-limits and
+# times out GitHub-hosted runners, which surfaces as a MinIO health-check
+# timeout and fails the whole E2E matrix for a reason unrelated to the change
+# under test. This mirrors the pinned upstream release into GHCR, where Actions
+# pulls use the workflow token and are not rate-limited.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/hosted-local-minio-image.yml"
+      - "packages/hosted-local-harness/src/dev-hosted-local/minio-image-contract.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mirror:
+    name: Mirror MinIO image to GHCR
+    if: ${{ github.ref == 'refs/heads/main' && github.ref_protected }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve pinned images
+        id: images
+        run: |
+          set -euo pipefail
+          contract="packages/hosted-local-harness/src/dev-hosted-local/minio-image-contract.ts"
+          upstream="$(grep -oE '"minio/minio:[^"]+"' "$contract" | tr -d '"')"
+          mirror="$(grep -oE '"ghcr\.io/[^"]+"' "$contract" | tr -d '"')"
+          if [[ -z "$upstream" || -z "$mirror" ]]; then
+            echo "Could not resolve the MinIO image contract from $contract." >&2
+            exit 1
+          fi
+          echo "upstream=$upstream" >> "$GITHUB_OUTPUT"
+          echo "mirror=$mirror" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        run: echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # linux/amd64 only: the hosted E2E runners are ubuntu-24.04, and pinning
+      # one platform keeps the mirrored digest unambiguous.
+      - name: Mirror image
+        run: |
+          set -euo pipefail
+          docker pull --platform linux/amd64 "${{ steps.images.outputs.upstream }}"
+          docker tag "${{ steps.images.outputs.upstream }}" "${{ steps.images.outputs.mirror }}"
+          docker push "${{ steps.images.outputs.mirror }}"
+
+      - name: Report published digest
+        run: docker image inspect --format '{{index .RepoDigests 0}}' "${{ steps.images.outputs.mirror }}"

--- a/packages/hosted-local-harness/src/dev-hosted-local/minio-image-contract.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/minio-image-contract.ts
@@ -1,0 +1,20 @@
+/**
+ * Image contract for the hosted-local MinIO sidecar (the local R2 stand-in).
+ *
+ * CI pulls this image on every hosted E2E run. Docker Hub rate-limits and times
+ * out GitHub-hosted runners, which fails the run with a health-check timeout
+ * that looks like a harness bug rather than a registry problem. Mirroring the
+ * exact upstream release into GHCR removes that dependency, because GHCR pulls
+ * from Actions use the workflow token and are not rate-limited.
+ *
+ * The mirror workflow publishes `MIRROR` from `UPSTREAM`; both live here so the
+ * workflow and the harness cannot drift, which a guard test enforces.
+ */
+
+/** Exact upstream release the mirror is built from. */
+export const HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE =
+  "minio/minio:RELEASE.2025-09-07T16-13-09Z";
+
+/** GHCR mirror of {@link HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE}, same digest. */
+export const HOSTED_LOCAL_MINIO_MIRROR_IMAGE =
+  "ghcr.io/cobuildwithus/murph-hosted-local-minio:RELEASE.2025-09-07T16-13-09Z";

--- a/packages/hosted-local-harness/src/dev-hosted-local/minio.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/minio.ts
@@ -23,8 +23,11 @@ import {
 import type {
   BufferedNamedChildProcess,
 } from "./types.ts";
+import { HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE } from "./minio-image-contract.ts";
 
-const DEFAULT_HOSTED_LOCAL_MINIO_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
+// Still the upstream ref: the GHCR mirror only becomes the default once the
+// mirror workflow has published it from main.
+const DEFAULT_HOSTED_LOCAL_MINIO_IMAGE = HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE;
 const DEFAULT_HOSTED_LOCAL_MINIO_DATA_DIR = path.join(".tmp", "hosted-local-minio-r2");
 const HOSTED_LOCAL_MINIO_DATA_DIR_ENV = "MURPH_DEV_MINIO_DATA_DIR";
 const HOSTED_LOCAL_MINIO_PORT_ENV = "MURPH_DEV_MINIO_PORT";

--- a/packages/hosted-local-harness/test/minio-image-contract.test.ts
+++ b/packages/hosted-local-harness/test/minio-image-contract.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { test } from "vitest";
+
+import {
+  HOSTED_LOCAL_MINIO_MIRROR_IMAGE,
+  HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE,
+} from "../src/dev-hosted-local/minio-image-contract.ts";
+
+test("the MinIO mirror workflow cannot drift from the image contract", () => {
+  const workflow = readFileSync(
+    new URL("../../../.github/workflows/hosted-local-minio-image.yml", import.meta.url),
+    "utf8",
+  );
+
+  // The workflow greps these exact patterns out of the contract module, so a
+  // rename or retag there must not silently publish the wrong image.
+  assert.match(workflow, /grep -oE '"minio\/minio:\[\^"\]\+"'/u);
+  assert.match(workflow, /grep -oE '"ghcr\\\.io\/\[\^"\]\+"'/u);
+
+  assert.match(HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE, /^minio\/minio:RELEASE\.[\w-]+$/u);
+  assert.match(
+    HOSTED_LOCAL_MINIO_MIRROR_IMAGE,
+    /^ghcr\.io\/cobuildwithus\/murph-hosted-local-minio:RELEASE\.[\w-]+$/u,
+  );
+
+  // The mirror must be built from the same release it claims to mirror.
+  const upstreamTag = HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE.split(":")[1];
+  const mirrorTag = HOSTED_LOCAL_MINIO_MIRROR_IMAGE.split(":")[1];
+  assert.equal(mirrorTag, upstreamTag);
+});


### PR DESCRIPTION
## Why this exists

Hosted E2E pulls the MinIO sidecar (the local R2 stand-in) on every run, straight
from Docker Hub. Docker Hub rate-limits and times out GitHub-hosted runners, and
when it does the failure surfaces as a MinIO health-check timeout — so it reads
as a harness bug and takes down the whole E2E matrix for a reason unrelated to
the change under test.

It did exactly that today on an unrelated PR:

```
[minio] docker: Error response from daemon:
  Get "https://registry-1.docker.io/v2/": context deadline exceeded
...
Error: Timed out waiting for minio to respond on .../minio/health/ready
```

10 of 11 E2E jobs passed; the one that failed was killed by the registry. GHCR
pulls from Actions use the workflow token and are not rate-limited, and we
already publish the Cloudflare runner base image there.

## What changed

**The mirror workflow only.** It resolves both refs from a single contract
module, pulls the pinned upstream release, retags it, and pushes to
`ghcr.io/cobuildwithus/murph-hosted-local-minio`.

The harness default deliberately **still points at the upstream ref**. The
mirrored image does not exist until this lands on main and the workflow runs, so
flipping the default in the same change would break every E2E run until then —
strictly worse than the current intermittent flake. That flip is a one-line
follow-up once the image is published.

## Invariants

- Both refs live in one contract module, and the workflow parses them from it, so
  the published image cannot drift from the one the harness expects. A guard test
  pins the workflow's parse patterns and asserts both refs share a release tag.
- The mirror is `linux/amd64` only, matching the `ubuntu-24.04` E2E runners, which
  keeps the mirrored digest unambiguous.
- Publishing is restricted to protected `main`, like the runner base image.
- `MURPH_DEV_MINIO_IMAGE` still overrides the image for local development.

## Verification

`pnpm test:diff` green. The guard test fails if the workflow stops parsing the
contract or if the two refs drift apart.

## Follow-ups before the default can flip

1. Merge this and let the workflow publish (or run it via `workflow_dispatch`).
2. Decide package visibility. **Public is simpler** — no `packages: read` and no
   `docker login` needed anywhere. If it stays private, the hosted E2E workflow
   needs both added; it currently has only `contents: read`.
3. Flip `DEFAULT_HOSTED_LOCAL_MINIO_IMAGE` to the mirror.

Worth considering at step 3: keeping a fallback to the upstream ref if the GHCR
pull fails. Pinning to GHCR alone relocates the single point of failure rather
than removing it, and the actual problem is a transient registry outage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787598278&installation_model_id=19880&pr_number=949&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F949&signature=f78edd14488d9551e333eae96820e2032d813cdcae191a1429ae4f81d4e0a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->