### PR TITLE
Run hosted-local MinIO from the GHCR mirror

### DIFF
--- a/.github/workflows/hosted-local-minio-image.yml
+++ b/.github/workflows/hosted-local-minio-image.yml
@@ -61,4 +61,11 @@ jobs:
           docker push "${{ steps.images.outputs.mirror }}"
 
       - name: Report published digest
-        run: docker image inspect --format '{{index .RepoDigests 0}}' "${{ steps.images.outputs.mirror }}"
+        run: |
+          set -euo pipefail
+          # RepoDigests holds every repo this image is known by, and the pulled
+          # upstream one sorts first, so select the mirror explicitly.
+          docker image inspect \
+            --format '{{range .RepoDigests}}{{println .}}{{end}}' \
+            "${{ steps.images.outputs.mirror }}" \
+            | grep "^ghcr.io/"

--- a/packages/hosted-local-harness/src/dev-hosted-local/minio.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/minio.ts
@@ -23,11 +23,17 @@ import {
 import type {
   BufferedNamedChildProcess,
 } from "./types.ts";
-import { HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE } from "./minio-image-contract.ts";
+import {
+  HOSTED_LOCAL_MINIO_MIRROR_IMAGE,
+  HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE,
+} from "./minio-image-contract.ts";
 
-// Still the upstream ref: the GHCR mirror only becomes the default once the
-// mirror workflow has published it from main.
-const DEFAULT_HOSTED_LOCAL_MINIO_IMAGE = HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE;
+// GHCR first: Actions pulls from it with the workflow token and are not
+// rate-limited, unlike Docker Hub. The upstream ref stays as a fallback because
+// pinning to one registry relocates the single point of failure rather than
+// removing it, and the failure this guards against is a transient registry
+// outage that either registry can have.
+const DEFAULT_HOSTED_LOCAL_MINIO_IMAGE = HOSTED_LOCAL_MINIO_MIRROR_IMAGE;
 const DEFAULT_HOSTED_LOCAL_MINIO_DATA_DIR = path.join(".tmp", "hosted-local-minio-r2");
 const HOSTED_LOCAL_MINIO_DATA_DIR_ENV = "MURPH_DEV_MINIO_DATA_DIR";
 const HOSTED_LOCAL_MINIO_PORT_ENV = "MURPH_DEV_MINIO_PORT";
@@ -44,6 +50,63 @@ const HOSTED_LOCAL_MINIO_E2E_LABEL = "murph.hosted-local.e2e=1";
 const HOSTED_LOCAL_MINIO_CONTAINER_NAME_PREFIX = "murph-hosted-local-r2-";
 const HOSTED_LOCAL_R2_DOCKER_BRIDGE_HOST_ENV = "MURPH_HOSTED_LOCAL_R2_DOCKER_BRIDGE_HOST";
 const HOSTED_LOCAL_MINIO_DOCKER_CLEANUP_TIMEOUT_MS = 10_000;
+
+/**
+ * The image to try first. An explicit override always wins so local development
+ * and one-off debugging can pin any build.
+ */
+export function resolveHostedLocalMinioImage(env: Record<string, string | undefined>): string {
+  return env[HOSTED_LOCAL_MINIO_IMAGE_ENV]?.trim() || DEFAULT_HOSTED_LOCAL_MINIO_IMAGE;
+}
+
+/**
+ * Resolves which image to run, falling back to the upstream ref only when the
+ * mirror cannot be *pulled*.
+ *
+ * The fallback is deliberately scoped to pull failures. A registry outage is
+ * transient and unrelated to the change under test, so it should not fail a
+ * run; but a container that pulls fine and then never becomes healthy is a real
+ * failure, and retrying that against a second registry would only double the
+ * time it takes to report the same problem.
+ *
+ * An explicit override disables the fallback entirely: if someone pinned a
+ * specific build, silently running a different one is worse than failing.
+ */
+export async function resolveHostedLocalMinioRunnableImage(
+  env: NodeJS.ProcessEnv,
+  pullImage: (image: string) => Promise<boolean> = (image) =>
+    pullHostedLocalMinioImage(env, image),
+): Promise<string> {
+  const requestedImage = resolveHostedLocalMinioImage(env);
+
+  if (requestedImage !== HOSTED_LOCAL_MINIO_MIRROR_IMAGE) {
+    return requestedImage;
+  }
+
+  if (await pullImage(requestedImage)) {
+    return requestedImage;
+  }
+
+  console.warn(
+    `[minio] could not pull ${HOSTED_LOCAL_MINIO_MIRROR_IMAGE}; falling back to ${HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE}.`,
+  );
+  return HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE;
+}
+
+/** True when the image is present locally after the pull attempt. */
+async function pullHostedLocalMinioImage(
+  env: NodeJS.ProcessEnv,
+  image: string,
+): Promise<boolean> {
+  await runDockerBestEffort(env, ["pull", image]);
+  return (await runDockerCaptureBestEffort(env, [
+    "image",
+    "inspect",
+    "--format",
+    "{{.Id}}",
+    image,
+  ])).trim().length > 0;
+}
 
 interface HostedLocalMinioPublishTarget {
   controlHost: string;
@@ -69,6 +132,8 @@ export async function maybeStartHostedLocalMinio(input: {
   containerHost: string;
   env: NodeJS.ProcessEnv;
   pipeOutput?: boolean;
+  /** Test seam: probe whether an image can be pulled. Defaults to real docker. */
+  pullImage?: (image: string) => Promise<boolean>;
   stderrTarget?: NodeJS.WritableStream;
   stdoutTarget?: NodeJS.WritableStream;
   tempDir: string;
@@ -102,7 +167,9 @@ export async function maybeStartHostedLocalMinio(input: {
   });
   const credentials = resolveHostedLocalMinioCredentials(input.env);
 
-  const startContainer = async (): Promise<BufferedNamedChildProcess> => {
+  const startContainer = async (
+    image: string = resolveHostedLocalMinioImage(input.env),
+  ): Promise<BufferedNamedChildProcess> => {
     await cleanupHostedLocalMinioContainerBestEffort(input.env, containerName, {
       buildId: buildIdLabelValue,
     });
@@ -129,7 +196,7 @@ export async function maybeStartHostedLocalMinio(input: {
       "MINIO_ROOT_PASSWORD",
       "-e",
       "MINIO_REGION_NAME",
-      input.env[HOSTED_LOCAL_MINIO_IMAGE_ENV]?.trim() || DEFAULT_HOSTED_LOCAL_MINIO_IMAGE,
+      image,
       "server",
       "/data",
       "--address",
@@ -166,7 +233,9 @@ export async function maybeStartHostedLocalMinio(input: {
     return childProcess;
   };
 
-  let childProcess = await startContainer();
+  let childProcess = await startContainer(
+    await resolveHostedLocalMinioRunnableImage(input.env, input.pullImage),
+  );
   const processes: BufferedNamedChildProcess[] = [childProcess];
   let restartPromise: Promise<BufferedNamedChildProcess | null> | null = null;
 

--- a/packages/hosted-local-harness/test/dev-hosted-local/minio.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/minio.test.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "node:events";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { HOSTED_LOCAL_MINIO_MIRROR_IMAGE } from "../../src/dev-hosted-local/minio-image-contract.ts";
+
 const runtimeMocks = vi.hoisted(() => ({
   spawnChildProcess: vi.fn(),
   terminateChildProcessAndWait: vi.fn(async () => {}),
@@ -162,6 +164,7 @@ describe("hosted-local MinIO sidecar", () => {
       env: {
         MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED: "1",
       },
+      pullImage: async () => true,
       tempDir: ".tmp/hosted-local-minio-test",
     });
 
@@ -214,7 +217,8 @@ describe("hosted-local MinIO sidecar", () => {
     expect(dockerArgs).toContain("murph.hosted-local.build-id=build-test");
     expect(dockerArgs).toContain("murph.hosted-local.e2e=1");
     expect(dockerArgs).toContain("MINIO_REGION_NAME");
-    expect(dockerArgs).toContain("minio/minio:RELEASE.2025-09-07T16-13-09Z");
+    // GHCR first; the upstream ref is only the fallback when that is unreachable.
+    expect(dockerArgs).toContain(HOSTED_LOCAL_MINIO_MIRROR_IMAGE);
     if (typeof process.getuid === "function" && typeof process.getgid === "function") {
       expect(dockerArgs).toEqual(expect.arrayContaining([
         "--user",
@@ -451,6 +455,7 @@ describe("hosted-local MinIO sidecar", () => {
       env: {
         MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED: "1",
       },
+      pullImage: async () => true,
       tempDir: ".tmp/hosted-local-minio-test",
     });
 
@@ -657,6 +662,7 @@ describe("hosted-local MinIO sidecar", () => {
       env: {
         MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED: "1",
       },
+      pullImage: async () => true,
       tempDir: ".tmp/hosted-local-minio-test",
     });
     if (!server) {
@@ -694,6 +700,7 @@ describe("hosted-local MinIO sidecar", () => {
       env: {
         MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED: "1",
       },
+      pullImage: async () => true,
       tempDir: ".tmp/hosted-local-minio-test",
     });
     if (!server) {

--- a/packages/hosted-local-harness/test/minio-image-fallback.test.ts
+++ b/packages/hosted-local-harness/test/minio-image-fallback.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+import {
+  HOSTED_LOCAL_MINIO_MIRROR_IMAGE,
+  HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE,
+} from "../src/dev-hosted-local/minio-image-contract.ts";
+import {
+  resolveHostedLocalMinioImage,
+  resolveHostedLocalMinioRunnableImage,
+} from "../src/dev-hosted-local/minio.ts";
+
+function recordingPull(failFor: readonly string[]) {
+  const attempted: string[] = [];
+
+  return {
+    attempted,
+    pull: async (image: string) => {
+      attempted.push(image);
+      return !failFor.includes(image);
+    },
+  };
+}
+
+test("MinIO runs from the GHCR mirror when it pulls", async () => {
+  const puller = recordingPull([]);
+
+  assert.equal(
+    await resolveHostedLocalMinioRunnableImage({}, puller.pull),
+    HOSTED_LOCAL_MINIO_MIRROR_IMAGE,
+  );
+  assert.deepEqual(puller.attempted, [HOSTED_LOCAL_MINIO_MIRROR_IMAGE]);
+});
+
+test("MinIO falls back to upstream when the mirror cannot be pulled", async () => {
+  const puller = recordingPull([HOSTED_LOCAL_MINIO_MIRROR_IMAGE]);
+
+  // A transient registry outage is unrelated to the change under test, so one
+  // unreachable registry must not fail the run.
+  assert.equal(
+    await resolveHostedLocalMinioRunnableImage({}, puller.pull),
+    HOSTED_LOCAL_MINIO_UPSTREAM_IMAGE,
+  );
+});
+
+test("an explicit image override is honored and never silently replaced", async () => {
+  const pinned = "minio/minio:RELEASE.2024-01-01T00-00-00Z";
+  assert.equal(resolveHostedLocalMinioImage({ MURPH_DEV_MINIO_IMAGE: pinned }), pinned);
+
+  const puller = recordingPull([pinned]);
+  // Running a different build than the one someone pinned would be worse than
+  // failing, so the fallback must not apply to an override.
+  assert.equal(
+    await resolveHostedLocalMinioRunnableImage({ MURPH_DEV_MINIO_IMAGE: pinned }, puller.pull),
+    pinned,
+  );
+  assert.deepEqual(puller.attempted, [], "an override must not be pull-probed for fallback");
+});


### PR DESCRIPTION
Follow-up to #949, which added the mirror workflow. That workflow has run on
main and published the image, and it is **anonymously pullable** (a token-less
manifest fetch returns 200), so no `docker login` or `packages: read` is needed
anywhere.

## What changed

`DEFAULT_HOSTED_LOCAL_MINIO_IMAGE` now points at the GHCR mirror, with the
upstream ref kept as a fallback. Actions pulls from GHCR use the workflow token
and are not rate-limited — Docker Hub timing out is what took down a hosted E2E
run on an unrelated PR:

```
[minio] docker: Error response from daemon:
  Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

Keeping the fallback matters: pinning to one registry relocates the single point
of failure rather than removing it, and the failure being guarded against is a
transient outage that either registry can have.

## The fallback is scoped to pull failures, deliberately

My first version fell back on *any* startup failure, and an existing test caught
it — a case asserting that a health-check failure rejects started passing,
because the fallback silently retried. That is the wrong semantics: a container
that pulls fine and then never becomes healthy is a real failure, and retrying it
against a second registry would only double the time taken to report the same
problem.

Image resolution now probes the pull and falls back only when *that* fails.
Health-check failures keep their original behavior.

## Invariants

- An explicit `MURPH_DEV_MINIO_IMAGE` override disables the fallback entirely.
  Silently running a different build than the one someone pinned is worse than
  failing, and the override is never even pull-probed.
- Both refs still live in one contract module, with the drift guard from #949.

## Also fixed

The mirror workflow's digest report printed the *pulled upstream* digest rather
than the pushed mirror one, because `RepoDigests[0]` is whichever repo the image
came from. It now selects the `ghcr.io/` entry explicitly.

## Verification

`pnpm test:diff` green. New coverage: mirror used when it pulls, upstream used
when the mirror pull fails, and an override honored without being pull-probed.
The existing sidecar suite mocks docker, so it stubs the pull probe rather than
having its assertions weakened.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787600136&installation_model_id=19880&pr_number=953&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F953&signature=f4d70b6f5b21b53370f2ed39cec1daf39b6809427d40bc4ec87951f9ed665bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->